### PR TITLE
refactor: complete console to pino logger migration

### DIFF
--- a/platform/backend/src/auth.ts
+++ b/platform/backend/src/auth.ts
@@ -178,7 +178,7 @@ export const auth = betterAuth({
               .where(eq(schema.invitation.id, invitationId));
             logger.info(`✅ Invitation ${invitationId} deleted from database`);
           } catch (error) {
-            logger.error("❌ Failed to delete invitation:", error);
+            logger.error({ err: error }, "❌ Failed to delete invitation:");
           }
         }
       }
@@ -196,7 +196,7 @@ export const auth = betterAuth({
               .where(eq(schema.session.userId, userId));
             logger.info(`✅ All sessions for user ${userId} invalidated`);
           } catch (error) {
-            logger.error("❌ Failed to invalidate user sessions:", error);
+            logger.error({ err: error }, "❌ Failed to invalidate user sessions:");
           }
         }
       }
@@ -238,7 +238,7 @@ export const auth = betterAuth({
               );
             }
           } catch (error) {
-            logger.error("❌ Failed to delete member:", error);
+            logger.error({ err: error }, "❌ Failed to delete member:");
           }
         }
       }
@@ -305,8 +305,8 @@ export const auth = betterAuth({
             );
           } catch (error) {
             logger.error(
+              { err: error },
               `❌ Failed to accept invitation ${invitationId}:`,
-              error,
             );
           }
 
@@ -343,7 +343,7 @@ export const auth = betterAuth({
               }
             }
           } catch (error) {
-            logger.error("❌ Failed to set active organization:", error);
+            logger.error({ err: error }, "❌ Failed to set active organization:");
           }
         }
       }

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -54,12 +54,12 @@ class McpClient {
           toolCall,
           toolResult,
         });
-        logger.info("✅ Saved early-return error:", {
+        logger.info({
           toolName: toolCall.name,
           error: errorMessage,
-        });
+        }, "✅ Saved early-return error:");
       } catch (dbError) {
-        logger.error("Failed to persist early-return error:", dbError);
+        logger.error({ err: dbError }, "Failed to persist early-return error:");
       }
     }
 
@@ -196,8 +196,8 @@ class McpClient {
                 );
               } catch (error) {
                 logger.error(
+                  { err: error },
                   `Error applying response modifier template for tool ${toolCall.name}:`,
-                  error,
                 );
                 // If template fails, use original content
               }
@@ -219,16 +219,16 @@ class McpClient {
                 toolCall,
                 toolResult,
               });
-              logger.info("✅ Saved local MCP tool call (success):", {
+              logger.info({
                 id: savedToolCall.id,
                 toolName: toolCall.name,
                 resultContent:
                   typeof toolResult.content === "string"
                     ? toolResult.content.substring(0, 100)
                     : JSON.stringify(toolResult.content).substring(0, 100),
-              });
+              }, "✅ Saved local MCP tool call (success):");
             } catch (dbError) {
-              logger.error("Failed to persist local MCP tool call:", dbError);
+              logger.error({ err: dbError }, "Failed to persist local MCP tool call:");
               // Continue execution even if persistence fails
             }
           } catch (error) {
@@ -249,13 +249,13 @@ class McpClient {
                 toolCall,
                 toolResult,
               });
-              logger.info("✅ Saved local MCP tool call (error):", {
+              logger.info({
                 id: savedToolCall.id,
                 toolName: toolCall.name,
                 error: toolResult.error,
-              });
+              }, "✅ Saved local MCP tool call (error):");
             } catch (dbError) {
-              logger.error("Failed to persist local MCP tool call:", dbError);
+              logger.error({ err: dbError }, "Failed to persist local MCP tool call:");
               // Continue execution even if persistence fails
             }
           }
@@ -322,8 +322,8 @@ class McpClient {
               );
             } catch (error) {
               logger.error(
+                { err: error },
                 `Error applying response modifier template for tool ${toolCall.name}:`,
-                error,
               );
               // If template fails, use original content
             }
