### PR TITLE
chore: use ellipsis for long MCP server names in Registry

### DIFF
--- a/platform/frontend/src/app/mcp-catalog/_parts/delete-catalog-dialog.tsx
+++ b/platform/frontend/src/app/mcp-catalog/_parts/delete-catalog-dialog.tsx
@@ -29,6 +29,13 @@ export function DeleteCatalogDialog({
     onClose();
   };
 
+  const ConfirmationContent = ({ name }: { name: string }) => (
+    <div>
+      Are you sure you want to delete{" "}
+      <span className="font-semibold break-all">"{name}"</span>?
+    </div>
+  );
+
   return (
     <Dialog open={!!item} onOpenChange={onClose}>
       <DialogContent className="max-w-md">
@@ -38,14 +45,16 @@ export function DeleteCatalogDialog({
             {item &&
               (() => {
                 return installationCount > 0 ? (
-                  <span>
-                    Are you sure you want to delete "{item.name}"? There are
-                    currently <strong>{installationCount}</strong>{" "}
-                    installation(s) of this server. Deleting this catalog entry
-                    will also uninstall all associated servers.
-                  </span>
+                  <div className="space-y-3">
+                    <ConfirmationContent name={item.name} />
+                    <div className="text-sm">
+                      There are currently <strong>{installationCount}</strong>{" "}
+                      installation(s) of this server. Deleting this catalog
+                      entry will also uninstall all associated servers.
+                    </div>
+                  </div>
                 ) : (
-                  `Are you sure you want to delete "${item.name}"?`
+                  <ConfirmationContent name={item.name} />
                 );
               })()}
           </DialogDescription>

--- a/platform/frontend/src/app/mcp-catalog/_parts/mcp-logs-dialog.tsx
+++ b/platform/frontend/src/app/mcp-catalog/_parts/mcp-logs-dialog.tsx
@@ -210,9 +210,9 @@ export function McpLogsDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-4xl max-h-[80vh] flex flex-col">
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <Terminal className="h-5 w-5" />
-            Logs: {serverName}
+          <DialogTitle className="flex items-center gap-2 overflow-hidden">
+            <Terminal className="h-5 w-5 flex-shrink-0" />
+            <span className="truncate">Logs: {serverName}</span>
           </DialogTitle>
           <DialogDescription>
             View the recent logs from the MCP server container

--- a/platform/frontend/src/app/mcp-catalog/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp-catalog/_parts/mcp-server-card.tsx
@@ -516,18 +516,16 @@ export function McpServerCard({
         }}
       />
 
-      {logsData && (
-        <McpLogsDialog
-          open={isLogsDialogOpen}
-          onOpenChange={setIsLogsDialogOpen}
-          serverName={installedServer?.name ?? item.name}
-          serverId={installedServer?.id}
-          logs={logsData.logs}
-          command={logsData.command}
-          isLoading={isLoadingLogs}
-          error={logsError}
-        />
-      )}
+      <McpLogsDialog
+        open={isLogsDialogOpen}
+        onOpenChange={setIsLogsDialogOpen}
+        serverName={installedServer?.name ?? item.name}
+        serverId={installedServer?.id}
+        logs={logsData?.logs ?? ""}
+        command={logsData?.command ?? "No command available"}
+        isLoading={isLoadingLogs}
+        error={logsError}
+      />
 
       <BulkAssignAgentDialog
         tools={bulkAssignTools.length > 0 ? bulkAssignTools : null}


### PR DESCRIPTION
## Summary

This PR addresses the issue where long MCP server names would overflow in the Registry cards, causing layout issues and poor readability.

## Changes

- Replace `CardTitle` component with a custom `div` that properly handles text overflow with CSS ellipsis
- Add a tooltip that displays the full server name when hovering over truncated text
- Improve layout structure with proper flexbox configuration (`flex-1`, `min-w-0`, gap spacing)
- Fix dropdown menu button positioning from absolute to relative for better alignment

## Screenshots

**Before**

<img width="445" height="240" alt="Screenshot 2025-11-06 at 12 18 04 PM" src="https://github.com/user-attachments/assets/25e97aab-da6a-40f2-a24a-cdaa5bb3c45c" />


**After**

<img width="439" height="257" alt="Screenshot 2025-11-06 at 12 18 11 PM" src="https://github.com/user-attachments/assets/722ee577-9b31-4ddf-92ff-45e10ac42213" />
