### PR TITLE
Add quickstart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **ALWAYS run all commands from the `desktop_app/` directory unless specifically instructed otherwise.**
 
+Note: The README.md includes a Developer Quickstart section that shows basic setup steps. When following those instructions, ensure you're in the `desktop_app/` directory for all commands after cloning.
+
 ## Important Rules
 
 1. **NEVER modify files in `src/ui/components/ui/`** - These are shadcn/ui components and should remain unchanged

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Archestra is an enterprise-grade platform that enables non-technical users to sa
 
 ## Developer Quickstart
 
+To build and start the local Electron application:
+
 ```bash
 # Clone the repository
 git clone https://github.com/archestra-ai/archestra.git

--- a/README.md
+++ b/README.md
@@ -33,3 +33,17 @@ Archestra is an enterprise-grade platform that enables non-technical users to sa
 - 💻 **Local-First Architecture** - Privacy-focused design with local LLM
 - 🎯 **Enterprise Ready** - Built for non-technical users with enterprise-level security and compliance
 - 🔧 **Extensible Tool System** - Support most of MCP servers: GitHub, Gmail, Slack, PostgreSQL, filesystem, and more
+
+## Developer Quickstart
+
+```bash
+# Clone the repository
+git clone https://github.com/archestra-ai/archestra.git
+cd archestra/desktop_app
+
+# Install dependencies
+pnpm install
+
+# Start the application
+pnpm start
+```


### PR DESCRIPTION
## Description

This PR adds a developer quickstart section to the README.md to help developers quickly get started with the Archestra project.

## Changes

- Added a new Developer Quickstart section in the README.md
- Included simple step-by-step instructions for:
  - Cloning the repository
  - Installing dependencies with pnpm
  - Starting the application

## Why

This change improves the developer experience by providing a clear and concise starting point for new contributors to the project. Previously, developers would need to dig through documentation to find the basic setup steps.