### PR TITLE
chore: persist search query on MCP registry page in URL

### DIFF
--- a/platform/frontend/src/app/mcp-catalog/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp-catalog/_parts/InternalMCPCatalog.tsx
@@ -106,7 +106,7 @@ export function InternalMCPCatalog({
       } else {
         params.delete("search");
       }
-      router.push(`${pathname}?${params.toString()}`, { scroll: false });
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
     },
     [searchParams, router, pathname],
   );


### PR DESCRIPTION
Persist search query in URL for MCP registry page to allow sharing and state restoration. Closes #1749.

---
<a href="https://cursor.com/background-agent?bcId=bc-d59e3565-853b-4b9c-97ab-01a768162ea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d59e3565-853b-4b9c-97ab-01a768162ea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Keeps the MCP registry search state in the URL for shareability and restoration.
> 
> - Initialize `searchQuery` from `useSearchParams()` (`?search=`) and sync on browser navigation
> - Add `handleSearchChange` to update both state and URL via `router.push` (no scroll)
> - Wire `Input` change handler to `handleSearchChange`
> - Changes confined to `InternalMCPCatalog.tsx`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54d9dc6b4cda6eaabad92927f1fe632eed5ba6da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->