### PR TITLE
fix: validate organization logo data URLs

### DIFF
--- a/platform/backend/src/types/organization.test.ts
+++ b/platform/backend/src/types/organization.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { UpdateOrganizationSchema } from "./organization";
+
+const basePayload = {
+  onboardingComplete: false,
+  convertToolResultsToToon: false,
+  autoConfigureNewTools: false,
+  allowChatFileUploads: true,
+  globalToolPolicy: "permissive" as const,
+};
+
+describe("UpdateOrganizationSchema", () => {
+  it("accepts valid image data URL logo", () => {
+    const result = UpdateOrganizationSchema.partial().safeParse({
+      ...basePayload,
+      logo: "data:image/png;base64,iVBORw0KGgo=",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-image data URL logo", () => {
+    const result = UpdateOrganizationSchema.partial().safeParse({
+      ...basePayload,
+      logo: "data:text/plain;base64,SGVsbG8=",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects malformed image data URL logo", () => {
+    const result = UpdateOrganizationSchema.partial().safeParse({
+      ...basePayload,
+      logo: "data:image/png;base64,NotAnImageJustText",
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/platform/backend/src/types/organization.ts
+++ b/platform/backend/src/types/organization.ts
@@ -40,9 +40,66 @@ export const InsertOrganizationSchema = createInsertSchema(
   schema.organizationsTable,
   extendedFields,
 );
+const LOGO_DATA_URL_REGEX =
+  /^data:(image\/(png|jpeg|jpg|webp|gif));base64,([A-Za-z0-9+/]+={0,2})$/;
+
+const hasExpectedImageSignature = (mime: string, bytes: Buffer): boolean => {
+  if (bytes.length < 4) {
+    return false;
+  }
+
+  if (mime === "image/png") {
+    return bytes.subarray(0, 8).equals(
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    );
+  }
+
+  if (mime === "image/jpeg" || mime === "image/jpg") {
+    return bytes[0] === 0xff && bytes[1] === 0xd8;
+  }
+
+  if (mime === "image/gif") {
+    return (
+      bytes.subarray(0, 6).equals(Buffer.from("GIF87a")) ||
+      bytes.subarray(0, 6).equals(Buffer.from("GIF89a"))
+    );
+  }
+
+  if (mime === "image/webp") {
+    return (
+      bytes.subarray(0, 4).equals(Buffer.from("RIFF")) &&
+      bytes.subarray(8, 12).equals(Buffer.from("WEBP"))
+    );
+  }
+
+  return false;
+};
+
+const LogoSchema = z
+  .string()
+  .refine((value) => {
+    const match = value.match(LOGO_DATA_URL_REGEX);
+
+    if (!match) {
+      return false;
+    }
+
+    const mime = match[1];
+    const base64 = match[3];
+
+    try {
+      const decoded = Buffer.from(base64, "base64");
+
+      return decoded.length > 0 && hasExpectedImageSignature(mime, decoded);
+    } catch {
+      return false;
+    }
+  }, "Logo must be a valid base64 encoded image data URL")
+  .nullable();
+
 export const UpdateOrganizationSchema = z.object({
   ...extendedFields,
-  logo: z.string().nullable(),
+  logo: LogoSchema,
   onboardingComplete: z.boolean(),
   convertToolResultsToToon: z.boolean(),
   compressionScope: OrganizationCompressionScopeSchema,


### PR DESCRIPTION
## Summary
Fixes #2563 by adding server-side validation for `logo` in `PATCH /api/organization`.

## What changed
- Added `LogoSchema` validation in `platform/backend/src/types/organization.ts`
- Restricts accepted `logo` values to image data URLs only:
  - `image/png`, `image/jpeg`, `image/jpg`, `image/webp`, `image/gif`
- Verifies base64 payload decodes and matches expected image signatures (magic bytes)
- Added focused tests in `platform/backend/src/types/organization.test.ts`

## Why
Prevents invalid/non-image payloads (e.g., `data:text/plain;base64,...`) from being persisted and breaking org logo rendering.

## Validation evidence
```powershell
PS> git show --stat --oneline HEAD
5f2af1c fix: validate organization logo data URLs
 platform/backend/src/types/organization.test.ts | 37 ++++++++++++++++++++++++
 platform/backend/src/types/organization.ts      | 60 +++++++++++++++++++++++++++++++++++++-
 2 files changed, 96 insertions(+), 1 deletion(-)
```

Test execution note:
```powershell
PS> corepack pnpm test -- src/types/organization.test.ts
'vitest' is not recognized ... node_modules missing
```
(Dependencies are not installed in this execution environment.)

## Risk
Low-medium: schema validation tightening for logo field only.
