### PR TITLE
ci: update claude GH actions workflow version

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -32,13 +32,8 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@e26577a930883943cf9d90885cd1e8da510078dd # beta tag
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # v0.0.63
         with:
-          # We need to use the default GitHub token as a workaround for a bug in Anthropic's
-          # GitHub Action
-          #
-          # see https://github.com/anthropics/claude-code-action/issues/443
-          github_token: ${{ github.token }}
           # Dynamically set the secret based on the user who triggered the workflow
           # use their oauth token, since otherwise Anthropic will ban accounts for abuse :(
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-dispatch.yml
+++ b/.github/workflows/claude-dispatch.yml
@@ -28,10 +28,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        # NOTE: for right now we're using the eap tag because that it what is present
-        # in the GitHub gist that we're using (and I can't seem to find the eap tag in
-        # Anthropic's repo)
-        uses: anthropics/claude-code-action@eap # zizmor: ignore[unpinned-uses]
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # v0.0.63
         with:
           mode: "remote-agent"
 

--- a/.github/workflows/claude-pull-requests.yml
+++ b/.github/workflows/claude-pull-requests.yml
@@ -26,13 +26,8 @@ jobs:
           persist-credentials: true # credentials are needed here as Claude will use them to read stuffs
 
       - name: Run Claude Code
-        uses: anthropics/claude-code-action@e26577a930883943cf9d90885cd1e8da510078dd # beta tag
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # v0.0.63
         with:
-          # We need to use the default GitHub token as a workaround for a bug in Anthropic's
-          # GitHub Action
-          #
-          # see https://github.com/anthropics/claude-code-action/issues/443
-          github_token: ${{ github.token }}
           # Dynamically set the secret based on the user who triggered the workflow
           # use their oauth token, since otherwise Anthropic will ban accounts for abuse :(
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

This PR updates the Claude GitHub Actions workflow to use a stable, pinned version (`v0.0.63`) instead of various beta/eap tags. This improves reliability and security by:

- Replacing unpinned `eap` tag with specific commit SHA
- Replacing `beta` tag with specific commit SHA  
- Removing workaround for GitHub token bug that has been fixed in the stable release

## Changes

- **`.github/workflows/claude-code.yml`**: Update from beta tag to v0.0.63, remove GitHub token workaround
- **`.github/workflows/claude-dispatch.yml`**: Update from unpinned `eap` tag to v0.0.63
- **`.github/workflows/claude-pull-requests.yml`**: Update from beta tag to v0.0.63, remove GitHub token workaround

## Testing

These changes have been tested in our CI/CD pipeline and the Claude integration continues to work as expected.