### PR TITLE
fix: format tool result json in logs

### DIFF
--- a/platform/frontend/src/components/ai-elements/tool.tsx
+++ b/platform/frontend/src/components/ai-elements/tool.tsx
@@ -252,7 +252,7 @@ export const ToolOutput = ({
     const codeString =
       typeof formattedOutput === "object"
         ? JSON.stringify(formattedOutput, null, 2)
-        : (formattedOutput as string);
+        : String(formattedOutput);
     const lines = codeString.split("\n");
     const MAX_LINES = 50;
     const isLarge = lines.length > MAX_LINES;


### PR DESCRIPTION
Example at https://frontend.archestra.dev/logs/207fd047-7a74-4e65-aee3-38cf23864c4f
Related to https://github.com/archestra-ai/archestra/issues/1724