### PR TITLE
fix: stop closing shared MCP client when browser stream unsubscribes

### DIFF
--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -329,42 +329,6 @@ export function clearChatMcpClient(agentId: string): void {
 }
 
 /**
- * Close and remove cached MCP client for a specific agent/user/conversation.
- * Should be called when browser stream unsubscribes to free resources.
- *
- * @param agentId - The agent (profile) ID
- * @param userId - The user ID
- * @param conversationId - The conversation ID
- */
-export function closeChatMcpClient(
-  agentId: string,
-  userId: string,
-  conversationId: string,
-): void {
-  const cacheKey = getCacheKey(agentId, userId, conversationId);
-  const client = clientCache.get(cacheKey);
-  if (client) {
-    try {
-      client.close();
-      logger.info(
-        { agentId, userId, conversationId, cacheKey },
-        "Closed MCP client connection for conversation",
-      );
-    } catch (error) {
-      logger.warn(
-        { agentId, userId, conversationId, cacheKey, error },
-        "Error closing MCP client connection (non-fatal)",
-      );
-    }
-    clientCache.delete(cacheKey);
-  }
-
-  // Also clear tool cache for this conversation
-  const toolCacheKey = getToolCacheKey(agentId, userId, conversationId);
-  toolCache.delete(toolCacheKey);
-}
-
-/**
  * Get or create MCP client for the specified agent and user
  * Connects to internal MCP Gateway with team token authentication
  *

--- a/platform/backend/src/features/browser-stream/websocket/browser-stream.websocket.ts
+++ b/platform/backend/src/features/browser-stream/websocket/browser-stream.websocket.ts
@@ -1,7 +1,6 @@
 import type { ServerWebSocketMessage } from "@shared";
 import type { WebSocket, WebSocketServer } from "ws";
 import { WebSocket as WS } from "ws";
-import { closeChatMcpClient } from "@/clients/chat-mcp-client";
 import { browserStreamFeature } from "@/features/browser-stream/services/browser-stream.feature";
 import type { BrowserUserContext } from "@/features/browser-stream/services/browser-stream.service";
 import { browserStateManager } from "@/features/browser-stream/services/browser-stream.state-manager";
@@ -189,20 +188,12 @@ export class BrowserStreamSocketClientContext {
       clearInterval(subscription.intervalId);
       this.browserSubscriptions.delete(ws);
 
-      // Close the MCP client connection for this conversation to free resources.
-      // Each conversation has its own MCP client and browser instance.
-      closeChatMcpClient(
-        subscription.agentId,
-        subscription.userContext.userId,
-        subscription.conversationId,
-      );
-
       logger.info(
         {
           conversationId: subscription.conversationId,
           agentId: subscription.agentId,
         },
-        "Browser stream client unsubscribed and MCP client closed",
+        "Browser stream client unsubscribed (MCP client kept alive for active tool execution)",
       );
     }
   }


### PR DESCRIPTION
Browser stream unsubscribe was calling closeChatMcpClient() which immediately closed the per-conversation MCP client. This caused McpError -32000 and AI_MissingToolResultsError when in-flight screenshot intervals or active tool executions were still using that client. The MCP client lifecycle is already managed by LRU eviction (max 500 clients with onEviction calling client.close()).