### PR TITLE
chore: improve default value of `archestra.kubernetes.namespace` to use `Release.Namespace`

### DIFF
--- a/platform/helm/templates/_helpers.tpl
+++ b/platform/helm/templates/_helpers.tpl
@@ -56,10 +56,8 @@ Environment variables for the Archestra Platform container
 {{- define "archestra-platform.env" -}}
 - name: DATABASE_URL
   value: {{ if .Values.postgresql.external_database_url }}{{ .Values.postgresql.external_database_url }}{{ else }}postgresql://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ include "archestra-platform.fullname" . }}-postgresql:5432/{{ .Values.postgresql.auth.database }}{{ end }}
-{{- if .Values.archestra.kubernetes.namespace }}
 - name: K8S_NAMESPACE
-  value: {{ .Values.archestra.kubernetes.namespace | quote }}
-{{- end }}
+  value: {{ default .Release.Namespace .Values.archestra.kubernetes.namespace | quote }}
 {{- if .Values.archestra.kubernetes.baseImage }}
 - name: MCP_SERVER_BASE_IMAGE
   value: {{ .Values.archestra.kubernetes.baseImage | quote }}

--- a/platform/helm/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/tests/archestra_platform_deployment_test.yaml
@@ -132,7 +132,7 @@ tests:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: ".*external-db.example.com.*5432.*"
 
-  - it: should only include DATABASE_URL when archestra.env is empty
+  - it: when archestra.env is empty should set a specific set of environment variables
     documentIndex: 1
     set:
       archestra.env: {}
@@ -142,6 +142,8 @@ tests:
           value:
             - name: DATABASE_URL
               value: postgresql://archestra:archestra_dev_password@RELEASE-NAME-archestra-platform-postgresql:5432/archestra_dev
+            - name: K8S_NAMESPACE
+              value: NAMESPACE
             - name: USE_IN_CLUSTER_KUBECONFIG
               value: "true"
 
@@ -191,6 +193,19 @@ tests:
             name: K8S_NAMESPACE
             value: "mcp-servers"
 
+  - it: should use custom namespace over release namespace when both are set
+    documentIndex: 1
+    set:
+      archestra.kubernetes.namespace: "custom-mcp-namespace"
+    release:
+      namespace: "release-namespace"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: K8S_NAMESPACE
+            value: "custom-mcp-namespace"
+
   - it: should set MCP_SERVER_BASE_IMAGE env var when baseImage is configured
     documentIndex: 1
     set:
@@ -202,15 +217,29 @@ tests:
             name: MCP_SERVER_BASE_IMAGE
             value: "my-registry/mcp-server:v1.0.0"
 
-  - it: should not set K8S_NAMESPACE env var when namespace is empty
+  - it: should set K8S_NAMESPACE to release namespace when namespace is empty
+    documentIndex: 1
+    set:
+      archestra.kubernetes.namespace: ""
+    release:
+      namespace: "test-namespace"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: K8S_NAMESPACE
+            value: "test-namespace"
+
+  - it: should set K8S_NAMESPACE to NAMESPACE when namespace is empty and no release namespace
     documentIndex: 1
     set:
       archestra.kubernetes.namespace: ""
     asserts:
-      - notContains:
+      - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: K8S_NAMESPACE
+            value: "NAMESPACE"
 
   - it: should not set MCP_SERVER_BASE_IMAGE env var when baseImage is empty
     documentIndex: 1

--- a/platform/helm/values.yaml
+++ b/platform/helm/values.yaml
@@ -43,7 +43,7 @@ archestra:
   # This controls how the Archestra platform connects to Kubernetes to manage MCP server pods
   kubernetes:
     # Namespace where MCP server pods will be created
-    # If not set, defaults to "default"
+    # If not set, defaults to the namespace specified in the helm release
     namespace: ""
 
     # Base image for MCP server containers


### PR DESCRIPTION
This will basically make it such that archestra platform pod will deploy MCP server pods to the same namespace as the helm release where you are deploying archestra (but you can still override this if you'd like)