### PR TITLE
fix: address MCP gateway connection error

### DIFF
--- a/platform/backend/src/routes/mcp-gateway.ts
+++ b/platform/backend/src/routes/mcp-gateway.ts
@@ -73,32 +73,36 @@ async function handleMcpPostRequest(
           "Re-initialize on existing session - will reuse existing server",
         );
       }
+    } else if (sessionId && !isInitialize) {
+      // Non-initialize request with expired/invalid session
+      // Return error to force client to re-initialize instead of creating orphan session
+      fastify.log.warn(
+        { profileId, sessionId, method: body?.method },
+        "Non-initialize request with expired session - returning error to trigger re-initialization",
+      );
+
+      reply.status(400);
+      return {
+        jsonrpc: "2.0",
+        error: {
+          code: -32000,
+          message: "Bad Request: Session expired or invalid. Please reconnect.",
+        },
+        id: (body?.id as string | number | null) ?? null,
+      };
     } else {
-      // Either initialize request OR request with invalid/expired session
-      // In both cases, create a new session
+      // Initialize request (with or without session ID) - create a new session
       const effectiveSessionId =
         sessionId || `session-${Date.now()}-${randomUUID()}`;
 
-      if (isInitialize) {
-        fastify.log.info(
-          {
-            profileId,
-            sessionId: effectiveSessionId,
-            hasTokenAuth: !!tokenAuthContext,
-          },
-          "Initialize request - creating NEW session",
-        );
-      } else {
-        fastify.log.info(
-          {
-            profileId,
-            sessionId: effectiveSessionId,
-            method: body?.method,
-            hasTokenAuth: !!tokenAuthContext,
-          },
-          "Request received with invalid/expired session - auto-creating new session",
-        );
-      }
+      fastify.log.info(
+        {
+          profileId,
+          sessionId: effectiveSessionId,
+          hasTokenAuth: !!tokenAuthContext,
+        },
+        "Initialize request - creating NEW session",
+      );
 
       const { server: newServer, agent } = await createAgentServer(
         profileId,


### PR DESCRIPTION
Return a "Session expired" error for non-initialize requests with invalid sessions to prompt client re-initialization.

Previously, the MCP Gateway would attempt to auto-create a new session for non-initialize requests with an expired session ID. However, the MCP SDK requires an `initialize` handshake before any other requests, leading to a "Server not initialized" error and preventing clients like Cursor from discovering tools. This change provides a clearer error, guiding clients to properly restart the connection with an `initialize` request.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd6c626b-fbc7-44ba-8149-42926673dd98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bd6c626b-fbc7-44ba-8149-42926673dd98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies MCP session lifecycle and prevents orphan sessions.
> 
> - Non-`initialize` requests with an invalid/expired `mcp-session-id` now return 400 with `"Bad Request: Session expired or invalid. Please reconnect."` and do not create a new session
> - `initialize` requests (with or without a session ID) create a new session; re-initializing on an existing session reuses the server
> - Tests updated/added in `mcp-gateway.test.ts` to assert the new error behavior and successful re-initialization; logging streamlined in `mcp-gateway.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb55fe14c4a5e9acdf3d777789971529a100a879. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->