### PR TITLE
chore: rename "New chat" to "Create new chat session" in shortcut dialog

### DIFF
--- a/platform/frontend/src/components/conversation-search-palette.tsx
+++ b/platform/frontend/src/components/conversation-search-palette.tsx
@@ -284,7 +284,7 @@ export function ConversationSearchPalette({
                   className="flex items-center gap-2 px-3 py-3 cursor-pointer aria-selected:bg-accent"
                 >
                   <Pencil className="h-4 w-4 shrink-0 text-muted-foreground" />
-                  <span className="font-medium">New chat</span>
+                  <span className="font-medium">Create new chat session</span>
                 </CommandItem>
               </CommandGroup>
             )}


### PR DESCRIPTION
Disambiguates the action label from the default chat session name to avoid user confusion.

https://claude.ai/code/session_011FoNw59GwPnMUsbg9ibZ9E