### PR TITLE
fix: in mcp server card, show transport type pill

### DIFF
--- a/platform/frontend/src/app/mcp-catalog/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp-catalog/_parts/InternalMCPCatalog.tsx
@@ -99,7 +99,10 @@ function InternalServerCard({
                   OAuth
                 </Badge>
               )}
-              <TransportBadges isRemote={item.serverType === "remote"} />
+              <TransportBadges
+                isRemote={item.serverType === "remote"}
+                transportType={item.localConfig?.transportType}
+              />
             </div>
           </div>
           <div className="flex flex-wrap gap-1 items-center flex-shrink-0 mt-1">

--- a/platform/frontend/src/app/mcp-catalog/_parts/transport-badges.tsx
+++ b/platform/frontend/src/app/mcp-catalog/_parts/transport-badges.tsx
@@ -2,43 +2,34 @@ import { Badge } from "@/components/ui/badge";
 
 export function TransportBadges({
   isRemote,
+  transportType,
   className,
 }: {
   isRemote?: boolean;
+  transportType?: string | null;
   className?: string;
 }) {
+  const displayTransportType = isRemote ? "HTTP" : transportType || "stdio";
+
   return (
     <div className={className}>
       <div className="flex flex-wrap gap-2">
         {isRemote && (
-          <>
-            <Badge variant="outline" className="text-xs bg-blue-700 text-white">
-              Remote
-            </Badge>
-            <Badge
-              variant="secondary"
-              className="text-xs bg-gray-500 text-white"
-            >
-              HTTP
-            </Badge>
-          </>
+          <Badge variant="outline" className="text-xs bg-blue-700 text-white">
+            Remote
+          </Badge>
         )}
         {!isRemote && (
-          <>
-            <Badge
-              variant="outline"
-              className="text-xs bg-emerald-700 text-white"
-            >
-              Local
-            </Badge>
-            <Badge
-              variant="secondary"
-              className="text-xs bg-gray-500 text-white"
-            >
-              stdio
-            </Badge>
-          </>
+          <Badge
+            variant="outline"
+            className="text-xs bg-emerald-700 text-white"
+          >
+            Local
+          </Badge>
         )}
+        <Badge variant="secondary" className="text-xs bg-gray-500 text-white">
+          {displayTransportType}
+        </Badge>
       </div>
     </div>
   );

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -298,7 +298,7 @@ export type OpenAiChatCompletionResponseInput = {
          */
         message: {
             content: string | unknown;
-            refusal: string | unknown;
+            refusal?: string | unknown;
             role: 'assistant';
             annotations?: Array<unknown>;
             audio?: unknown;
@@ -1322,7 +1322,7 @@ export type OpenAiChatCompletionResponse = {
          */
         message: {
             content: string | unknown;
-            refusal: string | unknown;
+            refusal?: string | unknown;
             role: 'assistant';
             annotations?: Array<unknown>;
             audio?: unknown;
@@ -4300,6 +4300,9 @@ export type GetInternalMcpCatalogResponses = {
                 [key: string]: string;
             };
             dockerImage?: string;
+            transportType?: 'stdio' | 'streamable-http';
+            httpPort?: number;
+            httpPath?: string;
         } | null;
         userConfig: {
             [key: string]: {
@@ -4370,6 +4373,9 @@ export type CreateInternalMcpCatalogItemData = {
                 [key: string]: string;
             };
             dockerImage?: string;
+            transportType?: 'stdio' | 'streamable-http';
+            httpPort?: number;
+            httpPath?: string;
         } | null;
         userConfig?: {
             [key: string]: {
@@ -4457,6 +4463,9 @@ export type CreateInternalMcpCatalogItemResponses = {
                 [key: string]: string;
             };
             dockerImage?: string;
+            transportType?: 'stdio' | 'streamable-http';
+            httpPort?: number;
+            httpPath?: string;
         } | null;
         userConfig: {
             [key: string]: {
@@ -4606,6 +4615,9 @@ export type GetInternalMcpCatalogItemResponses = {
                 [key: string]: string;
             };
             dockerImage?: string;
+            transportType?: 'stdio' | 'streamable-http';
+            httpPort?: number;
+            httpPath?: string;
         } | null;
         userConfig: {
             [key: string]: {
@@ -4676,6 +4688,9 @@ export type UpdateInternalMcpCatalogItemData = {
                 [key: string]: string;
             };
             dockerImage?: string;
+            transportType?: 'stdio' | 'streamable-http';
+            httpPort?: number;
+            httpPath?: string;
         } | null;
         userConfig?: {
             [key: string]: {
@@ -4774,6 +4789,9 @@ export type UpdateInternalMcpCatalogItemResponses = {
                 [key: string]: string;
             };
             dockerImage?: string;
+            transportType?: 'stdio' | 'streamable-http';
+            httpPort?: number;
+            httpPath?: string;
         } | null;
         userConfig: {
             [key: string]: {
@@ -4960,6 +4978,9 @@ export type GetMcpServerInstallationRequestsResponses = {
                     [key: string]: string;
                 };
                 dockerImage?: string;
+                transportType?: 'stdio' | 'streamable-http';
+                httpPort?: number;
+                httpPath?: string;
             };
         } | null;
         adminResponse: string | null;
@@ -5029,6 +5050,9 @@ export type CreateMcpServerInstallationRequestData = {
                     [key: string]: string;
                 };
                 dockerImage?: string;
+                transportType?: 'stdio' | 'streamable-http';
+                httpPort?: number;
+                httpPath?: string;
             };
         } | null;
     };
@@ -5125,6 +5149,9 @@ export type CreateMcpServerInstallationRequestResponses = {
                     [key: string]: string;
                 };
                 dockerImage?: string;
+                transportType?: 'stdio' | 'streamable-http';
+                httpPort?: number;
+                httpPath?: string;
             };
         } | null;
         adminResponse: string | null;
@@ -5311,6 +5338,9 @@ export type GetMcpServerInstallationRequestResponses = {
                     [key: string]: string;
                 };
                 dockerImage?: string;
+                transportType?: 'stdio' | 'streamable-http';
+                httpPort?: number;
+                httpPath?: string;
             };
         } | null;
         adminResponse: string | null;
@@ -5380,6 +5410,9 @@ export type UpdateMcpServerInstallationRequestData = {
                     [key: string]: string;
                 };
                 dockerImage?: string;
+                transportType?: 'stdio' | 'streamable-http';
+                httpPort?: number;
+                httpPath?: string;
             };
         } | null;
         adminResponse?: string | null;
