### PR TITLE
feat: add browser streaming panel for Playwright MCP tools

### DIFF
--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -258,7 +258,7 @@ export async function getChatMcpTools(
           // biome-ignore lint/suspicious/noExplicitAny: Tool execute function requires flexible typing for MCP integration
           execute: async (args: any) => {
             logger.info(
-              { agentId, toolName: mcpTool.name, arguments: args },
+              { agentId, toolName: mcpTool.name, toolArguments: args },
               "Executing MCP tool from chat",
             );
 

--- a/platform/backend/src/database/migrations/0072_confused_tattoo.sql
+++ b/platform/backend/src/database/migrations/0072_confused_tattoo.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "internal_mcp_catalog" ADD COLUMN "requires_trusted_context" boolean DEFAULT false NOT NULL;

--- a/platform/backend/src/database/migrations/meta/0071_snapshot.json
+++ b/platform/backend/src/database/migrations/meta/0071_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "90d85f6c-8e8d-4ab5-8aaf-26aeef7f8bf8",
+  "id": "0c570967-e77b-4555-a7e1-6e3c39af5d7c",
   "prevId": "091fc983-4197-47db-9598-0851be5780e2",
   "version": "7",
   "dialect": "postgresql",
@@ -1162,6 +1162,13 @@
           "notNull": false,
           "default": "'{}'::jsonb"
         },
+        "requires_trusted_context": {
+          "name": "requires_trusted_context",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
         "oauth_config": {
           "name": "oauth_config",
           "type": "jsonb",
@@ -2240,6 +2247,12 @@
         },
         "entity_id": {
           "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_type": {
+          "name": "rule_type",
           "type": "text",
           "primaryKey": false,
           "notNull": true

--- a/platform/backend/src/database/migrations/meta/0072_snapshot.json
+++ b/platform/backend/src/database/migrations/meta/0072_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "fc926eaf-43c0-4997-b133-74264c453b7b",
-  "prevId": "90d85f6c-8e8d-4ab5-8aaf-26aeef7f8bf8",
+  "id": "698cc87d-b87f-4410-a732-bc05082054b8",
+  "prevId": "5bdc6121-0557-4b42-b85d-cc76b353acc0",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1149,6 +1149,18 @@
           "primaryKey": false,
           "notNull": false
         },
+        "client_secret_id": {
+          "name": "client_secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_config_secret_id": {
+          "name": "local_config_secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
         "local_config": {
           "name": "local_config",
           "type": "jsonb",
@@ -1161,6 +1173,13 @@
           "primaryKey": false,
           "notNull": false,
           "default": "'{}'::jsonb"
+        },
+        "requires_trusted_context": {
+          "name": "requires_trusted_context",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
         },
         "oauth_config": {
           "name": "oauth_config",
@@ -1184,7 +1203,34 @@
         }
       },
       "indexes": {},
-      "foreignKeys": {},
+      "foreignKeys": {
+        "internal_mcp_catalog_client_secret_id_secret_id_fk": {
+          "name": "internal_mcp_catalog_client_secret_id_secret_id_fk",
+          "tableFrom": "internal_mcp_catalog",
+          "tableTo": "secret",
+          "columnsFrom": [
+            "client_secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "internal_mcp_catalog_local_config_secret_id_secret_id_fk": {
+          "name": "internal_mcp_catalog_local_config_secret_id_secret_id_fk",
+          "tableFrom": "internal_mcp_catalog",
+          "tableTo": "secret",
+          "columnsFrom": [
+            "local_config_secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
@@ -1900,12 +1946,6 @@
           "primaryKey": false,
           "notNull": false
         },
-        "auth_type": {
-          "name": "auth_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
         "reinstall_required": {
           "name": "reinstall_required",
           "type": "boolean",
@@ -2466,7 +2506,7 @@
           "type": "boolean",
           "primaryKey": false,
           "notNull": true,
-          "default": false
+          "default": true
         },
         "compression_scope": {
           "name": "compression_scope",
@@ -2769,6 +2809,12 @@
           "primaryKey": false,
           "notNull": false
         },
+        "role_mapping": {
+          "name": "role_mapping",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "user_id": {
           "name": "user_id",
           "type": "text",
@@ -2792,6 +2838,12 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
         }
       },
       "indexes": {},
@@ -2817,6 +2869,67 @@
           "nullsNotDistinct": false,
           "columns": [
             "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_external_group": {
+      "name": "team_external_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_identifier": {
+          "name": "group_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_external_group_team_id_team_id_fk": {
+          "name": "team_external_group_team_id_team_id_fk",
+          "tableFrom": "team_external_group",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_external_group_team_group_unique": {
+          "name": "team_external_group_team_group_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_id",
+            "group_identifier"
           ]
         }
       },
@@ -2852,6 +2965,13 @@
           "primaryKey": false,
           "notNull": true,
           "default": "'member'"
+        },
+        "synced_from_sso": {
+          "name": "synced_from_sso",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
         },
         "created_at": {
           "name": "created_at",
@@ -2994,6 +3114,12 @@
           "primaryKey": true,
           "notNull": true,
           "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
         },
         "model": {
           "name": "model",

--- a/platform/backend/src/database/migrations/meta/_journal.json
+++ b/platform/backend/src/database/migrations/meta/_journal.json
@@ -502,71 +502,15 @@
     {
       "idx": 71,
       "version": "7",
-      "when": 1764588841370,
-      "tag": "0071_mixed_deadpool",
+      "when": 1764893507203,
+      "tag": "0071_whole_elektra",
       "breakpoints": true
     },
     {
       "idx": 72,
       "version": "7",
-      "when": 1764595314504,
-      "tag": "0072_add secret name",
-      "breakpoints": true
-    },
-    {
-      "idx": 73,
-      "version": "7",
-      "when": 1764606110739,
-      "tag": "0073_curved_vampiro",
-      "breakpoints": true
-    },
-    {
-      "idx": 74,
-      "version": "7",
-      "when": 1764680281179,
-      "tag": "0074_left_maggott",
-      "breakpoints": true
-    },
-    {
-      "idx": 75,
-      "version": "7",
-      "when": 1764741373326,
-      "tag": "0075_natural_enchantress",
-      "breakpoints": true
-    },
-    {
-      "idx": 76,
-      "version": "7",
-      "when": 1764763021874,
-      "tag": "0076_lowly_mantis",
-      "breakpoints": true
-    },
-    {
-      "idx": 77,
-      "version": "7",
-      "when": 1764781755548,
-      "tag": "0077_secret_lethal_legion",
-      "breakpoints": true
-    },
-    {
-      "idx": 78,
-      "version": "7",
-      "when": 1764798610912,
-      "tag": "0078_wakeful_nightcrawler",
-      "breakpoints": true
-    },
-    {
-      "idx": 79,
-      "version": "7",
-      "when": 1764806886044,
-      "tag": "0079_mature_deathbird",
-      "breakpoints": true
-    },
-    {
-      "idx": 80,
-      "version": "7",
-      "when": 1764863811430,
-      "tag": "0080_brown_steve_rogers",
+      "when": 1765005212088,
+      "tag": "0072_confused_tattoo",
       "breakpoints": true
     }
   ]

--- a/platform/backend/src/database/schemas/internal-mcp-catalog.ts
+++ b/platform/backend/src/database/schemas/internal-mcp-catalog.ts
@@ -79,6 +79,11 @@ const internalMcpCatalogTable = pgTable("internal_mcp_catalog", {
       >
     >()
     .default({}),
+  // Flag for MCP servers that inherently require chained tool calls
+  // When true, tools from this catalog will have allowUsageWhenUntrustedDataIsPresent=true by default
+  requiresTrustedContext: boolean("requires_trusted_context")
+    .notNull()
+    .default(false),
   // OAuth configuration for remote servers
   oauthConfig: jsonb("oauth_config").$type<{
     name: string;

--- a/platform/backend/src/models/agent-tool.ts
+++ b/platform/backend/src/models/agent-tool.ts
@@ -249,6 +249,7 @@ class AgentToolModel {
     toolId: string,
     credentialSourceMcpServerId?: string | null,
     executionSourceMcpServerId?: string | null,
+    allowUsageWhenUntrustedDataIsPresent?: boolean,
   ): Promise<{ status: "created" | "updated" | "unchanged" }> {
     // Check if assignment already exists
     const [existing] = await db
@@ -283,31 +284,47 @@ class AgentToolModel {
         options.executionSourceMcpServerId = executionSourceMcpServerId;
       }
 
+      if (allowUsageWhenUntrustedDataIsPresent !== undefined) {
+        options.allowUsageWhenUntrustedDataIsPresent =
+          allowUsageWhenUntrustedDataIsPresent;
+      }
+
       await AgentToolModel.create(agentId, toolId, options);
       return { status: "created" };
     }
 
-    // Check if credentials need updating
+    // Check if credentials or allowUsageWhenUntrustedDataIsPresent need updating
     const needsUpdate =
       existing.credentialSourceMcpServerId !==
         (credentialSourceMcpServerId ?? null) ||
       existing.executionSourceMcpServerId !==
-        (executionSourceMcpServerId ?? null);
+        (executionSourceMcpServerId ?? null) ||
+      (allowUsageWhenUntrustedDataIsPresent !== undefined &&
+        existing.allowUsageWhenUntrustedDataIsPresent !==
+          allowUsageWhenUntrustedDataIsPresent);
 
     if (needsUpdate) {
-      // Update credentials
+      // Update credentials and/or allowUsageWhenUntrustedDataIsPresent
       const updateData: Partial<
         Pick<
           UpdateAgentTool,
-          "credentialSourceMcpServerId" | "executionSourceMcpServerId"
+          | "credentialSourceMcpServerId"
+          | "executionSourceMcpServerId"
+          | "allowUsageWhenUntrustedDataIsPresent"
         >
       > = {};
 
-      // Always set both fields to ensure they're updated correctly
+      // Always set both credential fields to ensure they're updated correctly
       updateData.credentialSourceMcpServerId =
         credentialSourceMcpServerId ?? null;
       updateData.executionSourceMcpServerId =
         executionSourceMcpServerId ?? null;
+
+      // Only update allowUsageWhenUntrustedDataIsPresent if explicitly provided
+      if (allowUsageWhenUntrustedDataIsPresent !== undefined) {
+        updateData.allowUsageWhenUntrustedDataIsPresent =
+          allowUsageWhenUntrustedDataIsPresent;
+      }
 
       await AgentToolModel.update(existing.id, updateData);
       return { status: "updated" };

--- a/platform/backend/src/models/conversation.ts
+++ b/platform/backend/src/models/conversation.ts
@@ -172,6 +172,44 @@ class ConversationModel {
         ),
       );
   }
+
+  /**
+   * Get the agentId for a conversation (without user context checks)
+   * Used by internal services that need to look up conversation -> agent mapping
+   */
+  static async getAgentId(conversationId: string): Promise<string | null> {
+    const result = await db
+      .select({ agentId: schema.conversationsTable.agentId })
+      .from(schema.conversationsTable)
+      .where(eq(schema.conversationsTable.id, conversationId))
+      .limit(1);
+
+    return result[0]?.agentId ?? null;
+  }
+
+  /**
+   * Get the agentId for a conversation scoped to a specific user and organization.
+   * Returns null when the conversation does not belong to the provided user/org.
+   */
+  static async getAgentIdForUser(
+    conversationId: string,
+    userId: string,
+    organizationId: string,
+  ): Promise<string | null> {
+    const result = await db
+      .select({ agentId: schema.conversationsTable.agentId })
+      .from(schema.conversationsTable)
+      .where(
+        and(
+          eq(schema.conversationsTable.id, conversationId),
+          eq(schema.conversationsTable.userId, userId),
+          eq(schema.conversationsTable.organizationId, organizationId),
+        ),
+      )
+      .limit(1);
+
+    return result[0]?.agentId ?? null;
+  }
 }
 
 export default ConversationModel;

--- a/platform/backend/src/routes/agent-tool.ts
+++ b/platform/backend/src/routes/agent-tool.ts
@@ -148,6 +148,7 @@ const agentToolRoutes: FastifyPluginAsyncZod = async (fastify) => {
               toolId: UuidIdSchema,
               credentialSourceMcpServerId: UuidIdSchema.nullable().optional(),
               executionSourceMcpServerId: UuidIdSchema.nullable().optional(),
+              allowUsageWhenUntrustedDataIsPresent: z.boolean().optional(),
             }),
           ),
         }),
@@ -220,6 +221,7 @@ const agentToolRoutes: FastifyPluginAsyncZod = async (fastify) => {
             assignment.credentialSourceMcpServerId,
             assignment.executionSourceMcpServerId,
             preFetchedData,
+            assignment.allowUsageWhenUntrustedDataIsPresent,
           ),
         ),
       );
@@ -563,6 +565,7 @@ export async function assignToolToAgent(
     toolsMap?: Map<string, Tool>;
     catalogItemsMap?: Map<string, InternalMcpCatalog>;
   },
+  allowUsageWhenUntrustedDataIsPresent?: boolean,
 ): Promise<
   | {
       status: 400 | 404;
@@ -674,6 +677,7 @@ export async function assignToolToAgent(
     toolId,
     credentialSourceMcpServerId,
     executionSourceMcpServerId,
+    allowUsageWhenUntrustedDataIsPresent,
   );
 
   // Return appropriate status

--- a/platform/backend/src/routes/browser-stream.test.ts
+++ b/platform/backend/src/routes/browser-stream.test.ts
@@ -1,0 +1,107 @@
+import Fastify from "fastify";
+import {
+  serializerCompiler,
+  validatorCompiler,
+  type ZodTypeProvider,
+} from "fastify-type-provider-zod";
+import { BrowserStreamService } from "@/services/browser-stream";
+import { beforeEach, describe, expect, test, vi } from "@/test";
+import type { User } from "@/types";
+import browserStreamRoutes from "./browser-stream";
+
+const buildAppWithUser = async (user: User, organizationId: string) => {
+  const app = Fastify({ logger: false })
+    .withTypeProvider<ZodTypeProvider>()
+    .setValidatorCompiler(validatorCompiler)
+    .setSerializerCompiler(serializerCompiler);
+
+  app.decorateRequest("user");
+  app.decorateRequest("organizationId");
+  app.addHook("preHandler", async (request) => {
+    request.user = user;
+    request.organizationId = organizationId;
+  });
+
+  await app.register(browserStreamRoutes);
+  await app.ready();
+  return app;
+};
+
+describe("browser-stream routes authorization", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("denies access to conversations not owned by the caller", async ({
+    makeAgent,
+    makeConversation,
+    makeOrganization,
+    makeUser,
+  }) => {
+    const org = await makeOrganization();
+    const owner = await makeUser();
+    const otherUser = await makeUser();
+    const agent = await makeAgent();
+    const conversation = await makeConversation(agent.id, {
+      userId: owner.id,
+      organizationId: org.id,
+    });
+
+    const app = await buildAppWithUser(otherUser as User, org.id);
+    const availabilitySpy = vi.spyOn(
+      BrowserStreamService.prototype,
+      "checkAvailability",
+    );
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/browser-stream/${conversation.id}/available`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      available: false,
+      error: "Conversation not found",
+    });
+    expect(availabilitySpy).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  test("allows owners to access their conversation browser stream", async ({
+    makeAgent,
+    makeConversation,
+    makeOrganization,
+    makeUser,
+  }) => {
+    const org = await makeOrganization();
+    const owner = (await makeUser()) as User;
+    const agent = await makeAgent();
+    const conversation = await makeConversation(agent.id, {
+      userId: owner.id,
+      organizationId: org.id,
+    });
+
+    const app = await buildAppWithUser(owner, org.id);
+    const availabilitySpy = vi
+      .spyOn(BrowserStreamService.prototype, "checkAvailability")
+      .mockResolvedValue({
+        available: true,
+        tools: ["browser_navigate"],
+      });
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/browser-stream/${conversation.id}/available`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      available: true,
+      tools: ["browser_navigate"],
+    });
+    expect(availabilitySpy).toHaveBeenCalledWith(agent.id);
+
+    await app.close();
+  });
+});

