### PR TITLE
fix(helm): handle empty sensitive env vars without creating invalid `Secret` keys

### DIFF
--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -116,8 +116,9 @@ If ARCHESTRA_AUTH_SECRET env variable is explicitly set, it will override the au
 {{- range $key, $value := .Values.archestra.env }}
 {{/* Check if env var is in the explicit sensitive list OR matches ARCHESTRA_CHAT_*_API_KEY pattern */}}
 {{- $isSensitive := or (has $key $sensitiveEnvVars) (and (hasPrefix "ARCHESTRA_CHAT_" $key) (hasSuffix "_API_KEY" $key)) }}
-{{- if $isSensitive }}
-{{/* Sensitive env vars are stored in the Secret and referenced via secretKeyRef */}}
+{{/* Only use secretKeyRef for sensitive vars with non-empty values; empty values are set as regular env vars */}}
+{{- if and $isSensitive $value }}
+{{/* Sensitive env vars with values are stored in the Secret and referenced via secretKeyRef */}}
 - name: {{ $key }}
   valueFrom:
     secretKeyRef:

--- a/platform/helm/archestra/templates/secret.yaml
+++ b/platform/helm/archestra/templates/secret.yaml
@@ -32,15 +32,18 @@ data:
   {{- if .Values.postgresql.external_database_url }}
   database-url: {{ .Values.postgresql.external_database_url | b64enc }}
   {{- end }}
-  {{/* Store sensitive env vars in the secret if they are provided */}}
+  {{/* Store sensitive env vars in the secret if they are provided with non-empty values */}}
   {{- range $sensitiveEnvVars }}
   {{- if hasKey $.Values.archestra.env . }}
-  {{ . | lower | replace "_" "-" }}: {{ index $.Values.archestra.env . | b64enc }}
+  {{- $value := index $.Values.archestra.env . }}
+  {{- if $value }}
+  {{ . | lower | replace "_" "-" }}: {{ $value | b64enc }}
   {{- end }}
   {{- end }}
-  {{/* Store any ARCHESTRA_CHAT_*_API_KEY env vars in the secret */}}
+  {{- end }}
+  {{/* Store any ARCHESTRA_CHAT_*_API_KEY env vars in the secret if non-empty */}}
   {{- range $key, $value := $.Values.archestra.env }}
-  {{- if and (hasPrefix "ARCHESTRA_CHAT_" $key) (hasSuffix "_API_KEY" $key) }}
+  {{- if and (hasPrefix "ARCHESTRA_CHAT_" $key) (hasSuffix "_API_KEY" $key) $value }}
   {{ $key | lower | replace "_" "-" }}: {{ $value | b64enc }}
   {{- end }}
   {{- end }}

--- a/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
@@ -1493,6 +1493,95 @@ tests:
                 name: RELEASE-NAME-archestra-platform-auth
                 key: archestra-chat-custom-provider-api-key
 
+  # Empty value edge case tests for sensitive env vars
+  - it: should use plain value for ARCHESTRA_METRICS_SECRET when set to empty string
+    documentIndex: 1
+    set:
+      archestra.env:
+        ARCHESTRA_METRICS_SECRET: ""
+    asserts:
+      # Empty sensitive env vars should use plain value, not secretKeyRef
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_METRICS_SECRET
+            value: ""
+
+  - it: should not use secretKeyRef for ARCHESTRA_METRICS_SECRET with empty value
+    documentIndex: 1
+    set:
+      archestra.env:
+        ARCHESTRA_METRICS_SECRET: ""
+    asserts:
+      # Should NOT contain secretKeyRef for empty values
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_METRICS_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-archestra-platform-auth
+                key: archestra-metrics-secret
+
+  - it: should use plain value for multiple empty sensitive env vars
+    documentIndex: 1
+    set:
+      archestra.env:
+        ARCHESTRA_METRICS_SECRET: ""
+        ARCHESTRA_AUTH_ADMIN_PASSWORD: ""
+        ARCHESTRA_HASHICORP_VAULT_TOKEN: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_METRICS_SECRET
+            value: ""
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_AUTH_ADMIN_PASSWORD
+            value: ""
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_HASHICORP_VAULT_TOKEN
+            value: ""
+
+  - it: should handle mix of empty and non-empty sensitive env vars
+    documentIndex: 1
+    set:
+      archestra.env:
+        ARCHESTRA_METRICS_SECRET: ""
+        ARCHESTRA_HASHICORP_VAULT_TOKEN: "valid-token"
+    asserts:
+      # Empty value should use plain value
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_METRICS_SECRET
+            value: ""
+      # Non-empty value should use secretKeyRef
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_HASHICORP_VAULT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-archestra-platform-auth
+                key: archestra-hashicorp-vault-token
+
+  - it: should use plain value for ARCHESTRA_CHAT_*_API_KEY with empty value
+    documentIndex: 1
+    set:
+      archestra.env:
+        ARCHESTRA_CHAT_ANTHROPIC_API_KEY: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_CHAT_ANTHROPIC_API_KEY
+            value: ""
+
   # Node selector tests
   - it: should not have nodeSelector when archestra.nodeSelector is empty
     documentIndex: 1

