### PR TITLE
fix: preserve MCP serviceAccount when re-installing

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -29178,6 +29178,9 @@
                           "dockerImage": {
                             "type": "string"
                           },
+                          "serviceAccount": {
+                            "type": "string"
+                          },
                           "transportType": {
                             "type": "string",
                             "enum": [
@@ -30116,6 +30119,9 @@
                         "dockerImage": {
                           "type": "string"
                         },
+                        "serviceAccount": {
+                          "type": "string"
+                        },
                         "transportType": {
                           "type": "string",
                           "enum": [
@@ -30716,6 +30722,9 @@
                           }
                         },
                         "dockerImage": {
+                          "type": "string"
+                        },
+                        "serviceAccount": {
                           "type": "string"
                         },
                         "transportType": {
@@ -31660,6 +31669,9 @@
                           }
                         },
                         "dockerImage": {
+                          "type": "string"
+                        },
+                        "serviceAccount": {
                           "type": "string"
                         },
                         "transportType": {

--- a/platform/backend/src/database/schemas/internal-mcp-catalog.ts
+++ b/platform/backend/src/database/schemas/internal-mcp-catalog.ts
@@ -58,6 +58,7 @@ const internalMcpCatalogTable = pgTable("internal_mcp_catalog", {
       description?: string; // Description to show in installation dialog
     }>;
     dockerImage?: string;
+    serviceAccount?: string;
     transportType?: "stdio" | "streamable-http";
     httpPort?: number;
     httpPath?: string;

--- a/platform/backend/src/types/mcp-catalog.ts
+++ b/platform/backend/src/types/mcp-catalog.ts
@@ -52,6 +52,7 @@ const LocalConfigSelectSchema = z.object({
     )
     .optional(),
   dockerImage: z.string().optional(),
+  serviceAccount: z.string().optional(),
   transportType: z.enum(["stdio", "streamable-http"]).optional(),
   httpPort: z.number().optional(),
   httpPath: z.string().optional(),

--- a/platform/frontend/src/app/mcp-catalog/_parts/mcp-catalog-form.utils.ts
+++ b/platform/frontend/src/app/mcp-catalog/_parts/mcp-catalog-form.utils.ts
@@ -41,6 +41,7 @@ export function transformFormToApiData(
         ? Number(values.localConfig.httpPort)
         : undefined,
       httpPath: values.localConfig.httpPath || undefined,
+      serviceAccount: values.localConfig.serviceAccount || undefined,
     };
 
     // BYOS: Include local config vault path and key if set
@@ -181,6 +182,7 @@ export function transformCatalogItemToFormValues(
         transportType?: "stdio" | "streamable-http";
         httpPort?: string;
         httpPath?: string;
+        serviceAccount?: string;
       }
     | undefined;
   if (item.localConfig) {
@@ -222,6 +224,7 @@ export function transformCatalogItemToFormValues(
       transportType: config.transportType || undefined,
       httpPort: config.httpPort?.toString() || undefined,
       httpPath: config.httpPath || undefined,
+      serviceAccount: config.serviceAccount || undefined,
     };
   }
 

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -9085,6 +9085,7 @@ export type GetInternalMcpCatalogResponses = {
                 default?: string | number | boolean;
             }>;
             dockerImage?: string;
+            serviceAccount?: string;
             transportType?: 'stdio' | 'streamable-http';
             httpPort?: number;
             httpPath?: string;
@@ -9314,6 +9315,7 @@ export type CreateInternalMcpCatalogItemResponses = {
                 default?: string | number | boolean;
             }>;
             dockerImage?: string;
+            serviceAccount?: string;
             transportType?: 'stdio' | 'streamable-http';
             httpPort?: number;
             httpPath?: string;
@@ -9546,6 +9548,7 @@ export type GetInternalMcpCatalogItemResponses = {
                 default?: string | number | boolean;
             }>;
             dockerImage?: string;
+            serviceAccount?: string;
             transportType?: 'stdio' | 'streamable-http';
             httpPort?: number;
             httpPath?: string;
@@ -9777,6 +9780,7 @@ export type UpdateInternalMcpCatalogItemResponses = {
                 default?: string | number | boolean;
             }>;
             dockerImage?: string;
+            serviceAccount?: string;
             transportType?: 'stdio' | 'streamable-http';
             httpPort?: number;
             httpPath?: string;

--- a/platform/shared/zod-schemas.ts
+++ b/platform/shared/zod-schemas.ts
@@ -71,6 +71,7 @@ export const LocalConfigFormSchema = z.object({
   transportType: z.enum(["stdio", "streamable-http"]).optional(),
   httpPort: z.string().optional(), // UI uses string, gets parsed to number
   httpPath: z.string().optional(), // HTTP endpoint path (e.g., /mcp)
+  serviceAccount: z.string().optional(), // Preserved from catalog item, not editable in form
 });
 
 /**


### PR DESCRIPTION
If you install k8s MCP from scratch, it's assigned a special `archestra-platform-mcp-k8s-operator` service account. But if you edit the MCP and re-install it, service account is lost. This fix preserves the service account. It's not shown in Edit MCP Modal, because its name currently does not matter, it's `archestra-platform-mcp-k8s-operator` always.