### PR TITLE
fix: JSON parsing error in trusted data policy evaluation on Jan.ai

### DIFF
--- a/platform/backend/src/routes/proxy/utils/trusted-data.ts
+++ b/platform/backend/src/routes/proxy/utils/trusted-data.ts
@@ -41,8 +41,17 @@ export const evaluatePolicies = async (
   for (const message of messages) {
     if (message.role === "tool") {
       const { tool_call_id: toolCallId, content } = message;
-      const toolResult =
-        typeof content === "string" ? JSON.parse(content) : content;
+      let toolResult: unknown;
+      if (typeof content === "string") {
+        try {
+          toolResult = JSON.parse(content);
+        } catch {
+          // If content is not valid JSON, use it as-is
+          toolResult = content;
+        }
+      } else {
+        toolResult = content;
+      }
 
       // Extract tool name from conversation history
       const toolName = await extractToolNameFromHistory(chatId, toolCallId);


### PR DESCRIPTION
## Problem

The backend was throwing 500 errors when processing tool results that contained plain text instead of JSON:

```
SyntaxError: Unexpected token 'C', "Contents o"... is not valid JSON
    at JSON.parse (<anonymous>)
    at Object.evaluatePolicies (/backend/src/routes/proxy/utils/trusted-data.ts:45:44)
```

## Root Cause

The trusted data policy evaluator assumed all string content from tool messages was valid JSON and called `JSON.parse()` without error handling. However, tools can return plain text responses (e.g., "Contents of..." from file reading tools).

## Solution

Added try-catch around `JSON.parse()` in `backend/src/routes/proxy/utils/trusted-data.ts:45`:

- Attempts to parse string content as JSON
- Falls back to using the string as-is when parsing fails
- Prevents crashes while maintaining support for both JSON and plain text tool results

## Impact

- Fixes 500 errors on `/api/proxy/openai/chat/completions` endpoint
- Allows trusted data policies to work with all tool result formats
