### PR TITLE
feat: add OpenRouter LLM provider integration

### DIFF
--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -518,6 +518,10 @@ export default {
       baseUrl:
         process.env.ARCHESTRA_CEREBRAS_BASE_URL || "https://api.cerebras.ai/v1",
     },
+    openrouter: {
+      baseUrl:
+        process.env.ARCHESTRA_OPENROUTER_BASE_URL || "https://openrouter.ai/api/v1",
+    },
     mistral: {
       baseUrl:
         process.env.ARCHESTRA_MISTRAL_BASE_URL || "https://api.mistral.ai/v1",
@@ -559,6 +563,10 @@ export default {
     cerebras: {
       apiKey: process.env.ARCHESTRA_CHAT_CEREBRAS_API_KEY || "",
     },
+    openrouter: {
+      baseUrl:
+        process.env.ARCHESTRA_OPENROUTER_BASE_URL || "https://openrouter.ai/api/v1",
+    },
     mistral: {
       apiKey: process.env.ARCHESTRA_CHAT_MISTRAL_API_KEY || "",
     },
@@ -576,6 +584,9 @@ export default {
     },
     bedrock: {
       apiKey: process.env.ARCHESTRA_CHAT_BEDROCK_API_KEY || "",
+    },
+    openrouter: {
+      apiKey: process.env.ARCHESTRA_CHAT_OPENROUTER_API_KEY || "",
     },
     defaultModel:
       process.env.ARCHESTRA_CHAT_DEFAULT_MODEL || "claude-opus-4-1-20250805",

--- a/platform/backend/src/routes/index.ts
+++ b/platform/backend/src/routes/index.ts
@@ -8,6 +8,7 @@ import ollamaProxyRoutesV2 from "./proxy/routesv2/ollama";
 import openAiProxyRoutesV2 from "./proxy/routesv2/openai";
 import vllmProxyRoutesV2 from "./proxy/routesv2/vllm";
 import zhipuaiProxyRoutesV2 from "./proxy/routesv2/zhipuai";
+import openrouterProxyRoutesV2 from "./proxy/routesv2/openrouter";
 
 export { default as browserStreamRoutes } from "@/features/browser-stream/routes/browser-stream.routes";
 export { default as a2aRoutes } from "./a2a";
@@ -49,6 +50,7 @@ export const ollamaProxyRoutes = ollamaProxyRoutesV2;
 export const zhipuaiProxyRoutes = zhipuaiProxyRoutesV2;
 // Bedrock proxy routes - V2 only (unified handler, AWS Converse API)
 export const bedrockProxyRoutes = bedrockProxyRoutesV2;
+export const openrouterProxyRoutes = openrouterProxyRoutesV2;
 export { default as secretsRoutes } from "./secrets";
 export { default as statisticsRoutes } from "./statistics";
 export { default as teamRoutes } from "./team";

--- a/platform/backend/src/routes/proxy/adapterV2/index.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/index.ts
@@ -8,3 +8,4 @@ export { ollamaAdapterFactory } from "./ollama";
 export { openaiAdapterFactory } from "./openai";
 export { vllmAdapterFactory } from "./vllm";
 export { zhipuaiAdapterFactory } from "./zhipuai";
+export { openrouterAdapterFactory } from "./openrouter";

--- a/platform/backend/src/routes/proxy/adapterV2/openrouter.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/openrouter.ts
@@ -1,0 +1,1171 @@
+/**
+ * OpenRouter LLM Proxy Adapter - OpenAI-compatible
+ *
+ * OpenRouter uses an OpenAI-compatible API at https://api.openrouter.ai/v1
+ * This adapter reuses OpenAI's logic with OpenRouter-specific configuration.
+ *
+ * @see https://inference-docs.openrouter.ai/
+ */
+import { encode as toonEncode } from "@toon-format/toon";
+import { get } from "lodash-es";
+import OpenAIProvider from "openai";
+import type {
+  ChatCompletionCreateParamsNonStreaming,
+  ChatCompletionCreateParamsStreaming,
+} from "openai/resources/chat/completions/completions";
+import config from "@/config";
+import logger from "@/logging";
+import { TokenPriceModel } from "@/models";
+import { metrics } from "@/observability";
+import { getTokenizer } from "@/tokenizers";
+import type {
+  OpenRouter,
+  ChunkProcessingResult,
+  CommonMcpToolDefinition,
+  CommonMessage,
+  CommonToolCall,
+  CommonToolResult,
+  CreateClientOptions,
+  LLMProvider,
+  LLMRequestAdapter,
+  LLMResponseAdapter,
+  LLMStreamAdapter,
+  StreamAccumulatorState,
+  ToolCompressionStats,
+  UsageView,
+} from "@/types";
+import { estimateMessagesSize } from "@/utils/message-size";
+import {
+  estimateToolResultContentLength,
+  previewToolResultContent,
+} from "@/utils/tool-result-preview";
+import { MockOpenAIClient } from "../mock-openai-client";
+import {
+  doesModelSupportImages,
+  hasImageContent,
+  isImageTooLarge,
+  isMcpImageBlock,
+} from "../utils/mcp-image";
+import { stripBrowserToolsResults } from "../utils/summarize-tool-results";
+import { unwrapToolContent } from "../utils/unwrap-tool-content";
+
+// =============================================================================
+// TYPE ALIASES
+// =============================================================================
+
+type OpenRouterRequest = OpenRouter.Types.ChatCompletionsRequest;
+type OpenRouterResponse = OpenRouter.Types.ChatCompletionsResponse;
+type OpenRouterMessages = OpenRouter.Types.ChatCompletionsRequest["messages"];
+type OpenRouterHeaders = OpenRouter.Types.ChatCompletionsHeaders;
+type OpenRouterStreamChunk = OpenRouter.Types.ChatCompletionChunk;
+
+type OpenRouterToolResultImageBlock = {
+  type: "image_url";
+  image_url: {
+    url: string;
+    detail?: "auto" | "low" | "high";
+  };
+};
+
+type OpenRouterToolResultTextBlock = {
+  type: "text";
+  text: string;
+};
+
+type OpenRouterToolResultContentBlock =
+  | OpenRouterToolResultImageBlock
+  | OpenRouterToolResultTextBlock;
+
+type OpenRouterToolResultContent = string | OpenRouterToolResultContentBlock[];
+
+// =============================================================================
+// REQUEST ADAPTER
+// =============================================================================
+
+class OpenRouterRequestAdapter
+  implements LLMRequestAdapter<OpenRouterRequest, OpenRouterMessages>
+{
+  readonly provider = "openrouter" as const;
+  private request: OpenRouterRequest;
+  private modifiedModel: string | null = null;
+  private toolResultUpdates: Record<string, string> = {};
+
+  constructor(request: OpenRouterRequest) {
+    this.request = request;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Read Access
+  // ---------------------------------------------------------------------------
+
+  getModel(): string {
+    return this.modifiedModel ?? this.request.model;
+  }
+
+  isStreaming(): boolean {
+    return this.request.stream === true;
+  }
+
+  getMessages(): CommonMessage[] {
+    return this.toCommonFormat(this.request.messages);
+  }
+
+  getToolResults(): CommonToolResult[] {
+    const results: CommonToolResult[] = [];
+
+    for (const message of this.request.messages) {
+      if (message.role === "tool") {
+        const toolName = this.findToolNameInMessages(
+          this.request.messages,
+          message.tool_call_id,
+        );
+
+        let content: unknown;
+        if (typeof message.content === "string") {
+          try {
+            content = JSON.parse(message.content);
+          } catch {
+            content = message.content;
+          }
+        } else {
+          content = message.content;
+        }
+
+        results.push({
+          id: message.tool_call_id,
+          name: toolName ?? "unknown",
+          content,
+          isError: false,
+        });
+      }
+    }
+
+    return results;
+  }
+
+  getTools(): CommonMcpToolDefinition[] {
+    if (!this.request.tools) return [];
+
+    const result: CommonMcpToolDefinition[] = [];
+    for (const tool of this.request.tools) {
+      if (tool.type === "function") {
+        result.push({
+          name: tool.function.name,
+          description: tool.function.description,
+          inputSchema: tool.function.parameters as Record<string, unknown>,
+        });
+      }
+    }
+    return result;
+  }
+
+  hasTools(): boolean {
+    return (this.request.tools?.length ?? 0) > 0;
+  }
+
+  getProviderMessages(): OpenRouterMessages {
+    return this.request.messages;
+  }
+
+  getOriginalRequest(): OpenRouterRequest {
+    return this.request;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Modify Access
+  // ---------------------------------------------------------------------------
+
+  setModel(model: string): void {
+    this.modifiedModel = model;
+  }
+
+  updateToolResult(toolCallId: string, newContent: string): void {
+    this.toolResultUpdates[toolCallId] = newContent;
+  }
+
+  applyToolResultUpdates(updates: Record<string, string>): void {
+    Object.assign(this.toolResultUpdates, updates);
+  }
+
+  async applyToonCompression(model: string): Promise<ToolCompressionStats> {
+    const { messages: compressedMessages, stats } =
+      await convertToolResultsToToon(this.request.messages, model);
+    this.request = {
+      ...this.request,
+      messages: compressedMessages,
+    };
+    return stats;
+  }
+
+  convertToolResultContent(messages: OpenRouterMessages): OpenRouterMessages {
+    const model = this.getModel();
+    const modelSupportsImages = doesModelSupportImages(model);
+    let toolMessagesWithImages = 0;
+    let strippedImageCount = 0;
+
+    // First, analyze all tool messages to understand what we're dealing with
+    for (const message of messages) {
+      if (message.role === "tool") {
+        const contentLength = estimateToolResultContentLength(message.content);
+        const contentSizeKB = Math.round(contentLength.length / 1024);
+        const contentPatternSample = previewToolResultContent(
+          message.content,
+          2000,
+        );
+        const contentPreview = contentPatternSample.slice(0, 200);
+
+        // Check for base64 patterns in preview to avoid full serialization.
+        const hasBase64 =
+          contentPatternSample.includes("data:image") ||
+          contentPatternSample.includes('"type":"image"') ||
+          contentPatternSample.includes('"data":"');
+
+        // Find tool name from previous assistant message
+        const toolName = this.findToolNameInMessages(
+          messages,
+          message.tool_call_id,
+        );
+
+        logger.info(
+          {
+            toolCallId: message.tool_call_id,
+            toolName,
+            contentSizeKB,
+            hasBase64,
+            contentLengthEstimated: contentLength.isEstimated,
+            isArray: Array.isArray(message.content),
+            contentPreview,
+          },
+          "[OpenRouterAdapter] Analyzing tool result content",
+        );
+
+        // If it's an array, analyze each item
+        if (Array.isArray(message.content)) {
+          for (const [idx, item] of message.content.entries()) {
+            if (typeof item === "object" && item !== null) {
+              const itemType = (item as Record<string, unknown>).type;
+              const itemLength = estimateToolResultContentLength(item);
+              logger.info(
+                {
+                  toolCallId: message.tool_call_id,
+                  itemIndex: idx,
+                  itemType,
+                  itemSizeKB: Math.round(itemLength.length / 1024),
+                  itemLengthEstimated: itemLength.isEstimated,
+                  isMcpImage: isMcpImageBlock(item),
+                },
+                "[OpenRouterAdapter] Tool result array item",
+              );
+            }
+          }
+        }
+      }
+    }
+
+    const result = messages.map((message) => {
+      if (message.role !== "tool") {
+        return message;
+      }
+
+      // Check if this tool message contains images
+      if (!hasImageContent(message.content)) {
+        return message;
+      }
+
+      // If model doesn't support images, strip image blocks from content
+      if (!modelSupportsImages) {
+        strippedImageCount++;
+        const strippedContent = stripImageBlocksFromContent(message.content);
+        return {
+          ...message,
+          content: strippedContent,
+        };
+      }
+
+      // Model supports images - convert MCP image blocks to OpenRouter format
+      const convertedContent = convertMcpImageBlocksToOpenRouter(message.content);
+      if (!convertedContent) {
+        return message;
+      }
+
+      toolMessagesWithImages++;
+      return {
+        ...message,
+        content: convertedContent,
+      };
+    });
+
+    if (toolMessagesWithImages > 0 || strippedImageCount > 0) {
+      logger.info(
+        {
+          model,
+          modelSupportsImages,
+          totalMessages: messages.length,
+          toolMessagesWithImages,
+          strippedImageCount,
+        },
+        "[OpenRouterAdapter] Processed tool messages with image content",
+      );
+    }
+
+    return result;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Build Modified Request
+  // ---------------------------------------------------------------------------
+
+  toProviderRequest(): OpenRouterRequest {
+    let messages = this.request.messages;
+
+    if (Object.keys(this.toolResultUpdates).length > 0) {
+      messages = this.applyUpdates(messages, this.toolResultUpdates);
+    }
+
+    if (config.features.browserStreamingEnabled) {
+      messages = this.convertToolResultContent(messages);
+      const sizeBeforeStrip = estimateMessagesSize(messages);
+      messages = stripBrowserToolsResults(messages);
+      const sizeAfterStrip = estimateMessagesSize(messages);
+
+      if (sizeBeforeStrip.length !== sizeAfterStrip.length) {
+        logger.info(
+          {
+            sizeBeforeKB: Math.round(sizeBeforeStrip.length / 1024),
+            sizeAfterKB: Math.round(sizeAfterStrip.length / 1024),
+            savedKB: Math.round(
+              (sizeBeforeStrip.length - sizeAfterStrip.length) / 1024,
+            ),
+          },
+          "[OpenRouterAdapter] Stripped browser tool results from messages",
+        );
+      }
+    }
+
+    return {
+      ...this.request,
+      model: this.getModel(),
+      messages,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private Helpers
+  // ---------------------------------------------------------------------------
+
+  private findToolNameInMessages(
+    messages: OpenRouterMessages,
+    toolCallId: string,
+  ): string | null {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+
+      if (message.role === "assistant" && message.tool_calls) {
+        for (const toolCall of message.tool_calls) {
+          if (toolCall.id === toolCallId) {
+            if (toolCall.type === "function") {
+              return toolCall.function.name;
+            } else {
+              return toolCall.custom.name;
+            }
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private toCommonFormat(messages: OpenRouterMessages): CommonMessage[] {
+    logger.debug(
+      { messageCount: messages.length },
+      "[OpenRouterAdapter] toCommonFormat: starting conversion",
+    );
+    const commonMessages: CommonMessage[] = [];
+
+    for (const message of messages) {
+      const commonMessage: CommonMessage = {
+        role: message.role as CommonMessage["role"],
+      };
+
+      // Handle tool messages (tool results)
+      if (message.role === "tool") {
+        const toolName = this.findToolNameInMessages(
+          messages,
+          message.tool_call_id,
+        );
+
+        if (toolName) {
+          logger.debug(
+            { toolCallId: message.tool_call_id, toolName },
+            "[OpenRouterAdapter] toCommonFormat: found tool message",
+          );
+          let toolResult: unknown;
+          if (typeof message.content === "string") {
+            try {
+              toolResult = JSON.parse(message.content);
+            } catch {
+              toolResult = message.content;
+            }
+          } else {
+            toolResult = message.content;
+          }
+
+          commonMessage.toolCalls = [
+            {
+              id: message.tool_call_id,
+              name: toolName,
+              content: toolResult,
+              isError: false,
+            },
+          ];
+        }
+      }
+
+      commonMessages.push(commonMessage);
+    }
+
+    logger.debug(
+      { inputCount: messages.length, outputCount: commonMessages.length },
+      "[OpenRouterAdapter] toCommonFormat: conversion complete",
+    );
+    return commonMessages;
+  }
+
+  private applyUpdates(
+    messages: OpenRouterMessages,
+    updates: Record<string, string>,
+  ): OpenRouterMessages {
+    const updateCount = Object.keys(updates).length;
+    logger.debug(
+      { messageCount: messages.length, updateCount },
+      "[OpenRouterAdapter] applyUpdates: starting",
+    );
+
+    if (updateCount === 0) {
+      logger.debug("[OpenRouterAdapter] applyUpdates: no updates to apply");
+      return messages;
+    }
+
+    let appliedCount = 0;
+    const result = messages.map((message) => {
+      if (message.role === "tool" && updates[message.tool_call_id]) {
+        appliedCount++;
+        logger.debug(
+          { toolCallId: message.tool_call_id },
+          "[OpenRouterAdapter] applyUpdates: applying update to tool message",
+        );
+        return {
+          ...message,
+          content: updates[message.tool_call_id],
+        };
+      }
+      return message;
+    });
+
+    logger.debug(
+      { updateCount, appliedCount },
+      "[OpenRouterAdapter] applyUpdates: complete",
+    );
+    return result;
+  }
+}
+
+// =============================================================================
+// IMAGE CONVERSION HELPERS
+// =============================================================================
+
+function convertMcpImageBlocksToOpenRouter(
+  content: unknown,
+): OpenRouterToolResultContent | null {
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  if (!hasImageContent(content)) {
+    return null;
+  }
+
+  const openrouterContent: OpenRouterToolResultContentBlock[] = [];
+  const imageTooLargePlaceholder = "[Image omitted due to size]";
+
+  for (const item of content) {
+    if (typeof item !== "object" || item === null) continue;
+    const candidate = item as Record<string, unknown>;
+
+    if (isMcpImageBlock(item)) {
+      const mimeType = item.mimeType ?? "image/png";
+      const base64Length = typeof item.data === "string" ? item.data.length : 0;
+      const estimatedSizeKB = Math.round((base64Length * 3) / 4 / 1024);
+      const shouldStripImage = isImageTooLarge(item);
+
+      if (shouldStripImage) {
+        logger.info(
+          {
+            mimeType,
+            base64Length,
+            estimatedSizeKB,
+          },
+          "[OpenRouterAdapter] Stripping MCP image block due to size limit",
+        );
+        openrouterContent.push({
+          type: "text",
+          text: imageTooLargePlaceholder,
+        });
+        continue;
+      }
+
+      logger.info(
+        {
+          mimeType,
+          base64Length,
+          estimatedSizeKB,
+          estimatedBase64Tokens: Math.round(base64Length / 4),
+        },
+        "[OpenRouterAdapter] Converting MCP image block to OpenRouter format",
+      );
+
+      openrouterContent.push({
+        type: "image_url",
+        image_url: {
+          url: `data:${mimeType};base64,${item.data}`,
+        },
+      });
+    } else if (candidate.type === "text" && "text" in candidate) {
+      openrouterContent.push({
+        type: "text",
+        text:
+          typeof candidate.text === "string"
+            ? candidate.text
+            : JSON.stringify(candidate),
+      });
+    }
+  }
+
+  logger.info(
+    {
+      totalBlocks: openrouterContent.length,
+      imageBlocks: openrouterContent.filter((b) => b.type === "image_url").length,
+      textBlocks: openrouterContent.filter((b) => b.type === "text").length,
+    },
+    "[OpenRouterAdapter] Converted MCP content to OpenRouter format",
+  );
+
+  return openrouterContent.length > 0 ? openrouterContent : null;
+}
+
+/**
+ * Strip image blocks from MCP content when model doesn't support images.
+ * Keeps text blocks and replaces image blocks with a placeholder message.
+ */
+function stripImageBlocksFromContent(content: unknown): string {
+  if (!Array.isArray(content)) {
+    return typeof content === "string" ? content : JSON.stringify(content);
+  }
+
+  const textParts: string[] = [];
+  let imageCount = 0;
+
+  for (const item of content) {
+    if (typeof item !== "object" || item === null) continue;
+    const candidate = item as Record<string, unknown>;
+
+    if (isMcpImageBlock(item)) {
+      imageCount++;
+    } else if (candidate.type === "text" && "text" in candidate) {
+      textParts.push(
+        typeof candidate.text === "string"
+          ? candidate.text
+          : JSON.stringify(candidate.text),
+      );
+    }
+  }
+
+  // Add placeholder for stripped images
+  if (imageCount > 0) {
+    textParts.push(
+      `[${imageCount} image(s) removed - model does not support image inputs]`,
+    );
+    logger.info(
+      { imageCount },
+      "[OpenRouterAdapter] Stripped image blocks from tool result",
+    );
+  }
+
+  return textParts.join("\n");
+}
+
+// =============================================================================
+// RESPONSE ADAPTER
+// =============================================================================
+
+class OpenRouterResponseAdapter implements LLMResponseAdapter<OpenRouterResponse> {
+  readonly provider = "openrouter" as const;
+  private response: OpenRouterResponse;
+
+  constructor(response: OpenRouterResponse) {
+    this.response = response;
+  }
+
+  getId(): string {
+    return this.response.id;
+  }
+
+  getModel(): string {
+    return this.response.model;
+  }
+
+  getText(): string {
+    const choice = this.response.choices[0];
+    if (!choice) return "";
+    return choice.message.content ?? "";
+  }
+
+  getToolCalls(): CommonToolCall[] {
+    const choice = this.response.choices[0];
+    if (!choice?.message.tool_calls) return [];
+
+    return choice.message.tool_calls.map((toolCall) => {
+      let name: string;
+      let args: Record<string, unknown>;
+
+      if (toolCall.type === "function" && toolCall.function) {
+        name = toolCall.function.name;
+        try {
+          args = JSON.parse(toolCall.function.arguments);
+        } catch {
+          args = {};
+        }
+      } else if (toolCall.type === "custom" && toolCall.custom) {
+        name = toolCall.custom.name;
+        try {
+          args = JSON.parse(toolCall.custom.input);
+        } catch {
+          args = {};
+        }
+      } else {
+        name = "unknown";
+        args = {};
+      }
+
+      return {
+        id: toolCall.id,
+        name,
+        arguments: args,
+      };
+    });
+  }
+
+  hasToolCalls(): boolean {
+    const choice = this.response.choices[0];
+    return (choice?.message.tool_calls?.length ?? 0) > 0;
+  }
+
+  getUsage(): UsageView {
+    return {
+      inputTokens: this.response.usage?.prompt_tokens ?? 0,
+      outputTokens: this.response.usage?.completion_tokens ?? 0,
+    };
+  }
+
+  getFinishReasons(): string[] {
+    const reason = this.response.choices[0]?.finish_reason;
+    return reason ? [reason] : [];
+  }
+
+  getOriginalResponse(): OpenRouterResponse {
+    return this.response;
+  }
+
+  toRefusalResponse(
+    _refusalMessage: string,
+    contentMessage: string,
+  ): OpenRouterResponse {
+    return {
+      ...this.response,
+      choices: [
+        {
+          ...this.response.choices[0],
+          message: {
+            role: "assistant",
+            content: contentMessage,
+            refusal: null,
+          },
+          finish_reason: "stop",
+        },
+      ],
+    };
+  }
+}
+
+// =============================================================================
+// STREAM ADAPTER
+// =============================================================================
+
+class OpenRouterStreamAdapter
+  implements LLMStreamAdapter<OpenRouterStreamChunk, OpenRouterResponse>
+{
+  readonly provider = "openrouter" as const;
+  readonly state: StreamAccumulatorState;
+  private currentToolCallIndices = new Map<number, number>();
+
+  constructor() {
+    this.state = {
+      responseId: "",
+      model: "",
+      text: "",
+      toolCalls: [],
+      rawToolCallEvents: [],
+      usage: null,
+      stopReason: null,
+      timing: {
+        startTime: Date.now(),
+        firstChunkTime: null,
+      },
+    };
+  }
+
+  processChunk(chunk: OpenRouterStreamChunk): ChunkProcessingResult {
+    if (this.state.timing.firstChunkTime === null) {
+      this.state.timing.firstChunkTime = Date.now();
+    }
+
+    let sseData: string | null = null;
+    let isToolCallChunk = false;
+    let isFinal = false;
+
+    this.state.responseId = chunk.id;
+    this.state.model = chunk.model;
+
+    // Handle usage first
+    if (chunk.usage) {
+      this.state.usage = {
+        inputTokens: chunk.usage.prompt_tokens ?? 0,
+        outputTokens: chunk.usage.completion_tokens ?? 0,
+      };
+    }
+
+    const choice = chunk.choices[0];
+    if (!choice) {
+      return {
+        sseData: null,
+        isToolCallChunk: false,
+        isFinal: this.state.usage !== null,
+      };
+    }
+
+    const delta = choice.delta;
+
+    // Handle text content
+    if (delta.content) {
+      this.state.text += delta.content;
+      sseData = `data: ${JSON.stringify(chunk)}\n\n`;
+    }
+
+    // Handle tool calls
+    if (delta.tool_calls) {
+      for (const toolCallDelta of delta.tool_calls) {
+        const index = toolCallDelta.index;
+
+        if (!this.currentToolCallIndices.has(index)) {
+          this.currentToolCallIndices.set(index, this.state.toolCalls.length);
+          this.state.toolCalls.push({
+            id: toolCallDelta.id ?? "",
+            name: toolCallDelta.function?.name ?? "",
+            arguments: "",
+          });
+        }
+
+        const toolCallIndex = this.currentToolCallIndices.get(index);
+        if (toolCallIndex === undefined) continue;
+        const toolCall = this.state.toolCalls[toolCallIndex];
+
+        if (toolCallDelta.id) {
+          toolCall.id = toolCallDelta.id;
+        }
+        if (toolCallDelta.function?.name) {
+          toolCall.name = toolCallDelta.function.name;
+        }
+        if (toolCallDelta.function?.arguments) {
+          toolCall.arguments += toolCallDelta.function.arguments;
+        }
+      }
+
+      this.state.rawToolCallEvents.push(chunk);
+      isToolCallChunk = true;
+    }
+
+    // Handle finish reason
+    if (choice.finish_reason) {
+      this.state.stopReason = choice.finish_reason;
+    }
+
+    // Mark as final after we've received usage data
+    if (this.state.usage !== null) {
+      isFinal = true;
+    }
+
+    return { sseData, isToolCallChunk, isFinal };
+  }
+
+  getSSEHeaders(): Record<string, string> {
+    return {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    };
+  }
+
+  formatTextDeltaSSE(text: string): string {
+    const chunk: OpenRouterStreamChunk = {
+      id: this.state.responseId,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            content: text,
+          },
+          finish_reason: null,
+        },
+      ],
+    };
+    return `data: ${JSON.stringify(chunk)}\n\n`;
+  }
+
+  getRawToolCallEvents(): string[] {
+    return this.state.rawToolCallEvents.map(
+      (event) => `data: ${JSON.stringify(event)}\n\n`,
+    );
+  }
+
+  formatCompleteTextSSE(text: string): string[] {
+    const chunk: OpenRouterStreamChunk = {
+      id: this.state.responseId || `chatcmpl-${Date.now()}`,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            role: "assistant",
+            content: text,
+          },
+          finish_reason: null,
+        },
+      ],
+    };
+    return [`data: ${JSON.stringify(chunk)}\n\n`];
+  }
+
+  formatEndSSE(): string {
+    const finalChunk: OpenRouterStreamChunk = {
+      id: this.state.responseId,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          delta: {},
+          finish_reason:
+            (this.state.stopReason as "stop" | "tool_calls") ?? "stop",
+        },
+      ],
+    };
+    return `data: ${JSON.stringify(finalChunk)}\n\ndata: [DONE]\n\n`;
+  }
+
+  toProviderResponse(): OpenRouterResponse {
+    const toolCalls =
+      this.state.toolCalls.length > 0
+        ? this.state.toolCalls.map((tc) => ({
+            id: tc.id,
+            type: "function" as const,
+            function: {
+              name: tc.name,
+              arguments: tc.arguments,
+            },
+          }))
+        : undefined;
+
+    return {
+      id: this.state.responseId,
+      object: "chat.completion",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: this.state.text || null,
+            refusal: null,
+            tool_calls: toolCalls,
+          },
+          logprobs: null,
+          finish_reason:
+            (this.state.stopReason as OpenRouter.Types.FinishReason) ?? "stop",
+        },
+      ],
+      usage: {
+        prompt_tokens: this.state.usage?.inputTokens ?? 0,
+        completion_tokens: this.state.usage?.outputTokens ?? 0,
+        total_tokens:
+          (this.state.usage?.inputTokens ?? 0) +
+          (this.state.usage?.outputTokens ?? 0),
+      },
+    };
+  }
+}
+
+// =============================================================================
+// TOON COMPRESSION
+// =============================================================================
+
+async function convertToolResultsToToon(
+  messages: OpenRouterMessages,
+  model: string,
+): Promise<{
+  messages: OpenRouterMessages;
+  stats: ToolCompressionStats;
+}> {
+  // Use tiktoken tokenizer (same as OpenAI) for OpenRouter
+  const tokenizer = getTokenizer("openrouter");
+  let toolResultCount = 0;
+  let totalTokensBefore = 0;
+  let totalTokensAfter = 0;
+
+  const result = messages.map((message) => {
+    if (message.role === "tool") {
+      logger.info(
+        {
+          toolCallId: message.tool_call_id,
+          contentType: typeof message.content,
+          provider: "openrouter",
+        },
+        "convertToolResultsToToon: tool message found",
+      );
+
+      if (typeof message.content === "string") {
+        try {
+          const unwrapped = unwrapToolContent(message.content);
+          const parsed = JSON.parse(unwrapped);
+          const noncompressed = unwrapped;
+          const compressed = toonEncode(parsed);
+
+          const tokensBefore = tokenizer.countTokens([
+            { role: "user", content: noncompressed },
+          ]);
+          const tokensAfter = tokenizer.countTokens([
+            { role: "user", content: compressed },
+          ]);
+
+          toolResultCount++;
+
+          // Always count tokens before
+          totalTokensBefore += tokensBefore;
+
+          // Only apply compression if it actually saves tokens
+          if (tokensAfter < tokensBefore) {
+            totalTokensAfter += tokensAfter;
+
+            logger.info(
+              {
+                toolCallId: message.tool_call_id,
+                beforeLength: noncompressed.length,
+                afterLength: compressed.length,
+                tokensBefore,
+                tokensAfter,
+                toonPreview: compressed.substring(0, 150),
+                provider: "openrouter",
+              },
+              "convertToolResultsToToon: compressed",
+            );
+
+            return {
+              ...message,
+              content: compressed,
+            };
+          }
+
+          // Compression not applied - count non-compressed tokens to track total tokens anyway
+          totalTokensAfter += tokensBefore;
+          logger.info(
+            {
+              toolCallId: message.tool_call_id,
+              tokensBefore,
+              tokensAfter,
+              provider: "openrouter",
+            },
+            "Skipping TOON compression - compressed output has more tokens",
+          );
+        } catch {
+          logger.info(
+            {
+              toolCallId: message.tool_call_id,
+              contentPreview:
+                typeof message.content === "string"
+                  ? message.content.substring(0, 100)
+                  : "non-string",
+            },
+            "Skipping TOON conversion - content is not JSON",
+          );
+          return message;
+        }
+      }
+    }
+
+    return message;
+  });
+
+  logger.info(
+    { messageCount: messages.length, toolResultCount },
+    "convertToolResultsToToon completed",
+  );
+
+  let toonCostSavings = 0;
+  const tokensSaved = totalTokensBefore - totalTokensAfter;
+  if (tokensSaved > 0) {
+    const tokenPrice = await TokenPriceModel.findByModel(model);
+    if (tokenPrice) {
+      const inputPricePerToken =
+        Number(tokenPrice.pricePerMillionInput) / 1000000;
+      toonCostSavings = tokensSaved * inputPricePerToken;
+    }
+  }
+
+  return {
+    messages: result,
+    stats: {
+      tokensBefore: totalTokensBefore,
+      tokensAfter: totalTokensAfter,
+      costSavings: toonCostSavings,
+      wasEffective: totalTokensAfter < totalTokensBefore,
+      hadToolResults: toolResultCount > 0,
+    },
+  };
+}
+
+// =============================================================================
+// ADAPTER FACTORY
+// =============================================================================
+
+export const openrouterAdapterFactory: LLMProvider<
+  OpenRouterRequest,
+  OpenRouterResponse,
+  OpenRouterMessages,
+  OpenRouterStreamChunk,
+  OpenRouterHeaders
+> = {
+  provider: "openrouter",
+  interactionType: "openrouter:chatCompletions",
+
+  createRequestAdapter(
+    request: OpenRouterRequest,
+  ): LLMRequestAdapter<OpenRouterRequest, OpenRouterMessages> {
+    return new OpenRouterRequestAdapter(request);
+  },
+
+  createResponseAdapter(
+    response: OpenRouterResponse,
+  ): LLMResponseAdapter<OpenRouterResponse> {
+    return new OpenRouterResponseAdapter(response);
+  },
+
+  createStreamAdapter(): LLMStreamAdapter<
+    OpenRouterStreamChunk,
+    OpenRouterResponse
+  > {
+    return new OpenRouterStreamAdapter();
+  },
+
+  extractApiKey(headers: OpenRouterHeaders): string | undefined {
+    // Return the authorization header as-is (same as OpenAI)
+    return headers.authorization;
+  },
+
+  getBaseUrl(): string | undefined {
+    return config.llm.openrouter.baseUrl;
+  },
+
+  spanName: "chat",
+
+  createClient(
+    apiKey: string | undefined,
+    options?: CreateClientOptions,
+  ): OpenAIProvider {
+    if (options?.mockMode) {
+      return new MockOpenAIClient() as unknown as OpenAIProvider;
+    }
+
+    // Use observable fetch for request duration metrics if agent is provided
+    const customFetch = options?.agent
+      ? metrics.llm.getObservableFetch(
+          "openrouter",
+          options.agent,
+          options.externalAgentId,
+        )
+      : undefined;
+
+    // Use OpenAI SDK with OpenRouter base URL (OpenAI-compatible API)
+    return new OpenAIProvider({
+      apiKey,
+      baseURL: options?.baseUrl,
+      fetch: customFetch,
+    });
+  },
+
+  async execute(
+    client: unknown,
+    request: OpenRouterRequest,
+  ): Promise<OpenRouterResponse> {
+    const openrouterClient = client as OpenAIProvider;
+    const openrouterRequest = {
+      ...request,
+      stream: false,
+    } as unknown as ChatCompletionCreateParamsNonStreaming;
+    return openrouterClient.chat.completions.create(
+      openrouterRequest,
+    ) as Promise<OpenRouterResponse>;
+  },
+
+  async executeStream(
+    client: unknown,
+    request: OpenRouterRequest,
+  ): Promise<AsyncIterable<OpenRouterStreamChunk>> {
+    const openrouterClient = client as OpenAIProvider;
+    const openrouterRequest = {
+      ...request,
+      stream: true,
+      stream_options: { include_usage: true },
+    } as unknown as ChatCompletionCreateParamsStreaming;
+    const stream =
+      await openrouterClient.chat.completions.create(openrouterRequest);
+
+    return {
+      [Symbol.asyncIterator]: async function* () {
+        for await (const chunk of stream) {
+          yield chunk as OpenRouterStreamChunk;
+        }
+      },
+    };
+  },
+
+  extractErrorMessage(error: unknown): string {
+    // OpenAI SDK error structure (same for OpenRouter)
+    const openaiMessage = get(error, "error.message");
+    if (typeof openaiMessage === "string") {
+      return openaiMessage;
+    }
+
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return "Internal server error";
+  },
+};

