### PR TITLE
[Provider] Add OpenRouter support

### DIFF
--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -451,6 +451,11 @@ export default {
       baseUrl:
         process.env.ARCHESTRA_MISTRAL_BASE_URL || "https://api.mistral.ai/v1",
     },
+    openrouter: {
+      baseUrl:
+        process.env.ARCHESTRA_OPENROUTER_BASE_URL ||
+        "https://openrouter.ai/api/v1",
+    },
     vllm: {
       enabled: Boolean(process.env.ARCHESTRA_VLLM_BASE_URL),
       baseUrl: process.env.ARCHESTRA_VLLM_BASE_URL,
@@ -487,6 +492,9 @@ export default {
     },
     mistral: {
       apiKey: process.env.ARCHESTRA_CHAT_MISTRAL_API_KEY || "",
+    },
+    openrouter: {
+      apiKey: process.env.ARCHESTRA_CHAT_OPENROUTER_API_KEY || "",
     },
     vllm: {
       apiKey: process.env.ARCHESTRA_CHAT_VLLM_API_KEY || "",

--- a/platform/backend/src/routes/index.ts
+++ b/platform/backend/src/routes/index.ts
@@ -6,6 +6,7 @@ import geminiProxyRoutesV2 from "./proxy/routesv2/gemini";
 import mistralProxyRoutesV2 from "./proxy/routesv2/mistral";
 import ollamaProxyRoutesV2 from "./proxy/routesv2/ollama";
 import openAiProxyRoutesV2 from "./proxy/routesv2/openai";
+import openrouterProxyRoutesV2 from "./proxy/routesv2/openrouter";
 import vllmProxyRoutesV2 from "./proxy/routesv2/vllm";
 import zhipuaiProxyRoutesV2 from "./proxy/routesv2/zhipuai";
 
@@ -43,6 +44,7 @@ export const cohereProxyRoutes = cohereProxyRoutesV2;
 export const geminiProxyRoutes = geminiProxyRoutesV2;
 export const mistralProxyRoutes = mistralProxyRoutesV2;
 export const openAiProxyRoutes = openAiProxyRoutesV2;
+export const openrouterProxyRoutes = openrouterProxyRoutesV2;
 export const vllmProxyRoutes = vllmProxyRoutesV2;
 export const ollamaProxyRoutes = ollamaProxyRoutesV2;
 export const zhipuaiProxyRoutes = zhipuaiProxyRoutesV2;

--- a/platform/backend/src/routes/proxy/adapterV2/index.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/index.ts
@@ -6,5 +6,6 @@ export { geminiAdapterFactory } from "./gemini";
 export { mistralAdapterFactory } from "./mistral";
 export { ollamaAdapterFactory } from "./ollama";
 export { openaiAdapterFactory } from "./openai";
+export { openrouterAdapterFactory } from "./openrouter";
 export { vllmAdapterFactory } from "./vllm";
 export { zhipuaiAdapterFactory } from "./zhipuai";

--- a/platform/backend/src/routes/proxy/adapterV2/openrouter.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/openrouter.ts
@@ -1,0 +1,299 @@
+/**
+ * OpenRouter LLM Proxy Adapter - OpenAI-compatible
+ *
+ * OpenRouter uses an OpenAI-compatible API at https://openrouter.ai/api/v1
+ * This adapter reuses OpenAI's adapter factory with OpenRouter-specific configuration.
+ *
+ * Since OpenRouter is 100% OpenAI-compatible, we delegate all adapter logic to OpenAI
+ * and only override the provider-specific configuration (baseUrl, provider name, etc.).
+ *
+ * @see https://openrouter.ai/docs/quickstart
+ */
+import { get } from "lodash-es";
+import OpenAIProvider from "openai";
+import type {
+  ChatCompletionCreateParamsNonStreaming,
+  ChatCompletionCreateParamsStreaming,
+} from "openai/resources/chat/completions/completions";
+import config from "@/config";
+import { getObservableFetch } from "@/llm-metrics";
+import type {
+  CreateClientOptions,
+  LLMProvider,
+  LLMRequestAdapter,
+  LLMResponseAdapter,
+  LLMStreamAdapter,
+  OpenRouter,
+} from "@/types";
+import { MockOpenAIClient } from "../mock-openai-client";
+import {
+  OpenAIRequestAdapter,
+  OpenAIResponseAdapter,
+  OpenAIStreamAdapter,
+} from "./openai";
+
+// =============================================================================
+// TYPE ALIASES (reuse OpenAI types since OpenRouter is OpenAI-compatible)
+// =============================================================================
+
+type OpenRouterRequest = OpenRouter.Types.ChatCompletionsRequest;
+type OpenRouterResponse = OpenRouter.Types.ChatCompletionsResponse;
+type OpenRouterMessages = OpenRouter.Types.ChatCompletionsRequest["messages"];
+type OpenRouterHeaders = OpenRouter.Types.ChatCompletionsHeaders;
+type OpenRouterStreamChunk = OpenRouter.Types.ChatCompletionChunk;
+
+// =============================================================================
+// ADAPTER CLASSES (delegate to OpenAI adapters, override provider)
+// =============================================================================
+
+/**
+ * OpenRouter request adapter - wraps OpenAI adapter with OpenRouter provider name.
+ * Uses composition to delegate all logic to OpenAI since APIs are identical.
+ */
+class OpenRouterRequestAdapter
+  implements LLMRequestAdapter<OpenRouterRequest, OpenRouterMessages>
+{
+  readonly provider = "openrouter" as const;
+  private delegate: OpenAIRequestAdapter;
+
+  constructor(request: OpenRouterRequest) {
+    this.delegate = new OpenAIRequestAdapter(request);
+  }
+
+  getModel() {
+    return this.delegate.getModel();
+  }
+  isStreaming() {
+    return this.delegate.isStreaming();
+  }
+  getMessages() {
+    return this.delegate.getMessages();
+  }
+  getToolResults() {
+    return this.delegate.getToolResults();
+  }
+  getTools() {
+    return this.delegate.getTools();
+  }
+  hasTools() {
+    return this.delegate.hasTools();
+  }
+  getProviderMessages() {
+    return this.delegate.getProviderMessages();
+  }
+  getOriginalRequest() {
+    return this.delegate.getOriginalRequest();
+  }
+  setModel(model: string) {
+    return this.delegate.setModel(model);
+  }
+  updateToolResult(toolCallId: string, newContent: string) {
+    return this.delegate.updateToolResult(toolCallId, newContent);
+  }
+  applyToolResultUpdates(updates: Record<string, string>) {
+    return this.delegate.applyToolResultUpdates(updates);
+  }
+  applyToonCompression(model: string) {
+    return this.delegate.applyToonCompression(model);
+  }
+  convertToolResultContent(messages: OpenRouterMessages) {
+    return this.delegate.convertToolResultContent(messages);
+  }
+  toProviderRequest() {
+    return this.delegate.toProviderRequest();
+  }
+}
+
+/**
+ * OpenRouter response adapter - wraps OpenAI adapter with OpenRouter provider name.
+ */
+class OpenRouterResponseAdapter
+  implements LLMResponseAdapter<OpenRouterResponse>
+{
+  readonly provider = "openrouter" as const;
+  private delegate: OpenAIResponseAdapter;
+
+  constructor(response: OpenRouterResponse) {
+    this.delegate = new OpenAIResponseAdapter(response);
+  }
+
+  getId() {
+    return this.delegate.getId();
+  }
+  getModel() {
+    return this.delegate.getModel();
+  }
+  getText() {
+    return this.delegate.getText();
+  }
+  getToolCalls() {
+    return this.delegate.getToolCalls();
+  }
+  hasToolCalls() {
+    return this.delegate.hasToolCalls();
+  }
+  getUsage() {
+    return this.delegate.getUsage();
+  }
+  getOriginalResponse() {
+    return this.delegate.getOriginalResponse();
+  }
+  toRefusalResponse(refusalMessage: string, contentMessage: string) {
+    return this.delegate.toRefusalResponse(refusalMessage, contentMessage);
+  }
+}
+
+/**
+ * OpenRouter stream adapter - wraps OpenAI adapter with OpenRouter provider name.
+ */
+class OpenRouterStreamAdapter
+  implements LLMStreamAdapter<OpenRouterStreamChunk, OpenRouterResponse>
+{
+  readonly provider = "openrouter" as const;
+  private delegate: OpenAIStreamAdapter;
+
+  constructor() {
+    this.delegate = new OpenAIStreamAdapter();
+  }
+
+  get state() {
+    return this.delegate.state;
+  }
+
+  processChunk(chunk: OpenRouterStreamChunk) {
+    return this.delegate.processChunk(chunk);
+  }
+  getSSEHeaders() {
+    return this.delegate.getSSEHeaders();
+  }
+  formatTextDeltaSSE(text: string) {
+    return this.delegate.formatTextDeltaSSE(text);
+  }
+  getRawToolCallEvents() {
+    return this.delegate.getRawToolCallEvents();
+  }
+  formatCompleteTextSSE(text: string) {
+    return this.delegate.formatCompleteTextSSE(text);
+  }
+  formatEndSSE() {
+    return this.delegate.formatEndSSE();
+  }
+  toProviderResponse() {
+    return this.delegate.toProviderResponse();
+  }
+}
+
+// =============================================================================
+// ADAPTER FACTORY
+// =============================================================================
+
+export const openrouterAdapterFactory: LLMProvider<
+  OpenRouterRequest,
+  OpenRouterResponse,
+  OpenRouterMessages,
+  OpenRouterStreamChunk,
+  OpenRouterHeaders
+> = {
+  provider: "openrouter",
+  interactionType: "openrouter:chatCompletions",
+
+  createRequestAdapter(
+    request: OpenRouterRequest,
+  ): LLMRequestAdapter<OpenRouterRequest, OpenRouterMessages> {
+    return new OpenRouterRequestAdapter(request);
+  },
+
+  createResponseAdapter(
+    response: OpenRouterResponse,
+  ): LLMResponseAdapter<OpenRouterResponse> {
+    return new OpenRouterResponseAdapter(response);
+  },
+
+  createStreamAdapter(): LLMStreamAdapter<
+    OpenRouterStreamChunk,
+    OpenRouterResponse
+  > {
+    return new OpenRouterStreamAdapter();
+  },
+
+  extractApiKey(headers: OpenRouterHeaders): string | undefined {
+    return headers.authorization;
+  },
+
+  getBaseUrl(): string | undefined {
+    return config.llm.openrouter.baseUrl;
+  },
+
+  getSpanName(): string {
+    return "openrouter.chat.completions";
+  },
+
+  createClient(
+    apiKey: string | undefined,
+    options?: CreateClientOptions,
+  ): OpenAIProvider {
+    if (options?.mockMode) {
+      return new MockOpenAIClient() as unknown as OpenAIProvider;
+    }
+
+    const customFetch = options?.agent
+      ? getObservableFetch("openrouter", options.agent, options.externalAgentId)
+      : undefined;
+
+    return new OpenAIProvider({
+      apiKey,
+      baseURL: options?.baseUrl ?? config.llm.openrouter.baseUrl,
+      fetch: customFetch,
+    });
+  },
+
+  async execute(
+    client: unknown,
+    request: OpenRouterRequest,
+  ): Promise<OpenRouterResponse> {
+    const openrouterClient = client as OpenAIProvider;
+    const openrouterRequest = {
+      ...request,
+      stream: false,
+    } as unknown as ChatCompletionCreateParamsNonStreaming;
+    // Cast through unknown because OpenRouterResponse uses .passthrough() which adds index signature
+    return openrouterClient.chat.completions.create(
+      openrouterRequest,
+    ) as unknown as Promise<OpenRouterResponse>;
+  },
+
+  async executeStream(
+    client: unknown,
+    request: OpenRouterRequest,
+  ): Promise<AsyncIterable<OpenRouterStreamChunk>> {
+    const openrouterClient = client as OpenAIProvider;
+    const openrouterRequest = {
+      ...request,
+      stream: true,
+      stream_options: { include_usage: true },
+    } as unknown as ChatCompletionCreateParamsStreaming;
+    const stream =
+      await openrouterClient.chat.completions.create(openrouterRequest);
+
+    return {
+      [Symbol.asyncIterator]: async function* () {
+        for await (const chunk of stream) {
+          yield chunk as OpenRouterStreamChunk;
+        }
+      },
+    };
+  },
+
+  extractErrorMessage(error: unknown): string {
+    const openaiMessage = get(error, "error.message");
+    if (typeof openaiMessage === "string") {
+      return openaiMessage;
+    }
+
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return "Internal server error";
+  },
+};

--- a/platform/backend/src/routes/proxy/routesv2/openrouter.ts
+++ b/platform/backend/src/routes/proxy/routesv2/openrouter.ts
@@ -1,0 +1,182 @@
+/**
+ * OpenRouter LLM Proxy Routes - OpenAI-compatible
+ *
+ * OpenRouter uses an OpenAI-compatible API at https://openrouter.ai/api/v1
+ * This module registers proxy routes for OpenRouter chat completions.
+ *
+ * @see https://openrouter.ai/docs/quickstart
+ */
+import fastifyHttpProxy from "@fastify/http-proxy";
+import { RouteId } from "@shared";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import config from "@/config";
+import logger from "@/logging";
+import { constructResponseSchema, OpenRouter, UuidIdSchema } from "@/types";
+import { openrouterAdapterFactory } from "../adapterV2";
+import { PROXY_API_PREFIX, PROXY_BODY_LIMIT } from "../common";
+import { handleLLMProxy } from "../llm-proxy-handler";
+import * as utils from "../utils";
+
+const openrouterProxyRoutesV2: FastifyPluginAsyncZod = async (fastify) => {
+  const API_PREFIX = `${PROXY_API_PREFIX}/openrouter`;
+  const CHAT_COMPLETIONS_SUFFIX = "/chat/completions";
+
+  logger.info("[UnifiedProxy] Registering unified OpenRouter routes");
+
+  /**
+   * Register HTTP proxy for OpenRouter routes
+   * Chat completions are handled separately with full agent support
+   */
+  await fastify.register(fastifyHttpProxy, {
+    upstream: config.llm.openrouter.baseUrl,
+    prefix: API_PREFIX,
+    rewritePrefix: "",
+    preHandler: (request, _reply, next) => {
+      // Skip chat/completions - handled by custom handler below
+      if (
+        request.method === "POST" &&
+        request.url.includes(CHAT_COMPLETIONS_SUFFIX)
+      ) {
+        logger.info(
+          {
+            method: request.method,
+            url: request.url,
+            action: "skip-proxy",
+            reason: "handled-by-custom-handler",
+          },
+          "OpenRouter proxy preHandler: skipping chat/completions route",
+        );
+        next(new Error("skip"));
+        return;
+      }
+
+      // Check if URL has UUID segment that needs stripping
+      const pathAfterPrefix = request.url.replace(API_PREFIX, "");
+      const uuidMatch = pathAfterPrefix.match(
+        /^\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(\/.*)?$/i,
+      );
+
+      if (uuidMatch) {
+        // Strip UUID: /v1/openrouter/:uuid/path -> /v1/openrouter/path
+        const remainingPath = uuidMatch[2] || "";
+        const originalUrl = request.raw.url;
+        request.raw.url = `${API_PREFIX}${remainingPath}`;
+
+        logger.info(
+          {
+            method: request.method,
+            originalUrl,
+            rewrittenUrl: request.raw.url,
+            upstream: config.llm.openrouter.baseUrl,
+            finalProxyUrl: `${config.llm.openrouter.baseUrl}${remainingPath}`,
+          },
+          "OpenRouter proxy preHandler: URL rewritten (UUID stripped)",
+        );
+      } else {
+        logger.info(
+          {
+            method: request.method,
+            url: request.url,
+            upstream: config.llm.openrouter.baseUrl,
+            finalProxyUrl: `${config.llm.openrouter.baseUrl}${pathAfterPrefix}`,
+          },
+          "OpenRouter proxy preHandler: proxying request",
+        );
+      }
+
+      next();
+    },
+  });
+
+  /**
+   * Chat completions with default agent
+   */
+  fastify.post(
+    `${API_PREFIX}${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        operationId: RouteId.OpenRouterChatCompletionsWithDefaultAgent,
+        description:
+          "Create a chat completion with OpenRouter (uses default agent)",
+        tags: ["llm-proxy"],
+        body: OpenRouter.API.ChatCompletionRequestSchema,
+        headers: OpenRouter.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(
+          OpenRouter.API.ChatCompletionResponseSchema,
+        ),
+      },
+    },
+    async (request, reply) => {
+      logger.debug(
+        { url: request.url },
+        "[UnifiedProxy] Handling OpenRouter request (default agent)",
+      );
+      const externalAgentId = utils.externalAgentId.getExternalAgentId(
+        request.headers,
+      );
+      const userId = await utils.userId.getUserId(request.headers);
+      return handleLLMProxy(
+        request.body,
+        request.headers,
+        reply,
+        openrouterAdapterFactory,
+        {
+          organizationId: request.organizationId,
+          agentId: undefined,
+          externalAgentId,
+          userId,
+        },
+      );
+    },
+  );
+
+  /**
+   * Chat completions with specific agent
+   */
+  fastify.post(
+    `${API_PREFIX}/:agentId${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        operationId: RouteId.OpenRouterChatCompletionsWithAgent,
+        description:
+          "Create a chat completion with OpenRouter for a specific agent",
+        tags: ["llm-proxy"],
+        params: z.object({
+          agentId: UuidIdSchema,
+        }),
+        body: OpenRouter.API.ChatCompletionRequestSchema,
+        headers: OpenRouter.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(
+          OpenRouter.API.ChatCompletionResponseSchema,
+        ),
+      },
+    },
+    async (request, reply) => {
+      logger.debug(
+        { url: request.url, agentId: request.params.agentId },
+        "[UnifiedProxy] Handling OpenRouter request (with agent)",
+      );
+      const externalAgentId = utils.externalAgentId.getExternalAgentId(
+        request.headers,
+      );
+      const userId = await utils.userId.getUserId(request.headers);
+      return handleLLMProxy(
+        request.body,
+        request.headers,
+        reply,
+        openrouterAdapterFactory,
+        {
+          organizationId: request.organizationId,
+          agentId: request.params.agentId,
+          externalAgentId,
+          userId,
+        },
+      );
+    },
+  );
+};
+
+export default openrouterProxyRoutesV2;

--- a/platform/backend/src/types/llm-providers/index.ts
+++ b/platform/backend/src/types/llm-providers/index.ts
@@ -6,5 +6,6 @@ export { default as Gemini } from "./gemini";
 export { default as Mistral } from "./mistral";
 export { default as Ollama } from "./ollama";
 export { default as OpenAi } from "./openai";
+export { default as OpenRouter } from "./openrouter";
 export { default as Vllm } from "./vllm";
 export { default as Zhipuai } from "./zhipuai";

--- a/platform/backend/src/types/llm-providers/openrouter/api.ts
+++ b/platform/backend/src/types/llm-providers/openrouter/api.ts
@@ -1,0 +1,31 @@
+/**
+ * OpenRouter API schemas
+ *
+ * OpenRouter uses an OpenAI-compatible API, so we reuse OpenAI schemas directly.
+ * This ensures type compatibility when delegating to OpenAI adapters.
+ *
+ * @see https://openrouter.ai/docs/quickstart
+ */
+
+import {
+  ChatCompletionRequestSchema,
+  ChatCompletionsHeadersSchema,
+  ChatCompletionUsageSchema,
+  FinishReasonSchema,
+  ChatCompletionResponseSchema as OpenAIChatCompletionResponseSchema,
+} from "../openai/api";
+
+// Re-export request and other schemas from OpenAI since OpenRouter is fully compatible
+export {
+  ChatCompletionRequestSchema,
+  ChatCompletionsHeadersSchema,
+  ChatCompletionUsageSchema,
+  FinishReasonSchema,
+};
+
+/**
+ * OpenRouter response schema with passthrough for extra fields.
+ * OpenRouter API may return additional fields not in the standard OpenAI schema.
+ */
+export const ChatCompletionResponseSchema =
+  OpenAIChatCompletionResponseSchema.passthrough();

--- a/platform/backend/src/types/llm-providers/openrouter/index.ts
+++ b/platform/backend/src/types/llm-providers/openrouter/index.ts
@@ -1,0 +1,42 @@
+/**
+ * OpenRouter LLM Provider Types - OpenAI-compatible
+ *
+ * OpenRouter uses an OpenAI-compatible API at https://openrouter.ai/api/v1
+ * We re-export OpenAI schemas with OpenRouter-specific namespace for type safety.
+ *
+ * @see https://openrouter.ai/docs/quickstart
+ */
+import type OpenAIProvider from "openai";
+import type { z } from "zod";
+import * as OpenRouterAPI from "./api";
+import * as OpenRouterMessages from "./messages";
+import * as OpenRouterTools from "./tools";
+
+namespace OpenRouter {
+  export const API = OpenRouterAPI;
+  export const Messages = OpenRouterMessages;
+  export const Tools = OpenRouterTools;
+
+  export namespace Types {
+    export type ChatCompletionsHeaders = z.infer<
+      typeof OpenRouterAPI.ChatCompletionsHeadersSchema
+    >;
+    export type ChatCompletionsRequest = z.infer<
+      typeof OpenRouterAPI.ChatCompletionRequestSchema
+    >;
+    export type ChatCompletionsResponse = z.infer<
+      typeof OpenRouterAPI.ChatCompletionResponseSchema
+    >;
+    export type Usage = z.infer<typeof OpenRouterAPI.ChatCompletionUsageSchema>;
+
+    export type FinishReason = z.infer<typeof OpenRouterAPI.FinishReasonSchema>;
+    export type Message = z.infer<typeof OpenRouterMessages.MessageParamSchema>;
+    export type Role = Message["role"];
+
+    // Use OpenAI's stream chunk type since OpenRouter is OpenAI-compatible
+    export type ChatCompletionChunk =
+      OpenAIProvider.Chat.Completions.ChatCompletionChunk;
+  }
+}
+
+export default OpenRouter;

--- a/platform/backend/src/types/llm-providers/openrouter/messages.ts
+++ b/platform/backend/src/types/llm-providers/openrouter/messages.ts
@@ -1,0 +1,7 @@
+/**
+ * OpenRouter message schemas - OpenAI-compatible
+ *
+ * OpenRouter uses an OpenAI-compatible API, so we re-export OpenAI schemas.
+ * @see https://openrouter.ai/docs/quickstart
+ */
+export { MessageParamSchema, ToolCallSchema } from "../openai/messages";

--- a/platform/backend/src/types/llm-providers/openrouter/tools.ts
+++ b/platform/backend/src/types/llm-providers/openrouter/tools.ts
@@ -1,0 +1,11 @@
+/**
+ * OpenRouter tool schemas - OpenAI-compatible
+ *
+ * OpenRouter uses an OpenAI-compatible API, so we re-export OpenAI schemas.
+ * @see https://openrouter.ai/docs/quickstart
+ */
+export {
+  FunctionDefinitionParametersSchema,
+  ToolChoiceOptionSchema,
+  ToolSchema,
+} from "../openai/tools";

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -11,6 +11,7 @@ export const SupportedProvidersSchema = z.enum([
   "cohere",
   "cerebras",
   "mistral",
+  "openrouter",
   "vllm",
   "ollama",
   "zhipuai",
@@ -24,6 +25,7 @@ export const SupportedProvidersDiscriminatorSchema = z.enum([
   "cohere:chat",
   "cerebras:chatCompletions",
   "mistral:chatCompletions",
+  "openrouter:chatCompletions",
   "vllm:chatCompletions",
   "ollama:chatCompletions",
   "zhipuai:chatCompletions",
@@ -43,6 +45,7 @@ export const providerDisplayNames: Record<SupportedProvider, string> = {
   cohere: "Cohere",
   cerebras: "Cerebras",
   mistral: "Mistral AI",
+  openrouter: "OpenRouter",
   vllm: "vLLM",
   ollama: "Ollama",
   zhipuai: "Zhipu AI",
@@ -89,6 +92,11 @@ export const MODEL_MARKER_PATTERNS: Record<
   mistral: {
     fastest: ["mistral-small", "ministral"],
     best: ["mistral-large"],
+  },
+  openrouter: {
+    // OpenRouter is a unified gateway - common model patterns
+    fastest: ["haiku", "flash", "mini", "instant"],
+    best: ["opus", "sonnet", "gpt-4o", "claude-3"],
   },
   ollama: {
     fastest: ["llama3.2", "phi"],

--- a/platform/shared/routes.ts
+++ b/platform/shared/routes.ts
@@ -170,6 +170,11 @@ export const RouteId = {
     "mistralChatCompletionsWithDefaultAgent",
   MistralChatCompletionsWithAgent: "mistralChatCompletionsWithAgent",
 
+  // Proxy Routes - OpenRouter
+  OpenRouterChatCompletionsWithDefaultAgent:
+    "openrouterChatCompletionsWithDefaultAgent",
+  OpenRouterChatCompletionsWithAgent: "openrouterChatCompletionsWithAgent",
+
   // Proxy Routes - vLLM
   VllmChatCompletionsWithDefaultAgent: "vllmChatCompletionsWithDefaultAgent",
   VllmChatCompletionsWithAgent: "vllmChatCompletionsWithAgent",


### PR DESCRIPTION
## Summary

Add OpenRouter as a new LLM provider for Archestra.

- OpenRouter is 100% OpenAI-compatible, so all adapter logic delegates to OpenAI adapters
- Follows the existing Mistral provider pattern exactly
- Base URL: `https://openrouter.ai/api/v1`

## Changes

**New Files:**
- `types/llm-providers/openrouter/` - Type definitions (re-exports from OpenAI)
- `adapterV2/openrouter.ts` - Adapter factory with delegation to OpenAI
- `routesv2/openrouter.ts` - Route handlers for chat completions

**Modified Files:**
- `config.ts` - Added `openrouter.baseUrl` and `openrouter.apiKey` configs
- `model-constants.ts` - Added to providers, discriminators, display names, model patterns
- `routes.ts` - Added `OpenRouterChatCompletionsWithDefaultAgent/WithAgent` RouteIds
- Various index files - Added exports

## Test Plan

- [ ] TypeScript compiles without errors
- [ ] Routes register correctly
- [ ] Can proxy requests to OpenRouter API

/claim #1929

---

🤖 Generated with [Claude Code](https://claude.ai/code)