### PR TITLE
fix: when installing mcp server, "refetch" available tools

### DIFF
--- a/platform/frontend/src/lib/mcp-server.query.ts
+++ b/platform/frontend/src/lib/mcp-server.query.ts
@@ -31,6 +31,10 @@ export function useInstallMcpServer() {
     },
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ["mcp-servers"] });
+      // Invalidate tools queries since MCP server installation creates new tools
+      queryClient.invalidateQueries({ queryKey: ["tools"] });
+      queryClient.invalidateQueries({ queryKey: ["tools", "unassigned"] });
+      queryClient.invalidateQueries({ queryKey: ["agent-tools"] });
       toast.success(`Successfully installed ${variables.name}`);
     },
     onError: (error, variables) => {


### PR DESCRIPTION
When installing an MCP server, the available tools need to be refetched to show the newly available tools from the installed server. This PR adds cache invalidation for tools-related queries after successful MCP server installation.