### PR TITLE
chore: enable Vertex AI with GKE Workload Identity for staging env

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -1,6 +1,24 @@
 archestra:
   replicaCount: 4
 
+  # Vertex AI Gemini configuration
+  # Uses Application Default Credentials (ADC) via GKE Workload Identity
+  # instead of API keys for authentication
+  env:
+    ARCHESTRA_GEMINI_VERTEX_AI_ENABLED: "true"
+    ARCHESTRA_GEMINI_VERTEX_AI_PROJECT: "friendly-path-465518-r6"
+    ARCHESTRA_GEMINI_VERTEX_AI_LOCATION: "us-central1"
+
+  # Orchestrator configuration with Workload Identity for Vertex AI
+  orchestrator:
+    kubernetes:
+      serviceAccount:
+        # GKE Workload Identity binding to allow Vertex AI access via ADC
+        # The GCP service account (archestra-vertex-ai@friendly-path-465518-r6.iam.gserviceaccount.com)
+        # is created and bound in the archestra-ai/infra repo (gke/main.tf)
+        annotations:
+          iam.gke.io/gcp-service-account: archestra-vertex-ai@friendly-path-465518-r6.iam.gserviceaccount.com
+
   service:
     annotations:
       # GKE BackendConfig for custom health checks

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Archestra Platform API",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "components": {
     "schemas": {
@@ -24528,12 +24528,16 @@
                         "1",
                         "2"
                       ]
+                    },
+                    "geminiVertexAiEnabled": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
                     "orchestrator-k8s-runtime",
                     "byosEnabled",
-                    "byosVaultKvVersion"
+                    "byosVaultKvVersion",
+                    "geminiVertexAiEnabled"
                   ],
                   "additionalProperties": false
                 }

--- a/platform/backend/src/routes/features.ts
+++ b/platform/backend/src/routes/features.ts
@@ -3,6 +3,7 @@ import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
 import config from "@/config";
 import { McpServerRuntimeManager } from "@/mcp-server-runtime";
+import { isVertexAiEnabled } from "@/routes/proxy/utils/gemini-client";
 import { getByosVaultKvVersion, isByosEnabled } from "@/secretsmanager";
 
 const featuresRoutes: FastifyPluginAsyncZod = async (fastify) => {
@@ -24,6 +25,8 @@ const featuresRoutes: FastifyPluginAsyncZod = async (fastify) => {
             byosEnabled: z.boolean(),
             /** Vault KV version when BYOS is enabled (null if BYOS is disabled) */
             byosVaultKvVersion: z.enum(["1", "2"]).nullable(),
+            /** Vertex AI Gemini mode - when enabled, no API key needed for Gemini */
+            geminiVertexAiEnabled: z.boolean(),
           }),
         },
       },
@@ -34,6 +37,7 @@ const featuresRoutes: FastifyPluginAsyncZod = async (fastify) => {
         "orchestrator-k8s-runtime": McpServerRuntimeManager.isEnabled,
         byosEnabled: isByosEnabled(),
         byosVaultKvVersion: getByosVaultKvVersion(),
+        geminiVertexAiEnabled: isVertexAiEnabled(),
       }),
   );
 };

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -51,6 +51,7 @@ import { useHasPermissions } from "@/lib/auth.query";
 import { useConversation, useCreateConversation } from "@/lib/chat.query";
 import { useChatApiKeysOptional } from "@/lib/chat-settings.query";
 import { useDialogs } from "@/lib/dialog.hook";
+import { useFeatures } from "@/lib/features.query";
 import { useDeletePrompt, usePrompt, usePrompts } from "@/lib/prompts.query";
 
 const CONVERSATION_QUERY_PARAM = "conversation";
@@ -99,7 +100,10 @@ export default function ChatPage() {
 
   // Check if API key is configured for any provider
   const { data: chatApiKeys = [] } = useChatApiKeysOptional();
-  const hasAnyApiKey = chatApiKeys.some((k) => k.secretId);
+  const { data: features } = useFeatures();
+  // Vertex AI Gemini mode doesn't require an API key (uses ADC)
+  const hasAnyApiKey =
+    chatApiKeys.some((k) => k.secretId) || features?.geminiVertexAiEnabled;
 
   // Sync conversation ID with URL
   useEffect(() => {

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -7733,6 +7733,7 @@ export type GetFeaturesResponses = {
         'orchestrator-k8s-runtime': boolean;
         byosEnabled: boolean;
         byosVaultKvVersion: '1' | '2';
+        geminiVertexAiEnabled: boolean;
     };
 };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enables Vertex AI Gemini in staging using GKE Workload Identity and exposes a feature flag used by chat to work without API keys.
> 
> - **Infrastructure (staging)**:
>   - Enable Vertex AI Gemini via `ARCHESRA_GEMINI_VERTEX_AI_*` env vars and GKE Workload Identity (`iam.gke.io/gcp-service-account` annotation) in `.github/values-staging.yaml`.
> - **Backend**:
>   - Extend `GET /api/features` to include `geminiVertexAiEnabled` (populated via `isVertexAiEnabled`).
> - **Frontend**:
>   - Update chat page to allow usage without API keys when `features.geminiVertexAiEnabled` is true.
> - **API/OpenAPI**:
>   - Bump version to `1.0.2`; add `geminiVertexAiEnabled` to features schema and required fields.
>   - Regenerate client types to include `geminiVertexAiEnabled`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bca7eb7d47d75ac82187d0a8a23aaf71eeb3bf30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->