### PR TITLE
fix: pnpm install needs CI=true

### DIFF
--- a/platform/dev/Tiltfile.dev
+++ b/platform/dev/Tiltfile.dev
@@ -5,7 +5,7 @@ is_prod = os.getenv('PROD') == 'true'
 
 local_resource(
   'pnpm-install',
-  cmd='pnpm install',
+  cmd='CI=true pnpm install',
   deps=[
     '../frontend/package.json',
     '../backend/package.json',


### PR DESCRIPTION
## Summary
- Set CI=true environment variable for pnpm install in Tiltfile.dev to prevent interactive prompts

## Test plan
- Run `tilt up` and verify pnpm install completes without hanging on interactive prompts
- Verify the development environment starts successfully