### PR TITLE
fix: use correct GitHub MCP tool name for issue comments

### DIFF
--- a/.claude/commands/triage-issue.md
+++ b/.claude/commands/triage-issue.md
@@ -28,24 +28,24 @@ $ARGUMENTS
 
 ## IMPORTANT: You MUST always leave a comment
 
-**Every issue MUST receive a comment via `mcp__github__create_issue_comment` before any other action (labeling, closing, etc.).** Never close or label an issue without commenting first.
+**Every issue MUST receive a comment via `mcp__github__add_issue_comment` before any other action (labeling, closing, etc.).** Never close or label an issue without commenting first.
 
 ### If closing as low-quality:
-You MUST use `mcp__github__create_issue_comment` to post a comment BEFORE closing. Be polite but direct. Explain why the issue doesn't meet quality standards. Suggest what information would be needed to reopen. Example:
+You MUST use `mcp__github__add_issue_comment` to post a comment BEFORE closing. Be polite but direct. Explain why the issue doesn't meet quality standards. Suggest what information would be needed to reopen. Example:
 "Thanks for reporting this. I'm closing this issue because [reason]. If you can provide [missing info], please feel free to reopen with those details."
 
 ### If closing as duplicate:
-You MUST use `mcp__github__create_issue_comment` to post a comment BEFORE closing. Example:
+You MUST use `mcp__github__add_issue_comment` to post a comment BEFORE closing. Example:
 "This appears to be a duplicate of #NNN. Please follow that issue for updates. If your case is different, please reopen with details about how it differs."
 
 ### If valid:
-You MUST use `mcp__github__create_issue_comment` to acknowledge the issue. Example:
+You MUST use `mcp__github__add_issue_comment` to acknowledge the issue. Example:
 "Thanks for reporting this! I've labeled this issue for the team to review."
 
 ## Tools to use
 - `mcp__github__get_issue` - Get issue details
 - `mcp__github__search_issues` - Search for duplicates
 - `mcp__github__list_issues` - List recent issues if needed
-- `mcp__github__create_issue_comment` - ALWAYS use this to comment before any other action
+- `mcp__github__add_issue_comment` - ALWAYS use this to comment before any other action
 - `mcp__github__update_issue` - Add labels, close issues (AFTER commenting)
 - `mcp__github__get_issue_comments` - Check existing comments

--- a/.claude/commands/triage-pr.md
+++ b/.claude/commands/triage-pr.md
@@ -34,22 +34,22 @@ If the PR adds or modifies an LLM provider (e.g. changes files under `backend/sr
 
 ## IMPORTANT: You MUST always leave a comment
 
-**Every PR MUST receive a comment via `mcp__github__create_issue_comment` before any other action (labeling, closing, etc.).** Never close or label a PR without commenting first.
+**Every PR MUST receive a comment via `mcp__github__add_issue_comment` before any other action (labeling, closing, etc.).** Never close or label a PR without commenting first.
 
 ### If closing as low-quality:
-You MUST use `mcp__github__create_issue_comment` to post a comment BEFORE closing. Be polite but direct. Example:
+You MUST use `mcp__github__add_issue_comment` to post a comment BEFORE closing. Be polite but direct. Example:
 "Thanks for your interest in contributing! I'm closing this PR because [reason]. If you'd like to contribute, please open an issue first to discuss the change."
 
 ### If closing as bounty claim without video:
-You MUST use `mcp__github__create_issue_comment` to post a comment BEFORE closing. Example:
+You MUST use `mcp__github__add_issue_comment` to post a comment BEFORE closing. Example:
 "This PR is a bounty claim but doesn't include a demo video. All bounty claims must include a video/gif/screen recording demonstrating the feature or fix. Please reopen with a demo attached."
 
 ### If valid but missing issue reference:
-You MUST use `mcp__github__create_issue_comment` to post a comment. Example:
+You MUST use `mcp__github__add_issue_comment` to post a comment. Example:
 "Thanks for the PR! Could you please link this to a related issue? If there isn't one, please create an issue first describing the problem or feature."
 
 ### If valid:
-You MUST use `mcp__github__create_issue_comment` to acknowledge the PR. Example:
+You MUST use `mcp__github__add_issue_comment` to acknowledge the PR. Example:
 "Thanks for the contribution! I've labeled this PR for the team to review."
 
 ## Tools to use
@@ -57,7 +57,7 @@ You MUST use `mcp__github__create_issue_comment` to acknowledge the PR. Example:
 - `mcp__github__list_pull_requests` - List recent PRs if needed
 - `mcp__github__search_issues` - Search for related issues
 - `mcp__github__create_pull_request_review` - Leave a review
-- `mcp__github__create_issue_comment` - ALWAYS use this to comment before any other action
+- `mcp__github__add_issue_comment` - ALWAYS use this to comment before any other action
 - `mcp__github__update_pull_request` - Add labels, close PRs (AFTER commenting)
 - `mcp__github__get_pull_request_diff` - View PR diff
 - `mcp__github__get_pull_request_files` - View changed files

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -57,4 +57,4 @@ jobs:
 
           # Restrict to GitHub MCP tools only - no file editing or bash
           claude_args: |
-            --allowedTools "mcp__github__get_issue,mcp__github__search_issues,mcp__github__list_issues,mcp__github__create_issue_comment,mcp__github__update_issue,mcp__github__get_issue_comments"
+            --allowedTools "mcp__github__get_issue,mcp__github__search_issues,mcp__github__list_issues,mcp__github__add_issue_comment,mcp__github__update_issue,mcp__github__get_issue_comments"

--- a/.github/workflows/claude-pr-triage.yml
+++ b/.github/workflows/claude-pr-triage.yml
@@ -57,4 +57,4 @@ jobs:
 
           # Restrict to GitHub MCP tools only - no file editing or bash
           claude_args: |
-            --allowedTools "mcp__github__get_pull_request,mcp__github__list_pull_requests,mcp__github__search_issues,mcp__github__create_pull_request_review,mcp__github__create_issue_comment,mcp__github__update_pull_request,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files"
+            --allowedTools "mcp__github__get_pull_request,mcp__github__list_pull_requests,mcp__github__search_issues,mcp__github__create_pull_request_review,mcp__github__add_issue_comment,mcp__github__update_pull_request,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files"


### PR DESCRIPTION
## Summary

The triage bot was closing issues/PRs without commenting because of a tool name mismatch. The GitHub MCP server exposes `mcp__github__add_issue_comment`, but we had `mcp__github__create_issue_comment` in both the workflow allowlists and the command files.

The logs showed `permission_denials` for every comment attempt - Claude tried the right tool but it wasn't in the allowlist.

## Test plan
- [ ] Re-test with new issues/PRs from external accounts