### PR TITLE
chore: update release please config to always bump patch version

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -68,9 +68,9 @@
     "platform": {
       "component": "platform",
       "release-type": "node",
+      "versioning": "always-bump-patch",
       "prerelease": true,
       "initial-version": "0.0.1",
-      "bump-patch-for-minor-pre-major": false,
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
Updates the release-please configuration to use 'versioning: always-bump-patch' instead of 'bump-patch-for-minor-pre-major: false'.

This ensures that every release will bump the patch version, providing consistent version increments for the platform package.