### PR TITLE
chore: add more debug logging for SSO provider role mapping

### DIFF
--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -138,10 +138,30 @@ export const auth: any = betterAuth({
         disabled: false,
         defaultRole: MEMBER_ROLE_NAME,
         getRole: async (data) => {
+          logger.debug(
+            {
+              providerId: data.provider?.providerId,
+              userId: data.user?.id,
+              userEmail: data.user?.email,
+            },
+            "SSO getRole callback: Invoking SsoProviderModel.resolveSsoRole",
+          );
+
           // Cast to the expected union type (better-auth expects "member" | "admin")
-          return (await SsoProviderModel.resolveSsoRole(data)) as
+          const resolvedRole = (await SsoProviderModel.resolveSsoRole(data)) as
             | "member"
             | "admin";
+
+          logger.debug(
+            {
+              providerId: data.provider?.providerId,
+              userId: data.user?.id,
+              resolvedRole,
+            },
+            "SSO getRole callback: Role resolved successfully",
+          );
+
+          return resolvedRole;
         },
       },
       defaultOverrideUserInfo: true,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds detailed debug logs throughout SSO role resolution (token decoding, provider config, rule evaluation, skipRoleSync, strict-mode, fallback) and team sync caching paths; no functional changes.
> 
> - **Backend**
>   - **Auth SSO (`platform/backend/src/auth/better-auth.ts`)**
>     - Add debug logs before invoking `SsoProviderModel.resolveSsoRole` and after role resolution, capturing `providerId`, `userId`, `userEmail`, and `resolvedRole`.
>   - **SSO Provider Model (`platform/backend/src/models/sso-provider.ts`)**
>     - Instrument `resolveSsoRole` with debug logs for: start of resolution, ID token decoding (success/failure), fetching provider config, `skipRoleSync` checks, rule evaluation inputs/results, strict-mode denial, and fallback role usage.
>     - Add debug logs when caching SSO groups for team sync across both skipRoleSync and no-role-mapping paths; refine error/warn messages for clarity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac0d88137ed835468bcd76a920e8d54c6ff55a20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->