### PR TITLE
fix: do not add /v1/ prefix when proxying and rely on OPENAI_BASE_URL

### DIFF
--- a/platform/backend/src/routes/proxy/openai.ts
+++ b/platform/backend/src/routes/proxy/openai.ts
@@ -66,15 +66,15 @@ const openAiProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
   /**
    * Register HTTP proxy for OpenAI routes
    * Handles both patterns:
-   * - /v1/openai/:agentId/* -> https://api.openai.com/v1/* (agentId stripped if UUID)
-   *  - /v1/openai/* -> https://api.openai.com/v1/* (direct proxy)
+   * - /v1/openai/:agentId/* -> config.llm.openai.baseUrl/* (agentId stripped if UUID)
+   *  - /v1/openai/* -> config.llm.openai.baseUrl/* (direct proxy)
    *
    * Chat completions are excluded and handled separately below with full agent support
    */
   await fastify.register(fastifyHttpProxy, {
     upstream: config.llm.openai.baseUrl,
     prefix: `${API_PREFIX}`,
-    rewritePrefix: "/v1",
+    rewritePrefix: "",
     preHandler: (request, _reply, next) => {
       // Skip chat/completions (we handle it specially below with full agent support)
       if (


### PR DESCRIPTION
Fix OpenAI proxy routing to respect OPENAI_BASE_URL without adding /v1/ prefix.

Previously, the proxy was hardcoding a /v1 prefix when rewriting URLs, which would cause issues when using custom OpenAI-compatible providers that may not follow the /v1 convention. This change removes the hardcoded prefix and relies on the configured OPENAI_BASE_URL value instead.

## Changes
- Removed hardcoded `rewritePrefix: "/v1"` from the HTTP proxy configuration
- Updated comments to reflect that the proxy now uses `config.llm.openai.baseUrl` directly

This allows the proxy to work correctly with both OpenAI's API (which includes /v1 in its base URL) and other OpenAI-compatible providers that may have different URL structures.