--- a/platform/backend/src/routes/proxy/routesv2/openrouter.ts
+++ b/platform/backend/src/routes/proxy/routesv2/openrouter.ts
@@ -1,0 +1,168 @@
+/**
+ * OpenRouter LLM Proxy Routes - OpenAI-compatible
+ *
+ * OpenRouter uses an OpenAI-compatible API at https://api.openrouter.ai/v1
+ * This module registers proxy routes for OpenRouter chat completions.
+ *
+ * @see https://inference-docs.openrouter.ai/
+ */
+import fastifyHttpProxy from "@fastify/http-proxy";
+import { RouteId } from "@shared";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import config from "@/config";
+import logger from "@/logging";
+import { OpenRouter, constructResponseSchema, UuidIdSchema } from "@/types";
+import { openrouterAdapterFactory } from "../adapterV2";
+import { PROXY_API_PREFIX, PROXY_BODY_LIMIT } from "../common";
+import { handleLLMProxy } from "../llm-proxy-handler";
+
+const openrouterProxyRoutesV2: FastifyPluginAsyncZod = async (fastify) => {
+  const API_PREFIX = `${PROXY_API_PREFIX}/openrouter`;
+  const CHAT_COMPLETIONS_SUFFIX = "/chat/completions";
+
+  logger.info("[UnifiedProxy] Registering unified OpenRouter routes");
+
+  /**
+   * Register HTTP proxy for OpenRouter routes
+   * Chat completions are handled separately with full agent support
+   */
+  await fastify.register(fastifyHttpProxy, {
+    upstream: config.llm.openrouter.baseUrl,
+    prefix: API_PREFIX,
+    rewritePrefix: "",
+    preHandler: (request, reply, next) => {
+      // Skip chat/completions - handled by custom handler below
+      const urlPath = request.url.split("?")[0];
+      if (
+        request.method === "POST" &&
+        urlPath.endsWith(CHAT_COMPLETIONS_SUFFIX)
+      ) {
+        logger.info(
+          {
+            method: request.method,
+            url: request.url,
+            action: "skip-proxy",
+            reason: "handled-by-custom-handler",
+          },
+          "OpenRouter proxy preHandler: skipping chat/completions route",
+        );
+        reply.code(400).send({
+          error: {
+            message:
+              "Chat completions requests should use the dedicated endpoint",
+            type: "invalid_request_error",
+          },
+        });
+        return;
+      }
+
+      // Check if URL has UUID segment that needs stripping
+      const pathAfterPrefix = request.url.replace(API_PREFIX, "");
+      const uuidMatch = pathAfterPrefix.match(
+        /^\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(\/.*)?$/i,
+      );
+
+      if (uuidMatch) {
+        // Strip UUID: /v1/openrouter/:uuid/path -> /v1/openrouter/path
+        const remainingPath = uuidMatch[2] || "";
+        const originalUrl = request.raw.url;
+        request.raw.url = `${API_PREFIX}${remainingPath}`;
+
+        logger.info(
+          {
+            method: request.method,
+            originalUrl,
+            rewrittenUrl: request.raw.url,
+            upstream: config.llm.openrouter.baseUrl,
+            finalProxyUrl: `${config.llm.openrouter.baseUrl}${remainingPath}`,
+          },
+          "OpenRouter proxy preHandler: URL rewritten (UUID stripped)",
+        );
+      } else {
+        logger.info(
+          {
+            method: request.method,
+            url: request.url,
+            upstream: config.llm.openrouter.baseUrl,
+            finalProxyUrl: `${config.llm.openrouter.baseUrl}${pathAfterPrefix}`,
+          },
+          "OpenRouter proxy preHandler: proxying request",
+        );
+      }
+
+      next();
+    },
+  });
+
+  /**
+   * Chat completions with default agent
+   */
+  fastify.post(
+    `${API_PREFIX}${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        operationId: RouteId.OpenRouterChatCompletionsWithDefaultAgent,
+        description:
+          "Create a chat completion with OpenRouter (uses default agent)",
+        tags: ["llm-proxy"],
+        body: OpenRouter.API.ChatCompletionRequestSchema,
+        headers: OpenRouter.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(
+          OpenRouter.API.ChatCompletionResponseSchema,
+        ),
+      },
+    },
+    async (request, reply) => {
+      logger.debug(
+        { url: request.url },
+        "[UnifiedProxy] Handling OpenRouter request (default agent)",
+      );
+      return handleLLMProxy(
+        request.body,
+        request,
+        reply,
+        openrouterAdapterFactory,
+      );
+    },
+  );
+
+  /**
+   * Chat completions with specific agent
+   */
+  fastify.post(
+    `${API_PREFIX}/:agentId${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        operationId: RouteId.OpenRouterChatCompletionsWithAgent,
+        description:
+          "Create a chat completion with OpenRouter for a specific agent",
+        tags: ["llm-proxy"],
+        params: z.object({
+          agentId: UuidIdSchema,
+        }),
+        body: OpenRouter.API.ChatCompletionRequestSchema,
+        headers: OpenRouter.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(
+          OpenRouter.API.ChatCompletionResponseSchema,
+        ),
+      },
+    },
+    async (request, reply) => {
+      logger.debug(
+        { url: request.url, agentId: request.params.agentId },
+        "[UnifiedProxy] Handling OpenRouter request (with agent)",
+      );
+      return handleLLMProxy(
+        request.body,
+        request,
+        reply,
+        openrouterAdapterFactory,
+      );
+    },
+  );
+};
+
+export default openrouterProxyRoutesV2;

