### PR TITLE
feat: Add DeepSeek LLM provider support

### DIFF
--- a/platform/backend/src/types/llm-providers/deepseek/api.ts
+++ b/platform/backend/src/types/llm-providers/deepseek/api.ts
@@ -1,0 +1,35 @@
+/**
+ * DeepSeek API schemas
+ *
+ * DeepSeek uses an OpenAI-compatible API, so we reuse OpenAI schemas directly.
+ * This ensures type compatibility when delegating to OpenAI adapters.
+ *
+ * Note: DeepSeek responses may include extra fields (e.g., reasoning_content)
+ * that are not in the standard OpenAI schema. We use .passthrough() on the response
+ * schema to allow these additional fields.
+ *
+ * @see https://api-docs.deepseek.com
+ */
+
+import {
+  ChatCompletionRequestSchema,
+  ChatCompletionsHeadersSchema,
+  ChatCompletionUsageSchema,
+  FinishReasonSchema,
+  ChatCompletionResponseSchema as OpenAIChatCompletionResponseSchema,
+} from "../openai/api";
+
+// Re-export request and other schemas from OpenAI since DeepSeek is fully compatible
+export {
+  ChatCompletionRequestSchema,
+  ChatCompletionsHeadersSchema,
+  ChatCompletionUsageSchema,
+  FinishReasonSchema,
+};
+
+/**
+ * DeepSeek response schema with passthrough for extra fields.
+ * DeepSeek API returns additional fields like "reasoning_content" that are not in the standard OpenAI schema.
+ */
+export const ChatCompletionResponseSchema =
+  OpenAIChatCompletionResponseSchema.passthrough();

--- a/platform/backend/src/types/llm-providers/deepseek/index.ts
+++ b/platform/backend/src/types/llm-providers/deepseek/index.ts
@@ -1,0 +1,42 @@
+/**
+ * DeepSeek LLM Provider Types - OpenAI-compatible
+ *
+ * DeepSeek uses an OpenAI-compatible API at https://api.deepseek.com/v1
+ * We re-export OpenAI schemas with DeepSeek-specific namespace for type safety.
+ *
+ * @see https://api-docs.deepseek.com
+ */
+import type OpenAIProvider from "openai";
+import type { z } from "zod";
+import * as DeepSeekAPI from "./api";
+import * as DeepSeekMessages from "./messages";
+import * as DeepSeekTools from "./tools";
+
+namespace DeepSeek {
+  export const API = DeepSeekAPI;
+  export const Messages = DeepSeekMessages;
+  export const Tools = DeepSeekTools;
+
+  export namespace Types {
+    export type ChatCompletionsHeaders = z.infer<
+      typeof DeepSeekAPI.ChatCompletionsHeadersSchema
+    >;
+    export type ChatCompletionsRequest = z.infer<
+      typeof DeepSeekAPI.ChatCompletionRequestSchema
+    >;
+    export type ChatCompletionsResponse = z.infer<
+      typeof DeepSeekAPI.ChatCompletionResponseSchema
+    >;
+    export type Usage = z.infer<typeof DeepSeekAPI.ChatCompletionUsageSchema>;
+
+    export type FinishReason = z.infer<typeof DeepSeekAPI.FinishReasonSchema>;
+    export type Message = z.infer<typeof DeepSeekMessages.MessageParamSchema>;
+    export type Role = Message["role"];
+
+    // Use OpenAI's stream chunk type since DeepSeek is OpenAI-compatible
+    export type ChatCompletionChunk =
+      OpenAIProvider.Chat.Completions.ChatCompletionChunk;
+  }
+}
+
+export default DeepSeek;

--- a/platform/backend/src/types/llm-providers/deepseek/messages.ts
+++ b/platform/backend/src/types/llm-providers/deepseek/messages.ts
@@ -1,0 +1,7 @@
+/**
+ * DeepSeek message schemas - OpenAI-compatible
+ *
+ * DeepSeek uses an OpenAI-compatible API, so we re-export OpenAI schemas.
+ * @see https://api-docs.deepseek.com
+ */
+export { MessageParamSchema, ToolCallSchema } from "../openai/messages";

