### PR TITLE
chore: disable next.js `devIndicators`

### DIFF
--- a/platform/frontend/next.config.ts
+++ b/platform/frontend/next.config.ts
@@ -5,9 +5,8 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   output: "standalone",
   transpilePackages: ["@shared"],
-  devIndicators: {
-    position: "bottom-right",
-  },
+  // Disable dev indicators so they don't show up in docs automated screenshots
+  devIndicators: false,
   logging: {
     fetches: {
       fullUrl: true,


### PR DESCRIPTION
Disable Next.js dev indicators to prevent them from appearing in automated documentation screenshots.

---
[Slack Thread](https://archestra-ai.slack.com/archives/C0966V616DC/p1764612330979909?thread_ts=1764612330.979909&cid=C0966V616DC)

<a href="https://cursor.com/background-agent?bcId=bc-001feb00-1beb-4716-8a45-0d3a98d9c1f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-001feb00-1beb-4716-8a45-0d3a98d9c1f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables Next.js dev indicators by setting `devIndicators: false` in `platform/frontend/next.config.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8bb818d7417ed5274bb04e8550734f7d5b1fadc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->