### PR TITLE
chore: Setup releases fro Windows and Linux

### DIFF
--- a/.github/workflows/linting-and-tests.yml
+++ b/.github/workflows/linting-and-tests.yml
@@ -128,8 +128,8 @@ jobs:
       - name: Check for changes and commit if needed
         working-directory: desktop
         run: |
-          
-          if ! git diff --exit-code; then
+          # Check both unstaged and staged changes
+          if ! git diff --exit-code || ! git diff --cached --exit-code; then
             git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git config --local user.name "github-actions[bot]"
             git add .

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -77,8 +77,9 @@ jobs:
 
       - name: Update version from release-please tag
         if: needs.release-please.outputs.desktop_release_created
+        env:
+          TAG_NAME: ${{ needs.release-please.outputs['desktop--tag_name'] }}
         run: |
-          TAG_NAME="${{ needs.release-please.outputs['desktop--tag_name'] }}"
           VERSION="${TAG_NAME#app-v}"
           echo "Updating version to $VERSION from tag $TAG_NAME"
           

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,7 +24,6 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      releases: write
       id-token: write
     outputs:
       desktop_release_created: ${{ steps.release-please.outputs['desktop--release_created'] }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -68,10 +68,17 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+          
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.ARCHESTRA_RELEASER_GITHUB_APP_ID }}
+          private-key: ${{ secrets.ARCHESTRA_RELEASER_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Fetch GitHub release for app-v0.1.0
         env:
-          GITHUB_TOKEN: ${{ secrets.ARCHESTRA_RELEASER_GITHUB_APP_CLIENT_SECRET }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           echo "Fetching GitHub release for tag app-v0.1.0..."
           gh release view app-v0.1.0 --json name,tagName,publishedAt,assets || echo "Release app-v0.1.0 not found or not accessible"
@@ -94,7 +101,7 @@ jobs:
 
       - uses: tauri-apps/tauri-action@564aea5a8075c7a54c167bb0cf5b3255314a7f9d # v0.5.22
         env:
-          GITHUB_TOKEN: ${{ secrets.ARCHESTRA_RELEASER_GITHUB_APP_CLIENT_SECRET }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         with:
           tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
           projectPath: desktop

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -73,7 +73,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.ARCHESTRA_RELEASER_GITHUB_APP_ID }}
+          app-id: ${{ secrets.ARCHESTRA_RELEASER_GITHUB_APP_ID }}
           private-key: ${{ secrets.ARCHESTRA_RELEASER_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Fetch GitHub release for app-v0.1.0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -69,6 +69,13 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Fetch GitHub release for app-v0.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.ARCHESTRA_RELEASER_GITHUB_APP_CLIENT_SECRET }}
+        run: |
+          echo "Fetching GitHub release for tag app-v0.1.0..."
+          gh release view app-v0.1.0 --json name,tagName,publishedAt,assets || echo "Release app-v0.1.0 not found or not accessible"
+
       - name: setup node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release-*
   workflow_dispatch:
 
 permissions:
@@ -23,6 +24,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      releases: write
       id-token: write
     outputs:
       desktop_release_created: ${{ steps.release-please.outputs['desktop--release_created'] }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -88,7 +88,7 @@ jobs:
 
       - uses: tauri-apps/tauri-action@564aea5a8075c7a54c167bb0cf5b3255314a7f9d # v0.5.22
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ARCHESTRA_RELEASER_GITHUB_APP_CLIENT_SECRET }}
         with:
           tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
           projectPath: desktop

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - release-*
   workflow_dispatch:
 
 permissions:
@@ -76,12 +75,21 @@ jobs:
           app-id: ${{ secrets.ARCHESTRA_RELEASER_GITHUB_APP_ID }}
           private-key: ${{ secrets.ARCHESTRA_RELEASER_GITHUB_APP_PRIVATE_KEY }}
 
-      - name: Fetch GitHub release for app-v0.1.0
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+      - name: Update version from release-please tag
+        if: needs.release-please.outputs.desktop_release_created
         run: |
-          echo "Fetching GitHub release for tag app-v0.1.0..."
-          gh release view app-v0.1.0 --json name,tagName,publishedAt,assets || echo "Release app-v0.1.0 not found or not accessible"
+          TAG_NAME="${{ needs.release-please.outputs['desktop--tag_name'] }}"
+          VERSION="${TAG_NAME#app-v}"
+          echo "Updating version to $VERSION from tag $TAG_NAME"
+          
+          # Update package.json
+          jq --arg version "$VERSION" '.version = $version' desktop/package.json > desktop/package.json.tmp && mv desktop/package.json.tmp desktop/package.json
+          
+          # Update Cargo.toml
+          sed -i.bak "s/^version = .*/version = \"$VERSION\"/" desktop/src-tauri/Cargo.toml && rm desktop/src-tauri/Cargo.toml.bak
+          
+          # Update tauri.conf.json
+          jq --arg version "$VERSION" '.version = $version' desktop/src-tauri/tauri.conf.json > desktop/src-tauri/tauri.conf.json.tmp && mv desktop/src-tauri/tauri.conf.json.tmp desktop/src-tauri/tauri.conf.json
 
       - name: setup node
         uses: actions/setup-node@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,6 +257,8 @@ The GitHub Actions CI/CD pipeline consists of several workflows with concurrency
 #### Release Please Workflow (`.github/workflows/release-please.yml`)
 - Manages automated releases using Google's release-please action
 - Creates and maintains release PRs with changelogs
+- **Triggers**: Runs on pushes to `main` branch and any `release-*` branches
+- **Permissions**: Has `releases: write` permission to create and manage GitHub releases
 - **Multi-platform desktop builds**: When a desktop release is created:
   - Builds Tauri desktop applications for Linux (ubuntu-latest) and Windows (windows-latest)
   - Uses matrix strategy with `fail-fast: false` to ensure all platforms build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,7 +258,7 @@ The GitHub Actions CI/CD pipeline consists of several workflows with concurrency
 - Manages automated releases using Google's release-please action
 - Creates and maintains release PRs with changelogs
 - **Triggers**: Runs on pushes to `main` branch and any `release-*` branches
-- **Permissions**: Has `releases: write` permission to create and manage GitHub releases
+- **Authentication**: Uses `ARCHESTRA_RELEASER_GITHUB_APP_CLIENT_SECRET` for the tauri-action to create releases
 - **Multi-platform desktop builds**: When a desktop release is created:
   - Builds Tauri desktop applications for Linux (ubuntu-latest) and Windows (windows-latest)
   - Uses matrix strategy with `fail-fast: false` to ensure all platforms build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,7 +258,7 @@ The GitHub Actions CI/CD pipeline consists of several workflows with concurrency
 - Manages automated releases using Google's release-please action
 - Creates and maintains release PRs with changelogs
 - **Triggers**: Runs on pushes to `main` branch and any `release-*` branches
-- **Authentication**: Uses `ARCHESTRA_RELEASER_GITHUB_APP_CLIENT_SECRET` for the tauri-action to create releases
+- **Authentication**: Uses GitHub App authentication by generating a token from `ARCHESTRA_RELEASER_GITHUB_APP_ID` and `ARCHESTRA_RELEASER_GITHUB_APP_PRIVATE_KEY` for creating releases
 - **Multi-platform desktop builds**: When a desktop release is created:
   - Builds Tauri desktop applications for Linux (ubuntu-latest) and Windows (windows-latest)
   - Uses matrix strategy with `fail-fast: false` to ensure all platforms build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,7 +258,10 @@ The GitHub Actions CI/CD pipeline consists of several workflows with concurrency
 - Manages automated releases using Google's release-please action
 - Creates and maintains release PRs with changelogs
 - **Triggers**: Runs on pushes to `main` branch
-- **Authentication**: Uses GitHub App authentication by generating a token from `ARCHESTRA_RELEASER_GITHUB_APP_ID` and `ARCHESTRA_RELEASER_GITHUB_APP_PRIVATE_KEY` for creating releases
+- **Authentication**: Uses GitHub App authentication:
+  - Generates a GitHub App installation token using `actions/create-github-app-token@v2`
+  - Token is created from `ARCHESTRA_RELEASER_GITHUB_APP_ID` and `ARCHESTRA_RELEASER_GITHUB_APP_PRIVATE_KEY` secrets
+  - Generated token is used for both fetching existing releases and creating new ones via tauri-action
 - **Version Management**: When a desktop release is created:
   - Automatically extracts version from release-please tag (format: `app-vX.Y.Z`)
   - Updates version in three locations:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,12 +257,18 @@ The GitHub Actions CI/CD pipeline consists of several workflows with concurrency
 #### Release Please Workflow (`.github/workflows/release-please.yml`)
 - Manages automated releases using Google's release-please action
 - Creates and maintains release PRs with changelogs
-- **Triggers**: Runs on pushes to `main` branch and any `release-*` branches
+- **Triggers**: Runs on pushes to `main` branch
 - **Authentication**: Uses GitHub App authentication by generating a token from `ARCHESTRA_RELEASER_GITHUB_APP_ID` and `ARCHESTRA_RELEASER_GITHUB_APP_PRIVATE_KEY` for creating releases
+- **Version Management**: When a desktop release is created:
+  - Automatically extracts version from release-please tag (format: `app-vX.Y.Z`)
+  - Updates version in three locations:
+    - `desktop/package.json` (using jq)
+    - `desktop/src-tauri/Cargo.toml` (using sed)
+    - `desktop/src-tauri/tauri.conf.json` (using jq)
 - **Multi-platform desktop builds**: When a desktop release is created:
   - Builds Tauri desktop applications for Linux (ubuntu-latest) and Windows (windows-latest)
   - Uses matrix strategy with `fail-fast: false` to ensure all platforms build
-  - Creates draft GitHub releases with platform-specific binaries
+  - Creates draft GitHub releases with platform-specific binaries using the generated GitHub App token
   - Tags releases with format `app-v__VERSION__`
 
 #### Interactive Claude Workflow (`.github/workflows/claude.yml`)


### PR DESCRIPTION
## Summary

This PR fixes the release-please workflow to properly authenticate with GitHub for creating releases by migrating from using a client secret directly to generating a proper GitHub App token.

## Changes

- Added a new step to generate a GitHub App token using the app ID and private key
- Updated the authentication for the "Fetch GitHub release" step to use the generated token
- Updated the authentication for the tauri-action step to use the generated token instead of the client secret

## Motivation

Previously, the workflow was attempting to use `ARCHESTRA_RELEASER_GITHUB_APP_CLIENT_SECRET` directly as a `GITHUB_TOKEN`, which is incorrect. GitHub App client secrets are not valid authentication tokens. This change properly generates a GitHub App installation token which has the necessary permissions to create releases.

## Testing

The workflow will be tested on the next release-please run to ensure it can successfully:
- Fetch existing releases
- Create new releases via the tauri-action