### PR TITLE
feat: improve sandbox initialization progress reporting

### DIFF
--- a/desktop_app/openapi/archestra/api/openapi.json
+++ b/desktop_app/openapi/archestra/api/openapi.json
@@ -171,6 +171,299 @@
               }
             },
             "required": ["type", "payload"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-startup-started"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["message"]
+              }
+            },
+            "required": ["type", "payload"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-startup-completed"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["message"]
+              }
+            },
+            "required": ["type", "payload"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-startup-failed"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["message"]
+              }
+            },
+            "required": ["type", "payload"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-podman-runtime-progress"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["message"]
+              }
+            },
+            "required": ["type", "payload"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-base-image-fetch-started"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["message"]
+              }
+            },
+            "required": ["type", "payload"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-base-image-fetch-progress"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["message"]
+              }
+            },
+            "required": ["type", "payload"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-base-image-fetch-completed"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["message"]
+              }
+            },
+            "required": ["type", "payload"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-base-image-fetch-failed"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["message"]
+              }
+            },
+            "required": ["type", "payload"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-mcp-server-starting"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "serverId": {
+                    "type": "string"
+                  },
+                  "serverName": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["serverId", "serverName", "message"]
+              }
+            },
+            "required": ["type", "payload"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-mcp-server-started"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "serverId": {
+                    "type": "string"
+                  },
+                  "serverName": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["serverId", "serverName", "message"]
+              }
+            },
+            "required": ["type", "payload"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-mcp-server-failed"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "serverId": {
+                    "type": "string"
+                  },
+                  "serverName": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["serverId", "serverName", "message"]
+              }
+            },
+            "required": ["type", "payload"]
           }
         ]
       },
@@ -797,6 +1090,321 @@
               },
               "payload": {
                 "$ref": "#/components/schemas/SandboxStatusSummary"
+              }
+            },
+            "required": ["type", "payload"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-startup-started"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["message"],
+                "additionalProperties": false
+              }
+            },
+            "required": ["type", "payload"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-startup-completed"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["message"],
+                "additionalProperties": false
+              }
+            },
+            "required": ["type", "payload"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-startup-failed"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["message"],
+                "additionalProperties": false
+              }
+            },
+            "required": ["type", "payload"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-podman-runtime-progress"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["message"],
+                "additionalProperties": false
+              }
+            },
+            "required": ["type", "payload"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-base-image-fetch-started"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["message"],
+                "additionalProperties": false
+              }
+            },
+            "required": ["type", "payload"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-base-image-fetch-progress"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["message"],
+                "additionalProperties": false
+              }
+            },
+            "required": ["type", "payload"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-base-image-fetch-completed"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["message"],
+                "additionalProperties": false
+              }
+            },
+            "required": ["type", "payload"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-base-image-fetch-failed"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["message"],
+                "additionalProperties": false
+              }
+            },
+            "required": ["type", "payload"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-mcp-server-starting"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "serverId": {
+                    "type": "string"
+                  },
+                  "serverName": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["serverId", "serverName", "message"],
+                "additionalProperties": false
+              }
+            },
+            "required": ["type", "payload"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-mcp-server-started"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "serverId": {
+                    "type": "string"
+                  },
+                  "serverName": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["serverId", "serverName", "message"],
+                "additionalProperties": false
+              }
+            },
+            "required": ["type", "payload"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sandbox-mcp-server-failed"]
+              },
+              "payload": {
+                "type": "object",
+                "properties": {
+                  "serverId": {
+                    "type": "string"
+                  },
+                  "serverName": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "progress": {
+                    "type": "number"
+                  },
+                  "error": {
+                    "type": "string"
+                  }
+                },
+                "required": ["serverId", "serverName", "message"],
+                "additionalProperties": false
               }
             },
             "required": ["type", "payload"],

