### PR TITLE
feat: allow specifying `Deployment.replicas` in helm chart

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -1,4 +1,6 @@
 archestra:
+  replicaCount: 4
+
   service:
     annotations:
       # GKE BackendConfig for custom health checks

--- a/platform/helm/archestra/templates/archestra-platform.yaml
+++ b/platform/helm/archestra/templates/archestra-platform.yaml
@@ -42,7 +42,7 @@ metadata:
   labels:
     {{- include "archestra-platform.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.archestra.replicaCount }}
   selector:
     matchLabels:
       {{- include "archestra-platform.selectorLabels" . | nindent 6 }}

--- a/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
@@ -56,6 +56,15 @@ tests:
           path: spec.replicas
           value: 1
 
+  - it: should allow configuring replica count
+    documentIndex: 1
+    set:
+      archestra.replicaCount: 4
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 4
+
   - it: should not configure deployment strategy by default
     documentIndex: 1
     asserts:

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -7,6 +7,9 @@ archestra:
   # Options: Always, IfNotPresent, Never
   imagePullPolicy: IfNotPresent
 
+  # Number of pod replicas for the Archestra Platform deployment
+  replicaCount: 1
+
   # Deployment strategy configuration for the Deployment
   # See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#:~:text=strategy%20(DeploymentStrategy)
   # When null, the default Kubernetes strategy is used


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make Deployment `spec.replicas` configurable via `archestra.replicaCount` (default 1); set staging to 4 and add tests.
> 
> - **Helm Chart**:
>   - Update `platform/helm/archestra/templates/archestra-platform.yaml` to set `Deployment.spec.replicas` from `Values.archestra.replicaCount`.
>   - Add `archestra.replicaCount` (default `1`) to `platform/helm/archestra/values.yaml`.
> - **Tests**:
>   - Extend `platform/helm/archestra/tests/archestra_platform_deployment_test.yaml` with a test validating configurable replica count (e.g., `4`).
> - **Staging Config**:
>   - Set `archestra.replicaCount: 4` in `.github/values-staging.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d31efdf0bfd3ca6af1db429361c8847d252818de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->