### PR TITLE
docs: expand out Terraform provider setup docs

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -391,6 +391,44 @@ Then visit:
 
 For managing Archestra Platform resources, you can use our official Terraform provider to manage Archestra Platform declaratively.
 
+**Provider Configuration**:
+
+```terraform
+terraform {
+  required_providers {
+    archestra = {
+      source = "archestra-ai/archestra"
+    }
+  }
+}
+
+provider "archestra" {
+  base_url = "http://localhost:9000" # Your Archestra API URL
+  api_key  = "your-api-key-here"     # Can also use ARCHESTRA_API_KEY env var
+}
+```
+
+**Obtaining an API Key**:
+
+1. Log in to the Archestra Admin UI (default: <http://localhost:3000>)
+2. Navigate to **Settings** → **Account**
+3. In the **API Keys** section, click **Create API Key**
+4. Copy the generated key — it will only be shown once
+
+**Configuring `base_url`**:
+
+The `base_url` should match your `ARCHESTRA_API_BASE_URL` environment variable — this is where your Archestra Platform API is accessible:
+
+- **Local development**: `http://localhost:9000` (default)
+- **Production**: Your externally-accessible API URL (e.g., `https://api.archestra.example.com`)
+
+You can also set these values via environment variables instead of hardcoding them:
+
+```bash
+export ARCHESTRA_API_KEY="your-api-key-here"
+export ARCHESTRA_BASE_URL="https://api.archestra.example.com"
+```
+
 For complete documentation, examples, and resource reference, visit the [Archestra Terraform Provider Documentation](https://registry.terraform.io/providers/archestra-ai/archestra/latest/docs).
 
 ## Environment Variables


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds Terraform provider setup details, including provider config, API key steps, base_url guidance, and env var examples.
> 
> - **Docs** (`docs/pages/platform-deployment.md`):
>   - **Terraform provider setup**:
>     - Add provider configuration example with `required_providers` and `provider "archestra"` (`base_url`, `api_key`).
>     - Document steps to obtain an API key via Admin UI.
>     - Clarify `base_url` configuration (local vs. production) and relation to `ARCHESTRA_API_BASE_URL`.
>     - Add environment variable alternatives for configuring `ARCHESTRA_API_KEY` and `ARCHESTRA_BASE_URL`.
>   - Link to the official Terraform provider docs for full reference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d81192ec8d5dd5364b55bac7fded4e76b7668bb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->