### PR TITLE
feat: add DeepSeek provider

### DIFF
--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -222,8 +222,7 @@ const parseIncomingEmailProvider = (): EmailProviderType | undefined => {
 /**
  * Parse knowledge graph provider from environment variable
  */
-const parseKnowledgeGraphProvider = ():
-  | KnowledgeGraphProviderType
+const parseKnowledgeGraphProvider = ():\n  | KnowledgeGraphProviderType
   | undefined => {
   const provider =
     process.env.ARCHESTRA_KNOWLEDGE_GRAPH_PROVIDER?.toLowerCase();
@@ -417,6 +416,10 @@ export default {
         process.env.ARCHESTRA_ZHIPUAI_BASE_URL ||
         "https://api.z.ai/api/paas/v4",
     },
+    deepseek: {
+      baseUrl:
+        process.env.ARCHESTRA_DEEPSEEK_BASE_URL || "https://api.deepseek.com",
+    },
   },
   chat: {
     openai: {
@@ -445,6 +448,11 @@ export default {
       baseUrl:
         process.env.ARCHESTRA_CHAT_ZHIPUAI_BASE_URL ||
         "https://api.z.ai/api/paas/v4",
+    },
+    deepseek: {
+      apiKey: process.env.ARCHESTRA_CHAT_DEEPSEEK_API_KEY || "",
+      baseUrl:
+        process.env.ARCHESTRA_CHAT_DEEPSEEK_BASE_URL || "https://api.deepseek.com",
     },
     mcp: {
       remoteServerUrl: process.env.ARCHESTRA_CHAT_MCP_SERVER_URL || "",

--- a/platform/backend/src/routes/proxy/adapterV2/deepseek.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/deepseek.ts
@@ -1,0 +1,1210 @@
+/**
+ * DeepSeek Adapter
+ *
+ * DeepSeek exposes an OpenAI-compatible API, so this adapter is largely based on the OpenAI adapter.
+ * See: https://api-docs.deepseek.com/
+ */
+import { encode as toonEncode } from "@toon-format/toon";
+import { get } from "lodash-es";
+import OpenAIProvider from "openai";
+import type {
+  ChatCompletionCreateParamsNonStreaming,
+  ChatCompletionCreateParamsStreaming,
+} from "openai/resources/chat/completions/completions";
+import config from "@/config";
+import { getObservableFetch } from "@/llm-metrics";
+import logger from "@/logging";
+import { TokenPriceModel } from "@/models";
+import { getTokenizer } from "@/tokenizers";
+import type {
+  ChunkProcessingResult,
+  CommonMcpToolDefinition,
+  CommonMessage,
+  CommonToolCall,
+  CommonToolResult,
+  CreateClientOptions,
+  LLMProvider,
+  LLMRequestAdapter,
+  LLMResponseAdapter,
+  LLMStreamAdapter,
+  StreamAccumulatorState,
+  ToolCompressionStats,
+  UsageView,
+  DeepSeek,
+} from "@/types";
+import { estimateMessagesSize } from "@/utils/message-size";
+import {
+  estimateToolResultContentLength,
+  previewToolResultContent,
+} from "@/utils/tool-result-preview";
+import { MockOpenAIClient } from "../mock-openai-client";
+import {
+  doesModelSupportImages,
+  hasImageContent,
+  isImageTooLarge,
+  isMcpImageBlock,
+} from "../utils/mcp-image";
+import { stripBrowserToolsResults } from "../utils/summarize-tool-results";
+import { unwrapToolContent } from "../utils/unwrap-tool-content";
+
+// =============================================================================
+// TYPE ALIASES
+// =============================================================================
+
+type DeepSeekRequest = DeepSeek.Types.ChatCompletionsRequest;
+type DeepSeekResponse = DeepSeek.Types.ChatCompletionsResponse;
+type DeepSeekMessages = DeepSeek.Types.ChatCompletionsRequest["messages"];
+type DeepSeekHeaders = DeepSeek.Types.ChatCompletionsHeaders;
+type DeepSeekStreamChunk = DeepSeek.Types.ChatCompletionChunk;
+
+type DeepSeekToolResultImageBlock = {
+  type: "image_url";
+  image_url: {
+    url: string;
+    detail?: "auto" | "low" | "high";
+  };
+};
+
+type DeepSeekToolResultTextBlock = {
+  type: "text";
+  text: string;
+};
+
+type DeepSeekToolResultContentBlock =
+  | DeepSeekToolResultImageBlock
+  | DeepSeekToolResultTextBlock;
+
+type DeepSeekToolResultContent = string | DeepSeekToolResultContentBlock[];
+
+// =============================================================================
+// REQUEST ADAPTER
+// =============================================================================
+
+class DeepSeekRequestAdapter
+  implements LLMRequestAdapter<DeepSeekRequest, DeepSeekMessages>
+{
+  readonly provider = "deepseek" as const;
+  private request: DeepSeekRequest;
+  private modifiedModel: string | null = null;
+  private toolResultUpdates: Record<string, string> = {};
+
+  constructor(request: DeepSeekRequest) {
+    this.request = request;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Read Access
+  // ---------------------------------------------------------------------------
+
+  getModel(): string {
+    return this.modifiedModel ?? this.request.model;
+  }
+
+  isStreaming(): boolean {
+    return this.request.stream === true;
+  }
+
+  getMessages(): CommonMessage[] {
+    return this.toCommonFormat(this.request.messages);
+  }
+
+  getToolResults(): CommonToolResult[] {
+    const results: CommonToolResult[] = [];
+
+    for (const message of this.request.messages) {
+      if (message.role === "tool") {
+        const toolName = this.findToolNameInMessages(
+          this.request.messages,
+          message.tool_call_id,
+        );
+
+        let content: unknown;
+        if (typeof message.content === "string") {
+          try {
+            content = JSON.parse(message.content);
+          } catch {
+            content = message.content;
+          }
+        } else {
+          content = message.content;
+        }
+
+        results.push({
+          id: message.tool_call_id,
+          name: toolName ?? "unknown",
+          content,
+          isError: false,
+        });
+      }
+    }
+
+    return results;
+  }
+
+  getTools(): CommonMcpToolDefinition[] {
+    if (!this.request.tools) return [];
+
+    const result: CommonMcpToolDefinition[] = [];
+    for (const tool of this.request.tools) {
+      if (tool.type === "function") {
+        result.push({
+          name: tool.function.name,
+          description: tool.function.description,
+          inputSchema: tool.function.parameters as Record<string, unknown>,
+        });
+      }
+    }
+    return result;
+  }
+
+  hasTools(): boolean {
+    return (this.request.tools?.length ?? 0) > 0;
+  }
+
+  getProviderMessages(): DeepSeekMessages {
+    return this.request.messages;
+  }
+
+  getOriginalRequest(): DeepSeekRequest {
+    return this.request;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Modify Access
+  // ---------------------------------------------------------------------------
+
+  setModel(model: string): void {
+    this.modifiedModel = model;
+  }
+
+  updateToolResult(toolCallId: string, newContent: string): void {
+    this.toolResultUpdates[toolCallId] = newContent;
+  }
+
+  applyToolResultUpdates(updates: Record<string, string>): void {
+    Object.assign(this.toolResultUpdates, updates);
+  }
+
+  async applyToonCompression(model: string): Promise<ToolCompressionStats> {
+    const { messages: compressedMessages, stats } =
+      await convertToolResultsToToon(this.request.messages, model);
+    this.request = {
+      ...this.request,
+      messages: compressedMessages,
+    };
+    return stats;
+  }
+
+  convertToolResultContent(messages: DeepSeekMessages): DeepSeekMessages {
+    const model = this.getModel();
+    const modelSupportsImages = doesModelSupportImages(model);
+    let toolMessagesWithImages = 0;
+    let strippedImageCount = 0;
+
+    // First, analyze all tool messages to understand what we're dealing with
+    for (const message of messages) {
+      if (message.role === "tool") {
+        const contentLength = estimateToolResultContentLength(message.content);
+        const contentSizeKB = Math.round(contentLength.length / 1024);
+        const contentPatternSample = previewToolResultContent(
+          message.content,
+          2000,
+        );
+        const contentPreview = contentPatternSample.slice(0, 200);
+
+        // Check for base64 patterns in preview to avoid full serialization.
+        const hasBase64 =
+          contentPatternSample.includes("data:image") ||
+          contentPatternSample.includes('"type":"image"') ||
+          contentPatternSample.includes('"data":"');
+
+        // Find tool name from previous assistant message
+        const toolName = this.findToolNameInMessages(
+          messages,
+          message.tool_call_id,
+        );
+
+        logger.info(
+          {
+            toolCallId: message.tool_call_id,
+            toolName,
+            contentSizeKB,
+            hasBase64,
+            contentLengthEstimated: contentLength.isEstimated,
+            isArray: Array.isArray(message.content),
+            contentPreview,
+          },
+          "[DeepSeekAdapter] Analyzing tool result content",
+        );
+
+        // If it's an array, analyze each item
+        if (Array.isArray(message.content)) {
+          for (const [idx, item] of message.content.entries()) {
+            if (typeof item === "object" && item !== null) {
+              const itemType = (item as Record<string, unknown>).type;
+              const itemLength = estimateToolResultContentLength(item);
+              logger.info(
+                {
+                  toolCallId: message.tool_call_id,
+                  itemIndex: idx,
+                  itemType,
+                  itemSizeKB: Math.round(itemLength.length / 1024),
+                  itemLengthEstimated: itemLength.isEstimated,
+                  isMcpImage: isMcpImageBlock(item),
+                },
+                "[DeepSeekAdapter] Tool result array item",
+              );
+            }
+          }
+        }
+      }
+    }
+
+    const result = messages.map((message) => {
+      if (message.role !== "tool") {
+        return message;
+      }
+
+      // Check if this tool message contains images
+      if (!hasImageContent(message.content)) {
+        return message;
+      }
+
+      // If model doesn't support images, strip image blocks from content
+      if (!modelSupportsImages) {
+        strippedImageCount++;
+        const strippedContent = stripImageBlocksFromContent(message.content);
+        return {
+          ...message,
+          content: strippedContent,
+        };
+      }
+
+      // Model supports images - convert MCP image blocks to DeepSeek/OpenAI format
+      const convertedContent = convertMcpImageBlocksToDeepSeek(message.content);
+      if (!convertedContent) {
+        return message;
+      }
+
+      toolMessagesWithImages++;
+      return {
+        ...message,
+        content: convertedContent,
+      };
+    });
+
+    if (toolMessagesWithImages > 0 || strippedImageCount > 0) {
+      logger.info(
+        {
+          model,
+          modelSupportsImages,
+          totalMessages: messages.length,
+          toolMessagesWithImages,
+          strippedImageCount,
+        },
+        "[DeepSeekAdapter] Processed tool messages with image content",
+      );
+    }
+
+    return result;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Build Modified Request
+  // ---------------------------------------------------------------------------
+
+  toProviderRequest(): DeepSeekRequest {
+    let messages = this.request.messages;
+
+    if (Object.keys(this.toolResultUpdates).length > 0) {
+      messages = this.applyUpdates(messages, this.toolResultUpdates);
+    }
+
+    if (config.features.browserStreamingEnabled) {
+      messages = this.convertToolResultContent(messages);
+      const sizeBeforeStrip = estimateMessagesSize(messages);
+      messages = stripBrowserToolsResults(messages);
+      const sizeAfterStrip = estimateMessagesSize(messages);
+
+      if (sizeBeforeStrip.length !== sizeAfterStrip.length) {
+        logger.info(
+          {
+            sizeBeforeKB: Math.round(sizeBeforeStrip.length / 1024),
+            sizeAfterKB: Math.round(sizeAfterStrip.length / 1024),
+            savedKB: Math.round(
+              (sizeBeforeStrip.length - sizeAfterStrip.length) / 1024,
+            ),
+            sizeEstimateReliable:
+              !sizeBeforeStrip.isEstimated && !sizeAfterStrip.isEstimated,
+          },
+          "[DeepSeekAdapter] Stripped browser tool results",
+        );
+      }
+    }
+
+    // Calculate approximate request size for debugging
+    const requestSize = estimateMessagesSize(messages);
+    const requestSizeKB = Math.round(requestSize.length / 1024);
+    const estimatedTokens = Math.round(requestSize.length / 4);
+    let imageCount = 0;
+    let totalImageBase64Length = 0;
+
+    for (const msg of messages) {
+      if (Array.isArray(msg.content)) {
+        for (const part of msg.content) {
+          if (
+            typeof part === "object" &&
+            part !== null &&
+            "type" in part &&
+            part.type === "image_url" &&
+            "image_url" in part &&
+            part.image_url &&
+            typeof part.image_url === "object" &&
+            "url" in part.image_url
+          ) {
+            imageCount++;
+            const imageUrl = part.image_url.url;
+            if (typeof imageUrl === "string" && imageUrl.startsWith("data:")) {
+              const base64Part = imageUrl.split(",")[1];
+              if (base64Part) {
+                totalImageBase64Length += base64Part.length;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    logger.info(
+      {
+        model: this.getModel(),
+        messageCount: messages.length,
+        requestSizeKB,
+        estimatedTokens,
+        sizeEstimateReliable: !requestSize.isEstimated,
+        hasToolResultUpdates: Object.keys(this.toolResultUpdates).length > 0,
+        imageCount,
+        totalImageBase64KB: Math.round((totalImageBase64Length * 3) / 4 / 1024),
+      },
+      "[DeepSeekAdapter] Building provider request",
+    );
+
+    return {
+      ...this.request,
+      model: this.getModel(),
+      messages,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private Helpers
+  // ---------------------------------------------------------------------------
+
+  private findToolNameInMessages(
+    messages: DeepSeekMessages,
+    toolCallId: string,
+  ): string | null {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+
+      if (message.role === "assistant" && message.tool_calls) {
+        for (const toolCall of message.tool_calls) {
+          if (toolCall.id === toolCallId) {
+            if (toolCall.type === "function") {
+              return toolCall.function.name;
+            } else {
+              return toolCall.custom.name;
+            }
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private toCommonFormat(messages: DeepSeekMessages): CommonMessage[] {
+    logger.debug(
+      { messageCount: messages.length },
+      "[DeepSeekAdapter] toCommonFormat: starting conversion",
+    );
+    const commonMessages: CommonMessage[] = [];
+
+    for (const message of messages) {
+      const commonMessage: CommonMessage = {
+        role: message.role as CommonMessage["role"],
+      };
+
+      // Handle tool messages (tool results)
+      if (message.role === "tool") {
+        const toolName = this.findToolNameInMessages(
+          messages,
+          message.tool_call_id,
+        );
+
+        if (toolName) {
+          logger.debug(
+            { toolCallId: message.tool_call_id, toolName },
+            "[DeepSeekAdapter] toCommonFormat: found tool message",
+          );
+          let toolResult: unknown;
+          if (typeof message.content === "string") {
+            try {
+              toolResult = JSON.parse(message.content);
+            } catch {
+              toolResult = message.content;
+            }
+          } else {
+            toolResult = message.content;
+          }
+
+          commonMessage.toolCalls = [
+            {
+              id: message.tool_call_id,
+              name: toolName,
+              content: toolResult,
+              isError: false,
+            },
+          ];
+        }
+      }
+
+      commonMessages.push(commonMessage);
+    }
+
+    logger.debug(
+      { inputCount: messages.length, outputCount: commonMessages.length },
+      "[DeepSeekAdapter] toCommonFormat: conversion complete",
+    );
+    return commonMessages;
+  }
+
+  private applyUpdates(
+    messages: DeepSeekMessages,
+    updates: Record<string, string>,
+  ): DeepSeekMessages {
+    const updateCount = Object.keys(updates).length;
+    logger.debug(
+      { messageCount: messages.length, updateCount },
+      "[DeepSeekAdapter] applyUpdates: starting",
+    );
+
+    if (updateCount === 0) {
+      logger.debug("[DeepSeekAdapter] applyUpdates: no updates to apply");
+      return messages;
+    }
+
+    let appliedCount = 0;
+    const result = messages.map((message) => {
+      if (message.role === "tool" && updates[message.tool_call_id]) {
+        appliedCount++;
+        logger.debug(
+          { toolCallId: message.tool_call_id },
+          "[DeepSeekAdapter] applyUpdates: applying update to tool message",
+        );
+        return {
+          ...message,
+          content: updates[message.tool_call_id],
+        };
+      }
+      return message;
+    });
+
+    logger.debug(
+      { updateCount, appliedCount },
+      "[DeepSeekAdapter] applyUpdates: complete",
+    );
+    return result;
+  }
+}
+
+function convertMcpImageBlocksToDeepSeek(
+  content: unknown,
+): DeepSeekToolResultContent | null {
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  if (!hasImageContent(content)) {
+    return null;
+  }
+
+  const deepSeekContent: DeepSeekToolResultContentBlock[] = [];
+  const imageTooLargePlaceholder = "[Image omitted due to size]";
+
+  for (const item of content) {
+    if (typeof item !== "object" || item === null) continue;
+    const candidate = item as Record<string, unknown>;
+
+    if (isMcpImageBlock(item)) {
+      const mimeType = item.mimeType ?? "image/png";
+      const base64Length = typeof item.data === "string" ? item.data.length : 0;
+      const estimatedSizeKB = Math.round((base64Length * 3) / 4 / 1024);
+      const shouldStripImage = isImageTooLarge(item);
+
+      if (shouldStripImage) {
+        logger.info(
+          {
+            mimeType,
+            base64Length,
+            estimatedSizeKB,
+          },
+          "[DeepSeekAdapter] Stripping MCP image block due to size limit",
+        );
+        deepSeekContent.push({
+          type: "text",
+          text: imageTooLargePlaceholder,
+        });
+        continue;
+      }
+
+      logger.info(
+        {
+          mimeType,
+          base64Length,
+          estimatedSizeKB,
+          estimatedBase64Tokens: Math.round(base64Length / 4),
+        },
+        "[DeepSeekAdapter] Converting MCP image block to DeepSeek format",
+      );
+
+      deepSeekContent.push({
+        type: "image_url",
+        image_url: {
+          url: `data:${mimeType};base64,${item.data}`,
+        },
+      });
+    } else if (candidate.type === "text" && "text" in candidate) {
+      deepSeekContent.push({
+        type: "text",
+        text:
+          typeof candidate.text === "string"
+            ? candidate.text
+            : JSON.stringify(candidate),
+      });
+    }
+  }
+
+  logger.info(
+    {
+      totalBlocks: deepSeekContent.length,
+      imageBlocks: deepSeekContent.filter((b) => b.type === "image_url").length,
+      textBlocks: deepSeekContent.filter((b) => b.type === "text").length,
+    },
+    "[DeepSeekAdapter] Converted MCP content to DeepSeek format",
+  );
+
+  return deepSeekContent.length > 0 ? deepSeekContent : null;
+}
+
+/**
+ * Strip image blocks from MCP content when model doesn't support images.
+ * Keeps text blocks and replaces image blocks with a placeholder message.
+ */
+function stripImageBlocksFromContent(content: unknown): string {
+  if (!Array.isArray(content)) {
+    return typeof content === "string" ? content : JSON.stringify(content);
+  }
+
+  const textParts: string[] = [];
+  let imageCount = 0;
+
+  for (const item of content) {
+    if (typeof item !== "object" || item === null) continue;
+    const candidate = item as Record<string, unknown>;
+
+    if (isMcpImageBlock(item)) {
+      imageCount++;
+    } else if (candidate.type === "text" && "text" in candidate) {
+      textParts.push(
+        typeof candidate.text === "string"
+          ? candidate.text
+          : JSON.stringify(candidate.text),
+      );
+    }
+  }
+
+  // Add placeholder for stripped images
+  if (imageCount > 0) {
+    textParts.push(
+      `[${imageCount} image(s) removed - model does not support image inputs]`,
+    );
+    logger.info(
+      { imageCount },
+      "[DeepSeekAdapter] Stripped images from tool result (model does not support images)",
+    );
+  }
+
+  return textParts.join("\n");
+}
+
+// =============================================================================
+// RESPONSE ADAPTER
+// =============================================================================
+
+class DeepSeekResponseAdapter implements LLMResponseAdapter<DeepSeekResponse> {
+  readonly provider = "deepseek" as const;
+  private response: DeepSeekResponse;
+
+  constructor(response: DeepSeekResponse) {
+    this.response = response;
+  }
+
+  getId(): string {
+    return this.response.id;
+  }
+
+  getModel(): string {
+    return this.response.model;
+  }
+
+  getText(): string {
+    const choice = this.response.choices[0];
+    if (!choice) return "";
+    return choice.message.content ?? "";
+  }
+
+  getToolCalls(): CommonToolCall[] {
+    const choice = this.response.choices[0];
+    if (!choice?.message.tool_calls) return [];
+
+    return choice.message.tool_calls.map((toolCall) => {
+      let name: string;
+      let args: Record<string, unknown>;
+
+      if (toolCall.type === "function" && toolCall.function) {
+        name = toolCall.function.name;
+        try {
+          args = JSON.parse(toolCall.function.arguments);
+        } catch {
+          args = {};
+        }
+      } else if (toolCall.type === "custom" && toolCall.custom) {
+        name = toolCall.custom.name;
+        try {
+          args = JSON.parse(toolCall.custom.input);
+        } catch {
+          args = {};
+        }
+      } else {
+        name = "unknown";
+        args = {};
+      }
+
+      return {
+        id: toolCall.id,
+        name,
+        arguments: args,
+      };
+    });
+  }
+
+  hasToolCalls(): boolean {
+    const choice = this.response.choices[0];
+    return (choice?.message.tool_calls?.length ?? 0) > 0;
+  }
+
+  getUsage(): UsageView {
+    return {
+      inputTokens: this.response.usage?.prompt_tokens ?? 0,
+      outputTokens: this.response.usage?.completion_tokens ?? 0,
+    };
+  }
+
+  getOriginalResponse(): DeepSeekResponse {
+    return this.response;
+  }
+
+  toRefusalResponse(
+    _refusalMessage: string,
+    contentMessage: string,
+  ): DeepSeekResponse {
+    return {
+      ...this.response,
+      choices: [
+        {
+          ...this.response.choices[0],
+          message: {
+            role: "assistant",
+            content: contentMessage,
+            refusal: null,
+          },
+          finish_reason: "stop",
+        },
+      ],
+    };
+  }
+}
+
+// =============================================================================
+// STREAM ADAPTER
+// =============================================================================
+
+class DeepSeekStreamAdapter
+  implements LLMStreamAdapter<DeepSeekStreamChunk, DeepSeekResponse>
+{
+  readonly provider = "deepseek" as const;
+  readonly state: StreamAccumulatorState;
+  private currentToolCallIndices = new Map<number, number>();
+
+  constructor() {
+    this.state = {
+      responseId: "",
+      model: "",
+      text: "",
+      toolCalls: [],
+      rawToolCallEvents: [],
+      usage: null,
+      stopReason: null,
+      timing: {
+        startTime: Date.now(),
+        firstChunkTime: null,
+      },
+    };
+  }
+
+  processChunk(chunk: DeepSeekStreamChunk): ChunkProcessingResult {
+    if (this.state.timing.firstChunkTime === null) {
+      this.state.timing.firstChunkTime = Date.now();
+    }
+
+    let sseData: string | null = null;
+    let isToolCallChunk = false;
+    let isFinal = false;
+
+    this.state.responseId = chunk.id;
+    this.state.model = chunk.model;
+
+    // Handle usage first - DeepSeek (like OpenAI) sends usage in a final chunk with empty choices[]
+    // when stream_options.include_usage is true
+    if (chunk.usage) {
+      this.state.usage = {
+        inputTokens: chunk.usage.prompt_tokens ?? 0,
+        outputTokens: chunk.usage.completion_tokens ?? 0,
+      };
+    }
+
+    const choice = chunk.choices[0];
+    if (!choice) {
+      // If we have usage, this is the final chunk
+      return {
+        sseData: null,
+        isToolCallChunk: false,
+        isFinal: this.state.usage !== null,
+      };
+    }
+
+    const delta = choice.delta;
+
+    // Handle text content
+    if (delta.content) {
+      this.state.text += delta.content;
+      sseData = `data: ${JSON.stringify(chunk)}\n\n`;
+    }
+
+    // Handle tool calls
+    if (delta.tool_calls) {
+      for (const toolCallDelta of delta.tool_calls) {
+        const index = toolCallDelta.index;
+
+        if (!this.currentToolCallIndices.has(index)) {
+          this.currentToolCallIndices.set(index, this.state.toolCalls.length);
+          this.state.toolCalls.push({
+            id: toolCallDelta.id ?? "",
+            name: toolCallDelta.function?.name ?? "",
+            arguments: "",
+          });
+        }
+
+        const toolCallIndex = this.currentToolCallIndices.get(index);
+        if (toolCallIndex === undefined) continue;
+        const toolCall = this.state.toolCalls[toolCallIndex];
+
+        if (toolCallDelta.id) {
+          toolCall.id = toolCallDelta.id;
+        }
+        if (toolCallDelta.function?.name) {
+          toolCall.name = toolCallDelta.function.name;
+        }
+        if (toolCallDelta.function?.arguments) {
+          toolCall.arguments += toolCallDelta.function.arguments;
+        }
+      }
+
+      this.state.rawToolCallEvents.push(chunk);
+      isToolCallChunk = true;
+    }
+
+    // Handle finish reason
+    if (choice.finish_reason) {
+      this.state.stopReason = choice.finish_reason;
+    }
+
+    // Only mark as final after we've received usage data
+    if (this.state.usage !== null) {
+      isFinal = true;
+    }
+
+    return { sseData, isToolCallChunk, isFinal };
+  }
+
+  getSSEHeaders(): Record<string, string> {
+    return {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    };
+  }
+
+  formatTextDeltaSSE(text: string): string {
+    const chunk: DeepSeekStreamChunk = {
+      id: this.state.responseId,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            content: text,
+          },
+          finish_reason: null,
+        },
+      ],
+    };
+    return `data: ${JSON.stringify(chunk)}\n\n`;
+  }
+
+  getRawToolCallEvents(): string[] {
+    return this.state.rawToolCallEvents.map(
+      (event) => `data: ${JSON.stringify(event)}\n\n`,
+    );
+  }
+
+  formatCompleteTextSSE(text: string): string[] {
+    const chunk: DeepSeekStreamChunk = {
+      id: this.state.responseId || `chatcmpl-${Date.now()}`,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            role: "assistant",
+            content: text,
+          },
+          finish_reason: null,
+        },
+      ],
+    };
+    return [`data: ${JSON.stringify(chunk)}\n\n`];
+  }
+
+  formatEndSSE(): string {
+    const finalChunk: DeepSeekStreamChunk = {
+      id: this.state.responseId,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          delta: {},
+          finish_reason:
+            (this.state.stopReason as "stop" | "tool_calls") ?? "stop",
+        },
+      ],
+    };
+    return `data: ${JSON.stringify(finalChunk)}\n\ndata: [DONE]\n\n`;
+  }
+
+  toProviderResponse(): DeepSeekResponse {
+    const toolCalls =
+      this.state.toolCalls.length > 0
+        ? this.state.toolCalls.map((tc) => ({
+            id: tc.id,
+            type: "function" as const,
+            function: {
+              name: tc.name,
+              arguments: tc.arguments,
+            },
+          }))
+        : undefined;
+
+    return {
+      id: this.state.responseId,
+      object: "chat.completion",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: this.state.text || null,
+            refusal: null,
+            tool_calls: toolCalls,
+          },
+          logprobs: null,
+          finish_reason:
+            (this.state.stopReason as DeepSeek.Types.FinishReason) ?? "stop",
+        },
+      ],
+      usage: {
+        prompt_tokens: this.state.usage?.inputTokens ?? 0,
+        completion_tokens: this.state.usage?.outputTokens ?? 0,
+        total_tokens:
+          (this.state.usage?.inputTokens ?? 0) +
+          (this.state.usage?.outputTokens ?? 0),
+      },
+    };
+  }
+}
+
+// =============================================================================
+// TOON COMPRESSION
+// =============================================================================
+
+async function convertToolResultsToToon(
+  messages: DeepSeekMessages,
+  model: string,
+): Promise<{
+  messages: DeepSeekMessages;
+  stats: ToolCompressionStats;
+}> {
+  // Use OpenAI tokenizer since DeepSeek uses similar tokenization
+  const tokenizer = getTokenizer("deepseek");
+  let toolResultCount = 0;
+  let totalTokensBefore = 0;
+  let totalTokensAfter = 0;
+
+  const result = messages.map((message) => {
+    if (message.role === "tool") {
+      logger.info(
+        {
+          toolCallId: message.tool_call_id,
+          contentType: typeof message.content,
+          provider: "deepseek",
+        },
+        "convertToolResultsToToon: tool message found",
+      );
+
+      if (typeof message.content === "string") {
+        try {
+          const unwrapped = unwrapToolContent(message.content);
+          const parsed = JSON.parse(unwrapped);
+          const noncompressed = unwrapped;
+          const compressed = toonEncode(parsed);
+
+          const tokensBefore = tokenizer.countTokens([
+            { role: "user", content: noncompressed },
+          ]);
+          const tokensAfter = tokenizer.countTokens([
+            { role: "user", content: compressed },
+          ]);
+
+          toolResultCount++;
+
+          // Always count tokens before
+          totalTokensBefore += tokensBefore;
+
+          // Only apply compression if it actually saves tokens
+          if (tokensAfter < tokensBefore) {
+            totalTokensAfter += tokensAfter;
+
+            logger.info(
+              {
+                toolCallId: message.tool_call_id,
+                beforeLength: noncompressed.length,
+                afterLength: compressed.length,
+                tokensBefore,
+                tokensAfter,
+                toonPreview: compressed.substring(0, 150),
+                provider: "deepseek",
+              },
+              "convertToolResultsToToon: compressed",
+            );
+            logger.debug(
+              {
+                toolCallId: message.tool_call_id,
+                before: noncompressed,
+                after: compressed,
+                provider: "deepseek",
+                supposedToBeJson: parsed,
+              },
+              "convertToolResultsToToon: before/after",
+            );
+
+            return {
+              ...message,
+              content: compressed,
+            };
+          }
+
+          // Compression not applied - count non-compressed tokens to track total tokens anyway
+          totalTokensAfter += tokensBefore;
+          logger.info(
+            {
+              toolCallId: message.tool_call_id,
+              tokensBefore,
+              tokensAfter,
+              provider: "deepseek",
+            },
+            "Skipping TOON compression - compressed output has more tokens",
+          );
+        } catch {
+          logger.info(
+            {
+              toolCallId: message.tool_call_id,
+              contentPreview:
+                typeof message.content === "string"
+                  ? message.content.substring(0, 100)
+                  : "non-string",
+            },
+            "Skipping TOON conversion - content is not JSON",
+          );
+          return message;
+        }
+      }
+    }
+
+    return message;
+  });
+
+  logger.info(
+    { messageCount: messages.length, toolResultCount },
+    "convertToolResultsToToon completed",
+  );
+
+  let toonCostSavings = 0;
+  const tokensSaved = totalTokensBefore - totalTokensAfter;
+  if (tokensSaved > 0) {
+    const tokenPrice = await TokenPriceModel.findByModel(model);
+    if (tokenPrice) {
+      const inputPricePerToken =
+        Number(tokenPrice.pricePerMillionInput) / 1000000;
+      toonCostSavings = tokensSaved * inputPricePerToken;
+    }
+  }
+
+  return {
+    messages: result,
+    stats: {
+      tokensBefore: totalTokensBefore,
+      tokensAfter: totalTokensAfter,
+      costSavings: toonCostSavings,
+      wasEffective: totalTokensAfter < totalTokensBefore,
+      hadToolResults: toolResultCount > 0,
+    },
+  };
+}
+
+// =============================================================================
+// ADAPTER FACTORY
+// =============================================================================
+
+export const deepseekAdapterFactory: LLMProvider<
+  DeepSeekRequest,
+  DeepSeekResponse,
+  DeepSeekMessages,
+  DeepSeekStreamChunk,
+  DeepSeekHeaders
+> = {
+  provider: "deepseek",
+  interactionType: "deepseek:chatCompletions",
+
+  createRequestAdapter(
+    request: DeepSeekRequest,
+  ): LLMRequestAdapter<DeepSeekRequest, DeepSeekMessages> {
+    return new DeepSeekRequestAdapter(request);
+  },
+
+  createResponseAdapter(
+    response: DeepSeekResponse,
+  ): LLMResponseAdapter<DeepSeekResponse> {
+    return new DeepSeekResponseAdapter(response);
+  },
+
+  createStreamAdapter(): LLMStreamAdapter<DeepSeekStreamChunk, DeepSeekResponse> {
+    return new DeepSeekStreamAdapter();
+  },
+
+  extractApiKey(headers: DeepSeekHeaders): string | undefined {
+    return headers.authorization ?? undefined;
+  },
+
+  getBaseUrl(): string | undefined {
+    return config.llm.deepseek.baseUrl;
+  },
+
+  getSpanName(): string {
+    return "deepseek.chat.completions";
+  },
+
+  createClient(
+    apiKey: string | undefined,
+    options?: CreateClientOptions,
+  ): OpenAIProvider {
+    if (options?.mockMode) {
+      return new MockOpenAIClient() as unknown as OpenAIProvider;
+    }
+
+    // Use observable fetch for request duration metrics if agent is provided
+    const customFetch = options?.agent
+      ? getObservableFetch("deepseek", options.agent, options.externalAgentId)
+      : undefined;
+
+    // DeepSeek uses OpenAI SDK
+    return new OpenAIProvider({
+      apiKey: apiKey || "EMPTY",
+      baseURL: options?.baseUrl,
+      fetch: customFetch,
+    });
+  },
+
+  async execute(client: unknown, request: DeepSeekRequest): Promise<DeepSeekResponse> {
+    const deepseekClient = client as OpenAIProvider;
+    const deepseekRequest = {
+      ...request,
+      stream: false,
+    } as unknown as ChatCompletionCreateParamsNonStreaming;
+    return deepseekClient.chat.completions.create(
+      deepseekRequest,
+    ) as Promise<DeepSeekResponse>;
+  },
+
+  async executeStream(
+    client: unknown,
+    request: DeepSeekRequest,
+  ): Promise<AsyncIterable<DeepSeekStreamChunk>> {
+    const deepseekClient = client as OpenAIProvider;
+    const deepseekRequest = {
+      ...request,
+      stream: true,
+      stream_options: { include_usage: true },
+    } as unknown as ChatCompletionCreateParamsStreaming;
+    const stream = await deepseekClient.chat.completions.create(deepseekRequest);
+
+    return {
+      [Symbol.asyncIterator]: async function* () {
+        for await (const chunk of stream) {
+          yield chunk as DeepSeekStreamChunk;
+        }
+      },
+    };
+  },
+
+  extractErrorMessage(error: unknown): string {
+    const message = get(error, "error.message");
+    if (typeof message === "string") {
+      return message;
+    }
+
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return "Internal server error";
+  },
+};

--- a/platform/backend/src/routes/proxy/adapterV2/index.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/index.ts
@@ -5,3 +5,4 @@ export { ollamaAdapterFactory } from "./ollama";
 export { openaiAdapterFactory } from "./openai";
 export { vllmAdapterFactory } from "./vllm";
 export { zhipuaiAdapterFactory } from "./zhipuai";
+export { deepseekAdapterFactory } from "./deepseek";

--- a/platform/backend/src/routes/proxy/routesv2/deepseek.ts
+++ b/platform/backend/src/routes/proxy/routesv2/deepseek.ts
@@ -1,0 +1,161 @@
+import fastifyHttpProxy from "@fastify/http-proxy";
+import { RouteId } from "@shared";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import config from "@/config";
+import logger from "@/logging";
+import { constructResponseSchema, DeepSeek, UuidIdSchema } from "@/types";
+import { deepseekAdapterFactory } from "../adapterV2";
+import { PROXY_API_PREFIX, PROXY_BODY_LIMIT } from "../common";
+import { handleLLMProxy } from "../llm-proxy-handler";
+import * as utils from "../utils";
+
+const deepseekProxyRoutesV2: FastifyPluginAsyncZod = async (fastify) => {
+  const API_PREFIX = `${PROXY_API_PREFIX}/deepseek`;
+  const CHAT_COMPLETIONS_SUFFIX = "/chat/completions";
+
+  logger.info("[UnifiedProxy] Registering unified DeepSeek routes");
+
+  await fastify.register(fastifyHttpProxy, {
+    upstream: config.llm.deepseek.baseUrl,
+    prefix: API_PREFIX,
+    rewritePrefix: "",
+    preHandler: (request, _reply, next) => {
+      if (
+        request.method === "POST" &&
+        request.url.includes(CHAT_COMPLETIONS_SUFFIX)
+      ) {
+        logger.info(
+          {
+            method: request.method,
+            url: request.url,
+            action: "skip-proxy",
+            reason: "handled-by-custom-handler",
+          },
+          "DeepSeek proxy preHandler: skipping chat/completions route",
+        );
+        next(new Error("skip"));
+        return;
+      }
+
+      const pathAfterPrefix = request.url.replace(API_PREFIX, "");
+      const uuidMatch = pathAfterPrefix.match(
+        /^\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(\/.*)?$/i,
+      );
+
+      if (uuidMatch) {
+        const remainingPath = uuidMatch[2] || "";
+        const originalUrl = request.raw.url;
+        request.raw.url = `${API_PREFIX}${remainingPath}`;
+
+        logger.info(
+          {
+            method: request.method,
+            originalUrl,
+            rewrittenUrl: request.raw.url,
+            upstream: config.llm.deepseek.baseUrl,
+            finalProxyUrl: `${config.llm.deepseek.baseUrl}${remainingPath}`,
+          },
+          "DeepSeek proxy preHandler: URL rewritten (UUID stripped)",
+        );
+      } else {
+        logger.info(
+          {
+            method: request.method,
+            url: request.url,
+            upstream: config.llm.deepseek.baseUrl,
+            finalProxyUrl: `${config.llm.deepseek.baseUrl}${pathAfterPrefix}`,
+          },
+          "DeepSeek proxy preHandler: proxying request",
+        );
+      }
+
+      next();
+    },
+  });
+
+  fastify.post(
+    `${API_PREFIX}${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        operationId: RouteId.DeepSeekChatCompletionsWithDefaultAgent,
+        description:
+          "Create a chat completion with DeepSeek (uses default agent)",
+        tags: ["llm-proxy"],
+        body: DeepSeek.API.ChatCompletionRequestSchema,
+        headers: DeepSeek.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(
+          DeepSeek.API.ChatCompletionResponseSchema,
+        ),
+      },
+    },
+    async (request, reply) => {
+      logger.debug(
+        { url: request.url },
+        "[UnifiedProxy] Handling DeepSeek request (default agent)",
+      );
+      const externalAgentId = utils.externalAgentId.getExternalAgentId(
+        request.headers,
+      );
+      const userId = await utils.userId.getUserId(request.headers);
+      return handleLLMProxy(
+        request.body,
+        request.headers,
+        reply,
+        deepseekAdapterFactory,
+        {
+          organizationId: request.organizationId,
+          agentId: undefined,
+          externalAgentId,
+          userId,
+        },
+      );
+    },
+  );
+
+  fastify.post(
+    `${API_PREFIX}/:agentId${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        operationId: RouteId.DeepSeekChatCompletionsWithAgent,
+        description:
+          "Create a chat completion with DeepSeek for a specific agent",
+        tags: ["llm-proxy"],
+        params: z.object({
+          agentId: UuidIdSchema,
+        }),
+        body: DeepSeek.API.ChatCompletionRequestSchema,
+        headers: DeepSeek.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(
+          DeepSeek.API.ChatCompletionResponseSchema,
+        ),
+      },
+    },
+    async (request, reply) => {
+      logger.debug(
+        { url: request.url, agentId: request.params.agentId },
+        "[UnifiedProxy] Handling DeepSeek request (with agent)",
+      );
+      const externalAgentId = utils.externalAgentId.getExternalAgentId(
+        request.headers,
+      );
+      const userId = await utils.userId.getUserId(request.headers);
+      return handleLLMProxy(
+        request.body,
+        request.headers,
+        reply,
+        deepseekAdapterFactory,
+        {
+          organizationId: request.organizationId,
+          agentId: request.params.agentId,
+          externalAgentId,
+          userId,
+        },
+      );
+    },
+  );
+};
+
+export default deepseekProxyRoutesV2;

--- a/platform/backend/src/routes/proxy/routesv2/index.ts
+++ b/platform/backend/src/routes/proxy/routesv2/index.ts
@@ -1,0 +1,22 @@
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import anthropicProxyRoutesV2 from "./anthropic";
+import cerebrasProxyRoutesV2 from "./cerebras";
+import deepseekProxyRoutesV2 from "./deepseek";
+import geminiProxyRoutesV2 from "./gemini";
+import ollamaProxyRoutesV2 from "./ollama";
+import openAiProxyRoutesV2 from "./openai";
+import vllmProxyRoutesV2 from "./vllm";
+import zhipuaiProxyRoutesV2 from "./zhipuai";
+
+const unifiedProxyRoutesV2: FastifyPluginAsyncZod = async (fastify) => {
+  await fastify.register(anthropicProxyRoutesV2);
+  await fastify.register(cerebrasProxyRoutesV2);
+  await fastify.register(geminiProxyRoutesV2);
+  await fastify.register(ollamaProxyRoutesV2);
+  await fastify.register(openAiProxyRoutesV2);
+  await fastify.register(vllmProxyRoutesV2);
+  await fastify.register(zhipuaiProxyRoutesV2);
+  await fastify.register(deepseekProxyRoutesV2);
+};
+
+export default unifiedProxyRoutesV2;

--- a/platform/backend/src/routes/proxy/utils/cost-optimization.ts
+++ b/platform/backend/src/routes/proxy/utils/cost-optimization.ts
@@ -10,6 +10,7 @@ import type {
   Agent,
   Anthropic,
   Cerebras,
+  DeepSeek,
   Gemini,
   OpenAi,
   Vllm,
@@ -24,6 +25,7 @@ type ProviderMessages = {
   vllm: Vllm.Types.ChatCompletionsRequest["messages"];
   ollama: Vllm.Types.ChatCompletionsRequest["messages"];
   zhipuai: Zhipuai.Types.ChatCompletionsRequest["messages"];
+  deepseek: DeepSeek.Types.ChatCompletionsRequest["messages"];
 };
 
 /**

--- a/platform/backend/src/tokenizers/index.ts
+++ b/platform/backend/src/tokenizers/index.ts
@@ -18,7 +18,8 @@ export function getTokenizer(provider: SupportedProvider): Tokenizer {
     case "openai":
     case "vllm":
     case "ollama":
-      // vLLM and Ollama use tiktoken-compatible tokenization for most models
+    case "deepseek":
+      // vLLM, Ollama and DeepSeek use tiktoken-compatible tokenization for most models
       return new TiktokenTokenizer();
     case "zhipuai":
       return new TiktokenTokenizer();

--- a/platform/backend/src/types/interaction.ts
+++ b/platform/backend/src/types/interaction.ts
@@ -5,6 +5,7 @@ import { schema } from "@/database";
 import {
   Anthropic,
   Cerebras,
+  DeepSeek,
   Gemini,
   Ollama,
   OpenAi,
@@ -30,6 +31,7 @@ export const InteractionRequestSchema = z.union([
   Vllm.API.ChatCompletionRequestSchema,
   Ollama.API.ChatCompletionRequestSchema,
   Zhipuai.API.ChatCompletionRequestSchema,
+  DeepSeek.API.ChatCompletionRequestSchema,
 ]);
 
 export const InteractionResponseSchema = z.union([
@@ -40,6 +42,7 @@ export const InteractionResponseSchema = z.union([
   Vllm.API.ChatCompletionResponseSchema,
   Ollama.API.ChatCompletionResponseSchema,
   Zhipuai.API.ChatCompletionResponseSchema,
+  DeepSeek.API.ChatCompletionResponseSchema,
 ]);
 
 /**
@@ -121,6 +124,13 @@ export const SelectInteractionSchema = z.discriminatedUnion("type", [
     processedRequest:
       Zhipuai.API.ChatCompletionRequestSchema.nullable().optional(),
     response: Zhipuai.API.ChatCompletionResponseSchema,
+  }),
+  BaseSelectInteractionSchema.extend({
+    type: z.enum(["deepseek:chatCompletions"]),
+    request: DeepSeek.API.ChatCompletionRequestSchema,
+    processedRequest:
+      DeepSeek.API.ChatCompletionRequestSchema.nullable().optional(),
+    response: DeepSeek.API.ChatCompletionResponseSchema,
   }),
 ]);
 

--- a/platform/backend/src/types/llm-providers/deepseek/api.ts
+++ b/platform/backend/src/types/llm-providers/deepseek/api.ts
@@ -1,0 +1,98 @@
+/**
+ * DeepSeek API Types
+ *
+ * DeepSeek exposes an OpenAI-compatible API server, so we re-export OpenAI schemas.
+ * See: https://api-docs.deepseek.com/
+ */
+import { z } from "zod";
+
+import { MessageParamSchema, ToolCallSchema } from "./messages";
+import { ToolChoiceOptionSchema, ToolSchema } from "./tools";
+
+export const ChatCompletionUsageSchema = z
+  .object({
+    completion_tokens: z.number(),
+    prompt_tokens: z.number(),
+    total_tokens: z.number(),
+    completion_tokens_details: z.any().optional(),
+    prompt_tokens_details: z.any().optional(),
+  })
+  .describe("Token usage statistics for the completion");
+
+export const FinishReasonSchema = z.enum([
+  "stop",
+  "length",
+  "tool_calls",
+  "content_filter",
+  "function_call",
+]);
+
+const ChoiceSchema = z
+  .object({
+    finish_reason: FinishReasonSchema,
+    index: z.number(),
+    logprobs: z.any().nullable(),
+    message: z
+      .object({
+        content: z.string().nullable(),
+        refusal: z.string().nullable().optional(),
+        role: z.enum(["assistant"]),
+        annotations: z.array(z.any()).optional(),
+        audio: z.any().nullable().optional(),
+        function_call: z
+          .object({
+            arguments: z.string(),
+            name: z.string(),
+          })
+          .nullable()
+          .optional(),
+        tool_calls: z.array(ToolCallSchema).optional(),
+        // DeepSeek-specific: reasoning field for models that support it
+        reasoning_content: z.string().nullable().optional(),
+      })
+      .describe("The assistant message in the response"),
+  })
+  .describe("A choice in the chat completion response");
+
+export const ChatCompletionRequestSchema = z
+  .object({
+    model: z.string(),
+    messages: z.array(MessageParamSchema),
+    tools: z.array(ToolSchema).optional(),
+    tool_choice: ToolChoiceOptionSchema.optional(),
+    temperature: z.number().nullable().optional(),
+    max_tokens: z.number().nullable().optional(),
+    stream: z.boolean().nullable().optional(),
+    top_p: z.number().nullable().optional(),
+    frequency_penalty: z.number().nullable().optional(),
+    presence_penalty: z.number().nullable().optional(),
+    stop: z.union([z.string(), z.array(z.string())]).optional(),
+    seed: z.number().nullable().optional(),
+    n: z.number().nullable().optional(),
+    logprobs: z.boolean().nullable().optional(),
+    top_logprobs: z.number().nullable().optional(),
+  })
+  .describe("DeepSeek chat completion request (OpenAI-compatible)");
+
+export const ChatCompletionResponseSchema = z
+  .object({
+    id: z.string(),
+    choices: z.array(ChoiceSchema),
+    created: z.number(),
+    model: z.string(),
+    object: z.enum(["chat.completion"]),
+    system_fingerprint: z.string().nullable().optional(),
+    usage: ChatCompletionUsageSchema.optional(),
+  })
+  .describe("DeepSeek chat completion response (OpenAI-compatible)");
+
+export const ChatCompletionsHeadersSchema = z.object({
+  "user-agent": z.string().optional().describe("The user agent of the client"),
+  authorization: z
+    .string()
+    .optional()
+    .describe("Bearer token for DeepSeek")
+    .transform((authorization) =>
+      authorization ? authorization.replace("Bearer ", "") : undefined,
+    ),
+});

--- a/platform/backend/src/types/llm-providers/deepseek/index.ts
+++ b/platform/backend/src/types/llm-providers/deepseek/index.ts
@@ -1,0 +1,42 @@
+/**
+ * DeepSeek Type Definitions
+ *
+ * DeepSeek is an OpenAI-compatible inference server.
+ * See: https://api-docs.deepseek.com/
+ */
+import type OpenAIProvider from "openai";
+import type { z } from "zod";
+import * as DeepSeekAPI from "./api";
+import * as DeepSeekMessages from "./messages";
+import type * as DeepSeekModels from "./models";
+import * as DeepSeekTools from "./tools";
+
+namespace DeepSeek {
+  export const API = DeepSeekAPI;
+  export const Messages = DeepSeekMessages;
+  export const Tools = DeepSeekTools;
+
+  export namespace Types {
+    export type ChatCompletionsHeaders = z.infer<
+      typeof DeepSeekAPI.ChatCompletionsHeadersSchema
+    >;
+    export type ChatCompletionsRequest = z.infer<
+      typeof DeepSeekAPI.ChatCompletionRequestSchema
+    >;
+    export type ChatCompletionsResponse = z.infer<
+      typeof DeepSeekAPI.ChatCompletionResponseSchema
+    >;
+    export type Usage = z.infer<typeof DeepSeekAPI.ChatCompletionUsageSchema>;
+
+    export type FinishReason = z.infer<typeof DeepSeekAPI.FinishReasonSchema>;
+    export type Message = z.infer<typeof DeepSeekMessages.MessageParamSchema>;
+    export type Role = Message["role"];
+
+    // DeepSeek uses OpenAI-compatible streaming format
+    export type ChatCompletionChunk =
+      OpenAIProvider.Chat.Completions.ChatCompletionChunk;
+    export type Model = z.infer<typeof DeepSeekModels.ModelSchema>;
+  }
+}
+
+export default DeepSeek;

--- a/platform/backend/src/types/llm-providers/deepseek/messages.ts
+++ b/platform/backend/src/types/llm-providers/deepseek/messages.ts
@@ -1,0 +1,68 @@
+/**
+ * DeepSeek Message Types
+ *
+ * DeepSeek uses OpenAI-compatible message formats.
+ */
+import { z } from "zod";
+import { ToolCallSchema } from "./tools";
+
+export { ToolCallSchema } from "./tools";
+
+export const SystemMessageSchema = z.object({
+  content: z.string(),
+  role: z.enum(["system"]),
+  name: z.string().optional(),
+});
+
+export const UserMessageSchema = z.object({
+  content: z.union([
+    z.string(),
+    z.array(
+      z.union([
+        z.object({
+          type: z.enum(["text"]),
+          text: z.string(),
+        }),
+        z.object({
+          type: z.enum(["image_url"]),
+          image_url: z.object({
+            url: z.string(),
+            detail: z.enum(["auto", "low", "high"]).optional(),
+          }),
+        }),
+      ]),
+    ),
+  ]),
+  role: z.enum(["user"]),
+  name: z.string().optional(),
+});
+
+export const AssistantMessageSchema = z.object({
+  content: z.string().nullable().optional(),
+  refusal: z.string().nullable().optional(),
+  role: z.enum(["assistant"]),
+  name: z.string().optional(),
+  tool_calls: z.array(ToolCallSchema).optional(),
+  // DeepSeek models might return reasoning content
+  reasoning_content: z.string().nullable().optional(),
+});
+
+export const ToolMessageSchema = z.object({
+  content: z.string(),
+  role: z.enum(["tool"]),
+  tool_call_id: z.string(),
+});
+
+export const FunctionMessageSchema = z.object({
+  content: z.string().nullable(),
+  role: z.enum(["function"]),
+  name: z.string(),
+});
+
+export const MessageParamSchema = z.union([
+  SystemMessageSchema,
+  UserMessageSchema,
+  AssistantMessageSchema,
+  ToolMessageSchema,
+  FunctionMessageSchema,
+]);

--- a/platform/backend/src/types/llm-providers/deepseek/models.ts
+++ b/platform/backend/src/types/llm-providers/deepseek/models.ts
@@ -1,0 +1,30 @@
+/**
+ * DeepSeek Model Types
+ *
+ * DeepSeek uses OpenAI-compatible model listing format.
+ */
+import { z } from "zod";
+
+export const ModelSchema = z
+  .object({
+    id: z
+      .string()
+      .describe(
+        "The model identifier, which can be referenced in the API endpoints.",
+      ),
+    created: z
+      .number()
+      .describe("The Unix timestamp (in seconds) when the model was created."),
+    object: z
+      .enum(["model"])
+      .describe('The object type, which is always "model".'),
+    owned_by: z.string().describe("The organization that owns the model."),
+  })
+  .describe("A DeepSeek model object");
+
+export const ModelsListResponseSchema = z
+  .object({
+    object: z.enum(["list"]),
+    data: z.array(ModelSchema),
+  })
+  .describe("DeepSeek models list response");

--- a/platform/backend/src/types/llm-providers/deepseek/tools.ts
+++ b/platform/backend/src/types/llm-providers/deepseek/tools.ts
@@ -1,0 +1,36 @@
+/**
+ * DeepSeek Tool Types
+ *
+ * DeepSeek uses OpenAI-compatible tool definitions.
+ */
+import { z } from "zod";
+
+export const FunctionSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  parameters: z.record(z.unknown()),
+});
+
+export const ToolSchema = z.object({
+  type: z.enum(["function"]),
+  function: FunctionSchema,
+});
+
+export const ToolChoiceOptionSchema = z.union([
+  z.enum(["none", "auto", "required"]),
+  z.object({
+    type: z.enum(["function"]),
+    function: z.object({
+      name: z.string(),
+    }),
+  }),
+]);
+
+export const ToolCallSchema = z.object({
+  id: z.string(),
+  type: z.enum(["function"]),
+  function: z.object({
+    name: z.string(),
+    arguments: z.string(),
+  }),
+});

--- a/platform/backend/src/types/llm-providers/index.ts
+++ b/platform/backend/src/types/llm-providers/index.ts
@@ -5,3 +5,4 @@ export { default as Ollama } from "./ollama";
 export { default as OpenAi } from "./openai";
 export { default as Vllm } from "./vllm";
 export { default as Zhipuai } from "./zhipuai";
+export { default as DeepSeek } from "./deepseek";

--- a/platform/frontend/src/components/chat-api-key-form.tsx
+++ b/platform/frontend/src/components/chat-api-key-form.tsx
@@ -115,6 +115,14 @@ const PROVIDER_CONFIG: Record<
     consoleUrl: "https://z.ai/model-api",
     consoleName: "Zhipu AI Platform",
   },
+  deepseek: {
+    name: "DeepSeek",
+    icon: "/icons/deepseek.png",
+    placeholder: "sk-...",
+    enabled: true,
+    consoleUrl: "https://platform.deepseek.com/api_keys",
+    consoleName: "DeepSeek Platform",
+  },
 } as const;
 
 export { PROVIDER_CONFIG };
@@ -358,8 +366,7 @@ export function ChatApiKeyForm({
                         <Badge variant="secondary" className="ml-2 text-xs">
                           Vertex AI
                         </Badge>
-                      )}
-                    </div>
+                      )}\n                    </div>
                   </SelectItem>
                 );
               })}

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -11,6 +11,7 @@ export const SupportedProvidersSchema = z.enum([
   "vllm",
   "ollama",
   "zhipuai",
+  "deepseek",
 ]);
 
 export const SupportedProvidersDiscriminatorSchema = z.enum([
@@ -21,6 +22,7 @@ export const SupportedProvidersDiscriminatorSchema = z.enum([
   "vllm:chatCompletions",
   "ollama:chatCompletions",
   "zhipuai:chatCompletions",
+  "deepseek:chatCompletions",
 ]);
 
 export const SupportedProviders = Object.values(SupportedProvidersSchema.enum);
@@ -37,4 +39,5 @@ export const providerDisplayNames: Record<SupportedProvider, string> = {
   vllm: "vLLM",
   ollama: "Ollama",
   zhipuai: "Zhipu AI",
+  deepseek: "DeepSeek",
 };


### PR DESCRIPTION
## Description

This PR implements the **DeepSeek** provider for the LLM Proxy and Chat, resolving issue #1846.

> **Note:** This supersedes PR #2259 which was closed during a git history squash to ensure a clean commit log.

## Changes

- Added `deepseek` to `SupportedProviders`.
- Added configuration for `ARCHESTRA_DEEPSEEK_BASE_URL` and API key.
- Implemented `DeepSeekAdapter` (using OpenAI compatibility layer).
- Added proxy routes for DeepSeek.
- Updated frontend API key form to include DeepSeek.

## Checklist

- [x] Provider registered in constants
- [x] Config updated
- [x] Adapter implemented
- [x] Routes added
- [x] Frontend updated

/claim #1846