### PR TITLE
claude/session-011CUZ6a9Nc4ix6UYFS6E8eG

### DIFF
--- a/platform/backend/src/database/migrations/0033_cascade_delete_secrets.sql
+++ b/platform/backend/src/database/migrations/0033_cascade_delete_secrets.sql
@@ -1,0 +1,5 @@
+-- Drop the existing foreign key constraint
+ALTER TABLE "mcp_server" DROP CONSTRAINT "mcp_server_secret_id_secret_id_fk";
+--> statement-breakpoint
+-- Add the foreign key constraint with cascade delete
+ALTER TABLE "mcp_server" ADD CONSTRAINT "mcp_server_secret_id_secret_id_fk" FOREIGN KEY ("secret_id") REFERENCES "public"."secret"("id") ON DELETE cascade ON UPDATE no action;

--- a/platform/backend/src/database/migrations/meta/_journal.json
+++ b/platform/backend/src/database/migrations/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1761563855511,
       "tag": "0032_serious_meggan",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1761631900103,
+      "tag": "0033_cascade_delete_secrets",
+      "breakpoints": true
     }
   ]
 }

--- a/platform/backend/src/database/schemas/mcp-server.ts
+++ b/platform/backend/src/database/schemas/mcp-server.ts
@@ -9,7 +9,7 @@ const mcpServerTable = pgTable("mcp_server", {
     onDelete: "set null",
   }),
   secretId: uuid("secret_id").references(() => secretTable.id, {
-    onDelete: "set null",
+    onDelete: "cascade",
   }),
   createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { mode: "date" })


### PR DESCRIPTION
When an MCP server is uninstalled or deleted from the /mcp-catalog page, the related secret should also be deleted to prevent orphaned records.

Changes:
- Updated mcp-server schema to use CASCADE delete for secret foreign key
- Created migration 0033 to alter existing constraint from SET NULL to CASCADE
- Secrets will now be automatically deleted when their MCP server is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)