### PR TITLE
fix: in sidebar hide chats while permission check pending

### DIFF
--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -216,8 +216,8 @@ const MainSideBarSection = ({
         permissions={{ conversation: ["read"] }}
         noPermissionHandle="tooltip"
       >
-        {({ hasPermission, isPending }) => {
-          return isPending ? null : hasPermission ? (
+        {({ hasPermission }) => {
+          return hasPermission === undefined ? null : hasPermission ? (
             <ChatSidebarSection />
           ) : (
             <SidebarGroup>

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -549,8 +549,9 @@ export default function ChatPage() {
                   permissions={{ profile: ["read"] }}
                   noPermissionHandle="tooltip"
                 >
-                  {({ hasPermission, isPending }) => {
-                    return isPending ? null : hasPermission ? (
+                  {({ hasPermission }) => {
+                    return hasPermission ===
+                      undefined ? null : hasPermission ? (
                       <McpToolsDisplay
                         agentId={currentProfileId}
                         className="text-xs text-muted-foreground"

--- a/platform/frontend/src/components/chat/prompt-dialog.tsx
+++ b/platform/frontend/src/components/chat/prompt-dialog.tsx
@@ -166,8 +166,8 @@ export function PromptDialog({
               permissions={{ profile: ["read"] }}
               noPermissionHandle="tooltip"
             >
-              {({ hasPermission, isPending }) => {
-                return isPending ? null : hasPermission ? (
+              {({ hasPermission }) => {
+                return hasPermission === undefined ? null : hasPermission ? (
                   <Select value={agentId} onValueChange={setProfileId}>
                     <SelectTrigger>
                       <SelectValue placeholder="Select a profile" />
@@ -192,8 +192,8 @@ export function PromptDialog({
                 permissions={{ profile: ["read"] }}
                 noPermissionHandle="tooltip"
               >
-                {({ hasPermission, isPending }) => {
-                  return isPending ? null : hasPermission ? (
+                {({ hasPermission }) => {
+                  return hasPermission === undefined ? null : hasPermission ? (
                     <McpToolsDisplay
                       agentId={agentId}
                       className="text-xs text-muted-foreground"

--- a/platform/frontend/src/components/chat/prompt-library-grid.tsx
+++ b/platform/frontend/src/components/chat/prompt-library-grid.tsx
@@ -140,10 +140,10 @@ export function PromptLibraryGrid({
           permissions={{ conversation: ["create"] }}
           noPermissionHandle="tooltip"
         >
-          {({ hasPermission, isPending }) => {
+          {({ hasPermission }) => {
             return (
               <Card
-                className={`h-[155px] justify-center items-center px-0 py-2 border-2 border-green-500 hover:border-green-600 cursor-pointer transition-colors bg-gradient-to-br from-green-50 to-green-100 dark:from-green-950 dark:to-green-900 ${isPending || hasPermission ? "" : "opacity-50 pointer-events-none"}`}
+                className={`h-[155px] justify-center items-center px-0 py-2 border-2 border-green-500 hover:border-green-600 cursor-pointer transition-colors bg-gradient-to-br from-green-50 to-green-100 dark:from-green-950 dark:to-green-900 ${hasPermission === false ? "opacity-50 pointer-events-none" : ""}`}
                 onClick={() => setIsFreeChatDialogOpen(true)}
               >
                 <CardTitle className="flex items-center gap-2 text-green-700 dark:text-green-300 text-base">
@@ -167,7 +167,7 @@ export function PromptLibraryGrid({
               permissions={{ conversation: ["create"] }}
               noPermissionHandle="tooltip"
             >
-              {({ hasPermission, isPending }) => {
+              {({ hasPermission }) => {
                 return (
                   <PromptTile
                     key={prompt.id}

--- a/platform/frontend/src/components/roles/with-permissions.tsx
+++ b/platform/frontend/src/components/roles/with-permissions.tsx
@@ -15,10 +15,8 @@ type WithPermissionsProps = {
       noPermissionHandle: "tooltip";
       children: ({
         hasPermission,
-        isPending,
       }: {
         hasPermission: boolean | undefined;
-        isPending: boolean;
       }) => React.ReactNode;
     }
   | {
@@ -37,7 +35,7 @@ export function WithPermissions({
   // if has permission, return children as is
   if (hasPermission) {
     return typeof children === "function"
-      ? children({ hasPermission: true, isPending })
+      ? children({ hasPermission: true })
       : children;
   }
 
@@ -53,10 +51,7 @@ export function WithPermissions({
       <Tooltip>
         <TooltipTrigger asChild>
           <span className="cursor-not-allowed">
-            {children({
-              hasPermission: isPending ? undefined : false,
-              isPending,
-            })}
+            {children({ hasPermission: isPending ? undefined : false })}
           </span>
         </TooltipTrigger>
         <TooltipContent className="max-w-60">{`${permissionError}.`}</TooltipContent>


### PR DESCRIPTION
In sidebar, while chat permission check is pending, show nothing. Not "Recent chats are not shown". `WithPermissions`'s state is now undefined while permission check is pending.