### PR TITLE
feat: Support MCP UI in Chat interface

### DIFF
--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -747,7 +747,9 @@ export async function getChatMcpTools({
               }
 
               // Convert MCP content to string for AI SDK
-              return (result.content as Array<{ type: string; text?: string }>)
+              const textContent = (
+                result.content as Array<{ type: string; text?: string }>
+              )
                 .map((item: { type: string; text?: string }) => {
                   if (item.type === "text" && item.text) {
                     return item.text;
@@ -755,6 +757,15 @@ export async function getChatMcpTools({
                   return JSON.stringify(item);
                 })
                 .join("\n");
+
+              if (result._meta) {
+                return {
+                  content: textContent,
+                  _meta: result._meta,
+                };
+              }
+
+              return textContent;
             } catch (error) {
               logger.error(
                 {

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -210,6 +210,7 @@ class McpClient {
           result.content,
           !!result.isError,
           tool.responseModifierTemplate,
+          result._meta,
         );
       } catch (error) {
         const errorMessage =
@@ -838,6 +839,7 @@ class McpClient {
     content: unknown,
     isError: boolean,
     template: string | null,
+    _meta?: Record<string, unknown>,
   ): Promise<CommonToolResult> {
     const modifiedContent = this.applyTemplate(
       content,
@@ -850,6 +852,7 @@ class McpClient {
       name: toolCall.name,
       content: modifiedContent,
       isError,
+      _meta,
     };
 
     await this.persistToolCall(agentId, mcpServerName, toolCall, toolResult);
@@ -1142,6 +1145,61 @@ class McpClient {
 
     await Promise.all([...disconnectPromises, ...activeDisconnectPromises]);
     this.activeConnections.clear();
+  }
+
+  /**
+   * Read a resource from its assigned MCP server
+   */
+  async readResource(
+    uri: string,
+    agentId: string,
+    tokenAuth?: TokenAuthContext,
+  ): Promise<{ contents: any[] }> {
+    // 1. Determine which catalog item / MCP server owns this resource
+    // For now, we assume the URI scheme or some mapping helps us find the server.
+    // In a real implementation, we might need a registry of resource templates or just search.
+    // However, the _meta.ui.resourceUri usually points to the same server that provided the tool.
+    // For the MVP, we'll try to find an MCP server installation that has access to this URI.
+
+    // Get all MCP servers assigned to this agent
+    const mcpServers = await McpServerModel.findAllForAgent(agentId);
+
+    // Try to read from each server until one succeeds or we run out
+    // In a better implementation, we'd use the URI authority to find the correct server.
+    for (const server of mcpServers) {
+      try {
+        // Resolve secrets
+        const secretResult = await this.getSecretsForMcpServer({
+          targetMcpServerId: server.id,
+          toolCall: { id: "resource-read", name: "read", arguments: {} },
+          agentId,
+        });
+
+        if ("error" in secretResult) continue;
+        const { secrets } = secretResult;
+
+        const catalogItem = await InternalMcpCatalogModel.findById(
+          server.catalogId,
+        );
+        if (!catalogItem) continue;
+
+        const transport = await this.getTransport(
+          catalogItem,
+          server.id,
+          secrets,
+        );
+        const connectionKey = `${catalogItem.id}:${server.id}`;
+        const client = await this.getOrCreateClient(connectionKey, transport);
+
+        const result = await client.readResource({ uri });
+        return result;
+      } catch (error) {
+        // Ignore and try next server
+        continue;
+      }
+    }
+
+    throw new Error(`Resource not found or no server could read it: ${uri}`);
   }
 }
 

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -3,6 +3,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
+  ReadResourceRequestSchema,
   type Tool,
 } from "@modelcontextprotocol/sdk/types.js";
 import {
@@ -119,6 +120,20 @@ export async function createAgentServer(
     }
 
     return { tools: toolsList };
+  });
+
+  server.setRequestHandler(ReadResourceRequestSchema, async ({ params: { uri } }) => {
+    try {
+      logger.info({ agentId, uri }, "MCP gateway read resource request received");
+      const result = await mcpClient.readResource(uri, agentId, tokenAuth);
+      return result;
+    } catch (error) {
+      throw {
+        code: -32603,
+        message: "Resource read failed",
+        data: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
   });
 
   server.setRequestHandler(

--- a/platform/backend/src/types/common-llm-format.ts
+++ b/platform/backend/src/types/common-llm-format.ts
@@ -29,6 +29,7 @@ export type CommonToolResult = {
   content: unknown;
   isError: boolean;
   error?: string;
+  _meta?: Record<string, unknown>;
 };
 
 /**

--- a/platform/frontend/package.json
+++ b/platform/frontend/package.json
@@ -43,6 +43,7 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@radix-ui/react-use-controllable-state": "^1.2.2",
+    "@mcp-ui/client": "latest",
     "@sentry/nextjs": "^10.34.0",
     "@shared": "workspace:*",
     "@tanstack/react-query": "^5.90.17",

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -1,5 +1,6 @@
 import type { UIMessage } from "@ai-sdk/react";
 import type { ChatStatus, DynamicToolUIPart, ToolUIPart } from "ai";
+import { AppRenderer } from "@mcp-ui/client";
 import Image from "next/image";
 import {
   Fragment,
@@ -879,12 +880,43 @@ function MessageTool({
   toolName: string;
   agentId?: string;
 }) {
+  const rawOutput = toolResultPart ? toolResultPart.output : part.output;
+  const meta = (rawOutput as any)?._meta;
+  const uiResourceUri = meta?.ui?.resourceUri;
+  const output =
+    (rawOutput as any)?.content !== undefined ? (rawOutput as any).content : rawOutput;
+
   const outputError = toolResultPart
-    ? tryToExtractErrorFromOutput(toolResultPart.output)
-    : tryToExtractErrorFromOutput(part.output);
+    ? tryToExtractErrorFromOutput(output)
+    : tryToExtractErrorFromOutput(output);
   const errorText = toolResultPart
     ? (toolResultPart.errorText ?? outputError)
     : (part.errorText ?? outputError);
+
+  // Simple MCP client bridge for AppRenderer
+  const mcpClient = useMemo(() => {
+    if (!agentId) return undefined;
+    return {
+      readResource: async ({ uri }: { uri: string }) => {
+        const response = await fetch(`/v1/mcp/${agentId}`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${agentId}`,
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "resources/read",
+            params: { uri },
+          }),
+        });
+        const json = await response.json();
+        if (json.error) throw new Error(json.error.message);
+        return json.result;
+      },
+    };
+  }, [agentId]);
 
   // OpenAI sends policy denials as tool errors (see case "text" above for Anthropic path)
   if (errorText) {
@@ -915,7 +947,7 @@ function MessageTool({
   const hasInput = part.input && Object.keys(part.input).length > 0;
   const hasContent = Boolean(
     hasInput ||
-      (toolResultPart && Boolean(toolResultPart.output)) ||
+      (toolResultPart && Boolean(output)) ||
       (!toolResultPart && Boolean(part.output)),
   );
 
@@ -939,10 +971,20 @@ function MessageTool({
       />
       <ToolContent>
         {hasInput ? <ToolInput input={part.input} /> : null}
+        {uiResourceUri && (
+          <div className="p-4 pt-0">
+            <AppRenderer
+              client={mcpClient as any}
+              toolName={toolName}
+              toolInput={part.input}
+              toolResult={output}
+            />
+          </div>
+        )}
         {toolResultPart && (
           <ToolOutput
             label={errorText ? "Error" : "Result"}
-            output={toolResultPart.output}
+            output={output}
             errorText={errorText}
           />
         )}


### PR DESCRIPTION
Implements the Model Context Protocol (MCP) UI standard. This allows tools to render rich, interactive interfaces directly in the chat by detecting the _meta.ui.resourceUri field in tool responses. Includes backend support for resource reading via the MCP Gateway and frontend integration with @mcp-ui/client.