### PR TITLE
feat: add speech-to-text 

### DIFF
--- a/desktop_app/openapi/archestra/api/openapi.json
+++ b/desktop_app/openapi/archestra/api/openapi.json
@@ -25,7 +25,9 @@
             "type": "string"
           }
         },
-        "required": ["access_token"],
+        "required": [
+          "access_token"
+        ],
         "additionalProperties": {}
       },
       "OAuthClientInformationInput": {
@@ -38,7 +40,9 @@
             "type": "string"
           }
         },
-        "required": ["client_id"],
+        "required": [
+          "client_id"
+        ],
         "additionalProperties": {}
       },
       "AuthorizationServerMetadataInput": {
@@ -180,7 +184,10 @@
             "type": "boolean"
           }
         },
-        "required": ["is_read", "is_write"]
+        "required": [
+          "is_read",
+          "is_write"
+        ]
       },
       "ToolInput": {
         "type": "object",
@@ -201,7 +208,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -222,7 +231,9 @@
                       },
                       {
                         "nullable": true,
-                        "enum": [null]
+                        "enum": [
+                          null
+                        ]
                       }
                     ]
                   },
@@ -238,7 +249,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -249,7 +262,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -260,7 +275,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -271,7 +288,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -300,7 +319,14 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["not_installed", "initializing", "running", "error", "stopping", "stopped"]
+            "enum": [
+              "not_installed",
+              "initializing",
+              "running",
+              "error",
+              "stopping",
+              "stopped"
+            ]
           },
           "runtime": {
             "type": "object",
@@ -317,7 +343,9 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               },
@@ -328,7 +356,9 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               },
@@ -344,7 +374,9 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               },
@@ -355,7 +387,9 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               },
@@ -371,7 +405,9 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               },
@@ -382,12 +418,18 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               }
             },
-            "required": ["startupPercentage", "startupMessage", "startupError"]
+            "required": [
+              "startupPercentage",
+              "startupMessage",
+              "startupError"
+            ]
           },
           "mcpServers": {
             "type": "object",
@@ -404,7 +446,10 @@
                   }
                 }
               },
-              "required": ["container", "tools"]
+              "required": [
+                "container",
+                "tools"
+              ]
             }
           },
           "allAvailableTools": {
@@ -414,7 +459,11 @@
             }
           }
         },
-        "required": ["status", "runtime", "mcpServers"]
+        "required": [
+          "status",
+          "runtime",
+          "mcpServers"
+        ]
       },
       "PodmanContainerStatusSummaryInput": {
         "type": "object",
@@ -445,7 +494,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -456,12 +507,19 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           }
         },
-        "required": ["startupPercentage", "state", "message", "error"]
+        "required": [
+          "startupPercentage",
+          "state",
+          "message",
+          "error"
+        ]
       },
       "OllamaModelDownloadProgressInput": {
         "type": "object",
@@ -471,7 +529,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["downloading", "verifying", "completed", "error"]
+            "enum": [
+              "downloading",
+              "verifying",
+              "completed",
+              "error"
+            ]
           },
           "progress": {
             "type": "number",
@@ -482,7 +545,12 @@
             "type": "string"
           }
         },
-        "required": ["model", "status", "progress", "message"]
+        "required": [
+          "model",
+          "status",
+          "progress",
+          "message"
+        ]
       },
       "ToolApprovalRequestInput": {
         "type": "object",
@@ -513,7 +581,15 @@
             "type": "number"
           }
         },
-        "required": ["requestId", "toolId", "toolName", "args", "isWrite", "sessionId", "chatId"]
+        "required": [
+          "requestId",
+          "toolId",
+          "toolName",
+          "args",
+          "isWrite",
+          "sessionId",
+          "chatId"
+        ]
       },
       "ToolApprovalResponseInput": {
         "type": "object",
@@ -523,13 +599,21 @@
           },
           "decision": {
             "type": "string",
-            "enum": ["approve", "approve_always", "decline"]
+            "enum": [
+              "approve",
+              "approve_always",
+              "decline"
+            ]
           },
           "sessionId": {
             "type": "string"
           }
         },
-        "required": ["requestId", "decision", "sessionId"]
+        "required": [
+          "requestId",
+          "decision",
+          "sessionId"
+        ]
       },
       "WebSocketMessageInput": {
         "anyOf": [
@@ -538,7 +622,9 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["chat-title-updated"]
+                "enum": [
+                  "chat-title-updated"
+                ]
               },
               "payload": {
                 "type": "object",
@@ -550,17 +636,25 @@
                     "type": "string"
                   }
                 },
-                "required": ["chatId", "title"]
+                "required": [
+                  "chatId",
+                  "title"
+                ]
               }
             },
-            "required": ["type", "payload"]
+            "required": [
+              "type",
+              "payload"
+            ]
           },
           {
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["chat-tools-updated"]
+                "enum": [
+                  "chat-tools-updated"
+                ]
               },
               "payload": {
                 "type": "object",
@@ -578,48 +672,68 @@
                       },
                       {
                         "nullable": true,
-                        "enum": [null]
+                        "enum": [
+                          null
+                        ]
                       }
                     ]
                   }
                 },
-                "required": ["chatId", "selectedTools"]
+                "required": [
+                  "chatId",
+                  "selectedTools"
+                ]
               }
             },
-            "required": ["type", "payload"]
+            "required": [
+              "type",
+              "payload"
+            ]
           },
           {
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["sandbox-status-update"]
+                "enum": [
+                  "sandbox-status-update"
+                ]
               },
               "payload": {
                 "$ref": "#/components/schemas/SandboxStatusSummaryInput"
               }
             },
-            "required": ["type", "payload"]
+            "required": [
+              "type",
+              "payload"
+            ]
           },
           {
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["ollama-model-download-progress"]
+                "enum": [
+                  "ollama-model-download-progress"
+                ]
               },
               "payload": {
                 "$ref": "#/components/schemas/OllamaModelDownloadProgressInput"
               }
             },
-            "required": ["type", "payload"]
+            "required": [
+              "type",
+              "payload"
+            ]
           },
           {
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["memory-updated"]
+                "enum": [
+                  "memory-updated"
+                ]
               },
               "payload": {
                 "type": "object",
@@ -645,21 +759,34 @@
                           "type": "string"
                         }
                       },
-                      "required": ["id", "name", "value", "createdAt", "updatedAt"]
+                      "required": [
+                        "id",
+                        "name",
+                        "value",
+                        "createdAt",
+                        "updatedAt"
+                      ]
                     }
                   }
                 },
-                "required": ["memories"]
+                "required": [
+                  "memories"
+                ]
               }
             },
-            "required": ["type", "payload"]
+            "required": [
+              "type",
+              "payload"
+            ]
           },
           {
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["tools-updated"]
+                "enum": [
+                  "tools-updated"
+                ]
               },
               "payload": {
                 "type": "object",
@@ -671,17 +798,25 @@
                     "type": "string"
                   }
                 },
-                "required": ["mcpServerId", "message"]
+                "required": [
+                  "mcpServerId",
+                  "message"
+                ]
               }
             },
-            "required": ["type", "payload"]
+            "required": [
+              "type",
+              "payload"
+            ]
           },
           {
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["tool-analysis-progress"]
+                "enum": [
+                  "tool-analysis-progress"
+                ]
               },
               "payload": {
                 "type": "object",
@@ -691,7 +826,12 @@
                   },
                   "status": {
                     "type": "string",
-                    "enum": ["started", "analyzing", "completed", "error"]
+                    "enum": [
+                      "started",
+                      "analyzing",
+                      "completed",
+                      "error"
+                    ]
                   },
                   "progress": {
                     "type": "number",
@@ -714,17 +854,25 @@
                     "type": "string"
                   }
                 },
-                "required": ["status", "message"]
+                "required": [
+                  "status",
+                  "message"
+                ]
               }
             },
-            "required": ["type", "payload"]
+            "required": [
+              "type",
+              "payload"
+            ]
           },
           {
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["chat-token-usage-updated"]
+                "enum": [
+                  "chat-token-usage-updated"
+                ]
               },
               "payload": {
                 "type": "object",
@@ -739,7 +887,9 @@
                       },
                       {
                         "nullable": true,
-                        "enum": [null]
+                        "enum": [
+                          null
+                        ]
                       }
                     ]
                   },
@@ -750,7 +900,9 @@
                       },
                       {
                         "nullable": true,
-                        "enum": [null]
+                        "enum": [
+                          null
+                        ]
                       }
                     ]
                   },
@@ -761,7 +913,9 @@
                       },
                       {
                         "nullable": true,
-                        "enum": [null]
+                        "enum": [
+                          null
+                        ]
                       }
                     ]
                   },
@@ -772,7 +926,9 @@
                       },
                       {
                         "nullable": true,
-                        "enum": [null]
+                        "enum": [
+                          null
+                        ]
                       }
                     ]
                   },
@@ -783,7 +939,9 @@
                       },
                       {
                         "nullable": true,
-                        "enum": [null]
+                        "enum": [
+                          null
+                        ]
                       }
                     ]
                   },
@@ -802,54 +960,74 @@
                 ]
               }
             },
-            "required": ["type", "payload"]
+            "required": [
+              "type",
+              "payload"
+            ]
           },
           {
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["tool-approval-request"]
+                "enum": [
+                  "tool-approval-request"
+                ]
               },
               "payload": {
                 "$ref": "#/components/schemas/ToolApprovalRequestInput"
               }
             },
-            "required": ["type", "payload"]
+            "required": [
+              "type",
+              "payload"
+            ]
           },
           {
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["tool-approval-response"]
+                "enum": [
+                  "tool-approval-response"
+                ]
               },
               "payload": {
                 "$ref": "#/components/schemas/ToolApprovalResponseInput"
               }
             },
-            "required": ["type", "payload"]
+            "required": [
+              "type",
+              "payload"
+            ]
           },
           {
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["user-authenticated"]
+                "enum": [
+                  "user-authenticated"
+                ]
               },
               "payload": {
                 "type": "object",
                 "properties": {}
               }
             },
-            "required": ["type", "payload"]
+            "required": [
+              "type",
+              "payload"
+            ]
           },
           {
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["enable-tools-called"]
+                "enum": [
+                  "enable-tools-called"
+                ]
               },
               "payload": {
                 "type": "object",
@@ -867,10 +1045,17 @@
                     }
                   }
                 },
-                "required": ["chatId", "sessionId", "enabledTools"]
+                "required": [
+                  "chatId",
+                  "sessionId",
+                  "enabledTools"
+                ]
               }
             },
-            "required": ["type", "payload"]
+            "required": [
+              "type",
+              "payload"
+            ]
           }
         ]
       },
@@ -892,7 +1077,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -913,7 +1100,9 @@
                       },
                       {
                         "nullable": true,
-                        "enum": [null]
+                        "enum": [
+                          null
+                        ]
                       }
                     ]
                   },
@@ -929,7 +1118,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -942,7 +1133,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -955,7 +1148,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -968,7 +1163,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -979,7 +1176,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -992,7 +1191,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -1017,14 +1218,24 @@
                 },
                 "role": {
                   "type": "string",
-                  "enum": ["user", "assistant", "system"]
+                  "enum": [
+                    "user",
+                    "assistant",
+                    "system"
+                  ]
                 },
                 "content": {},
                 "createdAt": {
                   "type": "string"
                 }
               },
