### PR TITLE
chore: make `lint:fix` a manual Tilt resource

### DIFF
--- a/platform/dev/Tiltfile.dev
+++ b/platform/dev/Tiltfile.dev
@@ -69,12 +69,10 @@ local_resource(
   cmd='pnpm type-check && pnpm lint:fix',
   labels=['dev'],
   resource_deps=['pnpm-install'],
-  deps=[
-    "../frontend/src",
-    "../backend/src",
-    "../experiments/src",
-    "../biome.json",
-  ]
+  # Disabled auto-watching to prevent spawning processes on every file change
+  # Trigger manually with: tilt trigger lint:fix
+  trigger_mode=TRIGGER_MODE_MANUAL,
+  auto_init=False,
 )
 
 local_resource(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches `lint:fix` in `platform/dev/Tiltfile.dev` to manual triggering to avoid auto-watching and removes file deps.
> 
> - **Dev tooling (Tilt)**
>   - Update `platform/dev/Tiltfile.dev`:
>     - Change `local_resource('lint:fix')` to manual trigger (`trigger_mode=TRIGGER_MODE_MANUAL`, `auto_init=False`).
>     - Remove watched `deps` to prevent auto-spawning on file changes.
>     - Add inline comments with manual trigger instructions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb95777c4fc8c066650a352957b62c72aba6f6cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->