### PR TITLE
feat: add `archestra.orchestrator.kubernetes.mcpServerRbac.additionalRoleBindings` to `helm` chart

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -27,11 +27,21 @@ archestra:
           iam.gke.io/gcp-service-account: archestra-vertex-ai@friendly-path-465518-r6.iam.gserviceaccount.com
 
       # Additional RBAC for MCP K8s operator service account
-      # Grants cluster-wide read access for the Kubernetes MCP server
-      # The ClusterRole is created in archestra-ai/infra repo (gke/archestra-rbac.tf)
+      # Grants cluster-wide read access and namespace-specific permissions for the Kubernetes MCP server
+      # The ClusterRole and Roles are created in archestra-ai/infra repo (gke/archestra-rbac.tf)
       mcpServerRbac:
         additionalClusterRoleBindings:
           - clusterRoleName: archestra-cluster-reader
+        additionalRoleBindings:
+          # Full access to ai-sre namespace (for AI SRE demo)
+          - roleName: archestra-ai-sre-admin
+            namespace: ai-sre
+          # Full access to argocd namespace (for GitOps operations)
+          - roleName: archestra-argocd-admin
+            namespace: argocd
+          # Read-only access to archestra namespace
+          - roleName: archestra-namespace-reader
+            namespace: archestra
 
   service:
     annotations:

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -43,7 +43,7 @@ This will start the platform with:
 
 **Note**: The `-v /var/run/docker.sock:/var/run/docker.sock` mount enables the embedded Kubernetes cluster for MCP server execution. This is required for the quick-start Docker deployment. For production, use the Helm deployment with an external Kubernetes cluster instead.
 
