### PR TITLE
fix: remove permissions from shared workflow to inherit from callers

### DIFF
--- a/.github/workflows/claude-community-shared.yml
+++ b/.github/workflows/claude-community-shared.yml
@@ -43,13 +43,6 @@ jobs:
   run-claude:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout_minutes }}
-    # Both pull-requests and issues write are needed because this shared workflow
-    # serves both PR triage and issue triage callers. The caller's permissions
-    # act as the ceiling, so the unused permission has no effect in practice.
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
 
     steps:
       - name: Generate GitHub App token


### PR DESCRIPTION
## Summary
- The shared Claude community workflow (`claude-community-shared.yml`) declared both `pull-requests: write` and `issues: write` permissions, but each caller only grants one of these
- GitHub Actions requires a reusable workflow's permissions to stay within the caller's ceiling, causing workflow validation failures for both PR triage and issue triage
- Fix: remove the `permissions` block from the shared workflow so it inherits whatever the caller grants

## Test plan
- [ ] Verify the `Claude PR Triage` workflow passes validation on new PRs
- [ ] Verify the `Claude Issue Triage` workflow passes validation on new issues