### PR TITLE
fix: vertical scrolling bug affecting many pages

### DIFF
--- a/platform/frontend/src/app/layout.tsx
+++ b/platform/frontend/src/app/layout.tsx
@@ -83,7 +83,7 @@ export default function RootLayout({
                       <header className="h-14 border-b border-border flex md:hidden items-center px-6 bg-card/50 backdrop-blur supports-[backdrop-filter]:bg-card/50">
                         <SidebarTrigger className="cursor-pointer hover:bg-accent transition-colors rounded-md p-2 -ml-2" />
                       </header>
-                      <div className="flex-1 min-w-0 overflow-auto flex flex-col">
+                      <div className="flex-1 min-w-0 flex flex-col">
                         <div className="flex-1">{children}</div>
                         <Version />
                       </div>


### PR DESCRIPTION
Fixed vertical scrolling issues affecting multiple pages by adjusting the flex container layout structure in the main app layout. The issue was preventing proper content scrolling in nested flex containers.