### PR TITLE
ci: change on comits to `main` workflow to `dev` branch

### DIFF
--- a/.github/workflows/on-commits-to-dev.yml
+++ b/.github/workflows/on-commits-to-dev.yml
@@ -1,9 +1,9 @@
-name: On commits to main
+name: On commits to dev
 
 on:
   push:
     branches:
-      - main
+      - dev
   # Allow manual triggering of the workflow
   workflow_dispatch:
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **CI workflow update**
> 
> - Rename workflow to `On commits to dev`
> - Change trigger from pushes to `main` to pushes to `dev`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2eb99a6df1fcfd7fc5bc825a544227dd291dfd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->