### PR TITLE
feat: allow whitelisting specific tool invocations even when data is untrusted

### DIFF
--- a/platform/CLAUDE.md
+++ b/platform/CLAUDE.md
@@ -179,7 +179,7 @@ The backend integrates advanced security guardrails:
 - **Tool Invocation Policies**: Fine-grained control over tool usage
   - Control when tools can be invoked based on argument values
   - Support for multiple operators (equal, notEqual, contains, startsWith, endsWith, regex)
-  - Actions: allow or block with optional custom block prompts
+  - Actions: allow_when_context_is_untrusted or block_always with optional custom block prompts
 - **Trusted Data Policies**: Mark specific data patterns as trusted sources
   - Uses attribute paths to identify data fields
   - Same operator support as invocation policies

--- a/platform/backend/src/database/migrations/0002_update_tool_invocation_policy_actions.sql
+++ b/platform/backend/src/database/migrations/0002_update_tool_invocation_policy_actions.sql
@@ -1,0 +1,8 @@
+-- Update existing tool invocation policy action values
+UPDATE "tool_invocation_policies"
+SET "action" = 'allow_when_context_is_untrusted'
+WHERE "action" = 'allow';
+
+UPDATE "tool_invocation_policies"
+SET "action" = 'block_always'
+WHERE "action" = 'block';

