### PR TITLE
fix: sanitize numeric label keys for Prometheus compatibility

### DIFF
--- a/platform/backend/src/llm-metrics.ts
+++ b/platform/backend/src/llm-metrics.ts
@@ -36,14 +36,27 @@ let currentLabelKeys: string[] = [];
 const sanitizeRegexp = /[^a-zA-Z0-9_]/g;
 
 /**
+ * Sanitize a label key for Prometheus compatibility.
+ * Prometheus label names must match [a-zA-Z_][a-zA-Z0-9_]*
+ * - Replace invalid characters with underscores
+ * - Prefix with underscore if starts with a digit
+ */
+function sanitizeLabelKey(key: string): string {
+  let sanitized = key.replace(sanitizeRegexp, "_");
+  // Prometheus labels cannot start with a digit
+  if (/^[0-9]/.test(sanitized)) {
+    sanitized = `_${sanitized}`;
+  }
+  return sanitized;
+}
+
+/**
  * Initialize LLM metrics with dynamic agent label keys
  * @param labelKeys Array of agent label keys to include as metric labels
  */
 export function initializeMetrics(labelKeys: string[]): void {
   // Prometheus labels have naming restrictions. Dashes are not allowed, for example.
-  const nextLabelKeys = labelKeys
-    .map((key) => key.replace(sanitizeRegexp, "_"))
-    .sort();
+  const nextLabelKeys = labelKeys.map(sanitizeLabelKey).sort();
   // Check if label keys have changed
   const labelKeysChanged =
     JSON.stringify(nextLabelKeys) !== JSON.stringify(currentLabelKeys);
@@ -176,7 +189,7 @@ function buildMetricLabels(
   for (const labelKey of currentLabelKeys) {
     // Find the label value for this key from the agent's labels
     const agentLabel = profile.labels?.find(
-      (l) => l.key.replace(sanitizeRegexp, "_") === labelKey,
+      (l) => sanitizeLabelKey(l.key) === labelKey,
     );
     labels[labelKey] = agentLabel?.value ?? "";
   }


### PR DESCRIPTION
Prometheus label names cannot start with a digit. Added sanitizeLabelKey function that prefixes numeric labels with underscore.