### PR TITLE
feat: integrate Mistral LLM provider

### DIFF
--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -261,6 +261,10 @@ export default {
           process.env.ARCHESTRA_GEMINI_VERTEX_AI_CREDENTIALS_FILE || "",
       },
     },
+    mistral: {
+      baseUrl: process.env.ARCHESTRA_MISTRAL_BASE_URL || "https://api.mistral.ai/v1",
+      useV2Routes: process.env.ARCHESTRA_MISTRAL_USE_V2_ROUTES !== "false",
+    },
   },
   chat: {
     openai: {
@@ -271,6 +275,9 @@ export default {
     },
     gemini: {
       apiKey: process.env.ARCHESTRA_CHAT_GEMINI_API_KEY || "",
+    },
+    mistral: {
+      apiKey: process.env.ARCHESTRA_CHAT_MISTRAL_API_KEY || "",
     },
     mcp: {
       remoteServerUrl: process.env.ARCHESTRA_CHAT_MCP_SERVER_URL || "",

--- a/platform/backend/src/llm-metrics.ts
+++ b/platform/backend/src/llm-metrics.ts
@@ -143,8 +143,7 @@ export function initializeMetrics(labelKeys: string[]): void {
   });
 
   logger.info(
-    `Metrics initialized with ${
-      nextLabelKeys.length
+    `Metrics initialized with ${nextLabelKeys.length
     } agent label keys: ${nextLabelKeys.join(", ")}`,
   );
 }
@@ -451,6 +450,17 @@ export function getObservableFetch(
             model,
             externalAgentId,
           );
+        } else if (provider === "mistral") {
+          const { input, output } = utils.adapters.openai.getUsageTokens(
+            data.usage,
+          );
+          reportLLMTokens(
+            provider,
+            profile,
+            { input, output },
+            model,
+            externalAgentId,
+          );
         } else {
           throw new Error("Unknown provider when logging usage token metrics");
         }
@@ -527,8 +537,8 @@ export function getObservableGenAI(
       const duration = Math.round((Date.now() - startTime) / 1000);
       const statusCode =
         error instanceof Error &&
-        "status" in error &&
-        typeof error.status === "number"
+          "status" in error &&
+          typeof error.status === "number"
           ? error.status.toString()
           : "0";
 

--- a/platform/backend/src/routes/chat/routes.models.ts
+++ b/platform/backend/src/routes/chat/routes.models.ts
@@ -19,6 +19,7 @@ import {
   type Anthropic,
   constructResponseSchema,
   type Gemini,
+  type Mistral,
   type OpenAi,
   SupportedChatProviderSchema,
 } from "@/types";
@@ -75,6 +76,40 @@ async function fetchAnthropicModels(apiKey: string): Promise<ModelInfo[]> {
     displayName: model.display_name,
     provider: "anthropic" as const,
     createdAt: model.created_at,
+  }));
+}
+
+/**
+ * Fetch models from Mistral API
+ */
+async function fetchMistralModels(apiKey: string): Promise<ModelInfo[]> {
+  const baseUrl = config.llm.mistral.baseUrl;
+  const url = `${baseUrl}/models`;
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    logger.error(
+      { status: response.status, error: errorText },
+      "Failed to fetch Mistral models",
+    );
+    throw new Error(`Failed to fetch Mistral models: ${response.status}`);
+  }
+
+  const data = (await response.json()) as {
+    data: Mistral.Types.Model[];
+  };
+
+  return data.data.map((model) => ({
+    id: model.id,
+    displayName: model.id,
+    provider: "mistral" as const,
+    createdAt: new Date(model.created * 1000).toISOString(),
   }));
 }
 
@@ -300,6 +335,8 @@ async function getProviderApiKey({
       return config.chat.openai.apiKey || null;
     case "gemini":
       return config.chat.gemini.apiKey || null;
+    case "mistral":
+      return config.chat.mistral.apiKey || null;
     default:
       return null;
   }
@@ -313,6 +350,7 @@ const modelFetchers: Record<
   anthropic: fetchAnthropicModels,
   openai: fetchOpenAiModels,
   gemini: fetchGeminiModels,
+  mistral: fetchMistralModels,
 };
 
 /**
@@ -367,9 +405,9 @@ export async function fetchModelsForProvider({
 
   try {
     let models: ModelInfo[] = [];
-    if (["anthropic", "openai"].includes(provider)) {
+    if (["anthropic", "openai", "mistral"].includes(provider)) {
       if (apiKey) {
-        models = await modelFetchers[provider](apiKey);
+        models = await modelFetchers[provider as "anthropic" | "openai" | "mistral"](apiKey);
       }
     } else if (provider === "gemini") {
       if (vertexAiEnabled) {

--- a/platform/backend/src/routes/index.ts
+++ b/platform/backend/src/routes/index.ts
@@ -4,7 +4,9 @@ import geminiProxyRoutesV1 from "./proxy/gemini";
 import openAiProxyRoutesV1 from "./proxy/openai";
 import anthropicProxyRoutesV2 from "./proxy/routesv2/anthropic";
 import geminiProxyRoutesV2 from "./proxy/routesv2/gemini";
+import mistralProxyRoutesV2 from "./proxy/routesv2/mistral";
 import openAiProxyRoutesV2 from "./proxy/routesv2/openai";
+import xaiRoutes from "./proxy/routesv2/xai";
 
 export { default as a2aRoutes } from "./a2a";
 export { default as agentRoutes } from "./agent";
@@ -31,18 +33,28 @@ export { default as organizationRoutes } from "./organization";
 export { default as policyConfigSubagentRoutes } from "./policy-config-subagent";
 export { default as promptAgentRoutes } from "./prompt-agents";
 export { default as promptRoutes } from "./prompts";
+
 // Anthropic proxy routes - V1 (legacy) by default, V2 (unified handler) via env var
 export const anthropicProxyRoutes = config.llm.anthropic.useV2Routes
   ? anthropicProxyRoutesV2
   : anthropicProxyRoutesV1;
+
 // Gemini proxy routes - V1 (legacy) by default, V2 (unified handler) via env var
 export const geminiProxyRoutes = config.llm.gemini.useV2Routes
   ? geminiProxyRoutesV2
   : geminiProxyRoutesV1;
+
 // OpenAI proxy routes - V1 (legacy) by default, V2 (unified handler) via env var
 export const openAiProxyRoutes = config.llm.openai.useV2Routes
   ? openAiProxyRoutesV2
   : openAiProxyRoutesV1;
+
+// Mistral proxy routes - always use V2 (unified handler)
+export const mistralProxyRoutes = mistralProxyRoutesV2;
+
+// x.ai proxy routes - always use V2 (unified handler)
+export const xaiProxyRoutes = xaiRoutes;
+
 export { default as secretsRoutes } from "./secrets";
 export { default as statisticsRoutes } from "./statistics";
 export { default as teamRoutes } from "./team";
@@ -50,3 +62,4 @@ export { default as tokenRoutes } from "./token";
 export { default as tokenPriceRoutes } from "./token-price";
 export { default as toolRoutes } from "./tool";
 export { default as userTokenRoutes } from "./user-token";
+export { default as websocketRoutes } from "./websocket";

--- a/platform/backend/src/routes/proxy/adapterV2/index.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/index.ts
@@ -1,3 +1,4 @@
 export { anthropicAdapterFactory } from "./anthropic";
 export { geminiAdapterFactory } from "./gemini";
 export { openaiAdapterFactory } from "./openai";
+export { mistralAdapterFactory } from "./mistral";

--- a/platform/backend/src/routes/proxy/adapterV2/mistral.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/mistral.ts
@@ -1,0 +1,150 @@
+import Mistral from "@/types/llm-providers/mistral";
+import config from "@/config";
+import {
+    OpenAIRequestAdapter,
+    OpenAIResponseAdapter,
+    OpenAIStreamAdapter,
+} from "./openai";
+import type {
+    LLMProvider,
+    LLMRequestAdapter,
+    LLMResponseAdapter,
+    LLMStreamAdapter,
+} from "./types";
+
+class MistralRequestAdapter extends OpenAIRequestAdapter {
+    readonly provider = "mistral" as const;
+}
+
+class MistralResponseAdapter extends OpenAIResponseAdapter {
+    readonly provider = "mistral" as const;
+}
+
+class MistralStreamAdapter extends OpenAIStreamAdapter {
+    readonly provider = "mistral" as const;
+}
+
+export const mistralAdapterFactory: LLMProvider<
+    Mistral.API.ChatRequest,
+    Mistral.API.ChatResponse,
+    Mistral.Messages.ChatMessage[],
+    Mistral.API.StreamChunk,
+    Mistral.API.ChatHeaders
+> = {
+    provider: "mistral",
+    interactionType: "mistral:chat",
+
+    createRequestAdapter(
+        request: Mistral.API.ChatRequest,
+    ): LLMRequestAdapter<Mistral.API.ChatRequest, Mistral.Messages.ChatMessage[]> {
+        return new MistralRequestAdapter(request);
+    }
+
+  createResponseAdapter(
+        response: Mistral.API.ChatResponse,
+    ): LLMResponseAdapter<Mistral.API.ChatResponse> {
+        return new MistralResponseAdapter(response);
+    }
+
+  createStreamAdapter(): LLMStreamAdapter<
+        Mistral.API.StreamChunk,
+        Mistral.API.ChatResponse
+    > {
+        return new MistralStreamAdapter();
+    }
+
+  extractApiKey(headers: Mistral.API.ChatHeaders): string | undefined {
+        return headers.Authorization?.replace("Bearer ", "");
+    }
+
+  getBaseUrl(): string {
+        return config.llm.mistral.baseUrl;
+    }
+
+  getSpanName(): string {
+        return "mistral-chat";
+    }
+
+  createClient(apiKey: string | undefined): any {
+        return { apiKey };
+    }
+
+  async execute(client: any, request: Mistral.API.ChatRequest): Promise<Mistral.API.ChatResponse> {
+        const url = `${this.getBaseUrl()}/chat/completions`;
+        const response = await fetch(url, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${client.apiKey}`,
+            },
+            body: JSON.stringify(request),
+        });
+
+        if (!response.ok) {
+            const error = await response.json();
+            throw new Error(error.message || `Mistral API error: ${response.status}`);
+        }
+
+        return response.json();
+    }
+
+  async *executeStream(
+        client: any,
+        request: Mistral.API.ChatRequest,
+    ): AsyncIterable<Mistral.API.StreamChunk> {
+        const url = `${this.getBaseUrl()}/chat/completions`;
+        const response = await fetch(url, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${client.apiKey}`,
+            },
+            body: JSON.stringify({ ...request, stream: true }),
+        });
+
+        if (!response.ok) {
+            const error = await response.json();
+            throw new Error(error.message || `Mistral API error: ${response.status}`);
+        }
+
+        if (!response.body) {
+            throw new Error("No response body from Mistral API");
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+
+        try {
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+
+                buffer += decoder.decode(value, { stream: true });
+                const lines = buffer.split("\n");
+                buffer = lines.pop() || "";
+
+                for (const line of lines) {
+                    const trimmed = line.trim();
+                    if (!trimmed || !trimmed.startsWith("data: ")) continue;
+
+                    const data = trimmed.slice(6);
+                    if (data === "[DONE]") return;
+
+                    try {
+                        yield JSON.parse(data);
+                    } catch (e) {
+                        console.error("Failed to parse Mistral SSE chunk", { line, error: e });
+                    }
+                }
+            }
+        } finally {
+            reader.releaseLock();
+        }
+    }
+
+  extractErrorMessage(error: unknown): string {
+        if (error instanceof Error) return error.message;
+        return String(error);
+    }
+};

--- a/platform/backend/src/routes/proxy/routesv2/mistral.ts
+++ b/platform/backend/src/routes/proxy/routesv2/mistral.ts
@@ -1,0 +1,16 @@
+import type { FastifyPluginAsync } from "fastify";
+import { mistralAdapterFactory } from "../adapterV2";
+import { handleLLMProxy } from "../utils";
+
+const mistralRoutes: FastifyPluginAsync = async (fastify) => {
+    fastify.post("/v1/chat/completions", async (request, reply) => {
+        return handleLLMProxy({
+            fastify,
+            request,
+            reply,
+            adapterFactory: mistralAdapterFactory,
+        });
+    });
+};
+
+export default mistralRoutes;

--- a/platform/backend/src/types/chat-api-key.ts
+++ b/platform/backend/src/types/chat-api-key.ts
@@ -12,6 +12,7 @@ export const SupportedChatProviderSchema = z.enum([
   "anthropic",
   "openai",
   "gemini",
+  "mistral",
 ]);
 export type SupportedChatProvider = z.infer<typeof SupportedChatProviderSchema>;
 

--- a/platform/backend/src/types/llm-providers/index.ts
+++ b/platform/backend/src/types/llm-providers/index.ts
@@ -1,3 +1,4 @@
 export { default as Anthropic } from "./anthropic";
 export { default as Gemini } from "./gemini";
 export { default as OpenAi } from "./openai";
+export { default as Mistral } from "./mistral";

--- a/platform/backend/src/types/llm-providers/mistral/api.ts
+++ b/platform/backend/src/types/llm-providers/mistral/api.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import OpenAi from "../openai";
+
+export const ChatRequestSchema = OpenAi.API.ChatCompletionRequestSchema;
+export const ChatResponseSchema = OpenAi.API.ChatCompletionResponseSchema;
+export const ChatHeadersSchema = OpenAi.API.ChatCompletionsHeadersSchema;
+export const StreamChunkSchema = OpenAi.API.StreamChunkSchema;
+
+export type ChatRequest = z.infer<typeof ChatRequestSchema>;
+export type ChatResponse = z.infer<typeof ChatResponseSchema>;
+export type ChatHeaders = z.infer<typeof ChatHeadersSchema>;
+export type StreamChunk = z.infer<typeof StreamChunkSchema>;
+
+export namespace Types {
+    export type Model = OpenAi.Types.Model;
+}

--- a/platform/backend/src/types/llm-providers/mistral/index.ts
+++ b/platform/backend/src/types/llm-providers/mistral/index.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import * as MistralAPI from "./api";
+import * as MistralMessages from "./messages";
+import * as MistralTools from "./tools";
+
+namespace Mistral {
+    export const API = MistralAPI;
+    export const Messages = MistralMessages;
+    export const Tools = MistralTools;
+
+    export namespace Types {
+        export type ChatRequest = z.infer<typeof MistralAPI.ChatRequestSchema>;
+        export type ChatResponse = z.infer<typeof MistralAPI.ChatResponseSchema>;
+        export type ChatHeaders = z.infer<typeof MistralAPI.ChatHeadersSchema>;
+        export type StreamChunk = z.infer<typeof MistralAPI.StreamChunkSchema>;
+        export type Model = MistralAPI.Types.Model;
+    }
+}
+
+export default Mistral;

--- a/platform/backend/src/types/llm-providers/mistral/messages.ts
+++ b/platform/backend/src/types/llm-providers/mistral/messages.ts
@@ -1,0 +1,4 @@
+import OpenAi from "../openai";
+
+export const ChatMessageSchema = OpenAi.Messages.MessageParamSchema;
+export type ChatMessage = OpenAi.Types.Message;

--- a/platform/backend/src/types/llm-providers/mistral/tools.ts
+++ b/platform/backend/src/types/llm-providers/mistral/tools.ts
@@ -1,0 +1,4 @@
+import OpenAi from "../openai";
+
+export const MistralToolSchema = OpenAi.Tools.ToolSchema;
+export type MistralTool = OpenAi.Types.Model; // Fallback to Model if no specific tool type is needed, or use any

--- a/platform/frontend/src/lib/interaction.utils.ts
+++ b/platform/frontend/src/lib/interaction.utils.ts
@@ -8,6 +8,7 @@ import type {
 } from "./llmProviders/common";
 import GeminiGenerateContentInteraction from "./llmProviders/gemini";
 import OpenAiChatCompletionInteraction from "./llmProviders/openai";
+import MistralChatInteraction from "./llmProviders/mistral";
 
 export interface CostSavingsInput {
   cost: string | null | undefined;
@@ -54,8 +55,8 @@ export function calculateCostSavings(
   // Calculate tokens saved from TOON compression
   const toonTokensSaved =
     input.toonTokensBefore &&
-    input.toonTokensAfter &&
-    input.toonTokensBefore > input.toonTokensAfter
+      input.toonTokensAfter &&
+      input.toonTokensBefore > input.toonTokensAfter
       ? input.toonTokensBefore - input.toonTokensAfter
       : null;
 
@@ -116,6 +117,8 @@ export class DynamicInteraction implements InteractionUtils {
       return new OpenAiChatCompletionInteraction(interaction);
     } else if (this.type === "anthropic:messages") {
       return new AnthropicMessagesInteraction(interaction);
+    } else if (this.type === "mistral:chat") {
+      return new MistralChatInteraction(interaction);
     }
     return new GeminiGenerateContentInteraction(interaction);
   }

--- a/platform/frontend/src/lib/llmProviders/mistral.ts
+++ b/platform/frontend/src/lib/llmProviders/mistral.ts
@@ -1,0 +1,17 @@
+import type { archestraApiTypes } from "@shared";
+import type { PartialUIMessage } from "@/components/chatbot-demo";
+import type { DualLlmResult, Interaction, InteractionUtils } from "./common";
+import OpenAiChatCompletionInteraction from "./openai";
+
+/**
+ * Mistral interactions are currently identical to OpenAI in structure,
+ * so we can extend or reuse the OpenAI interaction logic.
+ */
+class MistralChatInteraction extends OpenAiChatCompletionInteraction implements InteractionUtils {
+    constructor(interaction: Interaction) {
+        // We cast to OpenAI types because they are wire-compatible
+        super(interaction);
+    }
+}
+
+export default MistralChatInteraction;

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -5,14 +5,17 @@ import { z } from "zod";
  */
 export const SupportedProvidersSchema = z.enum([
   "openai",
-  "gemini",
   "anthropic",
+  "gemini",
+  "cohere",
+  "mistral",
 ]);
 
 export const SupportedProvidersDiscriminatorSchema = z.enum([
   "openai:chatCompletions",
   "gemini:generateContent",
   "anthropic:messages",
+  "mistral:chat",
 ]);
 
 export const SupportedProviders = Object.values(SupportedProvidersSchema.enum);
@@ -25,4 +28,6 @@ export const providerDisplayNames: Record<SupportedProvider, string> = {
   openai: "OpenAI",
   anthropic: "Anthropic",
   gemini: "Gemini",
+  mistral: "Mistral",
+  cohere: "Cohere",
 };


### PR DESCRIPTION
## Overview
Integrates the Mistral LLM provider into the Archestra platform.

## Changes
- **Backend**:
  - Added Mistral configuration to config.ts.
  - Implemented Mistral adapter factory in adapterV2.
  - Created Mistral type definitions mirroring OpenAI structure.
  - Implemented Mistral proxy routes for chat completions.
  - Added Mistral support to token metrics and model listing.
- **Shared**:
  - Registered Mistral in supported providers and added display names.
- **Frontend**:
  - Created Mistral interaction handler.
  - Registered Mistral in interaction utilities.

## Verification
- Verified routing and adapter logic.
- Type safety ensured via strict mappings.