### PR TITLE
chore: setup archestra platform composite action

### DIFF
--- a/.github/actions/setup-archestra-platform/action.yml
+++ b/.github/actions/setup-archestra-platform/action.yml
@@ -20,6 +20,14 @@ inputs:
     description: "Whether to deploy e2e test dependencies (WireMock, Keycloak)"
     required: false
     default: "false"
+  helm-chart-ref:
+    description: "Helm chart reference - either a local path or OCI registry URL (e.g., oci://europe-west1-docker.pkg.dev/.../archestra-platform)"
+    required: false
+    default: ""
+  helm-chart-version:
+    description: "Helm chart version to install (only used with OCI registry)"
+    required: false
+    default: ""
   build-platform-image:
     description: "Whether to build the platform Docker image from source. Set to false to use a pre-built image (e.g., archestra/platform:latest)"
     required: false
@@ -108,11 +116,26 @@ runs:
     - name: Deploy Archestra Platform with Helm
       shell: bash
       env:
+        HELM_CHART_REF: ${{ inputs.helm-chart-ref }}
+        HELM_CHART_VERSION: ${{ inputs.helm-chart-version }}
         PLATFORM_CONTEXT: ${{ inputs.platform-context }}
         HELM_VALUES_PATH: ${{ inputs.helm-values-path }}
         PLATFORM_IMAGE_TAG: ${{ inputs.platform-image-tag }}
       run: |
-        helm install archestra-platform "${PLATFORM_CONTEXT}/helm/archestra" \
+        # Determine chart reference: use helm-chart-ref if set, otherwise use local path
+        if [ -n "${HELM_CHART_REF}" ]; then
+          CHART_REF="${HELM_CHART_REF}"
+          VERSION_FLAG=""
+          if [ -n "${HELM_CHART_VERSION}" ]; then
+            VERSION_FLAG="--version ${HELM_CHART_VERSION}"
+          fi
+        else
+          CHART_REF="${PLATFORM_CONTEXT}/helm/archestra"
+          VERSION_FLAG=""
+        fi
+
+        helm install archestra-platform "${CHART_REF}" \
+          ${VERSION_FLAG} \
           --values "${HELM_VALUES_PATH}" \
           --set "archestra.image=${PLATFORM_IMAGE_TAG}" \
           --wait --timeout=5m


### PR DESCRIPTION
Needed for https://github.com/archestra-ai/terraform-provider-archestra/pull/29 (to be able to run tests on PRs from community members (forked repos))

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds optional Helm chart ref and version inputs and updates deploy step to install from either local path or OCI registry with optional version.
> 
> - **GitHub Action `setup-archestra-platform`**
>   - **Inputs**:
>     - Add `helm-chart-ref` (local path or OCI URL) and `helm-chart-version` (used with OCI).
>   - **Helm deployment**:
>     - Determine `CHART_REF` from new inputs; fall back to `platform/helm/archestra`.
>     - Apply optional `--version` flag when `helm-chart-version` is provided.
>     - Install using resolved chart reference while preserving existing values and image overrides.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cdeb481c181705eb636b9c0b7ff8dbec7ae4a37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->