### PR TITLE
fix: don't throw from api client

### DIFF
--- a/platform/frontend/src/lib/organization.query.ts
+++ b/platform/frontend/src/lib/organization.query.ts
@@ -222,6 +222,7 @@ export function useOrganization(enabled = true) {
       const { data } = await archestraApiSdk.getOrganization();
       return data;
     },
+    // Only fetch when user is authenticated to prevent 403 errors during initial auth check
     enabled: enabled && !!session.data?.user,
     retry: false, // Don't retry on auth pages to avoid repeated 401 errors
     throwOnError: false, // Don't throw errors to prevent crashes

--- a/platform/shared/hey-api/clients/api/custom-client.ts
+++ b/platform/shared/hey-api/clients/api/custom-client.ts
@@ -15,6 +15,8 @@ export const createClientConfig: CreateClientConfig = (config) => {
     ...config,
     baseUrl: isServer ? backendUrl : "",
     credentials: "include",
-    throwOnError: true,
+    // Set to false to let React Query handle errors gracefully instead of throwing exceptions
+    // that crash the app (especially important for 403 errors during auth checks)
+    throwOnError: false,
   };
 };


### PR DESCRIPTION
In frontend, don't throw on HTTP errors from API client. This is to prevent "white screen of death" (React's error boundary crash) on auth checks at race conditions.

We are moving away from ErrorBoundary and Suspence because they don't work too well for our tempo, scale and generative approach. Disabling the throw by default is the way to go.