### PR TITLE
fix: race condition with memory loading on chat reset

### DIFF
--- a/desktop_app/src/ui/components/Chat/ChatInput/index.tsx
+++ b/desktop_app/src/ui/components/Chat/ChatInput/index.tsx
@@ -41,6 +41,7 @@ interface ChatInputProps {
   handleSubmit: (e?: React.FormEvent<HTMLFormElement>) => void;
   isLoading: boolean;
   disabled: boolean;
+  rerunAgentDisabled: boolean;
   stop: () => void;
   hasMessages?: boolean;
   onRerunAgent?: () => void;
@@ -65,6 +66,7 @@ export default function ChatInput({
   handleSubmit,
   isLoading,
   disabled,
+  rerunAgentDisabled,
   stop,
   hasMessages = false,
   onRerunAgent,
@@ -632,7 +634,7 @@ export default function ChatInput({
             {hasMessages && onRerunAgent && (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <AIInputButton onClick={onRerunAgent} disabled={false} type="button" className="px-3">
+                  <AIInputButton onClick={onRerunAgent} disabled={rerunAgentDisabled} type="button" className="px-3">
                     <RefreshCw size={16} />
                     <span className="ml-1.5 text-sm">Restart Agent</span>
                   </AIInputButton>

--- a/desktop_app/src/ui/routes/chat.tsx
+++ b/desktop_app/src/ui/routes/chat.tsx
@@ -170,6 +170,8 @@ function ChatPage() {
       }
     },
   });
+
+  const chatIsSubmitted = status === 'submitted';
   const chatIsLoading = status === 'streaming';
   const chatHasError = status === 'error';
   const chatIsReady = status === 'ready';
@@ -505,26 +507,6 @@ function ChatPage() {
     return null;
   }
 
-  // Early return if no current chat exists (e.g., during deletion)
-  if (!currentChat) {
-    return (
-      <div className="flex flex-col h-full gap-2 max-w-full overflow-hidden">
-        <div className="flex-1 min-h-0 overflow-auto">
-          <EmptyChatState onPromptSelect={handlePromptSelect} />
-        </div>
-        <ChatInput
-          input=""
-          disabled={true}
-          isLoading={false}
-          handleInputChange={() => {}}
-          handleSubmit={() => {}}
-          stop={() => {}}
-          hasMessages={false}
-        />
-      </div>
-    );
-  }
-
   return (
     <div className="flex flex-col h-full gap-2 max-w-full overflow-hidden">
       {isChatEmpty && !pendingPrompt ? (
@@ -560,6 +542,7 @@ function ChatPage() {
           handleInputChange={handleInputChange}
           handleSubmit={handleSubmit}
           isLoading={chatIsLoading}
+          rerunAgentDisabled={chatIsSubmitted || chatIsLoading}
           disabled={isSubmittingDisabled}
           stop={stop}
           hasMessages={messages.length > 0}

--- a/desktop_app/src/ui/routes/chat.tsx
+++ b/desktop_app/src/ui/routes/chat.tsx
@@ -41,6 +41,7 @@ function ChatPage() {
   const { systemPrompt } = useDeveloperModeStore();
   const [hasLoadedMemories, setHasLoadedMemories] = useState(false);
   const [isLoadingMemories, setIsLoadingMemories] = useState(false);
+  const systemMemoryMessageRef = useRef<UIMessage | null>(null);
 
   const currentChat = getCurrentChat();
   const currentChatSessionId = currentChat?.sessionId || '';
@@ -54,6 +55,7 @@ function ChatPage() {
   useEffect(() => {
     setHasLoadedMemories(false);
     setIsLoadingMemories(false);
+    systemMemoryMessageRef.current = null;
   }, [currentChatSessionId]);
 
   // We use useRef because prepareSendMessagesRequest captures values when created.
@@ -86,6 +88,12 @@ function ChatPage() {
         const cloudModel = currentCloudProviderModels.find((m) => m.id === currentModel);
         const provider = cloudModel ? cloudModel.provider : 'ollama';
 
+        // Ensure system-memories message is included if it exists
+        let messagesToSend = messages;
+        if (systemMemoryMessageRef.current && !messages.some((msg) => msg.id === 'system-memories')) {
+          messagesToSend = [systemMemoryMessageRef.current, ...messages];
+        }
+
         // Prepend system prompt as a system message if it exists
         const messagesWithSystemPrompt = currentSystemPrompt
           ? [
@@ -94,9 +102,9 @@ function ChatPage() {
                 role: 'system',
                 parts: [{ type: 'text', text: currentSystemPrompt }],
               },
-              ...messages,
+              ...messagesToSend,
             ]
-          : messages;
+          : messagesToSend;
 
         return {
           body: {
@@ -112,7 +120,7 @@ function ChatPage() {
         };
       },
     });
-  }, [currentChatSessionId, getCurrentChat]);
+  }, [currentChatSessionId, getCurrentChat, systemMemoryMessageRef]);
 
   const { sendMessage, messages, setMessages, stop, status, regenerate } = useChat({
     id: currentChatSessionId || 'temp-id', // use the provided chat ID or a temp ID
@@ -314,6 +322,9 @@ function ChatPage() {
             parts: [{ type: 'text', text: `Previous memories loaded:\n${memoriesText}` }],
           };
 
+          // Save the system message to ref for later use
+          systemMemoryMessageRef.current = systemMessage;
+
           // Prepend the system message to the messages
           // If forceLoad is true (restart scenario), replace all messages
           // Otherwise, prepend to existing messages
@@ -330,12 +341,14 @@ function ChatPage() {
           return true;
         } else {
           console.log('No memories found to load');
+          systemMemoryMessageRef.current = null;
           setHasLoadedMemories(true);
           return false;
         }
       } catch (error) {
         console.error('Failed to load memories:', error);
         // Continue even if memory loading fails
+        systemMemoryMessageRef.current = null;
         setHasLoadedMemories(true);
         return false;
       } finally {
@@ -417,10 +430,10 @@ function ChatPage() {
     setIsLoadingMemories(false);
 
     // Small delay to ensure state updates are processed
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await new Promise((resolve) => setTimeout(resolve, 100));
 
     // Force load memories even though messages might not be empty yet
-    await loadMemoriesIfNeeded(true);
+    const memoriesLoaded = await loadMemoriesIfNeeded(true);
 
     // Check if more than 20 tools are selected and reset to default if so
     if (selectedToolIds.size > 20) {
@@ -433,6 +446,22 @@ function ChatPage() {
     sendMessage({ text: messageText });
     if (currentChat) {
       setPendingPrompts(currentChatSessionId, messageText);
+    }
+
+    // If memories were loaded, ensure the system message persists
+    // We use the ref to access the system message since it was saved during loadMemoriesIfNeeded
+    if (memoriesLoaded && systemMemoryMessageRef.current) {
+      // Use setTimeout to ensure this runs after sendMessage updates
+      setTimeout(() => {
+        setMessages((currentMessages) => {
+          const hasSystemMessage = currentMessages.some((msg) => msg.id === 'system-memories');
+          if (!hasSystemMessage && systemMemoryMessageRef.current) {
+            // Re-add the system message at the beginning
+            return [systemMemoryMessageRef.current, ...currentMessages];
+          }
+          return currentMessages;
+        });
+      }, 100);
     }
   };
 

--- a/desktop_app/src/ui/routes/chat.tsx
+++ b/desktop_app/src/ui/routes/chat.tsx
@@ -8,8 +8,14 @@ import ChatInput from '@ui/components/Chat/ChatInput';
 import EmptyChatState from '@ui/components/Chat/EmptyChatState';
 import SystemPrompt from '@ui/components/Chat/SystemPrompt';
 import config from '@ui/config';
-import { getAllMemories } from '@ui/lib/clients/archestra/api/gen';
-import { useChatStore, useCloudProvidersStore, useDeveloperModeStore, useOllamaStore, useToolsStore } from '@ui/stores';
+import {
+  useChatStore,
+  useCloudProvidersStore,
+  useDeveloperModeStore,
+  useMemoryStore,
+  useOllamaStore,
+  useToolsStore,
+} from '@ui/stores';
 import { useStatusBarStore } from '@ui/stores/status-bar-store';
 
 import { DEFAULT_ARCHESTRA_TOOLS } from '../../constants';
@@ -38,29 +44,32 @@ function ChatPage() {
     deleteMessage,
     setEditingMessageContent,
     updateMessages,
+    pendingPrompts,
+    setPendingPrompts,
+    removePendingPrompt,
   } = useChatStore();
   const { selectedToolIds, setOnlyTools } = useToolsStore();
   const { selectedModel } = useOllamaStore();
   const { availableCloudProviderModels } = useCloudProvidersStore();
   const { setChatInference } = useStatusBarStore();
   const { getSystemPrompt } = useDeveloperModeStore();
-  const [hasLoadedMemories, setHasLoadedMemories] = useState(false);
-  const [isLoadingMemories, setIsLoadingMemories] = useState(false);
-  const systemMemoryMessageRef = useRef<UIMessage | null>(null);
+  const { memories, isLoading: isLoadingMemories } = useMemoryStore();
+
+  const [regeneratingIndex, setRegeneratingIndex] = useState<number | null>(null);
+  const [fullMessagesBackup, setFullMessagesBackup] = useState<UIMessage[]>([]);
+
+  // Track pre-generation loading state (between submission and streaming start)
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submissionStartTime, setSubmissionStartTime] = useState<number>(Date.now());
 
   const currentChat = getCurrentChat();
   const currentChatSessionId = currentChat?.sessionId || '';
   const currentChatTitle = getCurrentChatTitle();
 
+  const pendingPrompt = pendingPrompts.get(currentChatSessionId);
+
   // Get current input from draft messages
   const currentInput = currentChat ? getDraftMessage(currentChat.id) : '';
-
-  // Reset memory loading flag when chat changes
-  useEffect(() => {
-    setHasLoadedMemories(false);
-    setIsLoadingMemories(false);
-    systemMemoryMessageRef.current = null;
-  }, [currentChatSessionId]);
 
   // We use useRef because prepareSendMessagesRequest captures values when created.
   // Without ref, switching models/providers wouldn't work - it would always use the old values.
@@ -78,11 +87,22 @@ function ChatPage() {
   const systemPromptRef = useRef(systemPrompt);
   systemPromptRef.current = systemPrompt;
 
-  const transport = useMemo(() => {
-    const apiEndpoint = `${chatStreamBaseUrl}/stream`;
+  const memoriesText = memories.map((m) => `${m.name}: ${m.value}`).join('\n');
+  const memoriesUIMessage = useMemo(
+    () =>
+      (memoriesText
+        ? {
+            id: systemMemoriesMessageId,
+            role: 'system',
+            parts: [{ type: 'text', text: `Previous memories loaded:\n${memoriesText}` }],
+          }
+        : null) as UIMessage | null,
+    [memoriesText]
+  );
 
+  const transport = useMemo(() => {
     return new DefaultChatTransport({
-      api: apiEndpoint,
+      api: `${chatStreamBaseUrl}/stream`,
       prepareSendMessagesRequest: ({ id, messages }) => {
         const currentModel = selectedModelRef.current;
         const currentCloudProviderModels = availableCloudProviderModelsRef.current;
@@ -94,9 +114,6 @@ function ChatPage() {
 
         // Ensure system-memories message is included if it exists
         let messagesToSend = messages;
-        if (systemMemoryMessageRef.current && !messages.some((msg) => msg.id === 'system-memories')) {
-          messagesToSend = [systemMemoryMessageRef.current, ...messages];
-        }
 
         // Prepend system prompt as a system message if it exists
         const messagesWithSystemPrompt = currentSystemPrompt
@@ -113,7 +130,7 @@ function ChatPage() {
         return {
           body: {
             messages: messagesWithSystemPrompt,
-            model: currentModel || 'llama3.1:8b',
+            model: currentModel,
             sessionId: id || currentChatSessionId,
             provider: provider,
             // Include chatId so backend can load chat-specific tools
@@ -124,7 +141,7 @@ function ChatPage() {
         };
       },
     });
-  }, [currentChatSessionId, getCurrentChat, systemMemoryMessageRef]);
+  }, [currentChatSessionId, getCurrentChat]);
 
   const { sendMessage, messages, setMessages, stop, status, regenerate } = useChat({
     id: currentChatSessionId || 'temp-id', // use the provided chat ID or a temp ID
@@ -152,18 +169,19 @@ function ChatPage() {
       }
     },
   });
+  const chatIsLoading = status === 'streaming';
+  const chatHasError = status === 'error';
+  const chatIsReady = status === 'ready';
 
-  // ================ Running on background logic ================ //
-  const pendingPrompts = useChatStore((s) => s.pendingPrompts);
-  const setPendingPrompts = useChatStore((s) => s.setPendingPrompts);
-  const removePendingPrompt = useChatStore((s) => s.removePendingPrompt);
+  const isSubmittingDisabled = !currentInput.trim() || chatIsLoading || isSubmitting || !!pendingPrompt;
+  const isChatEmpty = messages.length === 0;
 
-  const pendingPrompt = pendingPrompts.get(currentChatSessionId);
-
-  // When streaming finishes and there is an assistant reply and the second to
-  // last message is the same as the pending prompt, remove the pending prompt
+  /**
+   * When streaming finishes and there is an assistant reply and the second to
+   * last message is the same as the pending prompt, remove the pending prompt
+   */
   useEffect(() => {
-    if (status === 'ready' && currentChatSessionId) {
+    if (chatIsReady && currentChatSessionId) {
       const secondToLastMessage = messages.at(-2);
       const lastMessage = messages.at(-1);
 
@@ -173,87 +191,95 @@ function ChatPage() {
 
       if (isLastMessageAssistant && isSecondToLastMessageSameAsPendingPrompt) removePendingPrompt(currentChatSessionId);
     }
-  }, [status, currentChatSessionId, messages]);
-  // ================================== //
-
-  const isLoading = status === 'streaming';
-  const [regeneratingIndex, setRegeneratingIndex] = useState<number | null>(null);
-  const [fullMessagesBackup, setFullMessagesBackup] = useState<UIMessage[]>([]);
-
-  // Track pre-generation loading state (between submission and streaming start)
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [submissionStartTime, setSubmissionStartTime] = useState<number>(Date.now());
+  }, [chatIsReady, currentChatSessionId, messages]);
 
   // Wrapper functions for message editing actions
-  const handleSaveEdit = async (messageId: string) => {
-    // Save the updated messages in the zustand store
-    const updatedMessages = await saveEditMessage(messageId, messages);
-    // Also update local messages state
-    setMessages(updatedMessages);
-  };
+  const handleSaveEdit = useCallback(
+    async (messageId: string) => {
+      // Save the updated messages in the zustand store
+      const updatedMessages = await saveEditMessage(messageId, messages);
+      // Also update local messages state
+      setMessages(updatedMessages);
+    },
+    [messages, saveEditMessage]
+  );
 
-  const handleDeleteMessage = async (messageId: string) => {
-    await deleteMessage(messageId, messages);
-    // Also update local messages state
-    setMessages(messages.filter((msg) => msg.id !== messageId));
-  };
+  const handleDeleteMessage = useCallback(
+    async (messageId: string) => {
+      await deleteMessage(messageId, messages);
+      // Also update local messages state
+      setMessages(messages.filter((msg) => msg.id !== messageId));
+    },
+    [messages, deleteMessage]
+  );
 
   // Handle regeneration for specific message index
-  const handleRegenerateMessage = async (messageIndex: number) => {
-    const messageToRegenerate = messages[messageIndex];
+  const handleRegenerateMessage = useCallback(
+    async (messageIndex: number) => {
+      const messageToRegenerate = messages[messageIndex];
 
-    if (!messageToRegenerate || messageToRegenerate.role !== 'assistant') {
-      console.error('Can only regenerate assistant messages');
-      return;
-    }
+      if (!messageToRegenerate || messageToRegenerate.role !== 'assistant') {
+        console.error('Can only regenerate assistant messages');
+        return;
+      }
 
-    setRegeneratingIndex(messageIndex);
+      setRegeneratingIndex(messageIndex);
 
-    // Store the full messages array for display purposes
-    setFullMessagesBackup(messages);
+      // Store the full messages array for display purposes
+      setFullMessagesBackup(messages);
 
-    // Create a truncated conversation for the API call only
-    const conversationUpToAssistant = messages.slice(0, messageIndex + 1);
+      // Create a truncated conversation for the API call only
+      const conversationUpToAssistant = messages.slice(0, messageIndex + 1);
 
-    // Temporarily set messages to truncated version for API call
-    setMessages(conversationUpToAssistant);
+      // Temporarily set messages to truncated version for API call
+      setMessages(conversationUpToAssistant);
 
-    // Use the built-in regenerate function which will regenerate the last assistant message
-    regenerate();
-  };
+      // Use the built-in regenerate function which will regenerate the last assistant message
+      regenerate();
+    },
+    [messages, regenerate]
+  );
 
   // Track inference in StatusBar
   useEffect(() => {
-    if (status === 'streaming' || isSubmitting) {
+    if (chatIsLoading || isSubmitting) {
       setChatInference(currentChatSessionId, currentChatTitle, true);
-    } else if (status === 'ready' || status === 'error') {
+    } else if (chatIsReady || chatHasError) {
       // Only stop inference when this specific chat is done
       setChatInference(currentChatSessionId, currentChatTitle, false);
     }
-  }, [status, isSubmitting, currentChatSessionId, currentChatTitle, setChatInference]);
+  }, [
+    chatIsLoading,
+    isSubmitting,
+    chatIsReady,
+    chatHasError,
+    currentChatSessionId,
+    currentChatTitle,
+    setChatInference,
+  ]);
 
   useEffect(() => {
-    if (isLoading) {
+    if (chatIsLoading) {
       setIsSubmitting(false);
     }
-  }, [isLoading]);
+  }, [chatIsLoading]);
 
   useEffect(() => {
-    if (status === 'ready' || status === 'error') {
+    if (chatIsReady || chatHasError) {
       setIsSubmitting(false);
     }
 
     // Handle error case during regeneration - restore backup messages
-    if (status === 'error' && regeneratingIndex !== null && fullMessagesBackup.length > 0) {
+    if (chatHasError && regeneratingIndex !== null && fullMessagesBackup.length > 0) {
       setMessages(fullMessagesBackup);
       setFullMessagesBackup([]);
       setRegeneratingIndex(null);
     }
-  }, [status, regeneratingIndex, fullMessagesBackup]);
+  }, [chatIsReady, chatHasError, regeneratingIndex, fullMessagesBackup]);
 
   // Clear regenerating state and merge new message when streaming finishes
   useEffect(() => {
-    if (status === 'ready' && regeneratingIndex !== null && fullMessagesBackup.length > 0) {
+    if (chatIsReady && regeneratingIndex !== null && fullMessagesBackup.length > 0) {
       // Get the new regenerated message (last message in the current truncated array)
       const newRegeneratedMessage = messages[messages.length - 1];
 
@@ -271,11 +297,11 @@ function ChatPage() {
 
       setFullMessagesBackup([]);
       setRegeneratingIndex(null);
-    } else if (status === 'ready' && regeneratingIndex !== null) {
+    } else if (chatIsReady && regeneratingIndex !== null) {
       // No backup to restore, just clear the regenerating state
       setRegeneratingIndex(null);
     }
-  }, [status, regeneratingIndex, fullMessagesBackup, messages]);
+  }, [chatIsReady, regeneratingIndex, fullMessagesBackup, messages]);
 
   // Add a ref to track the last loaded chat
   const lastLoadedChatIdRef = useRef<string | null>(null);
@@ -303,7 +329,7 @@ function ChatPage() {
   useEffect(() => {
     // Sync messages back to store with debouncing
     // Only sync when we have a valid chat and messages
-    if (currentChat && messages.length > 0 && !isLoading) {
+    if (currentChat && messages.length > 0 && !chatIsLoading) {
       // Clear existing timeout
       if (messageSyncTimeoutRef.current) {
         clearTimeout(messageSyncTimeoutRef.current);
@@ -321,7 +347,7 @@ function ChatPage() {
         clearTimeout(messageSyncTimeoutRef.current);
       }
     };
-  }, [messages, currentChat?.id, isLoading, updateMessages]);
+  }, [messages, currentChat?.id, chatIsLoading, updateMessages]);
 
   // Simple debounce implementation
   const debounceRef = useRef<NodeJS.Timeout | null>(null);
@@ -345,116 +371,76 @@ function ChatPage() {
     };
   }, []);
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const newValue = e.target.value;
-    if (currentChat) {
-      // Immediately update UI by saving to store without debounce
-      saveDraftMessage(currentChat.id, newValue);
-      // Also save with debounce for potential future persistence
-      debouncedSaveDraft(currentChat.id, newValue);
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const newValue = e.target.value;
+      if (currentChat) {
+        // Immediately update UI by saving to store without debounce
+        saveDraftMessage(currentChat.id, newValue);
+        // Also save with debounce for potential future persistence
+        debouncedSaveDraft(currentChat.id, newValue);
+      }
+    },
+    [currentChat, saveDraftMessage, debouncedSaveDraft]
+  );
+
+  /**
+   * Check if more than 20 tools are selected and reset to default if so
+   */
+  const conditionallyResetTools = useCallback(() => {
+    if (selectedToolIds.size > 20) {
+      setOnlyTools(DEFAULT_ARCHESTRA_TOOLS);
     }
-  };
+  }, [selectedToolIds, setOnlyTools]);
 
-  const loadMemoriesIfNeeded = async (forceLoad = false): Promise<boolean> => {
-    // Only load memories for the first message in a chat
-    if ((forceLoad || messages.length === 0) && !hasLoadedMemories && !isLoadingMemories) {
-      setIsLoadingMemories(true);
-      try {
-        const { data } = await getAllMemories();
-        if (data && data.memories && data.memories.length > 0) {
-          // Format memories for logging
-          const memoriesText = data.memories.map((m) => `${m.name}: ${m.value}`).join('\n');
+  const handleSubmit = useCallback(
+    async (e?: React.FormEvent<HTMLFormElement>) => {
+      e?.preventDefault();
 
-          // Log memories to console instead of showing in UI
-          console.log('Previous memories loaded:');
-          console.log(memoriesText);
-          console.log(`Total memories loaded: ${data.memories.length}`);
-
-          // Add a system message with the memories (but don't display it)
-          const systemMessage: UIMessage = {
-            id: systemMemoriesMessageId,
-            role: 'system',
-            parts: [{ type: 'text', text: `Previous memories loaded:\n${memoriesText}` }],
-          };
-
-          // Save the system message to ref for later use
-          systemMemoryMessageRef.current = systemMessage;
-
-          // Prepend the system message to the messages
-          // If forceLoad is true (restart scenario), replace all messages
-          // Otherwise, prepend to existing messages
-          if (forceLoad) {
-            setMessages([systemMessage]);
-          } else {
-            setMessages((prevMessages) => [systemMessage, ...prevMessages]);
-          }
-
-          // Wait for next tick to ensure state is updated
-          await new Promise((resolve) => setTimeout(resolve, 0));
-
-          setHasLoadedMemories(true);
-          return true;
-        } else {
-          console.log('No memories found to load');
-          systemMemoryMessageRef.current = null;
-          setHasLoadedMemories(true);
-          return false;
+      if (isSubmittingDisabled) {
+        return;
+      } else if (currentInput.trim() && currentChat) {
+        if (messages.length === 0 && memoriesUIMessage) {
+          setMessages([memoriesUIMessage]);
         }
-      } catch (error) {
-        console.error('Failed to load memories:', error);
-        // Continue even if memory loading fails
-        systemMemoryMessageRef.current = null;
-        setHasLoadedMemories(true);
-        return false;
-      } finally {
-        setIsLoadingMemories(false);
+
+        conditionallyResetTools();
+
+        setIsSubmitting(true);
+        setSubmissionStartTime(Date.now());
+        sendMessage({ text: currentInput });
+        setPendingPrompts(currentChatSessionId, currentInput);
+        clearDraftMessage(currentChat.id);
       }
-    }
-    return false;
-  };
+    },
+    [
+      isSubmittingDisabled,
+      currentInput,
+      currentChat,
+      messages,
+      memoriesUIMessage,
+      setMessages,
+      conditionallyResetTools,
+      sendMessage,
+      setPendingPrompts,
+      clearDraftMessage,
+    ]
+  );
 
-  const handleSubmit = async (e?: React.FormEvent<HTMLFormElement>) => {
-    e?.preventDefault();
-    if (isSubmittingDisabled) return;
-    if (currentInput.trim() && currentChat) {
-      // Load memories before sending the first message
-      await loadMemoriesIfNeeded();
-
-      // Check if more than 20 tools are selected and reset to default if so
-      if (selectedToolIds.size > 20) {
-        await setOnlyTools(DEFAULT_ARCHESTRA_TOOLS);
-      }
-
-      const messageText = currentInput;
+  const handlePromptSelect = useCallback(
+    async (prompt: string) => {
+      conditionallyResetTools();
 
       setIsSubmitting(true);
       setSubmissionStartTime(Date.now());
-      sendMessage({ text: messageText });
-      setPendingPrompts(currentChatSessionId, messageText);
-      clearDraftMessage(currentChat.id);
-    }
-  };
 
-  const handlePromptSelect = async (prompt: string) => {
-    // If this is the first message in the chat, load memories first
-    if (messages.length === 0 && !hasLoadedMemories) {
-      // Load memories before sending the first message
-      // The function now properly waits for state updates
-      await loadMemoriesIfNeeded();
-    }
+      // Directly send the prompt when a tile is clicked
+      sendMessage({ text: prompt });
+    },
+    [conditionallyResetTools, sendMessage]
+  );
 
-    // Check if more than 20 tools are selected and reset to default if so
-    if (selectedToolIds.size > 20) {
-      await setOnlyTools(DEFAULT_ARCHESTRA_TOOLS);
-    }
-
-    setIsSubmitting(true);
-    setSubmissionStartTime(Date.now());
-    // Directly send the prompt when a tile is clicked
-    sendMessage({ text: prompt });
-  };
-
-  const handleRerunAgent = async () => {
+  const handleRerunAgent = useCallback(async () => {
     // Get the first user message (the original prompt)
     const firstUserMessage = messages.find((msg) => msg.role === 'user');
 
@@ -477,57 +463,31 @@ function ChatPage() {
       return;
     }
 
-    // Clear all messages to start fresh
-    setMessages([]);
-
-    // Reset memory loading flags to load memories again
-    setHasLoadedMemories(false);
-    setIsLoadingMemories(false);
-
-    // Small delay to ensure state updates are processed
-    await new Promise((resolve) => setTimeout(resolve, 100));
-
-    // Force load memories even though messages might not be empty yet
-    const memoriesLoaded = await loadMemoriesIfNeeded(true);
-
-    // Check if more than 20 tools are selected and reset to default if so
-    if (selectedToolIds.size > 20) {
-      await setOnlyTools(DEFAULT_ARCHESTRA_TOOLS);
-    }
+    setMessages(memoriesUIMessage ? [memoriesUIMessage] : []);
+    conditionallyResetTools();
 
     // Re-run with the first user message
     setIsSubmitting(true);
     setSubmissionStartTime(Date.now());
     sendMessage({ text: messageText });
+
     if (currentChat) {
       setPendingPrompts(currentChatSessionId, messageText);
     }
-
-    // If memories were loaded, ensure the system message persists
-    // We use the ref to access the system message since it was saved during loadMemoriesIfNeeded
-    if (memoriesLoaded && systemMemoryMessageRef.current) {
-      // Use setTimeout to ensure this runs after sendMessage updates
-      setTimeout(() => {
-        setMessages((currentMessages) => {
-          const hasSystemMessage = currentMessages.some((msg) => msg.id === 'system-memories');
-          if (!hasSystemMessage && systemMemoryMessageRef.current) {
-            // Re-add the system message at the beginning
-            return [systemMemoryMessageRef.current, ...currentMessages];
-          }
-          return currentMessages;
-        });
-      }, 100);
-    }
-  };
-
-  const isSubmittingDisabled = !currentInput.trim() || isLoading || isSubmitting || !!pendingPrompt;
+  }, [
+    messages,
+    memoriesUIMessage,
+    currentChatSessionId,
+    currentChat,
+    conditionallyResetTools,
+    setMessages,
+    sendMessage,
+    setPendingPrompts,
+  ]);
 
   if (!currentChat) {
-    // TODO: this is a temporary solution, maybe let's make some cool loading animations with a mascot?
     return null;
   }
-
-  const isChatEmpty = messages.length === 0;
 
   // Early return if no current chat exists (e.g., during deletion)
   if (!currentChat) {
@@ -570,22 +530,20 @@ function ChatPage() {
             onEditChange={setEditingMessageContent}
             onDeleteMessage={handleDeleteMessage}
             onRegenerateMessage={handleRegenerateMessage}
-            isRegenerating={regeneratingIndex !== null || isLoading}
+            isRegenerating={regeneratingIndex !== null || chatIsLoading}
             regeneratingIndex={regeneratingIndex}
             isSubmitting={isSubmitting}
             submissionStartTime={submissionStartTime}
           />
         </div>
       )}
-
       <SystemPrompt />
-
       <div className="flex-shrink-0">
         <ChatInput
           input={currentInput}
           handleInputChange={handleInputChange}
           handleSubmit={handleSubmit}
-          isLoading={isLoading}
+          isLoading={chatIsLoading}
           disabled={isSubmittingDisabled}
           stop={stop}
           hasMessages={messages.length > 0}


### PR DESCRIPTION
Fixes #411

https://www.loom.com/share/0ea86450c1a94e49a285ee57d8354590

## Description

- fixes a race condition w/ displaying the green "memory panel" inconsistently after resetting the chat
- fixed bug w/ "Restart Agent" button (previously you could smash that button as much as you wanted while the AI response was still pending)
- fixed bug w/ chat title summarization; previously we were including system/"memory" messages in that prompt