### PR TITLE
feat: mcp server installation request workflow

### DIFF
--- a/platform/backend/src/database/schemas/index.ts
+++ b/platform/backend/src/database/schemas/index.ts
@@ -14,6 +14,7 @@ export { default as dualLlmResultsTable } from "./dual-llm-result";
 export { default as interactionsTable } from "./interaction";
 export { default as internalMcpCatalogTable } from "./internal-mcp-catalog";
 export { default as mcpServersTable } from "./mcp-server";
+export { default as mcpServerInstallationRequestTable } from "./mcp-server-installation-request";
 export { default as mcpServerTeamTable } from "./mcp-server-team";
 export { default as organizationsTable } from "./organization";
 export { default as secretsTable } from "./secret";

--- a/platform/backend/src/database/schemas/mcp-server-installation-request.ts
+++ b/platform/backend/src/database/schemas/mcp-server-installation-request.ts
@@ -1,0 +1,39 @@
+import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import internalMcpCatalogTable from "./internal-mcp-catalog";
+import usersTable from "./user";
+
+const mcpServerInstallationRequestTable = pgTable(
+  "mcp_server_installation_request",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    catalogId: uuid("catalog_id")
+      .notNull()
+      .references(() => internalMcpCatalogTable.id, {
+        onDelete: "cascade",
+      }),
+    requestedBy: text("requested_by")
+      .notNull()
+      .references(() => usersTable.id, {
+        onDelete: "cascade",
+      }),
+    status: text("status")
+      .$type<"pending" | "approved" | "declined">()
+      .notNull()
+      .default("pending"),
+    requestNotes: text("request_notes"),
+    reviewNotes: text("review_notes"),
+    reviewedBy: text("reviewed_by").references(() => usersTable.id, {
+      onDelete: "set null",
+    }),
+    reviewedAt: timestamp("reviewed_at", { mode: "date" }),
+    createdAt: timestamp("created_at", { mode: "date" })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { mode: "date" })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+);
+
+export default mcpServerInstallationRequestTable;

--- a/platform/backend/src/middleware/auth.ts
+++ b/platform/backend/src/middleware/auth.ts
@@ -247,6 +247,27 @@ const routePermissionsConfig: Partial<
   [RouteId.RemoveTeamMember]: {
     team: ["update"],
   },
+  [RouteId.GetMcpServerInstallationRequests]: {
+    mcpServerInstallationRequest: ["read"],
+  },
+  [RouteId.GetMcpServerInstallationRequest]: {
+    mcpServerInstallationRequest: ["read"],
+  },
+  [RouteId.CreateMcpServerInstallationRequest]: {
+    mcpServerInstallationRequest: ["create"],
+  },
+  [RouteId.UpdateMcpServerInstallationRequest]: {
+    mcpServerInstallationRequest: ["update"],
+  },
+  [RouteId.ApproveMcpServerInstallationRequest]: {
+    mcpServerInstallationRequest: ["update"],
+  },
+  [RouteId.DeclineMcpServerInstallationRequest]: {
+    mcpServerInstallationRequest: ["update"],
+  },
+  [RouteId.DeleteMcpServerInstallationRequest]: {
+    mcpServerInstallationRequest: ["delete"],
+  },
 };
 
 const authMiddleware = new AuthMiddleware();

--- a/platform/backend/src/models/index.ts
+++ b/platform/backend/src/models/index.ts
@@ -6,6 +6,7 @@ export { default as DualLlmResultModel } from "./dual-llm-result";
 export { default as InteractionModel } from "./interaction";
 export { default as InternalMcpCatalogModel } from "./internal-mcp-catalog";
 export { default as McpServerModel } from "./mcp-server";
+export { default as McpServerInstallationRequestModel } from "./mcp-server-installation-request";
 export { default as McpServerTeamModel } from "./mcp-server-team";
 export { default as OrganizationModel } from "./organization";
 export { default as SecretModel } from "./secret";

