### PR TITLE
fix: Handle non-text content in Gemini getLastUserMessage (#2182)

### DIFF
--- a/platform/frontend/src/lib/llmProviders/gemini.ts
+++ b/platform/frontend/src/lib/llmProviders/gemini.ts
@@ -270,6 +270,24 @@ class GeminiGenerateContentInteraction implements InteractionUtils {
             return part.text;
           }
         }
+
+        // If no text part found, provide descriptive fallback for other content types
+        for (const part of message.parts) {
+          if (hasFunctionCall(part)) {
+            return `[Function call: ${part.functionCall.name}]`;
+          }
+          if (hasFunctionResponse(part)) {
+            return `[Function response: ${part.functionResponse.name}]`;
+          }
+          if (hasInlineData(part)) {
+            return `[${part.inlineData.mimeType} data]`;
+          }
+          if (hasFileData(part)) {
+            const fileName =
+              part.fileData.fileUri.split("/").pop() || part.fileData.fileUri;
+            return `[File: ${fileName}]`;
+          }
+        }
       }
     }
     return "";


### PR DESCRIPTION
## Description

Fixes #2182 - Session message showing as "No message" for Gemini interactions

The `getLastUserMessage()` method in the Gemini provider was returning an empty string when user messages contained only non-text content (function calls, inline data, files, etc.). This caused the session logs UI to display "No message" instead of a descriptive representation of the content.

## Changes

- Added fallback handling for `functionCall` parts - displays `[Function call: <name>]`
- Added fallback handling for `functionResponse` parts - displays `[Function response: <name>]`
- Added fallback handling for `inlineData` parts - displays `[<mimeType> data]`
- Added fallback handling for `fileData` parts - displays `[File: <filename>]`

## Testing

- ✅ Code passes Biome linting
- ✅ TypeScript compiles successfully
- ✅ Follows existing code patterns from other providers

## Algora Bounty

/claim #2182