### PR TITLE
chore: refactor provider selection UI from dropdown to button group

### DIFF
--- a/platform/frontend/src/components/proxy-connection-instructions.tsx
+++ b/platform/frontend/src/components/proxy-connection-instructions.tsx
@@ -72,7 +72,6 @@ const PRIMARY_PROVIDERS: ProviderOption[] = [
   "openai",
   "anthropic",
   "gemini",
-  "ollama",
   "claude-code",
 ];
 
@@ -93,6 +92,7 @@ export function ProxyConnectionInstructions({
   const [connectionUrl, setConnectionUrl] = useState<string>(
     externalProxyUrls.length >= 1 ? externalProxyUrls[0] : internalProxyUrl,
   );
+  const [popoverOpen, setPopoverOpen] = useState(false);
 
   const getProviderPath = (provider: ProviderOption) =>
     provider === "claude-code" ? "anthropic" : provider;
@@ -118,7 +118,7 @@ export function ProxyConnectionInstructions({
             {PROVIDER_CONFIG[provider].label}
           </Button>
         ))}
-        <Popover>
+        <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
           <PopoverTrigger asChild>
             <Button
               variant={
@@ -127,6 +127,7 @@ export function ProxyConnectionInstructions({
                   : "outline"
               }
               size="sm"
+              aria-label="More providers"
             >
               {DROPDOWN_PROVIDERS.includes(selectedProvider)
                 ? PROVIDER_CONFIG[selectedProvider].label
@@ -134,14 +135,20 @@ export function ProxyConnectionInstructions({
               <MoreHorizontal className="h-4 w-4" />
             </Button>
           </PopoverTrigger>
-          <PopoverContent className="w-auto p-1">
+          <PopoverContent
+            className="w-auto p-1 flex flex-col"
+            aria-label="Additional providers"
+          >
             {DROPDOWN_PROVIDERS.map((provider) => (
               <Button
                 key={provider}
                 variant={selectedProvider === provider ? "default" : "ghost"}
                 size="sm"
-                className="w-full justify-start"
-                onClick={() => setSelectedProvider(provider)}
+                className="justify-start"
+                onClick={() => {
+                  setSelectedProvider(provider);
+                  setPopoverOpen(false);
+                }}
               >
                 {PROVIDER_CONFIG[provider].label}
               </Button>


### PR DESCRIPTION
## Summary
Replaced the provider selection dropdown with a more prominent button-based interface that highlights featured providers as primary buttons and relegates less common providers to an overflow menu.

## Key Changes
- **UI Component Swap**: Replaced `Select` component with `ButtonGroup` and `Popover` components for better visual hierarchy
- **Provider Organization**: Split providers into two categories:
  - **Primary providers** (OpenAI, Anthropic, Gemini, Claude Code) displayed as direct buttons
  - **Dropdown providers** (all others) accessible via a "More" menu button
- **Updated Imports**: Removed `Label` and `Select` imports; added `ButtonGroup`, `Popover`, `PopoverContent`, `PopoverTrigger`, and `MoreHorizontal` icon
- **Improved UX**: Primary providers are now immediately accessible without opening a menu, while maintaining a clean interface for less frequently used options

## Implementation Details
- Primary providers are shown as individual buttons with active state styling
- The overflow button displays the currently selected provider name if it's from the dropdown, otherwise shows only the menu icon
- All buttons maintain consistent sizing and styling through the `ButtonGroup` wrapper
- Provider filtering logic ensures no duplication between primary and dropdown lists

https://claude.ai/code/session_01PTzVKuNJYjyY1BNAWmVmAg