### PR TITLE
fix: focus on textarea on chat create

### DIFF
--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -454,7 +454,7 @@ export default function ChatPage() {
   // Auto-focus textarea when status becomes ready (message sent or stream finished)
   // or when conversation loads (e.g., new chat created, hard refresh)
   useLayoutEffect(() => {
-    if (status === "ready" && textareaRef.current) {
+    if (status === "ready" && conversation?.id && textareaRef.current) {
       textareaRef.current.focus();
     }
   }, [status, conversation?.id]);


### PR DESCRIPTION
Focuses on textarea on chat create or after hard-refresh.
Closes https://github.com/archestra-ai/archestra/issues/1736