### PR TITLE
fix: unhide claude code connection button

### DIFF
--- a/platform/frontend/src/components/proxy-connection-instructions.tsx
+++ b/platform/frontend/src/components/proxy-connection-instructions.tsx
@@ -68,26 +68,20 @@ export function ProxyConnectionInstructions({
         >
           Cerebras
         </Button>
+        <Button
+          variant={selectedProvider === "claude-code" ? "default" : "outline"}
+          size="sm"
+          onClick={() => setSelectedProvider("claude-code")}
+        >
+          Claude Code
+        </Button>
         <Popover>
           <PopoverTrigger asChild>
-            <Button
-              variant={
-                selectedProvider === "claude-code" ? "default" : "outline"
-              }
-              size="sm"
-            >
+            <Button variant="outline" size="sm">
               <ChevronDown className="h-4 w-4" />
             </Button>
           </PopoverTrigger>
           <PopoverContent className="w-auto p-2">
-            <Button
-              variant="ghost"
-              size="sm"
-              className="w-full justify-start"
-              onClick={() => setSelectedProvider("claude-code")}
-            >
-              Claude Code
-            </Button>
             <p className="text-xs text-muted-foreground px-2 py-1">
               More providers coming soon
             </p>


### PR DESCRIPTION
- Fixes #2366

This PR moves the "Claude Code" connection button from the hidden popover dropdown into the main `ButtonGroup` within the [ProxyConnectionInstructions](https://github.com/abhinav-m22/archestra/blob/cc1c737f593c20fc4ee1c5619100b78ee2a5b0a5/platform/frontend/src/components/proxy-connection-instructions.tsx#L25) component. 

The chevron dropdown remains but now only contains the "More providers coming soon" placeholder.

<img width="1642" height="641" alt="Screenshot from 2026-01-25 12-05-41" src="https://github.com/user-attachments/assets/8da62eff-b570-43cb-925d-e101cfe1137f" />
<img width="1642" height="641" alt="Screenshot from 2026-01-25 12-04-20" src="https://github.com/user-attachments/assets/8add1421-fb1e-4d94-957e-1792a37d2ef0" />