### PR TITLE
feat: add Bearer token authentication support for OAuth providers

### DIFF
--- a/desktop_app/docs/ADDING_OAUTH_PROVIDERS.md
+++ b/desktop_app/docs/ADDING_OAUTH_PROVIDERS.md
@@ -261,7 +261,7 @@ jiraProvider: OAuthProviderDefinition = {
 };
 ```
 
-### Bearer Token Authentication (New Method)
+### Bearer Token Authentication
 
 Some APIs require OAuth tokens to be passed as Bearer tokens in HTTP headers instead of environment variables. This is now supported via the `authHeaderPattern` configuration:
 

--- a/desktop_app/docs/ADDING_OAUTH_PROVIDERS.md
+++ b/desktop_app/docs/ADDING_OAUTH_PROVIDERS.md
@@ -260,3 +260,60 @@ jiraProvider: OAuthProviderDefinition = {
   },
 };
 ```
+
+### Bearer Token Authentication (New Method)
+
+Some APIs require OAuth tokens to be passed as Bearer tokens in HTTP headers instead of environment variables. This is now supported via the `authHeaderPattern` configuration:
+
+```typescript
+// desktop_app/src/backend/server/plugins/oauth/providers/linkedin.ts
+export const linkedinProvider: OAuthProviderDefinition = {
+  name: 'linkedin',
+  authorizationUrl: 'https://www.linkedin.com/oauth/v2/authorization',
+  scopes: ['openid', 'profile', 'email', 'w_member_social'],
+  usePKCE: true,
+  clientId: 'your-public-client-id',
+
+  // NEW: Configure Bearer token authentication
+  authHeaderPattern: {
+    header: 'Authorization',
+    pattern: 'Bearer {token}', // {token} gets replaced with the actual OAuth token
+  },
+
+  metadata: {
+    displayName: 'LinkedIn',
+    supportsRefresh: true,
+  },
+};
+```
+
+With this configuration:
+
+1. The OAuth token is stored in the database as usual
+2. When the MCP server makes requests, the system automatically adds the header:
+   ```
+   Authorization: Bearer <actual_oauth_token>
+   ```
+3. The MCP server receives these headers in the `_meta.headers` field of the JSON-RPC request
+
+You can use any header name and pattern:
+
+```typescript
+// Example: API Key authentication
+authHeaderPattern: {
+  header: 'X-API-Key',
+  pattern: '{token}' // Results in: X-API-Key: <actual_token>
+}
+
+// Example: Custom header format
+authHeaderPattern: {
+  header: 'X-Company-Auth',
+  pattern: 'Token={token}' // Results in: X-Company-Auth: Token=<actual_token>
+}
+```
+
+**Note**: A provider can use ONE of these token passing methods:
+
+- `tokenEnvVarPattern` - Pass tokens as environment variables (default)
+- `authHeaderPattern` - Pass tokens as HTTP headers (for Bearer auth)
+- `tokenHandler` - Custom handler for special cases (like file-based credentials)

