### PR TITLE
fix: truncate long tool descriptions in tool policies

### DIFF
--- a/platform/frontend/src/app/tools/_parts/tool-details-dialog.tsx
+++ b/platform/frontend/src/app/tools/_parts/tool-details-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { archestraApiTypes } from "@shared";
+import { TruncatedText } from "@/components/truncated-text";
 import { Badge } from "@/components/ui/badge";
 import {
   Dialog,
@@ -48,9 +49,11 @@ export function ToolDetailsDialog({
                 {agentTool.tool.name}
               </DialogTitle>
               {agentTool.tool.description && (
-                <p className="text-sm text-muted-foreground mt-1">
-                  {agentTool.tool.description}
-                </p>
+                <TruncatedText
+                  message={agentTool.tool.description}
+                  maxLength={200}
+                  className="text-sm text-muted-foreground mt-1"
+                />
               )}
             </div>
             <div className="flex gap-6 text-sm ml-6">


### PR DESCRIPTION
## Summary
- use the existing `TruncatedText` component to shorten long tool descriptions in the tool details dialog
- keep the full description available via tooltip while reducing vertical space in the policy view