--- a/platform/backend/src/tokenizers/index.ts
+++ b/platform/backend/src/tokenizers/index.ts
@@ -20,6 +20,7 @@ const tokenizerFactories: Record<SupportedProvider, () => Tokenizer> = {
   vllm: () => new TiktokenTokenizer(),
   ollama: () => new TiktokenTokenizer(),
   zhipuai: () => new TiktokenTokenizer(),
+  openrouter: () => new TiktokenTokenizer(),
   gemini: () => new TiktokenTokenizer(),
   bedrock: () => new TiktokenTokenizer(),
 };

--- a/platform/backend/src/types/chat-api-key.ts
+++ b/platform/backend/src/types/chat-api-key.ts
@@ -19,6 +19,7 @@ export const SupportedChatProviderSchema = z.enum([
   "vllm",
   "ollama",
   "zhipuai",
+  "openrouter",
 ]);
 export type SupportedChatProvider = z.infer<typeof SupportedChatProviderSchema>;
 

--- a/platform/backend/src/types/interaction.ts
+++ b/platform/backend/src/types/interaction.ts
@@ -13,6 +13,7 @@ import {
   OpenAi,
   Vllm,
   Zhipuai,
+  OpenRouter,
 } from "./llm-providers";
 import { ToonSkipReasonSchema } from "./tool-result-compression";
 
