### PR TITLE
fix: auto-refresh Ollama models list after download completes

### DIFF
--- a/desktop_app/src/ui/stores/ollama-store/index.ts
+++ b/desktop_app/src/ui/stores/ollama-store/index.ts
@@ -246,6 +246,15 @@ export const useOllamaStore = create<OllamaStore>((set, get) => ({
           }
         : state.downloadProgress,
     }));
+    
+    // When download is completed, refresh the installed models list
+    if (progress.status === 'completed') {
+      // Add a small delay to ensure Ollama has registered the model
+      setTimeout(() => {
+        get().fetchInstalledModels();
+        get().fetchRequiredModelsStatus();
+      }, 500);
+    }
   },
 }));
 

--- a/desktop_app/src/ui/stores/ollama-store/index.ts
+++ b/desktop_app/src/ui/stores/ollama-store/index.ts
@@ -246,7 +246,7 @@ export const useOllamaStore = create<OllamaStore>((set, get) => ({
           }
         : state.downloadProgress,
     }));
-    
+
     // When download is completed, refresh the installed models list
     if (progress.status === 'completed') {
       // Add a small delay to ensure Ollama has registered the model


### PR DESCRIPTION
## Description

This PR fixes the issue where newly downloaded Ollama models don't appear in the chat selector without a manual refresh (CMD+R or close + reopen the app).

https://www.loom.com/share/f01c7ad73cd04cdeaa432ec88920d68a

## Changes

- Modified the `updateRequiredModelDownloadProgress` function to refresh models list when download completes
- Added automatic refresh of both installed models and required models status
- Included 500ms delay to ensure Ollama has registered the new model

Fixes #451