### PR TITLE
fix: refresh llm-proxy models immediately after auth success

### DIFF
--- a/desktop_app/src/ui/stores/cloud-providers-store.ts
+++ b/desktop_app/src/ui/stores/cloud-providers-store.ts
@@ -9,6 +9,7 @@ import {
   getAvailableCloudProviders,
   getCloudProviderModels,
 } from '@ui/lib/clients/archestra/api/gen';
+import webSocketService from '@ui/lib/websocket';
 
 interface CloudProvidersStore {
   cloudProviders: CloudProviderWithConfig[];
@@ -66,3 +67,12 @@ export const useCloudProvidersStore = create<CloudProvidersStore>((set, get) => 
 // Initialize data on store creation
 useCloudProvidersStore.getState().loadCloudProviders();
 useCloudProvidersStore.getState().getAvailableCloudProviderModels();
+
+// Subscribe to WebSocket events for real-time updates
+// Listen for user-authenticated event to refresh models
+webSocketService.subscribe('user-authenticated', () => {
+  console.log('User authenticated - refreshing cloud provider models');
+  // Refresh both cloud providers and models when user authenticates
+  useCloudProvidersStore.getState().loadCloudProviders();
+  useCloudProvidersStore.getState().getAvailableCloudProviderModels();
+});


### PR DESCRIPTION
## Summary

This PR fixes the issue where the llm-proxy model doesn't immediately appear in the model dropdown after successful authentication via deep-link.

## Changes

- Updated `cloud-providers-store.ts` to listen for the `user-authenticated` WebSocket event
- When the event is received, the store now refreshes both cloud providers and available models
- This ensures the llm-proxy model appears immediately without requiring a page refresh

## Testing

1. Start the application without any cloud provider configured
2. Initiate the llm-proxy authentication flow
3. Complete the authentication and get deep-linked back to the app
4. The llm-proxy model should now appear immediately in the model dropdown

Fixes #549