### PR TITLE
feat: add Groq model provider

### DIFF
--- a/platform/backend/src/clients/dual-llm-client.ts
+++ b/platform/backend/src/clients/dual-llm-client.ts
@@ -1177,6 +1177,85 @@ Return only the JSON object, no other text.`;
   }
 }
 
+/**
+ * Groq implementation of DualLlmClient (OpenAI-compatible)
+ */
+export class GroqDualLlmClient implements DualLlmClient {
+  private client: OpenAI;
+  private model: string;
+
+  constructor(apiKey: string, model = "llama-3.3-70b-versatile") {
+    logger.debug({ model }, "[dualLlmClient] Groq: initializing client");
+    this.client = new OpenAI({
+      apiKey,
+      baseURL: config.llm.groq.baseUrl,
+    });
+    this.model = model;
+  }
+
+  async chat(messages: DualLlmMessage[], temperature = 0): Promise<string> {
+    logger.debug(
+      { model: this.model, messageCount: messages.length, temperature },
+      "[dualLlmClient] Groq: starting chat completion",
+    );
+    const response = await this.client.chat.completions.create({
+      model: this.model,
+      messages,
+      temperature,
+    });
+
+    const content = response.choices[0].message.content?.trim() || "";
+    logger.debug(
+      { model: this.model, responseLength: content.length },
+      "[dualLlmClient] Groq: chat completion complete",
+    );
+    return content;
+  }
+
+  async chatWithSchema<T>(
+    messages: DualLlmMessage[],
+    schema: {
+      name: string;
+      schema: {
+        type: string;
+        properties: Record<string, unknown>;
+        required: string[];
+        additionalProperties: boolean;
+      };
+    },
+    temperature = 0,
+  ): Promise<T> {
+    logger.debug(
+      {
+        model: this.model,
+        schemaName: schema.name,
+        messageCount: messages.length,
+        temperature,
+      },
+      "[dualLlmClient] Groq: starting chat with schema",
+    );
+
+    // Groq supports tool calling which can be used for structured output,
+    // or JSON mode. Here we use OpenAI-compatible JSON schema if supported.
+    const response = await this.client.chat.completions.create({
+      model: this.model,
+      messages,
+      response_format: {
+        type: "json_schema",
+        json_schema: schema,
+      },
+      temperature,
+    });
+
+    const content = response.choices[0].message.content || "";
+    logger.debug(
+      { model: this.model, responseLength: content.length },
+      "[dualLlmClient] Groq: chat with schema complete, parsing response",
+    );
+    return JSON.parse(content) as T;
+  }
+}
+
 type DualLlmClientFactory = (
   apiKey: string | undefined,
   model: string | undefined,
@@ -1223,6 +1302,10 @@ const dualLlmClientFactories: Record<SupportedProvider, DualLlmClientFactory> =
     zhipuai: (apiKey, model) => {
       if (!apiKey) throw new Error("API key required for Zhipuai dual LLM");
       return new ZhipuaiDualLlmClient(apiKey, model);
+    },
+    groq: (apiKey, model) => {
+      if (!apiKey) throw new Error("API key required for Groq dual LLM");
+      return new GroqDualLlmClient(apiKey, model);
     },
     bedrock: (apiKey, model) => {
       if (!model) throw new Error("Model name required for Bedrock dual LLM");

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -87,6 +87,7 @@ const envApiKeyGetters: Record<
   openai: () => config.chat.openai.apiKey,
   vllm: () => config.chat.vllm.apiKey,
   zhipuai: () => config.chat.zhipuai.apiKey,
+  groq: () => config.chat.groq.apiKey,
 };
 
 /**
@@ -165,6 +166,7 @@ export const FAST_MODELS: Record<SupportedChatProvider, string> = {
   openai: "gpt-4o-mini",
   gemini: "gemini-2.0-flash-001",
   cerebras: "llama-3.3-70b", // Cerebras focuses on speed, all their models are fast
+  groq: "llama-3.3-70b-versatile",
   cohere: "command-light", // Cohere's fast model
   vllm: "default", // vLLM uses whatever model is deployed
   ollama: "llama3.2", // Common fast model for Ollama
@@ -339,6 +341,21 @@ const directModelCreators: Record<SupportedChatProvider, DirectModelCreator> = {
     });
     return client(modelName);
   },
+
+  groq: ({ apiKey, modelName }) => {
+    if (!apiKey) {
+      throw new ApiError(
+        400,
+        "Groq API key is required. Please configure ARCHESTRA_CHAT_GROQ_API_KEY.",
+      );
+    }
+    // Groq uses OpenAI-compatible API
+    const client = createOpenAI({
+      apiKey,
+      baseURL: config.llm.groq.baseUrl,
+    });
+    return client(modelName);
+  },
 };
 
 /**
@@ -504,6 +521,18 @@ const proxiedModelCreators: Record<SupportedChatProvider, ProxiedModelCreator> =
         headers,
       });
       return client(modelName);
+    },
+
+    groq: ({ apiKey, agentId, modelName, headers }) => {
+      // URL format: /v1/groq/:agentId (SDK appends /chat/completions)
+      // Groq is OpenAI-compatible
+      const client = createOpenAI({
+        apiKey,
+        baseURL: buildProxyBaseUrl("groq", agentId),
+        headers,
+      });
+      // Use .chat() to force Chat Completions API
+      return client.chat(modelName);
     },
   };
 

--- a/platform/backend/src/clients/models-dev-client.ts
+++ b/platform/backend/src/clients/models-dev-client.ts
@@ -50,7 +50,7 @@ const MODELS_DEV_PROVIDER_MAP: Record<string, SupportedProvider | null> = {
   // These providers use OpenAI-compatible API in Archestra
   llama: "openai",
   deepseek: "openai",
-  groq: "openai",
+  groq: "groq",
   "fireworks-ai": "openai",
   togetherai: "openai",
   // Explicitly unsupported providers (return null to skip)

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -464,6 +464,10 @@ export default {
         process.env.ARCHESTRA_ZHIPUAI_BASE_URL ||
         "https://api.z.ai/api/paas/v4",
     },
+    groq: {
+      baseUrl:
+        process.env.ARCHESTRA_GROQ_BASE_URL || "https://api.groq.com/openai/v1",
+    },
     bedrock: {
       enabled: Boolean(process.env.ARCHESTRA_BEDROCK_BASE_URL),
       baseUrl: process.env.ARCHESTRA_BEDROCK_BASE_URL || "",
@@ -499,6 +503,9 @@ export default {
     },
     zhipuai: {
       apiKey: process.env.ARCHESTRA_CHAT_ZHIPUAI_API_KEY || "",
+    },
+    groq: {
+      apiKey: process.env.ARCHESTRA_CHAT_GROQ_API_KEY || "",
     },
     bedrock: {
       apiKey: process.env.ARCHESTRA_CHAT_BEDROCK_API_KEY || "",

--- a/platform/backend/src/services/model-sync.ts
+++ b/platform/backend/src/services/model-sync.ts
@@ -215,7 +215,7 @@ const MODELS_DEV_PROVIDER_MAP: Record<string, SupportedProvider | null> = {
   mistral: "mistral",
   llama: "openai",
   deepseek: "openai",
-  groq: "openai",
+  groq: "groq",
   "fireworks-ai": "openai",
   togetherai: "openai",
   perplexity: null,

--- a/platform/backend/src/types/chat-api-key.ts
+++ b/platform/backend/src/types/chat-api-key.ts
@@ -19,6 +19,7 @@ export const SupportedChatProviderSchema = z.enum([
   "vllm",
   "ollama",
   "zhipuai",
+  "groq",
 ]);
 export type SupportedChatProvider = z.infer<typeof SupportedChatProviderSchema>;
 

--- a/platform/frontend/src/components/chat-api-key-form.tsx
+++ b/platform/frontend/src/components/chat-api-key-form.tsx
@@ -139,6 +139,14 @@ const PROVIDER_CONFIG: Record<
     consoleUrl: "https://console.aws.amazon.com/bedrock",
     consoleName: "AWS Console",
   },
+  groq: {
+    name: "Groq",
+    icon: "/icons/groq.png",
+    placeholder: "gsk-...",
+    enabled: true,
+    consoleUrl: "https://console.groq.com/keys",
+    consoleName: "Groq Console",
+  },
 } as const;
 
 export { PROVIDER_CONFIG };


### PR DESCRIPTION
Fixes #1856

This PR adds support for Groq as a first-class model provider.

### Changes:
- Added `groq` to `SupportedChatProvider` types.
- Implemented `GroqDualLlmClient` for OpenAI-compatible chat completions.
- Added Groq configuration to `backend/config.ts`.
- Registered Groq model creator and proxied creator in `llm-client.ts`.
- Updated `models-dev-client.ts` and `model-sync.ts` to map Groq models correctly.
- Added Groq to the Chat API Key form in the frontend.