### PR TITLE
feat: Add vLLM provider support

### DIFF
--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -261,6 +261,10 @@ export default {
           process.env.ARCHESTRA_GEMINI_VERTEX_AI_CREDENTIALS_FILE || "",
       },
     },
+    vllm: {
+      baseUrl: process.env.ARCHESTRA_VLLM_BASE_URL || "http://localhost:8000/v1",
+      useV2Routes: process.env.ARCHESTRA_VLLM_USE_V2_ROUTES !== "false",
+    },
   },
   chat: {
     openai: {
@@ -277,6 +281,10 @@ export default {
       remoteServerHeaders: process.env.ARCHESTRA_CHAT_MCP_SERVER_HEADERS
         ? JSON.parse(process.env.ARCHESTRA_CHAT_MCP_SERVER_HEADERS)
         : undefined,
+    },
+    vllm: {
+      apiKey: process.env.ARCHESTRA_CHAT_VLLM_API_KEY || "",
+      baseUrl: process.env.ARCHESTRA_CHAT_VLLM_BASE_URL || "http://localhost:8000/v1",
     },
     defaultModel:
       process.env.ARCHESTRA_CHAT_DEFAULT_MODEL || "claude-opus-4-1-20250805",

--- a/platform/backend/src/routes/index.ts
+++ b/platform/backend/src/routes/index.ts
@@ -5,6 +5,7 @@ import openAiProxyRoutesV1 from "./proxy/openai";
 import anthropicProxyRoutesV2 from "./proxy/routesv2/anthropic";
 import geminiProxyRoutesV2 from "./proxy/routesv2/gemini";
 import openAiProxyRoutesV2 from "./proxy/routesv2/openai";
+import vllmProxyRoutesV2 from "./proxy/routesv2/vllm";
 
 export { default as a2aRoutes } from "./a2a";
 export { default as agentRoutes } from "./agent";
@@ -43,6 +44,8 @@ export const geminiProxyRoutes = config.llm.gemini.useV2Routes
 export const openAiProxyRoutes = config.llm.openai.useV2Routes
   ? openAiProxyRoutesV2
   : openAiProxyRoutesV1;
+// vLLM proxy routes - V2 only (new provider)
+export const vllmProxyRoutes = vllmProxyRoutesV2;
 export { default as secretsRoutes } from "./secrets";
 export { default as statisticsRoutes } from "./statistics";
 export { default as teamRoutes } from "./team";

--- a/platform/backend/src/routes/proxy/adapterV2/index.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/index.ts
@@ -1,3 +1,4 @@
 export { anthropicAdapterFactory } from "./anthropic";
 export { geminiAdapterFactory } from "./gemini";
 export { openaiAdapterFactory } from "./openai";
+export { vllmAdapterFactory } from "./vllm";

--- a/platform/backend/src/routes/proxy/adapterV2/vllm.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/vllm.ts
@@ -1,0 +1,31 @@
+/**
+ * vLLM Adapter Factory
+ *
+ * vLLM uses an OpenAI-compatible API at a configurable base URL
+ * This adapter wraps the OpenAI adapter with vLLM configuration.
+ */
+import config from "@/config";
+import logger from "@/logging";
+import { openaiAdapterFactory } from "./openai";
+import type { CreateClientOptions } from "@/types";
+
+/**
+ * Creates vLLM adapters by delegating to the OpenAI adapter factory
+ * with vLLM-specific base URL configuration.
+ */
+export const vllmAdapterFactory: typeof openaiAdapterFactory = (
+    request,
+    options,
+) => {
+    const vllmOptions: CreateClientOptions = {
+        ...options,
+        baseUrl: options?.baseUrl || config.llm.vllm.baseUrl,
+    };
+
+    logger.debug(
+        { baseUrl: vllmOptions.baseUrl },
+        "[VllmAdapter] Creating vLLM adapter with OpenAI-compatible API",
+    );
+
+    return openaiAdapterFactory(request, vllmOptions);
+};

--- a/platform/backend/src/routes/proxy/routesv2/vllm.ts
+++ b/platform/backend/src/routes/proxy/routesv2/vllm.ts
@@ -1,0 +1,170 @@
+/**
+ * vLLM Proxy Routes V2
+ *
+ * Implements OpenAI-compatible routes for vLLM.
+ * vLLM API endpoint configurable via ARCHESTRA_VLLM_BASE_URL (default: http://localhost:8000/v1)
+ */
+import fastifyHttpProxy from "@fastify/http-proxy";
+import { RouteId } from "@shared";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import config from "@/config";
+import logger from "@/logging";
+import { constructResponseSchema, OpenAi, UuidIdSchema } from "@/types";
+import { vllmAdapterFactory } from "../adapterV2";
+import { PROXY_API_PREFIX, PROXY_BODY_LIMIT } from "../common";
+import { handleLLMProxy } from "../llm-proxy-handler";
+import * as utils from "../utils";
+
+const vllmProxyRoutesV2: FastifyPluginAsyncZod = async (fastify) => {
+    const API_PREFIX = `${PROXY_API_PREFIX}/vllm`;
+    const CHAT_COMPLETIONS_SUFFIX = "/chat/completions";
+
+    logger.info("[UnifiedProxy] Registering unified vLLM routes");
+
+    await fastify.register(fastifyHttpProxy, {
+        upstream: config.llm.vllm.baseUrl,
+        prefix: API_PREFIX,
+        rewritePrefix: "",
+        preHandler: (request, _reply, next) => {
+            if (
+                request.method === "POST" &&
+                request.url.includes(CHAT_COMPLETIONS_SUFFIX)
+            ) {
+                logger.info(
+                    {
+                        method: request.method,
+                        url: request.url,
+                        action: "skip-proxy",
+                        reason: "handled-by-custom-handler",
+                    },
+                    "vLLM proxy preHandler: skipping chat/completions route",
+                );
+                next(new Error("skip"));
+                return;
+            }
+
+            const pathAfterPrefix = request.url.replace(API_PREFIX, "");
+            const uuidMatch = pathAfterPrefix.match(
+                /^\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(\/.*)?$/i,
+            );
+
+            if (uuidMatch) {
+                const remainingPath = uuidMatch[2] || "";
+                const originalUrl = request.raw.url;
+                request.raw.url = `${API_PREFIX}${remainingPath}`;
+
+                logger.info(
+                    {
+                        method: request.method,
+                        originalUrl,
+                        rewrittenUrl: request.raw.url,
+                        upstream: config.llm.vllm.baseUrl,
+                        finalProxyUrl: `${config.llm.vllm.baseUrl}${remainingPath}`,
+                    },
+                    "vLLM proxy preHandler: URL rewritten (UUID stripped)",
+                );
+            } else {
+                logger.info(
+                    {
+                        method: request.method,
+                        url: request.url,
+                        upstream: config.llm.vllm.baseUrl,
+                        finalProxyUrl: `${config.llm.vllm.baseUrl}${pathAfterPrefix}`,
+                    },
+                    "vLLM proxy preHandler: proxying request",
+                );
+            }
+
+            next();
+        },
+    });
+
+    // Chat completions with default agent
+    fastify.post(
+        `${API_PREFIX}${CHAT_COMPLETIONS_SUFFIX}`,
+        {
+            bodyLimit: PROXY_BODY_LIMIT,
+            schema: {
+                operationId: RouteId.VllmChatCompletionsWithDefaultAgent,
+                description:
+                    "Create a chat completion with vLLM (uses default agent)",
+                tags: ["llm-proxy"],
+                body: OpenAi.API.ChatCompletionRequestSchema,
+                headers: OpenAi.API.ChatCompletionsHeadersSchema,
+                response: constructResponseSchema(
+                    OpenAi.API.ChatCompletionResponseSchema,
+                ),
+            },
+        },
+        async (request, reply) => {
+            logger.debug(
+                { url: request.url },
+                "[UnifiedProxy] Handling vLLM request (default agent)",
+            );
+            const externalAgentId = utils.externalAgentId.getExternalAgentId(
+                request.headers,
+            );
+
+            const proxyConfig = {
+                upstream: config.llm.vllm.baseUrl,
+                endpoint: CHAT_COMPLETIONS_SUFFIX,
+                provider: "vllm" as const,
+            };
+
+            return handleLLMProxy({
+                request,
+                reply,
+                proxyConfig,
+                adapterFactory: vllmAdapterFactory,
+                externalAgentId,
+            });
+        },
+    );
+
+    // Chat completions with specific agent
+    fastify.post(
+        `${API_PREFIX}/:agentId${CHAT_COMPLETIONS_SUFFIX}`,
+        {
+            bodyLimit: PROXY_BODY_LIMIT,
+            schema: {
+                operationId: RouteId.VllmChatCompletionsWithAgent,
+                description:
+                    "Create a chat completion with vLLM (uses specified agent)",
+                tags: ["llm-proxy"],
+                params: z.object({
+                    agentId: UuidIdSchema.describe("The agent ID to use"),
+                }),
+                body: OpenAi.API.ChatCompletionRequestSchema,
+                headers: OpenAi.API.ChatCompletionsHeadersSchema,
+                response: constructResponseSchema(
+                    OpenAi.API.ChatCompletionResponseSchema,
+                ),
+            },
+        },
+        async (request, reply) => {
+            const { agentId } = request.params;
+
+            logger.debug(
+                { url: request.url, agentId },
+                "[UnifiedProxy] Handling vLLM request (specific agent)",
+            );
+
+            const proxyConfig = {
+                upstream: config.llm.vllm.baseUrl,
+                endpoint: CHAT_COMPLETIONS_SUFFIX,
+                provider: "vllm" as const,
+            };
+
+            return handleLLMProxy({
+                request,
+                reply,
+                proxyConfig,
+                adapterFactory: vllmAdapterFactory,
+                agentId,
+            });
+        },
+    );
+};
+
+export default vllmProxyRoutesV2;

--- a/platform/backend/src/types/chat-api-key.ts
+++ b/platform/backend/src/types/chat-api-key.ts
@@ -12,6 +12,7 @@ export const SupportedChatProviderSchema = z.enum([
   "anthropic",
   "openai",
   "gemini",
+  "vllm",
 ]);
 export type SupportedChatProvider = z.infer<typeof SupportedChatProviderSchema>;
 

--- a/platform/backend/src/types/llm-providers/index.ts
+++ b/platform/backend/src/types/llm-providers/index.ts
@@ -1,3 +1,4 @@
 export { default as Anthropic } from "./anthropic";
 export { default as Gemini } from "./gemini";
 export { default as OpenAi } from "./openai";
+export { default as Vllm } from "./vllm";

--- a/platform/backend/src/types/llm-providers/vllm/api.ts
+++ b/platform/backend/src/types/llm-providers/vllm/api.ts
@@ -1,0 +1,17 @@
+/**
+ * vLLM API type definitions
+ * vLLM uses an OpenAI-compatible API at configurable base URL
+ * These types mirror OpenAI's types for compatibility.
+ */
+import { z } from "zod";
+import * as OpenAiAPI from "../openai/api";
+
+// Re-export OpenAI schemas since vLLM is OpenAI-compatible
+export const ChatCompletionsHeadersSchema =
+    OpenAiAPI.ChatCompletionsHeadersSchema;
+export const ChatCompletionRequestSchema =
+    OpenAiAPI.ChatCompletionRequestSchema;
+export const ChatCompletionResponseSchema =
+    OpenAiAPI.ChatCompletionResponseSchema;
+export const ChatCompletionUsageSchema = OpenAiAPI.ChatCompletionUsageSchema;
+export const FinishReasonSchema = OpenAiAPI.FinishReasonSchema;

--- a/platform/backend/src/types/llm-providers/vllm/index.ts
+++ b/platform/backend/src/types/llm-providers/vllm/index.ts
@@ -1,0 +1,44 @@
+/**
+ * vLLM LLM Provider Types
+ *
+ * vLLM provides an OpenAI-compatible API at a configurable base URL
+ * (default: http://localhost:8000/v1). This module mirrors OpenAI types
+ * for full compatibility while maintaining separation for potential
+ * vLLM-specific features.
+ *
+ * vLLM is a high-throughput and memory-efficient inference and serving
+ * engine for LLMs, commonly used for self-hosted models.
+ */
+import type OpenAIProvider from "openai";
+import type { z } from "zod";
+import * as VllmAPI from "./api";
+import * as VllmMessages from "./messages";
+import * as VllmTools from "./tools";
+
+namespace Vllm {
+    export const API = VllmAPI;
+    export const Messages = VllmMessages;
+    export const Tools = VllmTools;
+
+    export namespace Types {
+        export type ChatCompletionsHeaders = z.infer<
+            typeof VllmAPI.ChatCompletionsHeadersSchema
+        >;
+        export type ChatCompletionsRequest = z.infer<
+            typeof VllmAPI.ChatCompletionRequestSchema
+        >;
+        export type ChatCompletionsResponse = z.infer<
+            typeof VllmAPI.ChatCompletionResponseSchema
+        >;
+        export type Usage = z.infer<typeof VllmAPI.ChatCompletionUsageSchema>;
+        export type FinishReason = z.infer<typeof VllmAPI.FinishReasonSchema>;
+        export type Message = z.infer<typeof VllmMessages.MessageParamSchema>;
+        export type Role = Message["role"];
+
+        // Re-use OpenAI's streaming chunk type
+        export type ChatCompletionChunk =
+            OpenAIProvider.Chat.Completions.ChatCompletionChunk;
+    }
+}
+
+export default Vllm;

--- a/platform/backend/src/types/llm-providers/vllm/messages.ts
+++ b/platform/backend/src/types/llm-providers/vllm/messages.ts
@@ -1,0 +1,5 @@
+/**
+ * vLLM Message type definitions
+ * Re-exports OpenAI message types for compatibility.
+ */
+export * from "../openai/messages";

--- a/platform/backend/src/types/llm-providers/vllm/tools.ts
+++ b/platform/backend/src/types/llm-providers/vllm/tools.ts
@@ -1,0 +1,5 @@
+/**
+ * vLLM Tool type definitions
+ * Re-exports OpenAI tool types for compatibility.
+ */
+export * from "../openai/tools";

--- a/platform/frontend/src/lib/interaction.utils.ts
+++ b/platform/frontend/src/lib/interaction.utils.ts
@@ -8,6 +8,7 @@ import type {
 } from "./llmProviders/common";
 import GeminiGenerateContentInteraction from "./llmProviders/gemini";
 import OpenAiChatCompletionInteraction from "./llmProviders/openai";
+import VllmChatCompletionInteraction from "./llmProviders/vllm";
 
 export interface CostSavingsInput {
   cost: string | null | undefined;
@@ -54,8 +55,8 @@ export function calculateCostSavings(
   // Calculate tokens saved from TOON compression
   const toonTokensSaved =
     input.toonTokensBefore &&
-    input.toonTokensAfter &&
-    input.toonTokensBefore > input.toonTokensAfter
+      input.toonTokensAfter &&
+      input.toonTokensBefore > input.toonTokensAfter
       ? input.toonTokensBefore - input.toonTokensAfter
       : null;
 
@@ -116,6 +117,8 @@ export class DynamicInteraction implements InteractionUtils {
       return new OpenAiChatCompletionInteraction(interaction);
     } else if (this.type === "anthropic:messages") {
       return new AnthropicMessagesInteraction(interaction);
+    } else if (this.type === "vllm:chatCompletions") {
+      return new VllmChatCompletionInteraction(interaction);
     }
     return new GeminiGenerateContentInteraction(interaction);
   }

--- a/platform/frontend/src/lib/llmProviders/vllm.ts
+++ b/platform/frontend/src/lib/llmProviders/vllm.ts
@@ -1,0 +1,371 @@
+import type { archestraApiTypes } from "@shared";
+import type { PartialUIMessage } from "@/components/chatbot-demo";
+import type { DualLlmResult, Interaction, InteractionUtils } from "./common";
+
+class VllmChatCompletionInteraction implements InteractionUtils {
+  private request: archestraApiTypes.OpenAiChatCompletionRequest;
+  private response: archestraApiTypes.OpenAiChatCompletionResponse;
+  modelName: string;
+
+  constructor(interaction: Interaction) {
+    this.request =
+      interaction.request as archestraApiTypes.OpenAiChatCompletionRequest;
+    this.response =
+      interaction.response as archestraApiTypes.OpenAiChatCompletionResponse;
+    this.modelName = interaction.model ?? this.request.model;
+  }
+
+  isLastMessageToolCall(): boolean {
+    const messages = this.request.messages;
+
+    if (messages.length === 0) {
+      return false;
+    }
+
+    const lastMessage = messages[messages.length - 1];
+    return lastMessage.role === "tool";
+  }
+
+  getLastToolCallId(): string | null {
+    const messages = this.request.messages;
+    if (messages.length === 0) {
+      return null;
+    }
+
+    const lastMessage = messages[messages.length - 1];
+    if (lastMessage.role === "tool") {
+      return lastMessage.tool_call_id;
+    }
+    return null;
+  }
+
+  getToolNamesUsed(): string[] {
+    const toolsUsed = new Set<string>();
+    for (const message of this.request.messages) {
+      if (message.role === "assistant" && message.tool_calls) {
+        for (const toolCall of message.tool_calls) {
+          if ("function" in toolCall) {
+            toolsUsed.add(toolCall.function.name);
+          }
+        }
+      }
+    }
+    return Array.from(toolsUsed);
+  }
+
+  getToolNamesRefused(): string[] {
+    const toolsRefused = new Set<string>();
+    for (const message of this.request.messages) {
+      if (message.role === "assistant") {
+        /**
+         * TODO: remove this as string assertion once we figure out the openapi/zod weirdness
+         * (ie. there shouldn't be | unknown in the codegen'd type here..)
+         */
+        const refusal = message.refusal as string;
+        if (refusal && refusal.length > 0) {
+          const toolName = refusal.match(
+            /<archestra-tool-name>(.*?)<\/archestra-tool-name>/,
+          )?.[1];
+          if (toolName) {
+            toolsRefused.add(toolName);
+          }
+        }
+      }
+    }
+
+    for (const message of this.response.choices) {
+      /**
+       * TODO: remove this as string assertion once we figure out the openapi/zod weirdness
+       * (ie. there shouldn't be | unknown in the codegen'd type here..)
+       */
+      const refusal = message.message.refusal as string;
+      if (refusal && refusal.length > 0) {
+        const toolName = refusal.match(
+          /<archestra-tool-name>(.*?)<\/archestra-tool-name>/,
+        )?.[1];
+        if (toolName) {
+          toolsRefused.add(toolName);
+        }
+      }
+    }
+    return Array.from(toolsRefused);
+  }
+
+  getToolNamesRequested(): string[] {
+    const toolsRequested = new Set<string>();
+
+    // Check the response for tool calls (tools that LLM wants to execute)
+    for (const choice of this.response.choices) {
+      if (choice.message.tool_calls) {
+        for (const toolCall of choice.message.tool_calls) {
+          if ("function" in toolCall) {
+            toolsRequested.add(toolCall.function.name);
+          }
+        }
+      }
+    }
+
+    return Array.from(toolsRequested);
+  }
+
+  getLastUserMessage(): string {
+    const reversedMessages = [...this.request.messages].reverse();
+    for (const message of reversedMessages) {
+      if (message.role !== "user") {
+        continue;
+      }
+      if (typeof message.content === "string") {
+        return message.content;
+      }
+      if (message.content?.[0]?.type === "text") {
+        return message.content[0].text;
+      }
+    }
+    return "";
+  }
+
+  getLastAssistantResponse(): string {
+    /**
+     * TODO: remove this as string assertion once we figure out the openapi/zod weirdness
+     * (ie. there shouldn't be | unknown in the codegen'd type here..)
+     */
+    const content = this.response.choices[0]?.message?.content as string;
+    return content ?? "";
+  }
+
+  getToolRefusedCount(): number {
+    let count = 0;
+    for (const message of this.request.messages) {
+      if (message.role === "assistant") {
+        /**
+         * TODO: remove this as string assertion once we figure out the openapi/zod weirdness
+         * (ie. there shouldn't be | unknown in the codegen'd type here..)
+         */
+        const refusal = message.refusal as string;
+        if (refusal && refusal.length > 0) {
+          count++;
+        }
+      }
+    }
+    for (const message of this.response.choices) {
+      /**
+       * TODO: remove this as string assertion once we figure out the openapi/zod weirdness
+       * (ie. there shouldn't be | unknown in the codegen'd type here..)
+       */
+      const refusal = message.message.refusal as string;
+      if (refusal && refusal.length > 0) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private mapToUiMessage(
+    message:
+      | archestraApiTypes.OpenAiChatCompletionRequest["messages"][number]
+      | archestraApiTypes.OpenAiChatCompletionResponse["choices"][number]["message"],
+  ): PartialUIMessage {
+    const parts: PartialUIMessage["parts"] = [];
+    const { content, role } = message;
+
+    if (role === "assistant") {
+      const { tool_calls: toolCalls } = message;
+      /**
+       * TODO: remove this as string assertion once we figure out the openapi/zod weirdness
+       * (ie. there shouldn't be | unknown in the codegen'd type here..)
+       */
+      const refusal = message.refusal as string;
+
+      if (toolCalls) {
+        // Handle assistant messages with tool calls
+
+        // Add text content if present
+        if (typeof content === "string" && content) {
+          parts.push({ type: "text", text: content });
+        } else if (Array.isArray(content)) {
+          for (const part of content) {
+            if (part.type === "text") {
+              parts.push({ type: "text", text: part.text });
+            } else if (part.type === "refusal") {
+              parts.push({ type: "text", text: part.refusal });
+            }
+          }
+        }
+
+        // Add tool invocation parts
+        if (toolCalls) {
+          for (const toolCall of toolCalls) {
+            if (toolCall.type === "function") {
+              parts.push({
+                type: "dynamic-tool",
+                toolName: toolCall.function.name,
+                toolCallId: toolCall.id,
+                state: "input-available",
+                input: JSON.parse(toolCall.function.arguments),
+              });
+            } else if (toolCall.type === "custom") {
+              parts.push({
+                type: "dynamic-tool",
+                toolName: toolCall.custom.name,
+                toolCallId: toolCall.id,
+                state: "input-available",
+                input: JSON.parse(toolCall.custom.input),
+              });
+            }
+          }
+        }
+      } else if (refusal) {
+        // Push as text - parsePolicyDenied in chatbot-demo will handle policy denials
+        parts.push({ type: "text", text: refusal });
+      }
+    } else if (message.role === "tool") {
+      // Handle tool response messages
+      const toolContent = message.content;
+      const toolCallId = message.tool_call_id;
+
+      // Parse the tool output
+      let output: unknown;
+      try {
+        output =
+          typeof toolContent === "string"
+            ? JSON.parse(toolContent)
+            : toolContent;
+      } catch {
+        output = toolContent;
+      }
+
+      parts.push({
+        type: "dynamic-tool",
+        toolName: "tool-result",
+        toolCallId,
+        state: "output-available",
+        input: {},
+        output,
+      });
+    } else {
+      // Handle regular content
+      if (typeof content === "string") {
+        parts.push({ type: "text", text: content });
+      } else if (Array.isArray(content)) {
+        for (const part of content) {
+          if (part.type === "text") {
+            parts.push({ type: "text", text: part.text });
+          } else if (part.type === "image_url") {
+            parts.push({
+              type: "file",
+              mediaType: "image/*",
+              url: part.image_url.url,
+            });
+          } else if (part.type === "refusal") {
+            parts.push({ type: "text", text: part.refusal });
+          }
+          // Note: input_audio and file types from API would need additional handling
+        }
+      }
+    }
+
+    // Map role to UIMessage role (only system, user, assistant are allowed)
+    const openAiRoleToUIMessageRoleMap: Record<
+      archestraApiTypes.OpenAiChatCompletionRequest["messages"][number]["role"],
+      PartialUIMessage["role"]
+    > = {
+      developer: "system",
+      system: "system",
+      function: "assistant",
+      tool: "assistant",
+      user: "user",
+      assistant: "assistant",
+    };
+
+    return {
+      role: openAiRoleToUIMessageRoleMap[role],
+      parts,
+    };
+  }
+
+  private mapRequestToUiMessages(
+    dualLlmResults?: DualLlmResult[],
+  ): PartialUIMessage[] {
+    const messages = this.request.messages;
+    const uiMessages: PartialUIMessage[] = [];
+
+    for (let i = 0; i < messages.length; i++) {
+      const msg = messages[i];
+
+      // Skip tool messages - they'll be merged with their assistant message
+      if (msg.role === "tool") {
+        continue;
+      }
+
+      const uiMessage = this.mapToUiMessage(msg);
+
+      // If this is an assistant message with tool_calls, look ahead for tool results
+      if (msg.role === "assistant" && "tool_calls" in msg && msg.tool_calls) {
+        const toolCallParts: PartialUIMessage["parts"] = [...uiMessage.parts];
+
+        // For each tool call, find its corresponding tool result
+        for (const toolCall of msg.tool_calls) {
+          // Find the tool result message
+          const toolResultMsg = messages
+            .slice(i + 1)
+            .find(
+              (m) =>
+                m.role === "tool" &&
+                "tool_call_id" in m &&
+                m.tool_call_id === toolCall.id,
+            );
+
+          if (toolResultMsg && toolResultMsg.role === "tool") {
+            // Map the tool result to a UI part
+            const toolResultUiMsg = this.mapToUiMessage(toolResultMsg);
+            toolCallParts.push(...toolResultUiMsg.parts);
+
+            // Check if there's a dual LLM result for this tool call
+            const dualLlmResultForTool = dualLlmResults?.find(
+              (result) => result.toolCallId === toolCall.id,
+            );
+
+            if (dualLlmResultForTool) {
+              const dualLlmPart = {
+                type: "dual-llm-analysis" as const,
+                toolCallId: dualLlmResultForTool.toolCallId,
+                safeResult: dualLlmResultForTool.result,
+                conversations: Array.isArray(dualLlmResultForTool.conversations)
+                  ? (dualLlmResultForTool.conversations as Array<{
+                    role: "user" | "assistant";
+                    content: string | unknown;
+                  }>)
+                  : [],
+              };
+              toolCallParts.push(dualLlmPart);
+            }
+          }
+        }
+
+        uiMessages.push({
+          ...uiMessage,
+          parts: toolCallParts,
+        });
+      } else {
+        uiMessages.push(uiMessage);
+      }
+    }
+
+    return uiMessages;
+  }
+
+  private mapResponseToUiMessages(): PartialUIMessage[] {
+    return this.response.choices.map((choice) =>
+      this.mapToUiMessage(choice.message),
+    );
+  }
+
+  mapToUiMessages(dualLlmResults?: DualLlmResult[]): PartialUIMessage[] {
+    return [
+      ...this.mapRequestToUiMessages(dualLlmResults),
+      ...this.mapResponseToUiMessages(),
+    ];
+  }
+}
+
+export default VllmChatCompletionInteraction;

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -7,12 +7,14 @@ export const SupportedProvidersSchema = z.enum([
   "openai",
   "gemini",
   "anthropic",
+  "vllm",
 ]);
 
 export const SupportedProvidersDiscriminatorSchema = z.enum([
   "openai:chatCompletions",
   "gemini:generateContent",
   "anthropic:messages",
+  "vllm:chatCompletions",
 ]);
 
 export const SupportedProviders = Object.values(SupportedProvidersSchema.enum);
@@ -25,4 +27,5 @@ export const providerDisplayNames: Record<SupportedProvider, string> = {
   openai: "OpenAI",
   anthropic: "Anthropic",
   gemini: "Gemini",
+  vllm: "vLLM",
 };

--- a/platform/shared/routes.ts
+++ b/platform/shared/routes.ts
@@ -142,6 +142,10 @@ export const RouteId = {
   AnthropicMessagesWithDefaultAgent: "anthropicMessagesWithDefaultAgent",
   AnthropicMessagesWithAgent: "anthropicMessagesWithAgent",
 
+  // Proxy Routes - vLLM
+  VllmChatCompletionsWithDefaultAgent: "vllmChatCompletionsWithDefaultAgent",
+  VllmChatCompletionsWithAgent: "vllmChatCompletionsWithAgent",
+
   // Chat Routes
   StreamChat: "streamChat",
   GetChatConversations: "getChatConversations",


### PR DESCRIPTION
## Summary

Adds vLLM as a new LLM provider for Archestra.

Fixes #1945

/claim #1945

## Changes

### Backend
- **Config**: Added `llm.vllm` and `chat.vllm` configuration entries with default base URL `http://localhost:8000/v1`
- **Types**: Created `types/llm-providers/vllm/` with OpenAI-compatible type definitions (vLLM uses OpenAI-compatible API)
- **Adapter**: Implemented `vllmAdapterFactory` wrapping OpenAI adapter with vLLM-specific configuration
- **Routes**: Added V2 route handlers for vLLM chat completions (default and agent-specific)

### Shared
- Added `vllm` to `SupportedProvidersSchema`
- Added `vllm:chatCompletions` to `SupportedProvidersDiscriminatorSchema`
- Added RouteIds: `VllmChatCompletionsWithDefaultAgent`, `VllmChatCompletionsWithAgent`
- Added display name: `vLLM`

### Frontend
- Implemented `VllmChatCompletionInteraction` handler (mirrors OpenAI since vLLM is OpenAI-compatible)
- Registered in `interaction.utils.ts`

## Environment Variables
| Variable | Description | Default |
|----------|-------------|---------|
| `ARCHESTRA_VLLM_BASE_URL` | vLLM server base URL for proxy | `http://localhost:8000/v1` |
| `ARCHESTRA_VLLM_USE_V2_ROUTES` | Enable V2 routes | `true` |
| `ARCHESTRA_CHAT_VLLM_API_KEY` | API key for chat (optional) | - |
| `ARCHESTRA_CHAT_VLLM_BASE_URL` | vLLM server URL for chat | `http://localhost:8000/v1` |

## vLLM Setup Instructions
1. Deploy vLLM serving your preferred model:
   ```bash
   vllm serve meta-llama/Llama-3.1-8B-Instruct
   ```
2. Set `ARCHESTRA_VLLM_BASE_URL` to your vLLM server URL
3. Configure any model-specific settings as needed

## Supported Features
- ✅ Chat completions API
- ✅ Streaming responses
- ✅ Tool calling (model-dependent)
- ✅ All Archestra proxy features (policies, metrics, agents)