--- a/platform/backend/src/database/migrations/meta/0002_snapshot.json
+++ b/platform/backend/src/database/migrations/meta/0002_snapshot.json
@@ -1,0 +1,584 @@
+{
+  "id": "ba89763b-78bb-4fc6-8d39-72f7f5b41f59",
+  "prevId": "043d93c4-ca64-452e-b3d3-0dd3e4e011e8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_tool_invocation_policies": {
+      "name": "agent_tool_invocation_policies",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_tool_invocation_policies_agent_id_agents_id_fk": {
+          "name": "agent_tool_invocation_policies_agent_id_agents_id_fk",
+          "tableFrom": "agent_tool_invocation_policies",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_tool_invocation_policies_policy_id_tool_invocation_policies_id_fk": {
+          "name": "agent_tool_invocation_policies_policy_id_tool_invocation_policies_id_fk",
+          "tableFrom": "agent_tool_invocation_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "tableTo": "tool_invocation_policies",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_tool_invocation_policies_agent_id_policy_id_pk": {
+          "name": "agent_tool_invocation_policies_agent_id_policy_id_pk",
+          "columns": [
+            "agent_id",
+            "policy_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_trusted_data_policies": {
+      "name": "agent_trusted_data_policies",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_trusted_data_policies_agent_id_agents_id_fk": {
+          "name": "agent_trusted_data_policies_agent_id_agents_id_fk",
+          "tableFrom": "agent_trusted_data_policies",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_trusted_data_policies_policy_id_trusted_data_policies_id_fk": {
+          "name": "agent_trusted_data_policies_policy_id_trusted_data_policies_id_fk",
+          "tableFrom": "agent_trusted_data_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "tableTo": "trusted_data_policies",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_trusted_data_policies_agent_id_policy_id_pk": {
+          "name": "agent_trusted_data_policies_agent_id_policy_id_pk",
+          "columns": [
+            "agent_id",
+            "policy_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "hash_for_id": {
+          "name": "hash_for_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chats_agent_id_agents_id_fk": {
+          "name": "chats_agent_id_agents_id_fk",
+          "tableFrom": "chats",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interactions": {
+      "name": "interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tainted": {
+          "name": "tainted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "taint_reason": {
+          "name": "taint_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "interactions_chat_id_idx": {
+          "name": "interactions_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "interactions_chat_id_chats_id_fk": {
+          "name": "interactions_chat_id_chats_id_fk",
+          "tableFrom": "interactions",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "tableTo": "chats",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool_invocation_policies": {
+      "name": "tool_invocation_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "argument_name": {
+          "name": "argument_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator": {
+          "name": "operator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_prompt": {
+          "name": "block_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tool_invocation_policies_tool_id_tools_id_fk": {
+          "name": "tool_invocation_policies_tool_id_tools_id_fk",
+          "tableFrom": "tool_invocation_policies",
+          "columnsFrom": [
+            "tool_id"
+          ],
+          "tableTo": "tools",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tools": {
+      "name": "tools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tools_agent_id_agents_id_fk": {
+          "name": "tools_agent_id_agents_id_fk",
+          "tableFrom": "tools",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tools_name_unique": {
+          "name": "tools_name_unique",
+          "columns": [
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trusted_data_policies": {
+      "name": "trusted_data_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribute_path": {
+          "name": "attribute_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator": {
+          "name": "operator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trusted_data_policies_tool_id_tools_id_fk": {
+          "name": "trusted_data_policies_tool_id_tools_id_fk",
+          "tableFrom": "trusted_data_policies",
+          "columnsFrom": [
+            "tool_id"
+          ],
+          "tableTo": "tools",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/platform/backend/src/database/migrations/meta/_journal.json
+++ b/platform/backend/src/database/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1759350301277,
       "tag": "0001_jittery_union_jack",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1759431831339,
+      "tag": "0002_update_tool_invocation_policy_actions",
+      "breakpoints": true
     }
   ]
 }

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -58,7 +58,6 @@ class AgentModel {
     return result.rowCount !== null && result.rowCount > 0;
   }
 
-  // Tool Invocation Policy Assignment Methods
   static async assignToolInvocationPolicy(
     agentId: string,
     policyId: string,

--- a/platform/backend/src/models/interaction.ts
+++ b/platform/backend/src/models/interaction.ts
@@ -30,8 +30,11 @@ class InteractionModel {
       .orderBy(asc(schema.interactionsTable.createdAt));
   }
 
-  static async findTaintedByChatId(chatId: string) {
-    return await db
+  /**
+   * Check if context is tainted by querying for tainted interactions
+   */
+  static async checkIfChatIsTainted(chatId: string) {
+    const taintedInteractions = await db
       .select()
       .from(schema.interactionsTable)
       .where(
@@ -39,8 +42,8 @@ class InteractionModel {
           eq(schema.interactionsTable.chatId, chatId),
           eq(schema.interactionsTable.tainted, true),
         ),
-      )
-      .orderBy(asc(schema.interactionsTable.createdAt));
+      );
+    return taintedInteractions.length > 0;
   }
 }
 

--- a/platform/backend/src/routes/proxy/openai.ts
+++ b/platform/backend/src/routes/proxy/openai.ts
@@ -89,6 +89,7 @@ const openAiProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
             await utils.toolInvocation.evaluatePolicies(
               assistantMessage,
               agentId,
+              chatId,
             );
 
           if (toolInvocationRefusal) {
@@ -148,6 +149,7 @@ const openAiProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
             await utils.toolInvocation.evaluatePolicies(
               assistantMessage,
               agentId,
+              chatId,
             );
           if (toolInvocationRefusal) {
             assistantMessage = toolInvocationRefusal.message;

--- a/platform/backend/src/routes/proxy/utils/tool-invocation.ts
+++ b/platform/backend/src/routes/proxy/utils/tool-invocation.ts
@@ -11,6 +11,7 @@ import { ToolInvocationPolicyModel } from "../../../models";
 export const evaluatePolicies = async (
   { tool_calls: toolCalls }: OpenAI.Chat.Completions.ChatCompletionMessage,
   agentId: string,
+  chatId: string,
 ): Promise<null | OpenAI.Chat.Completions.ChatCompletion.Choice> => {
   for (const toolCall of toolCalls || []) {
     let toolCallName = "";
@@ -36,7 +37,8 @@ export const evaluatePolicies = async (
      */
     const toolInput = JSON.parse(toolCallArgs);
 
-    const { isAllowed } = await ToolInvocationPolicyModel.evaluateForAgent(
+    const { isAllowed } = await ToolInvocationPolicyModel.evaluate(
+      chatId,
       agentId,
       toolCallName,
       toolInput,

--- a/platform/backend/src/types/autonomy-policies/tool-invocation.ts
+++ b/platform/backend/src/types/autonomy-policies/tool-invocation.ts
@@ -3,7 +3,10 @@ import { z } from "zod";
 import { schema } from "../../database";
 import { SupportedOperatorSchema } from "./operator";
 
-const ToolInvocationPolicyActionSchema = z.enum(["allow", "block"]);
+const ToolInvocationPolicyActionSchema = z.enum([
+  "allow_when_context_is_untrusted",
+  "block_always",
+]);
 
 export const SelectToolInvocationPolicySchema = createSelectSchema(
   schema.toolInvocationPoliciesTable,

--- a/platform/frontend/src/app/settings/page.tsx
+++ b/platform/frontend/src/app/settings/page.tsx
@@ -71,7 +71,7 @@ export default function SettingsPage() {
     argumentName: string;
     operator: OperatorValue;
     value: string;
-    action: "allow" | "block";
+    action: "allow_when_context_is_untrusted" | "block_always";
     blockPrompt: string;
   }>({
     toolId: "",
@@ -79,7 +79,7 @@ export default function SettingsPage() {
     argumentName: "",
     operator: "equal",
     value: "",
-    action: "block",
+    action: "block_always",
     blockPrompt: "",
   });
 
@@ -175,7 +175,7 @@ export default function SettingsPage() {
           argumentName: "",
           operator: "equal",
           value: "",
-          action: "block",
+          action: "block_always",
           blockPrompt: "",
         });
       } catch (error) {
@@ -369,7 +369,11 @@ export default function SettingsPage() {
                     <Label htmlFor="tip-action">Action</Label>
                     <Select
                       value={newToolInvocationPolicy.action}
-                      onValueChange={(value: "allow" | "block") =>
+                      onValueChange={(
+                        value:
+                          | "allow_when_context_is_untrusted"
+                          | "block_always",
+                      ) =>
                         setNewToolInvocationPolicy({
                           ...newToolInvocationPolicy,
                           action: value,
@@ -381,8 +385,12 @@ export default function SettingsPage() {
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="block">Block</SelectItem>
-                        <SelectItem value="allow">Allow</SelectItem>
+                        <SelectItem value="block_always">
+                          Block Always
+                        </SelectItem>
+                        <SelectItem value="allow_when_context_is_untrusted">
+                          Allow When Context Is Untrusted
+                        </SelectItem>
                       </SelectContent>
                     </Select>
                   </div>
@@ -500,12 +508,14 @@ export default function SettingsPage() {
                     <div className="flex items-center gap-2">
                       <span
                         className={`text-xs px-2 py-1 rounded ${
-                          policy.action === "block"
+                          policy.action === "block_always"
                             ? "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200"
                             : "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
                         }`}
                       >
-                        {policy.action}
+                        {policy.action === "block_always"
+                          ? "Block Always"
+                          : "Allow When Context Is Untrusted"}
                       </span>
                       <Button
                         variant="ghost"

--- a/platform/shared/api-client/types.gen.ts
+++ b/platform/shared/api-client/types.gen.ts
@@ -1585,7 +1585,7 @@ export type CreateToolInvocationPolicyData = {
         argumentName: string;
         operator: 'equal' | 'notEqual' | 'contains' | 'notContains' | 'startsWith' | 'endsWith' | 'regex';
         value: string;
-        action: 'allow' | 'block';
+        action: 'allow_when_context_is_untrusted' | 'block_always';
         blockPrompt?: string | null;
     };
     path?: never;
@@ -1729,7 +1729,7 @@ export type UpdateToolInvocationPolicyData = {
         argumentName?: string;
         operator?: 'equal' | 'notEqual' | 'contains' | 'notContains' | 'startsWith' | 'endsWith' | 'regex';
         value?: string;
-        action?: 'allow' | 'block';
+        action?: 'allow_when_context_is_untrusted' | 'block_always';
         blockPrompt?: string | null;
     };
     path: {


### PR DESCRIPTION
## Summary

This PR enhances the tool invocation policy system by introducing more granular control over tool execution in untrusted contexts. The key changes include:

- **Renamed policy actions** for clarity:
  - `allow` → `allow_when_context_is_untrusted` 
  - `block` → `block_always`

- **Improved security model**: When a context is tainted (contains untrusted data), tools are blocked by default unless explicitly whitelisted via an `allow_when_context_is_untrusted` policy

- **UI updates**: Updated the frontend settings page to reflect the new action names and provide clearer policy configuration

## Key Changes

1. **Database migration**: Updates existing policy action values to new names
2. **Backend logic**: Modified the policy evaluation to implement the new security model where untrusted contexts block all tools unless explicitly allowed
3. **Frontend**: Updated action labels and options in the tool invocation policy UI

## Security Benefits

This change improves security by:
- Making the default behavior more restrictive when dealing with untrusted data
- Requiring explicit whitelisting of tool invocations in untrusted contexts
- Providing clearer naming that indicates the security implications of each action