### PR TITLE
fix(mcp): show Deleted user when credential owner is deleted

### DIFF
--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -1423,8 +1423,10 @@ class ToolModel {
         agent: { id: string; name: string };
         credentialSourceMcpServerId: string | null;
         credentialOwnerEmail: string | null;
+        credentialOwnerDeleted?: boolean;
         executionSourceMcpServerId: string | null;
         executionOwnerEmail: string | null;
+        executionOwnerDeleted?: boolean;
         useDynamicTeamCredential: boolean;
         responseModifierTemplate: string | null;
       }>
@@ -1444,6 +1446,16 @@ class ToolModel {
         !assignment.executionSourceMcpServerId ||
         accessibleMcpServerIds.has(assignment.executionSourceMcpServerId);
 
+      // When user has access but owner email is null, owner was deleted (LEFT JOIN returned no user row)
+      const credentialOwnerDeleted =
+        !!credentialServerAccessible &&
+        !!assignment.credentialSourceMcpServerId &&
+        assignment.credentialOwnerEmail == null;
+      const executionOwnerDeleted =
+        !!executionServerAccessible &&
+        !!assignment.executionSourceMcpServerId &&
+        assignment.executionOwnerEmail == null;
+
       existing.push({
         agentToolId: assignment.agentToolId,
         agent: {
@@ -1454,10 +1466,12 @@ class ToolModel {
         credentialOwnerEmail: credentialServerAccessible
           ? assignment.credentialOwnerEmail
           : null,
+        ...(credentialOwnerDeleted && { credentialOwnerDeleted: true }),
         executionSourceMcpServerId: assignment.executionSourceMcpServerId,
         executionOwnerEmail: executionServerAccessible
           ? assignment.executionOwnerEmail
           : null,
+        ...(executionOwnerDeleted && { executionOwnerDeleted: true }),
         useDynamicTeamCredential: assignment.useDynamicTeamCredential,
         responseModifierTemplate: assignment.responseModifierTemplate,
       });

--- a/platform/backend/src/types/tool.ts
+++ b/platform/backend/src/types/tool.ts
@@ -62,8 +62,10 @@ export const ToolAssignmentSchema = z.object({
   }),
   credentialSourceMcpServerId: z.string().nullable(),
   credentialOwnerEmail: z.string().nullable(),
+  credentialOwnerDeleted: z.boolean().optional(),
   executionSourceMcpServerId: z.string().nullable(),
   executionOwnerEmail: z.string().nullable(),
+  executionOwnerDeleted: z.boolean().optional(),
   useDynamicTeamCredential: z.boolean(),
   responseModifierTemplate: z.string().nullable(),
 });

--- a/platform/frontend/src/app/tools/_parts/tool-details-dialog.tsx
+++ b/platform/frontend/src/app/tools/_parts/tool-details-dialog.tsx
@@ -52,8 +52,8 @@ export function ToolDetailsDialog({
 
   // Check if this is a built-in Archestra tool (no credentials required)
   // Helper to get credential display text
-  // Backend returns null for emails when user doesn't have access to the credential's MCP server
-  // Returns null when there's no credential to display
+  // Backend returns null for emails when user doesn't have access to the credential's MCP server,
+  // or when the owner was deleted. credentialOwnerDeleted/executionOwnerDeleted flags distinguish.
   const getCredentialDisplay = (
     assignment: (typeof tool.assignments)[0],
   ): string | null => {
@@ -71,11 +71,17 @@ export function ToolDetailsDialog({
       return null;
     }
 
-    // Backend returns email if user has access, null if not
+    // Backend returns email if user has access and owner exists, null otherwise
     const email =
       assignment.credentialOwnerEmail || assignment.executionOwnerEmail;
 
     if (!email) {
+      // Owner was deleted (backend sets credentialOwnerDeleted/executionOwnerDeleted when accessible but email null)
+      if (
+        assignment.credentialOwnerDeleted ?? assignment.executionOwnerDeleted
+      ) {
+        return "Deleted user";
+      }
       // Credential server exists but user doesn't have access
       return "Owner outside your team";
     }

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -26071,8 +26071,10 @@ export type GetToolsWithAssignmentsResponses = {
                 };
                 credentialSourceMcpServerId: string | null;
                 credentialOwnerEmail: string | null;
+                credentialOwnerDeleted?: boolean;
                 executionSourceMcpServerId: string | null;
                 executionOwnerEmail: string | null;
+                executionOwnerDeleted?: boolean;
                 useDynamicTeamCredential: boolean;
                 responseModifierTemplate: string | null;
             }>;


### PR DESCRIPTION
Fixes #2331
## Summary
When the owner of an MCP server credential is deleted, the UI now shows **"Deleted user"** instead of "Unknown" .

<img width="1266" height="657" alt="Screenshot (126)" src="https://github.com/user-attachments/assets/7c2aba7c-5856-4c28-8745-a494235a3b6d" />

Tool details now shows “Deleted user” when the assignment’s credential was deleted; Manage credentials and token select were already correct.

## Testing
- [x] Manual: created team MCP credential, removed credential owner from org (user deleted), confirmed **Manage credentials** shows "Deleted user" for that credential (screenshot attached).
- [x] Manual: confirmed **Tool details** shows "Deleted user" for an assignment whose credential owner was deleted.
