### PR TITLE
feat: Support MCP UI rendering in chat

### DIFF
--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -747,8 +747,20 @@ export async function getChatMcpTools({
               }
 
               // Convert MCP content to string for AI SDK
-              return (result.content as Array<{ type: string; text?: string }>)
-                .map((item: { type: string; text?: string }) => {
+              // Preserve full content array as JSON when it contains resource items (for MCP UI rendering)
+              const contentArray = result.content as Array<{
+                type: string;
+                text?: string;
+                resource?: { uri?: string };
+              }>;
+              const hasResourceContent = contentArray.some(
+                (item) => item.type === "resource",
+              );
+              if (hasResourceContent) {
+                return JSON.stringify(contentArray);
+              }
+              return contentArray
+                .map((item) => {
                   if (item.type === "text" && item.text) {
                     return item.text;
                   }

--- a/platform/frontend/public/sandbox_proxy.html
+++ b/platform/frontend/public/sandbox_proxy.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>MCP UI Sandbox Proxy</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+    }
+    iframe {
+      width: 100%;
+      height: 100%;
+      border: none;
+    }
+  </style>
+</head>
+<body>
+  <script>
+    /**
+     * Sandbox proxy for MCP UI resources.
+     * This page acts as an intermediary that loads MCP UI content
+     * in a sandboxed environment. It receives content via postMessage
+     * and renders it in a child iframe with restricted permissions.
+     */
+    window.addEventListener('message', function(event) {
+      // Handle content loading
+      if (event.data && event.data.type === 'mcp-ui-load') {
+        const iframe = document.createElement('iframe');
+        iframe.sandbox = 'allow-scripts';
+        iframe.style.width = '100%';
+        iframe.style.height = '100%';
+        iframe.style.border = 'none';
+
+        if (event.data.html) {
+          iframe.srcdoc = event.data.html;
+        } else if (event.data.url) {
+          iframe.src = event.data.url;
+        }
+
+        document.body.innerHTML = '';
+        document.body.appendChild(iframe);
+
+        // Forward messages from child iframe to parent
+        window.addEventListener('message', function(childEvent) {
+          if (childEvent.source === iframe.contentWindow) {
+            window.parent.postMessage(childEvent.data, '*');
+          }
+        });
+      }
+
+      // Forward messages from parent to child iframe
+      if (event.data && event.data.type !== 'mcp-ui-load') {
+        const childIframe = document.querySelector('iframe');
+        if (childIframe && childIframe.contentWindow) {
+          childIframe.contentWindow.postMessage(event.data, '*');
+        }
+      }
+    });
+
+    // Notify parent that sandbox proxy is ready
+    window.parent.postMessage({ type: 'mcp-ui-sandbox-ready' }, '*');
+  </script>
+</body>
+</html>

--- a/platform/frontend/src/components/ai-elements/tool.tsx
+++ b/platform/frontend/src/components/ai-elements/tool.tsx
@@ -9,8 +9,13 @@ import {
   WrenchIcon,
   XCircleIcon,
 } from "lucide-react";
-import type { ComponentProps, ReactNode } from "react";
-import { createContext, useContext, useState } from "react";
+import React, {
+  type ComponentProps,
+  createContext,
+  type ReactNode,
+  useContext,
+  useState,
+} from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -264,6 +269,18 @@ export const ToolOutput = ({
             );
           })}
         </div>
+      </div>
+    );
+  }
+
+  // Support React elements as output (e.g., MCP UI components)
+  if (React.isValidElement(output)) {
+    return (
+      <div className={cn("space-y-2 p-4", className)} {...props}>
+        <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+          {label ?? (errorText ? "Error" : "Result")}
+        </h4>
+        <div className="rounded-md text-xs">{output}</div>
       </div>
     );
   }

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -36,6 +36,7 @@ import { extractFileAttachments, hasTextPart } from "./chat-messages.utils";
 import { EditableAssistantMessage } from "./editable-assistant-message";
 import { EditableUserMessage } from "./editable-user-message";
 import { InlineChatError } from "./inline-chat-error";
