### PR TITLE
feat: Unify fastify logs with the rest of the logs

### DIFF
--- a/desktop_app/src/backend/server/index.ts
+++ b/desktop_app/src/backend/server/index.ts
@@ -12,6 +12,7 @@ import mcpRequestLogRoutes from '@backend/server/plugins/mcpRequestLog';
 import mcpServerRoutes from '@backend/server/plugins/mcpServer';
 import ollamaRoutes from '@backend/server/plugins/ollama';
 import userRoutes from '@backend/server/plugins/user';
+import { electronLogStream } from '@backend/utils/fastify-logger-stream';
 import log from '@backend/utils/logger';
 
 let app: ReturnType<typeof fastify> | null = null;
@@ -20,10 +21,7 @@ export const startFastifyServer = async () => {
   app = fastify({
     logger: {
       level: config.logLevel,
-      serializers: {
-        req: (req) => ({ method: req.method, url: req.url }),
-        res: (res) => ({ statusCode: res.statusCode }),
-      },
+      stream: electronLogStream,
     },
   });
 

--- a/desktop_app/src/backend/utils/fastify-logger-stream.ts
+++ b/desktop_app/src/backend/utils/fastify-logger-stream.ts
@@ -5,10 +5,10 @@ export const electronLogStream = {
     try {
       const obj = JSON.parse(msg);
       const level = obj.level === 30 ? 'info' : obj.level === 40 ? 'warn' : obj.level === 50 ? 'error' : 'debug';
-      log[level](obj.msg || '', obj);
+      log[level](`[Server]: ${obj.msg || ''}`, obj);
     } catch (e) {
       // Fallback for non-JSON messages
-      log.info(msg);
+      log.info(`[Server]: ${msg}`);
     }
   },
 };

--- a/desktop_app/src/backend/utils/fastify-logger-stream.ts
+++ b/desktop_app/src/backend/utils/fastify-logger-stream.ts
@@ -1,0 +1,14 @@
+import log from '@backend/utils/logger';
+
+export const electronLogStream = {
+  write: (msg: string) => {
+    try {
+      const obj = JSON.parse(msg);
+      const level = obj.level === 30 ? 'info' : obj.level === 40 ? 'warn' : obj.level === 50 ? 'error' : 'debug';
+      log[level](obj.msg || '', obj);
+    } catch (e) {
+      // Fallback for non-JSON messages
+      log.info(msg);
+    }
+  },
+};


### PR DESCRIPTION
## Summary

This PR unifies Fastify''s logging system with the existing application logging infrastructure by routing all Fastify logs through the centralized electron-log backend logger.

## Changes

- **Added `fastify-logger-stream.ts`**: A custom write stream that intercepts Fastify''s JSON-formatted logs and routes them through the existing backend logger
- **Updated server configuration**: Modified the Fastify server initialization to use the custom logger stream instead of default console output

## Technical Details

The implementation creates a custom write stream that:
1. Parses Fastify''s JSON log messages
2. Maps Fastify''s numeric log levels (30=info, 40=warn, 50=error) to the backend logger''s string levels
3. Preserves the full log context while routing through electron-log

This ensures all application logs (both from the application code and Fastify server) now:
- Use the same formatting and structure
- Go to the same destination (electron-log files/console)
- Follow the same log level configuration
- Can be monitored and debugged through a single logging pipeline

## Benefits

- **Consistent logging**: All logs now flow through the same system
- **Better debugging**: Server request/response logs are now part of the main application logs
- **Unified configuration**: Log levels and destinations are controlled from a single place
- **Improved monitoring**: All logs can be collected and analyzed together