### PR TITLE
chore: fix `tilt up`

### DIFF
--- a/platform/dev/Tiltfile.integrations
+++ b/platform/dev/Tiltfile.integrations
@@ -74,14 +74,8 @@ helm_resource(
   ],
   port_forwards=['8200:8200'],
   labels=['integrations'],
+  auto_init=False,
   resource_deps=[],
-)
-
-k8s_resource(
-  'vault',
-  new_name='vault-k8s',
-  trigger_mode=TRIGGER_MODE_MANUAL,
-  auto_init=False
 )
 
 # Archestra running in K8s (for testing Vault K8s auth, etc.)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Disable auto-init for `vault-k8s` Helm resource and remove redundant `k8s_resource` definition.
> 
> - **Tilt integrations (`platform/dev/Tiltfile.integrations`)**:
>   - `vault-k8s` Helm resource: set `auto_init=false`.
>   - Remove redundant `k8s_resource` block for `vault`/`vault-k8s`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c06af15542b11ce80937afea92761bbad96539d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->