### PR TITLE
fix: address width of delete chat api key dialog

### DIFF
--- a/platform/frontend/src/app/settings/chat/page.tsx
+++ b/platform/frontend/src/app/settings/chat/page.tsx
@@ -593,7 +593,7 @@ function ChatSettingsContent() {
 
       {/* Delete Confirmation Dialog */}
       <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
-        <DialogContent>
+        <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>Delete API Key</DialogTitle>
             <DialogDescription>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Constrain the delete API key confirmation dialog in chat settings by adding `sm:max-w-md` to `DialogContent`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ab3cca40dc06ef68c0ee0f5f563f6f6bbb3d2ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->