### PR TITLE
fix(deploy): correct knowledge graph env var name for staging

### DIFF
--- a/.github/workflows/on-commits-to-main.yml
+++ b/.github/workflows/on-commits-to-main.yml
@@ -110,6 +110,6 @@ jobs:
             --set archestra.env.ARCHESTRA_CHAT_DEFAULT_MODEL="claude-opus-4-5-20251101" \
             --set archestra.env.ARCHESTRA_CHAT_ANTHROPIC_API_KEY="${{ secrets.ARCHESTRA_STAGING_CHAT_ANTHROPIC_API_KEY }}" \
             --set archestra.env.ARCHESTRA_KNOWLEDGE_GRAPH_PROVIDER="lightrag" \
-            --set archestra.env.ARCHESTRA_LIGHTRAG_API_URL="http://lightrag.knowledge-graph.svc.cluster.local:9621" \
+            --set archestra.env.ARCHESTRA_KNOWLEDGE_GRAPH_LIGHTRAG_API_URL="http://lightrag.knowledge-graph.svc.cluster.local:9621" \
             --values .github/values-staging.yaml \
             --wait


### PR DESCRIPTION
## Summary
- Fixes incorrect env var name for LightRAG API URL in staging deployment

The workflow was setting `ARCHESTRA_LIGHTRAG_API_URL` but the backend config expects `ARCHESTRA_KNOWLEDGE_GRAPH_LIGHTRAG_API_URL`.

This prevented the knowledge graph feature from being detected as enabled on staging, causing the KG Upload indicator to not appear in chat.