--- a/platform/backend/src/routes/browser-stream.ts
+++ b/platform/backend/src/routes/browser-stream.ts
@@ -1,0 +1,273 @@
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import logger from "@/logging";
+import { ConversationModel } from "@/models";
+import { BrowserStreamService } from "@/services/browser-stream";
+import { constructResponseSchema } from "@/types";
+
+const ConversationParamsSchema = z.object({
+  conversationId: z.string().uuid(),
+});
+
+const NavigateBodySchema = z.object({
+  url: z.string().url(),
+});
+
+const browserStreamRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  const browserStreamService = new BrowserStreamService();
+
+  /**
+   * Helper to get agentId from conversationId
+   */
+  async function getAgentIdFromConversation(
+    conversationId: string,
+    userId: string,
+    organizationId: string,
+  ): Promise<string | null> {
+    return ConversationModel.getAgentIdForUser(
+      conversationId,
+      userId,
+      organizationId,
+    );
+  }
+
+  // Check if Playwright MCP is available for a conversation's agent
+  fastify.get(
+    "/api/browser-stream/:conversationId/available",
+    {
+      schema: {
+        params: ConversationParamsSchema,
+        response: constructResponseSchema(
+          z.object({
+            available: z.boolean(),
+            tools: z.array(z.string()).optional(),
+            error: z.string().optional(),
+          }),
+        ),
+      },
+    },
+    async (request, reply) => {
+      const { conversationId } = ConversationParamsSchema.parse(request.params);
+
+      const agentId = await getAgentIdFromConversation(
+        conversationId,
+        request.user.id,
+        request.organizationId,
+      );
+      if (!agentId) {
+        return reply.send({
+          available: false,
+          error: "Conversation not found",
+        });
+      }
+
+      try {
+        const result = await browserStreamService.checkAvailability(agentId);
+        return reply.send(result);
+      } catch (error) {
+        logger.error(
+          { error, conversationId },
+          "Failed to check browser availability",
+        );
+        return reply.send({
+          available: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Availability check failed",
+        });
+      }
+    },
+  );
+
+  // Navigate to URL in conversation's browser tab
+  fastify.post(
+    "/api/browser-stream/:conversationId/navigate",
+    {
+      schema: {
+        params: ConversationParamsSchema,
+        body: NavigateBodySchema,
+        response: constructResponseSchema(
+          z.object({
+            success: z.boolean(),
+            url: z.string().optional(),
+            error: z.string().optional(),
+          }),
+        ),
+      },
+    },
+    async (request, reply) => {
+      const { conversationId } = ConversationParamsSchema.parse(request.params);
+      const { url } = NavigateBodySchema.parse(request.body);
+
+      const agentId = await getAgentIdFromConversation(
+        conversationId,
+        request.user.id,
+        request.organizationId,
+      );
+      if (!agentId) {
+        return reply.send({
+          success: false,
+          error: "Conversation not found",
+        });
+      }
+
+      try {
+        const result = await browserStreamService.navigate(
+          agentId,
+          conversationId,
+          url,
+        );
+        return reply.send(result);
+      } catch (error) {
+        logger.error(
+          { error, conversationId, url },
+          "Failed to navigate browser",
+        );
+        return reply.send({
+          success: false,
+          error: error instanceof Error ? error.message : "Navigation failed",
+        });
+      }
+    },
+  );
+
+  // Take screenshot of conversation's browser tab
+  fastify.get(
+    "/api/browser-stream/:conversationId/screenshot",
+    {
+      schema: {
+        params: ConversationParamsSchema,
+        response: constructResponseSchema(
+          z.object({
+            screenshot: z.string().optional(),
+            url: z.string().optional(),
+            error: z.string().optional(),
+          }),
+        ),
+      },
+    },
+    async (request, reply) => {
+      const { conversationId } = ConversationParamsSchema.parse(request.params);
+
+      const agentId = await getAgentIdFromConversation(
+        conversationId,
+        request.user.id,
+        request.organizationId,
+      );
+      if (!agentId) {
+        return reply.send({
+          error: "Conversation not found",
+        });
+      }
+
+      try {
+        const result = await browserStreamService.takeScreenshot(
+          agentId,
+          conversationId,
+        );
+        return reply.send(result);
+      } catch (error) {
+        logger.error({ error, conversationId }, "Failed to take screenshot");
+        return reply.send({
+          error: error instanceof Error ? error.message : "Screenshot failed",
+        });
+      }
+    },
+  );
+
+  // Activate/select tab for a conversation
+  fastify.post(
+    "/api/browser-stream/:conversationId/activate",
+    {
+      schema: {
+        params: ConversationParamsSchema,
+        response: constructResponseSchema(
+          z.object({
+            success: z.boolean(),
+            tabIndex: z.number().optional(),
+            error: z.string().optional(),
+          }),
+        ),
+      },
+    },
+    async (request, reply) => {
+      const { conversationId } = ConversationParamsSchema.parse(request.params);
+
+      const agentId = await getAgentIdFromConversation(
+        conversationId,
+        request.user.id,
+        request.organizationId,
+      );
+      if (!agentId) {
+        return reply.send({
+          success: false,
+          error: "Conversation not found",
+        });
+      }
+
+      try {
+        const result = await browserStreamService.activateTab(
+          agentId,
+          conversationId,
+        );
+        return reply.send(result);
+      } catch (error) {
+        logger.error(
+          { error, conversationId },
+          "Failed to activate browser tab",
+        );
+        return reply.send({
+          success: false,
+          error:
+            error instanceof Error ? error.message : "Tab activation failed",
+        });
+      }
+    },
+  );
+
+  // Close tab for a conversation
+  fastify.delete(
+    "/api/browser-stream/:conversationId/tab",
+    {
+      schema: {
+        params: ConversationParamsSchema,
+        response: constructResponseSchema(
+          z.object({
+            success: z.boolean(),
+            error: z.string().optional(),
+          }),
+        ),
+      },
+    },
+    async (request, reply) => {
+      const { conversationId } = ConversationParamsSchema.parse(request.params);
+
+      const agentId = await getAgentIdFromConversation(
+        conversationId,
+        request.user.id,
+        request.organizationId,
+      );
+      if (!agentId) {
+        // No conversation means no tab to close
+        return reply.send({ success: true });
+      }
+
+      try {
+        const result = await browserStreamService.closeTab(
+          agentId,
+          conversationId,
+        );
+        return reply.send(result);
+      } catch (error) {
+        logger.error({ error, conversationId }, "Failed to close browser tab");
+        return reply.send({
+          success: false,
+          error: error instanceof Error ? error.message : "Tab close failed",
+        });
+      }
+    },
+  );
+};
+
+export default browserStreamRoutes;

--- a/platform/backend/src/routes/index.ts
+++ b/platform/backend/src/routes/index.ts
@@ -2,6 +2,7 @@ export { default as agentRoutes } from "./agent";
 export { default as agentToolRoutes } from "./agent-tool";
 export { default as authRoutes } from "./auth";
 export { default as autonomyPolicyRoutes } from "./autonomy-policies";
+export { default as browserStreamRoutes } from "./browser-stream";
 export { default as chatRoutes } from "./chat";
 export { default as chatSettingsRoutes } from "./chat-settings";
 export { default as dualLlmConfigRoutes } from "./dual-llm-config";

--- a/platform/backend/src/routes/proxy/anthropic.ts
+++ b/platform/backend/src/routes/proxy/anthropic.ts
@@ -354,6 +354,12 @@ const anthropicProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
         "Messages filtered after trusted data evaluation",
       );
 
+      // Always convert MCP images to Anthropic format (regardless of TOON setting)
+      filteredMessages =
+        utils.adapters.anthropic.convertMcpImagesToAnthropicFormat(
+          filteredMessages,
+        );
+
       // Determine if TOON compression should be applied
       let toonTokensBefore: number | null = null;
       let toonTokensAfter: number | null = null;

