### PR TITLE
fix: release-please

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -63,7 +63,7 @@
       "section": "Other",
       "type": "*",
       "hidden": true
-    },
+    }
   ],
   "packages": {
     "desktop_app": {


### PR DESCRIPTION
## Summary

This PR fixes a JSON syntax error in the release-please configuration file by removing a trailing comma after the last object in the `changelog-sections` array.

## Changes

- Removed trailing comma from line 66 of `.github/release-please/release-please-config.json`

## Impact

This fix ensures the release-please configuration file is valid JSON, which should prevent parsing errors when release-please processes the configuration.