-              "required": ["id", "chatId", "role", "content", "createdAt"]
+              "required": [
+                "id",
+                "chatId",
+                "role",
+                "content",
+                "createdAt"
+              ]
             }
           }
         },
@@ -1088,7 +1299,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           }
@@ -1107,7 +1320,13 @@
       },
       "SupportedCloudProvidersInput": {
         "type": "string",
-        "enum": ["anthropic", "openai", "deepseek", "gemini", "archestra"]
+        "enum": [
+          "anthropic",
+          "openai",
+          "deepseek",
+          "gemini",
+          "archestra"
+        ]
       },
       "SupportedCloudProviderModelInput": {
         "type": "object",
@@ -1119,7 +1338,10 @@
             "$ref": "#/components/schemas/SupportedCloudProvidersInput"
           }
         },
-        "required": ["id", "provider"]
+        "required": [
+          "id",
+          "provider"
+        ]
       },
       "ExternalMcpClientInput": {
         "type": "object",
@@ -1131,11 +1353,18 @@
             "type": "string"
           }
         },
-        "required": ["clientName", "createdAt"]
+        "required": [
+          "clientName",
+          "createdAt"
+        ]
       },
       "ExternalMcpClientNameInput": {
         "type": "string",
-        "enum": ["claude", "cursor", "vscode"]
+        "enum": [
+          "claude",
+          "cursor",
+          "vscode"
+        ]
       },
       "McpRequestLogInput": {
         "type": "object",
@@ -1155,7 +1384,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -1166,7 +1397,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -1197,7 +1430,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -1216,7 +1451,9 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               },
@@ -1237,7 +1474,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -1248,7 +1487,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -1267,7 +1508,9 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               },
@@ -1293,7 +1536,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -1306,7 +1551,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -1354,11 +1601,21 @@
             }
           }
         },
-        "required": ["totalRequests", "successCount", "errorCount", "avgDurationMs", "requestsPerServer"]
+        "required": [
+          "totalRequests",
+          "successCount",
+          "errorCount",
+          "avgDurationMs",
+          "requestsPerServer"
+        ]
       },
       "McpRequestLogFilterStatusInput": {
         "type": "string",
-        "enum": ["HTTP 200", "HTTP 40x", "HTTP 50x"]
+        "enum": [
+          "HTTP 200",
+          "HTTP 40x",
+          "HTTP 50x"
+        ]
       },
       "McpServerConfigInput": {
         "type": "object",
@@ -1428,7 +1685,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -1439,7 +1698,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -1450,7 +1711,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -1461,7 +1724,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -1472,7 +1737,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -1481,17 +1748,27 @@
               {},
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
           "status": {
             "type": "string",
-            "enum": ["installing", "oauth_pending", "installed", "failed"]
+            "enum": [
+              "installing",
+              "oauth_pending",
+              "installed",
+              "failed"
+            ]
           },
           "serverType": {
             "type": "string",
-            "enum": ["local", "remote"]
+            "enum": [
+              "local",
+              "remote"
+            ]
           },
           "remoteUrl": {
             "anyOf": [
@@ -1500,7 +1777,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -1557,18 +1836,29 @@
           },
           "status": {
             "type": "string",
-            "enum": ["installing", "oauth_pending", "installed", "failed"]
+            "enum": [
+              "installing",
+              "oauth_pending",
+              "installed",
+              "failed"
+            ]
           },
           "serverType": {
             "type": "string",
-            "enum": ["local", "remote"]
+            "enum": [
+              "local",
+              "remote"
+            ]
           },
           "remote_url": {
             "type": "string"
           },
           "archestra_config": {}
         },
-        "required": ["displayName", "serverConfig"]
+        "required": [
+          "displayName",
+          "serverConfig"
+        ]
       },
       "McpServerContainerLogsInput": {
         "type": "object",
@@ -1580,7 +1870,10 @@
             "type": "string"
           }
         },
-        "required": ["logs", "containerName"]
+        "required": [
+          "logs",
+          "containerName"
+        ]
       },
       "AvailableToolInput": {
         "type": "object",
@@ -1615,7 +1908,12 @@
               "status": {
                 "description": "Analysis status",
                 "type": "string",
-                "enum": ["awaiting_ollama_model", "in_progress", "error", "completed"]
+                "enum": [
+                  "awaiting_ollama_model",
+                  "in_progress",
+                  "error",
+                  "completed"
+                ]
               },
               "error": {
                 "description": "Error message if analysis failed",
@@ -1625,7 +1923,9 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               },
@@ -1637,7 +1937,9 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               },
@@ -1649,15 +1951,28 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               }
             },
-            "required": ["status", "error", "is_read", "is_write"]
+            "required": [
+              "status",
+              "error",
+              "is_read",
+              "is_write"
+            ]
           }
         },
-        "required": ["id", "name", "mcpServerId", "mcpServerName", "analysis"]
+        "required": [
+          "id",
+          "name",
+          "mcpServerId",
+          "mcpServerName",
+          "analysis"
+        ]
       },
       "MemoryEntryInput": {
         "type": "object",
@@ -1678,7 +1993,13 @@
             "type": "string"
           }
         },
-        "required": ["id", "name", "value", "createdAt", "updatedAt"]
+        "required": [
+          "id",
+          "name",
+          "value",
+          "createdAt",
+          "updatedAt"
+        ]
       },
       "MemoryListResponseInput": {
         "type": "object",
@@ -1690,7 +2011,9 @@
             }
           }
         },
-        "required": ["memories"]
+        "required": [
+          "memories"
+        ]
       },
       "MemoryResponseInput": {
         "type": "object",
@@ -1702,12 +2025,16 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           }
         },
-        "required": ["memory"]
+        "required": [
+          "memory"
+        ]
       },
       "LegacyMemoryResponseInput": {
         "type": "object",
@@ -1716,7 +2043,9 @@
             "type": "string"
           }
         },
-        "required": ["content"]
+        "required": [
+          "content"
+        ]
       },
       "CreateMemoryInput": {
         "type": "object",
@@ -1731,7 +2060,10 @@
             "type": "string"
           }
         },
-        "required": ["name", "value"]
+        "required": [
+          "name",
+          "value"
+        ]
       },
       "DeleteResponseInput": {
         "type": "object",
@@ -1746,7 +2078,9 @@
             "type": "number"
           }
         },
-        "required": ["success"]
+        "required": [
+          "success"
+        ]
       },
       "OllamaRequiredModelStatusInput": {
         "type": "object",
@@ -1761,7 +2095,11 @@
             "type": "boolean"
           }
         },
-        "required": ["model", "reason", "installed"]
+        "required": [
+          "model",
+          "reason",
+          "installed"
+        ]
       },
       "SandboxActionResponseInput": {
         "type": "object",
@@ -1773,7 +2111,39 @@
             "type": "string"
           }
         },
-        "required": ["success", "message"]
+        "required": [
+          "success",
+          "message"
+        ]
+      },
+      "TranscribeRequestInput": {
+        "type": "object",
+        "properties": {
+          "audio": {
+            "description": "Base64-encoded audio data",
+            "type": "string"
+          },
+          "mimeType": {
+            "description": "Audio MIME type (e.g., audio/webm, audio/mp4)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "audio",
+          "mimeType"
+        ]
+      },
+      "TranscribeResponseInput": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "description": "Transcribed text from audio",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ]
       },
       "BackendLogsResponseInput": {
         "type": "object",
@@ -1790,12 +2160,17 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           }
         },
-        "required": ["logs", "error"]
+        "required": [
+          "logs",
+          "error"
+        ]
       },
       "UserInput": {
         "type": "object",
@@ -1812,7 +2187,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -1861,7 +2238,9 @@
             "type": "string"
           }
         },
-        "required": ["access_token"],
+        "required": [
+          "access_token"
+        ],
         "additionalProperties": {}
       },
       "OAuthClientInformation": {
@@ -1874,7 +2253,9 @@
             "type": "string"
           }
         },
-        "required": ["client_id"],
+        "required": [
+          "client_id"
+        ],
         "additionalProperties": {}
       },
       "AuthorizationServerMetadata": {
@@ -2017,7 +2398,10 @@
             "type": "boolean"
           }
         },
-        "required": ["is_read", "is_write"],
+        "required": [
+          "is_read",
+          "is_write"
+        ],
         "additionalProperties": false
       },
       "Tool": {
@@ -2039,7 +2423,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -2060,7 +2446,9 @@
                       },
                       {
                         "nullable": true,
-                        "enum": [null]
+                        "enum": [
+                          null
+                        ]
                       }
                     ]
                   },
@@ -2076,7 +2464,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -2087,7 +2477,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -2098,7 +2490,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -2109,7 +2503,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -2139,7 +2535,14 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["not_installed", "initializing", "running", "error", "stopping", "stopped"]
+            "enum": [
+              "not_installed",
+              "initializing",
+              "running",
+              "error",
+              "stopping",
+              "stopped"
+            ]
           },
           "runtime": {
             "type": "object",
@@ -2156,7 +2559,9 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               },
@@ -2167,7 +2572,9 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               },
@@ -2183,7 +2590,9 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               },
@@ -2194,7 +2603,9 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               },
@@ -2210,7 +2621,9 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               },
@@ -2221,12 +2634,18 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               }
             },
-            "required": ["startupPercentage", "startupMessage", "startupError"],
+            "required": [
+              "startupPercentage",
+              "startupMessage",
+              "startupError"
+            ],
             "additionalProperties": false
           },
           "mcpServers": {
@@ -2244,7 +2663,10 @@
                   }
                 }
               },
-              "required": ["container", "tools"],
+              "required": [
+                "container",
+                "tools"
+              ],
               "additionalProperties": false
             }
           },
@@ -2255,7 +2677,11 @@
             }
           }
         },
-        "required": ["status", "runtime", "mcpServers"],
+        "required": [
+          "status",
+          "runtime",
+          "mcpServers"
+        ],
         "additionalProperties": false
       },
       "PodmanContainerStatusSummary": {
@@ -2287,7 +2713,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -2298,12 +2726,19 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           }
         },
-        "required": ["startupPercentage", "state", "message", "error"],
+        "required": [
+          "startupPercentage",
+          "state",
+          "message",
+          "error"
+        ],
         "additionalProperties": false
       },
       "OllamaModelDownloadProgress": {
@@ -2314,7 +2749,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["downloading", "verifying", "completed", "error"]
+            "enum": [
+              "downloading",
+              "verifying",
+              "completed",
+              "error"
+            ]
           },
           "progress": {
             "type": "number",
@@ -2325,7 +2765,12 @@
             "type": "string"
           }
         },
-        "required": ["model", "status", "progress", "message"],
+        "required": [
+          "model",
+          "status",
+          "progress",
+          "message"
+        ],
         "additionalProperties": false
       },
       "ToolApprovalRequest": {
@@ -2357,7 +2802,15 @@
             "type": "number"
           }
         },