--- a/platform/backend/src/types/llm-providers/deepseek/tools.ts
+++ b/platform/backend/src/types/llm-providers/deepseek/tools.ts
@@ -1,0 +1,11 @@
+/**
+ * DeepSeek tool schemas - OpenAI-compatible
+ *
+ * DeepSeek uses an OpenAI-compatible API, so we re-export OpenAI schemas.
+ * @see https://api-docs.deepseek.com
+ */
+export {
+  FunctionDefinitionParametersSchema,
+  ToolChoiceOptionSchema,
+  ToolSchema,
+} from "../openai/tools";

--- a/platform/backend/src/types/llm-providers/index.ts
+++ b/platform/backend/src/types/llm-providers/index.ts
@@ -2,6 +2,7 @@ export { default as Anthropic } from "./anthropic";
 export { default as Bedrock } from "./bedrock";
 export { default as Cerebras } from "./cerebras";
 export { default as Cohere } from "./cohere";
+export { default as DeepSeek } from "./deepseek";
 export { default as Gemini } from "./gemini";
 export { default as Mistral } from "./mistral";
 export { default as Ollama } from "./ollama";

--- a/platform/e2e-tests/tests/api/llm-proxy/tool-invocation.spec.ts
+++ b/platform/e2e-tests/tests/api/llm-proxy/tool-invocation.spec.ts
@@ -771,6 +771,82 @@ const zhipuaiConfig: ToolInvocationTestConfig = {
     ),
 };
 
+const deepseekConfig: ToolInvocationTestConfig = {
+  providerName: "DeepSeek",
+
+  endpoint: (agentId) => `/v1/deepseek/${agentId}/chat/completions`,
+
+  headers: (wiremockStub) => ({
+    Authorization: `Bearer ${wiremockStub}`,
+    "Content-Type": "application/json",
+  }),
+
+  buildRequest: (content, tools) => ({
+    model: "deepseek-chat",
+    messages: [{ role: "user", content }],
+    tools: tools.map((t) => ({
+      type: "function",
+      function: {
+        name: t.name,
+        description: t.description,
+        parameters: t.parameters,
+      },
+    })),
+  }),
+
+  trustedDataPolicyAttributePath: "$.content",
+
+  assertToolCallBlocked: (response) => {
+    expect(response.choices).toBeDefined();
+    expect(response.choices[0]).toBeDefined();
+    expect(response.choices[0].message).toBeDefined();
+
+    const message = response.choices[0].message;
+    const refusalOrContent = message.refusal || message.content;
+
+    expect(refusalOrContent).toBeTruthy();
+    expect(refusalOrContent).toContain("read_file");
+    expect(refusalOrContent).toContain("denied");
+
+    if (message.tool_calls) {
+      expect(refusalOrContent).toContain("tool invocation policy");
+    }
+  },
+
+  assertToolCallsPresent: (response, expectedTools) => {
+    expect(response.choices).toBeDefined();
+    expect(response.choices[0]).toBeDefined();
+    expect(response.choices[0].message).toBeDefined();
+    expect(response.choices[0].message.tool_calls).toBeDefined();
+
+    const toolCalls = response.choices[0].message.tool_calls;
+    expect(toolCalls.length).toBe(expectedTools.length);
+
+    for (const toolName of expectedTools) {
+      const found = toolCalls.find(
+        (tc: { function: { name: string } }) => tc.function.name === toolName,
+      );
+      expect(found).toBeDefined();
+    }
+  },
+
+  assertToolArgument: (response, toolName, argName, matcher) => {
+    const toolCalls = response.choices[0].message.tool_calls;
+    const toolCall = toolCalls.find(
+      (tc: { function: { name: string } }) => tc.function.name === toolName,
+    );
+    const args = JSON.parse(toolCall.function.arguments);
+    matcher(args[argName]);
+  },
+
+  findInteractionByContent: (interactions, content) =>
+    interactions.find((i) =>
+      i.request?.messages?.some((m: { content?: string }) =>
+        m.content?.includes(content),
+      ),
+    ),
+};
+
 // =============================================================================
 // Test Suite
 // =============================================================================
@@ -785,6 +861,7 @@ const testConfigs: ToolInvocationTestConfig[] = [
   vllmConfig,
   ollamaConfig,
   zhipuaiConfig,
+  deepseekConfig,
 ];
 
 for (const config of testConfigs) {
@@ -1048,3 +1125,4 @@ for (const config of testConfigs) {
     });
   });
 }
+