--- a/platform/backend/src/routes/proxy/utils/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/utils/adapters/anthropic.ts
@@ -185,6 +185,73 @@ export function toolCallsToCommon(
 }
 
 /**
+ * Check if content array contains image blocks from MCP
+ */
+function hasImageContent(
+  content: unknown,
+): content is Array<{ type: string; data?: string; mimeType?: string }> {
+  if (!Array.isArray(content)) return false;
+  return content.some(
+    (item) =>
+      typeof item === "object" &&
+      item !== null &&
+      "type" in item &&
+      item.type === "image",
+  );
+}
+
+/**
+ * Convert MCP content array to Anthropic tool_result content format
+ * Handles both text and image content blocks
+ */
+function convertMcpContentToAnthropic(
+  content: unknown,
+): string | Array<{ type: string; [key: string]: unknown }> {
+  if (!Array.isArray(content)) {
+    return JSON.stringify(content);
+  }
+
+  // Check if there are any image blocks
+  if (!hasImageContent(content)) {
+    // No images, just stringify
+    return JSON.stringify(content);
+  }
+
+  // Convert to Anthropic content blocks format
+  const anthropicContent: Array<{ type: string; [key: string]: unknown }> = [];
+
+  for (const item of content) {
+    if (typeof item !== "object" || item === null) continue;
+
+    if ("type" in item && item.type === "image" && "data" in item) {
+      // Convert MCP image to Anthropic image block
+      const mimeType =
+        "mimeType" in item && typeof item.mimeType === "string"
+          ? item.mimeType
+          : "image/png";
+      anthropicContent.push({
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: mimeType,
+          data: item.data,
+        },
+      });
+    } else if ("type" in item && item.type === "text" && "text" in item) {
+      // Keep text blocks
+      anthropicContent.push({
+        type: "text",
+        text: item.text,
+      });
+    }
+  }
+
+  return anthropicContent.length > 0
+    ? anthropicContent
+    : JSON.stringify(content);
+}
+
+/**
  * Convert common tool results to Anthropic user message with tool_result blocks
  */
 export function toolResultsToMessages(
@@ -195,7 +262,7 @@ export function toolResultsToMessages(
   content: Array<{
     type: "tool_result";
     tool_use_id: string;
-    content: string;
+    content: string | Array<{ type: string; [key: string]: unknown }>;
     is_error?: boolean;
   }>;
 }> {
@@ -207,9 +274,20 @@ export function toolResultsToMessages(
     {
       role: "user" as const,
       content: results.map((result) => {
-        let content: string;
+        let content: string | Array<{ type: string; [key: string]: unknown }>;
         if (result.isError) {
           content = `Error: ${result.error || "Tool execution failed"}`;
+        } else if (hasImageContent(result.content)) {
+          // Handle image content - convert to Anthropic format
+          content = convertMcpContentToAnthropic(result.content);
+          logger.info(
+            {
+              toolName: result.name,
+              toolCallId: result.id,
+              hasImages: true,
+            },
+            "Tool result contains images, converting to Anthropic image blocks",
+          );
         } else if (convertToToon) {
           const beforeJson = JSON.stringify(result.content);
           const afterToon = toonEncode(result.content);
@@ -249,6 +327,79 @@ export function toolResultsToMessages(
       }),
     },
   ];
+}
+
+/**
+ * Convert MCP image blocks to Anthropic image format in tool results
+ * This should be called unconditionally to ensure images are properly formatted
+ *
+ * Note: We use type assertions here because the Anthropic SDK types don't include
+ * image blocks in tool_result content, but the API actually accepts them.
+ */
+export function convertMcpImagesToAnthropicFormat(
+  messages: AnthropicMessages,
+): AnthropicMessages {
+  // biome-ignore lint/suspicious/noExplicitAny: Anthropic types don't include image blocks in tool_result content
+  return messages.map((message: any) => {
+    // Only process user messages with content arrays that contain tool_result blocks
+    if (message.role === "user" && Array.isArray(message.content)) {
+      // biome-ignore lint/suspicious/noExplicitAny: Anthropic types don't include image blocks in tool_result content
+      const updatedContent = message.content.map((contentBlock: any) => {
+        if (contentBlock.type === "tool_result" && !contentBlock.is_error) {
+          // Handle array content (content blocks format from MCP)
+          if (Array.isArray(contentBlock.content)) {
+            // biome-ignore lint/suspicious/noExplicitAny: Anthropic types don't include image blocks in tool_result content
+            const updatedBlocks = contentBlock.content.map((block: any) => {
+              // Convert MCP image blocks to Anthropic image format
+              // MCP format: {type: "image", data: "...", mimeType: "..."}
+              // Anthropic format: {type: "image", source: {type: "base64", media_type: "...", data: "..."}}
+              if (
+                typeof block === "object" &&
+                block !== null &&
+                block.type === "image" &&
+                typeof block.data === "string"
+              ) {
+                const mimeType =
+                  typeof block.mimeType === "string"
+                    ? block.mimeType
+                    : "image/png";
+                logger.info(
+                  {
+                    toolCallId: contentBlock.tool_use_id,
+                    mimeType,
+                    dataLength: block.data.length,
+                  },
+                  "Converting MCP image block to Anthropic image format",
+                );
+                return {
+                  type: "image",
+                  source: {
+                    type: "base64",
+                    media_type: mimeType,
+                    data: block.data,
+                  },
+                };
+              }
+              return block;
+            });
+
+            return {
+              ...contentBlock,
+              content: updatedBlocks,
+            };
+          }
+        }
+        return contentBlock;
+      });
+
+      return {
+        ...message,
+        content: updatedContent,
+      };
+    }
+
+    return message;
+  }) as AnthropicMessages;
 }
 
 /**
@@ -344,6 +495,7 @@ export async function convertToolResultsToToon(
           }
 
           // Handle array content (content blocks format)
+          // Note: Image conversion is already handled by convertMcpImagesToAnthropicFormat
           if (Array.isArray(contentBlock.content)) {
             const updatedBlocks = contentBlock.content.map((block) => {
               if (block.type === "text" && typeof block.text === "string") {

--- a/platform/backend/src/services/browser-stream.ts
+++ b/platform/backend/src/services/browser-stream.ts
@@ -1,0 +1,1160 @@
+import { getChatMcpClient } from "@/clients/chat-mcp-client";
+import logger from "@/logging";
+import { ToolModel } from "@/models";
+
+interface AvailabilityResult {
+  available: boolean;
+  tools?: string[];
+  error?: string;
+}
+
+interface NavigateResult {
+  success: boolean;
+  url?: string;
+  error?: string;
+}
+
+interface ScreenshotResult {
+  screenshot?: string;
+  url?: string;
+  error?: string;
+}
+
+interface TabResult {
+  success: boolean;
+  tabIndex?: number;
+  tabs?: Array<{ index: number; title?: string; url?: string }>;
+  error?: string;
+}
+
+interface ClickResult {
+  success: boolean;
+  error?: string;
+}
+
+interface TypeResult {
+  success: boolean;
+  error?: string;
+}
+
+interface ScrollResult {
+  success: boolean;
+  error?: string;
+}
+
+interface SnapshotResult {
+  snapshot?: string;
+  error?: string;
+}
+
+/**
+ * Maps conversationId to browser tab index
+ * Each conversation gets its own browser tab
+ */
+const conversationTabMap = new Map<string, number>();
+
+/**
+ * Service for browser streaming via Playwright MCP
+ * Calls Playwright MCP tools directly through the MCP Gateway
+ */
+export class BrowserStreamService {
+  /**
+   * Check if Playwright MCP browser tools are available for an agent
+   */
+  async checkAvailability(agentId: string): Promise<AvailabilityResult> {
+    const tools = await ToolModel.getMcpToolsByAgent(agentId);
+    const browserTools = tools.filter(
+      (t: { name: string }) =>
+        t.name.includes("playwright") || t.name.startsWith("browser_"),
+    );
+
+    return {
+      available: browserTools.length > 0,
+      tools: browserTools.map((t: { name: string }) => t.name),
+    };
+  }
+
+  /**
+   * Find the Playwright browser navigate tool for an agent
+   */
+  private async findNavigateTool(agentId: string): Promise<string | null> {
+    const tools = await ToolModel.getMcpToolsByAgent(agentId);
+    const navigateTool = tools.find(
+      (t: { name: string }) =>
+        t.name.includes("browser_navigate") ||
+        t.name.endsWith("__navigate") ||
+        (t.name.includes("playwright") && t.name.includes("navigate")),
+    );
+    return navigateTool?.name ?? null;
+  }
+
+  /**
+   * Find the Playwright browser screenshot tool for an agent
+   */
+  private async findScreenshotTool(agentId: string): Promise<string | null> {
+    const tools = await ToolModel.getMcpToolsByAgent(agentId);
+    // Prefer browser_take_screenshot, fallback to browser_snapshot
+    const screenshotTool = tools.find(
+      (t: { name: string }) =>
+        t.name.includes("browser_take_screenshot") ||
+        t.name.includes("browser_screenshot"),
+    );
+    if (screenshotTool) return screenshotTool.name;
+
+    const snapshotTool = tools.find((t: { name: string }) =>
+      t.name.includes("browser_snapshot"),
+    );
+    return snapshotTool?.name ?? null;
+  }
+
+  /**
+   * Find the Playwright browser tabs tool for an agent
+   */
+  private async findTabsTool(agentId: string): Promise<string | null> {
+    const tools = await ToolModel.getMcpToolsByAgent(agentId);
+    const tabsTool = tools.find((t: { name: string }) =>
+      t.name.includes("browser_tabs"),
+    );
+    return tabsTool?.name ?? null;
+  }
+
+  /**
+   * Select or create a browser tab by index
+   * Uses Playwright MCP browser_tabs tool
+   */
+  async selectOrCreateTab(
+    agentId: string,
+    tabIndex: number,
+  ): Promise<TabResult> {
+    const tabsTool = await this.findTabsTool(agentId);
+    if (!tabsTool) {
+      logger.info(
+        { agentId, tabIndex },
+        "No browser_tabs tool available, using shared browser page",
+      );
+      return { success: true, tabIndex: 0 };
+    }
+
+    const client = await getChatMcpClient(agentId);
+    if (!client) {
+      return {
+        success: false,
+        error: "Failed to connect to MCP Gateway",
+      };
+    }
+
+    try {
+      logger.info({ agentId, tabIndex }, "Selecting/creating browser tab");
+
+      // First, list existing tabs (use "action" param like the old activateTab code)
+      const listResult = await client.callTool({
+        name: tabsTool,
+        arguments: { action: "list" },
+      });
+
+      if (listResult.isError) {
+        const errorText = this.extractTextContent(listResult.content);
+        logger.warn(
+          { agentId, error: errorText },
+          "Failed to list tabs, using default page",
+        );
+        return { success: true, tabIndex: 0 };
+      }
+
+      const tabsList = this.parseTabsList(listResult.content);
+      const existingCount = tabsList.length;
+
+      logger.info({ agentId, existingCount, tabIndex }, "Current tabs count");
+
+      // Create tabs until we have enough
+      for (let i = existingCount; i <= tabIndex; i++) {
+        logger.info(
+          { agentId, creatingTabIndex: i },
+          "Creating new browser tab",
+        );
+        const createResult = await client.callTool({
+          name: tabsTool,
+          arguments: { action: "new" },
+        });
+        if (createResult.isError) {
+          logger.warn({ agentId, i }, "Failed to create tab, stopping");
+          break;
+        }
+      }
+
+      // Select the target tab
+      const selectResult = await client.callTool({
+        name: tabsTool,
+        arguments: { action: "select", index: tabIndex },
+      });
+
+      if (selectResult.isError) {
+        const errorText = this.extractTextContent(selectResult.content);
+        logger.warn(
+          { agentId, tabIndex, error: errorText },
+          "Failed to select tab, using default",
+        );
+        // Don't fail - just use whatever tab is active
+        return { success: true, tabIndex: 0 };
+      }
+
+      return { success: true, tabIndex };
+    } catch (error) {
+      logger.error({ error, agentId, tabIndex }, "Tab select/create failed");
+      // Don't fail - just use whatever tab is active
+      return { success: true, tabIndex: 0 };
+    }
+  }
+
+  /**
+   * Find the Playwright browser click tool for an agent
+   */
+  private async findClickTool(agentId: string): Promise<string | null> {
+    const tools = await ToolModel.getMcpToolsByAgent(agentId);
+    const clickTool = tools.find((t: { name: string }) =>
+      t.name.includes("browser_click"),
+    );
+    return clickTool?.name ?? null;
+  }
+
+  /**
+   * Find the Playwright browser type tool for an agent
+   */
+  private async findTypeTool(agentId: string): Promise<string | null> {
+    const tools = await ToolModel.getMcpToolsByAgent(agentId);
+    const typeTool = tools.find((t: { name: string }) =>
+      t.name.includes("browser_type"),
+    );
+    return typeTool?.name ?? null;
+  }
+
+  /**
+   * Find the Playwright browser press key tool for an agent
+   */
+  private async findPressKeyTool(agentId: string): Promise<string | null> {
+    const tools = await ToolModel.getMcpToolsByAgent(agentId);
+    const pressKeyTool = tools.find((t: { name: string }) =>
+      t.name.includes("browser_press_key"),
+    );
+    return pressKeyTool?.name ?? null;
+  }
+
+  /**
+   * Find the Playwright browser navigate back tool for an agent
+   */
+  private async findNavigateBackTool(agentId: string): Promise<string | null> {
+    const tools = await ToolModel.getMcpToolsByAgent(agentId);
+    const navigateBackTool = tools.find((t: { name: string }) =>
+      t.name.includes("browser_navigate_back"),
+    );
+    return navigateBackTool?.name ?? null;
+  }
+
+  /**
+   * Find the Playwright browser snapshot tool for an agent
+   */
+  private async findSnapshotTool(agentId: string): Promise<string | null> {
+    const tools = await ToolModel.getMcpToolsByAgent(agentId);
+    const snapshotTool = tools.find((t: { name: string }) =>
+      t.name.includes("browser_snapshot"),
+    );
+    return snapshotTool?.name ?? null;
+  }
+
+  /**
+   * Navigate browser to a URL in a conversation's tab
+   */
+  async navigate(
+    agentId: string,
+    _conversationId: string,
+    url: string,
+  ): Promise<NavigateResult> {
+    // Note: Tab is already selected during subscription via selectOrCreateTab
+    // Do NOT call activateTab here as it creates a new blank tab
+
+    const toolName = await this.findNavigateTool(agentId);
+    if (!toolName) {
+      return {
+        success: false,
+        error: "No browser navigate tool available for this agent",
+      };
+    }
+
+    const client = await getChatMcpClient(agentId);
+    if (!client) {
+      return {
+        success: false,
+        error: "Failed to connect to MCP Gateway",
+      };
+    }
+
+    try {
+      logger.info({ agentId, toolName, url }, "Navigating browser via MCP");
+
+      const result = await client.callTool({
+        name: toolName,
+        arguments: { url },
+      });
+
+      if (result.isError) {
+        const errorText = this.extractTextContent(result.content);
+        return {
+          success: false,
+          error: errorText || "Navigation failed",
+        };
+      }
+
+      return {
+        success: true,
+        url,
+      };
+    } catch (error) {
+      logger.error({ error, agentId, url }, "Browser navigation failed");
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Navigation failed",
+      };
+    }
+  }
+
+  /**
+   * Navigate browser back to the previous page
+   */
+  async navigateBack(
+    agentId: string,
+    _conversationId: string,
+  ): Promise<NavigateResult> {
+    // Note: Tab is already selected during subscription via selectOrCreateTab
+    // Do NOT call activateTab here as it creates a new blank tab
+
+    const toolName = await this.findNavigateBackTool(agentId);
+    if (!toolName) {
+      return {
+        success: false,
+        error: "No browser navigate back tool available for this agent",
+      };
+    }
+
+    const client = await getChatMcpClient(agentId);
+    if (!client) {
+      return {
+        success: false,
+        error: "Failed to connect to MCP Gateway",
+      };
+    }
+
+    try {
+      logger.info({ agentId, toolName }, "Navigating browser back via MCP");
+
+      const result = await client.callTool({
+        name: toolName,
+        arguments: {},
+      });
+
+      if (result.isError) {
+        const errorText = this.extractTextContent(result.content);
+        return {
+          success: false,
+          error: errorText || "Navigate back failed",
+        };
+      }
+
+      return {
+        success: true,
+      };
+    } catch (error) {
+      logger.error({ error, agentId }, "Browser navigate back failed");
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Navigate back failed",
+      };
+    }
+  }
+
+  /**
+   * Activate a conversation's browser tab (create if doesn't exist, select if exists)
+   * Called when user switches to a chat with browser panel open
+   */
+  async activateTab(
+    agentId: string,
+    conversationId: string,
+  ): Promise<TabResult> {
+    const tabsTool = await this.findTabsTool(agentId);
+    if (!tabsTool) {
+      return {
+        success: false,
+        error: "No browser tabs tool available for this agent",
+      };
+    }
+
+    const client = await getChatMcpClient(agentId);
+    if (!client) {
+      return {
+        success: false,
+        error: "Failed to connect to MCP Gateway",
+      };
+    }
+
+    try {
+      // Check if this conversation already has a tab
+      const existingTabIndex = conversationTabMap.get(conversationId);
+
+      if (existingTabIndex !== undefined) {
+        // Select existing tab
+        logger.info(
+          { agentId, conversationId, tabIndex: existingTabIndex },
+          "Selecting existing browser tab for conversation",
+        );
+
+        const result = await client.callTool({
+          name: tabsTool,
+          arguments: { action: "select", index: existingTabIndex },
+        });
+
+        if (result.isError) {
+          // Tab might have been closed, create a new one
+          logger.warn(
+            { agentId, conversationId, tabIndex: existingTabIndex },
+            "Failed to select tab, creating new one",
+          );
+          conversationTabMap.delete(conversationId);
+          return this.createNewTab(client, tabsTool, agentId, conversationId);
+        }
+
+        return {
+          success: true,
+          tabIndex: existingTabIndex,
+        };
+      }
+
+      // Create new tab for this conversation
+      return this.createNewTab(client, tabsTool, agentId, conversationId);
+    } catch (error) {
+      logger.error({ error, agentId, conversationId }, "Tab activation failed");
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Tab activation failed",
+      };
+    }
+  }
+
+  /**
+   * Create a new browser tab for a conversation
+   */
+  private async createNewTab(
+    client: Awaited<ReturnType<typeof getChatMcpClient>>,
+    tabsTool: string,
+    agentId: string,
+    conversationId: string,
+  ): Promise<TabResult> {
+    if (!client) {
+      return { success: false, error: "No MCP client" };
+    }
+
+    logger.info(
+      { agentId, conversationId },
+      "Creating new browser tab for conversation",
+    );
+
+    const result = await client.callTool({
+      name: tabsTool,
+      arguments: { action: "new" },
+    });
+
+    if (result.isError) {
+      const errorText = this.extractTextContent(result.content);
+      return {
+        success: false,
+        error: errorText || "Failed to create tab",
+      };
+    }
+
+    // Parse the result to get the new tab index
+    const textContent = this.extractTextContent(result.content);
+    const tabIndex = this.parseTabIndex(textContent);
+
+    if (tabIndex !== undefined) {
+      conversationTabMap.set(conversationId, tabIndex);
+    }
+
+    return {
+      success: true,
+      tabIndex,
+    };
+  }
+
+  /**
+   * List all browser tabs
+   */
+  async listTabs(agentId: string): Promise<TabResult> {
+    const tabsTool = await this.findTabsTool(agentId);
+    if (!tabsTool) {
+      return {
+        success: false,
+        error: "No browser tabs tool available",
+      };
+    }
+
+    const client = await getChatMcpClient(agentId);
+    if (!client) {
+      return {
+        success: false,
+        error: "Failed to connect to MCP Gateway",
+      };
+    }
+
+    try {
+      const result = await client.callTool({
+        name: tabsTool,
+        arguments: { action: "list" },
+      });
+
+      if (result.isError) {
+        const errorText = this.extractTextContent(result.content);
+        return {
+          success: false,
+          error: errorText || "Failed to list tabs",
+        };
+      }
+
+      return {
+        success: true,
+        tabs: this.parseTabsList(result.content),
+      };
+    } catch (error) {
+      logger.error({ error, agentId }, "Failed to list tabs");
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to list tabs",
+      };
+    }
+  }
+
+  /**
+   * Close a conversation's browser tab
+   */
+  async closeTab(agentId: string, conversationId: string): Promise<TabResult> {
+    const tabIndex = conversationTabMap.get(conversationId);
+    if (tabIndex === undefined) {
+      return { success: true }; // No tab to close
+    }
+
+    const tabsTool = await this.findTabsTool(agentId);
+    if (!tabsTool) {
+      conversationTabMap.delete(conversationId);
+      return { success: true };
+    }
+
+    const client = await getChatMcpClient(agentId);
+    if (!client) {
+      conversationTabMap.delete(conversationId);
+      return { success: true };
+    }
+
+    try {
+      await client.callTool({
+        name: tabsTool,
+        arguments: { action: "close", index: tabIndex },
+      });
+
+      conversationTabMap.delete(conversationId);
+
+      return { success: true };
+    } catch (error) {
+      logger.error({ error, agentId, conversationId }, "Failed to close tab");
+      conversationTabMap.delete(conversationId);
+      return { success: true }; // Consider success even if close fails
+    }
+  }
+
+  /**
+   * Parse tab index from tool response
+   */
+  private parseTabIndex(content: string): number | undefined {
+    // Try to find tab index in response like "Tab 2 created" or "index: 2"
+    const match = content.match(/(?:tab\s*|index[:\s]*)\s*(\d+)/i);
+    return match ? Number.parseInt(match[1], 10) : undefined;
+  }
+
+  /**
+   * Parse tabs list from tool response
+   */
+  private parseTabsList(
+    content: unknown,
+  ): Array<{ index: number; title?: string; url?: string }> {
+    const textContent = this.extractTextContent(content);
+    // This is a simplified parser - actual format depends on Playwright MCP
+    const tabs: Array<{ index: number; title?: string; url?: string }> = [];
+
+    // Try to parse JSON if content is JSON
+    try {
+      const parsed = JSON.parse(textContent);
+      if (Array.isArray(parsed)) {
+        return parsed;
+      }
+    } catch {
+      // Not JSON, try line-by-line parsing
+      const lines = textContent.split("\n");
+      for (const line of lines) {
+        const match = line.match(/(\d+)[:\s]+(.+)/);
+        if (match) {
+          tabs.push({
+            index: Number.parseInt(match[1], 10),
+            title: match[2].trim(),
+          });
+        }
+      }
+    }
+
+    return tabs;
+  }
+
+  /**
+   * Take a screenshot of a conversation's browser tab
+   * Note: Tab should already be selected via selectOrCreateTab when subscribing
+   */
+  async takeScreenshot(
+    agentId: string,
+    conversationId: string,
+  ): Promise<ScreenshotResult> {
+    const toolName = await this.findScreenshotTool(agentId);
+    if (!toolName) {
+      return {
+        error: "No browser screenshot tool available for this agent",
+      };
+    }
+
+    const client = await getChatMcpClient(agentId);
+    if (!client) {
+      return {
+        error: "Failed to connect to MCP Gateway",
+      };
+    }
+
+    try {
+      logger.info(
+        { agentId, conversationId, toolName },
+        "Taking browser screenshot via MCP",
+      );
+
+      const result = await client.callTool({
+        name: toolName,
+        arguments: {
+          type: "jpeg",
+        },
+      });
+
+      if (result.isError) {
+        const errorText = this.extractTextContent(result.content);
+        return {
+          error: errorText || "Screenshot failed",
+        };
+      }
+
+      // Extract screenshot from MCP response
+      // Playwright MCP returns screenshots as base64 images in content array
+      const screenshot = this.extractScreenshot(result.content);
+      const url = this.extractUrl(result.content);
+
+      return {
+        screenshot,
+        url,
+      };
+    } catch (error) {
+      logger.error({ error, agentId }, "Browser screenshot failed");
+      return {
+        error: error instanceof Error ? error.message : "Screenshot failed",
+      };
+    }
+  }
+
+  /**
+   * Extract text content from MCP response
+   */
+  private extractTextContent(content: unknown): string {
+    if (!Array.isArray(content)) return "";
+
+    return content
+      .filter(
+        (item): item is { type: string; text: string } =>
+          typeof item === "object" &&
+          item !== null &&
+          "type" in item &&
+          item.type === "text" &&
+          "text" in item,
+      )
+      .map((item) => item.text)
+      .join("\n");
+  }
+
+  /**
+   * Extract screenshot (base64 image) from MCP response
+   */
+  private extractScreenshot(content: unknown): string | undefined {
+    if (!Array.isArray(content)) return undefined;
+
+    // Look for image content
+    for (const item of content) {
+      if (
+        typeof item === "object" &&
+        item !== null &&
+        "type" in item &&
+        item.type === "image" &&
+        "data" in item
+      ) {
+        // Return as data URL
+        const mimeType =
+          "mimeType" in item ? (item.mimeType as string) : "image/png";
+        return `data:${mimeType};base64,${item.data}`;
+      }
+    }
+
+    // Some tools might return base64 in text content
+    const textContent = this.extractTextContent(content);
+    if (textContent.startsWith("data:image")) {
+      return textContent;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Extract URL from MCP response (if available)
+   */
+  private extractUrl(content: unknown): string | undefined {
+    const textContent = this.extractTextContent(content);
+    // Try to find URL in the response - matches http://, https://, or about:
+    const urlMatch = textContent.match(
+      /(?:https?|about):\/\/[^\s)]+|about:[^\s)]+/,
+    );
+    return urlMatch?.[0];
+  }
+
+  /**
+   * Get current page URL using browser_evaluate
+   */
+  async getCurrentUrl(agentId: string): Promise<string | undefined> {
+    const evaluateTool = await this.findEvaluateTool(agentId);
+    if (!evaluateTool) {
+      return undefined;
+    }
+
+    const client = await getChatMcpClient(agentId);
+    if (!client) {
+      return undefined;
+    }
+
+    try {
+      const result = await client.callTool({
+        name: evaluateTool,
+        arguments: { expression: "window.location.href" },
+      });
+
+      if (result.isError) {
+        return undefined;
+      }
+
+      const textContent = this.extractTextContent(result.content);
+      // The result might be quoted or contain extra text
+      const urlMatch = textContent.match(
+        /(?:https?|about):\/\/[^\s"')]+|about:[^\s"')]+/,
+      );
+      return urlMatch?.[0];
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Find the Playwright browser run_code tool for an agent
+   * This tool allows running arbitrary Playwright code including mouse operations
+   */
+  private async findRunCodeTool(agentId: string): Promise<string | null> {
+    const tools = await ToolModel.getMcpToolsByAgent(agentId);
+    const runCodeTool = tools.find((t: { name: string }) =>
+      t.name.includes("browser_run_code"),
+    );
+    return runCodeTool?.name ?? null;
+  }
+
+  /**
+   * Find the Playwright browser evaluate tool for an agent
+   * This tool allows running JavaScript in the browser context
+   */
+  private async findEvaluateTool(agentId: string): Promise<string | null> {
+    const tools = await ToolModel.getMcpToolsByAgent(agentId);
+    const evaluateTool = tools.find((t: { name: string }) =>
+      t.name.includes("browser_evaluate"),
+    );
+    return evaluateTool?.name ?? null;
+  }
+
+  /**
+   * Click on an element using element ref from snapshot OR coordinates
+   * For coordinates, uses browser_run_code to perform Playwright mouse.click()
+   * Falls back to browser_evaluate for JavaScript-based click simulation
+   * @param agentId - Agent ID
+   * @param conversationId - Conversation ID
+   * @param element - Element reference (e.g., "e123") or selector
+   * @param x - X coordinate for click (optional)
+   * @param y - Y coordinate for click (optional)
+   */
+  async click(
+    agentId: string,
+    conversationId: string,
+    element?: string,
+    x?: number,
+    y?: number,
+  ): Promise<ClickResult> {
+    // Note: Tab is already selected during subscription via selectOrCreateTab
+    // Do NOT call activateTab here as it creates a new blank tab
+
+    const client = await getChatMcpClient(agentId);
+    if (!client) {
+      return {
+        success: false,
+        error: "Failed to connect to MCP Gateway",
+      };
+    }
+
+    try {
+      if (x !== undefined && y !== undefined) {
+        // Try browser_run_code first (Playwright native mouse click)
+        const runCodeTool = await this.findRunCodeTool(agentId);
+        if (runCodeTool) {
+          logger.info(
+            { agentId, conversationId, x, y },
+            "Clicking at coordinates via browser_run_code (Playwright mouse.click)",
+          );
+
+          // Use Playwright's page.mouse.click() for native coordinate click
+          const playwrightCode = `await page.mouse.click(${Math.round(
+            x,
+          )}, ${Math.round(y)});`;
+
+          const result = await client.callTool({
+            name: runCodeTool,
+            arguments: { code: playwrightCode },
+          });
+
+          if (!result.isError) {
+            return { success: true };
+          }
+
+          // Log error but try fallback
+          const errorText = this.extractTextContent(result.content);
+          logger.warn(
+            { agentId, error: errorText },
+            "browser_run_code failed, trying browser_evaluate fallback",
+          );
+        }
+
+        // Fallback: try browser_evaluate for JavaScript-based click
+        const evaluateTool = await this.findEvaluateTool(agentId);
+        if (evaluateTool) {
+          logger.info(
+            { agentId, conversationId, x, y },
+            "Clicking at coordinates via browser_evaluate (JavaScript)",
+          );
+
+          // Use JavaScript to find and click the element at coordinates
+          const script = `
+            (function() {
+              const x = ${Math.round(x)};
+              const y = ${Math.round(y)};
+              const element = document.elementFromPoint(x, y);
+              if (element) {
+                const events = ['mousedown', 'mouseup', 'click'];
+                events.forEach(eventType => {
+                  const event = new MouseEvent(eventType, {
+                    view: window,
+                    bubbles: true,
+                    cancelable: true,
+                    clientX: x,
+                    clientY: y
+                  });
+                  element.dispatchEvent(event);
+                });
+                return { success: true, element: element.tagName };
+              }
+              return { success: false, error: 'No element at coordinates' };
+            })()
+          `;
+
+          const result = await client.callTool({
+            name: evaluateTool,
+            arguments: { expression: script },
+          });
+
+          if (!result.isError) {
+            return { success: true };
+          }
+
+          const errorText = this.extractTextContent(result.content);
+          logger.warn(
+            { agentId, error: errorText },
+            "browser_evaluate also failed",
+          );
+        }
+
+        // No tool available or both failed
+        return {
+          success: false,
+          error:
+            "No browser_run_code or browser_evaluate tool available for coordinate clicks",
+        };
+      } else if (element) {
+        // Element ref-based click using browser_click
+        const toolName = await this.findClickTool(agentId);
+        if (!toolName) {
+          return {
+            success: false,
+            error: "No browser click tool available for this agent",
+          };
+        }
+
+        logger.info(
+          { agentId, conversationId, element },
+          "Clicking element via MCP",
+        );
+
+        const result = await client.callTool({
+          name: toolName,
+          arguments: { element, ref: element },
+        });
+
+        if (result.isError) {
+          const errorText = this.extractTextContent(result.content);
+          return {
+            success: false,
+            error: errorText || "Click failed",
+          };
+        }
+
+        return { success: true };
+      } else {
+        return {
+          success: false,
+          error: "Either element ref or coordinates required",
+        };
+      }
+    } catch (error) {
+      logger.error({ error, agentId, element, x, y }, "Browser click failed");
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Click failed",
+      };
+    }
+  }
+
+  /**
+   * Type text into the currently focused element or specified element
+   * @param agentId - Agent ID
+   * @param conversationId - Conversation ID
+   * @param text - Text to type
+   * @param element - Optional element reference to focus first
+   */
+  async type(
+    agentId: string,
+    conversationId: string,
+    text: string,
+    element?: string,
+  ): Promise<TypeResult> {
+    // Note: Tab is already selected during subscription via selectOrCreateTab
+    // Do NOT call activateTab here as it creates a new blank tab
+
+    const client = await getChatMcpClient(agentId);
+    if (!client) {
+      return {
+        success: false,
+        error: "Failed to connect to MCP Gateway",
+      };
+    }
+
+    try {
+      // If no element specified, use page.keyboard.type() to type into focused element
+      if (!element) {
+        const runCodeTool = await this.findRunCodeTool(agentId);
+        if (runCodeTool) {
+          logger.info(
+            { agentId, conversationId, textLength: text.length },
+            "Typing text into focused element via browser_run_code",
+          );
+
+          // Escape text for JavaScript string
+          const escapedText = text
+            .replace(/\\/g, "\\\\")
+            .replace(/`/g, "\\`")
+            .replace(/\$/g, "\\$");
+          const playwrightCode = `await page.keyboard.type(\`${escapedText}\`);`;
+
+          const result = await client.callTool({
+            name: runCodeTool,
+            arguments: { code: playwrightCode },
+          });
+
+          if (!result.isError) {
+            return { success: true };
+          }
+
+          const errorText = this.extractTextContent(result.content);
+          logger.warn(
+            { agentId, error: errorText },
+            "browser_run_code type failed, trying browser_type",
+          );
+        }
+      }
+
+      // Fall back to browser_type tool (requires element ref)
+      const toolName = await this.findTypeTool(agentId);
+      if (!toolName) {
+        return {
+          success: false,
+          error: "No browser type tool available for this agent",
+        };
+      }
+
+      logger.info(
+        { agentId, conversationId, textLength: text.length, element },
+        "Typing text via browser_type MCP tool",
+      );
+
+      const args: Record<string, string> = { text };
+      if (element) {
+        args.element = element;
+        args.ref = element;
+      }
+
+      const result = await client.callTool({
+        name: toolName,
+        arguments: args,
+      });
+
+      if (result.isError) {
+        const errorText = this.extractTextContent(result.content);
+        return {
+          success: false,
+          error: errorText || "Type failed",
+        };
+      }
+
+      return { success: true };
+    } catch (error) {
+      logger.error({ error, agentId }, "Browser type failed");
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Type failed",
+      };
+    }
+  }
+
+  /**
+   * Press a key (for scrolling, enter, tab, etc.)
+   * @param agentId - Agent ID
+   * @param conversationId - Conversation ID
+   * @param key - Key to press (e.g., "Enter", "Tab", "ArrowDown", "PageDown")
+   */
+  async pressKey(
+    agentId: string,
+    conversationId: string,
+    key: string,
+  ): Promise<ScrollResult> {
+    // Note: Tab is already selected during subscription via selectOrCreateTab
+    // Do NOT call activateTab here as it creates a new blank tab
+
+    const toolName = await this.findPressKeyTool(agentId);
+    if (!toolName) {
+      return {
+        success: false,
+        error: "No browser press key tool available for this agent",
+      };
+    }
+
+    const client = await getChatMcpClient(agentId);
+    if (!client) {
+      return {
+        success: false,
+        error: "Failed to connect to MCP Gateway",
+      };
+    }
+
+    try {
+      logger.info({ agentId, conversationId, key }, "Pressing key via MCP");
+
+      const result = await client.callTool({
+        name: toolName,
+        arguments: { key },
+      });
+
+      if (result.isError) {
+        const errorText = this.extractTextContent(result.content);
+        return {
+          success: false,
+          error: errorText || "Key press failed",
+        };
+      }
+
+      return { success: true };
+    } catch (error) {
+      logger.error({ error, agentId, key }, "Browser key press failed");
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Key press failed",
+      };
+    }
+  }
+
+  /**
+   * Get accessibility snapshot of the page (shows clickable elements with refs)
+   * @param agentId - Agent ID
+   * @param conversationId - Conversation ID
+   */
+  async getSnapshot(
+    agentId: string,
+    conversationId: string,
+  ): Promise<SnapshotResult> {
+    // Note: Tab is already selected during subscription via selectOrCreateTab
+    // Do NOT call activateTab here as it creates a new blank tab
+
+    const toolName = await this.findSnapshotTool(agentId);
+    if (!toolName) {
+      return {
+        error: "No browser snapshot tool available for this agent",
+      };
+    }
+
+    const client = await getChatMcpClient(agentId);
+    if (!client) {
+      return {
+        error: "Failed to connect to MCP Gateway",
+      };
+    }
+
+    try {
+      logger.info(
+        { agentId, conversationId },
+        "Getting browser snapshot via MCP",
+      );
+
+      const result = await client.callTool({
+        name: toolName,
+        arguments: {},
+      });
+
+      if (result.isError) {
+        const errorText = this.extractTextContent(result.content);
+        return {
+          error: errorText || "Snapshot failed",
+        };
+      }
+
+      const snapshot = this.extractTextContent(result.content);
+      return { snapshot };
+    } catch (error) {
+      logger.error({ error, agentId }, "Browser snapshot failed");
+      return {
+        error: error instanceof Error ? error.message : "Snapshot failed",
+      };
+    }
+  }
+}