--- a/platform/backend/src/models/mcp-server-installation-request.ts
+++ b/platform/backend/src/models/mcp-server-installation-request.ts
@@ -1,0 +1,136 @@
+import { and, desc, eq } from "drizzle-orm";
+import db, { schema } from "@/database";
+import type {
+  InsertMcpServerInstallationRequest,
+  McpServerInstallationRequest,
+  UpdateMcpServerInstallationRequest,
+} from "@/types";
+
+class McpServerInstallationRequestModel {
+  static async create(
+    request: InsertMcpServerInstallationRequest,
+  ): Promise<McpServerInstallationRequest> {
+    const [createdRequest] = await db
+      .insert(schema.mcpServerInstallationRequestTable)
+      .values(request)
+      .returning();
+
+    return createdRequest;
+  }
+
+  static async findAll(
+    status?: "pending" | "approved" | "declined",
+  ): Promise<McpServerInstallationRequest[]> {
+    let query = db
+      .select()
+      .from(schema.mcpServerInstallationRequestTable)
+      .orderBy(desc(schema.mcpServerInstallationRequestTable.createdAt))
+      .$dynamic();
+
+    if (status) {
+      query = query.where(
+        eq(schema.mcpServerInstallationRequestTable.status, status),
+      );
+    }
+
+    return await query;
+  }
+
+  static async findById(
+    id: string,
+  ): Promise<McpServerInstallationRequest | null> {
+    const [request] = await db
+      .select()
+      .from(schema.mcpServerInstallationRequestTable)
+      .where(eq(schema.mcpServerInstallationRequestTable.id, id));
+
+    return request || null;
+  }
+
+  static async findByUser(
+    userId: string,
+  ): Promise<McpServerInstallationRequest[]> {
+    return await db
+      .select()
+      .from(schema.mcpServerInstallationRequestTable)
+      .where(eq(schema.mcpServerInstallationRequestTable.requestedBy, userId))
+      .orderBy(desc(schema.mcpServerInstallationRequestTable.createdAt));
+  }
+
+  static async findByCatalogId(
+    catalogId: string,
+  ): Promise<McpServerInstallationRequest[]> {
+    return await db
+      .select()
+      .from(schema.mcpServerInstallationRequestTable)
+      .where(eq(schema.mcpServerInstallationRequestTable.catalogId, catalogId))
+      .orderBy(desc(schema.mcpServerInstallationRequestTable.createdAt));
+  }
+
+  static async findPendingRequestForCatalogByUser(
+    catalogId: string,
+    userId: string,
+  ): Promise<McpServerInstallationRequest | null> {
+    const [request] = await db
+      .select()
+      .from(schema.mcpServerInstallationRequestTable)
+      .where(
+        and(
+          eq(schema.mcpServerInstallationRequestTable.catalogId, catalogId),
+          eq(schema.mcpServerInstallationRequestTable.requestedBy, userId),
+          eq(schema.mcpServerInstallationRequestTable.status, "pending"),
+        ),
+      );
+
+    return request || null;
+  }
+
+  static async update(
+    id: string,
+    request: Partial<UpdateMcpServerInstallationRequest>,
+  ): Promise<McpServerInstallationRequest | null> {
+    const [updatedRequest] = await db
+      .update(schema.mcpServerInstallationRequestTable)
+      .set(request)
+      .where(eq(schema.mcpServerInstallationRequestTable.id, id))
+      .returning();
+
+    return updatedRequest || null;
+  }
+
+  static async approve(
+    id: string,
+    reviewedBy: string,
+    reviewNotes?: string,
+  ): Promise<McpServerInstallationRequest | null> {
+    return await this.update(id, {
+      status: "approved",
+      reviewedBy,
+      reviewedAt: new Date(),
+      reviewNotes,
+    });
+  }
+
+  static async decline(
+    id: string,
+    reviewedBy: string,
+    reviewNotes?: string,
+  ): Promise<McpServerInstallationRequest | null> {
+    return await this.update(id, {
+      status: "declined",
+      reviewedBy,
+      reviewedAt: new Date(),
+      reviewNotes,
+    });
+  }
+
+  static async delete(id: string): Promise<boolean> {
+    const result = await db
+      .delete(schema.mcpServerInstallationRequestTable)
+      .where(eq(schema.mcpServerInstallationRequestTable.id, id));
+
+    return result.rowCount !== null && result.rowCount > 0;
+  }
+}
+
+export default McpServerInstallationRequestModel;

--- a/platform/backend/src/routes/index.ts
+++ b/platform/backend/src/routes/index.ts
@@ -9,6 +9,7 @@ export { default as interactionRoutes } from "./interaction";
 export { default as internalMcpCatalogRoutes } from "./internal-mcp-catalog";
 export { default as mcpGatewayRoutes } from "./mcp-gateway";
 export { default as mcpServerRoutes } from "./mcp-server";
+export { default as mcpServerInstallationRequestRoutes } from "./mcp-server-installation-request";
 export { default as oauthRoutes } from "./oauth";
 export { default as anthropicProxyRoutes } from "./proxy/anthropic";
 export { default as geminiProxyRoutes } from "./proxy/gemini";

