### PR TITLE
fix: don't remount sign-in form

### DIFF
--- a/platform/frontend/src/app/_parts/with-auth-check.tsx
+++ b/platform/frontend/src/app/_parts/with-auth-check.tsx
@@ -88,7 +88,7 @@ export const WithAuthCheck: React.FC<React.PropsWithChildren> = ({
       // User is not logged in and not on auth page, redirect to sign-in
       router.push("/auth/sign-in");
     }
-  }, [isAuthInitializing, isAuthPage, isLoggedIn, router]);
+  }, [isAuthInitializing, isAuthRefetching, isAuthPage, isLoggedIn, router]);
 
   // Redirect to home if page is protected and user is not authorized
   useEffect(() => {


### PR DESCRIPTION
By default, react queries re-fetch when the browser tab regains focus and so does auth query, causing all child components of WithAuthCheck (i.e. entire app) to re-mount. In this fix, we are taking measures not to re-mount on the re-fetch.

Closes https://github.com/archestra-ai/archestra/issues/1263