### PR TITLE
fix: fix texts for dual llm

### DIFF
--- a/platform/frontend/src/app/tools/_parts/tool-result-policies.tsx
+++ b/platform/frontend/src/app/tools/_parts/tool-result-policies.tsx
@@ -267,13 +267,15 @@ export function ToolResultPolicies({
           {willTriggerDualLlm ? (
             <Badge variant="default" asChild>
               <Link href="/dual-llm" className="cursor-pointer">
-                Dual LLM will activate
+                Dual LLM is active
               </Link>
             </Badge>
           ) : (
-            <Button variant="outline" size="sm" asChild>
-              <Link href="/dual-llm">Configure Dual LLM →</Link>
-            </Button>
+            <Badge variant="secondary" asChild>
+              <Link href="/dual-llm" className="cursor-pointer">
+                Dual LLM is inactive (Click to enable)
+              </Link>
+            </Badge>
           )}
         </div>
       </div>


### PR DESCRIPTION
Update Dual LLM status display for improved clarity

Changes:
- Changed text from "Dual LLM will activate" to "Dual LLM is active" to better reflect the current state
- Replaced button with badge for consistent UI pattern when Dual LLM is inactive
- Added explicit instruction text "(Click to enable)" for the inactive state to improve user guidance

These changes make the Dual LLM status more intuitive and align with the existing UI patterns in the application.