### PR TITLE
fix: bug with certain characters in MCP server name

### DIFF
--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -557,7 +557,7 @@ class McpClient {
 
   /**
    * Strip server prefix from tool name
-   * Slugifies the prefix (lowercase + spaces to underscores) to match how tool names are created
+   * Slugifies the prefix using ToolModel.slugifyName to match how tool names are created
    */
   private stripServerPrefix(toolName: string, prefixName: string): string {
     // Slugify the prefix the same way ToolModel.slugifyName does

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -9,12 +9,14 @@ import AgentToolModel from "./agent-tool";
 
 class ToolModel {
   /**
-   * Slugify a tool name to get a unique name for the MCP server's tool
+   * Slugify a tool name to get a unique name for the MCP server's tool.
+   * Ensures the result matches the pattern ^[a-zA-Z0-9_-]{1,128}$ required by LLM providers.
    */
   static slugifyName(mcpServerName: string, toolName: string): string {
     return `${mcpServerName}${MCP_SERVER_TOOL_NAME_SEPARATOR}${toolName}`
       .toLowerCase()
-      .replace(/ /g, "_");
+      .replace(/\s+/g, "_") // Replace whitespace with underscores
+      .replace(/[^a-z0-9_-]/g, ""); // Remove any characters not allowed in tool names
   }
 
   /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures MCP tool names are consistently slugified and compliant with LLM provider constraints.
> 
> - Strengthen `ToolModel.slugifyName` to lowercase, collapse whitespace to `_`, and remove non-`[a-z0-9_-]` characters to meet `^[a-zA-Z0-9_-]{1,128}$`
> - Add comprehensive tests for `slugifyName` and `unslugifyName` covering spaces, brackets/parentheses, special chars, tabs/newlines, numbers, empty tool names, and provider pattern compliance
> - Update `mcp-client.ts` to strip server prefixes using `ToolModel.slugifyName` for consistent tool name handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3cd70d68e4597582d3f546174815be0ba44abb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->