### PR TITLE
chore: add metrics secret to staging deployment

### DIFF
--- a/.github/workflows/on-commits-to-main.yml
+++ b/.github/workflows/on-commits-to-main.yml
@@ -93,5 +93,6 @@ jobs:
             --create-namespace \
             --set archestra.image=europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/platform:${{ github.sha }} \
             --set archestra.databaseUrl="${{ secrets.ARCHESTRA_STAGING_DATABASE_URL }}" \
+            --set archestra.env.ARCHESTRA_METRICS_SECRET="${{ secrets.ARCHESTRA_STAGING_METRICS_SECRET }}" \
             --values .github/values-staging.yaml \
             --wait


### PR DESCRIPTION
Adds the ARCHESTRA_STAGING_METRICS_SECRET environment variable to the staging deployment via Helm configuration.

This secret is likely used for authentication or configuration of metrics collection in the staging environment.