### PR TITLE
fix: use latest base image

### DIFF
--- a/desktop_app/src/backend/config.ts
+++ b/desktop_app/src/backend/config.ts
@@ -1,6 +1,7 @@
-import { SYSTEM_MODELS } from '@constants';
 import { app } from 'electron';
 import * as os from 'os';
+
+import { SYSTEM_MODELS } from '@constants';
 
 const OLLAMA_SERVER_PORT = parseInt(process.env.ARCHESTRA_OLLAMA_SERVER_PORT || '54589', 10);
 const OLLAMA_GUARD_MODEL = SYSTEM_MODELS.GUARD;

--- a/desktop_app/src/backend/config.ts
+++ b/desktop_app/src/backend/config.ts
@@ -1,7 +1,6 @@
+import { SYSTEM_MODELS } from '@constants';
 import { app } from 'electron';
 import * as os from 'os';
-
-import { SYSTEM_MODELS } from '@constants';
 
 const OLLAMA_SERVER_PORT = parseInt(process.env.ARCHESTRA_OLLAMA_SERVER_PORT || '54589', 10);
 const OLLAMA_GUARD_MODEL = SYSTEM_MODELS.GUARD;
@@ -66,7 +65,7 @@ export default {
   sandbox: {
     baseDockerImage:
       process.env.MCP_BASE_DOCKER_IMAGE ||
-      'europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-base:0.0.1',
+      'europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-base:latest',
     podman: {
       baseUrl: 'http://d/v5.0.0',
     },


### PR DESCRIPTION
## Description

Updates the MCP server base Docker image from a specific version tag (0.0.1) to the latest tag. This ensures the application always uses the most recent version of the base image.

## Changes
- Changed Docker base image tag from 0.0.1 to latest in config.ts
- Reordered imports for better consistency