### PR TITLE
feat: Add x.ai (Grok) LLM provider support

### DIFF
--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -539,6 +539,10 @@ export default {
           process.env.ARCHESTRA_GEMINI_VERTEX_AI_CREDENTIALS_FILE || "",
       },
     },
+    xai: {
+      baseUrl:
+        process.env.ARCHESTRA_XAI_BASE_URL || "https://api.x.ai/v1",
+    },
     cohere: {
       enabled: Boolean(process.env.ARCHESTRA_COHERE_BASE_URL),
       baseUrl: process.env.ARCHESTRA_COHERE_BASE_URL || "https://api.cohere.ai",

--- a/platform/backend/src/routes/index.ts
+++ b/platform/backend/src/routes/index.ts
@@ -8,6 +8,7 @@ import ollamaProxyRoutesV2 from "./proxy/routesv2/ollama";
 import openAiProxyRoutesV2 from "./proxy/routesv2/openai";
 import perplexityProxyRoutesV2 from "./proxy/routesv2/perplexity";
 import vllmProxyRoutesV2 from "./proxy/routesv2/vllm";
+import xaiProxyRoutesV2 from "./proxy/routesv2/xai";
 import zhipuaiProxyRoutesV2 from "./proxy/routesv2/zhipuai";
 
 export { default as browserStreamRoutes } from "@/features/browser-stream/routes/browser-stream.routes";
@@ -48,6 +49,7 @@ export const geminiProxyRoutes = geminiProxyRoutesV2;
 export const mistralProxyRoutes = mistralProxyRoutesV2;
 export const perplexityProxyRoutes = perplexityProxyRoutesV2;
 export const openAiProxyRoutes = openAiProxyRoutesV2;
+export const xaiProxyRoutes = xaiProxyRoutesV2;
 export const vllmProxyRoutes = vllmProxyRoutesV2;
 export const ollamaProxyRoutes = ollamaProxyRoutesV2;
 export const zhipuaiProxyRoutes = zhipuaiProxyRoutesV2;

--- a/platform/backend/src/routes/proxy/adapterV2/index.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/index.ts
@@ -8,4 +8,5 @@ export { ollamaAdapterFactory } from "./ollama";
 export { openaiAdapterFactory } from "./openai";
 export { perplexityAdapterFactory } from "./perplexity";
 export { vllmAdapterFactory } from "./vllm";
+export { xaiAdapterFactory } from "./xai";
 export { zhipuaiAdapterFactory } from "./zhipuai";

--- a/platform/backend/src/routes/proxy/adapterV2/xai.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/xai.ts
@@ -1,0 +1,189 @@
+/**
+ * x.ai (Grok) LLM Provider Adapter
+ * 
+ * x.ai (Grok) is OpenAI compatible, so we reuse the OpenAI adapter implementation
+ * with x.ai-specific configuration.
+ * 
+ * Base URL: https://api.x.ai/v1
+ * API Documentation: https://docs.x.ai/docs/api-reference
+ * 
+ * Special features:
+ * - Supports reasoning_effort parameter for controlling reasoning depth
+ * - Vision processing supported
+ * - Models: grok-4, grok-4-1-fast-reasoning, grok-4-1-fast-non-reasoning, grok-code-fast-1
+ */
+
+import { get } from "lodash-es";
+import OpenAIProvider from "openai";
+import type {
+  ChatCompletionCreateParamsNonStreaming,
+  ChatCompletionCreateParamsStreaming,
+} from "openai/resources/chat/completions/completions";
+import config from "@/config";
+import logger from "@/logging";
+import { metrics } from "@/observability";
+import type {
+  ChunkProcessingResult,
+  CreateClientOptions,
+  LLMProvider,
+  LLMRequestAdapter,
+  LLMResponseAdapter,
+  LLMStreamAdapter,
+  OpenAi,
+} from "@/types";
+import { MockOpenAIClient } from "../mock-openai-client";
+import {
+  OpenAIRequestAdapter,
+  OpenAIResponseAdapter,
+  OpenAIStreamAdapter,
+} from "./openai";
+
+// =============================================================================
+// TYPE ALIASES
+// =============================================================================
+
+type XaiRequest = OpenAi.Types.ChatCompletionsRequest;
+type XaiResponse = OpenAi.Types.ChatCompletionsResponse;
+type XaiMessages = OpenAi.Types.ChatCompletionsRequest["messages"];
+type XaiHeaders = OpenAi.Types.ChatCompletionsHeaders;
+type XaiStreamChunk = OpenAi.Types.ChatCompletionChunk;
+
+// =============================================================================
+// X.AI REQUEST ADAPTER
+// =============================================================================
+
+class XaiRequestAdapter extends OpenAIRequestAdapter {
+  readonly provider = "xai" as const;
+}
+
+// =============================================================================
+// X.AI RESPONSE ADAPTER
+// =============================================================================
+
+class XaiResponseAdapter extends OpenAIResponseAdapter {
+  readonly provider = "xai" as const;
+}
+
+// =============================================================================
+// X.AI STREAM ADAPTER
+// =============================================================================
+
+class XaiStreamAdapter extends OpenAIStreamAdapter {
+  readonly provider = "xai" as const;
+}
+
+// =============================================================================
+// X.AI ADAPTER FACTORY
+// =============================================================================
+
+export const xaiAdapterFactory: LLMProvider<
+  XaiRequest,
+  XaiResponse,
+  XaiMessages,
+  XaiStreamChunk,
+  XaiHeaders
+> = {
+  provider: "xai",
+  interactionType: "xai:chatCompletions",
+
+  createRequestAdapter(
+    request: XaiRequest,
+  ): LLMRequestAdapter<XaiRequest, XaiMessages> {
+    return new XaiRequestAdapter(request);
+  },
+
+  createResponseAdapter(
+    response: XaiResponse,
+  ): LLMResponseAdapter<XaiResponse> {
+    return new XaiResponseAdapter(response);
+  },
+
+  createStreamAdapter(): LLMStreamAdapter<XaiStreamChunk, XaiResponse> {
+    return new XaiStreamAdapter();
+  },
+
+  extractApiKey(headers: XaiHeaders): string | undefined {
+    // Return the authorization header as-is (legacy behavior)
+    // x.ai API uses Bearer authentication like OpenAI
+    return headers.authorization;
+  },
+
+  getBaseUrl(): string | undefined {
+    return config.llm.xai?.baseUrl;
+  },
+
+  spanName: "chat",
+
+  createClient(
+    apiKey: string | undefined,
+    options?: CreateClientOptions,
+  ): OpenAIProvider {
+    if (options?.mockMode) {
+      return new MockOpenAIClient() as unknown as OpenAIProvider;
+    }
+
+    // Use observable fetch for request duration metrics if agent is provided
+    const customFetch = options?.agent
+      ? metrics.llm.getObservableFetch(
+          "xai",
+          options.agent,
+          options.externalAgentId,
+        )
+      : undefined;
+
+    return new OpenAIProvider({
+      apiKey,
+      baseURL: options?.baseUrl ?? "https://api.x.ai/v1",
+      fetch: customFetch,
+    });
+  },
+
+  async execute(
+    client: unknown,
+    request: XaiRequest,
+  ): Promise<XaiResponse> {
+    const xaiClient = client as OpenAIProvider;
+    const xaiRequest = {
+      ...request,
+      stream: false,
+    } as unknown as ChatCompletionCreateParamsNonStreaming;
+    return xaiClient.chat.completions.create(
+      xaiRequest,
+    ) as Promise<XaiResponse>;
+  },
+
+  async executeStream(
+    client: unknown,
+    request: XaiRequest,
+  ): Promise<AsyncIterable<XaiStreamChunk>> {
+    const xaiClient = client as OpenAIProvider;
+    const xaiRequest = {
+      ...request,
+      stream: true,
+      stream_options: { include_usage: true },
+    } as unknown as ChatCompletionCreateParamsStreaming;
+    const stream = await xaiClient.chat.completions.create(xaiRequest);
+
+    return {
+      [Symbol.asyncIterator]: async function* () {
+        for await (const chunk of stream) {
+          yield chunk as XaiStreamChunk;
+        }
+      },
+    };
+  },
+
+  extractErrorMessage(error: unknown): string {
+    // x.ai uses OpenAI-compatible SDK, so error structure should be similar
+    const xaiMessage = get(error, "error.message");
+    if (typeof xaiMessage === "string") {
+      return xaiMessage;
+    }
+
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return "Internal server error";
+  },
+};

--- a/platform/backend/src/routes/proxy/routesv2/xai.ts
+++ b/platform/backend/src/routes/proxy/routesv2/xai.ts
@@ -1,0 +1,85 @@
+import fastifyHttpProxy from "@fastify/http-proxy";
+import { RouteId } from "@shared";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import config from "@/config";
+import logger from "@/logging";
+import { constructResponseSchema, OpenAi, UuidIdSchema } from "@/types";
+import { xaiAdapterFactory } from "../adapterV2";
+import { PROXY_API_PREFIX, PROXY_BODY_LIMIT } from "../common";
+import { handleLLMProxy } from "../llm-proxy-handler";
+import { createProxyPreHandler } from "./proxy-prehandler";
+
+const xaiProxyRoutesV2: FastifyPluginAsyncZod = async (fastify) => {
+  const API_PREFIX = `${PROXY_API_PREFIX}/xai`;
+  const CHAT_COMPLETIONS_SUFFIX = "/chat/completions";
+
+  logger.info("[UnifiedProxy] Registering unified x.ai (Grok) routes");
+
+  await fastify.register(fastifyHttpProxy, {
+    upstream: "https://api.x.ai/v1",
+    prefix: API_PREFIX,
+    rewritePrefix: "",
+    preHandler: createProxyPreHandler({
+      apiPrefix: API_PREFIX,
+      endpointSuffix: CHAT_COMPLETIONS_SUFFIX,
+      upstream: "https://api.x.ai/v1",
+      providerName: "x.ai (Grok)",
+    }),
+  });
+
+  fastify.post(
+    `${API_PREFIX}${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        operationId: RouteId.XaiChatCompletionsWithDefaultAgent,
+        description:
+          "Create a chat completion with x.ai (Grok) (uses default agent)",
+        tags: ["llm-proxy"],
+        body: OpenAi.API.ChatCompletionRequestSchema,
+        headers: OpenAi.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(
+          OpenAi.API.ChatCompletionResponseSchema,
+        ),
+      },
+    },
+    async (request, reply) => {
+      logger.debug(
+        { url: request.url },
+        "[UnifiedProxy] Handling x.ai (Grok) request (default agent)",
+      );
+      return handleLLMProxy(request.body, request, reply, xaiAdapterFactory);
+    },
+  );
+
+  fastify.post(
+    `${API_PREFIX}/:agentId${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        operationId: RouteId.XaiChatCompletionsWithAgent,
+        description:
+          "Create a chat completion with x.ai (Grok) for a specific agent",
+        tags: ["llm-proxy"],
+        params: z.object({
+          agentId: UuidIdSchema,
+        }),
+        body: OpenAi.API.ChatCompletionRequestSchema,
+        headers: OpenAi.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(
+          OpenAi.API.ChatCompletionResponseSchema,
+        ),
+      },
+    },
+    async (request, reply) => {
+      logger.debug(
+        { url: request.url, agentId: request.params.agentId },
+        "[UnifiedProxy] Handling x.ai (Grok) request (with agent)",
+      );
+      return handleLLMProxy(request.body, request, reply, xaiAdapterFactory);
+    },
+  );
+};
+
+export default xaiProxyRoutesV2;

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -15,6 +15,7 @@ export const SupportedProvidersSchema = z.enum([
   "vllm",
   "ollama",
   "zhipuai",
+  "xai",
 ]);
 
 export const SupportedProvidersDiscriminatorSchema = z.enum([
@@ -29,6 +30,7 @@ export const SupportedProvidersDiscriminatorSchema = z.enum([
   "vllm:chatCompletions",
   "ollama:chatCompletions",
   "zhipuai:chatCompletions",
+  "xai:chatCompletions",
 ]);
 
 export const SupportedProviders = Object.values(SupportedProvidersSchema.enum);
@@ -49,6 +51,7 @@ export const providerDisplayNames: Record<SupportedProvider, string> = {
   vllm: "vLLM",
   ollama: "Ollama",
   zhipuai: "Zhipu AI",
+  xai: "x.ai (Grok)",
 };
 
 /**
@@ -80,6 +83,7 @@ export const DEFAULT_PROVIDER_BASE_URLS: Record<SupportedProvider, string> = {
   vllm: "",
   ollama: "http://localhost:11434/v1",
   zhipuai: "https://api.z.ai/api/paas/v4",
+  xai: "https://api.x.ai/v1",
 };
 
 /**
@@ -143,5 +147,9 @@ export const MODEL_MARKER_PATTERNS: Record<
   bedrock: {
     fastest: ["nova-lite", "nova-micro", "haiku"],
     best: ["nova-pro", "sonnet", "opus"],
+  },
+  xai: {
+    fastest: ["grok-4-1-fast-non-reasoning", "grok-code-fast-1"],
+    best: ["grok-4", "grok-4-1-fast-reasoning"],
   },
 };

--- a/platform/shared/routes.ts
+++ b/platform/shared/routes.ts
@@ -157,6 +157,11 @@ export const RouteId = {
     "openAiChatCompletionsWithDefaultAgent",
   OpenAiChatCompletionsWithAgent: "openAiChatCompletionsWithAgent",
 
+  // Proxy Routes - x.ai (Grok)
+  XaiChatCompletionsWithDefaultAgent:
+    "xaiChatCompletionsWithDefaultAgent",
+  XaiChatCompletionsWithAgent: "xaiChatCompletionsWithAgent",
+
   // Proxy Routes - Anthropic
   AnthropicMessagesWithDefaultAgent: "anthropicMessagesWithDefaultAgent",
   AnthropicMessagesWithAgent: "anthropicMessagesWithAgent",


### PR DESCRIPTION
- Add x.ai (Grok) to supported providers in model-constants.ts
- Add x.ai adapter based on OpenAI compatibility
- Add x.ai proxy routes and handlers
- Add x.ai configuration in config.ts
- Add x.ai route IDs for API endpoints

x.ai API compatible with OpenAI at https://api.x.ai/v1 Supports streaming and non-streaming responses, tool calls, vision processing. Special features: reasoning_effort parameter for controlling reasoning depth.

Models: grok-4, grok-4-1-fast-reasoning, grok-4-1-fast-non-reasoning, grok-code-fast-1

Closes #1850