### PR TITLE
fix: issue when adding "remote" MCP server to registry

### DIFF
--- a/platform/frontend/src/app/mcp-catalog/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp-catalog/_parts/mcp-catalog-form.tsx
@@ -83,6 +83,21 @@ export function McpCatalogForm({
   const authMethod = form.watch("authMethod");
   const currentServerType = form.watch("serverType");
 
+  // Set default redirect URI on client-side mount
+  useEffect(() => {
+    if (typeof window !== "undefined" && !initialValues) {
+      const currentRedirectUris = form.getValues("oauthConfig.redirect_uris");
+      // Only set if it's empty (from SSR)
+      if (!currentRedirectUris || currentRedirectUris.trim() === "") {
+        form.setValue(
+          "oauthConfig.redirect_uris",
+          `${window.location.origin}/oauth-callback`,
+          { shouldValidate: false }
+        );
+      }
+    }
+  }, [form, initialValues]);
+
   // Reset form when initial values change (for edit mode)
   useEffect(() => {
     if (initialValues) {

--- a/platform/frontend/src/app/mcp-catalog/_parts/mcp-catalog-form.types.ts
+++ b/platform/frontend/src/app/mcp-catalog/_parts/mcp-catalog-form.types.ts
@@ -54,6 +54,22 @@ export const formSchema = z
       message: "Either command or Docker image must be provided.",
       path: [],
     },
+  )
+  .refine(
+    (data) => {
+      // For OAuth authentication, redirect_uris is required
+      if (data.authMethod === "oauth") {
+        return (
+          data.oauthConfig?.redirect_uris &&
+          data.oauthConfig.redirect_uris.trim().length > 0
+        );
+      }
+      return true;
+    },
+    {
+      message: "At least one redirect URI is required for OAuth authentication.",
+      path: ["oauthConfig", "redirect_uris"],
+    },
   );
 
 export type McpCatalogFormValues = z.infer<typeof formSchema>;


### PR DESCRIPTION
This commit fixes issue #982 where the "Add Server" button appeared non-functional when adding remote MCP servers with OAuth authentication.

Changes:
1. Added form validation refinement to ensure redirect_uris is required when OAuth authentication is selected. Previously, the validation was silently failing without showing error messages to users.

2. Fixed SSR issue with redirect_uris default value by adding a useEffect that properly sets the default redirect URI when the component mounts on the client side.

These fixes ensure:
- Users receive clear validation errors when required OAuth fields are missing
- The form properly validates before submission
- The redirect URI field is correctly populated even in SSR contexts

Fixes #982