### PR TITLE
fix: polish MCP Gateway logs table

### DIFF
--- a/platform/frontend/src/app/logs/mcp-gateway/page.client.tsx
+++ b/platform/frontend/src/app/logs/mcp-gateway/page.client.tsx
@@ -182,7 +182,10 @@ function McpToolCallsTable({
       cell: ({ row }) => {
         return (
           <Badge variant="secondary" className="text-xs whitespace-normal">
-            <TruncatedText message={row.original.mcpServerName} maxLength={30} />
+            <TruncatedText
+              message={row.original.mcpServerName}
+              maxLength={15}
+            />
           </Badge>
         );
       },


### PR DESCRIPTION
Fixes #1057

## Summary
This PR improves the MCP Gateway logs table with two enhancements:

1. **Fixed date/time formatting**: Previously, `toLocaleDateString()` was called on the date before passing it to `formatDate()`, which caused incorrect formatting. Now passing the ISO string directly to `formatDate()` for proper date/time display.

2. **Added text truncation for MCP server names**: Long server names now truncate at 30 characters to prevent table layout issues and improve readability.

## Changes
- Removed redundant `toLocaleDateString()` call in date formatting
- Added `TruncatedText` component for MCP server name display

## Testing
- Verified date/time displays correctly in the logs table
- Confirmed long MCP server names truncate properly with ellipsis