### PR TITLE
chore: update default `deploymentStrategy` helm value + modify staging env

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -4,7 +4,9 @@ archestra:
   service:
     annotations:
       # GKE BackendConfig for custom health checks
-      cloud.google.com/backend-config: '{"ports": {"9000":"archestra-platform-backend-config"}}'
+      # Maps backend port (9000) and frontend port (3000) to their respective BackendConfigs
+      # These BackendConfigs are defined in archestra-ai/infra repo (gke/ingress.tf)
+      cloud.google.com/backend-config: '{"ports": {"9000":"archestra-platform-backend-config", "3000":"archestra-platform-frontend-config"}}'
 
   ingress:
     enabled: true

--- a/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
@@ -65,20 +65,27 @@ tests:
           path: spec.replicas
           value: 4
 
-  - it: should not configure deployment strategy by default
+  - it: should configure RollingUpdate deployment strategy with zero-downtime defaults
     documentIndex: 1
     asserts:
-      - isNull:
-          path: spec.strategy
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 1
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0
 
-  - it: should configure deployment strategy when provided
+  - it: should allow overriding deployment strategy
     documentIndex: 1
     set:
       archestra.deploymentStrategy:
         type: RollingUpdate
         rollingUpdate:
           maxSurge: "25%"
-          maxUnavailable: 0
+          maxUnavailable: 1
     asserts:
       - equal:
           path: spec.strategy.type
@@ -88,7 +95,15 @@ tests:
           value: "25%"
       - equal:
           path: spec.strategy.rollingUpdate.maxUnavailable
-          value: 0
+          value: 1
+
+  - it: should allow disabling deployment strategy by setting to null
+    documentIndex: 1
+    set:
+      archestra.deploymentStrategy: null
+    asserts:
+      - isNull:
+          path: spec.strategy
 
   - it: should configure container with correct image
     documentIndex: 1

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -12,8 +12,14 @@ archestra:
 
   # Deployment strategy configuration for the Deployment
   # See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#:~:text=strategy%20(DeploymentStrategy)
-  # When null, the default Kubernetes strategy is used
-  deploymentStrategy: null
+  # Default is RollingUpdate with maxUnavailable: 0 to ensure zero-downtime deployments.
+  # This ensures at least one pod is always available during updates, which is critical
+  # for GKE ingress health checks to always have healthy endpoints.
+  deploymentStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
 
   # Additional environment variables to pass to the container
   # These will be merged with the default DATABASE_URL environment variable


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sets RollingUpdate (maxUnavailable 0, maxSurge 1) as the default deployment strategy and updates tests; maps both backend (9000) and frontend (3000) ports to BackendConfigs in staging.
> 
> - **Helm values (`platform/helm/archestra/values.yaml`)**:
>   - Set default `deploymentStrategy` to `RollingUpdate` with `rollingUpdate.maxUnavailable: 0` and `rollingUpdate.maxSurge: 1`.
> - **Tests (`platform/helm/archestra/tests/archestra_platform_deployment_test.yaml`)**:
>   - Expect default `spec.strategy` as `RollingUpdate` with zero-downtime values.
>   - Allow overriding strategy (e.g., `maxSurge: "25%"`, `maxUnavailable: 1`).
>   - New case to disable strategy by setting `archestra.deploymentStrategy: null`.
> - **Staging config (`.github/values-staging.yaml`)**:
>   - Update service annotation `cloud.google.com/backend-config` to map ports `9000` and `3000` to their BackendConfigs; add clarifying comments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a06c614bf56c091b890ae7f46469b50cc050264b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->