### PR TITLE
fix: preserve assigned HTTP port for streamable containers after app …

### DIFF
--- a/desktop_app/src/backend/sandbox/sandboxedMcp/index.ts
+++ b/desktop_app/src/backend/sandbox/sandboxedMcp/index.ts
@@ -419,7 +419,11 @@ export default class SandboxedMcpServer {
         throw new Error(`OAuth MCP server ${this.mcpServer.name} is missing access_token - cannot start container`);
       }
 
-      this.podmanContainer = new PodmanContainer(this.mcpServer, this.podmanSocketPath!);
+      // Use the existing podmanContainer if it exists, otherwise create a new one
+      // This ensures we don't lose the assignedHttpPort discovered for existing containers
+      if (!this.podmanContainer) {
+        this.podmanContainer = new PodmanContainer(this.mcpServer, this.podmanSocketPath!);
+      }
 
       try {
         await this.podmanContainer.startOrCreateContainer();


### PR DESCRIPTION
## Problem

Streamable HTTP containers (MCP servers configured with OAuth) were losing their dynamically assigned HTTP ports after app restart. This happened because the `SandboxedMcpServer` was creating a new `PodmanContainer` instance in the `start()` method, which overwrites the existing container that already had its port discovered and stored.

## Solution

This PR fixes the issue by checking if a `podmanContainer` instance already exists before creating a new one. This ensures that:
- Existing container instances are preserved across restarts
- The `assignedHttpPort` property discovered during container startup remains available
- Streamable HTTP servers can continue to use their originally assigned ports

## Technical Details

The fix is a simple conditional check in the `start()` method:

```typescript
// Use the existing podmanContainer if it exists, otherwise create a new one
// This ensures we don't lose the assignedHttpPort discovered for existing containers
if (!this.podmanContainer) {
  this.podmanContainer = new PodmanContainer(this.mcpServer, this.podmanSocketPath!);
}
```

This preserves the container instance that already has its HTTP port discovered via the `startOrCreateContainer()` method, which is crucial for streamable HTTP servers that need consistent port access after app restarts.