### PR TITLE
fix: track version history when updating internal agents

### DIFF
--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -791,9 +791,29 @@ class AgentModel {
 
     // Only update agent table if there are fields to update
     if (Object.keys(agent).length > 0) {
+      // For internal agents, track version history on each update
+      let setPayload: typeof agent & {
+        promptVersion?: number;
+        promptHistory?: ReturnType<typeof sql>;
+      } = agent;
+
+      if (existingAgent.agentType === "agent") {
+        const historyEntry: AgentHistoryEntry = {
+          version: existingAgent.promptVersion || 1,
+          userPrompt: existingAgent.userPrompt || null,
+          systemPrompt: existingAgent.systemPrompt || null,
+          createdAt: existingAgent.updatedAt.toISOString(),
+        };
+        setPayload = {
+          ...agent,
+          promptVersion: (existingAgent.promptVersion || 1) + 1,
+          promptHistory: sql`${schema.agentsTable.promptHistory} || ${JSON.stringify([historyEntry])}::jsonb`,
+        };
+      }
+
       [updatedAgent] = await db
         .update(schema.agentsTable)
-        .set(agent)
+        .set(setPayload)
         .where(eq(schema.agentsTable.id, id))
         .returning();
 


### PR DESCRIPTION
## Summary

Fixes #2579

When internal agents are updated, their version history is now tracked by:
- Incrementing `promptVersion` on each update
- Appending the previous prompt state to `promptHistory` as a JSONB array entry
- Only applies to agents with `agentType === "agent"` (internal agents)

## Changes

- `platform/backend/src/models/agent.ts`: Before updating the agent record, captures the current prompt state as a history entry and appends it to `promptHistory` via JSONB concatenation. Increments `promptVersion`.

## Test plan

- [ ] Update an internal agent's prompt and verify `promptVersion` increments
- [ ] Verify `promptHistory` contains the previous prompt state
- [ ] Verify external agents (non-"agent" type) are not affected