### PR TITLE
chore: improve wording on mcp server config dialog

### DIFF
--- a/desktop_app/src/ui/components/ConnectorCatalog/McpServerInstallDialog/index.tsx
+++ b/desktop_app/src/ui/components/ConnectorCatalog/McpServerInstallDialog/index.tsx
@@ -184,7 +184,7 @@ export default function McpServerInstallDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-md max-h-[80vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>Configure {mcpServer.name}</DialogTitle>
+          <DialogTitle>Configure {mcpServer.display_name}</DialogTitle>
           <DialogDescription>
             {hasUserConfig
               ? 'This MCP server requires configuration before installation. Please provide the required values below.'


### PR DESCRIPTION
## Summary

This PR improves the user experience in the MCP server configuration dialog by displaying the server's `display_name` instead of its internal `name` in the dialog title.

## Changes

- Updated dialog title in `McpServerInstallDialog` component to use `mcpServer.display_name` instead of `mcpServer.name`

## Rationale

The `display_name` is intended for user-facing interfaces and provides a more readable, user-friendly name compared to the internal `name` field which may contain technical identifiers.