-        "required": ["requestId", "toolId", "toolName", "args", "isWrite", "sessionId", "chatId"],
+        "required": [
+          "requestId",
+          "toolId",
+          "toolName",
+          "args",
+          "isWrite",
+          "sessionId",
+          "chatId"
+        ],
         "additionalProperties": false
       },
       "ToolApprovalResponse": {
@@ -2368,13 +2821,21 @@
           },
           "decision": {
             "type": "string",
-            "enum": ["approve", "approve_always", "decline"]
+            "enum": [
+              "approve",
+              "approve_always",
+              "decline"
+            ]
           },
           "sessionId": {
             "type": "string"
           }
         },
-        "required": ["requestId", "decision", "sessionId"],
+        "required": [
+          "requestId",
+          "decision",
+          "sessionId"
+        ],
         "additionalProperties": false
       },
       "WebSocketMessage": {
@@ -2384,7 +2845,9 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["chat-title-updated"]
+                "enum": [
+                  "chat-title-updated"
+                ]
               },
               "payload": {
                 "type": "object",
@@ -2396,11 +2859,17 @@
                     "type": "string"
                   }
                 },
-                "required": ["chatId", "title"],
+                "required": [
+                  "chatId",
+                  "title"
+                ],
                 "additionalProperties": false
               }
             },
-            "required": ["type", "payload"],
+            "required": [
+              "type",
+              "payload"
+            ],
             "additionalProperties": false
           },
           {
@@ -2408,7 +2877,9 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["chat-tools-updated"]
+                "enum": [
+                  "chat-tools-updated"
+                ]
               },
               "payload": {
                 "type": "object",
@@ -2426,16 +2897,24 @@
                       },
                       {
                         "nullable": true,
-                        "enum": [null]
+                        "enum": [
+                          null
+                        ]
                       }
                     ]
                   }
                 },
-                "required": ["chatId", "selectedTools"],
+                "required": [
+                  "chatId",
+                  "selectedTools"
+                ],
                 "additionalProperties": false
               }
             },
-            "required": ["type", "payload"],
+            "required": [
+              "type",
+              "payload"
+            ],
             "additionalProperties": false
           },
           {
@@ -2443,13 +2922,18 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["sandbox-status-update"]
+                "enum": [
+                  "sandbox-status-update"
+                ]
               },
               "payload": {
                 "$ref": "#/components/schemas/SandboxStatusSummary"
               }
             },
-            "required": ["type", "payload"],
+            "required": [
+              "type",
+              "payload"
+            ],
             "additionalProperties": false
           },
           {
@@ -2457,13 +2941,18 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["ollama-model-download-progress"]
+                "enum": [
+                  "ollama-model-download-progress"
+                ]
               },
               "payload": {
                 "$ref": "#/components/schemas/OllamaModelDownloadProgress"
               }
             },
-            "required": ["type", "payload"],
+            "required": [
+              "type",
+              "payload"
+            ],
             "additionalProperties": false
           },
           {
@@ -2471,7 +2960,9 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["memory-updated"]
+                "enum": [
+                  "memory-updated"
+                ]
               },
               "payload": {
                 "type": "object",
@@ -2497,16 +2988,27 @@
                           "type": "string"
                         }
                       },
-                      "required": ["id", "name", "value", "createdAt", "updatedAt"],
+                      "required": [
+                        "id",
+                        "name",
+                        "value",
+                        "createdAt",
+                        "updatedAt"
+                      ],
                       "additionalProperties": false
                     }
                   }
                 },
-                "required": ["memories"],
+                "required": [
+                  "memories"
+                ],
                 "additionalProperties": false
               }
             },
-            "required": ["type", "payload"],
+            "required": [
+              "type",
+              "payload"
+            ],
             "additionalProperties": false
           },
           {
@@ -2514,7 +3016,9 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["tools-updated"]
+                "enum": [
+                  "tools-updated"
+                ]
               },
               "payload": {
                 "type": "object",
@@ -2526,11 +3030,17 @@
                     "type": "string"
                   }
                 },
-                "required": ["mcpServerId", "message"],
+                "required": [
+                  "mcpServerId",
+                  "message"
+                ],
                 "additionalProperties": false
               }
             },
-            "required": ["type", "payload"],
+            "required": [
+              "type",
+              "payload"
+            ],
             "additionalProperties": false
           },
           {
@@ -2538,7 +3048,9 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["tool-analysis-progress"]
+                "enum": [
+                  "tool-analysis-progress"
+                ]
               },
               "payload": {
                 "type": "object",
@@ -2548,7 +3060,12 @@
                   },
                   "status": {
                     "type": "string",
-                    "enum": ["started", "analyzing", "completed", "error"]
+                    "enum": [
+                      "started",
+                      "analyzing",
+                      "completed",
+                      "error"
+                    ]
                   },
                   "progress": {
                     "type": "number",
@@ -2571,11 +3088,17 @@
                     "type": "string"
                   }
                 },
-                "required": ["status", "message"],
+                "required": [
+                  "status",
+                  "message"
+                ],
                 "additionalProperties": false
               }
             },
-            "required": ["type", "payload"],
+            "required": [
+              "type",
+              "payload"
+            ],
             "additionalProperties": false
           },
           {
@@ -2583,7 +3106,9 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["chat-token-usage-updated"]
+                "enum": [
+                  "chat-token-usage-updated"
+                ]
               },
               "payload": {
                 "type": "object",
@@ -2598,7 +3123,9 @@
                       },
                       {
                         "nullable": true,
-                        "enum": [null]
+                        "enum": [
+                          null
+                        ]
                       }
                     ]
                   },
@@ -2609,7 +3136,9 @@
                       },
                       {
                         "nullable": true,
-                        "enum": [null]
+                        "enum": [
+                          null
+                        ]
                       }
                     ]
                   },
@@ -2620,7 +3149,9 @@
                       },
                       {
                         "nullable": true,
-                        "enum": [null]
+                        "enum": [
+                          null
+                        ]
                       }
                     ]
                   },
@@ -2631,7 +3162,9 @@
                       },
                       {
                         "nullable": true,
-                        "enum": [null]
+                        "enum": [
+                          null
+                        ]
                       }
                     ]
                   },
@@ -2642,7 +3175,9 @@
                       },
                       {
                         "nullable": true,
-                        "enum": [null]
+                        "enum": [
+                          null
+                        ]
                       }
                     ]
                   },
@@ -2662,7 +3197,10 @@
                 "additionalProperties": false
               }
             },
-            "required": ["type", "payload"],
+            "required": [
+              "type",
+              "payload"
+            ],
             "additionalProperties": false
           },
           {
@@ -2670,13 +3208,18 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["tool-approval-request"]
+                "enum": [
+                  "tool-approval-request"
+                ]
               },
               "payload": {
                 "$ref": "#/components/schemas/ToolApprovalRequest"
               }
             },
-            "required": ["type", "payload"],
+            "required": [
+              "type",
+              "payload"
+            ],
             "additionalProperties": false
           },
           {
@@ -2684,13 +3227,18 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["tool-approval-response"]
+                "enum": [
+                  "tool-approval-response"
+                ]
               },
               "payload": {
                 "$ref": "#/components/schemas/ToolApprovalResponse"
               }
             },
-            "required": ["type", "payload"],
+            "required": [
+              "type",
+              "payload"
+            ],
             "additionalProperties": false
           },
           {
@@ -2698,7 +3246,9 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["user-authenticated"]
+                "enum": [
+                  "user-authenticated"
+                ]
               },
               "payload": {
                 "type": "object",
@@ -2706,7 +3256,10 @@
                 "additionalProperties": false
               }
             },
-            "required": ["type", "payload"],
+            "required": [
+              "type",
+              "payload"
+            ],
             "additionalProperties": false
           },
           {
@@ -2714,7 +3267,9 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["enable-tools-called"]
+                "enum": [
+                  "enable-tools-called"
+                ]
               },
               "payload": {
                 "type": "object",
@@ -2732,11 +3287,18 @@
                     }
                   }
                 },
-                "required": ["chatId", "sessionId", "enabledTools"],
+                "required": [
+                  "chatId",
+                  "sessionId",
+                  "enabledTools"
+                ],
                 "additionalProperties": false
               }
             },
-            "required": ["type", "payload"],
+            "required": [
+              "type",
+              "payload"
+            ],
             "additionalProperties": false
           }
         ]
@@ -2759,7 +3321,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -2780,7 +3344,9 @@
                       },
                       {
                         "nullable": true,
-                        "enum": [null]
+                        "enum": [
+                          null
+                        ]
                       }
                     ]
                   },
@@ -2796,7 +3362,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -2809,7 +3377,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -2822,7 +3392,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -2835,7 +3407,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -2846,7 +3420,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -2859,7 +3435,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -2884,14 +3462,24 @@
                 },
                 "role": {
                   "type": "string",
-                  "enum": ["user", "assistant", "system"]
+                  "enum": [
+                    "user",
+                    "assistant",
+                    "system"
+                  ]
                 },
                 "content": {},
                 "createdAt": {
                   "type": "string"
                 }
               },
-              "required": ["id", "chatId", "role", "content", "createdAt"],
+              "required": [
+                "id",
+                "chatId",
+                "role",
+                "content",
+                "createdAt"
+              ],
               "additionalProperties": false
             }
           }
@@ -2957,7 +3545,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           }
@@ -2977,7 +3567,13 @@
       },
       "SupportedCloudProviders": {
         "type": "string",
-        "enum": ["anthropic", "openai", "deepseek", "gemini", "archestra"]
+        "enum": [
+          "anthropic",
+          "openai",
+          "deepseek",
+          "gemini",
+          "archestra"
+        ]
       },
       "SupportedCloudProviderModel": {
         "type": "object",
@@ -2989,7 +3585,10 @@
             "$ref": "#/components/schemas/SupportedCloudProviders"
           }
         },
-        "required": ["id", "provider"],
+        "required": [
+          "id",
+          "provider"
+        ],
         "additionalProperties": false
       },
       "ExternalMcpClient": {
@@ -3002,12 +3601,19 @@
             "type": "string"
           }
         },
-        "required": ["clientName", "createdAt"],
+        "required": [
+          "clientName",
+          "createdAt"
+        ],
         "additionalProperties": false
       },
       "ExternalMcpClientName": {
         "type": "string",
-        "enum": ["claude", "cursor", "vscode"]
+        "enum": [
+          "claude",
+          "cursor",
+          "vscode"
+        ]
       },
       "McpRequestLog": {
         "type": "object",
@@ -3027,7 +3633,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -3038,7 +3646,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -3070,7 +3680,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -3089,7 +3701,9 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               },
@@ -3110,7 +3724,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -3121,7 +3737,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -3140,7 +3758,9 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               },
@@ -3166,7 +3786,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -3179,7 +3801,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -3228,12 +3852,22 @@
             }
           }
         },
