### PR TITLE
fix: formatting of Docker commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,13 @@ Metrics, traces and logs allowing to come to a conclusion about per-org, per-age
 
 1. Start with Docker
 
-   ```bash
-  docker pull archestra/platform:latest;
-  docker run -p 9000:9000 -p 3000:3000 \
-    -v archestra-postgres-data:/var/lib/postgresql/data \
-    -v archestra-app-data:/app/data \
-    archestra/platform;
-   ```
+```
+docker pull archestra/platform:latest;
+docker run -p 9000:9000 -p 3000:3000 \
+  -v archestra-postgres-data:/var/lib/postgresql/data \
+  -v archestra-app-data:/app/data \
+  archestra/platform;
+```
 
 2. Open <http://localhost:3000>
 


### PR DESCRIPTION
Updated the formatting of Docker commands in the README.