### PR TITLE
chore: update `release-please` config to start bumping minor/patch version for platform

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -2,6 +2,7 @@
   "bootstrap-sha": "975dd9685457d367d96d55cb50c198715f4dc365",
   "changelog-path": "CHANGELOG.md",
   "changelog-type": "default",
+  "bump-minor-pre-major": true,
   "pull-request-footer": "",
   "include-v-in-tag": true,
   "draft": false,


### PR DESCRIPTION
Enable automatic minor version bumping for breaking changes before v1.0.0 by setting bump-minor-pre-major: true in the release-please configuration.

This ensures that breaking changes in pre-1.0 packages will bump the minor version instead of the major version, following semver conventions for pre-release software.