-        "required": ["totalRequests", "successCount", "errorCount", "avgDurationMs", "requestsPerServer"],
+        "required": [
+          "totalRequests",
+          "successCount",
+          "errorCount",
+          "avgDurationMs",
+          "requestsPerServer"
+        ],
         "additionalProperties": false
       },
       "McpRequestLogFilterStatus": {
         "type": "string",
-        "enum": ["HTTP 200", "HTTP 40x", "HTTP 50x"]
+        "enum": [
+          "HTTP 200",
+          "HTTP 40x",
+          "HTTP 50x"
+        ]
       },
       "McpServerConfig": {
         "type": "object",
@@ -3303,7 +3937,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -3314,7 +3950,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -3325,7 +3963,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -3336,7 +3976,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -3347,7 +3989,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -3356,17 +4000,27 @@
               {},
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
           "status": {
             "type": "string",
-            "enum": ["installing", "oauth_pending", "installed", "failed"]
+            "enum": [
+              "installing",
+              "oauth_pending",
+              "installed",
+              "failed"
+            ]
           },
           "serverType": {
             "type": "string",
-            "enum": ["local", "remote"]
+            "enum": [
+              "local",
+              "remote"
+            ]
           },
           "remoteUrl": {
             "anyOf": [
@@ -3375,7 +4029,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -3433,18 +4089,29 @@
           },
           "status": {
             "type": "string",
-            "enum": ["installing", "oauth_pending", "installed", "failed"]
+            "enum": [
+              "installing",
+              "oauth_pending",
+              "installed",
+              "failed"
+            ]
           },
           "serverType": {
             "type": "string",
-            "enum": ["local", "remote"]
+            "enum": [
+              "local",
+              "remote"
+            ]
           },
           "remote_url": {
             "type": "string"
           },
           "archestra_config": {}
         },
-        "required": ["displayName", "serverConfig"],
+        "required": [
+          "displayName",
+          "serverConfig"
+        ],
         "additionalProperties": false
       },
       "McpServerContainerLogs": {
@@ -3457,7 +4124,10 @@
             "type": "string"
           }
         },
-        "required": ["logs", "containerName"],
+        "required": [
+          "logs",
+          "containerName"
+        ],
         "additionalProperties": false
       },
       "AvailableTool": {
@@ -3493,7 +4163,12 @@
               "status": {
                 "description": "Analysis status",
                 "type": "string",
-                "enum": ["awaiting_ollama_model", "in_progress", "error", "completed"]
+                "enum": [
+                  "awaiting_ollama_model",
+                  "in_progress",
+                  "error",
+                  "completed"
+                ]
               },
               "error": {
                 "description": "Error message if analysis failed",
@@ -3503,7 +4178,9 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               },
@@ -3515,7 +4192,9 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               },
@@ -3527,16 +4206,29 @@
                   },
                   {
                     "nullable": true,
-                    "enum": [null]
+                    "enum": [
+                      null
+                    ]
                   }
                 ]
               }
             },
-            "required": ["status", "error", "is_read", "is_write"],
+            "required": [
+              "status",
+              "error",
+              "is_read",
+              "is_write"
+            ],
             "additionalProperties": false
           }
         },
-        "required": ["id", "name", "mcpServerId", "mcpServerName", "analysis"],
+        "required": [
+          "id",
+          "name",
+          "mcpServerId",
+          "mcpServerName",
+          "analysis"
+        ],
         "additionalProperties": false
       },
       "MemoryEntry": {
@@ -3558,7 +4250,13 @@
             "type": "string"
           }
         },
-        "required": ["id", "name", "value", "createdAt", "updatedAt"],
+        "required": [
+          "id",
+          "name",
+          "value",
+          "createdAt",
+          "updatedAt"
+        ],
         "additionalProperties": false
       },
       "MemoryListResponse": {
@@ -3571,7 +4269,9 @@
             }
           }
         },
-        "required": ["memories"],
+        "required": [
+          "memories"
+        ],
         "additionalProperties": false
       },
       "MemoryResponse": {
@@ -3584,12 +4284,16 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           }
         },
-        "required": ["memory"],
+        "required": [
+          "memory"
+        ],
         "additionalProperties": false
       },
       "LegacyMemoryResponse": {
@@ -3599,7 +4303,9 @@
             "type": "string"
           }
         },
-        "required": ["content"],
+        "required": [
+          "content"
+        ],
         "additionalProperties": false
       },
       "CreateMemory": {
@@ -3615,7 +4321,10 @@
             "type": "string"
           }
         },
-        "required": ["name", "value"],
+        "required": [
+          "name",
+          "value"
+        ],
         "additionalProperties": false
       },
       "DeleteResponse": {
@@ -3631,7 +4340,9 @@
             "type": "number"
           }
         },
-        "required": ["success"],
+        "required": [
+          "success"
+        ],
         "additionalProperties": false
       },
       "OllamaRequiredModelStatus": {
@@ -3647,7 +4358,11 @@
             "type": "boolean"
           }
         },
-        "required": ["model", "reason", "installed"],
+        "required": [
+          "model",
+          "reason",
+          "installed"
+        ],
         "additionalProperties": false
       },
       "SandboxActionResponse": {
@@ -3660,7 +4375,41 @@
             "type": "string"
           }
         },
-        "required": ["success", "message"],
+        "required": [
+          "success",
+          "message"
+        ],
+        "additionalProperties": false
+      },
+      "TranscribeRequest": {
+        "type": "object",
+        "properties": {
+          "audio": {
+            "description": "Base64-encoded audio data",
+            "type": "string"
+          },
+          "mimeType": {
+            "description": "Audio MIME type (e.g., audio/webm, audio/mp4)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "audio",
+          "mimeType"
+        ],
+        "additionalProperties": false
+      },
+      "TranscribeResponse": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "description": "Transcribed text from audio",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
         "additionalProperties": false
       },
       "BackendLogsResponse": {
@@ -3678,12 +4427,17 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           }
         },
-        "required": ["logs", "error"],
+        "required": [
+          "logs",
+          "error"
+        ],
         "additionalProperties": false
       },
       "User": {
@@ -3701,7 +4455,9 @@
               },
               {
                 "nullable": true,
-                "enum": [null]
+                "enum": [
+                  null
+                ]
               }
             ]
           },
@@ -3738,7 +4494,9 @@
     "/api/oauth/store-code": {
       "post": {
         "operationId": "storeOAuthCode",
-        "tags": ["OAuth"],
+        "tags": [
+          "OAuth"
+        ],
         "description": "Store OAuth authorization code from deep link callback (internal API)",
         "requestBody": {
           "content": {
@@ -3755,7 +4513,10 @@
                     "minLength": 1
                   }
                 },
-                "required": ["state", "code"]
+                "required": [
+                  "state",
+                  "code"
+                ]
               }
             }
           },
