### PR TITLE
feat: add x.ai (Grok) provider support

### DIFF
--- a/platform/backend/src/agents/subagents/policy-config-subagent.ts
+++ b/platform/backend/src/agents/subagents/policy-config-subagent.ts
@@ -304,4 +304,5 @@ const PROVIDER_TO_DISCRIMINATOR: Record<
   vllm: "vllm:chatCompletions",
   ollama: "ollama:chatCompletions",
   zhipuai: "zhipuai:chatCompletions",
+  grok: "grok:chatCompletions",
 };

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -64,6 +64,9 @@ export function detectProviderFromModel(model: string): SupportedChatProvider {
   if (lowerModel.includes("glm") || lowerModel.includes("chatglm")) {
     return "zhipuai";
   }
+  if (lowerModel.includes("grok") || lowerModel.includes("llama") || lowerModel.includes("mixtral") || lowerModel.includes("gemma")) {
+    return "grok";
+  }
 
   // Default to anthropic for backwards compatibility
   // Note: vLLM and Ollama cannot be auto-detected as they can serve any model
@@ -88,6 +91,7 @@ const envApiKeyGetters: Record<
   openai: () => config.chat.openai.apiKey,
   vllm: () => config.chat.vllm.apiKey,
   zhipuai: () => config.chat.zhipuai.apiKey,
+  grok: () => config.chat.grok.apiKey,
 };
 
 /**
@@ -145,6 +149,7 @@ export async function resolveProviderApiKey(params: {
       secret?.secret?.geminiApiKey ??
       secret?.secret?.openaiApiKey ??
       secret?.secret?.zhipuaiApiKey ??
+      secret?.secret?.grokApiKey ??
       secret?.secret?.cohereApiKey ??
       secret?.secret?.bedrockApiKey;
     if (secretValue) {
@@ -199,6 +204,7 @@ export const FAST_MODELS: Record<SupportedChatProvider, string> = {
   vllm: "default", // vLLM uses whatever model is deployed
   ollama: "llama3.2", // Common fast model for Ollama
   zhipuai: "glm-4-flash", // Zhipu's fast model
+  grok: "grok-2", // Grok's fast versatile model
   bedrock: "amazon.nova-lite-v1:0", // Bedrock's fast model, available in all regions for on-demand inference
   mistral: "mistral-small-latest", // Mistral's fast model
 };
@@ -342,6 +348,21 @@ const directModelCreators: Record<SupportedChatProvider, DirectModelCreator> = {
     const client = createOpenAI({
       apiKey,
       baseURL: config.llm.zhipuai.baseUrl,
+    });
+    return client(modelName);
+  },
+
+  grok: ({ apiKey, modelName }) => {
+    if (!apiKey) {
+      throw new ApiError(
+        400,
+        "Grok API key is required. Please configure ARCHESTRA_CHAT_GROK_API_KEY.",
+      );
+    }
+    // Grok uses OpenAI-compatible API
+    const client = createOpenAI({
+      apiKey,
+      baseURL: config.llm.grok.baseUrl,
     });
     return client(modelName);
   },
@@ -515,6 +536,17 @@ const proxiedModelCreators: Record<SupportedChatProvider, ProxiedModelCreator> =
       const client = createOpenAI({
         apiKey,
         baseURL: buildProxyBaseUrl("zhipuai", agentId),
+        headers,
+      });
+      return client.chat(modelName);
+    },
+
+    grok: ({ apiKey, agentId, modelName, headers }) => {
+      // URL format: /v1/grok/:agentId (SDK appends /chat/completions)
+      // Grok is OpenAI-compatible, so we use the OpenAI SDK with custom baseURL
+      const client = createOpenAI({
+        apiKey,
+        baseURL: buildProxyBaseUrl("grok", agentId),
         headers,
       });
       return client.chat(modelName);

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -486,6 +486,11 @@ export default {
         process.env.ARCHESTRA_ZHIPUAI_BASE_URL ||
         "https://api.z.ai/api/paas/v4",
     },
+    grok: {
+      baseUrl:
+        process.env.ARCHESTRA_GROK_BASE_URL ||
+        "https://api.x.ai/v1",
+    },
     bedrock: {
       enabled: Boolean(process.env.ARCHESTRA_BEDROCK_BASE_URL),
       baseUrl: process.env.ARCHESTRA_BEDROCK_BASE_URL || "",
@@ -521,6 +526,9 @@ export default {
     },
     zhipuai: {
       apiKey: process.env.ARCHESTRA_CHAT_ZHIPUAI_API_KEY || "",
+    },
+    grok: {
+      apiKey: process.env.ARCHESTRA_CHAT_GROK_API_KEY || "",
     },
     bedrock: {
       apiKey: process.env.ARCHESTRA_CHAT_BEDROCK_API_KEY || "",

--- a/platform/backend/src/database/seed.ts
+++ b/platform/backend/src/database/seed.ts
@@ -424,6 +424,7 @@ async function seedChatApiKeysFromEnv(): Promise<void> {
     ollama: config.chat.ollama.apiKey,
     vllm: config.chat.vllm.apiKey,
     zhipuai: config.chat.zhipuai.apiKey,
+    grok: config.chat.grok.apiKey,
     bedrock: config.chat.bedrock.apiKey,
   };
 
@@ -512,6 +513,7 @@ function getProviderDisplayName(provider: SupportedProvider): string {
     ollama: "Ollama",
     vllm: "vLLM",
     zhipuai: "ZhipuAI",
+    grok: "Grok",
     bedrock: "AWS Bedrock",
   };
   return displayNames[provider];

--- a/platform/backend/src/models/optimization-rule.ts
+++ b/platform/backend/src/models/optimization-rule.ts
@@ -276,6 +276,7 @@ class OptimizationRuleModel {
       vllm: [], // vLLM model pricing varies by deployment, so no defaults
       ollama: [], // Ollama model pricing varies by deployment, so no defaults
       zhipuai: [],
+      grok: [],
       bedrock: [], // Bedrock model pricing varies by region and usage, so no defaults
     };
 
@@ -310,6 +311,7 @@ class OptimizationRuleModel {
         vllm: [], // vLLM optimization rules are deployment-specific, no defaults
         ollama: [], // Ollama optimization rules are deployment-specific, no defaults
         zhipuai: [],
+        grok: [],
         bedrock: [], // Bedrock optimization rules are deployment-specific, no defaults
       };
 

--- a/platform/backend/src/observability/metrics/llm.ts
+++ b/platform/backend/src/observability/metrics/llm.ts
@@ -17,6 +17,7 @@ import { getUsageTokens as getCohereUsage } from "@/routes/proxy/adapterV2/coher
 import { getUsageTokens as getGeminiUsage } from "@/routes/proxy/adapterV2/gemini";
 import { getUsageTokens as getOpenAIUsage } from "@/routes/proxy/adapterV2/openai";
 import { getUsageTokens as getZhipuaiUsage } from "@/routes/proxy/adapterV2/zhipuai";
+import { getUsageTokens as getGrokUsage } from "@/routes/proxy/adapterV2/grok";
 import type { Agent } from "@/types";
 import { sanitizeLabelKey } from "./utils";
 
@@ -39,6 +40,7 @@ const fetchUsageExtractors: Record<SupportedProvider, UsageExtractor> = {
   anthropic: getAnthropicUsage,
   cohere: getCohereUsage,
   zhipuai: getZhipuaiUsage,
+  grok: getGrokUsage,
   gemini: null,
   bedrock: null,
 };

--- a/platform/backend/src/routes/chat/routes.models.ts
+++ b/platform/backend/src/routes/chat/routes.models.ts
@@ -425,6 +425,59 @@ async function fetchCohereModels(apiKey: string): Promise<ModelInfo[]> {
 }
 
 /**
+ * Fetch models from Grok API
+ */
+async function fetchGrokModels(apiKey: string): Promise<ModelInfo[]> {
+  const baseUrl = config.llm.grok.baseUrl;
+  const url = `${baseUrl}/models`;
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    logger.error(
+      { status: response.status, error: errorText },
+      "Failed to fetch Grok models",
+    );
+    throw new Error(`Failed to fetch Grok models: ${response.status}`);
+  }
+
+  const data = (await response.json()) as {
+    data: Array<{
+      id: string;
+      created: number;
+      owned_by: string;
+      active: boolean;
+    }>;
+  };
+
+  // Filter to active chat-compatible models
+  // Exclude whisper (speech-to-text) and other non-chat models
+  const excludePatterns = ["whisper", "distil-whisper", "playai", "tts"];
+
+  const models = data.data
+    .filter((model) => {
+      const id = model.id.toLowerCase();
+      const hasExcludedPattern = excludePatterns.some((pattern) =>
+        id.includes(pattern),
+      );
+      return !hasExcludedPattern && model.active !== false;
+    })
+    .map((model) => ({
+      id: model.id,
+      displayName: model.id,
+      provider: "grok" as const,
+      createdAt: new Date(model.created * 1000).toISOString(),
+    }));
+
+  return models;
+}
+
+/**
  * Fetch models from Zhipuai API
  */
 async function fetchZhipuaiModels(apiKey: string): Promise<ModelInfo[]> {
@@ -736,6 +789,7 @@ async function getProviderApiKey({
     openai: () => config.chat.openai.apiKey || null,
     vllm: () => config.chat.vllm.apiKey || "", // vLLM typically doesn't require API keys
     zhipuai: () => config.chat.zhipuai?.apiKey || null,
+    grok: () => config.chat.grok?.apiKey || null,
     bedrock: () => config.chat.bedrock.apiKey || null,
   };
 
@@ -757,6 +811,7 @@ const modelFetchers: Record<
   ollama: fetchOllamaModels,
   cohere: fetchCohereModels,
   zhipuai: fetchZhipuaiModels,
+  grok: fetchGrokModels,
 };
 
 // Register all model fetchers with the sync service
@@ -845,6 +900,10 @@ export async function fetchModelsForProvider({
       // Ollama doesn't require API key, pass empty or configured key
       models = await modelFetchers[provider](apiKey || "EMPTY");
     } else if (provider === "zhipuai") {
+      if (apiKey) {
+        models = await modelFetchers[provider](apiKey);
+      }
+    } else if (provider === "grok") {
       if (apiKey) {
         models = await modelFetchers[provider](apiKey);
       }

--- a/platform/backend/src/routes/index.ts
+++ b/platform/backend/src/routes/index.ts
@@ -8,6 +8,7 @@ import ollamaProxyRoutesV2 from "./proxy/routesv2/ollama";
 import openAiProxyRoutesV2 from "./proxy/routesv2/openai";
 import vllmProxyRoutesV2 from "./proxy/routesv2/vllm";
 import zhipuaiProxyRoutesV2 from "./proxy/routesv2/zhipuai";
+import grokProxyRoutesV2 from "./proxy/routesv2/grok";
 
 export { default as browserStreamRoutes } from "@/features/browser-stream/routes/browser-stream.routes";
 export { default as a2aRoutes } from "./a2a";
@@ -47,6 +48,7 @@ export const openAiProxyRoutes = openAiProxyRoutesV2;
 export const vllmProxyRoutes = vllmProxyRoutesV2;
 export const ollamaProxyRoutes = ollamaProxyRoutesV2;
 export const zhipuaiProxyRoutes = zhipuaiProxyRoutesV2;
+export const grokProxyRoutes = grokProxyRoutesV2;
 // Bedrock proxy routes - V2 only (unified handler, AWS Converse API)
 export const bedrockProxyRoutes = bedrockProxyRoutesV2;
 export { default as secretsRoutes } from "./secrets";

--- a/platform/backend/src/routes/proxy/adapterV2/grok.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/grok.ts
@@ -1,0 +1,1018 @@
+import { GrokErrorTypes } from "@shared";
+import { encode as toonEncode } from "@toon-format/toon";
+import { get } from "lodash-es";
+import config from "@/config";
+import logger from "@/logging";
+import { TokenPriceModel } from "@/models";
+import { metrics } from "@/observability";
+import { MockGrokClient } from "@/routes/proxy/mock-grok-client";
+import { getTokenizer } from "@/tokenizers";
+import type {
+  ChunkProcessingResult,
+  CommonMcpToolDefinition,
+  CommonMessage,
+  CommonToolCall,
+  CommonToolResult,
+  CreateClientOptions,
+  Grok,
+  LLMProvider,
+  LLMRequestAdapter,
+  LLMResponseAdapter,
+  LLMStreamAdapter,
+  StreamAccumulatorState,
+  ToolCompressionStats,
+  UsageView,
+} from "@/types";
+import { unwrapToolContent } from "../utils/unwrap-tool-content";
+
+// =============================================================================
+// TYPE ALIASES
+// =============================================================================
+
+type GrokRequest = Grok.Types.ChatCompletionsRequest;
+type GrokResponse = Grok.Types.ChatCompletionsResponse;
+type GrokMessages = Grok.Types.ChatCompletionsRequest["messages"];
+type GrokHeaders = Grok.Types.ChatCompletionsHeaders;
+type GrokStreamChunk = Grok.Types.ChatCompletionChunk;
+
+// =============================================================================
+// GROK SDK CLIENT
+// =============================================================================
+
+class GrokClient {
+  private apiKey: string | undefined;
+  private baseURL: string;
+  private customFetch?: typeof fetch;
+
+  constructor(
+    apiKey: string | undefined,
+    baseURL?: string,
+    customFetch?: typeof fetch,
+  ) {
+    this.apiKey = apiKey;
+    this.baseURL = baseURL || "https://api.x.ai/v1";
+    this.customFetch = customFetch;
+  }
+
+  async chatCompletions(request: GrokRequest): Promise<GrokResponse> {
+    const fetchFn = this.customFetch || fetch;
+    const response = await fetchFn(`${this.baseURL}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(this.apiKey && { Authorization: `Bearer ${this.apiKey}` }),
+      },
+      body: JSON.stringify({
+        ...request,
+        stream: false,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      let errorMessage = `Grok API error: ${response.status} ${response.statusText}`;
+
+      try {
+        const errorJson = JSON.parse(errorText);
+        const errorType = errorJson.error?.type;
+
+        if (errorType === GrokErrorTypes.MODEL_NOT_FOUND) {
+          errorMessage = `Model not found. Please check that the model name is correct and you have access to it.`;
+        } else if (errorType === GrokErrorTypes.RATE_LIMIT) {
+          errorMessage = `Rate limit exceeded. Please try again later.`;
+        } else if (errorType === GrokErrorTypes.INVALID_API_KEY) {
+          errorMessage = `Invalid API key. Please check your Grok API key.`;
+        } else if (errorJson.error?.message) {
+          errorMessage += ` - ${errorJson.error.message}`;
+        } else {
+          errorMessage += ` - ${errorText}`;
+        }
+      } catch {
+        errorMessage += ` - ${errorText}`;
+      }
+
+      throw new Error(errorMessage);
+    }
+
+    return response.json() as Promise<GrokResponse>;
+  }
+
+  async chatCompletionsStream(
+    request: GrokRequest,
+  ): Promise<AsyncIterable<GrokStreamChunk>> {
+    const fetchFn = this.customFetch || fetch;
+    const response = await fetchFn(`${this.baseURL}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(this.apiKey && { Authorization: `Bearer ${this.apiKey}` }),
+      },
+      body: JSON.stringify({
+        ...request,
+        stream: true,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      let errorMessage = `Grok API error: ${response.status} ${response.statusText}`;
+
+      try {
+        const errorJson = JSON.parse(errorText);
+        const errorType = errorJson.error?.type;
+
+        if (errorType === GrokErrorTypes.MODEL_NOT_FOUND) {
+          errorMessage = `Model not found. Please check that the model name is correct and you have access to it.`;
+        } else if (errorType === GrokErrorTypes.RATE_LIMIT) {
+          errorMessage = `Rate limit exceeded. Please try again later.`;
+        } else if (errorType === GrokErrorTypes.INVALID_API_KEY) {
+          errorMessage = `Invalid API key. Please check your Grok API key.`;
+        } else if (errorJson.error?.message) {
+          errorMessage += ` - ${errorJson.error.message}`;
+        } else {
+          errorMessage += ` - ${errorText}`;
+        }
+      } catch {
+        errorMessage += ` - ${errorText}`;
+      }
+
+      throw new Error(errorMessage);
+    }
+
+    return this.parseSSEStream(response);
+  }
+
+  private async *parseSSEStream(
+    response: Response,
+  ): AsyncIterable<GrokStreamChunk> {
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error("Response body is not readable");
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed || trimmed === "data: [DONE]") continue;
+
+          if (trimmed.startsWith("data: ")) {
+            try {
+              const jsonStr = trimmed.substring(6);
+              const chunk = JSON.parse(jsonStr) as GrokStreamChunk;
+              yield chunk;
+            } catch (error) {
+              logger.warn(
+                { error, line: trimmed },
+                "Failed to parse SSE chunk from Grok",
+              );
+            }
+          }
+        }
+      }
+
+      if (buffer.trim()) {
+        const trimmed = buffer.trim();
+        if (trimmed.startsWith("data: ") && trimmed !== "data: [DONE]") {
+          try {
+            const jsonStr = trimmed.substring(6);
+            const chunk = JSON.parse(jsonStr) as GrokStreamChunk;
+            yield chunk;
+          } catch (error) {
+            logger.warn(
+              { error, line: trimmed },
+              "Failed to parse final SSE chunk from Grok",
+            );
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+}
+
+// =============================================================================
+// REQUEST ADAPTER
+// =============================================================================
+
+class GrokRequestAdapter
+  implements LLMRequestAdapter<GrokRequest, GrokMessages>
+{
+  readonly provider = "grok" as const;
+  private request: GrokRequest;
+  private modifiedModel: string | null = null;
+  private toolResultUpdates: Record<string, string> = {};
+
+  constructor(request: GrokRequest) {
+    this.request = request;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Read Access
+  // ---------------------------------------------------------------------------
+
+  getModel(): string {
+    return this.modifiedModel ?? this.request.model;
+  }
+
+  isStreaming(): boolean {
+    return this.request.stream === true;
+  }
+
+  getMessages(): CommonMessage[] {
+    return this.toCommonFormat(this.request.messages);
+  }
+
+  getToolResults(): CommonToolResult[] {
+    const results: CommonToolResult[] = [];
+
+    for (const message of this.request.messages) {
+      if (message.role === "tool") {
+        const toolName = this.findToolNameInMessages(
+          this.request.messages,
+          message.tool_call_id,
+        );
+
+        let content: unknown;
+        if (typeof message.content === "string") {
+          try {
+            content = JSON.parse(message.content);
+          } catch {
+            content = message.content;
+          }
+        } else {
+          content = message.content;
+        }
+
+        results.push({
+          id: message.tool_call_id,
+          name: toolName ?? "unknown",
+          content,
+          isError: false,
+        });
+      }
+    }
+
+    return results;
+  }
+
+  getTools(): CommonMcpToolDefinition[] {
+    if (!this.request.tools) return [];
+
+    const result: CommonMcpToolDefinition[] = [];
+    for (const tool of this.request.tools) {
+      if (tool.type === "function") {
+        result.push({
+          name: tool.function.name,
+          description: tool.function.description,
+          inputSchema: tool.function.parameters as Record<string, unknown>,
+        });
+      }
+    }
+    return result;
+  }
+
+  hasTools(): boolean {
+    return (this.request.tools?.length ?? 0) > 0;
+  }
+
+  getProviderMessages(): GrokMessages {
+    return this.request.messages;
+  }
+
+  getOriginalRequest(): GrokRequest {
+    return this.request;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Modify Access
+  // ---------------------------------------------------------------------------
+
+  setModel(model: string): void {
+    this.modifiedModel = model;
+  }
+
+  updateToolResult(toolCallId: string, newContent: string): void {
+    this.toolResultUpdates[toolCallId] = newContent;
+  }
+
+  applyToolResultUpdates(updates: Record<string, string>): void {
+    Object.assign(this.toolResultUpdates, updates);
+  }
+
+  convertToolResultContent(messages: GrokMessages): GrokMessages {
+    return messages;
+  }
+
+  async applyToonCompression(model: string): Promise<ToolCompressionStats> {
+    const { messages: compressedMessages, stats } =
+      await convertToolResultsToToon(this.request.messages, model);
+    this.request = {
+      ...this.request,
+      messages: compressedMessages,
+    };
+    return stats;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Build Modified Request
+  // ---------------------------------------------------------------------------
+
+  toProviderRequest(): GrokRequest {
+    let messages = this.request.messages;
+
+    if (Object.keys(this.toolResultUpdates).length > 0) {
+      messages = this.applyUpdates(messages, this.toolResultUpdates);
+    }
+
+    return {
+      ...this.request,
+      model: this.getModel(),
+      messages,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private Helpers
+  // ---------------------------------------------------------------------------
+
+  private findToolNameInMessages(
+    messages: GrokMessages,
+    toolCallId: string,
+  ): string | null {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+
+      if (message.role === "assistant" && message.tool_calls) {
+        for (const toolCall of message.tool_calls) {
+          if (toolCall.id === toolCallId) {
+            if (toolCall.type === "function") {
+              return toolCall.function.name;
+            }
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private toCommonFormat(messages: GrokMessages): CommonMessage[] {
+    logger.debug(
+      { messageCount: messages.length },
+      "[GrokAdapter] toCommonFormat: starting conversion",
+    );
+    const commonMessages: CommonMessage[] = [];
+
+    for (const message of messages) {
+      const commonMessage: CommonMessage = {
+        role: message.role as CommonMessage["role"],
+      };
+
+      if (message.role === "tool") {
+        const toolName = this.findToolNameInMessages(
+          messages,
+          message.tool_call_id,
+        );
+
+        if (toolName) {
+          logger.debug(
+            { toolCallId: message.tool_call_id, toolName },
+            "[GrokAdapter] toCommonFormat: found tool message",
+          );
+          let toolResult: unknown;
+          if (typeof message.content === "string") {
+            try {
+              toolResult = JSON.parse(message.content);
+            } catch {
+              toolResult = message.content;
+            }
+          } else {
+            toolResult = message.content;
+          }
+
+          commonMessage.toolCalls = [
+            {
+              id: message.tool_call_id,
+              name: toolName,
+              content: toolResult,
+              isError: false,
+            },
+          ];
+        }
+      }
+
+      commonMessages.push(commonMessage);
+    }
+
+    logger.debug(
+      { inputCount: messages.length, outputCount: commonMessages.length },
+      "[GrokAdapter] toCommonFormat: conversion complete",
+    );
+    return commonMessages;
+  }
+
+  private applyUpdates(
+    messages: GrokMessages,
+    updates: Record<string, string>,
+  ): GrokMessages {
+    const updateCount = Object.keys(updates).length;
+    logger.debug(
+      { messageCount: messages.length, updateCount },
+      "[GrokAdapter] applyUpdates: starting",
+    );
+
+    if (updateCount === 0) {
+      logger.debug("[GrokAdapter] applyUpdates: no updates to apply");
+      return messages;
+    }
+
+    let appliedCount = 0;
+    const result = messages.map((message) => {
+      if (message.role === "tool" && updates[message.tool_call_id]) {
+        appliedCount++;
+        logger.debug(
+          { toolCallId: message.tool_call_id },
+          "[GrokAdapter] applyUpdates: applying update to tool message",
+        );
+        return {
+          ...message,
+          content: updates[message.tool_call_id],
+        };
+      }
+      return message;
+    });
+
+    logger.debug(
+      { updateCount, appliedCount },
+      "[GrokAdapter] applyUpdates: complete",
+    );
+    return result;
+  }
+}
+
+// =============================================================================
+// RESPONSE ADAPTER
+// =============================================================================
+
+class GrokResponseAdapter implements LLMResponseAdapter<GrokResponse> {
+  readonly provider = "grok" as const;
+  private response: GrokResponse;
+
+  constructor(response: GrokResponse) {
+    this.response = response;
+  }
+
+  getId(): string {
+    return this.response.id;
+  }
+
+  getModel(): string {
+    return this.response.model;
+  }
+
+  getText(): string {
+    const choice = this.response.choices[0];
+    if (!choice) return "";
+    return choice.message.content ?? "";
+  }
+
+  getToolCalls(): CommonToolCall[] {
+    const choice = this.response.choices[0];
+    if (!choice?.message.tool_calls) return [];
+
+    return choice.message.tool_calls.map((toolCall) => {
+      let name: string;
+      let args: Record<string, unknown>;
+
+      if (toolCall.type === "function" && toolCall.function) {
+        name = toolCall.function.name;
+        try {
+          args = JSON.parse(toolCall.function.arguments);
+        } catch {
+          args = {};
+        }
+      } else {
+        name = "unknown";
+        args = {};
+      }
+
+      return {
+        id: toolCall.id,
+        name,
+        arguments: args,
+      };
+    });
+  }
+
+  hasToolCalls(): boolean {
+    const choice = this.response.choices[0];
+    return (choice?.message.tool_calls?.length ?? 0) > 0;
+  }
+
+  getUsage(): UsageView {
+    if (!this.response.usage) {
+      return { inputTokens: 0, outputTokens: 0 };
+    }
+    const { input, output } = getUsageTokens(this.response.usage);
+    return { inputTokens: input, outputTokens: output };
+  }
+
+  getOriginalResponse(): GrokResponse {
+    return this.response;
+  }
+
+  toRefusalResponse(
+    _refusalMessage: string,
+    contentMessage: string,
+  ): GrokResponse {
+    return {
+      ...this.response,
+      choices: [
+        {
+          ...this.response.choices[0],
+          message: {
+            role: "assistant",
+            content: contentMessage,
+          },
+          finish_reason: "stop",
+        },
+      ],
+    };
+  }
+}
+
+// =============================================================================
+// STREAM ADAPTER
+// =============================================================================
+
+/**
+ * GrokStreamAdapter processes streaming chunks and accumulates state.
+ *
+ * Grok uses the OpenAI-compatible streaming format:
+ * - Sends usage in the final chunk (when stream_options.include_usage is true)
+ * - No reasoning_content (Grok does not support thinking mode)
+ * - Grok is known for extremely fast inference (LPU)
+ */
+class GrokStreamAdapter
+  implements LLMStreamAdapter<GrokStreamChunk, GrokResponse>
+{
+  readonly provider = "grok" as const;
+  readonly state: StreamAccumulatorState;
+  private currentToolCallIndices = new Map<number, number>();
+
+  constructor() {
+    this.state = {
+      responseId: "",
+      model: "",
+      text: "",
+      toolCalls: [],
+      rawToolCallEvents: [],
+      usage: null,
+      stopReason: null,
+      timing: {
+        startTime: Date.now(),
+        firstChunkTime: null,
+      },
+    };
+  }
+
+  processChunk(chunk: GrokStreamChunk): ChunkProcessingResult {
+    if (this.state.timing.firstChunkTime === null) {
+      this.state.timing.firstChunkTime = Date.now();
+    }
+
+    let sseData: string | null = null;
+    let isToolCallChunk = false;
+    let isFinal = false;
+
+    this.state.responseId = chunk.id;
+    this.state.model = chunk.model;
+
+    const choice = chunk.choices[0];
+    if (!choice) {
+      return {
+        sseData: null,
+        isToolCallChunk: false,
+        isFinal: false,
+      };
+    }
+
+    const delta = choice.delta;
+
+    if (delta.content) {
+      this.state.text += delta.content;
+    }
+
+    const hasContent = delta.content || delta.tool_calls || delta.role;
+
+    if (hasContent) {
+      sseData = `data: ${JSON.stringify(chunk)}\n\n`;
+    }
+
+    if (delta.tool_calls) {
+      for (const toolCallDelta of delta.tool_calls) {
+        const index = toolCallDelta.index;
+
+        if (!this.currentToolCallIndices.has(index)) {
+          this.currentToolCallIndices.set(index, this.state.toolCalls.length);
+          this.state.toolCalls.push({
+            id: toolCallDelta.id ?? "",
+            name: toolCallDelta.function?.name ?? "",
+            arguments: "",
+          });
+        }
+
+        const toolCallIndex = this.currentToolCallIndices.get(index);
+        if (toolCallIndex === undefined) continue;
+        const toolCall = this.state.toolCalls[toolCallIndex];
+
+        if (toolCallDelta.id) {
+          toolCall.id = toolCallDelta.id;
+        }
+        if (toolCallDelta.function?.name) {
+          toolCall.name = toolCallDelta.function.name;
+        }
+        if (toolCallDelta.function?.arguments) {
+          toolCall.arguments += toolCallDelta.function.arguments;
+        }
+      }
+
+      this.state.rawToolCallEvents.push(chunk);
+      isToolCallChunk = true;
+    }
+
+    if (choice.finish_reason) {
+      this.state.stopReason = choice.finish_reason;
+      isFinal = true;
+    }
+
+    if (chunk.usage) {
+      this.state.usage = {
+        inputTokens: chunk.usage.prompt_tokens ?? 0,
+        outputTokens: chunk.usage.completion_tokens ?? 0,
+      };
+    }
+
+    return { sseData, isToolCallChunk, isFinal };
+  }
+
+  getSSEHeaders(): Record<string, string> {
+    return {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    };
+  }
+
+  formatTextDeltaSSE(text: string): string {
+    const chunk: GrokStreamChunk = {
+      id: this.state.responseId,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            content: text,
+          },
+          finish_reason: null,
+        },
+      ],
+    };
+    return `data: ${JSON.stringify(chunk)}\n\n`;
+  }
+
+  getRawToolCallEvents(): string[] {
+    return this.state.rawToolCallEvents.map(
+      (event) => `data: ${JSON.stringify(event)}\n\n`,
+    );
+  }
+
+  formatCompleteTextSSE(text: string): string[] {
+    const chunk: GrokStreamChunk = {
+      id: this.state.responseId || `chatcmpl-${Date.now()}`,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            role: "assistant",
+            content: text,
+          },
+          finish_reason: null,
+        },
+      ],
+    };
+    return [`data: ${JSON.stringify(chunk)}\n\n`];
+  }
+
+  formatEndSSE(): string {
+    const finalChunk: GrokStreamChunk = {
+      id: this.state.responseId,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          delta: {},
+          finish_reason: this.state.stopReason ?? "stop",
+        },
+      ],
+    };
+    return `data: ${JSON.stringify(finalChunk)}\n\ndata: [DONE]\n\n`;
+  }
+
+  toProviderResponse(): GrokResponse {
+    const toolCalls =
+      this.state.toolCalls.length > 0
+        ? this.state.toolCalls.map((tc) => ({
+            id: tc.id,
+            type: "function" as const,
+            function: {
+              name: tc.name,
+              arguments: tc.arguments,
+            },
+          }))
+        : undefined;
+
+    return {
+      id: this.state.responseId,
+      object: "chat.completion",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: this.state.text || null,
+            tool_calls: toolCalls,
+          },
+          logprobs: null,
+          finish_reason:
+            (this.state.stopReason as Grok.Types.FinishReason) ?? "stop",
+        },
+      ],
+      usage: {
+        prompt_tokens: this.state.usage?.inputTokens ?? 0,
+        completion_tokens: this.state.usage?.outputTokens ?? 0,
+        total_tokens:
+          (this.state.usage?.inputTokens ?? 0) +
+          (this.state.usage?.outputTokens ?? 0),
+      },
+    };
+  }
+}
+
+// =============================================================================
+// TOON COMPRESSION
+// =============================================================================
+
+async function convertToolResultsToToon(
+  messages: GrokMessages,
+  model: string,
+): Promise<{
+  messages: GrokMessages;
+  stats: ToolCompressionStats;
+}> {
+  const tokenizer = getTokenizer("grok");
+  let toolResultCount = 0;
+  let totalTokensBefore = 0;
+  let totalTokensAfter = 0;
+
+  const result = messages.map((message) => {
+    if (message.role === "tool") {
+      logger.info(
+        {
+          toolCallId: message.tool_call_id,
+          contentType: typeof message.content,
+          provider: "grok",
+        },
+        "convertToolResultsToToon: tool message found",
+      );
+
+      if (typeof message.content === "string") {
+        try {
+          const unwrapped = unwrapToolContent(message.content);
+          const parsed = JSON.parse(unwrapped);
+          const noncompressed = unwrapped;
+          const compressed = toonEncode(parsed);
+
+          const tokensBefore = tokenizer.countTokens([
+            { role: "user", content: noncompressed },
+          ]);
+          const tokensAfter = tokenizer.countTokens([
+            { role: "user", content: compressed },
+          ]);
+
+          toolResultCount++;
+          totalTokensBefore += tokensBefore;
+
+          if (tokensAfter < tokensBefore) {
+            totalTokensAfter += tokensAfter;
+
+            logger.info(
+              {
+                toolCallId: message.tool_call_id,
+                beforeLength: noncompressed.length,
+                afterLength: compressed.length,
+                tokensBefore,
+                tokensAfter,
+                toonPreview: compressed.substring(0, 150),
+                provider: "grok",
+              },
+              "convertToolResultsToToon: compressed",
+            );
+            logger.debug(
+              {
+                toolCallId: message.tool_call_id,
+                before: noncompressed,
+                after: compressed,
+                provider: "grok",
+                supposedToBeJson: parsed,
+              },
+              "convertToolResultsToToon: before/after",
+            );
+
+            return {
+              ...message,
+              content: compressed,
+            };
+          }
+
+          totalTokensAfter += tokensBefore;
+          logger.info(
+            {
+              toolCallId: message.tool_call_id,
+              tokensBefore,
+              tokensAfter,
+              provider: "grok",
+            },
+            "Skipping TOON compression - compressed output has more tokens",
+          );
+        } catch {
+          logger.info(
+            {
+              toolCallId: message.tool_call_id,
+              contentPreview:
+                typeof message.content === "string"
+                  ? message.content.substring(0, 100)
+                  : "non-string",
+            },
+            "Skipping TOON conversion - content is not JSON",
+          );
+          return message;
+        }
+      }
+    }
+
+    return message;
+  });
+
+  logger.info(
+    { messageCount: messages.length, toolResultCount },
+    "convertToolResultsToToon completed",
+  );
+
+  let toonCostSavings = 0;
+  const tokensSaved = totalTokensBefore - totalTokensAfter;
+  if (tokensSaved > 0) {
+    const tokenPrice = await TokenPriceModel.findByModel(model);
+    if (tokenPrice) {
+      const inputPricePerToken =
+        Number(tokenPrice.pricePerMillionInput) / 1000000;
+      toonCostSavings = tokensSaved * inputPricePerToken;
+    }
+  }
+
+  return {
+    messages: result,
+    stats: {
+      tokensBefore: totalTokensBefore,
+      tokensAfter: totalTokensAfter,
+      costSavings: toonCostSavings,
+      wasEffective: totalTokensAfter < totalTokensBefore,
+      hadToolResults: toolResultCount > 0,
+    },
+  };
+}
+
+// =============================================================================
+// ADAPTER FACTORY
+// =============================================================================
+
+// =============================================================================
+// USAGE TOKEN HELPERS
+// =============================================================================
+
+export function getUsageTokens(usage: Grok.Types.Usage) {
+  return {
+    input: usage.prompt_tokens,
+    output: usage.completion_tokens,
+  };
+}
+
+export const grokAdapterFactory: LLMProvider<
+  GrokRequest,
+  GrokResponse,
+  GrokMessages,
+  GrokStreamChunk,
+  GrokHeaders
+> = {
+  provider: "grok",
+  interactionType: "grok:chatCompletions",
+
+  createRequestAdapter(
+    request: GrokRequest,
+  ): LLMRequestAdapter<GrokRequest, GrokMessages> {
+    return new GrokRequestAdapter(request);
+  },
+
+  createResponseAdapter(
+    response: GrokResponse,
+  ): LLMResponseAdapter<GrokResponse> {
+    return new GrokResponseAdapter(response);
+  },
+
+  createStreamAdapter(): LLMStreamAdapter<GrokStreamChunk, GrokResponse> {
+    return new GrokStreamAdapter();
+  },
+
+  extractApiKey(headers: GrokHeaders): string | undefined {
+    return headers.authorization;
+  },
+
+  getBaseUrl(): string | undefined {
+    return config.llm.grok.baseUrl;
+  },
+
+  getSpanName(): string {
+    return "grok.chat.completions";
+  },
+
+  createClient(
+    apiKey: string | undefined,
+    options?: CreateClientOptions,
+  ): GrokClient | MockGrokClient {
+    if (options?.mockMode) {
+      return new MockGrokClient() as unknown as GrokClient;
+    }
+
+    const customFetch = options?.agent
+      ? metrics.llm.getObservableFetch(
+          "grok",
+          options.agent,
+          options.externalAgentId,
+        )
+      : undefined;
+
+    return new GrokClient(apiKey, options?.baseUrl, customFetch);
+  },
+
+  async execute(
+    client: unknown,
+    request: GrokRequest,
+  ): Promise<GrokResponse> {
+    const grokClient = client as GrokClient;
+    return grokClient.chatCompletions(request);
+  },
+
+  async executeStream(
+    client: unknown,
+    request: GrokRequest,
+  ): Promise<AsyncIterable<GrokStreamChunk>> {
+    const grokClient = client as GrokClient;
+    return grokClient.chatCompletionsStream(request);
+  },
+
+  extractErrorMessage(error: unknown): string {
+    const grokMessage = get(error, "error.message");
+    if (typeof grokMessage === "string") {
+      return grokMessage;
+    }
+
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return "Internal server error";
+  },
+};

--- a/platform/backend/src/routes/proxy/adapterV2/index.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/index.ts
@@ -8,3 +8,4 @@ export { ollamaAdapterFactory } from "./ollama";
 export { openaiAdapterFactory } from "./openai";
 export { vllmAdapterFactory } from "./vllm";
 export { zhipuaiAdapterFactory } from "./zhipuai";
+export { grokAdapterFactory } from "./grok";

--- a/platform/backend/src/routes/proxy/mock-grok-client.ts
+++ b/platform/backend/src/routes/proxy/mock-grok-client.ts
@@ -1,0 +1,164 @@
+/**
+ * Mock Grok Client for Benchmarking
+ *
+ * Returns immediate tool call responses without making actual API calls.
+ * Used for benchmarking Archestra platform overhead without network latency.
+ */
+
+import type { Grok } from "@/types";
+
+/**
+ * Options for controlling mock stream behavior
+ */
+export interface MockStreamOptions {
+  /** If set, the stream will end early at this chunk index (0-based) */
+  interruptAtChunk?: number;
+}
+
+const MOCK_RESPONSE: Grok.Types.ChatCompletionsResponse = {
+  id: "chatcmpl-mock-grok-123",
+  object: "chat.completion",
+  created: Math.floor(Date.now() / 1000),
+  model: "grok-2",
+  choices: [
+    {
+      index: 0,
+      message: {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: "call_grok_mock789",
+            type: "function",
+            function: {
+              name: "list_files",
+              arguments: '{"path": "."}',
+            },
+          },
+        ],
+      },
+      finish_reason: "tool_calls",
+      logprobs: null,
+    },
+  ],
+  usage: {
+    prompt_tokens: 82,
+    completion_tokens: 17,
+    total_tokens: 99,
+  },
+};
+
+const MOCK_STREAMING_CHUNKS: Grok.Types.ChatCompletionChunk[] = [
+  {
+    id: "chatcmpl-mock-grok-123",
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model: "grok-2",
+    choices: [
+      {
+        index: 0,
+        delta: { role: "assistant", content: "" },
+        finish_reason: null,
+      },
+    ],
+  },
+  {
+    id: "chatcmpl-mock-grok-123",
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model: "grok-2",
+    choices: [
+      {
+        index: 0,
+        delta: { content: "Hello" },
+        finish_reason: null,
+      },
+    ],
+  },
+  {
+    id: "chatcmpl-mock-grok-123",
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model: "grok-2",
+    choices: [
+      {
+        index: 0,
+        delta: { content: ", how can I help you?" },
+        finish_reason: null,
+      },
+    ],
+  },
+  {
+    id: "chatcmpl-mock-grok-123",
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model: "grok-2",
+    choices: [
+      {
+        index: 0,
+        delta: {},
+        finish_reason: "stop",
+      },
+    ],
+    usage: {
+      prompt_tokens: 12,
+      completion_tokens: 10,
+      total_tokens: 22,
+    },
+  },
+];
+
+/**
+ * Mock Grok Client that returns immediate tool call responses
+ */
+export class MockGrokClient {
+  private static streamOptions: MockStreamOptions = {};
+
+  /**
+   * Configure stream behavior for testing (static method affects all instances)
+   */
+  static setStreamOptions(options: MockStreamOptions) {
+    MockGrokClient.streamOptions = options;
+  }
+
+  /**
+   * Reset stream options to default
+   */
+  static resetStreamOptions() {
+    MockGrokClient.streamOptions = {};
+  }
+
+  async chatCompletions(
+    _request: Grok.Types.ChatCompletionsRequest,
+  ): Promise<Grok.Types.ChatCompletionsResponse> {
+    return MOCK_RESPONSE;
+  }
+
+  async chatCompletionsStream(
+    _request: Grok.Types.ChatCompletionsRequest,
+  ): Promise<AsyncIterable<Grok.Types.ChatCompletionChunk>> {
+    return {
+      [Symbol.asyncIterator]() {
+        let index = 0;
+        return {
+          async next() {
+            if (
+              MockGrokClient.streamOptions.interruptAtChunk !== undefined &&
+              index === MockGrokClient.streamOptions.interruptAtChunk
+            ) {
+              return { done: true, value: undefined };
+            }
+
+            if (index < MOCK_STREAMING_CHUNKS.length) {
+              return {
+                value: MOCK_STREAMING_CHUNKS[index++],
+                done: false,
+              };
+            }
+            return { done: true, value: undefined };
+          },
+        };
+      },
+    };
+  }
+}

--- a/platform/backend/src/routes/proxy/routesv2/grok.ts
+++ b/platform/backend/src/routes/proxy/routesv2/grok.ts
@@ -1,0 +1,165 @@
+import fastifyHttpProxy from "@fastify/http-proxy";
+import { RouteId } from "@shared";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import config from "@/config";
+import logger from "@/logging";
+import { constructResponseSchema, UuidIdSchema, Grok } from "@/types";
+import { grokAdapterFactory } from "../adapterV2";
+import { PROXY_API_PREFIX, PROXY_BODY_LIMIT } from "../common";
+import { handleLLMProxy } from "../llm-proxy-handler";
+import * as utils from "../utils";
+
+const grokProxyRoutesV2: FastifyPluginAsyncZod = async (fastify) => {
+  const API_PREFIX = `${PROXY_API_PREFIX}/grok`;
+  const CHAT_COMPLETIONS_SUFFIX = "/chat/completions";
+
+  logger.info("[UnifiedProxy] Registering unified Grok routes");
+
+  await fastify.register(fastifyHttpProxy, {
+    upstream: config.llm.grok.baseUrl,
+    prefix: API_PREFIX,
+    rewritePrefix: "",
+    preHandler: (request, _reply, next) => {
+      if (
+        request.method === "POST" &&
+        request.url.includes(CHAT_COMPLETIONS_SUFFIX)
+      ) {
+        logger.info(
+          {
+            method: request.method,
+            url: request.url,
+            action: "skip-proxy",
+            reason: "handled-by-custom-handler",
+          },
+          "Grok proxy preHandler: skipping chat/completions route",
+        );
+        next(new Error("skip"));
+        return;
+      }
+
+      const pathAfterPrefix = request.url.replace(API_PREFIX, "");
+      const uuidMatch = pathAfterPrefix.match(
+        /^\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(\/.*)?$/i,
+      );
+
+      if (uuidMatch) {
+        const remainingPath = uuidMatch[2] || "";
+        const originalUrl = request.raw.url;
+        request.raw.url = `${API_PREFIX}${remainingPath}`;
+
+        logger.info(
+          {
+            method: request.method,
+            originalUrl,
+            rewrittenUrl: request.raw.url,
+            upstream: config.llm.grok.baseUrl,
+            finalProxyUrl: `${config.llm.grok.baseUrl}${remainingPath}`,
+          },
+          "Grok proxy preHandler: URL rewritten (UUID stripped)",
+        );
+      } else {
+        logger.info(
+          {
+            method: request.method,
+            url: request.url,
+            upstream: config.llm.grok.baseUrl,
+            finalProxyUrl: `${config.llm.grok.baseUrl}${pathAfterPrefix}`,
+          },
+          "Grok proxy preHandler: proxying request",
+        );
+      }
+
+      next();
+    },
+  });
+
+  fastify.post(
+    `${API_PREFIX}${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        operationId: RouteId.GrokChatCompletionsWithDefaultAgent,
+        description:
+          "Create a chat completion with Grok (uses default agent)",
+        tags: ["llm-proxy"],
+        body: Grok.API.ChatCompletionRequestSchema,
+        headers: Grok.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(
+          Grok.API.ChatCompletionResponseSchema,
+        ),
+      },
+    },
+    async (request, reply) => {
+      logger.debug(
+        { url: request.url },
+        "[UnifiedProxy] Handling Grok request (default agent)",
+      );
+      const externalAgentId = utils.externalAgentId.getExternalAgentId(
+        request.headers,
+      );
+      const executionId = utils.executionId.getExecutionId(request.headers);
+      const userId = (await utils.user.getUser(request.headers))?.userId;
+      return handleLLMProxy(
+        request.body,
+        request.headers,
+        reply,
+        grokAdapterFactory,
+        {
+          organizationId: request.organizationId,
+          agentId: undefined,
+          externalAgentId,
+          executionId,
+          userId,
+        },
+      );
+    },
+  );
+
+  fastify.post(
+    `${API_PREFIX}/:agentId${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        operationId: RouteId.GrokChatCompletionsWithAgent,
+        description:
+          "Create a chat completion with Grok for a specific agent",
+        tags: ["llm-proxy"],
+        params: z.object({
+          agentId: UuidIdSchema,
+        }),
+        body: Grok.API.ChatCompletionRequestSchema,
+        headers: Grok.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(
+          Grok.API.ChatCompletionResponseSchema,
+        ),
+      },
+    },
+    async (request, reply) => {
+      logger.debug(
+        { url: request.url, agentId: request.params.agentId },
+        "[UnifiedProxy] Handling Grok request (with agent)",
+      );
+      const externalAgentId = utils.externalAgentId.getExternalAgentId(
+        request.headers,
+      );
+      const executionId = utils.executionId.getExecutionId(request.headers);
+      const userId = (await utils.user.getUser(request.headers))?.userId;
+      return handleLLMProxy(
+        request.body,
+        request.headers,
+        reply,
+        grokAdapterFactory,
+        {
+          organizationId: request.organizationId,
+          agentId: request.params.agentId,
+          externalAgentId,
+          executionId,
+          userId,
+        },
+      );
+    },
+  );
+};
+
+export default grokProxyRoutesV2;

