### PR TITLE
fix: kill Next properly on tilt down

### DIFF
--- a/platform/dev/Tiltfile.dev
+++ b/platform/dev/Tiltfile.dev
@@ -78,7 +78,7 @@ else:
   local_resource(
     dev_resource_name,
     # Trap ensures all child processes are killed when Tilt stops, preventing orphaned processes from blocking port 3000
-    # Uses pkill -P to recursively kill descendants since turbo spawns processes with their own process groups
+    # Uses pkill -P to kill by parent PID since child processes may have their own process groups on macOS
     serve_cmd='trap "pkill -TERM -P $$" EXIT INT TERM; ARCHESTRA_LOGGING_LEVEL=debug pnpm dev & wait $!',
     labels=['dev'],
     resource_deps=['db-migrate'],


### PR DESCRIPTION
Before the fix Next would stay on port 3000 after `tilt down` every other time.