### PR TITLE
fix: address dark-mode theme styling in chat

### DIFF
--- a/platform/frontend/src/components/ai-elements/message.tsx
+++ b/platform/frontend/src/components/ai-elements/message.tsx
@@ -28,7 +28,7 @@ const messageContentVariants = cva(
           "max-w-[80%] px-4 py-3",
           "group-[.is-user]:bg-primary group-[.is-user]:text-primary-foreground",
           "group-[.is-user]:[&_a]:text-primary-foreground group-[.is-user]:[&_a]:underline group-[.is-user]:[&_a]:underline-offset-2 group-[.is-user]:[&_a]:decoration-primary-foreground/50 group-[.is-user]:[&_a]:hover:decoration-primary-foreground",
-          "group-[.is-assistant]:bg-secondary group-[.is-assistant]:text-foreground",
+          "group-[.is-assistant]:bg-secondary group-[.is-assistant]:text-secondary-foreground",
         ],
         flat: [
           "group-[.is-user]:max-w-[80%] group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",

--- a/platform/frontend/src/components/ai-elements/tool.tsx
+++ b/platform/frontend/src/components/ai-elements/tool.tsx
@@ -222,7 +222,7 @@ export const ToolOutput = ({
                     "max-w-[85%] rounded-lg px-3 py-2 text-xs whitespace-pre-wrap",
                     conv.role === "assistant"
                       ? "bg-primary text-primary-foreground"
-                      : "bg-secondary text-foreground",
+                      : "bg-secondary text-secondary-foreground",
                   )}
                 >
                   {contentStr}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches chat bubble text to `text-secondary-foreground` when using `bg-secondary` to ensure correct contrast (notably in dark mode).
> 
> - **Frontend (Chat UI)**:
>   - **Styling adjustments**:
>     - In `platform/frontend/src/components/ai-elements/message.tsx`, assistant messages on `bg-secondary` now use `text-secondary-foreground` instead of `text-foreground`.
>     - In `platform/frontend/src/components/ai-elements/tool.tsx`, conversation bubbles on `bg-secondary` now use `text-secondary-foreground` instead of `text-foreground`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17a7d6b072b0c75d34d784338391aba61e40c48a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->