### PR TITLE
Sidebar layout

### DIFF
--- a/desktop_app/src/ui/components/Sidebar/ChatSidebarSection/index.tsx
+++ b/desktop_app/src/ui/components/Sidebar/ChatSidebarSection/index.tsx
@@ -1,4 +1,5 @@
-import { Plus } from 'lucide-react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
 
 import { DeleteChatConfirmation } from '@ui/components/DeleteChatConfirmation';
 import { EditableTitle } from '@ui/components/EditableTitle';
@@ -9,55 +10,67 @@ import { useChatStore } from '@ui/stores';
 interface ChatSidebarProps {}
 
 export default function ChatSidebarSection(_props: ChatSidebarProps) {
-  const { chats, getCurrentChat, isLoadingChats, selectChat, createNewChat, deleteCurrentChat, updateChatTitle } =
-    useChatStore();
+  const { chats, getCurrentChat, isLoadingChats, selectChat, deleteCurrentChat, updateChatTitle } = useChatStore();
   const currentChatId = getCurrentChat()?.id;
+  const [showAllChats, setShowAllChats] = useState(false);
+
+  const VISIBLE_CHAT_COUNT = 5;
+  const visibleChats = showAllChats ? chats : chats.slice(0, VISIBLE_CHAT_COUNT);
+  const hiddenChatsCount = Math.max(0, chats.length - VISIBLE_CHAT_COUNT);
 
   return (
     <>
-      <SidebarMenuItem className="ml-6 group-data-[collapsible=icon]:hidden">
-        <SidebarMenuButton onClick={createNewChat} size="sm" className="cursor-pointer hover:bg-accent/50 text-sm">
-          <Plus className="h-3 w-3" />
-          <span>New Chat</span>
-        </SidebarMenuButton>
-      </SidebarMenuItem>
       {isLoadingChats ? (
-        <SidebarMenuItem className="ml-6 group-data-[collapsible=icon]:hidden">
+        <SidebarMenuItem className="group-data-[collapsible=icon]:hidden">
           <div className="flex items-center gap-2 px-2 py-1.5">
             <div className="h-3 w-3 animate-spin rounded-full border border-muted-foreground border-t-transparent" />
             <span className="text-xs text-muted-foreground">Loading chats...</span>
           </div>
         </SidebarMenuItem>
       ) : chats.length === 0 ? (
-        <SidebarMenuItem className="ml-6 group-data-[collapsible=icon]:hidden">
+        <SidebarMenuItem className="group-data-[collapsible=icon]:hidden">
           <div className="px-2 py-1.5 text-xs text-muted-foreground">No chats yet</div>
         </SidebarMenuItem>
       ) : (
-        chats.map((chat) => {
-          const { id, title } = chat;
-          const isCurrentChat = currentChatId === id;
+        <>
+          {visibleChats.map((chat) => {
+            const { id, title } = chat;
+            const isCurrentChat = currentChatId === id;
 
-          return (
-            <SidebarMenuItem key={id} className="ml-6 group-data-[collapsible=icon]:hidden group/chat-item">
-              <div className="flex items-center">
-                <SidebarMenuButton
-                  onClick={() => selectChat(id)}
-                  isActive={isCurrentChat}
-                  size="sm"
-                  className="cursor-pointer hover:bg-accent/50 text-sm flex-1 group/chat-button"
-                >
-                  <EditableTitle
-                    className="truncate"
-                    title={title || config.chat.defaultTitle}
-                    onSave={(newTitle) => updateChatTitle(id, newTitle)}
-                    isAnimated
-                  />
-                </SidebarMenuButton>
-                <DeleteChatConfirmation onDelete={deleteCurrentChat} />
-              </div>
+            return (
+              <SidebarMenuItem key={id} className="group-data-[collapsible=icon]:hidden group/chat-item">
+                <div className="flex items-center">
+                  <SidebarMenuButton
+                    onClick={() => selectChat(id)}
+                    isActive={isCurrentChat}
+                    size="sm"
+                    className="cursor-pointer hover:bg-accent/50 text-sm flex-1 group/chat-button"
+                  >
+                    <EditableTitle
+                      className="truncate"
+                      title={title || config.chat.defaultTitle}
+                      onSave={(newTitle) => updateChatTitle(id, newTitle)}
+                      isAnimated
+                    />
+                  </SidebarMenuButton>
+                  <DeleteChatConfirmation onDelete={deleteCurrentChat} />
+                </div>
+              </SidebarMenuItem>
+            );
+          })}
+          {hiddenChatsCount > 0 && (
+            <SidebarMenuItem className="group-data-[collapsible=icon]:hidden">
+              <SidebarMenuButton
+                onClick={() => setShowAllChats(!showAllChats)}
+                size="sm"
+                className="cursor-pointer hover:bg-accent/50 text-xs text-muted-foreground"
+              >
+                {showAllChats ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+                <span>{showAllChats ? 'Show less' : `Show ${hiddenChatsCount} more`}</span>
+              </SidebarMenuButton>
             </SidebarMenuItem>
-          );
-        })
+          )}
+        </>
       )}
     </>
   );

--- a/desktop_app/src/ui/components/Sidebar/index.tsx
+++ b/desktop_app/src/ui/components/Sidebar/index.tsx
@@ -17,13 +17,12 @@ import { useNavigationStore } from '@ui/stores';
 import { NavigationSubViewKey, NavigationViewKey } from '@ui/types';
 
 import ChatSidebarSection from './ChatSidebarSection';
-import LLMProvidersSidebarSection from './LLMProvidersSidebarSection';
 import McpServerWithToolsSidebarSection from './McpServerWithToolsSidebarSection';
 
 interface SidebarProps extends React.PropsWithChildren {}
 
 export default function Sidebar({ children }: SidebarProps) {
-  const { activeView, activeSubView, setActiveView, setActiveSubView } = useNavigationStore();
+  const { activeView, activeSubView, setActiveView } = useNavigationStore();
 
   return (
     <SidebarProvider className="flex flex-col flex-1">
@@ -45,22 +44,14 @@ export default function Sidebar({ children }: SidebarProps) {
                           <SidebarMenuButton
                             onClick={() => {
                               setActiveView(item.key);
-                              // TODO: when we add more LLM providers, we need to add a proper sub-navigation here
-                              if (item.key === NavigationViewKey.LLMProviders) {
-                                setActiveSubView(NavigationSubViewKey.Ollama);
-                              }
                             }}
                             isActive={activeView === item.key}
-                            tooltip={item.title}
                             className="cursor-pointer hover:bg-accent/50"
                           >
                             <item.icon className="h-4 w-4" />
                             <span>{item.title}</span>
                           </SidebarMenuButton>
                         </SidebarMenuItem>
-                      )}
-                      {item.key === NavigationViewKey.LLMProviders && activeView === NavigationViewKey.LLMProviders && (
-                        <LLMProvidersSidebarSection />
                       )}
                     </React.Fragment>
                   ))}

