### PR TITLE
ci: address Docker Scout CI job not running on PRs from forks

### DIFF
--- a/.github/workflows/platform-linting-and-tests.yml
+++ b/.github/workflows/platform-linting-and-tests.yml
@@ -338,8 +338,12 @@ jobs:
       #
       # Branch ruleset has been configured to block PRs with critical or high vulnerabilities.
       # https://docs.github.com/en/code-security/code-scanning/managing-code-scanning-alerts/about-code-scanning-alerts#pull-request-check-failures-for-code-scanning-alerts
+      #
+      # NOTE: This step is skipped for PRs from forks because GitHub doesn't expose
+      # repository secrets to workflows triggered by fork PRs (for security reasons).
+      # Docker Scout requires Docker Hub authentication to run.
       - name: Docker Scout
-        if: ${{ github.event_name == 'pull_request' && inputs.should-skip-running-and-always-succeed != true }}
+        if: ${{ github.event_name == 'pull_request' && inputs.should-skip-running-and-always-succeed != true && github.event.pull_request.head.repo.fork != true }}
         uses: docker/scout-action@f8c776824083494ab0d56b8105ba2ca85c86e4de # v1.18.2
         with:
           command: cves,recommendations,compare
@@ -355,8 +359,10 @@ jobs:
 
       # Upload SARIF result to GitHub Code Scanning
       # https://github.com/docker/scout-action?tab=readme-ov-file#analyze-vulnerabilities-and-upload-report-to-github-code-scanning
+      #
+      # NOTE: Skipped for fork PRs since Docker Scout step is skipped (no SARIF file generated).
       - name: Upload SARIF result
-        if: ${{ github.event_name == 'pull_request' && inputs.should-skip-running-and-always-succeed != true }}
+        if: ${{ github.event_name == 'pull_request' && inputs.should-skip-running-and-always-succeed != true && github.event.pull_request.head.repo.fork != true }}
         uses: github/codeql-action/upload-sarif@4e94bd11f71e507f7f87df81788dff88d1dacbfb # v4.31.0
         with:
           sarif_file: sarif.output.json


### PR DESCRIPTION
Skip Docker Scout and SARIF upload steps for PRs from forks to resolve credential errors.

GitHub does not expose repository secrets to workflows triggered by PRs from forks for security reasons. Since Docker Scout requires Docker Hub authentication, these steps were failing for external contributions. This change adds a condition to skip these steps when the PR originates from a fork.

---
[Slack Thread](https://archestra-ai.slack.com/archives/C0966V616DC/p1765212523787249?thread_ts=1765212523.787249&cid=C0966V616DC)

<a href="https://cursor.com/background-agent?bcId=bc-1efb3de4-e41d-4c84-9927-932f8da144fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1efb3de4-e41d-4c84-9927-932f8da144fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gate Docker Scout and SARIF upload steps in `platform-linting-and-tests.yml` to skip on PRs from forks (no secrets available).
> 
> - **CI/Workflows** (`.github/workflows/platform-linting-and-tests.yml`):
>   - Add condition to Docker Scout step: `github.event.pull_request.head.repo.fork != true`.
>   - Add same condition to SARIF upload step to align with Docker Scout gating.
>   - Add explanatory comments about skipping these steps for forked PRs due to missing secrets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e34ac872b5d10b9c894160344328b65d8027473d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->