### PR TITLE
ci: persist playwright results if any flaky tests

### DIFF
--- a/.github/workflows/platform-linting-and-tests.yml
+++ b/.github/workflows/platform-linting-and-tests.yml
@@ -291,16 +291,26 @@ jobs:
             "mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-noble" \
             /bin/bash -c "corepack enable && corepack prepare pnpm@10.24.0 --activate && pnpm test:e2e"
 
+      - name: Check for flaky tests
+        id: check-flaky
+        if: success()
+        run: |
+          # If there are retry directories in test-results after a successful run, tests were flaky
+          if ls platform/e2e-tests/test-results/*retry* 1>/dev/null 2>&1; then
+            echo "⚠️ Flaky tests detected (retry directories found)"
+            echo "has_flaky_tests=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Upload Playwright report
-        if: failure()
+        if: failure() || steps.check-flaky.outputs.has_flaky_tests == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
           path: platform/e2e-tests/playwright-report/
           retention-days: 30
 
-      - name: Show logs on failure
-        if: failure()
+      - name: Show logs on failure or flaky tests
+        if: failure() || steps.check-flaky.outputs.has_flaky_tests == 'true'
         run: |
           echo "=== Kubernetes Pods ==="
           kubectl get pods -o wide


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Detect flaky Playwright tests via retry directories and upload the report plus Kubernetes logs even on successful runs with flakiness.
> 
> - **CI/CD (`.github/workflows/platform-linting-and-tests.yml`)**:
>   - Add `Check for flaky tests` step that marks `has_flaky_tests` when `platform/e2e-tests/test-results/*retry*` exists.
>   - Update `Upload Playwright report` to run on failure or when flaky tests are detected.
>   - Update logs step to run on failure or flakiness and include additional logs: PostgreSQL, WireMock, Keycloak, and `kubectl describe` for platform and PostgreSQL pods.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 302ea87587b4437c8a91d390a6be4507a4bc2de1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->