### PR TITLE
feat: integrate MCP-UI rendering into Chat UI (#1301)

### DIFF
--- a/platform/examples/mcp-ui-github-wrapper/package.json
+++ b/platform/examples/mcp-ui-github-wrapper/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "mcp-ui-github-wrapper",
+    "version": "1.0.0",
+    "private": true,
+    "type": "module",
+    "description": "MCP-UI wrapper for GitHub API — renders interactive UI for repos, PRs, and issues",
+    "scripts": {
+        "start": "tsx src/index.ts",
+        "dev": "tsx watch src/index.ts"
+    },
+    "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1",
+        "@octokit/rest": "^21.1.1"
+    },
+    "devDependencies": {
+        "tsx": "^4.19.0",
+        "typescript": "^5.0.0"
+    }
+}

--- a/platform/examples/mcp-ui-github-wrapper/src/index.ts
+++ b/platform/examples/mcp-ui-github-wrapper/src/index.ts
@@ -1,0 +1,463 @@
+/**
+ * MCP-UI GitHub Wrapper
+ *
+ * An MCP server that wraps GitHub API calls and returns rich UIResource
+ * responses for rendering in the Archestra Chat UI.
+ *
+ * Tools:
+ * - list_repos: Lists user repositories as an interactive HTML table
+ * - view_pull_request: Shows a PR with diff stats, reviewers, and status
+ * - search_issues: Searches issues and renders a sortable results table
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+    CallToolRequestSchema,
+    ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { Octokit } from "@octokit/rest";
+
+const octokit = new Octokit({
+    auth: process.env.GITHUB_TOKEN,
+});
+
+const server = new Server(
+    { name: "mcp-ui-github", version: "1.0.0" },
+    { capabilities: { tools: { listChanged: false } } },
+);
+
+// =============================================================================
+// Tool definitions
+// =============================================================================
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+        {
+            name: "list_repos",
+            title: "List GitHub Repositories",
+            description:
+                "List repositories for a user or organization. Returns an interactive HTML table with repo stats.",
+            inputSchema: {
+                type: "object" as const,
+                properties: {
+                    username: {
+                        type: "string",
+                        description:
+                            "GitHub username or org name. Defaults to authenticated user.",
+                    },
+                    sort: {
+                        type: "string",
+                        enum: ["updated", "created", "pushed", "full_name"],
+                        description: "Sort field (default: updated)",
+                    },
+                },
+            },
+            annotations: {},
+            _meta: {},
+        },
+        {
+            name: "view_pull_request",
+            title: "View Pull Request",
+            description:
+                "View a pull request with rich UI showing diff stats, reviewers, checks status, and labels.",
+            inputSchema: {
+                type: "object" as const,
+                properties: {
+                    owner: { type: "string", description: "Repository owner" },
+                    repo: { type: "string", description: "Repository name" },
+                    pull_number: {
+                        type: "number",
+                        description: "Pull request number",
+                    },
+                },
+                required: ["owner", "repo", "pull_number"],
+            },
+            annotations: {},
+            _meta: {},
+        },
+        {
+            name: "search_issues",
+            title: "Search GitHub Issues",
+            description:
+                "Search GitHub issues and pull requests. Returns a rich HTML table with filters.",
+            inputSchema: {
+                type: "object" as const,
+                properties: {
+                    query: {
+                        type: "string",
+                        description:
+                            "Search query (GitHub search syntax, e.g. 'repo:owner/name is:open label:bug')",
+                    },
+                    per_page: {
+                        type: "number",
+                        description: "Results per page (default: 10, max: 30)",
+                    },
+                },
+                required: ["query"],
+            },
+            annotations: {},
+            _meta: {},
+        },
+    ],
+}));
+
+// =============================================================================
+// Tool execution
+// =============================================================================
+
+server.setRequestHandler(
+    CallToolRequestSchema,
+    async ({ params: { name, arguments: args } }) => {
+        switch (name) {
+            case "list_repos":
+                return handleListRepos(args as { username?: string; sort?: string });
+
+            case "view_pull_request":
+                return handleViewPullRequest(
+                    args as { owner: string; repo: string; pull_number: number },
+                );
+
+            case "search_issues":
+                return handleSearchIssues(
+                    args as { query: string; per_page?: number },
+                );
+
+            default:
+                return {
+                    content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],
+                    isError: true,
+                };
+        }
+    },
+);
+
+// =============================================================================
+// Start server
+// =============================================================================
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+
+// =============================================================================
+// Tool handlers
+// =============================================================================
+
+async function handleListRepos(args: { username?: string; sort?: string }) {
+    const { username, sort = "updated" } = args;
+
+    const response = username
+        ? await octokit.repos.listForUser({
+            username,
+            sort: sort as "updated" | "created" | "pushed" | "full_name",
+            per_page: 20,
+        })
+        : await octokit.repos.listForAuthenticatedUser({
+            sort: sort as "updated" | "created" | "pushed" | "full_name",
+            per_page: 20,
+        });
+
+    const repos = response.data;
+
+    const html = `<!DOCTYPE html>
+<html><head>
+<meta charset="utf-8">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; padding: 16px; background: #0d1117; color: #e6edf3; }
+  h2 { font-size: 16px; margin-bottom: 12px; color: #f0f6fc; }
+  .count { color: #8b949e; font-weight: normal; }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  th { text-align: left; padding: 8px 12px; border-bottom: 1px solid #30363d; color: #8b949e; font-weight: 600; font-size: 11px; text-transform: uppercase; }
+  td { padding: 8px 12px; border-bottom: 1px solid #21262d; }
+  tr:hover td { background: #161b22; }
+  a { color: #58a6ff; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .lang { display: inline-flex; align-items: center; gap: 4px; }
+  .lang-dot { width: 10px; height: 10px; border-radius: 50%; display: inline-block; }
+  .stars { color: #e3b341; }
+  .private { color: #f85149; font-size: 11px; padding: 2px 6px; background: rgba(248,81,73,0.1); border-radius: 12px; }
+  .desc { color: #8b949e; max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+</style>
+</head><body>
+<h2>📦 Repositories <span class="count">(${repos.length})</span></h2>
+<table>
+  <thead><tr><th>Name</th><th>Description</th><th>Language</th><th>⭐</th><th>🍴</th><th>Updated</th></tr></thead>
+  <tbody>
+    ${repos
+            .map(
+                (r) => `
+    <tr>
+      <td><a href="${r.html_url}" target="_blank">${r.name}</a>${r.private ? ' <span class="private">private</span>' : ""}</td>
+      <td class="desc">${r.description || "—"}</td>
+      <td><span class="lang">${r.language ? `<span class="lang-dot" style="background:${languageColor(r.language)}"></span>${r.language}` : "—"}</span></td>
+      <td class="stars">${r.stargazers_count}</td>
+      <td>${r.forks_count}</td>
+      <td>${timeAgo(r.updated_at || "")}</td>
+    </tr>`,
+            )
+            .join("")}
+  </tbody>
+</table>
+</body></html>`;
+
+    return createUiResourceResponse(`ui://github/repos/${username || "me"}`, html);
+}
+
+async function handleViewPullRequest(args: {
+    owner: string;
+    repo: string;
+    pull_number: number;
+}) {
+    const { owner, repo, pull_number } = args;
+
+    const [pr, reviews, files] = await Promise.all([
+        octokit.pulls.get({ owner, repo, pull_number }),
+        octokit.pulls.listReviews({ owner, repo, pull_number, per_page: 10 }),
+        octokit.pulls.listFiles({ owner, repo, pull_number, per_page: 30 }),
+    ]);
+
+    const prData = pr.data;
+    const reviewData = reviews.data;
+    const fileData = files.data;
+
+    const stateColor =
+        prData.state === "open"
+            ? "#3fb950"
+            : prData.merged
+                ? "#a371f7"
+                : "#f85149";
+    const stateIcon =
+        prData.state === "open" ? "🟢" : prData.merged ? "🟣" : "🔴";
+
+    const html = `<!DOCTYPE html>
+<html><head>
+<meta charset="utf-8">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; padding: 16px; background: #0d1117; color: #e6edf3; }
+  .header { display: flex; align-items: center; gap: 8px; margin-bottom: 16px; }
+  .title { font-size: 18px; font-weight: 600; }
+  .number { color: #8b949e; }
+  .badge { padding: 4px 10px; border-radius: 16px; font-size: 12px; font-weight: 600; color: white; background: ${stateColor}; }
+  .meta { display: flex; gap: 16px; margin-bottom: 16px; font-size: 13px; color: #8b949e; }
+  .section { margin-bottom: 16px; }
+  .section-title { font-size: 13px; font-weight: 600; color: #8b949e; text-transform: uppercase; margin-bottom: 8px; }
+  .stats { display: flex; gap: 16px; }
+  .stat { padding: 8px 16px; background: #161b22; border-radius: 8px; text-align: center; }
+  .stat-value { font-size: 20px; font-weight: 700; }
+  .stat-label { font-size: 11px; color: #8b949e; }
+  .additions { color: #3fb950; }
+  .deletions { color: #f85149; }
+  .files { font-size: 13px; }
+  .file { padding: 6px 0; border-bottom: 1px solid #21262d; display: flex; justify-content: space-between; }
+  .file-name { color: #58a6ff; }
+  .file-stats span { margin-left: 8px; }
+  .reviews { display: flex; gap: 8px; flex-wrap: wrap; }
+  .review { padding: 4px 10px; background: #161b22; border-radius: 8px; font-size: 12px; display: flex; align-items: center; gap: 4px; }
+  .labels { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 8px; }
+  .label { padding: 2px 8px; border-radius: 12px; font-size: 11px; font-weight: 600; }
+</style>
+</head><body>
+  <div class="header">
+    <span class="badge">${stateIcon} ${prData.merged ? "Merged" : prData.state}</span>
+    <span class="title">${escapeHtml(prData.title)}</span>
+    <span class="number">#${pull_number}</span>
+  </div>
+
+  <div class="meta">
+    <span>by <strong>${prData.user?.login}</strong></span>
+    <span>${prData.base.ref} ← ${prData.head.ref}</span>
+    <span>${prData.commits} commits</span>
+    <span>${prData.comments} comments</span>
+  </div>
+
+  <div class="section">
+    <div class="section-title">Changes</div>
+    <div class="stats">
+      <div class="stat"><div class="stat-value">${fileData.length}</div><div class="stat-label">Files</div></div>
+      <div class="stat"><div class="stat-value additions">+${prData.additions}</div><div class="stat-label">Additions</div></div>
+      <div class="stat"><div class="stat-value deletions">-${prData.deletions}</div><div class="stat-label">Deletions</div></div>
+    </div>
+  </div>
+
+  ${reviewData.length > 0
+            ? `
+  <div class="section">
+    <div class="section-title">Reviews</div>
+    <div class="reviews">
+      ${reviewData
+                .map(
+                    (r) =>
+                        `<div class="review">${reviewIcon(r.state)} ${r.user?.login}</div>`,
+                )
+                .join("")}
+    </div>
+  </div>`
+            : ""
+        }
+
+  <div class="section">
+    <div class="section-title">Files Changed</div>
+    <div class="files">
+      ${fileData
+            .slice(0, 15)
+            .map(
+                (f) => `
+      <div class="file">
+        <span class="file-name">${f.filename}</span>
+        <span class="file-stats"><span class="additions">+${f.additions}</span><span class="deletions">-${f.deletions}</span></span>
+      </div>`,
+            )
+            .join("")}
+      ${fileData.length > 15 ? `<div class="file" style="color:#8b949e">...and ${fileData.length - 15} more files</div>` : ""}
+    </div>
+  </div>
+
+  ${prData.labels.length > 0
+            ? `
+  <div class="labels">
+    ${prData.labels.map((l) => `<span class="label" style="background:${l.color ? `#${l.color}33` : "#30363d"};color:${l.color ? `#${l.color}` : "#8b949e"}">${l.name}</span>`).join("")}
+  </div>`
+            : ""
+        }
+</body></html>`;
+
+    return createUiResourceResponse(
+        `ui://github/pr/${owner}/${repo}/${pull_number}`,
+        html,
+    );
+}
+
+async function handleSearchIssues(args: {
+    query: string;
+    per_page?: number;
+}) {
+    const { query, per_page = 10 } = args;
+
+    const response = await octokit.search.issuesAndPullRequests({
+        q: query,
+        per_page: Math.min(per_page, 30),
+    });
+
+    const items = response.data.items;
+
+    const html = `<!DOCTYPE html>
+<html><head>
+<meta charset="utf-8">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; padding: 16px; background: #0d1117; color: #e6edf3; }
+  h2 { font-size: 16px; margin-bottom: 4px; color: #f0f6fc; }
+  .subtitle { color: #8b949e; font-size: 13px; margin-bottom: 12px; }
+  .item { padding: 10px 0; border-bottom: 1px solid #21262d; }
+  .item:hover { background: #161b22; }
+  .item-header { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; }
+  .item-title a { color: #58a6ff; text-decoration: none; font-weight: 600; font-size: 14px; }
+  .item-title a:hover { text-decoration: underline; }
+  .item-meta { font-size: 12px; color: #8b949e; }
+  .state-open { color: #3fb950; }
+  .state-closed { color: #f85149; }
+  .labels { display: inline-flex; gap: 4px; margin-left: 8px; }
+  .label { padding: 1px 6px; border-radius: 12px; font-size: 10px; font-weight: 600; }
+  .icon { font-size: 16px; }
+</style>
+</head><body>
+<h2>🔍 Search Results</h2>
+<div class="subtitle">${response.data.total_count} results for "${escapeHtml(query)}"</div>
+${items
+            .map(
+                (item) => `
+<div class="item">
+  <div class="item-header">
+    <span class="icon">${item.pull_request ? "🔀" : "📋"}</span>
+    <span class="item-title"><a href="${item.html_url}" target="_blank">${escapeHtml(item.title)}</a></span>
+    <span class="${item.state === "open" ? "state-open" : "state-closed"}">${item.state}</span>
+    ${item.labels.length > 0 ? `<span class="labels">${item.labels.map((l) => `<span class="label" style="background:${typeof l !== "string" && l.color ? `#${l.color}33` : "#30363d"};color:${typeof l !== "string" && l.color ? `#${l.color}` : "#8b949e"}">${typeof l === "string" ? l : l.name}</span>`).join("")}</span>` : ""}
+  </div>
+  <div class="item-meta">
+    ${item.repository_url?.split("/").slice(-2).join("/")} #${item.number} • ${item.user?.login} • ${timeAgo(item.updated_at)}
+    ${item.comments > 0 ? `• 💬 ${item.comments}` : ""}
+  </div>
+</div>`,
+            )
+            .join("")}
+</body></html>`;
+
+    return createUiResourceResponse(
+        `ui://github/search/${encodeURIComponent(query)}`,
+        html,
+    );
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function createUiResourceResponse(uri: string, html: string) {
+    return {
+        content: [
+            {
+                type: "resource" as const,
+                resource: {
+                    uri,
+                    mimeType: "text/html",
+                    text: html,
+                },
+            },
+        ],
+    };
+}
+
+function escapeHtml(str: string): string {
+    return str
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;");
+}
+
+function timeAgo(dateStr: string): string {
+    const diff = Date.now() - new Date(dateStr).getTime();
+    const mins = Math.floor(diff / 60000);
+    if (mins < 60) return `${mins}m ago`;
+    const hours = Math.floor(mins / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    if (days < 30) return `${days}d ago`;
+    return `${Math.floor(days / 30)}mo ago`;
+}
+
+function reviewIcon(state: string): string {
+    switch (state) {
+        case "APPROVED":
+            return "✅";
+        case "CHANGES_REQUESTED":
+            return "🔴";
+        case "COMMENTED":
+            return "💬";
+        default:
+            return "⏸️";
+    }
+}
+
+function languageColor(lang: string): string {
+    const colors: Record<string, string> = {
+        TypeScript: "#3178c6",
+        JavaScript: "#f1e05a",
+        Python: "#3572A5",
+        Rust: "#dea584",
+        Go: "#00ADD8",
+        Java: "#b07219",
+        Ruby: "#701516",
+        C: "#555555",
+        "C++": "#f34b7d",
+        "C#": "#178600",
+        Scala: "#c22d40",
+        Swift: "#F05138",
+        Kotlin: "#A97BFF",
+        PHP: "#4F5D95",
+        Shell: "#89e051",
+    };
+    return colors[lang] || "#8b949e";
+}

--- a/platform/examples/mcp-ui-weather-wrapper/package.json
+++ b/platform/examples/mcp-ui-weather-wrapper/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "mcp-ui-weather-wrapper",
+    "version": "1.0.0",
+    "private": true,
+    "type": "module",
+    "description": "MCP-UI wrapper for OpenWeatherMap API — renders visual weather cards",
+    "scripts": {
+        "start": "tsx src/index.ts",
+        "dev": "tsx watch src/index.ts"
+    },
+    "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1"
+    },
+    "devDependencies": {
+        "tsx": "^4.19.0",
+        "typescript": "^5.0.0"
+    }
+}

--- a/platform/examples/mcp-ui-weather-wrapper/src/index.ts
+++ b/platform/examples/mcp-ui-weather-wrapper/src/index.ts
@@ -1,0 +1,429 @@
+/**
+ * MCP-UI Weather Wrapper
+ *
+ * An MCP server that wraps OpenWeatherMap API and returns rich UIResource
+ * responses with visual weather cards.
+ *
+ * Tools:
+ * - get_weather: Current weather with visual card (temp, humidity, wind, icon)
+ * - get_forecast: 5-day forecast with chart visualization
+ *
+ * Set OPENWEATHERMAP_API_KEY env var to use real data.
+ * Falls back to mock data if no API key is set.
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+    CallToolRequestSchema,
+    ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+const API_KEY = process.env.OPENWEATHERMAP_API_KEY;
+const BASE_URL = "https://api.openweathermap.org/data/2.5";
+
+const server = new Server(
+    { name: "mcp-ui-weather", version: "1.0.0" },
+    { capabilities: { tools: { listChanged: false } } },
+);
+
+// =============================================================================
+// Tool definitions
+// =============================================================================
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+        {
+            name: "get_weather",
+            title: "Get Current Weather",
+            description:
+                "Get current weather for a city. Returns a visual weather card with temperature, conditions, and details.",
+            inputSchema: {
+                type: "object" as const,
+                properties: {
+                    city: {
+                        type: "string",
+                        description: "City name (e.g. 'London', 'Tokyo', 'New York')",
+                    },
+                    units: {
+                        type: "string",
+                        enum: ["metric", "imperial"],
+                        description: "Temperature units (default: metric)",
+                    },
+                },
+                required: ["city"],
+            },
+            annotations: {},
+            _meta: {},
+        },
+        {
+            name: "get_forecast",
+            title: "Get Weather Forecast",
+            description:
+                "Get 5-day weather forecast for a city. Returns a visual timeline with temperature trends.",
+            inputSchema: {
+                type: "object" as const,
+                properties: {
+                    city: {
+                        type: "string",
+                        description: "City name",
+                    },
+                    units: {
+                        type: "string",
+                        enum: ["metric", "imperial"],
+                        description: "Temperature units (default: metric)",
+                    },
+                },
+                required: ["city"],
+            },
+            annotations: {},
+            _meta: {},
+        },
+    ],
+}));
+
+// =============================================================================
+// Tool execution
+// =============================================================================
+
+server.setRequestHandler(
+    CallToolRequestSchema,
+    async ({ params: { name, arguments: args } }) => {
+        switch (name) {
+            case "get_weather":
+                return handleGetWeather(args as { city: string; units?: string });
+
+            case "get_forecast":
+                return handleGetForecast(args as { city: string; units?: string });
+
+            default:
+                return {
+                    content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],
+                    isError: true,
+                };
+        }
+    },
+);
+
+// =============================================================================
+// Start server
+// =============================================================================
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+
+// =============================================================================
+// Tool handlers
+// =============================================================================
+
+interface WeatherData {
+    name: string;
+    temp: number;
+    feelsLike: number;
+    humidity: number;
+    windSpeed: number;
+    description: string;
+    icon: string;
+    pressure: number;
+    visibility: number;
+    sunrise: string;
+    sunset: string;
+}
+
+async function handleGetWeather(args: { city: string; units?: string }) {
+    const { city, units = "metric" } = args;
+    const unitSymbol = units === "imperial" ? "°F" : "°C";
+    const speedUnit = units === "imperial" ? "mph" : "m/s";
+
+    const weather = API_KEY
+        ? await fetchCurrentWeather(city, units)
+        : getMockWeather(city);
+
+    const html = `<!DOCTYPE html>
+<html><head>
+<meta charset="utf-8">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; padding: 0; }
+  .card {
+    background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+    color: white; border-radius: 16px; padding: 24px; min-height: 280px;
+    display: flex; flex-direction: column; justify-content: space-between;
+  }
+  .header { display: flex; justify-content: space-between; align-items: flex-start; }
+  .city-name { font-size: 24px; font-weight: 700; }
+  .description { font-size: 14px; color: rgba(255,255,255,0.7); text-transform: capitalize; margin-top: 4px; }
+  .icon { font-size: 48px; }
+  .temp-section { display: flex; align-items: baseline; gap: 8px; margin: 20px 0; }
+  .temp { font-size: 56px; font-weight: 200; }
+  .unit { font-size: 24px; color: rgba(255,255,255,0.6); }
+  .feels-like { font-size: 13px; color: rgba(255,255,255,0.5); }
+  .details { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
+  .detail { text-align: center; background: rgba(255,255,255,0.08); border-radius: 12px; padding: 12px 8px; }
+  .detail-icon { font-size: 20px; margin-bottom: 4px; }
+  .detail-value { font-size: 16px; font-weight: 600; }
+  .detail-label { font-size: 10px; color: rgba(255,255,255,0.5); text-transform: uppercase; margin-top: 2px; }
+  .sun-times { display: flex; justify-content: center; gap: 24px; margin-top: 16px; font-size: 12px; color: rgba(255,255,255,0.5); }
+</style>
+</head><body>
+<div class="card">
+  <div class="header">
+    <div>
+      <div class="city-name">${escapeHtml(weather.name)}</div>
+      <div class="description">${escapeHtml(weather.description)}</div>
+    </div>
+    <div class="icon">${weather.icon}</div>
+  </div>
+
+  <div class="temp-section">
+    <span class="temp">${Math.round(weather.temp)}</span>
+    <span class="unit">${unitSymbol}</span>
+    <span class="feels-like">Feels like ${Math.round(weather.feelsLike)}${unitSymbol}</span>
+  </div>
+
+  <div class="details">
+    <div class="detail">
+      <div class="detail-icon">💧</div>
+      <div class="detail-value">${weather.humidity}%</div>
+      <div class="detail-label">Humidity</div>
+    </div>
+    <div class="detail">
+      <div class="detail-icon">💨</div>
+      <div class="detail-value">${weather.windSpeed}${speedUnit}</div>
+      <div class="detail-label">Wind</div>
+    </div>
+    <div class="detail">
+      <div class="detail-icon">🌡</div>
+      <div class="detail-value">${weather.pressure}</div>
+      <div class="detail-label">hPa</div>
+    </div>
+    <div class="detail">
+      <div class="detail-icon">👁</div>
+      <div class="detail-value">${(weather.visibility / 1000).toFixed(1)}km</div>
+      <div class="detail-label">Visibility</div>
+    </div>
+  </div>
+
+  <div class="sun-times">
+    <span>🌅 ${weather.sunrise}</span>
+    <span>🌇 ${weather.sunset}</span>
+  </div>
+</div>
+</body></html>`;
+
+    return createUiResourceResponse(`ui://weather/current/${encodeURIComponent(city)}`, html);
+}
+
+async function handleGetForecast(args: { city: string; units?: string }) {
+    const { city, units = "metric" } = args;
+    const unitSymbol = units === "imperial" ? "°F" : "°C";
+
+    const forecast = API_KEY
+        ? await fetchForecast(city, units)
+        : getMockForecast(city);
+
+    // Group by day (take noon readings)
+    const dailyForecasts = forecast.filter((_f, i) => i % 8 === 4).slice(0, 5);
+
+    const html = `<!DOCTYPE html>
+<html><head>
+<meta charset="utf-8">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; padding: 0; }
+  .card {
+    background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+    color: white; border-radius: 16px; padding: 24px;
+  }
+  .title { font-size: 18px; font-weight: 600; margin-bottom: 16px; }
+  .subtitle { color: rgba(255,255,255,0.5); font-size: 13px; }
+  .forecast-row { display: flex; gap: 8px; margin-top: 16px; }
+  .day-card {
+    flex: 1; text-align: center; background: rgba(255,255,255,0.06);
+    border-radius: 12px; padding: 12px 4px; transition: background 0.2s;
+  }
+  .day-card:hover { background: rgba(255,255,255,0.12); }
+  .day-name { font-size: 12px; font-weight: 600; color: rgba(255,255,255,0.7); }
+  .day-icon { font-size: 28px; margin: 8px 0; }
+  .day-temp { font-size: 18px; font-weight: 700; }
+  .day-desc { font-size: 10px; color: rgba(255,255,255,0.5); text-transform: capitalize; margin-top: 4px; }
+</style>
+</head><body>
+<div class="card">
+  <div class="title">${escapeHtml(city)} <span class="subtitle">5-Day Forecast</span></div>
+  <div class="forecast-row">
+    ${dailyForecasts
+            .map(
+                (f) => `
+    <div class="day-card">
+      <div class="day-name">${f.day}</div>
+      <div class="day-icon">${f.icon}</div>
+      <div class="day-temp">${Math.round(f.temp)}${unitSymbol}</div>
+      <div class="day-desc">${f.description}</div>
+    </div>`,
+            )
+            .join("")}
+  </div>
+</div>
+</body></html>`;
+
+    return createUiResourceResponse(`ui://weather/forecast/${encodeURIComponent(city)}`, html);
+}
+
+// =============================================================================
+// API fetching
+// =============================================================================
+
+async function fetchCurrentWeather(
+    city: string,
+    units: string,
+): Promise<WeatherData> {
+    const res = await fetch(
+        `${BASE_URL}/weather?q=${encodeURIComponent(city)}&units=${units}&appid=${API_KEY}`,
+    );
+    if (!res.ok) throw new Error(`Weather API error: ${res.statusText}`);
+    const data = await res.json();
+
+    return {
+        name: data.name,
+        temp: data.main.temp,
+        feelsLike: data.main.feels_like,
+        humidity: data.main.humidity,
+        windSpeed: data.wind.speed,
+        description: data.weather[0].description,
+        icon: weatherIcon(data.weather[0].icon),
+        pressure: data.main.pressure,
+        visibility: data.visibility,
+        sunrise: formatTime(data.sys.sunrise),
+        sunset: formatTime(data.sys.sunset),
+    };
+}
+
+async function fetchForecast(
+    city: string,
+    units: string,
+): Promise<Array<{ day: string; temp: number; description: string; icon: string }>> {
+    const res = await fetch(
+        `${BASE_URL}/forecast?q=${encodeURIComponent(city)}&units=${units}&appid=${API_KEY}`,
+    );
+    if (!res.ok) throw new Error(`Forecast API error: ${res.statusText}`);
+    const data = await res.json();
+
+    return data.list.map(
+        (item: {
+            dt: number;
+            main: { temp: number };
+            weather: Array<{ description: string; icon: string }>;
+        }) => ({
+            day: new Date(item.dt * 1000).toLocaleDateString("en", {
+                weekday: "short",
+            }),
+            temp: item.main.temp,
+            description: item.weather[0].description,
+            icon: weatherIcon(item.weather[0].icon),
+        }),
+    );
+}
+
+// =============================================================================
+// Mock data (for demos without API key)
+// =============================================================================
+
+function getMockWeather(city: string): WeatherData {
+    return {
+        name: city,
+        temp: 22,
+        feelsLike: 20,
+        humidity: 65,
+        windSpeed: 3.5,
+        description: "partly cloudy",
+        icon: "⛅",
+        pressure: 1013,
+        visibility: 10000,
+        sunrise: "06:42",
+        sunset: "18:15",
+    };
+}
+
+function getMockForecast(
+    _city: string,
+): Array<{ day: string; temp: number; description: string; icon: string }> {
+    const days = ["Mon", "Tue", "Wed", "Thu", "Fri"];
+    const conditions = [
+        { desc: "sunny", icon: "☀️", temp: 25 },
+        { desc: "partly cloudy", icon: "⛅", temp: 22 },
+        { desc: "cloudy", icon: "☁️", temp: 19 },
+        { desc: "light rain", icon: "🌧", temp: 17 },
+        { desc: "sunny", icon: "☀️", temp: 24 },
+    ];
+
+    return Array.from({ length: 40 }, (_, i) => {
+        const dayIndex = Math.floor(i / 8);
+        const c = conditions[dayIndex % conditions.length];
+        return {
+            day: days[dayIndex % days.length],
+            temp: c.temp + Math.round(Math.random() * 4 - 2),
+            description: c.desc,
+            icon: c.icon,
+        };
+    });
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function createUiResourceResponse(uri: string, html: string) {
+    return {
+        content: [
+            {
+                type: "resource" as const,
+                resource: {
+                    uri,
+                    mimeType: "text/html",
+                    text: html,
+                },
+            },
+        ],
+    };
+}
+
+function escapeHtml(str: string): string {
+    return str
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;");
+}
+
+function weatherIcon(code: string): string {
+    const icons: Record<string, string> = {
+        "01d": "☀️",
+        "01n": "🌙",
+        "02d": "⛅",
+        "02n": "☁️",
+        "03d": "☁️",
+        "03n": "☁️",
+        "04d": "☁️",
+        "04n": "☁️",
+        "09d": "🌧",
+        "09n": "🌧",
+        "10d": "🌦",
+        "10n": "🌧",
+        "11d": "⛈",
+        "11n": "⛈",
+        "13d": "🌨",
+        "13n": "🌨",
+        "50d": "🌫",
+        "50n": "🌫",
+    };
+    return icons[code] || "🌡";
+}
+
+function formatTime(timestamp: number): string {
+    return new Date(timestamp * 1000).toLocaleTimeString("en", {
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+    });
+}

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -1,4 +1,5 @@
 import type { UIMessage } from "@ai-sdk/react";
+import { extractInlineMcpUiResource, extractMcpUiResourceUri } from "@shared";
 import type { ChatStatus, DynamicToolUIPart, ToolUIPart } from "ai";
 import Image from "next/image";
 import {
@@ -40,6 +41,7 @@ import { extractFileAttachments, hasTextPart } from "./chat-messages.utils";
 import { EditableAssistantMessage } from "./editable-assistant-message";
 import { EditableUserMessage } from "./editable-user-message";
 import { InlineChatError } from "./inline-chat-error";
+import { McpUiRenderer } from "./mcp-ui-renderer";
 import { PolicyDeniedTool } from "./policy-denied-tool";
 import { TodoWriteTool } from "./todo-write-tool";
 import { ToolErrorLogsButton } from "./tool-error-logs-button";
@@ -927,9 +929,20 @@ function MessageTool({
     );
   }
 
+  // Check for MCP-UI resources in tool output
+  const toolOutput = toolResultPart?.output ?? part.output;
+  const mcpUiResource = toolOutput
+    ? extractInlineMcpUiResource(toolOutput)
+    : undefined;
+  const mcpUiResourceUri = toolOutput
+    ? extractMcpUiResourceUri(toolOutput)
+    : undefined;
+  const hasMcpUi = Boolean(mcpUiResource || mcpUiResourceUri);
+
   const hasInput = part.input && Object.keys(part.input).length > 0;
   const hasContent = Boolean(
-    hasInput ||
+    hasMcpUi ||
+      hasInput ||
       (toolResultPart && Boolean(toolResultPart.output)) ||
       (!toolResultPart && Boolean(part.output)),
   );
@@ -954,14 +967,19 @@ function MessageTool({
       />
       <ToolContent>
         {hasInput ? <ToolInput input={part.input} /> : null}
-        {toolResultPart && (
+        {/* Render MCP-UI resource if available */}
+        {mcpUiResource && !errorText && (
+          <McpUiRenderer resource={mcpUiResource} />
+        )}
+        {/* Fallback to standard output when no MCP-UI resource */}
+        {!mcpUiResource && toolResultPart && (
           <ToolOutput
             label={errorText ? "Error" : "Result"}
             output={toolResultPart.output}
             errorText={errorText}
           />
         )}
