### PR TITLE
feat: allow not specifying agent/chat id

### DIFF
--- a/platform/CLAUDE.md
+++ b/platform/CLAUDE.md
@@ -133,8 +133,10 @@ The production backend provides:
 - **Chat Management**:
   - `POST /api/chats` - Create new chat session
   - `GET /api/chats/:chatId` - Get chat with all interactions
+  - **Note**: Chat ID is now optional when using the OpenAI proxy - if not provided via `x-archestra-chat-id` header, a chat will be created/retrieved based on the hash of the first message
 - **LLM Integration**:
   - `POST /v1/:provider/chat/completions` - OpenAI-compatible chat endpoint
+    - Optional `x-archestra-chat-id` header - if not provided, automatically creates/retrieves default agent and chat based on message content hash
   - `GET /v1/:provider/models` - List available models for a provider
   - Supports streaming responses for real-time AI interactions
 - **Agent Management**:
@@ -205,6 +207,9 @@ The `experiments/` workspace contains prototype features:
 #### CLI Testing
 
 - `pnpm cli-chat-with-guardrails` - Test the production guardrails via CLI
+  - Supports `--agent-id <agent-id>` flag to specify an agent (optional)
+  - If no agent ID is provided, the backend will create/use a default agent
+  - Additional flags: `--include-external-email`, `--include-malicious-email`, `--debug`
 - Requires `OPENAI_API_KEY` in `.env` (copy from `.env.example`)
 
 ### Code Quality Tools

--- a/platform/backend/src/database/migrations/0001_jittery_union_jack.sql
+++ b/platform/backend/src/database/migrations/0001_jittery_union_jack.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "chats" ADD COLUMN "hash_for_id" text;

