### PR TITLE
fix: preserve user tool selection when tools update

### DIFF
--- a/desktop_app/src/ui/stores/tools-store.ts
+++ b/desktop_app/src/ui/stores/tools-store.ts
@@ -67,10 +67,10 @@ export const useToolsStore = create<ToolsStore>((set, get) => ({
         const { selectedToolIds: currentSelection } = get();
         // Only auto-select tools if no tools are currently selected
         const shouldAutoSelectAll = currentSelection.size === 0;
-        const selectedToolIds = shouldAutoSelectAll 
+        const selectedToolIds = shouldAutoSelectAll
           ? new Set(data.map((tool) => tool.id))
-          : new Set([...currentSelection].filter(id => data.some(tool => tool.id === id))); 
-        
+          : new Set([...currentSelection].filter((id) => data.some((tool) => tool.id === id)));
+
         set({
           availableTools: data,
           selectedToolIds,
@@ -87,10 +87,10 @@ export const useToolsStore = create<ToolsStore>((set, get) => ({
     const { selectedToolIds: currentSelection } = get();
     // Only auto-select tools if no tools are currently selected
     const shouldAutoSelectAll = currentSelection.size === 0;
-    const selectedToolIds = shouldAutoSelectAll 
+    const selectedToolIds = shouldAutoSelectAll
       ? new Set(tools.map((tool) => tool.id))
-      : new Set([...currentSelection].filter(id => tools.some(tool => tool.id === id))); 
-    
+      : new Set([...currentSelection].filter((id) => tools.some((tool) => tool.id === id)));
+
     set({
       availableTools: tools,
       selectedToolIds,

--- a/desktop_app/src/ui/stores/tools-store.ts
+++ b/desktop_app/src/ui/stores/tools-store.ts
@@ -40,16 +40,16 @@ export const useToolsStore = create<ToolsStore>((set, get) => ({
   // Actions
   addSelectedTool: (toolId: string) => {
     set(({ selectedToolIds }) => ({
-      selectedToolIds: selectedToolIds.add(toolId),
+      selectedToolIds: new Set(selectedToolIds).add(toolId),
     }));
   },
 
   removeSelectedTool: (toolId: string) => {
     set(({ selectedToolIds }) => {
-      selectedToolIds.delete(toolId);
-
+      const newSelectedToolIds = new Set(selectedToolIds);
+      newSelectedToolIds.delete(toolId);
       return {
-        selectedToolIds,
+        selectedToolIds: newSelectedToolIds,
       };
     });
   },
@@ -64,11 +64,16 @@ export const useToolsStore = create<ToolsStore>((set, get) => ({
     try {
       const { data } = await getAvailableTools();
       if (data) {
-        // Select all tools by default
-        const allToolIds = new Set(data.map((tool) => tool.id));
+        const { selectedToolIds: currentSelection } = get();
+        // Only auto-select tools if no tools are currently selected
+        const shouldAutoSelectAll = currentSelection.size === 0;
+        const selectedToolIds = shouldAutoSelectAll 
+          ? new Set(data.map((tool) => tool.id))
+          : new Set([...currentSelection].filter(id => data.some(tool => tool.id === id))); // Keep existing selection, remove tools that no longer exist
+        
         set({
           availableTools: data,
-          selectedToolIds: allToolIds,
+          selectedToolIds,
         });
       }
     } catch {
@@ -79,11 +84,16 @@ export const useToolsStore = create<ToolsStore>((set, get) => ({
   },
 
   setAvailableTools: (tools: Tool[]) => {
-    // Select all tools by default
-    const allToolIds = new Set(tools.map((tool) => tool.id));
+    const { selectedToolIds: currentSelection } = get();
+    // Only auto-select tools if no tools are currently selected
+    const shouldAutoSelectAll = currentSelection.size === 0;
+    const selectedToolIds = shouldAutoSelectAll 
+      ? new Set(tools.map((tool) => tool.id))
+      : new Set([...currentSelection].filter(id => tools.some(tool => tool.id === id))); // Keep existing selection, remove tools that no longer exist
+    
     set({
       availableTools: tools,
-      selectedToolIds: allToolIds,
+      selectedToolIds,
     });
   },
 

--- a/desktop_app/src/ui/stores/tools-store.ts
+++ b/desktop_app/src/ui/stores/tools-store.ts
@@ -69,7 +69,7 @@ export const useToolsStore = create<ToolsStore>((set, get) => ({
         const shouldAutoSelectAll = currentSelection.size === 0;
         const selectedToolIds = shouldAutoSelectAll 
           ? new Set(data.map((tool) => tool.id))
-          : new Set([...currentSelection].filter(id => data.some(tool => tool.id === id))); // Keep existing selection, remove tools that no longer exist
+          : new Set([...currentSelection].filter(id => data.some(tool => tool.id === id))); 
         
         set({
           availableTools: data,
@@ -89,7 +89,7 @@ export const useToolsStore = create<ToolsStore>((set, get) => ({
     const shouldAutoSelectAll = currentSelection.size === 0;
     const selectedToolIds = shouldAutoSelectAll 
       ? new Set(tools.map((tool) => tool.id))
-      : new Set([...currentSelection].filter(id => tools.some(tool => tool.id === id))); // Keep existing selection, remove tools that no longer exist
+      : new Set([...currentSelection].filter(id => tools.some(tool => tool.id === id))); 
     
     set({
       availableTools: tools,


### PR DESCRIPTION
/claim #278

## Summary
• Fixes bug where tool toggles in sidebar would reset to selected state after any tools update
• Preserves user's manual selection and only auto-selects all tools on first load when no selection exists
• Improves UX by maintaining user's intended tool configuration

## Test plan
- [x] Install Context7 MCP server (or any MCP server with tools)
- [x] Navigate to sidebar and toggle some tools off
- [x] Verify tools remain deselected and don't automatically re-select
- [x] Verify new tools are only auto-selected on first load when no previous selection exists
- [x] Verify existing selection is preserved when tools list updates