### PR TITLE
feat: MCP Apps (ext-apps) UI rendering support

### DIFF
--- a/docs/pages/platform-chat.md
+++ b/docs/pages/platform-chat.md
@@ -27,8 +27,20 @@ Chat will use LLM API Keys configured in Settings -> LLM API Keys. When a chat r
 
 See [Supported LLM Providers](/docs/platform-supported-llm-providers) for the full list.
 
+### MCP Apps (Interactive UI)
+
+When an MCP tool returns `_meta.ui.resourceUri` in its result, Chat automatically renders the tool's interactive UI in a sandboxed iframe alongside the text output. This follows the [MCP Apps (ext-apps) specification](https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/mcp-apps).
+
+The flow:
+1. The MCP server tool returns a result with `_meta.ui.resourceUri` pointing to a `ui://` resource
+2. Archestra reads the resource HTML via `resources/read` on the same MCP server connection
+3. The HTML is rendered in a sandboxed iframe (`allow-scripts` only) in the chat tool output
+
+The iframe supports `postMessage`-based communication for dynamic resizing. MCP Apps that send `{ type: "resize", height: number }` messages will have their iframe height adjusted automatically (clamped between 100px and 800px).
+
 ## Security Notes
 
 - API keys are stored encrypted using the configured [secrets manager](/docs/platform-secrets-management)
 - Keys are never exposed in the UI after creation
 - Profile assignments allow separation of billing/usage across teams
+- MCP App iframes are sandboxed with `allow-scripts` only (no access to parent page, cookies, or navigation)

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -1049,7 +1049,7 @@ async function executeMcpTool(ctx: ToolExecutionContext): Promise<string> {
   }
 
   // Convert MCP content to string for AI SDK
