### PR TITLE
fix: add backend validation for org logo upload

### DIFF
--- a/platform/backend/src/models/organization.test.ts
+++ b/platform/backend/src/models/organization.test.ts
@@ -161,19 +161,57 @@ describe("OrganizationModel", () => {
         OrganizationModel.patch(org.id, {
           logo: "data:image/jpeg;base64,/9j/4AAQSkZJRg==",
         }),
-      ).rejects.toThrow("Logo must be a PNG image in base64 format");
+      ).rejects.toThrow("Logo must be a PNG image in data URL format");
+    });
+
+    test("should reject plain text disguised as base64 logo", async ({
+      makeOrganization,
+    }) => {
+      const org = await makeOrganization();
+
+      await expect(
+        OrganizationModel.patch(org.id, {
+          logo: "data:image/png;base64,NotAnImageJustText",
+        }),
+      ).rejects.toThrow();
+    });
+
+    test("should reject logo with invalid PNG magic bytes", async ({
+      makeOrganization,
+    }) => {
+      const org = await makeOrganization();
+
+      // "SGVsbG8gV29ybGQh" decodes to "Hello World!" — not a PNG
+      await expect(
+        OrganizationModel.patch(org.id, {
+          logo: "data:image/png;base64,SGVsbG8gV29ybGQh",
+        }),
+      ).rejects.toThrow("invalid file signature");
     });
 
     test("should accept valid PNG logo", async ({ makeOrganization }) => {
       const org = await makeOrganization();
+      // Minimal 1x1 PNG with valid magic bytes
       const validLogo =
-        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB";
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQABNjN9GQAAAAlwSFlzAAAWJQAAFiUBSVIk8AAAAA0lEQVQI12P4z8BQDwAEgAF/QualzQAAAABJRU5ErkJggg==";
 
       const updated = await OrganizationModel.patch(org.id, {
         logo: validLogo,
       });
 
       expect(updated?.logo).toBe(validLogo);
+    });
+
+    test("should allow clearing logo with null", async ({
+      makeOrganization,
+    }) => {
+      const org = await makeOrganization();
+
+      const updated = await OrganizationModel.patch(org.id, {
+        logo: null,
+      });
+
+      expect(updated?.logo).toBeNull();
     });
 
     test("should return null for non-existent organization", async () => {

--- a/platform/backend/src/models/organization.ts
+++ b/platform/backend/src/models/organization.ts
@@ -7,6 +7,7 @@ import type {
   PublicAppearance,
   UpdateOrganization,
 } from "@/types";
+import { validateLogoDataUrl } from "@/utils/logo-validation";
 
 class OrganizationModel {
   /**
@@ -74,18 +75,9 @@ class OrganizationModel {
       "OrganizationModel.patch: updating organization",
     );
     if ("logo" in data && data.logo) {
-      const logo = data.logo;
-
-      if (!logo.startsWith("data:image/png;base64,")) {
-        throw new Error("Logo must be a PNG image in base64 format");
-      }
-
-      // Check size (rough estimate: base64 is ~1.33x original size)
-      // 2MB * 1.33 = ~2.66MB in base64
-      const maxSize = 2.66 * 1024 * 1024;
-      if (logo.length > maxSize) {
-        // ~2.66MB
-        throw new Error("Logo must be less than 2MB");
+      const validation = validateLogoDataUrl(data.logo);
+      if (!validation.valid) {
+        throw new Error(validation.error);
       }
     }
 

--- a/platform/backend/src/routes/organization.ts
+++ b/platform/backend/src/routes/organization.ts
@@ -13,6 +13,7 @@ import {
   SelectOrganizationSchema,
   UpdateOrganizationSchema,
 } from "@/types";
+import { validateLogoDataUrl } from "@/utils/logo-validation";
 
 const organizationRoutes: FastifyPluginAsyncZod = async (fastify) => {
   fastify.get(
@@ -48,6 +49,13 @@ const organizationRoutes: FastifyPluginAsyncZod = async (fastify) => {
       },
     },
     async ({ organizationId, body }, reply) => {
+      if ("logo" in body && body.logo !== null && body.logo !== undefined) {
+        const validation = validateLogoDataUrl(body.logo);
+        if (!validation.valid) {
+          throw new ApiError(400, validation.error);
+        }
+      }
+
       const organization = await OrganizationModel.patch(organizationId, body);
 
       if (!organization) {

--- a/platform/backend/src/utils/logo-validation.test.ts
+++ b/platform/backend/src/utils/logo-validation.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { validateLogoDataUrl } from "./logo-validation";
+
+// Minimal valid 1x1 transparent PNG encoded as base64
+const VALID_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQABNjN9GQAAAAlwSFlzAAAWJQAAFiUBSVIk8AAAAA0lEQVQI12P4z8BQDwAEgAF/QualzQAAAABJRU5ErkJggg==";
+
+const VALID_LOGO = `data:image/png;base64,${VALID_PNG_BASE64}`;
+
+describe("validateLogoDataUrl", () => {
+  it("should accept a valid PNG data URL", () => {
+    const result = validateLogoDataUrl(VALID_LOGO);
+    expect(result.valid).toBe(true);
+  });
+
+  it("should reject a JPEG data URL", () => {
+    const result = validateLogoDataUrl(
+      "data:image/jpeg;base64,/9j/4AAQSkZJRg==",
+    );
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("PNG");
+    }
+  });
+
+  it("should reject a data URL with wrong MIME type", () => {
+    const result = validateLogoDataUrl(
+      "data:text/plain;base64,SGVsbG8gV29ybGQ=",
+    );
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("PNG");
+    }
+  });
+
+  it("should reject a string that is not a data URL", () => {
+    const result = validateLogoDataUrl("NotAnImageJustText");
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("data URL");
+    }
+  });
+
+  it("should reject a data URL with empty base64 payload", () => {
+    const result = validateLogoDataUrl("data:image/png;base64,");
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("empty");
+    }
+  });
+
+  it("should reject invalid base64 characters", () => {
+    const result = validateLogoDataUrl(
+      "data:image/png;base64,!!!invalid-base64!!!",
+    );
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("invalid base64");
+    }
+  });
+
+  it("should reject base64 that decodes to data too short for a PNG signature", () => {
+    // "AQID" decodes to 3 bytes — not enough for 8-byte PNG signature
+    const result = validateLogoDataUrl("data:image/png;base64,AQID");
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("too small");
+    }
+  });
+
+  it("should reject base64 that decodes to non-PNG data (wrong magic bytes)", () => {
+    // "SGVsbG8gV29ybGQh" decodes to "Hello World!" — valid base64 but not PNG
+    const result = validateLogoDataUrl(
+      "data:image/png;base64,SGVsbG8gV29ybGQh",
+    );
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("invalid file signature");
+    }
+  });
+
+  it("should reject the exact payload from the issue reproduction", () => {
+    // The issue shows: data:image/png;base64,NotAnImageJustText
+    const result = validateLogoDataUrl(
+      "data:image/png;base64,NotAnImageJustText",
+    );
+    expect(result.valid).toBe(false);
+  });
+
+  it("should reject a logo exceeding the 2 MB file-size limit", () => {
+    // Create base64 for > 2 MB of data starting with PNG magic bytes
+    const pngMagic = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ]);
+    const padding = Buffer.alloc(2 * 1024 * 1024 + 1); // just over 2 MB total
+    const oversized = Buffer.concat([pngMagic, padding]);
+    const oversizedBase64 = oversized.toString("base64");
+    const result = validateLogoDataUrl(
+      `data:image/png;base64,${oversizedBase64}`,
+    );
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("2 MB");
+    }
+  });
+
+  it("should accept a logo at exactly the 2 MB boundary", () => {
+    const pngMagic = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ]);
+    const padding = Buffer.alloc(2 * 1024 * 1024 - pngMagic.length);
+    const exactLimit = Buffer.concat([pngMagic, padding]);
+    const base64 = exactLimit.toString("base64");
+    const result = validateLogoDataUrl(`data:image/png;base64,${base64}`);
+    expect(result.valid).toBe(true);
+  });
+
+  it("should reject SVG content disguised with PNG data URL prefix", () => {
+    // SVG content "<svg>" encodes to "PHN2Zz4=" — fails PNG magic byte check
+    const result = validateLogoDataUrl("data:image/png;base64,PHN2Zz4=");
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("invalid file signature");
+    }
+  });
+});

--- a/platform/backend/src/utils/logo-validation.ts
+++ b/platform/backend/src/utils/logo-validation.ts
@@ -1,0 +1,77 @@
+/**
+ * Validates an organization logo provided as a data URL.
+ *
+ * Checks:
+ * 1. Must be a data:image/png;base64 data URL
+ * 2. Base64 payload must be valid (decodable)
+ * 3. Decoded bytes must start with PNG magic bytes (89 50 4E 47 0D 0A 1A 0A)
+ * 4. Decoded size must be at most 2 MB
+ */
+export function validateLogoDataUrl(logo: string): LogoValidationResult {
+  if (!logo.startsWith(DATA_URL_PREFIX)) {
+    return {
+      valid: false,
+      error:
+        "Logo must be a PNG image in data URL format (data:image/png;base64,...)",
+    };
+  }
+
+  const base64Data = logo.slice(DATA_URL_PREFIX.length);
+
+  if (base64Data.length === 0) {
+    return { valid: false, error: "Logo base64 data is empty" };
+  }
+
+  // Validate base64 encoding: must match the standard base64 alphabet
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(base64Data)) {
+    return { valid: false, error: "Logo contains invalid base64 characters" };
+  }
+
+  let decoded: Buffer;
+  try {
+    decoded = Buffer.from(base64Data, "base64");
+  } catch {
+    return { valid: false, error: "Logo contains invalid base64 data" };
+  }
+
+  // A valid PNG must have at least the 8-byte signature
+  if (decoded.length < PNG_MAGIC_BYTES.length) {
+    return {
+      valid: false,
+      error: "Logo data is too small to be a valid PNG image",
+    };
+  }
+
+  // Verify PNG magic bytes
+  const hasPngSignature = PNG_MAGIC_BYTES.every(
+    (byte, index) => decoded[index] === byte,
+  );
+  if (!hasPngSignature) {
+    return {
+      valid: false,
+      error:
+        "Logo data does not contain a valid PNG image (invalid file signature)",
+    };
+  }
+
+  // Check decoded file size
+  if (decoded.length > MAX_LOGO_BYTES) {
+    return {
+      valid: false,
+      error: `Logo file size exceeds the 2 MB limit (got ${(decoded.length / (1024 * 1024)).toFixed(2)} MB)`,
+    };
+  }
+
+  return { valid: true };
+}
+
+// --- Internal constants & types ---
+
+const DATA_URL_PREFIX = "data:image/png;base64,";
+const MAX_LOGO_BYTES = 2 * 1024 * 1024; // 2 MB
+// PNG file signature: https://www.w3.org/TR/png/#5PNG-file-signature
+const PNG_MAGIC_BYTES = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+type LogoValidationResult =
+  | { valid: true }
+  | { valid: false; error: string };


### PR DESCRIPTION
## Summary

Fixes #2563

The `PATCH /api/organization` endpoint previously accepted any Base64 string for the `logo` field without verifying it was actually a valid PNG image. This allowed users to upload invalid data or non-image text via the browser console, permanently corrupting the organization logo for all members and potentially enabling stored XSS via malicious SVG payloads.

This PR adds comprehensive server-side validation for the `logo` field:

- **Data URL format**: Must start with `data:image/png;base64,`
- **Base64 integrity**: Validates the character set and ensures the payload is decodable
- **PNG magic bytes**: Verifies the decoded bytes begin with the PNG file signature (`89 50 4E 47 0D 0A 1A 0A`), preventing non-PNG content (including SVG scripts) from being stored
- **File size limit**: Enforces a 2 MB limit on the decoded file size (replacing the previous rough base64-length estimate)
- **Proper HTTP 400 responses**: The route now throws `ApiError(400, ...)` for validation failures instead of letting the model throw a generic `Error` that would produce a 500

### Changes

| File | Change |
|------|--------|
| `platform/backend/src/utils/logo-validation.ts` | New reusable validation utility with all checks |
| `platform/backend/src/utils/logo-validation.test.ts` | 12 unit tests covering valid PNGs, invalid formats, bad base64, wrong magic bytes, oversized files, SVG disguise, and the exact issue reproduction payload |
| `platform/backend/src/routes/organization.ts` | Added route-level validation before calling model, using `ApiError(400)` |
| `platform/backend/src/models/organization.ts` | Replaced inline validation with call to shared `validateLogoDataUrl()` |
| `platform/backend/src/models/organization.test.ts` | Updated existing tests and added new cases for magic byte validation, null clearing, and disguised payloads |

## Test plan

- [ ] Unit tests in `logo-validation.test.ts` pass (valid PNG accepted, JPEG rejected, plain text rejected, empty payload rejected, invalid base64 rejected, wrong magic bytes rejected, oversized rejected, SVG disguised as PNG rejected, issue reproduction payload rejected)
- [ ] Existing model tests in `organization.test.ts` pass with updated assertions
- [ ] Sending `{ logo: "data:image/png;base64,NotAnImageJustText" }` to `PATCH /api/organization` returns HTTP 400 instead of succeeding
- [ ] Uploading a valid PNG via the UI still works correctly
- [ ] Setting `logo: null` to remove the logo still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)