### PR TITLE
chore: fix `release-please` `extra-files` paths

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -73,22 +73,22 @@
       "extra-files": [
         {
           "type": "json",
-          "path": "platform/shared/package.json",
+          "path": "shared/package.json",
           "jsonpath": "$.version"
         },
         {
           "type": "json",
-          "path": "platform/frontend/package.json",
+          "path": "frontend/package.json",
           "jsonpath": "$.version"
         },
         {
           "type": "json",
-          "path": "platform/backend/package.json",
+          "path": "backend/package.json",
           "jsonpath": "$.version"
         },
         {
           "type": "yaml",
-          "path": "platform/helm/archestra/values.yaml",
+          "path": "helm/archestra/values.yaml",
           "jsonpath": "$.archestra.imageTag"
         }
       ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Aligns release automation with the current repo layout.
> 
> - Updates `.github/release-please/release-please-config.json` `extra-files` paths from `platform/...` to `shared/...`, `frontend/...`, `backend/...`, and `helm/archestra/...` so version bumps target the correct files
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 068873eed24278f1ec1a33e9e29c8b67b2edf207. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->