### PR TITLE
fix: explicitly pass `ARCHESTRA_ORCHESTRATOR_MCP_K8S_SERVICE_ACCOUNT_NAME` env var in helm chart

### DIFF
--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -112,6 +112,8 @@ If ARCHESTRA_AUTH_SECRET env variable is explicitly set, it will override the au
 - name: ARCHESTRA_ORCHESTRATOR_LOAD_KUBECONFIG_FROM_CURRENT_CLUSTER
   value: {{ .Values.archestra.orchestrator.kubernetes.loadKubeconfigFromCurrentCluster | quote }}
 {{- if .Values.archestra.orchestrator.kubernetes.mcpServerRbac.create }}
+- name: ARCHESTRA_ORCHESTRATOR_MCP_K8S_SERVICE_ACCOUNT_NAME
+  value: {{ include "archestra-platform.fullname" . }}-mcp-k8s-operator
 {{- end }}
 {{- range $key, $value := .Values.archestra.env }}
 {{/* Check if env var is in the explicit sensitive list OR matches ARCHESTRA_CHAT_*_API_KEY pattern */}}


### PR DESCRIPTION
Add `ARCHESTRA_ORCHESTRATOR_MCP_K8S_SERVICE_ACCOUNT_NAME` environment variable to the Helm chart to ensure Kubernetes MCP server pods use the correct service account.

The Helm chart had an empty conditional block for `mcpServerRbac.create`, preventing the `ARCHESTRA_ORCHESTRATOR_MCP_K8S_SERVICE_ACCOUNT_NAME` environment variable from being set. This caused MCP server pods to default to the `default` service account instead of `archestra-platform-mcp-k8s-operator` when RBAC was enabled.

---
[Slack Thread](https://archestra-ai.slack.com/archives/C0966V616DC/p1767110612036149?thread_ts=1767110612.036149&cid=C0966V616DC)

<a href="https://cursor.com/background-agent?bcId=bc-3de5fe7e-cc41-43f3-9ee1-25a7fc24c4a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3de5fe7e-cc41-43f3-9ee1-25a7fc24c4a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