--- a/platform/backend/src/types/websocket.ts
+++ b/platform/backend/src/types/websocket.ts
@@ -5,14 +5,193 @@ import { z } from "zod";
  */
 const HelloWorldWebsocketPayloadSchema = z.object({});
 
+// Browser stream payloads
+const SubscribeBrowserStreamPayloadSchema = z.object({
+  conversationId: z.string().uuid(),
+  tabIndex: z.number().int().min(0), // Tab index based on chat position in list
+});
+
+const UnsubscribeBrowserStreamPayloadSchema = z.object({
+  conversationId: z.string().uuid(),
+});
+
+const BrowserNavigatePayloadSchema = z.object({
+  conversationId: z.string().uuid(),
+  url: z.string().url(),
+});
+
+const BrowserClickPayloadSchema = z.object({
+  conversationId: z.string().uuid(),
+  // Either element ref OR coordinates
+  element: z.string().optional(), // Element ref like "e123" from snapshot
+  x: z.number().optional(), // X coordinate for click
+  y: z.number().optional(), // Y coordinate for click
+});
+
+const BrowserTypePayloadSchema = z.object({
+  conversationId: z.string().uuid(),
+  text: z.string(),
+  element: z.string().optional(), // Optional element ref to focus first
+});
+
+const BrowserPressKeyPayloadSchema = z.object({
+  conversationId: z.string().uuid(),
+  key: z.string(), // Key name like "Enter", "Tab", "ArrowDown", "PageDown"
+});
+
+const BrowserGetSnapshotPayloadSchema = z.object({
+  conversationId: z.string().uuid(),
+});
+
+const BrowserNavigateBackPayloadSchema = z.object({
+  conversationId: z.string().uuid(),
+});
+
+const BrowserSetZoomPayloadSchema = z.object({
+  conversationId: z.string().uuid(),
+  zoomPercent: z.number().min(10).max(200), // Zoom percentage (10% to 200%)
+});
+
 /**
- * Discriminated union of all possible websocket messages
+ * Discriminated union of all possible websocket messages (client -> server)
  */
 export const WebSocketMessageSchema = z.discriminatedUnion("type", [
   z.object({
-    type: z.enum(["hello-world"]),
+    type: z.literal("hello-world"),
     payload: HelloWorldWebsocketPayloadSchema,
+  }),
+  z.object({
+    type: z.literal("subscribe_browser_stream"),
+    payload: SubscribeBrowserStreamPayloadSchema,
+  }),
+  z.object({
+    type: z.literal("unsubscribe_browser_stream"),
+    payload: UnsubscribeBrowserStreamPayloadSchema,
+  }),
+  z.object({
+    type: z.literal("browser_navigate"),
+    payload: BrowserNavigatePayloadSchema,
+  }),
+  z.object({
+    type: z.literal("browser_click"),
+    payload: BrowserClickPayloadSchema,
+  }),
+  z.object({
+    type: z.literal("browser_type"),
+    payload: BrowserTypePayloadSchema,
+  }),
+  z.object({
+    type: z.literal("browser_press_key"),
+    payload: BrowserPressKeyPayloadSchema,
+  }),
+  z.object({
+    type: z.literal("browser_get_snapshot"),
+    payload: BrowserGetSnapshotPayloadSchema,
+  }),
+  z.object({
+    type: z.literal("browser_navigate_back"),
+    payload: BrowserNavigateBackPayloadSchema,
+  }),
+  z.object({
+    type: z.literal("browser_set_zoom"),
+    payload: BrowserSetZoomPayloadSchema,
   }),
 ]);
 
 export type WebSocketMessage = z.infer<typeof WebSocketMessageSchema>;
