### PR TITLE
fix: Add 'Other' section to release-please config

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -58,7 +58,12 @@
       "section": "Miscellaneous Chores",
       "type": "chore",
       "hidden": true
-    }
+    },
+    {
+      "section": "Other",
+      "type": "*",
+      "hidden": true
+    },
   ],
   "packages": {
     "desktop_app": {


### PR DESCRIPTION
## Summary

This PR adds an 'Other' section to the release-please configuration to capture commits that don't match any of the defined conventional commit types. The wildcard type `*` ensures all commits are categorized in release notes.

## Changes

- Added 'Other' section with wildcard type `*` to `changelog-sections` in release-please config
- Set section as hidden to avoid cluttering release notes with miscellaneous commits

## Context

This change prevents commits from being excluded from release notes if they don't follow conventional commit formats or use types not explicitly defined in the configuration.