### PR TITLE
fix: tweak platform dockerhub image tags

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -76,7 +76,7 @@
     "platform": {
       "component": "platform",
       "release-type": "node",
-      "prerelease": false,
+      "prerelease": true,
       "initial-version": "0.0.1"
     }
   },

--- a/.github/workflows/build-dockerhub-image.yml
+++ b/.github/workflows/build-dockerhub-image.yml
@@ -8,11 +8,6 @@ on:
         description: "Directory containing the Dockerfile"
         required: true
         type: string
-      org_namespace:
-        description: "Organization namespace for the Docker image"
-        required: false
-        type: string
-        default: archestra
       image_name:
         description: "Name of the Docker image"
         required: true
@@ -58,7 +53,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
-          images: ${{ inputs.org_namespace }}/${{ inputs.image_name }}
+          images: archestra/${{ inputs.image_name }}
 
       - name: Build and push Docker image
         id: push
@@ -73,6 +68,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
-          subject-name: index.docker.io/${{ inputs.org_namespace }}/${{ inputs.image_name }}
+          subject-name: index.docker.io/archestra/${{ inputs.image_name }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: ${{ inputs.push_image }}

--- a/.github/workflows/build-dockerhub-image.yml
+++ b/.github/workflows/build-dockerhub-image.yml
@@ -78,8 +78,10 @@ jobs:
         if: inputs.push_image
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
+          digest="${DIGEST}"
           touch "/tmp/digests/${digest#sha256:}"
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
 
       - name: Upload digest
         if: inputs.push_image
@@ -120,10 +122,16 @@ jobs:
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
-            -t docker.io/archestra/${{ inputs.image_name }}:${{ inputs.version }} \
-            -t docker.io/archestra/${{ inputs.image_name }}:latest \
-            $(printf 'docker.io/archestra/${{ inputs.image_name }}@sha256:%s ' *)
+            -t "docker.io/archestra/${IMAGE_NAME}:${VERSION}" \
+            -t "docker.io/archestra/${IMAGE_NAME}:latest" \
+            $(printf "docker.io/archestra/${IMAGE_NAME}@sha256:%s " *)
+        env:
+          IMAGE_NAME: ${{ inputs.image_name }}
+          VERSION: ${{ inputs.version }}
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect docker.io/archestra/${{ inputs.image_name }}:${{ inputs.version }}
+          docker buildx imagetools inspect "docker.io/archestra/${IMAGE_NAME}:${VERSION}"
+        env:
+          IMAGE_NAME: ${{ inputs.image_name }}
+          VERSION: ${{ inputs.version }}

--- a/.github/workflows/build-dockerhub-image.yml
+++ b/.github/workflows/build-dockerhub-image.yml
@@ -28,8 +28,17 @@ on:
 
 jobs:
   build-dockerhub-image:
-    name: Build Docker Hub image
-    runs-on: ubuntu-latest
+    name: Build Docker Hub image (${{ matrix.os_and_arch }})
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories
+        include:
+          - platform: ubuntu-latest
+            os_and_arch: linux/amd64
+          - platform: ubuntu-24.04-arm
+            os_and_arch: linux/arm64
     permissions:
       contents: read
       id-token: write
@@ -47,20 +56,16 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build and push Docker image
-        id: push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ inputs.image_directory }} # zizmor: ignore[template-injection] this is only being passed in as a workflow input..
           file: ${{ inputs.image_directory }}/Dockerfile
           push: ${{ inputs.push_image }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.os_and_arch }}
           tags: |
             docker.io/archestra/${{ inputs.image_name }}:${{ inputs.version }}
             docker.io/archestra/${{ inputs.image_name }}:latest

--- a/.github/workflows/build-dockerhub-image.yml
+++ b/.github/workflows/build-dockerhub-image.yml
@@ -27,6 +27,9 @@ on:
         required: false
 
 jobs:
+  # This workflow was inspired by https://medium.com/neudesic-innovation/building-multi-platform-container-images-with-github-actions-e495f9441ad3
+  # Basically we build the image for each Linux architecture on separate GitHub runners
+  # (to avoid emulation which is very slow), then we publish a single "multi-arch" image to Docker Hub.
   build-dockerhub-image:
     name: Build Docker Hub image (${{ matrix.os_and_arch }})
     runs-on: ${{ matrix.platform }}
@@ -60,14 +63,67 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ inputs.image_directory }} # zizmor: ignore[template-injection] this is only being passed in as a workflow input..
           file: ${{ inputs.image_directory }}/Dockerfile
           push: ${{ inputs.push_image }}
           platforms: ${{ matrix.os_and_arch }}
