### PR TITLE
chore: don't expose `/metrics`

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -25,6 +25,10 @@ archestra:
             pathType: Prefix
       - host: backend.archestra.dev
         paths:
+          # Block public access to metrics endpoint
+          - path: /metrics
+            port: 1
+            pathType: Exact
           - path: /
             port: 9000
             pathType: Prefix


### PR DESCRIPTION
- Add specific ingress path rule for /metrics with non-existent port
- Use Exact pathType to match only /metrics endpoint
- Rule placed before catch-all to ensure precedence