### PR TITLE
chore: update backend biome config to error on `console` usage

### DIFF
--- a/platform/backend/biome.json
+++ b/platform/backend/biome.json
@@ -4,7 +4,7 @@
   "linter": {
     "rules": {
       "suspicious": {
-        "noConsole": "off"
+        "noConsole": "error"
       }
     }
   }


### PR DESCRIPTION
This PR updates the backend Biome configuration to treat console usage as an error instead of a warning. This helps enforce cleaner production code by preventing console.log statements from being accidentally left in the codebase.