### PR TITLE
ci: move docs-publish webhook to release workflow

### DIFF
--- a/.github/workflows/on-commits-to-main.yml
+++ b/.github/workflows/on-commits-to-main.yml
@@ -12,25 +12,6 @@ on:
 permissions: {}
 
 jobs:
-  paths-filter:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # Required for actions/checkout
-    outputs:
-      docs: ${{ steps.filter.outputs.docs }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
-
-      - id: filter
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        with:
-          filters: |
-            docs:
-              - 'docs/**'
-
   build-staging-image:
     name: Build Platform Staging Docker Image
     runs-on: blacksmith-16vcpu-ubuntu-2404
@@ -132,17 +113,3 @@ jobs:
             --set archestra.env.ARCHESTRA_LIGHTRAG_API_URL="http://lightrag.knowledge-graph.svc.cluster.local:9621" \
             --values .github/values-staging.yaml \
             --wait
-
-  trigger-website-deploy:
-    name: Trigger Website Vercel Deploy
-    runs-on: ubuntu-latest
-    needs: paths-filter
-    if: needs.paths-filter.outputs.docs == 'true'
-    permissions:
-      contents: read
-    steps:
-      - name: Trigger Vercel Deploy Hook
-        env:
-          VERCEL_DEPLOY_HOOK_URL: ${{ secrets.WEBSITE_VERCEL_DEPLOY_HOOK_URL }}
-        run: |
-          curl -X POST "$VERCEL_DEPLOY_HOOK_URL"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -104,3 +104,16 @@ jobs:
     secrets:
       GCP_SERVICE_ACCOUNT_NAME: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_SERVICE_ACCOUNT_NAME }}
       GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER }}
+
+  trigger-website-deploy:
+    name: Trigger Website Vercel Deploy
+    runs-on: ubuntu-latest
+    needs:
+      - release-please
+    if: needs.release-please.outputs.platform_release_created
+    steps:
+      - name: Trigger Vercel Deploy Hook
+        env:
+          VERCEL_DEPLOY_HOOK_URL: ${{ secrets.WEBSITE_VERCEL_DEPLOY_HOOK_URL }}
+        run: |
+          curl -X POST "$VERCEL_DEPLOY_HOOK_URL"


### PR DESCRIPTION
Move the website Vercel deploy hook from on-commits-to-main to release-please workflow, so documentation deploys happen as part of the release process rather than on every commit to main.