### PR TITLE
Fix: Gemini sessions showing "No message" in logs page

### DIFF
--- a/platform/backend/src/models/interaction.ts
+++ b/platform/backend/src/models/interaction.ts
@@ -809,7 +809,14 @@ class InteractionModel {
           ) FILTER (WHERE
             ${schema.interactionsTable.request}::text NOT LIKE '%prompt suggestion generator%'
             AND ${schema.interactionsTable.request}::text NOT LIKE '%Please write a 5-10 word title%'
-            AND LENGTH(${schema.interactionsTable.request}->'messages'->0->>'content') > 20
+            AND COALESCE(
+              LENGTH(${schema.interactionsTable.request}->'messages'->0->>'content'),
+              -- For Gemini, just check if request has contents array (Gemini format)
+              CASE WHEN ${schema.interactionsTable.request}->>'contents' IS NOT NULL THEN 21
+                   ELSE 0
+              END,
+              0
+            ) > 20
           ))[1]`,
           lastInteractionType: sql<string>`(ARRAY_AGG(
             ${schema.interactionsTable.type}
@@ -817,7 +824,14 @@ class InteractionModel {
           ) FILTER (WHERE
             ${schema.interactionsTable.request}::text NOT LIKE '%prompt suggestion generator%'
             AND ${schema.interactionsTable.request}::text NOT LIKE '%Please write a 5-10 word title%'
-            AND LENGTH(${schema.interactionsTable.request}->'messages'->0->>'content') > 20
+            AND COALESCE(
+              LENGTH(${schema.interactionsTable.request}->'messages'->0->>'content'),
+              -- For Gemini, just check if request has contents array (Gemini format)
+              CASE WHEN ${schema.interactionsTable.request}->>'contents' IS NOT NULL THEN 21
+                   ELSE 0
+              END,
+              0
+            ) > 20
           ))[1]`,
           // Get conversation title if sessionId matches a conversation (for Archestra Chat sessions)
           conversationTitle: max(schema.conversationsTable.title),

--- a/platform/frontend/src/lib/llmProviders/gemini.ts
+++ b/platform/frontend/src/lib/llmProviders/gemini.ts
@@ -257,6 +257,10 @@ class GeminiGenerateContentInteraction implements InteractionUtils {
   }
 
   getLastUserMessage(): string {
+    // Handle case where contents might be undefined or not an array
+    if (!this.request.contents || !Array.isArray(this.request.contents)) {
+      return "";
+    }
     const reversedMessages = [...this.request.contents].reverse();
     for (const message of reversedMessages) {
       if (message.role !== "user") {


### PR DESCRIPTION
## Problem
Sessions using Gemini models were displaying "No message" in the Session column of the LLM Proxy logs page, while OpenAI and Anthropic sessions displayed correctly.

https://github.com/archestra-ai/archestra/issues/2182
/claim #2182

## Root Cause
The SQL filter in [getSessions()](cci:1://file:///d:/Telegram%20Bot/archestra/platform/backend/src/models/interaction.ts:662:2-921:3) was designed only for OpenAI/Anthropic request format (`messages[].content`). Gemini uses a different request structure (`contents[].parts[].text`), so all Gemini interactions were being filtered out.

## Solution

**Backend ([interaction.ts](cci:7://file:///d:/Telegram%20Bot/archestra/platform/backend/src/models/interaction.ts:0:0-0:0)):**
Updated SQL filter to check for both formats using COALESCE - checks for OpenAI/Anthropic `messages` key first, then falls back to checking for Gemini `contents` key.

**Frontend ([gemini.ts](cci:7://file:///d:/Telegram%20Bot/archestra/platform/frontend/src/lib/llmProviders/gemini.ts:0:0-0:0)):**
Added defensive check in [getLastUserMessage()](cci:1://file:///d:/Telegram%20Bot/archestra/platform/frontend/src/lib/llmProviders/anthropic.ts:96:2-117:3) to handle cases where `contents` might be undefined.

## Testing
- Verified Gemini sessions now display the user message correctly in the logs page
- Verified OpenAI/Anthropic sessions continue to work as expected

## Files Changed
- [backend/src/models/interaction.ts](cci:7://file:///d:/Telegram%20Bot/archestra/platform/backend/src/models/interaction.ts:0:0-0:0)
- [frontend/src/lib/llmProviders/gemini.ts](cci:7://file:///d:/Telegram%20Bot/archestra/platform/frontend/src/lib/llmProviders/gemini.ts:0:0-0:0)