### PR TITLE
feat: helm chart - allow configuring deployment strategy + `imagePullPolicy`

### DIFF
--- a/platform/helm/archestra/templates/archestra-platform.yaml
+++ b/platform/helm/archestra/templates/archestra-platform.yaml
@@ -46,6 +46,10 @@ spec:
   selector:
     matchLabels:
       {{- include "archestra-platform.selectorLabels" . | nindent 6 }}
+  {{- with .Values.archestra.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:
@@ -71,7 +75,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.archestra.image }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.archestra.imagePullPolicy | default "IfNotPresent" }}
           ports:
             - name: backend
               containerPort: 9000

--- a/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
@@ -56,6 +56,31 @@ tests:
           path: spec.replicas
           value: 1
 
+  - it: should not configure deployment strategy by default
+    documentIndex: 1
+    asserts:
+      - isNull:
+          path: spec.strategy
+
+  - it: should configure deployment strategy when provided
+    documentIndex: 1
+    set:
+      archestra.strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: "25%"
+          maxUnavailable: 0
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: "25%"
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0
+
   - it: should configure container with correct image
     documentIndex: 1
     set:
@@ -64,6 +89,15 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: archestra/platform:test-version
+
+  - it: should allow configuring image pull policy
+    documentIndex: 1
+    set:
+      archestra.imagePullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
 
   - it: should expose backend, metrics, and frontend ports
     documentIndex: 1

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -3,6 +3,15 @@ archestra:
   # This image contains both the backend API and frontend
   image: archestra/platform:latest
 
+  # Image pull policy for the Archestra container
+  # Options: Always, IfNotPresent, Never
+  imagePullPolicy: IfNotPresent
+
+  # Deployment strategy configuration for the Deployment
+  # See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#:~:text=strategy%20(DeploymentStrategy)
+  # When null, the default Kubernetes strategy is used
+  strategy: null
+
   # Additional environment variables to pass to the container
   # These will be merged with the default DATABASE_URL environment variable
   # Example:


### PR DESCRIPTION
## Summary
- allow providing the full deployment strategy from chart values and render it directly into the Deployment
- document the strategy field with the Kubernetes API reference while keeping it null by default
- update the Helm deployment tests for the new strategy input and keep the chart version unchanged