--- a/desktop_app/src/backend/sandbox/podman/image/index.ts
+++ b/desktop_app/src/backend/sandbox/podman/image/index.ts
@@ -70,8 +70,8 @@ export default class PodmanImage {
 
     try {
       // Update state before making the API call
-      this.pullPercentage = 10;
-      this.pullMessage = `Initiating pull for ${this.BASE_IMAGE_NAME}`;
+      this.pullPercentage = 5;
+      this.pullMessage = `Connecting to registry for ${this.BASE_IMAGE_NAME}`;
 
       const pullResponse = await imagePullLibpod({
         query: {
@@ -80,25 +80,79 @@ export default class PodmanImage {
       });
 
       // The pull endpoint streams JSON responses during the pull
-      // We need to wait for the complete response
+      // We need to parse the streaming response for progress
       if (pullResponse.response.status === 200) {
         log.info(`Image ${this.BASE_IMAGE_NAME} pull initiated...`);
 
-        // Update progress during pull
-        this.pullPercentage = 50;
-        this.pullMessage = `Downloading ${this.BASE_IMAGE_NAME}`;
+        // Parse the response body as text to handle streaming JSON
+        const responseText = await pullResponse.response.text();
+        const lines = responseText.split('\n').filter((line) => line.trim());
 
-        // The response contains streaming data - we should check if pull completed
-        if (pullResponse.data) {
-          log.info(`Image ${this.BASE_IMAGE_NAME} pulled successfully`);
+        // Track download progress
+        let totalSize = 0;
+        let downloadedSize = 0;
+        const layerProgress = new Map<string, { current: number; total: number }>();
 
-          // Update state on success
-          this.pullPercentage = 100;
-          this.pullMessage = `Successfully pulled ${this.BASE_IMAGE_NAME}`;
-          this.pullError = null;
+        // Parse each line as a JSON event
+        for (const line of lines) {
+          try {
+            const event = JSON.parse(line);
 
-          return;
+            // Handle different event types from Docker registry pull
+            if (event.stream) {
+              const streamMessage = event.stream.trim();
+
+              // Parse layer download progress
+              if (streamMessage.includes('Downloading')) {
+                const match = streamMessage.match(
+                  /(\w+):\s*Downloading\s*\[(=|>|\s)+\]\s*(\d+\.?\d*)\s*(\w+)\s*\/\s*(\d+\.?\d*)\s*(\w+)/
+                );
+                if (match) {
+                  const layerId = match[1];
+                  const current = this.parseSize(parseFloat(match[3]), match[4]);
+                  const total = this.parseSize(parseFloat(match[5]), match[6]);
+
+                  layerProgress.set(layerId, { current, total });
+
+                  // Calculate overall progress
+                  downloadedSize = 0;
+                  totalSize = 0;
+                  for (const [_, progress] of layerProgress) {
+                    downloadedSize += progress.current;
+                    totalSize += progress.total;
+                  }
+
+                  const percentage = Math.round((downloadedSize / totalSize) * 100);
+                  this.pullPercentage = Math.min(95, Math.max(10, percentage)); // Keep between 10-95%
+                  this.pullMessage = `Downloading layers: ${this.formatBytes(downloadedSize)} / ${this.formatBytes(totalSize)}`;
+                }
+              } else if (streamMessage.includes('Pull complete')) {
+                // Layer completed
+                this.pullMessage = `Extracting layers...`;
+                this.pullPercentage = Math.min(98, this.pullPercentage + 2);
+              } else if (streamMessage.includes('Already exists')) {
+                // Layer already cached
+                this.pullPercentage = Math.min(95, this.pullPercentage + 5);
+              }
+            }
+
+            // Check for completion
+            if (event.id && !event.stream && !event.status) {
+              // This typically indicates the final image ID
+              log.info(`Image ${this.BASE_IMAGE_NAME} pulled successfully with ID: ${event.id}`);
+            }
+          } catch (e) {
+            // Skip malformed JSON lines
+            log.debug(`Skipping malformed JSON line: ${line}`);
+          }
         }
+
+        // Update state on success
+        this.pullPercentage = 100;
+        this.pullMessage = `Successfully pulled ${this.BASE_IMAGE_NAME}`;
+        this.pullError = null;
+
+        return;
       } else {
         // Try to read the error body for more details
         let errorMessage = `Error pulling image ${this.BASE_IMAGE_NAME} - Status: ${pullResponse.response.status}`;
@@ -127,6 +181,31 @@ export default class PodmanImage {
 
       throw error;
     }
+  }
+
+  /**
+   * Parse size from different units to bytes
+   */
+  private parseSize(value: number, unit: string): number {
+    const units: Record<string, number> = {
+      B: 1,
+      kB: 1024,
+      KB: 1024,
+      MB: 1024 * 1024,
+      GB: 1024 * 1024 * 1024,
+    };
+    return value * (units[unit] || 1);
+  }
+
+  /**
+   * Format bytes to human-readable string
+   */
+  private formatBytes(bytes: number): string {
+    if (bytes === 0) return '0 B';
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB', 'GB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return `${(bytes / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`;
   }
 
   get statusSummary(): PodmanImageStatusSummary {

--- a/desktop_app/src/backend/websocket/index.ts
+++ b/desktop_app/src/backend/websocket/index.ts
@@ -10,9 +10,35 @@ const ChatTitleUpdatedPayloadSchema = z.object({
   title: z.string(),
 });
 
+const SandboxEventPayloadSchema = z.object({
+  message: z.string(),
+  progress: z.number().optional(),
+  error: z.string().optional(),
+});
+
+const McpServerEventPayloadSchema = z.object({
+  serverId: z.string(),
+  serverName: z.string(),
+  message: z.string(),
+  progress: z.number().optional(),
+  error: z.string().optional(),
+});
+
 export const WebSocketMessageSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('chat-title-updated'), payload: ChatTitleUpdatedPayloadSchema }),
   z.object({ type: z.literal('sandbox-status-update'), payload: SandboxStatusSummarySchema }),
+  // New granular sandbox events
+  z.object({ type: z.literal('sandbox-startup-started'), payload: SandboxEventPayloadSchema }),
+  z.object({ type: z.literal('sandbox-startup-completed'), payload: SandboxEventPayloadSchema }),
+  z.object({ type: z.literal('sandbox-startup-failed'), payload: SandboxEventPayloadSchema }),
+  z.object({ type: z.literal('sandbox-podman-runtime-progress'), payload: SandboxEventPayloadSchema }),
+  z.object({ type: z.literal('sandbox-base-image-fetch-started'), payload: SandboxEventPayloadSchema }),
+  z.object({ type: z.literal('sandbox-base-image-fetch-progress'), payload: SandboxEventPayloadSchema }),
+  z.object({ type: z.literal('sandbox-base-image-fetch-completed'), payload: SandboxEventPayloadSchema }),
+  z.object({ type: z.literal('sandbox-base-image-fetch-failed'), payload: SandboxEventPayloadSchema }),
+  z.object({ type: z.literal('sandbox-mcp-server-starting'), payload: McpServerEventPayloadSchema }),
+  z.object({ type: z.literal('sandbox-mcp-server-started'), payload: McpServerEventPayloadSchema }),
+  z.object({ type: z.literal('sandbox-mcp-server-failed'), payload: McpServerEventPayloadSchema }),
 ]);
 
 // type ChatTitleUpdatedPayload = z.infer<typeof ChatTitleUpdatedPayloadSchema>;

--- a/desktop_app/src/ui/components/SandboxStartupProgress/index.tsx
+++ b/desktop_app/src/ui/components/SandboxStartupProgress/index.tsx
@@ -1,0 +1,140 @@
+import { AlertCircle, CheckCircle2, Loader2 } from 'lucide-react';
+import * as React from 'react';
+
+import { Progress } from '@ui/components/ui/progress';
+import websocketService from '@ui/lib/websocket';
+import { useSandboxStore } from '@ui/stores';
+
+interface SandboxStartupProgressProps {
+  className?: string;
+}
+
+interface ProgressEvent {
+  message: string;
+  progress?: number;
+  error?: string;
+}
+
+export function SandboxStartupProgress({ className }: SandboxStartupProgressProps) {
+  const { statusSummary } = useSandboxStore();
+  const [currentEvent, setCurrentEvent] = React.useState<ProgressEvent | null>(null);
+  const [overallProgress, setOverallProgress] = React.useState(0);
+
+  React.useEffect(() => {
+    const unsubscribers = [
+      websocketService.subscribe('sandbox-startup-started', ({ payload }) => {
+        setCurrentEvent(payload);
+        setOverallProgress(5);
+      }),
+      websocketService.subscribe('sandbox-startup-completed', ({ payload }) => {
+        setCurrentEvent(payload);
+        setOverallProgress(100);
+      }),
+      websocketService.subscribe('sandbox-startup-failed', ({ payload }) => {
+        setCurrentEvent(payload);
+        setOverallProgress(0);
+      }),
+      websocketService.subscribe('sandbox-podman-runtime-progress', ({ payload }) => {
+        setCurrentEvent(payload);
+        // Podman runtime is 0-40% of overall progress
+        setOverallProgress(Math.round((payload.progress || 0) * 0.4));
+      }),
+      websocketService.subscribe('sandbox-base-image-fetch-started', ({ payload }) => {
+        setCurrentEvent(payload);
+        setOverallProgress(40);
+      }),
+      websocketService.subscribe('sandbox-base-image-fetch-progress', ({ payload }) => {
+        setCurrentEvent(payload);
+        // Base image pull is 40-80% of overall progress
+        setOverallProgress(40 + Math.round((payload.progress || 0) * 0.4));
+      }),
+      websocketService.subscribe('sandbox-base-image-fetch-completed', ({ payload }) => {
+        setCurrentEvent(payload);
+        setOverallProgress(80);
+      }),
+      websocketService.subscribe('sandbox-base-image-fetch-failed', ({ payload }) => {
+        setCurrentEvent(payload);
+      }),
+      websocketService.subscribe('sandbox-mcp-server-starting', ({ payload }) => {
+        setCurrentEvent({
+          message: payload.message,
+          progress: 85,
+        });
+        setOverallProgress(85);
+      }),
+      websocketService.subscribe('sandbox-mcp-server-started', ({ payload }) => {
+        setCurrentEvent({
+          message: payload.message,
+          progress: 95,
+        });
+        setOverallProgress(95);
+      }),
+      websocketService.subscribe('sandbox-mcp-server-failed', ({ payload }) => {
+        setCurrentEvent({
+          message: payload.message,
+          error: payload.error,
+        });
+      }),
+    ];
+
+    return () => {
+      unsubscribers.forEach((unsubscribe) => unsubscribe());
+    };
+  }, []);
+
+  // Don't show if sandbox is already running or not installed
+  if (statusSummary.status === 'running' || statusSummary.status === 'not_installed') {
+    return null;
+  }
+
+  const hasError = currentEvent?.error || statusSummary.status === 'error';
+  const isComplete = overallProgress === 100;
+
+  return (
+    <div className={`space-y-2 p-4 border rounded-lg ${className}`}>
+      <div className="flex items-center gap-2">
+        {hasError ? (
+          <AlertCircle className="h-4 w-4 text-destructive" />
+        ) : isComplete ? (
+          <CheckCircle2 className="h-4 w-4 text-green-500" />
+        ) : (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        )}
+        <h3 className="text-sm font-medium">Sandbox Initialization</h3>
+      </div>
+
+      <div className="space-y-1">
+        <p className="text-xs text-muted-foreground">
+          {currentEvent?.message || statusSummary.runtime.startupMessage || 'Initializing...'}
+        </p>
+        {hasError && (
+          <p className="text-xs text-destructive">{currentEvent?.error || statusSummary.runtime.startupError}</p>
+        )}
+      </div>
+
+      {!hasError && (
+        <div className="space-y-1">
+          <Progress value={overallProgress} className="h-2" />
+          <p className="text-xs text-muted-foreground text-right">{overallProgress}%</p>
+        </div>
+      )}
+
+      {/* Show detailed progress for specific stages */}
+      {statusSummary.runtime.startupPercentage > 0 && statusSummary.runtime.startupPercentage < 100 && (
+        <div className="mt-2 pt-2 border-t space-y-1">
+          <p className="text-xs text-muted-foreground">Podman Runtime</p>
+          <Progress value={statusSummary.runtime.startupPercentage} className="h-1" />
+        </div>
+      )}
+
+      {statusSummary.runtime.baseImage.pullPercentage > 0 && statusSummary.runtime.baseImage.pullPercentage < 100 && (
+        <div className="mt-2 pt-2 border-t space-y-1">
+          <p className="text-xs text-muted-foreground">
+            {statusSummary.runtime.baseImage.pullMessage || 'Pulling base image'}
+          </p>
+          <Progress value={statusSummary.runtime.baseImage.pullPercentage} className="h-1" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop_app/src/ui/components/Sidebar/McpServerWithToolsSidebarSection/index.tsx
+++ b/desktop_app/src/ui/components/Sidebar/McpServerWithToolsSidebarSection/index.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, Plus } from 'lucide-react';
+import { ChevronRight, Circle, Loader2, Plus } from 'lucide-react';
 import * as React from 'react';
 
 import { ToolHoverCard } from '@ui/components/ToolHoverCard';
@@ -13,13 +13,13 @@ import {
   SidebarMenuItem,
 } from '@ui/components/ui/sidebar';
 import { formatToolName } from '@ui/lib/utils/tools';
-import { useMcpServersStore, useNavigationStore, useToolsStore } from '@ui/stores';
+import { useMcpServersStore, useNavigationStore, useSandboxStore, useToolsStore } from '@ui/stores';
 import { NavigationViewKey } from '@ui/types';
 
 interface McpServerWithToolsSidebarSectionProps {}
 
 export default function McpServerWithToolsSidebarSection(_props: McpServerWithToolsSidebarSectionProps) {
-  const { loadingInstalledMcpServers } = useMcpServersStore();
+  const { loadingInstalledMcpServers, installedMcpServers } = useMcpServersStore();
   const {
     addSelectedTool,
     getAllAvailableToolsGroupedByServer,
@@ -28,6 +28,7 @@ export default function McpServerWithToolsSidebarSection(_props: McpServerWithTo
     setToolSearchQuery,
   } = useToolsStore();
   const { setActiveView } = useNavigationStore();
+  const { statusSummary } = useSandboxStore();
 
   const allAvailableToolsGroupedByServer = getAllAvailableToolsGroupedByServer();
   const filteredToolsGroupedByServer = getFilteredToolsGroupedByServer();
@@ -37,6 +38,14 @@ export default function McpServerWithToolsSidebarSection(_props: McpServerWithTo
   const toolSearchQueryIsEmpty = !toolSearchQuery.trim();
 
   const tools = toolSearchQueryIsEmpty ? allAvailableToolsGroupedByServer : filteredToolsGroupedByServer;
+
+  // Check if any MCP servers are initializing
+  const hasInitializingServers = installedMcpServers.some(
+    (server) => server.state === 'initializing' || server.state === 'created'
+  );
+  const isBaseImagePulling =
+    statusSummary.runtime.baseImage.pullPercentage > 0 && statusSummary.runtime.baseImage.pullPercentage < 100;
+  const isPodmanInitializing = statusSummary.status === 'initializing';
 
   return (
     <SidebarGroup className="group-data-[collapsible=icon]:hidden">
@@ -58,6 +67,143 @@ export default function McpServerWithToolsSidebarSection(_props: McpServerWithTo
                 <span className="text-xs text-muted-foreground">Loading...</span>
               </div>
             </SidebarMenuItem>
+          ) : (isPodmanInitializing || isBaseImagePulling || hasInitializingServers) && toolSearchQueryIsEmpty ? (
+            // Show initializing servers with loading states
+            <>
+              {isPodmanInitializing && (
+                <SidebarMenuItem>
+                  <div className="flex items-center gap-2 px-2 py-1.5 text-xs text-muted-foreground">
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                    <span>
+                      {statusSummary.runtime.startupMessage || 'Initializing sandbox...'}
+                      {statusSummary.runtime.startupPercentage > 0 && (
+                        <span className="ml-1">({statusSummary.runtime.startupPercentage}%)</span>
+                      )}
+                    </span>
+                  </div>
+                </SidebarMenuItem>
+              )}
+
+              {isBaseImagePulling && (
+                <SidebarMenuItem>
+                  <div className="flex items-center gap-2 px-2 py-1.5 text-xs text-muted-foreground">
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                    <span>
+                      {statusSummary.runtime.baseImage.pullMessage || 'Pulling base image...'}
+                      {statusSummary.runtime.baseImage.pullPercentage > 0 && (
+                        <span className="ml-1">({statusSummary.runtime.baseImage.pullPercentage}%)</span>
+                      )}
+                    </span>
+                  </div>
+                </SidebarMenuItem>
+              )}
+
+              {installedMcpServers.map((server) => {
+                const isInitializing = server.state === 'initializing' || server.state === 'created';
+                if (!isInitializing && !server.tools.length) return null;
+
+                return (
+                  <React.Fragment key={server.id}>
+                    <SidebarMenuItem>
+                      <div className="flex items-center gap-2 px-2 py-1.5 bg-muted/50 rounded-md">
+                        <ToolServerIcon
+                          toolServerName={server.name}
+                          widthHeightClassName="w-4 h-4"
+                          textClassName="text-[10px]"
+                        />
+                        <span className="text-sm font-medium capitalize flex-1">{server.name}</span>
+                        {isInitializing && <Circle className="h-2 w-2 fill-yellow-500 text-yellow-500" />}
+                      </div>
+                    </SidebarMenuItem>
+
+                    {isInitializing ? (
+                      <SidebarMenuItem>
+                        <div className="flex items-center gap-2 px-8 py-1 text-xs text-muted-foreground">
+                          <Loader2 className="h-3 w-3 animate-spin" />
+                          <span>Loading tools...</span>
+                        </div>
+                      </SidebarMenuItem>
+                    ) : (
+                      server.tools.map((tool, idx) => {
+                        const { serverName, name } = tool;
+                        return (
+                          <SidebarMenuItem key={`${serverName}-${idx}`}>
+                            <ToolHoverCard
+                              tool={tool}
+                              side="right"
+                              align="start"
+                              showInstructions={true}
+                              instructionText="Click to add to context"
+                            >
+                              <div className="w-full">
+                                <SidebarMenuButton
+                                  size="sm"
+                                  className="justify-between text-sm w-full cursor-pointer"
+                                  onClick={() => addSelectedTool(tool)}
+                                >
+                                  <div className="flex items-center gap-2">
+                                    <div className="w-2 h-2 bg-green-500 rounded-full" />
+                                    <span>{formatToolName(name)}</span>
+                                  </div>
+                                  <ChevronRight className="h-3 w-3 text-muted-foreground" />
+                                </SidebarMenuButton>
+                              </div>
+                            </ToolHoverCard>
+                          </SidebarMenuItem>
+                        );
+                      })
+                    )}
+                  </React.Fragment>
+                );
+              })}
+
+              {!hasInitializingServers &&
+                hasAllAvailableTools &&
+                // Show regular tools if no servers are initializing
+                Object.entries(tools).map(([serverName, tools]) => (
+                  <React.Fragment key={serverName}>
+                    <SidebarMenuItem>
+                      <div className="flex items-center gap-2 px-2 py-1.5 bg-muted/50 rounded-md">
+                        <ToolServerIcon
+                          toolServerName={serverName}
+                          widthHeightClassName="w-4 h-4"
+                          textClassName="text-[10px]"
+                        />
+                        <span className="text-sm font-medium capitalize">{serverName}</span>
+                      </div>
+                    </SidebarMenuItem>
+
+                    {tools.map((tool, idx) => {
+                      const { serverName, name } = tool;
+                      return (
+                        <SidebarMenuItem key={`${serverName}-${idx}`}>
+                          <ToolHoverCard
+                            tool={tool}
+                            side="right"
+                            align="start"
+                            showInstructions={true}
+                            instructionText="Click to add to context"
+                          >
+                            <div className="w-full">
+                              <SidebarMenuButton
+                                size="sm"
+                                className="justify-between text-sm w-full cursor-pointer"
+                                onClick={() => addSelectedTool(tool)}
+                              >
+                                <div className="flex items-center gap-2">
+                                  <div className="w-2 h-2 bg-green-500 rounded-full" />
+                                  <span>{formatToolName(name)}</span>
+                                </div>
+                                <ChevronRight className="h-3 w-3 text-muted-foreground" />
+                              </SidebarMenuButton>
+                            </div>
+                          </ToolHoverCard>
+                        </SidebarMenuItem>
+                      );
+                    })}
+                  </React.Fragment>
+                ))}
+            </>
           ) : hasNoFilteredTools && hasAllAvailableTools ? (
             <SidebarMenuItem>
               <div className="px-2 py-1.5 text-xs text-muted-foreground">

--- a/desktop_app/src/ui/lib/clients/archestra/api/gen/types.gen.ts
+++ b/desktop_app/src/ui/lib/clients/archestra/api/gen/types.gen.ts
@@ -44,6 +44,100 @@ export type WebSocketMessageInput =
   | {
       type: 'sandbox-status-update';
       payload: SandboxStatusSummaryInput;
+    }
+  | {
+      type: 'sandbox-startup-started';
+      payload: {
+        message: string;
+        progress?: number;
+        error?: string;
+      };
+    }
+  | {
+      type: 'sandbox-startup-completed';
+      payload: {
+        message: string;
+        progress?: number;
+        error?: string;
+      };
+    }
+  | {
+      type: 'sandbox-startup-failed';
+      payload: {
+        message: string;
+        progress?: number;
+        error?: string;
+      };
+    }
+  | {
+      type: 'sandbox-podman-runtime-progress';
+      payload: {
+        message: string;
+        progress?: number;
+        error?: string;
+      };
+    }
+  | {
+      type: 'sandbox-base-image-fetch-started';
+      payload: {
+        message: string;
+        progress?: number;
+        error?: string;
+      };
+    }
+  | {
+      type: 'sandbox-base-image-fetch-progress';
+      payload: {
+        message: string;
+        progress?: number;
+        error?: string;
+      };
+    }
+  | {
+      type: 'sandbox-base-image-fetch-completed';
+      payload: {
+        message: string;
+        progress?: number;
+        error?: string;
+      };
+    }
+  | {
+      type: 'sandbox-base-image-fetch-failed';
+      payload: {
+        message: string;
+        progress?: number;
+        error?: string;
+      };
+    }
+  | {
+      type: 'sandbox-mcp-server-starting';
+      payload: {
+        serverId: string;
+        serverName: string;
+        message: string;
+        progress?: number;
+        error?: string;
+      };
+    }
+  | {
+      type: 'sandbox-mcp-server-started';
+      payload: {
+        serverId: string;
+        serverName: string;
+        message: string;
+        progress?: number;
+        error?: string;
+      };
+    }
+  | {
+      type: 'sandbox-mcp-server-failed';
+      payload: {
+        serverId: string;
+        serverName: string;
+        message: string;
+        progress?: number;
+        error?: string;
+      };
     };
 
 export type ChatWithMessagesInput = {
@@ -201,6 +295,100 @@ export type WebSocketMessage =
   | {
       type: 'sandbox-status-update';
       payload: SandboxStatusSummary;
+    }
+  | {
+      type: 'sandbox-startup-started';
+      payload: {
+        message: string;
+        progress?: number;
+        error?: string;
+      };
+    }
+  | {
+      type: 'sandbox-startup-completed';
+      payload: {
+        message: string;
+        progress?: number;
+        error?: string;
+      };
+    }
+  | {
+      type: 'sandbox-startup-failed';
+      payload: {
+        message: string;
+        progress?: number;
+        error?: string;
+      };
+    }
+  | {
+      type: 'sandbox-podman-runtime-progress';
+      payload: {
+        message: string;
+        progress?: number;
+        error?: string;
+      };
+    }
+  | {
+      type: 'sandbox-base-image-fetch-started';
+      payload: {
+        message: string;
+        progress?: number;
+        error?: string;
+      };
+    }
+  | {
+      type: 'sandbox-base-image-fetch-progress';
+      payload: {
+        message: string;
+        progress?: number;
+        error?: string;
+      };
+    }
+  | {
+      type: 'sandbox-base-image-fetch-completed';
+      payload: {
+        message: string;
+        progress?: number;
+        error?: string;
+      };
+    }
+  | {
+      type: 'sandbox-base-image-fetch-failed';
+      payload: {
+        message: string;
+        progress?: number;
+        error?: string;
+      };
+    }
+  | {
+      type: 'sandbox-mcp-server-starting';
+      payload: {
+        serverId: string;
+        serverName: string;
+        message: string;
+        progress?: number;
+        error?: string;
+      };
+    }
+  | {
+      type: 'sandbox-mcp-server-started';
+      payload: {
+        serverId: string;
+        serverName: string;
+        message: string;
+        progress?: number;
+        error?: string;
+      };
+    }
+  | {
+      type: 'sandbox-mcp-server-failed';
+      payload: {
+        serverId: string;
+        serverName: string;
+        message: string;
+        progress?: number;
+        error?: string;
+      };
     };
 
 export type ChatWithMessages = {


### PR DESCRIPTION
Implements better sandbox-initialization progress reporting and UI improvements

Closes #189

## Summary

- Parse actual Docker registry pull progress with detailed percentages
- Add granular WebSocket events for different initialization stages
- Show MCP servers with loading states in sidebar during boot
- Display progress percentages for Podman machine (~900MB) and base image (~100MB) downloads
- Create SandboxStartupProgress component for comprehensive progress view