@@ -345,16 +345,16 @@ class McpClient {
               toolCall,
               toolResult,
             });
-            logger.info("✅ Saved successful MCP tool call:", {
+            logger.info({
               id: savedToolCall.id,
               toolName: toolCall.name,
               resultContent:
                 typeof toolResult.content === "string"
                   ? toolResult.content.substring(0, 100)
                   : JSON.stringify(toolResult.content).substring(0, 100),
-            });
+            }, "✅ Saved successful MCP tool call:");
           } catch (dbError) {
-            logger.error("Failed to persist MCP tool call:", dbError);
+            logger.error({ err: dbError }, "Failed to persist MCP tool call:");
             // Continue execution even if persistence fails
           }
         } catch (error) {
@@ -375,13 +375,13 @@ class McpClient {
               toolCall,
               toolResult,
             });
-            logger.info("✅ Saved failed MCP tool call:", {
+            logger.info({
               id: savedToolCall.id,
               toolName: toolCall.name,
               error: toolResult.error,
-            });
+            }, "✅ Saved failed MCP tool call:");
           } catch (dbError) {
-            logger.error("Failed to persist MCP tool call:", dbError);
+            logger.error({ err: dbError }, "Failed to persist MCP tool call:");
             // Continue execution even if persistence fails
           }
         }
@@ -407,7 +407,7 @@ class McpClient {
             toolResult,
           });
         } catch (dbError) {
-          logger.error("Failed to persist MCP tool call:", dbError);
+          logger.error({ err: dbError }, "Failed to persist MCP tool call:");
           // Continue execution even if persistence fails
         }
       }
@@ -616,7 +616,7 @@ class McpClient {
       try {
         await client.close();
       } catch (error) {
-        logger.error(`Error closing MCP client ${clientId}:`, error);
+        logger.error({ err: error }, `Error closing MCP client ${clientId}:`);
       }
       this.clients.delete(clientId);
     }
@@ -637,7 +637,7 @@ class McpClient {
       try {
         await client.close();
       } catch (error) {
-        logger.error("Error closing active MCP connection:", error);
+        logger.error({ err: error }, "Error closing active MCP connection:");
       }
     });
 

--- a/platform/backend/src/database/seed.ts
+++ b/platform/backend/src/database/seed.ts
@@ -41,7 +41,7 @@ export async function seedDatabase(): Promise<void> {
 
     logger.info("\n✅ Database seed completed successfully!\n");
   } catch (error) {
-    logger.error("\n❌ Error seeding database:", error);
+    logger.error({ err: error }, "\n❌ Error seeding database:");
     throw error;
   }
 }

--- a/platform/backend/src/mcp-server-runtime/k8s-pod.ts
+++ b/platform/backend/src/mcp-server-runtime/k8s-pod.ts
@@ -8,6 +8,7 @@ import config from "@/config";
 import InternalMcpCatalogModel from "@/models/internal-mcp-catalog";
 import type { InternalMcpCatalog, McpServer } from "@/types";
 import type { K8sPodState, K8sPodStatusSummary } from "./schemas";
+import logger from "@/logging";
 
 const {
   orchestrator: { mcpServerBaseImage },
@@ -193,7 +194,7 @@ export default class K8sPod {
       this.state = "failed";
       this.errorMessage =
         error instanceof Error ? error.message : "Unknown error";
-      logger.error(`Failed to start pod ${this.podName}:`, error);
+      logger.error({ err: error }, `Failed to start pod ${this.podName}:`);
       throw error;
     }
   }
@@ -279,7 +280,7 @@ export default class K8sPod {
       logger.info(`Pod ${this.podName} stopped`);
     } catch (error: unknown) {
       if (error instanceof Error && error.message.includes("404")) {
-        logger.error(`Failed to stop pod ${this.podName}:`, error);
+        logger.error({ err: error }, `Failed to stop pod ${this.podName}:`);
         throw error;
       }
       // Pod doesn't exist, that's fine
@@ -430,7 +431,7 @@ export default class K8sPod {
           });
       });
     } catch (error) {
-      logger.error(`Failed to stream to pod ${this.podName}:`, error);
+      logger.error({ err: error }, `Failed to stream to pod ${this.podName}:`);
       throw error;
     }
   }
