### PR TITLE
Handle MCP installation tool client-side

### DIFF
--- a/platform/backend/src/archestra-mcp-server.ts
+++ b/platform/backend/src/archestra-mcp-server.ts
@@ -20,7 +20,6 @@ import {
   type ToolInvocation,
   type TrustedData,
 } from "@/types";
-import websocketService from "@/websocket";
 
 /**
  * Constants for Archestra MCP server
@@ -28,8 +27,6 @@ import websocketService from "@/websocket";
 export const MCP_SERVER_NAME = "archestra";
 const TOOL_WHOAMI_NAME = "whoami";
 const TOOL_SEARCH_PRIVATE_MCP_REGISTRY_NAME = "search_private_mcp_registry";
-const TOOL_CREATE_MCP_SERVER_INSTALLATION_REQUEST_NAME =
-  "create_mcp_server_installation_request";
 const TOOL_CREATE_LIMIT_NAME = "create_limit";
 const TOOL_GET_LIMITS_NAME = "get_limits";
 const TOOL_UPDATE_LIMIT_NAME = "update_limit";
@@ -55,7 +52,6 @@ const TOOL_GET_PROFILE_NAME = "get_profile";
 // Construct fully-qualified tool names
 const TOOL_WHOAMI_FULL_NAME = `${MCP_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}${TOOL_WHOAMI_NAME}`;
 const TOOL_SEARCH_PRIVATE_MCP_REGISTRY_FULL_NAME = `${MCP_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}${TOOL_SEARCH_PRIVATE_MCP_REGISTRY_NAME}`;
-const TOOL_CREATE_MCP_SERVER_INSTALLATION_REQUEST_FULL_NAME = `${MCP_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}${TOOL_CREATE_MCP_SERVER_INSTALLATION_REQUEST_NAME}`;
 const TOOL_CREATE_LIMIT_FULL_NAME = `${MCP_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}${TOOL_CREATE_LIMIT_NAME}`;
 const TOOL_GET_LIMITS_FULL_NAME = `${MCP_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}${TOOL_GET_LIMITS_NAME}`;
 const TOOL_UPDATE_LIMIT_FULL_NAME = `${MCP_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}${TOOL_UPDATE_LIMIT_NAME}`;
@@ -255,48 +251,6 @@ export async function executeArchestraTool(
           {
             type: "text",
             text: `Error creating profile: ${
-              error instanceof Error ? error.message : "Unknown error"
-            }`,
-          },
-        ],
-        isError: true,
-      };
-    }
-  }
-
-  if (toolName === TOOL_CREATE_MCP_SERVER_INSTALLATION_REQUEST_FULL_NAME) {
-    logger.info(
-      { profileId: profile.id, requestArgs: args },
-      "create_mcp_server_installation_request tool called",
-    );
-
-    try {
-      // Send websocket message to open the installation dialog in the frontend
-      websocketService.broadcast({
-        type: "mcp-installation-request",
-        payload: {},
-      });
-
-      return {
-        content: [
-          {
-            type: "text",
-            // Return a user-friendly message explaining what will happen
-            text: "An installation request dialog for an MCP server should now be visible in the chat. Please review and submit the request to proceed with the installation.",
-          },
-        ],
-        isError: false,
-      };
-    } catch (error) {
-      logger.error(
-        { err: error },
-        "Error handling MCP server installation request",
-      );
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error handling installation request: ${
               error instanceof Error ? error.message : "Unknown error"
             }`,
           },
@@ -2069,19 +2023,6 @@ export function getArchestraMcpTools(): Tool[] {
           },
         },
         required: ["id"],
-      },
-      annotations: {},
-      _meta: {},
-    },
-    {
-      name: TOOL_CREATE_MCP_SERVER_INSTALLATION_REQUEST_FULL_NAME,
-      title: "Create MCP Server Installation Request",
-      description:
-        "Allows users from within a chat context to submit a request for an MCP server to be added to their Archestra Platform's internal MCP server registry. This will open a dialog for the user to submit an installation request. When you trigger this tool, just tell the user to go through the dialog to submit the request. Do not provider any additional information",
-      inputSchema: {
-        type: "object",
-        properties: {},
-        required: [],
       },
       annotations: {},
       _meta: {},

--- a/platform/backend/src/types/websocket.ts
+++ b/platform/backend/src/types/websocket.ts
@@ -3,15 +3,15 @@ import { z } from "zod";
 /**
  * WebSocket Message Payload Schemas
  */
-const McpInstallationRequestWebsocketPayloadSchema = z.object({});
+const HelloWorldWebsocketPayloadSchema = z.object({});
 
 /**
  * Discriminated union of all possible websocket messages
  */
 export const WebSocketMessageSchema = z.discriminatedUnion("type", [
   z.object({
-    type: z.enum(["mcp-installation-request"]),
-    payload: McpInstallationRequestWebsocketPayloadSchema,
+    type: z.enum(["hello-world"]),
+    payload: HelloWorldWebsocketPayloadSchema,
   }),
 ]);
 

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -48,9 +48,16 @@ import {
   useCreateConversation,
 } from "@/lib/chat.query";
 import { useChatSettingsOptional } from "@/lib/chat-settings.query";
