### PR TITLE
fix: prevent tool policy dialog header from overflowing boundary

### DIFF
--- a/platform/frontend/src/app/tools/_parts/tool-details-dialog.tsx
+++ b/platform/frontend/src/app/tools/_parts/tool-details-dialog.tsx
@@ -89,9 +89,28 @@ export function ToolDetailsDialog({
         <DialogHeader className="shrink-0">
           <div className="flex items-start justify-between">
             <div className="flex-1 min-w-0">
-              <DialogTitle className="text-xl font-semibold tracking-tight truncate">
-                {tool.name}
-              </DialogTitle>
+              {tool.description ? (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DialogTitle className="text-xl font-semibold tracking-tight truncate cursor-help">
+                        {tool.name}
+                      </DialogTitle>
+                    </TooltipTrigger>
+                    <TooltipContent
+                      side="bottom"
+                      align="start"
+                      className="max-w-md"
+                    >
+                      <p>{tool.description}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              ) : (
+                <DialogTitle className="text-xl font-semibold tracking-tight truncate">
+                  {tool.name}
+                </DialogTitle>
+              )}
               {tool.description && (
                 <TruncatedText
                   message={tool.description}


### PR DESCRIPTION
Fixes #2594

Adds `min-w-0` to the flex-1 title container and `truncate` to the DialogTitle so long tool names don't overflow the dialog boundary.