### PR TITLE
feat: implement slash command support for chat input (#487)

### DIFF
--- a/desktop_app/src/ui/components/Chat/SlashCommandDropdown/index.tsx
+++ b/desktop_app/src/ui/components/Chat/SlashCommandDropdown/index.tsx
@@ -1,0 +1,196 @@
+import { ChevronRight, Command, Cpu, Hash, HelpCircle, Minimize2, RotateCcw, Sparkles, Wrench } from 'lucide-react';
+import React, { memo, useCallback, useMemo } from 'react';
+
+import { SlashCommand } from '@ui/lib/utils/slash-commands';
+import { cn } from '@ui/lib/utils/tailwind';
+
+interface SlashCommandSuggestion {
+  command: SlashCommand;
+  description: string;
+}
+
+interface SlashCommandDropdownProps {
+  suggestions: SlashCommandSuggestion[];
+  selectedIndex: number;
+  onSelect: (command: SlashCommand) => void;
+  visible: boolean;
+  inputRect?: DOMRect;
+}
+
+const getCommandIcon = (command: SlashCommand) => {
+  switch (command) {
+    case SlashCommand.CLEAR:
+      return <Sparkles className="w-4 h-4" />;
+    case SlashCommand.COMPACT:
+      return <Minimize2 className="w-4 h-4" />;
+    case SlashCommand.HELP:
+      return <HelpCircle className="w-4 h-4" />;
+    case SlashCommand.RETRY:
+      return <RotateCcw className="w-4 h-4" />;
+    case SlashCommand.MODELS:
+      return <Cpu className="w-4 h-4" />;
+    case SlashCommand.TOOLS:
+      return <Wrench className="w-4 h-4" />;
+    default:
+      return <Command className="w-4 h-4" />;
+  }
+};
+
+const getCommandCategory = (command: SlashCommand) => {
+  switch (command) {
+    case SlashCommand.CLEAR:
+    case SlashCommand.COMPACT:
+      return 'Chat Management';
+    case SlashCommand.HELP:
+      return 'Help';
+    case SlashCommand.RETRY:
+      return 'Actions';
+    case SlashCommand.MODELS:
+    case SlashCommand.TOOLS:
+      return 'Configuration';
+    default:
+      return 'Other';
+  }
+};
+
+const getCommandShortcut = (command: SlashCommand) => {
+  switch (command) {
+    case SlashCommand.CLEAR:
+      return '⌘N';
+    case SlashCommand.COMPACT:
+      return '⌘K';
+    case SlashCommand.HELP:
+      return '?';
+    case SlashCommand.RETRY:
+      return '⌘R';
+    case SlashCommand.MODELS:
+      return '⌘M';
+    case SlashCommand.TOOLS:
+      return '⌘T';
+    default:
+      return '';
+  }
+};
+
+export const SlashCommandDropdown = memo<SlashCommandDropdownProps>(function SlashCommandDropdown({
+  suggestions,
+  selectedIndex,
+  onSelect,
+  visible,
+  inputRect,
+}) {
+  // Early return must happen before any hooks
+  if (!visible || suggestions.length === 0) {
+    return null;
+  }
+
+  const handleSelect = useCallback(
+    (command: SlashCommand) => {
+      onSelect(command);
+    },
+    [onSelect]
+  );
+
+  const dropdownStyle = useMemo(() => {
+    return inputRect
+      ? {
+          position: 'fixed' as const,
+          top: inputRect.top - 8,
+          left: inputRect.left,
+          width: Math.max(420, inputRect.width),
+          zIndex: 1000,
+          transform: 'translateY(-100%)',
+        }
+      : {
+          position: 'absolute' as const,
+          bottom: '100%',
+          left: 0,
+          right: 0,
+          zIndex: 1000,
+        };
+  }, [inputRect]);
+
+  return (
+    <div
+      style={dropdownStyle}
+      className="bg-background/95 backdrop-blur-sm border border-border rounded-lg shadow-2xl overflow-hidden mb-2 animate-in fade-in-0 zoom-in-95 duration-200"
+      role="listbox"
+      aria-label="Slash commands"
+      tabIndex={-1}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2 px-3 py-2 bg-muted/30 border-b border-border/50">
+        <Hash className="w-4 h-4 text-orange-500" />
+        <span className="text-sm font-medium text-foreground/80">SLASH COMMANDS</span>
+        <span className="ml-auto text-xs text-muted-foreground">{suggestions.length}</span>
+      </div>
+
+      {/* Commands */}
+      <div className="max-h-80 overflow-y-auto">
+        {suggestions.map((suggestion, index) => {
+          const isSelected = selectedIndex === index;
+          const shortcut = getCommandShortcut(suggestion.command);
+          const category = getCommandCategory(suggestion.command);
+
+          return (
+            <button
+              key={suggestion.command}
+              onClick={() => handleSelect(suggestion.command)}
+              className={cn(
+                'w-full text-left px-3 py-2.5 transition-colors flex items-center gap-3 group border-b border-border/20 last:border-b-0',
+                'hover:bg-accent/50 focus:outline-none focus:bg-accent/50',
+                isSelected && 'bg-accent text-accent-foreground'
+              )}
+              type="button"
+              tabIndex={-1}
+              role="option"
+              aria-selected={isSelected}
+              aria-describedby={`command-${suggestion.command.slice(1)}-desc`}
+            >
+              <div className="flex items-center justify-center w-5 h-5 text-muted-foreground group-hover:text-foreground">
+                {getCommandIcon(suggestion.command)}
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium text-sm leading-none">{suggestion.command}</span>
+                  <span className="text-xs text-muted-foreground bg-muted/50 px-1.5 py-0.5 rounded-md">{category}</span>
+                </div>
+                <div
+                  id={`command-${suggestion.command.slice(1)}-desc`}
+                  className="text-xs text-muted-foreground truncate leading-none mt-1"
+                >
+                  {suggestion.description}
+                </div>
+              </div>
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                {shortcut && (
+                  <kbd className="px-1.5 py-0.5 bg-muted/60 text-muted-foreground rounded text-xs font-mono">
+                    {shortcut}
+                  </kbd>
+                )}
+                {isSelected && <ChevronRight className="w-3 h-3" />}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between text-xs text-muted-foreground px-3 py-2 bg-muted/20 border-t border-border/50">
+        <span className="flex items-center gap-1">
+          <kbd className="px-1 py-0.5 bg-muted/60 rounded text-xs">↑</kbd>
+          <kbd className="px-1 py-0.5 bg-muted/60 rounded text-xs">↓</kbd>
+          Navigate
+        </span>
+        <span className="flex items-center gap-1">
+          <kbd className="px-1.5 py-0.5 bg-muted/60 rounded text-xs">⏎</kbd>
+          Execute
+        </span>
+        <span className="flex items-center gap-1">
+          <kbd className="px-1.5 py-0.5 bg-muted/60 rounded text-xs">esc</kbd>
+          Close
+        </span>
+      </div>
+    </div>
+  );
+});

--- a/desktop_app/src/ui/hooks/use-slash-commands.ts
+++ b/desktop_app/src/ui/hooks/use-slash-commands.ts
@@ -1,0 +1,191 @@
+import { UIMessage } from 'ai';
+import { useCallback, useState } from 'react';
+
+import config from '@ui/config';
+import { SlashCommand, getSlashCommandSuggestions, parseSlashCommand } from '@ui/lib/utils/slash-commands';
+import { useChatStore } from '@ui/stores';
+
+interface UseSlashCommandsProps {
+  messages: UIMessage[];
+  setMessages: (messages: UIMessage[]) => void;
+  sendMessage: (message: { text: string }) => void;
+  currentChat?: { id: number } | null;
+  clearDraftMessage: (chatId: number) => void;
+  updateMessages: (chatId: number, messages: UIMessage[]) => void;
+  setIsSubmitting?: (b: boolean) => void;
+  onShowHelp?: () => void;
+  onShowModels?: () => void;
+  onShowTools?: () => void;
+  onRetryLastMessage?: () => void;
+}
+
+export function useSlashCommands({
+  messages,
+  setMessages,
+  sendMessage,
+  currentChat,
+  clearDraftMessage,
+  updateMessages,
+  setIsSubmitting,
+  onShowHelp,
+  onShowModels,
+  onShowTools,
+  onRetryLastMessage,
+}: UseSlashCommandsProps) {
+  const [isSuggestionDropdownVisible, setIsSuggestionDropdownVisible] = useState(false);
+  const [highlightedSuggestionIndex, setHighlightedSuggestionIndex] = useState(0);
+  const [textInputBoundingRect, setTextInputBoundingRect] = useState<DOMRect | undefined>();
+  const chatStore = useChatStore();
+
+  // 1. Input validation utilities - First level: Basic input checking
+  const checkIfInputStartsWithSlash = useCallback((input: string) => {
+    const parseResult = parseSlashCommand(input);
+    return parseResult.isSlashCommand;
+  }, []);
+
+  const validateSlashCommandSyntax = useCallback((input: string) => {
+    const parseResult = parseSlashCommand(input);
+    return parseResult.isValidCommand;
+  }, []);
+
+  // 2. Suggestion dropdown management - Second level: UI state management
+  const refreshSuggestionDropdownBasedOnInput = useCallback((input: string, textareaElement?: HTMLTextAreaElement) => {
+    const suggestions = getSlashCommandSuggestions(input);
+
+    if (suggestions.length > 0) {
+      setIsSuggestionDropdownVisible(true);
+      setHighlightedSuggestionIndex(0);
+
+      if (textareaElement) {
+        const rect = textareaElement.getBoundingClientRect();
+        setTextInputBoundingRect(rect);
+      }
+    } else {
+      setIsSuggestionDropdownVisible(false);
+    }
+
+    return suggestions;
+  }, []);
+
+  const getSlashCommandFromSuggestionAtIndex = useCallback(
+    (index: number, suggestions: Array<{ command: SlashCommand; description: string }>) => {
+      if (index >= 0 && index < suggestions.length) {
+        return suggestions[index].command;
+      }
+      return null;
+    },
+    []
+  );
+
+  const moveHighlightThroughSuggestionsList = useCallback((direction: 'up' | 'down', maxIndex: number) => {
+    setHighlightedSuggestionIndex((prev) => {
+      if (direction === 'down') {
+        return prev < maxIndex - 1 ? prev + 1 : 0;
+      } else {
+        return prev > 0 ? prev - 1 : maxIndex - 1;
+      }
+    });
+  }, []);
+
+  const closeSuggestionDropdownAndResetState = useCallback(() => {
+    setIsSuggestionDropdownVisible(false);
+    setHighlightedSuggestionIndex(0);
+    setTextInputBoundingRect(undefined);
+  }, []);
+
+  // 3. Command execution utilities - Third level: Actual business logic
+  const executeDeleteCurrentChatAndCreateNew = useCallback(async () => {
+    if (!currentChat) return;
+
+    // Use the exact same logic as deleteCurrentChat from chat-store
+    // This will delete the current chat and create a new one
+    await chatStore.deleteCurrentChat();
+  }, [currentChat, chatStore]);
+
+  const generateConversationSummaryAndSend = useCallback(() => {
+    if (!currentChat) return;
+    const systemMemoriesId = config.chat.systemMemoriesMessageId;
+    const hasConversation = messages.some((m) => m.id !== systemMemoriesId);
+    if (!hasConversation) {
+      console.error('[SlashCommands] /compact ignored: no conversation to summarize');
+      return;
+    }
+    const conversationText = messages
+      .map((msg) => {
+        const content = msg.parts?.find((p) => p.type === 'text')?.text || '';
+        return `${msg.role}: ${content}`;
+      })
+      .join('\n');
+
+    const summarizationPrompt = `Summarize the existing conversation above. Provide a concise context summary we can continue from. Do not repeat all messages.\n\n---\n${conversationText}`;
+    setIsSubmitting?.(true);
+    sendMessage({ text: summarizationPrompt });
+    clearDraftMessage(currentChat.id);
+  }, [currentChat, messages, sendMessage, clearDraftMessage, setIsSubmitting]);
+
+  // 4. Command routing and execution - Fourth level: Command dispatcher
+  const executeSlashCommandAction = useCallback(
+    (command: SlashCommand) => {
+      switch (command) {
+        case SlashCommand.CLEAR:
+          void executeDeleteCurrentChatAndCreateNew();
+          break;
+        case SlashCommand.COMPACT:
+          generateConversationSummaryAndSend();
+          break;
+        case SlashCommand.HELP:
+          onShowHelp?.();
+          break;
+        case SlashCommand.RETRY:
+          onRetryLastMessage?.();
+          break;
+        case SlashCommand.MODELS:
+          onShowModels?.();
+          break;
+        case SlashCommand.TOOLS:
+          onShowTools?.();
+          break;
+        default:
+          console.warn('Unknown slash command:', command);
+      }
+    },
+    [
+      executeDeleteCurrentChatAndCreateNew,
+      generateConversationSummaryAndSend,
+      onShowHelp,
+      onRetryLastMessage,
+      onShowModels,
+      onShowTools,
+    ]
+  );
+
+  // 5. Main entry point - Fifth level: Public API
+  const parseAndExecuteSlashCommandFromInput = useCallback(
+    (input: string): boolean => {
+      const parseResult = parseSlashCommand(input);
+
+      if (parseResult.isSlashCommand && parseResult.isValidCommand && parseResult.command) {
+        executeSlashCommandAction(parseResult.command);
+        return true;
+      }
+
+      return false;
+    },
+    [executeSlashCommandAction]
+  );
+
+  return {
+    isSuggestionDropdownVisible,
+    highlightedSuggestionIndex,
+    textInputBoundingRect,
+    parseAndExecuteSlashCommandFromInput,
+    refreshSuggestionDropdownBasedOnInput,
+    getSlashCommandFromSuggestionAtIndex,
+    moveHighlightThroughSuggestionsList,
+    closeSuggestionDropdownAndResetState,
+    checkIfInputStartsWithSlash,
+    validateSlashCommandSyntax,
+    executeDeleteCurrentChatAndCreateNew,
+    generateConversationSummaryAndSend,
+  };
+}

--- a/desktop_app/src/ui/lib/utils/slash-commands.ts
+++ b/desktop_app/src/ui/lib/utils/slash-commands.ts
@@ -1,0 +1,101 @@
+export enum SlashCommand {
+  CLEAR = '/clear',
+  COMPACT = '/compact',
+  HELP = '/help',
+  RETRY = '/retry',
+  MODELS = '/models',
+  TOOLS = '/tools',
+}
+
+export interface SlashCommandConfig {
+  command: SlashCommand;
+  description: string;
+  handler?: () => Promise<void> | void;
+}
+
+export interface SlashCommandsConfig {
+  clear: SlashCommandConfig;
+  compact: SlashCommandConfig;
+  help: SlashCommandConfig;
+  retry: SlashCommandConfig;
+  models: SlashCommandConfig;
+  tools: SlashCommandConfig;
+}
+
+export interface SlashCommandParseResult {
+  isSlashCommand: boolean;
+  command?: SlashCommand;
+  fullCommand?: string;
+  isValidCommand: boolean;
+}
+
+export const AVAILABLE_SLASH_COMMANDS = {
+  clear: {
+    command: SlashCommand.CLEAR,
+    description: 'Clear the current chat and start a new conversation',
+  },
+  compact: {
+    command: SlashCommand.COMPACT,
+    description: 'Summarize the conversation and continue with compacted context',
+  },
+  help: {
+    command: SlashCommand.HELP,
+    description: 'Show available commands and keyboard shortcuts',
+  },
+  retry: {
+    command: SlashCommand.RETRY,
+    description: 'Retry the last message with the same prompt',
+  },
+  models: {
+    command: SlashCommand.MODELS,
+    description: 'Show available AI models and switch between them',
+  },
+  tools: {
+    command: SlashCommand.TOOLS,
+    description: 'Show connected tools and manage tool selection',
+  },
+} as const;
+
+export function parseSlashCommand(input: string): SlashCommandParseResult {
+  const trimmedInput = input.trim();
+
+  if (!trimmedInput.startsWith('/')) {
+    return {
+      isSlashCommand: false,
+      isValidCommand: false,
+    };
+  }
+
+  const fullCommand = trimmedInput;
+  const commandStr = trimmedInput.split(' ')[0];
+
+  // Check if the command string matches any of our enum values
+  const command = Object.values(SlashCommand).find((cmd) => cmd === commandStr);
+  const isValidCommand = command !== undefined;
+
+  return {
+    isSlashCommand: true,
+    command,
+    fullCommand,
+    isValidCommand,
+  };
+}
+
+export function getSlashCommandSuggestions(input: string): Array<{ command: SlashCommand; description: string }> {
+  const trimmedInput = input.trim().toLowerCase();
+
+  if (!trimmedInput.startsWith('/')) {
+    return [];
+  }
+
+  if (trimmedInput === '/') {
+    return Object.values(AVAILABLE_SLASH_COMMANDS);
+  }
+
+  return Object.values(AVAILABLE_SLASH_COMMANDS).filter((cmd) => cmd.command.toLowerCase().startsWith(trimmedInput));
+}
+
+export function isCompleteSlashCommand(input: string): boolean {
+  const trimmed = input.trim();
+  return Object.values(AVAILABLE_SLASH_COMMANDS).some((cmd) => cmd.command === trimmed);
+}


### PR DESCRIPTION
## Summary
Implements comprehensive slash command functionality for the chat input as requested in issue #487.

## Commands Available
- `/clear` - Clear current chat and start new conversation
- `/compact` - Summarize conversation with compacted context
- `/help` - Show available commands and shortcuts
- `/retry` - Retry the last message
- `/models` - Show available AI models
- `/tools` - Show connected tools




https://github.com/user-attachments/assets/f14496d0-0a3c-426a-96f6-9be5c14aba5b


https://github.com/user-attachments/assets/b1f378e3-5018-4125-9e4e-23bade85e5c2



<img width="1401" height="874" alt="image" src="https://github.com/user-attachments/assets/8180b1d5-51b6-4e14-b72b-4bb8101f4ff3" />



Fixes #487
/claim #487

