### PR TITLE
chore: deduplicate Platform docker image building CI logic

### DIFF
--- a/.github/actions/build-platform-docker-image/action.yml
+++ b/.github/actions/build-platform-docker-image/action.yml
@@ -1,0 +1,80 @@
+name: Build Platform Docker Image
+description: Build the Archestra platform Docker image using Blacksmith builder
+
+inputs:
+  context:
+    description: "Directory containing the Dockerfile"
+    required: true
+  dockerfile:
+    description: "Path to Dockerfile (defaults to {context}/Dockerfile)"
+    required: false
+    default: ""
+  push:
+    description: "Whether to push the image to a registry"
+    required: false
+    default: "false"
+  load:
+    description: "Whether to load the image into the local Docker daemon"
+    required: false
+    default: "false"
+  platforms:
+    description: "Target platforms for the build (e.g., linux/amd64,linux/arm64)"
+    required: false
+    default: ""
+  tags:
+    description: "Image tags (newline or comma separated)"
+    required: false
+    default: ""
+  outputs:
+    description: "Custom outputs configuration (e.g., for push-by-digest)"
+    required: false
+    default: ""
+  version:
+    description: "Version to pass as VERSION build arg"
+    required: false
+    default: ""
+  # Secrets must be passed as regular inputs in composite actions
+  turbo-team:
+    description: "Turborepo remote caching team"
+    required: true
+  turbo-token:
+    description: "Turborepo remote caching token"
+    required: true
+  sentry-auth-token:
+    description: "Sentry auth token for source map uploads (optional)"
+    required: false
+    default: ""
+
+outputs:
+  digest:
+    description: "Image digest"
+    value: ${{ steps.build.outputs.digest }}
+  imageid:
+    description: "Image ID"
+    value: ${{ steps.build.outputs.imageid }}
+  metadata:
+    description: "Build metadata"
+    value: ${{ steps.build.outputs.metadata }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Blacksmith Builder
+      uses: useblacksmith/setup-docker-builder@f9b57e1c7d5a57eed0b5609e1ffeadbf3bb0b726 # v1.1.0
+
+    - name: Build Docker image
+      id: build
+      uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
+      with:
+        context: ${{ inputs.context }}
+        file: ${{ inputs.dockerfile != '' && inputs.dockerfile || format('{0}/Dockerfile', inputs.context) }}
+        push: ${{ inputs.push }}
+        load: ${{ inputs.load }}
+        platforms: ${{ inputs.platforms }}
+        tags: ${{ inputs.tags }}
+        outputs: ${{ inputs.outputs }}
+        build-args: ${{ inputs.version != '' && format('VERSION={0}', inputs.version) || '' }}
+        secrets: |
+          turbo_team=${{ inputs.turbo-team }}
+          turbo_token=${{ inputs.turbo-token }}
+          ${{ inputs.sentry-auth-token != '' && format('sentry_auth_token={0}', inputs.sentry-auth-token) || '' }}

--- a/.github/workflows/build-dockerhub-image.yml
+++ b/.github/workflows/build-dockerhub-image.yml
@@ -65,24 +65,18 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@f9b57e1c7d5a57eed0b5609e1ffeadbf3bb0b726 # v1.1.0
-
-      - name: Build and push Docker image
+      - name: Build Docker image
         id: build
-        uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
+        uses: ./.github/actions/build-platform-docker-image
         with:
           context: ${{ inputs.image_directory }} # zizmor: ignore[template-injection] this is only being passed in as a workflow input..
-          file: ${{ inputs.image_directory }}/Dockerfile
           push: ${{ inputs.push_image }}
           platforms: ${{ matrix.os_and_arch }}
-          build-args: |
-            VERSION=${{ inputs.version }}
-          secrets: |
-            turbo_team=${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
-            turbo_token=${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
-            sentry_auth_token=${{ secrets.PLATFORM_NEXTJS_SOURCE_MAP_SENTRY_AUTH_TOKEN }}
+          version: ${{ inputs.version }}
           outputs: type=image,name=docker.io/archestra/${{ inputs.image_name }},push-by-digest=true,name-canonical=true,push=${{ inputs.push_image }}
+          turbo-team: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
+          turbo-token: ${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
+          sentry-auth-token: ${{ secrets.PLATFORM_NEXTJS_SOURCE_MAP_SENTRY_AUTH_TOKEN }}
 
       - name: Export digest
         if: inputs.push_image

--- a/.github/workflows/on-commits-to-main.yml
+++ b/.github/workflows/on-commits-to-main.yml
@@ -49,28 +49,21 @@ jobs:
           service_account: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_SERVICE_ACCOUNT_NAME }}
           workload_identity_provider: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER }}
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@f9b57e1c7d5a57eed0b5609e1ffeadbf3bb0b726 # v1.1.0
-
+      # NOTE: only build on amd64 for now as our staging environment runs on amd64
+      # if we will need to support arm64, we should follow the pattern we do in
+      # .github/workflows/build-dockerhub-image.yml and do a matrix build so that we are build
+      # on both amd64 and arm64 using native arch (to massively speed up the builds)
       - name: Build Docker image
