### PR TITLE
fix: allow null system_fingerprint in OpenAI response schema (for openwebUI)

### DIFF
--- a/platform/backend/src/types/llm-providers/openai/api.ts
+++ b/platform/backend/src/types/llm-providers/openai/api.ts
@@ -90,7 +90,7 @@ export const ChatCompletionResponseSchema = z
     model: z.string(),
     object: z.literal("chat.completion"),
     server_tier: z.string().optional(),
-    system_fingerprint: z.string().optional(),
+    system_fingerprint: z.string().nullable().optional(),
     usage: ChatCompletionUsageSchema.optional(),
   })
   .describe(


### PR DESCRIPTION
OpenAI API returns null for system_fingerprint in some responses, causing ResponseSerializationError. Updated schema to accept nullable values using z.string().nullable().optional().