### PR TITLE
fix: remove unique constraint on agents (organization_id, name)

### DIFF
--- a/platform/backend/src/database/migrations/0124_lumpy_golden_guardian.sql
+++ b/platform/backend/src/database/migrations/0124_lumpy_golden_guardian.sql
@@ -1,1 +1,3 @@
-CREATE UNIQUE INDEX "agents_organization_id_name_idx" ON "agents" USING btree ("organization_id","name");
+-- Removed: unique index not required and causes issues with existing duplicate data
+-- CREATE UNIQUE INDEX "agents_organization_id_name_idx" ON "agents" USING btree ("organization_id","name");
+SELECT 1;

--- a/platform/backend/src/database/migrations/meta/0124_snapshot.json
+++ b/platform/backend/src/database/migrations/meta/0124_snapshot.json
@@ -532,27 +532,6 @@
           "method": "btree",
           "with": {}
         },
-        "agents_organization_id_name_idx": {
-          "name": "agents_organization_id_name_idx",
-          "columns": [
-            {
-              "expression": "organization_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "name",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
         "agents_agent_type_idx": {
           "name": "agents_agent_type_idx",
           "columns": [

--- a/platform/backend/src/database/schemas/agent.ts
+++ b/platform/backend/src/database/schemas/agent.ts
@@ -8,7 +8,6 @@ import {
   pgTable,
   text,
   timestamp,
-  uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
 import type { ChatOpsProviderType } from "@/types/chatops";
@@ -96,11 +95,6 @@ const agentsTable = pgTable(
   (table) => [
     index("agents_organization_id_idx").on(table.organizationId),
     index("agents_agent_type_idx").on(table.agentType),
-    // Unique constraint on (organization_id, name) to prevent duplicate agent names
-    uniqueIndex("agents_organization_id_name_idx").on(
-      table.organizationId,
-      table.name,
-    ),
   ],
 );
 


### PR DESCRIPTION
- Make 0124 migration a no-op to avoid failing on duplicate data
- Remove uniqueIndex from agent schema
- Update snapshot to match