--- a/platform/helm/archestra/tests/archestra_platform_secret_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_secret_test.yaml
@@ -132,6 +132,46 @@ tests:
       - isNull:
           path: data["archestra-logging-level"]
 
+  # Empty value edge case tests
+  - it: should not include sensitive env vars with empty string values in secret
+    set:
+      archestra.env:
+        ARCHESTRA_METRICS_SECRET: ""
+        ARCHESTRA_AUTH_ADMIN_PASSWORD: ""
+        ARCHESTRA_HASHICORP_VAULT_TOKEN: ""
+    asserts:
+      # Empty values should NOT be stored in the secret to avoid invalid secret data
+      - isNull:
+          path: data["archestra-metrics-secret"]
+      - isNull:
+          path: data["archestra-auth-admin-password"]
+      - isNull:
+          path: data["archestra-hashicorp-vault-token"]
+
+  - it: should not include ARCHESTRA_CHAT_*_API_KEY with empty values in secret
+    set:
+      archestra.env:
+        ARCHESTRA_CHAT_ANTHROPIC_API_KEY: ""
+        ARCHESTRA_CHAT_OPENAI_API_KEY: ""
+    asserts:
+      - isNull:
+          path: data["archestra-chat-anthropic-api-key"]
+      - isNull:
+          path: data["archestra-chat-openai-api-key"]
+
+  - it: should handle mix of empty and non-empty sensitive env vars
+    set:
+      archestra.env:
+        ARCHESTRA_METRICS_SECRET: ""
+        ARCHESTRA_HASHICORP_VAULT_TOKEN: "valid-token"
+    asserts:
+      # Empty value should not be in secret
+      - isNull:
+          path: data["archestra-metrics-secret"]
+      # Non-empty value should be in secret
+      - isNotEmpty:
+          path: data["archestra-hashicorp-vault-token"]
+
   # ARCHESTRA_CHAT_*_API_KEY pattern matching tests
   - it: should include ARCHESTRA_CHAT_ANTHROPIC_API_KEY in secret when provided
     set:


### PR DESCRIPTION
When sensitive env vars (like `ARCHESTRA_METRICS_SECRET`) are set to empty strings to disable features, they were incorrectly being added to the `Secret` with empty values and referenced via `secretKeyRef`. This caused pods to fail with "couldn't find key" errors.

Now empty sensitive env vars are treated as regular env vars with value: "" instead of using `secretKeyRef`, allowing users to explicitly disable features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Treats empty sensitive env vars as plain values and only writes secret entries/secretKeyRefs when values are non-empty, with tests covering empty/mixed cases.
> 
> - **Helm templates**:
>   - `templates/_helpers.tpl`: Use `secretKeyRef` only when sensitive env vars (incl. `ARCHESTRA_CHAT_*_API_KEY`) have non-empty values; otherwise set plain `value`.
>   - `templates/secret.yaml`: Store sensitive env vars (incl. `ARCHESTRA_CHAT_*_API_KEY`) in `Secret` only when values are non-empty.
> - **Tests**:
>   - `tests/archestra_platform_deployment_test.yaml`: Add assertions ensuring empty sensitive env vars render as plain env `value` (no `secretKeyRef`) and mixed empty/non-empty behavior.
>   - `tests/archestra_platform_secret_test.yaml`: Add assertions ensuring empty sensitive env vars are omitted from `Secret` data and mixed cases handled correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15d675c538aeecae523aa7e0df455cbfba20febe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->