### PR TITLE
feat: improve chat delete confirmation UX

### DIFF
--- a/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
@@ -85,6 +85,9 @@ export function ChatSidebarSection() {
   const [showAllChats, setShowAllChats] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState("");
+  const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(
+    null,
+  );
   const inputRef = useRef<HTMLInputElement>(null);
 
   // Track conversations with recently auto-generated titles for animation
@@ -187,25 +190,32 @@ export function ChatSidebarSection() {
                   conv.id,
                 );
                 const isRegenerating = regeneratingTitles.has(conv.id);
+                const isConfirmingDelete = confirmingDeleteId === conv.id;
                 const buttons =
                   editingId !== conv.id ? (
                     <div className="absolute right-1 top-1/2 -translate-y-1/2 flex gap-0.5 opacity-0 group-hover/menu-item:opacity-100 has-[[data-confirm-open]]:opacity-100 transition-opacity">
-                      <PermissionButton
-                        permissions={{ conversation: ["update"] }}
-                        type="button"
-                        size="icon-sm"
-                        variant="ghost"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleStartEdit(conv.id, displayTitle);
-                        }}
-                        title="Edit chat name"
-                        className="p-1 w-fit"
-                      >
-                        <Edit2 className="h-4 w-4" />
-                      </PermissionButton>
+                      {!isConfirmingDelete && (
+                        <PermissionButton
+                          permissions={{ conversation: ["update"] }}
+                          type="button"
+                          size="icon-sm"
+                          variant="ghost"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleStartEdit(conv.id, displayTitle);
+                          }}
+                          title="Edit chat name"
+                          className="p-1 w-fit"
+                        >
+                          <Edit2 className="h-4 w-4" />
+                        </PermissionButton>
+                      )}
                       <WithInlineConfirm
                         onConfirm={() => handleDeleteConversation(conv.id)}
+                        replaceMode
+                        onOpenChange={(open) =>
+                          setConfirmingDeleteId(open ? conv.id : null)
+                        }
                       >
                         <Button
                           type="button"

--- a/platform/frontend/src/lib/chat.query.ts
+++ b/platform/frontend/src/lib/chat.query.ts
@@ -144,6 +144,7 @@ export function useDeleteConversation() {
     onSuccess: (_, deletedId) => {
       queryClient.invalidateQueries({ queryKey: ["conversations"] });
       queryClient.removeQueries({ queryKey: ["conversation", deletedId] });
+      toast.success("Conversation deleted");
     },
   });
 }


### PR DESCRIPTION
## Summary
- Improve delete confirmation UX in chat sidebar by replacing side popover with inline confirmation button
- The "Confirm" button with trash icon appears in place of the delete icon, eliminating mouse movement
- Hide edit button when delete confirmation is shown for cleaner UI
- Add toast notification when conversation is deleted

## Test plan
- [ ] Navigate to chat sidebar with existing conversations
- [ ] Hover over a conversation to see edit and delete icons
- [ ] Click delete icon and verify "Confirm" button appears in place
- [ ] Click "Confirm" to delete and verify toast notification appears
- [ ] Test canceling by moving mouse away from the button
- [ ] Verify edit icon is hidden during delete confirmation