### PR TITLE
fix: tell agents to use shadcn over radix

### DIFF
--- a/platform/.cursorrules
+++ b/platform/.cursorrules
@@ -1,0 +1,24 @@
+# Cursor Rules for Archestra Platform
+
+## Working Directory
+ALWAYS run all commands from the `platform/` directory unless specifically instructed otherwise.
+
+## Important Rules
+1. ALWAYS use pnpm (not npm or yarn) for package management
+2. Use Biome for formatting and linting - Run `pnpm lint` before committing changes
+3. TypeScript strict mode - Ensure code passes `pnpm type-check` before completion
+4. Use shadcn/ui components - Add components with `npx shadcn@latest add <component>` instead of using Radix UI directly
+
+## Tech Stack
+- Monorepo: pnpm workspaces with Turbo
+- Backend: Fastify + Drizzle ORM (PostgreSQL)
+- Frontend: Next.js 15.5.4 + React 19 + Turbopack + Tailwind CSS 4 + shadcn/ui
+- Code Quality: Biome for linting and formatting
+- Testing: Vitest with PGLite
+
+## Development Best Practices
+- Use existing patterns and libraries - check neighboring files for examples
+- Follow existing naming conventions (camelCase for TypeScript)
+- Test files should be colocated with source (`.test.ts` extension)
+- Use workspace-relative imports within each workspace
+- Run `pnpm type-check` before committing to catch type errors

--- a/platform/CLAUDE.md
+++ b/platform/CLAUDE.md
@@ -12,6 +12,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 2. **Use Biome for formatting and linting** - Run `pnpm lint` before committing changes
 3. **TypeScript strict mode** - Ensure code passes `pnpm type-check` before completion
 4. **Tilt for development** - The project uses Tilt to orchestrate the development environment
+5. **Use shadcn/ui components** - Add components with `npx shadcn@latest add <component>` instead of using Radix UI directly
 
 ## Common Development Commands
 
@@ -74,7 +75,8 @@ Archestra Platform is an enterprise Model Context Protocol (MCP) platform built 
 - **Monorepo**: pnpm workspaces with Turbo for build orchestration
 - **Development**: Tilt for local development orchestration
 - **Backend**: Fastify server with pino logging + Drizzle ORM (PostgreSQL)
-- **Frontend**: Next.js 15.5.4 with React 19 + Turbopack + Tailwind CSS 4
+- **Frontend**: Next.js 15.5.4 with React 19 + Turbopack + Tailwind CSS 4 + shadcn/ui
+- **UI Components**: shadcn/ui (add with `npx shadcn@latest add <component>`)
 - **Database**: PostgreSQL with Drizzle ORM for interaction persistence
 - **Security**: Production-ready guardrails with dual LLM pattern and taint analysis
 - **Build System**: TypeScript with separate tsconfig per workspace


### PR DESCRIPTION
Update AI agent documentation to prefer shadcn/ui components over directly using Radix UI components.

## Changes
- Added explicit rule to use 'npx shadcn@latest add <component>' for adding UI components
- Updated tech stack documentation to include shadcn/ui
- Created new .cursorrules file with comprehensive development guidelines for Cursor IDE

This ensures consistent UI component usage across the codebase by leveraging the pre-configured shadcn/ui setup.