### PR TITLE
chore: update `helm` `NOTES.txt` message

### DIFF
--- a/platform/helm/archestra/templates/NOTES.txt
+++ b/platform/helm/archestra/templates/NOTES.txt
@@ -1,16 +1,25 @@
 Archestra Platform has been installed!
 
+{{- $apiBaseUrl := index .Values.archestra.env "ARCHESTRA_API_BASE_URL" | default "" }}
+{{- $frontendUrl := index .Values.archestra.env "ARCHESTRA_FRONTEND_URL" | default "" }}
+
+{{- if or (not $apiBaseUrl) (not $frontendUrl) }}
 To access the platform, run the following commands:
+{{- if not $apiBaseUrl }}
 
   # Forward the backend API (port 9000)
   kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "archestra-platform.fullname" . }} 9000:9000
+{{- end }}
+{{- if not $frontendUrl }}
 
   # Forward the frontend (port 3000)
   kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "archestra-platform.fullname" . }} 3000:3000
+{{- end }}
+{{- end }}
 
 Then visit:
-  - Backend API: http://localhost:9000
-  - Frontend: http://localhost:3000
+  - Backend API: {{ $apiBaseUrl | default "http://localhost:9000" }}
+  - Frontend: {{ $frontendUrl | default "http://localhost:3000" }}
 
 {{- if .Values.postgresql.external_database_url }}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates Helm NOTES to conditionally show port-forward commands based on env vars and display API/frontend URLs from values with sensible defaults.
> 
> - **Helm template updates** (`platform/helm/archestra/templates/NOTES.txt`):
>   - Introduce `{{ $apiBaseUrl }}` and `{{ $frontendUrl }}` from `Values.archestra.env`.
>   - Conditionally render port-forward instructions only when corresponding URLs are not provided.
>   - Update "Then visit" section to show `Backend API` and `Frontend` using the env-derived URLs with fallbacks to `http://localhost:9000` and `http://localhost:3000`.
>   - Keep PostgreSQL connection info unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0480449fe990f3048a5a4ffc005558ed3245836. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->