### PR TITLE
chore: filter out noisy `/healthcheck` + mcp server healthcheck request/response server logs

### DIFF
--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -167,6 +167,7 @@ export async function registerApiRoutes(fastify: FastifyInstanceWithZod) {
 export const createFastifyInstance = () =>
   Fastify({
     loggerInstance: logger,
+    disableRequestLogging: true,
   })
     .withTypeProvider<ZodTypeProvider>()
     .setValidatorCompiler(validatorCompiler)
@@ -339,6 +340,43 @@ const startMcpServerRuntime = async (
 
 const start = async () => {
   const fastify = createFastifyInstance();
+
+  /**
+   * Custom request logging hook that excludes noisy endpoints:
+   * - /health: Kubernetes liveness/readiness probes
+   * - GET /v1/mcp/*: MCP Gateway SSE polling (happens every second)
+   */
+  const shouldSkipRequestLogging = (url: string, method: string): boolean => {
+    if (url === "/health") return true;
+    // Skip MCP Gateway SSE polling (GET requests to /v1/mcp/*)
+    if (method === "GET" && url.startsWith("/v1/mcp/")) return true;
+    return false;
+  };
+
+  fastify.addHook("onRequest", (request, _reply, done) => {
+    if (!shouldSkipRequestLogging(request.url, request.method)) {
+      request.log.info(
+        { url: request.url, method: request.method },
+        "incoming request",
+      );
+    }
+    done();
+  });
+
+  fastify.addHook("onResponse", (request, reply, done) => {
+    if (!shouldSkipRequestLogging(request.url, request.method)) {
+      request.log.info(
+        {
+          url: request.url,
+          method: request.method,
+          statusCode: reply.statusCode,
+          responseTime: reply.elapsedTime,
+        },
+        "request completed",
+      );
+    }
+    done();
+  });
 
   /**
    * Setup Sentry error handler for Fastify


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Disables Fastify’s built-in request logging and adds custom request/response logging that skips `/health` and `GET /v1/mcp/*` endpoints.
> 
> - **Backend — Logging (`platform/backend/src/server.ts`)**:
>   - Disable default Fastify request logging via `disableRequestLogging: true` in `createFastifyInstance`.
>   - Add custom `onRequest` and `onResponse` hooks to log concise request/response info.
>     - Skip logging for `/health` and `GET /v1/mcp/*` (MCP Gateway SSE polling).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81f3015d7ec454c79b5542f1b914e12b4b4346fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->