### PR TITLE
feat: add Ollama base URL env var for staging

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -25,6 +25,7 @@ archestra:
     ARCHESTRA_GEMINI_VERTEX_AI_LOCATION: "us-central1"
     ARCHESTRA_BEDROCK_BASE_URL: "https://bedrock-runtime.eu-north-1.amazonaws.com"
     ARCHESTRA_BEDROCK_INFERENCE_PROFILE_PREFIX: "eu"
+    ARCHESTRA_OLLAMA_BASE_URL: "http://open-webui-ollama.open-webui.svc.cluster.local:11434/v1"
 
   # Orchestrator configuration with Workload Identity for Vertex AI
   orchestrator:


### PR DESCRIPTION
## Summary
- Adds `ARCHESTRA_OLLAMA_BASE_URL` to staging env vars pointing to the Ollama OpenAI-compatible endpoint
- Static cluster-internal URL: `http://open-webui-ollama.open-webui.svc.cluster.local:11434/v1`

Depends on https://github.com/archestra-ai/infra/pull/10