### PR TITLE
fix: remove unnecessary `LABEL` configs in MCP server base Docker image

### DIFF
--- a/mcp_server_docker_image/Dockerfile
+++ b/mcp_server_docker_image/Dockerfile
@@ -107,9 +107,3 @@ ENTRYPOINT ["/sbin/tini", "--"]
 
 # Default command (override when running specific MCP server)
 CMD ["sh", "-c", "echo 'MCP base container ready. Override CMD to run your MCP server.'"]
-
-# Labels for container metadata
-LABEL org.opencontainers.image.title="MCP Server Base Image"
-LABEL org.opencontainers.image.description="Minimal base image for running Model Context Protocol servers"
-LABEL org.opencontainers.image.version="1.0.0"
-LABEL org.opencontainers.image.licenses="Apache-2.0"


### PR DESCRIPTION
Removes OCI image metadata labels from the MCP server base Dockerfile.

The following labels were removed as they are unnecessary for the base image:
- org.opencontainers.image.title
- org.opencontainers.image.description
- org.opencontainers.image.version
- org.opencontainers.image.licenses

These labels can be added by downstream images if needed.