--- a/platform/backend/src/routes/mcp-server-installation-request.ts
+++ b/platform/backend/src/routes/mcp-server-installation-request.ts
@@ -1,0 +1,459 @@
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import { McpServerInstallationRequestModel } from "@/models";
+import {
+  ErrorResponseSchema,
+  InsertMcpServerInstallationRequestSchema,
+  RouteId,
+  SelectMcpServerInstallationRequestSchema,
+  UuidIdSchema,
+} from "@/types";
+import { getUserFromRequest } from "@/utils";
+
+const mcpServerInstallationRequestRoutes: FastifyPluginAsyncZod = async (
+  fastify,
+) => {
+  // Get all installation requests (optionally filtered by status)
+  fastify.get(
+    "/api/mcp_server_installation_request",
+    {
+      schema: {
+        operationId: RouteId.GetMcpServerInstallationRequests,
+        description:
+          "Get all MCP server installation requests (optionally filtered by status)",
+        tags: ["MCP Server Installation Request"],
+        querystring: z.object({
+          status: z.enum(["pending", "approved", "declined"]).optional(),
+        }),
+        response: {
+          200: z.array(SelectMcpServerInstallationRequestSchema),
+          401: ErrorResponseSchema,
+          500: ErrorResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      try {
+        const user = await getUserFromRequest(request);
+
+        if (!user) {
+          return reply.status(401).send({
+            error: {
+              message: "Unauthorized",
+              type: "unauthorized",
+            },
+          });
+        }
+
+        const { status } = request.query;
+
+        // Admins can see all requests, members can only see their own
+        let requests;
+        if (user.isAdmin) {
+          requests = await McpServerInstallationRequestModel.findAll(status);
+        } else {
+          const allUserRequests =
+            await McpServerInstallationRequestModel.findByUser(user.id);
+          // Filter by status if provided
+          requests = status
+            ? allUserRequests.filter((req) => req.status === status)
+            : allUserRequests;
+        }
+
+        return reply.send(requests);
+      } catch (error) {
+        fastify.log.error(error);
+        return reply.status(500).send({
+          error: {
+            message:
+              error instanceof Error ? error.message : "Internal server error",
+            type: "api_error",
+          },
+        });
+      }
+    },
+  );
+
+  // Get a specific installation request by ID
+  fastify.get(
+    "/api/mcp_server_installation_request/:id",
+    {
+      schema: {
+        operationId: RouteId.GetMcpServerInstallationRequest,
+        description: "Get an MCP server installation request by ID",
+        tags: ["MCP Server Installation Request"],
+        params: z.object({
+          id: UuidIdSchema,
+        }),
+        response: {
+          200: SelectMcpServerInstallationRequestSchema,
+          401: ErrorResponseSchema,
+          403: ErrorResponseSchema,
+          404: ErrorResponseSchema,
+          500: ErrorResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      try {
+        const user = await getUserFromRequest(request);
+
+        if (!user) {
+          return reply.status(401).send({
+            error: {
+              message: "Unauthorized",
+              type: "unauthorized",
+            },
+          });
+        }
+
+        const installationRequest =
+          await McpServerInstallationRequestModel.findById(request.params.id);
+
+        if (!installationRequest) {
+          return reply.status(404).send({
+            error: {
+              message: "Installation request not found",
+              type: "not_found",
+            },
+          });
+        }
+
+        // Members can only see their own requests, admins can see all
+        if (!user.isAdmin && installationRequest.requestedBy !== user.id) {
+          return reply.status(403).send({
+            error: {
+              message: "Forbidden",
+              type: "forbidden",
+            },
+          });
+        }
+
+        return reply.send(installationRequest);
+      } catch (error) {
+        fastify.log.error(error);
+        return reply.status(500).send({
+          error: {
+            message:
+              error instanceof Error ? error.message : "Internal server error",
+            type: "api_error",
+          },
+        });
+      }
+    },
+  );
+
+  // Create a new installation request
+  fastify.post(
+    "/api/mcp_server_installation_request",
+    {
+      schema: {
+        operationId: RouteId.CreateMcpServerInstallationRequest,
+        description: "Create a new MCP server installation request",
+        tags: ["MCP Server Installation Request"],
+        body: InsertMcpServerInstallationRequestSchema.omit({
+          id: true,
+          requestedBy: true,
+          status: true,
+          reviewedBy: true,
+          reviewedAt: true,
+          reviewNotes: true,
+          createdAt: true,
+          updatedAt: true,
+        }),
+        response: {
+          200: SelectMcpServerInstallationRequestSchema,
+          400: ErrorResponseSchema,
+          401: ErrorResponseSchema,
+          500: ErrorResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      try {
+        const user = await getUserFromRequest(request);
+
+        if (!user) {
+          return reply.status(401).send({
+            error: {
+              message: "Unauthorized",
+              type: "unauthorized",
+            },
+          });
+        }
+
+        // Check if user already has a pending request for this catalog item
+        const existingRequest =
+          await McpServerInstallationRequestModel.findPendingRequestForCatalogByUser(
+            request.body.catalogId,
+            user.id,
+          );
+
+        if (existingRequest) {
+          return reply.status(400).send({
+            error: {
+              message:
+                "You already have a pending installation request for this MCP server",
+              type: "validation_error",
+            },
+          });
+        }
+
+        const installationRequest =
+          await McpServerInstallationRequestModel.create({
+            ...request.body,
+            requestedBy: user.id,
+            status: "pending",
+          });
+
+        return reply.send(installationRequest);
+      } catch (error) {
+        fastify.log.error(error);
+        return reply.status(500).send({
+          error: {
+            message:
+              error instanceof Error ? error.message : "Internal server error",
+            type: "api_error",
+          },
+        });
+      }
+    },
+  );
+
+  // Update an installation request (generic update)
+  fastify.put(
+    "/api/mcp_server_installation_request/:id",
+    {
+      schema: {
+        operationId: RouteId.UpdateMcpServerInstallationRequest,
+        description: "Update an MCP server installation request",
+        tags: ["MCP Server Installation Request"],
+        params: z.object({
+          id: UuidIdSchema,
+        }),
+        body: InsertMcpServerInstallationRequestSchema.omit({
+          id: true,
+          requestedBy: true,
+          createdAt: true,
+          updatedAt: true,
+        }).partial(),
+        response: {
+          200: SelectMcpServerInstallationRequestSchema,
+          401: ErrorResponseSchema,
+          404: ErrorResponseSchema,
+          500: ErrorResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      try {
+        const user = await getUserFromRequest(request);
+
+        if (!user) {
+          return reply.status(401).send({
+            error: {
+              message: "Unauthorized",
+              type: "unauthorized",
+            },
+          });
+        }
+
+        const installationRequest =
+          await McpServerInstallationRequestModel.update(
+            request.params.id,
+            request.body,
+          );
+
+        if (!installationRequest) {
+          return reply.status(404).send({
+            error: {
+              message: "Installation request not found",
+              type: "not_found",
+            },
+          });
+        }
+
+        return reply.send(installationRequest);
+      } catch (error) {
+        fastify.log.error(error);
+        return reply.status(500).send({
+          error: {
+            message:
+              error instanceof Error ? error.message : "Internal server error",
+            type: "api_error",
+          },
+        });
+      }
+    },
+  );
+
+  // Approve an installation request (admin only)
+  fastify.post(
+    "/api/mcp_server_installation_request/:id/approve",
+    {
+      schema: {
+        operationId: RouteId.ApproveMcpServerInstallationRequest,
+        description: "Approve an MCP server installation request",
+        tags: ["MCP Server Installation Request"],
+        params: z.object({
+          id: UuidIdSchema,
+        }),
+        body: z.object({
+          reviewNotes: z.string().optional(),
+        }),
+        response: {
+          200: SelectMcpServerInstallationRequestSchema,
+          401: ErrorResponseSchema,
+          404: ErrorResponseSchema,
+          500: ErrorResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      try {
+        const user = await getUserFromRequest(request);
+
+        if (!user) {
+          return reply.status(401).send({
+            error: {
+              message: "Unauthorized",
+              type: "unauthorized",
+            },
+          });
+        }
+
+        const installationRequest =
+          await McpServerInstallationRequestModel.approve(
+            request.params.id,
+            user.id,
+            request.body.reviewNotes,
+          );
+
+        if (!installationRequest) {
+          return reply.status(404).send({
+            error: {
+              message: "Installation request not found",
+              type: "not_found",
+            },
+          });
+        }
+
+        return reply.send(installationRequest);
+      } catch (error) {
+        fastify.log.error(error);
+        return reply.status(500).send({
+          error: {
+            message:
+              error instanceof Error ? error.message : "Internal server error",
+            type: "api_error",
+          },
+        });
+      }
+    },
+  );
+
+  // Decline an installation request (admin only)
+  fastify.post(
+    "/api/mcp_server_installation_request/:id/decline",
+    {
+      schema: {
+        operationId: RouteId.DeclineMcpServerInstallationRequest,
+        description: "Decline an MCP server installation request",
+        tags: ["MCP Server Installation Request"],
+        params: z.object({
+          id: UuidIdSchema,
+        }),
+        body: z.object({
+          reviewNotes: z.string().optional(),
+        }),
+        response: {
+          200: SelectMcpServerInstallationRequestSchema,
+          401: ErrorResponseSchema,
+          404: ErrorResponseSchema,
+          500: ErrorResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      try {
+        const user = await getUserFromRequest(request);
+
+        if (!user) {
+          return reply.status(401).send({
+            error: {
+              message: "Unauthorized",
+              type: "unauthorized",
+            },
+          });
+        }
+
+        const installationRequest =
+          await McpServerInstallationRequestModel.decline(
+            request.params.id,
+            user.id,
+            request.body.reviewNotes,
+          );
+
+        if (!installationRequest) {
+          return reply.status(404).send({
+            error: {
+              message: "Installation request not found",
+              type: "not_found",
+            },
+          });
+        }
+
+        return reply.send(installationRequest);
+      } catch (error) {
+        fastify.log.error(error);
+        return reply.status(500).send({
+          error: {
+            message:
+              error instanceof Error ? error.message : "Internal server error",
+            type: "api_error",
+          },
+        });
+      }
+    },
+  );
+
+  // Delete an installation request
+  fastify.delete(
+    "/api/mcp_server_installation_request/:id",
+    {
+      schema: {
+        operationId: RouteId.DeleteMcpServerInstallationRequest,
+        description: "Delete an MCP server installation request",
+        tags: ["MCP Server Installation Request"],
+        params: z.object({
+          id: UuidIdSchema,
+        }),
+        response: {
+          200: z.object({ success: z.boolean() }),
+          404: ErrorResponseSchema,
+          500: ErrorResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      try {
+        return reply.send({
+          success: await McpServerInstallationRequestModel.delete(
+            request.params.id,
+          ),
+        });
+      } catch (error) {
+        fastify.log.error(error);
+        return reply.status(500).send({
+          error: {
+            message:
+              error instanceof Error ? error.message : "Internal server error",
+            type: "api_error",
+          },
+        });
+      }
+    },
+  );
+};
+
+export default mcpServerInstallationRequestRoutes;

--- a/platform/backend/src/types/api.ts
+++ b/platform/backend/src/types/api.ts
@@ -126,6 +126,15 @@ export const RouteId = {
   InstallMcpServer: "installMcpServer",
   DeleteMcpServer: "deleteMcpServer",
 
+  // MCP Server Installation Request Routes
+  GetMcpServerInstallationRequests: "getMcpServerInstallationRequests",
+  GetMcpServerInstallationRequest: "getMcpServerInstallationRequest",
+  CreateMcpServerInstallationRequest: "createMcpServerInstallationRequest",
+  UpdateMcpServerInstallationRequest: "updateMcpServerInstallationRequest",
+  ApproveMcpServerInstallationRequest: "approveMcpServerInstallationRequest",
+  DeclineMcpServerInstallationRequest: "declineMcpServerInstallationRequest",
+  DeleteMcpServerInstallationRequest: "deleteMcpServerInstallationRequest",
+
   // OAuth Routes
   InitiateOAuth: "initiateOAuth",
   HandleOAuthCallback: "handleOAuthCallback",

--- a/platform/backend/src/types/index.ts
+++ b/platform/backend/src/types/index.ts
@@ -8,6 +8,7 @@ export * from "./interaction";
 export * from "./llm-providers";
 export * from "./mcp-catalog";
 export * from "./mcp-server";
+export * from "./mcp-server-installation-request";
 export * from "./organization";
 export * from "./team";
 export * from "./tool";

--- a/platform/backend/src/types/mcp-server-installation-request.ts
+++ b/platform/backend/src/types/mcp-server-installation-request.ts
@@ -1,0 +1,29 @@
+import {
+  createInsertSchema,
+  createSelectSchema,
+  createUpdateSchema,
+} from "drizzle-zod";
+import { z } from "zod";
+import { schema } from "@/database";
+
+export const SelectMcpServerInstallationRequestSchema = createSelectSchema(
+  schema.mcpServerInstallationRequestTable,
+);
+
+export const InsertMcpServerInstallationRequestSchema = createInsertSchema(
+  schema.mcpServerInstallationRequestTable,
+);
+
+export const UpdateMcpServerInstallationRequestSchema = createUpdateSchema(
+  schema.mcpServerInstallationRequestTable,
+);
+
+export type McpServerInstallationRequest = z.infer<
+  typeof SelectMcpServerInstallationRequestSchema
+>;
+export type InsertMcpServerInstallationRequest = z.infer<
+  typeof InsertMcpServerInstallationRequestSchema
+>;
+export type UpdateMcpServerInstallationRequest = z.infer<
+  typeof UpdateMcpServerInstallationRequestSchema
+>;

--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -13,6 +13,7 @@ import {
   FileJson2,
   Github,
   Info,
+  Inbox,
   LogIn,
   type LucideIcon,
   MessagesSquare,
@@ -84,6 +85,13 @@ const getNavigationItems = (
             title: "MCP Registry",
             url: "/mcp-catalog",
             icon: Router,
+            subItems: [
+              {
+                title: "Installation Requests",
+                url: "/mcp-catalog/installation-requests",
+                icon: Inbox,
+              },
+            ],
           },
           ...(role === "admin"
             ? [

--- a/platform/frontend/src/app/mcp-catalog/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp-catalog/_parts/InternalMCPCatalog.tsx
@@ -25,13 +25,16 @@ import type {
   GetInternalMcpCatalogResponses,
   GetMcpServersResponses,
 } from "@/lib/clients/api";
+import { useRole } from "@/lib/auth.hook";
 import { useInternalMcpCatalog } from "@/lib/internal-mcp-catalog.query";
+import { useCreateMcpServerInstallationRequest } from "@/lib/mcp-server-installation-request.query";
 import { useInstallMcpServer, useMcpServers } from "@/lib/mcp-server.query";
 import { CreateCatalogDialog } from "./create-catalog-dialog";
 import { DeleteCatalogDialog } from "./delete-catalog-dialog";
 import { EditCatalogDialog } from "./edit-catalog-dialog";
 import { GitHubInstallDialog } from "./github-install-dialog";
 import { RemoteServerInstallDialog } from "./remote-server-install-dialog";
+import { RequestInstallDialog } from "./request-install-dialog";
 import { TransportBadges } from "./transport-badges";
 import { UninstallServerDialog } from "./uninstall-server-dialog";
 
@@ -44,18 +47,24 @@ function InternalServerCard({
   item,
   installed,
   isInstalling,
+  isRequesting,
   onInstall,
   onUninstall,
+  onRequest,
   onEdit,
   onDelete,
+  isAdmin,
 }: {
   item: CatalogItemWithOptionalLabel;
   installed: boolean;
   isInstalling: boolean;
+  isRequesting: boolean;
   onInstall: () => void;
   onUninstall: () => void;
+  onRequest: () => void;
   onEdit: () => void;
   onDelete: () => void;
+  isAdmin: boolean;
 }) {
   return (
     <Card className="flex flex-col relative pt-4">
@@ -113,7 +122,7 @@ function InternalServerCard({
           >
             Uninstall
           </Button>
-        ) : (
+        ) : isAdmin ? (
           <Button
             onClick={onInstall}
             disabled={isInstalling}
@@ -122,6 +131,17 @@ function InternalServerCard({
           >
             <Download className="mr-2 h-4 w-4" />
             {isInstalling ? "Installing..." : "Install"}
+          </Button>
+        ) : (
+          <Button
+            onClick={onRequest}
+            disabled={isRequesting}
+            size="sm"
+            variant="outline"
+            className="w-full"
+          >
+            <Plus className="mr-2 h-4 w-4" />
+            {isRequesting ? "Requesting..." : "Request to add"}
           </Button>
         )}
       </CardContent>
@@ -136,11 +156,14 @@ export function InternalMCPCatalog({
   initialData?: GetInternalMcpCatalogResponses["200"];
   installedServers?: GetMcpServersResponses["200"];
 }) {
+  const role = useRole();
+  const isAdmin = role === "admin";
   const { data: catalogItems } = useInternalMcpCatalog({ initialData });
   const { data: installedServers } = useMcpServers({
     initialData: initialInstalledServers,
   });
   const installMutation = useInstallMcpServer();
+  const requestMutation = useCreateMcpServerInstallationRequest();
 
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<
@@ -154,10 +177,12 @@ export function InternalMCPCatalog({
     name: string;
   } | null>(null);
   const [installingItemId, setInstallingItemId] = useState<string | null>(null);
+  const [requestingItemId, setRequestingItemId] = useState<string | null>(null);
   const [catalogSearchQuery, setCatalogSearchQuery] = useState("");
   const [isGitHubDialogOpen, setIsGitHubDialogOpen] = useState(false);
   const [isRemoteServerDialogOpen, setIsRemoteServerDialogOpen] =
     useState(false);
+  const [isRequestDialogOpen, setIsRequestDialogOpen] = useState(false);
   const [selectedCatalogItem, setSelectedCatalogItem] = useState<
     GetInternalMcpCatalogResponses["200"][number] | null
   >(null);
@@ -268,6 +293,29 @@ export function InternalMCPCatalog({
     }
   }, [selectedCatalogItem]);
 
+  const handleRequest = useCallback(
+    async (catalogItem: GetInternalMcpCatalogResponses["200"][number]) => {
+      setSelectedCatalogItem(catalogItem);
+      setIsRequestDialogOpen(true);
+    },
+    [],
+  );
+
+  const handleRequestSubmit = useCallback(
+    async (
+      catalogItem: GetInternalMcpCatalogResponses["200"][number],
+      requestNotes: string,
+    ) => {
+      setRequestingItemId(catalogItem.id);
+      await requestMutation.mutateAsync({
+        catalogId: catalogItem.id,
+        requestNotes,
+      });
+      setRequestingItemId(null);
+    },
+    [requestMutation],
+  );
+
   const getInstallationCount = useCallback(
     (catalogId: string) => {
       return (
@@ -358,6 +406,7 @@ export function InternalMCPCatalog({
               item={itemWithLabel}
               installed={!!installedServer}
               isInstalling={installingItemId === item.id}
+              isRequesting={requestingItemId === item.id}
               onInstall={() => handleInstall(item)}
               onUninstall={() => {
                 if (installedServer) {
@@ -367,8 +416,10 @@ export function InternalMCPCatalog({
                   );
                 }
               }}
+              onRequest={() => handleRequest(item)}
               onEdit={() => setEditingItem(item)}
               onDelete={() => setDeletingItem(item)}
+              isAdmin={isAdmin}
             />
           );
         })}
@@ -440,6 +491,17 @@ export function InternalMCPCatalog({
       <UninstallServerDialog
         server={uninstallingServer}
         onClose={() => setUninstallingServer(null)}
+      />
+
+      <RequestInstallDialog
+        isOpen={isRequestDialogOpen}
+        onClose={() => {
+          setIsRequestDialogOpen(false);
+          setSelectedCatalogItem(null);
+        }}
+        onRequest={handleRequestSubmit}
+        catalogItem={selectedCatalogItem}
+        isRequesting={requestMutation.isPending}
       />
     </div>
   );

--- a/platform/frontend/src/app/mcp-catalog/_parts/request-install-dialog.tsx
+++ b/platform/frontend/src/app/mcp-catalog/_parts/request-install-dialog.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import type { GetInternalMcpCatalogResponses } from "@/lib/clients/api";
+
+interface RequestInstallDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onRequest: (
+    catalogItem: GetInternalMcpCatalogResponses["200"][number],
+    requestNotes: string,
+  ) => Promise<void>;
+  catalogItem: GetInternalMcpCatalogResponses["200"][number] | null;
+  isRequesting: boolean;
+}
+
+export function RequestInstallDialog({
+  isOpen,
+  onClose,
+  onRequest,
+  catalogItem,
+  isRequesting,
+}: RequestInstallDialogProps) {
+  const [requestNotes, setRequestNotes] = useState("");
+
+  const handleRequest = useCallback(async () => {
+    if (!catalogItem) {
+      return;
+    }
+
+    try {
+      await onRequest(catalogItem, requestNotes);
+      setRequestNotes("");
+      onClose();
+    } catch (_error) {
+      // Error handling is done in the parent component
+    }
+  }, [catalogItem, requestNotes, onRequest, onClose]);
+
+  const handleClose = useCallback(() => {
+    setRequestNotes("");
+    onClose();
+  }, [onClose]);
+
+  if (!catalogItem) {
+    return null;
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>Request MCP Server Installation</DialogTitle>
+          <DialogDescription>
+            Submit a request to add {catalogItem.label || catalogItem.name} to
+            the internal registry. An administrator will review your request.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <Label htmlFor="request-notes">Request Notes (Optional)</Label>
+            <Textarea
+              id="request-notes"
+              placeholder="Explain why you need this MCP server..."
+              value={requestNotes}
+              onChange={(e) => setRequestNotes(e.target.value)}
+              rows={4}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose} disabled={isRequesting}>
+            Cancel
+          </Button>
+          <Button onClick={handleRequest} disabled={isRequesting}>
+            {isRequesting ? "Submitting..." : "Submit Request"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/platform/frontend/src/app/mcp-catalog/installation-requests/[id]/page.client.tsx
+++ b/platform/frontend/src/app/mcp-catalog/installation-requests/[id]/page.client.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { format } from "date-fns";
+import { Check, Clock, X, ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { useRole } from "@/lib/auth.hook";
+import {
+  useApproveMcpServerInstallationRequest,
+  useDeclineMcpServerInstallationRequest,
+  useMcpServerInstallationRequest,
+} from "@/lib/mcp-server-installation-request.query";
+
+interface InstallationRequestDetailPageClientProps {
+  id: string;
+}
+
+export default function InstallationRequestDetailPageClient({
+  id,
+}: InstallationRequestDetailPageClientProps) {
+  const role = useRole();
+  const isAdmin = role === "admin";
+  const { data: request } = useMcpServerInstallationRequest(id);
+  const approveMutation = useApproveMcpServerInstallationRequest();
+  const declineMutation = useDeclineMcpServerInstallationRequest();
+
+  const [reviewNotes, setReviewNotes] = useState("");
+
+  const getStatusBadge = (status: string) => {
+    switch (status) {
+      case "pending":
+        return (
+          <Badge variant="outline" className="bg-yellow-500/10 text-yellow-600">
+            <Clock className="mr-1 h-3 w-3" />
+            Pending
+          </Badge>
+        );
+      case "approved":
+        return (
+          <Badge variant="outline" className="bg-green-500/10 text-green-600">
+            <Check className="mr-1 h-3 w-3" />
+            Approved
+          </Badge>
+        );
+      case "declined":
+        return (
+          <Badge variant="outline" className="bg-red-500/10 text-red-600">
+            <X className="mr-1 h-3 w-3" />
+            Declined
+          </Badge>
+        );
+      default:
+        return null;
+    }
+  };
+
+  const handleApprove = async () => {
+    await approveMutation.mutateAsync({
+      id,
+      reviewNotes: reviewNotes || undefined,
+    });
+  };
+
+  const handleDecline = async () => {
+    await declineMutation.mutateAsync({
+      id,
+      reviewNotes: reviewNotes || undefined,
+    });
+  };
+
+  if (!request) {
+    return <div>Loading...</div>;
+  }
+
+  const isPending = request.status === "pending";
+  const isProcessing = approveMutation.isPending || declineMutation.isPending;
+
+  return (
+    <div className="w-full h-full">
+      <div className="border-b border-border bg-card/30">
+        <div className="max-w-7xl mx-auto px-8 py-8">
+          <Button variant="ghost" size="sm" asChild className="mb-4">
+            <Link href="/mcp-catalog/installation-requests">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back to Requests
+            </Link>
+          </Button>
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-semibold tracking-tight mb-2">
+                Installation Request #{request.id.slice(0, 8)}
+              </h1>
+              <p className="text-sm text-muted-foreground">
+                Requested on{" "}
+                {format(new Date(request.createdAt), "MMM d, yyyy 'at' h:mm a")}
+              </p>
+            </div>
+            {getStatusBadge(request.status)}
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-7xl mx-auto px-8 py-8">
+        <div className="grid gap-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Request Details</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label>Catalog ID</Label>
+                <p className="text-sm font-mono">{request.catalogId}</p>
+              </div>
+
+              {request.requestNotes && (
+                <div className="space-y-2">
+                  <Label>Request Notes</Label>
+                  <p className="text-sm text-muted-foreground">
+                    {request.requestNotes}
+                  </p>
+                </div>
+              )}
+
+              {request.reviewedAt && (
+                <>
+                  <div className="space-y-2">
+                    <Label>Reviewed At</Label>
+                    <p className="text-sm">
+                      {format(
+                        new Date(request.reviewedAt),
+                        "MMM d, yyyy 'at' h:mm a",
+                      )}
+                    </p>
+                  </div>
+
+                  {request.reviewedBy && (
+                    <div className="space-y-2">
+                      <Label>Reviewed By</Label>
+                      <p className="text-sm font-mono">{request.reviewedBy}</p>
+                    </div>
+                  )}
+
+                  {request.reviewNotes && (
+                    <div className="space-y-2">
+                      <Label>Review Notes</Label>
+                      <p className="text-sm text-muted-foreground">
+                        {request.reviewNotes}
+                      </p>
+                    </div>
+                  )}
+                </>
+              )}
+            </CardContent>
+          </Card>
+
+          {isAdmin && isPending && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Review Request</CardTitle>
+                <CardDescription>
+                  Approve or decline this installation request
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="review-notes">Review Notes (Optional)</Label>
+                  <Textarea
+                    id="review-notes"
+                    placeholder="Add notes about your decision..."
+                    value={reviewNotes}
+                    onChange={(e) => setReviewNotes(e.target.value)}
+                    rows={4}
+                  />
+                </div>
+
+                <div className="flex gap-2">
+                  <Button
+                    onClick={handleApprove}
+                    disabled={isProcessing}
+                    className="flex-1"
+                  >
+                    <Check className="mr-2 h-4 w-4" />
+                    {approveMutation.isPending ? "Approving..." : "Approve"}
+                  </Button>
+                  <Button
+                    onClick={handleDecline}
+                    disabled={isProcessing}
+                    variant="destructive"
+                    className="flex-1"
+                  >
+                    <X className="mr-2 h-4 w-4" />
+                    {declineMutation.isPending ? "Declining..." : "Decline"}
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/platform/frontend/src/app/mcp-catalog/installation-requests/[id]/page.tsx
+++ b/platform/frontend/src/app/mcp-catalog/installation-requests/[id]/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from "react";
+import { withAuthCheck } from "@/app/_parts/with-auth-check";
+import InstallationRequestDetailPageClient from "./page.client";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+async function InstallationRequestDetailPage(props: PageProps) {
+  const params = await props.params;
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <InstallationRequestDetailPageClient id={params.id} />
+    </Suspense>
+  );
+}
+
+export default withAuthCheck(InstallationRequestDetailPage);

--- a/platform/frontend/src/app/mcp-catalog/installation-requests/page.client.tsx
+++ b/platform/frontend/src/app/mcp-catalog/installation-requests/page.client.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { format } from "date-fns";
+import { Check, Clock, X } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useRole } from "@/lib/auth.hook";
+import { useMcpServerInstallationRequests } from "@/lib/mcp-server-installation-request.query";
+
+export default function InstallationRequestsPageClient() {
+  const role = useRole();
+  const isAdmin = role === "admin";
+  const [statusFilter, setStatusFilter] = useState<
+    "pending" | "approved" | "declined" | undefined
+  >(undefined);
+
+  const { data: requests } = useMcpServerInstallationRequests({
+    status: statusFilter,
+  });
+
+  const getStatusBadge = (status: string) => {
+    switch (status) {
+      case "pending":
+        return (
+          <Badge variant="outline" className="bg-yellow-500/10 text-yellow-600">
+            <Clock className="mr-1 h-3 w-3" />
+            Pending
+          </Badge>
+        );
+      case "approved":
+        return (
+          <Badge variant="outline" className="bg-green-500/10 text-green-600">
+            <Check className="mr-1 h-3 w-3" />
+            Approved
+          </Badge>
+        );
+      case "declined":
+        return (
+          <Badge variant="outline" className="bg-red-500/10 text-red-600">
+            <X className="mr-1 h-3 w-3" />
+            Declined
+          </Badge>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="w-full h-full">
+      <div className="border-b border-border bg-card/30">
+        <div className="max-w-7xl mx-auto px-8 py-8">
+          <h1 className="text-2xl font-semibold tracking-tight mb-2">
+            MCP Server Installation Requests
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            {isAdmin
+              ? "Review and manage installation requests from team members."
+              : "View your MCP server installation requests and their status."}
+          </p>
+        </div>
+      </div>
+
+      <div className="max-w-7xl mx-auto px-8 py-8">
+        <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2">
+              <label className="text-sm font-medium">Filter:</label>
+              <Select
+                value={statusFilter || "all"}
+                onValueChange={(value) =>
+                  setStatusFilter(
+                    value === "all"
+                      ? undefined
+                      : (value as "pending" | "approved" | "declined"),
+                  )
+                }
+              >
+                <SelectTrigger className="w-[150px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All Requests</SelectItem>
+                  <SelectItem value="pending">Pending</SelectItem>
+                  <SelectItem value="approved">Approved</SelectItem>
+                  <SelectItem value="declined">Declined</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </div>
+
+        {requests && requests.length > 0 ? (
+          <div className="space-y-4">
+            {requests.map((request) => (
+              <Card key={request.id}>
+                <CardHeader>
+                  <div className="flex items-start justify-between">
+                    <div className="space-y-1">
+                      <CardTitle className="text-lg">
+                        Request #{request.id.slice(0, 8)}
+                      </CardTitle>
+                      <CardDescription>
+                        Requested on{" "}
+                        {format(new Date(request.createdAt), "MMM d, yyyy")}
+                      </CardDescription>
+                    </div>
+                    {getStatusBadge(request.status)}
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-1">
+                      {request.requestNotes && (
+                        <p className="text-sm text-muted-foreground">
+                          {request.requestNotes}
+                        </p>
+                      )}
+                      {request.reviewedAt && (
+                        <p className="text-xs text-muted-foreground">
+                          Reviewed on{" "}
+                          {format(new Date(request.reviewedAt), "MMM d, yyyy")}
+                        </p>
+                      )}
+                    </div>
+                    <Button asChild variant="outline" size="sm">
+                      <Link
+                        href={`/mcp-catalog/installation-requests/${request.id}`}
+                      >
+                        View Details
+                      </Link>
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-12">
+            <p className="text-muted-foreground">
+              No installation requests found.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/platform/frontend/src/app/mcp-catalog/installation-requests/page.tsx
+++ b/platform/frontend/src/app/mcp-catalog/installation-requests/page.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from "react";
+import { withAuthCheck } from "@/app/_parts/with-auth-check";
+import InstallationRequestsPageClient from "./page.client";
+
+async function InstallationRequestsPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <InstallationRequestsPageClient />
+    </Suspense>
+  );
+}
+
+export default withAuthCheck(InstallationRequestsPage);

--- a/platform/frontend/src/lib/mcp-server-installation-request.query.ts
+++ b/platform/frontend/src/lib/mcp-server-installation-request.query.ts
@@ -1,0 +1,156 @@
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  getMcpServerInstallationRequests,
+  getMcpServerInstallationRequest,
+  createMcpServerInstallationRequest,
+  approveMcpServerInstallationRequest,
+  declineMcpServerInstallationRequest,
+  deleteMcpServerInstallationRequest,
+  type GetMcpServerInstallationRequestsResponses,
+  type GetMcpServerInstallationRequestResponses,
+  type CreateMcpServerInstallationRequestData,
+  type ApproveMcpServerInstallationRequestData,
+  type DeclineMcpServerInstallationRequestData,
+} from "@/lib/clients/api";
+
+export function useMcpServerInstallationRequests(params?: {
+  status?: "pending" | "approved" | "declined";
+  initialData?: GetMcpServerInstallationRequestsResponses["200"];
+}) {
+  return useSuspenseQuery({
+    queryKey: ["mcp-server-installation-requests", params?.status],
+    queryFn: async () => {
+      const response = await getMcpServerInstallationRequests({
+        query: params?.status ? { status: params.status } : undefined,
+      });
+      return response.data ?? [];
+    },
+    initialData: params?.initialData,
+  });
+}
+
+export function useMcpServerInstallationRequest(
+  id: string,
+  params?: {
+    initialData?: GetMcpServerInstallationRequestResponses["200"];
+  },
+) {
+  return useSuspenseQuery({
+    queryKey: ["mcp-server-installation-request", id],
+    queryFn: async () => {
+      const response = await getMcpServerInstallationRequest({ path: { id } });
+      return response.data;
+    },
+    initialData: params?.initialData,
+  });
+}
+
+export function useCreateMcpServerInstallationRequest() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: CreateMcpServerInstallationRequestData["body"]) => {
+      const response = await createMcpServerInstallationRequest({
+        body: data,
+      });
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["mcp-server-installation-requests"],
+      });
+      toast.success("Installation request submitted successfully");
+    },
+    onError: (error) => {
+      console.error("Create installation request error:", error);
+      toast.error("Failed to submit installation request");
+    },
+  });
+}
+
+export function useApproveMcpServerInstallationRequest() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: {
+      id: string;
+      reviewNotes?: string;
+    }) => {
+      const response = await approveMcpServerInstallationRequest({
+        path: { id: data.id },
+        body: { reviewNotes: data.reviewNotes },
+      });
+      return response.data;
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["mcp-server-installation-requests"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["mcp-server-installation-request", variables.id],
+      });
+      toast.success("Installation request approved");
+    },
+    onError: (error) => {
+      console.error("Approve installation request error:", error);
+      toast.error("Failed to approve installation request");
+    },
+  });
+}
+
+export function useDeclineMcpServerInstallationRequest() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: {
+      id: string;
+      reviewNotes?: string;
+    }) => {
+      const response = await declineMcpServerInstallationRequest({
+        path: { id: data.id },
+        body: { reviewNotes: data.reviewNotes },
+      });
+      return response.data;
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["mcp-server-installation-requests"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["mcp-server-installation-request", variables.id],
+      });
+      toast.success("Installation request declined");
+    },
+    onError: (error) => {
+      console.error("Decline installation request error:", error);
+      toast.error("Failed to decline installation request");
+    },
+  });
+}
+
+export function useDeleteMcpServerInstallationRequest() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const response = await deleteMcpServerInstallationRequest({
+        path: { id },
+      });
+      return response.data;
+    },
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({
+        queryKey: ["mcp-server-installation-requests"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["mcp-server-installation-request", id],
+      });
+      toast.success("Installation request deleted");
+    },
+    onError: (error) => {
+      console.error("Delete installation request error:", error);
+      toast.error("Failed to delete installation request");
+    },
+  });
+}

--- a/platform/shared/access-control.ts
+++ b/platform/shared/access-control.ts
@@ -16,6 +16,7 @@ export type Resource =
   | "invitation"
   | "internalMcpCatalog"
   | "mcpServer"
+  | "mcpServerInstallationRequest"
   | "team"
 
 /**
@@ -44,6 +45,7 @@ export const allAvailableActions: Record<Resource, Action[]> = {
   invitation: ["create"],
   internalMcpCatalog: ["create", "read", "update", "delete"],
   mcpServer: ["create", "read", "update", "delete"],
+  mcpServerInstallationRequest: ["create", "read", "update", "delete"],
   team: ["create", "read", "update", "delete"],
 };
 
@@ -58,6 +60,7 @@ export const adminRole = ac.newRole({
 // - full access to tools, policies, interactions
 // - read-only access to dual LLM configs and results
 // - read-only access to MCP catalog and servers
+// - can create and read installation requests
 // - read-only access to teams
 export const memberRole = ac.newRole({
   agent: ["read"],
@@ -68,6 +71,7 @@ export const memberRole = ac.newRole({
   dualLlmResult: ["read"],
   internalMcpCatalog: ["read"],
   mcpServer: ["read"],
+  mcpServerInstallationRequest: ["create", "read"],
   team: ["read"],
 });
 


### PR DESCRIPTION
Closes #825 

Introduces a workflow to manage MCP server installation requests within the Archestra platform.

Backend Changes:
- Created database schema for mcp_server_installation_requests table
- Implemented McpServerInstallationRequestModel with full CRUD operations
- Added API routes for creating, viewing, approving, and declining requests
- Updated authorization system with new permissions and route IDs
- Added mcpServerInstallationRequest resource to access control

Frontend Changes:
- Created request installation dialog component
- Modified MCP catalog page with role-based buttons (Install for admins, Request to add for members)
- Added Installation Requests section to sidebar navigation
- Created list view page for viewing all installation requests
- Created detail view page for reviewing and managing individual requests
- Implemented query hooks for all installation request operations

Features:
- Members can request MCP server installations from the internal catalog
- Admins can view, approve, or decline installation requests
- Status tracking (pending, approved, declined) with timeline notes
- Role-based UI showing appropriate actions for admins vs members