### PR TITLE
fix: allow default admin user creation to bypass invitation check

### DIFF
--- a/platform/backend/src/auth.ts
+++ b/platform/backend/src/auth.ts
@@ -105,11 +105,20 @@ export const auth = betterAuth({
           ?.split("invitationId=")[1]
           ?.split("&")[0];
 
-        if (!invitationId) {
+        // Allow default admin user creation to bypass invitation check
+        const isDefaultAdminEmail =
+          body.email === config.auth.adminDefaultEmail;
+
+        if (!invitationId && !isDefaultAdminEmail) {
           throw new APIError("FORBIDDEN", {
             message:
               "Direct sign-up is disabled. You need an invitation to create an account.",
           });
+        }
+
+        // Skip invitation validation for default admin user
+        if (isDefaultAdminEmail) {
+          return ctx;
         }
 
         // Validate the invitation exists and is pending

--- a/platform/backend/src/models/user.ts
+++ b/platform/backend/src/models/user.ts
@@ -35,10 +35,12 @@ class User {
           .where(eq(schema.usersTable.email, email));
 
         console.log("Admin user created successfully:", email);
+        return result.user;
       }
-      return result.user;
+      return null;
     } catch (err) {
       console.error("Failed to create admin:", err);
+      return null;
     }
   }
 }


### PR DESCRIPTION
fixes: #803

### Problem

- when cleaning the database and running migrations, the default admin user was not being created during application startup. This prevented users from logging into the application, as there was no admin account available.

### Root Cause  

- the authentication system had a security hook that blocked all email-based sign-ups without a valid invitation, including the automatic creation of the default admin user during database seeding.

### Solution

- modified the authentication middleware to allow the default admin email (`admin@example.com`) to bypass the invitation requirement while maintaining security for all other user registrations.

### Changes Made
- **auth.ts**: Added logic to detect default admin email and skip invitation validation
- **user.ts**: Improved error handling to return `null` instead of `undefined` on failures