### PR TITLE
fix: add ARCHESTRA_ to ALLOWED_FRONTEND_ORIGINS

### DIFF
--- a/platform/.env.example
+++ b/platform/.env.example
@@ -11,10 +11,10 @@ ARCHESTRA_API_BASE_URL="http://localhost:9000"
 # Comma-separated list of frontend origins allowed to access the API, or "*" for all origins
 # If not set, defaults to "*" in development (NODE_ENV=development), localhost-only in production
 # Examples:
-#   Single domain: ALLOWED_FRONTEND_ORIGINS="https://app.example.com"
-#   Multiple domains: ALLOWED_FRONTEND_ORIGINS="https://app.example.com,https://dashboard.example.com"
-#   All origins: ALLOWED_FRONTEND_ORIGINS="*"
-# ALLOWED_FRONTEND_ORIGINS="https://app.example.com"
+#   Single domain: ARCHESTRA_ALLOWED_FRONTEND_ORIGINS="https://app.example.com"
+#   Multiple domains: ARCHESTRA_ALLOWED_FRONTEND_ORIGINS="https://app.example.com,https://dashboard.example.com"
+#   All origins: ARCHESTRA_ALLOWED_FRONTEND_ORIGINS="*"
+# ARCHESTRA_ALLOWED_FRONTEND_ORIGINS="https://app.example.com"
 
 # Configuration for docker compose demos, e.g. docker-compose-n8n.yml and docker-compose-mastra.yml
 DOMAIN_NAME=localhost

--- a/platform/CLAUDE.md
+++ b/platform/CLAUDE.md
@@ -109,12 +109,12 @@ ARCHESTRA_API_BASE_URL="http://localhost:9000"  # Proxy URL displayed in UI (def
 NEXT_PUBLIC_ARCHESTRA_API_BASE_URL="http://localhost:9000"  # Frontend-specific env var (defaults to ARCHESTRA_API_BASE_URL if not set)
 
 # Allowed Frontend Origins (optional)
-ALLOWED_FRONTEND_ORIGINS="https://app.example.com,https://dashboard.example.com"  # Comma-separated list of allowed frontend origins
+ARCHESTRA_ALLOWED_FRONTEND_ORIGINS="https://app.example.com,https://dashboard.example.com"  # Comma-separated list of allowed frontend origins
 # If not set, defaults to "*" in development (NODE_ENV=development), localhost-only in production
 # Examples:
-#   Single domain: ALLOWED_FRONTEND_ORIGINS="https://app.example.com"
-#   Multiple domains: ALLOWED_FRONTEND_ORIGINS="https://app.example.com,https://dashboard.example.com"
-#   All origins: ALLOWED_FRONTEND_ORIGINS="*"
+#   Single domain: ARCHESTRA_ALLOWED_FRONTEND_ORIGINS="https://app.example.com"
+#   Multiple domains: ARCHESTRA_ALLOWED_FRONTEND_ORIGINS="https://app.example.com,https://dashboard.example.com"
+#   All origins: ARCHESTRA_ALLOWED_FRONTEND_ORIGINS="*"
 
 # Provider API Keys (server-side configuration)
 OPENAI_API_KEY=your-api-key-here  # Required for OpenAI provider

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -42,7 +42,7 @@ const getPortFromUrl = (): number => {
  * - Empty/undefined: defaults to "*" in development, localhost regex in production
  */
 const getCorsOrigins = (): string | string[] | RegExp[] => {
-  const allowedFrontendOrigins = process.env.ALLOWED_FRONTEND_ORIGINS;
+  const allowedFrontendOrigins = process.env.ARCHESTRA_ALLOWED_FRONTEND_ORIGINS;
   const isDevelopment = process.env.NODE_ENV === "development";
 
   if (!allowedFrontendOrigins) {


### PR DESCRIPTION
## Summary

This PR standardizes the naming convention for environment variables by adding the `ARCHESTRA_` prefix to `ALLOWED_FRONTEND_ORIGINS`.

## Changes
- Renamed `ALLOWED_FRONTEND_ORIGINS` to `ARCHESTRA_ALLOWED_FRONTEND_ORIGINS` across:
  - `platform/.env.example`
  - `platform/CLAUDE.md`
  - `platform/backend/src/config.ts`

This follows the existing pattern used by other Archestra environment variables like `ARCHESTRA_API_BASE_URL` and `ARCHESTRA_ANALYTICS`.