### PR TITLE
chore: move helm chart sensitive environment variables to use `Secret` & `secretKeyRef`

### DIFF
--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -54,6 +54,18 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Environment variables for the Archestra Platform container
 */}}
 {{- define "archestra-platform.env" -}}
+{{/*
+List of sensitive environment variables that should be stored in the Secret
+and referenced via secretKeyRef instead of being exposed as plaintext in Pod specs.
+This must match the list in secret.yaml.
+*/}}
+{{- $sensitiveEnvVars := list
+  "ARCHESTRA_AUTH_ADMIN_PASSWORD"
+  "ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_PASSWORD"
+  "ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_BEARER"
+  "ARCHESTRA_METRICS_SECRET"
+  "ARCHESTRA_HASHICORP_VAULT_TOKEN"
+}}
 {{- if .Values.postgresql.external_database_url }}
 - name: ARCHESTRA_DATABASE_URL
   valueFrom:
@@ -100,8 +112,17 @@ If ARCHESTRA_AUTH_SECRET env variable is explicitly set, it will override the au
 {{- if .Values.archestra.orchestrator.kubernetes.mcpServerRbac.create }}
 {{- end }}
 {{- range $key, $value := .Values.archestra.env }}
+{{- if has $key $sensitiveEnvVars }}
+{{/* Sensitive env vars are stored in the Secret and referenced via secretKeyRef */}}
+- name: {{ $key }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "archestra-platform.authSecretName" $ }}
+      key: {{ $key | lower | replace "_" "-" }}
+{{- else }}
 - name: {{ $key }}
   value: {{ $value | quote }}
+{{- end }}
 {{- end }}
 {{- range .Values.archestra.envFromSecrets }}
 - name: {{ .name }}

