### PR TITLE
feat: add DeepSeek provider support

### DIFF
--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -64,6 +64,9 @@ export function detectProviderFromModel(model: string): SupportedChatProvider {
   if (lowerModel.includes("command")) {
     return "cohere";
   }
+  if (lowerModel.includes("deepseek")) {
+    return "deepseek";
+  }
   if (lowerModel.includes("glm") || lowerModel.includes("chatglm")) {
     return "zhipuai";
   }
@@ -84,6 +87,7 @@ const envApiKeyGetters: Record<
   anthropic: () => config.chat.anthropic.apiKey,
   bedrock: () => config.chat.bedrock.apiKey,
   cerebras: () => config.chat.cerebras.apiKey,
+  deepseek: () => config.chat.deepseek.apiKey,
   cohere: () => config.chat.cohere.apiKey,
   gemini: () => config.chat.gemini.apiKey,
   mistral: () => config.chat.mistral.apiKey,
@@ -215,6 +219,7 @@ export const FAST_MODELS: Record<SupportedChatProvider, string> = {
   openai: "gpt-4o-mini",
   gemini: "gemini-2.0-flash-001",
   cerebras: "llama-3.3-70b", // Cerebras focuses on speed, all their models are fast
+  deepseek: "deepseek-chat", // DeepSeek's fast model
   cohere: "command-light", // Cohere's fast model
   vllm: "default", // vLLM uses whatever model is deployed
   ollama: "llama3.2", // Common fast model for Ollama
@@ -314,6 +319,21 @@ const directModelCreators: Record<SupportedChatProvider, DirectModelCreator> = {
       baseURL: baseUrl ?? config.llm.cerebras.baseUrl,
     });
     return client(modelName);
+  },
+
+  deepseek: ({ apiKey, modelName, baseUrl }) => {
+    if (!apiKey) {
+      throw new ApiError(
+        400,
+        "DeepSeek API key is required. Please configure ARCHESTRA_CHAT_DEEPSEEK_API_KEY.",
+      );
+    }
+    // DeepSeek uses OpenAI-compatible API
+    const client = createOpenAI({
+      apiKey,
+      baseURL: baseUrl ?? config.llm.deepseek.baseUrl,
+    });
+    return client.chat(modelName);
   },
 
   cohere: ({ apiKey, modelName, baseUrl }) => {
@@ -557,6 +577,18 @@ const proxiedModelCreators: Record<SupportedChatProvider, ProxiedModelCreator> =
         fetch: createTracedFetch(),
       });
       return client(modelName);
