### PR TITLE
fix: [Provider] Add Perplexity support

### DIFF
--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -178,3 +178,47 @@ See the [Vertex AI authentication guide](https://cloud.google.com/vertex-ai/docs
 - **Default Ollama port**: Ollama runs on port `11434` by default. The OpenAI-compatible API is available at `http://localhost:11434/v1`.
 - **No API key required**: Ollama typically doesn't require authentication for local deployments.
 - **Model availability**: Models must be pulled first using `ollama pull <model-name>` before they can be used through Archestra.
+
+## Perplexity
+
+[Perplexity AI](https://www.perplexity.ai/) is an AI-powered search and answer engine that combines real-time web search with advanced language models to provide accurate, up-to-date responses with citations.
+
+### Supported Perplexity APIs
+
+- **Chat Completions API** (`/chat/completions`) - ✅ Fully supported (OpenAI-compatible)
+
+### Perplexity Connection Details
+
+- **Base URL**: `http://localhost:9000/v1/perplexity/{profile-id}`
+- **Authentication**: Pass your Perplexity API key in the `Authorization` header as `Bearer <your-api-key>`
+
+### Environment Variables
+
+| Variable                             | Required | Description                                                                |
+| ------------------------------------ | -------- | -------------------------------------------------------------------------- |
+| `ARCHESTRA_PERPLEXITY_BASE_URL`      | No       | Perplexity API base URL (defaults to `https://api.perplexity.ai`)          |
+| `ARCHESTRA_CHAT_PERPLEXITY_API_KEY`  | Yes      | Your Perplexity API key                                                    |
+
+### Available Models
+
+Perplexity offers the following models:
+
+| Model                  | Description                                        |
+| ---------------------- | -------------------------------------------------- |
+| `sonar`                | Standard search model                              |
+| `sonar-pro`            | Advanced search model with more capabilities       |
+| `sonar-reasoning`      | Search model with reasoning capabilities           |
+| `sonar-reasoning-pro`  | Advanced reasoning model with search               |
+
+### Getting an API Key
+
+1. Sign up at [Perplexity AI](https://www.perplexity.ai/)
+2. Navigate to API settings in your account
+3. Generate an API key
+4. Set the key as `ARCHESTRA_CHAT_PERPLEXITY_API_KEY` environment variable
+
+### Important Notes
+
+- **Real-time search**: Perplexity models are designed for search-augmented responses with citations. They automatically include web search results in their context.
+- **No streaming usage data**: Perplexity supports streaming but may not return usage data in all streaming scenarios.
+- **Search-specific parameters**: Perplexity supports additional parameters like `search_domain_filter`, `return_images`, `return_related_questions`, and `search_recency_filter` for fine-tuning search behavior.

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -10,6 +10,8 @@ ARCHESTRA_GEMINI_BASE_URL=https://generativelanguage.googleapis.com
 # ARCHESTRA_OLLAMA_BASE_URL=http://localhost:11434/v1
 # vLLM Base URL (uncomment if using vLLM)
 # ARCHESTRA_VLLM_BASE_URL=http://localhost:8000/v1
+# Perplexity Base URL (defaults to https://api.perplexity.ai)
+# ARCHESTRA_PERPLEXITY_BASE_URL=https://api.perplexity.ai
 
 # NOTE: use the following base URLs for testing w/ local wiremock service for e2e tests
 # (see dev/Tiltfile.test)
@@ -18,6 +20,7 @@ ARCHESTRA_GEMINI_BASE_URL=https://generativelanguage.googleapis.com
 # ARCHESTRA_GEMINI_BASE_URL=http://localhost:9092/gemini
 # ARCHESTRA_VLLM_BASE_URL=http://localhost:9092/vllm/v1
 # ARCHESTRA_OLLAMA_BASE_URL=http://localhost:9092/ollama/v1
+# ARCHESTRA_PERPLEXITY_BASE_URL=http://localhost:9092/perplexity
 
 # Public MCP catalog URL.
 # If you are making changes to the MCP catalog, point it to the port the archestra-ai/website listens on.

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -273,6 +273,12 @@ export default {
       baseUrl: process.env.ARCHESTRA_OLLAMA_BASE_URL,
       useV2Routes: process.env.ARCHESTRA_OLLAMA_USE_V2_ROUTES !== "false",
     },
+    perplexity: {
+      baseUrl:
+        process.env.ARCHESTRA_PERPLEXITY_BASE_URL ||
+        "https://api.perplexity.ai",
+      useV2Routes: process.env.ARCHESTRA_PERPLEXITY_USE_V2_ROUTES !== "false",
+    },
   },
   chat: {
     openai: {
@@ -289,6 +295,9 @@ export default {
     },
     ollama: {
       apiKey: process.env.ARCHESTRA_CHAT_OLLAMA_API_KEY || "",
+    },
+    perplexity: {
+      apiKey: process.env.ARCHESTRA_CHAT_PERPLEXITY_API_KEY || "",
     },
     mcp: {
       remoteServerUrl: process.env.ARCHESTRA_CHAT_MCP_SERVER_URL || "",

--- a/platform/backend/src/routes/chat/routes.models.ts
+++ b/platform/backend/src/routes/chat/routes.models.ts
@@ -286,6 +286,75 @@ async function fetchOllamaModels(apiKey: string): Promise<ModelInfo[]> {
 }
 
 /**
+ * Fetch models from Perplexity API
+ * Perplexity uses OpenAI-compatible format, but has a limited set of models
+ * See: https://docs.perplexity.ai/api-reference/chat-completions-post
+ */
+async function fetchPerplexityModels(apiKey: string): Promise<ModelInfo[]> {
+  const baseUrl = config.llm.perplexity.baseUrl;
+  const url = `${baseUrl}/models`;
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+
+  if (!response.ok) {
+    // Perplexity may not have a /models endpoint - return known models
+    logger.debug(
+      { status: response.status },
+      "Perplexity /models endpoint not available, returning known models",
+    );
+
+    // Return the known Perplexity models
+    return [
+      {
+        id: "sonar",
+        displayName: "Sonar",
+        provider: "perplexity" as const,
+      },
+      {
+        id: "sonar-pro",
+        displayName: "Sonar Pro",
+        provider: "perplexity" as const,
+      },
+      {
+        id: "sonar-reasoning",
+        displayName: "Sonar Reasoning",
+        provider: "perplexity" as const,
+      },
+      {
+        id: "sonar-reasoning-pro",
+        displayName: "Sonar Reasoning Pro",
+        provider: "perplexity" as const,
+      },
+    ];
+  }
+
+  const data = (await response.json()) as {
+    data: Array<{
+      id: string;
+      object: string;
+      created?: number;
+      owned_by?: string;
+    }>;
+  };
+
+  return data.data.map((model) => ({
+    id: model.id,
+    displayName: model.id
+      .split("-")
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" "),
+    provider: "perplexity" as const,
+    createdAt: model.created
+      ? new Date(model.created * 1000).toISOString()
+      : undefined,
+  }));
+}
+
+/**
  * Fetch models from Gemini API via Vertex AI SDK
  * Uses Application Default Credentials (ADC) for authentication
  *
@@ -400,6 +469,8 @@ async function getProviderApiKey({
     case "ollama":
       // Ollama typically doesn't require API keys, return empty or configured key
       return config.chat.ollama.apiKey || "";
+    case "perplexity":
+      return config.chat.perplexity.apiKey || null;
     default:
       return null;
   }
@@ -415,6 +486,7 @@ const modelFetchers: Record<
   gemini: fetchGeminiModels,
   vllm: fetchVllmModels,
   ollama: fetchOllamaModels,
+  perplexity: fetchPerplexityModels,
 };
 
 /**
@@ -473,7 +545,7 @@ export async function fetchModelsForProvider({
 
   try {
     let models: ModelInfo[] = [];
-    if (["anthropic", "openai"].includes(provider)) {
+    if (["anthropic", "openai", "perplexity"].includes(provider)) {
       if (apiKey) {
         models = await modelFetchers[provider](apiKey);
       }

--- a/platform/backend/src/routes/index.ts
+++ b/platform/backend/src/routes/index.ts
@@ -6,6 +6,7 @@ import anthropicProxyRoutesV2 from "./proxy/routesv2/anthropic";
 import geminiProxyRoutesV2 from "./proxy/routesv2/gemini";
 import ollamaProxyRoutesV2 from "./proxy/routesv2/ollama";
 import openAiProxyRoutesV2 from "./proxy/routesv2/openai";
+import perplexityProxyRoutesV2 from "./proxy/routesv2/perplexity";
 import vllmProxyRoutesV2 from "./proxy/routesv2/vllm";
 
 export { default as a2aRoutes } from "./a2a";
@@ -54,6 +55,10 @@ export const vllmProxyRoutes = config.llm.vllm.useV2Routes
 export const ollamaProxyRoutes = config.llm.ollama.useV2Routes
   ? ollamaProxyRoutesV2
   : ollamaProxyRoutesV2; // Ollama only has V2 since it was added after the unified handler
+// Perplexity proxy routes - V2 only (unified handler, OpenAI-compatible)
+export const perplexityProxyRoutes = config.llm.perplexity.useV2Routes
+  ? perplexityProxyRoutesV2
+  : perplexityProxyRoutesV2; // Perplexity only has V2 since it was added after the unified handler
 export { default as secretsRoutes } from "./secrets";
 export { default as statisticsRoutes } from "./statistics";
 export { default as teamRoutes } from "./team";

--- a/platform/backend/src/routes/proxy/adapterV2/index.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/index.ts
@@ -2,4 +2,5 @@ export { anthropicAdapterFactory } from "./anthropic";
 export { geminiAdapterFactory } from "./gemini";
 export { ollamaAdapterFactory } from "./ollama";
 export { openaiAdapterFactory } from "./openai";
+export { perplexityAdapterFactory } from "./perplexity";
 export { vllmAdapterFactory } from "./vllm";

--- a/platform/backend/src/routes/proxy/adapterV2/perplexity.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/perplexity.ts
@@ -1,0 +1,1192 @@
+/**
+ * Perplexity Adapter
+ *
+ * Perplexity exposes an OpenAI-compatible API, so this adapter is largely based on the OpenAI adapter.
+ * See: https://docs.perplexity.ai/api-reference/chat-completions-post
+ */
+import { encode as toonEncode } from "@toon-format/toon";
+import { get } from "lodash-es";
+import OpenAIProvider from "openai";
+import type {
+  ChatCompletionCreateParamsNonStreaming,
+  ChatCompletionCreateParamsStreaming,
+} from "openai/resources/chat/completions/completions";
+import config from "@/config";
+import { getObservableFetch } from "@/llm-metrics";
+import logger from "@/logging";
+import { TokenPriceModel } from "@/models";
+import { getTokenizer } from "@/tokenizers";
+import type {
+  ChunkProcessingResult,
+  CommonMcpToolDefinition,
+  CommonMessage,
+  CommonToolCall,
+  CommonToolResult,
+  CreateClientOptions,
+  LLMProvider,
+  LLMRequestAdapter,
+  LLMResponseAdapter,
+  LLMStreamAdapter,
+  Perplexity,
+  StreamAccumulatorState,
+  ToonCompressionResult,
+  UsageView,
+} from "@/types";
+import { estimateMessagesSize } from "@/utils/message-size";
+import {
+  estimateToolResultContentLength,
+  previewToolResultContent,
+} from "@/utils/tool-result-preview";
+import { MockOpenAIClient } from "../mock-openai-client";
+import {
+  doesModelSupportImages,
+  hasImageContent,
+  isImageTooLarge,
+  isMcpImageBlock,
+} from "../utils/mcp-image";
+import { stripBrowserToolsResults } from "../utils/summarize-tool-results";
+import type { CompressionStats } from "../utils/toon-conversion";
+import { unwrapToolContent } from "../utils/unwrap-tool-content";
+
+// =============================================================================
+// TYPE ALIASES
+// =============================================================================
+
+type PerplexityRequest = Perplexity.Types.ChatCompletionsRequest;
+type PerplexityResponse = Perplexity.Types.ChatCompletionsResponse;
+type PerplexityMessages = Perplexity.Types.ChatCompletionsRequest["messages"];
+type PerplexityHeaders = Perplexity.Types.ChatCompletionsHeaders;
+type PerplexityStreamChunk = Perplexity.Types.ChatCompletionChunk;
+
+type PerplexityToolResultImageBlock = {
+  type: "image_url";
+  image_url: {
+    url: string;
+    detail?: "auto" | "low" | "high";
+  };
+};
+
+type PerplexityToolResultTextBlock = {
+  type: "text";
+  text: string;
+};
+
+type PerplexityToolResultContentBlock =
+  | PerplexityToolResultImageBlock
+  | PerplexityToolResultTextBlock;
+
+type PerplexityToolResultContent = string | PerplexityToolResultContentBlock[];
+
+// =============================================================================
+// REQUEST ADAPTER
+// =============================================================================
+
+class PerplexityRequestAdapter
+  implements LLMRequestAdapter<PerplexityRequest, PerplexityMessages>
+{
+  readonly provider = "perplexity" as const;
+  private request: PerplexityRequest;
+  private modifiedModel: string | null = null;
+  private toolResultUpdates: Record<string, string> = {};
+
+  constructor(request: PerplexityRequest) {
+    this.request = request;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Read Access
+  // ---------------------------------------------------------------------------
+
+  getModel(): string {
+    return this.modifiedModel ?? this.request.model;
+  }
+
+  isStreaming(): boolean {
+    return this.request.stream === true;
+  }
+
+  getMessages(): CommonMessage[] {
+    return this.toCommonFormat(this.request.messages);
+  }
+
+  getToolResults(): CommonToolResult[] {
+    const results: CommonToolResult[] = [];
+
+    for (const message of this.request.messages) {
+      if (message.role === "tool") {
+        const toolName = this.findToolNameInMessages(
+          this.request.messages,
+          message.tool_call_id,
+        );
+
+        let content: unknown;
+        if (typeof message.content === "string") {
+          try {
+            content = JSON.parse(message.content);
+          } catch {
+            content = message.content;
+          }
+        } else {
+          content = message.content;
+        }
+
+        results.push({
+          id: message.tool_call_id,
+          name: toolName ?? "unknown",
+          content,
+          isError: false,
+        });
+      }
+    }
+
+    return results;
+  }
+
+  getTools(): CommonMcpToolDefinition[] {
+    if (!this.request.tools) return [];
+
+    const result: CommonMcpToolDefinition[] = [];
+    for (const tool of this.request.tools) {
+      if (tool.type === "function") {
+        result.push({
+          name: tool.function.name,
+          description: tool.function.description,
+          inputSchema: tool.function.parameters as Record<string, unknown>,
+        });
+      }
+    }
+    return result;
+  }
+
+  hasTools(): boolean {
+    return (this.request.tools?.length ?? 0) > 0;
+  }
+
+  getProviderMessages(): PerplexityMessages {
+    return this.request.messages;
+  }
+
+  getOriginalRequest(): PerplexityRequest {
+    return this.request;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Modify Access
+  // ---------------------------------------------------------------------------
+
+  setModel(model: string): void {
+    this.modifiedModel = model;
+  }
+
+  updateToolResult(toolCallId: string, newContent: string): void {
+    this.toolResultUpdates[toolCallId] = newContent;
+  }
+
+  applyToolResultUpdates(updates: Record<string, string>): void {
+    Object.assign(this.toolResultUpdates, updates);
+  }
+
+  async applyToonCompression(model: string): Promise<ToonCompressionResult> {
+    const { messages: compressedMessages, stats } =
+      await convertToolResultsToToon(this.request.messages, model);
+    this.request = {
+      ...this.request,
+      messages: compressedMessages,
+    };
+    return {
+      tokensBefore: stats.toonTokensBefore,
+      tokensAfter: stats.toonTokensAfter,
+      costSavings: stats.toonCostSavings,
+    };
+  }
+
+  convertToolResultContent(messages: PerplexityMessages): PerplexityMessages {
+    const model = this.getModel();
+    const modelSupportsImages = doesModelSupportImages(model);
+    let toolMessagesWithImages = 0;
+    let strippedImageCount = 0;
+
+    // First, analyze all tool messages to understand what we're dealing with
+    for (const message of messages) {
+      if (message.role === "tool") {
+        const contentLength = estimateToolResultContentLength(message.content);
+        const contentSizeKB = Math.round(contentLength.length / 1024);
+        const contentPatternSample = previewToolResultContent(
+          message.content,
+          2000,
+        );
+        const contentPreview = contentPatternSample.slice(0, 200);
+
+        // Check for base64 patterns in preview to avoid full serialization.
+        const hasBase64 =
+          contentPatternSample.includes("data:image") ||
+          contentPatternSample.includes('"type":"image"') ||
+          contentPatternSample.includes('"data":"');
+
+        // Find tool name from previous assistant message
+        const toolName = this.findToolNameInMessages(
+          messages,
+          message.tool_call_id,
+        );
+
+        logger.info(
+          {
+            toolCallId: message.tool_call_id,
+            toolName,
+            contentSizeKB,
+            hasBase64,
+            contentLengthEstimated: contentLength.isEstimated,
+            isArray: Array.isArray(message.content),
+            contentPreview,
+          },
+          "[PerplexityAdapter] Analyzing tool result content",
+        );
+
+        // If it's an array, analyze each item
+        if (Array.isArray(message.content)) {
+          for (const [idx, item] of message.content.entries()) {
+            if (typeof item === "object" && item !== null) {
+              const itemType = (item as Record<string, unknown>).type;
+              const itemLength = estimateToolResultContentLength(item);
+              logger.info(
+                {
+                  toolCallId: message.tool_call_id,
+                  itemIndex: idx,
+                  itemType,
+                  itemSizeKB: Math.round(itemLength.length / 1024),
+                  itemLengthEstimated: itemLength.isEstimated,
+                  isMcpImage: isMcpImageBlock(item),
+                },
+                "[PerplexityAdapter] Tool result array item",
+              );
+            }
+          }
+        }
+      }
+    }
+
+    const result = messages.map((message) => {
+      if (message.role !== "tool") {
+        return message;
+      }
+
+      // Check if this tool message contains images
+      if (!hasImageContent(message.content)) {
+        return message;
+      }
+
+      // If model doesn't support images, strip image blocks from content
+      if (!modelSupportsImages) {
+        strippedImageCount++;
+        const strippedContent = stripImageBlocksFromContent(message.content);
+        return {
+          ...message,
+          content: strippedContent,
+        };
+      }
+
+      // Model supports images - convert MCP image blocks to Perplexity/OpenAI format
+      const convertedContent = convertMcpImageBlocksToPerplexity(
+        message.content,
+      );
+      if (!convertedContent) {
+        return message;
+      }
+
+      toolMessagesWithImages++;
+      return {
+        ...message,
+        content: convertedContent,
+      };
+    });
+
+    if (toolMessagesWithImages > 0 || strippedImageCount > 0) {
+      logger.info(
+        {
+          model,
+          modelSupportsImages,
+          totalMessages: messages.length,
+          toolMessagesWithImages,
+          strippedImageCount,
+        },
+        "[PerplexityAdapter] Processed tool messages with image content",
+      );
+    }
+
+    return result;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Build Modified Request
+  // ---------------------------------------------------------------------------
+
+  toProviderRequest(): PerplexityRequest {
+    let messages = this.request.messages;
+
+    if (Object.keys(this.toolResultUpdates).length > 0) {
+      messages = this.applyUpdates(messages, this.toolResultUpdates);
+    }
+
+    if (config.features.browserStreamingEnabled) {
+      messages = this.convertToolResultContent(messages);
+      const sizeBeforeStrip = estimateMessagesSize(messages);
+      messages = stripBrowserToolsResults(messages);
+      const sizeAfterStrip = estimateMessagesSize(messages);
+
+      if (sizeBeforeStrip.length !== sizeAfterStrip.length) {
+        logger.info(
+          {
+            sizeBeforeKB: Math.round(sizeBeforeStrip.length / 1024),
+            sizeAfterKB: Math.round(sizeAfterStrip.length / 1024),
+            savedKB: Math.round(
+              (sizeBeforeStrip.length - sizeAfterStrip.length) / 1024,
+            ),
+            sizeEstimateReliable:
+              !sizeBeforeStrip.isEstimated && !sizeAfterStrip.isEstimated,
+          },
+          "[PerplexityAdapter] Stripped browser tool results",
+        );
+      }
+    }
+
+    // Calculate approximate request size for debugging
+    const requestSize = estimateMessagesSize(messages);
+    const requestSizeKB = Math.round(requestSize.length / 1024);
+    const estimatedTokens = Math.round(requestSize.length / 4);
+    let imageCount = 0;
+    let totalImageBase64Length = 0;
+
+    for (const msg of messages) {
+      if (Array.isArray(msg.content)) {
+        for (const part of msg.content) {
+          if (
+            typeof part === "object" &&
+            part !== null &&
+            "type" in part &&
+            part.type === "image_url" &&
+            "image_url" in part &&
+            part.image_url &&
+            typeof part.image_url === "object" &&
+            "url" in part.image_url
+          ) {
+            imageCount++;
+            const imageUrl = part.image_url.url;
+            if (typeof imageUrl === "string" && imageUrl.startsWith("data:")) {
+              const base64Part = imageUrl.split(",")[1];
+              if (base64Part) {
+                totalImageBase64Length += base64Part.length;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    logger.info(
+      {
+        model: this.getModel(),
+        messageCount: messages.length,
+        requestSizeKB,
+        estimatedTokens,
+        sizeEstimateReliable: !requestSize.isEstimated,
+        hasToolResultUpdates: Object.keys(this.toolResultUpdates).length > 0,
+        imageCount,
+        totalImageBase64KB: Math.round((totalImageBase64Length * 3) / 4 / 1024),
+      },
+      "[PerplexityAdapter] Building provider request",
+    );
+
+    return {
+      ...this.request,
+      model: this.getModel(),
+      messages,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private Helpers
+  // ---------------------------------------------------------------------------
+
+  private findToolNameInMessages(
+    messages: PerplexityMessages,
+    toolCallId: string,
+  ): string | null {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+
+      if (message.role === "assistant" && message.tool_calls) {
+        for (const toolCall of message.tool_calls) {
+          if (toolCall.id === toolCallId) {
+            return toolCall.function.name;
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private toCommonFormat(messages: PerplexityMessages): CommonMessage[] {
+    logger.debug(
+      { messageCount: messages.length },
+      "[PerplexityAdapter] toCommonFormat: starting conversion",
+    );
+    const commonMessages: CommonMessage[] = [];
+
+    for (const message of messages) {
+      const commonMessage: CommonMessage = {
+        role: message.role as CommonMessage["role"],
+      };
+
+      // Handle tool messages (tool results)
+      if (message.role === "tool") {
+        const toolName = this.findToolNameInMessages(
+          messages,
+          message.tool_call_id,
+        );
+
+        if (toolName) {
+          logger.debug(
+            { toolCallId: message.tool_call_id, toolName },
+            "[PerplexityAdapter] toCommonFormat: found tool message",
+          );
+          let toolResult: unknown;
+          if (typeof message.content === "string") {
+            try {
+              toolResult = JSON.parse(message.content);
+            } catch {
+              toolResult = message.content;
+            }
+          } else {
+            toolResult = message.content;
+          }
+
+          commonMessage.toolCalls = [
+            {
+              id: message.tool_call_id,
+              name: toolName,
+              content: toolResult,
+              isError: false,
+            },
+          ];
+        }
+      }
+
+      commonMessages.push(commonMessage);
+    }
+
+    logger.debug(
+      { inputCount: messages.length, outputCount: commonMessages.length },
+      "[PerplexityAdapter] toCommonFormat: conversion complete",
+    );
+    return commonMessages;
+  }
+
+  private applyUpdates(
+    messages: PerplexityMessages,
+    updates: Record<string, string>,
+  ): PerplexityMessages {
+    const updateCount = Object.keys(updates).length;
+    logger.debug(
+      { messageCount: messages.length, updateCount },
+      "[PerplexityAdapter] applyUpdates: starting",
+    );
+
+    if (updateCount === 0) {
+      logger.debug("[PerplexityAdapter] applyUpdates: no updates to apply");
+      return messages;
+    }
+
+    let appliedCount = 0;
+    const result = messages.map((message) => {
+      if (message.role === "tool" && updates[message.tool_call_id]) {
+        appliedCount++;
+        logger.debug(
+          { toolCallId: message.tool_call_id },
+          "[PerplexityAdapter] applyUpdates: applying update to tool message",
+        );
+        return {
+          ...message,
+          content: updates[message.tool_call_id],
+        };
+      }
+      return message;
+    });
+
+    logger.debug(
+      { updateCount, appliedCount },
+      "[PerplexityAdapter] applyUpdates: complete",
+    );
+    return result;
+  }
+}
+
+function convertMcpImageBlocksToPerplexity(
+  content: unknown,
+): PerplexityToolResultContent | null {
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  if (!hasImageContent(content)) {
+    return null;
+  }
+
+  const perplexityContent: PerplexityToolResultContentBlock[] = [];
+  const imageTooLargePlaceholder = "[Image omitted due to size]";
+
+  for (const item of content) {
+    if (typeof item !== "object" || item === null) continue;
+    const candidate = item as Record<string, unknown>;
+
+    if (isMcpImageBlock(item)) {
+      const mimeType = item.mimeType ?? "image/png";
+      const base64Length = typeof item.data === "string" ? item.data.length : 0;
+      const estimatedSizeKB = Math.round((base64Length * 3) / 4 / 1024);
+      const shouldStripImage = isImageTooLarge(item);
+
+      if (shouldStripImage) {
+        logger.info(
+          {
+            mimeType,
+            base64Length,
+            estimatedSizeKB,
+          },
+          "[PerplexityAdapter] Stripping MCP image block due to size limit",
+        );
+        perplexityContent.push({
+          type: "text",
+          text: imageTooLargePlaceholder,
+        });
+        continue;
+      }
+
+      logger.info(
+        {
+          mimeType,
+          base64Length,
+          estimatedSizeKB,
+          estimatedBase64Tokens: Math.round(base64Length / 4),
+        },
+        "[PerplexityAdapter] Converting MCP image block to Perplexity format",
+      );
+
+      perplexityContent.push({
+        type: "image_url",
+        image_url: {
+          url: `data:${mimeType};base64,${item.data}`,
+        },
+      });
+    } else if (candidate.type === "text" && "text" in candidate) {
+      perplexityContent.push({
+        type: "text",
+        text:
+          typeof candidate.text === "string"
+            ? candidate.text
+            : JSON.stringify(candidate),
+      });
+    }
+  }
+
+  logger.info(
+    {
+      totalBlocks: perplexityContent.length,
+      imageBlocks: perplexityContent.filter((b) => b.type === "image_url")
+        .length,
+      textBlocks: perplexityContent.filter((b) => b.type === "text").length,
+    },
+    "[PerplexityAdapter] Converted MCP content to Perplexity format",
+  );
+
+  return perplexityContent.length > 0 ? perplexityContent : null;
+}
+
+/**
+ * Strip image blocks from MCP content when model doesn't support images.
+ * Keeps text blocks and replaces image blocks with a placeholder message.
+ */
+function stripImageBlocksFromContent(content: unknown): string {
+  if (!Array.isArray(content)) {
+    return typeof content === "string" ? content : JSON.stringify(content);
+  }
+
+  const textParts: string[] = [];
+  let imageCount = 0;
+
+  for (const item of content) {
+    if (typeof item !== "object" || item === null) continue;
+    const candidate = item as Record<string, unknown>;
+
+    if (isMcpImageBlock(item)) {
+      imageCount++;
+    } else if (candidate.type === "text" && "text" in candidate) {
+      textParts.push(
+        typeof candidate.text === "string"
+          ? candidate.text
+          : JSON.stringify(candidate.text),
+      );
+    }
+  }
+
+  // Add placeholder for stripped images
+  if (imageCount > 0) {
+    textParts.push(
+      `[${imageCount} image(s) removed - model does not support image inputs]`,
+    );
+    logger.info(
+      { imageCount },
+      "[PerplexityAdapter] Stripped images from tool result (model does not support images)",
+    );
+  }
+
+  return textParts.join("\n");
+}
+
+// =============================================================================
+// RESPONSE ADAPTER
+// =============================================================================
+
+class PerplexityResponseAdapter
+  implements LLMResponseAdapter<PerplexityResponse>
+{
+  readonly provider = "perplexity" as const;
+  private response: PerplexityResponse;
+
+  constructor(response: PerplexityResponse) {
+    this.response = response;
+  }
+
+  getId(): string {
+    return this.response.id;
+  }
+
+  getModel(): string {
+    return this.response.model;
+  }
+
+  getText(): string {
+    const choice = this.response.choices[0];
+    if (!choice) return "";
+    return choice.message.content ?? "";
+  }
+
+  getToolCalls(): CommonToolCall[] {
+    const choice = this.response.choices[0];
+    if (!choice?.message.tool_calls) return [];
+
+    return choice.message.tool_calls.map((toolCall) => {
+      const name = toolCall.function.name;
+      let args: Record<string, unknown>;
+
+      try {
+        args = JSON.parse(toolCall.function.arguments);
+      } catch {
+        args = {};
+      }
+
+      return {
+        id: toolCall.id,
+        name,
+        arguments: args,
+      };
+    });
+  }
+
+  hasToolCalls(): boolean {
+    const choice = this.response.choices[0];
+    return (choice?.message.tool_calls?.length ?? 0) > 0;
+  }
+
+  getUsage(): UsageView {
+    return {
+      inputTokens: this.response.usage?.prompt_tokens ?? 0,
+      outputTokens: this.response.usage?.completion_tokens ?? 0,
+    };
+  }
+
+  getOriginalResponse(): PerplexityResponse {
+    return this.response;
+  }
+
+  toRefusalResponse(
+    _refusalMessage: string,
+    contentMessage: string,
+  ): PerplexityResponse {
+    return {
+      ...this.response,
+      choices: [
+        {
+          ...this.response.choices[0],
+          message: {
+            role: "assistant",
+            content: contentMessage,
+          },
+          finish_reason: "stop",
+        },
+      ],
+    };
+  }
+}
+
+// =============================================================================
+// STREAM ADAPTER
+// =============================================================================
+
+class PerplexityStreamAdapter
+  implements LLMStreamAdapter<PerplexityStreamChunk, PerplexityResponse>
+{
+  readonly provider = "perplexity" as const;
+  readonly state: StreamAccumulatorState;
+  private currentToolCallIndices = new Map<number, number>();
+
+  constructor() {
+    this.state = {
+      responseId: "",
+      model: "",
+      text: "",
+      toolCalls: [],
+      rawToolCallEvents: [],
+      usage: null,
+      stopReason: null,
+      timing: {
+        startTime: Date.now(),
+        firstChunkTime: null,
+      },
+    };
+  }
+
+  processChunk(chunk: PerplexityStreamChunk): ChunkProcessingResult {
+    if (this.state.timing.firstChunkTime === null) {
+      this.state.timing.firstChunkTime = Date.now();
+    }
+
+    let sseData: string | null = null;
+    let isToolCallChunk = false;
+    let isFinal = false;
+
+    this.state.responseId = chunk.id;
+    this.state.model = chunk.model;
+
+    // Handle usage first - Perplexity (like OpenAI) sends usage in a final chunk with empty choices[]
+    // when stream_options.include_usage is true
+    if (chunk.usage) {
+      this.state.usage = {
+        inputTokens: chunk.usage.prompt_tokens ?? 0,
+        outputTokens: chunk.usage.completion_tokens ?? 0,
+      };
+    }
+
+    const choice = chunk.choices[0];
+    if (!choice) {
+      // If we have usage, this is the final chunk
+      return {
+        sseData: null,
+        isToolCallChunk: false,
+        isFinal: this.state.usage !== null,
+      };
+    }
+
+    const delta = choice.delta;
+
+    // Handle text content
+    if (delta.content) {
+      this.state.text += delta.content;
+      sseData = `data: ${JSON.stringify(chunk)}\n\n`;
+    }
+
+    // Handle tool calls
+    if (delta.tool_calls) {
+      for (const toolCallDelta of delta.tool_calls) {
+        const index = toolCallDelta.index;
+
+        if (!this.currentToolCallIndices.has(index)) {
+          this.currentToolCallIndices.set(index, this.state.toolCalls.length);
+          this.state.toolCalls.push({
+            id: toolCallDelta.id ?? "",
+            name: toolCallDelta.function?.name ?? "",
+            arguments: "",
+          });
+        }
+
+        const toolCallIndex = this.currentToolCallIndices.get(index);
+        if (toolCallIndex === undefined) continue;
+        const toolCall = this.state.toolCalls[toolCallIndex];
+
+        if (toolCallDelta.id) {
+          toolCall.id = toolCallDelta.id;
+        }
+        if (toolCallDelta.function?.name) {
+          toolCall.name = toolCallDelta.function.name;
+        }
+        if (toolCallDelta.function?.arguments) {
+          toolCall.arguments += toolCallDelta.function.arguments;
+        }
+      }
+
+      this.state.rawToolCallEvents.push(chunk);
+      isToolCallChunk = true;
+    }
+
+    // Handle finish reason
+    if (choice.finish_reason) {
+      this.state.stopReason = choice.finish_reason;
+    }
+
+    // Only mark as final after we've received usage data
+    if (this.state.usage !== null) {
+      isFinal = true;
+    }
+
+    return { sseData, isToolCallChunk, isFinal };
+  }
+
+  getSSEHeaders(): Record<string, string> {
+    return {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    };
+  }
+
+  formatTextDeltaSSE(text: string): string {
+    const chunk: PerplexityStreamChunk = {
+      id: this.state.responseId,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            content: text,
+          },
+          finish_reason: null,
+        },
+      ],
+    };
+    return `data: ${JSON.stringify(chunk)}\n\n`;
+  }
+
+  getRawToolCallEvents(): string[] {
+    return this.state.rawToolCallEvents.map(
+      (event) => `data: ${JSON.stringify(event)}\n\n`,
+    );
+  }
+
+  formatCompleteTextSSE(text: string): string[] {
+    const chunk: PerplexityStreamChunk = {
+      id: this.state.responseId || `chatcmpl-${Date.now()}`,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            role: "assistant",
+            content: text,
+          },
+          finish_reason: null,
+        },
+      ],
+    };
+    return [`data: ${JSON.stringify(chunk)}\n\n`];
+  }
+
+  formatEndSSE(): string {
+    const finalChunk: PerplexityStreamChunk = {
+      id: this.state.responseId,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          delta: {},
+          finish_reason:
+            (this.state.stopReason as "stop" | "tool_calls") ?? "stop",
+        },
+      ],
+    };
+    return `data: ${JSON.stringify(finalChunk)}\n\ndata: [DONE]\n\n`;
+  }
+
+  toProviderResponse(): PerplexityResponse {
+    const toolCalls =
+      this.state.toolCalls.length > 0
+        ? this.state.toolCalls.map((tc) => ({
+            id: tc.id,
+            type: "function" as const,
+            function: {
+              name: tc.name,
+              arguments: tc.arguments,
+            },
+          }))
+        : undefined;
+
+    return {
+      id: this.state.responseId,
+      object: "chat.completion",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: this.state.text || null,
+            tool_calls: toolCalls,
+          },
+          logprobs: null,
+          finish_reason:
+            (this.state.stopReason as Perplexity.Types.FinishReason) ?? "stop",
+        },
+      ],
+      usage: {
+        prompt_tokens: this.state.usage?.inputTokens ?? 0,
+        completion_tokens: this.state.usage?.outputTokens ?? 0,
+        total_tokens:
+          (this.state.usage?.inputTokens ?? 0) +
+          (this.state.usage?.outputTokens ?? 0),
+      },
+    };
+  }
+}
+
+// =============================================================================
+// TOON COMPRESSION
+// =============================================================================
+
+async function convertToolResultsToToon(
+  messages: PerplexityMessages,
+  model: string,
+): Promise<{
+  messages: PerplexityMessages;
+  stats: CompressionStats;
+}> {
+  // Use OpenAI tokenizer since Perplexity uses similar tokenization
+  const tokenizer = getTokenizer("perplexity");
+  let toolResultCount = 0;
+  let totalTokensBefore = 0;
+  let totalTokensAfter = 0;
+
+  const result = messages.map((message) => {
+    if (message.role === "tool") {
+      logger.info(
+        {
+          toolCallId: message.tool_call_id,
+          contentType: typeof message.content,
+          provider: "perplexity",
+        },
+        "convertToolResultsToToon: tool message found",
+      );
+
+      if (typeof message.content === "string") {
+        try {
+          const unwrapped = unwrapToolContent(message.content);
+          const parsed = JSON.parse(unwrapped);
+          const noncompressed = unwrapped;
+          const compressed = toonEncode(parsed);
+
+          const tokensBefore = tokenizer.countTokens([
+            { role: "user", content: noncompressed },
+          ]);
+          const tokensAfter = tokenizer.countTokens([
+            { role: "user", content: compressed },
+          ]);
+
+          totalTokensBefore += tokensBefore;
+          totalTokensAfter += tokensAfter;
+          toolResultCount++;
+
+          logger.info(
+            {
+              toolCallId: message.tool_call_id,
+              beforeLength: noncompressed.length,
+              afterLength: compressed.length,
+              tokensBefore,
+              tokensAfter,
+              toonPreview: compressed.substring(0, 150),
+              provider: "perplexity",
+            },
+            "convertToolResultsToToon: compressed",
+          );
+          logger.debug(
+            {
+              toolCallId: message.tool_call_id,
+              before: noncompressed,
+              after: compressed,
+              provider: "perplexity",
+              supposedToBeJson: parsed,
+            },
+            "convertToolResultsToToon: before/after",
+          );
+
+          return {
+            ...message,
+            content: compressed,
+          };
+        } catch {
+          logger.info(
+            {
+              toolCallId: message.tool_call_id,
+              contentPreview:
+                typeof message.content === "string"
+                  ? message.content.substring(0, 100)
+                  : "non-string",
+            },
+            "Skipping TOON conversion - content is not JSON",
+          );
+          return message;
+        }
+      }
+    }
+
+    return message;
+  });
+
+  logger.info(
+    { messageCount: messages.length, toolResultCount },
+    "convertToolResultsToToon completed",
+  );
+
+  let toonCostSavings: number | null = null;
+  if (toolResultCount > 0) {
+    const tokensSaved = totalTokensBefore - totalTokensAfter;
+    if (tokensSaved > 0) {
+      const tokenPrice = await TokenPriceModel.findByModel(model);
+      if (tokenPrice) {
+        const inputPricePerToken =
+          Number(tokenPrice.pricePerMillionInput) / 1000000;
+        toonCostSavings = tokensSaved * inputPricePerToken;
+      }
+    }
+  }
+
+  return {
+    messages: result,
+    stats: {
+      toonTokensBefore: toolResultCount > 0 ? totalTokensBefore : null,
+      toonTokensAfter: toolResultCount > 0 ? totalTokensAfter : null,
+      toonCostSavings,
+    },
+  };
+}
+
+// =============================================================================
+// ADAPTER FACTORY
+// =============================================================================
+
+export const perplexityAdapterFactory: LLMProvider<
+  PerplexityRequest,
+  PerplexityResponse,
+  PerplexityMessages,
+  PerplexityStreamChunk,
+  PerplexityHeaders
+> = {
+  provider: "perplexity",
+  interactionType: "perplexity:chatCompletions",
+
+  createRequestAdapter(
+    request: PerplexityRequest,
+  ): LLMRequestAdapter<PerplexityRequest, PerplexityMessages> {
+    return new PerplexityRequestAdapter(request);
+  },
+
+  createResponseAdapter(
+    response: PerplexityResponse,
+  ): LLMResponseAdapter<PerplexityResponse> {
+    return new PerplexityResponseAdapter(response);
+  },
+
+  createStreamAdapter(): LLMStreamAdapter<
+    PerplexityStreamChunk,
+    PerplexityResponse
+  > {
+    return new PerplexityStreamAdapter();
+  },
+
+  extractApiKey(headers: PerplexityHeaders): string | undefined {
+    return headers.authorization ?? undefined;
+  },
+
+  getBaseUrl(): string | undefined {
+    return config.llm.perplexity.baseUrl;
+  },
+
+  getSpanName(): string {
+    return "perplexity.chat.completions";
+  },
+
+  createClient(
+    apiKey: string | undefined,
+    options?: CreateClientOptions,
+  ): OpenAIProvider {
+    if (options?.mockMode) {
+      return new MockOpenAIClient() as unknown as OpenAIProvider;
+    }
+
+    // Use observable fetch for request duration metrics if agent is provided
+    const customFetch = options?.agent
+      ? getObservableFetch("perplexity", options.agent, options.externalAgentId)
+      : undefined;
+
+    // Perplexity uses OpenAI SDK since it's OpenAI-compatible
+    return new OpenAIProvider({
+      apiKey: apiKey || "",
+      baseURL: options?.baseUrl,
+      fetch: customFetch,
+    });
+  },
+
+  async execute(
+    client: unknown,
+    request: PerplexityRequest,
+  ): Promise<PerplexityResponse> {
+    const perplexityClient = client as OpenAIProvider;
+    const perplexityRequest = {
+      ...request,
+      stream: false,
+    } as unknown as ChatCompletionCreateParamsNonStreaming;
+    return perplexityClient.chat.completions.create(
+      perplexityRequest,
+    ) as Promise<PerplexityResponse>;
+  },
+
+  async executeStream(
+    client: unknown,
+    request: PerplexityRequest,
+  ): Promise<AsyncIterable<PerplexityStreamChunk>> {
+    const perplexityClient = client as OpenAIProvider;
+    const perplexityRequest = {
+      ...request,
+      stream: true,
+      stream_options: { include_usage: true },
+    } as unknown as ChatCompletionCreateParamsStreaming;
+    const stream = await perplexityClient.chat.completions.create(
+      perplexityRequest,
+    );
+
+    return {
+      [Symbol.asyncIterator]: async function* () {
+        for await (const chunk of stream) {
+          yield chunk as PerplexityStreamChunk;
+        }
+      },
+    };
+  },
+
+  extractErrorMessage(error: unknown): string {
+    // Perplexity uses OpenAI SDK error structure
+    const perplexityMessage = get(error, "error.message");
+    if (typeof perplexityMessage === "string") {
+      return perplexityMessage;
+    }
+
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return "Internal server error";
+  },
+};

--- a/platform/backend/src/routes/proxy/routesv2/perplexity.ts
+++ b/platform/backend/src/routes/proxy/routesv2/perplexity.ts
@@ -1,0 +1,169 @@
+/**
+ * Perplexity Proxy Routes
+ *
+ * Perplexity exposes an OpenAI-compatible API, so these routes mirror the OpenAI routes.
+ * See: https://docs.perplexity.ai/api-reference/chat-completions-post
+ */
+import fastifyHttpProxy from "@fastify/http-proxy";
+import { RouteId } from "@shared";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import config from "@/config";
+import logger from "@/logging";
+import { constructResponseSchema, Perplexity, UuidIdSchema } from "@/types";
+import { perplexityAdapterFactory } from "../adapterV2";
+import { PROXY_API_PREFIX, PROXY_BODY_LIMIT } from "../common";
+import { handleLLMProxy } from "../llm-proxy-handler";
+import * as utils from "../utils";
+
+const perplexityProxyRoutesV2: FastifyPluginAsyncZod = async (fastify) => {
+  const API_PREFIX = `${PROXY_API_PREFIX}/perplexity`;
+  const CHAT_COMPLETIONS_SUFFIX = "/chat/completions";
+
+  logger.info("[UnifiedProxy] Registering unified Perplexity routes");
+
+  // Perplexity always has a base URL configured (defaults to https://api.perplexity.ai)
+  // Register HTTP proxy for non-chat-completions endpoints
+  await fastify.register(fastifyHttpProxy, {
+    upstream: config.llm.perplexity.baseUrl,
+    prefix: API_PREFIX,
+    rewritePrefix: "",
+    preHandler: (request, _reply, next) => {
+      if (
+        request.method === "POST" &&
+        request.url.includes(CHAT_COMPLETIONS_SUFFIX)
+      ) {
+        logger.info(
+          {
+            method: request.method,
+            url: request.url,
+            action: "skip-proxy",
+            reason: "handled-by-custom-handler",
+          },
+          "Perplexity proxy preHandler: skipping chat/completions route",
+        );
+        next(new Error("skip"));
+        return;
+      }
+
+      const pathAfterPrefix = request.url.replace(API_PREFIX, "");
+      const uuidMatch = pathAfterPrefix.match(
+        /^\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(\/.*)?$/i,
+      );
+
+      if (uuidMatch) {
+        const remainingPath = uuidMatch[2] || "";
+        const originalUrl = request.raw.url;
+        request.raw.url = `${API_PREFIX}${remainingPath}`;
+
+        logger.info(
+          {
+            method: request.method,
+            originalUrl,
+            rewrittenUrl: request.raw.url,
+            upstream: config.llm.perplexity.baseUrl,
+            finalProxyUrl: `${config.llm.perplexity.baseUrl}${remainingPath}`,
+          },
+          "Perplexity proxy preHandler: URL rewritten (UUID stripped)",
+        );
+      } else {
+        logger.info(
+          {
+            method: request.method,
+            url: request.url,
+            upstream: config.llm.perplexity.baseUrl,
+            finalProxyUrl: `${config.llm.perplexity.baseUrl}${pathAfterPrefix}`,
+          },
+          "Perplexity proxy preHandler: proxying request",
+        );
+      }
+
+      next();
+    },
+  });
+
+  fastify.post(
+    `${API_PREFIX}${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        operationId: RouteId.PerplexityChatCompletionsWithDefaultAgent,
+        description:
+          "Create a chat completion with Perplexity (uses default agent)",
+        tags: ["llm-proxy"],
+        body: Perplexity.API.ChatCompletionRequestSchema,
+        headers: Perplexity.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(
+          Perplexity.API.ChatCompletionResponseSchema,
+        ),
+      },
+    },
+    async (request, reply) => {
+      logger.debug(
+        { url: request.url },
+        "[UnifiedProxy] Handling Perplexity request (default agent)",
+      );
+      const externalAgentId = utils.externalAgentId.getExternalAgentId(
+        request.headers,
+      );
+      const userId = await utils.userId.getUserId(request.headers);
+      return handleLLMProxy(
+        request.body,
+        request.headers,
+        reply,
+        perplexityAdapterFactory,
+        {
+          organizationId: request.organizationId,
+          agentId: undefined,
+          externalAgentId,
+          userId,
+        },
+      );
+    },
+  );
+
+  fastify.post(
+    `${API_PREFIX}/:agentId${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        operationId: RouteId.PerplexityChatCompletionsWithAgent,
+        description:
+          "Create a chat completion with Perplexity for a specific agent",
+        tags: ["llm-proxy"],
+        params: z.object({
+          agentId: UuidIdSchema,
+        }),
+        body: Perplexity.API.ChatCompletionRequestSchema,
+        headers: Perplexity.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(
+          Perplexity.API.ChatCompletionResponseSchema,
+        ),
+      },
+    },
+    async (request, reply) => {
+      logger.debug(
+        { url: request.url, agentId: request.params.agentId },
+        "[UnifiedProxy] Handling Perplexity request (with agent)",
+      );
+      const externalAgentId = utils.externalAgentId.getExternalAgentId(
+        request.headers,
+      );
+      const userId = await utils.userId.getUserId(request.headers);
+      return handleLLMProxy(
+        request.body,
+        request.headers,
+        reply,
+        perplexityAdapterFactory,
+        {
+          organizationId: request.organizationId,
+          agentId: request.params.agentId,
+          externalAgentId,
+          userId,
+        },
+      );
+    },
+  );
+};
+
+export default perplexityProxyRoutesV2;

--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -45,6 +45,7 @@ import {
   Gemini,
   Ollama,
   OpenAi,
+  Perplexity,
   Vllm,
   WebSocketMessageSchema,
 } from "@/types";
@@ -105,6 +106,12 @@ export function registerOpenApiSchemas() {
   });
   z.globalRegistry.add(Ollama.API.ChatCompletionResponseSchema, {
     id: "OllamaChatCompletionResponse",
+  });
+  z.globalRegistry.add(Perplexity.API.ChatCompletionRequestSchema, {
+    id: "PerplexityChatCompletionRequest",
+  });
+  z.globalRegistry.add(Perplexity.API.ChatCompletionResponseSchema, {
+    id: "PerplexityChatCompletionResponse",
   });
   z.globalRegistry.add(WebSocketMessageSchema, {
     id: "WebSocketMessage",

--- a/platform/backend/src/types/llm-providers/index.ts
+++ b/platform/backend/src/types/llm-providers/index.ts
@@ -2,4 +2,5 @@ export { default as Anthropic } from "./anthropic";
 export { default as Gemini } from "./gemini";
 export { default as Ollama } from "./ollama";
 export { default as OpenAi } from "./openai";
+export { default as Perplexity } from "./perplexity";
 export { default as Vllm } from "./vllm";

--- a/platform/backend/src/types/llm-providers/perplexity/api.ts
+++ b/platform/backend/src/types/llm-providers/perplexity/api.ts
@@ -1,0 +1,89 @@
+/**
+ * Perplexity API Types
+ *
+ * Perplexity exposes an OpenAI-compatible API at https://api.perplexity.ai
+ * See: https://docs.perplexity.ai/api-reference/chat-completions-post
+ */
+import { z } from "zod";
+
+import { MessageParamSchema, ToolCallSchema } from "./messages";
+import { ToolChoiceOptionSchema, ToolSchema } from "./tools";
+
+export const ChatCompletionUsageSchema = z
+  .object({
+    completion_tokens: z.number(),
+    prompt_tokens: z.number(),
+    total_tokens: z.number(),
+    completion_tokens_details: z.any().optional(),
+    prompt_tokens_details: z.any().optional(),
+  })
+  .describe("Token usage statistics for the completion");
+
+export const FinishReasonSchema = z.enum([
+  "stop",
+  "length",
+  "tool_calls",
+  "content_filter",
+]);
+
+const ChoiceSchema = z
+  .object({
+    finish_reason: FinishReasonSchema,
+    index: z.number(),
+    logprobs: z.any().nullable(),
+    message: z
+      .object({
+        content: z.string().nullable(),
+        role: z.enum(["assistant"]),
+        tool_calls: z.array(ToolCallSchema).optional(),
+      })
+      .describe("The assistant message in the response"),
+  })
+  .describe("A choice in the chat completion response");
+
+export const ChatCompletionRequestSchema = z
+  .object({
+    model: z.string(),
+    messages: z.array(MessageParamSchema),
+    tools: z.array(ToolSchema).optional(),
+    tool_choice: ToolChoiceOptionSchema.optional(),
+    temperature: z.number().nullable().optional(),
+    max_tokens: z.number().nullable().optional(),
+    stream: z.boolean().nullable().optional(),
+    // Perplexity-specific parameters
+    top_p: z.number().nullable().optional(),
+    top_k: z.number().nullable().optional(),
+    frequency_penalty: z.number().nullable().optional(),
+    presence_penalty: z.number().nullable().optional(),
+    // Perplexity search-specific parameters
+    search_domain_filter: z.array(z.string()).optional(),
+    return_images: z.boolean().optional(),
+    return_related_questions: z.boolean().optional(),
+    search_recency_filter: z.enum(["month", "week", "day", "hour"]).optional(),
+  })
+  .describe("Perplexity chat completion request (OpenAI-compatible)");
+
+export const ChatCompletionResponseSchema = z
+  .object({
+    id: z.string(),
+    choices: z.array(ChoiceSchema),
+    created: z.number(),
+    model: z.string(),
+    object: z.enum(["chat.completion"]),
+    system_fingerprint: z.string().nullable().optional(),
+    usage: ChatCompletionUsageSchema.optional(),
+    // Perplexity-specific response fields
+    citations: z.array(z.string()).optional(),
+  })
+  .describe("Perplexity chat completion response (OpenAI-compatible)");
+
+export const ChatCompletionsHeadersSchema = z.object({
+  "user-agent": z.string().optional().describe("The user agent of the client"),
+  authorization: z
+    .string()
+    .optional()
+    .describe("Bearer token for Perplexity API")
+    .transform((authorization) =>
+      authorization ? authorization.replace("Bearer ", "") : undefined,
+    ),
+});

--- a/platform/backend/src/types/llm-providers/perplexity/index.ts
+++ b/platform/backend/src/types/llm-providers/perplexity/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Perplexity Type Definitions
+ *
+ * Perplexity AI is an OpenAI-compatible API at https://api.perplexity.ai
+ * See: https://docs.perplexity.ai/api-reference/chat-completions-post
+ *
+ * Available models:
+ * - sonar: Standard search model
+ * - sonar-pro: Advanced search model with more capabilities
+ * - sonar-reasoning: Search model with reasoning capabilities
+ * - sonar-reasoning-pro: Advanced reasoning model
+ */
+import type OpenAIProvider from "openai";
+import type { z } from "zod";
+import * as PerplexityAPI from "./api";
+import * as PerplexityMessages from "./messages";
+import type * as PerplexityModels from "./models";
+import * as PerplexityTools from "./tools";
+
+namespace Perplexity {
+  export const API = PerplexityAPI;
+  export const Messages = PerplexityMessages;
+  export const Tools = PerplexityTools;
+
+  export namespace Types {
+    export type ChatCompletionsHeaders = z.infer<
+      typeof PerplexityAPI.ChatCompletionsHeadersSchema
+    >;
+    export type ChatCompletionsRequest = z.infer<
+      typeof PerplexityAPI.ChatCompletionRequestSchema
+    >;
+    export type ChatCompletionsResponse = z.infer<
+      typeof PerplexityAPI.ChatCompletionResponseSchema
+    >;
+    export type Usage = z.infer<typeof PerplexityAPI.ChatCompletionUsageSchema>;
+
+    export type FinishReason = z.infer<typeof PerplexityAPI.FinishReasonSchema>;
+    export type Message = z.infer<typeof PerplexityMessages.MessageParamSchema>;
+    export type Role = Message["role"];
+
+    // Perplexity uses OpenAI-compatible streaming format
+    export type ChatCompletionChunk =
+      OpenAIProvider.Chat.Completions.ChatCompletionChunk;
+    export type Model = z.infer<typeof PerplexityModels.ModelSchema>;
+  }
+}
+
+export default Perplexity;

--- a/platform/backend/src/types/llm-providers/perplexity/messages.ts
+++ b/platform/backend/src/types/llm-providers/perplexity/messages.ts
@@ -1,0 +1,92 @@
+/**
+ * Perplexity Message Types
+ *
+ * Perplexity uses an OpenAI-compatible message format.
+ * See: https://docs.perplexity.ai/api-reference/chat-completions-post
+ */
+import { z } from "zod";
+
+const FunctionToolCallSchema = z
+  .object({
+    id: z.string(),
+    type: z.enum(["function"]),
+    function: z
+      .object({
+        arguments: z.string(),
+        name: z.string(),
+      })
+      .describe("Function call details"),
+  })
+  .describe("A function tool call in the message");
+
+export const ToolCallSchema = FunctionToolCallSchema.describe(
+  "A tool call in the assistant message",
+);
+
+const ContentPartTextSchema = z
+  .object({
+    type: z.enum(["text"]),
+    text: z.string(),
+  })
+  .describe("A text content part");
+
+const ContentPartImageSchema = z
+  .object({
+    type: z.enum(["image_url"]),
+    image_url: z
+      .object({
+        url: z.string(),
+        detail: z.enum(["auto", "low", "high"]).optional(),
+      })
+      .describe("Image URL details"),
+  })
+  .describe("An image content part");
+
+const ContentPartSchema = z
+  .union([ContentPartTextSchema, ContentPartImageSchema])
+  .describe("A content part in a message");
+
+const SystemMessageParamSchema = z
+  .object({
+    content: z.union([z.string(), z.array(ContentPartTextSchema)]),
+    role: z.enum(["system"]),
+    name: z.string().optional(),
+  })
+  .describe("A system message");
+
+const UserMessageParamSchema = z
+  .object({
+    content: z.union([z.string(), z.array(ContentPartSchema)]),
+    role: z.enum(["user"]),
+    name: z.string().optional(),
+  })
+  .describe("A user message");
+
+const AssistantMessageParamSchema = z
+  .object({
+    role: z.enum(["assistant"]),
+    content: z.string().nullable().optional(),
+    name: z.string().optional(),
+    tool_calls: z.array(ToolCallSchema).optional(),
+  })
+  .describe("An assistant message");
+
+const ToolMessageParamSchema = z
+  .object({
+    role: z.enum(["tool"]),
+    content: z.union([
+      z.string(),
+      z.array(z.union([ContentPartTextSchema, ContentPartImageSchema])),
+    ]),
+    tool_call_id: z.string(),
+  })
+  .describe("A tool result message");
+
+export const MessageParamSchema = z
+  .union([
+    SystemMessageParamSchema,
+    UserMessageParamSchema,
+    AssistantMessageParamSchema,
+    ToolMessageParamSchema,
+  ])
+  .describe("A message in the conversation");

--- a/platform/backend/src/types/llm-providers/perplexity/models.ts
+++ b/platform/backend/src/types/llm-providers/perplexity/models.ts
@@ -1,0 +1,37 @@
+/**
+ * Perplexity Model Types
+ *
+ * Perplexity uses an OpenAI-compatible model listing format.
+ * See: https://docs.perplexity.ai/api-reference/chat-completions-post
+ *
+ * Available models:
+ * - sonar: Standard search model
+ * - sonar-pro: Advanced search model with more capabilities
+ * - sonar-reasoning: Search model with reasoning capabilities
+ * - sonar-reasoning-pro: Advanced reasoning model
+ */
+import { z } from "zod";
+
+export const ModelSchema = z
+  .object({
+    id: z
+      .string()
+      .describe(
+        "The model identifier, which can be referenced in the API endpoints.",
+      ),
+    created: z
+      .number()
+      .describe("The Unix timestamp (in seconds) when the model was created."),
+    object: z
+      .enum(["model"])
+      .describe('The object type, which is always "model".'),
+    owned_by: z.string().describe("The organization that owns the model."),
+  })
+  .describe("A Perplexity model object");
+
+export const ModelsListResponseSchema = z
+  .object({
+    object: z.enum(["list"]),
+    data: z.array(ModelSchema),
+  })
+  .describe("Perplexity models list response");

--- a/platform/backend/src/types/llm-providers/perplexity/tools.ts
+++ b/platform/backend/src/types/llm-providers/perplexity/tools.ts
@@ -1,0 +1,46 @@
+/**
+ * Perplexity Tool Types
+ *
+ * Perplexity uses an OpenAI-compatible tool format.
+ * See: https://docs.perplexity.ai/api-reference/chat-completions-post
+ */
+import { z } from "zod";
+
+export const FunctionDefinitionParametersSchema = z
+  .record(z.string(), z.unknown())
+  .optional()
+  .describe(`
+    The parameters the functions accepts, described as a JSON Schema object.
+    Omitting parameters defines a function with an empty parameter list.
+  `);
+
+const FunctionDefinitionSchema = z
+  .object({
+    name: z.string(),
+    description: z.string().optional(),
+    parameters: FunctionDefinitionParametersSchema,
+    strict: z.boolean().nullable().optional(),
+  })
+  .describe("A function definition for tool calling");
+
+const FunctionToolSchema = z
+  .object({
+    type: z.enum(["function"]),
+    function: FunctionDefinitionSchema,
+  })
+  .describe("A function tool definition");
+
+const NamedToolChoiceSchema = z
+  .object({
+    type: z.enum(["function"]),
+    function: z.object({
+      name: z.string(),
+    }),
+  })
+  .describe("Named function tool choice");
+
+export const ToolSchema = FunctionToolSchema.describe("A tool definition");
+
+export const ToolChoiceOptionSchema = z
+  .union([z.enum(["none", "auto", "required"]), NamedToolChoiceSchema])
+  .describe("Tool choice option");

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -9,6 +9,7 @@ export const SupportedProvidersSchema = z.enum([
   "anthropic",
   "vllm",
   "ollama",
+  "perplexity",
 ]);
 
 export const SupportedProvidersDiscriminatorSchema = z.enum([
@@ -17,6 +18,7 @@ export const SupportedProvidersDiscriminatorSchema = z.enum([
   "anthropic:messages",
   "vllm:chatCompletions",
   "ollama:chatCompletions",
+  "perplexity:chatCompletions",
 ]);
 
 export const SupportedProviders = Object.values(SupportedProvidersSchema.enum);
@@ -31,4 +33,5 @@ export const providerDisplayNames: Record<SupportedProvider, string> = {
   gemini: "Gemini",
   vllm: "vLLM",
   ollama: "Ollama",
+  perplexity: "Perplexity",
 };

--- a/platform/shared/routes.ts
+++ b/platform/shared/routes.ts
@@ -152,6 +152,11 @@ export const RouteId = {
     "ollamaChatCompletionsWithDefaultAgent",
   OllamaChatCompletionsWithAgent: "ollamaChatCompletionsWithAgent",
 
+  // Proxy Routes - Perplexity
+  PerplexityChatCompletionsWithDefaultAgent:
+    "perplexityChatCompletionsWithDefaultAgent",
+  PerplexityChatCompletionsWithAgent: "perplexityChatCompletionsWithAgent",
+
   // Chat Routes
   StreamChat: "streamChat",
   GetChatConversations: "getChatConversations",


### PR DESCRIPTION
## Summary

This PR implements the solution for #1854.

## Changes

perplexity" to SupportedProvidersSchema, SupportedProvidersDiscriminatorSchema, and providerDisplayNames
2. **`platform/backend/src/config.ts`** - Added Perplexity configuration (baseUrl, useV2Routes, apiKey)
3. **`platform/backend/src/routes/proxy/adapterV2/index.ts`** - Exported perplexityAdapterFactory
4. **`platform/backend/src/types/llm-providers/index.ts`** - Exported Perplexity types
5. **`platform/backend/src/routes/index.ts`** - Added import and export for perplexityProxyRoutes
6. **`platform/backend/src/server.ts`** - Added Perplexity import and schema registration
7. **`platform/shared/routes.ts`** - Added PerplexityChatCompletionsWithDefaultAgent and PerplexityChatCompletionsWithAgent RouteIds
8. **`platform/backend/src/routes/chat/routes.models.ts`** - Added fetchPerplexityModels function and updated modelFetchers to include Perplexity
9. **`platform/.env.example`** - Added Perplexity configuration environment variables
10. **`docs/pages/platform-supported-llm-providers.md`** - Added Perplexity documentation section

### Key Features Implemented:

- **LLM Proxy Integration**: Full support for Perplexity's OpenAI-compatible `/chat/completions` endpoint
- **Non-streaming and Streaming Support**: Both modes are fully supported
- **Tool Invocation**: Support for function calling (tool use)
- **Token/Cost Tracking**: Token usage metrics integrated
- **Chat Integration**: Models listing and selection support with fallback to known models (sonar, sonar-pro, sonar-reasoning, sonar-reasoning-pro)
- **Model Optimization**: TOON compression for tool results
- **Observability**: Metrics and tracing integration

### Environment Variables:

- `ARCHESTRA_PERPLEXITY_BASE_URL` - Optional, defaults to `https://api.perplexity.ai`
- `ARCHESTRA_CHAT_PERPLEXITY_API_KEY` - Required for Chat features

### API Endpoints:

- `POST /v1/perplexity/chat/completions` - Default agent chat completions
- `POST /v1/perplexity/:agentId/chat/completions` - Agent-specific chat completions


## Files Modified

- `platform/backend/src/routes/proxy/routesv2/perplexity.ts`
- `ocs/pages/platform-supported-llm-providers.md`
- `platform/shared/model-constants.ts`
- `platform/backend/src/config.ts`
- `platform/backend/src/routes/chat/routes.models.ts`
- `platform/backend/src/routes/index.ts`
- `platform/backend/src/routes/proxy/adapterV2/index.ts`
- `platform/backend/src/server.ts`
- `platform/shared/routes.ts`
- `platform/backend/src/routes/proxy/adapterV2/perplexity.ts`
- `platform/.env.example`
- `platform/backend/src/types/llm-providers/index.ts`
- `platform/backend/src/types/llm-providers/perplexity/`

---
*This PR was generated by [Freelance Agent](https://github.com/jeffmarcilliat/freelance-agent) using Claude Code*