+
+/**
+ * Server -> Client message types (not validated, just typed)
+ */
+export type BrowserScreenshotMessage = {
+  type: "browser_screenshot";
+  payload: {
+    conversationId: string;
+    screenshot: string;
+    url?: string;
+  };
+};
+
+export type BrowserNavigateResultMessage = {
+  type: "browser_navigate_result";
+  payload: {
+    conversationId: string;
+    success: boolean;
+    url?: string;
+    error?: string;
+  };
+};
+
+export type BrowserStreamErrorMessage = {
+  type: "browser_stream_error";
+  payload: {
+    conversationId: string;
+    error: string;
+  };
+};
+
+export type BrowserClickResultMessage = {
+  type: "browser_click_result";
+  payload: {
+    conversationId: string;
+    success: boolean;
+    error?: string;
+  };
+};
+
+export type BrowserTypeResultMessage = {
+  type: "browser_type_result";
+  payload: {
+    conversationId: string;
+    success: boolean;
+    error?: string;
+  };
+};
+
+export type BrowserPressKeyResultMessage = {
+  type: "browser_press_key_result";
+  payload: {
+    conversationId: string;
+    success: boolean;
+    error?: string;
+  };
+};
+
+export type BrowserSnapshotMessage = {
+  type: "browser_snapshot";
+  payload: {
+    conversationId: string;
+    snapshot?: string;
+    error?: string;
+  };
+};
+
+export type BrowserSetZoomResultMessage = {
+  type: "browser_set_zoom_result";
+  payload: {
+    conversationId: string;
+    success: boolean;
+    error?: string;
+  };
+};
+
+export type BrowserNavigateBackResultMessage = {
+  type: "browser_navigate_back_result";
+  payload: {
+    conversationId: string;
+    success: boolean;
+    error?: string;
+  };
+};
+
+export type ServerWebSocketMessage =
+  | BrowserScreenshotMessage
+  | BrowserNavigateResultMessage
+  | BrowserNavigateBackResultMessage
+  | BrowserStreamErrorMessage
+  | BrowserClickResultMessage
+  | BrowserTypeResultMessage
+  | BrowserPressKeyResultMessage
+  | BrowserSnapshotMessage
+  | BrowserSetZoomResultMessage
+  | { type: "error"; payload: { message: string } };

--- a/platform/backend/src/websocket.auth.test.ts
+++ b/platform/backend/src/websocket.auth.test.ts
@@ -1,0 +1,98 @@
+import type { IncomingMessage } from "node:http";
+import { WebSocket as WS } from "ws";
+import { betterAuth } from "@/auth";
+import type { BrowserStreamService } from "@/services/browser-stream";
+import { beforeEach, describe, expect, test, vi } from "@/test";
+import type { WebSocketMessage } from "@/types";
+import websocketService from "@/websocket";
+
+const service = websocketService as unknown as {
+  authenticateConnection: (
+    request: IncomingMessage,
+  ) => Promise<{ userId: string; organizationId: string } | null>;
+  handleMessage: (message: WebSocketMessage, ws: WS) => Promise<void>;
+  clientContexts: Map<WS, { userId: string; organizationId: string }>;
+  browserSubscriptions: Map<WS, unknown>;
+  browserService: BrowserStreamService;
+};
+
+describe("websocket browser-stream authorization", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    service.clientContexts.clear();
+    service.browserSubscriptions.clear();
+  });
+
+  test("authenticateConnection rejects unauthenticated requests", async () => {
+    vi.spyOn(betterAuth.api, "getSession").mockResolvedValue(null);
+    vi.spyOn(betterAuth.api, "verifyApiKey").mockResolvedValue({
+      valid: false,
+      error: null,
+      key: null,
+    });
+
+    const request = {
+      headers: {},
+      socket: { remoteAddress: "127.0.0.1" },
+    } as unknown as IncomingMessage;
+
+    const result = await service.authenticateConnection(request);
+
+    expect(result).toBeNull();
+  });
+
+  test("rejects browser stream subscription for conversations the user does not own", async ({
+    makeAgent,
+    makeConversation,
+    makeOrganization,
+    makeUser,
+  }) => {
+    const org = await makeOrganization();
+    const owner = await makeUser();
+    const otherUser = await makeUser();
+    const agent = await makeAgent();
+    const conversation = await makeConversation(agent.id, {
+      userId: owner.id,
+      organizationId: org.id,
+    });
+
+    const ws = {
+      readyState: WS.OPEN,
+      send: vi.fn(),
+      close: vi.fn(),
+    } as unknown as WS;
+
+    service.clientContexts.set(ws, {
+      userId: otherUser.id,
+      organizationId: org.id,
+    });
+
+    const selectSpy = vi
+      .spyOn(service.browserService, "selectOrCreateTab")
+      .mockResolvedValue({ success: true, tabIndex: 0 });
+    const screenshotSpy = vi
+      .spyOn(service.browserService, "takeScreenshot")
+      .mockResolvedValue({ screenshot: "img", url: "http://example.com" });
+
+    await service.handleMessage(
+      {
+        type: "subscribe_browser_stream",
+        payload: { conversationId: conversation.id, tabIndex: 0 },
+      },
+      ws,
+    );
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: "browser_stream_error",
+        payload: {
+          conversationId: conversation.id,
+          error: "Conversation not found",
+        },
+      }),
+    );
+    expect(service.browserSubscriptions.has(ws)).toBe(false);
+    expect(selectSpy).not.toHaveBeenCalled();
+    expect(screenshotSpy).not.toHaveBeenCalled();
+  });
+});

--- a/platform/backend/src/websocket.ts
+++ b/platform/backend/src/websocket.ts
@@ -1,12 +1,38 @@
-import type { Server } from "node:http";
+import type { IncomingMessage, Server } from "node:http";
 import type { WebSocket, WebSocketServer } from "ws";
 import { WebSocket as WS, WebSocketServer as WSS } from "ws";
+import { betterAuth } from "@/auth";
 import config from "@/config";
 import logger from "@/logging";
