### PR TITLE
chore: fix `logo.png` console warning

### DIFF
--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -287,7 +287,7 @@ export function AppSidebar() {
           alt="Organization logo"
           width={200}
           height={60}
-          className="object-contain h-12 w-full max-w-[calc(100vw-6rem)]"
+          className="object-contain h-12 w-auto max-w-[calc(100vw-6rem)]"
         />
         <p className="text-[10px] text-muted-foreground">
           Powered by Archestra
@@ -296,7 +296,13 @@ export function AppSidebar() {
     </div>
   ) : (
     <div className="flex items-center gap-2 px-2">
-      <Image src="/logo.png" alt="Logo" width={28} height={28} />
+      <Image
+        src="/logo.png"
+        alt="Logo"
+        width={28}
+        height={28}
+        className="h-auto w-auto"
+      />
       <span className="text-base font-semibold">Archestra.AI</span>
     </div>
   );

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -192,7 +192,7 @@ export function ChatMessages({
                 alt="Loading logo"
                 width={40}
                 height={40}
-                className="object-contain h-8 animate-[bounce_700ms_ease_200ms_infinite]"
+                className="object-contain h-8 w-auto animate-[bounce_700ms_ease_200ms_infinite]"
               />
             </Message>
           )}


### PR DESCRIPTION
Addresses:

<img width="1410" height="37" alt="Screenshot 2025-12-03 at 1 25 03 PM" src="https://github.com/user-attachments/assets/c58a7962-990f-403b-bb0a-c18eaf2741b1" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch logo images to auto dimensions to fix Next/Image console warnings and preserve aspect ratio.
> 
> - **Frontend**
>   - **Sidebar (`platform/frontend/src/app/_parts/sidebar.tsx`)**:
>     - Organization logo: change `Image` classes to `w-auto` (from `w-full`) to maintain aspect ratio.
>     - Default logo: add `h-auto w-auto` to `Image`.
>   - **Chat (`platform/frontend/src/components/chat/chat-messages.tsx`)**:
>     - Loading logo: add `w-auto` to `Image` classes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0d9c56d445ea94a59f73c14bab13bbfe32c7e57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->