### PR TITLE
feat(helm): enable Pod Disruption Budget for staging

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -1,6 +1,12 @@
 archestra:
   replicaCount: 4
 
+  # Pod Disruption Budget: ensure at least 3 of 4 pods stay running during
+  # voluntary disruptions (node upgrades, autoscaling, maintenance)
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 1
+
   # Faster rolling updates: allow 2 pods to be created at once
   deploymentStrategy:
     type: RollingUpdate


### PR DESCRIPTION
## Summary
- Enable PodDisruptionBudget for the archestra-platform deployment in staging
- Configured with `maxUnavailable: 1` to ensure at least 3 of 4 pods stay running during voluntary disruptions