### PR TITLE
fix: make husky prepare script graceful in CI environments

### DIFF
--- a/platform/package.json
+++ b/platform/package.json
@@ -7,7 +7,7 @@
     "node": ">=18.0.0 <25.0.0"
   },
   "scripts": {
-    "prepare": "cd .. && husky platform/.husky",
+    "prepare": "cd .. && husky platform/.husky || true",
     "ci:check": "turbo check:ci",
     "dev": "turbo dev",
     "build": "turbo build",


### PR DESCRIPTION
## Summary
- Add `|| true` to the husky prepare script so it doesn't fail in CI/Docker environments where husky isn't available

## Test plan
- CI build should pass without `husky: not found` error