### PR TITLE
feat: use OpenAI's `previousResponseId` to improve context window usage

### DIFF
--- a/desktop_app/openapi/archestra/api/openapi.json
+++ b/desktop_app/openapi/archestra/api/openapi.json
@@ -891,6 +891,17 @@
               }
             ]
           },
+          "previousResponseId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "nullable": true,
+                "enum": [null]
+              }
+            ]
+          },
           "totalPromptTokens": {
             "anyOf": [
               {
@@ -991,6 +1002,7 @@
           "sessionId",
           "title",
           "selectedTools",
+          "previousResponseId",
           "totalPromptTokens",
           "totalCompletionTokens",
           "totalTokens",
@@ -2712,6 +2724,17 @@
               }
             ]
           },
+          "previousResponseId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "nullable": true,
+                "enum": [null]
+              }
+            ]
+          },
           "totalPromptTokens": {
             "anyOf": [
               {
@@ -2813,6 +2836,7 @@
           "sessionId",
           "title",
           "selectedTools",
+          "previousResponseId",
           "totalPromptTokens",
           "totalCompletionTokens",
           "totalTokens",

--- a/desktop_app/src/backend/database/migrations/0020_public_overlord.sql
+++ b/desktop_app/src/backend/database/migrations/0020_public_overlord.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `chats` ADD `previous_response_id` text;

--- a/desktop_app/src/backend/database/migrations/meta/0020_snapshot.json
+++ b/desktop_app/src/backend/database/migrations/meta/0020_snapshot.json
@@ -1,0 +1,806 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6a6d2e89-9a38-4c93-911f-587a27a89e9f",
+  "prevId": "7f2956a8-9f20-4f34-89d1-ee688299a994",
+  "tables": {
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(lower(hex(randomblob(4))) || '-' || lower(hex(randomblob(2))) || '-4' || substr(lower(hex(randomblob(2))),2) || '-' || substr('89ab',abs(random()) % 4 + 1, 1) || substr(lower(hex(randomblob(2))),2) || '-' || lower(hex(randomblob(6))))"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_tools": {
+          "name": "selected_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_response_id": {
+          "name": "previous_response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_prompt_tokens": {
+          "name": "total_prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_completion_tokens": {
+          "name": "total_completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_model": {
+          "name": "last_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_context_window": {
+          "name": "last_context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "chats_sessionId_unique": {
+          "name": "chats_sessionId_unique",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": true
+        },
+        "chats_created_at_idx": {
+          "name": "chats_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cloud_providers": {
+      "name": "cloud_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "cloud_providers_providerType_unique": {
+          "name": "cloud_providers_providerType_unique",
+          "columns": [
+            "provider_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "external_mcp_clients": {
+      "name": "external_mcp_clients",
+      "columns": {
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_request_logs": {
+      "name": "mcp_request_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_session_id": {
+          "name": "mcp_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_info": {
+          "name": "client_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_headers": {
+          "name": "request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_headers": {
+          "name": "response_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_request_logs_requestId_unique": {
+          "name": "mcp_request_logs_requestId_unique",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": true
+        },
+        "mcp_request_logs_server_name_idx": {
+          "name": "mcp_request_logs_server_name_idx",
+          "columns": [
+            "server_name"
+          ],
+          "isUnique": false
+        },
+        "mcp_request_logs_timestamp_idx": {
+          "name": "mcp_request_logs_timestamp_idx",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "mcp_request_logs_mcp_session_id_idx": {
+          "name": "mcp_request_logs_mcp_session_id_idx",
+          "columns": [
+            "mcp_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_config": {
+          "name": "server_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_config_values": {
+          "name": "user_config_values",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_tokens": {
+          "name": "oauth_tokens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_info": {
+          "name": "oauth_client_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_server_metadata": {
+          "name": "oauth_server_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_resource_metadata": {
+          "name": "oauth_resource_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_config": {
+          "name": "oauth_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'installing'"
+        },
+        "server_type": {
+          "name": "server_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "remote_url": {
+          "name": "remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memory_entries": {
+      "name": "memory_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "user_name_idx": {
+          "name": "user_name_idx",
+          "columns": [
+            "user_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "memory_entries_user_id_user_id_fk": {
+          "name": "memory_entries_user_id_user_id_fk",
+          "tableFrom": "memory_entries",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "messages_chat_id_idx": {
+          "name": "messages_chat_id_idx",
+          "columns": [
+            "chat_id"
+          ],
+          "isUnique": false
+        },
+        "messages_chat_id_created_at_idx": {
+          "name": "messages_chat_id_created_at_idx",
+          "columns": [
+            "chat_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tools": {
+      "name": "tools",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_write": {
+          "name": "is_write",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analyzed_at": {
+          "name": "analyzed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "tools_mcp_server_id_idx": {
+          "name": "tools_mcp_server_id_idx",
+          "columns": [
+            "mcp_server_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tools_mcp_server_id_mcp_servers_id_fk": {
+          "name": "tools_mcp_server_id_mcp_servers_id_fk",
+          "tableFrom": "tools",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "unique_id": {
+          "name": "unique_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_completed_onboarding": {
+          "name": "has_completed_onboarding",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "collect_telemetry_data": {
+          "name": "collect_telemetry_data",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "collect_analytics_data": {
+          "name": "collect_analytics_data",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "user_uniqueId_unique": {
+          "name": "user_uniqueId_unique",
+          "columns": [
+            "unique_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/desktop_app/src/backend/database/migrations/meta/_journal.json
+++ b/desktop_app/src/backend/database/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1758070965646,
       "tag": "0019_rapid_tag",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "6",
+      "when": 1758570650704,
+      "tag": "0020_public_overlord",
+      "breakpoints": true
     }
   ]
 }

--- a/desktop_app/src/backend/database/schema/chat.ts
+++ b/desktop_app/src/backend/database/schema/chat.ts
@@ -22,7 +22,7 @@ export const chatsTable = sqliteTable(
     /**
      * OpenAI Responses API: ID of the previous response for conversation state
      * This allows us to continue conversations without resending the entire history
-     * 
+     *
      * See https://ai-sdk.dev/providers/ai-sdk-providers/openai#responses-models:~:text=with%20the%20generation.-,previousResponseId,-string%20The%20ID
      * for more details
      */

--- a/desktop_app/src/backend/database/schema/chat.ts
+++ b/desktop_app/src/backend/database/schema/chat.ts
@@ -20,6 +20,14 @@ export const chatsTable = sqliteTable(
      */
     selectedTools: text({ mode: 'json' }).$type<string[] | null>(),
     /**
+     * OpenAI Responses API: ID of the previous response for conversation state
+     * This allows us to continue conversations without resending the entire history
+     * 
+     * See https://ai-sdk.dev/providers/ai-sdk-providers/openai#responses-models:~:text=with%20the%20generation.-,previousResponseId,-string%20The%20ID
+     * for more details
+     */
+    previousResponseId: text('previous_response_id'),
+    /**
      * Token usage tracking for the entire chat session
      */
     totalPromptTokens: int('total_prompt_tokens').default(0),

--- a/desktop_app/src/backend/models/chat/index.ts
+++ b/desktop_app/src/backend/models/chat/index.ts
@@ -158,6 +158,76 @@ export default class ChatModel {
     await this.updateSelectedTools(chatId, []);
   }
 
+  /**
+   * Update the previousResponseId for a chat (OpenAI Responses API)
+   * @param sessionId The chat session ID
+   * @param responseId The response ID from OpenAI
+   */
+  static async updatePreviousResponseId(sessionId: string, responseId: string): Promise<void> {
+    await db
+      .update(chatsTable)
+      .set({
+        previousResponseId: responseId,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(chatsTable.sessionId, sessionId));
+
+    log.info(`Updated previousResponseId for session ${sessionId}: ${responseId}`);
+  }
+
+  /**
+   * Get the previousResponseId for a chat
+   * @param sessionId The chat session ID
+   * @returns The previous response ID or null
+   */
+  static async getPreviousResponseId(sessionId: string): Promise<string | null> {
+    const [chat] = await db
+      .select({ previousResponseId: chatsTable.previousResponseId })
+      .from(chatsTable)
+      .where(eq(chatsTable.sessionId, sessionId))
+      .limit(1);
+
+    return chat?.previousResponseId || null;
+  }
+
+  /**
+   * Get only new messages since the last response (for OpenAI Responses API)
+   * @param sessionId The chat session ID
+   * @param allMessages All messages in the conversation
+   * @returns Messages to send and the previousResponseId
+   */
+  static async getMessagesToSend(sessionId: string, allMessages: UIMessage[]): Promise<{
+    messages: UIMessage[];
+    previousResponseId: string | null;
+  }> {
+    const previousResponseId = await this.getPreviousResponseId(sessionId);
+
+    if (!previousResponseId) {
+      // No previous response, send all messages
+      return { messages: allMessages, previousResponseId: null };
+    }
+
+    // Find the last assistant message and send only messages after it
+    let lastAssistantIndex = -1;
+    for (let i = allMessages.length - 1; i >= 0; i--) {
+      if (allMessages[i].role === 'assistant') {
+        lastAssistantIndex = i;
+        break;
+      }
+    }
+
+    if (lastAssistantIndex >= 0 && lastAssistantIndex < allMessages.length - 1) {
+      // Send only messages after the last assistant message
+      return { 
+        messages: allMessages.slice(lastAssistantIndex + 1), 
+        previousResponseId 
+      };
+    }
+
+    // If no assistant messages or something unexpected, send all messages for safety
+    return { messages: allMessages, previousResponseId: null };
+  }
+
   static async conditionallyGenerateAndUpdateChatTitle(
     chatId: number,
     currentTitle: string | null,

--- a/desktop_app/src/backend/models/chat/index.ts
+++ b/desktop_app/src/backend/models/chat/index.ts
@@ -196,7 +196,10 @@ export default class ChatModel {
    * @param allMessages All messages in the conversation
    * @returns Messages to send and the previousResponseId
    */
-  static async getMessagesToSend(sessionId: string, allMessages: UIMessage[]): Promise<{
+  static async getMessagesToSend(
+    sessionId: string,
+    allMessages: UIMessage[]
+  ): Promise<{
     messages: UIMessage[];
     previousResponseId: string | null;
   }> {
@@ -218,9 +221,9 @@ export default class ChatModel {
 
     if (lastAssistantIndex >= 0 && lastAssistantIndex < allMessages.length - 1) {
       // Send only messages after the last assistant message
-      return { 
-        messages: allMessages.slice(lastAssistantIndex + 1), 
-        previousResponseId 
+      return {
+        messages: allMessages.slice(lastAssistantIndex + 1),
+        previousResponseId,
       };
     }
 

--- a/desktop_app/src/backend/server/plugins/llm/index.ts
+++ b/desktop_app/src/backend/server/plugins/llm/index.ts
@@ -74,6 +74,7 @@ const llmRoutes: FastifyPluginAsync = async (fastify) => {
     async (request: FastifyRequest<{ Body: StreamRequestBody }>, reply: FastifyReply) => {
       const { messages, sessionId, model = 'gpt-4o', provider, requestedTools, toolChoice, chatId } = request.body;
       const isOllama = provider === 'ollama';
+      const isOpenAI = provider === 'openai';
 
       try {
         // Set the chat context for Archestra MCP tools
@@ -110,10 +111,26 @@ const llmRoutes: FastifyPluginAsync = async (fastify) => {
           wrappedTools[toolId] = toolService.wrapToolWithApproval(tool, toolId, sessionId || '', chatId || 0);
         }
 
+        // For OpenAI, check if we should use previousResponseId and only send new messages
+        let messagesToSend = messages;
+        let previousResponseId: string | null = null;
+
+        if (isOpenAI && sessionId) {
+          const result = await Chat.getMessagesToSend(sessionId, messages);
+          messagesToSend = result.messages;
+          previousResponseId = result.previousResponseId;
+
+          if (previousResponseId) {
+            fastify.log.info(
+              `Using previousResponseId: ${previousResponseId}, sending ${messagesToSend.length} messages instead of ${messages.length}`
+            );
+          }
+        }
+
         // Create the stream with the appropriate model
         const streamConfig: Parameters<typeof streamText>[0] = {
           model: await createModelInstance(model, provider),
-          messages: convertToModelMessages(messages),
+          messages: convertToModelMessages(messagesToSend),
           stopWhen: stepCountIs(vercelSdkConfig.maxToolCalls),
           providerOptions: {
             /**
@@ -121,6 +138,10 @@ const llmRoutes: FastifyPluginAsync = async (fastify) => {
              * https://ai-sdk.dev/providers/ai-sdk-providers/openai#responses-models
              */
             openai: {
+              /**
+               * Use previousResponseId for OpenAI Responses API to maintain conversation state
+               */
+              ...(previousResponseId ? { previousResponseId } : {}),
               /**
                * A cache key for manual prompt caching control.
                * Used by OpenAI to cache responses for similar requests to optimize your cache hit rates.
@@ -138,8 +159,17 @@ const llmRoutes: FastifyPluginAsync = async (fastify) => {
             },
             ollama: {},
           },
-          onFinish: async ({ response, usage, text: _text, finishReason: _finishReason }) => {
+          onFinish: async ({ response, usage, text: _text, finishReason: _finishReason, providerMetadata }) => {
             console.log(JSON.stringify(response.messages));
+
+            // Store the OpenAI response ID from providerMetadata for Responses API
+            if (isOpenAI && sessionId && providerMetadata?.openai?.responseId) {
+              const responseId = providerMetadata.openai.responseId as string;
+              await Chat.updatePreviousResponseId(sessionId, responseId);
+              fastify.log.info(
+                `Stored OpenAI response ID: ${responseId} for session: ${sessionId}`
+              );
+            }
             // Save chat token usage
             if (usage && sessionId) {
               let contextWindow: number;

--- a/desktop_app/src/backend/server/plugins/llm/index.ts
+++ b/desktop_app/src/backend/server/plugins/llm/index.ts
@@ -166,9 +166,7 @@ const llmRoutes: FastifyPluginAsync = async (fastify) => {
             if (isOpenAI && sessionId && providerMetadata?.openai?.responseId) {
               const responseId = providerMetadata.openai.responseId as string;
               await Chat.updatePreviousResponseId(sessionId, responseId);
-              fastify.log.info(
-                `Stored OpenAI response ID: ${responseId} for session: ${sessionId}`
-              );
+              fastify.log.info(`Stored OpenAI response ID: ${responseId} for session: ${sessionId}`);
             }
             // Save chat token usage
             if (usage && sessionId) {

--- a/desktop_app/src/ui/lib/clients/archestra/api/gen/types.gen.ts
+++ b/desktop_app/src/ui/lib/clients/archestra/api/gen/types.gen.ts
@@ -232,6 +232,7 @@ export type ChatWithMessagesInput = {
         | Array<unknown>
       )
     | null;
+  previousResponseId: string | null;
   totalPromptTokens: number | null;
   totalCompletionTokens: number | null;
   totalTokens: number | null;
@@ -734,6 +735,7 @@ export type ChatWithMessages = {
         | Array<unknown>
       )
     | null;
+  previousResponseId: string | null;
   totalPromptTokens: number | null;
   totalCompletionTokens: number | null;
   totalTokens: number | null;


### PR DESCRIPTION
## Summary

This PR implements OpenAI's `previousResponseId` feature to optimize context window usage when using OpenAI models. Instead of sending the entire conversation history with each request, we now:

- Store the `responseId` from OpenAI after each response
- Send only new messages since the last assistant response
- Maintain conversation continuity using OpenAI's Responses API

## Changes

- Added `previous_response_id` column to the `chats` table
- Implemented methods to store and retrieve the previous response ID
- Modified the LLM streaming endpoint to use `previousResponseId` when available for OpenAI
- Added logic to send only new messages instead of full history when a previous response exists

## Benefits

- Significantly reduces token usage for long conversations
- Improves response times by sending less data
- Better utilization of available context window
- Cost savings from reduced API usage

## Implementation Details

The implementation tracks OpenAI's `responseId` from the provider metadata and stores it in the database. On subsequent requests, if a `previousResponseId` exists, we:
1. Find the last assistant message in the conversation
2. Send only messages after that point
3. Include the `previousResponseId` in the request to maintain context

This feature is only active for OpenAI providers and maintains backward compatibility with other providers.