### PR TITLE
chore: update staging deployment values

### DIFF
--- a/.github/workflows/on-commits-to-main.yml
+++ b/.github/workflows/on-commits-to-main.yml
@@ -95,5 +95,9 @@ jobs:
             --set archestra.databaseUrl="${{ secrets.ARCHESTRA_STAGING_DATABASE_URL }}" \
             --set archestra.env.ARCHESTRA_METRICS_SECRET="${{ secrets.ARCHESTRA_STAGING_METRICS_SECRET }}" \
             --set archestra.env.ARCHESTRA_OTEL_EXPORTER_OTLP_ENDPOINT="${{ secrets.ARCHESTRA_STAGING_OTEL_EXPORTER_OTLP_ENDPOINT }}" \
+            --set archestra.env.ARCHESTRA_AUTH_COOKIE_DOMAIN="${{ secrets.ARCHESTRA_STAGING_AUTH_COOKIE_DOMAIN }}" \
+            --set archestra.env.ARCHESTRA_AUTH_SECRET="${{ secrets.ARCHESTRA_STAGING_AUTH_SECRET }}" \
+            --set archestra.env.ARCHESTRA_AUTH_ADMIN_EMAIL="${{ secrets.ARCHESTRA_STAGING_AUTH_ADMIN_EMAIL }}" \
+            --set archestra.env.ARCHESTRA_AUTH_ADMIN_PASSWORD="${{ secrets.ARCHESTRA_STAGING_AUTH_ADMIN_PASSWORD }}" \
             --values .github/values-staging.yaml \
             --wait


### PR DESCRIPTION
Add authentication-related environment variables to the staging deployment configuration.

This PR adds the following environment variables to the staging Helm deployment:
- ARCHESTRA_AUTH_COOKIE_DOMAIN - Domain for authentication cookies
- ARCHESTRA_AUTH_SECRET - Secret key for authentication
- ARCHESTRA_AUTH_ADMIN_EMAIL - Admin user email
- ARCHESTRA_AUTH_ADMIN_PASSWORD - Admin user password

These values are sourced from GitHub secrets and will be injected into the staging environment during deployment.