### PR TITLE
feat: implement prompt draft persistence

### DIFF
--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -130,7 +130,7 @@ const PromptInputContent = ({
 
   const storageKey = conversationId
     ? `archestra_chat_draft_${conversationId}`
-    : `archestra_chat_draft_new_${promptId || agentId || "default"}`;
+    : `archestra_chat_draft_new_${agentId}`;
 
   const isRestored = useRef(false);
 


### PR DESCRIPTION
- Fixes #2085 

- **Data Loss Prevention**: Implements automatic saving of unsent prompts to `localStorage`, ensuring users don't lose long or complex inputs on page refresh or accidental navigation.
- **Context-Aware Storage**: Drafts are uniquely keyed by `conversationId` for existing chats and by `promptId`/`agentId` for new chats, allowing independent drafts across different contexts.
- **Robust Syncing**: Utilizes a race-safe restoration mechanism to prevent accidental clearing during component mounting and automatically wipes drafts upon successful message submission.

### Video / Demo
[Screencast from 2026-01-14 21-51-39.webm](https://github.com/user-attachments/assets/e1897830-f310-4e85-bdc6-124257090d18)