@@ -36,6 +37,7 @@ export const InteractionRequestSchema = z.union([
   Ollama.API.ChatCompletionRequestSchema,
   Cohere.API.ChatRequestSchema,
   Zhipuai.API.ChatCompletionRequestSchema,
+  OpenRouter.API.ChatCompletionRequestSchema,
 ]);
 
 export const InteractionResponseSchema = z.union([
@@ -49,6 +51,7 @@ export const InteractionResponseSchema = z.union([
   Ollama.API.ChatCompletionResponseSchema,
   Cohere.API.ChatResponseSchema,
   Zhipuai.API.ChatCompletionResponseSchema,
+  OpenRouter.API.ChatCompletionResponseSchema,
 ]);
 
 /**
@@ -160,6 +163,15 @@ export const SelectInteractionSchema = z.discriminatedUnion("type", [
     response: Zhipuai.API.ChatCompletionResponseSchema,
     requestType: RequestTypeSchema.optional(),
     /** Resolved prompt name if externalAgentId matches a prompt ID */
+    externalAgentIdLabel: z.string().nullable().optional(),
+  }),
+  BaseSelectInteractionSchema.extend({
+    type: z.enum(["openrouter:chatCompletions"]),
+    request: OpenRouter.API.ChatCompletionRequestSchema,
+    processedRequest:
+      OpenRouter.API.ChatCompletionRequestSchema.nullable().optional(),
+    response: OpenRouter.API.ChatCompletionResponseSchema,
+    requestType: RequestTypeSchema.optional(),
     externalAgentIdLabel: z.string().nullable().optional(),
   }),
 ]);

