### PR TITLE
WIP: Fix member issues

### DIFF
--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -91,11 +91,23 @@ class AgentModel {
         false,
       );
 
-      if (accessibleAgentIds.length === 0) {
+      // Also get the default agent ID(s)
+      const defaultAgents = await db
+        .select({ id: schema.agentsTable.id })
+        .from(schema.agentsTable)
+        .where(eq(schema.agentsTable.isDefault, true));
+      const defaultAgentIds = defaultAgents.map((a) => a.id);
+
+      // Combine accessible IDs with default agent IDs
+      const allAccessibleIds = [
+        ...new Set([...accessibleAgentIds, ...defaultAgentIds]),
+      ];
+
+      if (allAccessibleIds.length === 0) {
         return [];
       }
 
-      whereConditions.push(inArray(schema.agentsTable.id, accessibleAgentIds));
+      whereConditions.push(inArray(schema.agentsTable.id, allAccessibleIds));
     }
 
     // Apply all where conditions if any exist
@@ -173,11 +185,23 @@ class AgentModel {
         false,
       );
 
-      if (accessibleAgentIds.length === 0) {
+      // Also get the default agent ID(s)
+      const defaultAgents = await db
+        .select({ id: schema.agentsTable.id })
+        .from(schema.agentsTable)
+        .where(eq(schema.agentsTable.isDefault, true));
+      const defaultAgentIds = defaultAgents.map((a) => a.id);
+
+      // Combine accessible IDs with default agent IDs
+      const allAccessibleIds = [
+        ...new Set([...accessibleAgentIds, ...defaultAgentIds]),
+      ];
+
+      if (allAccessibleIds.length === 0) {
         return createPaginatedResult([], 0, pagination);
       }
 
-      whereConditions.push(inArray(schema.agentsTable.id, accessibleAgentIds));
+      whereConditions.push(inArray(schema.agentsTable.id, allAccessibleIds));
     }
 
     const whereClause =
@@ -381,13 +405,22 @@ class AgentModel {
   ): Promise<Agent | null> {
     // Check access control for non-agent admins
     if (userId && !isAgentAdmin) {
-      const hasAccess = await AgentTeamModel.userHasAgentAccess(
-        userId,
-        id,
-        false,
-      );
-      if (!hasAccess) {
-        return null;
+      // Check if agent is default first (default agents are public)
+      const [agentRecord] = await db
+        .select({ isDefault: schema.agentsTable.isDefault })
+        .from(schema.agentsTable)
+        .where(eq(schema.agentsTable.id, id))
+        .limit(1);
+
+      if (!agentRecord?.isDefault) {
+        const hasAccess = await AgentTeamModel.userHasAgentAccess(
+          userId,
+          id,
+          false,
+        );
+        if (!hasAccess) {
+          return null;
+        }
       }
     }
 

--- a/platform/backend/src/routes/prompts.ts
+++ b/platform/backend/src/routes/prompts.ts
@@ -2,7 +2,7 @@ import { RouteId } from "@shared";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
 import { hasPermission } from "@/auth";
-import { AgentTeamModel, PromptModel, ToolModel } from "@/models";
+import { AgentModel, AgentTeamModel, PromptModel, ToolModel } from "@/models";
 import {
   ApiError,
   constructResponseSchema,
@@ -40,10 +40,16 @@ const promptRoutes: FastifyPluginAsyncZod = async (fastify) => {
         isAgentAdmin,
       );
 
+      // Also get the default agent ID(s) since they are public
+      const defaultAgents = await AgentModel.getAgentOrCreateDefault();
+      const allAccessibleIds = [
+        ...new Set([...accessibleAgentIds, defaultAgents.id]),
+      ];
+
       // Filter prompts to only those assigned to accessible agents
       const prompts = await PromptModel.findByOrganizationIdAndAccessibleAgents(
         organizationId,
-        accessibleAgentIds,
+        allAccessibleIds,
       );
 
       return reply.send(prompts);


### PR DESCRIPTION
# Fix issues when new member is added (without any team/profile)

## Description
Fixes #1992

This PR resolves multiple issues encountered by new users who are added to the organization but not yet assigned to any team. Previously, these users faced empty states or infinite loading screens on the Chat, Agents, and Profiles pages because the backend restricted resource visibility strictly to team members.

## Changes

### Backend
- **[platform/backend/src/models/agent.ts](cci:7://file:///Users/vanshkabra/Documents/Project/Github/archestra/platform/backend/src/models/agent.ts:0:0-0:0)**: Updated [findAll](cci:1://file:///Users/vanshkabra/Documents/Project/Github/archestra/platform/backend/src/models/agent.ts:66:2-157:3), [findAllPaginated](cci:1://file:///Users/vanshkabra/Documents/Project/Github/archestra/platform/backend/src/models/agent.ts:159:2-345:3), and [findById](cci:1://file:///Users/vanshkabra/Documents/Project/Github/archestra/platform/backend/src/models/agent.ts:400:2-460:3) to always include the **Default Agent** (`isDefault: true`) in the list of accessible agents. This ensures that every user has at least one visible agent profile (the public default), preventing empty state crashes.
- **[platform/backend/src/routes/prompts.ts](cci:7://file:///Users/vanshkabra/Documents/Project/Github/archestra/platform/backend/src/routes/prompts.ts:0:0-0:0)**: Updated the `GET /api/prompts` handler to include the Default Agent's ID when calculating `accessibleAgentIds`. This fixes the infinite loading issue on the `/agents` page by ensuring the user can see prompts associated with the default agent.

## Verification
1. Created a new user account without assigning it to any team.
2. Verified that `/chat` now loads correctly with the Default Agent selected.
3. Verified that `/profiles` displays the Default Agent card.
4. Verified that `/agents` properly loads the list of agents (prompts) instead of getting stuck on loading.

## before 
<img width="1468" height="880" alt="Screenshot 2026-01-14 at 11 18 06 PM" src="https://github.com/user-attachments/assets/37d01cfd-8b14-4fda-b191-200c93e47f59" />
<img width="1468" height="880" alt="Screenshot 2026-01-14 at 11 18 15 PM" src="https://github.com/user-attachments/assets/4eab62dd-f366-4806-86e2-ceda66518c34" />

## after
<img width="1468" height="880" alt="Screenshot 2026-01-14 at 11 19 17 PM" src="https://github.com/user-attachments/assets/ae3dcb94-4209-4e03-9f48-20682b3293d3" />
<img width="1468" height="880" alt="Screenshot 2026-01-14 at 11 19 41 PM" src="https://github.com/user-attachments/assets/dd60cfb3-83c1-433f-879b-842e2eb92800" />
