### PR TITLE
fix: Remove vertical padding from list items to fix copy-paste formatting

### DIFF
--- a/desktop_app/src/ui/components/kibo/ai-response.tsx
+++ b/desktop_app/src/ui/components/kibo/ai-response.tsx
@@ -37,7 +37,7 @@ const components: Options['components'] = {
     </ol>
   ),
   li: ({ node, children, className, ...props }) => (
-    <li className={cn('py-1', className)} {...props}>
+    <li className={cn('', className)} {...props}>
       {children}
     </li>
   ),


### PR DESCRIPTION
When copying lists from the chat to other applications like Slack, extra blank lines appeared between list items. This was caused by the py-1 class adding vertical padding to li elements. Removing this padding fixes the formatting issue while maintaining proper visual spacing through the browser's default list styles.

Fixes #415