### PR TITLE
fix: MCP server install button disable behavior

### DIFF
--- a/platform/frontend/src/app/mcp-catalog/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp-catalog/_parts/InternalMCPCatalog.tsx
@@ -549,9 +549,7 @@ export function InternalMCPCatalog({
               key={item.id}
               item={itemWithLabel}
               installed={!!installedServer}
-              isInstalling={
-                installingItemId === item.id || installMutation.isPending
-              }
+              isInstalling={installingItemId === item.id}
               localInstallationStatus={
                 mcpServerInstallationStatus.data ?? undefined
               }


### PR DESCRIPTION
Previously, when installing an MCP server from the private registry list, the "Installing..." state and disabled button were applied to ALL servers in the list due to checking `installMutation.isPending` which is a global state. Now only the specific server being installed shows this state by checking only `installingItemId === item.id`.