### PR TITLE
fix: don't disable save button in assign tools dialog

### DIFF
--- a/platform/frontend/src/app/profiles/assign-tools-dialog.tsx
+++ b/platform/frontend/src/app/profiles/assign-tools-dialog.tsx
@@ -600,7 +600,7 @@ export function AssignToolsDialog({
             disabled={
               isLoading ||
               isSaving ||
-              selectedTools.some((tool) => {
+              selectedTools.some(function isMissingCredentials(tool) {
                 // If using dynamic credential, it's valid
                 if (tool.useDynamicTeamCredential) return false;
 
@@ -608,7 +608,12 @@ export function AssignToolsDialog({
                 const mcpCatalogItem = internalMcpCatalogItems?.find(
                   (item) => item.id === mcpTool?.catalogId,
                 );
-                const isLocalServer = mcpCatalogItem?.serverType === "local";
+                // Tools without a catalog item can't have credentials configured - skip validation
+                if (!mcpCatalogItem) {
+                  return false;
+                }
+
+                const isLocalServer = mcpCatalogItem.serverType === "local";
                 return isLocalServer
                   ? !tool.executionSourceId
                   : !tool.credentialsSourceId;


### PR DESCRIPTION
Occurs because of the orphaned tools, i.e. tools without catalog_id, e.g. `jira__jira_create_version`