### PR TITLE
fix: double-slash in Grafana API paths by stripping trailing slash

### DIFF
--- a/platform/dev/grafana/install-dashboards.sh
+++ b/platform/dev/grafana/install-dashboards.sh
@@ -47,6 +47,7 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
 fi
 
 GRAFANA_URL="${GRAFANA_URL:-http://localhost:3000}"
+GRAFANA_URL="${GRAFANA_URL%/}"  # strip trailing slash to avoid double-slash in API paths
 GRAFANA_TOKEN="${GRAFANA_TOKEN:-}"
 GRAFANA_USER="${GRAFANA_USER:-}"
 GRAFANA_PASS="${GRAFANA_PASS:-}"


### PR DESCRIPTION
## Summary

The fix ensures that regardless of whether users provide `GRAFANA_URL` with or without a trailing slash (e.g., `http://localhost:3000` or `http://localhost:3000/`), the script will consistently construct API paths without double slashes. This prevents potential issues with API endpoint resolution and improves robustness of the dashboard installation script.