### PR TITLE
ci: fix pending db migration check

### DIFF
--- a/.github/workflows/platform-linting-and-tests.yml
+++ b/.github/workflows/platform-linting-and-tests.yml
@@ -223,20 +223,15 @@ jobs:
           set -e  # Re-enable exit on error
 
           # Check both unstaged and staged changes
+          # If db:generate produced new migration files, it means the PR is missing migrations
           if ! git diff --exit-code || ! git diff --cached --exit-code; then
-            echo "New migration files were generated - committing changes"
-            echo "db-migration-check=true" >> $GITHUB_OUTPUT
+            echo "::error::Database schema has changed but migrations are missing. Please run 'pnpm db:generate' locally and commit the resulting migration files."
+            git diff --name-only
+            git diff --cached --name-only
+            exit 1
           else
-            echo "No new migration files were generated"
-            echo "db-migration-check=false" >> $GITHUB_OUTPUT
+            echo "✅ No new migration files were generated - schema is in sync with migrations"
           fi
-
-      - name: Fail if PR from a fork has uncommitted migration changes
-        if: steps.db-migration-check.outputs.db-migration-check == 'true' && github.event.pull_request.head.repo.fork == true
-        working-directory: ./platform
-        run: |
-          echo "::error::Database migrations need to be generated. Please run 'pnpm db:generate' locally and commit the changes."
-          exit 1
 
       - name: Get Playwright version
         if: ${{ inputs.should-skip-running-and-always-succeed != true }}


### PR DESCRIPTION
Fix CI migration check to fail for all PRs if database migrations are missing.

Previously, the CI check for missing database migrations only failed for fork PRs, allowing PRs from the main repository to pass even when `pnpm db:generate` would create new migration files. This change ensures that any PR with an out-of-sync schema will fail CI immediately, prompting the developer to generate and commit the necessary migrations.

---
[Slack Thread](https://archestra-ai.slack.com/archives/C0966V616DC/p1764366076567419?thread_ts=1764366076.567419&cid=C0966V616DC)

<a href="https://cursor.com/background-agent?bcId=bc-3b19feff-b3af-40d5-8124-c460f9fce29c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3b19feff-b3af-40d5-8124-c460f9fce29c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tightens CI to fail any PR with missing DB migrations and adds a new `foo` column to the `organization` schema.
> 
> - **CI/Workflow (`.github/workflows/platform-linting-and-tests.yml`)**:
>   - **Enforce migration check for all PRs**: After `pnpm db:generate`, if any diff exists (staged/unstaged), emit error with changed files and `exit 1`.
>   - Remove fork-only failure step; add clearer success/error messages for schema/migration sync.
> - **Backend**:
>   - **Schema**: Add `foo` column to `organization` table in `platform/backend/src/database/schemas/organization.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9c62ad45d5faaf5bc5c0c1bc9740886d82a06f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->