### PR TITLE
fix: remove better-sqlite3 from main process bundle

### DIFF
--- a/desktop_app/src/backend/server/plugins/oauth/index.ts
+++ b/desktop_app/src/backend/server/plugins/oauth/index.ts
@@ -16,17 +16,19 @@ const oauthPlugin: FastifyPluginAsyncZod = async (fastify) => {
   await fastify.register(oauthRoutes);
 };
 
-// Re-export everything from providers and provider-interface for use in other parts of the app
+// Re-export database-free functions from provider-registry
 export {
   getOAuthProvider,
-  getOAuthProviderWithDiscovery,
   hasOAuthProvider,
   getOAuthProviderNames,
   oauthProviders,
   googleProvider,
   slackProvider,
   slackBrowserProvider,
-} from './providers';
+} from './provider-registry';
+
+// Re-export database-dependent functions from providers for server use only
+export { getOAuthProviderWithDiscovery } from './providers';
 export type {
   OAuthProviderDefinition,
   OAuthProviderRegistry,

--- a/desktop_app/src/backend/server/plugins/oauth/provider-registry.ts
+++ b/desktop_app/src/backend/server/plugins/oauth/provider-registry.ts
@@ -1,0 +1,48 @@
+import { OAuthProviderDefinition, OAuthProviderRegistry } from './provider-interface';
+import { googleProvider } from './providers/google';
+import { linkedinBrowserProvider } from './providers/linkedin-browser';
+import { slackProvider } from './providers/slack';
+import { slackBrowserProvider } from './providers/slack-browser';
+
+/**
+ * Registry of OAuth providers with extensible token handling.
+ * These are PUBLIC client IDs (not secrets) - safe to hardcode.
+ * The secrets are stored in the OAuth proxy server.
+ *
+ * This file contains ONLY database-free provider registry functions
+ * for use in the main process without pulling in better-sqlite3.
+ */
+export const oauthProviders: OAuthProviderRegistry = {
+  google: googleProvider,
+  slack: slackProvider,
+  'slack-browser': slackBrowserProvider,
+  'linkedin-browser': linkedinBrowserProvider,
+};
+
+/**
+ * Get OAuth provider definition
+ */
+export function getOAuthProvider(name: string): OAuthProviderDefinition {
+  const provider = oauthProviders[name.toLowerCase()];
+  if (!provider) {
+    throw new Error(`OAuth provider '${name}' not configured`);
+  }
+  return provider;
+}
+
+/**
+ * Check if a provider is configured
+ */
+export function hasOAuthProvider(name: string): boolean {
+  return name.toLowerCase() in oauthProviders;
+}
+
+/**
+ * Get all configured provider names
+ */
+export function getOAuthProviderNames(): string[] {
+  return Object.keys(oauthProviders);
+}
+
+// Re-export individual providers for direct access if needed
+export { googleProvider, slackProvider, slackBrowserProvider, linkedinBrowserProvider };

--- a/desktop_app/src/backend/server/plugins/oauth/providers.ts
+++ b/desktop_app/src/backend/server/plugins/oauth/providers.ts
@@ -1,48 +1,20 @@
 import { OAuthServerMetadata, oauthDiscoveryService } from '@backend/services/oauth-discovery';
 import log from '@backend/utils/logger';
 
-import { OAuthProviderDefinition, OAuthProviderRegistry } from './provider-interface';
-import { googleProvider } from './providers/google';
-import { linkedinBrowserProvider } from './providers/linkedin-browser';
-import { slackProvider } from './providers/slack';
-import { slackBrowserProvider } from './providers/slack-browser';
+import { OAuthProviderDefinition } from './provider-interface';
+import { oauthProviders } from './provider-registry';
 
-/**
- * Registry of OAuth providers with extensible token handling.
- * These are PUBLIC client IDs (not secrets) - safe to hardcode.
- * The secrets are stored in the OAuth proxy server.
- */
-export const oauthProviders: OAuthProviderRegistry = {
-  google: googleProvider,
-  slack: slackProvider,
-  'slack-browser': slackBrowserProvider,
-  'linkedin-browser': linkedinBrowserProvider,
-};
-
-/**
- * Get OAuth provider definition
- */
-export function getOAuthProvider(name: string): OAuthProviderDefinition {
-  const provider = oauthProviders[name.toLowerCase()];
-  if (!provider) {
-    throw new Error(`OAuth provider '${name}' not configured`);
-  }
-  return provider;
-}
-
-/**
- * Check if a provider is configured
- */
-export function hasOAuthProvider(name: string): boolean {
-  return name.toLowerCase() in oauthProviders;
-}
-
-/**
- * Get all configured provider names
- */
-export function getOAuthProviderNames(): string[] {
-  return Object.keys(oauthProviders);
-}
+// Re-export database-free functions from provider-registry
+export {
+  oauthProviders,
+  getOAuthProvider,
+  hasOAuthProvider,
+  getOAuthProviderNames,
+  googleProvider,
+  slackProvider,
+  slackBrowserProvider,
+  linkedinBrowserProvider,
+} from './provider-registry';
 
 /**
  * Helper function to get cached discovery metadata from database
@@ -148,6 +120,3 @@ export async function getOAuthProviderWithDiscovery(name: string, serverId?: str
     };
   }
 }
-
-// Re-export individual providers for direct access if needed
-export { googleProvider, slackProvider, slackBrowserProvider, linkedinBrowserProvider };

--- a/desktop_app/src/main-browser-auth.ts
+++ b/desktop_app/src/main-browser-auth.ts
@@ -6,12 +6,8 @@
  */
 import { BrowserWindow, ipcMain } from 'electron';
 
-import {
-  BrowserTokenResponse,
-  OAuthProviderDefinition,
-  getOAuthProvider,
-  hasOAuthProvider,
-} from './backend/server/plugins/oauth';
+import { BrowserTokenResponse, OAuthProviderDefinition } from './backend/server/plugins/oauth/provider-interface';
+import { getOAuthProvider, hasOAuthProvider } from './backend/server/plugins/oauth/provider-registry';
 import {
   BROWSER_AUTH_WINDOW_CONFIG,
   getProviderSessionPartition,


### PR DESCRIPTION
app build doesn't work when better-sqlite3 is imported in the main process, so remove database dependencies from it