### PR TITLE
deps: address CVE-2026-0621

### DIFF
--- a/platform/backend/package.json
+++ b/platform/backend/package.json
@@ -46,7 +46,7 @@
     "@google/genai": "^1.34.0",
     "@kubernetes/client-node": "^1.4.0",
     "@kubiks/otel-drizzle": "^2.1.0",
-    "@modelcontextprotocol/sdk": "^1.24.3",
+    "@modelcontextprotocol/sdk": "^1.25.2",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.67.3",
     "@opentelemetry/exporter-trace-otlp-http": "^0.208.0",

--- a/platform/experiments/package.json
+++ b/platform/experiments/package.json
@@ -45,7 +45,8 @@
   },
   "pnpm": {
     "overrides": {
-      "jws": "4.0.1"
+      "jws": "4.0.1",
+      "@modelcontextprotocol/sdk": "^1.25.2"
     }
   }
 }

--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -78,7 +78,7 @@ importers:
         version: 9.6.1
       '@google/genai':
         specifier: ^1.34.0
-        version: 1.34.0(@modelcontextprotocol/sdk@1.25.1(hono@4.11.1)(zod@4.2.1))
+        version: 1.34.0(@modelcontextprotocol/sdk@1.25.2(hono@4.11.1)(zod@4.2.1))
       '@kubernetes/client-node':
         specifier: ^1.4.0
         version: 1.4.0
@@ -86,8 +86,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0(@opentelemetry/api@1.9.0)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.14)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(kysely@0.28.9)(pg@8.16.3))
       '@modelcontextprotocol/sdk':
-        specifier: ^1.24.3
-        version: 1.25.1(hono@4.11.1)(zod@4.2.1)
+        specifier: ^1.25.2
+        version: 1.25.2(hono@4.11.1)(zod@4.2.1)
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
@@ -1570,8 +1570,8 @@ packages:
   '@mermaid-js/parser@0.6.3':
     resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
 
-  '@modelcontextprotocol/sdk@1.25.1':
-    resolution: {integrity: sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==}
+  '@modelcontextprotocol/sdk@1.25.2':
+    resolution: {integrity: sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -9192,12 +9192,12 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@google/genai@1.34.0(@modelcontextprotocol/sdk@1.25.1(hono@4.11.1)(zod@4.2.1))':
+  '@google/genai@1.34.0(@modelcontextprotocol/sdk@1.25.2(hono@4.11.1)(zod@4.2.1))':
     dependencies:
       google-auth-library: 10.5.0
       ws: 8.18.3
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.25.1(hono@4.11.1)(zod@4.2.1)
+      '@modelcontextprotocol/sdk': 1.25.2(hono@4.11.1)(zod@4.2.1)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -9487,7 +9487,7 @@ snapshots:
     dependencies:
       langium: 3.3.1
 
-  '@modelcontextprotocol/sdk@1.25.1(hono@4.11.1)(zod@4.2.1)':
+  '@modelcontextprotocol/sdk@1.25.2(hono@4.11.1)(zod@4.2.1)':
     dependencies:
       '@hono/node-server': 1.19.7(hono@4.11.1)
       ajv: 8.17.1


### PR DESCRIPTION
See https://github.com/modelcontextprotocol/typescript-sdk/pull/1365

Closes https://github.com/archestra-ai/archestra/security/dependabot/70

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Dependency upgrade**
> 
> - Bumps `@modelcontextprotocol/sdk` to `^1.25.2` in `platform/backend/package.json`
> - Adds `pnpm` override for `@modelcontextprotocol/sdk` `^1.25.2` in `platform/experiments/package.json`
> - Updates `pnpm-lock.yaml` to resolve `@modelcontextprotocol/sdk@1.25.2` and align `@google/genai` optional dependency references
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc193e5cc7dc394a239251b6e7bf2988ec1b1aa7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->