@@ -5497,6 +5530,9 @@ export type UpdateMcpServerInstallationRequestResponses = {
                     [key: string]: string;
                 };
                 dockerImage?: string;
+                transportType?: 'stdio' | 'streamable-http';
+                httpPort?: number;
+                httpPath?: string;
             };
         } | null;
         adminResponse: string | null;
@@ -5624,6 +5660,9 @@ export type ApproveMcpServerInstallationRequestResponses = {
                     [key: string]: string;
                 };
                 dockerImage?: string;
+                transportType?: 'stdio' | 'streamable-http';
+                httpPort?: number;
+                httpPath?: string;
             };
         } | null;
         adminResponse: string | null;
@@ -5751,6 +5790,9 @@ export type DeclineMcpServerInstallationRequestResponses = {
                     [key: string]: string;
                 };
                 dockerImage?: string;
+                transportType?: 'stdio' | 'streamable-http';
+                httpPort?: number;
+                httpPath?: string;
             };
         } | null;
         adminResponse: string | null;
@@ -5878,6 +5920,9 @@ export type AddMcpServerInstallationRequestNoteResponses = {
                     [key: string]: string;
                 };
                 dockerImage?: string;
+                transportType?: 'stdio' | 'streamable-http';
+                httpPort?: number;
+                httpPath?: string;
             };
         } | null;
         adminResponse: string | null;


### PR DESCRIPTION
This PR fixes the MCP server card UI to properly display transport type information.

## Changes
- Added transport type field (stdio/streamable-http) to the LocalConfig type in API types
- Updated TransportBadges component to pass and display the transport type from localConfig
- MCP server cards now show the correct transport type pill alongside the Local/Remote badge

## Visual Changes
The MCP server card now displays transport type pills as shown in the screenshot, making it clear whether a server uses stdio or streamable-http transport.