### PR TITLE
chore: setup default `--transport` of MCP inspector to `http`

### DIFF
--- a/platform/dev/Tiltfile.integrations
+++ b/platform/dev/Tiltfile.integrations
@@ -14,7 +14,7 @@ local_resource(
   serve_env={
     'DANGEROUSLY_OMIT_AUTH': 'true'
   },
-  serve_cmd='npx @modelcontextprotocol/inspector --server-url http://localhost:9000/v1/mcp',
+  serve_cmd='npx @modelcontextprotocol/inspector --transport http --server-url http://localhost:9000/v1/mcp',
   labels=['integrations'],
   trigger_mode=TRIGGER_MODE_MANUAL,
   auto_init=False,


### PR DESCRIPTION
Explicitly set the transport protocol to HTTP for the MCP inspector in the Tiltfile integration resources.

This ensures the MCP inspector uses HTTP transport when connecting to the server at http://localhost:9000/v1/mcp, making the transport protocol explicit rather than relying on defaults.