-        {!toolResultPart && Boolean(part.output) && (
+        {!mcpUiResource && !toolResultPart && Boolean(part.output) && (
           <ToolOutput
             label={errorText ? "Error" : "Result"}
             output={part.output}

--- a/platform/frontend/src/components/chat/mcp-ui-renderer.tsx
+++ b/platform/frontend/src/components/chat/mcp-ui-renderer.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import type { McpUiResource } from "@shared";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface McpUiRendererProps {
+  resource: McpUiResource;
+  className?: string;
+}
+
+/**
+ * Renders an MCP-UI resource inside a sandboxed iframe.
+ *
+ * Supports three MIME types:
+ * - text/html: inline HTML rendered via srcDoc
+ * - text/uri-list: external URL loaded in iframe
+ * - application/vnd.mcp-ui.remote-dom: remote DOM script (future)
+ *
+ * Security: iframe uses sandbox="allow-scripts" only (no allow-same-origin)
+ * to prevent the guest from accessing the host page.
+ */
+export function McpUiRenderer({ resource, className }: McpUiRendererProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [iframeHeight, setIframeHeight] = useState(300);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  // Listen for resize messages from the guest iframe
+  const handleMessage = useCallback((event: MessageEvent) => {
+    // Only accept messages from our iframe
+    if (iframeRef.current && event.source === iframeRef.current.contentWindow) {
+      try {
+        const data =
+          typeof event.data === "string" ? JSON.parse(event.data) : event.data;
+
+        // Handle resize messages
+        if (data.type === "mcp-ui-resize" && typeof data.height === "number") {
+          setIframeHeight(Math.min(Math.max(data.height, 100), 800));
+        }
+      } catch {
+        // Ignore unparseable messages
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [handleMessage]);
+
+  // Determine content to render
+  const content = resource.text ?? (resource.blob ? atob(resource.blob) : null);
+
+  if (!content) {
+    return (
+      <div className="text-sm text-muted-foreground italic p-3 border rounded-md">
+        MCP-UI resource has no content
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="text-sm text-destructive p-3 border border-destructive/20 rounded-md">
+        Failed to load MCP-UI: {loadError}
+      </div>
+    );
+  }
+
+  // Wrap HTML content with auto-resize script
+  const wrappedHtml =
+    resource.mimeType === "text/html"
+      ? wrapHtmlWithResizeScript(content)
+      : content;
+
+  if (resource.mimeType === "text/uri-list") {
+    // External URL: load in iframe with src
+    const url = content.trim().split("\n")[0];
+    return (
+      <iframe
+        ref={iframeRef}
+        src={url}
+        title="MCP-UI Resource"
+        sandbox="allow-scripts"
+        style={{ height: `${iframeHeight}px` }}
+        className={`w-full rounded-lg border bg-background ${className ?? ""}`}
+        onError={() => setLoadError("Failed to load external resource")}
+      />
+    );
+  }
+
+  // text/html or remote-dom: inline via srcDoc
+  return (
+    <iframe
+      ref={iframeRef}
+      srcDoc={wrappedHtml}
+      title="MCP-UI Resource"
+      sandbox="allow-scripts"
+      style={{ height: `${iframeHeight}px` }}
+      className={`w-full rounded-lg border bg-background ${className ?? ""}`}
+      onError={() => setLoadError("Failed to render MCP-UI content")}
+    />
+  );
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+/** Inject an auto-resize script into HTML content so the iframe adjusts height */
+function wrapHtmlWithResizeScript(html: string): string {
+  const resizeScript = `
+<script>
+(function() {
+  function sendHeight() {
+    var height = Math.max(
+      document.body.scrollHeight,
+      document.body.offsetHeight,
+      document.documentElement.scrollHeight
+    );
+    parent.postMessage(JSON.stringify({ type: 'mcp-ui-resize', height: height }), '*');
+  }
+  // Send height on load and on resize
+  if (document.readyState === 'complete') sendHeight();
+  else window.addEventListener('load', sendHeight);
+  window.addEventListener('resize', sendHeight);
+  // Also observe DOM mutations for dynamic content
+  var observer = new MutationObserver(sendHeight);
+  observer.observe(document.body, { childList: true, subtree: true, attributes: true });
+})();
+</script>`;
+
+  // Insert before </body> if it exists, otherwise append
+  if (html.includes("</body>")) {
+    return html.replace("</body>", `${resizeScript}</body>`);
+  }
+  return html + resizeScript;
+}

--- a/platform/shared/index.ts
+++ b/platform/shared/index.ts
@@ -7,6 +7,7 @@ export * as archestraApiTypes from "./hey-api/clients/api/types.gen";
 export * as archestraCatalogSdk from "./hey-api/clients/archestra-catalog/sdk.gen";
 export * as archestraCatalogTypes from "./hey-api/clients/archestra-catalog/types.gen";
 export * from "./mcp-orchestrator";
+export * from "./mcp-ui";
 export * from "./model-constants";
 export * from "./permission.types";
 export * from "./policy-conditions";

--- a/platform/shared/mcp-ui.test.ts
+++ b/platform/shared/mcp-ui.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { extractInlineMcpUiResource, extractMcpUiResourceUri } from "./mcp-ui";
+
+describe("extractMcpUiResourceUri", () => {
+  it("extracts resourceUri from _meta.ui.resourceUri", () => {
+    const output = {
+      _meta: { ui: { resourceUri: "ui://github/repos/me" } },
+      content: [{ type: "text", text: "hello" }],
+    };
+    expect(extractMcpUiResourceUri(output)).toBe("ui://github/repos/me");
+  });
+
+  it("extracts from JSON string", () => {
+    const output = JSON.stringify({
+      _meta: { ui: { resourceUri: "ui://weather/current/London" } },
+    });
+    expect(extractMcpUiResourceUri(output)).toBe("ui://weather/current/London");
+  });
+
+  it("returns undefined for missing _meta", () => {
+    expect(extractMcpUiResourceUri({ content: [] })).toBeUndefined();
+  });
+
+  it("returns undefined for null input", () => {
+    expect(extractMcpUiResourceUri(null)).toBeUndefined();
+  });
+
+  it("returns undefined for non-JSON string", () => {
+    expect(extractMcpUiResourceUri("not json")).toBeUndefined();
+  });
+
+  it("returns undefined for _meta without ui", () => {
+    expect(
+      extractMcpUiResourceUri({ _meta: { something: "else" } }),
+    ).toBeUndefined();
+  });
+});
+
+describe("extractInlineMcpUiResource", () => {
+  it("extracts resource from content array", () => {
+    const output = {
+      content: [
+        {
+          type: "resource",
+          resource: {
+            uri: "ui://github/repos/me",
+            mimeType: "text/html",
+            text: "<h1>Hello</h1>",
+          },
+        },
+      ],
+    };
+    const result = extractInlineMcpUiResource(output);
+    expect(result).toEqual({
+      uri: "ui://github/repos/me",
+      mimeType: "text/html",
+      text: "<h1>Hello</h1>",
+      blob: undefined,
+    });
+  });
+
+  it("extracts resource with blob", () => {
+    const output = {
+      content: [
+        {
+          type: "resource",
+          resource: {
+            uri: "ui://test",
+            mimeType: "text/html",
+            blob: btoa("<p>blob content</p>"),
+          },
+        },
+      ],
+    };
+    const result = extractInlineMcpUiResource(output);
+    expect(result?.uri).toBe("ui://test");
+    expect(result?.blob).toBeDefined();
+  });
+
+  it("extracts from direct resource object", () => {
+    const output = {
+      type: "resource",
+      resource: {
+        uri: "ui://direct",
+        mimeType: "text/html",
+        text: "<div>direct</div>",
+      },
+    };
+    const result = extractInlineMcpUiResource(output);
+    expect(result?.uri).toBe("ui://direct");
+  });
+
+  it("returns undefined for non-resource content", () => {
+    const output = {
+      content: [{ type: "text", text: "just text" }],
+    };
+    expect(extractInlineMcpUiResource(output)).toBeUndefined();
+  });
+
+  it("returns undefined for resource without required fields", () => {
+    const output = {
+      content: [
+        {
+          type: "resource",
+          resource: { uri: "ui://incomplete" },
+        },
+      ],
+    };
+    expect(extractInlineMcpUiResource(output)).toBeUndefined();
+  });
+
+  it("extracts from JSON string", () => {
+    const output = JSON.stringify({
+      content: [
+        {
+          type: "resource",
+          resource: {
+            uri: "ui://stringified",
+            mimeType: "text/html",
+            text: "<p>from string</p>",
+          },
+        },
+      ],
+    });
+    const result = extractInlineMcpUiResource(output);
+    expect(result?.uri).toBe("ui://stringified");
+  });
+});

--- a/platform/shared/mcp-ui.ts
+++ b/platform/shared/mcp-ui.ts
@@ -1,0 +1,136 @@
+/**
+ * MCP-UI types for rendering interactive UI from MCP tool results.
+ *
+ * When an MCP server returns a tool result with `_meta.ui.resourceUri`,
+ * the Chat UI renders the linked UIResource in a sandboxed iframe
+ * instead of showing raw JSON output.
+ *
+ * @see https://mcpui.dev
+ */
+
+/** MIME types supported by MCP-UI rendering */
+type McpUiMimeType =
+  | "text/html"
+  | "text/uri-list"
+  | "application/vnd.mcp-ui.remote-dom";
+
+/** A UI resource returned by an MCP-UI-enabled server */
+interface McpUiResource {
+  uri: string;
+  mimeType: McpUiMimeType;
+  text?: string;
+  blob?: string;
+}
+
+/** The _meta.ui field in an MCP tool result that signals UI availability */
+interface McpUiMeta {
+  ui: {
+    resourceUri: string;
+  };
+}
+
+/**
+ * Extract MCP-UI metadata from a tool result output.
+ * Returns the resourceUri if present, undefined otherwise.
+ */
+function extractMcpUiResourceUri(output: unknown): string | undefined {
+  if (typeof output === "string") {
+    try {
+      const parsed = JSON.parse(output);
+      return extractFromObject(parsed);
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (typeof output === "object" && output !== null) {
+    return extractFromObject(output);
+  }
+
+  return undefined;
+}
+
+/**
+ * Check if an MCP tool result contains embedded UIResource content.
+ * This handles the case where the resource is inline in the tool result
+ * rather than referenced by URI.
+ */
+function extractInlineMcpUiResource(
+  output: unknown,
+): McpUiResource | undefined {
+  const obj = parseOutput(output);
+  if (!obj) return undefined;
+
+  // Check for content array with resource items (MCP SDK format)
+  if (Array.isArray(obj.content)) {
+    for (const item of obj.content) {
+      if (item?.type === "resource" && item?.resource) {
+        const r = item.resource as Record<string, unknown>;
+        if (r.uri && r.mimeType && (r.text || r.blob)) {
+          return {
+            uri: r.uri as string,
+            mimeType: r.mimeType as McpUiMimeType,
+            text: r.text as string | undefined,
+            blob: r.blob as string | undefined,
+          };
+        }
+      }
+    }
+  }
+
+  // Check for direct resource object
+  if (obj.type === "resource" && obj.resource) {
+    const r = obj.resource as Record<string, unknown>;
+    if (r.uri && r.mimeType && (r.text || r.blob)) {
+      return {
+        uri: r.uri as string,
+        mimeType: r.mimeType as McpUiMimeType,
+        text: r.text as string | undefined,
+        blob: r.blob as string | undefined,
+      };
+    }
+  }
+
+  return undefined;
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+function parseOutput(output: unknown): Record<string, unknown> | undefined {
+  if (typeof output === "string") {
+    try {
+      return JSON.parse(output);
+    } catch {
+      return undefined;
+    }
+  }
+  if (typeof output === "object" && output !== null) {
+    return output as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+function extractFromObject(obj: unknown): string | undefined {
+  if (typeof obj !== "object" || obj === null) return undefined;
+
+  const record = obj as Record<string, unknown>;
+
+  // Check _meta.ui.resourceUri
+  const meta = record._meta;
+  if (typeof meta === "object" && meta !== null) {
+    const ui = (meta as Record<string, unknown>).ui;
+    if (typeof ui === "object" && ui !== null) {
+      const resourceUri = (ui as Record<string, unknown>).resourceUri;
+      if (typeof resourceUri === "string") {
+        return resourceUri;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+export type { McpUiMimeType, McpUiResource, McpUiMeta };
+export { extractMcpUiResourceUri, extractInlineMcpUiResource };


### PR DESCRIPTION
/claim #1301

## Summary

Integrate MCP-UI support into Archestra platform — when MCP servers return tool results containing `UIResource`, the Chat UI renders them as rich interactive HTML in sandboxed iframes instead of showing raw JSON.

## Changes

### Shared Types (`shared/mcp-ui.ts`)
- `McpUiResource`, `McpUiMeta`, `McpUiMimeType` types
- `extractMcpUiResourceUri()` — extracts `_meta.ui.resourceUri` from tool output
- `extractInlineMcpUiResource()` — extracts inline UIResource from MCP content arrays
- 12 unit tests covering JSON/object parsing and edge cases

### Frontend — Chat UI
- **`McpUiRenderer`** component: sandboxed iframe (`allow-scripts` only) with auto-resize via `postMessage`, supports `text/html`, `text/uri-list`, and remote-dom MIME types
- **`MessageTool`** modified: detects UIResource in tool results and renders via `McpUiRenderer` instead of raw ToolOutput`

### MCP Gateway
No changes needed — tool results already pass through as-is, preserving `_meta` and resource content.

### Vendor MCP-UI Wrappers (for catalog)
- **GitHub wrapper**: `list_repos`, `view_pull_request`, `search_issues` — dark-themed HTML tables with repo stats, PR diffs, and label rendering
- **Weather wrapper**: `get_weather`, `get_forecast` — gradient weather cards with mock data fallback for demos

## Verification
- ✅ 12/12 unit tests pass
- ✅ TypeScript type-check clean
- ✅ Biome lint clean (0 errors)
- ✅ Backward compatible — existing tool output renders identically when no UIResource is present

Closes #1301