+import { McpUiRenderer, parseMcpContent } from "./mcp-ui-renderer";
 import { PolicyDeniedTool } from "./policy-denied-tool";
 import { TodoWriteTool } from "./todo-write-tool";
 import { ToolErrorLogsButton } from "./tool-error-logs-button";
@@ -868,6 +869,19 @@ function useStreamingStallDetection(
   return isStreamingStalled;
 }
 
+/**
+ * Check if tool output contains MCP UI content and return appropriate rendering.
+ * If the output is a JSON array with resource/image items, render via McpUiRenderer.
+ * Otherwise, return the output as-is for standard rendering.
+ */
+function renderMcpUiOrPlain(output: unknown): unknown {
+  const mcpContent = parseMcpContent(output);
+  if (mcpContent) {
+    return <McpUiRenderer content={mcpContent} />;
+  }
+  return output;
+}
+
 function MessageTool({
   part,
   toolResultPart,
@@ -942,14 +956,14 @@ function MessageTool({
         {toolResultPart && (
           <ToolOutput
             label={errorText ? "Error" : "Result"}
-            output={toolResultPart.output}
+            output={renderMcpUiOrPlain(toolResultPart.output)}
             errorText={errorText}
           />
         )}
         {!toolResultPart && Boolean(part.output) && (
           <ToolOutput
             label={errorText ? "Error" : "Result"}
-            output={part.output}
+            output={renderMcpUiOrPlain(part.output)}
             errorText={errorText}
           />
         )}

--- a/platform/frontend/src/components/chat/mcp-ui-renderer.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-ui-renderer.test.tsx
@@ -1,0 +1,207 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import {
+  type MCPContentItem,
+  McpUiRenderer,
+  parseMcpContent,
+} from "./mcp-ui-renderer";
+
+describe("parseMcpContent", () => {
+  it("returns null for non-string input", () => {
+    expect(parseMcpContent(42)).toBeNull();
+    expect(parseMcpContent(null)).toBeNull();
+    expect(parseMcpContent(undefined)).toBeNull();
+    expect(parseMcpContent({ type: "text" })).toBeNull();
+  });
+
+  it("returns null for non-JSON strings", () => {
+    expect(parseMcpContent("just a plain string")).toBeNull();
+    expect(parseMcpContent("not json at all")).toBeNull();
+  });
+
+  it("returns null for non-array JSON", () => {
+    expect(parseMcpContent('{"type":"text","text":"hello"}')).toBeNull();
+    expect(parseMcpContent('"string"')).toBeNull();
+  });
+
+  it("returns null for arrays without type fields", () => {
+    expect(parseMcpContent("[1, 2, 3]")).toBeNull();
+    expect(parseMcpContent('[{"foo":"bar"}]')).toBeNull();
+  });
+
+  it("returns null for text-only arrays (no rich content)", () => {
+    expect(parseMcpContent('[{"type":"text","text":"hello"}]')).toBeNull();
+  });
+
+  it("parses content with resource items", () => {
+    const content = JSON.stringify([
+      { type: "text", text: "Here is the widget:" },
+      {
+        type: "resource",
+        resource: {
+          uri: "ui://my-server/widget",
+          mimeType: "text/html",
+          text: "<h1>Widget</h1>",
+        },
+      },
+    ]);
+    const result = parseMcpContent(content);
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(2);
+    expect(result?.[0].type).toBe("text");
+    expect(result?.[1].type).toBe("resource");
+  });
+
+  it("parses content with image items", () => {
+    const content = JSON.stringify([
+      { type: "text", text: "Generated chart:" },
+      {
+        type: "image",
+        data: "base64data",
+        mimeType: "image/png",
+      },
+    ]);
+    const result = parseMcpContent(content);
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(2);
+    expect(result?.[1].type).toBe("image");
+  });
+});
+
+describe("McpUiRenderer", () => {
+  it("renders nothing for empty content", () => {
+    const { container } = render(<McpUiRenderer content={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders text content", () => {
+    const content: MCPContentItem[] = [
+      { type: "text", text: "Hello from MCP tool" },
+    ];
+    render(<McpUiRenderer content={content} />);
+    expect(screen.getByText("Hello from MCP tool")).toBeInTheDocument();
+  });
+
+  it("renders image content", () => {
+    const content: MCPContentItem[] = [
+      {
+        type: "image",
+        data: "dGVzdA==", // base64 of "test"
+        mimeType: "image/png",
+      },
+    ];
+    render(<McpUiRenderer content={content} />);
+    const img = screen.getByAltText("MCP generated content");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", "data:image/png;base64,dGVzdA==");
+  });
+
+  it("renders resource with URI", () => {
+    const content: MCPContentItem[] = [
+      {
+        type: "resource",
+        resource: {
+          uri: "ui://my-server/widget",
+          mimeType: "text/html",
+          text: "<h1>Widget</h1>",
+        },
+      },
+    ];
+    render(<McpUiRenderer content={content} />);
+    expect(screen.getByText("ui://my-server/widget")).toBeInTheDocument();
+    expect(screen.getByText("MCP UI")).toBeInTheDocument();
+    expect(screen.getByText("Expand UI")).toBeInTheDocument();
+  });
+
+  it("renders non-HTML resource as preview", () => {
+    const content: MCPContentItem[] = [
+      {
+        type: "resource",
+        resource: {
+          uri: "data://my-server/output.json",
+          mimeType: "application/json",
+          text: '{"result": 42}',
+        },
+      },
+    ];
+    render(<McpUiRenderer content={content} />);
+    expect(
+      screen.getByText("data://my-server/output.json"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("application/json")).toBeInTheDocument();
+    expect(screen.getByText('{"result": 42}')).toBeInTheDocument();
+  });
+
+  it("expands HTML resource iframe on button click", async () => {
+    const user = userEvent.setup();
+    const content: MCPContentItem[] = [
+      {
+        type: "resource",
+        resource: {
+          uri: "ui://my-server/chart",
+          mimeType: "text/html",
+          text: "<h1>Chart</h1>",
+        },
+      },
+    ];
+    render(<McpUiRenderer content={content} />);
+
+    // Initially no iframe visible
+    expect(
+      screen.queryByTitle("MCP UI Resource: ui://my-server/chart"),
+    ).not.toBeInTheDocument();
+
+    // Click expand
+    await user.click(screen.getByText("Expand UI"));
+
+    // Now iframe should be visible
+    const iframe = screen.getByTitle("MCP UI Resource: ui://my-server/chart");
+    expect(iframe).toBeInTheDocument();
+    expect(iframe).toHaveAttribute("sandbox", "allow-scripts");
+  });
+
+  it("renders mixed content types", () => {
+    const content: MCPContentItem[] = [
+      { type: "text", text: "Analysis complete:" },
+      {
+        type: "image",
+        data: "imagedata",
+        mimeType: "image/jpeg",
+      },
+      {
+        type: "resource",
+        resource: {
+          uri: "ui://analytics/dashboard",
+          mimeType: "text/html;profile=mcp-app",
+          text: "<div>Dashboard</div>",
+        },
+      },
+    ];
+    render(<McpUiRenderer content={content} />);
+    expect(screen.getByText("Analysis complete:")).toBeInTheDocument();
+    expect(screen.getByAltText("MCP generated content")).toBeInTheDocument();
+    expect(screen.getByText("ui://analytics/dashboard")).toBeInTheDocument();
+  });
+
+  it("handles missing resource data gracefully", () => {
+    const content: MCPContentItem[] = [
+      {
+        type: "resource",
+        resource: undefined as unknown as MCPContentItem["resource"],
+      } as MCPContentItem,
+    ];
+    render(<McpUiRenderer content={content} />);
+    expect(screen.getByText("Missing resource data")).toBeInTheDocument();
+  });
+
+  it("handles unsupported content types gracefully", () => {
+    const content = [
+      { type: "unknown_type" as MCPContentItem["type"] },
+    ] as MCPContentItem[];
+    render(<McpUiRenderer content={content} />);
+    expect(
+      screen.getByText("Unsupported MCP content type: unknown_type"),
+    ).toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/components/chat/mcp-ui-renderer.tsx
+++ b/platform/frontend/src/components/chat/mcp-ui-renderer.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { ExternalLink, FileText } from "lucide-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * MCP content item types as defined by the MCP protocol.
+ * Tool results can contain text, image, and resource items.
+ */
+export interface MCPContentItem {
+  type: "text" | "image" | "resource";
+  text?: string;
+  data?: string;
+  mimeType?: string;
+  resource?: {
+    uri: string;
+    mimeType?: string;
+    text?: string;
+    blob?: string;
+  };
+}
+
+interface McpUiRendererProps {
+  content: MCPContentItem[];
+  className?: string;
+}
+
+/**
+ * Renders MCP content items including text, images, and UI resources.
+ * For resource items with ui:// URIs, renders interactive content in sandboxed iframes.
+ * Supports both inline HTML resources and text/blob resources.
+ */
+export function McpUiRenderer({ content, className }: McpUiRendererProps) {
+  if (!Array.isArray(content) || content.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      {content.map((item, index) => (
+        <McpContentItemRenderer
+          key={`mcp-content-${item.type}-${index}`}
+          item={item}
+        />
+      ))}
+    </div>
+  );
+}
+
+function McpContentItemRenderer({ item }: { item: MCPContentItem }) {
+  switch (item.type) {
+    case "text":
+      return <p className="text-sm whitespace-pre-wrap">{item.text}</p>;
+
+    case "image":
+      return (
+        <div className="rounded-lg overflow-hidden border bg-muted/30">
+          <img
+            src={`data:${item.mimeType || "image/png"};base64,${item.data}`}
+            alt="MCP generated content"
+            className="max-w-full h-auto object-contain mx-auto"
+          />
+        </div>
+      );
+
+    case "resource":
+      if (!item.resource) {
+        return (
+          <div className="text-xs text-muted-foreground italic">
+            Missing resource data
+          </div>
+        );
+      }
+      return <McpResourceRenderer resource={item.resource} />;
+
+    default:
+      return (
+        <div className="text-xs text-muted-foreground italic">
+          Unsupported MCP content type: {item.type}
+        </div>
+      );
+  }
+}
+
+/**
+ * Renders an MCP resource item.
+ * - HTML resources (text/html, text/html;profile=mcp-app) are rendered in sandboxed iframes
+ * - Other resources show metadata and content preview
+ */
+function McpResourceRenderer({
+  resource,
+}: {
+  resource: NonNullable<MCPContentItem["resource"]>;
+}) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const isHtml =
+    resource.mimeType === "text/html" ||
+    resource.mimeType === "text/html;profile=mcp-app" ||
+    resource.uri.endsWith(".html");
+
+  const isUiResource = resource.uri?.startsWith("ui://");
+
+  // HTML UI resources rendered in sandboxed iframes
+  if ((isHtml || isUiResource) && resource.text) {
+    return (
+      <div className="rounded-lg border bg-card overflow-hidden">
+        <div className="flex items-center justify-between px-3 py-2 border-b bg-muted/20">
+          <div className="flex items-center gap-2">
+            <ExternalLink className="w-3.5 h-3.5 text-primary" />
+            <span className="text-xs font-medium truncate max-w-[250px]">
+              {resource.uri}
+            </span>
+            {isUiResource && (
+              <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-primary/10 text-primary">
+                MCP UI
+              </span>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="text-[10px] text-primary hover:underline cursor-pointer"
+          >
+            {isExpanded ? "Collapse" : "Expand UI"}
+          </button>
+        </div>
+        {isExpanded && (
+          <div className="w-full bg-white" style={{ minHeight: "200px" }}>
+            <iframe
+              srcDoc={resource.text}
+              title={`MCP UI Resource: ${resource.uri}`}
+              className="w-full border-none"
+              style={{ minHeight: "300px", height: "400px" }}
+              sandbox="allow-scripts"
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Blob-based HTML resources
+  if ((isHtml || isUiResource) && resource.blob) {
+    const decodedHtml = atob(resource.blob);
+    return (
+      <div className="rounded-lg border bg-card overflow-hidden">
+        <div className="flex items-center justify-between px-3 py-2 border-b bg-muted/20">
+          <div className="flex items-center gap-2">
+            <ExternalLink className="w-3.5 h-3.5 text-primary" />
+            <span className="text-xs font-medium truncate max-w-[250px]">
+              {resource.uri}
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="text-[10px] text-primary hover:underline cursor-pointer"
+          >
+            {isExpanded ? "Collapse" : "Expand UI"}
+          </button>
+        </div>
+        {isExpanded && (
+          <div className="w-full bg-white" style={{ minHeight: "200px" }}>
+            <iframe
+              srcDoc={decodedHtml}
+              title={`MCP UI Resource: ${resource.uri}`}
+              className="w-full border-none"
+              style={{ minHeight: "300px", height: "400px" }}
+              sandbox="allow-scripts"
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Non-HTML resources: show metadata and text preview
+  return (
+    <div className="rounded-lg border p-3 bg-muted/10">
+      <div className="flex items-center gap-2 mb-2">
+        <FileText className="w-4 h-4 text-muted-foreground" />
+        <span className="text-xs font-medium truncate">{resource.uri}</span>
+        {resource.mimeType && (
+          <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground">
+            {resource.mimeType}
+          </span>
+        )}
+      </div>
+      {resource.text && (
+        <pre className="text-[10px] bg-muted/50 p-2 rounded overflow-x-auto max-h-40">
+          {resource.text}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Checks if a string output from a tool result contains MCP content items.
+ * MCP content is a JSON array where items have type "text", "image", or "resource".
+ */
+export function parseMcpContent(output: unknown): MCPContentItem[] | null {
+  if (typeof output !== "string") return null;
+
+  try {
+    const parsed = JSON.parse(output);
+    if (!Array.isArray(parsed)) return null;
+
+    // Validate that it looks like MCP content (array of items with type field)
+    const isMcpContent = parsed.every(
+      (item: unknown) =>
+        typeof item === "object" &&
+        item !== null &&
+        "type" in item &&
+        typeof (item as Record<string, unknown>).type === "string",
+    );
+
+    if (!isMcpContent) return null;
+
+    // Check if any items are resources (especially ui:// resources) or images
+    const hasRichContent = parsed.some(
+      (item: MCPContentItem) =>
+        item.type === "resource" || item.type === "image",
+    );
+
+    if (!hasRichContent) return null;
+
+    return parsed as MCPContentItem[];
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Adds MCP UI support to the Archestra Chat UI, enabling rich content rendering for MCP tool responses.

### Changes

**New files:**
- McpUiRenderer component (mcp-ui-renderer.tsx) — renders MCP content types: text, image, and resource (with sandboxed HTML iframe support)
- sandbox_proxy.html — secure iframe proxy for HTML resource rendering
- mcp-ui-renderer.test.tsx — 16 tests covering parsing, rendering, edge cases, and graceful degradation

**Modified files:**
- chat-mcp-client.ts — forwards MCP UI content arrays to the frontend
- 	ool.tsx — integrates McpUiRenderer into tool response display
- chat-messages.tsx — integrates McpUiRenderer into chat message rendering

### Testing
- **16/16 tests passing** (vitest)
- Biome lint: clean (0 issues)
- TypeScript: compiles without errors

Closes #1301

/claim #1301