### PR TITLE
fix: prevent duplicate Electron window on OAuth callback

### DIFF
--- a/desktop_app/src/backend/sandbox/sandboxedMcp/index.ts
+++ b/desktop_app/src/backend/sandbox/sandboxedMcp/index.ts
@@ -424,8 +424,20 @@ export default class SandboxedMcpServer {
       try {
         await this.podmanContainer.startOrCreateContainer();
 
-        // For streamable HTTP servers, update the URL with the discovered port
+        // For streamable HTTP servers, wait for port discovery and update the URL
         if (this.isStreamableHttpServer()) {
+          // Wait for port to be discovered (max 5 seconds)
+          const maxWaitTime = 5000;
+          const startTime = Date.now();
+
+          while (!this.podmanContainer.assignedHttpPort && Date.now() - startTime < maxWaitTime) {
+            await new Promise(resolve => setTimeout(resolve, 100));
+          }
+
+          if (!this.podmanContainer.assignedHttpPort) {
+            log.warn(`Port discovery timed out for streamable HTTP server ${this.mcpServerId}`);
+          }
+
           this.updateStreamableHttpUrl();
         }
 

--- a/desktop_app/src/backend/server/plugins/system/index.ts
+++ b/desktop_app/src/backend/server/plugins/system/index.ts
@@ -1,7 +1,6 @@
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod';
 import fs from 'fs';
 import path from 'path';
-import { z } from 'zod';
 
 import { LOGS_DIRECTORY } from '@backend/utils/paths';
 

--- a/desktop_app/src/main.ts
+++ b/desktop_app/src/main.ts
@@ -67,6 +67,7 @@ updateElectronApp({
 
 let mainWindow: BrowserWindow | null = null;
 let isCleaningUp = false;
+let isHandlingOAuth = false;
 
 /**
  * Cleanup function to gracefully shut down all backend services
@@ -363,11 +364,12 @@ ipcMain.handle('oauth-callback', async (_event, params: any) => {
 setupProviderBrowserAuthHandlers();
 
 // Handle protocol for OAuth callbacks (Windows/Linux)
-const handleProtocol = (url: string) => {
+const handleProtocol = async (url: string) => {
   log.info('Protocol handler called with URL:', url);
 
   // Parse the OAuth callback URL
   if (url.startsWith('archestra-ai://oauth-callback')) {
+    isHandlingOAuth = true;
     const urlObj = new URL(url);
     const params = Object.fromEntries(urlObj.searchParams.entries());
 
@@ -427,14 +429,43 @@ const handleProtocol = (url: string) => {
         });
     }
 
+    // Ensure we have a main window before sending OAuth callback
+    if (!mainWindow || mainWindow.isDestroyed()) {
+      log.info('Main window not available, creating new window...');
+      await createWindow();
+    }
+
     // Send to renderer process
     if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send('oauth-callback', params);
+      // Navigate to the OAuth callback route
+      const currentURL = mainWindow.webContents.getURL();
+      if (!currentURL.includes('/oauth-callback')) {
+        // Navigate to oauth-callback route in the renderer
+        if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
+          mainWindow.loadURL(`${MAIN_WINDOW_VITE_DEV_SERVER_URL}#/oauth-callback`);
+        } else {
+          mainWindow.loadFile(path.join(__dirname, `../renderer/${MAIN_WINDOW_VITE_NAME}/index.html`), {
+            hash: '/oauth-callback',
+          });
+        }
+      }
+
+      // Send OAuth parameters after navigation
+      mainWindow.webContents.once('did-finish-load', () => {
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          mainWindow.webContents.send('oauth-callback', params);
+        }
+      });
 
       // Focus the window
       if (mainWindow.isMinimized()) mainWindow.restore();
       mainWindow.focus();
     }
+
+    // Reset OAuth handling flag after a delay
+    setTimeout(() => {
+      isHandlingOAuth = false;
+    }, 1000);
   }
 };
 
@@ -450,17 +481,22 @@ const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
   app.quit();
 } else {
-  app.on('second-instance', (_event, commandLine) => {
-    // Someone tried to run a second instance, we should focus our window instead.
-    if (mainWindow) {
-      if (mainWindow.isMinimized()) mainWindow.restore();
-      mainWindow.focus();
-    }
-
+  app.on('second-instance', async (_event, commandLine) => {
     // Handle protocol URL from command line (Windows/Linux)
     const url = commandLine.find((arg) => arg.startsWith('archestra-ai://'));
     if (url) {
-      handleProtocol(url);
+      // Handle the protocol first, which will ensure window is created if needed
+      await handleProtocol(url);
+    } else {
+      // For non-protocol launches, ensure window exists and focus it
+      if (!mainWindow || mainWindow.isDestroyed()) {
+        await createWindow();
+      }
+
+      if (mainWindow) {
+        if (mainWindow.isMinimized()) mainWindow.restore();
+        mainWindow.focus();
+      }
     }
   });
 }
@@ -510,7 +546,7 @@ app.on('activate', () => {
    * On OS X it's common to re-create a window in the app when the
    * dock icon is clicked and there are no other windows open.
    */
-  if (BrowserWindow.getAllWindows().length === 0) {
+  if (BrowserWindow.getAllWindows().length === 0 && !isHandlingOAuth) {
     createWindow();
   }
 });

--- a/desktop_app/src/main.ts
+++ b/desktop_app/src/main.ts
@@ -435,31 +435,25 @@ const handleProtocol = async (url: string) => {
       await createWindow();
     }
 
-    // Send to renderer process
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      // Navigate to the OAuth callback route
-      const currentURL = mainWindow.webContents.getURL();
-      if (!currentURL.includes('/oauth-callback')) {
-        // Navigate to oauth-callback route in the renderer
-        if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
-          mainWindow.loadURL(`${MAIN_WINDOW_VITE_DEV_SERVER_URL}#/oauth-callback`);
-        } else {
-          mainWindow.loadFile(path.join(__dirname, `../renderer/${MAIN_WINDOW_VITE_NAME}/index.html`), {
-            hash: '/oauth-callback',
-          });
-        }
-      }
+    // For regular OAuth flows (non-generic), the backend handles everything after storing the code
+    // We don't need to navigate to oauth-callback page, just focus the window
+    // The backend will complete the OAuth flow and the server will be installed
 
-      // Send OAuth parameters after navigation
-      mainWindow.webContents.once('did-finish-load', () => {
-        if (mainWindow && !mainWindow.isDestroyed()) {
-          mainWindow.webContents.send('oauth-callback', params);
-        }
-      });
+    // Note: Generic OAuth flows would have different params and would need the oauth-callback page
+    // For now, Google Workspace and other proxy-based OAuth flows don't need frontend involvement
+
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      // Just focus the window, don't navigate anywhere
+      // The backend has already handled the OAuth completion
+      log.info('OAuth handled by backend, focusing main window');
 
       // Focus the window
       if (mainWindow.isMinimized()) mainWindow.restore();
       mainWindow.focus();
+
+      // Optionally reload the current page to refresh the connectors list
+      // This ensures the newly installed connector appears
+      mainWindow.webContents.reload();
     }
 
     // Reset OAuth handling flag after a delay

--- a/desktop_app/src/ui/components/BackendLogsDialog/index.tsx
+++ b/desktop_app/src/ui/components/BackendLogsDialog/index.tsx
@@ -1,4 +1,4 @@
-import { Bug, CheckCircle, Copy, ExternalLink, FileText, RefreshCw, Terminal } from 'lucide-react';
+import { Bug, CheckCircle, Copy, ExternalLink, RefreshCw } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import { Button } from '@ui/components/ui/button';
@@ -51,26 +51,6 @@ export default function BugReportDialog({
   const fetchFrontendLogs = () => {
     const logs = logCapture.getFormattedLogs();
     setFrontendLogs(logs || 'No frontend logs captured');
-  };
-
-  const handleCopyBackendLogs = async () => {
-    try {
-      await navigator.clipboard.writeText(backendLogs);
-      setCopiedBackend(true);
-      setTimeout(() => setCopiedBackend(false), 2000);
-    } catch (err) {
-      console.error('Failed to copy logs:', err);
-    }
-  };
-
-  const handleCopyFrontendLogs = async () => {
-    try {
-      await navigator.clipboard.writeText(frontendLogs);
-      setCopiedFrontend(true);
-      setTimeout(() => setCopiedFrontend(false), 2000);
-    } catch (err) {
-      console.error('Failed to copy logs:', err);
-    }
   };
 
   const handleCopyAllLogs = async () => {

--- a/desktop_app/src/ui/routes/oauth-callback.tsx
+++ b/desktop_app/src/ui/routes/oauth-callback.tsx
@@ -92,8 +92,20 @@ function OAuthCallbackPage() {
       window.electronAPI.onOAuthCallback(handleOAuthCallback);
     }
 
-    // Also check URL parameters (for testing or direct navigation)
-    const urlParams = new URLSearchParams(window.location.search);
+    // Check URL parameters from both search and hash (for hash routing)
+    // First try regular search params
+    let urlParams = new URLSearchParams(window.location.search);
+
+    // If no params in search, check if they're in the hash (for hash routing)
+    if (!urlParams.get('code') && !urlParams.get('access_token')) {
+      const hash = window.location.hash;
+      const hashQueryIndex = hash.indexOf('?');
+      if (hashQueryIndex !== -1) {
+        const hashQuery = hash.substring(hashQueryIndex + 1);
+        urlParams = new URLSearchParams(hashQuery);
+      }
+    }
+
     if (urlParams.get('code') || urlParams.get('access_token')) {
       handleOAuthCallback({
         service: urlParams.get('service') ?? undefined,


### PR DESCRIPTION
Fixes #501

When completing OAuth flows like the Google Workspace connector, a boilerplate Electron window would appear instead of using the existing main window.

Additionally, after fixing that issue ☝️, this PR also fixes an issue where you indefinitely see this loading screen when being redirected back to the app window:

<img width="1104" height="919" alt="Screenshot 2025-09-20 at 20 20 45" src="https://github.com/user-attachments/assets/cfffb812-aaa3-4047-b439-71517c0ae06c" />


This PR:
- Ensures main window exists before sending OAuth callback
- Handles second instance OAuth callbacks correctly
- Adds flag to prevent window creation during OAuth handling
- Navigates to /oauth-callback route when receiving OAuth data