### PR TITLE
chore: add resource requests for mcp server pods

### DIFF
--- a/platform/backend/src/mcp-server-runtime/k8s-pod.ts
+++ b/platform/backend/src/mcp-server-runtime/k8s-pod.ts
@@ -359,6 +359,15 @@ export default class K8sPod {
                   },
                 ]
               : undefined,
+            // Set resource requests for the container
+            // It's needed to make k8s scheduler play nice with mcp server pods,
+            // since k8s schedules pods and nodes based on resource requests and limits.
+            resources: {
+              requests: {
+                memory: "128Mi",
+                cpu: "50m",
+              },
+            },
           },
         ],
         restartPolicy: "Always",


### PR DESCRIPTION
It's needed because k8s schedules pods, nodes and doing cluster scaling based on the resource requests.