### PR TITLE
feat: assign PR to reviewer in auto-assign workflow

### DIFF
--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -42,3 +42,17 @@ jobs:
               // Don't fail the workflow if reviewer assignment fails
               // (e.g., if the reviewer doesn't have access to the repo)
             }
+
+            // Also assign the PR to the selected reviewer
+            try {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                assignees: [selectedReviewer]
+              });
+              console.log(`Successfully assigned ${selectedReviewer} as PR assignee`);
+            } catch (error) {
+              console.error(`Failed to assign PR assignee: ${error.message}`);
+              // Don't fail the workflow if assignee assignment fails
+            }


### PR DESCRIPTION
## Summary
- When a reviewer is randomly assigned to a PR, also assign the PR itself to that reviewer
- Uses GitHub's Issues API (`addAssignees`) to set the PR assignee
- Maintains consistent error handling (logs failures but doesn't fail the workflow)

## Test plan
- [ ] Open a new PR from an external contributor account
- [ ] Verify the PR gets both a reviewer assigned and the PR itself assigned to that reviewer