### PR TITLE
docs: reorder Concepts section with Agents first

### DIFF
--- a/docs/pages/platform-agents.md
+++ b/docs/pages/platform-agents.md
@@ -2,7 +2,7 @@
 title: Agents
 category: Archestra Platform
 subcategory: Concepts
-order: 3
+order: 1
 description: Agent invocation methods including A2A and incoming email
 lastUpdated: 2026-01-14
 ---

--- a/docs/pages/platform-costs-and-limits.md
+++ b/docs/pages/platform-costs-and-limits.md
@@ -2,7 +2,7 @@
 title: Costs & Limits
 category: Archestra Platform
 subcategory: Concepts
-order: 6
+order: 8
 ---
 
 Monitor and control AI model expenses with real-time tracking, spending limits, and automatic optimizations.

--- a/docs/pages/platform-llm-proxy.md
+++ b/docs/pages/platform-llm-proxy.md
@@ -2,7 +2,7 @@
 title: LLM Proxy
 category: Archestra Platform
 subcategory: Concepts
-order: 2
+order: 3
 description: Secure proxy for LLM provider interactions
 lastUpdated: 2025-10-31
 ---

--- a/docs/pages/platform-mcp-gateway.md
+++ b/docs/pages/platform-mcp-gateway.md
@@ -2,7 +2,7 @@
 title: MCP Gateway
 category: Archestra Platform
 subcategory: Concepts
-order: 3
+order: 5
 description: Unified access point for all MCP servers
 lastUpdated: 2025-10-31
 ---

--- a/docs/pages/platform-orchestrator.md
+++ b/docs/pages/platform-orchestrator.md
@@ -2,7 +2,7 @@
 title: MCP Orchestrator
 category: Archestra Platform
 subcategory: Concepts
-order: 5
+order: 7
 description: How Archestra orchestrates MCP servers in Kubernetes
 lastUpdated: 2025-10-31
 ---

--- a/docs/pages/platform-private-registry.md
+++ b/docs/pages/platform-private-registry.md
@@ -2,7 +2,7 @@
 title: Private MCP Registry
 category: Archestra Platform
 subcategory: Concepts
-order: 4
+order: 6
 description: Managing your organization's MCP servers in a private registry
 lastUpdated: 2025-10-31
 ---

--- a/docs/pages/platform-profiles.md
+++ b/docs/pages/platform-profiles.md
@@ -2,7 +2,7 @@
 title: Profiles
 category: Archestra Platform
 subcategory: Concepts
-order: 1
+order: 2
 description: Understanding and configuring profiles in Archestra Platform
 lastUpdated: 2025-10-17
 ---

--- a/docs/pages/platform-prompts.md
+++ b/docs/pages/platform-prompts.md
@@ -2,7 +2,7 @@
 title: Prompts
 category: Archestra Platform
 subcategory: Concepts
-order: 2
+order: 4
 description: Automate chat bootstrapping with reusable prompts
 lastUpdated: 2025-11-28
 ---


### PR DESCRIPTION
## Summary
- Reorder docs in the Concepts subcategory to put **Agents first**
- Fix duplicate order values (LLM Proxy and Prompts both had order: 2)

### New ordering:
1. Agents
2. Profiles
3. LLM Proxy
4. Prompts
5. MCP Gateway
6. Private MCP Registry
7. MCP Orchestrator
8. Costs & Limits

## Test plan
- [ ] Build website and verify Agents appears first under Concepts in the left sidebar

🤖 Generated with [Claude Code](https://claude.ai/code)