### PR TITLE
fix: address minor "strict mode" bug in SSO role mapping

### DIFF
--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -709,6 +709,17 @@ async function syncSsoRole(userId: string, userEmail: string): Promise<void> {
     "Role mapping evaluation result for role sync",
   );
 
+  // Handle strict mode: Deny login if no rules matched and strict mode is enabled
+  if (result.error) {
+    logger.warn(
+      { providerId, userEmail, error: result.error },
+      "SSO login denied for existing user due to strict mode - no role mapping rules matched",
+    );
+    throw new APIError("FORBIDDEN", {
+      message: result.error,
+    });
+  }
+
   if (!result.role) {
     logger.debug(
       { providerId, userEmail },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enforces strictMode during SSO role sync to forbid login when no rules match, with tests covering deny/allow scenarios.
> 
> - **Backend — SSO role sync** (`platform/backend/src/auth/better-auth.ts`):
>   - Enforce `strictMode`: when role mapping returns an error (no rules matched), log warning and throw `APIError("FORBIDDEN")` to deny login for existing users.
> - **Tests** (`platform/backend/src/auth/better-auth.test.ts`):
>   - Add tests verifying strict-mode denial when no rules match and successful login + role update when a rule matches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba219d672b91a5916ebd9b2da055ee2896b8e109. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->