--- a/platform/backend/src/types/llm-providers/index.ts
+++ b/platform/backend/src/types/llm-providers/index.ts
@@ -8,3 +8,4 @@ export { default as Ollama } from "./ollama";
 export { default as OpenAi } from "./openai";
 export { default as Vllm } from "./vllm";
 export { default as Zhipuai } from "./zhipuai";
+export { default as OpenRouter } from "./openrouter";

--- a/platform/backend/src/types/llm-providers/openrouter/api.ts
+++ b/platform/backend/src/types/llm-providers/openrouter/api.ts
@@ -1,0 +1,59 @@
+/**
+ * OpenRouter API schemas - OpenAI-compatible
+ * @see https://openrouter.ai/api
+ */
+import { z } from "zod";
+
+import { ToolCallSchema } from "./messages";
+
+// Re-export schemas that are identical to OpenAI
+export {
+  ChatCompletionRequestSchema,
+  ChatCompletionsHeadersSchema,
+  ChatCompletionUsageSchema,
+  FinishReasonSchema,
+} from "../openai/api";
+
+import { ChatCompletionUsageSchema, FinishReasonSchema } from "../openai/api";
+
+/**
+ * OpenRouter-specific Choice schema
+ * content is optional when tool_calls are present
+ */
+const OpenRouterChoiceSchema = z
+  .object({
+    finish_reason: FinishReasonSchema,
+    index: z.number(),
+    logprobs: z.any().nullable(),
+    message: z
+      .object({
+        content: z.string().nullable().optional(),
+        refusal: z.string().nullable().optional(),
+        role: z.enum(["assistant"]),
+        annotations: z.array(z.any()).optional(),
+        audio: z.any().nullable().optional(),
+        function_call: z
+          .object({
+            arguments: z.string(),
+            name: z.string(),
+          })
+          .nullable()
+          .optional(),
+        tool_calls: z.array(ToolCallSchema).optional(),
+      }),
+  });
+
+/**
+ * OpenRouter-specific ChatCompletionResponse schema
+ */
+export const ChatCompletionResponseSchema = z
+  .object({
+    id: z.string(),
+    choices: z.array(OpenRouterChoiceSchema),
+    created: z.number(),
+    model: z.string(),
+    object: z.enum(["chat.completion"]),
+    server_tier: z.string().optional(),
+    system_fingerprint: z.string().nullable().optional(),
+    usage: ChatCompletionUsageSchema.optional(),
+  });

