### PR TITLE
ci: manual trigger `on-commits-to-main` workflow

### DIFF
--- a/.github/workflows/on-commits-to-main.yml
+++ b/.github/workflows/on-commits-to-main.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  # Allow manual triggering of the workflow
+  workflow_dispatch:
 
 concurrency:
   # Cancel any running workflow when new commits are pushed to main.


### PR DESCRIPTION
Adds manual workflow dispatch trigger to the on-commits-to-main workflow.

This allows the workflow to be triggered manually via GitHub Actions UI or API, in addition to automatic triggers on pushes to main branch.