### PR TITLE
ci: user scoped claude GH action workflows

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,28 +1,18 @@
 name: Claude Code
 
 on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
-  issues:
-    types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
+  workflow_call:
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: true
 
 jobs:
-  claude:
-    # NOTE! This workflow will only run if the pull request was opened by the following users.
-    # If you'd like to be able to tap into this workflow, you'll need to add your username here +
-    # add the necessary GitHub Actions secret (see further down below)
-    #
-    # See here for more details:
-    # https://github.com/anthropics/claude-code-action/issues/4#issuecomment-3046770474
+  claude-code:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.user.login == 'joeyorlando') ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.user.login == 'joeyorlando') ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.review.user.login == 'joeyorlando') ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && github.event.issue.user.login == 'joeyorlando')
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -45,9 +35,8 @@ jobs:
         uses: anthropics/claude-code-action@e26577a930883943cf9d90885cd1e8da510078dd # beta tag
         with:
           # Dynamically set the secret based on the user who triggered the workflow
-          #
           # use their oauth token, since otherwise Anthropic will ban accounts for abuse :(
-          claude_code_oauth_token: ${{ secrets.joeyorlando_CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           # See https://github.com/anthropics/claude-code-action?tab=readme-ov-file#additional-permissions-for-cicd-integration

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -34,8 +34,10 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@e26577a930883943cf9d90885cd1e8da510078dd # beta tag
         with:
-          # Use the default GitHub token to avoid OIDC app-token exchange which
-          # requires workflow files to exactly match the default branch.
+          # We need to use the default GitHub token as a workaround for a bug in Anthropic's
+          # GitHub Action
+          #
+          # see https://github.com/anthropics/claude-code-action/issues/443
           github_token: ${{ github.token }}
           # Dynamically set the secret based on the user who triggered the workflow
           # use their oauth token, since otherwise Anthropic will ban accounts for abuse :(

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -34,6 +34,9 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@e26577a930883943cf9d90885cd1e8da510078dd # beta tag
         with:
+          # Use the default GitHub token to avoid OIDC app-token exchange which
+          # requires workflow files to exactly match the default branch.
+          github_token: ${{ github.token }}
           # Dynamically set the secret based on the user who triggered the workflow
           # use their oauth token, since otherwise Anthropic will ban accounts for abuse :(
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-pull-requests.yml
+++ b/.github/workflows/claude-pull-requests.yml
@@ -1,32 +1,16 @@
 name: Claude Pull Requests
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-    branches-ignore:
-      - release-please--branches--main
-
-concurrency:
-  # Cancel any running workflow for the same branch when new commits are pushed.
-  # We group both by ref_name (available when CI is triggered by a push to a branch/tag)
-  # and head_ref (available when CI is triggered by a PR).
-  group: "claude-pull-requests-${{ github.ref_name }}-${{ github.head_ref }}"
-  cancel-in-progress: true
+  workflow_call:
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: true
 
 jobs:
   claude-pull-requests:
     name: Claude Pull Requests
     runs-on: ubuntu-latest
-    # NOTE! This workflow will only run if the pull request was opened by the following users.
-    # If you'd like to be able to tap into this workflow, you'll need to add your username here +
-    # add the necessary GitHub Actions secret (see further down below)
-    #
-    # See here for more details:
-    # https://github.com/anthropics/claude-code-action/issues/4#issuecomment-3046770474
     if: |
-      github.event.pull_request.user.login == 'joeyorlando' &&
       !contains(github.event.pull_request.title, '[WIP]')
     permissions:
       contents: write
@@ -44,7 +28,9 @@ jobs:
       - name: Run Claude Code
         uses: anthropics/claude-code-action@e26577a930883943cf9d90885cd1e8da510078dd # beta tag
         with:
-          claude_code_oauth_token: ${{ secrets[format('{0}_CLAUDE_CODE_OAUTH_TOKEN', github.event.pull_request.user.login)] }}
+          # Dynamically set the secret based on the user who triggered the workflow
+          # use their oauth token, since otherwise Anthropic will ban accounts for abuse :(
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           use_sticky_comment: true

--- a/.github/workflows/claude-pull-requests.yml
+++ b/.github/workflows/claude-pull-requests.yml
@@ -28,8 +28,10 @@ jobs:
       - name: Run Claude Code
         uses: anthropics/claude-code-action@e26577a930883943cf9d90885cd1e8da510078dd # beta tag
         with:
-          # Use the default GitHub token to avoid OIDC app-token exchange which
-          # requires workflow files to exactly match the default branch.
+          # We need to use the default GitHub token as a workaround for a bug in Anthropic's
+          # GitHub Action
+          #
+          # see https://github.com/anthropics/claude-code-action/issues/443
           github_token: ${{ github.token }}
           # Dynamically set the secret based on the user who triggered the workflow
           # use their oauth token, since otherwise Anthropic will ban accounts for abuse :(

--- a/.github/workflows/claude-pull-requests.yml
+++ b/.github/workflows/claude-pull-requests.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Run Claude Code
         uses: anthropics/claude-code-action@e26577a930883943cf9d90885cd1e8da510078dd # beta tag
         with:
+          # Use the default GitHub token to avoid OIDC app-token exchange which
+          # requires workflow files to exactly match the default branch.
+          github_token: ${{ github.token }}
           # Dynamically set the secret based on the user who triggered the workflow
           # use their oauth token, since otherwise Anthropic will ban accounts for abuse :(
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/user-scoped-claude-code.yml
+++ b/.github/workflows/user-scoped-claude-code.yml
@@ -35,6 +35,21 @@ jobs:
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.JOEYORLANDO_CLAUDE_CODE_OAUTH_TOKEN }}
 