-        uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
+        uses: ./.github/actions/build-platform-docker-image
         with:
           context: ./platform
-          file: ./platform/Dockerfile
-          # NOTE: only build on amd64 for now as our staging environment runs on amd64
-          # if we will need to support arm64, we should follow the pattern we do in
-          # .github/workflows/build-dockerhub-image.yml and do a matrix build so that we are build
-          # on both amd64 and arm64 using native arch (to massively speed up the builds)
+          push: "true"
           platforms: linux/amd64
-          build-args: |
-            VERSION=${{ github.sha }}
-          secrets: |
-            turbo_team=${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
-            turbo_token=${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
-            sentry_auth_token=${{ secrets.PLATFORM_NEXTJS_SOURCE_MAP_SENTRY_AUTH_TOKEN }}
-          push: true
-          tags: |
-            europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/platform:${{ github.sha }}
+          version: ${{ github.sha }}
+          tags: europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/platform:${{ github.sha }}
+          turbo-team: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
+          turbo-token: ${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
+          sentry-auth-token: ${{ secrets.PLATFORM_NEXTJS_SOURCE_MAP_SENTRY_AUTH_TOKEN }}
 
   deploy-to-staging:
     name: Deploy to staging

--- a/.github/workflows/platform-linting-and-tests.yml
+++ b/.github/workflows/platform-linting-and-tests.yml
@@ -96,22 +96,15 @@ jobs:
           echo "=== Kubectl cluster info ==="
           kubectl cluster-info || echo "Cluster info failed"
 
-      - name: Setup Blacksmith Builder
-        if: ${{ inputs.should-skip-running-and-always-succeed != true }}
-        uses: useblacksmith/setup-docker-builder@f9b57e1c7d5a57eed0b5609e1ffeadbf3bb0b726 # v1.1.0
-
       - name: Build Docker image
         if: ${{ inputs.should-skip-running-and-always-succeed != true }}
-        uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
+        uses: ./.github/actions/build-platform-docker-image
         with:
           context: ./platform
-          file: ./platform/Dockerfile
-          push: false
-          secrets: |
-            turbo_team=${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
-            turbo_token=${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
-          load: true
+          load: "true"
           tags: archestra/platform:ci-test
+          turbo-team: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
+          turbo-token: ${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
 
       - name: Load Docker image into kind
         if: ${{ inputs.should-skip-running-and-always-succeed != true }}
@@ -310,22 +303,15 @@ jobs:
         with:
           persist-credentials: true
 
-      - name: Setup Blacksmith Builder
-        if: ${{ github.event_name == 'pull_request' && inputs.should-skip-running-and-always-succeed != true }}
-        uses: useblacksmith/setup-docker-builder@f9b57e1c7d5a57eed0b5609e1ffeadbf3bb0b726 # v1.1.0
-
       - name: Build Docker image
         if: ${{ github.event_name == 'pull_request' && inputs.should-skip-running-and-always-succeed != true }}
-        uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
+        uses: ./.github/actions/build-platform-docker-image
         with:
           context: ./platform
-          file: ./platform/Dockerfile
-          push: false
-          secrets: |
-            turbo_team=${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
-            turbo_token=${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
-          load: true
+          load: "true"
           tags: archestra/platform:ci-test
+          turbo-team: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
+          turbo-token: ${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
 
       # Run docker scout to check for vulnerabilities and recommendations
       # https://github.com/docker/scout-action


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce a reusable composite action for building the Platform Docker image and refactor workflows to use it, removing duplicated steps.
> 
> - **CI**:
>   - **Composite action**: Add `./.github/actions/build-platform-docker-image` to encapsulate Blacksmith builder setup and `build-push-action` with configurable `context`, `dockerfile`, `push`, `load`, `platforms`, `tags`, `outputs`, `version`, and secrets (`turbo-team`, `turbo-token`, `sentry-auth-token`). Exposes `digest`, `imageid`, `metadata` outputs.
>   - **Workflows updated to use composite action**:
>     - `build-dockerhub-image.yml`: Replace inline Blacksmith setup and build with composite; pass `version`, `platforms`, `outputs`, and secrets; keep digest export/artifacts.
>     - `on-commits-to-main.yml`: Use composite for platform image build; set `push: "true"`, `platforms: linux/amd64`, pass `version`, `tags`, and secrets; add note on amd64-only builds.
>     - `platform-linting-and-tests.yml`: Use composite in e2e and image scanning jobs; build with `load: "true"` and tag `archestra/platform:ci-test`; remove redundant builder setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1487ee0343db04c3aee67f8d78e9efec4dfd16fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->