### PR TITLE
WIP: Add AbortSignal support for cancelling AI executions on client disconnect

### DIFF
--- a/platform/backend/src/agents/a2a-executor.ts
+++ b/platform/backend/src/agents/a2a-executor.ts
@@ -42,6 +42,8 @@ export interface A2AExecuteParams {
    * and cleaned up after execution.
    */
   conversationId?: string;
+  /** Optional abort signal to cancel the execution when the client disconnects. */
+  abortSignal?: AbortSignal;
 }
 
 export interface A2AExecuteResult {
@@ -177,6 +179,7 @@ export async function executeA2AMessage(
       prompt: message,
       tools: mcpTools,
       stopWhen: stepCountIs(500),
+      abortSignal: params.abortSignal,
     });
 
     // Wait for the stream to complete and get the final text


### PR DESCRIPTION
closes https://github.com/archestra-ai/archestra/issues/2641

## Summary
This PR adds support for cancelling AI message executions when clients disconnect, improving resource efficiency and preventing unnecessary processing of abandoned requests.

## Key Changes
- **A2A Executor Interface**: Added optional `abortSignal` parameter to `A2AExecuteParams` interface to support cancellation
- **A2A Route Handler**: Implemented `AbortController` that triggers when the HTTP request closes, passing the signal to the executor
- **Chat Route Handler**: Implemented `AbortController` for chat requests to allow stopping tool-call loops when users click the stop button in the UI
- **Propagation**: The abort signal is now passed through to the underlying `streamText` call in both routes

## Implementation Details
- Uses Node.js's native `AbortController` and `AbortSignal` APIs
- Listens to the `close` event on `request.raw` (the underlying Node.js HTTP request) to detect client disconnections
- The abort signal is passed to the `streamText` function which respects it during execution
- This prevents unnecessary AI processing and tool invocations after a client has already disconnected or the user has cancelled the operation

## Benefits
- Reduces server resource usage by stopping processing when clients disconnect
- Improves user experience by allowing chat UI stop button to actually halt execution
- Follows standard web cancellation patterns using AbortSignal

https://claude.ai/code/session_01JaFZhJra5dag9mrHWVjw5E