### PR TITLE
Add jira provider 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,7 +270,8 @@ Archestra is an enterprise-grade Model Context Protocol (MCP) platform built as 
   - **Supported Providers**:
     - **Google**: OAuth with file-based credentials option
     - **Slack**: OAuth + browser auth (`slack-browser` provider)
-    - Extensible for Jira, LinkedIn, MS Teams, etc.
+    - **Jira**: OAuth 2.0 with multi-tenancy support (cloud_id handling)
+    - Extensible for LinkedIn, MS Teams, etc.
   - **Browser Authentication** (`src/main-browser-auth.ts`):
     - Extract tokens directly from provider web UI
     - Secure Electron BrowserWindow with sandboxing
@@ -321,6 +322,7 @@ oauth_proxy/
 │   ├── providers/     # OAuth provider implementations
 │   │   ├── base.js    # Base OAuth provider class
 │   │   ├── google.js  # Google OAuth specifics
+│   │   ├── jira.js   # Jira OAuth specifics
 │   │   └── slack.js   # Slack OAuth specifics
 │   └── routes/        # API routes
 │       ├── callback.js # OAuth callback handler


### PR DESCRIPTION
## Summary

This PR adds support for Jira OAuth provider to Archestra''s extensible OAuth system, enabling MCP servers to authenticate with Jira Cloud instances.

## Changes

- [ ] Add Jira provider configuration to desktop app (oauth-providers.ts)
- [ ] Implement Jira OAuth provider in proxy server 
- [ ] Add support for Jira''s multi-tenancy (cloud_id handling)
- [ ] Update documentation

## Implementation Details

The Jira provider will follow the existing patterns established by Google and Slack providers:

### Desktop App
- OAuth 2.0 with PKCE for enhanced security
- Support for offline_access scope to enable refresh tokens
- Token storage using environment variables pattern
- Multi-site support via cloud_id

### OAuth Proxy
- Client secret management
- Standard OAuth 2.0 token exchange
- Refresh token support (unlike Slack)

## Testing

- [ ] Test OAuth flow with Jira Cloud instance
- [ ] Verify token refresh functionality
- [ ] Test multi-site scenarios
- [ ] Ensure MCP servers can authenticate successfully