### PR TITLE
fix: remove Ollama from cloud models page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Note: The README.md includes a Developer Quickstart section that shows basic set
 2. **ALWAYS use pnpm** (not npm or yarn) for package management
 3. **Run database commands from `desktop_app/`** directory
 4. **Use Podman** (not Docker) for container operations
+5. **Prettier** for ANY code that you push, make sure you run `pnpm prettier --write .` to ensure it is properly formatted
 
 ## Common Development Commands
 
@@ -29,7 +30,7 @@ pnpm start:server       # Start backend server only
 
 ```bash
 cd desktop_app
-pnpm package           # Package app for current platform
+pnpm package          # Package app for current platform
 pnpm make             # Create platform installer
 pnpm build:universal  # Build universal macOS binary
 ```
@@ -38,12 +39,12 @@ pnpm build:universal  # Build universal macOS binary
 
 ```bash
 cd desktop_app
-pnpm test             # Run all tests
-pnpm test:ui          # Run UI tests only
-pnpm test:backend     # Run backend tests only
-pnpm test:e2e:packaged # Run E2E tests on packaged app
-pnpm typecheck        # Check TypeScript types
-pnpm prettier         # Format code
+pnpm test                       # Run all tests
+pnpm test:ui                    # Run UI tests only
+pnpm test:backend               # Run backend tests only
+pnpm test:e2e:packaged          # Run E2E tests on packaged app
+pnpm typecheck                  # Check TypeScript types
+pnpm prettier --write .         # Format code
 ```
 
 ### Database Management

--- a/desktop_app/openapi/archestra/api/openapi.json
+++ b/desktop_app/openapi/archestra/api/openapi.json
@@ -992,7 +992,7 @@
       },
       "SupportedCloudProvidersInput": {
         "type": "string",
-        "enum": ["anthropic", "openai", "deepseek", "gemini", "ollama"]
+        "enum": ["anthropic", "openai", "deepseek", "gemini"]
       },
       "SupportedCloudProviderModelInput": {
         "type": "object",
@@ -2727,7 +2727,7 @@
       },
       "SupportedCloudProviders": {
         "type": "string",
-        "enum": ["anthropic", "openai", "deepseek", "gemini", "ollama"]
+        "enum": ["anthropic", "openai", "deepseek", "gemini"]
       },
       "SupportedCloudProviderModel": {
         "type": "object",

--- a/desktop_app/src/backend/database/schema/cloudProvider.ts
+++ b/desktop_app/src/backend/database/schema/cloudProvider.ts
@@ -3,7 +3,7 @@ import { int, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import { createSelectSchema } from 'drizzle-zod';
 import { z } from 'zod';
 
-export const SupportedCloudProviderSchema = z.enum(['anthropic', 'openai', 'deepseek', 'gemini', 'ollama']);
+export const SupportedCloudProviderSchema = z.enum(['anthropic', 'openai', 'deepseek', 'gemini']);
 
 export const cloudProvidersTable = sqliteTable('cloud_providers', {
   id: int().primaryKey({ autoIncrement: true }),

--- a/desktop_app/src/backend/models/cloudProvider/index.ts
+++ b/desktop_app/src/backend/models/cloudProvider/index.ts
@@ -75,14 +75,6 @@ const PROVIDER_REGISTRY: Record<SupportedCloudProvider, CloudProvider> = {
     baseUrl: 'https://generativelanguage.googleapis.com/v1beta/',
     models: ['gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-1.5-pro'],
   },
-  ollama: {
-    type: 'ollama',
-    name: 'Ollama',
-    apiKeyUrl: config.ollama.server.host,
-    apiKeyPlaceholder: 'Not required (leave empty for local)',
-    baseUrl: config.ollama.server.host + '/api',
-    models: ['llama3.2', 'llama3.1', 'mistral', 'mixtral', 'codellama', 'phi3'],
-  },
 };
 
 // Helper function to get provider for a model

--- a/desktop_app/src/ui/lib/clients/archestra/api/gen/types.gen.ts
+++ b/desktop_app/src/ui/lib/clients/archestra/api/gen/types.gen.ts
@@ -236,7 +236,7 @@ export type CloudProviderWithConfigInput = {
   validatedAt: string | null;
 };
 
-export type SupportedCloudProvidersInput = 'anthropic' | 'openai' | 'deepseek' | 'gemini' | 'ollama';
+export type SupportedCloudProvidersInput = 'anthropic' | 'openai' | 'deepseek' | 'gemini';
 
 export type SupportedCloudProviderModelInput = {
   id: string;
@@ -707,7 +707,7 @@ export type CloudProviderWithConfig = {
   validatedAt: string | null;
 };
 
-export type SupportedCloudProviders = 'anthropic' | 'openai' | 'deepseek' | 'gemini' | 'ollama';
+export type SupportedCloudProviders = 'anthropic' | 'openai' | 'deepseek' | 'gemini';
 
 export type SupportedCloudProviderModel = {
   id: string;


### PR DESCRIPTION
Fixes #435

## Summary
Removed Ollama from the Cloud Models page as it should only appear under Local Models.

## Changes
- Removed 'ollama' from `SupportedCloudProviderSchema` enum
- Removed Ollama entry from `PROVIDER_REGISTRY`
- Ollama remains correctly available as Local Models