### PR TITLE
fix(settings): enable member invites in OSS version

### DIFF
--- a/platform/frontend/src/app/settings/members/page.tsx
+++ b/platform/frontend/src/app/settings/members/page.tsx
@@ -23,23 +23,22 @@ import {
 import config from "@/lib/config";
 import {
   organizationKeys,
-  useActiveMemberRole,
   useActiveOrganization,
 } from "@/lib/organization.query";
 
 function MembersSettingsContent() {
   const queryClient = useQueryClient();
   const { data: activeOrg } = useActiveOrganization();
-  const { data: activeMemberRole } = useActiveMemberRole(activeOrg?.id);
+
   const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
 
-  const hasPermissionTodo = "TODO:";
+
   const invitationsEnabled = !config.disableInvitations;
 
   const members = activeOrg ? (
     <div className="space-y-6">
-      {invitationsEnabled && activeMemberRole && hasPermissionTodo && (
+      {invitationsEnabled && (
         <Dialog
           open={inviteDialogOpen}
           onOpenChange={(open) => {
@@ -70,8 +69,8 @@ function MembersSettingsContent() {
         action={
           invitationsEnabled
             ? () => {
-                setInviteDialogOpen(true);
-              }
+              setInviteDialogOpen(true);
+            }
             : undefined
         }
       />


### PR DESCRIPTION
## Summary

Fixes #1892. The "Invite Member" button was blocked in the OSS version because the Invite Dialog was conditionally rendered based on `activeMemberRole`, which may not be present or required for OSS usage. This change removes the unnecessary condition, allowing the dialog to open when invitations are enabled.

## Changes

- Removed `activeMemberRole` check from Invite Dialog rendering condition in `page.tsx`.
- Removed unused `activeMemberRole` query and `hasPermissionTodo` placeholder.

## Verification

- Verified logic: Dialog now correctly renders when `invitationsEnabled` is true.
