### PR TITLE
fix: MCP install dropdown in logs dialog

### DIFF
--- a/platform/frontend/src/app/mcp-catalog/_parts/mcp-logs-dialog.tsx
+++ b/platform/frontend/src/app/mcp-catalog/_parts/mcp-logs-dialog.tsx
@@ -263,10 +263,7 @@ export function McpLogsDialog({
                   </SelectTrigger>
                   <SelectContent>
                     {installs.map((install) => (
-                      <SelectItem
-                        key={install.id}
-                        value={install.id}
-                      >
+                      <SelectItem key={install.id} value={install.id}>
                         {install.name}
                       </SelectItem>
                     ))}
@@ -336,30 +333,30 @@ export function McpLogsDialog({
               </div>
             </div>
 
-              <ScrollArea
-                ref={scrollAreaRef}
-                className="flex-[100%] min-h-[250px] rounded-md border bg-slate-950 overflow-auto"
-              >
-                <div className="p-4">
-                  {displayIsLoading ? (
-                    <div className="text-slate-400 font-mono text-sm">
-                      Loading logs...
-                    </div>
-                  ) : displayError ? (
-                    <div className="text-red-400 font-mono text-sm">
-                      Error loading logs: {displayError}
-                    </div>
-                  ) : displayLogs ? (
-                    <pre className="text-slate-200 font-mono text-xs whitespace-pre-wrap">
+            <ScrollArea
+              ref={scrollAreaRef}
+              className="flex-[100%] min-h-[250px] rounded-md border bg-slate-950 overflow-auto"
+            >
+              <div className="p-4">
+                {displayIsLoading ? (
+                  <div className="text-slate-400 font-mono text-sm">
+                    Loading logs...
+                  </div>
+                ) : displayError ? (
+                  <div className="text-red-400 font-mono text-sm">
+                    Error loading logs: {displayError}
+                  </div>
+                ) : displayLogs ? (
+                  <pre className="text-slate-200 font-mono text-xs whitespace-pre-wrap">
                     {displayLogs}
                   </pre>
-                  ) : (
-                    <div className="text-slate-400 font-mono text-sm">
-                      No logs available
-                    </div>
-                  )}
-                </div>
-              </ScrollArea>
+                ) : (
+                  <div className="text-slate-400 font-mono text-sm">
+                    No logs available
+                  </div>
+                )}
+              </div>
+            </ScrollArea>
           </div>
 
           {/* Command section */}

--- a/platform/frontend/src/app/mcp-catalog/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp-catalog/_parts/mcp-server-card.tsx
@@ -163,8 +163,12 @@ export function McpServerCard({
   } | null>(null);
 
   // Aggregate all installations for this catalog item (for logs dropdown)
-  let localInstalls = [];
-  if (installedServer?.catalogId && variant === "local" && allMcpServers?.length > 0) {
+  let localInstalls: typeof allMcpServers = [];
+  if (
+    installedServer?.catalogId &&
+    variant === "local" &&
+    allMcpServers?.length > 0
+  ) {
     localInstalls = allMcpServers
       .filter(({ catalogId, serverType }) => {
         return (
@@ -176,7 +180,7 @@ export function McpServerCard({
         return (
           new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
         );
-      })
+      });
   }
 
   const needsReinstall = installedServer?.reinstallRequired;


### PR DESCRIPTION
When there are multiple installs of the same MCP, shows MCP install dropdown in logs.
In addition to that:
- Moves some of the state management down from MCP card to log dialog. Fetching of the logs, too.
- Fixes the overlap of the log box and the command box, when the logs overflow
 