### PR TITLE
chore: enable `ARCHESTRA_ENTERPRISE_LICENSE_ACTIVATED` on staging env

### DIFF
--- a/.github/workflows/on-commits-to-main.yml
+++ b/.github/workflows/on-commits-to-main.yml
@@ -118,6 +118,7 @@ jobs:
             --set archestra.env.ARCHESTRA_SENTRY_ENVIRONMENT="archestra.dev" \
             --set archestra.env.ARCHESTRA_SENTRY_BACKEND_DSN="${{ secrets.ARCHESTRA_STAGING_SENTRY_BACKEND_DSN }}" \
             --set archestra.env.ARCHESTRA_SENTRY_FRONTEND_DSN="${{ secrets.ARCHESTRA_STAGING_SENTRY_FRONTEND_DSN }}" \
+            --set archestra.env.ARCHESTRA_ENTERPRISE_LICENSE_ACTIVATED="true" \
             --values .github/values-staging.yaml \
             --wait
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enables `ARCHESTRA_ENTERPRISE_LICENSE_ACTIVATED=true` in the staging Helm deploy step of the main-branch workflow.
> 
> - **CI/CD**:
>   - Update `.github/workflows/on-commits-to-main.yml` to set `archestra.env.ARCHESTRA_ENTERPRISE_LICENSE_ACTIVATED="true"` during the staging Helm deployment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82732b97686ae5cea0f01f573bffdee5e9f0d5f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->