### PR TITLE
fix: allow sending messages after chat error

### DIFF
--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -121,7 +121,7 @@ const PromptInputContent = ({
           placeholder="Type a message..."
           ref={textareaRef}
           className="px-4"
-          disableEnterSubmit={status !== "ready"}
+          disableEnterSubmit={status !== "ready" && status !== "error"}
         />
       </PromptInputBody>
       <PromptInputFooter>


### PR DESCRIPTION
When a chat error occurs, the status changes to "error" and the submit button shows an X icon. Previously, users couldn't send a new message because `disableEnterSubmit` was set when status !== "ready", which included the error state.

This fix allows users to press Enter to send a message when status is "error", enabling them to retry after a chat error.

Fixes #2170