### PR TITLE
chore: bump desktop app `sandbox.baseDockerImage` tag to `0.0.2`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ Archestra is an enterprise-grade Model Context Protocol (MCP) platform built as 
 
 - **McpServerSandboxManager**: Orchestrates multiple MCP servers
 
-  - Base image: `europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-base:latest`
+  - Base image: `europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-base:0.0.2`
   - WebSocket broadcasting for real-time status updates
   - Tool discovery and management across all servers
 

--- a/desktop_app/src/backend/config.ts
+++ b/desktop_app/src/backend/config.ts
@@ -66,7 +66,7 @@ export default {
   sandbox: {
     baseDockerImage:
       process.env.MCP_BASE_DOCKER_IMAGE ||
-      'europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-base:latest',
+      'europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-base:0.0.2',
     podman: {
       baseUrl: 'http://d/v5.0.0',
     },


### PR DESCRIPTION
Updates the MCP server base Docker image tag from `latest` to `0.0.2`.

This change pins the base Docker image to a specific version rather than using the `latest` tag, which improves reproducibility and prevents unexpected behavior from automatic updates to the base image.

The `0.0.2` tag corresponds to the [recent release](https://github.com/archestra-ai/archestra/pull/522) that included fixes for the MCP server base Docker image configuration.