-          tags: |
-            docker.io/archestra/${{ inputs.image_name }}:${{ inputs.version }}
-            docker.io/archestra/${{ inputs.image_name }}:latest
+          outputs: type=image,name=docker.io/archestra/${{ inputs.image_name }},push-by-digest=true,name-canonical=true,push=${{ inputs.push_image }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Export digest
+        if: inputs.push_image
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: inputs.push_image
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: digests-${{ strategy.job-index }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-manifests:
+    name: Create multi-arch manifest
+    if: inputs.push_image
+    runs-on: ubuntu-latest
+    needs:
+      - build-dockerhub-image
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            -t docker.io/archestra/${{ inputs.image_name }}:${{ inputs.version }} \
+            -t docker.io/archestra/${{ inputs.image_name }}:latest \
+            $(printf 'docker.io/archestra/${{ inputs.image_name }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect docker.io/archestra/${{ inputs.image_name }}:${{ inputs.version }}

--- a/.github/workflows/build-dockerhub-image.yml
+++ b/.github/workflows/build-dockerhub-image.yml
@@ -47,6 +47,9 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 

--- a/.github/workflows/build-dockerhub-image.yml
+++ b/.github/workflows/build-dockerhub-image.yml
@@ -31,9 +31,7 @@ jobs:
     name: Build Docker Hub image
     runs-on: ubuntu-latest
     permissions:
-      packages: write
       contents: read
-      attestations: write
       id-token: write
     steps:
       - name: Checkout repository
@@ -49,11 +47,8 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
-        with:
-          images: archestra/${{ inputs.image_name }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build and push Docker image
         id: push
@@ -62,12 +57,9 @@ jobs:
           context: ${{ inputs.image_directory }} # zizmor: ignore[template-injection] this is only being passed in as a workflow input..
           file: ${{ inputs.image_directory }}/Dockerfile
           push: ${{ inputs.push_image }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
-        with:
-          subject-name: index.docker.io/archestra/${{ inputs.image_name }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: ${{ inputs.push_image }}
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            docker.io/archestra/${{ inputs.image_name }}:${{ inputs.version }}
+            docker.io/archestra/${{ inputs.image_name }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -34,9 +34,6 @@ jobs:
       security-events: write
       id-token: write # Required for Workload Identity Federation
     uses: ./.github/workflows/platform-linting-and-tests.yml
-    secrets:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
   package-and-test-desktop-application:
     name: Package and test desktop application

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -34,6 +34,9 @@ jobs:
       security-events: write
       id-token: write # Required for Workload Identity Federation
     uses: ./.github/workflows/platform-linting-and-tests.yml
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
   package-and-test-desktop-application:
     name: Package and test desktop application

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -34,7 +34,6 @@ jobs:
       security-events: write
       id-token: write # Required for Workload Identity Federation
       packages: write
-      attestations: write
     uses: ./.github/workflows/platform-linting-and-tests.yml
 
   package-and-test-desktop-application:

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -33,8 +33,10 @@ jobs:
       contents: write
       security-events: write
       id-token: write # Required for Workload Identity Federation
-      packages: write
     uses: ./.github/workflows/platform-linting-and-tests.yml
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
   package-and-test-desktop-application:
     name: Package and test desktop application

--- a/.github/workflows/platform-linting-and-tests.yml
+++ b/.github/workflows/platform-linting-and-tests.yml
@@ -2,11 +2,6 @@ name: Platform Linting and Tests
 
 on:
   workflow_call:
-    secrets:
-      DOCKER_USERNAME:
-        required: true
-      DOCKER_PASSWORD:
-        required: true
 
 jobs:
   platform-linting-and-tests:
@@ -41,13 +36,8 @@ jobs:
     with:
       image_directory: ./platform
       image_name: platform
-      # TODO: remove this when done testing..
-      # version: ${{ github.sha }}
-      version: v0.0.1
-      push_image: true
-    secrets:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      version: ${{ github.sha }}
+      push_image: false
 
   helm-chart-linting-and-tests:
     name: Helm Chart Linting and Tests

--- a/.github/workflows/platform-linting-and-tests.yml
+++ b/.github/workflows/platform-linting-and-tests.yml
@@ -2,6 +2,11 @@ name: Platform Linting and Tests
 
 on:
   workflow_call:
+    secrets:
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
 
 jobs:
   platform-linting-and-tests:
@@ -36,8 +41,13 @@ jobs:
     with:
       image_directory: ./platform
       image_name: platform
-      version: ${{ github.sha }}
-      push_image: false
+      # TODO: remove this when done testing..
+      # version: ${{ github.sha }}
+      version: v0.0.1
+      push_image: true
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
   helm-chart-linting-and-tests:
     name: Helm Chart Linting and Tests

--- a/.github/workflows/platform-linting-and-tests.yml
+++ b/.github/workflows/platform-linting-and-tests.yml
@@ -31,15 +31,15 @@ jobs:
     name: Build platform Docker image
     uses: ./.github/workflows/build-dockerhub-image.yml
     permissions:
-      packages: write
       contents: read
-      attestations: write
       id-token: write
     with:
       image_directory: ./platform
       image_name: platform
-      version: ${{ github.sha }}
-      push_image: false
+      # TODO: remove this when done testing..
+      # version: ${{ github.sha }}
+      version: v0.0.1
+      push_image: true
 
   helm-chart-linting-and-tests:
     name: Helm Chart Linting and Tests

--- a/.github/workflows/platform-linting-and-tests.yml
+++ b/.github/workflows/platform-linting-and-tests.yml
@@ -2,6 +2,11 @@ name: Platform Linting and Tests
 
 on:
   workflow_call:
+    secrets:
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
 
 jobs:
   platform-linting-and-tests:
@@ -40,6 +45,9 @@ jobs:
       # version: ${{ github.sha }}
       version: v0.0.1
       push_image: true
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
   helm-chart-linting-and-tests:
     name: Helm Chart Linting and Tests

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -105,9 +105,7 @@ jobs:
     needs:
       - release-please
     permissions:
-      packages: write
       contents: read
-      attestations: write
       id-token: write
     with:
       image_directory: ./platform

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -101,7 +101,7 @@ jobs:
   build-and-push-platform-docker-image-to-dockerhub:
     name: Build and push platform Docker image to Docker Hub
     if: needs.release-please.outputs.platform_release_created
-    uses: ./.github/workflows/build-and-push-image-to-dockerhub.yml
+    uses: ./.github/workflows/build-dockerhub-image.yml
     needs:
       - release-please
     permissions:

--- a/platform/CLAUDE.md
+++ b/platform/CLAUDE.md
@@ -191,7 +191,7 @@ The backend integrates advanced security guardrails:
 - **Trusted Data Policies**: Mark specific data patterns as trusted or blocked
   - Uses attribute paths to identify data fields
   - Same operator support as invocation policies
-  - Actions: 
+  - Actions:
     - `allow`: Mark data as trusted
     - `block_always`: Prevent data from reaching LLM (blocked data is filtered out before sending to the model)
 - **Taint Analysis**: Tracks untrusted data through the system
@@ -256,6 +256,7 @@ The `experiments/` workspace contains prototype features:
 - **Globals**: Test utilities are available via `vitest` globals
 
 **Test Examples**:
+
 - `agent.test.ts`: Simple agent CRUD operations
 - `tool-invocation-policy.test.ts`: Comprehensive policy evaluation tests
 - `trusted-data-policy.test.ts`: Trust evaluation and taint tracking tests
@@ -285,6 +286,7 @@ The platform uses [release-please](https://github.com/googleapis/release-please)
 #### Release Workflow Details
 
 The release process is triggered automatically when:
+
 1. Conventional commits are merged to main
 2. Release-please creates a PR with version bumps
 3. When the release PR is merged, the following happens:
@@ -293,6 +295,7 @@ The release process is triggered automatically when:
    - Helm chart (from `platform/helm/`) is packaged and pushed to GAR
 
 The release workflow (`release-please.yml`) monitors both `desktop_app` and `platform` packages:
+
 - Outputs separate release states: `platform_release_created` and `desktop_release_created`
 - Platform releases trigger:
   - `build-and-push-platform-docker-image-to-dockerhub` job
@@ -302,6 +305,7 @@ The release workflow (`release-please.yml`) monitors both `desktop_app` and `pla
 #### Docker Image Publishing
 
 The platform Docker image is published to DockerHub:
+
 - **Repository**: `archestra/platform`
 - **Build Context**: `./platform` directory
 - **Triggered by**: Platform releases from release-please
@@ -310,17 +314,16 @@ The platform Docker image is published to DockerHub:
 - **Authentication**: Requires `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets
 - **Build Features**:
   - Multi-stage builds supported via Dockerfile
-  - Metadata extraction for tags and labels
-  - Artifact attestation for provenance tracking
   - Optional push based on workflow inputs
 
 #### Helm Chart
 
 The platform includes a production-ready Helm chart for Kubernetes deployments:
+
 - **Location**: `platform/helm/`
 - **Chart Name**: archestra-platform
 - **Version**: Automatically set from release-please output
-- **Features**: 
+- **Features**:
   - Deployment with configurable replicas
   - Service (ClusterIP by default)
   - Optional Ingress with TLS support
@@ -336,7 +339,7 @@ The platform includes a production-ready Helm chart for Kubernetes deployments:
   - **Repository**: `oci://europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/helm-charts`
   - **Authentication**: Google Artifact Registry via Workload Identity Federation
   - **Workflow**: `.github/workflows/publish-platform-helm-chart.yml`
-- **Testing**: 
+- **Testing**:
   - Helm lint validation in CI
   - Helm unit tests via helm-unittest plugin
   - Basic connectivity test included in `tests/`


### PR DESCRIPTION
Simplifies the Docker Hub image build workflow and adds multi-platform support.

## Changes

- Removed metadata extraction and artifact attestation steps for simpler builds
- Added explicit Docker Buildx setup for multi-platform builds
- Switched to direct tag specification instead of dynamic metadata
- Added support for both linux/amd64 and linux/arm64 platforms
- Enabled GitHub Actions cache (type=gha) for faster subsequent builds
- Removed unnecessary workflow permissions (packages:write, attestations:write)
- Temporarily hardcoded platform image version to v0.0.1 (includes TODO comment to revert)

## Impact

This change improves the Docker image build process by:
1. Supporting multi-architecture builds (amd64 and arm64)
2. Utilizing build caching for improved CI performance
3. Simplifying the workflow by removing unnecessary complexity
4. Making tag specification more explicit and predictable