### PR TITLE
feat(provider): add x.ai (Grok) LLM provider support

### DIFF
--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -459,6 +459,10 @@ export default {
       enabled: Boolean(process.env.ARCHESTRA_OLLAMA_BASE_URL),
       baseUrl: process.env.ARCHESTRA_OLLAMA_BASE_URL,
     },
+    xai: {
+      baseUrl:
+        process.env.ARCHESTRA_XAI_BASE_URL || "https://api.x.ai/v1",
+    },
     zhipuai: {
       baseUrl:
         process.env.ARCHESTRA_ZHIPUAI_BASE_URL ||
@@ -496,6 +500,9 @@ export default {
     },
     cohere: {
       apiKey: process.env.ARCHESTRA_CHAT_COHERE_API_KEY || "",
+    },
+    xai: {
+      apiKey: process.env.ARCHESTRA_CHAT_XAI_API_KEY || "",
     },
     zhipuai: {
       apiKey: process.env.ARCHESTRA_CHAT_ZHIPUAI_API_KEY || "",

--- a/platform/backend/src/routes/index.ts
+++ b/platform/backend/src/routes/index.ts
@@ -7,6 +7,7 @@ import mistralProxyRoutesV2 from "./proxy/routesv2/mistral";
 import ollamaProxyRoutesV2 from "./proxy/routesv2/ollama";
 import openAiProxyRoutesV2 from "./proxy/routesv2/openai";
 import vllmProxyRoutesV2 from "./proxy/routesv2/vllm";
+import xaiProxyRoutesV2 from "./proxy/routesv2/xai";
 import zhipuaiProxyRoutesV2 from "./proxy/routesv2/zhipuai";
 
 export { default as browserStreamRoutes } from "@/features/browser-stream/routes/browser-stream.routes";
@@ -45,6 +46,7 @@ export const mistralProxyRoutes = mistralProxyRoutesV2;
 export const openAiProxyRoutes = openAiProxyRoutesV2;
 export const vllmProxyRoutes = vllmProxyRoutesV2;
 export const ollamaProxyRoutes = ollamaProxyRoutesV2;
+export const xaiProxyRoutes = xaiProxyRoutesV2;
 export const zhipuaiProxyRoutes = zhipuaiProxyRoutesV2;
 // Bedrock proxy routes - V2 only (unified handler, AWS Converse API)
 export const bedrockProxyRoutes = bedrockProxyRoutesV2;

--- a/platform/backend/src/routes/proxy/adapterV2/index.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/index.ts
@@ -7,4 +7,5 @@ export { mistralAdapterFactory } from "./mistral";
 export { ollamaAdapterFactory } from "./ollama";
 export { openaiAdapterFactory } from "./openai";
 export { vllmAdapterFactory } from "./vllm";
+export { xaiAdapterFactory } from "./xai";
 export { zhipuaiAdapterFactory } from "./zhipuai";

--- a/platform/backend/src/routes/proxy/adapterV2/xai.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/xai.ts
@@ -1,0 +1,293 @@
+/**
+ * x.ai (Grok) LLM Proxy Adapter - OpenAI-compatible
+ *
+ * x.ai uses an OpenAI-compatible API at https://api.x.ai/v1
+ * This adapter reuses OpenAI's adapter factory with x.ai-specific configuration.
+ *
+ * Since x.ai is 100% OpenAI-compatible, we delegate all adapter logic to OpenAI
+ * and only override the provider-specific configuration (baseUrl, provider name, etc.).
+ *
+ * @see https://docs.x.ai/api
+ */
+import { get } from "lodash-es";
+import OpenAIProvider from "openai";
+import type {
+  ChatCompletionCreateParamsNonStreaming,
+  ChatCompletionCreateParamsStreaming,
+} from "openai/resources/chat/completions/completions";
+import config from "@/config";
+import { getObservableFetch } from "@/llm-metrics";
+import type {
+  CreateClientOptions,
+  LLMProvider,
+  LLMRequestAdapter,
+  LLMResponseAdapter,
+  LLMStreamAdapter,
+  Xai,
+} from "@/types";
+import { MockOpenAIClient } from "../mock-openai-client";
+import {
+  OpenAIRequestAdapter,
+  OpenAIResponseAdapter,
+  OpenAIStreamAdapter,
+} from "./openai";
+
+// =============================================================================
+// TYPE ALIASES (reuse OpenAI types since x.ai is OpenAI-compatible)
+// =============================================================================
+
+type XaiRequest = Xai.Types.ChatCompletionsRequest;
+type XaiResponse = Xai.Types.ChatCompletionsResponse;
+type XaiMessages = Xai.Types.ChatCompletionsRequest["messages"];
+type XaiHeaders = Xai.Types.ChatCompletionsHeaders;
+type XaiStreamChunk = Xai.Types.ChatCompletionChunk;
+
+// =============================================================================
+// ADAPTER CLASSES (delegate to OpenAI adapters, override provider)
+// =============================================================================
+
+/**
+ * x.ai request adapter - wraps OpenAI adapter with x.ai provider name.
+ * Uses composition to delegate all logic to OpenAI since APIs are identical.
+ */
+class XaiRequestAdapter
+  implements LLMRequestAdapter<XaiRequest, XaiMessages>
+{
+  readonly provider = "xai" as const;
+  private delegate: OpenAIRequestAdapter;
+
+  constructor(request: XaiRequest) {
+    this.delegate = new OpenAIRequestAdapter(request);
+  }
+
+  getModel() {
+    return this.delegate.getModel();
+  }
+  isStreaming() {
+    return this.delegate.isStreaming();
+  }
+  getMessages() {
+    return this.delegate.getMessages();
+  }
+  getToolResults() {
+    return this.delegate.getToolResults();
+  }
+  getTools() {
+    return this.delegate.getTools();
+  }
+  hasTools() {
+    return this.delegate.hasTools();
+  }
+  getProviderMessages() {
+    return this.delegate.getProviderMessages();
+  }
+  getOriginalRequest() {
+    return this.delegate.getOriginalRequest();
+  }
+  setModel(model: string) {
+    return this.delegate.setModel(model);
+  }
+  updateToolResult(toolCallId: string, newContent: string) {
+    return this.delegate.updateToolResult(toolCallId, newContent);
+  }
+  applyToolResultUpdates(updates: Record<string, string>) {
+    return this.delegate.applyToolResultUpdates(updates);
+  }
+  applyToonCompression(model: string) {
+    return this.delegate.applyToonCompression(model);
+  }
+  convertToolResultContent(messages: XaiMessages) {
+    return this.delegate.convertToolResultContent(messages);
+  }
+  toProviderRequest() {
+    return this.delegate.toProviderRequest();
+  }
+}
+
+/**
+ * x.ai response adapter - wraps OpenAI adapter with x.ai provider name.
+ */
+class XaiResponseAdapter implements LLMResponseAdapter<XaiResponse> {
+  readonly provider = "xai" as const;
+  private delegate: OpenAIResponseAdapter;
+
+  constructor(response: XaiResponse) {
+    this.delegate = new OpenAIResponseAdapter(response);
+  }
+
+  getId() {
+    return this.delegate.getId();
+  }
+  getModel() {
+    return this.delegate.getModel();
+  }
+  getText() {
+    return this.delegate.getText();
+  }
+  getToolCalls() {
+    return this.delegate.getToolCalls();
+  }
+  hasToolCalls() {
+    return this.delegate.hasToolCalls();
+  }
+  getUsage() {
+    return this.delegate.getUsage();
+  }
+  getOriginalResponse() {
+    return this.delegate.getOriginalResponse();
+  }
+  toRefusalResponse(refusalMessage: string, contentMessage: string) {
+    return this.delegate.toRefusalResponse(refusalMessage, contentMessage);
+  }
+}
+
+/**
+ * x.ai stream adapter - wraps OpenAI adapter with x.ai provider name.
+ */
+class XaiStreamAdapter
+  implements LLMStreamAdapter<XaiStreamChunk, XaiResponse>
+{
+  readonly provider = "xai" as const;
+  private delegate: OpenAIStreamAdapter;
+
+  constructor() {
+    this.delegate = new OpenAIStreamAdapter();
+  }
+
+  get state() {
+    return this.delegate.state;
+  }
+
+  processChunk(chunk: XaiStreamChunk) {
+    return this.delegate.processChunk(chunk);
+  }
+  getSSEHeaders() {
+    return this.delegate.getSSEHeaders();
+  }
+  formatTextDeltaSSE(text: string) {
+    return this.delegate.formatTextDeltaSSE(text);
+  }
+  getRawToolCallEvents() {
+    return this.delegate.getRawToolCallEvents();
+  }
+  formatCompleteTextSSE(text: string) {
+    return this.delegate.formatCompleteTextSSE(text);
+  }
+  formatEndSSE() {
+    return this.delegate.formatEndSSE();
+  }
+  toProviderResponse() {
+    return this.delegate.toProviderResponse();
+  }
+}
+
+// =============================================================================
+// ADAPTER FACTORY
+// =============================================================================
+
+export const xaiAdapterFactory: LLMProvider<
+  XaiRequest,
+  XaiResponse,
+  XaiMessages,
+  XaiStreamChunk,
+  XaiHeaders
+> = {
+  provider: "xai",
+  interactionType: "xai:chatCompletions",
+
+  createRequestAdapter(
+    request: XaiRequest,
+  ): LLMRequestAdapter<XaiRequest, XaiMessages> {
+    return new XaiRequestAdapter(request);
+  },
+
+  createResponseAdapter(
+    response: XaiResponse,
+  ): LLMResponseAdapter<XaiResponse> {
+    return new XaiResponseAdapter(response);
+  },
+
+  createStreamAdapter(): LLMStreamAdapter<XaiStreamChunk, XaiResponse> {
+    return new XaiStreamAdapter();
+  },
+
+  extractApiKey(headers: XaiHeaders): string | undefined {
+    return headers.authorization;
+  },
+
+  getBaseUrl(): string | undefined {
+    return config.llm.xai.baseUrl;
+  },
+
+  getSpanName(): string {
+    return "xai.chat.completions";
+  },
+
+  createClient(
+    apiKey: string | undefined,
+    options?: CreateClientOptions,
+  ): OpenAIProvider {
+    if (options?.mockMode) {
+      return new MockOpenAIClient() as unknown as OpenAIProvider;
+    }
+
+    const customFetch = options?.agent
+      ? getObservableFetch("xai", options.agent, options.externalAgentId)
+      : undefined;
+
+    return new OpenAIProvider({
+      apiKey,
+      baseURL: options?.baseUrl ?? config.llm.xai.baseUrl,
+      fetch: customFetch,
+    });
+  },
+
+  async execute(
+    client: unknown,
+    request: XaiRequest,
+  ): Promise<XaiResponse> {
+    const xaiClient = client as OpenAIProvider;
+    const xaiRequest = {
+      ...request,
+      stream: false,
+    } as unknown as ChatCompletionCreateParamsNonStreaming;
+    // Cast through unknown because XaiResponse uses .passthrough() which adds index signature
+    return xaiClient.chat.completions.create(
+      xaiRequest,
+    ) as unknown as Promise<XaiResponse>;
+  },
+
+  async executeStream(
+    client: unknown,
+    request: XaiRequest,
+  ): Promise<AsyncIterable<XaiStreamChunk>> {
+    const xaiClient = client as OpenAIProvider;
+    const xaiRequest = {
+      ...request,
+      stream: true,
+      stream_options: { include_usage: true },
+    } as unknown as ChatCompletionCreateParamsStreaming;
+    const stream = await xaiClient.chat.completions.create(xaiRequest);
+
+    return {
+      [Symbol.asyncIterator]: async function* () {
+        for await (const chunk of stream) {
+          yield chunk as XaiStreamChunk;
+        }
+      },
+    };
+  },
+
+  extractErrorMessage(error: unknown): string {
+    const openaiMessage = get(error, "error.message");
+    if (typeof openaiMessage === "string") {
+      return openaiMessage;
+    }
+
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return "Internal server error";
+  },
+};

--- a/platform/backend/src/routes/proxy/routesv2/xai.ts
+++ b/platform/backend/src/routes/proxy/routesv2/xai.ts
@@ -1,0 +1,182 @@
+/**
+ * x.ai (Grok) LLM Proxy Routes - OpenAI-compatible
+ *
+ * x.ai uses an OpenAI-compatible API at https://api.x.ai/v1
+ * This module registers proxy routes for x.ai chat completions.
+ *
+ * @see https://docs.x.ai/api
+ */
+import fastifyHttpProxy from "@fastify/http-proxy";
+import { RouteId } from "@shared";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import config from "@/config";
+import logger from "@/logging";
+import { constructResponseSchema, Xai, UuidIdSchema } from "@/types";
+import { xaiAdapterFactory } from "../adapterV2";
+import { PROXY_API_PREFIX, PROXY_BODY_LIMIT } from "../common";
+import { handleLLMProxy } from "../llm-proxy-handler";
+import * as utils from "../utils";
+
+const xaiProxyRoutesV2: FastifyPluginAsyncZod = async (fastify) => {
+  const API_PREFIX = `${PROXY_API_PREFIX}/xai`;
+  const CHAT_COMPLETIONS_SUFFIX = "/chat/completions";
+
+  logger.info("[UnifiedProxy] Registering unified x.ai routes");
+
+  /**
+   * Register HTTP proxy for x.ai routes
+   * Chat completions are handled separately with full agent support
+   */
+  await fastify.register(fastifyHttpProxy, {
+    upstream: config.llm.xai.baseUrl,
+    prefix: API_PREFIX,
+    rewritePrefix: "",
+    preHandler: (request, _reply, next) => {
+      // Skip chat/completions - handled by custom handler below
+      if (
+        request.method === "POST" &&
+        request.url.includes(CHAT_COMPLETIONS_SUFFIX)
+      ) {
+        logger.info(
+          {
+            method: request.method,
+            url: request.url,
+            action: "skip-proxy",
+            reason: "handled-by-custom-handler",
+          },
+          "x.ai proxy preHandler: skipping chat/completions route",
+        );
+        next(new Error("skip"));
+        return;
+      }
+
+      // Check if URL has UUID segment that needs stripping
+      const pathAfterPrefix = request.url.replace(API_PREFIX, "");
+      const uuidMatch = pathAfterPrefix.match(
+        /^\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(\/.*)?$/i,
+      );
+
+      if (uuidMatch) {
+        // Strip UUID: /v1/xai/:uuid/path -> /v1/xai/path
+        const remainingPath = uuidMatch[2] || "";
+        const originalUrl = request.raw.url;
+        request.raw.url = `${API_PREFIX}${remainingPath}`;
+
+        logger.info(
+          {
+            method: request.method,
+            originalUrl,
+            rewrittenUrl: request.raw.url,
+            upstream: config.llm.xai.baseUrl,
+            finalProxyUrl: `${config.llm.xai.baseUrl}${remainingPath}`,
+          },
+          "x.ai proxy preHandler: URL rewritten (UUID stripped)",
+        );
+      } else {
+        logger.info(
+          {
+            method: request.method,
+            url: request.url,
+            upstream: config.llm.xai.baseUrl,
+            finalProxyUrl: `${config.llm.xai.baseUrl}${pathAfterPrefix}`,
+          },
+          "x.ai proxy preHandler: proxying request",
+        );
+      }
+
+      next();
+    },
+  });
+
+  /**
+   * Chat completions with default agent
+   */
+  fastify.post(
+    `${API_PREFIX}${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        operationId: RouteId.XaiChatCompletionsWithDefaultAgent,
+        description:
+          "Create a chat completion with x.ai (uses default agent)",
+        tags: ["llm-proxy"],
+        body: Xai.API.ChatCompletionRequestSchema,
+        headers: Xai.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(
+          Xai.API.ChatCompletionResponseSchema,
+        ),
+      },
+    },
+    async (request, reply) => {
+      logger.debug(
+        { url: request.url },
+        "[UnifiedProxy] Handling x.ai request (default agent)",
+      );
+      const externalAgentId = utils.externalAgentId.getExternalAgentId(
+        request.headers,
+      );
+      const userId = await utils.userId.getUserId(request.headers);
+      return handleLLMProxy(
+        request.body,
+        request.headers,
+        reply,
+        xaiAdapterFactory,
+        {
+          organizationId: request.organizationId,
+          agentId: undefined,
+          externalAgentId,
+          userId,
+        },
+      );
+    },
+  );
+
+  /**
+   * Chat completions with specific agent
+   */
+  fastify.post(
+    `${API_PREFIX}/:agentId${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        operationId: RouteId.XaiChatCompletionsWithAgent,
+        description:
+          "Create a chat completion with x.ai for a specific agent",
+        tags: ["llm-proxy"],
+        params: z.object({
+          agentId: UuidIdSchema,
+        }),
+        body: Xai.API.ChatCompletionRequestSchema,
+        headers: Xai.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(
+          Xai.API.ChatCompletionResponseSchema,
+        ),
+      },
+    },
+    async (request, reply) => {
+      logger.debug(
+        { url: request.url, agentId: request.params.agentId },
+        "[UnifiedProxy] Handling x.ai request (with agent)",
+      );
+      const externalAgentId = utils.externalAgentId.getExternalAgentId(
+        request.headers,
+      );
+      const userId = await utils.userId.getUserId(request.headers);
+      return handleLLMProxy(
+        request.body,
+        request.headers,
+        reply,
+        xaiAdapterFactory,
+        {
+          organizationId: request.organizationId,
+          agentId: request.params.agentId,
+          externalAgentId,
+          userId,
+        },
+      );
+    },
+  );
+};
+
+export default xaiProxyRoutesV2;

--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -67,6 +67,7 @@ import {
   Ollama,
   OpenAi,
   Vllm,
+  Xai,
   Zhipuai,
 } from "@/types";
 import websocketService from "@/websocket";
@@ -147,6 +148,12 @@ export function registerOpenApiSchemas() {
   });
   z.globalRegistry.add(Ollama.API.ChatCompletionResponseSchema, {
     id: "OllamaChatCompletionResponse",
+  });
+  z.globalRegistry.add(Xai.API.ChatCompletionRequestSchema, {
+    id: "XaiChatCompletionRequest",
+  });
+  z.globalRegistry.add(Xai.API.ChatCompletionResponseSchema, {
+    id: "XaiChatCompletionResponse",
   });
   z.globalRegistry.add(Zhipuai.API.ChatCompletionRequestSchema, {
     id: "ZhipuaiChatCompletionRequest",

--- a/platform/backend/src/types/llm-providers/index.ts
+++ b/platform/backend/src/types/llm-providers/index.ts
@@ -7,4 +7,5 @@ export { default as Mistral } from "./mistral";
 export { default as Ollama } from "./ollama";
 export { default as OpenAi } from "./openai";
 export { default as Vllm } from "./vllm";
+export { default as Xai } from "./xai";
 export { default as Zhipuai } from "./zhipuai";

--- a/platform/backend/src/types/llm-providers/xai/api.ts
+++ b/platform/backend/src/types/llm-providers/xai/api.ts
@@ -1,0 +1,30 @@
+/**
+ * x.ai (Grok) API schemas
+ *
+ * x.ai uses an OpenAI-compatible API, so we reuse OpenAI schemas directly.
+ * This ensures type compatibility when delegating to OpenAI adapters.
+ *
+ * @see https://docs.x.ai/api
+ */
+
+import {
+  ChatCompletionRequestSchema,
+  ChatCompletionsHeadersSchema,
+  ChatCompletionUsageSchema,
+  FinishReasonSchema,
+  ChatCompletionResponseSchema as OpenAIChatCompletionResponseSchema,
+} from "../openai/api";
+
+// Re-export request and other schemas from OpenAI since x.ai is fully compatible
+export {
+  ChatCompletionRequestSchema,
+  ChatCompletionsHeadersSchema,
+  ChatCompletionUsageSchema,
+  FinishReasonSchema,
+};
+
+/**
+ * x.ai response schema with passthrough for extra fields.
+ */
+export const ChatCompletionResponseSchema =
+  OpenAIChatCompletionResponseSchema.passthrough();

--- a/platform/backend/src/types/llm-providers/xai/index.ts
+++ b/platform/backend/src/types/llm-providers/xai/index.ts
@@ -1,0 +1,42 @@
+/**
+ * x.ai (Grok) LLM Provider Types - OpenAI-compatible
+ *
+ * x.ai uses an OpenAI-compatible API at https://api.x.ai/v1
+ * We re-export OpenAI schemas with x.ai-specific namespace for type safety.
+ *
+ * @see https://docs.x.ai/api
+ */
+import type OpenAIProvider from "openai";
+import type { z } from "zod";
+import * as XaiAPI from "./api";
+import * as XaiMessages from "./messages";
+import * as XaiTools from "./tools";
+
+namespace Xai {
+  export const API = XaiAPI;
+  export const Messages = XaiMessages;
+  export const Tools = XaiTools;
+
+  export namespace Types {
+    export type ChatCompletionsHeaders = z.infer<
+      typeof XaiAPI.ChatCompletionsHeadersSchema
+    >;
+    export type ChatCompletionsRequest = z.infer<
+      typeof XaiAPI.ChatCompletionRequestSchema
+    >;
+    export type ChatCompletionsResponse = z.infer<
+      typeof XaiAPI.ChatCompletionResponseSchema
+    >;
+    export type Usage = z.infer<typeof XaiAPI.ChatCompletionUsageSchema>;
+
+    export type FinishReason = z.infer<typeof XaiAPI.FinishReasonSchema>;
+    export type Message = z.infer<typeof XaiMessages.MessageParamSchema>;
+    export type Role = Message["role"];
+
+    // Use OpenAI's stream chunk type since x.ai is OpenAI-compatible
+    export type ChatCompletionChunk =
+      OpenAIProvider.Chat.Completions.ChatCompletionChunk;
+  }
+}
+
+export default Xai;

--- a/platform/backend/src/types/llm-providers/xai/messages.ts
+++ b/platform/backend/src/types/llm-providers/xai/messages.ts
@@ -1,0 +1,7 @@
+/**
+ * x.ai (Grok) message schemas - OpenAI-compatible
+ *
+ * x.ai uses an OpenAI-compatible API, so we re-export OpenAI schemas.
+ * @see https://docs.x.ai/api
+ */
+export { MessageParamSchema, ToolCallSchema } from "../openai/messages";

--- a/platform/backend/src/types/llm-providers/xai/tools.ts
+++ b/platform/backend/src/types/llm-providers/xai/tools.ts
@@ -1,0 +1,11 @@
+/**
+ * x.ai (Grok) tool schemas - OpenAI-compatible
+ *
+ * x.ai uses an OpenAI-compatible API, so we re-export OpenAI schemas.
+ * @see https://docs.x.ai/api
+ */
+export {
+  FunctionDefinitionParametersSchema,
+  ToolChoiceOptionSchema,
+  ToolSchema,
+} from "../openai/tools";

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -13,6 +13,7 @@ export const SupportedProvidersSchema = z.enum([
   "mistral",
   "vllm",
   "ollama",
+  "xai",
   "zhipuai",
 ]);
 
@@ -26,6 +27,7 @@ export const SupportedProvidersDiscriminatorSchema = z.enum([
   "mistral:chatCompletions",
   "vllm:chatCompletions",
   "ollama:chatCompletions",
+  "xai:chatCompletions",
   "zhipuai:chatCompletions",
 ]);
 
@@ -45,6 +47,7 @@ export const providerDisplayNames: Record<SupportedProvider, string> = {
   mistral: "Mistral AI",
   vllm: "vLLM",
   ollama: "Ollama",
+  xai: "xAI (Grok)",
   zhipuai: "Zhipu AI",
 };
 
@@ -97,6 +100,10 @@ export const MODEL_MARKER_PATTERNS: Record<
   vllm: {
     fastest: ["llama3.2", "phi"],
     best: ["llama3.1", "mixtral"],
+  },
+  xai: {
+    fastest: ["grok-2"],
+    best: ["grok-2"],
   },
   zhipuai: {
     fastest: ["glm-4-flash", "glm-flash"],

--- a/platform/shared/routes.ts
+++ b/platform/shared/routes.ts
@@ -178,6 +178,11 @@ export const RouteId = {
   OllamaChatCompletionsWithDefaultAgent:
     "ollamaChatCompletionsWithDefaultAgent",
   OllamaChatCompletionsWithAgent: "ollamaChatCompletionsWithAgent",
+
+  // Proxy Routes - x.ai (Grok)
+  XaiChatCompletionsWithDefaultAgent: "xaiChatCompletionsWithDefaultAgent",
+  XaiChatCompletionsWithAgent: "xaiChatCompletionsWithAgent",
+
   // Proxy Routes - Zhipu AI
   ZhipuaiChatCompletionsWithDefaultAgent:
     "zhipuaiChatCompletionsWithDefaultAgent",


### PR DESCRIPTION
## Summary

Add x.ai (Grok) as a new LLM provider using the OpenAI-compatible API delegation pattern.

- x.ai uses an OpenAI-compatible REST API at `api.x.ai/v1`
- Follows the same delegation pattern as other OpenAI-compatible providers (Mistral, Cerebras, Zhipuai, etc.)
- Adds types, adapter factory, and proxy routes for x.ai chat completions
- Configurable via `ARCHESTRA_XAI_BASE_URL` and `ARCHESTRA_CHAT_XAI_API_KEY`

## Changes

- Add x.ai types delegating to OpenAI schemas (`platform/backend/src/types/llm-providers/xai/`)
- Add `xaiAdapterFactory` delegating to OpenAI adapters
- Add x.ai proxy routes for chat completions
- Add x.ai to `SupportedProvidersSchema` in model-constants
- Register x.ai routes and OpenAPI schemas in server.ts

## Test plan

- [ ] x.ai proxy routes work with valid API key
- [ ] Chat completions route through x.ai provider
- [ ] OpenAPI spec includes x.ai schemas

/claim #1850

🤖 Generated with [Claude Code](https://claude.com/claude-code)