### PR TITLE
feat(provider): add DeepSeek LLM provider support

### DIFF
--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -451,6 +451,10 @@ export default {
       baseUrl:
         process.env.ARCHESTRA_MISTRAL_BASE_URL || "https://api.mistral.ai/v1",
     },
+    deepseek: {
+      baseUrl:
+        process.env.ARCHESTRA_DEEPSEEK_BASE_URL || "https://api.deepseek.com",
+    },
     vllm: {
       enabled: Boolean(process.env.ARCHESTRA_VLLM_BASE_URL),
       baseUrl: process.env.ARCHESTRA_VLLM_BASE_URL,
@@ -487,6 +491,9 @@ export default {
     },
     mistral: {
       apiKey: process.env.ARCHESTRA_CHAT_MISTRAL_API_KEY || "",
+    },
+    deepseek: {
+      apiKey: process.env.ARCHESTRA_CHAT_DEEPSEEK_API_KEY || "",
     },
     vllm: {
       apiKey: process.env.ARCHESTRA_CHAT_VLLM_API_KEY || "",

--- a/platform/backend/src/routes/index.ts
+++ b/platform/backend/src/routes/index.ts
@@ -2,6 +2,7 @@ import anthropicProxyRoutesV2 from "./proxy/routesv2/anthropic";
 import bedrockProxyRoutesV2 from "./proxy/routesv2/bedrock";
 import cerebrasProxyRoutesV2 from "./proxy/routesv2/cerebras";
 import cohereProxyRoutesV2 from "./proxy/routesv2/cohere";
+import deepseekProxyRoutesV2 from "./proxy/routesv2/deepseek";
 import geminiProxyRoutesV2 from "./proxy/routesv2/gemini";
 import mistralProxyRoutesV2 from "./proxy/routesv2/mistral";
 import ollamaProxyRoutesV2 from "./proxy/routesv2/ollama";
@@ -40,6 +41,7 @@ export { default as policyConfigSubagentRoutes } from "./policy-config-subagent"
 export const anthropicProxyRoutes = anthropicProxyRoutesV2;
 export const cerebrasProxyRoutes = cerebrasProxyRoutesV2;
 export const cohereProxyRoutes = cohereProxyRoutesV2;
+export const deepseekProxyRoutes = deepseekProxyRoutesV2;
 export const geminiProxyRoutes = geminiProxyRoutesV2;
 export const mistralProxyRoutes = mistralProxyRoutesV2;
 export const openAiProxyRoutes = openAiProxyRoutesV2;

--- a/platform/backend/src/routes/proxy/adapterV2/deepseek.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/deepseek.ts
@@ -1,0 +1,293 @@
+/**
+ * DeepSeek LLM Proxy Adapter - OpenAI-compatible
+ *
+ * DeepSeek uses an OpenAI-compatible API at https://api.deepseek.com
+ * This adapter reuses OpenAI's adapter factory with DeepSeek-specific configuration.
+ *
+ * Since DeepSeek is 100% OpenAI-compatible, we delegate all adapter logic to OpenAI
+ * and only override the provider-specific configuration (baseUrl, provider name, etc.).
+ *
+ * @see https://platform.deepseek.com/api-docs/
+ */
+import { get } from "lodash-es";
+import OpenAIProvider from "openai";
+import type {
+  ChatCompletionCreateParamsNonStreaming,
+  ChatCompletionCreateParamsStreaming,
+} from "openai/resources/chat/completions/completions";
+import config from "@/config";
+import { getObservableFetch } from "@/llm-metrics";
+import type {
+  CreateClientOptions,
+  DeepSeek,
+  LLMProvider,
+  LLMRequestAdapter,
+  LLMResponseAdapter,
+  LLMStreamAdapter,
+} from "@/types";
+import { MockOpenAIClient } from "../mock-openai-client";
+import {
+  OpenAIRequestAdapter,
+  OpenAIResponseAdapter,
+  OpenAIStreamAdapter,
+} from "./openai";
+
+// =============================================================================
+// TYPE ALIASES (reuse OpenAI types since DeepSeek is OpenAI-compatible)
+// =============================================================================
+
+type DeepSeekRequest = DeepSeek.Types.ChatCompletionRequest;
+type DeepSeekResponse = DeepSeek.Types.ChatCompletionResponse;
+type DeepSeekMessages = DeepSeek.Types.ChatCompletionRequest["messages"];
+type DeepSeekHeaders = DeepSeek.Types.ChatCompletionsHeaders;
+type DeepSeekStreamChunk = DeepSeek.Types.ChatCompletionResponse;
+
+// =============================================================================
+// ADAPTER CLASSES (delegate to OpenAI adapters, override provider)
+// =============================================================================
+
+/**
+ * DeepSeek request adapter - wraps OpenAI adapter with DeepSeek provider name.
+ * Uses composition to delegate all logic to OpenAI since APIs are identical.
+ */
+class DeepSeekRequestAdapter
+  implements LLMRequestAdapter<DeepSeekRequest, DeepSeekMessages>
+{
+  readonly provider = "deepseek" as const;
+  private delegate: OpenAIRequestAdapter;
+
+  constructor(request: DeepSeekRequest) {
+    this.delegate = new OpenAIRequestAdapter(request);
+  }
+
+  getModel() {
+    return this.delegate.getModel();
+  }
+  isStreaming() {
+    return this.delegate.isStreaming();
+  }
+  getMessages() {
+    return this.delegate.getMessages();
+  }
+  getToolResults() {
+    return this.delegate.getToolResults();
+  }
+  getTools() {
+    return this.delegate.getTools();
+  }
+  hasTools() {
+    return this.delegate.hasTools();
+  }
+  getProviderMessages() {
+    return this.delegate.getProviderMessages();
+  }
+  getOriginalRequest() {
+    return this.delegate.getOriginalRequest();
+  }
+  setModel(model: string) {
+    return this.delegate.setModel(model);
+  }
+  updateToolResult(toolCallId: string, newContent: string) {
+    return this.delegate.updateToolResult(toolCallId, newContent);
+  }
+  applyToolResultUpdates(updates: Record<string, string>) {
+    return this.delegate.applyToolResultUpdates(updates);
+  }
+  applyToonCompression(model: string) {
+    return this.delegate.applyToonCompression(model);
+  }
+  convertToolResultContent(messages: DeepSeekMessages) {
+    return this.delegate.convertToolResultContent(messages);
+  }
+  toProviderRequest() {
+    return this.delegate.toProviderRequest();
+  }
+}
+
+/**
+ * DeepSeek response adapter - wraps OpenAI adapter with DeepSeek provider name.
+ */
+class DeepSeekResponseAdapter implements LLMResponseAdapter<DeepSeekResponse> {
+  readonly provider = "deepseek" as const;
+  private delegate: OpenAIResponseAdapter;
+
+  constructor(response: DeepSeekResponse) {
+    this.delegate = new OpenAIResponseAdapter(response);
+  }
+
+  getId() {
+    return this.delegate.getId();
+  }
+  getModel() {
+    return this.delegate.getModel();
+  }
+  getText() {
+    return this.delegate.getText();
+  }
+  getToolCalls() {
+    return this.delegate.getToolCalls();
+  }
+  hasToolCalls() {
+    return this.delegate.hasToolCalls();
+  }
+  getUsage() {
+    return this.delegate.getUsage();
+  }
+  getOriginalResponse() {
+    return this.delegate.getOriginalResponse();
+  }
+  toRefusalResponse(refusalMessage: string, contentMessage: string) {
+    return this.delegate.toRefusalResponse(refusalMessage, contentMessage);
+  }
+}
+
+/**
+ * DeepSeek stream adapter - wraps OpenAI adapter with DeepSeek provider name.
+ */
+class DeepSeekStreamAdapter
+  implements LLMStreamAdapter<DeepSeekStreamChunk, DeepSeekResponse>
+{
+  readonly provider = "deepseek" as const;
+  private delegate: OpenAIStreamAdapter;
+
+  constructor() {
+    this.delegate = new OpenAIStreamAdapter();
+  }
+
+  get state() {
+    return this.delegate.state;
+  }
+
+  processChunk(chunk: DeepSeekStreamChunk) {
+    return this.delegate.processChunk(chunk);
+  }
+  getSSEHeaders() {
+    return this.delegate.getSSEHeaders();
+  }
+  formatTextDeltaSSE(text: string) {
+    return this.delegate.formatTextDeltaSSE(text);
+  }
+  getRawToolCallEvents() {
+    return this.delegate.getRawToolCallEvents();
+  }
+  formatCompleteTextSSE(text: string) {
+    return this.delegate.formatCompleteTextSSE(text);
+  }
+  formatEndSSE() {
+    return this.delegate.formatEndSSE();
+  }
+  toProviderResponse() {
+    return this.delegate.toProviderResponse();
+  }
+}
+
+// =============================================================================
+// ADAPTER FACTORY
+// =============================================================================
+
+export const deepseekAdapterFactory: LLMProvider<
+  DeepSeekRequest,
+  DeepSeekResponse,
+  DeepSeekMessages,
+  DeepSeekStreamChunk,
+  DeepSeekHeaders
+> = {
+  provider: "deepseek",
+  interactionType: "deepseek:chatCompletions",
+
+  createRequestAdapter(
+    request: DeepSeekRequest,
+  ): LLMRequestAdapter<DeepSeekRequest, DeepSeekMessages> {
+    return new DeepSeekRequestAdapter(request);
+  },
+
+  createResponseAdapter(
+    response: DeepSeekResponse,
+  ): LLMResponseAdapter<DeepSeekResponse> {
+    return new DeepSeekResponseAdapter(response);
+  },
+
+  createStreamAdapter(): LLMStreamAdapter<DeepSeekStreamChunk, DeepSeekResponse> {
+    return new DeepSeekStreamAdapter();
+  },
+
+  extractApiKey(headers: DeepSeekHeaders): string | undefined {
+    return headers.authorization;
+  },
+
+  getBaseUrl(): string | undefined {
+    return config.llm.deepseek.baseUrl;
+  },
+
+  getSpanName(): string {
+    return "deepseek.chat.completions";
+  },
+
+  createClient(
+    apiKey: string | undefined,
+    options?: CreateClientOptions,
+  ): OpenAIProvider {
+    if (options?.mockMode) {
+      return new MockOpenAIClient() as unknown as OpenAIProvider;
+    }
+
+    const customFetch = options?.agent
+      ? getObservableFetch("deepseek", options.agent, options.externalAgentId)
+      : undefined;
+
+    return new OpenAIProvider({
+      apiKey,
+      baseURL: options?.baseUrl ?? config.llm.deepseek.baseUrl,
+      fetch: customFetch,
+    });
+  },
+
+  async execute(
+    client: unknown,
+    request: DeepSeekRequest,
+  ): Promise<DeepSeekResponse> {
+    const deepseekClient = client as OpenAIProvider;
+    const deepseekRequest = {
+      ...request,
+      stream: false,
+    } as unknown as ChatCompletionCreateParamsNonStreaming;
+    // Cast through unknown because DeepSeekResponse uses .passthrough() which adds index signature
+    return deepseekClient.chat.completions.create(
+      deepseekRequest,
+    ) as unknown as Promise<DeepSeekResponse>;
+  },
+
+  async executeStream(
+    client: unknown,
+    request: DeepSeekRequest,
+  ): Promise<AsyncIterable<DeepSeekStreamChunk>> {
+    const deepseekClient = client as OpenAIProvider;
+    const deepseekRequest = {
+      ...request,
+      stream: true,
+      stream_options: { include_usage: true },
+    } as unknown as ChatCompletionCreateParamsStreaming;
+    const stream = await deepseekClient.chat.completions.create(deepseekRequest);
+
+    return {
+      [Symbol.asyncIterator]: async function* () {
+        for await (const chunk of stream) {
+          yield chunk as DeepSeekStreamChunk;
+        }
+      },
+    };
+  },
+
+  extractErrorMessage(error: unknown): string {
+    const openaiMessage = get(error, "error.message");
+    if (typeof openaiMessage === "string") {
+      return openaiMessage;
+    }
+
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return "Internal server error";
+  },
+};

--- a/platform/backend/src/routes/proxy/adapterV2/index.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/index.ts
@@ -2,6 +2,7 @@ export { anthropicAdapterFactory } from "./anthropic";
 export { bedrockAdapterFactory } from "./bedrock";
 export { cerebrasAdapterFactory } from "./cerebras";
 export { cohereAdapterFactory } from "./cohere";
+export { deepseekAdapterFactory } from "./deepseek";
 export { geminiAdapterFactory } from "./gemini";
 export { mistralAdapterFactory } from "./mistral";
 export { ollamaAdapterFactory } from "./ollama";

--- a/platform/backend/src/routes/proxy/routesv2/deepseek.ts
+++ b/platform/backend/src/routes/proxy/routesv2/deepseek.ts
@@ -1,0 +1,182 @@
+/**
+ * DeepSeek LLM Proxy Routes - OpenAI-compatible
+ *
+ * DeepSeek uses an OpenAI-compatible API at https://api.deepseek.com
+ * This module registers proxy routes for DeepSeek chat completions.
+ *
+ * @see https://platform.deepseek.com/api-docs/
+ */
+import fastifyHttpProxy from "@fastify/http-proxy";
+import { RouteId } from "@shared";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import config from "@/config";
+import logger from "@/logging";
+import { constructResponseSchema, DeepSeek, UuidIdSchema } from "@/types";
+import { deepseekAdapterFactory } from "../adapterV2";
+import { PROXY_API_PREFIX, PROXY_BODY_LIMIT } from "../common";
+import { handleLLMProxy } from "../llm-proxy-handler";
+import * as utils from "../utils";
+
+const deepseekProxyRoutesV2: FastifyPluginAsyncZod = async (fastify) => {
+  const API_PREFIX = `${PROXY_API_PREFIX}/deepseek`;
+  const CHAT_COMPLETIONS_SUFFIX = "/chat/completions";
+
+  logger.info("[UnifiedProxy] Registering unified DeepSeek routes");
+
+  /**
+   * Register HTTP proxy for DeepSeek routes
+   * Chat completions are handled separately with full agent support
+   */
+  await fastify.register(fastifyHttpProxy, {
+    upstream: config.llm.deepseek.baseUrl,
+    prefix: API_PREFIX,
+    rewritePrefix: "",
+    preHandler: (request, _reply, next) => {
+      // Skip chat/completions - handled by custom handler below
+      if (
+        request.method === "POST" &&
+        request.url.includes(CHAT_COMPLETIONS_SUFFIX)
+      ) {
+        logger.info(
+          {
+            method: request.method,
+            url: request.url,
+            action: "skip-proxy",
+            reason: "handled-by-custom-handler",
+          },
+          "DeepSeek proxy preHandler: skipping chat/completions route",
+        );
+        next(new Error("skip"));
+        return;
+      }
+
+      // Check if URL has UUID segment that needs stripping
+      const pathAfterPrefix = request.url.replace(API_PREFIX, "");
+      const uuidMatch = pathAfterPrefix.match(
+        /^\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(\/.*)?$/i,
+      );
+
+      if (uuidMatch) {
+        // Strip UUID: /v1/deepseek/:uuid/path -> /v1/deepseek/path
+        const remainingPath = uuidMatch[2] || "";
+        const originalUrl = request.raw.url;
+        request.raw.url = `${API_PREFIX}${remainingPath}`;
+
+        logger.info(
+          {
+            method: request.method,
+            originalUrl,
+            rewrittenUrl: request.raw.url,
+            upstream: config.llm.deepseek.baseUrl,
+            finalProxyUrl: `${config.llm.deepseek.baseUrl}${remainingPath}`,
+          },
+          "DeepSeek proxy preHandler: URL rewritten (UUID stripped)",
+        );
+      } else {
+        logger.info(
+          {
+            method: request.method,
+            url: request.url,
+            upstream: config.llm.deepseek.baseUrl,
+            finalProxyUrl: `${config.llm.deepseek.baseUrl}${pathAfterPrefix}`,
+          },
+          "DeepSeek proxy preHandler: proxying request",
+        );
+      }
+
+      next();
+    },
+  });
+
+  /**
+   * Chat completions with default agent
+   */
+  fastify.post(
+    `${API_PREFIX}${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        operationId: RouteId.DeepSeekChatCompletionsWithDefaultAgent,
+        description:
+          "Create a chat completion with DeepSeek (uses default agent)",
+        tags: ["llm-proxy"],
+        body: DeepSeek.API.ChatCompletionRequestSchema,
+        headers: DeepSeek.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(
+          DeepSeek.API.ChatCompletionResponseSchema,
+        ),
+      },
+    },
+    async (request, reply) => {
+      logger.debug(
+        { url: request.url },
+        "[UnifiedProxy] Handling DeepSeek request (default agent)",
+      );
+      const externalAgentId = utils.externalAgentId.getExternalAgentId(
+        request.headers,
+      );
+      const userId = await utils.userId.getUserId(request.headers);
+      return handleLLMProxy(
+        request.body,
+        request.headers,
+        reply,
+        deepseekAdapterFactory,
+        {
+          organizationId: request.organizationId,
+          agentId: undefined,
+          externalAgentId,
+          userId,
+        },
+      );
+    },
+  );
+
+  /**
+   * Chat completions with specific agent
+   */
+  fastify.post(
+    `${API_PREFIX}/:agentId${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        operationId: RouteId.DeepSeekChatCompletionsWithAgent,
+        description:
+          "Create a chat completion with DeepSeek for a specific agent",
+        tags: ["llm-proxy"],
+        params: z.object({
+          agentId: UuidIdSchema,
+        }),
+        body: DeepSeek.API.ChatCompletionRequestSchema,
+        headers: DeepSeek.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(
+          DeepSeek.API.ChatCompletionResponseSchema,
+        ),
+      },
+    },
+    async (request, reply) => {
+      logger.debug(
+        { url: request.url, agentId: request.params.agentId },
+        "[UnifiedProxy] Handling DeepSeek request (with agent)",
+      );
+      const externalAgentId = utils.externalAgentId.getExternalAgentId(
+        request.headers,
+      );
+      const userId = await utils.userId.getUserId(request.headers);
+      return handleLLMProxy(
+        request.body,
+        request.headers,
+        reply,
+        deepseekAdapterFactory,
+        {
+          organizationId: request.organizationId,
+          agentId: request.params.agentId,
+          externalAgentId,
+          userId,
+        },
+      );
+    },
+  );
+};
+
+export default deepseekProxyRoutesV2;

--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -62,6 +62,7 @@ import {
   ApiError,
   Cerebras,
   Cohere,
+  DeepSeek,
   Gemini,
   Mistral,
   Ollama,
@@ -135,6 +136,12 @@ export function registerOpenApiSchemas() {
   });
   z.globalRegistry.add(Mistral.API.ChatCompletionResponseSchema, {
     id: "MistralChatCompletionResponse",
+  });
+  z.globalRegistry.add(DeepSeek.API.ChatCompletionRequestSchema, {
+    id: "DeepSeekChatCompletionRequest",
+  });
+  z.globalRegistry.add(DeepSeek.API.ChatCompletionResponseSchema, {
+    id: "DeepSeekChatCompletionResponse",
   });
   z.globalRegistry.add(Vllm.API.ChatCompletionRequestSchema, {
     id: "VllmChatCompletionRequest",

--- a/platform/backend/src/types/llm-providers/deepseek/api.ts
+++ b/platform/backend/src/types/llm-providers/deepseek/api.ts
@@ -1,0 +1,16 @@
+/**
+ * DeepSeek API types (OpenAI-compatible)
+ *
+ * DeepSeek uses an OpenAI-compatible API, so we re-export OpenAI schemas.
+ */
+import {
+  ChatCompletionRequestSchema,
+  ChatCompletionsHeadersSchema,
+  ChatCompletionResponseSchema as OpenAIChatCompletionResponseSchema,
+} from "../openai/api";
+
+export { ChatCompletionRequestSchema, ChatCompletionsHeadersSchema };
+
+// Use passthrough to allow DeepSeek-specific fields
+export const ChatCompletionResponseSchema =
+  OpenAIChatCompletionResponseSchema.passthrough();

--- a/platform/backend/src/types/llm-providers/deepseek/index.ts
+++ b/platform/backend/src/types/llm-providers/deepseek/index.ts
@@ -1,0 +1,29 @@
+/**
+ * DeepSeek LLM Provider types
+ *
+ * DeepSeek uses an OpenAI-compatible API at api.deepseek.com
+ */
+import type { z } from "zod";
+import * as DeepSeekAPI from "./api";
+import * as DeepSeekMessages from "./messages";
+import * as DeepSeekTools from "./tools";
+
+namespace DeepSeek {
+  export const API = DeepSeekAPI;
+  export const Messages = DeepSeekMessages.Messages;
+  export const Tools = DeepSeekTools.Tools;
+
+  export namespace Types {
+    export type ChatCompletionRequest = z.infer<
+      typeof DeepSeekAPI.ChatCompletionRequestSchema
+    >;
+    export type ChatCompletionResponse = z.infer<
+      typeof DeepSeekAPI.ChatCompletionResponseSchema
+    >;
+    export type ChatCompletionsHeaders = z.infer<
+      typeof DeepSeekAPI.ChatCompletionsHeadersSchema
+    >;
+  }
+}
+
+export default DeepSeek;

--- a/platform/backend/src/types/llm-providers/deepseek/messages.ts
+++ b/platform/backend/src/types/llm-providers/deepseek/messages.ts
@@ -1,0 +1,6 @@
+/**
+ * DeepSeek Messages types (OpenAI-compatible)
+ */
+import * as OpenAiMessages from "../openai/messages";
+
+export const Messages = OpenAiMessages;

--- a/platform/backend/src/types/llm-providers/deepseek/tools.ts
+++ b/platform/backend/src/types/llm-providers/deepseek/tools.ts
@@ -1,0 +1,6 @@
+/**
+ * DeepSeek Tools types (OpenAI-compatible)
+ */
+import * as OpenAiTools from "../openai/tools";
+
+export const Tools = OpenAiTools;

--- a/platform/backend/src/types/llm-providers/index.ts
+++ b/platform/backend/src/types/llm-providers/index.ts
@@ -2,6 +2,7 @@ export { default as Anthropic } from "./anthropic";
 export { default as Bedrock } from "./bedrock";
 export { default as Cerebras } from "./cerebras";
 export { default as Cohere } from "./cohere";
+export { default as DeepSeek } from "./deepseek";
 export { default as Gemini } from "./gemini";
 export { default as Mistral } from "./mistral";
 export { default as Ollama } from "./ollama";

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -10,6 +10,7 @@ export const SupportedProvidersSchema = z.enum([
   "bedrock",
   "cohere",
   "cerebras",
+  "deepseek",
   "mistral",
   "vllm",
   "ollama",
@@ -23,6 +24,7 @@ export const SupportedProvidersDiscriminatorSchema = z.enum([
   "bedrock:converse",
   "cohere:chat",
   "cerebras:chatCompletions",
+  "deepseek:chatCompletions",
   "mistral:chatCompletions",
   "vllm:chatCompletions",
   "ollama:chatCompletions",
@@ -42,6 +44,7 @@ export const providerDisplayNames: Record<SupportedProvider, string> = {
   gemini: "Gemini",
   cohere: "Cohere",
   cerebras: "Cerebras",
+  deepseek: "DeepSeek",
   mistral: "Mistral AI",
   vllm: "vLLM",
   ollama: "Ollama",
@@ -89,6 +92,10 @@ export const MODEL_MARKER_PATTERNS: Record<
   mistral: {
     fastest: ["mistral-small", "ministral"],
     best: ["mistral-large"],
+  },
+  deepseek: {
+    fastest: ["deepseek-chat"],
+    best: ["deepseek-reasoner", "deepseek-coder"],
   },
   ollama: {
     fastest: ["llama3.2", "phi"],

--- a/platform/shared/routes.ts
+++ b/platform/shared/routes.ts
@@ -170,6 +170,11 @@ export const RouteId = {
     "mistralChatCompletionsWithDefaultAgent",
   MistralChatCompletionsWithAgent: "mistralChatCompletionsWithAgent",
 
+  // Proxy Routes - DeepSeek
+  DeepSeekChatCompletionsWithDefaultAgent:
+    "deepseekChatCompletionsWithDefaultAgent",
+  DeepSeekChatCompletionsWithAgent: "deepseekChatCompletionsWithAgent",
+
   // Proxy Routes - vLLM
   VllmChatCompletionsWithDefaultAgent: "vllmChatCompletionsWithDefaultAgent",
   VllmChatCompletionsWithAgent: "vllmChatCompletionsWithAgent",


### PR DESCRIPTION
## Summary

Add DeepSeek as a new LLM provider using the OpenAI-compatible API delegation pattern.

- DeepSeek uses an OpenAI-compatible REST API at `api.deepseek.com`
- Follows the same delegation pattern as other OpenAI-compatible providers (Mistral, Cerebras, Zhipuai, etc.)
- Adds types, adapter factory, and proxy routes for DeepSeek chat completions
- Configurable via `ARCHESTRA_DEEPSEEK_BASE_URL` and `ARCHESTRA_CHAT_DEEPSEEK_API_KEY`

## Changes

- Add DeepSeek types delegating to OpenAI schemas (`platform/backend/src/types/llm-providers/deepseek/`)
- Add `deepseekAdapterFactory` delegating to OpenAI adapters
- Add DeepSeek proxy routes for chat completions
- Add DeepSeek to `SupportedProvidersSchema` in model-constants
- Register DeepSeek routes and OpenAPI schemas in server.ts

## Test plan

- [ ] DeepSeek proxy routes work with valid API key
- [ ] Chat completions route through DeepSeek provider
- [ ] OpenAPI spec includes DeepSeek schemas

/claim #1846

🤖 Generated with [Claude Code](https://claude.com/claude-code)