### PR TITLE
fix: increase max tool calls from 10 to 30

### DIFF
--- a/desktop_app/src/config.ts
+++ b/desktop_app/src/config.ts
@@ -6,7 +6,7 @@ export default {
     replaysOnErrorSampleRate: 1.0,
   },
   vercelSdk: {
-    maxToolCalls: 10,
+    maxToolCalls: 30,
   },
   build: {
     updateInterval: '1 hour',


### PR DESCRIPTION
## Summary

This PR increases the maximum number of tool calls allowed in the Vercel SDK configuration from 10 to 30 to address issue #428.

## Changes

- Increased `maxToolCalls` from 10 to 30 in `desktop_app/src/config.ts`

## Context

This change allows AI agents to make more tool calls within a single interaction, providing more flexibility for complex workflows that require multiple tool invocations.

closes https://github.com/archestra-ai/archestra/issues/428