--- a/platform/backend/src/tokenizers/index.ts
+++ b/platform/backend/src/tokenizers/index.ts
@@ -20,6 +20,7 @@ const tokenizerFactories: Record<SupportedProvider, () => Tokenizer> = {
   vllm: () => new TiktokenTokenizer(),
   ollama: () => new TiktokenTokenizer(),
   zhipuai: () => new TiktokenTokenizer(),
+  grok: () => new TiktokenTokenizer(),
   gemini: () => new TiktokenTokenizer(),
   bedrock: () => new TiktokenTokenizer(),
 };

--- a/platform/backend/src/types/chat-api-key.ts
+++ b/platform/backend/src/types/chat-api-key.ts
@@ -19,6 +19,7 @@ export const SupportedChatProviderSchema = z.enum([
   "vllm",
   "ollama",
   "zhipuai",
+  "grok",
 ]);
 export type SupportedChatProvider = z.infer<typeof SupportedChatProviderSchema>;
 

--- a/platform/backend/src/types/interaction.ts
+++ b/platform/backend/src/types/interaction.ts
@@ -13,6 +13,7 @@ import {
   OpenAi,
   Vllm,
   Zhipuai,
+  Grok,
 } from "./llm-providers";
 import { ToonSkipReasonSchema } from "./tool-result-compression";
 
