### PR TITLE
fix: explicit namespaces for k8s resources

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -124,7 +124,7 @@ openssl rand -base64 32
 **Kubernetes Settings**:
 
 - `archestra.orchestrator.kubernetes.namespace` - Kubernetes namespace where MCP server pods will be created (defaults to Helm release namespace)
-- `archestra.orchestrator.kubernetes.sameCluster` - Use in-cluster configuration (recommended when running inside K8s)
+- `archestra.orchestrator.kubernetes.loadKubeconfigFromCurrentCluster` - Use in-cluster configuration (recommended when running inside K8s)
 - `archestra.orchestrator.kubernetes.kubeconfig.enabled` - Enable mounting kubeconfig from a secret
 - `archestra.orchestrator.kubernetes.kubeconfig.secretName` - Name of secret containing kubeconfig file
 - `archestra.orchestrator.kubernetes.kubeconfig.mountPath` - Path where kubeconfig will be mounted

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -273,8 +273,7 @@ export default {
     kubernetes: {
       namespace: process.env.ARCHESTRA_ORCHESTRATOR_K8S_NAMESPACE || "default",
       kubeconfig: process.env.ARCHESTRA_ORCHESTRATOR_KUBECONFIG,
-      /** When true, indicates that backend and MCP orchestrator are in the same cluster. */
-      sameCluster:
+      loadKubeconfigFromCurrentCluster:
         process.env
           .ARCHESTRA_ORCHESTRATOR_LOAD_KUBECONFIG_FROM_CURRENT_CLUSTER ===
         "true",

--- a/platform/backend/src/mcp-server-runtime/k8s-pod.test.ts
+++ b/platform/backend/src/mcp-server-runtime/k8s-pod.test.ts
@@ -1202,10 +1202,11 @@ describe("K8sPod.generatePodSpec", () => {
 
   test("rewrite localhost URLs when backend is external to MCP pods", () => {
     // Save original value
-    const originalValue = config.orchestrator.kubernetes.sameCluster;
+    const originalValue =
+      config.orchestrator.kubernetes.loadKubeconfigFromCurrentCluster;
 
     // Mock config to simulate backend running in-cluster (production deployment)
-    config.orchestrator.kubernetes.sameCluster = false;
+    config.orchestrator.kubernetes.loadKubeconfigFromCurrentCluster = false;
 
     const mockCatalogItem = {
       id: "test-catalog-id",
@@ -1262,7 +1263,8 @@ describe("K8sPod.generatePodSpec", () => {
     expect(grafanaUrl?.value).toBe("http://host.docker.internal:3002/");
     expect(apiEndpoint?.value).toBe("http://host.docker.internal:8080/api");
 
-    config.orchestrator.kubernetes.sameCluster = originalValue;
+    config.orchestrator.kubernetes.loadKubeconfigFromCurrentCluster =
+      originalValue;
   });
 
   test("does not rewrite non-localhost URLs", () => {
@@ -1380,10 +1382,11 @@ describe("K8sPod.generatePodSpec", () => {
 
   test("does not rewrite localhost URLs when backend shares environment with K8s cluster", () => {
     // Save original value
-    const originalValue = config.orchestrator.kubernetes.sameCluster;
+    const originalValue =
+      config.orchestrator.kubernetes.loadKubeconfigFromCurrentCluster;
 
     // Mock config to simulate backend running in-cluster (production deployment)
-    config.orchestrator.kubernetes.sameCluster = true;
+    config.orchestrator.kubernetes.loadKubeconfigFromCurrentCluster = true;
 
     const mockCatalogItem = {
       id: "test-catalog-id",
@@ -1442,7 +1445,8 @@ describe("K8sPod.generatePodSpec", () => {
     expect(apiEndpoint?.value).toBe("http://127.0.0.1:8080/api");
 
     // Restore original value
-    config.orchestrator.kubernetes.sameCluster = originalValue;
+    config.orchestrator.kubernetes.loadKubeconfigFromCurrentCluster =
+      originalValue;
   });
 });
 

--- a/platform/backend/src/mcp-server-runtime/k8s-pod.ts
+++ b/platform/backend/src/mcp-server-runtime/k8s-pod.ts
@@ -526,7 +526,7 @@ export default class K8sPod {
         // Rewrite localhost URLs to host.docker.internal for Docker Desktop K8s
         // Only when backend is running on host machine (connecting to K8s from outside)
         // When backend runs inside cluster, pods shouldn't access host services
-        if (!config.orchestrator.kubernetes.sameCluster) {
+        if (!config.orchestrator.kubernetes.loadKubeconfigFromCurrentCluster) {
           processedValue = this.rewriteLocalhostUrl(processedValue);
         }
 
@@ -565,7 +565,9 @@ export default class K8sPod {
 
             // Use service DNS for in-cluster, localhost with NodePort for local dev
             let baseUrl: string | undefined;
-            if (config.orchestrator.kubernetes.sameCluster) {
+            if (
+              config.orchestrator.kubernetes.loadKubeconfigFromCurrentCluster
+            ) {
               const serviceName = `${this.podName}-service`;
               baseUrl = `http://${serviceName}.${this.namespace}.svc.cluster.local:${httpPort}`;
             } else {
@@ -676,7 +678,7 @@ export default class K8sPod {
 
         // Use service DNS for in-cluster, localhost with NodePort for local dev
         let baseUrl: string;
-        if (config.orchestrator.kubernetes.sameCluster) {
+        if (config.orchestrator.kubernetes.loadKubeconfigFromCurrentCluster) {
           // In-cluster: use service DNS name
           const serviceName = `${this.podName}-service`;
           baseUrl = `http://${serviceName}.${this.namespace}.svc.cluster.local:${httpPort}`;
@@ -756,7 +758,8 @@ export default class K8sPod {
 
       // Create the service
       // Use NodePort for local dev, ClusterIP for production
-      const serviceType = config.orchestrator.kubernetes.sameCluster
+      const serviceType = config.orchestrator.kubernetes
+        .loadKubeconfigFromCurrentCluster
         ? "ClusterIP"
         : "NodePort";
 

--- a/platform/backend/src/mcp-server-runtime/manager.test.ts
+++ b/platform/backend/src/mcp-server-runtime/manager.test.ts
@@ -57,7 +57,7 @@ vi.mock("@/config", async (importOriginal) => {
         kubernetes: {
           namespace: "test-namespace",
           kubeconfig: undefined,
-          sameCluster: false,
+          loadKubeconfigFromCurrentCluster: false,
         },
       },
     },

--- a/platform/backend/src/mcp-server-runtime/manager.ts
+++ b/platform/backend/src/mcp-server-runtime/manager.ts
@@ -16,7 +16,7 @@ import type {
 
 const {
   orchestrator: {
-    kubernetes: { namespace, kubeconfig, sameCluster },
+    kubernetes: { namespace, kubeconfig, loadKubeconfigFromCurrentCluster },
   },
 } = config;
 
@@ -103,7 +103,7 @@ export class McpServerRuntimeManager {
 
     try {
       // Validate and load kubeconfig based on configuration
-      if (sameCluster) {
+      if (loadKubeconfigFromCurrentCluster) {
         this.k8sConfig.loadFromCluster();
         logger.info("Loaded kubeconfig from current cluster");
       } else if (kubeconfigPath) {

--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -78,7 +78,7 @@ If ARCHESTRA_AUTH_SECRET env variable is explicitly set, it will override the au
   value: {{ printf "%s/config" .Values.archestra.orchestrator.kubernetes.kubeconfig.mountPath | quote }}
 {{- end }}
 - name: ARCHESTRA_ORCHESTRATOR_LOAD_KUBECONFIG_FROM_CURRENT_CLUSTER
-  value: {{ .Values.archestra.orchestrator.kubernetes.sameCluster | quote }}
+  value: {{ .Values.archestra.orchestrator.kubernetes.loadKubeconfigFromCurrentCluster | quote }}
 {{- if .Values.archestra.orchestrator.kubernetes.mcpServerRbac.create }}
 - name: ARCHESTRA_ORCHESTRATOR_MCP_K8S_SERVICE_ACCOUNT_NAME
   value: {{ include "archestra-platform.fullname" . | quote }}

--- a/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
@@ -446,7 +446,7 @@ tests:
   - it: should set ARCHESTRA_ORCHESTRATOR_LOAD_KUBECONFIG_FROM_CURRENT_CLUSTER to false when configured
     documentIndex: 1
     set:
-      archestra.orchestrator.kubernetes.sameCluster: false
+      archestra.orchestrator.kubernetes.loadKubeconfigFromCurrentCluster: false
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -457,7 +457,7 @@ tests:
   - it: should set ARCHESTRA_ORCHESTRATOR_LOAD_KUBECONFIG_FROM_CURRENT_CLUSTER to true when configured
     documentIndex: 1
     set:
-      archestra.orchestrator.kubernetes.sameCluster: true
+      archestra.orchestrator.kubernetes.loadKubeconfigFromCurrentCluster: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -98,10 +98,10 @@ archestra:
 
       # Method 1: Use in-cluster configuration (recommended when running inside K8s)
       # No additional configuration needed - the platform will automatically use the service account
-      sameCluster: true
+      loadKubeconfigFromCurrentCluster: true
 
       # Method 2: Mount a kubeconfig file from a secret
-      # Set sameCluster to false and configure the secret below
+      # Set useInClusterConfig to false and configure the secret below
       kubeconfig:
         # Enable kubeconfig volume mount
         enabled: false


### PR DESCRIPTION
Added namespace to k8s resources:
1. Ingress: HTTP/HTTPS routing rules that expose your services externally through a load balancerAdded to line 6
2. ServiceAccount: Identity for your main Archestra platform pods to authenticate with Kubernetes API and manage MCP server pods
3. Role: Permissions (RBAC) that allow the platform to create/manage MCP server pods, services, and secrets in the namespace
4. RoleBinding: Links the ServiceAccount to the Role, granting the permissions
5. Secret: Stores the auto-generated authentication secret (ARCHESTRA_AUTH_SECRET) used by better-auth for session management
6. Service: Network endpoint that exposes your platform's 3 ports (backend:9000, metrics:9050, frontend:3000)
7. Deployment: The main Archestra platform workload - manages your application pods (backend + frontend container)
8. BackendConfig: GKE-specific configuration for load balancer behavior on backend port (9000) - health checks, timeouts
9. BackendConfig - GKE-specific configuration for load balancer behavior on frontend port (3000) - health checks, timeouts
10. HorizontalPodAutoscaler: auto-scaling configuration that adjusts replica count based on CPU/memory metrics (only created if enabled)
11. PodDisruptionBudget: Limits how many pods can be down during voluntary disruptions (node maintenance, upgrades) to ensure availability