### PR TITLE
deps: address `CVE-2025-15284`

### DIFF
--- a/platform/package.json
+++ b/platform/package.json
@@ -43,7 +43,8 @@
       "node-forge": "1.3.2",
       "mdast-util-to-hast": "13.2.1",
       "express": "5.2.0",
-      "jws": "4.0.1"
+      "jws": "4.0.1",
+      "qs": "6.14.1"
     }
   },
   "packageManager": "pnpm@10.27.0"

--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   mdast-util-to-hast: 13.2.1
   express: 5.2.0
   jws: 4.0.1
+  qs: 6.14.1
 
 importers:
 
@@ -6994,12 +6995,8 @@ packages:
   qr.js@0.0.0:
     resolution: {integrity: sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==}
 
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
-    engines: {node: '>=0.6'}
-
-  qs@6.5.3:
-    resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
+  qs@6.14.1:
+    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
     engines: {node: '>=0.6'}
 
   quansync@1.0.0:
@@ -12861,7 +12858,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.1
       on-finished: 2.4.1
-      qs: 6.14.0
+      qs: 6.14.1
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -13574,7 +13571,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.0
+      qs: 6.14.1
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -15370,7 +15367,7 @@ snapshots:
       json-stringify-safe: 5.0.1
       mime-types: 2.1.35
       oauth-sign: 0.9.0
-      qs: 6.5.3
+      qs: 6.14.1
       safe-buffer: 5.2.1
       socks-proxy-agent: 8.0.5
       stream-length: 1.0.2
@@ -15452,11 +15449,9 @@ snapshots:
 
   qr.js@0.0.0: {}
 
-  qs@6.14.0:
+  qs@6.14.1:
     dependencies:
       side-channel: 1.1.0
-
-  qs@6.5.3: {}
 
   quansync@1.0.0: {}
 


### PR DESCRIPTION
addresses https://github.com/archestra-ai/archestra/security/dependabot/68

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses security advisories by standardizing on `qs@6.14.1`.
> 
> - Adds `qs: 6.14.1` to `pnpm.overrides` in `platform/package.json`
> - Updates `pnpm-lock.yaml` to resolve all transitive uses to `qs@6.14.1`, removing older `qs@6.14.0` and `qs@6.5.3` entries (e.g., under `body-parser` and `express`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b635aed609c17ca66a1dea634f257aeebbf2140. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->