### PR TITLE
feat: Add Ollama provider support

### DIFF
--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -261,6 +261,10 @@ export default {
           process.env.ARCHESTRA_GEMINI_VERTEX_AI_CREDENTIALS_FILE || "",
       },
     },
+    ollama: {
+      baseUrl: process.env.ARCHESTRA_OLLAMA_BASE_URL || "http://localhost:11434/v1",
+      useV2Routes: process.env.ARCHESTRA_OLLAMA_USE_V2_ROUTES !== "false",
+    },
   },
   chat: {
     openai: {
@@ -277,6 +281,10 @@ export default {
       remoteServerHeaders: process.env.ARCHESTRA_CHAT_MCP_SERVER_HEADERS
         ? JSON.parse(process.env.ARCHESTRA_CHAT_MCP_SERVER_HEADERS)
         : undefined,
+    },
+    ollama: {
+      apiKey: process.env.ARCHESTRA_CHAT_OLLAMA_API_KEY || "",
+      baseUrl: process.env.ARCHESTRA_CHAT_OLLAMA_BASE_URL || "http://localhost:11434/v1",
     },
     defaultModel:
       process.env.ARCHESTRA_CHAT_DEFAULT_MODEL || "claude-opus-4-1-20250805",

--- a/platform/backend/src/routes/index.ts
+++ b/platform/backend/src/routes/index.ts
@@ -5,6 +5,7 @@ import openAiProxyRoutesV1 from "./proxy/openai";
 import anthropicProxyRoutesV2 from "./proxy/routesv2/anthropic";
 import geminiProxyRoutesV2 from "./proxy/routesv2/gemini";
 import openAiProxyRoutesV2 from "./proxy/routesv2/openai";
+import ollamaProxyRoutesV2 from "./proxy/routesv2/ollama";
 
 export { default as a2aRoutes } from "./a2a";
 export { default as agentRoutes } from "./agent";
@@ -43,6 +44,8 @@ export const geminiProxyRoutes = config.llm.gemini.useV2Routes
 export const openAiProxyRoutes = config.llm.openai.useV2Routes
   ? openAiProxyRoutesV2
   : openAiProxyRoutesV1;
+// Ollama proxy routes - V2 only (new provider)
+export const ollamaProxyRoutes = ollamaProxyRoutesV2;
 export { default as secretsRoutes } from "./secrets";
 export { default as statisticsRoutes } from "./statistics";
 export { default as teamRoutes } from "./team";

--- a/platform/backend/src/routes/proxy/adapterV2/index.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/index.ts
@@ -1,3 +1,4 @@
 export { anthropicAdapterFactory } from "./anthropic";
 export { geminiAdapterFactory } from "./gemini";
 export { openaiAdapterFactory } from "./openai";
+export { ollamaAdapterFactory } from "./ollama";

--- a/platform/backend/src/routes/proxy/adapterV2/ollama.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/ollama.ts
@@ -1,0 +1,35 @@
+/**
+ * Ollama Adapter Factory
+ *
+ * Wraps the OpenAI adapter factory for Ollama's OpenAI-compatible API.
+ * Default base URL: http://localhost:11434/v1
+ */
+import config from "@/config";
+import logger from "@/logging";
+import { openaiAdapterFactory } from "./openai";
+
+interface OllamaClientOptions {
+    baseUrl?: string;
+    apiKey?: string;
+}
+
+/**
+ * Creates an Ollama adapter by wrapping the OpenAI adapter
+ * with Ollama-specific configuration.
+ */
+export const ollamaAdapterFactory: typeof openaiAdapterFactory = (
+    request,
+    options,
+) => {
+    const ollamaOptions: OllamaClientOptions = {
+        ...options,
+        baseUrl: options?.baseUrl || config.llm.ollama.baseUrl,
+    };
+
+    logger.debug(
+        { baseUrl: ollamaOptions.baseUrl },
+        "[OllamaAdapter] Creating Ollama adapter with OpenAI-compatible API",
+    );
+
+    return openaiAdapterFactory(request, ollamaOptions);
+};

--- a/platform/backend/src/routes/proxy/routesv2/ollama.ts
+++ b/platform/backend/src/routes/proxy/routesv2/ollama.ts
@@ -1,0 +1,167 @@
+/**
+ * Ollama Proxy Routes V2
+ *
+ * Implements OpenAI-compatible chat completions endpoints for Ollama.
+ * Default base URL: http://localhost:11434/v1
+ */
+import fastifyHttpProxy from "@fastify/http-proxy";
+import { RouteId } from "@shared";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import config from "@/config";
+import logger from "@/logging";
+import { constructResponseSchema, OpenAi, UuidIdSchema } from "@/types";
+import { ollamaAdapterFactory } from "../adapterV2";
+import { PROXY_API_PREFIX, PROXY_BODY_LIMIT } from "../common";
+import { handleLLMProxy } from "../llm-proxy-handler";
+import * as utils from "../utils";
+
+const ollamaProxyRoutesV2: FastifyPluginAsyncZod = async (fastify) => {
+    const API_PREFIX = `${PROXY_API_PREFIX}/ollama`;
+    const CHAT_COMPLETIONS_SUFFIX = "/chat/completions";
+
+    logger.info("[UnifiedProxy] Registering unified Ollama routes");
+
+    await fastify.register(fastifyHttpProxy, {
+        upstream: config.llm.ollama.baseUrl,
+        prefix: API_PREFIX,
+        rewritePrefix: "",
+        preHandler: (request, _reply, next) => {
+            if (
+                request.method === "POST" &&
+                request.url.includes(CHAT_COMPLETIONS_SUFFIX)
+            ) {
+                logger.info(
+                    {
+                        method: request.method,
+                        url: request.url,
+                        action: "skip-proxy",
+                        reason: "handled-by-custom-handler",
+                    },
+                    "Ollama proxy preHandler: skipping chat/completions route",
+                );
+                next(new Error("skip"));
+                return;
+            }
+
+            const pathAfterPrefix = request.url.replace(API_PREFIX, "");
+            const uuidMatch = pathAfterPrefix.match(
+                /^\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(\/.*)?$/i,
+            );
+
+            if (uuidMatch) {
+                const remainingPath = uuidMatch[2] || "";
+                const originalUrl = request.raw.url;
+                request.raw.url = `${API_PREFIX}${remainingPath}`;
+
+                logger.info(
+                    {
+                        method: request.method,
+                        originalUrl,
+                        rewrittenUrl: request.raw.url,
+                        upstream: config.llm.ollama.baseUrl,
+                        finalProxyUrl: `${config.llm.ollama.baseUrl}${remainingPath}`,
+                    },
+                    "Ollama proxy preHandler: URL rewritten (UUID stripped)",
+                );
+            } else {
+                logger.info(
+                    {
+                        method: request.method,
+                        url: request.url,
+                        upstream: config.llm.ollama.baseUrl,
+                        finalProxyUrl: `${config.llm.ollama.baseUrl}${pathAfterPrefix}`,
+                    },
+                    "Ollama proxy preHandler: proxying request",
+                );
+            }
+
+            next();
+        },
+    });
+
+    fastify.post(
+        `${API_PREFIX}${CHAT_COMPLETIONS_SUFFIX}`,
+        {
+            bodyLimit: PROXY_BODY_LIMIT,
+            schema: {
+                operationId: RouteId.OllamaChatCompletionsWithDefaultAgent,
+                description:
+                    "Create a chat completion with Ollama (uses default agent)",
+                tags: ["llm-proxy"],
+                body: OpenAi.API.ChatCompletionRequestSchema,
+                headers: OpenAi.API.ChatCompletionsHeadersSchema,
+                response: constructResponseSchema(
+                    OpenAi.API.ChatCompletionResponseSchema,
+                ),
+            },
+        },
+        async (request, reply) => {
+            logger.debug(
+                { url: request.url },
+                "[UnifiedProxy] Handling Ollama request (default agent)",
+            );
+            const externalAgentId = utils.externalAgentId.getExternalAgentId(
+                request.headers,
+            );
+            const userId = await utils.userId.getUserId(request.headers);
+            return handleLLMProxy(
+                request.body,
+                request.headers,
+                reply,
+                ollamaAdapterFactory,
+                {
+                    organizationId: request.organizationId,
+                    agentId: undefined,
+                    externalAgentId,
+                    userId,
+                },
+            );
+        },
+    );
+
+    fastify.post(
+        `${API_PREFIX}/:agentId${CHAT_COMPLETIONS_SUFFIX}`,
+        {
+            bodyLimit: PROXY_BODY_LIMIT,
+            schema: {
+                operationId: RouteId.OllamaChatCompletionsWithAgent,
+                description:
+                    "Create a chat completion with Ollama for a specific agent",
+                tags: ["llm-proxy"],
+                params: z.object({
+                    agentId: UuidIdSchema,
+                }),
+                body: OpenAi.API.ChatCompletionRequestSchema,
+                headers: OpenAi.API.ChatCompletionsHeadersSchema,
+                response: constructResponseSchema(
+                    OpenAi.API.ChatCompletionResponseSchema,
+                ),
+            },
+        },
+        async (request, reply) => {
+            logger.debug(
+                { url: request.url, agentId: request.params.agentId },
+                "[UnifiedProxy] Handling Ollama request (with agent)",
+            );
+            const externalAgentId = utils.externalAgentId.getExternalAgentId(
+                request.headers,
+            );
+            const userId = await utils.userId.getUserId(request.headers);
+            return handleLLMProxy(
+                request.body,
+                request.headers,
+                reply,
+                ollamaAdapterFactory,
+                {
+                    organizationId: request.organizationId,
+                    agentId: request.params.agentId,
+                    externalAgentId,
+                    userId,
+                },
+            );
+        },
+    );
+};
+
+export default ollamaProxyRoutesV2;

--- a/platform/backend/src/types/chat-api-key.ts
+++ b/platform/backend/src/types/chat-api-key.ts
@@ -12,6 +12,7 @@ export const SupportedChatProviderSchema = z.enum([
   "anthropic",
   "openai",
   "gemini",
+  "ollama",
 ]);
 export type SupportedChatProvider = z.infer<typeof SupportedChatProviderSchema>;
 

--- a/platform/backend/src/types/llm-providers/index.ts
+++ b/platform/backend/src/types/llm-providers/index.ts
@@ -1,3 +1,4 @@
 export { default as Anthropic } from "./anthropic";
 export { default as Gemini } from "./gemini";
 export { default as OpenAi } from "./openai";
+export { Ollama } from "./ollama";

--- a/platform/backend/src/types/llm-providers/ollama/api.ts
+++ b/platform/backend/src/types/llm-providers/ollama/api.ts
@@ -1,0 +1,22 @@
+/**
+ * Ollama API Types
+ *
+ * Ollama provides an OpenAI-compatible API, so we re-export
+ * OpenAI's schemas for maximum compatibility.
+ */
+import { z } from "zod";
+import * as OpenAiAPI from "../openai/api";
+
+// Re-export OpenAI schemas for Ollama compatibility
+export const ChatCompletionRequestSchema = OpenAiAPI.ChatCompletionRequestSchema;
+export const ChatCompletionResponseSchema = OpenAiAPI.ChatCompletionResponseSchema;
+export const ChatCompletionsHeadersSchema = OpenAiAPI.ChatCompletionsHeadersSchema;
+export const ChatCompletionUsageSchema = OpenAiAPI.ChatCompletionUsageSchema;
+export const FinishReasonSchema = OpenAiAPI.FinishReasonSchema;
+
+// Ollama-specific: model pull/list endpoints could be added here in the future
+export const OllamaModelInfoSchema = z.object({
+    name: z.string(),
+    modified_at: z.string().optional(),
+    size: z.number().optional(),
+});

--- a/platform/backend/src/types/llm-providers/ollama/index.ts
+++ b/platform/backend/src/types/llm-providers/ollama/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Ollama Provider Types
+ *
+ * Ollama provides an OpenAI-compatible API at /v1/chat/completions,
+ * so most types are re-exported from OpenAI for maximum compatibility.
+ *
+ * Default endpoint: http://localhost:11434/v1
+ */
+import type OpenAIProvider from "openai";
+import { z } from "zod";
+import * as OllamaAPI from "./api";
+import * as OllamaMessages from "./messages";
+import * as OllamaTools from "./tools";
+
+namespace Ollama {
+    export const API = OllamaAPI;
+    export const Messages = OllamaMessages;
+    export const Tools = OllamaTools;
+
+    export namespace Types {
+        export type ChatCompletionsHeaders = z.infer<
+            typeof OllamaAPI.ChatCompletionsHeadersSchema
+        >;
+        export type ChatCompletionsRequest = z.infer<
+            typeof OllamaAPI.ChatCompletionRequestSchema
+        >;
+        export type ChatCompletionsResponse = z.infer<
+            typeof OllamaAPI.ChatCompletionResponseSchema
+        >;
+        export type Usage = z.infer<typeof OllamaAPI.ChatCompletionUsageSchema>;
+        export type FinishReason = z.infer<typeof OllamaAPI.FinishReasonSchema>;
+        export type Message = z.infer<typeof OllamaMessages.MessageParamSchema>;
+        export type Role = Message["role"];
+
+        // Re-use OpenAI's streaming chunk type for Ollama compatibility
+        export type ChatCompletionChunk =
+            OpenAIProvider.Chat.Completions.ChatCompletionChunk;
+    }
+}
+
+export { Ollama };

--- a/platform/backend/src/types/llm-providers/ollama/messages.ts
+++ b/platform/backend/src/types/llm-providers/ollama/messages.ts
@@ -1,0 +1,6 @@
+/**
+ * Ollama Message Types
+ *
+ * Re-exports OpenAI message types for Ollama's OpenAI-compatible API.
+ */
+export * from "../openai/messages";

--- a/platform/backend/src/types/llm-providers/ollama/tools.ts
+++ b/platform/backend/src/types/llm-providers/ollama/tools.ts
@@ -1,0 +1,6 @@
+/**
+ * Ollama Tool Types
+ *
+ * Re-exports OpenAI tool types for Ollama's OpenAI-compatible API.
+ */
+export * from "../openai/tools";

--- a/platform/frontend/src/lib/interaction.utils.ts
+++ b/platform/frontend/src/lib/interaction.utils.ts
@@ -8,6 +8,7 @@ import type {
 } from "./llmProviders/common";
 import GeminiGenerateContentInteraction from "./llmProviders/gemini";
 import OpenAiChatCompletionInteraction from "./llmProviders/openai";
+import OllamaChatCompletionInteraction from "./llmProviders/ollama";
 
 export interface CostSavingsInput {
   cost: string | null | undefined;
@@ -54,8 +55,8 @@ export function calculateCostSavings(
   // Calculate tokens saved from TOON compression
   const toonTokensSaved =
     input.toonTokensBefore &&
-    input.toonTokensAfter &&
-    input.toonTokensBefore > input.toonTokensAfter
+      input.toonTokensAfter &&
+      input.toonTokensBefore > input.toonTokensAfter
       ? input.toonTokensBefore - input.toonTokensAfter
       : null;
 
@@ -116,6 +117,8 @@ export class DynamicInteraction implements InteractionUtils {
       return new OpenAiChatCompletionInteraction(interaction);
     } else if (this.type === "anthropic:messages") {
       return new AnthropicMessagesInteraction(interaction);
+    } else if (this.type === "ollama:chatCompletions") {
+      return new OllamaChatCompletionInteraction(interaction);
     }
     return new GeminiGenerateContentInteraction(interaction);
   }

--- a/platform/frontend/src/lib/llmProviders/ollama.ts
+++ b/platform/frontend/src/lib/llmProviders/ollama.ts
@@ -1,0 +1,371 @@
+import type { archestraApiTypes } from "@shared";
+import type { PartialUIMessage } from "@/components/chatbot-demo";
+import type { DualLlmResult, Interaction, InteractionUtils } from "./common";
+
+class OllamaChatCompletionInteraction implements InteractionUtils {
+  private request: archestraApiTypes.OpenAiChatCompletionRequest;
+  private response: archestraApiTypes.OpenAiChatCompletionResponse;
+  modelName: string;
+
+  constructor(interaction: Interaction) {
+    this.request =
+      interaction.request as archestraApiTypes.OpenAiChatCompletionRequest;
+    this.response =
+      interaction.response as archestraApiTypes.OpenAiChatCompletionResponse;
+    this.modelName = interaction.model ?? this.request.model;
+  }
+
+  isLastMessageToolCall(): boolean {
+    const messages = this.request.messages;
+
+    if (messages.length === 0) {
+      return false;
+    }
+
+    const lastMessage = messages[messages.length - 1];
+    return lastMessage.role === "tool";
+  }
+
+  getLastToolCallId(): string | null {
+    const messages = this.request.messages;
+    if (messages.length === 0) {
+      return null;
+    }
+
+    const lastMessage = messages[messages.length - 1];
+    if (lastMessage.role === "tool") {
+      return lastMessage.tool_call_id;
+    }
+    return null;
+  }
+
+  getToolNamesUsed(): string[] {
+    const toolsUsed = new Set<string>();
+    for (const message of this.request.messages) {
+      if (message.role === "assistant" && message.tool_calls) {
+        for (const toolCall of message.tool_calls) {
+          if ("function" in toolCall) {
+            toolsUsed.add(toolCall.function.name);
+          }
+        }
+      }
+    }
+    return Array.from(toolsUsed);
+  }
+
+  getToolNamesRefused(): string[] {
+    const toolsRefused = new Set<string>();
+    for (const message of this.request.messages) {
+      if (message.role === "assistant") {
+        /**
+         * TODO: remove this as string assertion once we figure out the openapi/zod weirdness
+         * (ie. there shouldn't be | unknown in the codegen'd type here..)
+         */
+        const refusal = message.refusal as string;
+        if (refusal && refusal.length > 0) {
+          const toolName = refusal.match(
+            /<archestra-tool-name>(.*?)<\/archestra-tool-name>/,
+          )?.[1];
+          if (toolName) {
+            toolsRefused.add(toolName);
+          }
+        }
+      }
+    }
+
+    for (const message of this.response.choices) {
+      /**
+       * TODO: remove this as string assertion once we figure out the openapi/zod weirdness
+       * (ie. there shouldn't be | unknown in the codegen'd type here..)
+       */
+      const refusal = message.message.refusal as string;
+      if (refusal && refusal.length > 0) {
+        const toolName = refusal.match(
+          /<archestra-tool-name>(.*?)<\/archestra-tool-name>/,
+        )?.[1];
+        if (toolName) {
+          toolsRefused.add(toolName);
+        }
+      }
+    }
+    return Array.from(toolsRefused);
+  }
+
+  getToolNamesRequested(): string[] {
+    const toolsRequested = new Set<string>();
+
+    // Check the response for tool calls (tools that LLM wants to execute)
+    for (const choice of this.response.choices) {
+      if (choice.message.tool_calls) {
+        for (const toolCall of choice.message.tool_calls) {
+          if ("function" in toolCall) {
+            toolsRequested.add(toolCall.function.name);
+          }
+        }
+      }
+    }
+
+    return Array.from(toolsRequested);
+  }
+
+  getLastUserMessage(): string {
+    const reversedMessages = [...this.request.messages].reverse();
+    for (const message of reversedMessages) {
+      if (message.role !== "user") {
+        continue;
+      }
+      if (typeof message.content === "string") {
+        return message.content;
+      }
+      if (message.content?.[0]?.type === "text") {
+        return message.content[0].text;
+      }
+    }
+    return "";
+  }
+
+  getLastAssistantResponse(): string {
+    /**
+     * TODO: remove this as string assertion once we figure out the openapi/zod weirdness
+     * (ie. there shouldn't be | unknown in the codegen'd type here..)
+     */
+    const content = this.response.choices[0]?.message?.content as string;
+    return content ?? "";
+  }
+
+  getToolRefusedCount(): number {
+    let count = 0;
+    for (const message of this.request.messages) {
+      if (message.role === "assistant") {
+        /**
+         * TODO: remove this as string assertion once we figure out the openapi/zod weirdness
+         * (ie. there shouldn't be | unknown in the codegen'd type here..)
+         */
+        const refusal = message.refusal as string;
+        if (refusal && refusal.length > 0) {
+          count++;
+        }
+      }
+    }
+    for (const message of this.response.choices) {
+      /**
+       * TODO: remove this as string assertion once we figure out the openapi/zod weirdness
+       * (ie. there shouldn't be | unknown in the codegen'd type here..)
+       */
+      const refusal = message.message.refusal as string;
+      if (refusal && refusal.length > 0) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private mapToUiMessage(
+    message:
+      | archestraApiTypes.OpenAiChatCompletionRequest["messages"][number]
+      | archestraApiTypes.OpenAiChatCompletionResponse["choices"][number]["message"],
+  ): PartialUIMessage {
+    const parts: PartialUIMessage["parts"] = [];
+    const { content, role } = message;
+
+    if (role === "assistant") {
+      const { tool_calls: toolCalls } = message;
+      /**
+       * TODO: remove this as string assertion once we figure out the openapi/zod weirdness
+       * (ie. there shouldn't be | unknown in the codegen'd type here..)
+       */
+      const refusal = message.refusal as string;
+
+      if (toolCalls) {
+        // Handle assistant messages with tool calls
+
+        // Add text content if present
+        if (typeof content === "string" && content) {
+          parts.push({ type: "text", text: content });
+        } else if (Array.isArray(content)) {
+          for (const part of content) {
+            if (part.type === "text") {
+              parts.push({ type: "text", text: part.text });
+            } else if (part.type === "refusal") {
+              parts.push({ type: "text", text: part.refusal });
+            }
+          }
+        }
+
+        // Add tool invocation parts
+        if (toolCalls) {
+          for (const toolCall of toolCalls) {
+            if (toolCall.type === "function") {
+              parts.push({
+                type: "dynamic-tool",
+                toolName: toolCall.function.name,
+                toolCallId: toolCall.id,
+                state: "input-available",
+                input: JSON.parse(toolCall.function.arguments),
+              });
+            } else if (toolCall.type === "custom") {
+              parts.push({
+                type: "dynamic-tool",
+                toolName: toolCall.custom.name,
+                toolCallId: toolCall.id,
+                state: "input-available",
+                input: JSON.parse(toolCall.custom.input),
+              });
+            }
+          }
+        }
+      } else if (refusal) {
+        // Push as text - parsePolicyDenied in chatbot-demo will handle policy denials
+        parts.push({ type: "text", text: refusal });
+      }
+    } else if (message.role === "tool") {
+      // Handle tool response messages
+      const toolContent = message.content;
+      const toolCallId = message.tool_call_id;
+
+      // Parse the tool output
+      let output: unknown;
+      try {
+        output =
+          typeof toolContent === "string"
+            ? JSON.parse(toolContent)
+            : toolContent;
+      } catch {
+        output = toolContent;
+      }
+
+      parts.push({
+        type: "dynamic-tool",
+        toolName: "tool-result",
+        toolCallId,
+        state: "output-available",
+        input: {},
+        output,
+      });
+    } else {
+      // Handle regular content
+      if (typeof content === "string") {
+        parts.push({ type: "text", text: content });
+      } else if (Array.isArray(content)) {
+        for (const part of content) {
+          if (part.type === "text") {
+            parts.push({ type: "text", text: part.text });
+          } else if (part.type === "image_url") {
+            parts.push({
+              type: "file",
+              mediaType: "image/*",
+              url: part.image_url.url,
+            });
+          } else if (part.type === "refusal") {
+            parts.push({ type: "text", text: part.refusal });
+          }
+          // Note: input_audio and file types from API would need additional handling
+        }
+      }
+    }
+
+    // Map role to UIMessage role (only system, user, assistant are allowed)
+    const openAiRoleToUIMessageRoleMap: Record<
+      archestraApiTypes.OpenAiChatCompletionRequest["messages"][number]["role"],
+      PartialUIMessage["role"]
+    > = {
+      developer: "system",
+      system: "system",
+      function: "assistant",
+      tool: "assistant",
+      user: "user",
+      assistant: "assistant",
+    };
+
+    return {
+      role: openAiRoleToUIMessageRoleMap[role],
+      parts,
+    };
+  }
+
+  private mapRequestToUiMessages(
+    dualLlmResults?: DualLlmResult[],
+  ): PartialUIMessage[] {
+    const messages = this.request.messages;
+    const uiMessages: PartialUIMessage[] = [];
+
+    for (let i = 0; i < messages.length; i++) {
+      const msg = messages[i];
+
+      // Skip tool messages - they'll be merged with their assistant message
+      if (msg.role === "tool") {
+        continue;
+      }
+
+      const uiMessage = this.mapToUiMessage(msg);
+
+      // If this is an assistant message with tool_calls, look ahead for tool results
+      if (msg.role === "assistant" && "tool_calls" in msg && msg.tool_calls) {
+        const toolCallParts: PartialUIMessage["parts"] = [...uiMessage.parts];
+
+        // For each tool call, find its corresponding tool result
+        for (const toolCall of msg.tool_calls) {
+          // Find the tool result message
+          const toolResultMsg = messages
+            .slice(i + 1)
+            .find(
+              (m) =>
+                m.role === "tool" &&
+                "tool_call_id" in m &&
+                m.tool_call_id === toolCall.id,
+            );
+
+          if (toolResultMsg && toolResultMsg.role === "tool") {
+            // Map the tool result to a UI part
+            const toolResultUiMsg = this.mapToUiMessage(toolResultMsg);
+            toolCallParts.push(...toolResultUiMsg.parts);
+
+            // Check if there's a dual LLM result for this tool call
+            const dualLlmResultForTool = dualLlmResults?.find(
+              (result) => result.toolCallId === toolCall.id,
+            );
+
+            if (dualLlmResultForTool) {
+              const dualLlmPart = {
+                type: "dual-llm-analysis" as const,
+                toolCallId: dualLlmResultForTool.toolCallId,
+                safeResult: dualLlmResultForTool.result,
+                conversations: Array.isArray(dualLlmResultForTool.conversations)
+                  ? (dualLlmResultForTool.conversations as Array<{
+                    role: "user" | "assistant";
+                    content: string | unknown;
+                  }>)
+                  : [],
+              };
+              toolCallParts.push(dualLlmPart);
+            }
+          }
+        }
+
+        uiMessages.push({
+          ...uiMessage,
+          parts: toolCallParts,
+        });
+      } else {
+        uiMessages.push(uiMessage);
+      }
+    }
+
+    return uiMessages;
+  }
+
+  private mapResponseToUiMessages(): PartialUIMessage[] {
+    return this.response.choices.map((choice) =>
+      this.mapToUiMessage(choice.message),
+    );
+  }
+
+  mapToUiMessages(dualLlmResults?: DualLlmResult[]): PartialUIMessage[] {
+    return [
+      ...this.mapRequestToUiMessages(dualLlmResults),
+      ...this.mapResponseToUiMessages(),
+    ];
+  }
+}
+
+export default OllamaChatCompletionInteraction;

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -7,12 +7,14 @@ export const SupportedProvidersSchema = z.enum([
   "openai",
   "gemini",
   "anthropic",
+  "ollama",
 ]);
 
 export const SupportedProvidersDiscriminatorSchema = z.enum([
   "openai:chatCompletions",
   "gemini:generateContent",
   "anthropic:messages",
+  "ollama:chatCompletions",
 ]);
 
 export const SupportedProviders = Object.values(SupportedProvidersSchema.enum);
@@ -25,4 +27,5 @@ export const providerDisplayNames: Record<SupportedProvider, string> = {
   openai: "OpenAI",
   anthropic: "Anthropic",
   gemini: "Gemini",
+  ollama: "Ollama",
 };

--- a/platform/shared/routes.ts
+++ b/platform/shared/routes.ts
@@ -142,6 +142,10 @@ export const RouteId = {
   AnthropicMessagesWithDefaultAgent: "anthropicMessagesWithDefaultAgent",
   AnthropicMessagesWithAgent: "anthropicMessagesWithAgent",
 
+  // Proxy Routes - Ollama
+  OllamaChatCompletionsWithDefaultAgent: "ollamaChatCompletionsWithDefaultAgent",
+  OllamaChatCompletionsWithAgent: "ollamaChatCompletionsWithAgent",
+
   // Chat Routes
   StreamChat: "streamChat",
   GetChatConversations: "getChatConversations",


### PR DESCRIPTION
## Summary

Adds Ollama as a new LLM provider for Archestra.

Fixes #1944

/claim #1944

## Changes

### Backend

- **Config**: Added llm.ollama and chat.ollama configuration entries with default base URL http://localhost:11434/v1
- **Types**: Created 	ypes/llm-providers/ollama/ with OpenAI-compatible type definitions (Ollama uses OpenAI-compatible API)
- **Adapter**: Implemented ollamaAdapterFactory wrapping OpenAI adapter with Ollama-specific configuration
- **Routes**: Added V2 route handlers for Ollama chat completions (default and agent-specific)
- **Chat Provider**: Added ollama to SupportedChatProviderSchema for API key storage

### Shared

- Added ollama to SupportedProvidersSchema
- Added ollama:chatCompletions to SupportedProvidersDiscriminatorSchema
- Added RouteIds: OllamaChatCompletionsWithDefaultAgent, OllamaChatCompletionsWithAgent
- Added display name: Ollama

### Frontend

- Implemented OllamaChatCompletionInteraction handler (mirrors OpenAI since Ollama is OpenAI-compatible)
- Registered in interaction.utils.ts

## Environment Variables

| Variable | Description | Default |
|----------|-------------|---------|
| ARCHESTRA_OLLAMA_BASE_URL | Ollama server base URL for proxy | http://localhost:11434/v1 |
| ARCHESTRA_OLLAMA_USE_V2_ROUTES | Enable V2 routes | 	rue |
| ARCHESTRA_CHAT_OLLAMA_API_KEY | API key for chat (optional) | - |
| ARCHESTRA_CHAT_OLLAMA_BASE_URL | Ollama server URL for chat | http://localhost:11434/v1 |

## Ollama Setup Instructions

1. Install Ollama from https://ollama.ai
2. Pull a model: ollama pull llama3.1
3. Start the server: ollama serve
4. Set ARCHESTRA_OLLAMA_BASE_URL to your Ollama server URL (default: http://localhost:11434/v1)

## Supported Features

-  Chat completions API
-  Streaming responses
-  Tool calling (model-dependent)
-  All Archestra proxy features (policies, metrics, agents)