-  return (result.content as Array<{ type: string; text?: string }>)
+  const textContent = (result.content as Array<{ type: string; text?: string }>)
     .map((item: { type: string; text?: string }) => {
       if (item.type === "text" && item.text) {
         return item.text;
@@ -1057,6 +1057,42 @@ async function executeMcpTool(ctx: ToolExecutionContext): Promise<string> {
       return JSON.stringify(item);
     })
     .join("\n");
+
+  // If the tool result has _meta (e.g. MCP Apps UI), wrap the result so the
+  // frontend can detect and render the app UI alongside the text content.
+  if (result._meta) {
+    const ui = (result._meta as { ui?: { resourceUri?: string } }).ui;
+    let appHtml: string | undefined;
+
+    // When a ui:// resource URI is present, read the HTML content so the
+    // frontend can render it directly in a sandboxed iframe via srcdoc.
+    if (ui?.resourceUri) {
+      const html = await mcpClient.readResource(
+        toolName,
+        agentId,
+        ui.resourceUri,
+        mcpGwToken
+          ? {
+              tokenId: mcpGwToken.tokenId,
+              teamId: mcpGwToken.teamId,
+              isOrganizationToken: mcpGwToken.isOrganizationToken,
+              organizationId,
+              userId,
+            }
+          : undefined,
+        { conversationId },
+      );
+      if (html) appHtml = html;
+    }
+
+    return JSON.stringify({
+      _mcpMeta: result._meta,
+      ...(appHtml && { _appHtml: appHtml }),
+      content: textContent,
+    });
+  }
+
+  return textContent;
 }
 
 /**

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -19,6 +19,7 @@ const mockConnect = vi.fn();
 const mockClose = vi.fn();
 const mockListTools = vi.fn();
 const mockPing = vi.fn();
+const mockReadResource = vi.fn();
 
 vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
   // biome-ignore lint/suspicious/noExplicitAny: test..
@@ -28,6 +29,7 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
     this.close = mockClose;
     this.listTools = mockListTools;
     this.ping = mockPing;
+    this.readResource = mockReadResource;
   }),
 }));
 
@@ -104,6 +106,7 @@ describe("McpClient", () => {
     mockClose.mockReset();
     mockListTools.mockReset();
     mockPing.mockReset();
+    mockReadResource.mockReset();
     mockUsesStreamableHttp.mockReset();
     mockGetHttpEndpointUrl.mockReset();
     mockGetOrLoadDeployment.mockReset();
@@ -1538,6 +1541,160 @@ describe("McpClient", () => {
 
         // callTool should have been called twice (first stale, then fresh)
         expect(mockCallTool).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe("_meta preservation", () => {
+      test("preserves _meta from callTool result in CommonToolResult", async () => {
+        const tool = await ToolModel.createToolIfNotExists({
+          name: "github-mcp-server__ui_tool",
+          description: "Tool with _meta.ui",
+          parameters: {},
+          catalogId,
+          mcpServerId,
+        });
+
+        await AgentToolModel.create(agentId, tool.id, {
+          credentialSourceMcpServerId: mcpServerId,
+        });
+
+        mockCallTool.mockResolvedValueOnce({
+          content: [{ type: "text", text: "Map rendered" }],
+          isError: false,
+          _meta: {
+            ui: {
+              resourceUri: "ui://mapbox-server/map-view",
+            },
+          },
+        });
+
+        const toolCall = {
+          id: "call_meta_1",
+          name: "github-mcp-server__ui_tool",
+          arguments: { location: "New York" },
+        };
+
+        const result = await mcpClient.executeToolCall(toolCall, agentId);
+
+        expect(result).toEqual({
+          id: "call_meta_1",
+          name: "github-mcp-server__ui_tool",
+          content: [{ type: "text", text: "Map rendered" }],
+          isError: false,
+          _meta: {
+            ui: {
+              resourceUri: "ui://mapbox-server/map-view",
+            },
+          },
+        });
+      });
+
+      test("omits _meta when callTool response has no _meta", async () => {
+        const tool = await ToolModel.createToolIfNotExists({
+          name: "github-mcp-server__no_meta_tool",
+          description: "Tool without _meta",
+          parameters: {},
+          catalogId,
+          mcpServerId,
+        });
+
+        await AgentToolModel.create(agentId, tool.id, {
+          credentialSourceMcpServerId: mcpServerId,
+        });
+
+        mockCallTool.mockResolvedValueOnce({
+          content: [{ type: "text", text: "No meta" }],
+          isError: false,
+        });
+
+        const toolCall = {
+          id: "call_no_meta",
+          name: "github-mcp-server__no_meta_tool",
+          arguments: {},
+        };
+
+        const result = await mcpClient.executeToolCall(toolCall, agentId);
+
+        expect(result).toEqual({
+          id: "call_no_meta",
+          name: "github-mcp-server__no_meta_tool",
+          content: [{ type: "text", text: "No meta" }],
+          isError: false,
+        });
+        expect(result._meta).toBeUndefined();
+      });
+    });
+
+    describe("readResource", () => {
+      test("reads a ui:// resource using the same MCP server connection as the tool", async () => {
+        const tool = await ToolModel.createToolIfNotExists({
+          name: "github-mcp-server__map_tool",
+          description: "Tool with UI resource",
+          parameters: {},
+          catalogId,
+          mcpServerId,
+        });
+
+        await AgentToolModel.create(agentId, tool.id, {
+          credentialSourceMcpServerId: mcpServerId,
+        });
+
+        mockReadResource.mockResolvedValueOnce({
+          contents: [
+            {
+              uri: "ui://github-mcp-server/map-view",
+              text: "<html><body>Map UI</body></html>",
+              mimeType: "text/html",
+            },
+          ],
+        });
+
+        const content = await mcpClient.readResource(
+          "github-mcp-server__map_tool",
+          agentId,
+          "ui://github-mcp-server/map-view",
+        );
+
+        expect(content).toBe("<html><body>Map UI</body></html>");
+        expect(mockReadResource).toHaveBeenCalledWith({
+          uri: "ui://github-mcp-server/map-view",
+        });
+      });
+
+      test("returns null when resource has no contents", async () => {
+        const tool = await ToolModel.createToolIfNotExists({
+          name: "github-mcp-server__empty_res_tool",
+          description: "Tool with empty resource",
+          parameters: {},
+          catalogId,
+          mcpServerId,
+        });
+
+        await AgentToolModel.create(agentId, tool.id, {
+          credentialSourceMcpServerId: mcpServerId,
+        });
+
+        mockReadResource.mockResolvedValueOnce({
+          contents: [],
+        });
+
+        const content = await mcpClient.readResource(
+          "github-mcp-server__empty_res_tool",
+          agentId,
+          "ui://github-mcp-server/empty",
+        );
+
+        expect(content).toBeNull();
+      });
+
+      test("returns null when tool is not found", async () => {
+        const content = await mcpClient.readResource(
+          "nonexistent-server__tool",
+          agentId,
+          "ui://nonexistent-server/resource",
+        );
+
+        expect(content).toBeNull();
       });
     });
 

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -292,6 +292,7 @@ class McpClient {
           !!result.isError,
           tool.responseModifierTemplate,
           authInfo,
+          result._meta as Record<string, unknown> | undefined,
         );
       } catch (error) {
         // Handle stale HTTP session.  The MCP SDK skips the `initialize`
@@ -1160,6 +1161,7 @@ class McpClient {
     isError: boolean,
     template: string | null,
     authInfo?: { userId?: string; authMethod?: MCPGatewayAuthMethod },
+    meta?: Record<string, unknown>,
   ): Promise<CommonToolResult> {
     const modifiedContent = this.applyTemplate(
       content,
@@ -1172,6 +1174,7 @@ class McpClient {
       name: toolCall.name,
       content: modifiedContent,
       isError,
+      ...(meta && { _meta: meta }),
     };
 
     await this.persistToolCall(
@@ -1442,6 +1445,74 @@ class McpClient {
         lastError?.message || "Unknown error"
       }`,
     );
+  }
+
+  /**
+   * Read a MCP resource (e.g. ui:// for MCP Apps) using the same server
+   * connection as a given tool. Returns the text content or null on failure.
+   */
+  async readResource(
+    toolName: string,
+    agentId: string,
+    resourceUri: string,
+    tokenAuth?: TokenAuthContext,
+    options?: { conversationId?: string },
+  ): Promise<string | null> {
+    try {
+      // Reuse the same validation & connection flow as executeToolCall
+      const toolCall = { id: "resource-read", name: toolName, arguments: {} };
+      const validationResult = await this.validateAndGetTool(
+        toolCall,
+        agentId,
+        tokenAuth,
+      );
+      if ("error" in validationResult) return null;
+      const { tool, catalogItem } = validationResult;
+
+      const targetResult = await this.determineTargetMcpServerIdForCatalogItem({
+        tool,
+        toolCall,
+        agentId,
+        tokenAuth,
+        catalogItem,
+      });
+      if ("error" in targetResult) return null;
+      const { targetMcpServerId } = targetResult;
+
+      const secretsResult = await this.getSecretsForMcpServer({
+        targetMcpServerId,
+        toolCall,
+        agentId,
+      });
+      if ("error" in secretsResult) return null;
+      const { secrets } = secretsResult;
+
+      const connectionKey = options?.conversationId
+        ? `${catalogItem.id}:${targetMcpServerId}:${agentId}:${options.conversationId}`
+        : `${catalogItem.id}:${targetMcpServerId}`;
+
+      const transport = await this.getTransport(
+        catalogItem,
+        targetMcpServerId,
+        secrets,
+        connectionKey,
+      );
+      const client = await this.getOrCreateClient(connectionKey, transport);
+
+      const result = await client.readResource({ uri: resourceUri });
+
+      const firstContent = result.contents[0];
+      if (!firstContent) return null;
+      return "text" in firstContent
+        ? firstContent.text
+        : (firstContent.blob ?? null);
+    } catch (error) {
+      logger.warn(
+        { toolName, agentId, resourceUri, err: error },
+        "Failed to read MCP resource (non-fatal)",
+      );
+      return null;
+    }
   }
 
   /**

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -257,6 +257,7 @@ export async function createAgentServer(
             ? result.content
             : [{ type: "text", text: JSON.stringify(result.content) }],
           isError: result.isError,
+          ...(result._meta && { _meta: result._meta }),
         };
       } catch (error) {
         if (typeof error === "object" && error !== null && "code" in error) {

--- a/platform/backend/src/types/common-llm-format.ts
+++ b/platform/backend/src/types/common-llm-format.ts
@@ -29,6 +29,8 @@ export type CommonToolResult = {
   content: unknown;
   isError: boolean;
   error?: string;
+  /** MCP _meta from CallToolResult (e.g. _meta.ui for MCP Apps) */
+  _meta?: Record<string, unknown>;
 };
 
 /**

--- a/platform/frontend/src/components/ai-elements/tool.tsx
+++ b/platform/frontend/src/components/ai-elements/tool.tsx
@@ -10,7 +10,14 @@ import {
   XCircleIcon,
 } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
-import { createContext, useContext, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -211,6 +218,38 @@ export type ToolOutputProps = ComponentProps<"div"> & {
   }>;
 };
 
+/**
+ * Try to extract MCP Apps metadata from tool output.
+ * When a tool result contains `_meta.ui`, it's wrapped as:
+ * `{"_mcpMeta": {"ui": {"resourceUri": "ui://..."}}, "_appHtml": "...", "content": "..."}`
+ */
+function extractMcpMeta(output: unknown): {
+  meta: Record<string, unknown>;
+  appHtml?: string;
+  content: string;
+} | null {
+  if (typeof output !== "string") return null;
+  try {
+    const parsed = JSON.parse(output);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      "_mcpMeta" in parsed &&
+      typeof parsed._mcpMeta === "object"
+    ) {
+      return {
+        meta: parsed._mcpMeta,
+        appHtml:
+          typeof parsed._appHtml === "string" ? parsed._appHtml : undefined,
+        content: parsed.content ?? "",
+      };
+    }
+  } catch {
+    // Not JSON or not our format
+  }
+  return null;
+}
+
 export const ToolOutput = ({
   className,
   output,
@@ -223,6 +262,24 @@ export const ToolOutput = ({
 
   if (!(output || errorText || conversations)) {
     return null;
+  }
+
+  // Check for MCP Apps UI metadata with embedded HTML content
+  const mcpMeta = extractMcpMeta(output);
+  if (mcpMeta?.appHtml) {
+    return (
+      <div className={cn("space-y-2 p-4", className)} {...props}>
+        <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+          {label ?? "Result"}
+        </h4>
+        <McpAppFrame appHtml={mcpMeta.appHtml} />
+        {mcpMeta.content && (
+          <div className="rounded-md bg-muted/50 p-3 text-xs text-foreground">
+            {mcpMeta.content}
+          </div>
+        )}
+      </div>
+    );
   }
 
   // Render conversations as chat bubbles if provided
@@ -343,3 +400,43 @@ export const ToolOutput = ({
     </div>
   );
 };
+
+/**
+ * Renders an MCP App UI in a sandboxed iframe.
+ * The HTML content was fetched at tool execution time via `resources/read`
+ * and is embedded directly using the iframe `srcdoc` attribute.
+ */
+function McpAppFrame({ appHtml }: { appHtml: string }) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [height, setHeight] = useState(300);
+
+  const handleMessage = useCallback((event: MessageEvent) => {
+    // Only accept messages from our iframe
+    if (iframeRef.current?.contentWindow !== event.source) return;
+
+    const data = event.data;
+    if (typeof data !== "object" || data === null) return;
+
+    // Handle resize messages from the app
+    if (data.type === "resize" && typeof data.height === "number") {
+      setHeight(Math.min(Math.max(data.height, 100), 800));
+    }
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [handleMessage]);
+
+  return (
+    <div className="rounded-md border bg-background overflow-hidden">
+      <iframe
+        ref={iframeRef}
+        srcDoc={appHtml}
+        title="MCP App"
+        sandbox="allow-scripts"
+        style={{ width: "100%", height: `${height}px`, border: "none" }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Preserve `_meta` from MCP `CallToolResult` through the entire backend pipeline (`mcp-client` → `CommonToolResult` → `mcp-gateway.utils` → `chat-mcp-client`)
- Add `readResource()` to `McpClient` for fetching `ui://` resources via the MCP SDK `resources/read` method
- Render MCP App UI in sandboxed iframes in chat tool output using the `srcdoc` attribute
- Support `postMessage`-based iframe resize per the ext-apps spec

## How it works

1. When an MCP tool returns `_meta.ui.resourceUri`, the backend immediately reads the HTML resource from the same MCP server connection
2. The HTML is wrapped alongside `_mcpMeta` in the tool result JSON that flows to the frontend
3. The frontend `ToolOutput` component detects the `_appHtml` field and renders it in a sandboxed iframe
4. The iframe only has `allow-scripts` — no access to parent page, cookies, or navigation

## Files changed

| File | Change |
|------|--------|
| `common-llm-format.ts` | Add `_meta` field to `CommonToolResult` |
| `mcp-client.ts` | Preserve `_meta` in `createSuccessResult`, add `readResource()` method |
| `mcp-gateway.utils.ts` | Forward `_meta` in MCP Gateway tool call responses |
| `chat-mcp-client.ts` | Wrap `_mcpMeta` + `_appHtml` in tool output, read `ui://` resources |
| `tool.tsx` | Extract MCP metadata, render `McpAppFrame` with `srcdoc` |
| `mcp-client.test.ts` | Add 5 new tests for `_meta` preservation and `readResource` |
| `platform-chat.md` | Document MCP Apps UI feature |

## Test plan

- [x] All 2402 backend tests pass (36 mcp-client, 18 mcp-gateway)
- [x] TypeScript type-check passes (backend + frontend)
- [x] Biome lint passes
- [ ] Manual test with an MCP server that returns `_meta.ui.resourceUri`

Closes #1301

🤖 Generated with [Claude Code](https://claude.com/claude-code)