### PR TITLE
fix: tooltip overflow in start free chat dialog

### DIFF
--- a/platform/frontend/src/components/chat/mcp-tools-display.tsx
+++ b/platform/frontend/src/components/chat/mcp-tools-display.tsx
@@ -87,7 +87,7 @@ export function McpToolsDisplay({ agentId, className }: McpToolsDisplayProps) {
       <TooltipProvider>
         <div className="flex flex-wrap gap-2">
           {Object.entries(groupedTools).map(([serverName, tools]) => (
-            <Tooltip key={serverName}>
+            <Tooltip key={serverName} delayDuration={300}>
               <TooltipTrigger asChild>
                 <div className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-secondary text-foreground cursor-default">
                   <span className="font-medium text-xs">{serverName}</span>
@@ -97,8 +97,10 @@ export function McpToolsDisplay({ agentId, className }: McpToolsDisplayProps) {
                 </div>
               </TooltipTrigger>
               <TooltipContent
-                side="top"
-                className="max-w-sm max-h-64 overflow-y-auto"
+                side="bottom"
+                align="center"
+                avoidCollisions={true}
+                className="max-w-xs max-h-48 overflow-y-auto text-xs"
                 onWheel={(e) => e.stopPropagation()}
                 onTouchMove={(e) => e.stopPropagation()}
               >

--- a/platform/frontend/src/components/chat/prompt-library-grid.tsx
+++ b/platform/frontend/src/components/chat/prompt-library-grid.tsx
@@ -482,7 +482,7 @@ function PromptTile({
         <div className="flex flex-wrap gap-1">
           {profileName && (
             <TooltipProvider>
-              <Tooltip delayDuration={300}>
+              <Tooltip>
                 <TooltipTrigger asChild>
                   <Badge
                     variant="secondary"
@@ -492,9 +492,8 @@ function PromptTile({
                   </Badge>
                 </TooltipTrigger>
                 <TooltipContent
-                  side="bottom"
-                  align="center"
-                  avoidCollisions={true}
+                  side="top"
+                  className="max-w-sm max-h-64 overflow-y-auto"
                 >
                   <div className="space-y-2">
                     <div className="font-medium text-sm">

--- a/platform/frontend/src/components/chat/prompt-library-grid.tsx
+++ b/platform/frontend/src/components/chat/prompt-library-grid.tsx
@@ -482,7 +482,7 @@ function PromptTile({
         <div className="flex flex-wrap gap-1">
           {profileName && (
             <TooltipProvider>
-              <Tooltip>
+              <Tooltip delayDuration={300}>
                 <TooltipTrigger asChild>
                   <Badge
                     variant="secondary"
@@ -492,8 +492,12 @@ function PromptTile({
                   </Badge>
                 </TooltipTrigger>
                 <TooltipContent
-                  side="top"
-                  className="max-w-sm max-h-64 overflow-y-auto"
+                  side="bottom"
+                  align="center"
+                  avoidCollisions={true}
+                  className="max-w-xs max-h-48 overflow-y-auto text-xs"
+                  onWheel={(e) => e.stopPropagation()}
+                  onTouchMove={(e) => e.stopPropagation()}
                 >
                   <div className="space-y-2">
                     <div className="font-medium text-sm">

--- a/platform/frontend/src/components/chat/prompt-library-grid.tsx
+++ b/platform/frontend/src/components/chat/prompt-library-grid.tsx
@@ -495,9 +495,6 @@ function PromptTile({
                   side="bottom"
                   align="center"
                   avoidCollisions={true}
-                  className="max-w-xs max-h-48 overflow-y-auto text-xs"
-                  onWheel={(e) => e.stopPropagation()}
-                  onTouchMove={(e) => e.stopPropagation()}
                 >
                   <div className="space-y-2">
                     <div className="font-medium text-sm">


### PR DESCRIPTION
## Summary
  - Fixed tooltip overflow issue in "Start Free Chat" dialog
  - Changed tooltip positioning from `side="top"` to `side="bottom"`
  - Added collision avoidance to prevent dialog overflow
  - Reduced tooltip size for better fit in dialog constraints

Fixes #1586 
  
## Solution
Moved tooltips to appear below elements instead of above, preventing interference with the profile selection dropdown. Added smart positioning with collision avoidance.


https://github.com/user-attachments/assets/faa12c26-f00b-47a5-b0d3-3b7fa94f5b64


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts MCP tools tooltip to appear below with collision avoidance, centered alignment, reduced size, and a slight show delay.
> 
> - **UI**
>   - **Tooltip behavior in `platform/frontend/src/components/chat/mcp-tools-display.tsx`**:
>     - Set `Tooltip` `delayDuration={300}`.
>     - Change `TooltipContent` positioning to `side="bottom"` with `align="center"` and `avoidCollisions` enabled.
>     - Reduce tooltip dimensions and text size (`max-w-sm → max-w-xs`, `max-h-64 → max-h-48`, add `text-xs`).
>     - Preserve scroll handling by stopping `wheel` and `touchmove` propagation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24ff984fe99fbfd66642d9b7b5eb8e443b62d562. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->