### PR TITLE
chore: nicely show sso redirect errors in UI

### DIFF
--- a/platform/frontend/src/app/auth/sign-in/error/page.tsx
+++ b/platform/frontend/src/app/auth/sign-in/error/page.tsx
@@ -1,0 +1,34 @@
+import { redirect } from "next/navigation";
+
+/**
+ * SSO Error Redirect Handler
+ *
+ * This route handles SSO authentication errors from Better Auth's SSO plugin.
+ * When an internal SSO error occurs (e.g., JWKS endpoint not found, token verification failed),
+ * Better Auth redirects to `{errorCallbackURL}/error?error=...&error_description=...`.
+ *
+ * This page captures those error parameters and redirects to /auth/sign-in where the
+ * AuthViewWithErrorHandling component displays the appropriate error message.
+ */
+export default async function SsoErrorPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string; error_description?: string }>;
+}) {
+  const params = await searchParams;
+  const { error, error_description } = params;
+
+  // Build the redirect URL with error params
+  const redirectUrl = new URL("/auth/sign-in", "http://localhost");
+
+  if (error) {
+    redirectUrl.searchParams.set("error", error);
+  }
+  if (error_description) {
+    redirectUrl.searchParams.set("error_description", error_description);
+  }
+
+  // Redirect to the sign-in page with error params preserved
+  // The pathname + search gives us the relative URL
+  redirect(redirectUrl.pathname + redirectUrl.search);
+}


### PR DESCRIPTION
better-auth, when there is an error, redirects to `/auth/sign-in/error?error=<error_code>` -- this PR simply adds a redirect to send the user to `/auth/sign-in`, while maintaining the relevant query params and then on that page we already nicely map those error codes to a human readable message as such:

<img width="929" height="706" alt="Screenshot 2025-12-04 at 3 49 52 PM" src="https://github.com/user-attachments/assets/4e4c6932-02df-4eaf-9a41-aaf0deaed431" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Next.js route to capture SSO error params and redirect to `/auth/sign-in` with query preserved.
> 
> - **Frontend/Auth**
>   - Adds `platform/frontend/src/app/auth/sign-in/error/page.tsx` to handle Better Auth SSO errors by reading `searchParams` (`error`, `error_description`) and redirecting to `/auth/sign-in` with the same query parameters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 566b8e8a0bb9ade653c412b3551189be7e61b778. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->