### PR TITLE
chore: tweak release please config

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -3,10 +3,11 @@
   "changelog-path": "CHANGELOG.md",
   "changelog-type": "default",
   "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
+  "include-component-in-tag": false,
   "pull-request-footer": "",
   "include-v-in-tag": true,
   "draft": false,
-  "separate-pull-requests": true,
   "changelog-sections": [
     {
       "section": "Features",
@@ -68,9 +69,7 @@
     "platform": {
       "component": "platform",
       "release-type": "node",
-      "prerelease": true,
       "initial-version": "0.0.1",
-      "bump-patch-for-minor-pre-major": false,
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
Updates release-please configuration:
- Adds 'bump-patch-for-minor-pre-major: true' globally (moved from platform-specific)
- Adds 'include-component-in-tag: false' to prevent component names in version tags
- Removes 'separate-pull-requests: true' (consolidates release PRs)
- Removes 'prerelease: true' from platform package (no longer in prerelease)