### PR TITLE
chore: remove "Show Tool calls" toggle button from chat header

### DIFF
--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -2,7 +2,7 @@
 
 import type { UIMessage } from "@ai-sdk/react";
 
-import { Bot, Edit, FileText, Globe, Plus, Wrench } from "lucide-react";
+import { Bot, Edit, FileText, Globe, Plus } from "lucide-react";
 
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -72,7 +72,6 @@ import ArchestraPromptInput from "./prompt-input";
 const CONVERSATION_QUERY_PARAM = "conversation";
 
 const LocalStorageKeys = {
-  hideToolCalls: "archestra-chat-hide-tool-calls",
   artifactOpen: "archestra-chat-artifact-open",
   browserOpen: "archestra-chat-browser-open",
   selectedChatModel: "archestra-chat-selected-chat-model",
@@ -92,13 +91,6 @@ export default function ChatPage() {
     document.body.classList.add("hide-version");
     return () => document.body.classList.remove("hide-version");
   }, []);
-  const [hideToolCalls, setHideToolCalls] = useState(() => {
-    // Initialize from localStorage
-    if (typeof window !== "undefined") {
-      return localStorage.getItem(LocalStorageKeys.hideToolCalls) === "true";
-    }
-    return false;
-  });
   const [isArtifactOpen, setIsArtifactOpen] = useState(false);
   const loadedConversationRef = useRef<string | undefined>(undefined);
   const pendingPromptRef = useRef<string | undefined>(undefined);
@@ -450,13 +442,6 @@ export default function ChatPage() {
 
   // Update enabled tools mutation (for applying pending actions)
   const updateEnabledToolsMutation = useUpdateConversationEnabledTools();
-
-  // Persist hide tool calls preference
-  const toggleHideToolCalls = useCallback(() => {
-    const newValue = !hideToolCalls;
-    setHideToolCalls(newValue);
-    localStorage.setItem(LocalStorageKeys.hideToolCalls, String(newValue));
-  }, [hideToolCalls]);
 
   // Persist artifact panel state
   const toggleArtifactPanel = useCallback(() => {
@@ -1106,16 +1091,6 @@ export default function ChatPage() {
               <div className="flex items-center gap-2 flex-shrink-0">
                 <span className="text-xs text-muted-foreground">Show:</span>
                 <Button
-                  variant={!hideToolCalls ? "secondary" : "ghost"}
-                  size="sm"
-                  onClick={toggleHideToolCalls}
-                  className="text-xs"
-                >
-                  <Wrench className="h-3 w-3 mr-1" />
-                  Tool calls
-                </Button>
-                <div className="w-px h-4 bg-border" />
-                <Button
                   variant={isArtifactOpen ? "secondary" : "ghost"}
                   size="sm"
                   onClick={toggleArtifactPanel}
@@ -1175,7 +1150,6 @@ export default function ChatPage() {
                     }
               }
               messages={messages}
-              hideToolCalls={hideToolCalls}
               status={status}
               isLoadingConversation={isLoadingConversation}
               onMessagesUpdate={setMessages}

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -48,7 +48,6 @@ interface ChatMessagesProps {
   conversationId: string | undefined;
   agentId?: string;
   messages: UIMessage[];
-  hideToolCalls?: boolean;
   status: ChatStatus;
   isLoadingConversation?: boolean;
   onMessagesUpdate?: (messages: UIMessage[]) => void;
@@ -91,7 +90,6 @@ export function ChatMessages({
   suggestedPrompt,
   onSuggestedPromptClick,
   messages,
-  hideToolCalls = false,
   status,
   isLoadingConversation = false,
   onMessagesUpdate,
@@ -462,16 +460,6 @@ export function ChatMessages({
                     ) {
                       return null;
                     }
-                  }
-
-                  // Hide tool calls if hideToolCalls is true
-                  if (
-                    hideToolCalls &&
-                    isToolPart(part) &&
-                    (part.type?.startsWith("tool-") ||
-                      part.type === "dynamic-tool")
-                  ) {
-                    return null;
                   }
 
                   switch (part.type) {


### PR DESCRIPTION
Tool calls are now always visible. The toggle was confusing users who couldn't see subagent calls when it was disabled.

Removes:
- Tool calls toggle button from the sticky header
- hideToolCalls state, localStorage persistence, and toggle callback
- hideToolCalls prop from ChatMessages component
- Tool call filtering logic in message rendering

Fixes #2643