--- a/platform/backend/src/database/migrations/meta/0001_snapshot.json
+++ b/platform/backend/src/database/migrations/meta/0001_snapshot.json
@@ -1,0 +1,584 @@
+{
+  "id": "043d93c4-ca64-452e-b3d3-0dd3e4e011e8",
+  "prevId": "878472a9-9c70-4477-b64c-59438ebe9d76",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_tool_invocation_policies": {
+      "name": "agent_tool_invocation_policies",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_tool_invocation_policies_agent_id_agents_id_fk": {
+          "name": "agent_tool_invocation_policies_agent_id_agents_id_fk",
+          "tableFrom": "agent_tool_invocation_policies",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tool_invocation_policies_policy_id_tool_invocation_policies_id_fk": {
+          "name": "agent_tool_invocation_policies_policy_id_tool_invocation_policies_id_fk",
+          "tableFrom": "agent_tool_invocation_policies",
+          "tableTo": "tool_invocation_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_tool_invocation_policies_agent_id_policy_id_pk": {
+          "name": "agent_tool_invocation_policies_agent_id_policy_id_pk",
+          "columns": [
+            "agent_id",
+            "policy_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_trusted_data_policies": {
+      "name": "agent_trusted_data_policies",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_trusted_data_policies_agent_id_agents_id_fk": {
+          "name": "agent_trusted_data_policies_agent_id_agents_id_fk",
+          "tableFrom": "agent_trusted_data_policies",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_trusted_data_policies_policy_id_trusted_data_policies_id_fk": {
+          "name": "agent_trusted_data_policies_policy_id_trusted_data_policies_id_fk",
+          "tableFrom": "agent_trusted_data_policies",
+          "tableTo": "trusted_data_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_trusted_data_policies_agent_id_policy_id_pk": {
+          "name": "agent_trusted_data_policies_agent_id_policy_id_pk",
+          "columns": [
+            "agent_id",
+            "policy_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "hash_for_id": {
+          "name": "hash_for_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chats_agent_id_agents_id_fk": {
+          "name": "chats_agent_id_agents_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interactions": {
+      "name": "interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tainted": {
+          "name": "tainted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "taint_reason": {
+          "name": "taint_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "interactions_chat_id_idx": {
+          "name": "interactions_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interactions_chat_id_chats_id_fk": {
+          "name": "interactions_chat_id_chats_id_fk",
+          "tableFrom": "interactions",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool_invocation_policies": {
+      "name": "tool_invocation_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "argument_name": {
+          "name": "argument_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator": {
+          "name": "operator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_prompt": {
+          "name": "block_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tool_invocation_policies_tool_id_tools_id_fk": {
+          "name": "tool_invocation_policies_tool_id_tools_id_fk",
+          "tableFrom": "tool_invocation_policies",
+          "tableTo": "tools",
+          "columnsFrom": [
+            "tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tools": {
+      "name": "tools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tools_agent_id_agents_id_fk": {
+          "name": "tools_agent_id_agents_id_fk",
+          "tableFrom": "tools",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tools_name_unique": {
+          "name": "tools_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trusted_data_policies": {
+      "name": "trusted_data_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribute_path": {
+          "name": "attribute_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator": {
+          "name": "operator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trusted_data_policies_tool_id_tools_id_fk": {
+          "name": "trusted_data_policies_tool_id_tools_id_fk",
+          "tableFrom": "trusted_data_policies",
+          "tableTo": "tools",
+          "columnsFrom": [
+            "tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/platform/backend/src/database/migrations/meta/_journal.json
+++ b/platform/backend/src/database/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1759338262347,
       "tag": "0000_lush_spiral",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1759350301277,
+      "tag": "0001_jittery_union_jack",
+      "breakpoints": true
     }
   ]
 }

--- a/platform/backend/src/database/schemas/chat.ts
+++ b/platform/backend/src/database/schemas/chat.ts
@@ -1,8 +1,9 @@
-import { pgTable, timestamp, uuid } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import agentsTable from "./agent";
 
 const chatsTable = pgTable("chats", {
   id: uuid("id").primaryKey().defaultRandom(),
+  hashForId: text("hash_for_id"),
   agentId: uuid("agent_id")
     .notNull()
     .references(() => agentsTable.id, { onDelete: "cascade" }),

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -2,6 +2,8 @@ import { and, eq } from "drizzle-orm";
 import db, { schema } from "../database";
 import type { Agent, InsertAgent, ToolInvocation, TrustedData } from "../types";
 
+const DEFAULT_AGENT_NAME = "Default Agent";
+
 class AgentModel {
   static async create(agent: InsertAgent): Promise<Agent> {
     const [createdAgent] = await db
@@ -21,6 +23,18 @@ class AgentModel {
       .from(schema.agentsTable)
       .where(eq(schema.agentsTable.id, id));
     return agent || null;
+  }
+
+  static async ensureDefaultAgentExists(): Promise<Agent> {
+    const [agent] = await db
+      .select()
+      .from(schema.agentsTable)
+      .where(eq(schema.agentsTable.name, DEFAULT_AGENT_NAME));
+
+    if (!agent) {
+      return await AgentModel.create({ name: DEFAULT_AGENT_NAME });
+    }
+    return agent;
   }
 
   static async update(

--- a/platform/backend/src/models/chat.ts
+++ b/platform/backend/src/models/chat.ts
@@ -9,6 +9,23 @@ class ChatModel {
     return chat;
   }
 
+  static async createOrGetByHash(data: { agentId: string; hashForId: string }) {
+    const [chat] = await db
+      .select()
+      .from(schema.chatsTable)
+      .where(eq(schema.chatsTable.hashForId, data.hashForId));
+
+    if (chat) {
+      return chat;
+    } else {
+      const [chat] = await db
+        .insert(schema.chatsTable)
+        .values(data)
+        .returning();
+      return chat;
+    }
+  }
+
   static async findAll(): Promise<ChatWithInteractions[]> {
     const chats = await db
       .select()

--- a/platform/backend/src/routes/proxy/openai.ts
+++ b/platform/backend/src/routes/proxy/openai.ts
@@ -56,13 +56,19 @@ const extractToolNameFromHistory = async (
   return null;
 };
 
+/**
+ * We need to explicitly get the first user message
+ * (because if there is a system message it may be consistent across multiple chats and we'll end up with the same hash)
+ */
 const generateChatIdHashFromRequest = ({
   messages,
-}: z.infer<typeof OpenAi.API.ChatCompletionRequestSchema>) =>
-  crypto
+}: z.infer<typeof OpenAi.API.ChatCompletionRequestSchema>) => {
+  const firstUserMessage = messages.find((message) => message.role === "user");
+  return crypto
     .createHash("sha256")
-    .update(JSON.stringify(messages[0].content))
+    .update(JSON.stringify(firstUserMessage))
     .digest("hex");
+};
 
 const getAgentAndChatIdFromRequest = async (
   request: z.infer<typeof OpenAi.API.ChatCompletionRequestSchema>,

--- a/platform/backend/src/routes/proxy/openai.ts
+++ b/platform/backend/src/routes/proxy/openai.ts
@@ -1,14 +1,28 @@
+import crypto from "node:crypto";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import OpenAI from "openai";
 import { z } from "zod";
 import {
+  AgentModel,
   ChatModel,
   InteractionModel,
   ToolInvocationPolicyModel,
   ToolModel,
   TrustedDataPolicyModel,
 } from "../../models";
-import { ErrorResponseSchema, OpenAi, UuidIdSchema } from "../../types";
+import {
+  type Chat,
+  ErrorResponseSchema,
+  OpenAi,
+  UuidIdSchema,
+} from "../../types";
+
+const ChatCompletionsHeadersSchema = z.object({
+  "x-archestra-chat-id": UuidIdSchema.optional().describe(
+    "If specified, interactions will be associated with this chat, otherwise a new chat will be created",
+  ),
+  authorization: OpenAi.API.ApiKeySchema,
+});
 
 /**
  * Extract tool name from conversation history by finding the assistant message
@@ -42,6 +56,63 @@ const extractToolNameFromHistory = async (
   return null;
 };
 
+const generateChatIdHashFromRequest = ({
+  messages,
+}: z.infer<typeof OpenAi.API.ChatCompletionRequestSchema>) =>
+  crypto
+    .createHash("sha256")
+    .update(JSON.stringify(messages[0].content))
+    .digest("hex");
+
+const getAgentAndChatIdFromRequest = async (
+  request: z.infer<typeof OpenAi.API.ChatCompletionRequestSchema>,
+  {
+    "x-archestra-chat-id": chatIdHeader,
+  }: z.infer<typeof ChatCompletionsHeadersSchema>,
+): Promise<
+  { chatId: string; agentId: string } | z.infer<typeof ErrorResponseSchema>
+> => {
+  let chatId = chatIdHeader;
+  let agentId: string | undefined;
+  let chat: Chat | null = null;
+
+  if (chatId) {
+    /**
+     * User has specified a particular chat ID, therefore let's first get the chat and then get the agent ID
+     * associated with that chat
+     */
+
+    // Validate chat exists and get agent ID
+    chat = await ChatModel.findById(chatId);
+    if (!chat) {
+      return {
+        error: {
+          message: `Specified chat ID ${chatId} not found`,
+          type: "not_found",
+        },
+      };
+    }
+
+    agentId = chat.agentId;
+  } else {
+    /**
+     * User has not specified a particular chat ID, therefore let's first create or get the
+     * "first" agent, and then we will take a hash of the first chat message to create a new chat ID
+     */
+    const agent = await AgentModel.ensureDefaultAgentExists();
+    agentId = agent.id;
+
+    // Create or get chat
+    chat = await ChatModel.createOrGetByHash({
+      agentId,
+      hashForId: generateChatIdHashFromRequest(request), // Generate chat ID hash from request
+    });
+    chatId = chat.id;
+  }
+
+  return { chatId, agentId };
+};
+
 /**
  * NOTE: we may just want to use something like fastify-http-proxy to proxy ALL openai endpoints
  * except for the ones that we are handling "specially" (ex. chat/completions)
@@ -60,10 +131,7 @@ const openAiProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
         description: "Create a chat completion with OpenAI",
         tags: ["llm-proxy"],
         body: OpenAi.API.ChatCompletionRequestSchema,
-        headers: z.object({
-          "x-archestra-chat-id": UuidIdSchema,
-          authorization: OpenAi.API.ApiKeySchema,
-        }),
+        headers: ChatCompletionsHeadersSchema,
         response: {
           200: OpenAi.API.ChatCompletionResponseSchema,
           400: ErrorResponseSchema,
@@ -73,24 +141,18 @@ const openAiProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
         },
       },
     },
-    async (
-      {
-        body: { ...requestBody },
-        headers: { "x-archestra-chat-id": chatId, authorization: openAiApiKey },
-      },
-      reply,
-    ) => {
-      // Validate chat exists and get agent ID
-      const chat = await ChatModel.findById(chatId);
-      if (!chat) {
-        return reply.status(404).send({
-          error: {
-            message: "Chat not found",
-            type: "invalid_request_error",
-          },
-        });
+    async ({ body: { ...requestBody }, headers }, reply) => {
+      const chatAndAgent = await getAgentAndChatIdFromRequest(
+        requestBody,
+        headers,
+      );
+
+      if ("error" in chatAndAgent) {
+        return reply.status(400).send(chatAndAgent);
       }
-      const agentId = chat.agentId;
+
+      const { chatId, agentId } = chatAndAgent;
+      const { authorization: openAiApiKey } = headers;
 
       const openAiClient = new OpenAI({ apiKey: openAiApiKey });
 

--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -41,6 +41,7 @@ const start = async () => {
     // Register CORS plugin to allow cross-origin requests from frontend
     await fastify.register(fastifyCors, {
       origin: ["http://localhost:3000"],
+      methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
       credentials: true,
     });
 

--- a/platform/shared/api-client/types.gen.ts
+++ b/platform/shared/api-client/types.gen.ts
@@ -532,6 +532,7 @@ export type GetChatsResponses = {
      */
     200: Array<{
         id: string;
+        hashForId: string | null;
         agentId: string;
         createdAt: string;
         updatedAt: string;
@@ -658,6 +659,7 @@ export type GetChatsResponse = GetChatsResponses[keyof GetChatsResponses];
 
 export type CreateChatData = {
     body: {
+        hashForId?: string | null;
         agentId: string;
     };
     path?: never;
@@ -671,6 +673,7 @@ export type CreateChatResponses = {
      */
     200: {
         id: string;
+        hashForId: string | null;
         agentId: string;
         createdAt: string;
         updatedAt: string;
@@ -708,6 +711,7 @@ export type GetChatResponses = {
      */
     200: {
         id: string;
+        hashForId: string | null;
         agentId: string;
         createdAt: string;
         updatedAt: string;
@@ -1115,7 +1119,10 @@ export type OpenAiChatCompletionsData = {
         stream?: boolean | null;
     };
     headers: {
-        'x-archestra-chat-id': string;
+        /**
+         * If specified, interactions will be associated with this chat, otherwise a new chat will be created
+         */
+        'x-archestra-chat-id'?: string;
         /**
          * Bearer token for OpenAI
          */


### PR DESCRIPTION
This PR introduces the ability to use the Archestra backend without explicitly specifying agent and chat IDs, making the integration more flexible and user-friendly.

## Changes

- **Database**: Added `hash_for_id` column to the chats table to support hash-based chat identification
- **Models**: 
  - Added `ensureDefaultAgentExists()` method to automatically create a default agent when none is specified
  - Added `createOrGetByHash()` method to find or create chats based on message content hash
- **OpenAI Proxy**: Modified to support optional `x-archestra-chat-id` header - when not provided:
  - Automatically ensures a default agent exists
  - Creates/retrieves chat sessions based on SHA-256 hash of the first message content
- **CLI Chat**: Updated to support optional agent ID flag (`--agent-id`) - when not specified, relies on the proxy's automatic handling

## Benefits

- Simplifies initial setup and experimentation
- Allows stateless API usage without pre-creating agents/chats
- Maintains backward compatibility with explicit ID specification
- Enables consistent chat sessions based on conversation content