### PR TITLE
[Provider] Add MiniMax support

### DIFF
--- a/platform/backend/src/clients/dual-llm-client.ts
+++ b/platform/backend/src/clients/dual-llm-client.ts
@@ -194,7 +194,9 @@ Return only the JSON object, no other text.`;
       if (idx === 0 && msg.role === "user") {
         return {
           ...msg,
-          content: `${systemPrompt}\n\n${msg.content}`,
+          content: `${systemPrompt}
+
+${msg.content}`,
         };
       }
       return msg;
@@ -302,6 +304,84 @@ export class CerebrasDualLlmClient implements DualLlmClient {
     logger.debug(
       { model: this.model, responseLength: content.length },
       "[dualLlmClient] Cerebras: chat with schema complete, parsing response",
+    );
+    return JSON.parse(content) as T;
+  }
+}
+
+/**
+ * MiniMax implementation of DualLlmClient (OpenAI-compatible)
+ */
+export class MiniMaxDualLlmClient implements DualLlmClient {
+  private client: OpenAI;
+  private model: string;
+
+  constructor(apiKey: string, model = "llama-3.3-70b-versatile") {
+    logger.debug({ model }, "[dualLlmClient] MiniMax: initializing client");
+    this.client = new OpenAI({
+      apiKey,
+      baseURL: config.llm.minimax.baseUrl,
+    });
+    this.model = model;
+  }
+
+  async chat(messages: DualLlmMessage[], temperature = 0): Promise<string> {
+    logger.debug(
+      { model: this.model, messageCount: messages.length, temperature },
+      "[dualLlmClient] MiniMax: starting chat completion",
+    );
+    const response = await this.client.chat.completions.create({
+      model: this.model,
+      messages,
+      temperature,
+    });
+
+    const content = response.choices[0].message.content?.trim() || "";
+    logger.debug(
+      { model: this.model, responseLength: content.length },
+      "[dualLlmClient] MiniMax: chat completion complete",
+    );
+    return content;
+  }
+
+  async chatWithSchema<T>(
+    messages: DualLlmMessage[],
+    schema: {
+      name: string;
+      schema: {
+        type: string;
+        properties: Record<string, unknown>;
+        required: string[];
+        additionalProperties: boolean;
+      };
+    },
+    temperature = 0,
+  ): Promise<T> {
+    logger.debug(
+      {
+        model: this.model,
+        schemaName: schema.name,
+        messageCount: messages.length,
+        temperature,
+      },
+      "[dualLlmClient] MiniMax: starting chat with schema",
+    );
+
+    // MiniMax uses OpenAI-compatible API with JSON schema support
+    const response = await this.client.chat.completions.create({
+      model: this.model,
+      messages,
+      response_format: {
+        type: "json_schema",
+        json_schema: schema,
+      },
+      temperature,
+    });
+
+    const content = response.choices[0].message.content || "";
+    logger.debug(
+      { model: this.model, responseLength: content.length },
+      "[dualLlmClient] MiniMax: chat with schema complete, parsing response",
     );
     return JSON.parse(content) as T;
   }
@@ -583,7 +663,9 @@ Return only the JSON object, no other text.`;
         if (idx === 0 && msg.role === "user") {
           return {
             ...msg,
-            content: `${systemPrompt}\n\n${msg.content}`,
+            content: `${systemPrompt}
+
+${msg.content}`,
           };
         }
         return msg;
@@ -702,7 +784,9 @@ Return only the JSON object, no other text.`;
         if (idx === 0 && msg.role === "user") {
           return {
             ...msg,
-            content: `${systemPrompt}\n\n${msg.content}`,
+            content: `${systemPrompt}
+
+${msg.content}`,
           };
         }
         return msg;
@@ -816,7 +900,9 @@ Return only the JSON object, no other text.`;
       if (idx === 0 && msg.role === "user") {
         return {
           ...msg,
-          content: `${systemPrompt}\n\n${msg.content}`,
+          content: `${systemPrompt}
+
+${msg.content}`,
         };
       }
       return msg;
@@ -970,7 +1056,9 @@ Return only the JSON object, no other text.`;
         if (idx === 0 && msg.role === "user") {
           return {
             ...msg,
-            content: `${systemPrompt}\n\n${msg.content}`,
+            content: `${systemPrompt}
+
+${msg.content}`,
           };
         }
         return msg;
@@ -1101,7 +1189,9 @@ Return only the JSON object, no other text.`;
       if (idx === 0 && msg.role === "user") {
         return {
           ...msg,
-          content: `${systemPrompt}\n\n${msg.content}`,
+          content: `${systemPrompt}
+
+${msg.content}`,
         };
       }
       return msg;
@@ -1195,6 +1285,10 @@ const dualLlmClientFactories: Record<SupportedProvider, DualLlmClientFactory> =
     cerebras: (apiKey) => {
       if (!apiKey) throw new Error("API key required for Cerebras dual LLM");
       return new CerebrasDualLlmClient(apiKey);
+    },
+    minimax: (apiKey) => {
+      if (!apiKey) throw new Error("API key required for MiniMax dual LLM");
+      return new MiniMaxDualLlmClient(apiKey);
     },
     cohere: (apiKey, model) => {
       if (!apiKey) throw new Error("API key required for Cohere dual LLM");

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -81,6 +81,7 @@ const envApiKeyGetters: Record<
   bedrock: () => config.chat.bedrock.apiKey,
   cerebras: () => config.chat.cerebras.apiKey,
   cohere: () => config.chat.cohere.apiKey,
+  minimax: () => config.chat.minimax.apiKey,
   gemini: () => config.chat.gemini.apiKey,
   mistral: () => config.chat.mistral.apiKey,
   ollama: () => config.chat.ollama.apiKey,
@@ -166,6 +167,7 @@ export const FAST_MODELS: Record<SupportedChatProvider, string> = {
   gemini: "gemini-2.0-flash-001",
   cerebras: "llama-3.3-70b", // Cerebras focuses on speed, all their models are fast
   cohere: "command-light", // Cohere's fast model
+  minimax: "llama-3.1-8b-instant", // MiniMax's fastest model with instant inference
   vllm: "default", // vLLM uses whatever model is deployed
   ollama: "llama3.2", // Common fast model for Ollama
   zhipuai: "glm-4-flash", // Zhipu's fast model
@@ -265,6 +267,21 @@ const directModelCreators: Record<SupportedChatProvider, DirectModelCreator> = {
     const client = createCohere({
       apiKey,
       baseURL: config.llm.cohere.baseUrl,
+    });
+    return client(modelName);
+  },
+
+  minimax: ({ apiKey, modelName }) => {
+    if (!apiKey) {
+      throw new ApiError(
+        400,
+        "MiniMax API key is required. Please configure MINIMAX_API_KEY.",
+      );
+    }
+    // MiniMax uses OpenAI-compatible API at https://api.minimax.chat/v1
+    const client = createOpenAI({
+      apiKey,
+      baseURL: config.llm.minimax.baseUrl,
     });
     return client(modelName);
   },
@@ -443,6 +460,18 @@ const proxiedModelCreators: Record<SupportedChatProvider, ProxiedModelCreator> =
         headers,
       });
       return client(modelName);