@@ -3776,7 +4537,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["success", "message"],
+                  "required": [
+                    "success",
+                    "message"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -3793,7 +4557,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -3810,7 +4576,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -3822,7 +4590,9 @@
     "/api/chat": {
       "get": {
         "operationId": "getChats",
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "Get all chats",
         "responses": {
           "200": {
@@ -3842,7 +4612,9 @@
       },
       "post": {
         "operationId": "createChat",
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "Create new chat",
         "requestBody": {
           "content": {
@@ -3871,7 +4643,9 @@
     "/api/chat/{id}": {
       "get": {
         "operationId": "getChatById",
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "Get single chat with messages",
         "parameters": [
           {
@@ -3905,7 +4679,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -3915,7 +4691,9 @@
       },
       "patch": {
         "operationId": "updateChat",
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "Update chat",
         "requestBody": {
           "content": {
@@ -3930,7 +4708,9 @@
                       },
                       {
                         "nullable": true,
-                        "enum": [null]
+                        "enum": [
+                          null
+                        ]
                       }
                     ]
                   }
@@ -3971,7 +4751,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -3981,7 +4763,9 @@
       },
       "delete": {
         "operationId": "deleteChat",
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "Delete chat",
         "parameters": [
           {
@@ -4008,7 +4792,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4020,7 +4806,9 @@
     "/api/chat/{id}/tools": {
       "get": {
         "operationId": "getChatSelectedTools",
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "Get selected tools for a specific chat",
         "parameters": [
           {
@@ -4050,7 +4838,9 @@
                         },
                         {
                           "nullable": true,
-                          "enum": [null]
+                          "enum": [
+                            null
+                          ]
                         }
                       ]
                     },
@@ -4061,7 +4851,10 @@
                       }
                     }
                   },
-                  "required": ["selectedTools", "availableTools"],
+                  "required": [
+                    "selectedTools",
+                    "availableTools"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4078,7 +4871,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4090,7 +4885,9 @@
     "/api/chat/{id}/tools/select": {
       "post": {
         "operationId": "selectChatTools",
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "Add tools to chat selection",
         "requestBody": {
           "content": {
@@ -4105,7 +4902,9 @@
                     }
                   }
                 },
-                "required": ["toolIds"]
+                "required": [
+                  "toolIds"
+                ]
               }
             }
           },
@@ -4136,7 +4935,9 @@
                       }
                     }
                   },
-                  "required": ["selectedTools"],
+                  "required": [
+                    "selectedTools"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4153,7 +4954,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4165,7 +4968,9 @@
     "/api/chat/{id}/tools/deselect": {
       "post": {
         "operationId": "deselectChatTools",
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "Remove tools from chat selection",
         "requestBody": {
           "content": {
@@ -4180,7 +4985,9 @@
                     }
                   }
                 },
-                "required": ["toolIds"]
+                "required": [
+                  "toolIds"
+                ]
               }
             }
           },
@@ -4211,7 +5018,9 @@
                       }
                     }
                   },
-                  "required": ["selectedTools"],
+                  "required": [
+                    "selectedTools"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4228,7 +5037,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4245,7 +5056,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4257,7 +5070,9 @@
     "/api/chat/{id}/tools/select-all": {
       "post": {
         "operationId": "selectAllChatTools",
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "Select all available tools for this chat",
         "parameters": [
           {
@@ -4281,7 +5096,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"],
+                  "required": [
+                    "message"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4298,7 +5115,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4310,7 +5129,9 @@
     "/api/chat/{id}/tools/deselect-all": {
       "post": {
         "operationId": "deselectAllChatTools",
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "Clear all tool selections for this chat",
         "parameters": [
           {
@@ -4334,7 +5155,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"],
+                  "required": [
+                    "message"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4351,7 +5174,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4363,7 +5188,9 @@
     "/api/chat/{id}/tools/available": {
       "get": {
         "operationId": "getChatAvailableTools",
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "List all tools available for selection",
         "parameters": [
           {
@@ -4395,7 +5222,9 @@
     "/api/message/{id}": {
       "put": {
         "operationId": "updateChatMessage",
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "Update a specific message",
         "requestBody": {
           "content": {
@@ -4405,7 +5234,9 @@
                 "properties": {
                   "content": {}
                 },
-                "required": ["content"]
+                "required": [
+                  "content"
+                ]
               }
             }
           },
@@ -4434,7 +5265,9 @@
                       "type": "boolean"
                     }
                   },
-                  "required": ["success"],
+                  "required": [
+                    "success"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4451,7 +5284,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4461,7 +5296,9 @@
       },
       "delete": {
         "operationId": "deleteChatMessage",
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "Delete a specific message",
         "parameters": [
           {
@@ -4489,7 +5326,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4501,7 +5340,9 @@
     "/api/chat/{sessionId}/reset-token-usage": {
       "post": {
         "operationId": "resetChatTokenUsage",
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "Reset token usage counters for a chat session",
         "parameters": [
           {
@@ -4526,7 +5367,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"],
+                  "required": [
+                    "message"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4543,7 +5386,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4555,7 +5400,9 @@
     "/api/cloud-providers/available": {
       "get": {
         "operationId": "getAvailableCloudProviders",
-        "tags": ["Cloud Providers"],
+        "tags": [
+          "Cloud Providers"
+        ],
         "description": "Get all available cloud providers with configuration status",
         "responses": {
           "200": {
@@ -4577,7 +5424,9 @@
     "/api/cloud-providers": {
       "post": {
         "operationId": "configureCloudProvider",
-        "tags": ["Cloud Providers"],
+        "tags": [
+          "Cloud Providers"
+        ],
         "description": "Configure a cloud provider with API key",
         "requestBody": {
           "content": {
@@ -4592,7 +5441,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["type", "apiKey"]
+                "required": [
+                  "type",
+                  "apiKey"
+                ]
               }
             }
           },
@@ -4610,7 +5462,9 @@
                       "type": "boolean"
                     }
                   },
-                  "required": ["success"],
+                  "required": [
+                    "success"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4622,7 +5476,9 @@
     "/api/cloud-providers/{type}": {
       "delete": {
         "operationId": "deleteCloudProvider",
-        "tags": ["Cloud Providers"],
+        "tags": [
+          "Cloud Providers"
+        ],
         "description": "Remove cloud provider configuration",
         "parameters": [
           {
@@ -4646,7 +5502,9 @@
                       "type": "boolean"
                     }
                   },
-                  "required": ["success"],
+                  "required": [
+                    "success"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4658,7 +5516,9 @@
     "/api/cloud-providers/models": {
       "get": {
         "operationId": "getCloudProviderModels",
-        "tags": ["Cloud Providers"],
+        "tags": [
+          "Cloud Providers"
+        ],
         "description": "Get all available models from configured providers",
         "responses": {
           "200": {
@@ -4680,7 +5540,9 @@
     "/api/external_mcp_client": {
       "get": {
         "operationId": "getConnectedExternalMcpClients",
-        "tags": ["External MCP Client"],
+        "tags": [
+          "External MCP Client"
+        ],
         "description": "Get all connected external MCP clients",
         "responses": {
           "200": {
@@ -4702,7 +5564,9 @@
     "/api/external_mcp_client/supported": {
       "get": {
         "operationId": "getSupportedExternalMcpClients",
-        "tags": ["External MCP Client"],
+        "tags": [
+          "External MCP Client"
+        ],
         "description": "Get supported external MCP client names",
         "responses": {
           "200": {
@@ -4724,7 +5588,9 @@
     "/api/external_mcp_client/connect": {
       "post": {
         "operationId": "connectExternalMcpClient",
-        "tags": ["External MCP Client"],
+        "tags": [
+          "External MCP Client"
+        ],
         "description": "Connect an external MCP client",
         "requestBody": {
           "content": {
@@ -4736,7 +5602,9 @@
                     "$ref": "#/components/schemas/ExternalMcpClientNameInput"
                   }
                 },
-                "required": ["clientName"]
+                "required": [
+                  "clientName"
+                ]
               }
             }
           },
@@ -4754,7 +5622,9 @@
                       "type": "boolean"
                     }
                   },
-                  "required": ["success"],
+                  "required": [
+                    "success"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4766,7 +5636,9 @@
     "/api/external_mcp_client/{clientName}/disconnect": {
       "delete": {
         "operationId": "disconnectExternalMcpClient",
-        "tags": ["External MCP Client"],
+        "tags": [
+          "External MCP Client"
+        ],
         "description": "Disconnect an external MCP client",
         "parameters": [
           {
@@ -4790,7 +5662,9 @@
                       "type": "boolean"
                     }
                   },
-                  "required": ["success"],
+                  "required": [
+                    "success"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4802,7 +5676,9 @@
     "/api/mcp_server/start_oauth": {
       "post": {
         "operationId": "startGenericOAuth",
-        "tags": ["OAuth"],
+        "tags": [
+          "OAuth"
+        ],
         "description": "Start generic OAuth flow for MCP server installation",
         "requestBody": {
           "content": {
@@ -4814,7 +5690,9 @@
                     "$ref": "#/components/schemas/McpServerInstallInput"
                   }
                 },
-                "required": ["installData"]
+                "required": [
+                  "installData"
+                ]
               }
             }
           },
@@ -4838,7 +5716,11 @@
                       "type": "string"
                     }
                   },
-                  "required": ["server", "authUrl", "message"],
+                  "required": [
+                    "server",
+                    "authUrl",
+                    "message"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4855,7 +5737,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4872,7 +5756,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4884,7 +5770,9 @@
     "/api/mcp_server/complete_oauth": {
       "post": {
         "operationId": "completeGenericOAuth",
-        "tags": ["OAuth"],
+        "tags": [
+          "OAuth"
+        ],
         "description": "Complete generic OAuth flow with authorization code",
         "requestBody": {
           "content": {
@@ -4899,7 +5787,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["code", "state"]
+                "required": [
+                  "code",
+                  "state"
+                ]
               }
             }
           },
@@ -4920,7 +5811,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["server", "message"],
+                  "required": [
+                    "server",
+                    "message"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4937,7 +5831,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4954,7 +5850,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -4966,7 +5864,9 @@
     "/api/mcp_request_log": {
       "get": {
         "operationId": "getMcpRequestLogs",
-        "tags": ["MCP Request Log"],
+        "tags": [
+          "MCP Request Log"
+        ],
         "description": "Get MCP request logs with filtering and pagination",
         "parameters": [
           {
@@ -5072,7 +5972,12 @@
                       "type": "number"
                     }
                   },
-                  "required": ["data", "total", "page", "pageSize"],
+                  "required": [
+                    "data",
+                    "total",
+                    "page",
+                    "pageSize"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -5082,7 +5987,9 @@
       },
       "delete": {
         "operationId": "clearMcpRequestLogs",
-        "tags": ["MCP Request Log"],
+        "tags": [
+          "MCP Request Log"
+        ],
         "description": "Clear MCP request logs",
         "requestBody": {
           "content": {
@@ -5094,7 +6001,9 @@
                     "type": "boolean"
                   }
                 },
-                "required": ["clearAll"]
+                "required": [
+                  "clearAll"
+                ]
               }
             }
           },
@@ -5112,7 +6021,9 @@
                       "type": "number"
                     }
                   },
-                  "required": ["cleared"],
+                  "required": [
+                    "cleared"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -5124,7 +6035,9 @@
     "/api/mcp_request_log/{id}": {
       "get": {
         "operationId": "getMcpRequestLogById",
-        "tags": ["MCP Request Log"],
+        "tags": [
+          "MCP Request Log"
+        ],
         "description": "Get a single MCP request log by ID",
         "parameters": [
           {
@@ -5158,7 +6071,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -5170,7 +6085,9 @@
     "/api/mcp_request_log/stats": {
       "get": {
         "operationId": "getMcpRequestLogStats",
-        "tags": ["MCP Request Log"],
+        "tags": [
+          "MCP Request Log"
+        ],
         "description": "Get MCP request log statistics",
         "parameters": [
           {
@@ -5247,7 +6164,9 @@
     "/api/mcp_server": {
       "get": {
         "operationId": "getMcpServers",
-        "tags": ["MCP Server"],
+        "tags": [
+          "MCP Server"
+        ],
         "description": "Get all installed MCP servers",
         "responses": {
           "200": {
@@ -5269,7 +6188,9 @@
     "/api/mcp_server/install": {
       "post": {
         "operationId": "installMcpServer",
-        "tags": ["MCP Server"],
+        "tags": [
+          "MCP Server"
+        ],
         "description": "Install an MCP server. Either from the catalog, or a customer server",
         "requestBody": {
           "content": {
@@ -5302,7 +6223,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -5319,7 +6242,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -5331,7 +6256,9 @@
     "/api/mcp_server/{id}": {
       "delete": {
         "operationId": "uninstallMcpServer",
-        "tags": ["MCP Server"],
+        "tags": [
+          "MCP Server"
+        ],
         "description": "Uninstall MCP server",
         "parameters": [
           {
@@ -5355,7 +6282,9 @@
                       "type": "boolean"
                     }
                   },
-                  "required": ["success"],
+                  "required": [
+                    "success"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -5367,7 +6296,9 @@
     "/mcp_proxy/{id}/logs": {
       "get": {
         "operationId": "getMcpServerLogs",
-        "tags": ["MCP Server"],
+        "tags": [
+          "MCP Server"
+        ],
         "description": "Get logs for a specific MCP server container",
         "parameters": [
           {
@@ -5410,7 +6341,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -5422,7 +6355,9 @@
     "/api/mcp_server/tools": {
       "get": {
         "operationId": "getAvailableTools",
-        "tags": ["MCP Server"],
+        "tags": [
+          "MCP Server"
+        ],
         "description": "Get all available tools from connected MCP servers",
         "responses": {
           "200": {
@@ -5444,7 +6379,9 @@
     "/api/mcp_server/oauth_install": {
       "post": {
         "operationId": "installMcpServerWithOauth",
-        "tags": ["MCP Server"],
+        "tags": [
+          "MCP Server"
+        ],
         "description": "Install MCP server with OAuth authentication",
         "requestBody": {
           "content": {
@@ -5456,7 +6393,9 @@
                     "$ref": "#/components/schemas/McpServerInstallInput"
                   }
                 },
-                "required": ["installData"]
+                "required": [
+                  "installData"
+                ]
               }
             }
           },
@@ -5474,7 +6413,9 @@
                       "$ref": "#/components/schemas/McpServer"
                     }
                   },
-                  "required": ["server"],
+                  "required": [
+                    "server"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -5491,7 +6432,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -5508,7 +6451,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -5520,7 +6465,9 @@
     "/api/memories": {
       "get": {
         "operationId": "getAllMemories",
-        "tags": ["Memory"],
+        "tags": [
+          "Memory"
+        ],
         "description": "Get all memory entries for the current user",
         "responses": {
           "200": {
@@ -5537,7 +6484,9 @@
       },
       "delete": {
         "operationId": "deleteAllMemories",
-        "tags": ["Memory"],
+        "tags": [
+          "Memory"
+        ],
         "description": "Delete all memory entries for the current user",
         "responses": {
           "200": {
@@ -5556,7 +6505,9 @@
     "/api/memories/{name}": {
       "get": {
         "operationId": "getMemoryByName",
-        "tags": ["Memory"],
+        "tags": [
+          "Memory"
+        ],
         "description": "Get a specific memory entry by name",
         "parameters": [
           {
@@ -5583,7 +6534,9 @@
       },
       "put": {
         "operationId": "setMemory",
-        "tags": ["Memory"],
+        "tags": [
+          "Memory"
+        ],
         "description": "Create or update a memory entry",
         "requestBody": {
           "content": {
@@ -5595,7 +6548,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["value"]
+                "required": [
+                  "value"
+                ]
               }
             }
           },
@@ -5636,7 +6591,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error", "message"],
+                  "required": [
+                    "error",
+                    "message"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -5646,7 +6604,9 @@
       },
       "delete": {
         "operationId": "deleteMemory",
-        "tags": ["Memory"],
+        "tags": [
+          "Memory"
+        ],
         "description": "Delete a specific memory entry by name",
         "parameters": [
           {
@@ -5675,7 +6635,9 @@
     "/api/ollama/required-models": {
       "get": {
         "operationId": "getOllamaRequiredModelsStatus",
-        "tags": ["Ollama"],
+        "tags": [
+          "Ollama"
+        ],
         "description": "Get the status of all Ollama required models",
         "responses": {
           "200": {
@@ -5692,7 +6654,9 @@
                       }
                     }
                   },
-                  "required": ["models"],
+                  "required": [
+                    "models"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -5704,7 +6668,9 @@
     "/api/ollama/models/{modelName}": {
       "delete": {
         "operationId": "removeOllamaModel",
-        "tags": ["Ollama"],
+        "tags": [
+          "Ollama"
+        ],
         "description": "Remove/uninstall an Ollama model",
         "parameters": [
           {
@@ -5731,7 +6697,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["success", "message"],
+                  "required": [
+                    "success",
+                    "message"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -5748,7 +6717,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -5765,7 +6736,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -5777,7 +6750,9 @@
     "/api/ollama/pull": {
       "post": {
         "operationId": "pullOllamaModel",
-        "tags": ["Ollama"],
+        "tags": [
+          "Ollama"
+        ],
         "description": "Pull an Ollama model",
         "requestBody": {
           "content": {
@@ -5790,7 +6765,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["model"]
+                "required": [
+                  "model"
+                ]
               }
             }
           },
@@ -5811,7 +6788,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["success", "message"],
+                  "required": [
+                    "success",
+                    "message"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -5828,7 +6808,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -5840,7 +6822,9 @@
     "/api/sandbox/restart": {
       "post": {
         "operationId": "restartSandbox",
-        "tags": ["Sandbox"],
+        "tags": [
+          "Sandbox"
+        ],
         "description": "Restart the Archestra MCP Sandbox (podman machine + all MCP servers)",
         "responses": {
           "200": {
@@ -5864,7 +6848,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -5876,7 +6862,9 @@
     "/api/sandbox/reset": {
       "post": {
         "operationId": "resetSandbox",
-        "tags": ["Sandbox"],
+        "tags": [
+          "Sandbox"
+        ],
         "description": "Clean/purge all data (uninstall all MCP servers + reset podman machine)",
         "responses": {
           "200": {
@@ -5900,7 +6888,151 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/speech/transcribe": {
+      "post": {
+        "operationId": "transcribeAudio",
+        "tags": [
+          "Speech"
+        ],
+        "description": "Transcribe audio to text using OpenAI Whisper",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TranscribeRequestInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TranscribeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "message"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "message"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "message"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "message"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -5912,7 +7044,9 @@
     "/api/system/backend-logs": {
       "get": {
         "operationId": "getSystemBackendLogs",
-        "tags": ["System"],
+        "tags": [
+          "System"
+        ],
         "description": "Get backend log file content",
         "parameters": [
           {
@@ -5953,7 +7087,9 @@
     "/api/user": {
       "get": {
         "operationId": "getUser",
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "Get the current user",
         "responses": {
           "200": {
@@ -5970,7 +7106,9 @@
       },
       "patch": {
         "operationId": "updateUser",
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "Update user settings",
         "requestBody": {
           "content": {

--- a/desktop_app/package.json
+++ b/desktop_app/package.json
@@ -121,6 +121,7 @@
     "lucide-react": "^0.544.0",
     "ollama": "^0.5.18",
     "ollama-ai-provider-v2": "1.3.1",
+    "openai": "^6.0.0",
     "posthog-js": "^1.266.0",
     "radix-ui": "^1.4.3",
     "react": "^19.1.1",

--- a/desktop_app/pnpm-lock.yaml
+++ b/desktop_app/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       ollama-ai-provider-v2:
         specifier: 1.3.1
         version: 1.3.1(zod@4.1.8)
+      openai:
+        specifier: ^6.0.0
+        version: 6.0.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@4.1.8)
       posthog-js:
         specifier: ^1.266.0
         version: 1.266.0
@@ -6266,6 +6269,18 @@ packages:
   open@10.1.2:
     resolution: {integrity: sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==}
     engines: {node: '>=18'}
+
+  openai@6.0.0:
+    resolution: {integrity: sha512-J7LEmTn3WLZnbyEmMYcMPyT5A0fGzhPwSvVUcNRKy6j2hJIbqSFrJERnUHYNkcoCCalRumypnj9AVoe5bVHd3Q==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
@@ -14998,6 +15013,11 @@ snapshots:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       is-wsl: 3.1.0
+
+  openai@6.0.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@4.1.8):
+    optionalDependencies:
+      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5)
+      zod: 4.1.8
 
   openapi-types@12.1.3: {}
 

--- a/desktop_app/src/backend/server/index.ts
+++ b/desktop_app/src/backend/server/index.ts
@@ -16,6 +16,7 @@ import memoryRoutes from '@backend/server/plugins/memory';
 import ollamaRoutes from '@backend/server/plugins/ollama';
 import ollamaProxyRoutes from '@backend/server/plugins/ollama/proxy';
 import sandboxRoutes from '@backend/server/plugins/sandbox';
+import speechRoutes from '@backend/server/plugins/speech';
 import systemRoutes from '@backend/server/plugins/system';
 import userRoutes from '@backend/server/plugins/user';
 import { electronLogStream } from '@backend/utils/fastify-logger-stream';
@@ -63,6 +64,7 @@ export const startFastifyServer = async () => {
   await app.register(ollamaRoutes);
   await app.register(ollamaProxyRoutes);
   await app.register(sandboxRoutes);
+  await app.register(speechRoutes);
   await app.register(systemRoutes);
   await app.register(userRoutes);
 

--- a/desktop_app/src/backend/server/plugins/speech/index.ts
+++ b/desktop_app/src/backend/server/plugins/speech/index.ts
@@ -1,0 +1,131 @@
+import { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+import OpenAI from 'openai';
+
+import CloudProviderModel from '@backend/models/cloudProvider';
+import log from '@backend/utils/logger';
+
+const TranscribeRequestSchema = z.object({
+  audio: z.string().describe('Base64-encoded audio data'),
+  mimeType: z.string().describe('Audio MIME type (e.g., audio/webm, audio/mp4)'),
+});
+
+const TranscribeResponseSchema = z.object({
+  text: z.string().describe('Transcribed text from audio'),
+});
+
+const ErrorResponseSchema = z.object({
+  error: z.object({
+    message: z.string(),
+  }),
+});
+
+// Register schemas
+z.globalRegistry.add(TranscribeRequestSchema, { id: 'TranscribeRequest' });
+z.globalRegistry.add(TranscribeResponseSchema, { id: 'TranscribeResponse' });
+
+const speechRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.post(
+    '/api/speech/transcribe',
+    {
+      schema: {
+        operationId: 'transcribeAudio',
+        description: 'Transcribe audio to text using OpenAI Whisper',
+        tags: ['Speech'],
+        body: TranscribeRequestSchema,
+        response: {
+          200: TranscribeResponseSchema,
+          400: ErrorResponseSchema,
+          401: ErrorResponseSchema,
+          402: ErrorResponseSchema,
+          500: ErrorResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      try {
+        const { audio, mimeType } = request.body as z.infer<typeof TranscribeRequestSchema>;
+
+        // Get OpenAI API key from cloud provider config
+        const openAIConfig = await CloudProviderModel.getByType('openai');
+
+        if (!openAIConfig || !openAIConfig.enabled) {
+          return reply.code(401).send({
+            error: {
+              message: 'OpenAI API key not configured. Please configure it in Settings > LLM Providers.',
+            },
+          });
+        }
+
+        const { apiKey } = openAIConfig;
+        const baseUrl = 'https://api.openai.com/v1';
+
+        // Initialize OpenAI client
+        const openai = new OpenAI({
+          apiKey,
+          baseURL: baseUrl,
+        });
+
+        // Decode base64 audio
+        const audioBuffer = Buffer.from(audio, 'base64');
+
+        // Determine file extension from MIME type
+        const mimeToExt: Record<string, string> = {
+          'audio/webm': 'webm',
+          'audio/webm;codecs=opus': 'webm',
+          'audio/mp4': 'mp4',
+          'audio/mpeg': 'mp3',
+          'audio/wav': 'wav',
+          'audio/x-wav': 'wav',
+        };
+
+        const extension = mimeToExt[mimeType] || 'webm';
+        const fileName = `audio.${extension}`;
+
+        // Create a File-like object for OpenAI API
+        const audioFile = new File([audioBuffer], fileName, { type: mimeType });
+
+        log.info(`Transcribing audio file: ${fileName}, size: ${audioBuffer.length} bytes`);
+
+        // Call OpenAI Whisper API
+        const transcription = await openai.audio.transcriptions.create({
+          file: audioFile,
+          model: 'whisper-1',
+          language: 'en', // Can be made configurable later
+        });
+
+        log.info(`Transcription successful: ${transcription.text.substring(0, 100)}...`);
+
+        return reply.send({
+          text: transcription.text,
+        });
+      } catch (error: any) {
+        log.error('Error transcribing audio:', error);
+
+        if (error.status === 401) {
+          return reply.code(401).send({
+            error: {
+              message: 'Invalid OpenAI API key. Please check your configuration.',
+            },
+          });
+        }
+
+        if (error.status === 402) {
+          return reply.code(402).send({
+            error: {
+              message: 'OpenAI API quota exceeded. Please check your account limits.',
+            },
+          });
+        }
+
+        return reply.code(500).send({
+          error: {
+            message: error.message || 'Failed to transcribe audio',
+          },
+        });
+      }
+    }
+  );
+};
+
+export default speechRoutes;

--- a/desktop_app/src/ui/components/Chat/ChatInput/index.tsx
+++ b/desktop_app/src/ui/components/Chat/ChatInput/index.tsx
@@ -6,7 +6,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { deconstructToolId } from '@constants';
 import ChatTokenUsage from '@ui/components/ChatTokenUsage';
-import { ToolHoverCard } from '@ui/components/ToolHoverCard';
+import Microphone from '@ui/components/icons/Microphone';
 import {
   AIInput,
   AIInputButton,
@@ -20,7 +20,10 @@ import {
   AIInputToolbar,
   AIInputTools,
 } from '@ui/components/kibo/ai-input';
+import { ToolHoverCard } from '@ui/components/ToolHoverCard';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@ui/components/ui/tooltip';
+import { WaveformVisualizer } from '@ui/components/WaveformVisualizer';
+import { useSpeech } from '@ui/hooks/useSpeech';
 import { cn } from '@ui/lib/utils/tailwind';
 import { formatToolName } from '@ui/lib/utils/tools';
 import {
@@ -81,9 +84,35 @@ export default function ChatInput({
   const { isDeveloperMode, toggleDeveloperMode } = useDeveloperModeStore();
   const { selectedModel, setSelectedModel } = useChatStore();
   const userSelectableModels = useUserSelectableModels();
-  const { availableCloudProviderModels } = useCloudProvidersStore();
+  const { availableCloudProviderModels, cloudProviders } = useCloudProvidersStore();
   const { availableTools, selectedToolIds, removeSelectedTool } = useToolsStore();
   const { installedMcpServers } = useMcpServersStore();
+
+  // Check if OpenAI is configured for speech
+  const openAIConfigured = useMemo(() => {
+    const openAI = cloudProviders.find((p) => p.type === 'openai');
+    return openAI?.configured && openAI?.enabled;
+  }, [cloudProviders]);
+
+  // Speech hook
+  const { isRecording, isTranscribing, startRecording, stopRecording, cancelRecording } = useSpeech({
+    onTranscription: (text) => {
+      // Append transcribed text to input
+      const newValue = input.trim() ? `${input.trim()} ${text}` : text;
+      const syntheticEvent = {
+        target: { value: newValue },
+      } as React.ChangeEvent<HTMLTextAreaElement>;
+      handleInputChange(syntheticEvent);
+    },
+    onError: (error) => {
+      console.error('Speech Error:', error.message);
+      // TODO: Show user-friendly error notification
+    },
+    onSizeWarning: (sizeMB) => {
+      console.warn(`Recording Size Warning: ${sizeMB.toFixed(1)}MB (near 25MB limit)`);
+      // TODO: Show user-friendly size warning
+    },
+  });
 
   // Rotating placeholder state
   const [placeholderIndex, setPlaceholderIndex] = useState(0);
@@ -352,7 +381,7 @@ export default function ChatInput({
                                     >
                                       {/* Status indicator */}
                                       {tool.analysis?.status === 'awaiting_ollama_model' ||
-                                      tool.analysis?.status === 'in_progress' ? (
+                                        tool.analysis?.status === 'in_progress' ? (
                                         <div className="w-2 h-2 border border-muted-foreground rounded-full animate-spin border-t-transparent flex-shrink-0" />
                                       ) : tool.analysis?.status === 'error' ? (
                                         <div className="w-2 h-2 bg-red-500 rounded-full flex-shrink-0" />
@@ -398,7 +427,7 @@ export default function ChatInput({
                                     >
                                       {/* Status indicator */}
                                       {tool.analysis?.status === 'awaiting_ollama_model' ||
-                                      tool.analysis?.status === 'in_progress' ? (
+                                        tool.analysis?.status === 'in_progress' ? (
                                         <div className="w-2 h-2 border border-muted-foreground rounded-full animate-spin border-t-transparent flex-shrink-0" />
                                       ) : tool.analysis?.status === 'error' ? (
                                         <div className="w-2 h-2 bg-red-500 rounded-full flex-shrink-0" />
@@ -444,7 +473,7 @@ export default function ChatInput({
                                     >
                                       {/* Status indicator */}
                                       {tool.analysis?.status === 'awaiting_ollama_model' ||
-                                      tool.analysis?.status === 'in_progress' ? (
+                                        tool.analysis?.status === 'in_progress' ? (
                                         <div className="w-2 h-2 border border-muted-foreground rounded-full animate-spin border-t-transparent flex-shrink-0" />
                                       ) : tool.analysis?.status === 'error' ? (
                                         <div className="w-2 h-2 bg-red-500 rounded-full flex-shrink-0" />
@@ -490,7 +519,7 @@ export default function ChatInput({
                                     >
                                       {/* Status indicator */}
                                       {tool.analysis?.status === 'awaiting_ollama_model' ||
-                                      tool.analysis?.status === 'in_progress' ? (
+                                        tool.analysis?.status === 'in_progress' ? (
                                         <div className="w-2 h-2 border border-muted-foreground rounded-full animate-spin border-t-transparent flex-shrink-0" />
                                       ) : tool.analysis?.status === 'error' ? (
                                         <div className="w-2 h-2 bg-red-500 rounded-full flex-shrink-0" />
@@ -529,12 +558,36 @@ export default function ChatInput({
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
             placeholder=""
-            disabled={false}
+            disabled={isRecording || isTranscribing}
             minHeight={48}
             maxHeight={164}
             className="relative z-10"
+            style={
+              isRecording || isTranscribing
+                ? {
+                  color: 'transparent',
+                  textShadow: '0 0 0 rgba(0, 0, 0, 0.15)',
+                }
+                : undefined
+            }
           />
-          {!input && !hasMessages && (
+          {/* Show waveform when recording - aligned left */}
+          {isRecording && (
+            <div className="absolute inset-0 flex items-center pointer-events-none px-4">
+              <WaveformVisualizer isRecording={isRecording} className="h-6 w-48" />
+            </div>
+          )}
+          {/* Show transcribing message - aligned left */}
+          {isTranscribing && (
+            <div className="absolute inset-0 flex items-center pointer-events-none px-4">
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                <span className="text-sm">Transcribing...</span>
+              </div>
+            </div>
+          )}
+          {/* Show placeholder when idle */}
+          {!input && !hasMessages && !isRecording && !isTranscribing && (
             <div className="absolute inset-0 flex items-start pointer-events-none overflow-hidden">
               <div className="relative w-full h-full pt-2.5 px-4">
                 {PLACEHOLDER_EXAMPLES.map((example, index) => {
@@ -654,6 +707,62 @@ export default function ChatInput({
                 </TooltipContent>
               </Tooltip>
             )}
+
+            {/* Speech controls - show only if OpenAI is configured */}
+            {openAIConfigured && (
+              <>
+                {isRecording || isTranscribing ? (
+                  // Show X (cancel) and checkmark (stop & transcribe) when recording
+                  <>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <AIInputButton onClick={cancelRecording} type="button" disabled={isTranscribing}>
+                          <X size={16} />
+                        </AIInputButton>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <span>Cancel</span>
+                      </TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <AIInputButton onClick={stopRecording} type="button" disabled={isTranscribing}>
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="16"
+                            height="16"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          >
+                            <polyline points="20 6 9 17 4 12" />
+                          </svg>
+                        </AIInputButton>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <span>{isTranscribing ? 'Transcribing...' : 'Stop & transcribe'}</span>
+                      </TooltipContent>
+                    </Tooltip>
+                  </>
+                ) : (
+                  // Show normal microphone when idle
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <AIInputButton onClick={startRecording} type="button">
+                        <Microphone />
+                      </AIInputButton>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <span>Dictate</span>
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+              </>
+            )}
+
             <AIInputSubmit
               onClick={status === 'streaming' || status === 'submitted' || isSubmitting ? stop : undefined}
               disabled={status === 'streaming' || status === 'submitted' || isSubmitting ? false : disabled}

--- a/desktop_app/src/ui/components/WaveformVisualizer.tsx
+++ b/desktop_app/src/ui/components/WaveformVisualizer.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useRef } from 'react';
+
+interface WaveformVisualizerProps {
+  isRecording: boolean;
+  className?: string;
+}
+
+export function WaveformVisualizer({ isRecording, className = '' }: WaveformVisualizerProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animationFrameRef = useRef<number>();
+
+  useEffect(() => {
+    if (!isRecording || !canvasRef.current) return;
+
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    // Set canvas size to match container
+    const updateSize = () => {
+      const rect = canvas.getBoundingClientRect();
+      canvas.width = rect.width * window.devicePixelRatio;
+      canvas.height = rect.height * window.devicePixelRatio;
+      ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
+    };
+    updateSize();
+
+    // Ultra-minimal waveform - very small, subtle bars like OpenAI
+    const bars = 30;
+    const barWidth = 1.5; // Very thin
+    const gap = 2; // Tight spacing
+    const heights = Array(bars).fill(0).map(() => Math.random() * 0.2 + 0.1); // Very small heights
+    let phase = 0;
+
+    const animate = () => {
+      if (!ctx || !canvas) return;
+
+      const width = canvas.width / window.devicePixelRatio;
+      const height = canvas.height / window.devicePixelRatio;
+
+      // Clear canvas
+      ctx.clearRect(0, 0, width, height);
+
+      // Draw ultra-minimal bars (left-aligned)
+      for (let i = 0; i < bars; i++) {
+        // Very subtle sine wave animation
+        const targetHeight = Math.abs(Math.sin(phase + i * 0.15) * 0.3 + 0.15);
+        heights[i] += (targetHeight - heights[i]) * 0.06;
+
+        const barHeight = Math.max(heights[i] * height, 2); // Min 2px height
+        const x = i * (barWidth + gap);
+        const y = (height - barHeight) / 2;
+
+        // Very subtle gray with low opacity
+        ctx.fillStyle = 'rgba(156, 163, 175, 0.4)';
+        ctx.fillRect(x, y, barWidth, barHeight);
+      }
+
+      phase += 0.03; // Very slow animation
+      animationFrameRef.current = requestAnimationFrame(animate);
+    };
+
+    animate();
+
+    return () => {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+    };
+  }, [isRecording]);
+
+  if (!isRecording) return null;
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className={`${className}`}
+      style={{ width: '100%', height: '100%' }}
+    />
+  );
+}

--- a/desktop_app/src/ui/components/icons/Microphone.tsx
+++ b/desktop_app/src/ui/components/icons/Microphone.tsx
@@ -1,0 +1,18 @@
+export default function Microphone({ className = 'w-4 h-4' }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
+      <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+      <line x1="12" x2="12" y1="19" y2="22" />
+    </svg>
+  );
+}

--- a/desktop_app/src/ui/hooks/useSpeech.ts
+++ b/desktop_app/src/ui/hooks/useSpeech.ts
@@ -1,0 +1,258 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { transcribeAudio } from '@ui/lib/clients/archestra/api/gen';
+
+interface UseSpeechOptions {
+  onTranscription?: (text: string) => void;
+  onError?: (error: Error) => void;
+  onSizeWarning?: (sizeInMB: number) => void;
+}
+
+// Constants
+const MAX_AUDIO_SIZE_MB = 25;
+const MAX_RECORDING_DURATION_SECONDS = 600; // 10 minutes
+const WARNING_SIZE_MB = 20; // Warn at 20MB
+
+export const useSpeech = ({ onTranscription, onError, onSizeWarning }: UseSpeechOptions = {}) => {
+  const [isRecording, setIsRecording] = useState(false);
+  const [isTranscribing, setIsTranscribing] = useState(false);
+  const [recordingDuration, setRecordingDuration] = useState(0);
+  const [estimatedSize, setEstimatedSize] = useState(0);
+
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const audioChunksRef = useRef<Blob[]>([]);
+  const streamRef = useRef<MediaStream | null>(null);
+  const recordingStartTimeRef = useRef<number | null>(null);
+  const durationIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const currentSizeRef = useRef<number>(0);
+  const shouldTranscribeRef = useRef<boolean>(true); // Track if we should transcribe on stop
+
+  // Define stopRecording before startRecording to avoid circular dependency
+  const stopRecording = useCallback(() => {
+    setIsRecording(false);
+
+    if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
+      mediaRecorderRef.current.stop();
+    }
+
+    // Clear interval
+    if (durationIntervalRef.current) {
+      clearInterval(durationIntervalRef.current);
+      durationIntervalRef.current = null;
+    }
+
+    // Stop all tracks in the stream
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+    }
+  }, []);
+
+  // Cleanup effect to prevent memory leaks
+  useEffect(() => {
+    return () => {
+      // Cleanup on unmount
+      if (durationIntervalRef.current) {
+        clearInterval(durationIntervalRef.current);
+      }
+      if (streamRef.current) {
+        streamRef.current.getTracks().forEach((track) => track.stop());
+      }
+    };
+  }, []);
+
+  const transcribeAudioData = useCallback(
+    async (audioBlob: Blob) => {
+      setIsTranscribing(true);
+
+      try {
+        // Check final size
+        const sizeMB = audioBlob.size / (1024 * 1024);
+        if (sizeMB > MAX_AUDIO_SIZE_MB) {
+          throw new Error(
+            `Audio file too large (${sizeMB.toFixed(1)}MB). Maximum size is ${MAX_AUDIO_SIZE_MB}MB.`
+          );
+        }
+
+        // Convert blob to base64 for easier transport
+        const reader = new FileReader();
+        const base64Audio = await new Promise<string>((resolve, reject) => {
+          reader.onloadend = () => {
+            const base64 = reader.result as string;
+            resolve(base64.split(',')[1]); // Remove data:audio/webm;base64, prefix
+          };
+          reader.onerror = reject;
+          reader.readAsDataURL(audioBlob);
+        });
+
+        const mimeType = audioBlob.type;
+        if (!mimeType) {
+          throw new Error('Unable to determine audio format. Please try again.');
+        }
+
+        // Call backend transcription API
+        const { data, error } = await transcribeAudio({
+          body: {
+            audio: base64Audio,
+            mimeType,
+          },
+        });
+
+        if (error) {
+          throw new Error(error.error?.message || 'Transcription failed');
+        }
+
+        if (data?.text) {
+          onTranscription?.(data.text);
+        }
+      } catch (error) {
+        console.error('Error transcribing audio:', error);
+        stopRecording();
+        onError?.(error as Error);
+      } finally {
+        setIsTranscribing(false);
+        setRecordingDuration(0);
+        setEstimatedSize(0);
+      }
+    },
+    [onTranscription, onError, stopRecording]
+  );
+
+  const startRecording = useCallback(async () => {
+    try {
+      // Request microphone permission
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+          sampleRate: 44100,
+        },
+      });
+      streamRef.current = stream;
+
+      // Verify we have valid audio tracks
+      const audioTracks = stream.getAudioTracks();
+      if (audioTracks.length === 0) {
+        throw new Error('No audio tracks available in the microphone stream');
+      }
+
+      // Determine best supported MIME type
+      const supportedTypes = ['audio/webm;codecs=opus', 'audio/webm', 'audio/mp4', 'audio/wav'];
+
+      const mimeType = supportedTypes.find((type) => MediaRecorder.isTypeSupported(type)) || '';
+
+      const mediaRecorder = new MediaRecorder(stream, mimeType ? { mimeType } : {});
+
+      mediaRecorderRef.current = mediaRecorder;
+      audioChunksRef.current = [];
+      currentSizeRef.current = 0;
+      recordingStartTimeRef.current = Date.now();
+
+      // Start duration and size tracking
+      durationIntervalRef.current = setInterval(() => {
+        const elapsed = (Date.now() - (recordingStartTimeRef.current || 0)) / 1000;
+        setRecordingDuration(elapsed);
+
+        // Estimate size based on typical webm bitrate (~128kbps)
+        const estimatedSizeMB = (elapsed * 128 * 1024) / (8 * 1024 * 1024);
+        setEstimatedSize(estimatedSizeMB);
+
+        // Check if we're approaching the limit
+        if (estimatedSizeMB > WARNING_SIZE_MB) {
+          onSizeWarning?.(estimatedSizeMB);
+        }
+
+        // Auto-stop if we hit the duration limit
+        if (elapsed >= MAX_RECORDING_DURATION_SECONDS) {
+          stopRecording();
+          onError?.(
+            new Error(`Maximum recording duration (${MAX_RECORDING_DURATION_SECONDS / 60} minutes) reached.`)
+          );
+        }
+      }, 100);
+
+      mediaRecorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          audioChunksRef.current.push(event.data);
+          currentSizeRef.current += event.data.size;
+
+          // Check actual size
+          const actualSizeMB = currentSizeRef.current / (1024 * 1024);
+          if (actualSizeMB > MAX_AUDIO_SIZE_MB) {
+            stopRecording();
+            onError?.(new Error(`Maximum file size (${MAX_AUDIO_SIZE_MB}MB) reached.`));
+          }
+        }
+      };
+
+      mediaRecorder.onstop = async () => {
+        const audioBlob = new Blob(audioChunksRef.current, { type: mimeType || 'audio/webm' });
+
+        // Check if the blob is empty
+        if (audioBlob.size === 0) {
+          onError?.(
+            new Error('No audio data was recorded. Please check your microphone permissions and try again.')
+          );
+          return;
+        }
+
+        // Only transcribe if shouldTranscribeRef is true (not cancelled)
+        if (shouldTranscribeRef.current) {
+          await transcribeAudioData(audioBlob);
+        }
+
+        // Reset the flag for next recording
+        shouldTranscribeRef.current = true;
+      };
+
+      // Add error handler for MediaRecorder
+      mediaRecorder.onerror = (event) => {
+        console.error('MediaRecorder error:', event);
+        onError?.(new Error('Recording failed: Unknown error'));
+      };
+
+      if (!stream.active) {
+        throw new Error('Audio stream became inactive before recording could start');
+      }
+
+      // Check audio tracks again before starting recording
+      if (audioTracks.length === 0) {
+        throw new Error('No audio tracks available in the stream');
+      }
+
+      const activeAudioTracks = audioTracks.filter((track) => track.readyState === 'live');
+      if (activeAudioTracks.length === 0) {
+        throw new Error('No live audio tracks available');
+      }
+
+      try {
+        mediaRecorder.start(100);
+        setIsRecording(true);
+      } catch (startError) {
+        console.error('Error calling mediaRecorder.start():', startError);
+        const errorMessage = startError instanceof Error ? startError.message : String(startError);
+        throw new Error(`Failed to start recording: ${errorMessage}`);
+      }
+    } catch (error) {
+      console.error('Error starting recording:', error);
+      stopRecording();
+      onError?.(error as Error);
+    }
+  }, [onError, onSizeWarning, transcribeAudioData, stopRecording]);
+
+  const cancelRecording = useCallback(() => {
+    // Set flag to not transcribe, then stop recording
+    shouldTranscribeRef.current = false;
+    stopRecording();
+  }, [stopRecording]);
+
+  return {
+    isRecording,
+    isTranscribing,
+    startRecording,
+    stopRecording,
+    cancelRecording,
+    recordingDuration,
+    estimatedSize,
+  };
+};

--- a/desktop_app/src/ui/lib/clients/archestra/api/gen/sdk.gen.ts
+++ b/desktop_app/src/ui/lib/clients/archestra/api/gen/sdk.gen.ts
@@ -112,6 +112,9 @@ import type {
   StoreOAuthCodeData,
   StoreOAuthCodeErrors,
   StoreOAuthCodeResponses,
+  TranscribeAudioData,
+  TranscribeAudioErrors,
+  TranscribeAudioResponses,
   UninstallMcpServerData,
   UninstallMcpServerResponses,
   UpdateChatData,
@@ -742,6 +745,22 @@ export const resetSandbox = <ThrowOnError extends boolean = false>(
   return (options?.client ?? _heyApiClient).post<ResetSandboxResponses, ResetSandboxErrors, ThrowOnError>({
     url: '/api/sandbox/reset',
     ...options,
+  });
+};
+
+/**
+ * Transcribe audio to text using OpenAI Whisper
+ */
+export const transcribeAudio = <ThrowOnError extends boolean = false>(
+  options?: Options<TranscribeAudioData, ThrowOnError>
+) => {
+  return (options?.client ?? _heyApiClient).post<TranscribeAudioResponses, TranscribeAudioErrors, ThrowOnError>({
+    url: '/api/speech/transcribe',
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options?.headers,
+    },
   });
 };
 

--- a/desktop_app/src/ui/lib/clients/archestra/api/gen/types.gen.ts
+++ b/desktop_app/src/ui/lib/clients/archestra/api/gen/types.gen.ts
@@ -495,6 +495,24 @@ export type SandboxActionResponseInput = {
   message: string;
 };
 
+export type TranscribeRequestInput = {
+  /**
+   * Base64-encoded audio data
+   */
+  audio: string;
+  /**
+   * Audio MIME type (e.g., audio/webm, audio/mp4)
+   */
+  mimeType: string;
+};
+
+export type TranscribeResponseInput = {
+  /**
+   * Transcribed text from audio
+   */
+  text: string;
+};
+
 export type BackendLogsResponseInput = {
   /**
    * The log content or error message
@@ -1009,6 +1027,24 @@ export type OllamaRequiredModelStatus = {
 export type SandboxActionResponse = {
   success: boolean;
   message: string;
+};
+
+export type TranscribeRequest = {
+  /**
+   * Base64-encoded audio data
+   */
+  audio: string;
+  /**
+   * Audio MIME type (e.g., audio/webm, audio/mp4)
+   */
+  mimeType: string;
+};
+
+export type TranscribeResponse = {
+  /**
+   * Transcribed text from audio
+   */
+  text: string;
 };
 
 export type BackendLogsResponse = {
@@ -2211,6 +2247,59 @@ export type ResetSandboxResponses = {
 };
 
 export type ResetSandboxResponse = ResetSandboxResponses[keyof ResetSandboxResponses];
+
+export type TranscribeAudioData = {
+  body?: TranscribeRequestInput;
+  path?: never;
+  query?: never;
+  url: '/api/speech/transcribe';
+};
+
+export type TranscribeAudioErrors = {
+  /**
+   * Default Response
+   */
+  400: {
+    error: {
+      message: string;
+    };
+  };
+  /**
+   * Default Response
+   */
+  401: {
+    error: {
+      message: string;
+    };
+  };
+  /**
+   * Default Response
+   */
+  402: {
+    error: {
+      message: string;
+    };
+  };
+  /**
+   * Default Response
+   */
+  500: {
+    error: {
+      message: string;
+    };
+  };
+};
+
+export type TranscribeAudioError = TranscribeAudioErrors[keyof TranscribeAudioErrors];
+
+export type TranscribeAudioResponses = {
+  /**
+   * Default Response
+   */
+  200: TranscribeResponse;
+};
+
+export type TranscribeAudioResponse = TranscribeAudioResponses[keyof TranscribeAudioResponses];
 
 export type GetSystemBackendLogsData = {
   body?: never;


### PR DESCRIPTION
 Adds voice dictation with OpenAI Whisper, inspired by ChatGPT's speech input and Block Goose's (AI agent) implementation.

  ## Changes
  - **Backend**: `/api/speech/transcribe` endpoint using OpenAI Whisper API
  - **Frontend**: Microphone button, minimal waveform visualizer
  (OpenAI-style), X/✓ controls
  - **UX**: Click mic → record with waveform → click ✓ to transcribe or X to cancel

  ## Features
  - Only available when OpenAI is configured
  - Minimal animated waveform (left-aligned like OpenAI)
  - Real-time recording with cancel/confirm controls
  - Auto-appends transcribed text to chat input
  - Max 25MB/10min recordings

https://github.com/user-attachments/assets/6aa15665-673d-4fe2-bbf9-9d0ac814a652

Closes #503