### PR TITLE
docs: document `ARCHESTRA_OPENAI_BASE_URL`, `ARCHESTRA_ANTHROPIC_BASE_URL`, and `ARCHESTRA_GEMINI_BASE_URL`

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -482,6 +482,21 @@ The following environment variables can be used to configure Archestra Platform:
   - When enabled, administrators cannot create new invitations, and the invitation management UI is hidden
   - Useful for environments where user provisioning is handled externally (e.g., via SSO with automatic provisioning)
 
+- **`ARCHESTRA_OPENAI_BASE_URL`** - Override the OpenAI API base URL.
+
+  - Default: `https://api.openai.com/v1`
+  - Use this to point to your own proxy, an OpenAI-compatible API, or other custom endpoints
+
+- **`ARCHESTRA_ANTHROPIC_BASE_URL`** - Override the Anthropic API base URL.
+
+  - Default: `https://api.anthropic.com`
+  - Use this to point to your own proxy or other custom endpoints
+
+- **`ARCHESTRA_GEMINI_BASE_URL`** - Override the Google Gemini API base URL.
+
+  - Default: `https://generativelanguage.googleapis.com`
+  - Use this to point to your own proxy, Vertex AI API, or other custom endpoints
+
 - **`ARCHESTRA_ORCHESTRATOR_K8S_NAMESPACE`** - Kubernetes namespace to run MCP server pods.
 
   - Default: `default`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Documents new environment variables to override OpenAI, Anthropic, and Gemini API base URLs in platform deployment docs.
> 
> - **Docs**:
>   - **Environment variables** in `docs/pages/platform-deployment.md`:
>     - Add `ARCHESTRA_OPENAI_BASE_URL` (default `https://api.openai.com/v1`) for custom/proxy OpenAI endpoints.
>     - Add `ARCHESTRA_ANTHROPIC_BASE_URL` (default `https://api.anthropic.com`) for custom/proxy Anthropic endpoints.
>     - Add `ARCHESTRA_GEMINI_BASE_URL` (default `https://generativelanguage.googleapis.com`) for custom/proxy or Vertex AI Gemini endpoints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 388b7b02389a814784181a341370f9785f812e60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->