@@ -448,7 +449,7 @@ export default class K8sPod {
 
       return logs || "";
     } catch (error: unknown) {
-      logger.error(`Failed to get logs for pod ${this.podName}:`, error);
+      logger.error({ err: error }, `Failed to get logs for pod ${this.podName}:`);
       if (error instanceof Error && error.message.includes("404")) {
         return "Pod not found";
       }

--- a/platform/backend/src/mcp-server-runtime/manager.ts
+++ b/platform/backend/src/mcp-server-runtime/manager.ts
@@ -59,7 +59,7 @@ class McpServerRuntimeManager {
         this.k8sConfig.loadFromDefault();
       }
     } catch (error) {
-      logger.error("Failed to load Kubernetes config:", error);
+      logger.error({ err: error }, "Failed to load Kubernetes config:");
       this.status = "error";
     }
 
@@ -178,7 +178,7 @@ class McpServerRuntimeManager {
       await k8sPod.startOrCreatePod();
       logger.info(`Successfully started MCP server pod ${id} (${name})`);
     } catch (error) {
-      logger.error(`Failed to start MCP server pod ${id} (${name}):`, error);
+      logger.error({ err: error }, `Failed to start MCP server pod ${id} (${name}):`);
       // Keep the pod in the map even if it failed to start
       // This ensures it appears in status updates with error state
       logger.warn(
@@ -223,7 +223,7 @@ class McpServerRuntimeManager {
       await k8sPod.removePod();
       logger.info(`Successfully removed MCP server pod ${mcpServerId}`);
     } catch (error) {
-      logger.error(`Failed to remove MCP server pod ${mcpServerId}:`, error);
+      logger.error({ err: error }, `Failed to remove MCP server pod ${mcpServerId}:`);
       throw error;
     } finally {
       this.mcpServerIdToPodMap.delete(mcpServerId);
@@ -255,7 +255,7 @@ class McpServerRuntimeManager {
 
       logger.info(`MCP server pod ${mcpServerId} restarted successfully`);
     } catch (error) {
-      logger.error(`Failed to restart MCP server pod ${mcpServerId}:`, error);
+      logger.error({ err: error }, `Failed to restart MCP server pod ${mcpServerId}:`);
       throw error;
     }
   }
@@ -336,8 +336,8 @@ class McpServerRuntimeManager {
           await this.stopServer(serverId);
         } catch (error) {
           logger.error(
+            { err: error },
             `Failed to stop MCP server pod ${serverId} during shutdown:`,
-            error,
           );
         }
       },

--- a/platform/backend/src/models/mcp-server-installation-request.ts
+++ b/platform/backend/src/models/mcp-server-installation-request.ts
@@ -181,7 +181,7 @@ class McpServerInstallationRequestModel {
       }
     } catch (error) {
       // Log the error but still approve the request - admin can handle catalog creation manually
-      logger.error("Failed to create catalog item during approval:", error);
+      logger.error({ err: error }, "Failed to create catalog item during approval:");
     }
 
     // Update the request status

--- a/platform/backend/src/models/mcp-server.ts
+++ b/platform/backend/src/models/mcp-server.ts
@@ -183,8 +183,8 @@ class McpServerModel {
           logger.info(`Cleaned up K8s pod for MCP server: ${mcpServer.name}`);
         } catch (error) {
           logger.error(
+            { err: error },
             `Failed to clean up K8s pod for MCP server ${mcpServer.name}:`,
-            error,
           );
           // Continue with deletion even if pod cleanup fails
         }
@@ -250,8 +250,8 @@ class McpServerModel {
         }));
       } catch (error) {
         logger.error(
+          { err: error },
           `Failed to get tools from remote MCP server ${mcpServer.name}:`,
-          error,
         );
         throw error;
       }
