### PR TITLE
fix: backport a2a executor model name fix

### DIFF
--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -30,6 +30,7 @@ import { ApiError, type SupportedChatProvider } from "@/types";
 export type LLMModel = Parameters<typeof streamText>[0]["model"];
 
 /**
+ * @deprecated DO NOT USE THIS FUNCTION FOR NEW CODE.
  * Detect which provider a model belongs to based on its name
  * It's a recommended to rely on explicit provider selection whenever possible,
  * Since same models could be served by different providers.


### PR DESCRIPTION
## Summary
- Backports commit 2c917c40 from `hotfix/a2a-executor` to `main`
- Fixes a2a executor to not rely on model name

## Test plan
- [ ] Verify a2a executor works correctly without model name dependency