### PR TITLE
fix: initial state of chat promt suggestions

### DIFF
--- a/platform/frontend/src/components/chat/prompt-suggestions.tsx
+++ b/platform/frontend/src/components/chat/prompt-suggestions.tsx
@@ -20,9 +20,7 @@ export function PromptSuggestions({
   onSelectPrompt,
 }: PromptSuggestionsProps) {
   // Fetch prompts assigned to the agent (hook must be called before any returns)
-  const { data: agentPrompts } = useAgentPrompts(agentId ?? "", {
-    initialData: [],
-  });
+  const { data: agentPrompts } = useAgentPrompts(agentId ?? "");
 
   // If no agentId, show empty state
   if (!agentId) {


### PR DESCRIPTION
Removes `initialData` so that promts are properly loaded