+  matvey-claude-code:
+    if: |
+      (github.event_name == 'issue_comment' && github.event.comment.user.login == 'Matvey-Kuk') ||
+      (github.event_name == 'pull_request_review_comment' && github.event.comment.user.login == 'Matvey-Kuk') ||
+      (github.event_name == 'pull_request_review' && github.event.review.user.login == 'Matvey-Kuk')
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    uses: ./.github/workflows/claude-code.yml
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.MATVEY_CLAUDE_CODE_OAUTH_TOKEN }}
+
   ildar-claude-code:
     if: |
       (github.event_name == 'issue_comment' && github.event.comment.user.login == 'iskhakov') ||

--- a/.github/workflows/user-scoped-claude-code.yml
+++ b/.github/workflows/user-scoped-claude-code.yml
@@ -1,0 +1,51 @@
+# NOTE! This workflow will only run if the pull request was opened by
+# the below configured users.
+#
+# It will "invoke Claude" using the user's specific OAuth token. This is being done so that
+# we respect Anthropic's terms-of-service wrt Max accounts/oauth tokens only being able to be
+# used by a single account.
+#
+# See here for more details:
+# https://github.com/anthropics/claude-code-action/issues/4#issuecomment-3046770474
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  joey-claude-code:
+    if: |
+      (github.event_name == 'issue_comment' && github.event.comment.user.login == 'joeyorlando') ||
+      (github.event_name == 'pull_request_review_comment' && github.event.comment.user.login == 'joeyorlando') ||
+      (github.event_name == 'pull_request_review' && github.event.review.user.login == 'joeyorlando')
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    uses: ./.github/workflows/claude-code.yml
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.JOEYORLANDO_CLAUDE_CODE_OAUTH_TOKEN }}
+
+  ildar-claude-code:
+    if: |
+      (github.event_name == 'issue_comment' && github.event.comment.user.login == 'iskhakov') ||
+      (github.event_name == 'pull_request_review_comment' && github.event.comment.user.login == 'iskhakov') ||
+      (github.event_name == 'pull_request_review' && github.event.review.user.login == 'iskhakov')
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    uses: ./.github/workflows/claude-code.yml
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.ILDAR_CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/user-scoped-claude-pull-requests.yml
+++ b/.github/workflows/user-scoped-claude-pull-requests.yml
@@ -39,6 +39,20 @@ jobs:
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.JOEYORLANDO_CLAUDE_CODE_OAUTH_TOKEN }}
 
+  matvey-claude-pull-requests:
+    name: Claude Pull Requests for Matvey
+    if: |
+      github.event.pull_request.user.login == 'Matvey-Kuk'
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    uses: ./.github/workflows/claude-pull-requests.yml
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.MATVEY_CLAUDE_CODE_OAUTH_TOKEN }}
+
   ildar-claude-pull-requests:
     name: Claude Pull Requests for Ildar
     if: |

