### PR TITLE
chore: don't flash "LLM Provider API Keys" dialog on /chat

### DIFF
--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -26,6 +26,7 @@ interface ChatMessagesProps {
   messages: UIMessage[];
   hideToolCalls?: boolean;
   status: ChatStatus;
+  isLoadingConversation?: boolean;
 }
 
 // Type guards for tool parts
@@ -52,10 +53,16 @@ export function ChatMessages({
   messages,
   hideToolCalls = false,
   status,
+  isLoadingConversation = false,
 }: ChatMessagesProps) {
   const isStreamingStalled = useStreamingStallDetection(messages, status);
 
   if (messages.length === 0) {
+    // Don't show "start conversation" message while loading - prevents flash of empty state
+    if (isLoadingConversation) {
+      return null;
+    }
+
     return (
       <div className="flex-1 flex h-full items-center justify-center text-center text-muted-foreground">
         <p className="text-sm">Start a conversation by sending a message</p>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Avoids flashing the API key required dialog and empty-state during loading, initializes `conversationId` from the URL, and wires loading state through to `ChatMessages`.
> 
> - **Chat Page (`app/chat/page.tsx`)**:
>   - Initialize `conversationId` from URL search param `conversation`.
>   - Add loading guards for API key check (`isLoadingApiKeyCheck`) and conversation (`isLoadingConversation`).
>   - Show API key required card only after loading completes.
>   - Pass `isLoadingConversation` to `ChatMessages`.
> - **ChatMessages (`components/chat/chat-messages.tsx`)**:
>   - Accept `isLoadingConversation` prop and suppress empty-state message while conversation is loading.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9072ce01f9fecfe9a62636d48fabb90c147363ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->