@@ -281,8 +281,8 @@ class McpServerModel {
         }));
       } catch (error) {
         logger.error(
+          { err: error },
           `Failed to get tools from local MCP server ${mcpServer.name}:`,
-          error,
         );
         throw error;
       }
@@ -327,8 +327,8 @@ class McpServerModel {
         }
       } catch (error) {
         logger.error(
+          { err: error },
           `Validation failed for remote MCP server ${serverName}:`,
-          error,
         );
         return false;
       }

--- a/platform/backend/src/models/user.ts
+++ b/platform/backend/src/models/user.ts
@@ -15,7 +15,7 @@ class User {
         .from(schema.usersTable)
         .where(eq(schema.usersTable.email, email));
       if (existing.length > 0) {
-        logger.info("Admin already exists:", email);
+        logger.info({ email }, "Admin already exists:");
         return existing[0];
       }
 
@@ -35,11 +35,11 @@ class User {
           })
           .where(eq(schema.usersTable.email, email));
 
-        logger.info("Admin user created successfully:", email);
+        logger.info({ email }, "Admin user created successfully:");
       }
       return result.user;
     } catch (err) {
-      logger.error("Failed to create admin:", err);
+      logger.error({ err }, "Failed to create admin:");
     }
   }
 }

--- a/platform/backend/src/routes/proxy/utils/dual-llm-subagent.ts
+++ b/platform/backend/src/routes/proxy/utils/dual-llm-subagent.ts
@@ -6,6 +6,7 @@ import {
   type DualLlmMessage,
 } from "./dual-llm-client";
 import type { CommonDualLlmParams, SupportedProviders } from "./types";
+import logger from "@/logging";
 
 /**
  * DualLlmSubagent implements the dual LLM quarantine pattern for safely

--- a/platform/backend/src/standalone-scripts/clean-db-on-dev.ts
+++ b/platform/backend/src/standalone-scripts/clean-db-on-dev.ts
@@ -65,7 +65,7 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
       process.exit(0);
     })
     .catch((error) => {
-      logger.error("\n❌ Error clearing database:", error);
+      logger.error({ err: error }, "\n❌ Error clearing database:");
       process.exit(1);
     });
 }

--- a/platform/backend/src/standalone-scripts/seed-db.ts
+++ b/platform/backend/src/standalone-scripts/seed-db.ts
@@ -12,7 +12,7 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
       process.exit(0);
     })
     .catch((error) => {
-      logger.error("\n❌ Error seeding database:", error);
+      logger.error({ err: error }, "\n❌ Error seeding database:");
       process.exit(1);
     });
 }

--- a/platform/backend/src/standalone-scripts/seed-mock-data.ts
+++ b/platform/backend/src/standalone-scripts/seed-mock-data.ts
@@ -95,7 +95,7 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
       process.exit(0);
     })
     .catch((error) => {
-      logger.error("\n❌ Error seeding database:", error);
+      logger.error({ err: error }, "\n❌ Error seeding database:");
       process.exit(1);
     });
 }


### PR DESCRIPTION
- Merged jorlando/unified-logging branch with initial pino logger setup
- Fixed all logger call signatures to match pino's format: logger.method({object}, 'message')
- Added missing logger imports in dual-llm-subagent.ts and k8s-pod.ts
- Updated error logging to use {err: error} format throughout codebase
- All type-check errors resolved

Files modified:
- auth.ts: Fixed 5 error logger calls
- clients/mcp-client.ts: Fixed multiple logger calls
- database/seed.ts: Fixed error logger call
- mcp-server-runtime/{k8s-pod.ts,manager.ts}: Added logger import and fixed error calls
- models/{user.ts,mcp-server.ts,mcp-server-installation-request.ts}: Fixed logger calls
- routes/proxy/utils/dual-llm-subagent.ts: Added logger import
- standalone-scripts/*: Fixed error logger calls