--- a/.github/workflows/user-scoped-claude-pull-requests.yml
+++ b/.github/workflows/user-scoped-claude-pull-requests.yml
@@ -1,0 +1,54 @@
+# NOTE! This workflow will only run if the pull request was opened by
+# the below configured users.
+#
+# It will "invoke Claude" using the user's specific OAuth token. This is being done so that
+# we respect Anthropic's terms-of-service wrt Max accounts/oauth tokens only being able to be
+# used by a single account.
+#
+# See here for more details:
+# https://github.com/anthropics/claude-code-action/issues/4#issuecomment-3046770474
+name: Claude Pull Requests
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+    branches-ignore:
+      - release-please--branches--main
+
+concurrency:
+  # Cancel any running workflow for the same branch when new commits are pushed.
+  # We group both by ref_name (available when CI is triggered by a push to a branch/tag)
+  # and head_ref (available when CI is triggered by a PR).
+  group: "claude-pull-requests-${{ github.ref_name }}-${{ github.head_ref }}"
+  cancel-in-progress: true
+
+jobs:
+  joey-claude-pull-requests:
+    name: Claude Pull Requests for Joey
+    if: |
+      github.event.pull_request.user.login == 'joeyorlando'
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    uses: ./.github/workflows/claude-pull-requests.yml
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.JOEYORLANDO_CLAUDE_CODE_OAUTH_TOKEN }}
+
+  ildar-claude-pull-requests:
+    name: Claude Pull Requests for Ildar
+    if: |
+      github.event.pull_request.user.login == 'iskhakov'
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    uses: ./.github/workflows/claude-pull-requests.yml
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.ILDAR_CLAUDE_CODE_OAUTH_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,13 @@ Key tables (snake_case naming):
 - **Build Desktop Application**: Multi-platform builds
 - **Release Please**: Automated versioning and changelog
 - **Claude Integration**: AI-powered PR reviews
+  - **User-Scoped Authentication**: Each authorized user has their own Claude OAuth token
+  - **Workflow Structure**:
+    - `claude-code.yml` and `claude-pull-requests.yml`: Reusable workflow templates
+    - `user-scoped-claude-code.yml` and `user-scoped-claude-pull-requests.yml`: User-specific orchestrators
+  - **Authorized Users**: Currently configured for `joeyorlando`, `Matvey-Kuk`, and `iskhakov`
+  - **Compliance**: Ensures adherence to Anthropic's single-account OAuth token policy
+  - **Adding New Users**: Add repository secret `USERNAME_CLAUDE_CODE_OAUTH_TOKEN` and update user-scoped workflows
 
 ### Development Notes
 


### PR DESCRIPTION
## Summary

This PR refactors our Claude GitHub Action workflows to implement user-scoped authentication, ensuring compliance with Anthropic''s terms of service regarding OAuth token usage.

## Changes

### Architecture Refactoring
- **Before**: Single shared OAuth token (`CLAUDE_CODE_OAUTH_TOKEN`) used by all users
- **After**: Individual OAuth tokens per authorized user, preventing token sharing

### Implementation Details
1. **Converted existing workflows to reusable templates**:
   - `claude-code.yml` - Now accepts OAuth token as input
   - `claude-pull-requests.yml` - Now accepts OAuth token as input

2. **Added user-scoped wrapper workflows**:
   - `user-scoped-claude-code.yml` - Orchestrates Claude code actions per user
   - `user-scoped-claude-pull-requests.yml` - Orchestrates Claude PR actions per user

3. **Currently authorized users**:
   - `joeyorlando` → `JOEYORLANDO_CLAUDE_CODE_OAUTH_TOKEN`
   - `Matvey-Kuk` → `MATVEY_CLAUDE_CODE_OAUTH_TOKEN`
   - `iskhakov` → `ILDAR_CLAUDE_CODE_OAUTH_TOKEN`

## Motivation

As stated in the workflow comments:
> This is being done so that we respect Anthropic''s terms-of-service wrt Max accounts/oauth tokens only being able to be used by a single account.

## How It Works

1. User triggers Claude action (via issue/PR comment)
2. User-scoped workflow checks if the user is authorized
3. If authorized, it calls the template workflow with the user''s specific OAuth token
4. Claude performs the requested action with proper authentication

## Adding New Users

To add a new authorized user:
1. Add their OAuth token as a repository secret (e.g., `USERNAME_CLAUDE_CODE_OAUTH_TOKEN`)
2. Add a new job in both user-scoped workflows with their username and token reference

## Benefits

- ✅ Complies with Anthropic''s single-account OAuth token policy
- ✅ Improved security through isolated user authentication
- ✅ Better auditability of Claude usage per user
- ✅ Scalable design for adding/removing users