### PR TITLE
chore: address chat "tool pill" height inconsistency + remove duplicate function

### DIFF
--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -49,7 +49,7 @@ import { useChatSession } from "@/contexts/global-chat-context";
 import { useProfiles } from "@/lib/agent.query";
 import { useHasPermissions } from "@/lib/auth.query";
 import { useConversation, useCreateConversation } from "@/lib/chat.query";
-import { useChatApiKeysOptional } from "@/lib/chat-settings.query";
+import { useChatApiKeys } from "@/lib/chat-settings.query";
 import { useDialogs } from "@/lib/dialog.hook";
 import { useFeatures } from "@/lib/features.query";
 import { useDeletePrompt, usePrompt, usePrompts } from "@/lib/prompts.query";
@@ -102,7 +102,7 @@ export default function ChatPage() {
 
   // Check if API key is configured for any provider
   const { data: chatApiKeys = [], isLoading: isLoadingApiKeys } =
-    useChatApiKeysOptional();
+    useChatApiKeys();
   const { data: features, isLoading: isLoadingFeatures } = useFeatures();
   // Vertex AI Gemini mode doesn't require an API key (uses ADC)
   const hasAnyApiKey =

--- a/platform/frontend/src/components/chat/create-chat-api-key-form.tsx
+++ b/platform/frontend/src/components/chat/create-chat-api-key-form.tsx
@@ -18,10 +18,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  useChatApiKeysOptional,
-  useCreateChatApiKey,
-} from "@/lib/chat-settings.query";
+import { useChatApiKeys, useCreateChatApiKey } from "@/lib/chat-settings.query";
 
 type SupportedChatProvider =
   archestraApiTypes.GetChatApiKeysResponses["200"][number]["provider"];
@@ -90,7 +87,7 @@ export function CreateChatApiKeyForm({
   onSuccess,
   showConsoleLink = true,
 }: CreateChatApiKeyFormProps) {
-  const { data: chatApiKeys = [] } = useChatApiKeysOptional();
+  const { data: chatApiKeys = [] } = useChatApiKeys();
   const createChatApiKey = useCreateChatApiKey();
 
   const [provider, setProvider] = useState<SupportedChatProvider>("anthropic");

--- a/platform/frontend/src/components/chat/mcp-tools-display.tsx
+++ b/platform/frontend/src/components/chat/mcp-tools-display.tsx
@@ -89,7 +89,7 @@ export function McpToolsDisplay({ agentId, className }: McpToolsDisplayProps) {
           {Object.entries(groupedTools).map(([serverName, tools]) => (
             <Tooltip key={serverName}>
               <TooltipTrigger asChild>
-                <div className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-secondary text-foreground cursor-default">
+                <div className="inline-flex items-center gap-1.5 px-2 h-9 rounded-md bg-secondary text-secondary-foreground cursor-default">
                   <span className="font-medium text-xs">{serverName}</span>
                   <span className="text-muted-foreground text-xs">
                     ({tools.length} {tools.length === 1 ? "tool" : "tools"})

--- a/platform/frontend/src/components/onboarding-dialog.tsx
+++ b/platform/frontend/src/components/onboarding-dialog.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/components/ui/dialog";
 import { useDefaultProfile } from "@/lib/agent.query";
 import { useHasPermissions } from "@/lib/auth.query";
-import { useChatApiKeysOptional } from "@/lib/chat-settings.query";
+import { useChatApiKeys } from "@/lib/chat-settings.query";
 import {
   useOrganizationOnboardingStatus,
   useUpdateOrganization,
@@ -42,7 +42,7 @@ export function OnboardingDialog({ open }: OnboardingDialogProps) {
     );
 
   // Chat settings state
-  const { data: chatApiKeys = [] } = useChatApiKeysOptional();
+  const { data: chatApiKeys = [] } = useChatApiKeys();
   const { data: canUpdateChatSettings } = useHasPermissions({
     chatSettings: ["update"],
   });

--- a/platform/frontend/src/lib/chat-settings.query.ts
+++ b/platform/frontend/src/lib/chat-settings.query.ts
@@ -1,7 +1,6 @@
 import { archestraApiSdk, type archestraApiTypes } from "@shared";
 import {
   useMutation,
-  useQuery,
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
@@ -21,23 +20,6 @@ const {
 
 export function useChatApiKeys() {
   return useSuspenseQuery({
-    queryKey: ["chat-api-keys"],
-    queryFn: async () => {
-      const { data, error } = await getChatApiKeys();
-      if (error) {
-        throw new Error(
-          typeof error.error === "string"
-            ? error.error
-            : error.error?.message || "Failed to fetch chat API keys",
-        );
-      }
-      return data ?? [];
-    },
-  });
-}
-
-export function useChatApiKeysOptional() {
-  return useQuery({
     queryKey: ["chat-api-keys"],
     queryFn: async () => {
       const { data, error } = await getChatApiKeys();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces `useChatApiKeysOptional` with `useChatApiKeys` across chat/onboarding and standardizes MCP tool pills to a consistent height/color.
> 
> - **Refactor (Chat API keys)**
>   - Remove duplicate `useChatApiKeysOptional` and its non-suspense `useQuery` implementation in `lib/chat-settings.query.ts`.
>   - Use `useChatApiKeys` (suspense) everywhere: `app/chat/page.tsx`, `components/chat/create-chat-api-key-form.tsx`, `components/onboarding-dialog.tsx`.
> - **UI (MCP tools)**
>   - Standardize tool pill styling in `components/chat/mcp-tools-display.tsx` to fixed height (`h-9`) and `text-secondary-foreground`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a85a8845e1773b8182ae74696cbf8f635d43441. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->