@@ -158,6 +159,16 @@ export const SelectInteractionSchema = z.discriminatedUnion("type", [
     processedRequest:
       Zhipuai.API.ChatCompletionRequestSchema.nullable().optional(),
     response: Zhipuai.API.ChatCompletionResponseSchema,
+    requestType: RequestTypeSchema.optional(),
+    /** Resolved prompt name if externalAgentId matches a prompt ID */
+    externalAgentIdLabel: z.string().nullable().optional(),
+  }),
+  BaseSelectInteractionSchema.extend({
+    type: z.enum(["grok:chatCompletions"]),
+    request: Grok.API.ChatCompletionRequestSchema,
+    processedRequest:
+      Grok.API.ChatCompletionRequestSchema.nullable().optional(),
+    response: Grok.API.ChatCompletionResponseSchema,
     requestType: RequestTypeSchema.optional(),
     /** Resolved prompt name if externalAgentId matches a prompt ID */
     externalAgentIdLabel: z.string().nullable().optional(),

--- a/platform/backend/src/types/llm-providers/grok/api.ts
+++ b/platform/backend/src/types/llm-providers/grok/api.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+
+import { MessageParamSchema, ToolCallSchema } from "./messages";
+import { ToolChoiceOptionSchema, ToolSchema } from "./tools";
+
+export const ChatCompletionUsageSchema = z
+  .object({
+    completion_tokens: z.number(),
+    prompt_tokens: z.number(),
+    total_tokens: z.number(),
+    prompt_time: z.number().optional(),
+    completion_time: z.number().optional(),
+    queue_time: z.number().optional(),
+    total_time: z.number().optional(),
+  })
+  .describe(`https://console.grok.com/docs/api-reference#chat-create`);
+
+export const FinishReasonSchema = z.enum([
+  "stop",
+  "length",
+  "tool_calls",
+  "content_filter",
+]);
+
+const ChoiceSchema = z
+  .object({
+    finish_reason: FinishReasonSchema,
+    index: z.number(),
+    logprobs: z.any().nullable(),
+    message: z
+      .object({
+        content: z.string().nullable(),
+        role: z.enum(["assistant"]),
+        tool_calls: z.array(ToolCallSchema).optional(),
+      })
+      .describe(`https://console.grok.com/docs/api-reference#chat-create`),
+  })
+  .describe(`https://console.grok.com/docs/api-reference#chat-create`);
+
+export const ChatCompletionRequestSchema = z
+  .object({
+    model: z.string(),
+    messages: z.array(MessageParamSchema),
+    tools: z.array(ToolSchema).optional(),
+    tool_choice: ToolChoiceOptionSchema.optional(),
+    stream: z.boolean().optional(),
+    temperature: z.number().nullable().optional(),
+    top_p: z.number().nullable().optional(),
+    max_tokens: z.number().nullable().optional(),
+    max_completion_tokens: z.number().nullable().optional(),
+    stop: z.union([z.string(), z.array(z.string())]).optional(),
+    frequency_penalty: z.number().nullable().optional(),
+    presence_penalty: z.number().nullable().optional(),
+    n: z.number().nullable().optional(),
+    seed: z.number().nullable().optional(),
+    response_format: z
+      .object({
+        type: z.enum(["text", "json_object"]),
+      })
+      .optional(),
+    user: z.string().optional(),
+  })
+  .describe(`https://console.grok.com/docs/api-reference#chat-create`);
+
+export const ChatCompletionResponseSchema = z
+  .object({
+    id: z.string(),
+    choices: z.array(ChoiceSchema),
+    created: z.number(),
+    model: z.string(),
+    object: z.enum(["chat.completion"]),
+    system_fingerprint: z.string().nullable().optional(),
+    usage: ChatCompletionUsageSchema.optional(),
+    x_grok: z
+      .object({
+        id: z.string().optional(),
+      })
+      .optional(),
+  })
+  .describe(`https://console.grok.com/docs/api-reference#chat-create`);
+
+export const ChatCompletionsHeadersSchema = z.object({
+  "user-agent": z.string().optional().describe("The user agent of the client"),
+  authorization: z
+    .string()
+    .describe("Bearer token for Grok")
+    .transform((authorization) => authorization.replace("Bearer ", "")),
+  "accept-language": z.string().optional(),
+});

--- a/platform/backend/src/types/llm-providers/grok/index.ts
+++ b/platform/backend/src/types/llm-providers/grok/index.ts
@@ -1,0 +1,67 @@
+/**
+ * Grok LLM provider type definitions.
+ *
+ * Grok provides an OpenAI-compatible API with ultra-fast inference.
+ * Base URL: https://api.x.ai/v1
+ */
+import type { z } from "zod";
+import * as GrokAPI from "./api";
+import * as GrokMessages from "./messages";
+import * as GrokTools from "./tools";
+
+namespace Grok {
+  export const API = GrokAPI;
+  export const Messages = GrokMessages;
+  export const Tools = GrokTools;
+
+  export namespace Types {
+    export type ChatCompletionsHeaders = z.infer<
+      typeof GrokAPI.ChatCompletionsHeadersSchema
+    >;
+    export type ChatCompletionsRequest = z.infer<
+      typeof GrokAPI.ChatCompletionRequestSchema
+    >;
+    export type ChatCompletionsResponse = z.infer<
+      typeof GrokAPI.ChatCompletionResponseSchema
+    >;
+    export type Usage = z.infer<typeof GrokAPI.ChatCompletionUsageSchema>;
+
+    export type FinishReason = z.infer<typeof GrokAPI.FinishReasonSchema>;
+    export type Message = z.infer<typeof GrokMessages.MessageParamSchema>;
+    export type Role = Message["role"];
+
+    export type ChatCompletionChunk = {
+      id: string;
+      object: "chat.completion.chunk";
+      created: number;
+      model: string;
+      choices: Array<{
+        index: number;
+        delta: {
+          role?: "assistant";
+          content?: string;
+          tool_calls?: Array<{
+            index: number;
+            id?: string;
+            type?: "function";
+            function?: {
+              name?: string;
+              arguments?: string;
+            };
+          }>;
+        };
+        finish_reason: string | null;
+      }>;
+      usage?: {
+        prompt_tokens: number;
+        completion_tokens: number;
+        total_tokens: number;
+      };
+      x_grok?: {
+        id?: string;
+      };
+    };
+  }
+}
+
+export default Grok;

--- a/platform/backend/src/types/llm-providers/grok/messages.ts
+++ b/platform/backend/src/types/llm-providers/grok/messages.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+
+const FunctionToolCallSchema = z
+  .object({
+    id: z.string(),
+    type: z.enum(["function"]),
+    function: z
+      .object({
+        arguments: z.string(),
+        name: z.string(),
+      })
+      .describe(`https://console.grok.com/docs/api-reference#chat-create`),
+  })
+  .describe(`https://console.grok.com/docs/api-reference#chat-create`);
+
+export const ToolCallSchema = z
+  .union([FunctionToolCallSchema])
+  .describe(`https://console.grok.com/docs/api-reference#chat-create`);
+
+const ContentPartTextSchema = z
+  .object({
+    type: z.enum(["text"]),
+    text: z.string(),
+  })
+  .describe(`https://console.grok.com/docs/api-reference#chat-create`);
+
+const ContentPartImageSchema = z
+  .object({
+    type: z.enum(["image_url"]),
+    image_url: z
+      .object({
+        url: z.string(),
+        detail: z.enum(["auto", "low", "high"]).optional(),
+      })
+      .describe(`https://console.grok.com/docs/api-reference#chat-create`),
+  })
+  .describe(`https://console.grok.com/docs/api-reference#chat-create`);
+
+const ContentPartSchema = z
+  .union([ContentPartTextSchema, ContentPartImageSchema])
+  .describe(`https://console.grok.com/docs/api-reference#chat-create`);
+
+const SystemMessageParamSchema = z
+  .object({
+    role: z.enum(["system"]),
+    content: z.string(),
+    name: z.string().optional(),
+  })
+  .describe(`https://console.grok.com/docs/api-reference#chat-create`);
+
+const UserMessageParamSchema = z
+  .object({
+    role: z.enum(["user"]),
+    content: z.union([z.string(), z.array(ContentPartSchema)]),
+    name: z.string().optional(),
+  })
+  .describe(`https://console.grok.com/docs/api-reference#chat-create`);
+
+const AssistantMessageParamSchema = z
+  .object({
+    role: z.enum(["assistant"]),
+    content: z.string().nullable().optional(),
+    name: z.string().optional(),
+    tool_calls: z.array(ToolCallSchema).optional(),
+  })
+  .describe(`https://console.grok.com/docs/api-reference#chat-create`);
+
+const ToolMessageParamSchema = z
+  .object({
+    role: z.enum(["tool"]),
+    content: z.string(),
+    tool_call_id: z.string(),
+  })
+  .describe(`https://console.grok.com/docs/api-reference#chat-create`);
+
+export const MessageParamSchema = z
+  .union([
+    SystemMessageParamSchema,
+    UserMessageParamSchema,
+    AssistantMessageParamSchema,
+    ToolMessageParamSchema,
+  ])
+  .describe(`https://console.grok.com/docs/api-reference#chat-create`);

--- a/platform/backend/src/types/llm-providers/grok/tools.ts
+++ b/platform/backend/src/types/llm-providers/grok/tools.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+export const FunctionDefinitionParametersSchema = z
+  .record(z.string(), z.unknown())
+  .optional()
+  .describe(`
+    https://console.grok.com/docs/api-reference#chat-create
+
+    The parameters the functions accepts, described as a JSON Schema object. See the
+    [JSON Schema reference](https://json-schema.org/understanding-json-schema/) for
+    documentation about the format.
+
+    Omitting parameters defines a function with an empty parameter list.
+  `);
+
+const FunctionDefinitionSchema = z
+  .object({
+    name: z.string(),
+    description: z.string().optional(),
+    parameters: FunctionDefinitionParametersSchema,
+    strict: z.boolean().nullable().optional(),
+  })
+  .describe(`https://console.grok.com/docs/api-reference#chat-create`);
+
+const FunctionToolSchema = z
+  .object({
+    type: z.enum(["function"]),
+    function: FunctionDefinitionSchema,
+  })
+  .describe(`https://console.grok.com/docs/api-reference#chat-create`);
+
+const NamedToolChoiceSchema = z
+  .object({
+    type: z.enum(["function"]),
+    function: z.object({
+      name: z.string(),
+    }),
+  })
+  .describe(`
+  Specifies a tool the model should use. Use to force the model to call a specific function.
+
+  https://console.grok.com/docs/api-reference#chat-create
+  `);
+
+export const ToolSchema = z.union([FunctionToolSchema]).describe(`
+  A function tool that can be used to generate a response.
+
+  https://console.grok.com/docs/api-reference#chat-create
+  `);
+
+export const ToolChoiceOptionSchema = z
+  .union([z.enum(["auto", "none", "required"]), NamedToolChoiceSchema])
+  .describe(`https://console.grok.com/docs/api-reference#chat-create`);

--- a/platform/backend/src/types/llm-providers/index.ts
+++ b/platform/backend/src/types/llm-providers/index.ts
@@ -8,3 +8,4 @@ export { default as Ollama } from "./ollama";
 export { default as OpenAi } from "./openai";
 export { default as Vllm } from "./vllm";
 export { default as Zhipuai } from "./zhipuai";
+export { default as Grok } from "./grok";

--- a/platform/frontend/src/lib/interaction.utils.ts
+++ b/platform/frontend/src/lib/interaction.utils.ts
@@ -15,6 +15,7 @@ import OllamaChatCompletionInteraction from "./llmProviders/ollama";
 import OpenAiChatCompletionInteraction from "./llmProviders/openai";
 import VllmChatCompletionInteraction from "./llmProviders/vllm";
 import ZhipuaiChatCompletionInteraction from "./llmProviders/zhipuai";
+import GrokChatCompletionInteraction from "./llmProviders/grok";
 
 export interface CostSavingsInput {
   cost: string | null | undefined;
@@ -130,6 +131,8 @@ export class DynamicInteraction implements InteractionUtils {
       return new BedrockConverseInteraction(interaction);
     } else if (type === "zhipuai:chatCompletions") {
       return new ZhipuaiChatCompletionInteraction(interaction);
+    } else if (type === "grok:chatCompletions") {
+      return new GrokChatCompletionInteraction(interaction);
     } else if (type === "cerebras:chatCompletions") {
       return new CerebrasChatCompletionInteraction(interaction);
     } else if (type === "mistral:chatCompletions") {

--- a/platform/frontend/src/lib/llmProviders/grok.ts
+++ b/platform/frontend/src/lib/llmProviders/grok.ts
@@ -1,0 +1,273 @@
+import type { archestraApiTypes } from "@shared";
+import type { PartialUIMessage } from "@/components/chatbot-demo";
+import type { DualLlmResult, Interaction, InteractionUtils } from "./common";
+
+class GrokChatCompletionInteraction implements InteractionUtils {
+  private request: archestraApiTypes.GrokChatCompletionRequest;
+  private response: archestraApiTypes.GrokChatCompletionResponse;
+  modelName: string;
+
+  constructor(interaction: Interaction) {
+    this.request =
+      interaction.request as archestraApiTypes.GrokChatCompletionRequest;
+    this.response =
+      interaction.response as archestraApiTypes.GrokChatCompletionResponse;
+    this.modelName = interaction.model ?? this.request.model;
+  }
+
+  isLastMessageToolCall(): boolean {
+    const messages = this.request.messages;
+
+    if (messages.length === 0) {
+      return false;
+    }
+
+    const lastMessage = messages[messages.length - 1];
+    return lastMessage.role === "tool";
+  }
+
+  getLastToolCallId(): string | null {
+    const messages = this.request.messages;
+    if (messages.length === 0) {
+      return null;
+    }
+
+    const lastMessage = messages[messages.length - 1];
+    if (lastMessage.role === "tool") {
+      return lastMessage.tool_call_id;
+    }
+    return null;
+  }
+
+  getToolNamesUsed(): string[] {
+    const toolsUsed = new Set<string>();
+    for (const message of this.request.messages) {
+      if (message.role === "assistant" && message.tool_calls) {
+        for (const toolCall of message.tool_calls) {
+          toolsUsed.add(toolCall.function.name);
+        }
+      }
+    }
+    return Array.from(toolsUsed);
+  }
+
+  getToolNamesRefused(): string[] {
+    return [];
+  }
+
+  getToolNamesRequested(): string[] {
+    const toolsRequested = new Set<string>();
+
+    for (const choice of this.response.choices) {
+      if (choice.message.tool_calls) {
+        for (const toolCall of choice.message.tool_calls) {
+          toolsRequested.add(toolCall.function.name);
+        }
+      }
+    }
+
+    return Array.from(toolsRequested);
+  }
+
+  getLastUserMessage(): string {
+    const reversedMessages = [...this.request.messages].reverse();
+    for (const message of reversedMessages) {
+      if (message.role !== "user") {
+        continue;
+      }
+      if (typeof message.content === "string") {
+        return message.content;
+      }
+      if (
+        Array.isArray(message.content) &&
+        message.content[0]?.type === "text"
+      ) {
+        return message.content[0].text;
+      }
+    }
+    return "";
+  }
+
+  getLastAssistantResponse(): string {
+    const content = this.response.choices[0]?.message?.content as string;
+    return content ?? "";
+  }
+
+  getToolRefusedCount(): number {
+    let count = 0;
+    for (const choice of this.response.choices) {
+      if (choice.finish_reason === "content_filter") {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private mapToUiMessage(
+    message:
+      | archestraApiTypes.GrokChatCompletionRequest["messages"][number]
+      | archestraApiTypes.GrokChatCompletionResponse["choices"][number]["message"],
+  ): PartialUIMessage {
+    const parts: PartialUIMessage["parts"] = [];
+    const { content, role } = message;
+
+    if (role === "assistant") {
+      const { tool_calls: toolCalls } = message;
+
+      if (toolCalls) {
+        if (typeof content === "string" && content) {
+          parts.push({ type: "text", text: content });
+        } else if (Array.isArray(content)) {
+          for (const part of content) {
+            if (part.type === "text") {
+              parts.push({ type: "text", text: part.text });
+            }
+          }
+        }
+
+        for (const toolCall of toolCalls) {
+          parts.push({
+            type: "dynamic-tool",
+            toolName: toolCall.function.name,
+            toolCallId: toolCall.id,
+            state: "input-available",
+            input: JSON.parse(toolCall.function.arguments),
+          });
+        }
+      }
+    } else if (message.role === "tool") {
+      const toolContent = message.content;
+      const toolCallId = message.tool_call_id;
+
+      let output: unknown;
+      try {
+        output =
+          typeof toolContent === "string"
+            ? JSON.parse(toolContent)
+            : toolContent;
+      } catch {
+        output = toolContent;
+      }
+
+      parts.push({
+        type: "dynamic-tool",
+        toolName: "tool-result",
+        toolCallId,
+        state: "output-available",
+        input: {},
+        output,
+      });
+    } else {
+      if (typeof content === "string") {
+        parts.push({ type: "text", text: content });
+      } else if (Array.isArray(content)) {
+        for (const part of content) {
+          if (part.type === "text") {
+            parts.push({ type: "text", text: part.text });
+          } else if (part.type === "image_url") {
+            parts.push({
+              type: "file",
+              mediaType: "image/*",
+              url: part.image_url.url,
+            });
+          }
+        }
+      }
+    }
+
+    const grokRoleToUIMessageRoleMap: Record<
+      archestraApiTypes.GrokChatCompletionRequest["messages"][number]["role"],
+      PartialUIMessage["role"]
+    > = {
+      system: "system",
+      tool: "assistant",
+      user: "user",
+      assistant: "assistant",
+    };
+
+    return {
+      role: grokRoleToUIMessageRoleMap[role],
+      parts,
+    };
+  }
+
+  private mapRequestToUiMessages(
+    dualLlmResults?: DualLlmResult[],
+  ): PartialUIMessage[] {
+    const messages = this.request.messages;
+    const uiMessages: PartialUIMessage[] = [];
+
+    for (let i = 0; i < messages.length; i++) {
+      const msg = messages[i];
+
+      if (msg.role === "tool") {
+        continue;
+      }
+
+      const uiMessage = this.mapToUiMessage(msg);
+
+      if (msg.role === "assistant" && "tool_calls" in msg && msg.tool_calls) {
+        const toolCallParts: PartialUIMessage["parts"] = [...uiMessage.parts];
+
+        for (const toolCall of msg.tool_calls) {
+          const toolResultMsg = messages
+            .slice(i + 1)
+            .find(
+              (m) =>
+                m.role === "tool" &&
+                "tool_call_id" in m &&
+                m.tool_call_id === toolCall.id,
+            );
+
+          if (toolResultMsg && toolResultMsg.role === "tool") {
+            const toolResultUiMsg = this.mapToUiMessage(toolResultMsg);
+            toolCallParts.push(...toolResultUiMsg.parts);
+
+            const dualLlmResultForTool = dualLlmResults?.find(
+              (result) => result.toolCallId === toolCall.id,
+            );
+
+            if (dualLlmResultForTool) {
+              const dualLlmPart = {
+                type: "dual-llm-analysis" as const,
+                toolCallId: dualLlmResultForTool.toolCallId,
+                safeResult: dualLlmResultForTool.result,
+                conversations: Array.isArray(dualLlmResultForTool.conversations)
+                  ? (dualLlmResultForTool.conversations as Array<{
+                      role: "user" | "assistant";
+                      content: string | unknown;
+                    }>)
+                  : [],
+              };
+              toolCallParts.push(dualLlmPart);
+            }
+          }
+        }
+
+        uiMessages.push({
+          ...uiMessage,
+          parts: toolCallParts,
+        });
+      } else {
+        uiMessages.push(uiMessage);
+      }
+    }
+
+    return uiMessages;
+  }
+
+  private mapResponseToUiMessages(): PartialUIMessage[] {
+    return this.response.choices.map((choice) =>
+      this.mapToUiMessage(choice.message),
+    );
+  }
+
+  mapToUiMessages(dualLlmResults?: DualLlmResult[]): PartialUIMessage[] {
+    return [
+      ...this.mapRequestToUiMessages(dualLlmResults),
+      ...this.mapResponseToUiMessages(),
+    ];
+  }
+}
+
+export default GrokChatCompletionInteraction;

--- a/platform/shared/chat-error.ts
+++ b/platform/shared/chat-error.ts
@@ -177,6 +177,31 @@ export const ZhipuaiErrorTypes = {
   RATE_LIMIT: "1305",
 } as const;
 
+/**
+ * Grok API error types (from response body `error.type` field)
+ * Grok uses string-based error types in OpenAI-compatible format
+ * @see https://console.grok.com/docs/errors
+ */
+export const GrokErrorTypes = {
+  // Rate limiting
+  RATE_LIMIT: "rate_limit_exceeded",
+
+  // Model errors
+  MODEL_NOT_FOUND: "model_not_found",
+
+  // Authentication errors
+  INVALID_API_KEY: "invalid_api_key",
+
+  // Request errors
+  INVALID_REQUEST: "invalid_request_error",
+
+  // Server errors
+  SERVER_ERROR: "server_error",
+
+  // Content moderation
+  CONTENT_FILTER: "content_filter",
+} as const;
+
 // =============================================================================
 // Normalized Chat Error Codes
 // =============================================================================

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -14,6 +14,7 @@ export const SupportedProvidersSchema = z.enum([
   "vllm",
   "ollama",
   "zhipuai",
+  "grok",
 ]);
 
 export const SupportedProvidersDiscriminatorSchema = z.enum([
@@ -27,6 +28,7 @@ export const SupportedProvidersDiscriminatorSchema = z.enum([
   "vllm:chatCompletions",
   "ollama:chatCompletions",
   "zhipuai:chatCompletions",
+  "grok:chatCompletions",
 ]);
 
 export const SupportedProviders = Object.values(SupportedProvidersSchema.enum);
@@ -46,6 +48,7 @@ export const providerDisplayNames: Record<SupportedProvider, string> = {
   vllm: "vLLM",
   ollama: "Ollama",
   zhipuai: "Zhipu AI",
+  grok: "Grok",
 };
 
 /**
@@ -105,5 +108,9 @@ export const MODEL_MARKER_PATTERNS: Record<
   bedrock: {
     fastest: ["nova-lite", "nova-micro", "haiku"],
     best: ["nova-pro", "sonnet", "opus"],
+  },
+  grok: {
+    fastest: ["llama-3.3-70b", "gemma2-9b"],
+    best: ["grok-2", "mixtral-8x7b"],
   },
 };

--- a/platform/shared/routes.ts
+++ b/platform/shared/routes.ts
@@ -184,6 +184,10 @@ export const RouteId = {
   ZhipuaiChatCompletionsWithDefaultAgent:
     "zhipuaiChatCompletionsWithDefaultAgent",
   ZhipuaiChatCompletionsWithAgent: "zhipuaiChatCompletionsWithAgent",
+  // Proxy Routes - Grok
+  GrokChatCompletionsWithDefaultAgent:
+    "grokChatCompletionsWithDefaultAgent",
+  GrokChatCompletionsWithAgent: "grokChatCompletionsWithAgent",
 
   // Proxy Routes - AWS Bedrock
   BedrockConverseWithDefaultAgent: "bedrockConverseWithDefaultAgent",


### PR DESCRIPTION
## Summary
Adds x.ai (Grok) as a new AI provider, enabling access to Grok models.

## Changes
- Added x.ai provider configuration and API integration
- Added model constants for Grok models
- Added x.ai to LLM client routing
- Added Grok models to API routes

## Implementation
Follows the same pattern as existing providers. Uses x.ai's OpenAI-compatible API endpoint.

/claim #1850