### PR TITLE
fix: Fix mcp-gateway personal tokens for admins

### DIFF
--- a/platform/backend/src/auth/utils.ee.ts
+++ b/platform/backend/src/auth/utils.ee.ts
@@ -1,6 +1,7 @@
 import type { IncomingHttpHeaders } from "node:http";
-import type { Permissions } from "@shared";
+import type { Action, Permissions, Resource } from "@shared";
 import logger from "@/logging";
+import { getUserPermissions } from "@/models/user.ee";
 import { auth as betterAuth } from "./better-auth";
 
 export const hasPermission = async (
@@ -60,4 +61,21 @@ export const hasPermission = async (
     logger.debug("[hasPermission] No valid API key provided");
     return { success: false, error: new Error("No API key provided") };
   }
+};
+
+/**
+ * Check if a user has a specific permission based on their role
+ * @param userId - The user's ID
+ * @param organizationId - The organization ID
+ * @param resource - The resource to check (e.g., "profile", "mcpServer")
+ * @param action - The action to check (e.g., "admin", "read", "write")
+ */
+export const userHasPermission = async (
+  userId: string,
+  organizationId: string,
+  resource: Resource,
+  action: Action,
+): Promise<boolean> => {
+  const permissions = await getUserPermissions(userId, organizationId);
+  return permissions[resource]?.includes(action) ?? false;
 };

--- a/platform/backend/src/auth/utils.ts
+++ b/platform/backend/src/auth/utils.ts
@@ -1,5 +1,5 @@
 import type { IncomingHttpHeaders } from "node:http";
-import type { Permissions } from "@shared";
+import type { Action, Permissions, Resource } from "@shared";
 import config from "@/config";
 
 export async function hasPermission(
@@ -20,4 +20,32 @@ export async function hasPermission(
         },
       };
   return hasPermission.apply(null, args);
+}
+
+/**
+ * Check if a user has a specific permission.
+ * Different form hasPermission, because it doesn't require the request headers, but user and organization IDs.
+ * In EE mode: checks the user's role permissions
+ * In non-EE mode: returns true (no permission restrictions)
+ */
+export async function userHasPermission(
+  userId: string,
+  organizationId: string,
+  resource: Resource,
+  action: Action,
+): Promise<boolean> {
+  const { userHasPermission } = config.enterpriseLicenseActivated
+    ? // biome-ignore lint/style/noRestrictedImports: conditional EE import
+      await import("./utils.ee")
+    : {
+        userHasPermission: async (
+          _userId: string,
+          _organizationId: string,
+          _resource: Resource,
+          _action: Action,
+        ): Promise<boolean> => {
+          return true; // Always allow - no permission check in non-enterprise version
+        },
+      };
+  return userHasPermission(userId, organizationId, resource, action);
 }

--- a/platform/backend/src/routes/mcp-gateway.utils.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.test.ts
@@ -1,6 +1,6 @@
+import { TeamTokenModel, UserTokenModel } from "@/models";
 import { describe, expect, test } from "@/test";
 import { validateMCPGatewayToken } from "./mcp-gateway.utils";
-import { TeamTokenModel, UserTokenModel } from "@/models";
 
 describe("validateMCPGatewayToken", () => {
   describe("invalid token scenarios", () => {
@@ -14,7 +14,9 @@ describe("validateMCPGatewayToken", () => {
   });
 
   describe("team token validation", () => {
-    test("validates org token for any profile", async ({ makeOrganization }) => {
+    test("validates org token for any profile", async ({
+      makeOrganization,
+    }) => {
       const org = await makeOrganization();
 
       const { token, value } = await TeamTokenModel.create({
@@ -164,7 +166,9 @@ describe("validateMCPGatewayToken", () => {
       await makeMember(regularUser.id, org.id, { role: "member" });
 
       // Create a team with regular user only (admin is NOT in this team)
-      const team = await makeTeam(org.id, regularUser.id, { name: "Other Team" });
+      const team = await makeTeam(org.id, regularUser.id, {
+        name: "Other Team",
+      });
 
       // Agent assigned to team
       const agent = await makeAgent({ teams: [team.id] });

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -15,6 +15,7 @@ import {
   executeArchestraTool,
   getArchestraMcpTools,
 } from "@/archestra-mcp-server";
+import { userHasPermission } from "@/auth/utils";
 import { clearChatMcpClient } from "@/clients/chat-mcp-client";
 import mcpClient, { type TokenAuthContext } from "@/clients/mcp-client";
 import config from "@/config";
@@ -401,27 +402,6 @@ export async function validateTeamToken(
 }
 
 /**
- * Check if a user has profile admin permission
- * In EE mode: checks the user's role permissions
- * In non-EE mode: returns true (no permission restrictions)
- */
-async function userHasProfileAdminPermission(
-  userId: string,
-  organizationId: string,
-): Promise<boolean> {
-  if (!config.enterpriseLicenseActivated) {
-    // Non-EE mode: all users have full access
-    return true;
-  }
-
-  // EE mode: check user's role permissions
-  // biome-ignore lint/style/noRestrictedImports: conditional EE import
-  const { getUserPermissions } = await import("@/models/user.ee");
-  const permissions = await getUserPermissions(userId, organizationId);
-  return permissions.profile?.includes("admin") ?? false;
-}
-
-/**
  * Validate a user token for a specific profile
  * Returns token auth info if valid, null otherwise
  *
@@ -442,9 +422,11 @@ export async function validateUserToken(
   }
 
   // Check if user has profile admin permission (can access all profiles)
-  const isProfileAdmin = await userHasProfileAdminPermission(
+  const isProfileAdmin = await userHasPermission(
     token.userId,
     token.organizationId,
+    "profile",
+    "admin",
   );
 
   if (isProfileAdmin) {


### PR DESCRIPTION
Personal tokens were checking if there is a intersection of user's and profile's team. It didn't work for admin personal tokens, since admins are able to access any profie <-> mcp-gw connection in the UI, but were not able to use their personal token.
Fix it to check profile:admin permission 