### PR TITLE
chore: sort chat sidebar by updated date instead of created date

### DIFF
--- a/platform/backend/src/models/conversation.ts
+++ b/platform/backend/src/models/conversation.ts
@@ -92,7 +92,7 @@ class ConversationModel {
         ),
       )
       .orderBy(
-        desc(schema.conversationsTable.createdAt),
+        desc(schema.conversationsTable.updatedAt),
         schema.messagesTable.createdAt,
       );
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sorts conversations by most recent activity.
> 
> - In `ConversationModel.findAll`, changes ordering from `createdAt` to `updatedAt` (descending) for conversations; message ordering within conversations remains by `messages.createdAt`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1d0ba220d58a5b0ab1eb5cb3484a19e1b76f488. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->