### PR TITLE
bug: don't call `useOrganizationAppearance` if not authenticated

### DIFF
--- a/platform/frontend/src/lib/organization.query.ts
+++ b/platform/frontend/src/lib/organization.query.ts
@@ -204,12 +204,15 @@ export function useCreateInvitation(organizationId: string | undefined) {
  * Fetch organization appearance settings
  */
 export function useOrganizationAppearance() {
+  const session = authClient.useSession();
+
   return useQuery({
     queryKey: organizationKeys.appearance(),
     queryFn: async () => {
       const response = await getOrganizationAppearance();
       return response.data;
     },
+    enabled: !!session.data?.user,
   });
 }
 


### PR DESCRIPTION
## Summary

This PR fixes a bug where the `useOrganizationAppearance` hook was attempting to fetch organization appearance settings even when a user is not authenticated, which could cause errors.

## Changes

- Added `enabled: !!session.data?.user` condition to the `useQuery` in `useOrganizationAppearance` hook
- This ensures the API call is only made when there is an authenticated user session

## Impact

Prevents unnecessary API calls and potential errors for unauthenticated users trying to access organization appearance settings.