-import { type WebSocketMessage, WebSocketMessageSchema } from "@/types";
+import { ConversationModel, UserModel } from "@/models";
+import { BrowserStreamService } from "@/services/browser-stream";
+import {
+  type ServerWebSocketMessage,
+  type WebSocketMessage,
+  WebSocketMessageSchema,
+} from "@/types";
+
+const SCREENSHOT_INTERVAL_MS = 1000; // Stream at ~1 FPS
+
+interface BrowserStreamSubscription {
+  conversationId: string;
+  agentId: string;
+  tabIndex: number;
+  intervalId: NodeJS.Timeout;
+}
+
+interface WebSocketClientContext {
+  userId: string;
+  organizationId: string;
+}
 
 class WebSocketService {
   private wss: WebSocketServer | null = null;
+  private browserService = new BrowserStreamService();
+  // Track browser stream subscriptions per client
+  private browserSubscriptions: Map<WebSocket, BrowserStreamSubscription> =
+    new Map();
+  private clientContexts: Map<WebSocket, WebSocketClientContext> = new Map();
 
   /**
    * Start the WebSocket server
@@ -21,47 +47,75 @@ class WebSocketService {
 
     logger.info(`WebSocket server started on path ${path}`);
 
-    this.wss.on("connection", (ws: WebSocket) => {
-      logger.info(
-        `WebSocket client connected. Total connections: ${this.wss?.clients.size}`,
-      );
+    this.wss.on(
+      "connection",
+      async (ws: WebSocket, request: IncomingMessage) => {
+        const clientContext = await this.authenticateConnection(request);
 
-      ws.on("message", async (data) => {
-        try {
-          const message = JSON.parse(data.toString());
-          logger.info("Received WebSocket message:", message);
+        if (!clientContext) {
+          logger.warn(
+            {
+              clientAddress:
+                request.socket.remoteAddress ?? "unknown_websocket_client",
+            },
+            "Unauthorized WebSocket connection attempt",
+          );
+          this.sendUnauthorized(ws);
+          return;
+        }
 
-          // Validate the message against our schema
-          const validatedMessage = WebSocketMessageSchema.parse(message);
+        this.clientContexts.set(ws, clientContext);
 
-          // Handle different message types
-          await this.handleMessage(validatedMessage, ws);
-        } catch (error) {
-          logger.error({ error }, "Failed to parse WebSocket message");
+        logger.info(
+          {
+            connections: this.wss?.clients.size,
+            userId: clientContext.userId,
+            organizationId: clientContext.organizationId,
+          },
+          "WebSocket client connected",
+        );
 
-          // Send error back to client
-          ws.send(
-            JSON.stringify({
+        ws.on("message", async (data) => {
+          try {
+            const message = JSON.parse(data.toString());
+
+            // Validate the message against our schema
+            const validatedMessage = WebSocketMessageSchema.parse(message);
+
+            // Handle different message types
+            await this.handleMessage(validatedMessage, ws);
+          } catch (error) {
+            logger.error({ error }, "Failed to parse WebSocket message");
+
+            // Send error back to client
+            this.sendToClient(ws, {
               type: "error",
               payload: {
                 message:
                   error instanceof Error ? error.message : "Invalid message",
               },
-            }),
+            });
+          }
+        });
+
+        ws.on("close", () => {
+          // Clean up browser stream subscription
+          this.unsubscribeBrowserStream(ws);
+
+          logger.info(
+            `WebSocket client disconnected. Remaining connections: ${this.wss?.clients.size}`,
           );
-        }
-      });
+          this.clientContexts.delete(ws);
+        });
 
-      ws.on("close", () => {
-        logger.info(
-          `WebSocket client disconnected. Remaining connections: ${this.wss?.clients.size}`,
-        );
-      });
-
-      ws.on("error", (error) => {
-        logger.error({ error }, "WebSocket error");
-      });
-    });
+        ws.on("error", (error) => {
+          logger.error({ error }, "WebSocket error");
+          // Clean up browser stream subscription on error
+          this.unsubscribeBrowserStream(ws);
+          this.clientContexts.delete(ws);
+        });
+      },
+    );
 
     this.wss.on("error", (error) => {
       logger.error({ error }, "WebSocket server error");
@@ -73,18 +127,523 @@ class WebSocketService {
    */
   private async handleMessage(
     message: WebSocketMessage,
-    _ws: WebSocket,
+    ws: WebSocket,
   ): Promise<void> {
+    const clientContext = this.getClientContext(ws);
+    if (!clientContext) {
+      return;
+    }
+
     switch (message.type) {
+      case "hello-world":
+        logger.info("Received hello-world message");
+        break;
+
+      case "subscribe_browser_stream":
+        await this.handleSubscribeBrowserStream(
+          ws,
+          message.payload.conversationId,
+          message.payload.tabIndex,
+          clientContext,
+        );
+        break;
+
+      case "unsubscribe_browser_stream":
+        this.unsubscribeBrowserStream(ws);
+        break;
+
+      case "browser_navigate":
+        await this.handleBrowserNavigate(
+          ws,
+          message.payload.conversationId,
+          message.payload.url,
+        );
+        break;
+
+      case "browser_navigate_back":
+        await this.handleBrowserNavigateBack(
+          ws,
+          message.payload.conversationId,
+        );
+        break;
+
+      case "browser_click":
+        await this.handleBrowserClick(
+          ws,
+          message.payload.conversationId,
+          message.payload.element,
+          message.payload.x,
+          message.payload.y,
+        );
+        break;
+
+      case "browser_type":
+        await this.handleBrowserType(
+          ws,
+          message.payload.conversationId,
+          message.payload.text,
+          message.payload.element,
+        );
+        break;
+
+      case "browser_press_key":
+        await this.handleBrowserPressKey(
+          ws,
+          message.payload.conversationId,
+          message.payload.key,
+        );
+        break;
+
+      case "browser_get_snapshot":
+        await this.handleBrowserGetSnapshot(ws, message.payload.conversationId);
+        break;
+
       default:
         logger.warn({ message }, "Unknown WebSocket message type");
     }
   }
 
   /**
+   * Subscribe client to browser stream for a conversation
+   */
+  private async handleSubscribeBrowserStream(
+    ws: WebSocket,
+    conversationId: string,
+    tabIndex: number,
+    clientContext: WebSocketClientContext,
+  ): Promise<void> {
+    // Unsubscribe from any existing stream first
+    this.unsubscribeBrowserStream(ws);
+
+    // Get agentId from conversation with user/org scoping
+    const agentId = await ConversationModel.getAgentIdForUser(
+      conversationId,
+      clientContext.userId,
+      clientContext.organizationId,
+    );
+    if (!agentId) {
+      logger.warn(
+        {
+          conversationId,
+          userId: clientContext.userId,
+          organizationId: clientContext.organizationId,
+        },
+        "Unauthorized or missing conversation for browser stream",
+      );
+      this.sendToClient(ws, {
+        type: "browser_stream_error",
+        payload: {
+          conversationId,
+          error: "Conversation not found",
+        },
+      });
+      return;
+    }
+
+    logger.info(
+      { conversationId, agentId, tabIndex },
+      "Browser stream client subscribed",
+    );
+
+    // Select or create the tab for this chat index
+    const tabResult = await this.browserService.selectOrCreateTab(
+      agentId,
+      tabIndex,
+    );
+    if (!tabResult.success) {
+      logger.warn(
+        { conversationId, agentId, tabIndex, error: tabResult.error },
+        "Failed to select/create browser tab",
+      );
+      // Continue anyway - screenshot will work on current tab
+    }
+
+    // Send initial screenshot
+    this.sendScreenshot(ws, agentId, conversationId);
+
+    // Set up interval for continuous streaming
+    const intervalId = setInterval(() => {
+      if (ws.readyState === WS.OPEN) {
+        this.sendScreenshot(ws, agentId, conversationId);
+      } else {
+        this.unsubscribeBrowserStream(ws);
+      }
+    }, SCREENSHOT_INTERVAL_MS);
+
+    // Store subscription
+    this.browserSubscriptions.set(ws, {
+      conversationId,
+      agentId,
+      tabIndex,
+      intervalId,
+    });
+  }
+
+  /**
+   * Unsubscribe client from browser stream
+   */
+  private unsubscribeBrowserStream(ws: WebSocket): void {
+    const subscription = this.browserSubscriptions.get(ws);
+    if (subscription) {
+      clearInterval(subscription.intervalId);
+      this.browserSubscriptions.delete(ws);
+      logger.info(
+        { conversationId: subscription.conversationId },
+        "Browser stream client unsubscribed",
+      );
+    }
+  }
+
+  /**
+   * Handle browser navigation request
+   */
+  private async handleBrowserNavigate(
+    ws: WebSocket,
+    conversationId: string,
+    url: string,
+  ): Promise<void> {
+    const subscription = this.browserSubscriptions.get(ws);
+    if (!subscription || subscription.conversationId !== conversationId) {
+      this.sendToClient(ws, {
+        type: "browser_navigate_result",
+        payload: {
+          conversationId,
+          success: false,
+          error: "Not subscribed to this conversation's browser stream",
+        },
+      });
+      return;
+    }
+
+    try {
+      const result = await this.browserService.navigate(
+        subscription.agentId,
+        conversationId,
+        url,
+      );
+      this.sendToClient(ws, {
+        type: "browser_navigate_result",
+        payload: {
+          conversationId,
+          success: result.success,
+          url: result.url,
+          error: result.error,
+        },
+      });
+    } catch (error) {
+      logger.error({ error, conversationId, url }, "Browser navigation failed");
+      this.sendToClient(ws, {
+        type: "browser_navigate_result",
+        payload: {
+          conversationId,
+          success: false,
+          error: error instanceof Error ? error.message : "Navigation failed",
+        },
+      });
+    }
+  }
+
+  /**
+   * Handle browser navigate back request
+   */
+  private async handleBrowserNavigateBack(
+    ws: WebSocket,
+    conversationId: string,
+  ): Promise<void> {
+    const subscription = this.browserSubscriptions.get(ws);
+    if (!subscription || subscription.conversationId !== conversationId) {
+      this.sendToClient(ws, {
+        type: "browser_navigate_back_result",
+        payload: {
+          conversationId,
+          success: false,
+          error: "Not subscribed to this conversation's browser stream",
+        },
+      });
+      return;
+    }
+
+    try {
+      const result = await this.browserService.navigateBack(
+        subscription.agentId,
+        conversationId,
+      );
+      this.sendToClient(ws, {
+        type: "browser_navigate_back_result",
+        payload: {
+          conversationId,
+          success: result.success,
+          error: result.error,
+        },
+      });
+    } catch (error) {
+      logger.error({ error, conversationId }, "Browser navigate back failed");
+      this.sendToClient(ws, {
+        type: "browser_navigate_back_result",
+        payload: {
+          conversationId,
+          success: false,
+          error:
+            error instanceof Error ? error.message : "Navigate back failed",
+        },
+      });
+    }
+  }
+
+  /**
+   * Handle browser click request
+   */
+  private async handleBrowserClick(
+    ws: WebSocket,
+    conversationId: string,
+    element?: string,
+    x?: number,
+    y?: number,
+  ): Promise<void> {
+    const subscription = this.browserSubscriptions.get(ws);
+    if (!subscription || subscription.conversationId !== conversationId) {
+      this.sendToClient(ws, {
+        type: "browser_click_result",
+        payload: {
+          conversationId,
+          success: false,
+          error: "Not subscribed to this conversation's browser stream",
+        },
+      });
+      return;
+    }
+
+    try {
+      const result = await this.browserService.click(
+        subscription.agentId,
+        conversationId,
+        element,
+        x,
+        y,
+      );
+      this.sendToClient(ws, {
+        type: "browser_click_result",
+        payload: {
+          conversationId,
+          success: result.success,
+          error: result.error,
+        },
+      });
+    } catch (error) {
+      logger.error(
+        { error, conversationId, element, x, y },
+        "Browser click failed",
+      );
+      this.sendToClient(ws, {
+        type: "browser_click_result",
+        payload: {
+          conversationId,
+          success: false,
+          error: error instanceof Error ? error.message : "Click failed",
+        },
+      });
+    }
+  }
+
+  /**
+   * Handle browser type request
+   */
+  private async handleBrowserType(
+    ws: WebSocket,
+    conversationId: string,
+    text: string,
+    element?: string,
+  ): Promise<void> {
+    const subscription = this.browserSubscriptions.get(ws);
+    if (!subscription || subscription.conversationId !== conversationId) {
+      this.sendToClient(ws, {
+        type: "browser_type_result",
+        payload: {
+          conversationId,
+          success: false,
+          error: "Not subscribed to this conversation's browser stream",
+        },
+      });
+      return;
+    }
+
+    try {
+      const result = await this.browserService.type(
+        subscription.agentId,
+        conversationId,
+        text,
+        element,
+      );
+      this.sendToClient(ws, {
+        type: "browser_type_result",
+        payload: {
+          conversationId,
+          success: result.success,
+          error: result.error,
+        },
+      });
+    } catch (error) {
+      logger.error({ error, conversationId }, "Browser type failed");
+      this.sendToClient(ws, {
+        type: "browser_type_result",
+        payload: {
+          conversationId,
+          success: false,
+          error: error instanceof Error ? error.message : "Type failed",
+        },
+      });
+    }
+  }
+
+  /**
+   * Handle browser press key request
+   */
+  private async handleBrowserPressKey(
+    ws: WebSocket,
+    conversationId: string,
+    key: string,
+  ): Promise<void> {
+    const subscription = this.browserSubscriptions.get(ws);
+    if (!subscription || subscription.conversationId !== conversationId) {
+      this.sendToClient(ws, {
+        type: "browser_press_key_result",
+        payload: {
+          conversationId,
+          success: false,
+          error: "Not subscribed to this conversation's browser stream",
+        },
+      });
+      return;
+    }
+
+    try {
+      const result = await this.browserService.pressKey(
+        subscription.agentId,
+        conversationId,
+        key,
+      );
+      this.sendToClient(ws, {
+        type: "browser_press_key_result",
+        payload: {
+          conversationId,
+          success: result.success,
+          error: result.error,
+        },
+      });
+    } catch (error) {
+      logger.error({ error, conversationId, key }, "Browser press key failed");
+      this.sendToClient(ws, {
+        type: "browser_press_key_result",
+        payload: {
+          conversationId,
+          success: false,
+          error: error instanceof Error ? error.message : "Press key failed",
+        },
+      });
+    }
+  }
+
+  /**
+   * Handle browser get snapshot request
+   */
+  private async handleBrowserGetSnapshot(
+    ws: WebSocket,
+    conversationId: string,
+  ): Promise<void> {
+    const subscription = this.browserSubscriptions.get(ws);
+    if (!subscription || subscription.conversationId !== conversationId) {
+      this.sendToClient(ws, {
+        type: "browser_snapshot",
+        payload: {
+          conversationId,
+          error: "Not subscribed to this conversation's browser stream",
+        },
+      });
+      return;
+    }
+
+    try {
+      const result = await this.browserService.getSnapshot(
+        subscription.agentId,
+        conversationId,
+      );
+      this.sendToClient(ws, {
+        type: "browser_snapshot",
+        payload: {
+          conversationId,
+          snapshot: result.snapshot,
+          error: result.error,
+        },
+      });
+    } catch (error) {
+      logger.error({ error, conversationId }, "Browser get snapshot failed");
+      this.sendToClient(ws, {
+        type: "browser_snapshot",
+        payload: {
+          conversationId,
+          error: error instanceof Error ? error.message : "Snapshot failed",
+        },
+      });
+    }
+  }
+
+  /**
+   * Take and send a screenshot to a client
+   */
+  private async sendScreenshot(
+    ws: WebSocket,
+    agentId: string,
+    conversationId: string,
+  ): Promise<void> {
+    if (ws.readyState !== WS.OPEN) {
+      return;
+    }
+
+    try {
+      const result = await this.browserService.takeScreenshot(
+        agentId,
+        conversationId,
+      );
+
+      if (result.screenshot) {
+        this.sendToClient(ws, {
+          type: "browser_screenshot",
+          payload: {
+            conversationId,
+            screenshot: result.screenshot,
+            url: result.url,
+          },
+        });
+      } else if (result.error) {
+        this.sendToClient(ws, {
+          type: "browser_stream_error",
+          payload: {
+            conversationId,
+            error: result.error,
+          },
+        });
+      }
+    } catch (error) {
+      logger.error(
+        { error, conversationId },
+        "Error taking screenshot for stream",
+      );
+    }
+  }
+
+  /**
+   * Send a message to a specific client
+   */
+  private sendToClient(ws: WebSocket, message: ServerWebSocketMessage): void {
+    if (ws.readyState === WS.OPEN) {
+      ws.send(JSON.stringify(message));
+    }
+  }
+
+  /**
    * Broadcast a message to all connected clients
    */
-  broadcast(message: WebSocketMessage) {
+  broadcast(message: ServerWebSocketMessage) {
     if (!this.wss) {
       logger.warn("WebSocket server not initialized");
       return;
@@ -117,7 +676,7 @@ class WebSocketService {
    * Send a message to specific clients (filtered by a predicate)
    */
   sendToClients(
-    message: WebSocketMessage,
+    message: ServerWebSocketMessage,
     filter?: (client: WebSocket) => boolean,
   ) {
     if (!this.wss) {
@@ -145,6 +704,13 @@ class WebSocketService {
    * Stop the WebSocket server
    */
   stop() {
+    // Clear all browser stream subscriptions
+    for (const [ws, subscription] of this.browserSubscriptions) {
+      clearInterval(subscription.intervalId);
+      this.browserSubscriptions.delete(ws);
+    }
+    this.clientContexts.clear();
+
     if (this.wss) {
       this.wss.clients.forEach((client) => {
         client.close();
@@ -162,6 +728,69 @@ class WebSocketService {
    */
   getClientCount(): number {
     return this.wss?.clients.size ?? 0;
+  }
+
+  /**
+   * Authenticate websocket connections using the same auth mechanisms as HTTP routes.
+   */
+  private async authenticateConnection(
+    request: IncomingMessage,
+  ): Promise<WebSocketClientContext | null> {
+    const headers = new Headers(request.headers as HeadersInit);
+
+    try {
+      const session = await betterAuth.api.getSession({
+        headers,
+        query: { disableCookieCache: true },
+      });
+
+      if (session?.user?.id) {
+        const { organizationId, ...user } = await UserModel.getById(
+          session.user.id,
+        );
+        return { userId: user.id, organizationId };
+      }
+    } catch (_sessionError) {
+      // Fall through to API key verification
+    }
+
+    const authHeader = headers.get("authorization");
+    if (authHeader) {
+      try {
+        const apiKeyResult = await betterAuth.api.verifyApiKey({
+          body: { key: authHeader },
+        });
+
+        if (apiKeyResult?.valid && apiKeyResult.key?.userId) {
+          const { organizationId, ...user } = await UserModel.getById(
+            apiKeyResult.key.userId,
+          );
+          return { userId: user.id, organizationId };
+        }
+      } catch (_apiKeyError) {
+        return null;
+      }
+    }
+
+    return null;
+  }
+
+  private getClientContext(ws: WebSocket): WebSocketClientContext | null {
+    const context = this.clientContexts.get(ws);
+    if (!context) {
+      this.sendUnauthorized(ws);
+      return null;
+    }
+
+    return context;
+  }
+
+  private sendUnauthorized(ws: WebSocket): void {
+    this.sendToClient(ws, {
+      type: "error",
+      payload: { message: "Unauthorized" },
+    });
+    ws.close(4401, "Unauthorized");
   }
 }
 

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { UIMessage } from "@ai-sdk/react";
-import { Eye, EyeOff, Plus } from "lucide-react";
+import { Eye, EyeOff, Globe, Plus } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
@@ -21,6 +21,7 @@ import {
   PromptInputToolbar,
   PromptInputTools,
 } from "@/components/ai-elements/prompt-input";
+import { BrowserPanel } from "@/components/chat/browser-panel";
 import { ChatError } from "@/components/chat/chat-error";
 import { ChatMessages } from "@/components/chat/chat-messages";
 import { McpToolsDisplay } from "@/components/chat/mcp-tools-display";
@@ -48,7 +49,12 @@ import {
 import { useChatSession } from "@/contexts/global-chat-context";
 import { useProfiles } from "@/lib/agent.query";
 import { useHasPermissions } from "@/lib/auth.query";
-import { useConversation, useCreateConversation } from "@/lib/chat.query";
+import {
+  useConversation,
+  useConversations,
+  useCreateConversation,
+  useHasPlaywrightMcpTools,
+} from "@/lib/chat.query";
 import { useChatSettingsOptional } from "@/lib/chat-settings.query";
 import { useDialogs } from "@/lib/dialog.hook";
 import { useDeletePrompt, usePrompt, usePrompts } from "@/lib/prompts.query";
@@ -82,6 +88,9 @@ export default function ChatPage() {
     internalMcpCatalog: ["create"],
   });
 
+  // State for browser panel
+  const [isBrowserPanelOpen, setIsBrowserPanelOpen] = useState(false);
+
   // State for prompt management
   const [isPromptDialogOpen, setIsPromptDialogOpen] = useState(false);
   const [editingPromptId, setEditingPromptId] = useState<string | null>(null);
@@ -94,8 +103,14 @@ export default function ChatPage() {
   const { data: editingPrompt } = usePrompt(editingPromptId || "");
   const deletePromptMutation = useDeletePrompt();
   const { data: allProfiles = [] } = useProfiles();
+  const { data: allConversations = [] } = useConversations();
 
   const chatSession = useChatSession(conversationId);
+
+  // Calculate tab index based on conversation position in list
+  const tabIndex = conversationId
+    ? allConversations.findIndex((c) => c.id === conversationId)
+    : 0;
 
   // Check if API key is configured
   const { data: chatSettings } = useChatSettingsOptional();
@@ -131,6 +146,9 @@ export default function ChatPage() {
 
   // Get current agent info
   const currentProfileId = conversation?.agentId;
+
+  // Check if Playwright MCP is available for browser panel
+  const hasPlaywrightMcp = useHasPlaywrightMcpTools(currentProfileId);
 
   // Clear MCP Gateway sessions when opening a NEW conversation
   useEffect(() => {
@@ -497,7 +515,7 @@ export default function ChatPage() {
 
   return (
     <div className="flex h-screen w-full">
-      <div className="flex-1 flex flex-col w-full">
+      <div className="flex-1 flex flex-col min-w-0">
         <div className="flex flex-col h-full">
           {error && <ChatError error={error} />}
           <StreamTimeoutWarning status={status} messages={messages} />
@@ -513,6 +531,17 @@ export default function ChatPage() {
             )}
             <div className="flex-1 flex justify-end gap-2 items-center">
               {promptBadge}
+              {hasPlaywrightMcp && (
+                <Button
+                  variant={isBrowserPanelOpen ? "secondary" : "ghost"}
+                  size="sm"
+                  onClick={() => setIsBrowserPanelOpen(!isBrowserPanelOpen)}
+                  className="text-xs"
+                >
+                  <Globe className="h-3 w-3 mr-1" />
+                  Browser
+                </Button>
+              )}
               <Button
                 variant="ghost"
                 size="sm"
@@ -590,6 +619,15 @@ export default function ChatPage() {
         onClose={() => closeDialog("create-catalog")}
         onSuccess={() => router.push("/mcp-catalog/registry")}
       />
+
+      {isBrowserPanelOpen && (
+        <BrowserPanel
+          isOpen={isBrowserPanelOpen}
+          onClose={() => setIsBrowserPanelOpen(false)}
+          conversationId={conversationId}
+          tabIndex={tabIndex >= 0 ? tabIndex : 0}
+        />
+      )}
     </div>
   );
 }

--- a/platform/frontend/src/components/chat/browser-panel.tsx
+++ b/platform/frontend/src/components/chat/browser-panel.tsx
@@ -1,0 +1,776 @@
+"use client";
+
+import {
+  ArrowLeft,
+  ChevronDown,
+  ChevronUp,
+  Globe,
+  GripVertical,
+  Keyboard,
+  Loader2,
+  Maximize2,
+  Minimize2,
+  Move,
+  Type,
+  X,
+  ZoomOut,
+} from "lucide-react";
+import {
+  type FormEvent,
+  type MouseEvent as ReactMouseEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import websocketService from "@/lib/websocket";
+
+interface BrowserPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  conversationId: string | undefined;
+  tabIndex: number; // Tab index based on chat position in list
+}
+
+// Fixed size for the browser viewport (matches typical browser dimensions)
+const PANEL_WIDTH = 800;
+const PANEL_HEIGHT = 600;
+
+export function BrowserPanel({
+  isOpen,
+  onClose,
+  tabIndex,
+  conversationId,
+}: BrowserPanelProps) {
+  const [isMaximized, setIsMaximized] = useState(false);
+  const [isMinimized, setIsMinimized] = useState(false);
+  const [screenshot, setScreenshot] = useState<string | null>(null);
+  const [urlInput, setUrlInput] = useState<string>("");
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [isNavigating, setIsNavigating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+
+  // Dragging state for floating panel
+  const [position, setPosition] = useState({ x: 20, y: 20 });
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStartRef = useRef({ x: 0, y: 0, posX: 0, posY: 0 });
+
+  // Zoom state - toggle between 50% and 100%
+  const [isZoomedOut, setIsZoomedOut] = useState(false);
+
+  // Interaction state
+  const [typeText, setTypeText] = useState("");
+  const [isInteracting, setIsInteracting] = useState(false);
+
+  const panelRef = useRef<HTMLDivElement>(null);
+  const imageRef = useRef<HTMLImageElement>(null);
+  const subscribedConversationIdRef = useRef<string | null>(null);
+
+  // Subscribe to browser stream via existing WebSocket
+  useEffect(() => {
+    if (!isOpen || !conversationId) {
+      // Unsubscribe when panel closes
+      if (subscribedConversationIdRef.current) {
+        websocketService.send({
+          type: "unsubscribe_browser_stream",
+          payload: { conversationId: subscribedConversationIdRef.current },
+        });
+        subscribedConversationIdRef.current = null;
+      }
+      setIsConnected(false);
+      setScreenshot(null);
+      return;
+    }
+
+    // Clear state when switching conversations
+    if (
+      subscribedConversationIdRef.current &&
+      subscribedConversationIdRef.current !== conversationId
+    ) {
+      websocketService.send({
+        type: "unsubscribe_browser_stream",
+        payload: { conversationId: subscribedConversationIdRef.current },
+      });
+      subscribedConversationIdRef.current = null;
+      setScreenshot(null);
+      setUrlInput("");
+      setIsConnected(false);
+    }
+
+    setIsConnecting(true);
+    setError(null);
+
+    // Connect to WebSocket if not already connected
+    websocketService.connect();
+
+    // Subscribe to browser screenshot messages
+    const unsubScreenshot = websocketService.subscribe(
+      "browser_screenshot",
+      (message) => {
+        if (message.payload.conversationId === conversationId) {
+          setScreenshot(message.payload.screenshot);
+          if (message.payload.url) {
+            setUrlInput(message.payload.url);
+          }
+          setError(null);
+          setIsConnecting(false);
+          setIsConnected(true);
+        }
+      },
+    );
+
+    // Subscribe to navigation results
+    const unsubNavigate = websocketService.subscribe(
+      "browser_navigate_result",
+      (message) => {
+        if (message.payload.conversationId === conversationId) {
+          setIsNavigating(false);
+          if (!message.payload.success && message.payload.error) {
+            setError(message.payload.error);
+          }
+        }
+      },
+    );
+
+    // Subscribe to stream errors
+    const unsubError = websocketService.subscribe(
+      "browser_stream_error",
+      (message) => {
+        if (message.payload.conversationId === conversationId) {
+          setError(message.payload.error);
+          setIsConnecting(false);
+        }
+      },
+    );
+
+    // Subscribe to click results
+    const unsubClick = websocketService.subscribe(
+      "browser_click_result",
+      (message) => {
+        if (message.payload.conversationId === conversationId) {
+          setIsInteracting(false);
+          if (!message.payload.success && message.payload.error) {
+            setError(message.payload.error);
+          }
+        }
+      },
+    );
+
+    // Subscribe to type results
+    const unsubType = websocketService.subscribe(
+      "browser_type_result",
+      (message) => {
+        if (message.payload.conversationId === conversationId) {
+          setIsInteracting(false);
+          if (!message.payload.success && message.payload.error) {
+            setError(message.payload.error);
+          }
+        }
+      },
+    );
+
+    // Subscribe to press key results
+    const unsubPressKey = websocketService.subscribe(
+      "browser_press_key_result",
+      (message) => {
+        if (message.payload.conversationId === conversationId) {
+          setIsInteracting(false);
+          if (!message.payload.success && message.payload.error) {
+            setError(message.payload.error);
+          }
+        }
+      },
+    );
+
+    // Subscribe to zoom results
+    const unsubZoom = websocketService.subscribe(
+      "browser_set_zoom_result",
+      (message) => {
+        if (message.payload.conversationId === conversationId) {
+          setIsInteracting(false);
+          if (!message.payload.success && message.payload.error) {
+            setError(message.payload.error);
+          }
+        }
+      },
+    );
+
+    // Subscribe to navigate back results
+    const unsubNavigateBack = websocketService.subscribe(
+      "browser_navigate_back_result",
+      (message) => {
+        if (message.payload.conversationId === conversationId) {
+          setIsNavigating(false);
+          if (!message.payload.success && message.payload.error) {
+            setError(message.payload.error);
+          }
+        }
+      },
+    );
+
+    // Send subscribe message after a short delay to ensure connection is ready
+    const subscribeTimeout = setTimeout(() => {
+      // Cast needed as tabIndex is not in OpenAPI-generated types
+      websocketService.send({
+        type: "subscribe_browser_stream",
+        payload: { conversationId, tabIndex },
+      } as Parameters<typeof websocketService.send>[0]);
+      subscribedConversationIdRef.current = conversationId;
+    }, 100);
+
+    return () => {
+      clearTimeout(subscribeTimeout);
+      unsubScreenshot();
+      unsubNavigate();
+      unsubError();
+      unsubClick();
+      unsubType();
+      unsubPressKey();
+      unsubZoom();
+      unsubNavigateBack();
+
+      // Unsubscribe from browser stream
+      if (subscribedConversationIdRef.current) {
+        websocketService.send({
+          type: "unsubscribe_browser_stream",
+          payload: { conversationId: subscribedConversationIdRef.current },
+        });
+        subscribedConversationIdRef.current = null;
+      }
+    };
+  }, [isOpen, conversationId, tabIndex]);
+
+  // Navigate to URL via WebSocket
+  const handleNavigate = useCallback(
+    (e: FormEvent) => {
+      e.preventDefault();
+      if (!websocketService.isConnected() || !conversationId) return;
+      if (!urlInput.trim()) return;
+
+      let url = urlInput.trim();
+      // Add https:// if no protocol specified
+      if (!url.startsWith("http://") && !url.startsWith("https://")) {
+        url = `https://${url}`;
+      }
+
+      setIsNavigating(true);
+      setError(null);
+      setUrlInput(url);
+
+      websocketService.send({
+        type: "browser_navigate",
+        payload: { conversationId, url },
+      });
+    },
+    [urlInput, conversationId],
+  );
+
+  // Navigate back
+  const handleNavigateBack = useCallback(() => {
+    if (!websocketService.isConnected() || !conversationId) return;
+
+    setIsNavigating(true);
+    setError(null);
+
+    websocketService.send({
+      type: "browser_navigate_back",
+      payload: { conversationId },
+    });
+  }, [conversationId]);
+
+  // Type text
+  const handleType = useCallback(
+    (e: FormEvent) => {
+      e.preventDefault();
+      if (!websocketService.isConnected() || !conversationId) return;
+      if (!typeText) return;
+
+      setIsInteracting(true);
+      setError(null);
+
+      websocketService.send({
+        type: "browser_type",
+        payload: {
+          conversationId,
+          text: typeText,
+        },
+      });
+      setTypeText("");
+    },
+    [typeText, conversationId],
+  );
+
+  // Press key
+  const handlePressKey = useCallback(
+    (key: string) => {
+      if (!websocketService.isConnected() || !conversationId) return;
+
+      setIsInteracting(true);
+      setError(null);
+
+      websocketService.send({
+        type: "browser_press_key",
+        payload: { conversationId, key },
+      });
+    },
+    [conversationId],
+  );
+
+  // Handle dragging for floating panel position
+  const handleDragStart = useCallback(
+    (e: ReactMouseEvent) => {
+      e.preventDefault();
+      setIsDragging(true);
+      dragStartRef.current = {
+        x: e.clientX,
+        y: e.clientY,
+        posX: position.x,
+        posY: position.y,
+      };
+    },
+    [position],
+  );
+
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const deltaX = e.clientX - dragStartRef.current.x;
+      const deltaY = e.clientY - dragStartRef.current.y;
+      setPosition({
+        x: Math.max(0, dragStartRef.current.posX + deltaX),
+        y: Math.max(0, dragStartRef.current.posY + deltaY),
+      });
+    };
+
+    const handleMouseUp = () => {
+      setIsDragging(false);
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [isDragging]);
+
+  const toggleMaximize = useCallback(() => {
+    setIsMaximized((prev) => !prev);
+    if (!isMaximized) {
+      setIsMinimized(false);
+    }
+  }, [isMaximized]);
+
+  const toggleMinimize = useCallback(() => {
+    setIsMinimized((prev) => !prev);
+    if (!isMinimized) {
+      setIsMaximized(false);
+    }
+  }, [isMinimized]);
+
+  if (!isOpen) return null;
+
+  // Calculate dimensions based on state
+  // When zoomed out, reduce panel size to 50% to match the image scale
+  const effectiveWidth = isZoomedOut ? PANEL_WIDTH * 0.5 : PANEL_WIDTH;
+  const effectiveHeight = isZoomedOut ? PANEL_HEIGHT * 0.5 : PANEL_HEIGHT;
+
+  const panelStyle = isMaximized
+    ? { left: 0, top: 0, right: 0, bottom: 0, width: "100%", height: "100%" }
+    : isMinimized
+      ? { right: 20, bottom: 20, width: 300, height: 48 }
+      : {
+          left: position.x,
+          top: position.y,
+          width: effectiveWidth,
+          height: effectiveHeight,
+        };
+
+  return (
+    <div
+      ref={panelRef}
+      className={cn(
+        "fixed z-50 bg-background border rounded-lg shadow-2xl flex flex-col overflow-hidden",
+        isDragging && "select-none cursor-grabbing",
+        isMaximized && "rounded-none",
+      )}
+      style={panelStyle}
+    >
+      {/* Draggable Header */}
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: drag handle needs onMouseDown */}
+      <div
+        className={cn(
+          "flex flex-col gap-2 p-2 border-b bg-muted/50",
+          !isMaximized && !isMinimized && "cursor-grab",
+        )}
+        onMouseDown={!isMaximized && !isMinimized ? handleDragStart : undefined}
+      >
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            {!isMaximized && !isMinimized && (
+              <Move className="h-3 w-3 text-muted-foreground flex-shrink-0" />
+            )}
+            <Globe className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+            <span className="text-xs font-medium">Browser Preview</span>
+            {isConnected && (
+              <span
+                className="w-2 h-2 rounded-full bg-green-500"
+                title="Connected"
+              />
+            )}
+          </div>
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: stops drag propagation */}
+          <div
+            className="flex items-center gap-1"
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            {!isMinimized && (
+              <>
+                {/* Type tool */}
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6"
+                      disabled={!isConnected || isInteracting}
+                      title="Type text into focused input"
+                    >
+                      <Type className="h-3 w-3" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-64" align="end">
+                    <form onSubmit={handleType} className="space-y-2">
+                      <div className="text-xs font-medium">
+                        Type into focused input
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        Click on an input field first, then type here
+                      </p>
+                      <Textarea
+                        placeholder="Text to type..."
+                        value={typeText}
+                        onChange={(e) => setTypeText(e.target.value)}
+                        className="text-xs min-h-[60px]"
+                        autoFocus
+                      />
+                      <Button
+                        type="submit"
+                        size="sm"
+                        className="w-full h-7 text-xs"
+                        disabled={!typeText}
+                      >
+                        Type
+                      </Button>
+                    </form>
+                  </PopoverContent>
+                </Popover>
+
+                {/* Keyboard tool */}
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6"
+                      disabled={!isConnected || isInteracting}
+                      title="Press key"
+                    >
+                      <Keyboard className="h-3 w-3" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-48" align="end">
+                    <div className="space-y-2">
+                      <div className="text-xs font-medium">Press Key</div>
+                      <div className="grid grid-cols-2 gap-1">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-7 text-xs"
+                          onClick={() => handlePressKey("Enter")}
+                        >
+                          Enter
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-7 text-xs"
+                          onClick={() => handlePressKey("Tab")}
+                        >
+                          Tab
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-7 text-xs"
+                          onClick={() => handlePressKey("Escape")}
+                        >
+                          Escape
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-7 text-xs"
+                          onClick={() => handlePressKey("Backspace")}
+                        >
+                          Backspace
+                        </Button>
+                      </div>
+                    </div>
+                  </PopoverContent>
+                </Popover>
+
+                {/* Scroll buttons */}
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6"
+                  onClick={() => handlePressKey("PageUp")}
+                  disabled={!isConnected || isInteracting}
+                  title="Scroll up"
+                >
+                  <ChevronUp className="h-3 w-3" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6"
+                  onClick={() => handlePressKey("PageDown")}
+                  disabled={!isConnected || isInteracting}
+                  title="Scroll down"
+                >
+                  <ChevronDown className="h-3 w-3" />
+                </Button>
+
+                {/* Zoom toggle button - CSS scale only */}
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6"
+                  onClick={() => setIsZoomedOut((prev) => !prev)}
+                  disabled={!isConnected}
+                  title={isZoomedOut ? "Zoom to 100%" : "Zoom out to 50%"}
+                >
+                  <ZoomOut className="h-3 w-3" />
+                </Button>
+
+                <div className="w-px h-4 bg-border mx-1" />
+              </>
+            )}
+
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6"
+              onClick={toggleMinimize}
+              title={isMinimized ? "Restore" : "Minimize"}
+            >
+              {isMinimized ? (
+                <Maximize2 className="h-3 w-3" />
+              ) : (
+                <Minimize2 className="h-3 w-3" />
+              )}
+            </Button>
+            {!isMinimized && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                onClick={toggleMaximize}
+                title={isMaximized ? "Restore" : "Maximize"}
+              >
+                {isMaximized ? (
+                  <GripVertical className="h-3 w-3" />
+                ) : (
+                  <Maximize2 className="h-3 w-3" />
+                )}
+              </Button>
+            )}
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6"
+              onClick={onClose}
+              title="Close"
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          </div>
+        </div>
+
+        {/* URL input - hidden when minimized */}
+        {!isMinimized && (
+          <form
+            onSubmit={handleNavigate}
+            className="flex gap-2"
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="h-7 w-7 flex-shrink-0"
+              onClick={handleNavigateBack}
+              disabled={isNavigating || !isConnected}
+              title="Go back"
+            >
+              <ArrowLeft className="h-3 w-3" />
+            </Button>
+            <Input
+              type="text"
+              placeholder="Enter URL..."
+              value={urlInput}
+              onChange={(e) => setUrlInput(e.target.value)}
+              className="h-7 text-xs"
+              disabled={isNavigating || !isConnected}
+            />
+            <Button
+              type="submit"
+              size="sm"
+              className="h-7 px-3 text-xs"
+              disabled={isNavigating || !urlInput.trim() || !isConnected}
+            >
+              {isNavigating ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                "Go"
+              )}
+            </Button>
+          </form>
+        )}
+      </div>
+
+      {/* Error display - absolute positioned */}
+      {error && !isMinimized && (
+        <div className="absolute top-14 left-2 right-2 z-10 text-xs text-destructive bg-destructive/10 border border-destructive/20 px-2 py-1 rounded shadow-sm">
+          {error}
+        </div>
+      )}
+
+      {/* Content - Screenshot with clickable overlay - hidden when minimized */}
+      {!isMinimized && (
+        <div className="flex-1 overflow-auto bg-black">
+          {isConnecting ? (
+            <div className="flex items-center justify-center h-full">
+              <div className="text-center space-y-2">
+                <div className="animate-pulse">
+                  <Globe className="h-12 w-12 text-muted-foreground mx-auto" />
+                </div>
+                <p className="text-sm text-muted-foreground">Connecting...</p>
+              </div>
+            </div>
+          ) : screenshot ? (
+            <div className="relative w-full h-full flex items-start justify-start">
+              <img
+                ref={imageRef}
+                src={screenshot}
+                alt="Browser screenshot"
+                className="block w-full h-full object-contain"
+              />
+              {/* Clickable overlay - captures clicks and sends coordinates */}
+              {/* biome-ignore lint/a11y/useSemanticElements: Need div for absolute positioning overlay */}
+              <div
+                className="absolute inset-0 cursor-pointer"
+                onClick={(e) => {
+                  if (!isConnected || isInteracting || !conversationId) return;
+
+                  const img = imageRef.current;
+                  if (!img) return;
+
+                  // Get the actual rendered position of the image (accounting for object-contain)
+                  const imgRect = img.getBoundingClientRect();
+                  const naturalRatio = img.naturalWidth / img.naturalHeight;
+                  const containerRatio = imgRect.width / imgRect.height;
+
+                  let renderedWidth: number;
+                  let renderedHeight: number;
+                  let offsetX: number;
+                  let offsetY: number;
+
+                  if (naturalRatio > containerRatio) {
+                    // Image is wider - letterboxed top/bottom
+                    renderedWidth = imgRect.width;
+                    renderedHeight = imgRect.width / naturalRatio;
+                    offsetX = 0;
+                    offsetY = (imgRect.height - renderedHeight) / 2;
+                  } else {
+                    // Image is taller - letterboxed left/right
+                    renderedHeight = imgRect.height;
+                    renderedWidth = imgRect.height * naturalRatio;
+                    offsetX = (imgRect.width - renderedWidth) / 2;
+                    offsetY = 0;
+                  }
+
+                  const clickX = e.clientX - imgRect.left - offsetX;
+                  const clickY = e.clientY - imgRect.top - offsetY;
+
+                  // Check if click is within the actual image area
+                  if (
+                    clickX < 0 ||
+                    clickX > renderedWidth ||
+                    clickY < 0 ||
+                    clickY > renderedHeight
+                  ) {
+                    return; // Click was on letterbox area
+                  }
+
+                  // Scale coordinates from displayed size to original image size
+                  const scaleX = img.naturalWidth / renderedWidth;
+                  const scaleY = img.naturalHeight / renderedHeight;
+                  const x = clickX * scaleX;
+                  const y = clickY * scaleY;
+
+                  setIsInteracting(true);
+                  setError(null);
+
+                  websocketService.send({
+                    type: "browser_click",
+                    payload: { conversationId, x, y },
+                  });
+                }}
+                onKeyDown={(e) => {
+                  // Handle keyboard navigation
+                  if (e.key === "Enter" || e.key === " ") {
+                    // For keyboard, we can't get coordinates, so just ignore
+                    e.preventDefault();
+                  }
+                }}
+                role="button"
+                tabIndex={0}
+                aria-label="Click to interact with browser"
+              />
+            </div>
+          ) : (
+            <div className="flex items-center justify-center h-full">
+              <div className="text-center space-y-2">
+                <Globe className="h-12 w-12 text-muted-foreground mx-auto" />
+                <p className="text-sm text-muted-foreground">
+                  Enter a URL above to start browsing
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Loading overlay */}
+      {isInteracting && !isMinimized && (
+        <div className="absolute inset-0 bg-black/20 flex items-center justify-center pointer-events-none">
+          <Loader2 className="h-8 w-8 animate-spin text-white" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/platform/frontend/src/lib/chat.query.ts
+++ b/platform/frontend/src/lib/chat.query.ts
@@ -155,3 +155,21 @@ export function useChatProfileMcpTools(agentId: string | undefined) {
     gcTime: 10 * 60 * 1000,
   });
 }
+
+export function useHasPlaywrightMcpTools(agentId: string | undefined) {
+  const result = useQuery({
+    queryKey: ["chat", "agents", agentId, "mcp-tools", "has-playwright"],
+    queryFn: async () => {
+      if (!agentId) return false;
+      const { data, error } = await getChatAgentMcpTools({
+        path: { agentId },
+      });
+      if (error) throw new Error("Failed to fetch MCP tools");
+      return data.some(
+        (tool) =>
+          tool.name.includes("playwright") || tool.name.startsWith("browser_"),
+      );
+    },
+  });
+  return result.data ?? false;
+}

--- a/platform/frontend/src/lib/config.ts
+++ b/platform/frontend/src/lib/config.ts
@@ -46,14 +46,25 @@ export const getDisplayProxyUrl = (): string => {
 };
 
 /**
- * Get the WebSocket URL
+ * Get the WebSocket base URL (without path)
  */
-export const getWebSocketUrl = (): string => {
+const getWebSocketBaseUrl = (): string => {
   const backendBaseUrl = getBackendBaseUrl();
 
+  // In development, use localhost
+  if (!backendBaseUrl || typeof window === "undefined") {
+    return "ws://localhost:9000";
+  }
+
   // Convert http(s) to ws(s)
-  const wsUrl = backendBaseUrl.replace(/^http/, "ws");
-  return `${wsUrl}/ws`;
+  return backendBaseUrl.replace(/^http/, "ws");
+};
+
+/**
+ * Get the WebSocket URL for general communication
+ */
+export const getWebSocketUrl = (): string => {
+  return `${getWebSocketBaseUrl()}/ws`;
 };
 
 /**

--- a/platform/frontend/src/lib/websocket.ts
+++ b/platform/frontend/src/lib/websocket.ts
@@ -1,17 +1,119 @@
 import type { archestraApiTypes } from "@shared";
 import config from "@/lib/config";
 
-type WebSocketMessage = archestraApiTypes.WebSocketMessage;
+// Client -> Server messages (validated by backend)
+type ClientWebSocketMessage = archestraApiTypes.WebSocketMessage;
 
-type MessageHandler<T extends WebSocketMessage = WebSocketMessage> = (
-  message: T,
-) => void;
+// Server -> Client messages (not in OpenAPI spec)
+type BrowserScreenshotMessage = {
+  type: "browser_screenshot";
+  payload: {
+    conversationId: string;
+    screenshot: string;
+    url?: string;
+  };
+};
+
+type BrowserNavigateResultMessage = {
+  type: "browser_navigate_result";
+  payload: {
+    conversationId: string;
+    success: boolean;
+    url?: string;
+    error?: string;
+  };
+};
+
+type BrowserStreamErrorMessage = {
+  type: "browser_stream_error";
+  payload: {
+    conversationId: string;
+    error: string;
+  };
+};
+
+type BrowserClickResultMessage = {
+  type: "browser_click_result";
+  payload: {
+    conversationId: string;
+    success: boolean;
+    error?: string;
+  };
+};
+
+type BrowserTypeResultMessage = {
+  type: "browser_type_result";
+  payload: {
+    conversationId: string;
+    success: boolean;
+    error?: string;
+  };
+};
+
+type BrowserPressKeyResultMessage = {
+  type: "browser_press_key_result";
+  payload: {
+    conversationId: string;
+    success: boolean;
+    error?: string;
+  };
+};
+
+type BrowserSnapshotMessage = {
+  type: "browser_snapshot";
+  payload: {
+    conversationId: string;
+    snapshot?: string;
+    error?: string;
+  };
+};
+
+type BrowserSetZoomResultMessage = {
+  type: "browser_set_zoom_result";
+  payload: {
+    conversationId: string;
+    success: boolean;
+    error?: string;
+  };
+};
+
+type BrowserNavigateBackResultMessage = {
+  type: "browser_navigate_back_result";
+  payload: {
+    conversationId: string;
+    success: boolean;
+    error?: string;
+  };
+};
+
+type ErrorMessage = {
+  type: "error";
+  payload: {
+    message: string;
+  };
+};
+
+type ServerWebSocketMessage =
+  | BrowserScreenshotMessage
+  | BrowserNavigateResultMessage
+  | BrowserNavigateBackResultMessage
+  | BrowserStreamErrorMessage
+  | BrowserClickResultMessage
+  | BrowserTypeResultMessage
+  | BrowserPressKeyResultMessage
+  | BrowserSnapshotMessage
+  | BrowserSetZoomResultMessage
+  | ErrorMessage;
+
+// All message types that can be received
+type IncomingWebSocketMessage = ClientWebSocketMessage | ServerWebSocketMessage;
+
+// biome-ignore lint/suspicious/noExplicitAny: Generic message handler needs to accept any message type
+type MessageHandler<T = any> = (message: T) => void;
 
 class WebSocketService {
   private ws: WebSocket | null = null;
-  // biome-ignore lint/suspicious/noExplicitAny: Generic message handler
-  private handlers: Map<WebSocketMessage["type"], Set<MessageHandler<any>>> =
-    new Map();
+  private handlers: Map<string, Set<MessageHandler>> = new Map();
   private reconnectTimeout: NodeJS.Timeout | null = null;
   private reconnectAttempts = 0;
   private maxReconnectAttempts = Infinity;
@@ -38,7 +140,7 @@ class WebSocketService {
 
       this.ws.addEventListener("message", (event) => {
         try {
-          const message: WebSocketMessage = JSON.parse(event.data);
+          const message: IncomingWebSocketMessage = JSON.parse(event.data);
           this.handleMessage(message);
         } catch (error) {
           console.error("[WebSocket] Failed to parse message:", error);
@@ -94,9 +196,12 @@ class WebSocketService {
     }
   }
 
-  subscribe<T extends WebSocketMessage["type"]>(
+  /**
+   * Subscribe to messages of a specific type (typed version for known types)
+   */
+  subscribe<T extends IncomingWebSocketMessage["type"]>(
     type: T,
-    handler: MessageHandler<Extract<WebSocketMessage, { type: T }>>,
+    handler: MessageHandler<Extract<IncomingWebSocketMessage, { type: T }>>,
   ): () => void {
     if (!this.handlers.has(type)) {
       this.handlers.set(type, new Set());
@@ -116,7 +221,7 @@ class WebSocketService {
     };
   }
 
-  private handleMessage(message: WebSocketMessage): void {
+  private handleMessage(message: IncomingWebSocketMessage): void {
     const handlers = this.handlers.get(message.type);
     if (handlers) {
       handlers.forEach((handler) => {
@@ -133,7 +238,10 @@ class WebSocketService {
     return this.ws?.readyState === WebSocket.OPEN;
   }
 
-  send(message: WebSocketMessage): void {
+  /**
+   * Send a message to the server (only client messages allowed)
+   */
+  send(message: ClientWebSocketMessage): void {
     if (!this.isConnected()) {
       console.error("[WebSocket] Not connected, cannot send message");
       return;

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -1026,9 +1026,58 @@ export type AnthropicMessagesResponseInput = {
 };
 
 export type WebSocketMessageInput = {
-    type: 'hello-world';
+    type: string;
     payload: {
         [key: string]: unknown;
+    };
+} | {
+    type: string;
+    payload: {
+        conversationId: string;
+        tabIndex: number;
+    };
+} | {
+    type: string;
+    payload: {
+        conversationId: string;
+    };
+} | {
+    type: string;
+    payload: {
+        conversationId: string;
+        url: string;
+    };
+} | {
+    type: string;
+    payload: {
+        conversationId: string;
+        element?: string;
+        x?: number;
+        y?: number;
+    };
+} | {
+    type: string;
+    payload: {
+        conversationId: string;
+        text: string;
+        element?: string;
+    };
+} | {
+    type: string;
+    payload: {
+        conversationId: string;
+        key: string;
+    };
+} | {
+    type: string;
+    payload: {
+        conversationId: string;
+    };
+} | {
+    type: string;
+    payload: {
+        conversationId: string;
+        zoomPercent: number;
     };
 };
 
@@ -2054,9 +2103,58 @@ export type AnthropicMessagesResponse = {
 };
 
 export type WebSocketMessage = {
-    type: 'hello-world';
+    type: string;
     payload: {
         [key: string]: never;
+    };
+} | {
+    type: string;
+    payload: {
+        conversationId: string;
+        tabIndex: number;
+    };
+} | {
+    type: string;
+    payload: {
+        conversationId: string;
+    };
+} | {
+    type: string;
+    payload: {
+        conversationId: string;
+        url: string;
+    };
+} | {
+    type: string;
+    payload: {
+        conversationId: string;
+        element?: string;
+        x?: number;
+        y?: number;
+    };
+} | {
+    type: string;
+    payload: {
+        conversationId: string;
+        text: string;
+        element?: string;
+    };
+} | {
+    type: string;
+    payload: {
+        conversationId: string;
+        key: string;
+    };
+} | {
+    type: string;
+    payload: {
+        conversationId: string;
+    };
+} | {
+    type: string;
+    payload: {
+        conversationId: string;
+        zoomPercent: number;
     };
 };
 
@@ -7317,6 +7415,7 @@ export type GetInternalMcpCatalogResponses = {
                 max?: number;
             };
         } | null;
+        requiresTrustedContext: boolean;
         oauthConfig: {
             name: string;
             server_url: string;
@@ -7396,6 +7495,7 @@ export type CreateInternalMcpCatalogItemData = {
                 max?: number;
             };
         } | null;
+        requiresTrustedContext?: boolean;
         oauthConfig?: {
             name: string;
             server_url: string;
@@ -7537,6 +7637,7 @@ export type CreateInternalMcpCatalogItemResponses = {
                 max?: number;
             };
         } | null;
+        requiresTrustedContext: boolean;
         oauthConfig: {
             name: string;
             server_url: string;
@@ -7767,6 +7868,7 @@ export type GetInternalMcpCatalogItemResponses = {
                 max?: number;
             };
         } | null;
+        requiresTrustedContext: boolean;
         oauthConfig: {
             name: string;
             server_url: string;
@@ -7846,6 +7948,7 @@ export type UpdateInternalMcpCatalogItemData = {
                 max?: number;
             };
         } | null;
+        requiresTrustedContext?: boolean;
         oauthConfig?: {
             name: string;
             server_url: string;
@@ -7989,6 +8092,7 @@ export type UpdateInternalMcpCatalogItemResponses = {
                 max?: number;
             };
         } | null;
+        requiresTrustedContext: boolean;
         oauthConfig: {
             name: string;
             server_url: string;


### PR DESCRIPTION
## Summary
- Add BrowserPanel component to display live browser screenshots during Playwright MCP tool execution
- Implement WebSocket-based streaming for real-time screenshot updates from browser automation
- Add browser-stream routes/service with conversation ownership authorization

## Test plan
- [ ] Verify browser panel appears when using Playwright tools in chat
- [ ] Confirm real-time screenshot streaming works via WebSocket
- [ ] Test that users can only access browser streams for their own conversations
- [ ] Verify TypeScript type-check and linting pass