--- a/platform/backend/src/types/llm-providers/openrouter/index.ts
+++ b/platform/backend/src/types/llm-providers/openrouter/index.ts
@@ -1,0 +1,37 @@
+/**
+ * OpenRouter LLM Provider Types - OpenAI-compatible
+ * @see https://openrouter.ai/api
+ */
+import type OpenAIProvider from "openai";
+import type { z } from "zod";
+import * as OpenRouterAPI from "./api";
+import * as OpenRouterMessages from "./messages";
+import * as OpenRouterTools from "./tools";
+
+namespace OpenRouter {
+  export const API = OpenRouterAPI;
+  export const Messages = OpenRouterMessages;
+  export const Tools = OpenRouterTools;
+
+  export namespace Types {
+    export type ChatCompletionsHeaders = z.infer<
+      typeof OpenRouterAPI.ChatCompletionsHeadersSchema
+    >;
+    export type ChatCompletionsRequest = z.infer<
+      typeof OpenRouterAPI.ChatCompletionRequestSchema
+    >;
+    export type ChatCompletionsResponse = z.infer<
+      typeof OpenRouterAPI.ChatCompletionResponseSchema
+    >;
+    export type Usage = z.infer<typeof OpenRouterAPI.ChatCompletionUsageSchema>;
+
+    export type FinishReason = z.infer<typeof OpenRouterAPI.FinishReasonSchema>;
+    export type Message = z.infer<typeof OpenRouterMessages.MessageParamSchema>;
+    export type Role = Message["role"];
+
+    export type ChatCompletionChunk =
+      OpenAIProvider.Chat.Completions.ChatCompletionChunk;
+  }
+}
+
+export default OpenRouter;

