### PR TITLE
add Docker runtime for MCP servers (no K8s required)

### DIFF
--- a/platform/.env.example
+++ b/platform/.env.example
@@ -71,15 +71,28 @@ ARCHESTRA_AUTH_ADMIN_PASSWORD=password
 # Feature Flags
 # FEATURES_XYZ_ENABLED=false
 
-# Kubernetes Configuration for MCP Server Runtime
+# MCP Server Runtime Configuration
+# Archestra can run MCP servers using either Kubernetes or Docker.
+# Priority: 1) K8s if explicitly configured, 2) Docker if enabled, 3) K8s default config
 
+# --- Kubernetes Configuration ---
 # Whether to load kubeconfig from current cluster (set to "true" when running inside K8s)
 ARCHESTRA_ORCHESTRATOR_LOAD_KUBECONFIG_FROM_CURRENT_CLUSTER=false
 # Path to kubeconfig file (optional if running inside K8s cluster or using default ~/.kube/config)
 ARCHESTRA_ORCHESTRATOR_KUBECONFIG=
 # Kubernetes namespace for MCP server pods (defaults to "default")
 ARCHESTRA_ORCHESTRATOR_K8S_NAMESPACE=default
-# Base image for MCP server containers
+
+# --- Docker Configuration ---
+# Enable Docker runtime for MCP servers (useful for Docker deployments without K8s)
+# Set to "true" to enable, "false" to disable
+# When K8s is not configured, Docker is enabled by default
+ARCHESTRA_ORCHESTRATOR_DOCKER_ENABLED=true
+# Path to Docker socket (defaults to /var/run/docker.sock on Linux/macOS, //./pipe/docker_engine on Windows)
+ARCHESTRA_ORCHESTRATOR_DOCKER_SOCKET_PATH=
+
+# --- Common Configuration ---
+# Base image for MCP server containers (used by both K8s and Docker)
 ARCHESTRA_ORCHESTRATOR_MCP_SERVER_BASE_IMAGE=europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-base:0.0.3
 # Frontend-accessible base image (for display purposes in UI)
 NEXT_PUBLIC_ARCHESTRA_ORCHESTRATOR_MCP_SERVER_BASE_IMAGE=europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-base:0.0.3

--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -72,6 +72,9 @@ ENV ARCHESTRA_VERSION=${VERSION}
 ENV ARCHESTRA_API_BASE_URL="http://localhost:9000"
 ENV ARCHESTRA_ANALYTICS="enabled"
 ENV ARCHESTRA_ORCHESTRATOR_MCP_SERVER_BASE_IMAGE="europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-base:0.0.3"
+# Docker runtime is enabled by default for Docker deployments (no K8s config)
+# MCP servers will run as sibling Docker containers when Docker socket is mounted
+ENV ARCHESTRA_ORCHESTRATOR_DOCKER_ENABLED="true"
 ENV ARCHESTRA_ENTERPRISE_LICENSE_ACTIVATED="false"
 ENV ARCHESTRA_AUTH_DISABLE_BASIC_AUTH="false"
 ENV ARCHESTRA_AUTH_DISABLE_INVITATIONS="false"

--- a/platform/backend/package.json
+++ b/platform/backend/package.json
@@ -41,6 +41,7 @@
     "@fastify/swagger": "^9.6.1",
     "@google/genai": "^1.29.1",
     "@kubernetes/client-node": "^1.4.0",
+    "dockerode": "^4.0.6",
     "@kubiks/otel-drizzle": "^2.1.0",
     "@modelcontextprotocol/sdk": "^1.24.0",
     "@opentelemetry/api": "^1.9.0",
