### PR TITLE
fix: fix benchmarks

### DIFF
--- a/platform/benchmarks/.env.example
+++ b/platform/benchmarks/.env.example
@@ -4,8 +4,8 @@ GCP_ZONE=us-central1-a
 GCP_MACHINE_TYPE=n2-standard-4
 
 # Benchmark Configuration
-NUM_REQUESTS=1000
-CONCURRENCY=10
+NUM_REQUESTS=40000
+CONCURRENCY=1000
 
 # Platform Configuration (set on Archestra VM)
 BENCHMARK_MOCK_MODE=true

--- a/platform/benchmarks/setup-gcp-benchmark.sh
+++ b/platform/benchmarks/setup-gcp-benchmark.sh
@@ -93,9 +93,9 @@ apt-get update
 apt-get install -y docker-ce docker-ce-cli containerd.io
 
 echo "Starting Archestra Platform..."
-docker run -d -p 9000:9000 -p 3000:3000 --name archestra archestra/platform:latest
+docker run -d -p 9000:9000 -p 3000:3000 -e BENCHMARK_MOCK_MODE=true --name archestra archestra/platform:latest
 
-echo "✅ Archestra Platform is running"
+echo "✅ Archestra Platform is running (mock mode enabled)"
 echo "API: http://$(hostname -I | awk "{print \$1}"):9000"
 '
 

--- a/platform/docker-compose-n8n.yml
+++ b/platform/docker-compose-n8n.yml
@@ -28,6 +28,7 @@ services:
       - "3000:3000"
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@archestra-db:5432/archestra
+      - BENCHMARK_MOCK_MODE=true
     volumes:
       - archestra_data:/app/data
     depends_on:


### PR DESCRIPTION
## Summary

This PR fixes benchmark configuration issues to ensure consistent testing environments:

- Enables mock mode (BENCHMARK_MOCK_MODE=true) across all benchmark environments for deterministic performance testing
- Updates benchmark load test parameters to more realistic values (40k requests with 1000 concurrent connections)
- Ensures Docker Compose and GCP benchmark setups both run in mock mode to avoid external dependencies during benchmarking

These changes ensure benchmarks run with predictable performance characteristics by using mock responses instead of real external service calls.