### PR TITLE
chore: polish Archestra LLM deep-linking flows in all spots

### DIFF
--- a/desktop_app/src/backend/config.ts
+++ b/desktop_app/src/backend/config.ts
@@ -3,6 +3,12 @@ import * as os from 'os';
 
 import { SYSTEM_MODELS } from '@constants';
 
+/**
+ * TODO: update this to use import.meta.env.VITE_ARCHESTRA_WEBSITE_BASE_URL
+ * aka the same environment variable that the frontend consumes...
+ */
+const ARCHESTRA_WEBSITE_BASE_URL = process.env.ARCHESTRA_WEBSITE_BASE_URL || 'https://www.archestra.ai';
+
 const OLLAMA_SERVER_PORT = parseInt(process.env.ARCHESTRA_OLLAMA_SERVER_PORT || '54589', 10);
 const OLLAMA_GUARD_MODEL = SYSTEM_MODELS.GUARD;
 const OLLAMA_GENERAL_MODEL = SYSTEM_MODELS.GENERAL;
@@ -32,11 +38,8 @@ export default {
   debug: DEBUG,
   logLevel: process.env.LOG_LEVEL || (DEBUG ? 'debug' : 'info'),
   archestra: {
-    /**
-     * TODO: update this to use import.meta.env.VITE_ARCHESTRA_WEBSITE_BASE_URL
-     * aka the same environment variable that the frontend consumes...
-     */
-    websiteUrl: process.env.ARCHESTRA_WEBSITE_BASE_URL || 'https://www.archestra.ai',
+    websiteUrl: ARCHESTRA_WEBSITE_BASE_URL,
+    cloudLlmProxyAuthUrl: `${ARCHESTRA_WEBSITE_BASE_URL}/signin?callbackURL=${encodeURIComponent('archestra-ai://auth-success')}`,
   },
   server: {
     http: {

--- a/desktop_app/src/backend/models/cloudProvider/index.ts
+++ b/desktop_app/src/backend/models/cloudProvider/index.ts
@@ -78,8 +78,8 @@ const PROVIDER_REGISTRY: Record<SupportedCloudProvider, CloudProvider> = {
   archestra: {
     type: 'archestra',
     name: 'Archestra LLM',
-    apiKeyUrl: `${config.archestra.websiteUrl}/signin`,
-    apiKeyPlaceholder: '1234',
+    apiKeyUrl: config.archestra.cloudLlmProxyAuthUrl,
+    apiKeyPlaceholder: 'Click Get API Key → to start the OAuth flow',
     baseUrl: `${config.archestra.websiteUrl}/api/llm-proxy/gemini`,
     models: ['archestra/gemini-2.5-flash'],
   },

--- a/desktop_app/src/ui/components/OnboardingWizard/index.tsx
+++ b/desktop_app/src/ui/components/OnboardingWizard/index.tsx
@@ -112,9 +112,7 @@ export default function OnboardingWizard({ onOpenChange }: OnboardingWizardProps
   );
 
   const handleGoogleSignIn = useCallback(async () => {
-    const callbackUrl = encodeURIComponent('archestra-ai://auth-success');
-    const authUrl = `${config.archestra.websiteUrl}/signin?callbackURL=${callbackUrl}`;
-    await window.electronAPI.openExternal(authUrl);
+    await window.electronAPI.openExternal(config.archestra.cloudLlmProxyAuthUrl);
 
     // Subscribe to authentication success event and move to next step
     subscribeToUserAuthenticatedEvent('onboarding', () => {

--- a/desktop_app/src/ui/config.ts
+++ b/desktop_app/src/ui/config.ts
@@ -25,7 +25,7 @@ export default {
     chatStreamBaseUrl: `${BASE_URL}/api/llm`,
     ollamaProxyUrl: `${BASE_URL}/llm/ollama`,
     websocketUrl: `ws://${HOST}:${WEBSOCKET_PORT}/ws`,
-    websiteUrl: ARCHESTRA_WEBSITE_BASE_URL,
+    cloudLlmProxyAuthUrl: `${ARCHESTRA_WEBSITE_BASE_URL}/signin?callbackURL=${encodeURIComponent('archestra-ai://auth-success')}`,
     catalogUrl: `${ARCHESTRA_WEBSITE_BASE_URL}/mcp-catalog/api`,
   },
   chat: {


### PR DESCRIPTION
## Summary

This PR improves the Archestra LLM OAuth authentication flow across the application by:

- Unifying the auth callback URL configuration between backend and frontend
- Fixing the CloudProviderConfigDialog to use the existing auth event subscription
- Adding automatic model refresh after successful authentication

## Key Changes

1. **Config Unification**: Both backend (`config.ts`) and frontend (`ui/config.ts`) now use the same callback URL pattern: `archestra-ai://auth-success`

2. **CloudProviderConfigDialog Enhancement**: 
   - Added auth event subscription for Archestra provider
   - Auto-closes dialog on successful authentication
   - Disabled API key input for Archestra provider (OAuth-based)

3. **User Store Improvements**:
   - Added `authLocation` parameter to track where authentication originated
   - Refreshes cloud provider models immediately after auth success
   - Added PostHog analytics tracking for auth events

4. **OnboardingWizard Cleanup**:
   - Removed unused imports and dead code
   - Simplified Google Sign-In flow using existing auth patterns

## Testing

- Test OAuth flow from onboarding wizard
- Test OAuth flow from CloudProviderConfigDialog
- Verify models refresh after authentication
- Confirm dialog auto-closes on successful auth