### PR TITLE
fix: when uninstalling mcp server, properly remove container

### DIFF
--- a/desktop_app/src/backend/sandbox/manager/index.ts
+++ b/desktop_app/src/backend/sandbox/manager/index.ts
@@ -208,7 +208,7 @@ class McpServerSandboxManager {
     }
 
     try {
-      await sandboxedMcpServer.stop();
+      await sandboxedMcpServer.delete();
       log.info(`Successfully removed MCP server ${mcpServerId}`);
     } catch (error) {
       log.error(`Failed to remove MCP server ${mcpServerId}:`, error);

--- a/desktop_app/src/backend/sandbox/sandboxedMcp/index.ts
+++ b/desktop_app/src/backend/sandbox/sandboxedMcp/index.ts
@@ -458,6 +458,12 @@ export default class SandboxedMcpServer {
     }
   }
 
+  async disconnectMcpClient() {
+    if (this.mcpClient) {
+      await this.mcpClient.close();
+    }
+  }
+
   async stop() {
     this.stopPeriodicAnalysisUpdates();
 
@@ -470,9 +476,14 @@ export default class SandboxedMcpServer {
       await this.podmanContainer!.stopContainer();
     }
 
-    if (this.mcpClient) {
-      await this.mcpClient.close();
+    await this.disconnectMcpClient();
+  }
+
+  async delete() {
+    if (!this.isRemoteServer) {
+      await this.podmanContainer!.removeContainer();
     }
+    await this.disconnectMcpClient();
   }
 
   /**


### PR DESCRIPTION
This was (likely) leading to some issues when installing, uninstalling, and reinstalling MCP servers as podman would reuse the old container which may have old configuration associated with it