### PR TITLE
fix: schedule chat cleanup on unmount

### DIFF
--- a/platform/frontend/src/contexts/global-chat-context.tsx
+++ b/platform/frontend/src/contexts/global-chat-context.tsx
@@ -158,7 +158,14 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       scheduleCleanup,
       cancelCleanup,
     }),
-    [registerSession, getSession, clearSession, notifySessionUpdate, scheduleCleanup, cancelCleanup],
+    [
+      registerSession,
+      getSession,
+      clearSession,
+      notifySessionUpdate,
+      scheduleCleanup,
+      cancelCleanup,
+    ],
   );
 
   return (


### PR DESCRIPTION
Schedules chat cleanup on chat unmount, cancelling this cleanup if chat is re-mounted.

Closes https://github.com/archestra-ai/archestra/issues/1739