### PR TITLE
fix: remove /v1 suffix from Ollama base URL

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -25,7 +25,7 @@ archestra:
     ARCHESTRA_GEMINI_VERTEX_AI_LOCATION: "us-central1"
     ARCHESTRA_BEDROCK_BASE_URL: "https://bedrock-runtime.eu-north-1.amazonaws.com"
     ARCHESTRA_BEDROCK_INFERENCE_PROFILE_PREFIX: "eu"
-    ARCHESTRA_OLLAMA_BASE_URL: "http://open-webui-ollama.open-webui.svc.cluster.local:11434/v1"
+    ARCHESTRA_OLLAMA_BASE_URL: "http://open-webui-ollama.open-webui.svc.cluster.local:11434"
 
   # Orchestrator configuration with Workload Identity for Vertex AI
   orchestrator:


### PR DESCRIPTION
## Summary
- Removes `/v1` suffix from `ARCHESTRA_OLLAMA_BASE_URL` in staging values
- The Ollama proxy code (`ollama.ts`) appends paths like `/api/tags` directly to the base URL
- With `/v1` in the base URL, requests hit `/v1/api/tags` which returns 404 from Ollama
- The `/v1` prefix is only for OpenAI-compat endpoints, not native Ollama API paths

## Test plan
- [ ] After deploy, `GET /v1/ollama/<agentId>/api/tags` returns model list instead of 404
- [ ] Open WebUI at localhost:8080 shows available models

🤖 Generated with [Claude Code](https://claude.com/claude-code)