--- a/desktop_app/src/backend/sandbox/podman/container/index.ts
+++ b/desktop_app/src/backend/sandbox/podman/container/index.ts
@@ -943,7 +943,11 @@ export default class PodmanContainer {
    *
    * https://docs.podman.io/en/latest/_static/api.html#tag/containers/operation/ContainerAttachLibpod
    */
-  async streamToContainer(requestBody: any, responseStream: RawReplyDefaultExpression) {
+  async streamToContainer(
+    requestBody: any,
+    responseStream: RawReplyDefaultExpression,
+    headers?: Record<string, string>
+  ) {
     // Log the original request
     log.info(`MCP request:`, {
       method: requestBody.method,
@@ -972,8 +976,13 @@ export default class PodmanContainer {
       // For requests with IDs, we need to track the response
       const requestId = originalId !== undefined ? originalId.toString() : uuidv4();
 
+      // Add headers to the request if provided
+      // MCP servers can access these through the request context
+      const requestWithHeaders =
+        headers && Object.keys(headers).length > 0 ? { ...requestBody, _meta: { headers } } : requestBody;
+
       // Prepare the JSON-RPC request with newline (MCP servers expect line-delimited JSON)
-      const jsonRequest = JSON.stringify(requestBody) + '\n';
+      const jsonRequest = JSON.stringify(requestWithHeaders) + '\n';
       log.info(`Sending JSON-RPC request: ${jsonRequest}`);
 
       // Set up response handler

--- a/desktop_app/src/backend/sandbox/sandboxedMcp/index.ts
+++ b/desktop_app/src/backend/sandbox/sandboxedMcp/index.ts
@@ -271,8 +271,8 @@ export default class SandboxedMcpServer {
   /**
    * Stream a request to the MCP server container
    */
-  async streamToContainer(request: any, responseStream: RawReplyDefaultExpression) {
-    await this.podmanContainer.streamToContainer(request, responseStream);
+  async streamToContainer(request: any, responseStream: RawReplyDefaultExpression, headers?: Record<string, string>) {
+    await this.podmanContainer.streamToContainer(request, responseStream, headers);
   }
 
   /**

--- a/desktop_app/src/backend/server/plugins/mcpServer/index.ts
+++ b/desktop_app/src/backend/server/plugins/mcpServer/index.ts
@@ -12,6 +12,7 @@ import McpServerModel, { McpServerInstallSchema } from '@backend/models/mcpServe
 import McpServerSandboxManager from '@backend/sandbox/manager';
 import { AvailableToolSchema, McpServerContainerLogsSchema } from '@backend/sandbox/sandboxedMcp';
 import { ErrorResponseSchema } from '@backend/schemas';
+import { getOAuthProvider, hasOAuthProvider } from '@backend/server/plugins/oauth/providers';
 import log from '@backend/utils/logger';
 
 /**
@@ -132,7 +133,17 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
       if (!sandboxedMcpServer) {
         return reply.code(404).send({ error: 'MCP server not found' });
       }
-      const { name: mcpServerName } = sandboxedMcpServer.mcpServer;
+      const { name: mcpServerName, oauthProvider, oauthAccessToken } = sandboxedMcpServer.mcpServer;
+
+      // Prepare additional headers for MCP server if OAuth provider uses header auth
+      let additionalHeaders: Record<string, string> = {};
+      if (oauthProvider && oauthAccessToken && hasOAuthProvider(oauthProvider)) {
+        const provider = getOAuthProvider(oauthProvider);
+        if (provider.authHeaderPattern) {
+          const headerValue = provider.authHeaderPattern.pattern.replace('{token}', oauthAccessToken);
+          additionalHeaders[provider.authHeaderPattern.header] = headerValue;
+        }
+      }
 
       // Create MCP request log entry
       const requestId = uuidv4();
@@ -201,8 +212,8 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           return originalEnd(chunk, encoding);
         };
 
-        // Stream the request to the container!
-        await sandboxedMcpServer.streamToContainer(body, reply.raw);
+        // Stream the request to the container with additional headers if needed!
+        await sandboxedMcpServer.streamToContainer(body, reply.raw, additionalHeaders);
 
         // Return undefined when hijacking to prevent Fastify from sending response
         return;

--- a/desktop_app/src/backend/server/plugins/oauth/provider-interface.ts
+++ b/desktop_app/src/backend/server/plugins/oauth/provider-interface.ts
@@ -127,6 +127,36 @@ export interface OAuthProviderDefinition {
   };
 
   /**
+   * Optional header authentication pattern.
+   * Used to pass tokens as HTTP headers instead of environment variables.
+   * The pattern should include a placeholder {token} that will be replaced with the actual token.
+   *
+   * @example
+   * ```typescript
+   * authHeaderPattern: {
+   *   header: 'Authorization',
+   *   pattern: 'Bearer {token}'
+   * }
+   * // Results in: Authorization: Bearer <actual_token>
+   * ```
+   *
+   * @example
+   * ```typescript
+   * authHeaderPattern: {
+   *   header: 'X-API-Key',
+   *   pattern: '{token}'
+   * }
+   * // Results in: X-API-Key: <actual_token>
+   * ```
+   */
+  authHeaderPattern?: {
+    /** The header name (e.g., 'Authorization', 'X-API-Key') */
+    header: string;
+    /** The pattern for the header value with {token} placeholder */
+    pattern: string;
+  };
+
+  /**
    * Optional browser-based authentication configuration.
    * Some providers (like Slack) support extracting tokens directly from their web interface.
    */

--- a/desktop_app/src/backend/server/plugins/oauth/utils/oauth-provider-helper.ts
+++ b/desktop_app/src/backend/server/plugins/oauth/utils/oauth-provider-helper.ts
@@ -146,14 +146,26 @@ export function validateProvider(provider: OAuthProviderDefinition): void {
     throw new Error(`Provider ${provider.name} must have a client ID`);
   }
 
-  // Must have either custom handler or env var pattern
-  if (!provider.tokenHandler && !provider.tokenEnvVarPattern) {
-    throw new Error(`Provider ${provider.name} must have either tokenHandler or tokenEnvVarPattern configured`);
+  // Must have either custom handler, env var pattern, or auth header pattern
+  if (!provider.tokenHandler && !provider.tokenEnvVarPattern && !provider.authHeaderPattern) {
+    throw new Error(
+      `Provider ${provider.name} must have either tokenHandler, tokenEnvVarPattern, or authHeaderPattern configured`
+    );
   }
 
   // If using env var pattern, must have at least access token var
   if (provider.tokenEnvVarPattern && !provider.tokenEnvVarPattern.accessToken) {
     throw new Error(`Provider ${provider.name} tokenEnvVarPattern must define accessToken variable`);
+  }
+
+  // If using auth header pattern, must have header and pattern defined
+  if (provider.authHeaderPattern) {
+    if (!provider.authHeaderPattern.header) {
+      throw new Error(`Provider ${provider.name} authHeaderPattern must define header`);
+    }
+    if (!provider.authHeaderPattern.pattern || !provider.authHeaderPattern.pattern.includes('{token}')) {
+      throw new Error(`Provider ${provider.name} authHeaderPattern.pattern must include {token} placeholder`);
+    }
   }
 
   // Validate usePKCE is defined (required field)

--- a/oauth_proxy/.env.example
+++ b/oauth_proxy/.env.example
@@ -1,11 +1,3 @@
-# Server Configuration
-PORT=8080
-USE_LOCAL_HTTPS=false
-LOG_LEVEL=info
-
-# CORS Configuration (comma-separated origins)
-CORS_ORIGIN=http://localhost:3000,https://localhost:3000
-
 # Google OAuth
 GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret

--- a/oauth_proxy/README.md
+++ b/oauth_proxy/README.md
@@ -62,13 +62,6 @@ cp .env.example .env
 Edit `.env` file with your OAuth credentials:
 
 ```env
-# Server
-PORT=8080
-LOG_LEVEL=info
-
-# CORS
-CORS_ORIGIN=http://localhost:3000,https://localhost:3000
-
 # Google OAuth
 GOOGLE_CLIENT_ID=your_client_id
 GOOGLE_CLIENT_SECRET=your_client_secret


### PR DESCRIPTION
Add support for passing OAuth tokens as Bearer tokens in HTTP headers, providing a third authentication method alongside environment variables and file-based credentials.

- Add authHeaderPattern field to OAuthProviderDefinition interface
- Update MCP proxy endpoint to inject Authorization headers
- Modify container communication to accept and forward headers
- Update token handler validation to recognize authHeaderPattern
- Pass headers through MCP client chain via _meta.headers in JSON-RPC