### PR TITLE
fix: correct misleading error message for block_always tool policy

### DIFF
--- a/platform/backend/src/models/tool-invocation-policy.ts
+++ b/platform/backend/src/models/tool-invocation-policy.ts
@@ -473,8 +473,7 @@ class ToolInvocationPolicyModel {
       if (!isContextTrusted) {
         return {
           isAllowed: false,
-          reason:
-            NO_POLICY_UNTRUSTED_REASON,
+          reason: NO_POLICY_UNTRUSTED_REASON,
           toolCallName,
         };
       }


### PR DESCRIPTION
## Summary
- Fixed `block_always` action in the default policies branch using wrong fallback reason ("context contains untrusted data" instead of a block-always-specific message)
- Extracted all policy rejection messages into constants to prevent similar copy-paste bugs

Related: #2731