### PR TITLE
Preselect first profile in chat

### DIFF
--- a/platform/frontend/src/components/chat/prompt-dialog.tsx
+++ b/platform/frontend/src/components/chat/prompt-dialog.tsx
@@ -57,17 +57,19 @@ export function PromptDialog({
     if (open) {
       if (prompt) {
         setName(prompt.name);
-        setAgentId(prompt.agentId);
+        // Preselect first available agent when editing existing prompt
+        setAgentId(agents.length > 0 ? agents[0].id : "");
         setUserPrompt(prompt.userPrompt || "");
         setSystemPrompt(prompt.systemPrompt || "");
       } else {
         setName("");
-        setAgentId("");
+        // Preselect first available agent when creating new prompt
+        setAgentId(agents.length > 0 ? agents[0].id : "");
         setUserPrompt("");
         setSystemPrompt("");
       }
     }
-  }, [open, prompt]);
+  }, [open, prompt, agents]);
 
   const handleSave = async () => {
     if (!name || !agentId) {

--- a/platform/frontend/src/components/chat/prompt-library-grid.tsx
+++ b/platform/frontend/src/components/chat/prompt-library-grid.tsx
@@ -12,7 +12,7 @@ import {
   Search,
   Trash2,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -83,6 +83,13 @@ export function PromptLibraryGrid({
   const [promptToDelete, setPromptToDelete] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
 
+  // Preselect first available agent when Free Chat dialog opens
+  useEffect(() => {
+    if (isFreeChatDialogOpen && agents.length > 0) {
+      setSelectedAgentId(agents[0].id);
+    }
+  }, [isFreeChatDialogOpen, agents]);
+
   // Filter prompts based on search query
   const filteredPrompts = useMemo(() => {
     if (!searchQuery.trim()) {
@@ -104,7 +111,6 @@ export function PromptLibraryGrid({
     if (selectedAgentId) {
       onSelectPrompt(selectedAgentId);
       setIsFreeChatDialogOpen(false);
-      setSelectedAgentId("");
     }
   };
 
@@ -189,7 +195,6 @@ export function PromptLibraryGrid({
               variant="outline"
               onClick={() => {
                 setIsFreeChatDialogOpen(false);
-                setSelectedAgentId("");
               }}
             >
               Cancel


### PR DESCRIPTION
Preselect the first available profile when adding new prompts, editing existing prompts, and opening the Free Chat dialog.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e12fe81-4daa-42f2-8956-b025a703f114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4e12fe81-4daa-42f2-8956-b025a703f114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

