### PR TITLE
fix: make triage bot comments mandatory before closing

### DIFF
--- a/.claude/commands/triage-issue.md
+++ b/.claude/commands/triage-issue.md
@@ -26,24 +26,26 @@ $ARGUMENTS
    - `documentation` - Documentation improvements or corrections
    - `question` - Legitimate technical questions (if complex enough to warrant an issue)
 
-## Response format
+## IMPORTANT: You MUST always leave a comment
 
-When commenting on the issue:
+**Every issue MUST receive a comment via `mcp__github__create_issue_comment` before any other action (labeling, closing, etc.).** Never close or label an issue without commenting first.
 
 ### If closing as low-quality:
-Be polite but direct. Explain why the issue doesn't meet quality standards. Suggest what information would be needed to reopen. Example:
-"Thanks for reporting this. I'm closing this issue because [reason]. If you can provide [missing info], please reopen with those details."
+You MUST use `mcp__github__create_issue_comment` to post a comment BEFORE closing. Be polite but direct. Explain why the issue doesn't meet quality standards. Suggest what information would be needed to reopen. Example:
+"Thanks for reporting this. I'm closing this issue because [reason]. If you can provide [missing info], please feel free to reopen with those details."
 
 ### If closing as duplicate:
+You MUST use `mcp__github__create_issue_comment` to post a comment BEFORE closing. Example:
 "This appears to be a duplicate of #NNN. Please follow that issue for updates. If your case is different, please reopen with details about how it differs."
 
 ### If valid:
-Add labels only. Do not comment unless there's something specific to clarify.
+You MUST use `mcp__github__create_issue_comment` to acknowledge the issue. Example:
+"Thanks for reporting this! I've labeled this issue for the team to review."
 
 ## Tools to use
 - `mcp__github__get_issue` - Get issue details
 - `mcp__github__search_issues` - Search for duplicates
 - `mcp__github__list_issues` - List recent issues if needed
-- `mcp__github__create_issue_comment` - Add comments
-- `mcp__github__update_issue` - Add labels, close issues
+- `mcp__github__create_issue_comment` - ALWAYS use this to comment before any other action
+- `mcp__github__update_issue` - Add labels, close issues (AFTER commenting)
 - `mcp__github__get_issue_comments` - Check existing comments

--- a/.claude/commands/triage-pr.md
+++ b/.claude/commands/triage-pr.md
@@ -15,7 +15,7 @@ $ARGUMENTS
 - PR modifies only CI/workflow files without prior discussion
 
 ### Bounty claim PRs:
-If the PR title or description contains "bounty" or the PR has a bounty-related label (e.g. "Bounty claim"), it MUST include a demo video (a link to a video, gif, or screen recording) showcasing the feature or fix. If no demo video is present, close the PR with:
+If the PR title or description contains "bounty" or the PR has a bounty-related label (e.g. "Bounty claim"), it MUST include a demo video (a link to a video, gif, or screen recording) showcasing the feature or fix. If no demo video is present, close the PR with a comment explaining:
 "This PR is a bounty claim but doesn't include a demo video. All bounty claims must include a video/gif/screen recording demonstrating the feature or fix. Please reopen with a demo attached."
 
 ### LLM provider PRs:
@@ -32,21 +32,32 @@ If the PR adds or modifies an LLM provider (e.g. changes files under `backend/sr
 
 6. If the PR is valid and high-quality, leave a brief welcoming comment.
 
-## Response format
+## IMPORTANT: You MUST always leave a comment
+
+**Every PR MUST receive a comment via `mcp__github__create_issue_comment` before any other action (labeling, closing, etc.).** Never close or label a PR without commenting first.
 
 ### If closing as low-quality:
-Be polite but direct. Example:
+You MUST use `mcp__github__create_issue_comment` to post a comment BEFORE closing. Be polite but direct. Example:
 "Thanks for your interest in contributing! I'm closing this PR because [reason]. If you'd like to contribute, please open an issue first to discuss the change."
 
+### If closing as bounty claim without video:
+You MUST use `mcp__github__create_issue_comment` to post a comment BEFORE closing. Example:
+"This PR is a bounty claim but doesn't include a demo video. All bounty claims must include a video/gif/screen recording demonstrating the feature or fix. Please reopen with a demo attached."
+
 ### If valid but missing issue reference:
+You MUST use `mcp__github__create_issue_comment` to post a comment. Example:
 "Thanks for the PR! Could you please link this to a related issue? If there isn't one, please create an issue first describing the problem or feature."
+
+### If valid:
+You MUST use `mcp__github__create_issue_comment` to acknowledge the PR. Example:
+"Thanks for the contribution! I've labeled this PR for the team to review."
 
 ## Tools to use
 - `mcp__github__get_pull_request` - Get PR details
 - `mcp__github__list_pull_requests` - List recent PRs if needed
 - `mcp__github__search_issues` - Search for related issues
 - `mcp__github__create_pull_request_review` - Leave a review
-- `mcp__github__create_issue_comment` - Add comments
-- `mcp__github__update_pull_request` - Add labels, close PRs
+- `mcp__github__create_issue_comment` - ALWAYS use this to comment before any other action
+- `mcp__github__update_pull_request` - Add labels, close PRs (AFTER commenting)
 - `mcp__github__get_pull_request_diff` - View PR diff
 - `mcp__github__get_pull_request_files` - View changed files


### PR DESCRIPTION
## Summary

The triage bot was closing/labeling issues and PRs without leaving comments explaining why. Updated both triage commands to make commenting **mandatory** before any other action.

## Changes

- Added `## IMPORTANT: You MUST always leave a comment` section to both `triage-issue.md` and `triage-pr.md`
- Every scenario (low-quality, duplicate, bounty without video, valid) now explicitly requires `mcp__github__create_issue_comment` BEFORE labeling/closing
- Tool list annotations updated to reinforce the ordering: comment first, then act