### PR TITLE
fix: restore claude[bot] identity and sticky comments in PR reviews

### DIFF
--- a/.github/actions/run-claude/action.yml
+++ b/.github/actions/run-claude/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
     default: ""
   github_token:
-    description: GitHub token for API calls (defaults to GITHUB_TOKEN)
+    description: GitHub token for API calls. Only pass this when NOT using claude_code_oauth_token, otherwise the OIDC flow (which posts as claude[bot]) will be skipped.
     required: false
     default: ""
   allowed_non_write_users:
@@ -63,7 +63,7 @@ runs:
         prompt: ${{ inputs.prompt }}
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
-        github_token: ${{ inputs.github_token || github.token }}
+        github_token: ${{ inputs.github_token }}
         allowed_non_write_users: ${{ inputs.allowed_non_write_users }}
         use_sticky_comment: ${{ inputs.use_sticky_comment }}
         track_progress: ${{ inputs.track_progress }}


### PR DESCRIPTION
## Summary
- The `run-claude` composite action was defaulting `github_token` to `github.token` via `${{ inputs.github_token || github.token }}`, even when callers use `claude_code_oauth_token` (OAuth auth)
- This caused `claude-code-action`'s `OVERRIDE_GITHUB_TOKEN` env var to be non-empty, which short-circuits the OIDC flow in `setupGitHubToken()` that generates a Claude App installation token
- Result: comments posted as `github-actions[bot]` instead of `claude[bot]`, and sticky comments broken (the action searches for existing comments by Claude's bot ID `209825114` / name containing "claude", which never matches `github-actions[bot]`)

**Fix**: Pass `github_token` through as-is (empty when not provided by callers). The underlying `claude-code-action` already has `DEFAULT_WORKFLOW_TOKEN: ${{ github.token }}` for fallback operations. Callers that need an explicit token (community triage workflows using `anthropic_api_key` + GitHub App token) already pass it explicitly.

## Test plan
- [ ] Merge and verify next core team PR review posts as `claude[bot]`
- [ ] Verify sticky comments work (synchronize events update existing comment instead of creating new ones)
- [ ] Verify community triage workflows still work (they explicitly pass `github_token`)