--- a/platform/helm/archestra/templates/secret.yaml
+++ b/platform/helm/archestra/templates/secret.yaml
@@ -1,5 +1,16 @@
 {{- $secretName := include "archestra-platform.authSecretName" . }}
 {{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{/*
+List of sensitive environment variables that should be stored in the Secret
+and referenced via secretKeyRef instead of being exposed as plaintext in Pod specs
+*/}}
+{{- $sensitiveEnvVars := list
+  "ARCHESTRA_AUTH_ADMIN_PASSWORD"
+  "ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_PASSWORD"
+  "ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_BEARER"
+  "ARCHESTRA_METRICS_SECRET"
+  "ARCHESTRA_HASHICORP_VAULT_TOKEN"
+}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -18,4 +29,10 @@ data:
   {{- end }}
   {{- if .Values.postgresql.external_database_url }}
   database-url: {{ .Values.postgresql.external_database_url | b64enc }}
+  {{- end }}
+  {{/* Store sensitive env vars in the secret if they are provided */}}
+  {{- range $sensitiveEnvVars }}
+  {{- if hasKey $.Values.archestra.env . }}
+  {{ . | lower | replace "_" "-" }}: {{ index $.Values.archestra.env . | b64enc }}
+  {{- end }}
   {{- end }}

--- a/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
@@ -1212,3 +1212,162 @@ tests:
       - equal:
           path: spec.template.metadata.annotations["config.linkerd.io/proxy-cpu-request"]
           value: "100m"
+
+  # Sensitive environment variable secretKeyRef tests
+  - it: should use secretKeyRef for ARCHESTRA_AUTH_ADMIN_PASSWORD when provided
+    documentIndex: 1
+    set:
+      archestra.env:
+        ARCHESTRA_AUTH_ADMIN_PASSWORD: "my-secure-admin-password"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_AUTH_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-archestra-platform-auth
+                key: archestra-auth-admin-password
+
+  - it: should use secretKeyRef for ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_PASSWORD when provided
+    documentIndex: 1
+    set:
+      archestra.env:
+        ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_PASSWORD: "otel-password-123"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-archestra-platform-auth
+                key: archestra-otel-exporter-otlp-auth-password
+
+  - it: should use secretKeyRef for ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_BEARER when provided
+    documentIndex: 1
+    set:
+      archestra.env:
+        ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_BEARER: "bearer-token-xyz"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_BEARER
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-archestra-platform-auth
+                key: archestra-otel-exporter-otlp-auth-bearer
+
+  - it: should use secretKeyRef for ARCHESTRA_METRICS_SECRET when provided
+    documentIndex: 1
+    set:
+      archestra.env:
+        ARCHESTRA_METRICS_SECRET: "metrics-secret-token"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_METRICS_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-archestra-platform-auth
+                key: archestra-metrics-secret
+
+  - it: should use secretKeyRef for ARCHESTRA_HASHICORP_VAULT_TOKEN when provided
+    documentIndex: 1
+    set:
+      archestra.env:
+        ARCHESTRA_HASHICORP_VAULT_TOKEN: "vault-token-abc123"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_HASHICORP_VAULT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-archestra-platform-auth
+                key: archestra-hashicorp-vault-token
+
+  - it: should use secretKeyRef for multiple sensitive env vars when provided together
+    documentIndex: 1
+    set:
+      archestra.env:
+        ARCHESTRA_AUTH_ADMIN_PASSWORD: "admin-password"
+        ARCHESTRA_METRICS_SECRET: "metrics-secret"
+        ARCHESTRA_API_BASE_URL: "https://api.example.com"
+    asserts:
+      # Sensitive vars should use secretKeyRef
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_AUTH_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-archestra-platform-auth
+                key: archestra-auth-admin-password
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_METRICS_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-archestra-platform-auth
+                key: archestra-metrics-secret
+      # Non-sensitive vars should use plain value
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_API_BASE_URL
+            value: "https://api.example.com"
+
+  - it: should not expose sensitive env var values as plaintext
+    documentIndex: 1
+    set:
+      archestra.env:
+        ARCHESTRA_AUTH_ADMIN_PASSWORD: "super-secret-password"
+    asserts:
+      # Should NOT contain the value as plaintext
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_AUTH_ADMIN_PASSWORD
+            value: "super-secret-password"
+
+  - it: should handle mix of sensitive and non-sensitive env vars correctly
+    documentIndex: 1
+    set:
+      archestra.env:
+        ARCHESTRA_FRONTEND_URL: "https://frontend.example.com"
+        ARCHESTRA_HASHICORP_VAULT_TOKEN: "hvs.secret-token"
+        ARCHESTRA_LOGGING_LEVEL: "debug"
+        ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_BEARER: "my-bearer-token"
+    asserts:
+      # Non-sensitive vars should use plain value
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_FRONTEND_URL
+            value: "https://frontend.example.com"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_LOGGING_LEVEL
+            value: "debug"
+      # Sensitive vars should use secretKeyRef
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_HASHICORP_VAULT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-archestra-platform-auth
+                key: archestra-hashicorp-vault-token
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_BEARER
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-archestra-platform-auth
+                key: archestra-otel-exporter-otlp-auth-bearer

--- a/platform/helm/archestra/tests/archestra_platform_secret_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_secret_test.yaml
@@ -31,3 +31,93 @@ tests:
     asserts:
       - isNotEmpty:
           path: data["database-url"]
+
+  # Sensitive environment variable tests
+  - it: should not include sensitive env vars in secret when not provided
+    set:
+      archestra.env: {}
+    asserts:
+      - isNull:
+          path: data["archestra-auth-admin-password"]
+      - isNull:
+          path: data["archestra-otel-exporter-otlp-auth-password"]
+      - isNull:
+          path: data["archestra-otel-exporter-otlp-auth-bearer"]
+      - isNull:
+          path: data["archestra-metrics-secret"]
+      - isNull:
+          path: data["archestra-hashicorp-vault-token"]
+
+  - it: should include ARCHESTRA_AUTH_ADMIN_PASSWORD in secret when provided
+    set:
+      archestra.env:
+        ARCHESTRA_AUTH_ADMIN_PASSWORD: "my-secure-admin-password"
+    asserts:
+      - isNotEmpty:
+          path: data["archestra-auth-admin-password"]
+
+  - it: should include ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_PASSWORD in secret when provided
+    set:
+      archestra.env:
+        ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_PASSWORD: "otel-password-123"
+    asserts:
+      - isNotEmpty:
+          path: data["archestra-otel-exporter-otlp-auth-password"]
+
+  - it: should include ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_BEARER in secret when provided
+    set:
+      archestra.env:
+        ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_BEARER: "bearer-token-xyz"
+    asserts:
+      - isNotEmpty:
+          path: data["archestra-otel-exporter-otlp-auth-bearer"]
+
+  - it: should include ARCHESTRA_METRICS_SECRET in secret when provided
+    set:
+      archestra.env:
+        ARCHESTRA_METRICS_SECRET: "metrics-secret-token"
+    asserts:
+      - isNotEmpty:
+          path: data["archestra-metrics-secret"]
+
+  - it: should include ARCHESTRA_HASHICORP_VAULT_TOKEN in secret when provided
+    set:
+      archestra.env:
+        ARCHESTRA_HASHICORP_VAULT_TOKEN: "vault-token-abc123"
+    asserts:
+      - isNotEmpty:
+          path: data["archestra-hashicorp-vault-token"]
+
+  - it: should include multiple sensitive env vars when provided together
+    set:
+      archestra.env:
+        ARCHESTRA_AUTH_ADMIN_PASSWORD: "admin-password"
+        ARCHESTRA_METRICS_SECRET: "metrics-secret"
+        ARCHESTRA_HASHICORP_VAULT_TOKEN: "vault-token"
+    asserts:
+      - isNotEmpty:
+          path: data["archestra-auth-admin-password"]
+      - isNotEmpty:
+          path: data["archestra-metrics-secret"]
+      - isNotEmpty:
+          path: data["archestra-hashicorp-vault-token"]
+      # These should still be null since not provided
+      - isNull:
+          path: data["archestra-otel-exporter-otlp-auth-password"]
+      - isNull:
+          path: data["archestra-otel-exporter-otlp-auth-bearer"]
+
+  - it: should not include non-sensitive env vars in secret
+    set:
+      archestra.env:
+        ARCHESTRA_API_BASE_URL: "https://api.example.com"
+        ARCHESTRA_FRONTEND_URL: "https://frontend.example.com"
+        ARCHESTRA_LOGGING_LEVEL: "debug"
+    asserts:
+      # Non-sensitive vars should not be stored in the secret
+      - isNull:
+          path: data["archestra-api-base-url"]
+      - isNull:
+          path: data["archestra-frontend-url"]
+      - isNull:
+          path: data["archestra-logging-level"]


### PR DESCRIPTION
Move sensitive environment variables to Kubernetes Secrets to enhance security by preventing plaintext exposure in Pod specifications.

---
[Slack Thread](https://archestra-ai.slack.com/archives/C0966V616DC/p1765912284543719?thread_ts=1765912284.543719&cid=C0966V616DC)

<a href="https://cursor.com/background-agent?bcId=bc-f5eb674b-68b9-4c50-93b7-f55bd3238f5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f5eb674b-68b9-4c50-93b7-f55bd3238f5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Templates now store specific sensitive env vars in the chart Secret and reference them via secretKeyRef; comprehensive tests validate rendering and Secret contents.
> 
> - **Helm templates**:
>   - `templates/_helpers.tpl`:
>     - Define list of sensitive env vars (`ARCHESTRA_AUTH_ADMIN_PASSWORD`, `ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_PASSWORD`, `ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_BEARER`, `ARCHESTRA_METRICS_SECRET`, `ARCHESTRA_HASHICORP_VAULT_TOKEN`).
>     - In `archestra-platform.env`, emit sensitive vars via `secretKeyRef` (kebab-case keys) and non-sensitive via plain `value`.
>     - Retain database URL handling (`database-url` from Secret or internal `$(PGPASSWORD)`).
>   - `templates/secret.yaml`:
>     - Mirror sensitive env var list and, when provided, store them as Secret data (kebab-case keys); include `database-url` when external.
> - **Tests**:
>   - `tests/archestra_platform_deployment_test.yaml`:
>     - Assert sensitive envs use `secretKeyRef`, non-sensitive use plain values, and no plaintext exposure for sensitive values.
>   - `tests/archestra_platform_secret_test.yaml`:
>     - Assert Secret includes sensitive keys only when provided and excludes non-sensitive envs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef56ca13075450a48efaa04299c9eb77119c9d20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->