### PR TITLE
fix: prevent horizontal scroll in agent edit dialog

### DIFF
--- a/platform/frontend/src/components/chat/prompt-dialog.tsx
+++ b/platform/frontend/src/components/chat/prompt-dialog.tsx
@@ -191,7 +191,7 @@ export function PromptDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto">
+      <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto overflow-x-hidden">
         <DialogHeader>
           <DialogTitle>
             {prompt ? "Edit Agent" : "Create New Agent"}


### PR DESCRIPTION
Add overflow-x-hidden to DialogContent to ensure only vertical scrolling when editing long system prompts in the agent dialog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents unintended horizontal scrolling in the agent edit dialog.
> 
> - In `prompt-dialog.tsx`, adds `overflow-x-hidden` to `DialogContent` (retaining `overflow-y-auto`) to constrain scrolling to the vertical axis during long prompt edits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7121c75965a4bb9fd32a6b13ff7604b0a578ab4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->