+    },
+
+    minimax: ({ apiKey, agentId, modelName, headers }) => {
+      // URL format: /v1/minimax/:agentId (SDK appends /chat/completions)
+      // MiniMax uses OpenAI-compatible API, so we use the OpenAI SDK
+      const client = createOpenAI({
+        apiKey,
+        baseURL: buildProxyBaseUrl("minimax", agentId),
+        headers,
+      });
+      // Use .chat() to force Chat Completions API
+      return client.chat(modelName);
     },
 
     mistral: ({ apiKey, agentId, modelName, headers }) => {

--- a/platform/backend/src/clients/models-dev-client.ts
+++ b/platform/backend/src/clients/models-dev-client.ts
@@ -49,7 +49,7 @@ const MODELS_DEV_PROVIDER_MAP: Record<string, SupportedProvider | null> = {
   mistral: "mistral",
   // These providers use OpenAI-compatible API in Archestra
   llama: "openai",
-  deepseek: "openai",
+  minimax: "openai",
   groq: "openai",
   "fireworks-ai": "openai",
   togetherai: "openai",
@@ -402,10 +402,11 @@ class ModelsDevClient {
     // provider (e.g., "google/gemini-2.5-flash" vs "google-vertex/gemini-2.5-flash").
     const preferredSourcePrefixes: Record<SupportedProvider, string[]> = {
       gemini: ["google/"], // Prefer google over google-vertex
-      openai: ["openai/", "deepseek/"], // Prefer direct providers over aggregators
+      openai: ["openai/", "minimax/"], // Prefer direct providers over aggregators
       anthropic: ["anthropic/"],
       cohere: ["cohere/"],
       cerebras: ["cerebras/"],
+      minimax: ["minimax/"],
       mistral: ["mistral/"],
       bedrock: ["amazon-bedrock/"],
       ollama: ["ollama/"],

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -466,6 +466,10 @@ export default {
       baseUrl:
         process.env.ARCHESTRA_CEREBRAS_BASE_URL || "https://api.cerebras.ai/v1",
     },
+    minimax: {
+      baseUrl:
+        process.env.ARCHESTRA_MINIMAX_BASE_URL || "https://api.minimax.chat/v1",
+    },
     mistral: {
       baseUrl:
         process.env.ARCHESTRA_MISTRAL_BASE_URL || "https://api.mistral.ai/v1",
@@ -506,6 +510,9 @@ export default {
     },
     cerebras: {
       apiKey: process.env.ARCHESTRA_CHAT_CEREBRAS_API_KEY || "",
+    },
+    minimax: {
+      apiKey: process.env.ARCHESTRA_CHAT_MINIMAX_API_KEY || "",
     },
     mistral: {
       apiKey: process.env.ARCHESTRA_CHAT_MISTRAL_API_KEY || "",
@@ -558,7 +565,7 @@ export default {
     // See: https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files
     mcpServerBaseImage:
       process.env.ARCHESTRA_ORCHESTRATOR_MCP_SERVER_BASE_IMAGE ||
-      "europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-base:1.0.41", // x-release-please-version
+      "europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-base:1.0.42", // x-release-please-version
     kubernetes: {
       namespace: process.env.ARCHESTRA_ORCHESTRATOR_K8S_NAMESPACE || "default",
       kubeconfig: process.env.ARCHESTRA_ORCHESTRATOR_KUBECONFIG,

--- a/platform/backend/src/database/seed.ts
+++ b/platform/backend/src/database/seed.ts
@@ -8,6 +8,7 @@ import {
   testMcpServerCommand,
 } from "@shared";
 import { and, eq } from "drizzle-orm";
+import { isEqual } from "lodash-es";
 import { auth } from "@/auth/better-auth";
 import config from "@/config";
 import db, { schema } from "@/database";
@@ -221,8 +222,7 @@ async function seedPlaywrightCatalog(): Promise<void> {
   );
   const configChanged =
     !existingCatalog ||
-    JSON.stringify(existingCatalog.localConfig) !==
-      JSON.stringify(playwrightLocalConfig);
+    !isEqual(existingCatalog.localConfig, playwrightLocalConfig);
 
   await db
     .insert(schema.internalMcpCatalogTable)
@@ -396,6 +396,7 @@ async function seedChatApiKeysFromEnv(): Promise<void> {
     openai: config.chat.openai.apiKey,
     gemini: config.chat.gemini.apiKey,
     cerebras: config.chat.cerebras.apiKey,
+    minimax: config.chat.minimax.apiKey,
     cohere: config.chat.cohere.apiKey,
     mistral: config.chat.mistral.apiKey,
     ollama: config.chat.ollama.apiKey,
@@ -484,6 +485,7 @@ function getProviderDisplayName(provider: SupportedProvider): string {
     openai: "OpenAI",
     gemini: "Google",
     cerebras: "Cerebras",
+    minimax: "MiniMax",
     cohere: "Cohere",
     mistral: "Mistral",
     ollama: "Ollama",

--- a/platform/backend/src/llm-metrics.ts
+++ b/platform/backend/src/llm-metrics.ts
@@ -32,6 +32,7 @@ type UsageExtractor =
 const fetchUsageExtractors: Record<SupportedProvider, UsageExtractor> = {
   openai: getOpenAIUsage,
   cerebras: getOpenAIUsage,
+  minimax: getOpenAIUsage,
   vllm: getOpenAIUsage,
   ollama: getOpenAIUsage,
   mistral: getOpenAIUsage,

--- a/platform/backend/src/models/optimization-rule.ts
+++ b/platform/backend/src/models/optimization-rule.ts
@@ -272,6 +272,7 @@ class OptimizationRuleModel {
       gemini: [],
       cohere: [],
       cerebras: [],
+      minimax: [],
       mistral: [],
       vllm: [], // vLLM model pricing varies by deployment, so no defaults
       ollama: [], // Ollama model pricing varies by deployment, so no defaults
@@ -306,6 +307,7 @@ class OptimizationRuleModel {
         gemini: [],
         cohere: [],
         cerebras: [],
+        minimax: [],
         mistral: [],
         vllm: [], // vLLM optimization rules are deployment-specific, no defaults
         ollama: [], // Ollama optimization rules are deployment-specific, no defaults

--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -17,6 +17,22 @@ import { APICallError, RetryError } from "ai";
 import logger from "@/logging";
 
 // =============================================================================
+// ProviderError — carries a fully-mapped ChatErrorResponse with correct provider
+// =============================================================================
+
+export class ProviderError extends Error {
+  public readonly chatErrorResponse: ChatErrorResponse;
+
+  constructor(chatErrorResponse: ChatErrorResponse) {
+    super(
+      chatErrorResponse.originalError?.message || chatErrorResponse.message,
+    );
+    this.name = "ProviderError";
+    this.chatErrorResponse = chatErrorResponse;
+  }
+}
+
+// =============================================================================
 // Safe Serialization
 // =============================================================================
 
@@ -1106,6 +1122,7 @@ const providerParsers: Record<SupportedProvider, ErrorParser> = {
   gemini: parseGeminiError,
   bedrock: parseBedrockError,
   cerebras: parseOpenAIError, // Cerebras uses OpenAI-compatible API
+  minimax: parseOpenAIError, // MiniMax uses OpenAI-compatible API
   cohere: parseCohereError,
   mistral: parseOpenAIError, // Mistral uses OpenAI-compatible API
   vllm: parseVllmError,
@@ -1124,6 +1141,7 @@ const providerMappers: Record<SupportedProvider, ErrorMapper> = {
   gemini: mapGeminiErrorWrapper,
   bedrock: mapBedrockErrorWrapper,
   cerebras: mapOpenAIErrorWrapper, // Cerebras uses OpenAI-compatible API
+  minimax: mapOpenAIErrorWrapper, // MiniMax uses OpenAI-compatible API
   cohere: mapCohereErrorWrapper,
   mistral: mapOpenAIErrorWrapper, // Mistral uses OpenAI-compatible API
   vllm: mapVllmErrorWrapper,

--- a/platform/backend/src/routes/chat/routes.models.ts
+++ b/platform/backend/src/routes/chat/routes.models.ts
@@ -242,6 +242,44 @@ async function fetchCerebrasModels(apiKey: string): Promise<ModelInfo[]> {
 }
 
 /**
+ * Fetch models from MiniMax API (OpenAI-compatible)
+ */
+async function fetchMiniMaxModels(apiKey: string): Promise<ModelInfo[]> {
+  const baseUrl = config.llm.minimax.baseUrl;
+  const url = `${baseUrl}/models`;
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    logger.error(
+      { status: response.status, error: errorText },
+      "Failed to fetch MiniMax models",
+    );
+    throw new Error(`Failed to fetch MiniMax models: ${response.status}`);
+  }
+
+  const data = (await response.json()) as {
+    data: Array<{
+      id: string;
+      created: number;
+      owned_by: string;
+    }>;
+  };
+
+  return data.data.map((model) => ({
+    id: model.id,
+    displayName: model.id,
+    provider: "minimax" as const,
+    createdAt: new Date(model.created * 1000).toISOString(),
+  }));
+}
+
+/**
  * Fetch models from Mistral API (OpenAI-compatible)
  */
 async function fetchMistralModels(apiKey: string): Promise<ModelInfo[]> {
@@ -729,6 +767,7 @@ async function getProviderApiKey({
   const envApiKeyFallbacks: Record<SupportedProvider, () => string | null> = {
     anthropic: () => config.chat.anthropic.apiKey || null,
     cerebras: () => config.chat.cerebras.apiKey || null,
+    minimax: () => config.chat.minimax.apiKey || null,
     cohere: () => config.chat.cohere?.apiKey || null,
     gemini: () => config.chat.gemini.apiKey || null,
     mistral: () => config.chat.mistral.apiKey || null,
@@ -750,6 +789,7 @@ const modelFetchers: Record<
   anthropic: fetchAnthropicModels,
   bedrock: fetchBedrockModels,
   cerebras: fetchCerebrasModels,
+  minimax: fetchMiniMaxModels,
   gemini: fetchGeminiModels,
   mistral: fetchMistralModels,
   openai: fetchOpenAiModels,
@@ -823,7 +863,7 @@ export async function fetchModelsForProvider({
   try {
     let models: ModelInfo[] = [];
     if (
-      ["anthropic", "cerebras", "cohere", "mistral", "openai"].includes(
+      ["anthropic", "cerebras", "minimax", "cohere", "mistral", "openai"].includes(
         provider,
       )
     ) {

--- a/platform/backend/src/routes/index.ts
+++ b/platform/backend/src/routes/index.ts
@@ -2,6 +2,7 @@ import anthropicProxyRoutesV2 from "./proxy/routesv2/anthropic";
 import bedrockProxyRoutesV2 from "./proxy/routesv2/bedrock";
 import cerebrasProxyRoutesV2 from "./proxy/routesv2/cerebras";
 import cohereProxyRoutesV2 from "./proxy/routesv2/cohere";
+import minimaxProxyRoutesV2 from "./proxy/routesv2/minimax";
 import geminiProxyRoutesV2 from "./proxy/routesv2/gemini";
 import mistralProxyRoutesV2 from "./proxy/routesv2/mistral";
 import ollamaProxyRoutesV2 from "./proxy/routesv2/ollama";
@@ -41,6 +42,7 @@ export { default as policyConfigSubagentRoutes } from "./policy-config-subagent"
 export const anthropicProxyRoutes = anthropicProxyRoutesV2;
 export const cerebrasProxyRoutes = cerebrasProxyRoutesV2;
 export const cohereProxyRoutes = cohereProxyRoutesV2;
+export const minimaxProxyRoutes = minimaxProxyRoutesV2;
 export const geminiProxyRoutes = geminiProxyRoutesV2;
 export const mistralProxyRoutes = mistralProxyRoutesV2;
 export const openAiProxyRoutes = openAiProxyRoutesV2;

--- a/platform/backend/src/routes/proxy/adapterV2/index.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/index.ts
@@ -2,6 +2,7 @@ export { anthropicAdapterFactory } from "./anthropic";
 export { bedrockAdapterFactory } from "./bedrock";
 export { cerebrasAdapterFactory } from "./cerebras";
 export { cohereAdapterFactory } from "./cohere";
+export { minimaxAdapterFactory } from "./minimax";
 export { geminiAdapterFactory } from "./gemini";
 export { mistralAdapterFactory } from "./mistral";
 export { ollamaAdapterFactory } from "./ollama";

--- a/platform/backend/src/routes/proxy/adapterV2/minimax.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/minimax.ts
@@ -1,0 +1,1176 @@
+/**
+ * MiniMax LLM Proxy Adapter - OpenAI-compatible
+ *
+ * MiniMax uses an OpenAI-compatible API at https://api.minimax.com
+ * This adapter reuses OpenAI's logic with MiniMax-specific configuration.
+ *
+ * @see https://console.minimax.com/docs/api-reference
+ */
+import { encode as toonEncode } from "@toon-format/toon";
+import { get } from "lodash-es";
+import OpenAIProvider from "openai";
+import type {
+  ChatCompletionCreateParamsNonStreaming,
+  ChatCompletionCreateParamsStreaming,
+} from "openai/resources/chat/completions/completions";
+import config from "@/config";
+import { getObservableFetch } from "@/llm-metrics";
+import logger from "@/logging";
+import { TokenPriceModel } from "@/models";
+import { getTokenizer } from "@/tokenizers";
+import type {
+  MiniMax,
+  ChunkProcessingResult,
+  CommonMcpToolDefinition,
+  CommonMessage,
+  CommonToolCall,
+  CommonToolResult,
+  CreateClientOptions,
+  LLMProvider,
+  LLMRequestAdapter,
+  LLMResponseAdapter,
+  LLMStreamAdapter,
+  StreamAccumulatorState,
+  ToolCompressionStats,
+  UsageView,
+} from "@/types";
+import { estimateMessagesSize } from "@/utils/message-size";
+import {
+  estimateToolResultContentLength,
+  previewToolResultContent,
+} from "@/utils/tool-result-preview";
+import { MockOpenAIClient } from "../mock-openai-client";
+import {
+  doesModelSupportImages,
+  hasImageContent,
+  isImageTooLarge,
+  isMcpImageBlock,
+} from "../utils/mcp-image";
+import { stripBrowserToolsResults } from "../utils/summarize-tool-results";
+import { unwrapToolContent } from "../utils/unwrap-tool-content";
+
+// =============================================================================
+// TYPE ALIASES
+// =============================================================================
+
+type MiniMaxRequest = MiniMax.Types.ChatCompletionsRequest;
+type MiniMaxResponse = MiniMax.Types.ChatCompletionsResponse;
+type MiniMaxMessages = MiniMax.Types.ChatCompletionsRequest["messages"];
+type MiniMaxHeaders = MiniMax.Types.ChatCompletionsHeaders;
+type MiniMaxStreamChunk = MiniMax.Types.ChatCompletionChunk;
+
+type MiniMaxToolResultImageBlock = {
+  type: "image_url";
+  image_url: {
+    url: string;
+    detail?: "auto" | "low" | "high";
+  };
+};
+
+type MiniMaxToolResultTextBlock = {
+  type: "text";
+  text: string;
+};
+
+type MiniMaxToolResultContentBlock =
+  | MiniMaxToolResultImageBlock
+  | MiniMaxToolResultTextBlock;
+
+type MiniMaxToolResultContent = string | MiniMaxToolResultContentBlock[];
+
+// =============================================================================
+// REQUEST ADAPTER
+// =============================================================================
+
+class MiniMaxRequestAdapter
+  implements LLMRequestAdapter<MiniMaxRequest, MiniMaxMessages>
+{
+  readonly provider = "minimax" as const;
+  private request: MiniMaxRequest;
+  private modifiedModel: string | null = null;
+  private toolResultUpdates: Record<string, string> = {};
+
+  constructor(request: MiniMaxRequest) {
+    this.request = request;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Read Access
+  // ---------------------------------------------------------------------------
+
+  getModel(): string {
+    return this.modifiedModel ?? this.request.model;
+  }
+
+  isStreaming(): boolean {
+    return this.request.stream === true;
+  }
+
+  getMessages(): CommonMessage[] {
+    return this.toCommonFormat(this.request.messages);
+  }
+
+  getToolResults(): CommonToolResult[] {
+    const results: CommonToolResult[] = [];
+
+    for (const message of this.request.messages) {
+      if (message.role === "tool") {
+        const toolName = this.findToolNameInMessages(
+          this.request.messages,
+          message.tool_call_id,
+        );
+
+        let content: unknown;
+        if (typeof message.content === "string") {
+          try {
+            content = JSON.parse(message.content);
+          } catch {
+            content = message.content;
+          }
+        } else {
+          content = message.content;
+        }
+
+        results.push({
+          id: message.tool_call_id,
+          name: toolName ?? "unknown",
+          content,
+          isError: false,
+        });
+      }
+    }
+
+    return results;
+  }
+
+  getTools(): CommonMcpToolDefinition[] {
+    if (!this.request.tools) return [];
+
+    const result: CommonMcpToolDefinition[] = [];
+    for (const tool of this.request.tools) {
+      if (tool.type === "function") {
+        result.push({
+          name: tool.function.name,
+          description: tool.function.description,
+          inputSchema: tool.function.parameters as Record<string, unknown>,
+        });
+      }
+    }
+    return result;
+  }
+
+  hasTools(): boolean {
+    return (this.request.tools?.length ?? 0) > 0;
+  }
+
+  getProviderMessages(): MiniMaxMessages {
+    return this.request.messages;
+  }
+
+  getOriginalRequest(): MiniMaxRequest {
+    return this.request;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Modify Access
+  // ---------------------------------------------------------------------------
+
+  setModel(model: string): void {
+    this.modifiedModel = model;
+  }
+
+  updateToolResult(toolCallId: string, newContent: string): void {
+    this.toolResultUpdates[toolCallId] = newContent;
+  }
+
+  applyToolResultUpdates(updates: Record<string, string>): void {
+    Object.assign(this.toolResultUpdates, updates);
+  }
+
+  async applyToonCompression(model: string): Promise<ToolCompressionStats> {
+    const { messages: compressedMessages, stats } =
+      await convertToolResultsToToon(this.request.messages, model);
+    this.request = {
+      ...this.request,
+      messages: compressedMessages,
+    };
+    return stats;
+  }
+
+  convertToolResultContent(messages: MiniMaxMessages): MiniMaxMessages {
+    const model = this.getModel();
+    const modelSupportsImages = doesModelSupportImages(model);
+    let toolMessagesWithImages = 0;
+    let strippedImageCount = 0;
+
+    // First, analyze all tool messages to understand what we're dealing with
+    for (const message of messages) {
+      if (message.role === "tool") {
+        const contentLength = estimateToolResultContentLength(message.content);
+        const contentSizeKB = Math.round(contentLength.length / 1024);
+        const contentPatternSample = previewToolResultContent(
+          message.content,
+          2000,
+        );
+        const contentPreview = contentPatternSample.slice(0, 200);
+
+        // Check for base64 patterns in preview to avoid full serialization.
+        const hasBase64 =
+          contentPatternSample.includes("data:image") ||
+          contentPatternSample.includes('"type":"image"') ||
+          contentPatternSample.includes('"data":"');
+
+        // Find tool name from previous assistant message
+        const toolName = this.findToolNameInMessages(
+          messages,
+          message.tool_call_id,
+        );
+
+        logger.info(
+          {
+            toolCallId: message.tool_call_id,
+            toolName,
+            contentSizeKB,
+            hasBase64,
+            contentLengthEstimated: contentLength.isEstimated,
+            isArray: Array.isArray(message.content),
+            contentPreview,
+          },
+          "[MiniMaxAdapter] Analyzing tool result content",
+        );
+
+        // If it's an array, analyze each item
+        if (Array.isArray(message.content)) {
+          for (const [idx, item] of message.content.entries()) {
+            if (typeof item === "object" && item !== null) {
+              const itemType = (item as Record<string, unknown>).type;
+              const itemLength = estimateToolResultContentLength(item);
+              logger.info(
+                {
+                  toolCallId: message.tool_call_id,
+                  itemIndex: idx,
+                  itemType,
+                  itemSizeKB: Math.round(itemLength.length / 1024),
+                  itemLengthEstimated: itemLength.isEstimated,
+                  isMcpImage: isMcpImageBlock(item),
+                },
+                "[MiniMaxAdapter] Tool result array item",
+              );
+            }
+          }
+        }
+      }
+    }
+
+    const result = messages.map((message) => {
+      if (message.role !== "tool") {
+        return message;
+      }
+
+      // Check if this tool message contains images
+      if (!hasImageContent(message.content)) {
+        return message;
+      }
+
+      // If model doesn't support images, strip image blocks from content
+      if (!modelSupportsImages) {
+        strippedImageCount++;
+        const strippedContent = stripImageBlocksFromContent(message.content);
+        return {
+          ...message,
+          content: strippedContent,
+        };
+      }
+
+      // Model supports images - convert MCP image blocks to MiniMax format
+      const convertedContent = convertMcpImageBlocksToMiniMax(message.content);
+      if (!convertedContent) {
+        return message;
+      }
+
+      toolMessagesWithImages++;
+      return {
+        ...message,
+        content: convertedContent,
+      };
+    });
+
+    if (toolMessagesWithImages > 0 || strippedImageCount > 0) {
+      logger.info(
+        {
+          model,
+          modelSupportsImages,
+          totalMessages: messages.length,
+          toolMessagesWithImages,
+          strippedImageCount,
+        },
+        "[MiniMaxAdapter] Processed tool messages with image content",
+      );
+    }
+
+    return result;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Build Modified Request
+  // ---------------------------------------------------------------------------
+
+  toProviderRequest(): MiniMaxRequest {
+    let messages = this.request.messages;
+
+    if (Object.keys(this.toolResultUpdates).length > 0) {
+      messages = this.applyUpdates(messages, this.toolResultUpdates);
+    }
+
+    if (config.features.browserStreamingEnabled) {
+      messages = this.convertToolResultContent(messages);
+      const sizeBeforeStrip = estimateMessagesSize(messages);
+      messages = stripBrowserToolsResults(messages);
+      const sizeAfterStrip = estimateMessagesSize(messages);
+
+      if (sizeBeforeStrip.length !== sizeAfterStrip.length) {
+        logger.info(
+          {
+            sizeBeforeKB: Math.round(sizeBeforeStrip.length / 1024),
+            sizeAfterKB: Math.round(sizeAfterStrip.length / 1024),
+            savedKB: Math.round(
+              (sizeBeforeStrip.length - sizeAfterStrip.length) / 1024,
+            ),
+          },
+          "[MiniMaxAdapter] Stripped browser tool results from messages",
+        );
+      }
+    }
+
+    return {
+      ...this.request,
+      model: this.getModel(),
+      messages,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private Helpers
+  // ---------------------------------------------------------------------------
+
+  private findToolNameInMessages(
+    messages: MiniMaxMessages,
+    toolCallId: string,
+  ): string | null {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+
+      if (message.role === "assistant" && message.tool_calls) {
+        for (const toolCall of message.tool_calls) {
+          if (toolCall.id === toolCallId) {
+            if (toolCall.type === "function") {
+              return toolCall.function.name;
+            } else {
+              return toolCall.custom.name;
+            }
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private toCommonFormat(messages: MiniMaxMessages): CommonMessage[] {
+    logger.debug(
+      { messageCount: messages.length },
+      "[MiniMaxAdapter] toCommonFormat: starting conversion",
+    );
+    const commonMessages: CommonMessage[] = [];
+
+    for (const message of messages) {
+      const commonMessage: CommonMessage = {
+        role: message.role as CommonMessage["role"],
+      };
+
+      // Handle tool messages (tool results)
+      if (message.role === "tool") {
+        const toolName = this.findToolNameInMessages(
+          messages,
+          message.tool_call_id,
+        );
+
+        if (toolName) {
+          logger.debug(
+            { toolCallId: message.tool_call_id, toolName },
+            "[MiniMaxAdapter] toCommonFormat: found tool message",
+          );
+          let toolResult: unknown;
+          if (typeof message.content === "string") {
+            try {
+              toolResult = JSON.parse(message.content);
+            } catch {
+              toolResult = message.content;
+            }
+          } else {
+            toolResult = message.content;
+          }
+
+          commonMessage.toolCalls = [
+            {
+              id: message.tool_call_id,
+              name: toolName,
+              content: toolResult,
+              isError: false,
+            },
+          ];
+        }
+      }
+
+      commonMessages.push(commonMessage);
+    }
+
+    logger.debug(
+      { inputCount: messages.length, outputCount: commonMessages.length },
+      "[MiniMaxAdapter] toCommonFormat: conversion complete",
+    );
+    return commonMessages;
+  }
+
+  private applyUpdates(
+    messages: MiniMaxMessages,
+    updates: Record<string, string>,
+  ): MiniMaxMessages {
+    const updateCount = Object.keys(updates).length;
+    logger.debug(
+      { messageCount: messages.length, updateCount },
+      "[MiniMaxAdapter] applyUpdates: starting",
+    );
+
+    if (updateCount === 0) {
+      logger.debug("[MiniMaxAdapter] applyUpdates: no updates to apply");
+      return messages;
+    }
+
+    let appliedCount = 0;
+    const result = messages.map((message) => {
+      if (message.role === "tool" && updates[message.tool_call_id]) {
+        appliedCount++;
+        logger.debug(
+          { toolCallId: message.tool_call_id },
+          "[MiniMaxAdapter] applyUpdates: applying update to tool message",
+        );
+        return {
+          ...message,
+          content: updates[message.tool_call_id],
+        };
+      }
+      return message;
+    });
+
+    logger.debug(
+      { updateCount, appliedCount },
+      "[MiniMaxAdapter] applyUpdates: complete",
+    );
+    return result;
+  }
+}
+
+// =============================================================================
+// IMAGE CONVERSION HELPERS
+// =============================================================================
+
+function convertMcpImageBlocksToMiniMax(
+  content: unknown,
+): MiniMaxToolResultContent | null {
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  if (!hasImageContent(content)) {
+    return null;
+  }
+
+  const minimaxContent: MiniMaxToolResultContentBlock[] = [];
+  const imageTooLargePlaceholder = "[Image omitted due to size]";
+
+  for (const item of content) {
+    if (typeof item !== "object" || item === null) continue;
+    const candidate = item as Record<string, unknown>;
+
+    if (isMcpImageBlock(item)) {
+      const mimeType = item.mimeType ?? "image/png";
+      const base64Length = typeof item.data === "string" ? item.data.length : 0;
+      const estimatedSizeKB = Math.round((base64Length * 3) / 4 / 1024);
+      const shouldStripImage = isImageTooLarge(item);
+
+      if (shouldStripImage) {
+        logger.info(
+          {
+            mimeType,
+            base64Length,
+            estimatedSizeKB,
+          },
+          "[MiniMaxAdapter] Stripping MCP image block due to size limit",
+        );
+        minimaxContent.push({
+          type: "text",
+          text: imageTooLargePlaceholder,
+        });
+        continue;
+      }
+
+      logger.info(
+        {
+          mimeType,
+          base64Length,
+          estimatedSizeKB,
+          estimatedBase64Tokens: Math.round(base64Length / 4),
+        },
+        "[MiniMaxAdapter] Converting MCP image block to MiniMax format",
+      );
+
+      minimaxContent.push({
+        type: "image_url",
+        image_url: {
+          url: `data:${mimeType};base64,${item.data}`,
+        },
+      });
+    } else if (candidate.type === "text" && "text" in candidate) {
+      minimaxContent.push({
+        type: "text",
+        text:
+          typeof candidate.text === "string"
+            ? candidate.text
+            : JSON.stringify(candidate),
+      });
+    }
+  }
+
+  logger.info(
+    {
+      totalBlocks: minimaxContent.length,
+      imageBlocks: minimaxContent.filter((b) => b.type === "image_url").length,
+      textBlocks: minimaxContent.filter((b) => b.type === "text").length,
+    },
+    "[MiniMaxAdapter] Converted MCP content to MiniMax format",
+  );
+
+  return minimaxContent.length > 0 ? minimaxContent : null;
+}
+
+/**
+ * Strip image blocks from MCP content when model doesn't support images.
+ * Keeps text blocks and replaces image blocks with a placeholder message.
+ */
+function stripImageBlocksFromContent(content: unknown): string {
+  if (!Array.isArray(content)) {
+    return typeof content === "string" ? content : JSON.stringify(content);
+  }
+
+  const textParts: string[] = [];
+  let imageCount = 0;
+
+  for (const item of content) {
+    if (typeof item !== "object" || item === null) continue;
+    const candidate = item as Record<string, unknown>;
+
+    if (isMcpImageBlock(item)) {
+      imageCount++;
+    } else if (candidate.type === "text" && "text" in candidate) {
+      textParts.push(
+        typeof candidate.text === "string"
+          ? candidate.text
+          : JSON.stringify(candidate.text),
+      );
+    }
+  }
+
+  // Add placeholder for stripped images
+  if (imageCount > 0) {
+    textParts.push(
+      `[${imageCount} image(s) removed - model does not support image inputs]`,
+    );
+    logger.info(
+      { imageCount },
+      "[MiniMaxAdapter] Stripped image blocks from tool result",
+    );
+  }
+
+  return textParts.join("\n");
+}
+
+// =============================================================================
+// RESPONSE ADAPTER
+// =============================================================================
+
+class MiniMaxResponseAdapter implements LLMResponseAdapter<MiniMaxResponse> {
+  readonly provider = "minimax" as const;
+  private response: MiniMaxResponse;
+
+  constructor(response: MiniMaxResponse) {
+    this.response = response;
+  }
+
+  getId(): string {
+    return this.response.id;
+  }
+
+  getModel(): string {
+    return this.response.model;
+  }
+
+  getText(): string {
+    const choice = this.response.choices[0];
+    if (!choice) return "";
+    return choice.message.content ?? "";
+  }
+
+  getToolCalls(): CommonToolCall[] {
+    const choice = this.response.choices[0];
+    if (!choice?.message.tool_calls) return [];
+
+    return choice.message.tool_calls.map((toolCall) => {
+      let name: string;
+      let args: Record<string, unknown>;
+
+      if (toolCall.type === "function" && toolCall.function) {
+        name = toolCall.function.name;
+        try {
+          args = JSON.parse(toolCall.function.arguments);
+        } catch {
+          args = {};
+        }
+      } else if (toolCall.type === "custom" && toolCall.custom) {
+        name = toolCall.custom.name;
+        try {
+          args = JSON.parse(toolCall.custom.input);
+        } catch {
+          args = {};
+        }
+      } else {
+        name = "unknown";
+        args = {};
+      }
+
+      return {
+        id: toolCall.id,
+        name,
+        arguments: args,
+      };
+    });
+  }
+
+  hasToolCalls(): boolean {
+    const choice = this.response.choices[0];
+    return (choice?.message.tool_calls?.length ?? 0) > 0;
+  }
+
+  getUsage(): UsageView {
+    return {
+      inputTokens: this.response.usage?.prompt_tokens ?? 0,
+      outputTokens: this.response.usage?.completion_tokens ?? 0,
+    };
+  }
+
+  getOriginalResponse(): MiniMaxResponse {
+    return this.response;
+  }
+
+  toRefusalResponse(
+    _refusalMessage: string,
+    contentMessage: string,
+  ): MiniMaxResponse {
+    return {
+      ...this.response,
+      choices: [
+        {
+          ...this.response.choices[0],
+          message: {
+            role: "assistant",
+            content: contentMessage,
+            refusal: null,
+          },
+          finish_reason: "stop",
+        },
+      ],
+    };
+  }
+}
+
+// =============================================================================
+// STREAM ADAPTER
+// =============================================================================
+
+class MiniMaxStreamAdapter
+  implements LLMStreamAdapter<MiniMaxStreamChunk, MiniMaxResponse>
+{
+  readonly provider = "minimax" as const;
+  readonly state: StreamAccumulatorState;
+  private currentToolCallIndices = new Map<number, number>();
+
+  constructor() {
+    this.state = {
+      responseId: "",
+      model: "",
+      text: "",
+      toolCalls: [],
+      rawToolCallEvents: [],
+      usage: null,
+      stopReason: null,
+      timing: {
+        startTime: Date.now(),
+        firstChunkTime: null,
+      },
+    };
+  }
+
+  processChunk(chunk: MiniMaxStreamChunk): ChunkProcessingResult {
+    if (this.state.timing.firstChunkTime === null) {
+      this.state.timing.firstChunkTime = Date.now();
+    }
+
+    let sseData: string | null = null;
+    let isToolCallChunk = false;
+    let isFinal = false;
+
+    this.state.responseId = chunk.id;
+    this.state.model = chunk.model;
+
+    // Handle usage first
+    if (chunk.usage) {
+      this.state.usage = {
+        inputTokens: chunk.usage.prompt_tokens ?? 0,
+        outputTokens: chunk.usage.completion_tokens ?? 0,
+      };
+    }
+
+    const choice = chunk.choices[0];
+    if (!choice) {
+      return {
+        sseData: null,
+        isToolCallChunk: false,
+        isFinal: this.state.usage !== null,
+      };
+    }
+
+    const delta = choice.delta;
+
+    // Handle text content
+    if (delta.content) {
+      this.state.text += delta.content;
+      sseData = `data: ${JSON.stringify(chunk)}
+
+`;
+    }
+
+    // Handle tool calls
+    if (delta.tool_calls) {
+      for (const toolCallDelta of delta.tool_calls) {
+        const index = toolCallDelta.index;
+
+        if (!this.currentToolCallIndices.has(index)) {
+          this.currentToolCallIndices.set(index, this.state.toolCalls.length);
+          this.state.toolCalls.push({
+            id: toolCallDelta.id ?? "",
+            name: toolCallDelta.function?.name ?? "",
+            arguments: "",
+          });
+        }
+
+        const toolCallIndex = this.currentToolCallIndices.get(index);
+        if (toolCallIndex === undefined) continue;
+        const toolCall = this.state.toolCalls[toolCallIndex];
+
+        if (toolCallDelta.id) {
+          toolCall.id = toolCallDelta.id;
+        }
+        if (toolCallDelta.function?.name) {
+          toolCall.name = toolCallDelta.function.name;
+        }
+        if (toolCallDelta.function?.arguments) {
+          toolCall.arguments += toolCallDelta.function.arguments;
+        }
+      }
+
+      this.state.rawToolCallEvents.push(chunk);
+      isToolCallChunk = true;
+    }
+
+    // Handle finish reason
+    if (choice.finish_reason) {
+      this.state.stopReason = choice.finish_reason;
+    }
+
+    // Mark as final after we've received usage data
+    if (this.state.usage !== null) {
+      isFinal = true;
+    }
+
+    return { sseData, isToolCallChunk, isFinal };
+  }
+
+  getSSEHeaders(): Record<string, string> {
+    return {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    };
+  }
+
+  formatTextDeltaSSE(text: string): string {
+    const chunk: MiniMaxStreamChunk = {
+      id: this.state.responseId,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            content: text,
+          },
+          finish_reason: null,
+        },
+      ],
+    };
+    return `data: ${JSON.stringify(chunk)}
+
+`;
+  }
+
+  getRawToolCallEvents(): string[] {
+    return this.state.rawToolCallEvents.map(
+      (event) => `data: ${JSON.stringify(event)}
+
+`,
+    );
+  }
+
+  formatCompleteTextSSE(text: string): string[] {
+    const chunk: MiniMaxStreamChunk = {
+      id: this.state.responseId || `chatcmpl-${Date.now()}`,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            role: "assistant",
+            content: text,
+          },
+          finish_reason: null,
+        },
+      ],
+    };
+    return [`data: ${JSON.stringify(chunk)}
+
+`];
+  }
+
+  formatEndSSE(): string {
+    const finalChunk: MiniMaxStreamChunk = {
+      id: this.state.responseId,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          delta: {},
+          finish_reason:
+            (this.state.stopReason as "stop" | "tool_calls") ?? "stop",
+        },
+      ],
+    };
+    return `data: ${JSON.stringify(finalChunk)}
+
+data: [DONE]
+
+`;
+  }
+
+  toProviderResponse(): MiniMaxResponse {
+    const toolCalls =
+      this.state.toolCalls.length > 0
+        ? this.state.toolCalls.map((tc) => ({
+            id: tc.id,
+            type: "function" as const,
+            function: {
+              name: tc.name,
+              arguments: tc.arguments,
+            },
+          }))
+        : undefined;
+
+    return {
+      id: this.state.responseId,
+      object: "chat.completion",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: this.state.text || null,
+            refusal: null,
+            tool_calls: toolCalls,
+          },
+          logprobs: null,
+          finish_reason:
+            (this.state.stopReason as MiniMax.Types.FinishReason) ?? "stop",
+        },
+      ],
+      usage: {
+        prompt_tokens: this.state.usage?.inputTokens ?? 0,
+        completion_tokens: this.state.usage?.outputTokens ?? 0,
+        total_tokens:
+          (this.state.usage?.inputTokens ?? 0) +
+          (this.state.usage?.outputTokens ?? 0),
+      },
+    };
+  }
+}
+
+// =============================================================================
+// TOON COMPRESSION
+// =============================================================================
+
+async function convertToolResultsToToon(
+  messages: MiniMaxMessages,
+  model: string,
+): Promise<{
+  messages: MiniMaxMessages;
+  stats: ToolCompressionStats;
+}> {
+  // Use tiktoken tokenizer (same as OpenAI) for MiniMax
+  const tokenizer = getTokenizer("minimax");
+  let toolResultCount = 0;
+  let totalTokensBefore = 0;
+  let totalTokensAfter = 0;
+
+  const result = messages.map((message) => {
+    if (message.role === "tool") {
+      logger.info(
+        {
+          toolCallId: message.tool_call_id,
+          contentType: typeof message.content,
+          provider: "minimax",
+        },
+        "convertToolResultsToToon: tool message found",
+      );
+
+      if (typeof message.content === "string") {
+        try {
+          const unwrapped = unwrapToolContent(message.content);
+          const parsed = JSON.parse(unwrapped);
+          const noncompressed = unwrapped;
+          const compressed = toonEncode(parsed);
+
+          const tokensBefore = tokenizer.countTokens([
+            { role: "user", content: noncompressed },
+          ]);
+          const tokensAfter = tokenizer.countTokens([
+            { role: "user", content: compressed },
+          ]);
+
+          toolResultCount++;
+
+          // Always count tokens before
+          totalTokensBefore += tokensBefore;
+
+          // Only apply compression if it actually saves tokens
+          if (tokensAfter < tokensBefore) {
+            totalTokensAfter += tokensAfter;
+
+            logger.info(
+              {
+                toolCallId: message.tool_call_id,
+                beforeLength: noncompressed.length,
+                afterLength: compressed.length,
+                tokensBefore,
+                tokensAfter,
+                toonPreview: compressed.substring(0, 150),
+                provider: "minimax",
+              },
+              "convertToolResultsToToon: compressed",
+            );
+
+            return {
+              ...message,
+              content: compressed,
+            };
+          }
+
+          // Compression not applied - count non-compressed tokens to track total tokens anyway
+          totalTokensAfter += tokensBefore;
+          logger.info(
+            {
+              toolCallId: message.tool_call_id,
+              tokensBefore,
+              tokensAfter,
+              provider: "minimax",
+            },
+            "Skipping TOON compression - compressed output has more tokens",
+          );
+        } catch {
+          logger.info(
+            {
+              toolCallId: message.tool_call_id,
+              contentPreview:
+                typeof message.content === "string"
+                  ? message.content.substring(0, 100)
+                  : "non-string",
+            },
+            "Skipping TOON conversion - content is not JSON",
+          );
+          return message;
+        }
+      }
+    }
+
+    return message;
+  });
+
+  logger.info(
+    { messageCount: messages.length, toolResultCount },
+    "convertToolResultsToToon completed",
+  );
+
+  let toonCostSavings = 0;
+  const tokensSaved = totalTokensBefore - totalTokensAfter;
+  if (tokensSaved > 0) {
+    const tokenPrice = await TokenPriceModel.findByModel(model);
+    if (tokenPrice) {
+      const inputPricePerToken =
+        Number(tokenPrice.pricePerMillionInput) / 1000000;
+      toonCostSavings = tokensSaved * inputPricePerToken;
+    }
+  }
+
+  return {
+    messages: result,
+    stats: {
+      tokensBefore: totalTokensBefore,
+      tokensAfter: totalTokensAfter,
+      costSavings: toonCostSavings,
+      wasEffective: totalTokensAfter < totalTokensBefore,
+      hadToolResults: toolResultCount > 0,
+    },
+  };
+}
+
+// =============================================================================
+// ADAPTER FACTORY
+// =============================================================================
+
+export const minimaxAdapterFactory: LLMProvider<
+  MiniMaxRequest,
+  MiniMaxResponse,
+  MiniMaxMessages,
+  MiniMaxStreamChunk,
+  MiniMaxHeaders
+> = {
+  provider: "minimax",
+  interactionType: "minimax:chatCompletions",
+
+  createRequestAdapter(
+    request: MiniMaxRequest,
+  ): LLMRequestAdapter<MiniMaxRequest, MiniMaxMessages> {
+    return new MiniMaxRequestAdapter(request);
+  },
+
+  createResponseAdapter(
+    response: MiniMaxResponse,
+  ): LLMResponseAdapter<MiniMaxResponse> {
+    return new MiniMaxResponseAdapter(response);
+  },
+
+  createStreamAdapter(): LLMStreamAdapter<
+    MiniMaxStreamChunk,
+    MiniMaxResponse
+  > {
+    return new MiniMaxStreamAdapter();
+  },
+
+  extractApiKey(headers: MiniMaxHeaders): string | undefined {
+    // Return the authorization header as-is (same as OpenAI)
+    return headers.authorization;
+  },
+
+  getBaseUrl(): string | undefined {
+    return config.llm.minimax.baseUrl;
+  },
+
+  getSpanName(_streaming: boolean): string {
+    return "minimax.chat.completions";
+  },
+
+  createClient(
+    apiKey: string | undefined,
+    options?: CreateClientOptions,
+  ): OpenAIProvider {
+    if (options?.mockMode) {
+      return new MockOpenAIClient() as unknown as OpenAIProvider;
+    }
+
+    // Use observable fetch for request duration metrics if agent is provided
+    const customFetch = options?.agent
+      ? getObservableFetch("minimax", options.agent, options.externalAgentId)
+      : undefined;
+
+    // Use OpenAI SDK with MiniMax base URL (OpenAI-compatible API)
+    return new OpenAIProvider({
+      apiKey,
+      baseURL: options?.baseUrl,
+      fetch: customFetch,
+    });
+  },
+
+  async execute(
+    client: unknown,
+    request: MiniMaxRequest,
+  ): Promise<MiniMaxResponse> {
+    const minimaxClient = client as OpenAIProvider;
+    const minimaxRequest = {
+      ...request,
+      stream: false,
+    } as unknown as ChatCompletionCreateParamsNonStreaming;
+    return minimaxClient.chat.completions.create(
+      minimaxRequest,
+    ) as Promise<MiniMaxResponse>;
+  },
+
+  async executeStream(
+    client: unknown,
+    request: MiniMaxRequest,
+  ): Promise<AsyncIterable<MiniMaxStreamChunk>> {
+    const minimaxClient = client as OpenAIProvider;
+    const minimaxRequest = {
+      ...request,
+      stream: true,
+      stream_options: { include_usage: true },
+    } as unknown as ChatCompletionCreateParamsStreaming;
+    const stream =
+      await minimaxClient.chat.completions.create(minimaxRequest);
+
+    return {
+      [Symbol.asyncIterator]: async function* () {
+        for await (const chunk of stream) {
+          yield chunk as MiniMaxStreamChunk;
+        }
+      },
+    };
+  },
+
+  extractErrorMessage(error: unknown): string {
+    // OpenAI SDK error structure (same for MiniMax)
+    const openaiMessage = get(error, "error.message");
+    if (typeof openaiMessage === "string") {
+      return openaiMessage;
+    }
+
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return "Internal server error";
+  },
+};

--- a/platform/backend/src/routes/proxy/routesv2/minimax.ts
+++ b/platform/backend/src/routes/proxy/routesv2/minimax.ts
@@ -1,0 +1,182 @@
+/**
+ * MiniMax LLM Proxy Routes - OpenAI-compatible
+ *
+ * MiniMax uses an OpenAI-compatible API at https://api.minimax.ai/v1
+ * This module registers proxy routes for MiniMax chat completions.
+ *
+ * @see https://console.minimax.com/docs/api-reference
+ */
+import fastifyHttpProxy from "@fastify/http-proxy";
+import { RouteId } from "@shared";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import config from "@/config";
+import logger from "@/logging";
+import { MiniMax, constructResponseSchema, UuidIdSchema } from "@/types";
+import { minimaxAdapterFactory } from "../adapterV2";
+import { PROXY_API_PREFIX, PROXY_BODY_LIMIT } from "../common";
+import { handleLLMProxy } from "../llm-proxy-handler";
+import * as utils from "../utils";
+
+const minimaxProxyRoutesV2: FastifyPluginAsyncZod = async (fastify) => {
+  const API_PREFIX = `${PROXY_API_PREFIX}/minimax`;
+  const CHAT_COMPLETIONS_SUFFIX = "/chat/completions";
+
+  logger.info("[UnifiedProxy] Registering unified MiniMax routes");
+
+  /**
+   * Register HTTP proxy for MiniMax routes
+   * Chat completions are handled separately with full agent support
+   */
+  await fastify.register(fastifyHttpProxy, {
+    upstream: config.llm.minimax.baseUrl,
+    prefix: API_PREFIX,
+    rewritePrefix: "",
+    preHandler: (request, _reply, next) => {
+      // Skip chat/completions - handled by custom handler below
+      if (
+        request.method === "POST" &&
+        request.url.includes(CHAT_COMPLETIONS_SUFFIX)
+      ) {
+        logger.info(
+          {
+            method: request.method,
+            url: request.url,
+            action: "skip-proxy",
+            reason: "handled-by-custom-handler",
+          },
+          "MiniMax proxy preHandler: skipping chat/completions route",
+        );
+        next(new Error("skip"));
+        return;
+      }
+
+      // Check if URL has UUID segment that needs stripping
+      const pathAfterPrefix = request.url.replace(API_PREFIX, "");
+      const uuidMatch = pathAfterPrefix.match(
+        /^\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(\/.*)?$/i,
+      );
+
+      if (uuidMatch) {
+        // Strip UUID: /v1/minimax/:uuid/path -> /v1/minimax/path
+        const remainingPath = uuidMatch[2] || "";
+        const originalUrl = request.raw.url;
+        request.raw.url = `${API_PREFIX}${remainingPath}`;
+
+        logger.info(
+          {
+            method: request.method,
+            originalUrl,
+            rewrittenUrl: request.raw.url,
+            upstream: config.llm.minimax.baseUrl,
+            finalProxyUrl: `${config.llm.minimax.baseUrl}${remainingPath}`,
+          },
+          "MiniMax proxy preHandler: URL rewritten (UUID stripped)",
+        );
+      } else {
+        logger.info(
+          {
+            method: request.method,
+            url: request.url,
+            upstream: config.llm.minimax.baseUrl,
+            finalProxyUrl: `${config.llm.minimax.baseUrl}${pathAfterPrefix}`,
+          },
+          "MiniMax proxy preHandler: proxying request",
+        );
+      }
+
+      next();
+    },
+  });
+
+  /**
+   * Chat completions with default agent
+   */
+  fastify.post(
+    `${API_PREFIX}${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        operationId: RouteId.MiniMaxChatCompletionsWithDefaultAgent,
+        description:
+          "Create a chat completion with MiniMax (uses default agent)",
+        tags: ["llm-proxy"],
+        body: MiniMax.API.ChatCompletionRequestSchema,
+        headers: MiniMax.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(
+          MiniMax.API.ChatCompletionResponseSchema,
+        ),
+      },
+    },
+    async (request, reply) => {
+      logger.debug(
+        { url: request.url },
+        "[UnifiedProxy] Handling MiniMax request (default agent)",
+      );
+      const externalAgentId = utils.externalAgentId.getExternalAgentId(
+        request.headers,
+      );
+      const userId = (await utils.user.getUser(request.headers))?.userId;
+      return handleLLMProxy(
+        request.body,
+        request.headers,
+        reply,
+        minimaxAdapterFactory,
+        {
+          organizationId: request.organizationId,
+          agentId: undefined,
+          externalAgentId,
+          userId,
+        },
+      );
+    },
+  );
+
+  /**
+   * Chat completions with specific agent
+   */
+  fastify.post(
+    `${API_PREFIX}/:agentId${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        operationId: RouteId.MiniMaxChatCompletionsWithAgent,
+        description:
+          "Create a chat completion with MiniMax for a specific agent",
+        tags: ["llm-proxy"],
+        params: z.object({
+          agentId: UuidIdSchema,
+        }),
+        body: MiniMax.API.ChatCompletionRequestSchema,
+        headers: MiniMax.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(
+          MiniMax.API.ChatCompletionResponseSchema,
+        ),
+      },
+    },
+    async (request, reply) => {
+      logger.debug(
+        { url: request.url, agentId: request.params.agentId },
+        "[UnifiedProxy] Handling MiniMax request (with agent)",
+      );
+      const externalAgentId = utils.externalAgentId.getExternalAgentId(
+        request.headers,
+      );
+      const userId = (await utils.user.getUser(request.headers))?.userId;
+      return handleLLMProxy(
+        request.body,
+        request.headers,
+        reply,
+        minimaxAdapterFactory,
+        {
+          organizationId: request.organizationId,
+          agentId: request.params.agentId,
+          externalAgentId,
+          userId,
+        },
+      );
+    },
+  );
+};
+
+export default minimaxProxyRoutesV2;

--- a/platform/backend/src/routes/proxy/utils/cost-optimization.ts
+++ b/platform/backend/src/routes/proxy/utils/cost-optimization.ts
@@ -12,6 +12,7 @@ import type {
   Cerebras,
   Cohere,
   Gemini,
+  MiniMax,
   Mistral,
   OpenAi,
   Vllm,
@@ -21,6 +22,7 @@ import type {
 type ProviderMessages = {
   anthropic: Anthropic.Types.MessagesRequest["messages"];
   cerebras: Cerebras.Types.ChatCompletionsRequest["messages"];
+  minimax: MiniMax.Types.ChatCompletionsRequest["messages"];
   cohere: Cohere.Types.ChatRequest["messages"];
   gemini: Gemini.Types.GenerateContentRequest["contents"];
   mistral: Mistral.Types.ChatCompletionsRequest["messages"];

--- a/platform/backend/src/tokenizers/index.ts
+++ b/platform/backend/src/tokenizers/index.ts
@@ -15,6 +15,7 @@ const tokenizerFactories: Record<SupportedProvider, () => Tokenizer> = {
   anthropic: () => new AnthropicTokenizer(),
   openai: () => new TiktokenTokenizer(),
   cerebras: () => new TiktokenTokenizer(),
+  minimax: () => new TiktokenTokenizer(),
   cohere: () => new TiktokenTokenizer(),
   mistral: () => new TiktokenTokenizer(),
   vllm: () => new TiktokenTokenizer(),

--- a/platform/backend/src/types/chat-api-key.ts
+++ b/platform/backend/src/types/chat-api-key.ts
@@ -14,6 +14,7 @@ export const SupportedChatProviderSchema = z.enum([
   "cerebras",
   "cohere",
   "gemini",
+  "minimax",
   "mistral",
   "openai",
   "vllm",

--- a/platform/backend/src/types/interaction.ts
+++ b/platform/backend/src/types/interaction.ts
@@ -8,6 +8,7 @@ import {
   Cerebras,
   Cohere,
   Gemini,
+  MiniMax,
   Mistral,
   Ollama,
   OpenAi,
@@ -31,6 +32,7 @@ export const InteractionRequestSchema = z.union([
   Anthropic.API.MessagesRequestSchema,
   Bedrock.API.ConverseRequestSchema,
   Cerebras.API.ChatCompletionRequestSchema,
+  MiniMax.API.ChatCompletionRequestSchema,
   Mistral.API.ChatCompletionRequestSchema,
   Vllm.API.ChatCompletionRequestSchema,
   Ollama.API.ChatCompletionRequestSchema,
@@ -44,6 +46,7 @@ export const InteractionResponseSchema = z.union([
   Anthropic.API.MessagesResponseSchema,
   Bedrock.API.ConverseResponseSchema,
   Cerebras.API.ChatCompletionResponseSchema,
+  MiniMax.API.ChatCompletionResponseSchema,
   Mistral.API.ChatCompletionResponseSchema,
   Vllm.API.ChatCompletionResponseSchema,
   Ollama.API.ChatCompletionResponseSchema,
@@ -115,6 +118,16 @@ export const SelectInteractionSchema = z.discriminatedUnion("type", [
     processedRequest:
       Cerebras.API.ChatCompletionRequestSchema.nullable().optional(),
     response: Cerebras.API.ChatCompletionResponseSchema,
+    requestType: RequestTypeSchema.optional(),
+    /** Resolved prompt name if externalAgentId matches a prompt ID */
+    externalAgentIdLabel: z.string().nullable().optional(),
+  }),
+  BaseSelectInteractionSchema.extend({
+    type: z.enum(["minimax:chatCompletions"]),
+    request: MiniMax.API.ChatCompletionRequestSchema,
+    processedRequest:
+      MiniMax.API.ChatCompletionRequestSchema.nullable().optional(),
+    response: MiniMax.API.ChatCompletionResponseSchema,
     requestType: RequestTypeSchema.optional(),
     /** Resolved prompt name if externalAgentId matches a prompt ID */
     externalAgentIdLabel: z.string().nullable().optional(),

--- a/platform/backend/src/types/llm-providers/index.ts
+++ b/platform/backend/src/types/llm-providers/index.ts
@@ -3,6 +3,7 @@ export { default as Bedrock } from "./bedrock";
 export { default as Cerebras } from "./cerebras";
 export { default as Cohere } from "./cohere";
 export { default as Gemini } from "./gemini";
+export { default as MiniMax } from "./minimax";
 export { default as Mistral } from "./mistral";
 export { default as Ollama } from "./ollama";
 export { default as OpenAi } from "./openai";

--- a/platform/backend/src/types/llm-providers/minimax/api.ts
+++ b/platform/backend/src/types/llm-providers/minimax/api.ts
@@ -1,0 +1,82 @@
+/**
+ * MiniMax API schemas
+ *
+ * MiniMax uses an OpenAI-compatible API with minor differences:
+ * - Base URL: https://api.minimax.com/openai/v1
+ * - Supports tool_calls with parallel_tool_calls parameter
+ * - Uses x_minimax field in responses for MiniMax-specific metadata
+ *
+ * @see https://console.minimax.com/docs/api-reference#chat-create
+ */
+import { z } from "zod";
+
+import { ToolCallSchema } from "./messages";
+
+// Re-export schemas that are identical to OpenAI
+export {
+  ChatCompletionRequestSchema,
+  ChatCompletionsHeadersSchema,
+  ChatCompletionUsageSchema,
+  FinishReasonSchema,
+} from "../openai/api";
+
+import { ChatCompletionUsageSchema, FinishReasonSchema } from "../openai/api";
+
+/**
+ * MiniMax-specific Choice schema
+ *
+ * Differs from OpenAI: content is optional (can be omitted when tool_calls present)
+ * @see https://console.minimax.com/docs/api-reference#chat-create
+ */
+const MiniMaxChoiceSchema = z
+  .object({
+    finish_reason: FinishReasonSchema,
+    index: z.number(),
+    logprobs: z.any().nullable(),
+    message: z
+      .object({
+        content: z.string().nullable().optional(),
+        refusal: z.string().nullable().optional(),
+        role: z.enum(["assistant"]),
+        annotations: z.array(z.any()).optional(),
+        audio: z.any().nullable().optional(),
+        function_call: z
+          .object({
+            arguments: z.string(),
+            name: z.string(),
+          })
+          .nullable()
+          .optional(),
+        tool_calls: z.array(ToolCallSchema).optional(),
+      })
+      .describe(
+        `https://console.minimax.com/docs/api-reference#chat-create`,
+      ),
+  })
+  .describe(
+    `https://console.minimax.com/docs/api-reference#chat-create`,
+  );
+
+/**
+ * MiniMax-specific ChatCompletionResponse schema
+ *
+ * Includes x_minimax field for MiniMax-specific metadata (request ID, etc.)
+ */
+export const ChatCompletionResponseSchema = z
+  .object({
+    id: z.string(),
+    choices: z.array(MiniMaxChoiceSchema),
+    created: z.number(),
+    model: z.string(),
+    object: z.enum(["chat.completion"]),
+    system_fingerprint: z.string().nullable().optional(),
+    usage: ChatCompletionUsageSchema.optional(),
+    x_minimax: z
+      .object({
+        id: z.string().optional(),
+      })
+      .optional(),
+  })
+  .describe(
+    `https://console.minimax.com/docs/api-reference#chat-create`,
+  );

--- a/platform/backend/src/types/llm-providers/minimax/index.ts
+++ b/platform/backend/src/types/llm-providers/minimax/index.ts
@@ -1,0 +1,42 @@
+/**
+ * MiniMax LLM Provider Types - OpenAI-compatible
+ *
+ * MiniMax uses an OpenAI-compatible API at https://api.minimax.com/openai/v1
+ * We re-export OpenAI schemas with MiniMax-specific namespace for type safety.
+ *
+ * @see https://console.minimax.com/docs/api-reference
+ */
+import type OpenAIProvider from "openai";
+import type { z } from "zod";
+import * as MiniMaxAPI from "./api";
+import * as MiniMaxMessages from "./messages";
+import * as MiniMaxTools from "./tools";
+
+namespace MiniMax {
+  export const API = MiniMaxAPI;
+  export const Messages = MiniMaxMessages;
+  export const Tools = MiniMaxTools;
+
+  export namespace Types {
+    export type ChatCompletionsHeaders = z.infer<
+      typeof MiniMaxAPI.ChatCompletionsHeadersSchema
+    >;
+    export type ChatCompletionsRequest = z.infer<
+      typeof MiniMaxAPI.ChatCompletionRequestSchema
+    >;
+    export type ChatCompletionsResponse = z.infer<
+      typeof MiniMaxAPI.ChatCompletionResponseSchema
+    >;
+    export type Usage = z.infer<typeof MiniMaxAPI.ChatCompletionUsageSchema>;
+
+    export type FinishReason = z.infer<typeof MiniMaxAPI.FinishReasonSchema>;
+    export type Message = z.infer<typeof MiniMaxMessages.MessageParamSchema>;
+    export type Role = Message["role"];
+
+    // Use OpenAI's stream chunk type since MiniMax is OpenAI-compatible
+    export type ChatCompletionChunk =
+      OpenAIProvider.Chat.Completions.ChatCompletionChunk;
+  }
+}
+
+export default MiniMax;

--- a/platform/backend/src/types/llm-providers/minimax/messages.ts
+++ b/platform/backend/src/types/llm-providers/minimax/messages.ts
@@ -1,0 +1,7 @@
+/**
+ * MiniMax message schemas - OpenAI-compatible
+ *
+ * MiniMax uses an OpenAI-compatible API, so we re-export OpenAI schemas.
+ * @see https://console.minimax.com/docs/api-reference#chat-create
+ */
+export { MessageParamSchema, ToolCallSchema } from "../openai/messages";

--- a/platform/backend/src/types/llm-providers/minimax/tools.ts
+++ b/platform/backend/src/types/llm-providers/minimax/tools.ts
@@ -1,0 +1,11 @@
+/**
+ * MiniMax tool schemas - OpenAI-compatible
+ *
+ * MiniMax uses an OpenAI-compatible API, so we re-export OpenAI schemas.
+ * @see https://console.minimax.com/docs/api-reference#chat-create
+ */
+export {
+  FunctionDefinitionParametersSchema,
+  ToolChoiceOptionSchema,
+  ToolSchema,
+} from "../openai/tools";

--- a/platform/frontend/src/components/chat-api-key-form.tsx
+++ b/platform/frontend/src/components/chat-api-key-form.tsx
@@ -92,6 +92,14 @@ const PROVIDER_CONFIG: Record<
     consoleUrl: "https://cloud.cerebras.ai/platform",
     consoleName: "Cerebras Cloud",
   },
+  minimax: {
+    name: "MiniMax",
+    icon: "/icons/minimax.png",
+    placeholder: "gsk_...",
+    enabled: true,
+    consoleUrl: "https://console.minimax.com/keys",
+    consoleName: "MiniMax Console",
+  },
   cohere: {
     name: "Cohere",
     icon: "/icons/cohere.png",

--- a/platform/frontend/src/components/chat/model-selector.tsx
+++ b/platform/frontend/src/components/chat/model-selector.tsx
@@ -97,6 +97,7 @@ const providerToLogoProvider: Record<SupportedProvider, string> = {
   gemini: "google",
   bedrock: "amazon-bedrock",
   cerebras: "cerebras",
+  minimax: "minimax",
   cohere: "cohere",
   mistral: "mistral",
   vllm: "vllm",

--- a/platform/frontend/src/components/proxy-connection-instructions.tsx
+++ b/platform/frontend/src/components/proxy-connection-instructions.tsx
@@ -40,6 +40,10 @@ const PROVIDER_CONFIG: Record<
     label: providerDisplayNames.cerebras,
     originalUrl: "https://api.cerebras.ai/v1/",
   },
+  minimax: {
+    label: providerDisplayNames.minimax,
+    originalUrl: "https://api.minimax.chat/v1/",
+  },
   mistral: {
     label: providerDisplayNames.mistral,
     originalUrl: "https://api.mistral.ai/v1/",

--- a/platform/frontend/src/lib/interaction.utils.ts
+++ b/platform/frontend/src/lib/interaction.utils.ts
@@ -4,6 +4,7 @@ import AnthropicMessagesInteraction from "./llmProviders/anthropic";
 import BedrockConverseInteraction from "./llmProviders/bedrock";
 import CerebrasChatCompletionInteraction from "./llmProviders/cerebras";
 import CohereChatInteraction from "./llmProviders/cohere";
+import MiniMaxChatCompletionInteraction from "./llmProviders/minimax";
 import type {
   DualLlmResult,
   Interaction,
@@ -130,6 +131,8 @@ export class DynamicInteraction implements InteractionUtils {
       return new ZhipuaiChatCompletionInteraction(interaction);
     } else if (type === "cerebras:chatCompletions") {
       return new CerebrasChatCompletionInteraction(interaction);
+    } else if (type === "minimax:chatCompletions") {
+      return new MiniMaxChatCompletionInteraction(interaction);
     } else if (type === "mistral:chatCompletions") {
       return new MistralChatCompletionInteraction(interaction);
     } else if (type === "vllm:chatCompletions") {

--- a/platform/frontend/src/lib/llmProviders/minimax.ts
+++ b/platform/frontend/src/lib/llmProviders/minimax.ts
@@ -1,0 +1,12 @@
+/**
+ * MiniMax LLM Provider Interaction Handler
+ *
+ * MiniMax uses an OpenAI-compatible API, so we re-export the OpenAI interaction handler.
+ * @see https://console.minimax.com/docs/api-reference
+ */
+import OpenAiChatCompletionInteraction from "./openai";
+
+// MiniMax uses the same request/response format as OpenAI
+class MiniMaxChatCompletionInteraction extends OpenAiChatCompletionInteraction {}
+
+export default MiniMaxChatCompletionInteraction;

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -6262,6 +6262,7 @@ export type PostV1A2aByAgentIdResponses = {
         error?: {
             code: number;
             message: string;
+            data?: unknown;
         };
     };
 };
@@ -12039,7 +12040,7 @@ export type GetChatApiKeysResponses = {
         id: string;
         organizationId: string;
         name: string;
-        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'minimax' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
         secretId: string | null;
         scope: 'personal' | 'team' | 'org_wide';
         userId: string | null;
@@ -12062,7 +12063,7 @@ export type GetChatApiKeysResponse = GetChatApiKeysResponses[keyof GetChatApiKey
 export type CreateChatApiKeyData = {
     body: {
         name: string;
-        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'minimax' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
         apiKey?: string;
         scope?: 'personal' | 'team' | 'org_wide';
         teamId?: string;
@@ -12141,7 +12142,7 @@ export type CreateChatApiKeyResponses = {
         id: string;
         organizationId: string;
         name: string;
-        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'minimax' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
         secretId: string | null;
         scope: 'personal' | 'team' | 'org_wide';
         userId: string | null;
@@ -12158,7 +12159,7 @@ export type GetAvailableChatApiKeysData = {
     body?: never;
     path?: never;
     query?: {
-        provider?: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
+        provider?: 'anthropic' | 'bedrock' | 'cerebras' | 'minimax' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
         includeKeyId?: string;
     };
     url: '/api/chat-api-keys/available';
@@ -12231,7 +12232,7 @@ export type GetAvailableChatApiKeysResponses = {
         id: string;
         organizationId: string;
         name: string;
-        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'minimax' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
         secretId: string | null;
         scope: 'personal' | 'team' | 'org_wide';
         userId: string | null;
@@ -12406,7 +12407,7 @@ export type GetChatApiKeyResponses = {
         id: string;
         organizationId: string;
         name: string;
-        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'minimax' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
         secretId: string | null;
         scope: 'personal' | 'team' | 'org_wide';
         userId: string | null;
@@ -12509,7 +12510,7 @@ export type UpdateChatApiKeyResponses = {
         id: string;
         organizationId: string;
         name: string;
-        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'minimax' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
         secretId: string | null;
         scope: 'personal' | 'team' | 'org_wide';
         userId: string | null;
@@ -12526,7 +12527,7 @@ export type GetChatModelsData = {
     body?: never;
     path?: never;
     query?: {
-        provider?: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
+        provider?: 'anthropic' | 'bedrock' | 'cerebras' | 'minimax' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
     };
     url: '/api/chat/models';
 };
@@ -12597,7 +12598,7 @@ export type GetChatModelsResponses = {
     200: Array<{
         id: string;
         displayName: string;
-        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'minimax' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
         createdAt?: string;
         capabilities?: {
             contextLength: number | null;
@@ -12762,7 +12763,7 @@ export type GetModelsWithApiKeysResponses = {
     200: Array<{
         id: string;
         externalId: string;
-        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'minimax' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
         modelId: string;
         description: string | null;
         contextLength: number | null;
@@ -12946,7 +12947,7 @@ export type GetChatConversationsResponses = {
         chatApiKeyId: string | null;
         title: string | null;
         selectedModel: string;
-        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
+        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'minimax' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
         hasCustomToolSelection: boolean;
         todoList: string | number | boolean | null | {
             [key: string]: unknown;
@@ -12973,7 +12974,7 @@ export type CreateChatConversationData = {
         agentId: string;
         title?: string | null;
         selectedModel?: string;
-        selectedProvider?: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
+        selectedProvider?: 'anthropic' | 'bedrock' | 'cerebras' | 'minimax' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
         chatApiKeyId?: string | null;
     };
     path?: never;
@@ -13052,7 +13053,7 @@ export type CreateChatConversationResponses = {
         chatApiKeyId: string | null;
         title: string | null;
         selectedModel: string;
-        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
+        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'minimax' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
         hasCustomToolSelection: boolean;
         todoList: string | number | boolean | null | {
             [key: string]: unknown;
@@ -13233,7 +13234,7 @@ export type GetChatConversationResponses = {
         chatApiKeyId: string | null;
         title: string | null;
         selectedModel: string;
-        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
+        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'minimax' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
         hasCustomToolSelection: boolean;
         todoList: string | number | boolean | null | {
             [key: string]: unknown;
@@ -13259,7 +13260,7 @@ export type UpdateChatConversationData = {
     body?: {
         title?: string | null;
         selectedModel?: string;
-        selectedProvider?: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
+        selectedProvider?: 'anthropic' | 'bedrock' | 'cerebras' | 'minimax' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
         chatApiKeyId?: string | null;
         agentId?: string;
         artifact?: string | null;
@@ -13342,7 +13343,7 @@ export type UpdateChatConversationResponses = {
         chatApiKeyId: string | null;
         title: string | null;
         selectedModel: string;
-        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
+        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'minimax' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
         hasCustomToolSelection: boolean;
         todoList: string | number | boolean | null | {
             [key: string]: unknown;
@@ -13612,7 +13613,7 @@ export type GenerateChatConversationTitleResponses = {
         chatApiKeyId: string | null;
         title: string | null;
         selectedModel: string;
-        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
+        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'minimax' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
         hasCustomToolSelection: boolean;
         todoList: string | number | boolean | null | {
             [key: string]: unknown;
@@ -13718,7 +13719,7 @@ export type UpdateChatMessageResponses = {
         chatApiKeyId: string | null;
         title: string | null;
         selectedModel: string;
-        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
+        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'minimax' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'vllm' | 'ollama' | 'zhipuai';
         hasCustomToolSelection: boolean;
         todoList: string | number | boolean | null | {
             [key: string]: unknown;
@@ -16554,6 +16555,30 @@ export type GetInteractionsResponses = {
             userId: string | null;
             sessionId: string | null;
             sessionSource: string | null;
+            request: OpenAiChatCompletionRequest;
+            processedRequest?: OpenAiChatCompletionRequest | null;
+            response: OpenAiChatCompletionResponse;
+            type: 'minimax:chatCompletions';
+            model: string | null;
+            baselineModel: string | null;
+            inputTokens: number | null;
+            outputTokens: number | null;
+            baselineCost: string | null;
+            cost: string | null;
+            toonTokensBefore: number | null;
+            toonTokensAfter: number | null;
+            toonCostSavings: string | null;
+            toonSkipReason: string | null;
+            createdAt: string;
+            requestType?: 'main' | 'subagent';
+            externalAgentIdLabel?: string | null;
+        } | {
+            id: string;
+            profileId: string;
+            externalAgentId: string | null;
+            userId: string | null;
+            sessionId: string | null;
+            sessionSource: string | null;
             request: MistralChatCompletionRequest;
             processedRequest?: MistralChatCompletionRequest | null;
             response: MistralChatCompletionResponse;
@@ -17520,6 +17545,30 @@ export type GetInteractionResponses = {
         processedRequest?: MistralChatCompletionRequest | null;
         response: CerebrasChatCompletionResponse;
         type: 'cerebras:chatCompletions';
+        model: string | null;
+        baselineModel: string | null;
+        inputTokens: number | null;
+        outputTokens: number | null;
+        baselineCost: string | null;
+        cost: string | null;
+        toonTokensBefore: number | null;
+        toonTokensAfter: number | null;
+        toonCostSavings: string | null;
+        toonSkipReason: string | null;
+        createdAt: string;
+        requestType?: 'main' | 'subagent';
+        externalAgentIdLabel?: string | null;
+    } | {
+        id: string;
+        profileId: string;
+        externalAgentId: string | null;
+        userId: string | null;
+        sessionId: string | null;
+        sessionSource: string | null;
+        request: OpenAiChatCompletionRequest;
+        processedRequest?: OpenAiChatCompletionRequest | null;
+        response: OpenAiChatCompletionResponse;
+        type: 'minimax:chatCompletions';
         model: string | null;
         baselineModel: string | null;
         inputTokens: number | null;
@@ -22691,7 +22740,7 @@ export type GetOptimizationRulesResponses = {
         } | {
             hasTools: boolean;
         }>;
-        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'minimax' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
         targetModel: string;
         enabled: boolean;
         createdAt: string;
@@ -22711,7 +22760,7 @@ export type CreateOptimizationRuleData = {
         } | {
             hasTools: boolean;
         }>;
-        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'minimax' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
         targetModel: string;
         enabled?: boolean;
         createdAt?: unknown;
@@ -22794,7 +22843,7 @@ export type CreateOptimizationRuleResponses = {
         } | {
             hasTools: boolean;
         }>;
-        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'minimax' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
         targetModel: string;
         enabled: boolean;
         createdAt: string;
@@ -22893,7 +22942,7 @@ export type UpdateOptimizationRuleData = {
         } | {
             hasTools: boolean;
         }>;
-        provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
+        provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'minimax' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
         targetModel?: string;
         enabled?: boolean;
         createdAt?: unknown;
@@ -22978,7 +23027,7 @@ export type UpdateOptimizationRuleResponses = {
         } | {
             hasTools: boolean;
         }>;
-        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'minimax' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
         targetModel: string;
         enabled: boolean;
         createdAt: string;
@@ -25656,7 +25705,7 @@ export type GetTokenPricesResponses = {
      */
     200: Array<{
         id: string;
-        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'minimax' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
         model: string;
         pricePerMillionInput: string;
         pricePerMillionOutput: string;
@@ -25669,7 +25718,7 @@ export type GetTokenPricesResponse = GetTokenPricesResponses[keyof GetTokenPrice
 
 export type CreateTokenPriceData = {
     body: {
-        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'minimax' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
         model: string;
         pricePerMillionInput: string;
         pricePerMillionOutput: string;
@@ -25744,7 +25793,7 @@ export type CreateTokenPriceResponses = {
      */
     200: {
         id: string;
-        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'minimax' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
         model: string;
         pricePerMillionInput: string;
         pricePerMillionOutput: string;
@@ -25908,7 +25957,7 @@ export type GetTokenPriceResponses = {
      */
     200: {
         id: string;
-        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'minimax' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
         model: string;
         pricePerMillionInput: string;
         pricePerMillionOutput: string;
@@ -25921,7 +25970,7 @@ export type GetTokenPriceResponse = GetTokenPriceResponses[keyof GetTokenPriceRe
 
 export type UpdateTokenPriceData = {
     body?: {
-        provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
+        provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'minimax' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
         model?: string;
         pricePerMillionInput?: string;
         pricePerMillionOutput?: string;
@@ -25998,7 +26047,7 @@ export type UpdateTokenPriceResponses = {
      */
     200: {
         id: string;
-        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'minimax' | 'mistral' | 'vllm' | 'ollama' | 'zhipuai';
         model: string;
         pricePerMillionInput: string;
         pricePerMillionOutput: string;

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -10,6 +10,7 @@ export const SupportedProvidersSchema = z.enum([
   "bedrock",
   "cohere",
   "cerebras",
+  "minimax",
   "mistral",
   "vllm",
   "ollama",
@@ -23,6 +24,7 @@ export const SupportedProvidersDiscriminatorSchema = z.enum([
   "bedrock:converse",
   "cohere:chat",
   "cerebras:chatCompletions",
+  "minimax:chatCompletions",
   "mistral:chatCompletions",
   "vllm:chatCompletions",
   "ollama:chatCompletions",
@@ -42,6 +44,7 @@ export const providerDisplayNames: Record<SupportedProvider, string> = {
   gemini: "Gemini",
   cohere: "Cohere",
   cerebras: "Cerebras",
+  minimax: "MiniMax",
   mistral: "Mistral AI",
   vllm: "vLLM",
   ollama: "Ollama",
@@ -81,6 +84,10 @@ export const MODEL_MARKER_PATTERNS: Record<
   cerebras: {
     fastest: ["llama-3.3-70b"],
     best: ["llama-3.3-70b"],
+  },
+  minimax: {
+    fastest: ["llama-3.1-8b", "gemma2-9b"],
+    best: ["llama-3.3-70b", "llama-3.1-70b", "mixtral-8x7b"],
   },
   cohere: {
     fastest: ["command-light"],

--- a/platform/shared/routes.ts
+++ b/platform/shared/routes.ts
@@ -167,6 +167,11 @@ export const RouteId = {
     "cerebrasChatCompletionsWithDefaultAgent",
   CerebrasChatCompletionsWithAgent: "cerebrasChatCompletionsWithAgent",
 
+  // Proxy Routes - MiniMax
+  MiniMaxChatCompletionsWithDefaultAgent:
+    "minimaxChatCompletionsWithDefaultAgent",
+  MiniMaxChatCompletionsWithAgent: "minimaxChatCompletionsWithAgent",
+
   // Proxy Routes - Mistral
   MistralChatCompletionsWithDefaultAgent:
     "mistralChatCompletionsWithDefaultAgent",


### PR DESCRIPTION
## [Provider] Add MiniMax support

Closes #1855

### Summary
Adds full MiniMax LLM provider support. OpenAI-compatible API.

### API Key
Get key at https://www.minimaxi.com/platform

### Env Vars
- `ARCHESTRA_MINIMAX_BASE_URL` (default: https://api.minimax.chat/v1)
- `ARCHESTRA_CHAT_MINIMAX_API_KEY`

### Type Check
All packages: 0 errors ✅