### PR TITLE
fix: clear localStorage data when conversation is deleted

### DIFF
--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -62,6 +62,7 @@ import {
   type SupportedChatProvider,
   useChatApiKeys,
 } from "@/lib/chat-settings.query";
+import { conversationStorageKeys } from "@/lib/chat-utils";
 import { useDialogs } from "@/lib/dialog.hook";
 import { useFeatureFlag } from "@/lib/features.hook";
 import { useFeatures } from "@/lib/features.query";
@@ -76,7 +77,6 @@ import ArchestraPromptInput from "./prompt-input";
 const CONVERSATION_QUERY_PARAM = "conversation";
 
 const LocalStorageKeys = {
-  artifactOpen: "archestra-chat-artifact-open",
   browserOpen: "archestra-chat-browser-open",
   selectedChatModel: "archestra-chat-selected-chat-model",
 } as const;
@@ -338,15 +338,16 @@ export default function ChatPage() {
     if (isLoadingConversation) return;
 
     // Check for conversation-specific preference
-    const storageKey = `archestra-chat-artifact-open-${conversationId}`;
-    const storedState = localStorage.getItem(storageKey);
+    const { artifactOpen: artifactOpenKey } =
+      conversationStorageKeys(conversationId);
+    const storedState = localStorage.getItem(artifactOpenKey);
     if (storedState !== null) {
       // User has explicitly set a preference for this conversation
       setIsArtifactOpen(storedState === "true");
     } else if (conversation?.artifact) {
       // First time viewing this conversation with an artifact - auto-open
       setIsArtifactOpen(true);
-      localStorage.setItem(storageKey, "true");
+      localStorage.setItem(artifactOpenKey, "true");
     } else {
       // No artifact or no stored preference - keep closed
       setIsArtifactOpen(false);
@@ -456,8 +457,10 @@ export default function ChatPage() {
     setIsArtifactOpen(newValue);
     // Only persist state for active conversations
     if (conversationId) {
-      const storageKey = `archestra-chat-artifact-open-${conversationId}`;
-      localStorage.setItem(storageKey, String(newValue));
+      localStorage.setItem(
+        conversationStorageKeys(conversationId).artifactOpen,
+        String(newValue),
+      );
     }
   }, [isArtifactOpen, conversationId]);
 
@@ -479,8 +482,10 @@ export default function ChatPage() {
     ) {
       setIsArtifactOpen(true);
       // Save the preference for this conversation
-      const storageKey = `archestra-chat-artifact-open-${conversationId}`;
-      localStorage.setItem(storageKey, "true");
+      localStorage.setItem(
+        conversationStorageKeys(conversationId).artifactOpen,
+        "true",
+      );
     }
 
     // Update the ref for next comparison

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -44,6 +44,7 @@ import { useAgentDelegations } from "@/lib/agent-tools.query";
 import { useHasPermissions } from "@/lib/auth.query";
 import { useProfileToolsWithIds } from "@/lib/chat.query";
 import type { SupportedChatProvider } from "@/lib/chat-settings.query";
+import { conversationStorageKeys } from "@/lib/chat-utils";
 
 interface ArchestraPromptInputProps {
   onSubmit: (
@@ -137,7 +138,7 @@ const PromptInputContent = ({
   });
 
   const storageKey = conversationId
-    ? `archestra_chat_draft_${conversationId}`
+    ? conversationStorageKeys(conversationId).draft
     : `archestra_chat_draft_new_${agentId}`;
 
   const isRestored = useRef(false);

--- a/platform/frontend/src/lib/chat-utils.ts
+++ b/platform/frontend/src/lib/chat-utils.ts
@@ -1,6 +1,18 @@
 const DEFAULT_SESSION_NAME = "New Chat Session";
 
 /**
+ * Generates localStorage keys scoped to a specific conversation.
+ * Use this everywhere conversation-specific keys are read/written/removed
+ * so that key formats stay in sync (especially for cleanup on deletion).
+ */
+export function conversationStorageKeys(conversationId: string) {
+  return {
+    artifactOpen: `archestra-chat-artifact-open-${conversationId}`,
+    draft: `archestra_chat_draft_${conversationId}`,
+  };
+}
+
+/**
  * Extracts a display title for a conversation.
  * Priority: explicit title > first user message > default session name
  */

--- a/platform/frontend/src/lib/chat.query.ts
+++ b/platform/frontend/src/lib/chat.query.ts
@@ -8,6 +8,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { invalidateToolAssignmentQueries } from "./agent-tools.hook";
+import { conversationStorageKeys } from "./chat-utils";
 import { authClient } from "./clients/auth/auth-client";
 import { useMcpServers } from "./mcp-server.query";
 import { handleApiError } from "./utils";
@@ -191,8 +192,9 @@ export function useDeleteConversation() {
 
       // Clean up localStorage keys associated with this conversation
       if (typeof window !== "undefined") {
-        localStorage.removeItem(`archestra-chat-artifact-open-${deletedId}`);
-        localStorage.removeItem(`archestra_chat_draft_${deletedId}`);
+        const keys = conversationStorageKeys(deletedId);
+        localStorage.removeItem(keys.artifactOpen);
+        localStorage.removeItem(keys.draft);
       }
 
       toast.success("Conversation deleted");


### PR DESCRIPTION
## Description
When deleting a conversation, several storage keys related to that specific chat session are now correctly cleared from the browser's local storage to prevent data leakage and cumulative storage growth.

### Changes
- Updated `useDeleteConversation` mutation in `chat.query.ts` to remove the following keys on successful deletion:
    - `archestra-chat-artifact-open-{conversationId}` (Artifact Panel state)
    - `archestra_chat_draft_{conversationId}` (Conversation drafts)

## Related Issue
Fixes #2665