### PR TITLE
fix: show settings link in file upload tooltip for admins

### DIFF
--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -196,6 +196,7 @@ const PromptInputContent = ({
                     <a
                       href="/settings/security"
                       className="underline hover:no-underline"
+                      aria-label="Enable file uploads in security settings"
                     >
                       Enable in settings
                     </a>


### PR DESCRIPTION
When file uploads are disabled, administrators now see a link to /settings/security where they can enable the feature. Regular users continue to see the message that uploads are disabled by their admin.

Closes #2382