### PR TITLE
fix(frontend): improve dark theme readability in optimization rules and chat

### DIFF
--- a/platform/frontend/src/app/cost/optimization-rules/_parts/condition.tsx
+++ b/platform/frontend/src/app/cost/optimization-rules/_parts/condition.tsx
@@ -24,7 +24,7 @@ type ChangeHandler = (condition: Condition) => void;
 
 function ConditionBlock({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex flex-row gap-2 whitespace-nowrap items-center rounded-md bg-secondary h-9 px-4">
+    <div className="flex flex-row gap-2 whitespace-nowrap items-center rounded-md bg-muted h-9 px-4">
       {children}
     </div>
   );
@@ -74,7 +74,7 @@ export function Condition({
       return (
         <ConditionBlock>
           content length <span>&lt;</span>
-          <Badge variant="outline" className="text-sm bg-background">
+          <Badge variant="outline" className="text-sm bg-muted">
             {maxLength}
           </Badge>
           tokens
@@ -84,7 +84,7 @@ export function Condition({
       return (
         <ConditionBlock>
           tools{" "}
-          <Badge variant="outline" className="text-sm bg-background">
+          <Badge variant="outline" className="text-sm bg-muted">
             {hasTools ? "present" : "absent"}
           </Badge>
         </ConditionBlock>
@@ -101,7 +101,7 @@ export function Condition({
           name="maxTokens"
           value={maxLength}
           placeholder="count"
-          className="px-2 h-7 w-20 bg-background"
+          className="px-2 h-7 w-20 bg-muted"
           onChange={(e) => onMaxLengthChange(Number(e.target.value))}
           min="1"
           max="999999"
@@ -115,7 +115,7 @@ export function Condition({
         value={hasTools ? "true" : "false"}
         onValueChange={(value) => onToolsChange(value === "true")}
       >
-        <SelectTrigger size="sm" className="bg-background !h-7">
+        <SelectTrigger size="sm" className="bg-muted !h-7">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>

--- a/platform/frontend/src/components/ai-elements/response.tsx
+++ b/platform/frontend/src/components/ai-elements/response.tsx
@@ -22,8 +22,8 @@ export const Response = memo(
         // Add proper paragraph spacing
         "[&_p]:my-2",
         // Add proper code block styling
-        "[&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded",
-        "[&_pre]:bg-muted [&_pre]:p-3 [&_pre]:rounded [&_pre]:my-2 [&_pre]:overflow-x-auto",
+        "[&_code]:bg-secondary-foreground/5 [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded",
+        "[&_pre]:bg-secondary-foreground/5 [&_pre]:p-3 [&_pre]:rounded [&_pre]:my-2 [&_pre]:overflow-x-auto",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Description
This PR fixes dark theme readability issues in the Optimization Rules and Chat interfaces by updating background colors to provide better contrast.

## Changes Made
- Changed `bg-secondary` to `bg-muted` in ConditionBlock component for better contrast
- Updated Badge and Input components from `bg-background` to `bg-muted` 
- Fixed code block styling from `bg-muted` to `bg-secondary-foreground/5` to prevent dark-on-dark text issue in chat

## Fixes
Closes #1761

## Testing
- Tested in dark mode to verify improved readability
- Verified that optimization rule condition pills now have proper contrast
- Confirmed chat tool name pills are now readable

## Screenshots
Before and after screenshots showing the improved contrast in dark mode.