### PR TITLE
fix: invalidate model selector query when updating chat api key

### DIFF
--- a/platform/.env.example
+++ b/platform/.env.example
@@ -27,7 +27,7 @@ ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_PASSWORD=""
 # OTEL Authentication - Bearer token (takes precedence over basic auth if provided)
 ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_BEARER=""
 
-# Bearer token auth secret for exposed /metrics endpoint (port 9050)
+# Bearer token for /metrics endpoint (port 9050). If set, update dev/prometheus.yml with matching token.
 ARCHESTRA_METRICS_SECRET=""
 
 # Sentry Configuration
@@ -92,8 +92,6 @@ NEXT_PUBLIC_ARCHESTRA_ORCHESTRATOR_MCP_SERVER_BASE_IMAGE=europe-west1-docker.pkg
 # Logging
 ARCHESTRA_LOGGING_LEVEL=info
 
-# Bearer token for /metrics endpoint
-ARCHESTRA_METRICS_SECRET=foo-bar
 
 # Enterprise license toggle
 ARCHESTRA_ENTERPRISE_LICENSE_ACTIVATED=true

--- a/platform/frontend/src/lib/chat-settings.query.ts
+++ b/platform/frontend/src/lib/chat-settings.query.ts
@@ -59,6 +59,8 @@ export function useCreateChatApiKey() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["chat-api-keys"] });
+      // Invalidate chat models so the model picker refetches available models
+      queryClient.invalidateQueries({ queryKey: ["chat-models"] });
     },
   });
 }
@@ -91,6 +93,8 @@ export function useUpdateChatApiKey() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["chat-api-keys"] });
+      // Invalidate chat models so the model picker refetches available models
+      queryClient.invalidateQueries({ queryKey: ["chat-models"] });
     },
   });
 }
@@ -113,6 +117,8 @@ export function useDeleteChatApiKey() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["chat-api-keys"] });
+      // Invalidate chat models so the model picker refetches available models
+      queryClient.invalidateQueries({ queryKey: ["chat-models"] });
     },
   });
 }


### PR DESCRIPTION
for example, in case you had an invalid chat API key, went to `/chat` you'll see no models. Then if you go and update the key, you have to currently refresh the browser to refetch models w/ new key

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Invalidate the `chat-models` query after creating/updating/deleting chat API keys; clarify `ARCHESTRA_METRICS_SECRET` comment and remove redundant lines in `.env.example`.
> 
> - **Frontend**
>   - **Query invalidation**: After `create/update/delete` of chat API keys, invalidate `"chat-models"` to refresh the model picker in `platform/frontend/src/lib/chat-settings.query.ts`.
> - **Config/Docs**
>   - **.env.example**: Clarify `ARCHESTRA_METRICS_SECRET` comment (note about matching Prometheus token) and remove redundant/duplicate lines.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4904356b1f3b205266cb7a0552e4125b3add6a91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->