### PR TITLE
fix: in SSO role mapping rules, don't hardcode available roles

### DIFF
--- a/platform/frontend/src/app/settings/sso-providers/_parts/role-mapping-form.tsx
+++ b/platform/frontend/src/app/settings/sso-providers/_parts/role-mapping-form.tsx
@@ -35,6 +35,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useRoles } from "@/lib/role.query";
 
 interface RoleMappingFormProps {
   form: UseFormReturn<SsoProviderFormValues>;
@@ -69,6 +70,8 @@ export function RoleMappingForm({ form }: RoleMappingFormProps) {
   const [ruleIds, setRuleIds] = useState<string[]>(() =>
     rules.map((_, i) => `${baseId}-rule-${i}`),
   );
+  // Fetch all roles (predefined + custom)
+  const { data: roles = [] } = useRoles();
 
   // Scroll the accordion content into view when expanded
   const handleAccordionChange = useCallback((value: string) => {
@@ -211,8 +214,11 @@ export function RoleMappingForm({ form }: RoleMappingFormProps) {
                                   </SelectTrigger>
                                 </FormControl>
                                 <SelectContent>
-                                  <SelectItem value="admin">Admin</SelectItem>
-                                  <SelectItem value="member">Member</SelectItem>
+                                  {roles.map((role) => (
+                                    <SelectItem key={role.id} value={role.role}>
+                                      {role.name}
+                                    </SelectItem>
+                                  ))}
                                 </SelectContent>
                               </Select>
                               <FormMessage />
@@ -253,8 +259,11 @@ export function RoleMappingForm({ form }: RoleMappingFormProps) {
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      <SelectItem value="admin">Admin</SelectItem>
-                      <SelectItem value="member">Member</SelectItem>
+                      {roles.map((role) => (
+                        <SelectItem key={role.id} value={role.role}>
+                          {role.name}
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                   <FormDescription>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Dynamically loads role options for SSO role mapping selects using `useRoles()` instead of hardcoded values.
> 
> - **Settings › SSO Providers — Role Mapping Form**:
>   - Replace hardcoded role options with dynamic options fetched via `useRoles()`.
>   - Populate both `roleMapping.rules[].role` and `roleMapping.defaultRole` selects from fetched `roles`.
>   - Add `useRoles` integration and render `SelectItem` entries using `role.id`, `role.role`, and `role.name`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 755fc6030e2cf1ce66ffd86b998a2608285f1d24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->