### PR TITLE
SSR: Hydrate Profiles & Tools

### DIFF
--- a/platform/frontend/src/app/profiles/page.client.tsx
+++ b/platform/frontend/src/app/profiles/page.client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { archestraApiTypes } from "@shared";
 import { archestraApiSdk, E2eTestId } from "@shared";
 import { useQuery } from "@tanstack/react-query";
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
@@ -13,7 +14,7 @@ import {
   X,
 } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
 import {
@@ -22,7 +23,6 @@ import {
   type ProfileLabelsRef,
 } from "@/components/agent-labels";
 import { DebouncedInput } from "@/components/debounced-input";
-import { LoadingSpinner } from "@/components/loading";
 import { McpConnectionInstructions } from "@/components/mcp-connection-instructions";
 import { PageLayout } from "@/components/page-layout";
 import { ProxyConnectionInstructions } from "@/components/proxy-connection-instructions";
@@ -66,13 +66,23 @@ import { ProfileActions } from "./agent-actions";
 import { AssignToolsDialog } from "./assign-tools-dialog";
 // Removed ChatConfigDialog - chat configuration is now managed in /chat via Prompt Library
 
-export default function ProfilesPage() {
+export default function ProfilesPage({
+  initialData,
+  initialTeams,
+  initialLabelKeys,
+}: {
+  initialData?: archestraApiTypes.GetAgentsResponses["200"];
+  initialTeams?: archestraApiTypes.GetTeamsResponses["200"];
+  initialLabelKeys?: archestraApiTypes.GetLabelKeysResponses["200"];
+}) {
   return (
     <div className="w-full h-full">
       <ErrorBoundary>
-        <Suspense fallback={<LoadingSpinner />}>
-          <Profiles />
-        </Suspense>
+        <Profiles
+          initialAgents={initialData}
+          initialTeams={initialTeams}
+          initialLabelKeys={initialLabelKeys}
+        />
       </ErrorBoundary>
     </div>
   );
@@ -144,7 +154,15 @@ function ProfileTeamsBadges({
   );
 }
 
-function Profiles() {
+function Profiles({
+  initialAgents,
+  initialTeams,
+  initialLabelKeys,
+}: {
+  initialAgents?: archestraApiTypes.GetAgentsResponses["200"] | null;
+  initialTeams?: archestraApiTypes.GetTeamsResponses["200"];
+  initialLabelKeys?: archestraApiTypes.GetLabelKeysResponses["200"];
+}) {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
@@ -178,6 +196,7 @@ function Profiles() {
     sortBy,
     sortDirection,
     name: nameFilter || undefined,
+    initialData: initialAgents ?? undefined,
   });
 
   const agents = agentsResponse?.data || [];
@@ -498,6 +517,8 @@ function Profiles() {
           <CreateProfileDialog
             open={isCreateDialogOpen}
             onOpenChange={setIsCreateDialogOpen}
+            initialTeams={initialTeams}
+            initialLabelKeys={initialLabelKeys}
           />
 
           {connectingProfile && (
@@ -523,6 +544,8 @@ function Profiles() {
               agent={editingProfile}
               open={!!editingProfile}
               onOpenChange={(open) => !open && setEditingProfile(null)}
+              initialTeams={initialTeams}
+              initialLabelKeys={initialLabelKeys}
             />
           )}
 
@@ -542,9 +565,13 @@ function Profiles() {
 function CreateProfileDialog({
   open,
   onOpenChange,
+  initialTeams,
+  initialLabelKeys,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  initialTeams?: archestraApiTypes.GetTeamsResponses["200"];
+  initialLabelKeys?: archestraApiTypes.GetLabelKeysResponses["200"];
 }) {
   const [name, setName] = useState("");
   const [assignedTeamIds, setAssignedTeamIds] = useState<string[]>([]);
@@ -557,8 +584,11 @@ function CreateProfileDialog({
       const response = await archestraApiSdk.getTeams();
       return response.data || [];
     },
+    initialData: initialTeams,
   });
-  const { data: availableKeys = [] } = useLabelKeys();
+  const { data: availableKeys = [] } = useLabelKeys({
+    initialData: initialLabelKeys,
+  });
   const [selectedTeamId, setSelectedTeamId] = useState<string>("");
   const [createdProfile, setCreatedProfile] = useState<{
     id: string;
@@ -796,6 +826,8 @@ function EditProfileDialog({
   agent,
   open,
   onOpenChange,
+  initialTeams,
+  initialLabelKeys,
 }: {
   agent: {
     id: string;
@@ -806,6 +838,8 @@ function EditProfileDialog({
   };
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  initialTeams?: archestraApiTypes.GetTeamsResponses["200"];
+  initialLabelKeys?: archestraApiTypes.GetLabelKeysResponses["200"];
 }) {
   const [name, setName] = useState(agent.name);
   const [assignedTeamIds, setAssignedTeamIds] = useState<string[]>(
@@ -821,8 +855,11 @@ function EditProfileDialog({
       const response = await archestraApiSdk.getTeams();
       return response.data || [];
     },
+    initialData: initialTeams,
   });
-  const { data: availableKeys = [] } = useLabelKeys();
+  const { data: availableKeys = [] } = useLabelKeys({
+    initialData: initialLabelKeys,
+  });
   const [selectedTeamId, setSelectedTeamId] = useState<string>("");
   const updateProfile = useUpdateProfile();
   const agentLabelsRef = useRef<ProfileLabelsRef>(null);
@@ -964,7 +1001,9 @@ function EditProfileDialog({
                         <button
                           type="button"
                           onClick={() => handleRemoveTeam(teamId)}
-                          data-testid={`${E2eTestId.RemoveTeamBadge}-${team?.name || teamId}`}
+                          data-testid={`${E2eTestId.RemoveTeamBadge}-${
+                            team?.name || teamId
+                          }`}
                           className="ml-1 hover:bg-destructive/20 rounded-full p-0.5"
                         >
                           <X className="h-3 w-3" />

--- a/platform/frontend/src/app/profiles/page.tsx
+++ b/platform/frontend/src/app/profiles/page.tsx
@@ -1,7 +1,49 @@
+import { archestraApiSdk, type ErrorExtended } from "@shared";
+import { ServerErrorFallback } from "@/components/error-fallback";
+import { getServerApiHeaders } from "@/lib/server-utils";
+import { DEFAULT_TABLE_LIMIT } from "@/lib/utils";
 import ProfilesPage from "./page.client";
 
 export const dynamic = "force-dynamic";
 
 export default async function ProfilesPageServer() {
-  return <ProfilesPage />;
+  try {
+    const headers = await getServerApiHeaders();
+
+    const agentsResponse = await archestraApiSdk.getAgents({
+      headers,
+      query: {
+        limit: 20,
+        offset: 0,
+        sortBy: "createdAt",
+        sortDirection: "desc",
+      },
+    });
+
+    const teamsResponse = await archestraApiSdk.getTeams({ headers });
+    const labelKeysResponse = await archestraApiSdk.getLabelKeys({ headers });
+
+    const initialAgents = agentsResponse.data ?? {
+      data: [],
+      pagination: {
+        currentPage: 1,
+        limit: DEFAULT_TABLE_LIMIT,
+        total: 0,
+        totalPages: 0,
+        hasNext: false,
+        hasPrev: false,
+      },
+    };
+
+    return (
+      <ProfilesPage
+        initialData={initialAgents}
+        initialTeams={teamsResponse.data ?? []}
+        initialLabelKeys={labelKeysResponse.data ?? []}
+      />
+    );
+  } catch (error) {
+    console.error(error);
+    return <ServerErrorFallback error={error as ErrorExtended} />;
+  }
 }

--- a/platform/frontend/src/app/tools/_parts/assigned-tools-table.tsx
+++ b/platform/frontend/src/app/tools/_parts/assigned-tools-table.tsx
@@ -69,6 +69,9 @@ type ToolResultTreatment = ProfileToolData["toolResultTreatment"];
 
 interface AssignedToolsTableProps {
   onToolClick: (tool: ProfileToolData) => void;
+  initialAgentTools?: archestraApiTypes.GetAllAgentToolsResponses["200"];
+  initialAgents?: archestraApiTypes.GetAllAgentsResponses["200"];
+  initialInternalMcpCatalog?: archestraApiTypes.GetInternalMcpCatalogResponses["200"];
 }
 
 function SortIcon({ isSorted }: { isSorted: false | "asc" | "desc" }) {
@@ -85,14 +88,21 @@ function SortIcon({ isSorted }: { isSorted: false | "asc" | "desc" }) {
   );
 }
 
-export function AssignedToolsTable({ onToolClick }: AssignedToolsTableProps) {
+export function AssignedToolsTable({
+  onToolClick,
+  initialAgentTools,
+  initialAgents,
+  initialInternalMcpCatalog,
+}: AssignedToolsTableProps) {
   const agentToolPatchMutation = useProfileToolPatchMutation();
   const bulkUpdateMutation = useBulkUpdateProfileTools();
   const unassignToolMutation = useUnassignTool();
   const { data: invocationPolicies } = useToolInvocationPolicies();
   const { data: resultPolicies } = useToolResultPolicies();
-  const { data: internalMcpCatalogItems } = useInternalMcpCatalog();
-  const { data: agents } = useProfiles();
+  const { data: internalMcpCatalogItems } = useInternalMcpCatalog({
+    initialData: initialInternalMcpCatalog,
+  });
+  const { data: agents } = useProfiles({ initialData: initialAgents });
   const { data: mcpServers } = useMcpServers();
 
   const searchParams = useSearchParams();
@@ -136,6 +146,7 @@ export function AssignedToolsTable({ onToolClick }: AssignedToolsTableProps) {
 
   // Fetch agent tools with server-side pagination, filtering, and sorting
   const { data: agentToolsData, isLoading } = useAllProfileTools({
+    initialData: initialAgentTools,
     pagination: {
       limit: pageSize,
       offset: pageIndex * pageSize,

--- a/platform/frontend/src/app/tools/page.client.tsx
+++ b/platform/frontend/src/app/tools/page.client.tsx
@@ -2,8 +2,7 @@
 
 import type { archestraApiTypes } from "@shared";
 import { useQueryClient } from "@tanstack/react-query";
-import { Suspense, useEffect, useState } from "react";
-import { LoadingSpinner } from "@/components/loading";
+import { useEffect, useState } from "react";
 import {
   prefetchOperators,
   prefetchToolInvocationPolicies,
@@ -16,7 +15,15 @@ import { ToolDetailsDialog } from "./_parts/tool-details-dialog";
 type ProfileToolData =
   archestraApiTypes.GetAllAgentToolsResponses["200"]["data"][number];
 
-export function ToolsClient() {
+export function ToolsClient({
+  initialAgentTools,
+  initialAgents,
+  initialInternalMcpCatalog,
+}: {
+  initialAgentTools?: archestraApiTypes.GetAllAgentToolsResponses["200"];
+  initialAgents?: archestraApiTypes.GetAllAgentsResponses["200"];
+  initialInternalMcpCatalog?: archestraApiTypes.GetInternalMcpCatalogResponses["200"];
+}) {
   const queryClient = useQueryClient();
 
   // Prefetch policy data on mount
@@ -29,15 +36,25 @@ export function ToolsClient() {
   return (
     <div className="w-full h-full">
       <ErrorBoundary>
-        <Suspense fallback={<LoadingSpinner className="mt-[30vh]" />}>
-          <ToolsList />
-        </Suspense>
+        <ToolsList
+          initialAgentTools={initialAgentTools}
+          initialAgents={initialAgents}
+          initialInternalMcpCatalog={initialInternalMcpCatalog}
+        />
       </ErrorBoundary>
     </div>
   );
 }
 
-function ToolsList() {
+function ToolsList({
+  initialAgentTools,
+  initialAgents,
+  initialInternalMcpCatalog,
+}: {
+  initialAgentTools?: archestraApiTypes.GetAllAgentToolsResponses["200"];
+  initialAgents?: archestraApiTypes.GetAllAgentsResponses["200"];
+  initialInternalMcpCatalog?: archestraApiTypes.GetInternalMcpCatalogResponses["200"];
+}) {
   const queryClient = useQueryClient();
   const [selectedToolForDialog, setSelectedToolForDialog] =
     useState<ProfileToolData | null>(null);
@@ -70,7 +87,12 @@ function ToolsList() {
 
   return (
     <div>
-      <AssignedToolsTable onToolClick={setSelectedToolForDialog} />
+      <AssignedToolsTable
+        onToolClick={setSelectedToolForDialog}
+        initialAgentTools={initialAgentTools}
+        initialAgents={initialAgents}
+        initialInternalMcpCatalog={initialInternalMcpCatalog}
+      />
 
       <ToolDetailsDialog
         agentTool={selectedToolForDialog}

--- a/platform/frontend/src/app/tools/page.tsx
+++ b/platform/frontend/src/app/tools/page.tsx
@@ -1,7 +1,49 @@
+import { archestraApiSdk, type ErrorExtended } from "@shared";
+
+import { ServerErrorFallback } from "@/components/error-fallback";
+import { getServerApiHeaders } from "@/lib/server-utils";
 import { ToolsClient } from "./page.client";
 
 export const dynamic = "force-dynamic";
 
 export default async function ToolsPage() {
-  return <ToolsClient />;
+  try {
+    const headers = await getServerApiHeaders();
+
+    const agentToolsResponse = await archestraApiSdk.getAllAgentTools({
+      headers,
+      query: {
+        limit: 50,
+        offset: 0,
+      },
+    });
+
+    const agentsResponse = await archestraApiSdk.getAllAgents({ headers });
+    const internalCatalogResponse = await archestraApiSdk.getInternalMcpCatalog(
+      { headers },
+    );
+
+    const initialAgentTools = agentToolsResponse.data ?? {
+      data: [],
+      pagination: {
+        currentPage: 1,
+        limit: 50,
+        total: 0,
+        totalPages: 0,
+        hasNext: false,
+        hasPrev: false,
+      },
+    };
+
+    return (
+      <ToolsClient
+        initialAgentTools={initialAgentTools}
+        initialAgents={agentsResponse.data ?? []}
+        initialInternalMcpCatalog={internalCatalogResponse.data ?? []}
+      />
+    );
+  } catch (error) {
+    console.error(error);
+    return <ServerErrorFallback error={error as ErrorExtended} />;
+  }
 }

--- a/platform/frontend/src/lib/agent.query.ts
+++ b/platform/frontend/src/lib/agent.query.ts
@@ -42,6 +42,7 @@ export function useProfilesPaginated(params?: {
   sortBy?: "name" | "createdAt" | "toolsCount" | "team";
   sortDirection?: "asc" | "desc";
   name?: string;
+  initialData?: archestraApiTypes.GetAgentsResponses["200"];
 }) {
   const { limit, offset, sortBy, sortDirection, name } = params || {};
 
@@ -59,6 +60,7 @@ export function useProfilesPaginated(params?: {
           },
         })
       ).data ?? null,
+    initialData: params?.initialData,
   });
 }
 
@@ -141,10 +143,13 @@ export function useDeleteProfile() {
   });
 }
 
-export function useLabelKeys() {
+export function useLabelKeys(params?: {
+  initialData?: archestraApiTypes.GetLabelKeysResponses["200"];
+}) {
   return useQuery({
     queryKey: ["agents", "labels", "keys"],
     queryFn: async () => (await getLabelKeys()).data ?? [],
+    initialData: params?.initialData,
   });
 }
 


### PR DESCRIPTION
## Summary

Convert the `/profiles` and `/tools` pages to fetch and pass initial data from the server to client components (including dialog props), eliminating client-side loading spinners on first paint.

https://github.com/user-attachments/assets/55b5ca9b-201a-4371-9470-4c20d67cfccf

/claim #1427 
Closes #1427
