### PR TITLE
fix: handlebars highlighting in monaco editor

### DIFF
--- a/platform/frontend/src/app/tools/_parts/response-modifier-editor.tsx
+++ b/platform/frontend/src/app/tools/_parts/response-modifier-editor.tsx
@@ -95,7 +95,7 @@ export function ResponseModifierEditor({
           <div className="border rounded-md overflow-hidden">
             <Editor
               height="200px"
-              defaultLanguage="Handlebars"
+              defaultLanguage="handlebars"
               value={template}
               onChange={(value) => setTemplate(value || "")}
               options={{


### PR DESCRIPTION
Enable proper syntax highlighting for Handlebars templates in the Monaco editor by setting defaultLanguage="handlebars". This improves the developer experience when editing response modifier templates for MCP tools.