@@ -85,6 +86,7 @@
   "devDependencies": {
     "@electric-sql/pglite": "^0.3.14",
     "@sentry/cli": "^2.47.0",
+    "@types/dockerode": "^3.3.37",
     "@types/jmespath": "^0.15.2",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^24.10.1",

--- a/platform/backend/src/clients/docker-attach-transport.ts
+++ b/platform/backend/src/clients/docker-attach-transport.ts
@@ -1,0 +1,180 @@
+import type { Duplex } from "node:stream";
+import {
+  ReadBuffer,
+  serializeMessage,
+} from "@modelcontextprotocol/sdk/shared/stdio.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import type Dockerode from "dockerode";
+import logger from "@/logging";
+
+export interface DockerAttachTransportParams {
+  docker: Dockerode;
+  containerId: string;
+  containerName: string;
+}
+
+/**
+ * MCP Transport that uses Docker attach to communicate with containers via stdio.
+ * This allows using the MCP SDK Client with stdio-based MCP servers running in Docker.
+ */
+export class DockerAttachTransport implements Transport {
+  private stream?: Duplex;
+  private readBuffer = new ReadBuffer();
+  private isStarted = false;
+  private isClosing = false;
+
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: JSONRPCMessage) => void;
+
+  constructor(private params: DockerAttachTransportParams) {}
+
+  async start(): Promise<void> {
+    if (this.isStarted) {
+      return;
+    }
+
+    const { docker, containerId, containerName } = this.params;
+
+    try {
+      const container = docker.getContainer(containerId);
+
+      this.stream = (await container.attach({
+        stream: true,
+        stdin: true,
+        stdout: true,
+        stderr: true,
+        hijack: true,
+      })) as Duplex;
+
+      this.isStarted = true;
+
+      this.stream.on("data", (chunk: Buffer) => {
+        if (this.isClosing) {
+          return;
+        }
+
+        const payload = this.demultiplexDockerStream(chunk);
+        if (payload.length === 0) {
+          return;
+        }
+
+        this.readBuffer.append(payload);
+
+        try {
+          let message = this.readBuffer.readMessage();
+          while (message !== null) {
+            this.onmessage?.(message);
+            message = this.readBuffer.readMessage();
+          }
+        } catch (error) {
+          logger.debug(
+            { err: error, containerName },
+            "Failed to parse message from MCP server stdout - skipping invalid line",
+          );
+        }
+      });
+
+      this.stream.on("close", () => {
+        logger.debug({ containerName }, "DockerAttachTransport stream closed");
+        this.isStarted = false;
+        this.onclose?.();
+      });
+
+      this.stream.on("error", (error: Error) => {
+        logger.error(
+          { err: error, containerName },
+          "DockerAttachTransport stream error",
+        );
+        this.onerror?.(error);
+      });
+    } catch (error) {
+      logger.error(
+        { err: error, containerName },
+        "Failed to attach to container",
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Demultiplex Docker stream format.
+   * Docker uses an 8-byte header: [STREAM_TYPE, 0, 0, 0, SIZE1, SIZE2, SIZE3, SIZE4]
+   * STREAM_TYPE: 0=stdin, 1=stdout, 2=stderr
+   */
+  private demultiplexDockerStream(chunk: Buffer): Buffer {
+    const payloads: Buffer[] = [];
+    let offset = 0;
+
+    while (offset < chunk.length) {
+      if (offset + 8 > chunk.length) {
+        payloads.push(chunk.slice(offset));
+        break;
+      }
+
+      const streamType = chunk[offset];
+
+      if (streamType > 2) {
+        payloads.push(chunk.slice(offset));
+        break;
+      }
+
+      const size = chunk.readUInt32BE(offset + 4);
+      offset += 8;
+
+      if (size > 10 * 1024 * 1024) {
+        payloads.push(chunk.slice(offset - 8));
+        break;
+      }
+
+      if (offset + size > chunk.length) {
+        payloads.push(chunk.slice(offset));
+        break;
+      }
+
+      if (streamType === 1) {
+        payloads.push(chunk.slice(offset, offset + size));
+      }
+
+      offset += size;
+    }
+
+    return Buffer.concat(payloads);
+  }
+
+  async send(message: JSONRPCMessage): Promise<void> {
+    if (!this.isStarted || !this.stream) {
+      throw new Error("Transport not started");
+    }
+
+    const serialized = serializeMessage(message);
+
+    return new Promise((resolve, reject) => {
+      if (!this.stream) {
+        reject(new Error("Transport not started"));
+        return;
+      }
+      this.stream.write(serialized, (error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
+  async close(): Promise<void> {
+    this.isClosing = true;
+
+    if (this.stream) {
+      this.stream.end();
+      this.stream = undefined;
+    }
+
+    this.isStarted = false;
+    this.readBuffer.clear();
+    this.onclose?.();
+  }
+}

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -17,6 +17,7 @@ import type {
   CommonToolResult,
   InternalMcpCatalog,
 } from "@/types";
+import { DockerAttachTransport } from "./docker-attach-transport";
 import { K8sAttachTransport } from "./k8s-attach-transport";
 
 /**
@@ -289,7 +290,7 @@ class McpClient {
         await McpServerRuntimeManager.usesStreamableHttp(targetMcpServerId);
 
       if (usesStreamableHttp) {
-        // HTTP transport
+        // HTTP transport (works for both K8s and Docker)
         const url =
           McpServerRuntimeManager.getHttpEndpointUrl(targetMcpServerId);
         if (!url) {
@@ -303,18 +304,43 @@ class McpClient {
         });
       }
 
-      // Stdio transport - use K8s attach!
-      const k8sPod = McpServerRuntimeManager.getPod(targetMcpServerId);
-      if (!k8sPod) {
-        throw new Error("Pod not found for MCP server");
-      }
+      // Stdio transport - check runtime type and use appropriate transport
+      const runtimeType = McpServerRuntimeManager.currentRuntimeType;
 
-      return new K8sAttachTransport({
-        k8sAttach: k8sPod.k8sAttachClient,
-        namespace: k8sPod.k8sNamespace,
-        podName: k8sPod.k8sPodName,
-        containerName: "mcp-server",
-      });
+      if (runtimeType === "kubernetes") {
+        // K8s runtime - use K8s attach transport
+        const k8sPod = McpServerRuntimeManager.getK8sPod(targetMcpServerId);
+        if (!k8sPod) {
+          throw new Error("K8s pod not found for MCP server");
+        }
+
+        return new K8sAttachTransport({
+          k8sAttach: k8sPod.k8sAttachClient,
+          namespace: k8sPod.k8sNamespace,
+          podName: k8sPod.k8sPodName,
+          containerName: "mcp-server",
+        });
+      } else if (runtimeType === "docker") {
+        // Docker runtime - use Docker attach transport
+        const dockerPod =
+          McpServerRuntimeManager.getDockerPod(targetMcpServerId);
+        if (!dockerPod) {
+          throw new Error("Docker container not found for MCP server");
+        }
+
+        const containerId = dockerPod.id;
+        if (!containerId) {
+          throw new Error("Docker container ID not found");
+        }
+
+        return new DockerAttachTransport({
+          docker: dockerPod.dockerClient,
+          containerId,
+          containerName: dockerPod.name,
+        });
+      } else {
+        throw new Error("No runtime available for local MCP server");
+      }
     }
 
     // Remote server

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -256,6 +256,29 @@ export default {
           .ARCHESTRA_ORCHESTRATOR_LOAD_KUBECONFIG_FROM_CURRENT_CLUSTER ===
         "true",
     },
+    docker: {
+      /**
+       * Enable Docker runtime for MCP servers.
+       * When enabled, MCP servers will run as Docker containers instead of K8s pods.
+       * This is useful for Docker deployments where K8s is not available.
+       *
+       * Set to "true" to enable, "auto" to auto-detect (default), or "false" to disable.
+       * When set to "auto", Docker will be used if K8s is not configured and Docker socket is available.
+       */
+      enabled:
+        process.env.ARCHESTRA_ORCHESTRATOR_DOCKER_ENABLED === "true" ||
+        process.env.ARCHESTRA_ORCHESTRATOR_DOCKER_ENABLED === "auto" ||
+        // Default to true if no K8s config is specified (for Docker deployments)
+        (!process.env.ARCHESTRA_ORCHESTRATOR_KUBECONFIG &&
+          process.env
+            .ARCHESTRA_ORCHESTRATOR_LOAD_KUBECONFIG_FROM_CURRENT_CLUSTER !==
+            "true"),
+      /**
+       * Path to Docker socket.
+       * Defaults to /var/run/docker.sock on Linux/macOS or //./pipe/docker_engine on Windows.
+       */
+      socketPath: process.env.ARCHESTRA_ORCHESTRATOR_DOCKER_SOCKET_PATH,
+    },
   },
   observability: {
     otel: {

--- a/platform/backend/src/mcp-server-runtime/docker-pod.ts
+++ b/platform/backend/src/mcp-server-runtime/docker-pod.ts
@@ -1,0 +1,830 @@
+import { PassThrough } from "node:stream";
+import type { LocalConfigSchema } from "@shared";
+import type Dockerode from "dockerode";
+import type z from "zod";
+import config from "@/config";
+import logger from "@/logging";
+import { InternalMcpCatalogModel } from "@/models";
+import type { InternalMcpCatalog, McpServer } from "@/types";
+import type { DockerPodState, DockerPodStatusSummary } from "./schemas";
+
+const {
+  orchestrator: { mcpServerBaseImage },
+} = config;
+
+/**
+ * DockerPod manages a single MCP server running as a Docker container.
+ * This is the Docker-native alternative to K8sPod for users running Archestra via Docker.
+ */
+export default class DockerPod {
+  private mcpServer: McpServer;
+  private docker: Dockerode;
+  private containerName: string;
+  private containerId?: string;
+  private state: DockerPodState = "not_created";
+  private errorMessage: string | null = null;
+  private catalogItem?: InternalMcpCatalog | null;
+  private userConfigValues?: Record<string, string>;
+  private environmentValues?: Record<string, string>;
+
+  // Track assigned port for HTTP-based MCP servers
+  assignedHttpPort?: number;
+  // Track the HTTP endpoint URL for streamable-http servers
+  httpEndpointUrl?: string;
+
+  constructor(
+    mcpServer: McpServer,
+    docker: Dockerode,
+    catalogItem?: InternalMcpCatalog | null,
+    userConfigValues?: Record<string, string>,
+    environmentValues?: Record<string, string>,
+  ) {
+    this.mcpServer = mcpServer;
+    this.docker = docker;
+    this.catalogItem = catalogItem;
+    this.userConfigValues = userConfigValues;
+    this.environmentValues = environmentValues;
+    this.containerName = DockerPod.constructContainerName(mcpServer);
+  }
+
+  /**
+   * Constructs a valid Docker container name for an MCP server.
+   * Container names must match [a-zA-Z0-9][a-zA-Z0-9_.-]+
+   */
+  static constructContainerName(mcpServer: McpServer): string {
+    const slugified = DockerPod.ensureDockerNameCompliant(mcpServer.name);
+    return `mcp-${slugified}`.substring(0, 128);
+  }
+
+  /**
+   * Ensures a string is Docker container name compliant.
+   * Docker container names must:
+   * - Start with a letter or number
+   * - Contain only letters, numbers, underscores, periods, or hyphens
+   */
+  static ensureDockerNameCompliant(input: string): string {
+    return input
+      .toLowerCase()
+      .replace(/\s+/g, "-") // replace whitespace with hyphens
+      .replace(/[^a-z0-9_.-]/g, "") // remove invalid characters
+      .replace(/-+/g, "-") // collapse consecutive hyphens
+      .replace(/^[^a-z0-9]+/, "") // remove leading non-alphanumeric
+      .replace(/[^a-z0-9]+$/, ""); // remove trailing non-alphanumeric
+  }
+
+  /**
+   * Get catalog item for this MCP server
+   */
+  private async getCatalogItem(): Promise<InternalMcpCatalog | null> {
+    if (!this.mcpServer.catalogId) {
+      return null;
+    }
+
+    return await InternalMcpCatalogModel.findById(this.mcpServer.catalogId);
+  }
+
+  /**
+   * Create environment variables for the container
+   */
+  createContainerEnv(): string[] {
+    const env: string[] = [];
+    const envMap = new Map<string, string>();
+
+    // Process all environment variables from catalog
+    if (this.catalogItem?.localConfig?.environment) {
+      for (const envDef of this.catalogItem.localConfig.environment) {
+        let value: string | undefined;
+        if (envDef.promptOnInstallation) {
+          value = this.environmentValues?.[envDef.key];
+        } else {
+          value = envDef.value;
+
+          // Interpolate ${user_config.xxx} placeholders
+          if (value && (this.environmentValues || this.userConfigValues)) {
+            value = value.replace(
+              /\$\{user_config\.([^}]+)\}/g,
+              (match, configKey) => {
+                return (
+                  this.environmentValues?.[configKey] ||
+                  this.userConfigValues?.[configKey] ||
+                  match
+                );
+              },
+            );
+          }
+        }
+
+        if (value) {
+          envMap.set(envDef.key, value);
+        }
+      }
+    } else if (this.environmentValues) {
+      // Fallback: process environmentValues directly
+      Object.entries(this.environmentValues).forEach(([key, value]) => {
+        envMap.set(key, value);
+      });
+    }
+
+    // Add user config values as environment variables
+    if (this.userConfigValues) {
+      Object.entries(this.userConfigValues).forEach(([key, value]) => {
+        const envKey = key.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+        envMap.set(envKey, value);
+      });
+    }
+
+    // Convert map to Docker env format (KEY=VALUE)
+    envMap.forEach((value, key) => {
+      let processedValue = String(value);
+
+      // Strip surrounding quotes
+      if (
+        processedValue.length > 1 &&
+        ((processedValue.startsWith("'") && processedValue.endsWith("'")) ||
+          (processedValue.startsWith('"') && processedValue.endsWith('"')))
+      ) {
+        processedValue = processedValue.slice(1, -1);
+      }
+
+      env.push(`${key}=${processedValue}`);
+    });
+
+    return env;
+  }
+
+  /**
+   * Generate container creation options
+   */
+  generateContainerOptions(
+    dockerImage: string,
+    localConfig: z.infer<typeof LocalConfigSchema>,
+    needsHttp: boolean,
+    httpPort: number,
+  ): Dockerode.ContainerCreateOptions {
+    const cmd: string[] = [];
+
+    if (localConfig.command) {
+      cmd.push(localConfig.command);
+    }
+
+    if (localConfig.arguments) {
+      const processedArgs = localConfig.arguments.map((arg) => {
+        if (this.environmentValues || this.userConfigValues) {
+          return arg.replace(
+            /\$\{user_config\.([^}]+)\}/g,
+            (match, configKey) => {
+              return (
+                this.environmentValues?.[configKey] ||
+                this.userConfigValues?.[configKey] ||
+                match
+              );
+            },
+          );
+        }
+        return arg;
+      });
+      cmd.push(...processedArgs);
+    }
+
+    const options: Dockerode.ContainerCreateOptions = {
+      name: this.containerName,
+      Image: dockerImage,
+      Env: this.createContainerEnv(),
+      Labels: {
+        "archestra.mcp-server": "true",
+        "archestra.mcp-server-id": this.mcpServer.id,
+        "archestra.mcp-server-name": this.mcpServer.name,
+      },
+      // For stdio-based MCP servers, we need stdin open
+      OpenStdin: true,
+      StdinOnce: false,
+      Tty: false,
+      AttachStdin: true,
+      AttachStdout: true,
+      AttachStderr: true,
+      HostConfig: {
+        AutoRemove: false,
+        RestartPolicy: {
+          Name: "unless-stopped",
+        },
+      },
+    };
+
+    // Only set Cmd if we have a command
+    if (cmd.length > 0) {
+      options.Cmd = cmd;
+    }
+
+    // For HTTP-based servers, expose port
+    if (needsHttp) {
+      options.ExposedPorts = {
+        [`${httpPort}/tcp`]: {},
+      };
+      options.HostConfig = {
+        ...options.HostConfig,
+        PortBindings: {
+          [`${httpPort}/tcp`]: [{ HostPort: "0" }], // Dynamic port assignment
+        },
+      };
+    }
+
+    return options;
+  }
+
+  /**
+   * Check if this MCP server needs an HTTP port
+   */
+  private async needsHttpPort(): Promise<boolean> {
+    const catalogItem = await this.getCatalogItem();
+    if (!catalogItem?.localConfig) {
+      return false;
+    }
+    const transportType = catalogItem.localConfig.transportType || "stdio";
+    return transportType === "streamable-http";
+  }
+
+  /**
+   * Create or start the container for this MCP server
+   */
+  async startOrCreateContainer(): Promise<void> {
+    try {
+      // Check if container already exists
+      try {
+        const existingContainer = this.docker.getContainer(this.containerName);
+        const inspectData = await existingContainer.inspect();
+        this.containerId = inspectData.Id;
+
+        if (inspectData.State.Running) {
+          this.state = "running";
+          await this.assignHttpPortIfNeeded(inspectData);
+          logger.info(`Container ${this.containerName} is already running`);
+          return;
+        }
+
+        // Container exists but not running - start it
+        if (
+          inspectData.State.Status === "exited" ||
+          inspectData.State.Status === "created"
+        ) {
+          logger.info(`Starting existing container ${this.containerName}`);
+          await existingContainer.start();
+          this.state = "running";
+          const updatedInspect = await existingContainer.inspect();
+          await this.assignHttpPortIfNeeded(updatedInspect);
+          return;
+        }
+
+        // Container in failed state - remove and recreate
+        if (
+          inspectData.State.Status === "dead" ||
+          inspectData.State.ExitCode !== 0
+        ) {
+          logger.info(`Removing failed container ${this.containerName}`);
+          await existingContainer.remove({ force: true });
+        }
+      } catch (error: unknown) {
+        // Container doesn't exist (404), we'll create it below
+        const isNotFound =
+          error &&
+          typeof error === "object" &&
+          "statusCode" in error &&
+          error.statusCode === 404;
+
+        if (!isNotFound) {
+          throw error;
+        }
+      }
+
+      // Get catalog item for local config
+      const catalogItem = await this.getCatalogItem();
+
+      if (!catalogItem?.localConfig) {
+        throw new Error(
+          `Local config not found for MCP server ${this.mcpServer.name}`,
+        );
+      }
+
+      // Create new container
+      logger.info(
+        `Creating container ${this.containerName} for MCP server ${this.mcpServer.name}`,
+      );
+
+      if (catalogItem.localConfig.command) {
+        logger.info(
+          `Using command: ${catalogItem.localConfig.command} ${(catalogItem.localConfig.arguments || []).join(" ")}`,
+        );
+      } else {
+        logger.info("Using Docker image's default CMD");
+      }
+
+      this.state = "pending";
+
+      // Use custom Docker image if provided
+      const dockerImage =
+        catalogItem.localConfig.dockerImage || mcpServerBaseImage;
+      logger.info(`Using Docker image: ${dockerImage}`);
+
+      // Pull image if needed
+      await this.pullImageIfNeeded(dockerImage);
+
+      // Check if HTTP port is needed
+      const needsHttp = await this.needsHttpPort();
+      const httpPort = catalogItem.localConfig.httpPort || 8080;
+
+      // Create the container
+      const normalizedLocalConfig = {
+        ...catalogItem.localConfig,
+        environment: catalogItem.localConfig.environment?.map((env) => ({
+          ...env,
+          required: env.required ?? false,
+          description: env.description ?? "",
+        })),
+      };
+
+      const container = await this.docker.createContainer(
+        this.generateContainerOptions(
+          dockerImage,
+          normalizedLocalConfig,
+          needsHttp,
+          httpPort,
+        ),
+      );
+
+      this.containerId = container.id;
+
+      // Start the container
+      await container.start();
+
+      logger.info(`Container ${this.containerName} created and started`);
+
+      // For HTTP servers, get the assigned port
+      if (needsHttp) {
+        const inspectData = await container.inspect();
+        await this.assignHttpPortIfNeeded(inspectData);
+
+        const httpPath = catalogItem.localConfig.httpPath || "/mcp";
+        if (this.assignedHttpPort) {
+          this.httpEndpointUrl = `http://localhost:${this.assignedHttpPort}${httpPath}`;
+          logger.info(
+            `HTTP endpoint URL for ${this.containerName}: ${this.httpEndpointUrl}`,
+          );
+        }
+      }
+
+      this.state = "running";
+      logger.info(`Container ${this.containerName} is now running`);
+    } catch (error: unknown) {
+      this.state = "failed";
+      this.errorMessage =
+        error instanceof Error ? error.message : "Unknown error";
+      logger.error(
+        { err: error },
+        `Failed to start container ${this.containerName}:`,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Pull Docker image if not present locally
+   */
+  private async pullImageIfNeeded(image: string): Promise<void> {
+    try {
+      // Check if image exists locally
+      await this.docker.getImage(image).inspect();
+      logger.debug(`Image ${image} already exists locally`);
+    } catch (error: unknown) {
+      const isNotFound =
+        error &&
+        typeof error === "object" &&
+        "statusCode" in error &&
+        error.statusCode === 404;
+
+      if (isNotFound) {
+        logger.info(`Pulling image ${image}...`);
+
+        await new Promise<void>((resolve, reject) => {
+          this.docker.pull(image, {}, (err, stream) => {
+            if (err) {
+              reject(err);
+              return;
+            }
+
+            if (!stream) {
+              reject(new Error("Failed to get pull stream"));
+              return;
+            }
+
+            // Follow the pull progress
+            this.docker.modem.followProgress(
+              stream,
+              (pullErr: Error | null) => {
+                if (pullErr) {
+                  reject(pullErr);
+                } else {
+                  logger.info(`Successfully pulled image ${image}`);
+                  resolve();
+                }
+              },
+              (event: { status?: string; progress?: string }) => {
+                if (event.status) {
+                  logger.debug(`Pull progress: ${event.status}`);
+                }
+              },
+            );
+          });
+        });
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Assign HTTP port from container port bindings
+   */
+  private async assignHttpPortIfNeeded(
+    inspectData: Dockerode.ContainerInspectInfo,
+  ): Promise<void> {
+    const needsHttp = await this.needsHttpPort();
+    if (!needsHttp) {
+      return;
+    }
+
+    const catalogItem = await this.getCatalogItem();
+    const httpPort = catalogItem?.localConfig?.httpPort || 8080;
+
+    const portBindings = inspectData.NetworkSettings?.Ports;
+    const binding = portBindings?.[`${httpPort}/tcp`]?.[0];
+
+    if (binding?.HostPort) {
+      this.assignedHttpPort = parseInt(binding.HostPort, 10);
+      const httpPath = catalogItem?.localConfig?.httpPath || "/mcp";
+      this.httpEndpointUrl = `http://localhost:${this.assignedHttpPort}${httpPath}`;
+      logger.info(
+        `Assigned HTTP port ${this.assignedHttpPort} for container ${this.containerName}`,
+      );
+    }
+  }
+
+  /**
+   * Wait for container to be ready
+   * Alias: waitForPodReady for compatibility with K8sPod interface
+   */
+  async waitForContainerReady(
+    maxAttempts = 30,
+    intervalMs = 2000,
+  ): Promise<void> {
+    for (let i = 0; i < maxAttempts; i++) {
+      try {
+        const container = this.docker.getContainer(
+          this.containerId || this.containerName,
+        );
+        const inspectData = await container.inspect();
+
+        if (inspectData.State.Running) {
+          return;
+        }
+
+        if (inspectData.State.Status === "exited") {
+          this.state = "failed";
+          this.errorMessage = `Container exited with code ${inspectData.State.ExitCode}`;
+          throw new Error(
+            `Container ${this.containerName} exited unexpectedly`,
+          );
+        }
+      } catch (error: unknown) {
+        if (
+          error instanceof Error &&
+          error.message.includes("exited unexpectedly")
+        ) {
+          throw error;
+        }
+        // Continue waiting for other errors
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+
+    throw new Error(
+      `Container ${this.containerName} did not become ready after ${maxAttempts} attempts`,
+    );
+  }
+
+  /**
+   * Alias for waitForContainerReady - for compatibility with K8sPod interface
+   */
+  async waitForPodReady(maxAttempts = 30, intervalMs = 2000): Promise<void> {
+    return this.waitForContainerReady(maxAttempts, intervalMs);
+  }
+
+  /**
+   * Stop the container
+   */
+  async stopContainer(): Promise<void> {
+    try {
+      logger.info(`Stopping container ${this.containerName}`);
+      const container = this.docker.getContainer(
+        this.containerId || this.containerName,
+      );
+
+      try {
+        await container.stop({ t: 10 }); // 10 second timeout
+      } catch (error: unknown) {
+        // Container might already be stopped
+        const isNotRunning =
+          error &&
+          typeof error === "object" &&
+          "statusCode" in error &&
+          error.statusCode === 304;
+
+        if (!isNotRunning) {
+          throw error;
+        }
+      }
+
+      this.state = "not_created";
+      logger.info(`Container ${this.containerName} stopped`);
+    } catch (error: unknown) {
+      const isNotFound =
+        error &&
+        typeof error === "object" &&
+        "statusCode" in error &&
+        error.statusCode === 404;
+
+      if (isNotFound) {
+        logger.info(`Container ${this.containerName} already removed`);
+        this.state = "not_created";
+        return;
+      }
+
+      logger.error(
+        { err: error },
+        `Failed to stop container ${this.containerName}:`,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Remove the container completely
+   */
+  async removeContainer(): Promise<void> {
+    try {
+      const container = this.docker.getContainer(
+        this.containerId || this.containerName,
+      );
+
+      // Stop first if running
+      try {
+        const inspectData = await container.inspect();
+        if (inspectData.State.Running) {
+          await container.stop({ t: 10 });
+        }
+      } catch {
+        // Ignore errors - container might not exist
+      }
+
+      // Remove the container
+      await container.remove({ force: true });
+      this.state = "not_created";
+      this.containerId = undefined;
+      logger.info(`Container ${this.containerName} removed`);
+    } catch (error: unknown) {
+      const isNotFound =
+        error &&
+        typeof error === "object" &&
+        "statusCode" in error &&
+        error.statusCode === 404;
+
+      if (isNotFound) {
+        logger.info(`Container ${this.containerName} already removed`);
+        this.state = "not_created";
+        return;
+      }
+
+      logger.error(
+        { err: error },
+        `Failed to remove container ${this.containerName}:`,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Get recent logs from the container
+   */
+  async getRecentLogs(lines: number = 100): Promise<string> {
+    try {
+      const container = this.docker.getContainer(
+        this.containerId || this.containerName,
+      );
+
+      const logs = await container.logs({
+        stdout: true,
+        stderr: true,
+        tail: lines,
+        timestamps: false,
+      });
+
+      // Docker logs come as Buffer with stream headers, clean them up
+      return this.cleanDockerLogs(logs);
+    } catch (error: unknown) {
+      logger.error(
+        { err: error },
+        `Failed to get logs for container ${this.containerName}:`,
+      );
+
+      const isNotFound =
+        error &&
+        typeof error === "object" &&
+        "statusCode" in error &&
+        error.statusCode === 404;
+
+      if (isNotFound) {
+        return "Container not found";
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Clean Docker log output (remove stream headers)
+   */
+  private cleanDockerLogs(logs: Buffer | string): string {
+    if (typeof logs === "string") {
+      return logs;
+    }
+
+    // Docker multiplexed stream format: 8-byte header followed by payload
+    // Header: [STREAM_TYPE, 0, 0, 0, SIZE1, SIZE2, SIZE3, SIZE4]
+    const lines: string[] = [];
+    let offset = 0;
+
+    while (offset < logs.length) {
+      if (offset + 8 > logs.length) {
+        // Not enough bytes for header, treat rest as raw data
+        lines.push(logs.slice(offset).toString("utf8"));
+        break;
+      }
+
+      // Read payload size from header bytes 4-7 (big-endian)
+      const size = logs.readUInt32BE(offset + 4);
+      offset += 8;
+
+      if (offset + size > logs.length) {
+        // Incomplete payload, read what's available
+        lines.push(logs.slice(offset).toString("utf8"));
+        break;
+      }
+
+      const payload = logs.slice(offset, offset + size).toString("utf8");
+      lines.push(payload);
+      offset += size;
+    }
+
+    return lines.join("");
+  }
+
+  /**
+   * Stream logs from the container with follow enabled
+   */
+  async streamLogs(
+    responseStream: NodeJS.WritableStream,
+    lines: number = 100,
+  ): Promise<void> {
+    try {
+      const container = this.docker.getContainer(
+        this.containerId || this.containerName,
+      );
+
+      const logStream = await container.logs({
+        stdout: true,
+        stderr: true,
+        tail: lines,
+        follow: true,
+        timestamps: false,
+      });
+
+      // Create a PassThrough to handle the stream
+      const passThrough = new PassThrough();
+
+      // Pipe container logs through our processor
+      if (logStream instanceof Buffer) {
+        passThrough.write(this.cleanDockerLogs(logStream));
+        passThrough.end();
+      } else {
+        logStream.on("data", (chunk: Buffer) => {
+          const cleaned = this.cleanDockerLogs(chunk);
+          passThrough.write(cleaned);
+        });
+
+        logStream.on("end", () => {
+          passThrough.end();
+        });
+
+        logStream.on("error", (error: Error) => {
+          passThrough.destroy(error);
+        });
+      }
+
+      // Handle data flow
+      passThrough.on("data", (chunk) => {
+        if (!("destroyed" in responseStream) || !responseStream.destroyed) {
+          responseStream.write(chunk);
+        }
+      });
+
+      passThrough.on("end", () => {
+        if (!("destroyed" in responseStream) || !responseStream.destroyed) {
+          responseStream.end();
+        }
+      });
+
+      passThrough.on("error", (error) => {
+        logger.error(
+          { err: error },
+          `Log stream error for container ${this.containerName}:`,
+        );
+        if (!("destroyed" in responseStream) || !responseStream.destroyed) {
+          if (
+            "destroy" in responseStream &&
+            typeof responseStream.destroy === "function"
+          ) {
+            responseStream.destroy(error);
+          }
+        }
+      });
+
+      // Handle response stream cleanup
+      responseStream.on("close", () => {
+        passThrough.destroy();
+      });
+    } catch (error: unknown) {
+      logger.error(
+        { err: error },
+        `Failed to stream logs for container ${this.containerName}:`,
+      );
+
+      if (!("destroyed" in responseStream) || !responseStream.destroyed) {
+        if (
+          "destroy" in responseStream &&
+          typeof responseStream.destroy === "function"
+        ) {
+          responseStream.destroy(error as Error);
+        }
+      }
+
+      throw error;
+    }
+  }
+
+  /**
+   * Get the container's status summary
+   */
+  get statusSummary(): DockerPodStatusSummary {
+    return {
+      state: this.state,
+      message:
+        this.state === "running"
+          ? "Container is running"
+          : this.state === "pending"
+            ? "Container is starting"
+            : this.state === "failed"
+              ? "Container failed"
+              : "Container not created",
+      error: this.errorMessage,
+      containerName: this.containerName,
+      containerId: this.containerId || null,
+    };
+  }
+
+  get name(): string {
+    return this.containerName;
+  }
+
+  get id(): string | undefined {
+    return this.containerId;
+  }
+
+  /**
+   * Get the Docker client instance
+   */
+  get dockerClient(): Dockerode {
+    return this.docker;
+  }
+
+  /**
+   * Check if this container uses streamable HTTP transport
+   */
+  async usesStreamableHttp(): Promise<boolean> {
+    return await this.needsHttpPort();
+  }
+
+  /**
+   * Get the HTTP endpoint URL for streamable-http servers
+   */
+  getHttpEndpointUrl(): string | undefined {
+    return this.httpEndpointUrl;
+  }
+}

--- a/platform/backend/src/mcp-server-runtime/manager.ts
+++ b/platform/backend/src/mcp-server-runtime/manager.ts
@@ -1,105 +1,212 @@
 import * as k8s from "@kubernetes/client-node";
 import { Attach } from "@kubernetes/client-node";
+import Dockerode from "dockerode";
 import config from "@/config";
 import logger from "@/logging";
 import { InternalMcpCatalogModel, McpServerModel } from "@/models";
 import { secretManager } from "@/secretsmanager";
 import type { McpServer } from "@/types";
+import DockerPod from "./docker-pod";
 import K8sPod from "./k8s-pod";
 import type {
   AvailableTool,
-  K8sRuntimeStatus,
-  K8sRuntimeStatusSummary,
+  DockerPodStatusSummary,
+  K8sPodStatusSummary,
   McpServerContainerLogs,
+  RuntimeStatus,
+  RuntimeType,
+  UnifiedRuntimeStatusSummary,
 } from "./schemas";
 
 const {
   orchestrator: {
     kubernetes: { namespace, kubeconfig, loadKubeconfigFromCurrentCluster },
+    docker: { enabled: dockerEnabled, socketPath: dockerSocketPath },
   },
 } = config;
 
 /**
- * McpServerRuntimeManager manages MCP servers running in Kubernetes pods.
- * This is analogous to McpServerSandboxManager in the desktop app,
- * but uses Kubernetes instead of Podman.
+ * McpServerRuntimeManager manages MCP servers running in Kubernetes pods or Docker containers.
+ *
+ * Runtime Selection Priority:
+ * 1. If K8s is explicitly configured (kubeconfig or loadFromCluster), use K8s
+ * 2. If Docker socket is available and enabled, use Docker
+ * 3. Otherwise, runtime is disabled
+ *
+ * This allows Docker deployments to run MCP servers without needing Kubernetes.
  */
 export class McpServerRuntimeManager {
-  private k8sConfig: k8s.KubeConfig;
+  // K8s components
+  private k8sConfig?: k8s.KubeConfig;
   private k8sApi?: k8s.CoreV1Api;
-  private k8sAttach: Attach;
-  private k8sLog: k8s.Log;
-  private namespace: string;
-  private mcpServerIdToPodMap: Map<string, K8sPod> = new Map();
-  private status: K8sRuntimeStatus = "not_initialized";
+  private k8sAttach?: Attach;
+  private k8sLog?: k8s.Log;
+  private k8sNamespace: string;
+
+  // Docker components
+  private docker?: Dockerode;
+
+  // Unified state
+  private runtimeType: RuntimeType = "none";
+  private mcpServerIdToPodMap: Map<string, K8sPod | DockerPod> = new Map();
+  private status: RuntimeStatus = "not_initialized";
 
   // Callbacks for initialization events
   onRuntimeStartupSuccess: () => void = () => {};
   onRuntimeStartupError: (error: Error) => void = () => {};
 
   constructor() {
-    this.k8sConfig = new k8s.KubeConfig();
-
-    // Load K8s config from environment or default locations
-    try {
-      if (loadKubeconfigFromCurrentCluster) {
-        /**
-         * Running inside a K8s cluster
-         *
-         * Automatically configure the client to connect to the Kubernetes API
-         * when the application is running inside a Kubernetes cluster
-         */
-        this.k8sConfig.loadFromCluster();
-      } else if (kubeconfig) {
-        // Load from KUBECONFIG env var
-        this.k8sConfig.loadFromFile(kubeconfig);
-      } else {
-        // Load from default location (~/.kube/config)
-        this.k8sConfig.loadFromDefault();
-      }
-
-      // Only create API client if K8s config loaded successfully
-      this.k8sApi = this.k8sConfig.makeApiClient(k8s.CoreV1Api);
-    } catch (error) {
-      logger.error({ err: error }, "Failed to load Kubernetes config:");
-      this.status = "error";
-    }
-
-    this.k8sAttach = new Attach(this.k8sConfig);
-    this.k8sLog = new k8s.Log(this.k8sConfig);
-    this.namespace = namespace;
+    this.k8sNamespace = namespace;
+    this.initializeRuntime();
   }
 
   /**
-   * Check if the orchestrator K8s runtime is enabled
-   * Returns true if the K8s config loaded successfully (constructor didn't fail)
-   * and the runtime hasn't been stopped
+   * Initialize the appropriate runtime based on configuration and availability
+   */
+  private initializeRuntime(): void {
+    // Priority 1: Try Kubernetes if explicitly configured
+    if (loadKubeconfigFromCurrentCluster || kubeconfig) {
+      if (this.initializeK8s()) {
+        this.runtimeType = "kubernetes";
+        logger.info("MCP Server Runtime: Using Kubernetes");
+        return;
+      }
+    }
+
+    // Priority 2: Try Docker if enabled and available
+    if (dockerEnabled) {
+      if (this.initializeDocker()) {
+        this.runtimeType = "docker";
+        logger.info("MCP Server Runtime: Using Docker");
+        return;
+      }
+    }
+
+    // Priority 3: Try K8s with default config (for local dev with kind/minikube)
+    if (!loadKubeconfigFromCurrentCluster && !kubeconfig) {
+      if (this.initializeK8s()) {
+        this.runtimeType = "kubernetes";
+        logger.info("MCP Server Runtime: Using Kubernetes (default config)");
+        return;
+      }
+    }
+
+    // No runtime available
+    this.runtimeType = "none";
+    this.status = "error";
+    logger.warn(
+      "MCP Server Runtime: No runtime available. Local MCP servers will not work. " +
+        "Configure Kubernetes (ARCHESTRA_ORCHESTRATOR_KUBECONFIG) or Docker (ARCHESTRA_ORCHESTRATOR_DOCKER_ENABLED=true).",
+    );
+  }
+
+  /**
+   * Initialize Kubernetes runtime
+   */
+  private initializeK8s(): boolean {
+    try {
+      this.k8sConfig = new k8s.KubeConfig();
+
+      if (loadKubeconfigFromCurrentCluster) {
+        this.k8sConfig.loadFromCluster();
+      } else if (kubeconfig) {
+        this.k8sConfig.loadFromFile(kubeconfig);
+      } else {
+        this.k8sConfig.loadFromDefault();
+      }
+
+      this.k8sApi = this.k8sConfig.makeApiClient(k8s.CoreV1Api);
+      this.k8sAttach = new Attach(this.k8sConfig);
+      this.k8sLog = new k8s.Log(this.k8sConfig);
+
+      return true;
+    } catch (error) {
+      logger.debug(
+        { err: error },
+        "Failed to initialize Kubernetes runtime (will try Docker next)",
+      );
+      this.k8sConfig = undefined;
+      this.k8sApi = undefined;
+      this.k8sAttach = undefined;
+      this.k8sLog = undefined;
+      return false;
+    }
+  }
+
+  /**
+   * Initialize Docker runtime
+   */
+  private initializeDocker(): boolean {
+    try {
+      const dockerOptions: Dockerode.DockerOptions = {};
+
+      if (dockerSocketPath) {
+        dockerOptions.socketPath = dockerSocketPath;
+      } else if (process.platform === "win32") {
+        // Windows named pipe
+        dockerOptions.socketPath = "//./pipe/docker_engine";
+      } else {
+        // Unix socket (Linux/macOS)
+        dockerOptions.socketPath = "/var/run/docker.sock";
+      }
+
+      this.docker = new Dockerode(dockerOptions);
+
+      // We'll verify connectivity in start() to avoid blocking constructor
+      return true;
+    } catch (error) {
+      logger.debug({ err: error }, "Failed to initialize Docker runtime");
+      this.docker = undefined;
+      return false;
+    }
+  }
+
+  /**
+   * Check if the orchestrator runtime is enabled
    */
   get isEnabled(): boolean {
-    return this.status !== "error" && this.status !== "stopped";
+    return (
+      this.runtimeType !== "none" &&
+      this.status !== "error" &&
+      this.status !== "stopped"
+    );
+  }
+
+  /**
+   * Get the current runtime type
+   */
+  get currentRuntimeType(): RuntimeType {
+    return this.runtimeType;
   }
 
   /**
    * Initialize the runtime and start all installed MCP servers
    */
   async start(): Promise<void> {
-    if (!this.k8sApi) {
-      throw new Error("Kubernetes API client not initialized");
+    if (this.runtimeType === "none") {
+      logger.warn("No runtime available, skipping MCP server startup");
+      return;
     }
 
     try {
       this.status = "initializing";
-      logger.info("Initializing Kubernetes MCP Server Runtime...");
+      logger.info(
+        `Initializing ${this.runtimeType === "kubernetes" ? "Kubernetes" : "Docker"} MCP Server Runtime...`,
+      );
 
-      // Verify K8s connectivity
-      await this.verifyK8sConnection();
+      // Verify connectivity
+      if (this.runtimeType === "kubernetes") {
+        await this.verifyK8sConnection();
+      } else if (this.runtimeType === "docker") {
+        await this.verifyDockerConnection();
+      }
 
       this.status = "running";
 
       // Get all installed local MCP servers from database
       const installedServers = await McpServerModel.findAll();
 
-      // Filter for local servers only (remote servers don't need pods)
+      // Filter for local servers only (remote servers don't need pods/containers)
       const localServers: McpServer[] = [];
       for (const server of installedServers) {
         if (server.catalogId) {
@@ -152,7 +259,7 @@ export class McpServerRuntimeManager {
   }
 
   /**
-   * Verify that we can connect to Kubernetes
+   * Verify Kubernetes connectivity
    */
   private async verifyK8sConnection(): Promise<void> {
     if (!this.k8sApi) {
@@ -160,11 +267,10 @@ export class McpServerRuntimeManager {
     }
 
     try {
-      logger.info(`Verifying K8s connection to namespace: ${this.namespace}`);
-
-      // Try to list pods in the namespace to verify connectivity
-      await this.k8sApi.listNamespacedPod({ namespace: this.namespace });
-
+      logger.info(
+        `Verifying K8s connection to namespace: ${this.k8sNamespace}`,
+      );
+      await this.k8sApi.listNamespacedPod({ namespace: this.k8sNamespace });
       logger.info("K8s connection verified successfully");
     } catch (error: unknown) {
       const errorMsg = error instanceof Error ? error.message : "Unknown error";
@@ -174,22 +280,66 @@ export class McpServerRuntimeManager {
   }
 
   /**
-   * Start a single MCP server pod
+   * Verify Docker connectivity
+   */
+  private async verifyDockerConnection(): Promise<void> {
+    if (!this.docker) {
+      throw new Error("Docker client not initialized");
+    }
+
+    try {
+      logger.info("Verifying Docker connection...");
+      await this.docker.ping();
+      const info = await this.docker.info();
+      logger.info(
+        `Docker connection verified: ${info.Name} (${info.ServerVersion})`,
+      );
+    } catch (error: unknown) {
+      const errorMsg = error instanceof Error ? error.message : "Unknown error";
+      logger.error(`Failed to connect to Docker: ${errorMsg}`);
+      throw new Error(
+        `Docker connection failed: ${errorMsg}. Ensure Docker is running and the socket is accessible.`,
+      );
+    }
+  }
+
+  /**
+   * Start a single MCP server
    */
   async startServer(
     mcpServer: McpServer,
     userConfigValues?: Record<string, string>,
     environmentValues?: Record<string, string>,
   ): Promise<void> {
-    if (!this.k8sApi) {
+    if (this.runtimeType === "kubernetes") {
+      await this.startK8sServer(mcpServer, userConfigValues, environmentValues);
+    } else if (this.runtimeType === "docker") {
+      await this.startDockerServer(
+        mcpServer,
+        userConfigValues,
+        environmentValues,
+      );
+    } else {
+      throw new Error("No runtime available to start MCP server");
+    }
+  }
+
+  /**
+   * Start MCP server as K8s pod
+   */
+  private async startK8sServer(
+    mcpServer: McpServer,
+    userConfigValues?: Record<string, string>,
+    environmentValues?: Record<string, string>,
+  ): Promise<void> {
+    if (!this.k8sApi || !this.k8sAttach || !this.k8sLog) {
       throw new Error("Kubernetes API client not initialized");
     }
 
     const { id, name } = mcpServer;
-    logger.info(`Starting MCP server pod: id="${id}", name="${name}"`);
+    logger.info(`Starting MCP server K8s pod: id="${id}", name="${name}"`);
 
     try {
-      // Fetch catalog item (needed for conditional env var logic)
       let catalogItem = null;
       if (mcpServer.catalogId) {
         catalogItem = await InternalMcpCatalogModel.findById(
@@ -202,29 +352,23 @@ export class McpServerRuntimeManager {
         this.k8sApi,
         this.k8sAttach,
         this.k8sLog,
-        this.namespace,
+        this.k8sNamespace,
         catalogItem,
         userConfigValues,
         environmentValues,
       );
 
-      // Register the pod BEFORE starting it
       this.mcpServerIdToPodMap.set(id, k8sPod);
       logger.info(`Registered MCP server pod ${id} in map`);
 
-      // If MCP server has a secretId, fetch secret from database and create K8s Secret
+      // Create K8s Secret if needed
       if (mcpServer.secretId) {
         const secret = await secretManager.getSecret(mcpServer.secretId);
-
         if (secret?.secret && typeof secret.secret === "object") {
           const secretData: Record<string, string> = {};
-
-          // Convert secret.secret (Record<string, unknown>) to Record<string, string>
           for (const [key, value] of Object.entries(secret.secret)) {
             secretData[key] = String(value);
           }
-
-          // Create K8s Secret from database secret
           await k8sPod.createK8sSecret(secretData);
           logger.info(
             { mcpServerId: id, secretId: mcpServer.secretId },
@@ -240,8 +384,6 @@ export class McpServerRuntimeManager {
         { err: error },
         `Failed to start MCP server pod ${id} (${name}):`,
       );
-      // Keep the pod in the map even if it failed to start
-      // This ensures it appears in status updates with error state
       logger.warn(
         `MCP server pod ${id} failed to start but remains registered for error display`,
       );
@@ -250,48 +392,138 @@ export class McpServerRuntimeManager {
   }
 
   /**
-   * Stop a single MCP server pod
+   * Start MCP server as Docker container
    */
-  async stopServer(mcpServerId: string): Promise<void> {
-    const k8sPod = this.mcpServerIdToPodMap.get(mcpServerId);
+  private async startDockerServer(
+    mcpServer: McpServer,
+    userConfigValues?: Record<string, string>,
+    environmentValues?: Record<string, string>,
+  ): Promise<void> {
+    if (!this.docker) {
+      throw new Error("Docker client not initialized");
+    }
 
-    if (k8sPod) {
-      // Delete pod first
-      await k8sPod.stopPod();
+    const { id, name } = mcpServer;
+    logger.info(
+      `Starting MCP server Docker container: id="${id}", name="${name}"`,
+    );
 
-      // Delete K8s Secret (if it exists)
-      await k8sPod.deleteK8sSecret();
+    try {
+      let catalogItem = null;
+      if (mcpServer.catalogId) {
+        catalogItem = await InternalMcpCatalogModel.findById(
+          mcpServer.catalogId,
+        );
+      }
 
-      this.mcpServerIdToPodMap.delete(mcpServerId);
+      // For Docker, we pass secrets as environment variables directly
+      const mergedEnvValues = { ...environmentValues };
+      if (mcpServer.secretId) {
+        const secret = await secretManager.getSecret(mcpServer.secretId);
+        if (secret?.secret && typeof secret.secret === "object") {
+          for (const [key, value] of Object.entries(secret.secret)) {
+            mergedEnvValues[key] = String(value);
+          }
+        }
+      }
+
+      const dockerPod = new DockerPod(
+        mcpServer,
+        this.docker,
+        catalogItem,
+        userConfigValues,
+        mergedEnvValues,
+      );
+
+      this.mcpServerIdToPodMap.set(id, dockerPod);
+      logger.info(`Registered MCP server container ${id} in map`);
+
+      await dockerPod.startOrCreateContainer();
+      logger.info(`Successfully started MCP server container ${id} (${name})`);
+    } catch (error) {
+      logger.error(
+        { err: error },
+        `Failed to start MCP server container ${id} (${name}):`,
+      );
+      logger.warn(
+        `MCP server container ${id} failed to start but remains registered for error display`,
+      );
+      throw error;
     }
   }
 
   /**
-   * Get a pod by MCP server ID
+   * Stop a single MCP server
    */
-  getPod(mcpServerId: string): K8sPod | undefined {
+  async stopServer(mcpServerId: string): Promise<void> {
+    const pod = this.mcpServerIdToPodMap.get(mcpServerId);
+
+    if (!pod) {
+      return;
+    }
+
+    if (pod instanceof K8sPod) {
+      await pod.stopPod();
+      await pod.deleteK8sSecret();
+    } else if (pod instanceof DockerPod) {
+      await pod.stopContainer();
+    }
+
+    this.mcpServerIdToPodMap.delete(mcpServerId);
+  }
+
+  /**
+   * Get a pod/container by MCP server ID
+   */
+  getPod(mcpServerId: string): K8sPod | DockerPod | undefined {
     return this.mcpServerIdToPodMap.get(mcpServerId);
   }
 
   /**
-   * Remove an MCP server pod completely
+   * Get a K8s pod by MCP server ID (for transport creation)
+   */
+  getK8sPod(mcpServerId: string): K8sPod | undefined {
+    const pod = this.mcpServerIdToPodMap.get(mcpServerId);
+    if (pod instanceof K8sPod) {
+      return pod;
+    }
+    return undefined;
+  }
+
+  /**
+   * Get a Docker pod by MCP server ID (for transport creation)
+   */
+  getDockerPod(mcpServerId: string): DockerPod | undefined {
+    const pod = this.mcpServerIdToPodMap.get(mcpServerId);
+    if (pod instanceof DockerPod) {
+      return pod;
+    }
+    return undefined;
+  }
+
+  /**
+   * Remove an MCP server completely
    */
   async removeMcpServer(mcpServerId: string): Promise<void> {
-    logger.info(`Removing MCP server pod for: ${mcpServerId}`);
+    logger.info(`Removing MCP server for: ${mcpServerId}`);
 
-    const k8sPod = this.mcpServerIdToPodMap.get(mcpServerId);
-    if (!k8sPod) {
-      logger.warn(`No pod found for MCP server ${mcpServerId}`);
+    const pod = this.mcpServerIdToPodMap.get(mcpServerId);
+    if (!pod) {
+      logger.warn(`No pod/container found for MCP server ${mcpServerId}`);
       return;
     }
 
     try {
-      await k8sPod.removePod();
-      logger.info(`Successfully removed MCP server pod ${mcpServerId}`);
+      if (pod instanceof K8sPod) {
+        await pod.removePod();
+      } else if (pod instanceof DockerPod) {
+        await pod.removeContainer();
+      }
+      logger.info(`Successfully removed MCP server ${mcpServerId}`);
     } catch (error) {
       logger.error(
         { err: error },
-        `Failed to remove MCP server pod ${mcpServerId}:`,
+        `Failed to remove MCP server ${mcpServerId}:`,
       );
       throw error;
     } finally {
@@ -300,33 +532,26 @@ export class McpServerRuntimeManager {
   }
 
   /**
-   * Restart a single MCP server pod
+   * Restart a single MCP server
    */
   async restartServer(mcpServerId: string): Promise<void> {
-    logger.info(`Restarting MCP server pod: ${mcpServerId}`);
+    logger.info(`Restarting MCP server: ${mcpServerId}`);
 
     try {
-      // Get the MCP server from database
       const mcpServer = await McpServerModel.findById(mcpServerId);
-
       if (!mcpServer) {
         throw new Error(`MCP server with id ${mcpServerId} not found`);
       }
 
-      // Stop the pod
       await this.stopServer(mcpServerId);
-
-      // Wait a moment for shutdown to complete
       await new Promise((resolve) => setTimeout(resolve, 2000));
-
-      // Start the pod again
       await this.startServer(mcpServer);
 
-      logger.info(`MCP server pod ${mcpServerId} restarted successfully`);
+      logger.info(`MCP server ${mcpServerId} restarted successfully`);
     } catch (error) {
       logger.error(
         { err: error },
-        `Failed to restart MCP server pod ${mcpServerId}:`,
+        `Failed to restart MCP server ${mcpServerId}:`,
       );
       throw error;
     }
@@ -336,85 +561,96 @@ export class McpServerRuntimeManager {
    * Check if an MCP server uses streamable HTTP transport
    */
   async usesStreamableHttp(mcpServerId: string): Promise<boolean> {
-    const k8sPod = this.mcpServerIdToPodMap.get(mcpServerId);
-    if (!k8sPod) {
+    const pod = this.mcpServerIdToPodMap.get(mcpServerId);
+    if (!pod) {
       return false;
     }
-    return await k8sPod.usesStreamableHttp();
+    return await pod.usesStreamableHttp();
   }
 
   /**
    * Get the HTTP endpoint URL for a streamable-http server
    */
   getHttpEndpointUrl(mcpServerId: string): string | undefined {
-    const k8sPod = this.mcpServerIdToPodMap.get(mcpServerId);
-    if (!k8sPod) {
+    const pod = this.mcpServerIdToPodMap.get(mcpServerId);
+    if (!pod) {
       return undefined;
     }
-    return k8sPod.getHttpEndpointUrl();
+    return pod.getHttpEndpointUrl();
   }
 
   /**
-   * Get logs from an MCP server pod
+   * Get logs from an MCP server
    */
   async getMcpServerLogs(
     mcpServerId: string,
     lines: number = 100,
   ): Promise<McpServerContainerLogs> {
-    const k8sPod = this.mcpServerIdToPodMap.get(mcpServerId);
-    if (!k8sPod) {
-      throw new Error(`Pod not found for MCP server ${mcpServerId}`);
+    const pod = this.mcpServerIdToPodMap.get(mcpServerId);
+    if (!pod) {
+      throw new Error(`Pod/container not found for MCP server ${mcpServerId}`);
     }
 
-    const containerName = k8sPod.containerName;
-    return {
-      logs: await k8sPod.getRecentLogs(lines),
-      containerName,
-      // Construct the kubectl command for the user to manually get the logs if they'd like
-      command: `kubectl logs -n ${this.namespace} ${containerName} --tail=${lines}`,
-      namespace: this.namespace,
-    };
+    if (pod instanceof K8sPod) {
+      const containerName = pod.containerName;
+      return {
+        logs: await pod.getRecentLogs(lines),
+        containerName,
+        command: `kubectl logs -n ${this.k8sNamespace} ${containerName} --tail=${lines}`,
+        namespace: this.k8sNamespace,
+      };
+    } else if (pod instanceof DockerPod) {
+      return {
+        logs: await pod.getRecentLogs(lines),
+        containerName: pod.name,
+        command: `docker logs --tail=${lines} ${pod.name}`,
+        namespace: "docker",
+      };
+    }
+
+    throw new Error("Unknown pod type");
   }
 
   /**
-   * Stream logs from an MCP server pod with follow enabled
+   * Stream logs from an MCP server with follow enabled
    */
   async streamMcpServerLogs(
     mcpServerId: string,
     responseStream: NodeJS.WritableStream,
     lines: number = 100,
   ): Promise<void> {
-    const k8sPod = this.mcpServerIdToPodMap.get(mcpServerId);
-    if (!k8sPod) {
-      throw new Error(`Pod not found for MCP server ${mcpServerId}`);
+    const pod = this.mcpServerIdToPodMap.get(mcpServerId);
+    if (!pod) {
+      throw new Error(`Pod/container not found for MCP server ${mcpServerId}`);
     }
 
-    await k8sPod.streamLogs(responseStream, lines);
+    await pod.streamLogs(responseStream, lines);
   }
 
   /**
-   * Get all available tools from all running MCP servers
-   * Note: In the platform, tools are managed via the database and MCP client,
-   * not directly through the runtime manager like in desktop app.
-   * This is a placeholder for compatibility.
+   * Get all available tools (placeholder for compatibility)
    */
   get allAvailableTools(): AvailableTool[] {
-    // Tools are managed by the MCP client and stored in the database
-    // This method is here for compatibility with the desktop app interface
     return [];
   }
 
   /**
    * Get the runtime status summary
    */
-  get statusSummary(): K8sRuntimeStatusSummary {
+  get statusSummary(): UnifiedRuntimeStatusSummary {
+    const mcpServers: Record<
+      string,
+      K8sPodStatusSummary | DockerPodStatusSummary
+    > = {};
+
+    for (const [mcpServerId, pod] of this.mcpServerIdToPodMap.entries()) {
+      mcpServers[mcpServerId] = pod.statusSummary;
+    }
+
     return {
+      runtimeType: this.runtimeType,
       status: this.status,
-      mcpServers: Object.fromEntries(
-        Array.from(this.mcpServerIdToPodMap.entries()).map(
-          ([mcpServerId, k8sPod]) => [mcpServerId, k8sPod.statusSummary],
-        ),
-      ),
+      mcpServers,
     };
   }
 
@@ -425,7 +661,6 @@ export class McpServerRuntimeManager {
     logger.info("Shutting down MCP Server Runtime...");
     this.status = "stopped";
 
-    // Stop all pods
     const stopPromises = Array.from(this.mcpServerIdToPodMap.keys()).map(
       async (serverId) => {
         try {
@@ -433,7 +668,7 @@ export class McpServerRuntimeManager {
         } catch (error) {
           logger.error(
             { err: error },
-            `Failed to stop MCP server pod ${serverId} during shutdown:`,
+            `Failed to stop MCP server ${serverId} during shutdown:`,
           );
         }
       },

--- a/platform/backend/src/mcp-server-runtime/schemas.ts
+++ b/platform/backend/src/mcp-server-runtime/schemas.ts
@@ -1,11 +1,15 @@
 import { z } from "zod";
 
-export type K8sRuntimeStatus =
+// Common runtime status (used by both K8s and Docker)
+export type RuntimeStatus =
   | "not_initialized"
   | "initializing"
   | "running"
   | "error"
   | "stopped";
+
+// K8s-specific types (kept for backward compatibility)
+export type K8sRuntimeStatus = RuntimeStatus;
 
 export type K8sPodState =
   | "not_created"
@@ -25,6 +29,38 @@ export interface K8sPodStatusSummary {
 export interface K8sRuntimeStatusSummary {
   status: K8sRuntimeStatus;
   mcpServers: Record<string, K8sPodStatusSummary>;
+}
+
+// Docker-specific types
+export type DockerRuntimeStatus = RuntimeStatus;
+
+export type DockerPodState =
+  | "not_created"
+  | "pending"
+  | "running"
+  | "failed"
+  | "succeeded";
+
+export interface DockerPodStatusSummary {
+  state: DockerPodState;
+  message: string;
+  error: string | null;
+  containerName: string | null;
+  containerId: string | null;
+}
+
+export interface DockerRuntimeStatusSummary {
+  status: DockerRuntimeStatus;
+  mcpServers: Record<string, DockerPodStatusSummary>;
+}
+
+// Unified runtime status (can be either K8s or Docker)
+export type RuntimeType = "kubernetes" | "docker" | "none";
+
+export interface UnifiedRuntimeStatusSummary {
+  runtimeType: RuntimeType;
+  status: RuntimeStatus;
+  mcpServers: Record<string, K8sPodStatusSummary | DockerPodStatusSummary>;
 }
 
 export const AvailableToolAnalysisSchema = z.object({

--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       better-auth:
         specifier: 1.4.6-beta.3
         version: 1.4.6-beta.3(next@16.0.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      dockerode:
+        specifier: ^4.0.6
+        version: 4.0.9
       dotenv:
         specifier: ^17.2.2
         version: 17.2.3
@@ -199,6 +202,9 @@ importers:
       '@sentry/cli':
         specifier: ^2.47.0
         version: 2.58.2
+      '@types/dockerode':
+        specifier: ^3.3.37
+        version: 3.3.47
       '@types/jmespath':
         specifier: ^0.15.2
         version: 0.15.2
@@ -792,6 +798,9 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
+  '@balena/dockerignore@1.0.2':
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
+
   '@better-auth/core@1.4.6-beta.3':
     resolution: {integrity: sha512-yjiu7wva4a0HFiWNWoaKfazLXMOx0+2mpyIbB5A1ov1Ta/YXZAg7jeh9A9uyBGXI8Y2qBVMYExumXVp1m1Xz+w==}
     peerDependencies:
@@ -1228,6 +1237,11 @@ packages:
   '@grpc/grpc-js@1.14.1':
     resolution: {integrity: sha512-sPxgEWtPUR3EnRJCEtbGZG2iX8LQDUls2wUS3o27jg07KqJFMq6YDeWvMo1wfpmy3rqRdS0rivpLwhqQtEyCuQ==}
     engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   '@grpc/proto-loader@0.8.0':
     resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
@@ -3786,6 +3800,12 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/docker-modem@3.0.6':
+    resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
+
+  '@types/dockerode@3.3.47':
+    resolution: {integrity: sha512-ShM1mz7rCjdssXt7Xz0u1/R2BJC7piWa3SJpUBiVjCf2A3XNn4cP6pUVaD8bLanpPVVn4IKzJuw3dOvkJ8IbYw==}
+
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
@@ -3865,6 +3885,9 @@ packages:
 
   '@types/react@19.2.6':
     resolution: {integrity: sha512-p/jUvulfgU7oKtj6Xpk8cA2Y1xKTtICGpJYeJXz2YVO2UcvjQgeRMLDGfDeqeRW2Ta+0QNFwcc8X3GH8SxZz6w==}
+
+  '@types/ssh2@1.15.5':
+    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
   '@types/stream-buffers@3.0.8':
     resolution: {integrity: sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==}
@@ -4252,6 +4275,9 @@ packages:
   birpc@2.8.0:
     resolution: {integrity: sha512-Bz2a4qD/5GRhiHSwj30c/8kC8QGj12nNDwz3D4ErQ4Xhy35dsSDvF+RA/tWpjyU0pdGtSDiEk6B5fBGE1qNVhw==}
 
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
   bluebird@2.11.0:
     resolution: {integrity: sha512-UfFSr22dmHPQqPP9XWHRhq+gWnHCYguQGkXQlbyPtW5qTnhFWA8/iXg765tH0cAjy7l/zPJ1aBTO0g5XgA7kvQ==}
 
@@ -4279,6 +4305,13 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -4356,6 +4389,9 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -4475,6 +4511,10 @@ packages:
 
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -4742,6 +4782,14 @@ packages:
   diff@8.0.2:
     resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
     engines: {node: '>=0.3.1'}
+
+  docker-modem@5.0.6:
+    resolution: {integrity: sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ==}
+    engines: {node: '>= 8.0'}
+
+  dockerode@4.0.9:
+    resolution: {integrity: sha512-iND4mcOWhPaCNh54WmK/KoSb35AFqPAUWFMffTQcp52uQt36b5uNwEJTSXntJZBbeGad72Crbi/hvDIv6us/6Q==}
+    engines: {node: '>= 8.0'}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -5187,6 +5235,9 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -5426,6 +5477,9 @@ packages:
   iconv-lite@0.7.0:
     resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
     engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   import-in-the-middle@2.0.0:
     resolution: {integrity: sha512-yNZhyQYqXpkT0AKq3F3KLasUSK4fHvebNH5hOsKQw2dhGSALvQ4U0BqUc5suziKvydO5u5hgN2hy1RJaho8U5A==}
@@ -6084,6 +6138,9 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
@@ -6107,6 +6164,9 @@ packages:
   mutative@1.3.0:
     resolution: {integrity: sha512-8MJj6URmOZAV70dpFe1YnSppRTKC4DsMkXQiBDFayLcDI4ljGokHxmpqaBQuDWa4iAxWaJJ1PS8vAmbntjjKmQ==}
     engines: {node: '>=14.0'}
+
+  nan@2.24.0:
+    resolution: {integrity: sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -6650,6 +6710,10 @@ packages:
     resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -6964,9 +7028,16 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  split-ca@1.0.1:
+    resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  ssh2@1.17.0:
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
 
   sshpk@1.18.0:
     resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
@@ -7012,6 +7083,9 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -7087,8 +7161,15 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
   tar-fs@3.1.1:
     resolution: {integrity: sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
@@ -7403,6 +7484,13 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -8310,6 +8398,8 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@balena/dockerignore@1.0.2': {}
+
   '@better-auth/core@1.4.6-beta.3(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.4(zod@4.1.13))(jose@6.1.2)(kysely@0.28.8)(nanostores@1.1.0)':
     dependencies:
       '@better-auth/utils': 0.3.0
@@ -8695,6 +8785,13 @@ snapshots:
     dependencies:
       '@grpc/proto-loader': 0.8.0
       '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.7.15':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.4
+      yargs: 17.7.2
 
   '@grpc/proto-loader@0.8.0':
     dependencies:
@@ -11512,6 +11609,17 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/docker-modem@3.0.6':
+    dependencies:
+      '@types/node': 24.10.1
+      '@types/ssh2': 1.15.5
+
+  '@types/dockerode@3.3.47':
+    dependencies:
+      '@types/docker-modem': 3.0.6
+      '@types/node': 24.10.1
+      '@types/ssh2': 1.15.5
+
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
@@ -11602,6 +11710,10 @@ snapshots:
   '@types/react@19.2.6':
     dependencies:
       csstype: 3.2.3
+
+  '@types/ssh2@1.15.5':
+    dependencies:
+      '@types/node': 18.19.130
 
   '@types/stream-buffers@3.0.8':
     dependencies:
@@ -11966,6 +12078,12 @@ snapshots:
 
   birpc@2.8.0: {}
 
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   bluebird@2.11.0: {}
 
   body-parser@2.2.1:
@@ -12003,6 +12121,14 @@ snapshots:
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  buildcheck@0.0.7:
+    optional: true
 
   bundle-name@4.1.0:
     dependencies:
@@ -12088,6 +12214,8 @@ snapshots:
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
+
+  chownr@1.1.4: {}
 
   chrome-trace-event@1.0.4: {}
 
@@ -12177,6 +12305,12 @@ snapshots:
   cose-base@2.2.0:
     dependencies:
       layout-base: 2.0.1
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.7
+      nan: 2.24.0
+    optional: true
 
   cross-spawn@7.0.6:
     dependencies:
@@ -12448,6 +12582,27 @@ snapshots:
       dequal: 2.0.3
 
   diff@8.0.2: {}
+
+  docker-modem@5.0.6:
+    dependencies:
+      debug: 4.4.3
+      readable-stream: 3.6.2
+      split-ca: 1.0.1
+      ssh2: 1.17.0
+    transitivePeerDependencies:
+      - supports-color
+
+  dockerode@4.0.9:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@grpc/grpc-js': 1.14.1
+      '@grpc/proto-loader': 0.7.15
+      docker-modem: 5.0.6
+      protobufjs: 7.5.4
+      tar-fs: 2.1.4
+      uuid: 10.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   dom-accessibility-api@0.5.16: {}
 
@@ -12857,6 +13012,8 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fs-constants@1.0.0: {}
+
   fsevents@2.3.2:
     optional: true
 
@@ -13217,6 +13374,8 @@ snapshots:
   iconv-lite@0.7.0:
     dependencies:
       safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
 
   import-in-the-middle@2.0.0:
     dependencies:
@@ -14063,6 +14222,8 @@ snapshots:
 
   minipass@7.1.2: {}
 
+  mkdirp-classic@0.5.3: {}
+
   mlly@1.8.0:
     dependencies:
       acorn: 8.15.0
@@ -14084,6 +14245,9 @@ snapshots:
   mustache@4.2.0: {}
 
   mutative@1.3.0: {}
+
+  nan@2.24.0:
+    optional: true
 
   nanoid@3.3.11: {}
 
@@ -14680,6 +14844,12 @@ snapshots:
 
   react@19.2.0: {}
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
@@ -15136,7 +15306,17 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  split-ca@1.0.1: {}
+
   split2@4.2.0: {}
+
+  ssh2@1.17.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.24.0
 
   sshpk@1.18.0:
     dependencies:
@@ -15219,6 +15399,10 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.1.2
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
@@ -15281,6 +15465,13 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.3
+      tar-stream: 2.2.0
+
   tar-fs@3.1.1:
     dependencies:
       pump: 3.0.3
@@ -15292,6 +15483,14 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   tar-stream@3.1.7:
     dependencies:
@@ -15579,6 +15778,10 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.0):
     dependencies:
       react: 19.2.0
+
+  util-deprecate@1.0.2: {}
+
+  uuid@10.0.0: {}
 
   uuid@11.1.0: {}
 


### PR DESCRIPTION
fixes #1445
/claim #1445 

adds docker-native mcp server runtime allowing docker deployments to run mcp servers as sibling containers without
requiring Kubernetes.

<img width="581" height="332" alt="image" src="https://github.com/user-attachments/assets/b7ba89d4-d464-4817-9067-0a4cfefddb9a" />
<img width="608" height="159" alt="image" src="https://github.com/user-attachments/assets/3035a0fa-e130-4def-8f45-71912d7e901f" />
