### PR TITLE
fix: invalidate correct query key when security setting changes

### DIFF
--- a/platform/frontend/src/lib/organization.query.ts
+++ b/platform/frontend/src/lib/organization.query.ts
@@ -294,8 +294,8 @@ export function useUpdateOrganization(
         customFont: updatedOrganization.customFont,
         logo: updatedOrganization.logo,
       });
-      // Invalidate features cache since globalToolPolicy comes from organization record
-      queryClient.invalidateQueries({ queryKey: ["features"] });
+      // Invalidate config cache since globalToolPolicy comes from organization record
+      queryClient.invalidateQueries({ queryKey: ["config"] });
       toast.success(onSuccessMessage);
     },
   });


### PR DESCRIPTION
Fixes #2948

## Summary
- Fixed query key mismatch in `useUpdateOrganization` that prevented the sidebar security alert from appearing immediately when the security engine is disabled
- Changed invalidation from `["features"]` (non-existent) to `["config"]` (the actual query key used by `useConfig()`)