### PR TITLE
fix: remove incorrect Bearer prefix from API key auth docs

### DIFF
--- a/docs/pages/platform-api-reference.md
+++ b/docs/pages/platform-api-reference.md
@@ -20,7 +20,7 @@ To authenticate with the Archestra Platform API, you'll need an API key:
 Include the API key in your requests using the `Authorization` header:
 
 ```bash
-curl -H "Authorization: Bearer YOUR_API_KEY" \
+curl -H "Authorization: YOUR_API_KEY" \
   http://localhost:9000/api/agents
 ```
 


### PR DESCRIPTION
## Summary
- The API reference docs incorrectly showed `Authorization: Bearer YOUR_API_KEY` — Archestra API keys should be passed directly as `Authorization: YOUR_API_KEY` (no Bearer prefix)
- Using `Bearer` causes a `401 Unauthenticated` error

## Test plan
- [x] Verified `Authorization: archestra_...` returns 200
- [x] Verified `Authorization: Bearer archestra_...` returns 401