### PR TITLE
Persist archestra platform data with docker volumes

### DIFF
--- a/docs/pages/platform-quickstart.md
+++ b/docs/pages/platform-quickstart.md
@@ -23,8 +23,13 @@ Put the screenshot of the main page here as the last step after deployment.
 
    ```bash
    docker pull archestra/platform:latest;
-   docker run -p 9000:9000 -p 3000:3000 archestra/platform
+   docker run -p 9000:9000 -p 3000:3000 \
+     -v archestra-postgres-data:/var/lib/postgresql/data \
+     -v archestra-app-data:/app/data \
+     archestra/platform
    ```
+
+   **Note:** The volume mounts (`-v` flags) ensure that your data (chats, prompts, database) persists across container restarts. Without these volumes, all data will be lost when the container is stopped and removed.
 
 2. Open <http://localhost:3000>
 


### PR DESCRIPTION
Add Docker volume mounts to the quickstart guide to persist data across container runs.

The previous `docker run` command did not include volume mounts, causing all user-created data (chats, prompts, database, auth secrets) to be lost when the container was stopped and removed.

---
<a href="https://cursor.com/background-agent?bcId=bc-7a294e80-7ba7-4ecd-ab86-087f907b483d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7a294e80-7ba7-4ecd-ab86-087f907b483d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

