### PR TITLE
Add office 365 provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,7 @@ Archestra is an enterprise-grade Model Context Protocol (MCP) platform built as 
   - **Supported Providers**:
     - **Google**: OAuth with file-based credentials option
     - **Slack**: OAuth + browser auth (`slack-browser` provider)
+    - **Microsoft**: OAuth for Microsoft 365/Office 365 services
     - Extensible for Jira, LinkedIn, MS Teams, etc.
   - **Browser Authentication** (`src/main-browser-auth.ts`):
     - Extract tokens directly from provider web UI

--- a/desktop_app/docs/AZURE_AD_APP_REGISTRATION.md
+++ b/desktop_app/docs/AZURE_AD_APP_REGISTRATION.md
@@ -1,0 +1,178 @@
+# Azure AD App Registration for Microsoft 365 OAuth
+
+This guide walks you through setting up an Azure AD application for Microsoft 365 OAuth integration with Archestra.
+
+## Prerequisites
+
+- Microsoft Azure account with access to Azure Active Directory
+- Admin permissions to create app registrations
+
+## Step 1: Create Azure AD App Registration
+
+1. Go to [Azure Portal](https://portal.azure.com)
+2. Navigate to **Azure Active Directory** → **App registrations**
+3. Click **New registration**
+4. Configure the app:
+   - **Name**: `Archestra Microsoft 365 Integration` (or your preferred name)
+   - **Supported account types**:
+     - For personal accounts only: "Accounts in any organizational directory and personal Microsoft accounts"
+     - For work/school accounts only: "Accounts in any organizational directory"
+     - For both: "Accounts in any organizational directory and personal Microsoft accounts" (recommended)
+   - **Redirect URI**:
+     - Platform: Web
+     - URI: `https://oauth-proxy-new-354887056155.europe-west1.run.app/callback`
+
+## Step 2: Configure API Permissions
+
+1. In your app registration, go to **API permissions**
+2. Click **Add a permission** → **Microsoft Graph** → **Delegated permissions**
+3. Add the following permissions:
+
+### Core Permissions (Always Required)
+
+- `User.Read` - Sign in and read user profile
+- `offline_access` - Maintain access to data
+
+### Email Permissions
+
+- `Mail.Read` - Read user mail
+- `Mail.Send` - Send mail as the user
+- `Mail.ReadWrite` - Read and write user mail
+
+### Calendar Permissions
+
+- `Calendars.Read` - Read user calendars
+- `Calendars.ReadWrite` - Read and write user calendars
+
+### File Permissions (OneDrive)
+
+- `Files.Read` - Read user files
+- `Files.ReadWrite` - Read and write user files
+- `Files.Read.All` - Read all files user can access
+- `Files.ReadWrite.All` - Read and write all files user can access
+
+### OneNote Permissions
+
+- `Notes.Read` - Read user OneNote notebooks
+- `Notes.Create` - Create pages in user notebooks
+
+### To Do Permissions
+
+- `Tasks.Read` - Read user tasks
+- `Tasks.ReadWrite` - Create, read, update and delete user tasks
+
+### Planner Permissions
+
+- `Tasks.Read.Shared` - Read user and shared tasks
+- `Tasks.ReadWrite.Shared` - Create, read, update, and delete user and shared tasks
+
+### Contacts Permissions
+
+- `Contacts.Read` - Read user contacts
+- `Contacts.ReadWrite` - Read and write user contacts
+
+### Search Permissions
+
+- `ExternalItem.Read.All` - Read external items
+
+### Organization Mode Permissions (Teams, SharePoint)
+
+- `Chat.Read` - Read user chat messages
+- `Chat.ReadWrite` - Read and write user chat messages
+- `Team.ReadBasic.All` - Read basic team information
+- `Channel.ReadBasic.All` - Read basic channel information
+- `ChannelMessage.Read.All` - Read channel messages
+- `ChannelMessage.Send` - Send channel messages
+- `Sites.Read.All` - Read items in all site collections
+- `Sites.ReadWrite.All` - Edit or delete items in all site collections
+- `User.Read.All` - Read all users' full profiles
+- `Mail.Read.Shared` - Read shared mailboxes
+- `Mail.Send.Shared` - Send mail from shared mailboxes
+
+4. Click **Grant admin consent** (if you have admin permissions)
+
+## Step 3: Create Client Secret
+
+1. Go to **Certificates & secrets**
+2. Click **New client secret**
+3. Add a description: `Archestra OAuth Secret`
+4. Choose expiration (recommend 24 months)
+5. Click **Add**
+6. **IMPORTANT**: Copy the secret value immediately - you won't be able to see it again!
+
+## Step 4: Get Application IDs
+
+1. Go to **Overview** in your app registration
+2. Copy these values:
+   - **Application (client) ID**: This is your `MICROSOFT_CLIENT_ID`
+   - **Directory (tenant) ID**: This is your `MICROSOFT_TENANT_ID` (use "common" for multi-tenant)
+
+## Step 5: Configure OAuth Proxy
+
+Add these environment variables to your OAuth proxy `.env` file:
+
+```bash
+# oauth_proxy/.env
+MICROSOFT_CLIENT_ID=your-application-client-id
+MICROSOFT_CLIENT_SECRET=your-client-secret
+MICROSOFT_TENANT_ID=common  # or your specific tenant ID
+```
+
+## Step 6: Configure Desktop App (Optional)
+
+If you want to use a custom client ID for the desktop app, set this environment variable:
+
+```bash
+# desktop_app/.env
+MICROSOFT_OAUTH_CLIENT_ID=your-application-client-id
+```
+
+## Testing Your Configuration
+
+1. Start the OAuth proxy:
+
+   ```bash
+   cd oauth_proxy && npm run dev
+   ```
+
+2. Start Archestra:
+
+   ```bash
+   cd desktop_app && pnpm start
+   ```
+
+3. Go to Connectors page and install a Microsoft 365 MCP server
+4. Complete the OAuth flow
+5. Verify tokens are stored in the database
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"Invalid client" error**: Check that your client ID and secret are correct
+2. **"Invalid redirect URI" error**: Ensure the redirect URI matches exactly
+3. **"Unauthorized client" error**: Grant admin consent for the permissions
+4. **"Invalid tenant" error**: Check your tenant ID configuration
+
+### Token Information
+
+The Microsoft OAuth integration stores tokens as follows:
+
+- Access token: `MS365_MCP_OAUTH_TOKEN`
+- Refresh token: `MS365_MCP_REFRESH_TOKEN`
+- Token expiry: `MS365_MCP_TOKEN_EXPIRY`
+
+These environment variables are automatically added to the MCP server container.
+
+## Security Notes
+
+- Never commit client secrets to version control
+- Rotate client secrets regularly (every 12-24 months)
+- Use the principle of least privilege - only request permissions you need
+- Consider using separate app registrations for development and production
+
+## Additional Resources
+
+- [Microsoft identity platform documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/)
+- [Microsoft Graph permissions reference](https://docs.microsoft.com/en-us/graph/permissions-reference)
+- [OAuth 2.0 authorization code flow](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow)

--- a/desktop_app/src/backend/config/oauth-providers.ts
+++ b/desktop_app/src/backend/config/oauth-providers.ts
@@ -241,6 +241,77 @@ export const oauthProviders: OAuthProviderRegistry = {
       notes: 'Direct browser authentication using xoxc/xoxd tokens. No OAuth app required.',
     },
   },
+
+  microsoft: {
+    name: 'microsoft',
+    authorizationUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
+    scopes: [
+      // Core scopes
+      'User.Read',
+      'offline_access',
+      // Email scopes
+      'Mail.Read',
+      'Mail.Send',
+      'Mail.ReadWrite',
+      // Calendar scopes
+      'Calendars.Read',
+      'Calendars.ReadWrite',
+      // OneDrive scopes
+      'Files.Read',
+      'Files.ReadWrite',
+      'Files.Read.All',
+      'Files.ReadWrite.All',
+      // OneNote scopes
+      'Notes.Read',
+      'Notes.Create',
+      // To Do scopes
+      'Tasks.Read',
+      'Tasks.ReadWrite',
+      // Planner scopes
+      'Tasks.Read.Shared',
+      'Tasks.ReadWrite.Shared',
+      // Contacts scopes
+      'Contacts.Read',
+      'Contacts.ReadWrite',
+      // Search scopes
+      'ExternalItem.Read.All',
+      // Organization mode scopes (Teams, SharePoint, etc.)
+      'Chat.Read',
+      'Chat.ReadWrite',
+      'Team.ReadBasic.All',
+      'Channel.ReadBasic.All',
+      'ChannelMessage.Read.All',
+      'ChannelMessage.Send',
+      'Sites.Read.All',
+      'Sites.ReadWrite.All',
+      'User.Read.All',
+      'Mail.Read.Shared',
+      'Mail.Send.Shared',
+    ],
+    usePKCE: true,
+    clientId: process.env.MICROSOFT_OAUTH_CLIENT_ID || 'f94d5e70-7111-447b-bba5-316ba6b99b59',
+
+    // Microsoft tokens go to specific env vars for MS365 MCP server
+    tokenEnvVarPattern: {
+      accessToken: 'MS365_MCP_OAUTH_TOKEN',
+      refreshToken: 'MS365_MCP_REFRESH_TOKEN',
+      expiryDate: 'MS365_MCP_TOKEN_EXPIRY',
+    },
+
+    // Microsoft-specific authorization parameters
+    authorizationParams: {
+      response_mode: 'query',
+      prompt: 'select_account',
+    },
+
+    metadata: {
+      displayName: 'Microsoft 365',
+      documentationUrl: 'https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow',
+      supportsRefresh: true,
+      notes:
+        'Supports both personal (outlook.com, hotmail.com) and work/school accounts. Organization mode features require work/school account.',
+    },
+  },
 };
 
 /**

--- a/desktop_app/src/backend/models/mcpServer/index.ts
+++ b/desktop_app/src/backend/models/mcpServer/index.ts
@@ -28,7 +28,7 @@ export const McpServerInstallSchema = z.object({
     .regex(/^[A-Za-z0-9-\s]{1,63}$/, 'Name can only contain letters, numbers, spaces, and dashes (-)'),
   serverConfig: McpServerConfigSchema,
   userConfigValues: McpServerUserConfigValuesSchema.optional(),
-  oauthProvider: z.enum(['google', 'slack', 'slack-browser']).optional(),
+  oauthProvider: z.enum(['google', 'slack', 'slack-browser', 'microsoft']).optional(),
   oauthAccessToken: z.string().optional(),
   oauthRefreshToken: z.string().optional(),
   oauthExpiryDate: z.string().nullable().optional(),

--- a/oauth_proxy/src/config/index.js
+++ b/oauth_proxy/src/config/index.js
@@ -23,6 +23,13 @@ export const config = {
       tokenEndpoint: 'https://slack.com/api/oauth.v2.access',
       revokeEndpoint: 'https://slack.com/api/auth.revoke',
     },
+    
+    microsoft: {
+      clientId: process.env.MICROSOFT_CLIENT_ID,
+      clientSecret: process.env.MICROSOFT_CLIENT_SECRET,
+      tenant: process.env.MICROSOFT_TENANT_ID || 'common',
+      // Token endpoint is constructed in provider class with tenant
+    },
   },
   
   cors: {

--- a/oauth_proxy/src/providers/index.js
+++ b/oauth_proxy/src/providers/index.js
@@ -1,6 +1,7 @@
 import { config } from '../config/index.js';
 import { GoogleOAuthProvider } from './google.js';
 import { SlackOAuthProvider } from './slack.js';
+import { MicrosoftOAuthProvider } from './microsoft.js';
 
 // Provider registry
 const providers = new Map();
@@ -17,6 +18,12 @@ export function initializeProviders() {
   if (config.providers.slack.clientId && config.providers.slack.clientSecret) {
     providers.set('slack', new SlackOAuthProvider(config.providers.slack));
     console.log('✓ Slack OAuth provider initialized');
+  }
+
+  // Microsoft OAuth
+  if (config.providers.microsoft.clientId && config.providers.microsoft.clientSecret) {
+    providers.set('microsoft', new MicrosoftOAuthProvider(config.providers.microsoft));
+    console.log('✓ Microsoft OAuth provider initialized');
   }
 
   if (providers.size === 0) {

--- a/oauth_proxy/src/providers/microsoft.js
+++ b/oauth_proxy/src/providers/microsoft.js
@@ -1,0 +1,39 @@
+import { OAuthProvider } from './base.js';
+
+export class MicrosoftOAuthProvider extends OAuthProvider {
+  constructor(config) {
+    super(config);
+    
+    // Microsoft has additional tenant parameter in endpoints
+    this.tenant = config.tenant || 'common';
+    this.tokenEndpoint = `https://login.microsoftonline.com/${this.tenant}/oauth2/v2.0/token`;
+    this.revokeEndpoint = null; // Microsoft doesn't support token revocation via API
+  }
+
+  /**
+   * Microsoft requires client_id and client_secret in the POST body
+   * Base class already handles this correctly
+   */
+  prepareTokenRequest(baseParams, originalParams) {
+    // Microsoft expects standard OAuth 2.0 parameters
+    // The base class already includes client_id, client_secret, code, etc.
+    return baseParams;
+  }
+
+  /**
+   * Prepare refresh token request
+   * Microsoft uses standard OAuth 2.0 refresh flow
+   */
+  prepareRefreshRequest(baseParams, originalParams) {
+    return baseParams;
+  }
+
+  /**
+   * Override revoke method since Microsoft doesn't support token revocation
+   */
+  async revokeToken(params) {
+    // Microsoft doesn't provide a revoke endpoint
+    // Tokens expire naturally or can be revoked through Azure AD portal
+    throw new Error('Microsoft does not support programmatic token revocation. Tokens can be managed in Azure AD portal.');
+  }
+}


### PR DESCRIPTION
## Summary

This PR is intended to add support for Office 365 as an OAuth provider to Archestra''s OAuth integration system. However, the current implementation only adds an empty test file.

## Expected Changes

Based on the existing OAuth provider architecture, a complete Office 365 integration would require:

1. **Desktop App Changes** (`desktop_app/src/backend/config/oauth-providers.ts`):
   - Add Office 365 provider configuration with appropriate scopes and endpoints
   - Configure Microsoft Azure AD OAuth endpoints
   - Set up token environment variable patterns

2. **OAuth Proxy Changes** (`oauth_proxy/src/providers/`):
   - Create `office365.js` provider implementation
   - Handle Microsoft-specific OAuth requirements
   - Register provider in `index.js`

3. **Environment Configuration**:
   - Add Office 365 client ID and secret to OAuth proxy
   - Configure appropriate redirect URIs

## Current State

The PR currently only contains an empty test file (`desktop_app/test`) and does not implement any of the required OAuth functionality.