### PR TITLE
fix: hide unused row selection indicator in table footer

### DIFF
--- a/platform/frontend/src/components/ui/data-table.tsx
+++ b/platform/frontend/src/components/ui/data-table.tsx
@@ -61,9 +61,11 @@ export function DataTable<TData, TValue>({
   onRowClick,
   rowSelection,
   onRowSelectionChange,
-  hideSelectedCount = false,
+  hideSelectedCount,
   getRowId,
 }: DataTableProps<TData, TValue>) {
+  const shouldHideSelectedCount =
+    hideSelectedCount ?? onRowSelectionChange === undefined;
   const [internalSorting, setInternalSorting] = useState<SortingState>([]);
   const [internalPagination, setInternalPagination] = useState({
     pageIndex: 0,
@@ -211,7 +213,7 @@ export function DataTable<TData, TValue>({
         <DataTablePagination
           table={table}
           totalRows={pagination?.total}
-          hideSelectedCount={hideSelectedCount}
+          hideSelectedCount={shouldHideSelectedCount}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- hide footer selection count by default when row selection is not enabled
- preserve existing behavior for tables that explicitly use row selection
- remove noisy `0 of N row(s) selected` indicator from non-selectable tables

## Changes
- compute `shouldHideSelectedCount` from `hideSelectedCount ?? onRowSelectionChange === undefined`
- pass computed value into `DataTablePagination`

Closes #2862
