### PR TITLE
feat: add `mcpServerRbac.additionalClusterRoleBindings` to helm chart

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -26,6 +26,13 @@ archestra:
         annotations:
           iam.gke.io/gcp-service-account: archestra-vertex-ai@friendly-path-465518-r6.iam.gserviceaccount.com
 
+      # Additional RBAC for MCP K8s operator service account
+      # Grants cluster-wide read access for the Kubernetes MCP server
+      # The ClusterRole is created in archestra-ai/infra repo (gke/archestra-rbac.tf)
+      mcpServerRbac:
+        additionalClusterRoleBindings:
+          - clusterRoleName: archestra-cluster-reader
+
   service:
     annotations:
       # GKE BackendConfig for custom health checks

--- a/platform/helm/archestra/templates/mcp-serviceaccount.yaml
+++ b/platform/helm/archestra/templates/mcp-serviceaccount.yaml
@@ -65,4 +65,24 @@ roleRef:
   kind: Role
   name: {{ include "archestra-platform.fullname" . }}-mcp-server-operator
   apiGroup: rbac.authorization.k8s.io
+{{- range .Values.archestra.orchestrator.kubernetes.mcpServerRbac.additionalClusterRoleBindings }}
+---
+# Additional ClusterRoleBinding to grant cluster-wide permissions to the mcp-k8s-operator service account
+# The ClusterRole "{{ .clusterRoleName }}" must be created externally (e.g., via Terraform or kubectl)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .name | default (printf "%s-mcp-k8s-operator-%s" (include "archestra-platform.fullname" $) .clusterRoleName) }}
+  labels:
+    {{- include "archestra-platform.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: mcp-serviceaccount
+subjects:
+- kind: ServiceAccount
+  name: {{ include "archestra-platform.fullname" $ }}-mcp-k8s-operator
+  namespace: {{ $.Values.archestra.orchestrator.kubernetes.namespace | default $.Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .clusterRoleName }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/platform/helm/archestra/tests/archestra_platform_mcp_service_account_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_mcp_service_account_test.yaml
@@ -1,0 +1,252 @@
+suite: test archestra platform -- MCP ServiceAccount/Role/RoleBinding/ClusterRoleBinding
+templates:
+  - mcp-serviceaccount.yaml
+tests:
+  # ServiceAccount tests
+  - it: should create MCP K8s operator ServiceAccount by default
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - matchRegex:
+          path: metadata.name
+          pattern: -mcp-k8s-operator$
+
+  - it: should not create any resources when mcpServerRbac.create is false
+    set:
+      archestra.orchestrator.kubernetes.mcpServerRbac.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # Role tests
+  - it: should create MCP server operator Role by default
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Role
+      - matchRegex:
+          path: metadata.name
+          pattern: -mcp-server-operator$
+
+  - it: should have read-only pod permissions in Role
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["pods"]
+            verbs: ["get", "list", "watch"]
+
+  - it: should have pod/log permissions in Role
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["pods/log"]
+            verbs: ["get"]
+
+  - it: should have read-only services permissions in Role
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["services"]
+            verbs: ["get", "list", "watch"]
+
+  - it: should have read-only workload permissions in Role
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["apps"]
+            resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+            verbs: ["get", "list", "watch"]
+
+  - it: should have read-only events permissions in Role
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["events"]
+            verbs: ["get", "list", "watch"]
+
+  # RoleBinding tests
+  - it: should create MCP server operator RoleBinding by default
+    documentIndex: 2
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - matchRegex:
+          path: metadata.name
+          pattern: -mcp-server-operator$
+
+  - it: should bind to the correct MCP K8s operator ServiceAccount
+    documentIndex: 2
+    asserts:
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - matchRegex:
+          path: subjects[0].name
+          pattern: -mcp-k8s-operator$
+      - equal:
+          path: subjects[0].namespace
+          value: NAMESPACE
+
+  - it: should reference the correct Role
+    documentIndex: 2
+    asserts:
+      - equal:
+          path: roleRef.kind
+          value: Role
+      - matchRegex:
+          path: roleRef.name
+          pattern: -mcp-server-operator$
+      - equal:
+          path: roleRef.apiGroup
+          value: rbac.authorization.k8s.io
+
+  # Custom namespace tests
+  - it: should use custom namespace when configured
+    set:
+      archestra.orchestrator.kubernetes.namespace: "custom-namespace"
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: "custom-namespace"
+
+  - it: should use custom namespace in RoleBinding subject
+    set:
+      archestra.orchestrator.kubernetes.namespace: "custom-namespace"
+    documentIndex: 2
+    asserts:
+      - equal:
+          path: subjects[0].namespace
+          value: "custom-namespace"
+
+  # Integration tests
+  - it: should create all default resources (ServiceAccount, Role, RoleBinding)
+    asserts:
+      - hasDocuments:
+          count: 3
+
+  # Additional ClusterRoleBinding tests
+  - it: should not create ClusterRoleBindings when additionalClusterRoleBindings is empty
+    asserts:
+      - hasDocuments:
+          count: 3
+
+  - it: should create ClusterRoleBinding when additionalClusterRoleBindings is configured
+    set:
+      archestra.orchestrator.kubernetes.mcpServerRbac.additionalClusterRoleBindings:
+        - clusterRoleName: cluster-reader
+    asserts:
+      - hasDocuments:
+          count: 4
+
+  - it: should create multiple ClusterRoleBindings when multiple are configured
+    set:
+      archestra.orchestrator.kubernetes.mcpServerRbac.additionalClusterRoleBindings:
+        - clusterRoleName: cluster-reader
+        - clusterRoleName: another-role
+    asserts:
+      - hasDocuments:
+          count: 5
+
+  - it: should create ClusterRoleBinding with auto-generated name
+    set:
+      archestra.orchestrator.kubernetes.mcpServerRbac.additionalClusterRoleBindings:
+        - clusterRoleName: cluster-reader
+    documentIndex: 3
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - matchRegex:
+          path: metadata.name
+          pattern: -mcp-k8s-operator-cluster-reader$
+
+  - it: should create ClusterRoleBinding with custom name when provided
+    set:
+      archestra.orchestrator.kubernetes.mcpServerRbac.additionalClusterRoleBindings:
+        - clusterRoleName: cluster-reader
+          name: my-custom-binding-name
+    documentIndex: 3
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: metadata.name
+          value: my-custom-binding-name
+
+  - it: should bind ClusterRoleBinding to the correct ServiceAccount
+    set:
+      archestra.orchestrator.kubernetes.mcpServerRbac.additionalClusterRoleBindings:
+        - clusterRoleName: cluster-reader
+    documentIndex: 3
+    asserts:
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - matchRegex:
+          path: subjects[0].name
+          pattern: -mcp-k8s-operator$
+      - equal:
+          path: subjects[0].namespace
+          value: NAMESPACE
+
+  - it: should reference the correct ClusterRole in ClusterRoleBinding
+    set:
+      archestra.orchestrator.kubernetes.mcpServerRbac.additionalClusterRoleBindings:
+        - clusterRoleName: cluster-reader
+    documentIndex: 3
+    asserts:
+      - equal:
+          path: roleRef.kind
+          value: ClusterRole
+      - equal:
+          path: roleRef.name
+          value: cluster-reader
+      - equal:
+          path: roleRef.apiGroup
+          value: rbac.authorization.k8s.io
+
+  - it: should use custom namespace in ClusterRoleBinding subject
+    set:
+      archestra.orchestrator.kubernetes.namespace: "custom-namespace"
+      archestra.orchestrator.kubernetes.mcpServerRbac.additionalClusterRoleBindings:
+        - clusterRoleName: cluster-reader
+    documentIndex: 3
+    asserts:
+      - equal:
+          path: subjects[0].namespace
+          value: "custom-namespace"
+
+  - it: should include standard labels in ClusterRoleBinding
+    set:
+      archestra.orchestrator.kubernetes.mcpServerRbac.additionalClusterRoleBindings:
+        - clusterRoleName: cluster-reader
+    documentIndex: 3
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: mcp-serviceaccount
+
+  - it: should not create ClusterRoleBindings when mcpServerRbac.create is false
+    set:
+      archestra.orchestrator.kubernetes.mcpServerRbac.create: false
+      archestra.orchestrator.kubernetes.mcpServerRbac.additionalClusterRoleBindings:
+        - clusterRoleName: cluster-reader
+    asserts:
+      - hasDocuments:
+          count: 0
+

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -165,6 +165,16 @@ archestra:
         # Specifies whether RBAC resources (ServiceAccount, Role, RoleBinding) should be created
         create: true
 
+        # Additional ClusterRoleBindings to attach to the mcp-k8s-operator service account
+        # Use this to grant cluster-wide permissions (e.g., read access to all namespaces)
+        # The ClusterRoles must be created externally (e.g., via Terraform or kubectl)
+        # Example:
+        #   additionalClusterRoleBindings:
+        #     - clusterRoleName: cluster-reader
+        #     - clusterRoleName: custom-role
+        #       name: custom-binding-name  # Optional: override the auto-generated binding name
+        additionalClusterRoleBindings: []
+
   # Service configuration
   service:
     # Service type - ClusterIP, NodePort, or LoadBalancer


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces configurable cluster-wide RBAC bindings for the Kubernetes MCP server.
> 
> - Template `templates/mcp-serviceaccount.yaml` now renders `ClusterRoleBinding` objects from `archestra.orchestrator.kubernetes.mcpServerRbac.additionalClusterRoleBindings`, binding the `mcp-k8s-operator` `ServiceAccount` to specified external `ClusterRole`s (auto-generated or custom names, namespace-aware)
> - Adds `mcpServerRbac.additionalClusterRoleBindings` to `values.yaml` with documentation/example
> - New helm-unittest suite `tests/archestra_platform_mcp_service_account_test.yaml` covering creation, multiples, custom naming, subject/roleRef/labels, and `create: false` gating
> - Staging values (`.github/values-staging.yaml`) enable binding to `archestra-cluster-reader`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1850267da6119d7735b5454bceb0132706f0444e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->