### PR TITLE
fix: track version history when updating internal agents

### DIFF
--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -791,9 +791,30 @@ class AgentModel {
 
     // Only update agent table if there are fields to update
     if (Object.keys(agent).length > 0) {
+      // For internal agents (agentType='agent'), automatically track version history
+      // so that the version history feature works correctly.
+      let updatePayload: typeof agent & {
+        promptVersion?: number;
+        promptHistory?: ReturnType<typeof sql>;
+      } = agent;
+
+      if (existingAgent.agentType === "agent") {
+        const historyEntry: AgentHistoryEntry = {
+          version: existingAgent.promptVersion || 1,
+          userPrompt: existingAgent.userPrompt || null,
+          systemPrompt: existingAgent.systemPrompt || null,
+          createdAt: existingAgent.updatedAt.toISOString(),
+        };
+        updatePayload = {
+          ...agent,
+          promptVersion: (existingAgent.promptVersion || 1) + 1,
+          promptHistory: sql`${schema.agentsTable.promptHistory} || ${JSON.stringify([historyEntry])}::jsonb`,
+        };
+      }
+
       [updatedAgent] = await db
         .update(schema.agentsTable)
-        .set(agent)
+        .set(updatePayload)
         .where(eq(schema.agentsTable.id, id))
         .returning();
 


### PR DESCRIPTION
## Problem

The agent version history feature was broken. When you click "Version History" on an internal agent, it always shows empty history even after multiple edits.

**Root Cause:** `AgentModel.update()` is called on every agent update via the `PUT /api/agents/:id` route, but this method never increments `promptVersion` or appends to `promptHistory`. The `updateWithVersion()` method existed for this purpose but was never wired into the update route.

As a result, `agent.promptHistory` always remains `[]` (the default), making the version history dialog permanently empty.

## Fix

Integrate version tracking directly into `AgentModel.update()` for internal agents (`agentType='agent'`). Before applying each update, the current agent state is saved as a history entry and `promptVersion` is incremented. This:

1. Ensures the Version History dialog populates correctly after agent edits
2. Enables rollback functionality to work as expected
3. Handles the full update path (including teams/labels sync) which `updateWithVersion()` alone didn't cover

The change is minimal and scoped only to internal agents — profile, mcp_gateway, and llm_proxy agents are unaffected.

## Testing

1. Create an internal agent
2. Edit the agent's system prompt and save
3. Open Version History — should now show the previous version
4. Click Rollback — should restore the previous prompt

Fixes #2579

/claim #2579