### PR TITLE
fix: progressively save chat messages during streaming

### DIFF
--- a/platform/backend/src/models/message.ts
+++ b/platform/backend/src/models/message.ts
@@ -66,6 +66,16 @@ class MessageModel {
       .where(eq(schema.messagesTable.conversationId, conversationId));
   }
 
+  static async updateContent(
+    messageId: string,
+    content: unknown,
+  ): Promise<void> {
+    await db
+      .update(schema.messagesTable)
+      .set({ content, updatedAt: new Date() })
+      .where(eq(schema.messagesTable.id, messageId));
+  }
+
   static async findById(messageId: string): Promise<Message | null> {
     const [message] = await db
       .select()

--- a/platform/backend/src/routes/chat/map-step-to-ui-parts.test.ts
+++ b/platform/backend/src/routes/chat/map-step-to-ui-parts.test.ts
@@ -1,0 +1,738 @@
+/**
+ * Tests for mapStepContentToUIMessageParts.
+ *
+ * Verifies that the mapping from AI SDK ContentPart[] (onStepFinish)
+ * produces the exact same UIMessage part format as toUIMessageStream (onFinish).
+ *
+ * Reference format (from real DB rows saved by onFinish / toUIMessageStream):
+ *
+ * Text:       { type: "text", text: "...", state: "done" }
+ * Step start: { type: "step-start" }
+ * Tool call:  { type: "tool-{toolName}", toolCallId, state: "input-available", input, callProviderMetadata? }
+ * Tool result: { type: "tool-{toolName}", toolCallId, state: "output-available", input, output, callProviderMetadata? }
+ * Tool error: { type: "tool-{toolName}", toolCallId, state: "output-error", input, errorText, callProviderMetadata? }
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  mapStepContentToUIMessageParts,
+  type StepContentPart,
+} from "./map-step-to-ui-parts";
+
+describe("mapStepContentToUIMessageParts", () => {
+  describe("step-start marker", () => {
+    it("adds step-start before each step", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      mapStepContentToUIMessageParts([{ type: "text", text: "Hello" }], parts);
+
+      expect(parts[0]).toEqual({ type: "step-start" });
+    });
+
+    it("adds step-start for every step call", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      mapStepContentToUIMessageParts([{ type: "text", text: "Step 1" }], parts);
+      mapStepContentToUIMessageParts([{ type: "text", text: "Step 2" }], parts);
+
+      expect(parts[0]).toEqual({ type: "step-start" });
+      expect(parts[2]).toEqual({ type: "step-start" });
+    });
+  });
+
+  describe("text parts", () => {
+    it("maps text ContentPart to UIMessage text part", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      mapStepContentToUIMessageParts(
+        [{ type: "text", text: "Hello world" }],
+        parts,
+      );
+
+      expect(parts[1]).toEqual({ type: "text", text: "Hello world" });
+    });
+
+    it("skips empty text parts", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      mapStepContentToUIMessageParts([{ type: "text", text: "" }], parts);
+
+      // Only step-start, no text part
+      expect(parts).toHaveLength(1);
+      expect(parts[0]).toEqual({ type: "step-start" });
+    });
+  });
+
+  describe("tool-call parts", () => {
+    it("maps tool-call to tool-{toolName} with input-available state", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      mapStepContentToUIMessageParts(
+        [
+          {
+            type: "tool-call",
+            toolCallId: "tc_123",
+            toolName: "microsoft__playwright-mcp__browser_navigate",
+            input: { url: "https://example.com" },
+          },
+        ],
+        parts,
+      );
+
+      expect(parts[1]).toEqual({
+        type: "tool-microsoft__playwright-mcp__browser_navigate",
+        toolCallId: "tc_123",
+        state: "input-available",
+        input: { url: "https://example.com" },
+      });
+    });
+
+    it("includes callProviderMetadata when providerMetadata is present", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      mapStepContentToUIMessageParts(
+        [
+          {
+            type: "tool-call",
+            toolCallId: "tc_456",
+            toolName: "archestra__todo_write",
+            input: { todos: [] },
+            providerMetadata: { anthropic: { caller: { type: "direct" } } },
+          },
+        ],
+        parts,
+      );
+
+      expect(parts[1]).toEqual({
+        type: "tool-archestra__todo_write",
+        toolCallId: "tc_456",
+        state: "input-available",
+        input: { todos: [] },
+        callProviderMetadata: { anthropic: { caller: { type: "direct" } } },
+      });
+    });
+
+    it("omits callProviderMetadata when providerMetadata is absent", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      mapStepContentToUIMessageParts(
+        [
+          {
+            type: "tool-call",
+            toolCallId: "tc_789",
+            toolName: "search",
+            input: { query: "test" },
+          },
+        ],
+        parts,
+      );
+
+      expect(parts[1]).not.toHaveProperty("callProviderMetadata");
+    });
+  });
+
+  describe("tool-result parts", () => {
+    it("updates matching tool part to output-available state", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      // Step 1: tool call + tool result in same step
+      mapStepContentToUIMessageParts(
+        [
+          {
+            type: "tool-call",
+            toolCallId: "tc_100",
+            toolName: "search",
+            input: { query: "AI" },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tc_100",
+            toolName: "search",
+            output: "Search results...",
+          },
+        ],
+        parts,
+      );
+
+      // Tool part should be updated in place
+      expect(parts[1]).toEqual({
+        type: "tool-search",
+        toolCallId: "tc_100",
+        state: "output-available",
+        input: { query: "AI" },
+        output: "Search results...",
+      });
+    });
+
+    it("preserves callProviderMetadata when updating to output-available", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      mapStepContentToUIMessageParts(
+        [
+          {
+            type: "tool-call",
+            toolCallId: "tc_200",
+            toolName: "fetch",
+            input: { url: "https://example.com" },
+            providerMetadata: { anthropic: { caller: { type: "direct" } } },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tc_200",
+            toolName: "fetch",
+            output: "<html>...</html>",
+          },
+        ],
+        parts,
+      );
+
+      expect(parts[1].callProviderMetadata).toEqual({
+        anthropic: { caller: { type: "direct" } },
+      });
+      expect(parts[1].state).toBe("output-available");
+    });
+
+    it("handles tool-result arriving in a later step", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      // Step 1: tool call only
+      mapStepContentToUIMessageParts(
+        [
+          {
+            type: "tool-call",
+            toolCallId: "tc_300",
+            toolName: "long_running_tool",
+            input: { task: "process" },
+          },
+        ],
+        parts,
+      );
+
+      expect(parts[1].state).toBe("input-available");
+
+      // Step 2: tool result arrives
+      mapStepContentToUIMessageParts(
+        [
+          {
+            type: "tool-result",
+            toolCallId: "tc_300",
+            toolName: "long_running_tool",
+            output: "Done!",
+          },
+          { type: "text", text: "The task is complete." },
+        ],
+        parts,
+      );
+
+      // Original tool part (index 1) should be updated
+      expect(parts[1].state).toBe("output-available");
+      expect(parts[1].output).toBe("Done!");
+    });
+  });
+
+  describe("tool-error parts", () => {
+    it("updates matching tool part to output-error state with string error", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      mapStepContentToUIMessageParts(
+        [
+          {
+            type: "tool-call",
+            toolCallId: "tc_400",
+            toolName: "browser_click",
+            input: { ref: "e22" },
+          },
+          {
+            type: "tool-error",
+            toolCallId: "tc_400",
+            toolName: "browser_click",
+            error: "Timeout 5000ms exceeded",
+          },
+        ],
+        parts,
+      );
+
+      expect(parts[1]).toEqual({
+        type: "tool-browser_click",
+        toolCallId: "tc_400",
+        state: "output-error",
+        input: { ref: "e22" },
+        errorText: "Timeout 5000ms exceeded",
+      });
+    });
+
+    it("converts Error object to errorText", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      mapStepContentToUIMessageParts(
+        [
+          {
+            type: "tool-call",
+            toolCallId: "tc_500",
+            toolName: "browser_click",
+            input: { ref: "e10" },
+          },
+          {
+            type: "tool-error",
+            toolCallId: "tc_500",
+            toolName: "browser_click",
+            error: new Error("Element not found"),
+          },
+        ],
+        parts,
+      );
+
+      expect(parts[1].state).toBe("output-error");
+      expect(parts[1].errorText).toBe("Element not found");
+    });
+
+    it("JSON-stringifies object errors", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      mapStepContentToUIMessageParts(
+        [
+          {
+            type: "tool-call",
+            toolCallId: "tc_600",
+            toolName: "api_call",
+            input: {},
+          },
+          {
+            type: "tool-error",
+            toolCallId: "tc_600",
+            toolName: "api_call",
+            error: { code: "TIMEOUT", message: "Request timed out" },
+          },
+        ],
+        parts,
+      );
+
+      expect(parts[1].state).toBe("output-error");
+      expect(parts[1].errorText).toBe(
+        '{"code":"TIMEOUT","message":"Request timed out"}',
+      );
+    });
+  });
+
+  describe("multi-step agentic scenarios", () => {
+    it("produces correct format for a multi-step agentic loop", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      // Step 1: LLM calls a tool
+      mapStepContentToUIMessageParts(
+        [
+          {
+            type: "tool-call",
+            toolCallId: "tc_a",
+            toolName: "microsoft__playwright-mcp__browser_navigate",
+            input: { url: "https://acurio.vc" },
+            providerMetadata: { anthropic: { caller: { type: "direct" } } },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tc_a",
+            toolName: "microsoft__playwright-mcp__browser_navigate",
+            output: "[Page snapshot here]",
+          },
+        ],
+        parts,
+      );
+
+      // Step 2: LLM calls another tool then responds with text
+      mapStepContentToUIMessageParts(
+        [
+          {
+            type: "tool-call",
+            toolCallId: "tc_b",
+            toolName: "archestra__todo_write",
+            input: { todos: [{ id: 1, content: "Research fund" }] },
+            providerMetadata: { anthropic: { caller: { type: "direct" } } },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tc_b",
+            toolName: "archestra__todo_write",
+            output: "Successfully wrote 1 todo item(s)",
+          },
+        ],
+        parts,
+      );
+
+      // Step 3: LLM responds with text
+      mapStepContentToUIMessageParts(
+        [{ type: "text", text: "I've completed my research." }],
+        parts,
+      );
+
+      // Verify the complete structure
+      expect(parts).toEqual([
+        // Step 1
+        { type: "step-start" },
+        {
+          type: "tool-microsoft__playwright-mcp__browser_navigate",
+          toolCallId: "tc_a",
+          state: "output-available",
+          input: { url: "https://acurio.vc" },
+          output: "[Page snapshot here]",
+          callProviderMetadata: { anthropic: { caller: { type: "direct" } } },
+        },
+        // Step 2
+        { type: "step-start" },
+        {
+          type: "tool-archestra__todo_write",
+          toolCallId: "tc_b",
+          state: "output-available",
+          input: { todos: [{ id: 1, content: "Research fund" }] },
+          output: "Successfully wrote 1 todo item(s)",
+          callProviderMetadata: { anthropic: { caller: { type: "direct" } } },
+        },
+        // Step 3
+        { type: "step-start" },
+        { type: "text", text: "I've completed my research." },
+      ]);
+    });
+
+    it("handles multiple tool calls within a single step", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      mapStepContentToUIMessageParts(
+        [
+          {
+            type: "tool-call",
+            toolCallId: "tc_1",
+            toolName: "search",
+            input: { query: "topic A" },
+          },
+          {
+            type: "tool-call",
+            toolCallId: "tc_2",
+            toolName: "search",
+            input: { query: "topic B" },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tc_1",
+            toolName: "search",
+            output: "Results for A",
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tc_2",
+            toolName: "search",
+            output: "Results for B",
+          },
+        ],
+        parts,
+      );
+
+      // Both tool parts should be output-available
+      expect(parts[1].toolCallId).toBe("tc_1");
+      expect(parts[1].state).toBe("output-available");
+      expect(parts[2].toolCallId).toBe("tc_2");
+      expect(parts[2].state).toBe("output-available");
+    });
+
+    it("matches real DB format from toUIMessageStream", () => {
+      // This test uses the exact format observed in a real working conversation
+      // (7df16938) saved by onFinish / toUIMessageStream
+      const parts: Record<string, unknown>[] = [];
+
+      mapStepContentToUIMessageParts(
+        [
+          {
+            type: "tool-call",
+            toolCallId: "toolu_01PqyxvUKThQwoJvXQHJpJJu",
+            toolName: "microsoft__playwright-mcp__browser_navigate",
+            input: { url: "https://acurio.vc" },
+            providerMetadata: { anthropic: { caller: { type: "direct" } } },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "toolu_01PqyxvUKThQwoJvXQHJpJJu",
+            toolName: "microsoft__playwright-mcp__browser_navigate",
+            output: "[Page https://www.acurio.vc/ browser_navigate was here]",
+          },
+        ],
+        parts,
+      );
+
+      // Compare against actual DB row format from the working conversation
+      const expectedToolPart = {
+        type: "tool-microsoft__playwright-mcp__browser_navigate",
+        toolCallId: "toolu_01PqyxvUKThQwoJvXQHJpJJu",
+        state: "output-available",
+        input: { url: "https://acurio.vc" },
+        output: "[Page https://www.acurio.vc/ browser_navigate was here]",
+        callProviderMetadata: { anthropic: { caller: { type: "direct" } } },
+      };
+
+      expect(parts[1]).toEqual(expectedToolPart);
+    });
+  });
+
+  describe("reasoning parts", () => {
+    it("maps reasoning to UIMessage reasoning part with state done", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      mapStepContentToUIMessageParts(
+        [{ type: "reasoning", text: "Let me think about this..." }],
+        parts,
+      );
+
+      expect(parts[1]).toEqual({
+        type: "reasoning",
+        text: "Let me think about this...",
+        providerMetadata: undefined,
+        state: "done",
+      });
+    });
+
+    it("includes providerMetadata when present", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      mapStepContentToUIMessageParts(
+        [
+          {
+            type: "reasoning",
+            text: "Thinking...",
+            providerMetadata: {
+              anthropic: { cacheControl: { type: "ephemeral" } },
+            },
+          },
+        ],
+        parts,
+      );
+
+      expect(parts[1]).toEqual({
+        type: "reasoning",
+        text: "Thinking...",
+        providerMetadata: {
+          anthropic: { cacheControl: { type: "ephemeral" } },
+        },
+        state: "done",
+      });
+    });
+  });
+
+  describe("source parts", () => {
+    it("maps source with sourceType url to source-url part", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      mapStepContentToUIMessageParts(
+        [
+          {
+            type: "source",
+            sourceType: "url",
+            id: "src_1",
+            url: "https://example.com/article",
+            title: "Example Article",
+          } as StepContentPart,
+        ],
+        parts,
+      );
+
+      expect(parts[1]).toEqual({
+        type: "source-url",
+        sourceId: "src_1",
+        url: "https://example.com/article",
+        title: "Example Article",
+        providerMetadata: undefined,
+      });
+    });
+
+    it("maps source with sourceType document to source-document part", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      mapStepContentToUIMessageParts(
+        [
+          {
+            type: "source",
+            sourceType: "document",
+            id: "src_2",
+            mediaType: "application/pdf",
+            title: "Report.pdf",
+            filename: "report.pdf",
+          } as StepContentPart,
+        ],
+        parts,
+      );
+
+      expect(parts[1]).toEqual({
+        type: "source-document",
+        sourceId: "src_2",
+        mediaType: "application/pdf",
+        title: "Report.pdf",
+        filename: "report.pdf",
+        providerMetadata: undefined,
+      });
+    });
+
+    it("sets optional fields to undefined when absent on source-url", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      mapStepContentToUIMessageParts(
+        [
+          {
+            type: "source",
+            sourceType: "url",
+            id: "src_3",
+            url: "https://example.com",
+          } as StepContentPart,
+        ],
+        parts,
+      );
+
+      expect(parts[1]).toEqual({
+        type: "source-url",
+        sourceId: "src_3",
+        url: "https://example.com",
+        title: undefined,
+        providerMetadata: undefined,
+      });
+    });
+
+    it("sets optional filename to undefined when absent on source-document", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      mapStepContentToUIMessageParts(
+        [
+          {
+            type: "source",
+            sourceType: "document",
+            id: "src_4",
+            mediaType: "text/plain",
+            title: "Notes",
+          } as StepContentPart,
+        ],
+        parts,
+      );
+
+      expect(parts[1]).toEqual({
+        type: "source-document",
+        sourceId: "src_4",
+        mediaType: "text/plain",
+        title: "Notes",
+        filename: undefined,
+        providerMetadata: undefined,
+      });
+    });
+  });
+
+  describe("file parts", () => {
+    it("maps file to UIMessage file part with data URL", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      mapStepContentToUIMessageParts(
+        [
+          {
+            type: "file",
+            file: { base64: "iVBORw0KGgo=", mediaType: "image/png" },
+          } as StepContentPart,
+        ],
+        parts,
+      );
+
+      expect(parts[1]).toEqual({
+        type: "file",
+        mediaType: "image/png",
+        url: "data:image/png;base64,iVBORw0KGgo=",
+      });
+    });
+  });
+
+  describe("multi-step with all part types", () => {
+    it("handles reasoning, sources, files, text, and tools across steps", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      // Step 1: reasoning + tool call with result
+      mapStepContentToUIMessageParts(
+        [
+          { type: "reasoning", text: "I should search for this." },
+          {
+            type: "tool-call",
+            toolCallId: "tc_mix",
+            toolName: "search",
+            input: { query: "test" },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tc_mix",
+            toolName: "search",
+            output: "Found results",
+          },
+        ],
+        parts,
+      );
+
+      // Step 2: text + source + file
+      mapStepContentToUIMessageParts(
+        [
+          { type: "text", text: "Here are the results." },
+          {
+            type: "source",
+            sourceType: "url",
+            id: "s1",
+            url: "https://example.com",
+            title: "Source",
+          } as StepContentPart,
+          {
+            type: "file",
+            file: { base64: "AAAA", mediaType: "image/jpeg" },
+          } as StepContentPart,
+        ],
+        parts,
+      );
+
+      expect(parts).toEqual([
+        // Step 1
+        { type: "step-start" },
+        {
+          type: "reasoning",
+          text: "I should search for this.",
+          providerMetadata: undefined,
+          state: "done",
+        },
+        {
+          type: "tool-search",
+          toolCallId: "tc_mix",
+          state: "output-available",
+          input: { query: "test" },
+          output: "Found results",
+        },
+        // Step 2
+        { type: "step-start" },
+        { type: "text", text: "Here are the results." },
+        {
+          type: "source-url",
+          sourceId: "s1",
+          url: "https://example.com",
+          title: "Source",
+          providerMetadata: undefined,
+        },
+        {
+          type: "file",
+          mediaType: "image/jpeg",
+          url: "data:image/jpeg;base64,AAAA",
+        },
+      ]);
+    });
+  });
+
+  describe("unknown part types", () => {
+    it("ignores unknown part types gracefully", () => {
+      const parts: Record<string, unknown>[] = [];
+
+      mapStepContentToUIMessageParts(
+        [
+          { type: "some-future-type" } as StepContentPart,
+          { type: "text", text: "Result" },
+        ],
+        parts,
+      );
+
+      expect(parts).toHaveLength(2);
+      expect(parts[0]).toEqual({ type: "step-start" });
+      expect(parts[1]).toEqual({ type: "text", text: "Result" });
+    });
+  });
+});

--- a/platform/backend/src/routes/chat/map-step-to-ui-parts.ts
+++ b/platform/backend/src/routes/chat/map-step-to-ui-parts.ts
@@ -1,0 +1,174 @@
+/**
+ * Maps AI SDK ContentPart[] (from onStepFinish) to UIMessage parts format.
+ *
+ * The AI SDK's toUIMessageStream produces UIMessage parts with a specific structure
+ * (e.g. type: "tool-{toolName}", state: "output-available", input/output properties).
+ * When we progressively save via onStepFinish, we receive ContentPart[] which has a
+ * different structure (e.g. type: "tool-call", part.input, part.output).
+ *
+ * This module maps ContentPart[] to the exact same UIMessage parts format so that
+ * messages saved by the draft mechanism render identically to messages saved by onFinish.
+ */
+
+/**
+ * A single UIMessage part in the format the AI SDK frontend expects.
+ * Uses `any` because the exact shape depends on the tool and is dynamic.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: UIMessage parts are dynamic
+type UIMessagePart = Record<string, any>;
+
+/**
+ * A step content part from AI SDK's onStepFinish callback.
+ * Covers text, tool-call, tool-result, tool-error, reasoning, source, and file types.
+ */
+export interface StepContentPart {
+  type: string;
+  text?: string;
+  toolCallId?: string;
+  toolName?: string;
+  input?: unknown;
+  output?: unknown;
+  error?: unknown;
+  providerMetadata?: Record<string, unknown>;
+  // source parts
+  sourceType?: "url" | "document";
+  id?: string;
+  url?: string;
+  title?: string;
+  mediaType?: string;
+  filename?: string;
+  // file parts
+  file?: { base64?: string; mediaType?: string; uint8Array?: Uint8Array };
+}
+
+/**
+ * Maps a single step's content parts into UIMessage-compatible parts,
+ * mutating the accumulated parts array in place.
+ *
+ * Produces the same format as AI SDK's toUIMessageStream:
+ * - Adds { type: "step-start" } before each step's content
+ * - text       → { type: "text", text }
+ * - tool-call  → { type: "tool-{toolName}", toolCallId, state: "input-available", input }
+ * - tool-result→ updates matching tool part to state: "output-available" with output
+ * - tool-error → updates matching tool part to state: "output-error" with errorText
+ *
+ * @param stepContent - ContentPart[] from onStepFinish's stepResult.content
+ * @param accumulatedParts - The running array of UIMessage parts (mutated in place)
+ */
+export function mapStepContentToUIMessageParts(
+  stepContent: StepContentPart[],
+  accumulatedParts: UIMessagePart[],
+): void {
+  // The SDK inserts a step-start marker before each step's content
+  accumulatedParts.push({ type: "step-start" });
+
+  for (const part of stepContent) {
+    switch (part.type) {
+      case "text": {
+        if (part.text && part.text.length > 0) {
+          accumulatedParts.push({ type: "text", text: part.text });
+        }
+        break;
+      }
+
+      case "tool-call": {
+        accumulatedParts.push({
+          type: `tool-${part.toolName}`,
+          toolCallId: part.toolCallId,
+          state: "input-available",
+          input: part.input,
+          ...(part.providerMetadata != null
+            ? { callProviderMetadata: part.providerMetadata }
+            : {}),
+        });
+        break;
+      }
+
+      case "tool-result": {
+        const idx = accumulatedParts.findIndex(
+          (p) =>
+            p.type === `tool-${part.toolName}` &&
+            p.toolCallId === part.toolCallId,
+        );
+        if (idx >= 0) {
+          accumulatedParts[idx] = {
+            ...accumulatedParts[idx],
+            state: "output-available",
+            output: part.output,
+          };
+        }
+        break;
+      }
+
+      case "tool-error": {
+        const idx = accumulatedParts.findIndex(
+          (p) =>
+            p.type === `tool-${part.toolName}` &&
+            p.toolCallId === part.toolCallId,
+        );
+        if (idx >= 0) {
+          const errorText =
+            part.error instanceof Error
+              ? part.error.message
+              : typeof part.error === "string"
+                ? part.error
+                : JSON.stringify(part.error);
+          accumulatedParts[idx] = {
+            ...accumulatedParts[idx],
+            state: "output-error",
+            errorText,
+          };
+        }
+        break;
+      }
+
+      case "reasoning": {
+        accumulatedParts.push({
+          type: "reasoning",
+          text: part.text,
+          providerMetadata: part.providerMetadata,
+          state: "done",
+        });
+        break;
+      }
+
+      case "source": {
+        if (part.sourceType === "url") {
+          accumulatedParts.push({
+            type: "source-url",
+            sourceId: part.id,
+            url: part.url,
+            title: part.title,
+            providerMetadata: part.providerMetadata,
+          });
+        } else if (part.sourceType === "document") {
+          accumulatedParts.push({
+            type: "source-document",
+            sourceId: part.id,
+            mediaType: part.mediaType,
+            title: part.title,
+            filename: part.filename,
+            providerMetadata: part.providerMetadata,
+          });
+        }
+        break;
+      }
+
+      case "file": {
+        if (part.file) {
+          const mediaType = part.file.mediaType;
+          const base64 = part.file.base64;
+          accumulatedParts.push({
+            type: "file",
+            mediaType,
+            url: `data:${mediaType};base64,${base64}`,
+          });
+        }
+        break;
+      }
+
+      default:
+        break;
+    }
+  }
+}

--- a/platform/backend/src/routes/chat/message-persistence.test.ts
+++ b/platform/backend/src/routes/chat/message-persistence.test.ts
@@ -1,0 +1,610 @@
+/**
+ * Tests for chat message persistence behavior.
+ *
+ * These tests verify the progressive save approach:
+ * 1. User messages are saved on the first onStepFinish call (not pre-saved before streaming)
+ * 2. A draft assistant message is created on the first step and updated on subsequent steps
+ * 3. onFinish atomically updates the draft with the proper UIMessage content (no delete-then-create)
+ * 4. If onFinish never fires (crash, error), the draft survives with partial content
+ * 5. Falls back to count-based dedup when no steps completed
+ */
+
+import { describe, expect } from "vitest";
+import ConversationModel from "@/models/conversation";
+import MessageModel from "@/models/message";
+import { test } from "@/test";
+import { mapStepContentToUIMessageParts } from "./map-step-to-ui-parts";
+
+/**
+ * Helper to create a UIMessage-like object matching the structure used by the chat route.
+ */
+function makeUIMessage(role: "user" | "assistant", text: string) {
+  return {
+    id: crypto.randomUUID(),
+    role,
+    content: text,
+    parts: [{ type: "text", text }],
+    createdAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Simulates the onStepFinish save logic from routes.chat.ts.
+ * On the first call, saves new user messages and creates a draft assistant message.
+ * On subsequent calls, updates the draft with accumulated content.
+ *
+ * Returns the updated state (draftAssistantMessageId, userMessagesSaved, accumulatedParts)
+ * so the caller can chain multiple steps.
+ */
+async function simulateOnStepFinishSave(
+  conversationId: string,
+  stepContent: Array<
+    | { type: "text"; text: string }
+    | {
+        type: "tool-call";
+        toolCallId: string;
+        toolName: string;
+        input: unknown;
+      }
+    | {
+        type: "tool-result";
+        toolCallId: string;
+        toolName: string;
+        output: unknown;
+      }
+  >,
+  state: {
+    incomingMessages: ReturnType<typeof makeUIMessage>[];
+    preSaveExistingCount: number;
+    draftAssistantMessageId: string | null;
+    userMessagesSaved: boolean;
+    // biome-ignore lint/suspicious/noExplicitAny: UIMessage parts are dynamic
+    accumulatedParts: any[];
+  },
+) {
+  // Save user messages on first step
+  if (!state.userMessagesSaved) {
+    state.userMessagesSaved = true;
+    const newIncomingMessages = state.incomingMessages.slice(
+      state.preSaveExistingCount,
+    );
+    const newUserMessages = newIncomingMessages.filter(
+      (m) => m.role === "user",
+    );
+    if (newUserMessages.length > 0) {
+      await MessageModel.bulkCreate(
+        newUserMessages.map((msg) => ({
+          conversationId,
+          role: "user" as const,
+          content: msg,
+        })),
+      );
+    }
+  }
+
+  // Map step content to UIMessage-compatible parts (same format as toUIMessageStream)
+  mapStepContentToUIMessageParts(stepContent, state.accumulatedParts);
+
+  // Build UIMessage-like object for DB storage
+  const assistantContent = {
+    id: state.draftAssistantMessageId || crypto.randomUUID(),
+    role: "assistant",
+    parts: [...state.accumulatedParts],
+    createdAt: new Date().toISOString(),
+  };
+
+  if (!state.draftAssistantMessageId) {
+    const created = await MessageModel.create({
+      conversationId,
+      role: "assistant",
+      content: assistantContent,
+    });
+    state.draftAssistantMessageId = created.id;
+  } else {
+    await MessageModel.updateContent(
+      state.draftAssistantMessageId,
+      assistantContent,
+    );
+  }
+
+  return state;
+}
+
+/**
+ * Simulates the onFinish callback logic from routes.chat.ts.
+ * When a draft exists, atomically updates it with the proper UIMessage content.
+ * When no draft exists, falls back to count-based dedup.
+ */
+async function simulateOnFinishSave(
+  conversationId: string,
+  finalMessages: ReturnType<typeof makeUIMessage>[],
+  state: {
+    draftAssistantMessageId: string | null;
+    userMessagesSaved: boolean;
+    incomingMessages: ReturnType<typeof makeUIMessage>[];
+    preSaveExistingCount: number;
+  },
+) {
+  if (state.draftAssistantMessageId) {
+    // Atomically update the draft with the proper UIMessage content
+    const lastAssistant = [...finalMessages]
+      .reverse()
+      .find((m) => m.role === "assistant");
+
+    if (lastAssistant) {
+      await MessageModel.updateContent(
+        state.draftAssistantMessageId,
+        lastAssistant,
+      );
+    }
+
+    state.draftAssistantMessageId = null;
+
+    // Edge case: save user messages if onStepFinish never fired
+    if (!state.userMessagesSaved) {
+      state.userMessagesSaved = true;
+      const newIncomingMessages = state.incomingMessages.slice(
+        state.preSaveExistingCount,
+      );
+      const newUserMessages = newIncomingMessages.filter(
+        (m) => m.role === "user",
+      );
+      if (newUserMessages.length > 0) {
+        await MessageModel.bulkCreate(
+          newUserMessages.map((msg) => ({
+            conversationId,
+            role: "user" as const,
+            content: msg,
+          })),
+        );
+      }
+    }
+  } else {
+    // No steps completed — fall back to count-based dedup
+    const existingMessages =
+      await MessageModel.findByConversation(conversationId);
+    const existingCount = existingMessages.length;
+    const newMessages = finalMessages.slice(existingCount);
+
+    if (newMessages.length > 0) {
+      let messagesToSave = newMessages;
+      if (newMessages[newMessages.length - 1].parts.length === 0) {
+        messagesToSave = newMessages.slice(0, -1);
+      }
+
+      if (messagesToSave.length > 0) {
+        await MessageModel.bulkCreate(
+          messagesToSave.map((msg) => ({
+            conversationId,
+            role: msg.role ?? "assistant",
+            content: msg,
+          })),
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Helper to create a fresh step state for chaining onStepFinish calls.
+ */
+function makeStepState(
+  incomingMessages: ReturnType<typeof makeUIMessage>[],
+  preSaveExistingCount: number,
+) {
+  return {
+    incomingMessages,
+    preSaveExistingCount,
+    draftAssistantMessageId: null as string | null,
+    userMessagesSaved: false,
+    // biome-ignore lint/suspicious/noExplicitAny: UIMessage parts are dynamic
+    accumulatedParts: [] as any[],
+  };
+}
+
+describe("chat message persistence", () => {
+  describe("first step saves user messages and creates draft", () => {
+    test("first onStepFinish saves user message and creates draft assistant", async ({
+      makeUser,
+      makeOrganization,
+      makeAgent,
+    }) => {
+      const user = await makeUser();
+      const org = await makeOrganization();
+      const agent = await makeAgent({ organizationId: org.id });
+
+      const conversation = await ConversationModel.create({
+        userId: user.id,
+        organizationId: org.id,
+        agentId: agent.id,
+        title: "Test",
+        selectedModel: "claude-3-haiku-20240307",
+      });
+
+      const userMessage = makeUIMessage("user", "Hello");
+      const state = makeStepState([userMessage], 0);
+
+      // First step: LLM responds with text
+      await simulateOnStepFinishSave(
+        conversation.id,
+        [{ type: "text", text: "Hi there!" }],
+        state,
+      );
+
+      const messages = await MessageModel.findByConversation(conversation.id);
+
+      // Should have 2 messages: user + draft assistant
+      expect(messages).toHaveLength(2);
+      expect(messages[0].role).toBe("user");
+      expect(messages[1].role).toBe("assistant");
+      expect(state.draftAssistantMessageId).toBeTruthy();
+    });
+
+    test("user message survives when onFinish never fires (the 50-step scenario)", async ({
+      makeUser,
+      makeOrganization,
+      makeAgent,
+    }) => {
+      const user = await makeUser();
+      const org = await makeOrganization();
+      const agent = await makeAgent({ organizationId: org.id });
+
+      const conversation = await ConversationModel.create({
+        userId: user.id,
+        organizationId: org.id,
+        agentId: agent.id,
+        title: null,
+        selectedModel: "claude-opus-4-5-20251101",
+      });
+
+      const userMessage = makeUIMessage("user", "Research AI companies");
+      const state = makeStepState([userMessage], 0);
+
+      // First step fires — saves user message + creates draft
+      await simulateOnStepFinishSave(
+        conversation.id,
+        [{ type: "text", text: "I'll research AI companies..." }],
+        state,
+      );
+
+      // Stream runs for many steps but crashes — onFinish never fires
+
+      const messages = await MessageModel.findByConversation(conversation.id);
+
+      // At minimum, both user message and draft assistant survive
+      expect(messages.length).toBeGreaterThanOrEqual(2);
+      expect(messages[0].role).toBe("user");
+      expect(messages[1].role).toBe("assistant");
+    });
+  });
+
+  describe("subsequent steps update draft content", () => {
+    test("second step updates draft with accumulated content", async ({
+      makeUser,
+      makeOrganization,
+      makeAgent,
+    }) => {
+      const user = await makeUser();
+      const org = await makeOrganization();
+      const agent = await makeAgent({ organizationId: org.id });
+
+      const conversation = await ConversationModel.create({
+        userId: user.id,
+        organizationId: org.id,
+        agentId: agent.id,
+        title: "Test",
+        selectedModel: "claude-3-haiku-20240307",
+      });
+
+      const userMessage = makeUIMessage("user", "Search for info");
+      const state = makeStepState([userMessage], 0);
+
+      // Step 1: tool call
+      await simulateOnStepFinishSave(
+        conversation.id,
+        [
+          {
+            type: "tool-call",
+            toolCallId: "tc1",
+            toolName: "search",
+            input: { query: "AI" },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tc1",
+            toolName: "search",
+            output: "Search results...",
+          },
+        ],
+        state,
+      );
+
+      const afterStep1 = await MessageModel.findByConversation(conversation.id);
+      expect(afterStep1).toHaveLength(2);
+      // biome-ignore lint/suspicious/noExplicitAny: test assertion on dynamic content
+      const step1Parts = (afterStep1[1].content as any).parts;
+      // step-start + tool-search (output-available) = 2 parts
+      expect(step1Parts).toHaveLength(2);
+      expect(step1Parts[0]).toEqual({ type: "step-start" });
+      expect(step1Parts[1].type).toBe("tool-search");
+      expect(step1Parts[1].state).toBe("output-available");
+
+      // Step 2: LLM summarizes results
+      await simulateOnStepFinishSave(
+        conversation.id,
+        [{ type: "text", text: "Based on the results..." }],
+        state,
+      );
+
+      const afterStep2 = await MessageModel.findByConversation(conversation.id);
+      // Still 2 messages — draft was updated in place
+      expect(afterStep2).toHaveLength(2);
+      // biome-ignore lint/suspicious/noExplicitAny: test assertion on dynamic content
+      const step2Parts = (afterStep2[1].content as any).parts;
+      // step1: step-start + tool-search, step2: step-start + text = 4 parts
+      expect(step2Parts).toHaveLength(4);
+      expect(step2Parts[2]).toEqual({ type: "step-start" });
+      expect(step2Parts[3].type).toBe("text");
+      expect(step2Parts[3].text).toBe("Based on the results...");
+    });
+  });
+
+  describe("onFinish atomically updates draft", () => {
+    test("onFinish updates draft to proper UIMessage format", async ({
+      makeUser,
+      makeOrganization,
+      makeAgent,
+    }) => {
+      const user = await makeUser();
+      const org = await makeOrganization();
+      const agent = await makeAgent({ organizationId: org.id });
+
+      const conversation = await ConversationModel.create({
+        userId: user.id,
+        organizationId: org.id,
+        agentId: agent.id,
+        title: "Test",
+        selectedModel: "claude-3-haiku-20240307",
+      });
+
+      const userMessage = makeUIMessage("user", "Hello");
+      const state = makeStepState([userMessage], 0);
+
+      // Step 1
+      await simulateOnStepFinishSave(
+        conversation.id,
+        [{ type: "text", text: "Hi!" }],
+        state,
+      );
+
+      const draftId = state.draftAssistantMessageId;
+      expect(draftId).toBeTruthy();
+
+      // onFinish fires with the proper UIMessage
+      const finalAssistant = makeUIMessage("assistant", "Hi there!");
+      await simulateOnFinishSave(
+        conversation.id,
+        [userMessage, finalAssistant],
+        {
+          draftAssistantMessageId: state.draftAssistantMessageId,
+          userMessagesSaved: state.userMessagesSaved,
+          incomingMessages: [userMessage],
+          preSaveExistingCount: 0,
+        },
+      );
+
+      const messages = await MessageModel.findByConversation(conversation.id);
+
+      // Still 2 messages — draft was updated, not deleted and recreated
+      expect(messages).toHaveLength(2);
+      expect(messages[0].role).toBe("user");
+      expect(messages[1].role).toBe("assistant");
+      // The draft row persists with the same ID
+      expect(messages[1].id).toBe(draftId);
+      // Content is the final UIMessage, not the draft
+      // biome-ignore lint/suspicious/noExplicitAny: test assertion on dynamic content
+      const content = messages[1].content as any;
+      expect(content.parts[0].text).toBe("Hi there!");
+    });
+
+    test("onFinish falls back to count-based dedup when no steps completed", async ({
+      makeUser,
+      makeOrganization,
+      makeAgent,
+    }) => {
+      const user = await makeUser();
+      const org = await makeOrganization();
+      const agent = await makeAgent({ organizationId: org.id });
+
+      const conversation = await ConversationModel.create({
+        userId: user.id,
+        organizationId: org.id,
+        agentId: agent.id,
+        title: "Test",
+        selectedModel: "claude-3-haiku-20240307",
+      });
+
+      const userMessage = makeUIMessage("user", "Hello");
+      const assistant = makeUIMessage("assistant", "Hi!");
+
+      // No onStepFinish ever fired — go straight to onFinish
+      await simulateOnFinishSave(conversation.id, [userMessage, assistant], {
+        draftAssistantMessageId: null,
+        userMessagesSaved: false,
+        incomingMessages: [userMessage],
+        preSaveExistingCount: 0,
+      });
+
+      const messages = await MessageModel.findByConversation(conversation.id);
+
+      expect(messages).toHaveLength(2);
+      expect(messages[0].role).toBe("user");
+      expect(messages[1].role).toBe("assistant");
+    });
+  });
+
+  describe("multi-turn conversations", () => {
+    test("second turn works correctly after first turn completes", async ({
+      makeUser,
+      makeOrganization,
+      makeAgent,
+    }) => {
+      const user = await makeUser();
+      const org = await makeOrganization();
+      const agent = await makeAgent({ organizationId: org.id });
+
+      const conversation = await ConversationModel.create({
+        userId: user.id,
+        organizationId: org.id,
+        agentId: agent.id,
+        title: "Test",
+        selectedModel: "claude-3-haiku-20240307",
+      });
+
+      // Turn 1
+      const msg1 = makeUIMessage("user", "What is 2+2?");
+      const state1 = makeStepState([msg1], 0);
+      await simulateOnStepFinishSave(
+        conversation.id,
+        [{ type: "text", text: "4" }],
+        state1,
+      );
+      const msg2 = makeUIMessage("assistant", "4");
+      await simulateOnFinishSave(conversation.id, [msg1, msg2], {
+        draftAssistantMessageId: state1.draftAssistantMessageId,
+        userMessagesSaved: state1.userMessagesSaved,
+        incomingMessages: [msg1],
+        preSaveExistingCount: 0,
+      });
+
+      const afterTurn1 = await MessageModel.findByConversation(conversation.id);
+      expect(afterTurn1).toHaveLength(2);
+
+      // Turn 2: preSaveExistingCount = 2 (user + assistant from turn 1)
+      const msg3 = makeUIMessage("user", "And 3+3?");
+      const state2 = makeStepState([msg1, msg2, msg3], 2);
+      await simulateOnStepFinishSave(
+        conversation.id,
+        [{ type: "text", text: "6" }],
+        state2,
+      );
+      const msg4 = makeUIMessage("assistant", "6");
+      await simulateOnFinishSave(conversation.id, [msg1, msg2, msg3, msg4], {
+        draftAssistantMessageId: state2.draftAssistantMessageId,
+        userMessagesSaved: state2.userMessagesSaved,
+        incomingMessages: [msg1, msg2, msg3],
+        preSaveExistingCount: 2,
+      });
+
+      const afterTurn2 = await MessageModel.findByConversation(conversation.id);
+      expect(afterTurn2).toHaveLength(4);
+      expect(afterTurn2[2].role).toBe("user");
+      expect(afterTurn2[3].role).toBe("assistant");
+    });
+
+    test("draft survives when onFinish never fires on second turn", async ({
+      makeUser,
+      makeOrganization,
+      makeAgent,
+    }) => {
+      const user = await makeUser();
+      const org = await makeOrganization();
+      const agent = await makeAgent({ organizationId: org.id });
+
+      const conversation = await ConversationModel.create({
+        userId: user.id,
+        organizationId: org.id,
+        agentId: agent.id,
+        title: "Test",
+        selectedModel: "claude-3-haiku-20240307",
+      });
+
+      // Turn 1: completes normally
+      const msg1 = makeUIMessage("user", "Hello");
+      const state1 = makeStepState([msg1], 0);
+      await simulateOnStepFinishSave(
+        conversation.id,
+        [{ type: "text", text: "Hi!" }],
+        state1,
+      );
+      const msg2 = makeUIMessage("assistant", "Hi!");
+      await simulateOnFinishSave(conversation.id, [msg1, msg2], {
+        draftAssistantMessageId: state1.draftAssistantMessageId,
+        userMessagesSaved: state1.userMessagesSaved,
+        incomingMessages: [msg1],
+        preSaveExistingCount: 0,
+      });
+
+      // Turn 2: step fires but onFinish never fires (crash)
+      const msg3 = makeUIMessage("user", "Write me an essay");
+      const state2 = makeStepState([msg1, msg2, msg3], 2);
+      await simulateOnStepFinishSave(
+        conversation.id,
+        [{ type: "text", text: "I'll write an essay about..." }],
+        state2,
+      );
+
+      // Pod crashes — onFinish never fires
+
+      const messages = await MessageModel.findByConversation(conversation.id);
+
+      // 4 messages: turn1 user + turn1 assistant + turn2 user + turn2 draft assistant
+      expect(messages).toHaveLength(4);
+      expect(messages[2].role).toBe("user");
+      expect(messages[3].role).toBe("assistant");
+    });
+  });
+
+  describe("regenerate scenario (no new user messages)", () => {
+    test("regenerate does not duplicate user message", async ({
+      makeUser,
+      makeOrganization,
+      makeAgent,
+    }) => {
+      const user = await makeUser();
+      const org = await makeOrganization();
+      const agent = await makeAgent({ organizationId: org.id });
+
+      const conversation = await ConversationModel.create({
+        userId: user.id,
+        organizationId: org.id,
+        agentId: agent.id,
+        title: "Test",
+        selectedModel: "claude-3-haiku-20240307",
+      });
+
+      // Turn 1: complete
+      const msg1 = makeUIMessage("user", "Hello");
+      const state1 = makeStepState([msg1], 0);
+      await simulateOnStepFinishSave(
+        conversation.id,
+        [{ type: "text", text: "Hi!" }],
+        state1,
+      );
+      const msg2 = makeUIMessage("assistant", "Hi!");
+      await simulateOnFinishSave(conversation.id, [msg1, msg2], {
+        draftAssistantMessageId: state1.draftAssistantMessageId,
+        userMessagesSaved: state1.userMessagesSaved,
+        incomingMessages: [msg1],
+        preSaveExistingCount: 0,
+      });
+
+      // Regenerate: same incoming messages (user only), preSaveExistingCount = 1
+      // (assistant message was deleted by frontend before regenerate)
+      const state2 = makeStepState([msg1], 1);
+      await simulateOnStepFinishSave(
+        conversation.id,
+        [{ type: "text", text: "Hello! How can I help?" }],
+        state2,
+      );
+
+      const messages = await MessageModel.findByConversation(conversation.id);
+
+      // 3 messages: original user + original assistant (from turn 1) + new draft assistant
+      // The user message was NOT duplicated because slice(1) on [msg1] = [] (no new user messages)
+      expect(messages).toHaveLength(3);
+      expect(messages[0].role).toBe("user");
+      expect(messages[2].role).toBe("assistant");
+    });
+  });
+});


### PR DESCRIPTION
Previously, all messages were saved only in onFinish. If the stream crashed or hit the 50-step limit, onFinish never fired and both user messages and assistant responses were lost, leaving empty conversations.

Now on each onStepFinish, we build a draft of the current assistant message and persist it to the database. User messages are saved on the first step. The draft is replaced with the final message on onFinish, ensuring the proper UIMessage format from toUIMessageStream is stored. Falls back to count-based dedup when no steps complete.

Extracts map-step-to-ui-parts module to convert AI SDK ContentPart[] to the same UIMessage format produced by toUIMessageStream.