-import websocketService from "@/lib/websocket";
 
 const CONVERSATION_QUERY_PARAM = "conversation";
+const ARCHESTRA_SERVER_NAME = "archestra";
+const SPECIAL_CREATE_CUSTOM_SERVER_TOOL_NAME = `${ARCHESTRA_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}create_mcp_server_installation_request`;
+const SPECIAL_CREATE_CUSTOM_SERVER_TOOL = {
+  name: SPECIAL_CREATE_CUSTOM_SERVER_TOOL_NAME,
+  description:
+    "Request a new custom MCP server installation via the Archestra dialog.",
+  parameters: {},
+} as const;
 
 export default function ChatPage() {
   const router = useRouter();
@@ -73,24 +80,11 @@ export default function ChatPage() {
   // State for MCP installation request dialogs
   const [isCustomServerDialogOpen, setIsCustomServerDialogOpen] =
     useState(false);
+  const [pendingCustomServerToolCall, setPendingCustomServerToolCall] =
+    useState<{ toolCallId: string; toolName: string } | null>(null);
 
   // Check if API key is configured
   const { data: chatSettings } = useChatSettingsOptional();
-
-  // Subscribe to MCP installation requests
-  useEffect(() => {
-    const unsubscribe = websocketService.subscribe(
-      "mcp-installation-request",
-      (_message) => {
-        setIsCustomServerDialogOpen(true);
-      },
-    );
-
-    // Cleanup on unmount
-    return () => {
-      unsubscribe();
-    };
-  }, []);
 
   // Sync conversation ID with URL
   useEffect(() => {
@@ -153,6 +147,23 @@ export default function ChatPage() {
   // Fetch MCP tools from gateway (same as used in chat backend)
   const { data: mcpTools = [] } = useChatAgentMcpTools(currentAgentId);
 
+  const toolsForUseChat = useMemo(() => {
+    if (!currentAgentId) {
+      return [];
+    }
+
+    const combinedTools = [...mcpTools];
+    const hasSpecialTool = combinedTools.some(
+      (tool) => tool.name === SPECIAL_CREATE_CUSTOM_SERVER_TOOL.name,
+    );
+
+    if (!hasSpecialTool) {
+      combinedTools.push(SPECIAL_CREATE_CUSTOM_SERVER_TOOL);
+    }
+
+    return combinedTools;
+  }, [currentAgentId, mcpTools]);
+
   // Group tools by MCP server name (everything before the last __)
   const groupedTools = useMemo(
     () =>
@@ -203,12 +214,29 @@ export default function ChatPage() {
     localStorage.setItem("archestra-chat-hide-tool-calls", String(newValue));
   }, [hideToolCalls]);
 
+  const chatTransport = useMemo(
+    () =>
+      new DefaultChatTransport({
+        api: "/api/chat",
+        credentials: "include",
+        body: () => ({
+          tools: toolsForUseChat,
+        }),
+      }),
+    [toolsForUseChat],
+  );
+
   // useChat hook for streaming (AI SDK 5.0 - manages messages only)
-  const { messages, sendMessage, status, setMessages, stop, error } = useChat({
-    transport: new DefaultChatTransport({
-      api: "/api/chat", // Must match backend route
-      credentials: "include", // Send cookies for authentication
-    }),
+  const {
+    messages,
+    sendMessage,
+    status,
+    setMessages,
+    stop,
+    error,
+    addToolResult,
+  } = useChat({
+    transport: chatTransport,
     id: conversationId,
     onFinish: () => {
       // Invalidate the conversation query to refetch with new messages
@@ -226,7 +254,41 @@ export default function ChatPage() {
         stack: error.stack,
       });
     },
-  });
+    onToolCall: ({ toolCall }) => {
+      if (toolCall.toolName === SPECIAL_CREATE_CUSTOM_SERVER_TOOL_NAME) {
+        setPendingCustomServerToolCall(toolCall);
+      }
+    },
+    tools: toolsForUseChat,
+  } as Parameters<typeof useChat>[0]);
+
+  useEffect(() => {
+    if (!pendingCustomServerToolCall) {
+      return;
+    }
+
+    setIsCustomServerDialogOpen(true);
+
+    void (async () => {
+      try {
+        await addToolResult({
+          tool: pendingCustomServerToolCall.toolName as never,
+          toolCallId: pendingCustomServerToolCall.toolCallId,
+          output: {
+            type: "text",
+            text: "Opening the custom MCP server installation dialog.",
+          } as never,
+        });
+      } catch (toolError) {
+        console.error("[Chat] Failed to add custom server tool result", {
+          toolCallId: pendingCustomServerToolCall.toolCallId,
+          toolError,
+        });
+      }
+    })();
+
+    setPendingCustomServerToolCall(null);
+  }, [pendingCustomServerToolCall, addToolResult]);
 
   // Sync messages when conversation loads or changes
   useEffect(() => {


### PR DESCRIPTION
## Summary
- swap the websocket payload schema over to the placeholder `hello-world` schema
- remove the `create_mcp_server_installation_request` tool from the Archestra MCP server implementation
- pass the chat tool metadata to the chat hook and handle the custom MCP server dialog tool completely on the frontend

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dec17140883269aa8d75a4d1a5330)