### PR TITLE
ci: disable docker scout PR comments

### DIFF
--- a/.github/workflows/platform-linting-and-tests.yml
+++ b/.github/workflows/platform-linting-and-tests.yml
@@ -295,8 +295,7 @@ jobs:
           dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
           ignore-unchanged: true
           only-severities: critical,high
-          write-comment: true
-          github-token: ${{ secrets.GITHUB_TOKEN }} # to be able to write the comment
+          write-comment: false
           sarif-file: sarif.output.json
 
       # Upload SARIF result to GitHub Code Scanning


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Disables Docker Scout PR comments in `.github/workflows/platform-linting-and-tests.yml` by setting `write-comment: false` and removing the `github-token` input.
> 
> - **CI/CD (GitHub Actions)**:
>   - **Docker Scout** in `platform-docker-image-scanning`:
>     - Set `write-comment: false` and removed `github-token` to stop posting PR comments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7563f08738d16143352d933aa75adcac242b01c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->