### PR TITLE
docs: cap node version at 24

### DIFF
--- a/docs/pages/platform-developer-quickstart.md
+++ b/docs/pages/platform-developer-quickstart.md
@@ -16,7 +16,7 @@ Ensure you have the following tools installed:
 
 ### Core Requirements
 
-- **Node.js** (v18 or higher) - JavaScript runtime
+- **Node.js** (v18 – v24) - JavaScript runtime
 - **pnpm** (v8 or higher) - Package manager
 
   ```bash


### PR DESCRIPTION
Archestra is not starting on node 24 due to some sentry packages not working for node25 yet