### PR TITLE
chore: address CRLF issues for Windows developers

### DIFF
--- a/platform/.gitattributes
+++ b/platform/.gitattributes
@@ -1,0 +1,32 @@
+# Enforce LF line endings for all text files
+# This prevents CRLF issues on Windows that can break shell scripts, env files, and Tiltfiles
+* text=auto eol=lf
+
+# Explicitly mark certain file types as text with LF
+*.ts text eol=lf
+*.tsx text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.sh text eol=lf
+*.sql text eol=lf
+*.css text eol=lf
+*.html text eol=lf
+*.env* text eol=lf
+Tiltfile text eol=lf
+Dockerfile text eol=lf
+
+# Binary files - don't modify
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.tgz binary


### PR DESCRIPTION
Address [issue](https://archestracommunity.slack.com/archives/C0975QYN5LZ/p1764426535123499?thread_ts=1764417886.147729&cid=C0975QYN5LZ) reported by community member in the Slack community channel:

> I discovered the issue. My .env file is saved with Windows Line Endings (CRLF). The Linux-based tools (Tilt) do not understand the invisible "Carriage Return" character (\r) at the end of the lines and treat it as a syntax error.
So i changed the CRLF to LF and it worked,
I'll set my default to LF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `platform/.gitattributes` to enforce LF line endings for text files and mark common binaries as binary to prevent CRLF issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 333568fbeafab54d0b4ce13ae6938526fdd5edc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->