--- a/platform/backend/src/types/llm-providers/openrouter/messages.ts
+++ b/platform/backend/src/types/llm-providers/openrouter/messages.ts
@@ -1,0 +1,5 @@
+/**
+ * OpenRouter message schemas - OpenAI-compatible
+ * @see https://openrouter.ai/api
+ */
+export { MessageParamSchema, ToolCallSchema } from "../openai/messages";

--- a/platform/backend/src/types/llm-providers/openrouter/tools.ts
+++ b/platform/backend/src/types/llm-providers/openrouter/tools.ts
@@ -1,0 +1,9 @@
+/**
+ * OpenRouter tool schemas - OpenAI-compatible
+ * @see https://openrouter.ai/api
+ */
+export {
+  FunctionDefinitionParametersSchema,
+  ToolChoiceOptionSchema,
+  ToolSchema,
+} from "../openai/tools";

--- a/platform/frontend/src/lib/llmProviders/openrouter.ts
+++ b/platform/frontend/src/lib/llmProviders/openrouter.ts
@@ -1,0 +1,10 @@
+/**
+ * OpenRouter LLM Provider Interaction Handler - OpenAI-compatible
+ * @see https://openrouter.ai/docs
+ */
+import OpenAiChatCompletionInteraction from "./openai";
+
+// OpenRouter uses the same request/response format as OpenAI
+class OpenRouterChatCompletionInteraction extends OpenAiChatCompletionInteraction {}
+
+export default OpenRouterChatCompletionInteraction;

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -14,6 +14,7 @@ export const SupportedProvidersSchema = z.enum([
   "vllm",
   "ollama",
   "zhipuai",
+  "openrouter",
 ]);
 
 export const SupportedProvidersDiscriminatorSchema = z.enum([
@@ -27,6 +28,7 @@ export const SupportedProvidersDiscriminatorSchema = z.enum([
   "vllm:chatCompletions",
   "ollama:chatCompletions",
   "zhipuai:chatCompletions",
+  "openrouter:chatCompletions",
 ]);
 
 export const SupportedProviders = Object.values(SupportedProvidersSchema.enum);
@@ -46,6 +48,11 @@ export const providerDisplayNames: Record<SupportedProvider, string> = {
   vllm: "vLLM",
   ollama: "Ollama",
   zhipuai: "Zhipu AI",
+  openrouter: "OpenRouter",
+  openrouter: {
+    fastest: ["meta-llama/llama-3.1-8b-instruct"],
+    best: ["anthropic/claude-3.5-sonnet"],
+  },
 };
 
 /**

--- a/platform/shared/routes.ts
+++ b/platform/shared/routes.ts
@@ -185,6 +185,12 @@ export const RouteId = {
     "zhipuaiChatCompletionsWithDefaultAgent",
   ZhipuaiChatCompletionsWithAgent: "zhipuaiChatCompletionsWithAgent",
 
+
+  // Proxy Routes - OpenRouter
+  OpenRouterChatCompletionsWithDefaultAgent:
+    "openrouterChatCompletionsWithDefaultAgent",
+  OpenRouterChatCompletionsWithAgent: "openrouterChatCompletionsWithAgent",
+
   // Proxy Routes - AWS Bedrock
   BedrockConverseWithDefaultAgent: "bedrockConverseWithDefaultAgent",
   BedrockConverseWithAgent: "bedrockConverseWithAgent",


### PR DESCRIPTION
## Summary
Adds OpenRouter as a new LLM provider, following the existing provider pattern.

## Changes
- Backend types: `llm-providers/openrouter/` (api, messages, tools, index)
- Frontend config: `llmProviders/openrouter.ts`
- Proxy adapter: `adapterV2/openrouter.ts`
- Proxy route: `routesv2/openrouter.ts`
- Registry updates: config, routes, types, tokenizers, shared constants

## Implementation
OpenRouter uses an OpenAI-compatible API at `api.openrouter.ai`. The implementation follows the same pattern as existing providers (OpenAI, Anthropic, etc.) with the addition of the `HTTP-Referer` header required by OpenRouter's API.

Closes #1929

Labels: enhancement