### PR TITLE
Investigate ingress tf fix

### DIFF
--- a/platform/helm/archestra/templates/backend-config.yaml
+++ b/platform/helm/archestra/templates/backend-config.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.archestra.backendConfig.enabled }}
+# GKE BackendConfig for configuring load balancer health checks
+# This allows fine-tuning of health check settings to prevent downtime during deployments
+# Reference: https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: {{ include "archestra-platform.fullname" . }}-backend-config
+  labels:
+    {{- include "archestra-platform.labels" . | nindent 4 }}
+spec:
+  healthCheck:
+    checkIntervalSec: {{ .Values.archestra.backendConfig.healthCheck.checkIntervalSec }}
+    timeoutSec: {{ .Values.archestra.backendConfig.healthCheck.timeoutSec }}
+    healthyThreshold: {{ .Values.archestra.backendConfig.healthCheck.healthyThreshold }}
+    unhealthyThreshold: {{ .Values.archestra.backendConfig.healthCheck.unhealthyThreshold }}
+    type: {{ .Values.archestra.backendConfig.healthCheck.type }}
+    requestPath: {{ .Values.archestra.backendConfig.healthCheck.requestPath }}
+    port: {{ .Values.archestra.backendConfig.healthCheck.port }}
+{{- end }}

--- a/platform/helm/archestra/tests/archestra_platform_backend_config_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_backend_config_test.yaml
@@ -1,0 +1,77 @@
+suite: test archestra platform -- GKE BackendConfig
+templates:
+  - backend-config.yaml
+tests:
+  - it: should not create BackendConfig when disabled
+    set:
+      archestra.backendConfig.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create BackendConfig when enabled
+    set:
+      archestra.backendConfig.enabled: true
+    asserts:
+      - isKind:
+          of: BackendConfig
+      - matchRegex:
+          path: metadata.name
+          pattern: -backend-config$
+
+  - it: should configure health check with default values
+    set:
+      archestra.backendConfig.enabled: true
+    asserts:
+      - equal:
+          path: spec.healthCheck.checkIntervalSec
+          value: 15
+      - equal:
+          path: spec.healthCheck.timeoutSec
+          value: 10
+      - equal:
+          path: spec.healthCheck.healthyThreshold
+          value: 1
+      - equal:
+          path: spec.healthCheck.unhealthyThreshold
+          value: 10
+      - equal:
+          path: spec.healthCheck.type
+          value: HTTP
+      - equal:
+          path: spec.healthCheck.requestPath
+          value: /health
+      - equal:
+          path: spec.healthCheck.port
+          value: 9000
+
+  - it: should allow customizing health check values
+    set:
+      archestra.backendConfig.enabled: true
+      archestra.backendConfig.healthCheck:
+        checkIntervalSec: 30
+        timeoutSec: 15
+        healthyThreshold: 2
+        unhealthyThreshold: 5
+        type: HTTP
+        requestPath: /api/health
+        port: 8080
+    asserts:
+      - equal:
+          path: spec.healthCheck.checkIntervalSec
+          value: 30
+      - equal:
+          path: spec.healthCheck.timeoutSec
+          value: 15
+      - equal:
+          path: spec.healthCheck.healthyThreshold
+          value: 2
+      - equal:
+          path: spec.healthCheck.unhealthyThreshold
+          value: 5
+      - equal:
+          path: spec.healthCheck.requestPath
+          value: /api/health
+      - equal:
+          path: spec.healthCheck.port
+          value: 8080

--- a/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
@@ -65,20 +65,27 @@ tests:
           path: spec.replicas
           value: 4
 
-  - it: should not configure deployment strategy by default
+  - it: should configure default deployment strategy for zero-downtime deployments
     documentIndex: 1
     asserts:
-      - isNull:
-          path: spec.strategy
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 1
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0
 
-  - it: should configure deployment strategy when provided
+  - it: should allow overriding deployment strategy
     documentIndex: 1
     set:
       archestra.deploymentStrategy:
         type: RollingUpdate
         rollingUpdate:
           maxSurge: "25%"
-          maxUnavailable: 0
+          maxUnavailable: 1
     asserts:
       - equal:
           path: spec.strategy.type
@@ -88,7 +95,15 @@ tests:
           value: "25%"
       - equal:
           path: spec.strategy.rollingUpdate.maxUnavailable
-          value: 0
+          value: 1
+
+  - it: should allow null deployment strategy to use Kubernetes defaults
+    documentIndex: 1
+    set:
+      archestra.deploymentStrategy: null
+    asserts:
+      - isNull:
+          path: spec.strategy
 
   - it: should configure container with correct image
     documentIndex: 1

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -12,8 +12,13 @@ archestra:
 
   # Deployment strategy configuration for the Deployment
   # See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#:~:text=strategy%20(DeploymentStrategy)
-  # When null, the default Kubernetes strategy is used
-  deploymentStrategy: null
+  # Default: RollingUpdate with maxUnavailable=0 to prevent zero-downtime deployments
+  # This ensures at least one pod is always available during deployments
+  deploymentStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
 
   # Additional environment variables to pass to the container
   # These will be merged with the default DATABASE_URL environment variable
@@ -112,6 +117,9 @@ archestra:
     # Service type - ClusterIP, NodePort, or LoadBalancer
     type: ClusterIP
     # Annotations to add to the Kubernetes Service
+    # For GKE, you can reference a BackendConfig like this:
+    #   annotations:
+    #     cloud.google.com/backend-config: '{"ports": {"9000":"archestra-backend-config"}}'
     annotations: {}
     # Node ports for NodePort service type (optional)
     # Only used when service.type is NodePort
@@ -119,6 +127,31 @@ archestra:
       backend: null
       metrics: null
       frontend: null
+
+  # GKE BackendConfig for configuring health checks and other load balancer settings
+  # This is only applicable when running on GKE with an Ingress
+  # See: https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#configuring_ingress_features_through_backendconfig_parameters
+  backendConfig:
+    # Enable or disable BackendConfig creation
+    enabled: false
+    # Health check configuration for the GKE Load Balancer
+    # These values override the Ingress-level health check settings
+    healthCheck:
+      # How often to check health (in seconds)
+      checkIntervalSec: 15
+      # Timeout for each health check request (in seconds)
+      timeoutSec: 10
+      # Number of consecutive successes to mark as healthy
+      healthyThreshold: 1
+      # Number of consecutive failures to mark as unhealthy
+      # Set high enough to allow for pod startup time (startup probe allows ~305s)
+      unhealthyThreshold: 10
+      # HTTP/HTTPS health check type
+      type: HTTP
+      # Path to check for health
+      requestPath: /health
+      # Port to check (backend port)
+      port: 9000
 
   # Ingress configuration
   ingress:


### PR DESCRIPTION
Configure default Kubernetes rolling update strategy and add GKE BackendConfig support to prevent downtime during deployments.

The current GKE Load Balancer health checks are too aggressive (marking pods unhealthy after ~30s) compared to the pod startup probe (allowing up to 305s). This mismatch, combined with a default deployment strategy that could allow zero available pods, causes intermittent 500 errors during deployments. This PR sets a default `RollingUpdate` strategy with `maxUnavailable: 0` and introduces a `BackendConfig` template to allow GKE LB health checks to be configured with higher tolerance for pod startup.

---
[Slack Thread](https://archestra-ai.slack.com/archives/C0966V616DC/p1765284396476109?thread_ts=1765284396.476109&cid=C0966V616DC)

<a href="https://cursor.com/background-agent?bcId=bc-79c9c814-9761-4776-a1fe-874034029e88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-79c9c814-9761-4776-a1fe-874034029e88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

