### PR TITLE
fix: only auto-discover proxy-sniffed tools for llm_proxy agents

### DIFF
--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -212,22 +212,20 @@ export async function handleLLMProxy<
     );
 
     // Persist tools declared by client (only for llm_proxy agents)
-    if (resolvedAgent.agentType === "llm_proxy") {
-      const tools = requestAdapter.getTools();
-      if (tools.length > 0) {
-        logger.debug(
-          { toolCount: tools.length },
-          `[${providerName}Proxy] Processing tools from request`,
-        );
-        await utils.tools.persistTools(
-          tools.map((t) => ({
-            toolName: t.name,
-            toolParameters: t.inputSchema,
-            toolDescription: t.description,
-          })),
-          resolvedAgentId,
-        );
-      }
+    const tools = requestAdapter.getTools();
+    if (resolvedAgent.agentType === "llm_proxy" && tools.length > 0) {
+      logger.debug(
+        { toolCount: tools.length },
+        `[${providerName}Proxy] Processing tools from request`,
+      );
+      await utils.tools.persistTools(
+        tools.map((t) => ({
+          toolName: t.name,
+          toolParameters: t.inputSchema,
+          toolDescription: t.description,
+        })),
+        resolvedAgentId,
+      );
     }
 
     // Cost optimization - potentially switch to cheaper model


### PR DESCRIPTION
## Summary
- Restricts proxy-sniffed tool auto-discovery to only `llm_proxy` agent types
- Other agent types (`profile`, `mcp_gateway`, `agent`) going through the proxy handler will no longer trigger tool persistence