### PR TITLE
ci: update `linting-and-tests` CI job (for required GH PR checks)

### DIFF
--- a/.github/workflows/linting-and-tests.yml
+++ b/.github/workflows/linting-and-tests.yml
@@ -27,19 +27,23 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: "ubuntu-latest"
+          - name: "Ubuntu"
+            platform: "ubuntu-latest"
             args: ""
-          - platform: "macos-latest" # for Arm based macs (M1 and above).
+          - name: "macOS (Arm)"
+            platform: "macos-latest" # for Arm based macs (M1 and above).
             args: "--target aarch64-apple-darwin"
-          - platform: "macos-latest" # for Intel based macs.
+          - name: "macOS (Intel)"
+            platform: "macos-latest" # for Intel based macs.
             args: "--target x86_64-apple-darwin"
-          - platform: "windows-latest"
+          - name: "Windows"
+            platform: "windows-latest"
             args: ""
     runs-on: ${{ matrix.platform }}
     defaults:
       run:
         working-directory: ./desktop/src-tauri
-    name: Rust Linting and Tests (${{ matrix.platform }})
+    name: Rust Linting and Tests (${{ matrix.name }})
     steps:
       - name: Checkout project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,6 +376,7 @@ The GitHub Actions CI/CD pipeline consists of several workflows with concurrency
 - PR title linting with conventional commits
 - **Automatic Rust formatting and fixes**: CI automatically applies `cargo fix` and `cargo fmt` changes and commits them back to the PR
 - Rust tests on Ubuntu, macOS (ARM64 & x86_64), and Windows
+  - **Improved job naming**: CI jobs now display human-friendly names (e.g., "Rust Linting and Tests (Ubuntu)") instead of technical platform identifiers (e.g., "Rust Linting and Tests (ubuntu-latest)")
 - Frontend formatting and tests
 - Frontend build verification
 - **Automatic OpenAPI schema updates**: CI automatically regenerates and commits OpenAPI schema and TypeScript client if they're outdated


### PR DESCRIPTION
This PR improves the readability of CI job names in the GitHub Actions UI.

## Changes
- Added human-friendly `name` field to each matrix configuration in the `rust-linting-and-tests` job
- Updated the job name to use `${ matrix.name }` instead of `${ matrix.platform }`

## Result
Instead of seeing technical platform names like `ubuntu-latest` in the CI checks, we now see more readable names:
- `Rust Linting and Tests (Ubuntu)` instead of `Rust Linting and Tests (ubuntu-latest)`
- `Rust Linting and Tests (macOS (Arm))` instead of `Rust Linting and Tests (macos-latest)`
- `Rust Linting and Tests (macOS (Intel))` instead of `Rust Linting and Tests (macos-latest)`
- `Rust Linting and Tests (Windows)` instead of `Rust Linting and Tests (windows-latest)`

This makes it easier to understand which platform each CI job is running on at a glance.