### PR TITLE
feat: switch to gemini-2.5-pro

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ Key tables:
   - Tool analysis using local models
   - Configurable port (default: 54589)
 - **Free LLM Option**: "archestra-llm" model
-  - Proxies requests to Google Gemini (gemini-2.5-flash) via configurable proxy
+  - Proxies requests to Google Gemini (gemini-2.5-pro) via configurable proxy
   - Requires external proxy service at {archestra.websiteUrl}/api/llm-proxy/gemini
   - No API key configuration needed in Archestra (handled by proxy)
   - Authentication: Session token sent as Bearer token in Authorization header

--- a/desktop_app/src/backend/models/cloudProvider/index.ts
+++ b/desktop_app/src/backend/models/cloudProvider/index.ts
@@ -81,7 +81,7 @@ const PROVIDER_REGISTRY: Record<SupportedCloudProvider, CloudProvider> = {
     apiKeyUrl: config.archestra.cloudLlmProxyAuthUrl,
     apiKeyPlaceholder: 'Click Get API Key → to start the OAuth flow',
     baseUrl: `${config.archestra.websiteUrl}/api/llm-proxy/gemini`,
-    models: ['archestra/gemini-2.5-flash'],
+    models: ['archestra/gemini-2.5-pro'],
   },
 };
 


### PR DESCRIPTION
Switch Archestra's free LLM proxy from gemini-2.5-flash to gemini-2.5-pro for enhanced performance capabilities