--- a/platform/frontend/src/lib/interaction.utils.ts
+++ b/platform/frontend/src/lib/interaction.utils.ts
@@ -4,6 +4,7 @@ import AnthropicMessagesInteraction from "./llmProviders/anthropic";
 import BedrockConverseInteraction from "./llmProviders/bedrock";
 import CerebrasChatCompletionInteraction from "./llmProviders/cerebras";
 import CohereChatInteraction from "./llmProviders/cohere";
+import DeepseekChatCompletionInteraction from "./llmProviders/deepseek";
 import type {
   DualLlmResult,
   Interaction,
@@ -130,6 +131,8 @@ export class DynamicInteraction implements InteractionUtils {
       return new ZhipuaiChatCompletionInteraction(interaction);
     } else if (type === "cerebras:chatCompletions") {
       return new CerebrasChatCompletionInteraction(interaction);
+    } else if (type === "deepseek:chatCompletions") {
+      return new DeepseekChatCompletionInteraction(interaction);
     } else if (type === "mistral:chatCompletions") {
       return new MistralChatCompletionInteraction(interaction);
     } else if (type === "vllm:chatCompletions") {

--- a/platform/frontend/src/lib/llmProviders/deepseek.ts
+++ b/platform/frontend/src/lib/llmProviders/deepseek.ts
@@ -1,0 +1,12 @@
+/**
+ * DeepSeek LLM Provider Interaction Handler
+ *
+ * DeepSeek uses an OpenAI-compatible API, so we re-export the OpenAI interaction handler.
+ * @see https://api-docs.deepseek.com
+ */
+import OpenAiChatCompletionInteraction from "./openai";
+
+// DeepSeek uses the same request/response format as OpenAI
+class DeepseekChatCompletionInteraction extends OpenAiChatCompletionInteraction {}
+
+export default DeepseekChatCompletionInteraction;

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -10,6 +10,7 @@ export const SupportedProvidersSchema = z.enum([
   "bedrock",
   "cohere",
   "cerebras",
+  "deepseek",
   "mistral",
   "vllm",
   "ollama",
@@ -23,6 +24,7 @@ export const SupportedProvidersDiscriminatorSchema = z.enum([
   "bedrock:converse",
   "cohere:chat",
   "cerebras:chatCompletions",
+  "deepseek:chatCompletions",
   "mistral:chatCompletions",
   "vllm:chatCompletions",
   "ollama:chatCompletions",
@@ -42,6 +44,7 @@ export const providerDisplayNames: Record<SupportedProvider, string> = {
   gemini: "Gemini",
   cohere: "Cohere",
   cerebras: "Cerebras",
+  deepseek: "DeepSeek",
   mistral: "Mistral AI",
   vllm: "vLLM",
   ollama: "Ollama",
@@ -85,6 +88,10 @@ export const MODEL_MARKER_PATTERNS: Record<
   cohere: {
     fastest: ["command-light"],
     best: ["command-r-plus", "command-r"],
+  },
+  deepseek: {
+    fastest: ["deepseek-chat"],
+    best: ["deepseek-reasoner"],
   },
   mistral: {
     fastest: ["mistral-small", "ministral"],


### PR DESCRIPTION
Adds support for DeepSeek AI models to the Archestra platform.

DeepSeek uses an OpenAI-compatible API at https://api.deepseek.com/v1.

## Changes
- Add DeepSeek provider types (backend)
- Add DeepSeek interaction handler (frontend)  
- Register DeepSeek in model constants with markers:
  * fastest: deepseek-chat
  * best: deepseek-reasoner
- Add DeepSeek to e2e test suite (tool-invocation)

## Implementation Notes
The implementation follows the same pattern as Mistral since both use OpenAI-compatible APIs. Uses .passthrough() on response schema to handle DeepSeek's extra fields like reasoning_content.

## Testing
- [x] E2E tests added to tool-invocation.spec.ts
- [ ] Demo video (Will update soon. I'm setting up my local environment)

## API Key
Get your API key at: https://platform.deepseek.com/

## Files Changed
- platform/backend/src/types/llm-providers/deepseek/* (new)
- platform/frontend/src/lib/llmProviders/deepseek.ts (new)
- platform/backend/src/types/llm-providers/index.ts
- platform/frontend/src/lib/interaction.utils.ts
- platform/shared/model-constants.ts
- platform/e2e-tests/tests/api/llm-proxy/tool-invocation.spec.ts

Closes #1846