+    },
+
+    deepseek: ({ apiKey, agentId, modelName, headers }) => {
+      // URL format: /v1/deepseek/:agentId (SDK appends /chat/completions)
+      // DeepSeek uses OpenAI-compatible API
+      const client = createOpenAI({
+        apiKey,
+        baseURL: buildProxyBaseUrl("deepseek", agentId),
+        headers,
+        fetch: createTracedFetch(),
+      });
+      return client.chat(modelName);
     },
 
     mistral: ({ apiKey, agentId, modelName, headers }) => {

--- a/platform/backend/src/clients/models-dev-client.test.ts
+++ b/platform/backend/src/clients/models-dev-client.test.ts
@@ -161,7 +161,7 @@ describe("ModelsDevClient", () => {
 
     test("maps OpenAI-compatible providers to openai", () => {
       expect(modelsDevClient.mapProvider("llama")).toBe("openai");
-      expect(modelsDevClient.mapProvider("deepseek")).toBe("openai");
+      expect(modelsDevClient.mapProvider("deepseek")).toBe("deepseek");
       expect(modelsDevClient.mapProvider("groq")).toBe("openai");
       expect(modelsDevClient.mapProvider("fireworks-ai")).toBe("openai");
       expect(modelsDevClient.mapProvider("togetherai")).toBe("openai");

--- a/platform/backend/src/clients/models-dev-client.ts
+++ b/platform/backend/src/clients/models-dev-client.ts
@@ -49,7 +49,7 @@ const MODELS_DEV_PROVIDER_MAP: Record<string, SupportedProvider | null> = {
   mistral: "mistral",
   // These providers use OpenAI-compatible API in Archestra
   llama: "openai",
-  deepseek: "openai",
+  deepseek: "deepseek",
   groq: "openai",
   "fireworks-ai": "openai",
   togetherai: "openai",
@@ -402,7 +402,8 @@ class ModelsDevClient {
     // provider (e.g., "google/gemini-2.5-flash" vs "google-vertex/gemini-2.5-flash").
     const preferredSourcePrefixes: Record<SupportedProvider, string[]> = {
       gemini: ["google/"], // Prefer google over google-vertex
-      openai: ["openai/", "deepseek/"], // Prefer direct providers over aggregators
+      openai: ["openai/"], // Prefer direct providers over aggregators
+      deepseek: ["deepseek/"],
       anthropic: ["anthropic/"],
       cohere: ["cohere/"],
       cerebras: ["cerebras/"],

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -543,6 +543,10 @@ export default {
       enabled: Boolean(process.env.ARCHESTRA_COHERE_BASE_URL),
       baseUrl: process.env.ARCHESTRA_COHERE_BASE_URL || "https://api.cohere.ai",
     },
+    deepseek: {
+      baseUrl:
+        process.env.ARCHESTRA_DEEPSEEK_BASE_URL || "https://api.deepseek.com",
+    },
     cerebras: {
       baseUrl:
         process.env.ARCHESTRA_CEREBRAS_BASE_URL || "https://api.cerebras.ai/v1",
@@ -592,6 +596,9 @@ export default {
     },
     cerebras: {
       apiKey: process.env.ARCHESTRA_CHAT_CEREBRAS_API_KEY || "",
+    },
+    deepseek: {
+      apiKey: process.env.ARCHESTRA_CHAT_DEEPSEEK_API_KEY || "",
     },
     mistral: {
       apiKey: process.env.ARCHESTRA_CHAT_MISTRAL_API_KEY || "",

--- a/platform/backend/src/routes/chat/routes.chat.ts
+++ b/platform/backend/src/routes/chat/routes.chat.ts
@@ -77,6 +77,7 @@ const DEFAULT_MODELS: Record<SupportedProvider, string> = {
   ollama: "llama3.2",
   vllm: "default",
   cerebras: "llama-4-scout-17b-16e-instruct",
+  deepseek: "deepseek-chat",
   mistral: "mistral-large-latest",
   perplexity: "sonar-pro",
   zhipuai: "glm-4-plus",

--- a/platform/backend/src/services/model-sync.ts
+++ b/platform/backend/src/services/model-sync.ts
@@ -214,7 +214,7 @@ const MODELS_DEV_PROVIDER_MAP: Record<string, SupportedProvider | null> = {
   cerebras: "cerebras",
   mistral: "mistral",
   llama: "openai",
-  deepseek: "openai",
+  deepseek: "deepseek",
   groq: "openai",
   "fireworks-ai": "openai",
   togetherai: "openai",

--- a/platform/backend/src/types/chat-api-key.ts
+++ b/platform/backend/src/types/chat-api-key.ts
@@ -12,6 +12,7 @@ export const SupportedChatProviderSchema = z.enum([
   "anthropic",
   "bedrock",
   "cerebras",
+  "deepseek",
   "cohere",
   "gemini",
   "mistral",

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -10,6 +10,7 @@ export const SupportedProvidersSchema = z.enum([
   "bedrock",
   "cohere",
   "cerebras",
+  "deepseek",
   "mistral",
   "perplexity",
   "vllm",
@@ -24,6 +25,7 @@ export const SupportedProvidersDiscriminatorSchema = z.enum([
   "bedrock:converse",
   "cohere:chat",
   "cerebras:chatCompletions",
+  "deepseek:chatCompletions",
   "mistral:chatCompletions",
   "perplexity:chatCompletions",
   "vllm:chatCompletions",
@@ -44,6 +46,7 @@ export const providerDisplayNames: Record<SupportedProvider, string> = {
   gemini: "Gemini",
   cohere: "Cohere",
   cerebras: "Cerebras",
+  deepseek: "DeepSeek",
   mistral: "Mistral AI",
   perplexity: "Perplexity AI",
   vllm: "vLLM",
@@ -75,6 +78,7 @@ export const DEFAULT_PROVIDER_BASE_URLS: Record<SupportedProvider, string> = {
   bedrock: "",
   cohere: "https://api.cohere.ai",
   cerebras: "https://api.cerebras.ai/v1",
+  deepseek: "https://api.deepseek.com",
   mistral: "https://api.mistral.ai/v1",
   perplexity: "https://api.perplexity.ai",
   vllm: "",
@@ -115,6 +119,10 @@ export const MODEL_MARKER_PATTERNS: Record<
   cerebras: {
     fastest: ["llama-3.3-70b"],
     best: ["llama-3.3-70b"],
+  },
+  deepseek: {
+    fastest: ["deepseek-chat"],
+    best: ["deepseek-reasoner"],
   },
   cohere: {
     fastest: ["command-light"],


### PR DESCRIPTION
Adds DeepSeek as a supported LLM provider. This allows users to leverage DeepSeek-Chat and DeepSeek-Reasoner models within Archestra.

Verified with local testing. Follows the provider integration guide.