### PR TITLE
fix: add v1 prefix to mcp and proxy all llm requests via agent

### DIFF
--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -106,7 +106,7 @@ export default {
     authHeaderName: "X-Archestra-API-Key",
   },
   mcpGateway: {
-    endpoint: "/mcp",
+    endpoint: "/v1/mcp",
   },
   auth: {
     secret: process.env.ARCHESTRA_AUTH_SECRET,


### PR DESCRIPTION
## Summary

This PR adds a `/v1` prefix to the MCP gateway endpoint and introduces proxy handling for agent-specific LLM API routes.

### Changes:
- Updated MCP gateway endpoint from `/mcp` to `/v1/mcp` for API versioning consistency
- Added HTTP proxy configuration for OpenAI agent routes that forwards non-chat-completion requests to the OpenAI API
- Added HTTP proxy configuration for Anthropic agent routes that forwards non-messages requests to the Anthropic API

This enables routing of auxiliary API calls (like model listings) through to the upstream APIs while preserving custom handling for the main chat/message endpoints.

### Technical Details:
- OpenAI proxy: Excludes `/chat/completions` routes from proxy handling
- Anthropic proxy: Excludes `/messages` routes from proxy handling  
- Both proxies support agent-specific routing via `/:agentId/` path parameter

### Testing:
- [ ] Verify MCP gateway works with new `/v1/mcp` endpoint
- [ ] Test OpenAI proxy routes (e.g., `/v1/openai/models`)
- [ ] Test Anthropic proxy routes with proper API versioning
- [ ] Confirm chat/messages endpoints still use custom handling