- If you have Kubernetes installed locally, you can use it for the MCP orchestrator. Make sure `kubectl` points to the right cluster and run the container without the socket and without `ARCHESTRA_QUICKSTART`. The orchestrator will create a cluster in the current context. See [Development with Standalone Kubernetes](./platform-orchestrator#local-development-with-docker-and-standalone-kubernetes)
+If you have Kubernetes installed locally, you can use it for the MCP orchestrator. Make sure `kubectl` points to the right cluster and run the container without the socket and without `ARCHESTRA_QUICKSTART`. The orchestrator will create a cluster in the current context. See [Development with Standalone Kubernetes](./platform-orchestrator#local-development-with-docker-and-standalone-kubernetes)
 
 ```diff
 docker run -p 9000:9000 -p 3000:3000 \
@@ -54,7 +54,7 @@ docker run -p 9000:9000 -p 3000:3000 \
    archestra/platform;
 ```
 
- Running the platform without Kubernetes (or its alternatives) is also possible. This just makes MCP orchestrator unavailable in the app.
+Running the platform without Kubernetes (or its alternatives) is also possible. This just makes MCP orchestrator unavailable in the app.
 
 ### Using External PostgreSQL
 
@@ -108,7 +108,11 @@ The Helm chart provides extensive configuration options through values. For the 
 **Archestra Platform Settings**:
 
 - `archestra.image` - Docker image for the Archestra Platform (contains both backend API and frontend). See [available tags](https://hub.docker.com/r/archestra/platform/tags)
-- `archestra.env` - Environment variables to pass to the container (see Environment Variables section above for available options)
+- `archestra.imagePullPolicy` - Image pull policy for the Archestra container (default: IfNotPresent). Options: Always, IfNotPresent, Never
+- `archestra.replicaCount` - Number of pod replicas (default: 1). Ignored when HPA is enabled
+- `archestra.env` - Environment variables to pass to the container (see Environment Variables section for available options)
+- `archestra.envFromSecrets` - Environment variables from Kubernetes Secrets (inject sensitive data from secrets)
+- `archestra.envFrom` - Import all key-value pairs from Secrets or ConfigMaps as environment variables
 
 **Example**:
 
@@ -150,17 +154,24 @@ openssl rand -base64 32
 - `archestra.orchestrator.kubernetes.serviceAccount.name` - Name of the service account (auto-generated if not set)
 - `archestra.orchestrator.kubernetes.serviceAccount.imagePullSecrets` - Image pull secrets for the service account
 - `archestra.orchestrator.kubernetes.rbac.create` - Create RBAC resources (default: true)
+- `archestra.orchestrator.kubernetes.mcpServerRbac.create` - Create MCP server RBAC resources (ServiceAccount, Role, RoleBinding) for Kubernetes MCP server (default: true)
+- `archestra.orchestrator.kubernetes.mcpServerRbac.additionalClusterRoleBindings` - Additional ClusterRoleBindings to attach to the MCP K8s operator service account for cluster-wide permissions
+- `archestra.orchestrator.kubernetes.mcpServerRbac.additionalRoleBindings` - Additional RoleBindings to attach to the MCP K8s operator service account for namespace-scoped permissions
 
 #### Service, Deployment, & Ingress Configuration
 
 **Deployment Settings**:
 
 - `archestra.podAnnotations` - Annotations to add to pods (useful for Prometheus, Vault agent, service mesh sidecars, etc.)
+- `archestra.nodeSelector` - Node selector for scheduling pods on specific nodes (e.g., specific node pools or instance types)
+- `archestra.deploymentStrategy` - Deployment strategy configuration (default: RollingUpdate with maxUnavailable: 0 for zero-downtime deployments)
 - `archestra.resources` - CPU and memory requests/limits for the container (default: 2Gi request, 3Gi limit for memory)
 
 **Service Settings**:
 
+- `archestra.service.type` - Service type: ClusterIP, NodePort, or LoadBalancer (default: ClusterIP)
 - `archestra.service.annotations` - Annotations to add to the Kubernetes Service for cloud provider integrations
+- `archestra.service.nodePorts` - Node ports for NodePort service type (backend, metrics, frontend)
 
 **Ingress Settings**:
 

--- a/platform/helm/archestra/templates/mcp-serviceaccount.yaml
+++ b/platform/helm/archestra/templates/mcp-serviceaccount.yaml
@@ -85,4 +85,25 @@ roleRef:
   name: {{ .clusterRoleName }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
+{{- range .Values.archestra.orchestrator.kubernetes.mcpServerRbac.additionalRoleBindings }}
+---
+# Additional RoleBinding to grant namespace-scoped permissions to the mcp-k8s-operator service account
+# The Role "{{ .roleName }}" in namespace "{{ .namespace }}" must be created externally (e.g., via Terraform or kubectl)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .name | default (printf "%s-mcp-k8s-operator-%s" (include "archestra-platform.fullname" $) .roleName) }}
+  namespace: {{ .namespace }}
+  labels:
+    {{- include "archestra-platform.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: mcp-serviceaccount
+subjects:
+- kind: ServiceAccount
+  name: {{ include "archestra-platform.fullname" $ }}-mcp-k8s-operator
+  namespace: {{ $.Values.archestra.orchestrator.kubernetes.namespace | default $.Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .roleName }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/platform/helm/archestra/tests/archestra_platform_mcp_service_account_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_mcp_service_account_test.yaml
@@ -66,7 +66,8 @@ tests:
           path: rules
           content:
             apiGroups: ["apps"]
-            resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+            resources:
+              ["deployments", "replicasets", "statefulsets", "daemonsets"]
             verbs: ["get", "list", "watch"]
 
   - it: should have read-only events permissions in Role
@@ -250,3 +251,144 @@ tests:
       - hasDocuments:
           count: 0
 
+  # Additional RoleBinding tests
+  - it: should not create RoleBindings when additionalRoleBindings is empty
+    asserts:
+      - hasDocuments:
+          count: 3
+
+  - it: should create RoleBinding when additionalRoleBindings is configured
+    set:
+      archestra.orchestrator.kubernetes.mcpServerRbac.additionalRoleBindings:
+        - roleName: namespace-admin
+          namespace: my-app-namespace
+    asserts:
+      - hasDocuments:
+          count: 4
+
+  - it: should create multiple RoleBindings when multiple are configured
+    set:
+      archestra.orchestrator.kubernetes.mcpServerRbac.additionalRoleBindings:
+        - roleName: namespace-admin
+          namespace: my-app-namespace
+        - roleName: another-role
+          namespace: another-namespace
+    asserts:
+      - hasDocuments:
+          count: 5
+
+  - it: should create RoleBinding with auto-generated name
+    set:
+      archestra.orchestrator.kubernetes.mcpServerRbac.additionalRoleBindings:
+        - roleName: namespace-admin
+          namespace: my-app-namespace
+    documentIndex: 3
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - matchRegex:
+          path: metadata.name
+          pattern: -mcp-k8s-operator-namespace-admin$
+
+  - it: should create RoleBinding with custom name when provided
+    set:
+      archestra.orchestrator.kubernetes.mcpServerRbac.additionalRoleBindings:
+        - roleName: namespace-admin
+          namespace: my-app-namespace
+          name: my-custom-rolebinding-name
+    documentIndex: 3
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: metadata.name
+          value: my-custom-rolebinding-name
+
+  - it: should create RoleBinding in the specified namespace
+    set:
+      archestra.orchestrator.kubernetes.mcpServerRbac.additionalRoleBindings:
+        - roleName: namespace-admin
+          namespace: my-app-namespace
+    documentIndex: 3
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: my-app-namespace
+
+  - it: should bind RoleBinding to the correct ServiceAccount
+    set:
+      archestra.orchestrator.kubernetes.mcpServerRbac.additionalRoleBindings:
+        - roleName: namespace-admin
+          namespace: my-app-namespace
+    documentIndex: 3
+    asserts:
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - matchRegex:
+          path: subjects[0].name
+          pattern: -mcp-k8s-operator$
+      - equal:
+          path: subjects[0].namespace
+          value: NAMESPACE
+
+  - it: should reference the correct Role in RoleBinding
+    set:
+      archestra.orchestrator.kubernetes.mcpServerRbac.additionalRoleBindings:
+        - roleName: namespace-admin
+          namespace: my-app-namespace
+    documentIndex: 3
+    asserts:
+      - equal:
+          path: roleRef.kind
+          value: Role
+      - equal:
+          path: roleRef.name
+          value: namespace-admin
+      - equal:
+          path: roleRef.apiGroup
+          value: rbac.authorization.k8s.io
+
+  - it: should use custom orchestrator namespace in RoleBinding subject
+    set:
+      archestra.orchestrator.kubernetes.namespace: "archestra-custom"
+      archestra.orchestrator.kubernetes.mcpServerRbac.additionalRoleBindings:
+        - roleName: namespace-admin
+          namespace: my-app-namespace
+    documentIndex: 3
+    asserts:
+      - equal:
+          path: subjects[0].namespace
+          value: "archestra-custom"
+
+  - it: should include standard labels in RoleBinding
+    set:
+      archestra.orchestrator.kubernetes.mcpServerRbac.additionalRoleBindings:
+        - roleName: namespace-admin
+          namespace: my-app-namespace
+    documentIndex: 3
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: mcp-serviceaccount
+
+  - it: should not create RoleBindings when mcpServerRbac.create is false
+    set:
+      archestra.orchestrator.kubernetes.mcpServerRbac.create: false
+      archestra.orchestrator.kubernetes.mcpServerRbac.additionalRoleBindings:
+        - roleName: namespace-admin
+          namespace: my-app-namespace
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create both ClusterRoleBindings and RoleBindings when both are configured
+    set:
+      archestra.orchestrator.kubernetes.mcpServerRbac.additionalClusterRoleBindings:
+        - clusterRoleName: cluster-reader
+      archestra.orchestrator.kubernetes.mcpServerRbac.additionalRoleBindings:
+        - roleName: namespace-admin
+          namespace: my-app-namespace
+    asserts:
+      - hasDocuments:
+          count: 5

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -175,6 +175,18 @@ archestra:
         #       name: custom-binding-name  # Optional: override the auto-generated binding name
         additionalClusterRoleBindings: []
 
+        # Additional RoleBindings to attach to the mcp-k8s-operator service account
+        # Use this to grant namespace-scoped permissions (e.g., full access to specific namespaces)
+        # The Roles must be created externally (e.g., via Terraform or kubectl) in the specified namespaces
+        # Example:
+        #   additionalRoleBindings:
+        #     - roleName: my-namespace-admin
+        #       namespace: my-app-namespace
+        #     - roleName: another-role
+        #       namespace: another-namespace
+        #       name: custom-binding-name  # Optional: override the auto-generated binding name
+        additionalRoleBindings: []
+
   # Service configuration
   service:
     # Service type - ClusterIP, NodePort, or LoadBalancer


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces configurable namespace-scoped RBAC for the Kubernetes MCP server.
> 
> - Adds `archestra.orchestrator.kubernetes.mcpServerRbac.additionalRoleBindings` to `values.yaml`; `templates/mcp-serviceaccount.yaml` now renders a `RoleBinding` per entry targeting the MCP operator `ServiceAccount`
> - Expands docs to cover new `mcpServerRbac.*` options and other chart settings (`imagePullPolicy`, `replicaCount`, `envFromSecrets`, `envFrom`, `nodeSelector`, `deploymentStrategy`, `service.type`, `nodePorts`); minor Docker section formatting fixes
> - Updates staging values to include sample role bindings for `ai-sre`, `argocd`, and `archestra` namespaces
> - Extends chart tests to validate RoleBinding creation, naming, namespaces, labels, and interaction with `create` flag (alongside existing ClusterRoleBinding tests)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb847b98435cb38b75819c73d45d0523036c2aad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->