### PR TITLE
Add linkedin provider and run servers from original docker images

### DIFF
--- a/desktop_app/openapi/archestra/api/openapi.json
+++ b/desktop_app/openapi/archestra/api/openapi.json
@@ -848,7 +848,7 @@
           },
           "oauthProvider": {
             "type": "string",
-            "enum": ["google", "slack", "slack-browser"]
+            "enum": ["google", "slack", "slack-browser", "linkedin-browser"]
           },
           "oauthAccessToken": {
             "type": "string"
@@ -1883,7 +1883,7 @@
           },
           "oauthProvider": {
             "type": "string",
-            "enum": ["google", "slack", "slack-browser"]
+            "enum": ["google", "slack", "slack-browser", "linkedin-browser"]
           },
           "oauthAccessToken": {
             "type": "string"

--- a/desktop_app/src/backend/models/mcpServer/index.ts
+++ b/desktop_app/src/backend/models/mcpServer/index.ts
@@ -28,7 +28,7 @@ export const McpServerInstallSchema = z.object({
     .regex(/^[A-Za-z0-9-\s]{1,63}$/, 'Name can only contain letters, numbers, spaces, and dashes (-)'),
   serverConfig: McpServerConfigSchema,
   userConfigValues: McpServerUserConfigValuesSchema.optional(),
-  oauthProvider: z.enum(['google', 'slack', 'slack-browser']).optional(),
+  oauthProvider: z.enum(['google', 'slack', 'slack-browser', 'linkedin-browser']).optional(),
   oauthAccessToken: z.string().optional(),
   oauthRefreshToken: z.string().optional(),
   oauthExpiryDate: z.string().nullable().optional(),
@@ -123,12 +123,13 @@ export default class McpServerModel {
         // Use the provider's token handler to get the correct env vars
         const tokenEnvVars = await handleProviderTokens(provider, tokens, id);
 
-        // Use env variabled from oauth provider intead default ones
+        // Merge OAuth env variables with existing ones (including those from server_docker)
         if (tokenEnvVars) {
           finalServerConfig = {
             ...serverConfig,
             env: {
-              ...tokenEnvVars,
+              ...serverConfig.env, // Keep existing env vars
+              ...tokenEnvVars, // Add/override with OAuth tokens
             },
           };
         }

--- a/desktop_app/src/backend/server/plugins/oauth/providers.ts
+++ b/desktop_app/src/backend/server/plugins/oauth/providers.ts
@@ -1,5 +1,6 @@
 import { OAuthProviderDefinition, OAuthProviderRegistry } from './provider-interface';
 import { googleProvider } from './providers/google';
+import { linkedinBrowserProvider } from './providers/linkedin-browser';
 import { slackProvider } from './providers/slack';
 import { slackBrowserProvider } from './providers/slack-browser';
 
@@ -12,6 +13,7 @@ export const oauthProviders: OAuthProviderRegistry = {
   google: googleProvider,
   slack: slackProvider,
   'slack-browser': slackBrowserProvider,
+  'linkedin-browser': linkedinBrowserProvider,
 };
 
 /**
@@ -40,4 +42,4 @@ export function getOAuthProviderNames(): string[] {
 }
 
 // Re-export individual providers for direct access if needed
-export { googleProvider, slackProvider, slackBrowserProvider };
+export { googleProvider, slackProvider, slackBrowserProvider, linkedinBrowserProvider };

--- a/desktop_app/src/backend/server/plugins/oauth/providers/linkedin-browser.ts
+++ b/desktop_app/src/backend/server/plugins/oauth/providers/linkedin-browser.ts
@@ -1,0 +1,115 @@
+import { OAuthProviderDefinition } from '../provider-interface';
+import {
+  buildLinkedInTokenExtractionScript,
+  isLinkedInAuthenticatedPage,
+  isLinkedInLoginPage,
+} from '../utils/linkedin-token-extractor';
+
+export const linkedinBrowserProvider: OAuthProviderDefinition = {
+  name: 'linkedin-browser',
+  authorizationUrl: '', // Not used for browser auth
+  scopes: [], // Not used for browser auth
+  usePKCE: false, // Not used for browser auth
+  clientId: 'browser-auth', // Placeholder
+
+  // Token pattern for LinkedIn li_at cookie
+  tokenEnvVarPattern: {
+    accessToken: 'LINKEDIN_COOKIE', // Maps to primary_token (li_at cookie) - matches what container expects
+  },
+
+  // Browser-based authentication configuration
+  browserAuthConfig: {
+    enabled: true,
+    loginUrl: 'https://www.linkedin.com/login',
+
+    // Map browser tokens to environment variables
+    tokenMapping: {
+      primary: 'LINKEDIN_COOKIE', // Changed to match what the container expects
+    },
+
+    navigationRules: (url: string) => {
+      // Only allow navigation to official LinkedIn domains
+      try {
+        const parsedUrl = new URL(url);
+        const hostname = parsedUrl.hostname;
+        return (
+          hostname === 'linkedin.com' ||
+          hostname === 'www.linkedin.com' ||
+          (hostname.endsWith('.linkedin.com') && hostname.length > '.linkedin.com'.length)
+        );
+      } catch (e) {
+        // If URL parsing fails, deny navigation
+        return false;
+      }
+    },
+
+    extractTokens: async (windowWithContext: any) => {
+      // Extract the actual window parts and context
+      const { webContents, session, context } = windowWithContext;
+      const url = webContents.getURL();
+
+      console.log('[LinkedIn Browser Auth] Attempting token extraction on:', url);
+
+      // Check if we're on a login page
+      if (isLinkedInLoginPage(url)) {
+        console.log('[LinkedIn Browser Auth] Still on login page, waiting for authentication');
+        return null;
+      }
+
+      // Only try to extract on authenticated pages
+      if (!isLinkedInAuthenticatedPage(url)) {
+        console.log('[LinkedIn Browser Auth] Not an authenticated page, waiting for user to log in');
+        return null;
+      }
+
+      console.log('[LinkedIn Browser Auth] On authenticated page, extracting li_at cookie...');
+
+      // Get li_at token from cookies
+      const cookies = await session.cookies.get({
+        url: 'https://www.linkedin.com',
+        name: 'li_at',
+      });
+
+      const liAtCookie = cookies.length > 0 ? cookies[0] : null;
+      const liAtToken = liAtCookie ? liAtCookie.value : null;
+
+      console.log('[LinkedIn Browser Auth] Found li_at token:', !!liAtToken);
+
+      // Execute the extraction script to verify we're on LinkedIn
+      const extractionScript = buildLinkedInTokenExtractionScript();
+      const result = await webContents.executeJavaScript(extractionScript);
+
+      console.log('[LinkedIn Browser Auth] Page verification result:', {
+        success: result.success,
+        hasLiAtToken: !!liAtToken,
+        error: result.error,
+      });
+
+      if (result.success && liAtToken) {
+        // Log success
+        console.log('[LinkedIn Browser Auth] Successfully extracted li_at token');
+
+        // Return proper BrowserTokenResponse
+        return {
+          primary_token: 'li_at=' + liAtToken,
+        };
+      }
+
+      // Log the error for debugging
+      if (!result.success) {
+        console.error('[LinkedIn Browser Auth] Page verification failed:', result.error);
+      } else if (!liAtToken) {
+        console.error('[LinkedIn Browser Auth] Missing li_at token (cookie not found)');
+      }
+
+      return null;
+    },
+  },
+
+  metadata: {
+    displayName: 'LinkedIn (Browser Auth)',
+    documentationUrl: 'https://github.com/stickerdaniel/linkedin-mcp-server',
+    supportsRefresh: false,
+    notes: 'Direct browser authentication using li_at cookie. No OAuth app required. Based on linkedin-mcp-server.',
+  },
+};

--- a/desktop_app/src/backend/server/plugins/oauth/providers/slack-browser.ts
+++ b/desktop_app/src/backend/server/plugins/oauth/providers/slack-browser.ts
@@ -35,10 +35,7 @@ export const slackBrowserProvider: OAuthProviderDefinition = {
         return (
           hostname === 'slack.com' ||
           hostname === 'app.slack.com' ||
-          (
-            hostname.endsWith('.slack.com') &&
-            hostname.length > '.slack.com'.length
-          )
+          (hostname.endsWith('.slack.com') && hostname.length > '.slack.com'.length)
         );
       } catch (e) {
         // If URL parsing fails, deny navigation

--- a/desktop_app/src/backend/server/plugins/oauth/utils/linkedin-token-extractor.ts
+++ b/desktop_app/src/backend/server/plugins/oauth/utils/linkedin-token-extractor.ts
@@ -1,0 +1,85 @@
+/**
+ * LinkedIn Token Extraction Utilities
+ *
+ * Utilities for extracting LinkedIn authentication tokens from the browser
+ * Uses the li_at cookie for authentication
+ */
+
+interface LinkedInTokenExtractionResult {
+  success: boolean;
+  liAtToken?: string;
+  error?: string;
+}
+
+/**
+ * Extract LinkedIn tokens from cookies
+ * The li_at cookie is the main authentication token for LinkedIn API
+ * This runs in the browser context
+ */
+export const LINKEDIN_TOKEN_EXTRACTION_SCRIPT = `
+  (function() {
+    try {
+      console.log('[LinkedIn Token Extraction] Starting token extraction...');
+      console.log('[LinkedIn Token Extraction] Current URL:', window.location.href);
+      
+      // Check if we're on LinkedIn
+      const hostname = window.location.hostname;
+      if (!hostname.includes('linkedin.com')) {
+        return { success: false, error: 'Not on LinkedIn domain' };
+      }
+      
+      // The li_at token is stored in cookies, not accessible via JavaScript
+      // We'll return success to indicate we're on the right page
+      // The actual cookie extraction happens in the main process
+      return { success: true };
+      
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
+  })();
+`;
+
+/**
+ * Build the LinkedIn token extraction script
+ */
+export function buildLinkedInTokenExtractionScript(): string {
+  return LINKEDIN_TOKEN_EXTRACTION_SCRIPT;
+}
+
+/**
+ * Validate LinkedIn page URL
+ */
+export function isLinkedInAuthenticatedPage(url: string): boolean {
+  try {
+    const parsedUrl = new URL(url);
+    // Check if we're on LinkedIn and likely authenticated (on feed or profile pages)
+    return (
+      parsedUrl.hostname.includes('linkedin.com') &&
+      (parsedUrl.pathname.startsWith('/feed') ||
+        parsedUrl.pathname.startsWith('/in/') ||
+        parsedUrl.pathname.startsWith('/mynetwork') ||
+        parsedUrl.pathname.startsWith('/jobs') ||
+        parsedUrl.pathname.startsWith('/messaging'))
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if URL is LinkedIn login page
+ */
+export function isLinkedInLoginPage(url: string): boolean {
+  try {
+    const parsedUrl = new URL(url);
+    return (
+      parsedUrl.hostname.includes('linkedin.com') &&
+      (parsedUrl.pathname.includes('/login') ||
+        parsedUrl.pathname.includes('/signin') ||
+        parsedUrl.pathname === '/' ||
+        parsedUrl.pathname.includes('/checkpoint'))
+    );
+  } catch {
+    return false;
+  }
+}

--- a/desktop_app/src/ui/lib/clients/archestra/api/gen/types.gen.ts
+++ b/desktop_app/src/ui/lib/clients/archestra/api/gen/types.gen.ts
@@ -202,7 +202,7 @@ export type McpServerInstallInput = {
   displayName: string;
   serverConfig: McpServerConfigInput;
   userConfigValues?: McpServerUserConfigValuesInput;
-  oauthProvider?: 'google' | 'slack' | 'slack-browser';
+  oauthProvider?: 'google' | 'slack' | 'slack-browser' | 'linkedin-browser';
   oauthAccessToken?: string;
   oauthRefreshToken?: string;
   oauthExpiryDate?: string | null;
@@ -485,7 +485,7 @@ export type McpServerInstall = {
   displayName: string;
   serverConfig: McpServerConfig;
   userConfigValues?: McpServerUserConfigValues;
-  oauthProvider?: 'google' | 'slack' | 'slack-browser';
+  oauthProvider?: 'google' | 'slack' | 'slack-browser' | 'linkedin-browser';
   oauthAccessToken?: string;
   oauthRefreshToken?: string;
   oauthExpiryDate?: string | null;

--- a/desktop_app/src/ui/lib/clients/archestra/catalog/gen/types.gen.ts
+++ b/desktop_app/src/ui/lib/clients/archestra/catalog/gen/types.gen.ts
@@ -38,6 +38,13 @@ export type ArchestraMcpServerManifest = {
       };
     };
   };
+  server_docker?: {
+    command: string;
+    args?: Array<string>;
+    env?: {
+      [key: string]: string;
+    };
+  };
   tools?: Array<{
     name: string;
     description?: string;

--- a/desktop_app/src/ui/routes/connectors.tsx
+++ b/desktop_app/src/ui/routes/connectors.tsx
@@ -51,12 +51,13 @@ function ConnectorCatalogPage() {
        *
        * https://github.com/anthropics/dxt/blob/main/MANIFEST.md#server-configuration
        */
-      serverConfig: mcpServer.server.mcp_config,
+      // Prefer server_docker over server.mcp_config when available
+      serverConfig: mcpServer.server_docker || mcpServer.server.mcp_config,
       userConfigValues: userConfigValues || {},
-      // If using browser auth for Slack, use the slack-browser provider
+      // If using browser auth, append -browser to the provider name
       oauthProvider:
-        useBrowserAuth && mcpServer.archestra_config.oauth?.provider === 'slack'
-          ? 'slack-browser'
+        useBrowserAuth && mcpServer.archestra_config.oauth?.provider
+          ? `${mcpServer.archestra_config.oauth.provider}-browser`
           : mcpServer.archestra_config.oauth?.provider,
     };
 
@@ -85,11 +86,9 @@ function ConnectorCatalogPage() {
   };
 
   const handleBrowserInstallClick = async (mcpServer: ArchestraMcpServerManifest) => {
-    // Special handling for Slack MCP server - skip the config dialog and use browser auth
-    if (mcpServer.name === 'korotovsky__slack-mcp-server') {
-      // Directly install with browser auth flag
-      await installMcpServer(mcpServer, undefined, true);
-    }
+    // For any server that supports browser-based authentication
+    // Directly install with browser auth flag
+    await installMcpServer(mcpServer, undefined, true);
   };
 
   const handleInstallWithConfig = async (config: McpServerUserConfigValues) => {

--- a/mcp_server_docker_image/Dockerfile
+++ b/mcp_server_docker_image/Dockerfile
@@ -90,7 +90,7 @@ WORKDIR /home/mcp
 # Configure git for the mcp user before switching
 RUN git config --system http.sslVerify true && \
     git config --system http.postBuffer 524288000 && \
-    git config --system http.timeout 120 && \
+    git config --system http.timeout 180 && \
     git config --system core.compression 0
 
 USER mcp


### PR DESCRIPTION
This PR adds support for https://github.com/stickerdaniel/linkedin-mcp-server and implements support for original Docker images.I experienced an issue where the LinkedIn MCP server would sometimes fail to start due to flaky networking connectivity errors with GitHub. Currently, it would use docker if the catalog has a `server_docker` field. I didn't merge it with the main `server` to keep DXT compatibility, however, I think we should extend DXT in this case.