### PR TITLE
feat: helm chart - allow configuring deployment strategy + `imagePullPolicy`

### DIFF
--- a/platform/helm/archestra/templates/archestra-platform.yaml
+++ b/platform/helm/archestra/templates/archestra-platform.yaml
@@ -46,7 +46,7 @@ spec:
   selector:
     matchLabels:
       {{- include "archestra-platform.selectorLabels" . | nindent 6 }}
-  {{- with .Values.archestra.strategy }}
+  {{- with .Values.archestra.deploymentStrategy }}
   strategy:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
@@ -65,7 +65,7 @@ tests:
   - it: should configure deployment strategy when provided
     documentIndex: 1
     set:
-      archestra.strategy:
+      archestra.deploymentStrategy:
         type: RollingUpdate
         rollingUpdate:
           maxSurge: "25%"

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -10,7 +10,7 @@ archestra:
   # Deployment strategy configuration for the Deployment
   # See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#:~:text=strategy%20(DeploymentStrategy)
   # When null, the default Kubernetes strategy is used
-  strategy: null
+  deploymentStrategy: null
 
   # Additional environment variables to pass to the container
   # These will be merged with the default DATABASE_URL environment variable


### PR DESCRIPTION
## Summary
- allow providing the full deployment strategy from chart values and render it directly into the Deployment
- document the strategy field with the Kubernetes API reference while keeping it null by default
- update the Helm deployment tests for the new strategy input and keep the chart version unchanged