### PR TITLE
feat: keep tools after editing MCP

### DIFF
--- a/platform/backend/src/models/agent-tool.ts
+++ b/platform/backend/src/models/agent-tool.ts
@@ -754,17 +754,19 @@ class AgentToolModel {
   }
 
   /**
-   * Delete all agent-tool assignments that use a specific MCP server as their execution source.
-   * Used when a local MCP server is deleted/uninstalled.
+   * Update executionSourceMcpServerId for agent-tool assignments.
+   * Used during MCP server reinstall to point assignments to the new server.
    */
-  static async deleteByExecutionSourceMcpServerId(
-    mcpServerId: string,
+  static async updateExecutionSourceForTools(
+    toolIds: string[],
+    newMcpServerId: string,
   ): Promise<number> {
+    if (toolIds.length === 0) return 0;
+
     const result = await db
-      .delete(schema.agentToolsTable)
-      .where(
-        eq(schema.agentToolsTable.executionSourceMcpServerId, mcpServerId),
-      );
+      .update(schema.agentToolsTable)
+      .set({ executionSourceMcpServerId: newMcpServerId })
+      .where(inArray(schema.agentToolsTable.toolId, toolIds));
     return result.rowCount ?? 0;
   }
 

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -328,9 +328,9 @@ class ToolModel {
   }
 
   /**
-   * Bulk create tools for an MCP server (catalog-based tools)
-   * Fetches existing tools in a single query, then bulk inserts only new tools
-   * Returns all tools (existing + newly created) to avoid N+1 queries
+   * Bulk create or update tools for an MCP server (catalog-based tools).
+   * Matches by raw tool name (part after prefix) to handle catalog renames.
+   * Returns all tools (existing/updated + newly created).
    */
   static async bulkCreateToolsIfNotExists(
     tools: Array<{
@@ -345,11 +345,15 @@ class ToolModel {
       return [];
     }
 
-    // Group tools by catalogId (all tools should have the same catalogId in practice)
     const catalogId = tools[0].catalogId;
-    const toolNames = tools.map((t) => t.name);
 
-    // Fetch all existing tools for this catalog in a single query
+    // Extract raw tool name (e.g., "list_pods" from "kubernetes__list_pods")
+    // or port_forward from flux159__mcp-server-kubernetes__port_forward
+    const extractRawName = (slugifiedName: string): string => {
+      return slugifiedName.split(MCP_SERVER_TOOL_NAME_SEPARATOR).pop() ?? slugifiedName;
+    };
+
+    // Fetch ALL existing tools for this catalog (not filtered by name)
     const existingTools = await db
       .select()
       .from(schema.toolsTable)
@@ -357,20 +361,33 @@ class ToolModel {
         and(
           isNull(schema.toolsTable.agentId),
           eq(schema.toolsTable.catalogId, catalogId),
-          inArray(schema.toolsTable.name, toolNames),
         ),
       );
 
-    const existingToolsByName = new Map(existingTools.map((t) => [t.name, t]));
+    const existingByRawName = new Map(
+      existingTools.map((t) => [extractRawName(t.name), t]),
+    );
 
-    // Prepare tools to insert (only those that don't exist)
-    const toolsToInsert: InsertTool[] = [];
     const resultTools: Tool[] = [];
+    const toolsToInsert: InsertTool[] = [];
 
     for (const tool of tools) {
-      const existingTool = existingToolsByName.get(tool.name);
+      const rawName = extractRawName(tool.name);
+      const existingTool = existingByRawName.get(rawName);
+
       if (existingTool) {
-        resultTools.push(existingTool);
+        // Update existing tool (preserves ID and agent_tools assignments)
+        const [updatedTool] = await db
+          .update(schema.toolsTable)
+          .set({
+            name: tool.name,
+            description: tool.description,
+            parameters: tool.parameters,
+            mcpServerId: tool.mcpServerId,
+          })
+          .where(eq(schema.toolsTable.id, existingTool.id))
+          .returning();
+        resultTools.push(updatedTool);
       } else {
         toolsToInsert.push({
           name: tool.name,
@@ -418,11 +435,7 @@ class ToolModel {
       }
     }
 
-    // Return tools in the same order as input
-    const resultToolsByName = new Map(resultTools.map((t) => [t.name, t]));
-    return tools
-      .map((t) => resultToolsByName.get(t.name))
-      .filter((t): t is Tool => t !== undefined);
+    return resultTools;
   }
 
   /**

--- a/platform/backend/src/routes/internal-mcp-catalog.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.ts
@@ -2,7 +2,7 @@ import { RouteId } from "@shared";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
 import logger from "@/logging";
-import { InternalMcpCatalogModel, McpServerModel, ToolModel } from "@/models";
+import { InternalMcpCatalogModel, McpServerModel } from "@/models";
 import { isByosEnabled, secretManager } from "@/secrets-manager";
 import {
   ApiError,
@@ -376,7 +376,8 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
       }
 
       // Mark all installed servers for reinstall
-      // and delete existing tools so they can be rediscovered
+      // Tools are NOT deleted - they will be reused by bulkCreateToolsIfNotExists during reinstall
+      // This preserves profile-tool assignments (tools are keyed by catalogId + name)
       const installedServers = await McpServerModel.findByCatalogId(id);
 
       for (const server of installedServers) {
@@ -384,10 +385,6 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
           reinstallRequired: true,
         });
       }
-
-      // Delete all tools associated with this catalog id
-      // This ensures tools are rediscovered with updated configuration during reinstall
-      await ToolModel.deleteByCatalogId(id);
 
       return reply.send(catalogItem);
     },


### PR DESCRIPTION
We want to preserve profile-tool bindings on MCP edit. Currently, these bindings are deleted after we edit the MCP.
This PR keeps the bindings, detaching them from the installation / pod during reinstall. However, there is a catch: MCP reinstall is not a transaction. It's uninstall + install, and this process can be abandoned in the middle. If so, the user ends up with orpaned tools bound to profile and naturally errors when calling them.

Related to https://github.com/archestra-ai/archestra/issues/1710