### PR TITLE
ci: reuse `./.github/actions/setup-env` composite action for license checker job

### DIFF
--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -143,18 +143,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
         with:
-          node-version: '24'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-        with:
-          version: 10
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          working-directory: ./platform
 
       - name: Run license compliance check
         run: pnpm license-check --ci


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors the license compliance job to use the shared `setup-env` action instead of manual Node/pnpm setup, with `./platform` as the working directory.
> 
> - **CI**
>   - **License Compliance Check (`.github/workflows/on-pull-requests.yml`)**:
>     - Replace manual Node.js/pnpm setup and install with shared composite action `./.github/actions/setup-env`.
>     - Provide `working-directory: ./platform` to the setup step.
>     - Retain license check and failure summary steps unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 047a5e72d5f2c7758ca507b93c2bfde1582812c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->