--- a/desktop_app/src/ui/components/Sidebar/index.tsx
+++ b/desktop_app/src/ui/components/Sidebar/index.tsx
@@ -37,27 +37,27 @@ export default function Sidebar({ children }: SidebarProps) {
             <SidebarGroup>
               <SidebarGroupContent>
                 <SidebarMenu>
+                  <ChatSidebarSection />
                   {config.navigation.map((item) => (
                     <React.Fragment key={item.key}>
-                      <SidebarMenuItem>
-                        <SidebarMenuButton
-                          onClick={() => {
-                            setActiveView(item.key);
-                            // TODO: when we add more LLM providers, we need to add a proper sub-navigation here
-                            if (item.key === NavigationViewKey.LLMProviders) {
-                              setActiveSubView(NavigationSubViewKey.Ollama);
-                            }
-                          }}
-                          isActive={activeView === item.key}
-                          tooltip={item.title}
-                          className="cursor-pointer hover:bg-accent/50"
-                        >
-                          <item.icon className="h-4 w-4" />
-                          <span>{item.title}</span>
-                        </SidebarMenuButton>
-                      </SidebarMenuItem>
-                      {item.key === NavigationViewKey.Chat && activeView === NavigationViewKey.Chat && (
-                        <ChatSidebarSection />
+                      {item.key !== NavigationViewKey.Chat && (
+                        <SidebarMenuItem>
+                          <SidebarMenuButton
+                            onClick={() => {
+                              setActiveView(item.key);
+                              // TODO: when we add more LLM providers, we need to add a proper sub-navigation here
+                              if (item.key === NavigationViewKey.LLMProviders) {
+                                setActiveSubView(NavigationSubViewKey.Ollama);
+                              }
+                            }}
+                            isActive={activeView === item.key}
+                            tooltip={item.title}
+                            className="cursor-pointer hover:bg-accent/50"
+                          >
+                            <item.icon className="h-4 w-4" />
+                            <span>{item.title}</span>
+                          </SidebarMenuButton>
+                        </SidebarMenuItem>
                       )}
                       {item.key === NavigationViewKey.LLMProviders && activeView === NavigationViewKey.LLMProviders && (
                         <LLMProvidersSidebarSection />

--- a/desktop_app/src/ui/components/SiteHeader/index.tsx
+++ b/desktop_app/src/ui/components/SiteHeader/index.tsx
@@ -4,7 +4,6 @@ import { ThemeToggler } from '@ui/components/ThemeToggler';
 import { Button } from '@ui/components/ui/button';
 import { Separator } from '@ui/components/ui/separator';
 import { useSidebar } from '@ui/components/ui/sidebar';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@ui/components/ui/tooltip';
 import config from '@ui/config';
 import { useChatStore, useNavigationStore } from '@ui/stores';
 import { NavigationSubViewKey, NavigationViewKey } from '@ui/types';
@@ -33,7 +32,7 @@ export function SiteHeader({ activeView, activeSubView }: SiteHeaderProps) {
   return (
     <header className="bg-background sticky top-0 z-50 flex w-full items-center border-b">
       <div
-        className="flex h-[var(--header-height)] w-full items-center gap-2 px-4 pl-[80px]"
+        className="flex h-[var(--header-height)] w-64 items-center gap-2 px-4 pl-20 border-r"
         // @ts-expect-error - WebkitAppRegion is not a valid property
         style={{ WebkitAppRegion: 'drag' }}
       >
@@ -47,35 +46,34 @@ export function SiteHeader({ activeView, activeSubView }: SiteHeaderProps) {
         >
           <SidebarIcon />
         </Button>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              className="h-8 w-8 cursor-pointer"
-              variant="ghost"
-              size="icon"
-              onClick={async () => {
-                await createNewChat();
-                setActiveView(NavigationViewKey.Chat);
-              }}
-              // @ts-expect-error - WebkitAppRegion is not a valid property
-              style={{ WebkitAppRegion: 'no-drag' }}
-            >
-              <Plus className="h-4 w-4" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>New Chat</p>
-          </TooltipContent>
-        </Tooltip>
-        <Separator orientation="vertical" className="mr-2 h-4" />
+        <Button
+          className="h-8 cursor-pointer"
+          variant="ghost"
+          size="sm"
+          onClick={async () => {
+            await createNewChat();
+            setActiveView(NavigationViewKey.Chat);
+          }}
+          // @ts-expect-error - WebkitAppRegion is not a valid property
+          style={{ WebkitAppRegion: 'no-drag' }}
+        >
+          <Plus className="h-4 w-4 mr-1" />
+          New Chat
+        </Button>
+      </div>
+      <div
+        className="flex h-[var(--header-height)] flex-1 items-center justify-between px-4"
+        // @ts-expect-error - WebkitAppRegion is not a valid property
+        style={{ WebkitAppRegion: 'drag' }}
+      >
         {/* @ts-expect-error - WebkitAppRegion is not a valid property */}
         <div style={{ WebkitAppRegion: 'no-drag' }}>
           <Breadcrumbs breadcrumbs={breadcrumbs} isAnimatedTitle={activeView === NavigationViewKey.Chat} />
         </div>
-      </div>
-      {/* @ts-expect-error - WebkitAppRegion is not a valid property */}
-      <div className="flex items-center gap-2 mr-4" style={{ WebkitAppRegion: 'no-drag' }}>
-        <ThemeToggler />
+        {/* @ts-expect-error - WebkitAppRegion is not a valid property */}
+        <div className="flex items-center gap-2" style={{ WebkitAppRegion: 'no-drag' }}>
+          <ThemeToggler />
+        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary

This PR refactors the sidebar layout to improve UI organization and fix a critical context provider issue. The changes include:

- **Fixed SiteHeader context error**: Moved SiteHeader inside SidebarProvider to resolve the "useSidebar must be used within a SidebarProvider" error reported by Sentry
- **Improved sidebar structure**: Consolidated the chat sidebar section to always display at the top, removing conditional rendering based on active view
- **Enhanced chat list UI**: Added expandable chat list that shows 5 chats by default with a "Show more" button for better UX when users have many chats
- **Simplified navigation**: Removed the LLMProvidersSidebarSection component and cleaned up navigation logic
- **Moved "New Chat" button**: Relocated from chat sidebar to site header for better accessibility and cleaner design

## Changes

### ChatSidebarSection (`src/ui/components/Sidebar/ChatSidebarSection/index.tsx`)
- Removed "New Chat" button from sidebar (moved to header)
- Added expandable chat list functionality with chevron icons
- Shows 5 chats by default, with ability to expand to show all
- Improved loading and empty states UI

### Sidebar (`src/ui/components/Sidebar/index.tsx`) 
- Removed LLMProvidersSidebarSection import and conditional rendering
- Moved ChatSidebarSection outside of navigation map to always display at top
- Simplified navigation button click handlers
- Removed tooltip prop from sidebar menu buttons
- Cleaned up activeSubView management for LLM providers

### SiteHeader (`src/ui/components/SiteHeader/index.tsx`)
- Split header into two sections with proper layout
- Added "New Chat" button with text label (previously was icon-only in sidebar)
- Removed tooltip wrapper around new chat button
- Improved header layout with border separators
- Fixed theme toggler positioning

## Test Plan

- [ ] Verify the Sentry error "useSidebar must be used within a SidebarProvider" is resolved
- [ ] Test creating new chats from the header button
- [ ] Test chat list expansion/collapse with >5 chats
- [ ] Verify sidebar navigation works correctly
- [ ] Test responsive behavior and collapsed sidebar state
- [ ] Ensure theme toggler remains accessible