### PR TITLE
fix: delete cached MCP client if ping failed

### DIFF
--- a/platform/backend/src/clients/chat-mcp-client.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.test.ts
@@ -48,6 +48,8 @@ describe("chat-mcp-client health check", () => {
 
     // Ping should have been called on the dead client
     expect(deadClient.ping).toHaveBeenCalledTimes(1);
+    // close() should have been called to clean up resources before cache removal
+    expect(deadClient.close).toHaveBeenCalledTimes(1);
     // listTools should NOT have been called on the dead client
     expect(deadClient.listTools).not.toHaveBeenCalled();
     // Tools will be empty since we can't create a real client in tests

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -293,6 +293,15 @@ export async function getChatMcpClient(
         },
         "Cached MCP client ping failed, creating fresh client",
       );
+      // Close the dead client before removing from cache to prevent resource leaks
+      try {
+        cachedClient.close();
+      } catch (closeError) {
+        logger.warn(
+          { agentId, userId, closeError },
+          "Error closing dead MCP client (non-fatal)",
+        );
+      }
       clientCache.delete(cacheKey);
       // Fall through to create new client
     }


### PR DESCRIPTION
If you leave the chat open for a while and then edit a message, the tools in the assistant response aren't called.
Solved by pinging cached MCP client and delete it if ping failed.

Closes https://github.com/archestra-ai/archestra/issues/1729