### PR TITLE
chore: skip backend auth for /.well-known/acme-challenge

### DIFF
--- a/platform/backend/src/middleware/auth.test.ts
+++ b/platform/backend/src/middleware/auth.test.ts
@@ -1,0 +1,139 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import { authMiddleware } from "./auth";
+
+describe("AuthMiddleware", () => {
+  describe("shouldSkipAuthCheck", () => {
+    it("should skip auth for ACME challenge paths", async () => {
+      const mockRequest = {
+        url: "/.well-known/acme-challenge/test-token",
+        method: "GET",
+        headers: {},
+      } as FastifyRequest;
+
+      const mockReply = {
+        status: vi.fn().mockReturnThis(),
+        send: vi.fn(),
+      } as unknown as FastifyReply;
+
+      // The middleware should not call reply.status() for ACME challenge paths
+      await authMiddleware.handle(mockRequest, mockReply);
+
+      expect(mockReply.status).not.toHaveBeenCalled();
+      expect(mockReply.send).not.toHaveBeenCalled();
+    });
+
+    it("should skip auth for various ACME challenge token formats", async () => {
+      const acmeUrls = [
+        "/.well-known/acme-challenge/",
+        "/.well-known/acme-challenge/simple-token",
+        "/.well-known/acme-challenge/complex-token-with-numbers-123",
+        "/.well-known/acme-challenge/very_long_token_with_underscores_and_hyphens-123-456_789",
+      ];
+
+      for (const url of acmeUrls) {
+        const mockRequest = {
+          url,
+          method: "GET",
+          headers: {},
+        } as FastifyRequest;
+
+        const mockReply = {
+          status: vi.fn().mockReturnThis(),
+          send: vi.fn(),
+        } as unknown as FastifyReply;
+
+        await authMiddleware.handle(mockRequest, mockReply);
+
+        expect(mockReply.status).not.toHaveBeenCalled();
+        expect(mockReply.send).not.toHaveBeenCalled();
+      }
+    });
+
+    it("should skip auth for OPTIONS and HEAD requests", async () => {
+      const methods = ["OPTIONS", "HEAD"];
+
+      for (const method of methods) {
+        const mockRequest = {
+          url: "/some/protected/path",
+          method,
+          headers: {},
+        } as FastifyRequest;
+
+        const mockReply = {
+          status: vi.fn().mockReturnThis(),
+          send: vi.fn(),
+        } as unknown as FastifyReply;
+
+        await authMiddleware.handle(mockRequest, mockReply);
+
+        expect(mockReply.status).not.toHaveBeenCalled();
+        expect(mockReply.send).not.toHaveBeenCalled();
+      }
+    });
+
+    it("should skip auth for existing whitelisted paths", async () => {
+      const whitelistedPaths = [
+        "/api/auth/session",
+        "/v1/openai/completions",
+        "/v1/anthropic/messages",
+        "/v1/gemini/generate",
+        "/json",
+        "/openapi.json",
+        "/health",
+        "/metrics",
+        "/api/features",
+      ];
+
+      for (const url of whitelistedPaths) {
+        const mockRequest = {
+          url,
+          method: "GET",
+          headers: {},
+        } as FastifyRequest;
+
+        const mockReply = {
+          status: vi.fn().mockReturnThis(),
+          send: vi.fn(),
+        } as unknown as FastifyReply;
+
+        await authMiddleware.handle(mockRequest, mockReply);
+
+        expect(mockReply.status).not.toHaveBeenCalled();
+        expect(mockReply.send).not.toHaveBeenCalled();
+      }
+    });
+
+    it("should NOT skip auth for similar but different paths", async () => {
+      const protectedPaths = [
+        "/.well-known/something-else",
+        "/.well-known-acme-challenge/test", // missing slash
+        "/well-known/acme-challenge/test", // missing leading dot
+        "/api/protected-endpoint",
+      ];
+
+      for (const url of protectedPaths) {
+        const mockRequest = {
+          url,
+          method: "GET",
+          headers: {},
+          routeOptions: {
+            schema: {
+              operationId: "SomeProtectedRoute",
+            },
+          },
+        } as FastifyRequest;
+
+        const mockReply = {
+          status: vi.fn().mockReturnThis(),
+          send: vi.fn(),
+        } as unknown as FastifyReply;
+
+        await authMiddleware.handle(mockRequest, mockReply);
+
+        // Should return 401 for unauthenticated requests to protected paths
+        expect(mockReply.status).toHaveBeenCalledWith(401);
+      }
+    });
+  });
+});

--- a/platform/backend/src/middleware/auth.ts
+++ b/platform/backend/src/middleware/auth.ts
@@ -66,7 +66,9 @@ class AuthMiddleware {
        * [02:59:53 UTC] INFO: Started K8s pod for local MCP server: context7-local-mcp-server
        * ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
        */
-      url.includes("/mcp_proxy")
+      url.includes("/mcp_proxy") ||
+      // Skip ACME challenge paths for SSL certificate domain validation
+      url.startsWith("/.well-known/acme-challenge/")
     )
       return true;
     return false;


### PR DESCRIPTION
Adds an exception in the authentication middleware to skip auth checks for ACME challenge endpoints (`/.well-known/acme-challenge/*`). 

This is necessary for SSL certificate domain validation, where certificate authorities need to access challenge files without authentication to verify domain ownership.

## Changes
- Added `/.well-known/acme-challenge/` to the auth skip list in `auth.ts`
- Added comprehensive test coverage in `auth.test.ts` for the new ACME challenge path

## Testing
- Tests verify that ACME challenge paths skip auth
- Tests ensure similar paths that don't match the pattern still require auth
- Tests cover various ACME token formats