### PR TITLE
fix: add better-auth default permissions to non-EE access control

### DIFF
--- a/platform/shared/access-control.ts
+++ b/platform/shared/access-control.ts
@@ -1,10 +1,17 @@
+import { defaultStatements } from "better-auth/plugins/organization/access";
 import type { Permissions } from "./permission.types";
 import type { RouteId } from "./routes";
-export const allAvailableActions: Permissions = {};
 
-export const editorPermissions: Permissions = {};
+// Include better-auth's default permissions for organization operations
+// This ensures basic operations like invitations work in non-EE mode
+export const allAvailableActions: Permissions = defaultStatements;
 
-export const memberPermissions: Permissions = {};
+export const editorPermissions: Permissions = defaultStatements;
+
+export const memberPermissions: Permissions = {
+  organization: ["read"],
+  team: ["read"],
+};
 
 // Allows all endpoints
 export const requiredEndpointPermissionsMap = new Proxy(


### PR DESCRIPTION
Fixes e2e test failures in non-EE mode where admin users couldn't invite other users.

The issue was that the non-EE version of access-control.ts had empty permissions, preventing basic operations like invitations from working.

Added better-auth's defaultStatements which includes essential permissions for organization operations.