### PR TITLE
chore: e2e test - ignore status check for agent tools fixture

### DIFF
--- a/platform/e2e-tests/tests/api/fixtures.ts
+++ b/platform/e2e-tests/tests/api/fixtures.ts
@@ -321,6 +321,7 @@ const waitForAgentTool = async (
       request,
       method: "get",
       urlSuffix: "/api/agent-tools",
+      ignoreStatusCheck: true,
     });
 
     if (agentToolsResponse.ok()) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates `waitForAgentTool` to pass `ignoreStatusCheck: true` when requesting `/api/agent-tools`, preventing errors on non-OK responses during retries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3460a7e93f572fa3f1fd3ac484d7b61354d1b22f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->