### PR TITLE
ci: add job dependency to ensure MCP server image is built before platform image

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -96,10 +96,12 @@ jobs:
 
   publish-platform-helm-chart:
     name: Publish platform Helm chart
+    # Depends on platform Docker image being published first, as the Helm chart references it
     if: needs.release-please.outputs.platform_release_created
     uses: ./.github/workflows/publish-platform-helm-chart.yml
     needs:
       - release-please
+      - build-and-push-platform-docker-image-to-dockerhub
     permissions:
       contents: write
       id-token: write # Required for Workload Identity Federation
@@ -112,9 +114,11 @@ jobs:
 
   trigger-website-deploy:
     name: Trigger Website Deploy
+    # Depends on Helm chart being published first, so the website shows the latest release info
     if: needs.release-please.outputs.platform_release_created
     uses: ./.github/workflows/trigger-website-deploy.yml
     needs:
       - release-please
+      - publish-platform-helm-chart
     secrets:
       WEBSITE_VERCEL_DEPLOY_HOOK_URL: ${{ secrets.WEBSITE_VERCEL_DEPLOY_HOOK_URL }}


### PR DESCRIPTION
## Summary

- Adds a dependency from `build-and-push-platform-docker-image-to-dockerhub` to `build-and-push-mcp-server-docker-image` in the release workflow

## Why

The platform Docker image references the MCP server base image via `ARCHESTRA_ORCHESTRATOR_MCP_SERVER_BASE_IMAGE`. Without this dependency, if the MCP server image build fails, the platform image could still be built and published, referencing a non-existent MCP server base image tag.

This change ensures the MCP server base image is published first. If it fails, the platform image build won't run.

## Test plan

- [ ] Verify the release-please workflow runs correctly on next release