### PR TITLE
feat: add DeepSeek provider support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "archestra-deepseek",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -64,6 +64,10 @@ export function detectProviderFromModel(model: string): SupportedChatProvider {
     return "zhipuai";
   }
 
+  if (lowerModel.includes("deepseek")) {
+    return "deepseek";
+  }
+
   // Default to anthropic for backwards compatibility
   // Note: vLLM and Ollama cannot be auto-detected as they can serve any model
   return "anthropic";
@@ -81,6 +85,7 @@ const envApiKeyGetters: Record<
   bedrock: () => config.chat.bedrock.apiKey,
   cerebras: () => config.chat.cerebras.apiKey,
   cohere: () => config.chat.cohere.apiKey,
+  deepseek: () => config.chat.deepseek.apiKey,
   gemini: () => config.chat.gemini.apiKey,
   mistral: () => config.chat.mistral.apiKey,
   ollama: () => config.chat.ollama.apiKey,
@@ -122,6 +127,7 @@ export async function resolveProviderApiKey(params: {
       secret?.secret?.geminiApiKey ??
       secret?.secret?.openaiApiKey ??
       secret?.secret?.zhipuaiApiKey ??
+      secret?.secret?.deepseekApiKey ??
       secret?.secret?.cohereApiKey ??
       secret?.secret?.bedrockApiKey;
     if (secretValue) {
@@ -163,6 +169,7 @@ export const FAST_MODELS: Record<SupportedChatProvider, string> = {
   gemini: "gemini-2.0-flash-001",
   cerebras: "llama-3.3-70b", // Cerebras focuses on speed, all their models are fast
   cohere: "command-light", // Cohere's fast model
+  deepseek: "deepseek-chat", // DeepSeek's fast model
   vllm: "default", // vLLM uses whatever model is deployed
   ollama: "llama3.2", // Common fast model for Ollama
   zhipuai: "glm-4-flash", // Zhipu's fast model
@@ -262,6 +269,21 @@ const directModelCreators: Record<SupportedChatProvider, DirectModelCreator> = {
     const client = createCohere({
       apiKey,
       baseURL: config.llm.cohere.baseUrl,
+    });
+    return client(modelName);
+  },
+
+  deepseek: ({ apiKey, modelName }) => {
+    if (!apiKey) {
+      throw new ApiError(
+        400,
+        "DeepSeek API key is required. Please configure DEEPSEEK_API_KEY.",
+      );
+    }
+    // DeepSeek uses OpenAI-compatible API
+    const client = createOpenAI({
+      apiKey,
+      baseURL: config.llm.deepseek.baseUrl,
     });
     return client(modelName);
   },
@@ -430,6 +452,18 @@ const proxiedModelCreators: Record<SupportedChatProvider, ProxiedModelCreator> =
         headers,
       });
       return client(modelName);
+    },
+
+    deepseek: ({ apiKey, agentId, modelName, headers }) => {
+      // URL format: /v1/deepseek/:agentId (SDK appends /chat/completions)
+      // DeepSeek uses OpenAI-compatible API, so we use the OpenAI SDK
+      const client = createOpenAI({
+        apiKey,
+        baseURL: buildProxyBaseUrl("deepseek", agentId),
+        headers,
+      });
+      // Use .chat() to force Chat Completions API
+      return client.chat(modelName);
     },
 
     cerebras: ({ apiKey, agentId, modelName, headers }) => {

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -464,6 +464,10 @@ export default {
         process.env.ARCHESTRA_ZHIPUAI_BASE_URL ||
         "https://api.z.ai/api/paas/v4",
     },
+    deepseek: {
+      baseUrl:
+        process.env.ARCHESTRA_DEEPSEEK_BASE_URL || "https://api.deepseek.com",
+    },
     bedrock: {
       enabled: Boolean(process.env.ARCHESTRA_BEDROCK_BASE_URL),
       baseUrl: process.env.ARCHESTRA_BEDROCK_BASE_URL || "",
@@ -499,6 +503,9 @@ export default {
     },
     zhipuai: {
       apiKey: process.env.ARCHESTRA_CHAT_ZHIPUAI_API_KEY || "",
+    },
+    deepseek: {
+      apiKey: process.env.ARCHESTRA_CHAT_DEEPSEEK_API_KEY || "",
     },
     bedrock: {
       apiKey: process.env.ARCHESTRA_CHAT_BEDROCK_API_KEY || "",

--- a/platform/backend/src/routes/index.ts
+++ b/platform/backend/src/routes/index.ts
@@ -2,6 +2,7 @@ import anthropicProxyRoutesV2 from "./proxy/routesv2/anthropic";
 import bedrockProxyRoutesV2 from "./proxy/routesv2/bedrock";
 import cerebrasProxyRoutesV2 from "./proxy/routesv2/cerebras";
 import cohereProxyRoutesV2 from "./proxy/routesv2/cohere";
+import deepseekProxyRoutesV2 from "./proxy/routesv2/deepseek";
 import geminiProxyRoutesV2 from "./proxy/routesv2/gemini";
 import mistralProxyRoutesV2 from "./proxy/routesv2/mistral";
 import ollamaProxyRoutesV2 from "./proxy/routesv2/ollama";
@@ -40,6 +41,7 @@ export { default as policyConfigSubagentRoutes } from "./policy-config-subagent"
 export const anthropicProxyRoutes = anthropicProxyRoutesV2;
 export const cerebrasProxyRoutes = cerebrasProxyRoutesV2;
 export const cohereProxyRoutes = cohereProxyRoutesV2;
+export const deepseekProxyRoutes = deepseekProxyRoutesV2;
 export const geminiProxyRoutes = geminiProxyRoutesV2;
 export const mistralProxyRoutes = mistralProxyRoutesV2;
 export const openAiProxyRoutes = openAiProxyRoutesV2;

--- a/platform/backend/src/routes/proxy/adapterV2/deepseek.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/deepseek.ts
@@ -1,0 +1,1003 @@
+import { encode as toonEncode } from "@toon-format/toon";
+import { get } from "lodash-es";
+import config from "@/config";
+import { getObservableFetch } from "@/llm-metrics";
+import logger from "@/logging";
+import { TokenPriceModel } from "@/models";
+import { getTokenizer } from "@/tokenizers";
+import type {
+  ChunkProcessingResult,
+  CommonMcpToolDefinition,
+  CommonMessage,
+  CommonToolCall,
+  CommonToolResult,
+  CreateClientOptions,
+  DeepSeek,
+  LLMProvider,
+  LLMRequestAdapter,
+  LLMResponseAdapter,
+  LLMStreamAdapter,
+  StreamAccumulatorState,
+  ToolCompressionStats,
+  UsageView,
+} from "@/types";
+import { unwrapToolContent } from "../utils/unwrap-tool-content";
+
+// =============================================================================
+// TYPE ALIASES
+// =============================================================================
+
+type DeepSeekRequest = DeepSeek.Types.ChatCompletionsRequest;
+type DeepSeekResponse = DeepSeek.Types.ChatCompletionsResponse;
+type DeepSeekMessages = DeepSeek.Types.ChatCompletionsRequest["messages"];
+type DeepSeekHeaders = DeepSeek.Types.ChatCompletionsHeaders;
+type DeepSeekStreamChunk = DeepSeek.Types.ChatCompletionChunk;
+
+// =============================================================================
+// DEEPSEEK SDK CLIENT
+// =============================================================================
+
+class DeepSeekClient {
+  private apiKey: string | undefined;
+  private baseURL: string;
+  private customFetch?: typeof fetch;
+
+  constructor(
+    apiKey: string | undefined,
+    baseURL?: string,
+    customFetch?: typeof fetch,
+  ) {
+    this.apiKey = apiKey;
+    this.baseURL = baseURL || "https://api.deepseek.com";
+    this.customFetch = customFetch;
+  }
+
+  async chatCompletions(request: DeepSeekRequest): Promise<DeepSeekResponse> {
+    const fetchFn = this.customFetch || fetch;
+    const response = await fetchFn(`${this.baseURL}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(this.apiKey && { Authorization: `Bearer ${this.apiKey}` }),
+      },
+      body: JSON.stringify({
+        ...request,
+        stream: false,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      let errorMessage = `DeepSeek API error: ${response.status} ${response.statusText}`;
+
+      try {
+        const errorJson = JSON.parse(errorText);
+        if (errorJson.error?.message) {
+          errorMessage += ` - ${errorJson.error.message}`;
+        } else {
+          errorMessage += ` - ${errorText}`;
+        }
+      } catch {
+        errorMessage += ` - ${errorText}`;
+      }
+
+      throw new Error(errorMessage);
+    }
+
+    return response.json() as Promise<DeepSeekResponse>;
+  }
+
+  async chatCompletionsStream(
+    request: DeepSeekRequest,
+  ): Promise<AsyncIterable<DeepSeekStreamChunk>> {
+    const fetchFn = this.customFetch || fetch;
+    const response = await fetchFn(`${this.baseURL}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(this.apiKey && { Authorization: `Bearer ${this.apiKey}` }),
+      },
+      body: JSON.stringify({
+        ...request,
+        stream: true,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      let errorMessage = `DeepSeek API error: ${response.status} ${response.statusText}`;
+
+      try {
+        const errorJson = JSON.parse(errorText);
+        if (errorJson.error?.message) {
+          errorMessage += ` - ${errorJson.error.message}`;
+        } else {
+          errorMessage += ` - ${errorText}`;
+        }
+      } catch {
+        errorMessage += ` - ${errorText}`;
+      }
+
+      throw new Error(errorMessage);
+    }
+
+    return this.parseSSEStream(response);
+  }
+
+  private async *parseSSEStream(
+    response: Response,
+  ): AsyncIterable<DeepSeekStreamChunk> {
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error("Response body is not readable");
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed || trimmed === "data: [DONE]") continue;
+
+          if (trimmed.startsWith("data: ")) {
+            try {
+              const jsonStr = trimmed.substring(6);
+              const chunk = JSON.parse(jsonStr) as DeepSeekStreamChunk;
+              yield chunk;
+            } catch (error) {
+              logger.warn(
+                { error, line: trimmed },
+                "Failed to parse SSE chunk from DeepSeek",
+              );
+            }
+          }
+        }
+      }
+
+      if (buffer.trim()) {
+        const trimmed = buffer.trim();
+        if (trimmed.startsWith("data: ") && trimmed !== "data: [DONE]") {
+          try {
+            const jsonStr = trimmed.substring(6);
+            const chunk = JSON.parse(jsonStr) as DeepSeekStreamChunk;
+            yield chunk;
+          } catch (error) {
+            logger.warn(
+              { error, line: trimmed },
+              "Failed to parse final SSE chunk from DeepSeek",
+            );
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+}
+
+// =============================================================================
+// REQUEST ADAPTER
+// =============================================================================
+
+class DeepSeekRequestAdapter
+  implements LLMRequestAdapter<DeepSeekRequest, DeepSeekMessages>
+{
+  readonly provider = "deepseek" as const;
+  private request: DeepSeekRequest;
+  private modifiedModel: string | null = null;
+  private toolResultUpdates: Record<string, string> = {};
+
+  constructor(request: DeepSeekRequest) {
+    this.request = request;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Read Access
+  // ---------------------------------------------------------------------------
+
+  getModel(): string {
+    return this.modifiedModel ?? this.request.model;
+  }
+
+  isStreaming(): boolean {
+    return this.request.stream === true;
+  }
+
+  getMessages(): CommonMessage[] {
+    return this.toCommonFormat(this.request.messages);
+  }
+
+  getToolResults(): CommonToolResult[] {
+    const results: CommonToolResult[] = [];
+
+    for (const message of this.request.messages) {
+      if (message.role === "tool") {
+        const toolName = this.findToolNameInMessages(
+          this.request.messages,
+          message.tool_call_id,
+        );
+
+        let content: unknown;
+        if (typeof message.content === "string") {
+          try {
+            content = JSON.parse(message.content);
+          } catch {
+            content = message.content;
+          }
+        } else {
+          content = message.content;
+        }
+
+        results.push({
+          id: message.tool_call_id,
+          name: toolName ?? "unknown",
+          content,
+          isError: false,
+        });
+      }
+    }
+
+    return results;
+  }
+
+  getTools(): CommonMcpToolDefinition[] {
+    if (!this.request.tools) return [];
+
+    const result: CommonMcpToolDefinition[] = [];
+    for (const tool of this.request.tools) {
+      if (tool.type === "function") {
+        result.push({
+          name: tool.function.name,
+          description: tool.function.description,
+          inputSchema: tool.function.parameters as Record<string, unknown>,
+        });
+      }
+    }
+    return result;
+  }
+
+  hasTools(): boolean {
+    return (this.request.tools?.length ?? 0) > 0;
+  }
+
+  getProviderMessages(): DeepSeekMessages {
+    return this.request.messages;
+  }
+
+  getOriginalRequest(): DeepSeekRequest {
+    return this.request;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Modify Access
+  // ---------------------------------------------------------------------------
+
+  setModel(model: string): void {
+    this.modifiedModel = model;
+  }
+
+  updateToolResult(toolCallId: string, newContent: string): void {
+    this.toolResultUpdates[toolCallId] = newContent;
+  }
+
+  applyToolResultUpdates(updates: Record<string, string>): void {
+    Object.assign(this.toolResultUpdates, updates);
+  }
+
+  convertToolResultContent(messages: DeepSeekMessages): DeepSeekMessages {
+    // DeepSeek uses OpenAI-compatible format, so no conversion needed
+    return messages;
+  }
+
+  async applyToonCompression(model: string): Promise<ToolCompressionStats> {
+    const { messages: compressedMessages, stats } =
+      await convertToolResultsToToon(this.request.messages, model);
+    this.request = {
+      ...this.request,
+      messages: compressedMessages,
+    };
+    return stats;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Build Modified Request
+  // ---------------------------------------------------------------------------
+
+  toProviderRequest(): DeepSeekRequest {
+    let messages = this.request.messages;
+
+    if (Object.keys(this.toolResultUpdates).length > 0) {
+      messages = this.applyUpdates(messages, this.toolResultUpdates);
+    }
+
+    return {
+      ...this.request,
+      model: this.getModel(),
+      messages,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private Helpers
+  // ---------------------------------------------------------------------------
+
+  private findToolNameInMessages(
+    messages: DeepSeekMessages,
+    toolCallId: string,
+  ): string | null {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+
+      if (message.role === "assistant" && message.tool_calls) {
+        for (const toolCall of message.tool_calls) {
+          if (toolCall.id === toolCallId) {
+            if (toolCall.type === "function") {
+              return toolCall.function.name;
+            }
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private toCommonFormat(messages: DeepSeekMessages): CommonMessage[] {
+    logger.debug(
+      { messageCount: messages.length },
+      "[DeepSeekAdapter] toCommonFormat: starting conversion",
+    );
+    const commonMessages: CommonMessage[] = [];
+
+    for (const message of messages) {
+      const commonMessage: CommonMessage = {
+        role: message.role as CommonMessage["role"],
+      };
+
+      if (message.role === "tool") {
+        const toolName = this.findToolNameInMessages(
+          messages,
+          message.tool_call_id,
+        );
+
+        if (toolName) {
+          logger.debug(
+            { toolCallId: message.tool_call_id, toolName },
+            "[DeepSeekAdapter] toCommonFormat: found tool message",
+          );
+          let toolResult: unknown;
+          if (typeof message.content === "string") {
+            try {
+              toolResult = JSON.parse(message.content);
+            } catch {
+              toolResult = message.content;
+            }
+          } else {
+            toolResult = message.content;
+          }
+
+          commonMessage.toolCalls = [
+            {
+              id: message.tool_call_id,
+              name: toolName,
+              content: toolResult,
+              isError: false,
+            },
+          ];
+        }
+      }
+
+      commonMessages.push(commonMessage);
+    }
+
+    logger.debug(
+      { inputCount: messages.length, outputCount: commonMessages.length },
+      "[DeepSeekAdapter] toCommonFormat: conversion complete",
+    );
+    return commonMessages;
+  }
+
+  private applyUpdates(
+    messages: DeepSeekMessages,
+    updates: Record<string, string>,
+  ): DeepSeekMessages {
+    const updateCount = Object.keys(updates).length;
+    logger.debug(
+      { messageCount: messages.length, updateCount },
+      "[DeepSeekAdapter] applyUpdates: starting",
+    );
+
+    if (updateCount === 0) {
+      logger.debug("[DeepSeekAdapter] applyUpdates: no updates to apply");
+      return messages;
+    }
+
+    let appliedCount = 0;
+    const result = messages.map((message) => {
+      if (message.role === "tool" && updates[message.tool_call_id]) {
+        appliedCount++;
+        logger.debug(
+          { toolCallId: message.tool_call_id },
+          "[DeepSeekAdapter] applyUpdates: applying update to tool message",
+        );
+        return {
+          ...message,
+          content: updates[message.tool_call_id],
+        };
+      }
+      return message;
+    });
+
+    logger.debug(
+      { updateCount, appliedCount },
+      "[DeepSeekAdapter] applyUpdates: complete",
+    );
+    return result;
+  }
+}
+
+// =============================================================================
+// RESPONSE ADAPTER
+// =============================================================================
+
+class DeepSeekResponseAdapter implements LLMResponseAdapter<DeepSeekResponse> {
+  readonly provider = "deepseek" as const;
+  private response: DeepSeekResponse;
+
+  constructor(response: DeepSeekResponse) {
+    this.response = response;
+  }
+
+  getId(): string {
+    return this.response.id;
+  }
+
+  getModel(): string {
+    return this.response.model;
+  }
+
+  getText(): string {
+    const choice = this.response.choices[0];
+    if (!choice) return "";
+    return choice.message.content ?? "";
+  }
+
+  getToolCalls(): CommonToolCall[] {
+    const choice = this.response.choices[0];
+    if (!choice?.message.tool_calls) return [];
+
+    return choice.message.tool_calls.map((toolCall) => {
+      let name: string;
+      let args: Record<string, unknown>;
+
+      if (toolCall.type === "function" && toolCall.function) {
+        name = toolCall.function.name;
+        try {
+          args = JSON.parse(toolCall.function.arguments);
+        } catch {
+          args = {};
+        }
+      } else {
+        name = "unknown";
+        args = {};
+      }
+
+      return {
+        id: toolCall.id,
+        name,
+        arguments: args,
+      };
+    });
+  }
+
+  hasToolCalls(): boolean {
+    const choice = this.response.choices[0];
+    return (choice?.message.tool_calls?.length ?? 0) > 0;
+  }
+
+  getUsage(): UsageView {
+    if (!this.response.usage) {
+      return { inputTokens: 0, outputTokens: 0 };
+    }
+    const { input, output } = getUsageTokens(this.response.usage);
+    return { inputTokens: input, outputTokens: output };
+  }
+
+  getOriginalResponse(): DeepSeekResponse {
+    return this.response;
+  }
+
+  toRefusalResponse(
+    _refusalMessage: string,
+    contentMessage: string,
+  ): DeepSeekResponse {
+    return {
+      ...this.response,
+      choices: [
+        {
+          ...this.response.choices[0],
+          message: {
+            role: "assistant",
+            content: contentMessage,
+          },
+          finish_reason: "stop",
+        },
+      ],
+    };
+  }
+}
+
+// =============================================================================
+// STREAM ADAPTER
+// =============================================================================
+
+/**
+ * DeepSeekStreamAdapter processes streaming chunks and accumulates state.
+ *
+ * COMPARISON WITH OPENAI:
+ * - DeepSeek uses OpenAI-compatible streaming format
+ * - DeepSeek has extra reasoning_content field in delta (for DeepSeek-R1 reasoning models)
+ */
+class DeepSeekStreamAdapter
+  implements LLMStreamAdapter<DeepSeekStreamChunk, DeepSeekResponse>
+{
+  readonly provider = "deepseek" as const;
+  readonly state: StreamAccumulatorState;
+  private currentToolCallIndices = new Map<number, number>();
+
+  constructor() {
+    this.state = {
+      responseId: "",
+      model: "",
+      text: "",
+      toolCalls: [],
+      rawToolCallEvents: [],
+      usage: null,
+      stopReason: null,
+      timing: {
+        startTime: Date.now(),
+        firstChunkTime: null,
+      },
+    };
+  }
+
+  processChunk(chunk: DeepSeekStreamChunk): ChunkProcessingResult {
+    if (this.state.timing.firstChunkTime === null) {
+      this.state.timing.firstChunkTime = Date.now();
+    }
+
+    let sseData: string | null = null;
+    let isToolCallChunk = false;
+    let isFinal = false;
+
+    this.state.responseId = chunk.id;
+    this.state.model = chunk.model;
+
+    const choice = chunk.choices[0];
+    if (!choice) {
+      return {
+        sseData: null,
+        isToolCallChunk: false,
+        isFinal: false,
+      };
+    }
+
+    const delta = choice.delta;
+
+    // Handle text content accumulation
+    if (delta.content) {
+      this.state.text += delta.content;
+    }
+
+    // Only forward chunks with meaningful content updates
+    const hasContent =
+      delta.content ||
+      delta.reasoning_content ||
+      delta.tool_calls ||
+      delta.role;
+
+    if (hasContent) {
+      sseData = `data: ${JSON.stringify(chunk)}\n\n`;
+    }
+
+    if (delta.tool_calls) {
+      for (const toolCallDelta of delta.tool_calls) {
+        const index = toolCallDelta.index;
+
+        if (!this.currentToolCallIndices.has(index)) {
+          this.currentToolCallIndices.set(index, this.state.toolCalls.length);
+          this.state.toolCalls.push({
+            id: toolCallDelta.id ?? "",
+            name: toolCallDelta.function?.name ?? "",
+            arguments: "",
+          });
+        }
+
+        const toolCallIndex = this.currentToolCallIndices.get(index);
+        if (toolCallIndex === undefined) continue;
+        const toolCall = this.state.toolCalls[toolCallIndex];
+
+        if (toolCallDelta.id) {
+          toolCall.id = toolCallDelta.id;
+        }
+        if (toolCallDelta.function?.name) {
+          toolCall.name = toolCallDelta.function.name;
+        }
+        if (toolCallDelta.function?.arguments) {
+          toolCall.arguments += toolCallDelta.function.arguments;
+        }
+      }
+
+      this.state.rawToolCallEvents.push(chunk);
+      isToolCallChunk = true;
+    }
+
+    if (choice.finish_reason) {
+      this.state.stopReason = choice.finish_reason;
+      isFinal = true;
+    }
+
+    if (chunk.usage) {
+      this.state.usage = {
+        inputTokens: chunk.usage.prompt_tokens ?? 0,
+        outputTokens: chunk.usage.completion_tokens ?? 0,
+      };
+    }
+
+    return { sseData, isToolCallChunk, isFinal };
+  }
+
+  getSSEHeaders(): Record<string, string> {
+    return {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    };
+  }
+
+  formatTextDeltaSSE(text: string): string {
+    const chunk: DeepSeekStreamChunk = {
+      id: this.state.responseId,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            content: text,
+          },
+          finish_reason: null,
+        },
+      ],
+    };
+    return `data: ${JSON.stringify(chunk)}\n\n`;
+  }
+
+  getRawToolCallEvents(): string[] {
+    return this.state.rawToolCallEvents.map(
+      (event) => `data: ${JSON.stringify(event)}\n\n`,
+    );
+  }
+
+  formatCompleteTextSSE(text: string): string[] {
+    const chunk: DeepSeekStreamChunk = {
+      id: this.state.responseId || `chatcmpl-${Date.now()}`,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            role: "assistant",
+            content: text,
+          },
+          finish_reason: null,
+        },
+      ],
+    };
+    return [`data: ${JSON.stringify(chunk)}\n\n`];
+  }
+
+  formatEndSSE(): string {
+    const finalChunk: DeepSeekStreamChunk = {
+      id: this.state.responseId,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          delta: {},
+          finish_reason: this.state.stopReason ?? "stop",
+        },
+      ],
+    };
+    return `data: ${JSON.stringify(finalChunk)}\n\ndata: [DONE]\n\n`;
+  }
+
+  toProviderResponse(): DeepSeekResponse {
+    const toolCalls =
+      this.state.toolCalls.length > 0
+        ? this.state.toolCalls.map((tc) => ({
+            id: tc.id,
+            type: "function" as const,
+            function: {
+              name: tc.name,
+              arguments: tc.arguments,
+            },
+          }))
+        : undefined;
+
+    return {
+      id: this.state.responseId,
+      object: "chat.completion",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: this.state.text || null,
+            tool_calls: toolCalls,
+          },
+          logprobs: null,
+          finish_reason:
+            (this.state.stopReason as DeepSeek.Types.FinishReason) ?? "stop",
+        },
+      ],
+      usage: {
+        prompt_tokens: this.state.usage?.inputTokens ?? 0,
+        completion_tokens: this.state.usage?.outputTokens ?? 0,
+        total_tokens:
+          (this.state.usage?.inputTokens ?? 0) +
+          (this.state.usage?.outputTokens ?? 0),
+      },
+    };
+  }
+}
+
+// =============================================================================
+// TOON COMPRESSION
+// =============================================================================
+
+async function convertToolResultsToToon(
+  messages: DeepSeekMessages,
+  model: string,
+): Promise<{
+  messages: DeepSeekMessages;
+  stats: ToolCompressionStats;
+}> {
+  const tokenizer = getTokenizer("deepseek");
+  let toolResultCount = 0;
+  let totalTokensBefore = 0;
+  let totalTokensAfter = 0;
+
+  const result = messages.map((message) => {
+    if (message.role === "tool") {
+      logger.info(
+        {
+          toolCallId: message.tool_call_id,
+          contentType: typeof message.content,
+          provider: "deepseek",
+        },
+        "convertToolResultsToToon: tool message found",
+      );
+
+      if (typeof message.content === "string") {
+        try {
+          const unwrapped = unwrapToolContent(message.content);
+          const parsed = JSON.parse(unwrapped);
+          const noncompressed = unwrapped;
+          const compressed = toonEncode(parsed);
+
+          const tokensBefore = tokenizer.countTokens([
+            { role: "user", content: noncompressed },
+          ]);
+          const tokensAfter = tokenizer.countTokens([
+            { role: "user", content: compressed },
+          ]);
+
+          toolResultCount++;
+
+          // Always count tokens before
+          totalTokensBefore += tokensBefore;
+
+          // Only apply compression if it actually saves tokens
+          if (tokensAfter < tokensBefore) {
+            totalTokensAfter += tokensAfter;
+
+            logger.info(
+              {
+                toolCallId: message.tool_call_id,
+                beforeLength: noncompressed.length,
+                afterLength: compressed.length,
+                tokensBefore,
+                tokensAfter,
+                toonPreview: compressed.substring(0, 150),
+                provider: "deepseek",
+              },
+              "convertToolResultsToToon: compressed",
+            );
+            logger.debug(
+              {
+                toolCallId: message.tool_call_id,
+                before: noncompressed,
+                after: compressed,
+                provider: "deepseek",
+                supposedToBeJson: parsed,
+              },
+              "convertToolResultsToToon: before/after",
+            );
+
+            return {
+              ...message,
+              content: compressed,
+            };
+          }
+
+          // Compression not applied - count non-compressed tokens to track total tokens anyway
+          totalTokensAfter += tokensBefore;
+          logger.info(
+            {
+              toolCallId: message.tool_call_id,
+              tokensBefore,
+              tokensAfter,
+              provider: "deepseek",
+            },
+            "Skipping TOON compression - compressed output has more tokens",
+          );
+        } catch {
+          logger.info(
+            {
+              toolCallId: message.tool_call_id,
+              contentPreview:
+                typeof message.content === "string"
+                  ? message.content.substring(0, 100)
+                  : "non-string",
+            },
+            "Skipping TOON conversion - content is not JSON",
+          );
+          return message;
+        }
+      }
+    }
+
+    return message;
+  });
+
+  logger.info(
+    { messageCount: messages.length, toolResultCount },
+    "convertToolResultsToToon completed",
+  );
+
+  let toonCostSavings = 0;
+  const tokensSaved = totalTokensBefore - totalTokensAfter;
+  if (tokensSaved > 0) {
+    const tokenPrice = await TokenPriceModel.findByModel(model);
+    if (tokenPrice) {
+      const inputPricePerToken =
+        Number(tokenPrice.pricePerMillionInput) / 1000000;
+      toonCostSavings = tokensSaved * inputPricePerToken;
+    }
+  }
+
+  return {
+    messages: result,
+    stats: {
+      tokensBefore: totalTokensBefore,
+      tokensAfter: totalTokensAfter,
+      costSavings: toonCostSavings,
+      wasEffective: totalTokensAfter < totalTokensBefore,
+      hadToolResults: toolResultCount > 0,
+    },
+  };
+}
+
+// =============================================================================
+// ADAPTER FACTORY
+// =============================================================================
+
+// =============================================================================
+// USAGE TOKEN HELPERS
+// =============================================================================
+
+export function getUsageTokens(usage: DeepSeek.Types.Usage) {
+  return {
+    input: usage.prompt_tokens,
+    output: usage.completion_tokens,
+  };
+}
+
+export const deepseekAdapterFactory: LLMProvider<
+  DeepSeekRequest,
+  DeepSeekResponse,
+  DeepSeekMessages,
+  DeepSeekStreamChunk,
+  DeepSeekHeaders
+> = {
+  provider: "deepseek",
+  interactionType: "deepseek:chatCompletions",
+
+  createRequestAdapter(
+    request: DeepSeekRequest,
+  ): LLMRequestAdapter<DeepSeekRequest, DeepSeekMessages> {
+    return new DeepSeekRequestAdapter(request);
+  },
+
+  createResponseAdapter(
+    response: DeepSeekResponse,
+  ): LLMResponseAdapter<DeepSeekResponse> {
+    return new DeepSeekResponseAdapter(response);
+  },
+
+  createStreamAdapter(): LLMStreamAdapter<DeepSeekStreamChunk, DeepSeekResponse> {
+    return new DeepSeekStreamAdapter();
+  },
+
+  extractApiKey(headers: DeepSeekHeaders): string | undefined {
+    return headers.authorization;
+  },
+
+  getBaseUrl(): string | undefined {
+    return config.llm.deepseek.baseUrl;
+  },
+
+  getSpanName(): string {
+    return "deepseek.chat.completions";
+  },
+
+  createClient(
+    apiKey: string | undefined,
+    options?: CreateClientOptions,
+  ): DeepSeekClient {
+    const customFetch = options?.agent
+      ? getObservableFetch("deepseek", options.agent, options.externalAgentId)
+      : undefined;
+
+    return new DeepSeekClient(apiKey, options?.baseUrl, customFetch);
+  },
+
+  async execute(
+    client: unknown,
+    request: DeepSeekRequest,
+  ): Promise<DeepSeekResponse> {
+    const deepseekClient = client as DeepSeekClient;
+    return deepseekClient.chatCompletions(request);
+  },
+
+  async executeStream(
+    client: unknown,
+    request: DeepSeekRequest,
+  ): Promise<AsyncIterable<DeepSeekStreamChunk>> {
+    const deepseekClient = client as DeepSeekClient;
+    return deepseekClient.chatCompletionsStream(request);
+  },
+
+  extractErrorMessage(error: unknown): string {
+    // Try to extract message from DeepSeek error structure
+    const deepseekMessage = get(error, "error.message");
+    if (typeof deepseekMessage === "string") {
+      return deepseekMessage;
+    }
+
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return "Internal server error";
+  },
+};

--- a/platform/backend/src/routes/proxy/adapterV2/index.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/index.ts
@@ -2,6 +2,7 @@ export { anthropicAdapterFactory } from "./anthropic";
 export { bedrockAdapterFactory } from "./bedrock";
 export { cerebrasAdapterFactory } from "./cerebras";
 export { cohereAdapterFactory } from "./cohere";
+export { deepseekAdapterFactory } from "./deepseek";
 export { geminiAdapterFactory } from "./gemini";
 export { mistralAdapterFactory } from "./mistral";
 export { ollamaAdapterFactory } from "./ollama";

--- a/platform/backend/src/routes/proxy/routesv2/deepseek.ts
+++ b/platform/backend/src/routes/proxy/routesv2/deepseek.ts
@@ -1,0 +1,161 @@
+import fastifyHttpProxy from "@fastify/http-proxy";
+import { RouteId } from "@shared";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import config from "@/config";
+import logger from "@/logging";
+import { constructResponseSchema, DeepSeek, UuidIdSchema } from "@/types";
+import { deepseekAdapterFactory } from "../adapterV2";
+import { PROXY_API_PREFIX, PROXY_BODY_LIMIT } from "../common";
+import { handleLLMProxy } from "../llm-proxy-handler";
+import * as utils from "../utils";
+
+const deepseekProxyRoutesV2: FastifyPluginAsyncZod = async (fastify) => {
+  const API_PREFIX = `${PROXY_API_PREFIX}/deepseek`;
+  const CHAT_COMPLETIONS_SUFFIX = "/chat/completions";
+
+  logger.info("[UnifiedProxy] Registering unified DeepSeek routes");
+
+  await fastify.register(fastifyHttpProxy, {
+    upstream: config.llm.deepseek.baseUrl,
+    prefix: API_PREFIX,
+    rewritePrefix: "",
+    preHandler: (request, _reply, next) => {
+      if (
+        request.method === "POST" &&
+        request.url.includes(CHAT_COMPLETIONS_SUFFIX)
+      ) {
+        logger.info(
+          {
+            method: request.method,
+            url: request.url,
+            action: "skip-proxy",
+            reason: "handled-by-custom-handler",
+          },
+          "DeepSeek proxy preHandler: skipping chat/completions route",
+        );
+        next(new Error("skip"));
+        return;
+      }
+
+      const pathAfterPrefix = request.url.replace(API_PREFIX, "");
+      const uuidMatch = pathAfterPrefix.match(
+        /^\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(\/.*)?$/i,
+      );
+
+      if (uuidMatch) {
+        const remainingPath = uuidMatch[2] || "";
+        const originalUrl = request.raw.url;
+        request.raw.url = `${API_PREFIX}${remainingPath}`;
+
+        logger.info(
+          {
+            method: request.method,
+            originalUrl,
+            rewrittenUrl: request.raw.url,
+            upstream: config.llm.deepseek.baseUrl,
+            finalProxyUrl: `${config.llm.deepseek.baseUrl}${remainingPath}`,
+          },
+          "DeepSeek proxy preHandler: URL rewritten (UUID stripped)",
+        );
+      } else {
+        logger.info(
+          {
+            method: request.method,
+            url: request.url,
+            upstream: config.llm.deepseek.baseUrl,
+            finalProxyUrl: `${config.llm.deepseek.baseUrl}${pathAfterPrefix}`,
+          },
+          "DeepSeek proxy preHandler: proxying request",
+        );
+      }
+
+      next();
+    },
+  });
+
+  fastify.post(
+    `${API_PREFIX}${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        operationId: RouteId.DeepSeekChatCompletionsWithDefaultAgent,
+        description:
+          "Create a chat completion with DeepSeek (uses default agent)",
+        tags: ["llm-proxy"],
+        body: DeepSeek.API.ChatCompletionRequestSchema,
+        headers: DeepSeek.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(
+          DeepSeek.API.ChatCompletionResponseSchema,
+        ),
+      },
+    },
+    async (request, reply) => {
+      logger.debug(
+        { url: request.url },
+        "[UnifiedProxy] Handling DeepSeek request (default agent)",
+      );
+      const externalAgentId = utils.externalAgentId.getExternalAgentId(
+        request.headers,
+      );
+      const userId = await utils.userId.getUserId(request.headers);
+      return handleLLMProxy(
+        request.body,
+        request.headers,
+        reply,
+        deepseekAdapterFactory,
+        {
+          organizationId: request.organizationId,
+          agentId: undefined,
+          externalAgentId,
+          userId,
+        },
+      );
+    },
+  );
+
+  fastify.post(
+    `${API_PREFIX}/:agentId${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        operationId: RouteId.DeepSeekChatCompletionsWithAgent,
+        description:
+          "Create a chat completion with DeepSeek for a specific agent",
+        tags: ["llm-proxy"],
+        params: z.object({
+          agentId: UuidIdSchema,
+        }),
+        body: DeepSeek.API.ChatCompletionRequestSchema,
+        headers: DeepSeek.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(
+          DeepSeek.API.ChatCompletionResponseSchema,
+        ),
+      },
+    },
+    async (request, reply) => {
+      logger.debug(
+        { url: request.url, agentId: request.params.agentId },
+        "[UnifiedProxy] Handling DeepSeek request (with agent)",
+      );
+      const externalAgentId = utils.externalAgentId.getExternalAgentId(
+        request.headers,
+      );
+      const userId = await utils.userId.getUserId(request.headers);
+      return handleLLMProxy(
+        request.body,
+        request.headers,
+        reply,
+        deepseekAdapterFactory,
+        {
+          organizationId: request.organizationId,
+          agentId: request.params.agentId,
+          externalAgentId,
+          userId,
+        },
+      );
+    },
+  );
+};
+
+export default deepseekProxyRoutesV2;

--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -62,6 +62,7 @@ import {
   ApiError,
   Cerebras,
   Cohere,
+  DeepSeek,
   Gemini,
   Mistral,
   Ollama,
@@ -153,6 +154,12 @@ export function registerOpenApiSchemas() {
   });
   z.globalRegistry.add(Zhipuai.API.ChatCompletionResponseSchema, {
     id: "ZhipuaiChatCompletionResponse",
+  });
+  z.globalRegistry.add(DeepSeek.API.ChatCompletionRequestSchema, {
+    id: "DeepSeekChatCompletionRequest",
+  });
+  z.globalRegistry.add(DeepSeek.API.ChatCompletionResponseSchema, {
+    id: "DeepSeekChatCompletionResponse",
   });
 }
 

--- a/platform/backend/src/tokenizers/index.ts
+++ b/platform/backend/src/tokenizers/index.ts
@@ -16,6 +16,7 @@ export function getTokenizer(provider: SupportedProvider): Tokenizer {
       return new AnthropicTokenizer();
     case "cerebras":
     case "cohere":
+    case "deepseek":
     case "mistral":
     case "openai":
     case "vllm":

--- a/platform/backend/src/types/chat-api-key.ts
+++ b/platform/backend/src/types/chat-api-key.ts
@@ -13,6 +13,7 @@ export const SupportedChatProviderSchema = z.enum([
   "bedrock",
   "cerebras",
   "cohere",
+  "deepseek",
   "gemini",
   "mistral",
   "openai",

--- a/platform/backend/src/types/interaction.ts
+++ b/platform/backend/src/types/interaction.ts
@@ -7,6 +7,7 @@ import {
   Bedrock,
   Cerebras,
   Cohere,
+  DeepSeek,
   Gemini,
   Mistral,
   Ollama,
@@ -31,6 +32,7 @@ export const InteractionRequestSchema = z.union([
   Anthropic.API.MessagesRequestSchema,
   Bedrock.API.ConverseRequestSchema,
   Cerebras.API.ChatCompletionRequestSchema,
+  DeepSeek.API.ChatCompletionRequestSchema,
   Mistral.API.ChatCompletionRequestSchema,
   Vllm.API.ChatCompletionRequestSchema,
   Ollama.API.ChatCompletionRequestSchema,
@@ -44,6 +46,7 @@ export const InteractionResponseSchema = z.union([
   Anthropic.API.MessagesResponseSchema,
   Bedrock.API.ConverseResponseSchema,
   Cerebras.API.ChatCompletionResponseSchema,
+  DeepSeek.API.ChatCompletionResponseSchema,
   Mistral.API.ChatCompletionResponseSchema,
   Vllm.API.ChatCompletionResponseSchema,
   Ollama.API.ChatCompletionResponseSchema,
@@ -158,6 +161,16 @@ export const SelectInteractionSchema = z.discriminatedUnion("type", [
     processedRequest:
       Zhipuai.API.ChatCompletionRequestSchema.nullable().optional(),
     response: Zhipuai.API.ChatCompletionResponseSchema,
+    requestType: RequestTypeSchema.optional(),
+    /** Resolved prompt name if externalAgentId matches a prompt ID */
+    externalAgentIdLabel: z.string().nullable().optional(),
+  }),
+  BaseSelectInteractionSchema.extend({
+    type: z.enum(["deepseek:chatCompletions"]),
+    request: DeepSeek.API.ChatCompletionRequestSchema,
+    processedRequest:
+      DeepSeek.API.ChatCompletionRequestSchema.nullable().optional(),
+    response: DeepSeek.API.ChatCompletionResponseSchema,
     requestType: RequestTypeSchema.optional(),
     /** Resolved prompt name if externalAgentId matches a prompt ID */
     externalAgentIdLabel: z.string().nullable().optional(),

--- a/platform/backend/src/types/llm-providers/deepseek/api.ts
+++ b/platform/backend/src/types/llm-providers/deepseek/api.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+
+import { MessageParamSchema, ToolCallSchema } from "./messages";
+import { ToolChoiceOptionSchema, ToolSchema } from "./tools";
+
+export const ChatCompletionUsageSchema = z
+  .object({
+    completion_tokens: z.number(),
+    prompt_tokens: z.number(),
+    total_tokens: z.number(),
+    prompt_cache_hit_tokens: z.number().optional(),
+    prompt_cache_miss_tokens: z.number().optional(),
+    completion_tokens_details: z
+      .object({
+        reasoning_tokens: z.number().optional(),
+      })
+      .optional(),
+  })
+  .describe(`https://api-docs.deepseek.com/api/create-chat-completion`);
+
+export const FinishReasonSchema = z.enum([
+  "stop",
+  "length",
+  "tool_calls",
+  "content_filter",
+]);
+
+const ChoiceSchema = z
+  .object({
+    finish_reason: FinishReasonSchema,
+    index: z.number(),
+    logprobs: z.any().nullable(),
+    message: z
+      .object({
+        content: z.string().nullable(),
+        role: z.enum(["assistant"]),
+        reasoning_content: z.string().nullable().optional(),
+        tool_calls: z.array(ToolCallSchema).optional(),
+      })
+      .describe(`https://api-docs.deepseek.com/api/create-chat-completion`),
+  })
+  .describe(`https://api-docs.deepseek.com/api/create-chat-completion`);
+
+export const ChatCompletionRequestSchema = z
+  .object({
+    model: z.string(),
+    messages: z.array(MessageParamSchema),
+    tools: z.array(ToolSchema).optional(),
+    tool_choice: ToolChoiceOptionSchema.optional(),
+    stream: z.boolean().optional(),
+    temperature: z.number().nullable().optional(),
+    top_p: z.number().nullable().optional(),
+    max_tokens: z.number().nullable().optional(),
+    stop: z.union([z.string(), z.array(z.string())]).optional(),
+    frequency_penalty: z.number().nullable().optional(),
+    presence_penalty: z.number().nullable().optional(),
+    logprobs: z.boolean().optional(),
+    top_logprobs: z.number().nullable().optional(),
+    response_format: z
+      .object({
+        type: z.enum(["text", "json_object"]),
+      })
+      .optional(),
+  })
+  .describe(`https://api-docs.deepseek.com/api/create-chat-completion`);
+
+export const ChatCompletionResponseSchema = z
+  .object({
+    id: z.string(),
+    choices: z.array(ChoiceSchema),
+    created: z.number(),
+    model: z.string(),
+    object: z.enum(["chat.completion"]),
+    system_fingerprint: z.string().nullable().optional(),
+    usage: ChatCompletionUsageSchema.optional(),
+  })
+  .describe(`https://api-docs.deepseek.com/api/create-chat-completion`);
+
+export const ChatCompletionsHeadersSchema = z.object({
+  "user-agent": z.string().optional().describe("The user agent of the client"),
+  authorization: z
+    .string()
+    .describe("Bearer token for DeepSeek")
+    .transform((authorization) => authorization.replace("Bearer ", "")),
+  "accept-language": z.string().optional(),
+});

--- a/platform/backend/src/types/llm-providers/deepseek/index.ts
+++ b/platform/backend/src/types/llm-providers/deepseek/index.ts
@@ -1,0 +1,70 @@
+/**
+ * DeepSeek API Types
+ *
+ * DeepSeek uses an OpenAI-compatible API with some extensions for reasoning models.
+ * @see https://api-docs.deepseek.com/
+ */
+import type { z } from "zod";
+import * as DeepSeekAPI from "./api";
+import * as DeepSeekMessages from "./messages";
+import * as DeepSeekTools from "./tools";
+
+namespace DeepSeek {
+  export const API = DeepSeekAPI;
+  export const Messages = DeepSeekMessages;
+  export const Tools = DeepSeekTools;
+
+  export namespace Types {
+    export type ChatCompletionsHeaders = z.infer<
+      typeof DeepSeekAPI.ChatCompletionsHeadersSchema
+    >;
+    export type ChatCompletionsRequest = z.infer<
+      typeof DeepSeekAPI.ChatCompletionRequestSchema
+    >;
+    export type ChatCompletionsResponse = z.infer<
+      typeof DeepSeekAPI.ChatCompletionResponseSchema
+    >;
+    export type Usage = z.infer<typeof DeepSeekAPI.ChatCompletionUsageSchema>;
+
+    export type FinishReason = z.infer<typeof DeepSeekAPI.FinishReasonSchema>;
+    export type Message = z.infer<typeof DeepSeekMessages.MessageParamSchema>;
+    export type Role = Message["role"];
+
+    export type ChatCompletionChunk = {
+      id: string;
+      object: "chat.completion.chunk";
+      created: number;
+      model: string;
+      choices: Array<{
+        index: number;
+        delta: {
+          role?: "assistant";
+          content?: string;
+          reasoning_content?: string;
+          tool_calls?: Array<{
+            index: number;
+            id?: string;
+            type?: "function";
+            function?: {
+              name?: string;
+              arguments?: string;
+            };
+          }>;
+        };
+        finish_reason: string | null;
+      }>;
+      usage?: {
+        prompt_tokens: number;
+        completion_tokens: number;
+        total_tokens: number;
+        prompt_cache_hit_tokens?: number;
+        prompt_cache_miss_tokens?: number;
+        completion_tokens_details?: {
+          reasoning_tokens?: number;
+        };
+      };
+    };
+  }
+}
+
+export default DeepSeek;

--- a/platform/backend/src/types/llm-providers/deepseek/messages.ts
+++ b/platform/backend/src/types/llm-providers/deepseek/messages.ts
@@ -1,0 +1,85 @@
+import { z } from "zod";
+
+const FunctionToolCallSchema = z
+  .object({
+    id: z.string(),
+    type: z.enum(["function"]),
+    function: z
+      .object({
+        arguments: z.string(),
+        name: z.string(),
+      })
+      .describe(`https://api-docs.deepseek.com/api/create-chat-completion`),
+  })
+  .describe(`https://api-docs.deepseek.com/api/create-chat-completion`);
+
+export const ToolCallSchema = z
+  .union([FunctionToolCallSchema])
+  .describe(`https://api-docs.deepseek.com/api/create-chat-completion`);
+
+const ContentPartTextSchema = z
+  .object({
+    type: z.enum(["text"]),
+    text: z.string(),
+  })
+  .describe(`https://api-docs.deepseek.com/api/create-chat-completion`);
+
+const ContentPartImageSchema = z
+  .object({
+    type: z.enum(["image_url"]),
+    image_url: z
+      .object({
+        url: z.string(),
+        detail: z.enum(["auto", "low", "high"]).optional(),
+      })
+      .describe(`https://api-docs.deepseek.com/api/create-chat-completion`),
+  })
+  .describe(`https://api-docs.deepseek.com/api/create-chat-completion`);
+
+const ContentPartSchema = z
+  .union([ContentPartTextSchema, ContentPartImageSchema])
+  .describe(`https://api-docs.deepseek.com/api/create-chat-completion`);
+
+const SystemMessageParamSchema = z
+  .object({
+    role: z.enum(["system"]),
+    content: z.string(),
+    name: z.string().optional(),
+  })
+  .describe(`https://api-docs.deepseek.com/api/create-chat-completion`);
+
+const UserMessageParamSchema = z
+  .object({
+    role: z.enum(["user"]),
+    content: z.union([z.string(), z.array(ContentPartSchema)]),
+    name: z.string().optional(),
+  })
+  .describe(`https://api-docs.deepseek.com/api/create-chat-completion`);
+
+const AssistantMessageParamSchema = z
+  .object({
+    role: z.enum(["assistant"]),
+    content: z.string().nullable().optional(),
+    name: z.string().optional(),
+    prefix: z.boolean().optional(),
+    reasoning_content: z.string().nullable().optional(),
+    tool_calls: z.array(ToolCallSchema).optional(),
+  })
+  .describe(`https://api-docs.deepseek.com/api/create-chat-completion`);
+
+const ToolMessageParamSchema = z
+  .object({
+    role: z.enum(["tool"]),
+    content: z.string(),
+    tool_call_id: z.string(),
+  })
+  .describe(`https://api-docs.deepseek.com/api/create-chat-completion`);
+
+export const MessageParamSchema = z
+  .union([
+    SystemMessageParamSchema,
+    UserMessageParamSchema,
+    AssistantMessageParamSchema,
+    ToolMessageParamSchema,
+  ])
+  .describe(`https://api-docs.deepseek.com/api/create-chat-completion`);

--- a/platform/backend/src/types/llm-providers/deepseek/tools.ts
+++ b/platform/backend/src/types/llm-providers/deepseek/tools.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+
+export const FunctionDefinitionParametersSchema = z
+  .record(z.string(), z.unknown())
+  .optional()
+  .describe(`
+    https://api-docs.deepseek.com/api/create-chat-completion
+
+    The parameters the functions accepts, described as a JSON Schema object. See the
+    [JSON Schema reference](https://json-schema.org/understanding-json-schema/) for
+    documentation about the format.
+
+    Omitting parameters defines a function with an empty parameter list.
+  `);
+
+const FunctionDefinitionSchema = z
+  .object({
+    name: z.string(),
+    description: z.string().optional(),
+    parameters: FunctionDefinitionParametersSchema,
+  })
+  .describe(`https://api-docs.deepseek.com/api/create-chat-completion`);
+
+const FunctionToolSchema = z
+  .object({
+    type: z.enum(["function"]),
+    function: FunctionDefinitionSchema,
+  })
+  .describe(`https://api-docs.deepseek.com/api/create-chat-completion`);
+
+const NamedToolChoiceSchema = z
+  .object({
+    type: z.enum(["function"]),
+    function: z.object({
+      name: z.string(),
+    }),
+  })
+  .describe(`
+  Specifies a tool the model should use. Use to force the model to call a specific function.
+
+  https://api-docs.deepseek.com/api/create-chat-completion
+  `);
+
+export const ToolSchema = z.union([FunctionToolSchema]).describe(`
+  A function tool that can be used to generate a response.
+
+  https://api-docs.deepseek.com/api/create-chat-completion
+  `);
+
+export const ToolChoiceOptionSchema = z
+  .union([z.enum(["none", "auto", "required"]), NamedToolChoiceSchema])
+  .describe(`https://api-docs.deepseek.com/api/create-chat-completion`);

--- a/platform/backend/src/types/llm-providers/index.ts
+++ b/platform/backend/src/types/llm-providers/index.ts
@@ -2,6 +2,7 @@ export { default as Anthropic } from "./anthropic";
 export { default as Bedrock } from "./bedrock";
 export { default as Cerebras } from "./cerebras";
 export { default as Cohere } from "./cohere";
+export { default as DeepSeek } from "./deepseek";
 export { default as Gemini } from "./gemini";
 export { default as Mistral } from "./mistral";
 export { default as Ollama } from "./ollama";

--- a/platform/shared/chat-error.ts
+++ b/platform/shared/chat-error.ts
@@ -177,6 +177,25 @@ export const ZhipuaiErrorTypes = {
   RATE_LIMIT: "1305",
 } as const;
 
+/**
+ * DeepSeek API error types (from response body `error.type` field)
+ * DeepSeek uses OpenAI-compatible error format
+ * @see https://api-docs.deepseek.com/
+ */
+export const DeepSeekErrorTypes = {
+  INVALID_REQUEST: "invalid_request_error",
+  AUTHENTICATION: "authentication_error",
+  INVALID_API_KEY: "invalid_api_key",
+  PERMISSION_DENIED: "insufficient_quota",
+  NOT_FOUND: "not_found_error",
+  RATE_LIMIT: "rate_limit_exceeded",
+  SERVER_ERROR: "server_error",
+  SERVICE_UNAVAILABLE: "service_unavailable",
+  MODEL_NOT_FOUND: "model_not_found",
+  CONTEXT_LENGTH_EXCEEDED: "context_length_exceeded",
+  CONTENT_FILTERED: "content_filter",
+} as const;
+
 // =============================================================================
 // Normalized Chat Error Codes
 // =============================================================================

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -10,6 +10,7 @@ export const SupportedProvidersSchema = z.enum([
   "bedrock",
   "cohere",
   "cerebras",
+  "deepseek",
   "mistral",
   "vllm",
   "ollama",
@@ -23,6 +24,7 @@ export const SupportedProvidersDiscriminatorSchema = z.enum([
   "bedrock:converse",
   "cohere:chat",
   "cerebras:chatCompletions",
+  "deepseek:chatCompletions",
   "mistral:chatCompletions",
   "vllm:chatCompletions",
   "ollama:chatCompletions",
@@ -42,6 +44,7 @@ export const providerDisplayNames: Record<SupportedProvider, string> = {
   gemini: "Gemini",
   cohere: "Cohere",
   cerebras: "Cerebras",
+  deepseek: "DeepSeek",
   mistral: "Mistral AI",
   vllm: "vLLM",
   ollama: "Ollama",
@@ -85,6 +88,10 @@ export const MODEL_MARKER_PATTERNS: Record<
   cohere: {
     fastest: ["command-light"],
     best: ["command-r-plus", "command-r"],
+  },
+  deepseek: {
+    fastest: ["deepseek-chat"],
+    best: ["deepseek-reasoner"],
   },
   mistral: {
     fastest: ["mistral-small", "ministral"],

--- a/platform/shared/routes.ts
+++ b/platform/shared/routes.ts
@@ -183,6 +183,11 @@ export const RouteId = {
     "zhipuaiChatCompletionsWithDefaultAgent",
   ZhipuaiChatCompletionsWithAgent: "zhipuaiChatCompletionsWithAgent",
 
+  // Proxy Routes - DeepSeek
+  DeepSeekChatCompletionsWithDefaultAgent:
+    "deepseekChatCompletionsWithDefaultAgent",
+  DeepSeekChatCompletionsWithAgent: "deepseekChatCompletionsWithAgent",
+
   // Proxy Routes - AWS Bedrock
   BedrockConverseWithDefaultAgent: "bedrockConverseWithDefaultAgent",
   BedrockConverseWithAgent: "bedrockConverseWithAgent",


### PR DESCRIPTION
## Summary

This PR adds full support for DeepSeek as an LLM provider, enabling users to use DeepSeek's models (deepseek-chat, deepseek-reasoner) through the Archestra platform.

Closes #1846

## Changes

### Types (`platform/backend/src/types/llm-providers/deepseek/`)
- `api.ts` - Request/response schemas for DeepSeek chat completions API
- `messages.ts` - Message parameter schemas (system, user, assistant, tool)
- `tools.ts` - Function tool definitions and tool choice options
- `index.ts` - Namespace export with TypeScript types

### Adapter (`platform/backend/src/routes/proxy/adapterV2/deepseek.ts`)
- `DeepSeekClient` - HTTP client for DeepSeek API (streaming and non-streaming)
- `DeepSeekRequestAdapter` - Transforms requests to DeepSeek format
- `DeepSeekResponseAdapter` - Parses DeepSeek responses
- `DeepSeekStreamAdapter` - Handles streaming responses with SSE
- TOON compression support for tool results

### Routes (`platform/backend/src/routes/proxy/routesv2/deepseek.ts`)
- `POST /v1/deepseek/chat/completions` - Default agent
- `POST /v1/deepseek/:agentId/chat/completions` - Specific agent

### Configuration
- `ARCHESTRA_DEEPSEEK_BASE_URL` - Base URL (default: https://api.deepseek.com)
- `ARCHESTRA_CHAT_DEEPSEEK_API_KEY` - API key for DeepSeek

### Other Updates
- Added `deepseek` to `SupportedProvider` and `SupportedChatProvider` enums
- Added `deepseek:chatCompletions` to provider discriminator
- Added DeepSeek to model detection (`detectProviderFromModel`)
- Added DeepSeek to tokenizer (uses tiktoken, OpenAI-compatible)
- Added DeepSeek error types
- Added DeepSeek to model marker patterns (fastest: deepseek-chat, best: deepseek-reasoner)
- Updated interaction schema for DeepSeek interactions
- Registered DeepSeek schemas for OpenAPI generation

## Implementation Notes

DeepSeek uses an OpenAI-compatible API, so the implementation follows the same pattern as other OpenAI-compatible providers (Zhipuai, vLLM, Ollama). The adapter includes support for:
- DeepSeek-R1 reasoning models (`reasoning_content` field in responses)
- Function calling / tool use
- Streaming responses
- Token usage tracking (including reasoning tokens and cache hit/miss)

## Testing

Manual testing can be done by:
1. Setting `ARCHESTRA_CHAT_DEEPSEEK_API_KEY` environment variable
2. Creating an agent with DeepSeek as the provider
3. Using models like `deepseek-chat` or `deepseek-reasoner`
