### PR TITLE
feat: copy button for requests and response

### DIFF
--- a/platform/frontend/src/app/logs/[id]/page.client.tsx
+++ b/platform/frontend/src/app/logs/[id]/page.client.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { Suspense } from "react";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
 import ChatBotDemo from "@/components/chatbot-demo";
+import { CopyButton } from "@/components/copy-button";
 import Divider from "@/components/divider";
 import { LoadingSpinner } from "@/components/loading";
 import { Savings } from "@/components/savings";
@@ -251,7 +252,11 @@ function LogDetail({
                 </span>
               </AccordionTrigger>
               <AccordionContent className="px-6 pb-4">
-                <div className="bg-muted rounded-lg p-4 overflow-auto max-h-[600px]">
+                <div className="bg-muted rounded-lg p-4 overflow-auto max-h-[600px] relative">
+                  <CopyButton
+                    text={JSON.stringify(dynamicInteraction.request, null, 2)}
+                    className="absolute top-2 right-2"
+                  />
                   <pre className="text-xs whitespace-pre-wrap break-words">
                     {JSON.stringify(dynamicInteraction.request, null, 2)}
                   </pre>
@@ -270,7 +275,15 @@ function LogDetail({
                   </span>
                 </AccordionTrigger>
                 <AccordionContent className="px-6 pb-4">
-                  <div className="bg-muted rounded-lg p-4 overflow-auto max-h-[600px]">
+                  <div className="bg-muted rounded-lg p-4 overflow-auto max-h-[600px] relative">
+                    <CopyButton
+                      text={JSON.stringify(
+                        dynamicInteraction.processedRequest,
+                        null,
+                        2,
+                      )}
+                      className="absolute top-2 right-2"
+                    />
                     <pre className="text-xs whitespace-pre-wrap break-words">
                       {JSON.stringify(
                         dynamicInteraction.processedRequest,
@@ -295,7 +308,11 @@ function LogDetail({
                 <span className="text-base font-semibold">Raw Response</span>
               </AccordionTrigger>
               <AccordionContent className="px-6 pb-4">
-                <div className="bg-muted rounded-lg p-4 overflow-auto max-h-[600px]">
+                <div className="bg-muted rounded-lg p-4 overflow-auto max-h-[600px] relative">
+                  <CopyButton
+                    text={JSON.stringify(dynamicInteraction.response, null, 2)}
+                    className="absolute top-2 right-2"
+                  />
                   <pre className="text-xs whitespace-pre-wrap break-words">
                     {JSON.stringify(dynamicInteraction.response, null, 2)}
                   </pre>

--- a/platform/frontend/src/components/copy-button.tsx
+++ b/platform/frontend/src/components/copy-button.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+
+export function CopyButton({
+  text,
+  className,
+  size = 14,
+  behavior = "checkmark",
+}: {
+  text: string;
+  className?: string;
+  size?: number;
+  behavior?: "checkmark" | "text";
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (_error) {
+      // Fallback for older browsers
+      const textArea = document.createElement("textarea");
+      textArea.value = text;
+      textArea.style.position = "fixed";
+      textArea.style.left = "-999999px";
+      document.body.appendChild(textArea);
+      textArea.select();
+      try {
+        document.execCommand("copy");
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch (err) {
+        console.error("Failed to copy:", err);
+      }
+      document.body.removeChild(textArea);
+    }
+  };
+
+  if (behavior === "text") {
+    return (
+      <>
+        <Button
+          variant="ghost"
+          size="sm"
+          className={`h-6 w-6 p-0 hover:bg-background/50 ${className ?? ""}`}
+          title="Copy to Clipboard"
+          onClick={handleCopy}
+        >
+          <Copy size={size} />
+        </Button>
+        {copied && <span className="ml-1 text-xs">Copied!</span>}
+      </>
+    );
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className={`h-6 w-6 p-0 hover:bg-background/50 ${className ?? ""}`}
+      title="Copy to Clipboard"
+      onClick={handleCopy}
+    >
+      {copied ? <Check size={size} /> : <Copy size={size} />}
+    </Button>
+  );
+}

--- a/platform/frontend/src/components/default-credentials-warning.tsx
+++ b/platform/frontend/src/components/default-credentials-warning.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { DEFAULT_ADMIN_EMAIL, DEFAULT_ADMIN_PASSWORD } from "@shared";
-import { Copy, Link } from "lucide-react";
-import { useState } from "react";
+import { Link } from "lucide-react";
+import { CopyButton } from "@/components/copy-button";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Button } from "@/components/ui/button";
 import { useDefaultCredentialsEnabled } from "@/lib/auth.query";
 import { authClient } from "@/lib/clients/auth/auth-client";
 
@@ -17,42 +16,6 @@ export function DefaultCredentialsWarning({
   const userEmail = session?.user?.email;
   const { data: defaultCredentialsEnabled, isLoading } =
     useDefaultCredentialsEnabled();
-  const [copiedEmail, setCopiedEmail] = useState(false);
-  const [copiedPassword, setCopiedPassword] = useState(false);
-
-  const copyToClipboard = async (text: string, type: "email" | "password") => {
-    try {
-      await navigator.clipboard.writeText(text);
-      if (type === "email") {
-        setCopiedEmail(true);
-        setTimeout(() => setCopiedEmail(false), 2000);
-      } else {
-        setCopiedPassword(true);
-        setTimeout(() => setCopiedPassword(false), 2000);
-      }
-    } catch (_error) {
-      // Fallback for older browsers or when clipboard API is not available
-      const textArea = document.createElement("textarea");
-      textArea.value = text;
-      textArea.style.position = "fixed";
-      textArea.style.left = "-999999px";
-      document.body.appendChild(textArea);
-      textArea.select();
-      try {
-        document.execCommand("copy");
-        if (type === "email") {
-          setCopiedEmail(true);
-          setTimeout(() => setCopiedEmail(false), 2000);
-        } else {
-          setCopiedPassword(true);
-          setTimeout(() => setCopiedPassword(false), 2000);
-        }
-      } catch (err) {
-        console.error("Failed to copy:", err);
-      }
-      document.body.removeChild(textArea);
-    }
-  };
 
   // Loading state - don't show anything yet
   if (isLoading || defaultCredentialsEnabled === undefined) {
@@ -78,29 +41,21 @@ export function DefaultCredentialsWarning({
         <div className="space-y-1">
           <div className="flex items-center gap-1">
             <code className="break-all">- {DEFAULT_ADMIN_EMAIL}</code>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-4 w-4 p-0 hover:bg-transparent"
-              onClick={() => copyToClipboard(DEFAULT_ADMIN_EMAIL, "email")}
-            >
-              <Copy size={10} />
-            </Button>
-            {copiedEmail && <span className="ml-1 text-xs">Copied!</span>}
+            <CopyButton
+              text={DEFAULT_ADMIN_EMAIL}
+              className="h-4 w-4 hover:bg-transparent"
+              size={10}
+              behavior="text"
+            />
           </div>
           <div className="flex items-center gap-1">
             <code className="break-all">- {DEFAULT_ADMIN_PASSWORD}</code>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-4 w-4 p-0 hover:bg-transparent"
-              onClick={() =>
-                copyToClipboard(DEFAULT_ADMIN_PASSWORD, "password")
-              }
-            >
-              <Copy size={10} />
-            </Button>
-            {copiedPassword && <span className="ml-1 text-xs">Copied!</span>}
+            <CopyButton
+              text={DEFAULT_ADMIN_PASSWORD}
+              className="h-4 w-4 hover:bg-transparent"
+              size={10}
+              behavior="text"
+            />
           </div>
         </div>
         <p className="mt-1">


### PR DESCRIPTION
Use same "copy to clipboard" button in request and response code block on log entry page, and in default credentials block (the one with admin@example.com).