### PR TITLE
fix: hide Logs button when logs are unavailable

### DIFF
--- a/platform/frontend/src/app/mcp-catalog/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp-catalog/_parts/mcp-server-card.tsx
@@ -789,7 +789,7 @@ export function McpServerCard({
 
   return (
     <Card
-      className="flex flex-col relative pt-4 gap-2 h-full"
+      className="flex flex-col relative pt-4 gap-4 h-full"
       data-testid={`${E2eTestId.McpServerCard}-${item.name}`}
     >
       <CardHeader className="gap-0">
@@ -837,7 +837,7 @@ export function McpServerCard({
           {userIsMcpServerAdmin && manageCatalogItemDropdownMenu}
         </div>
       </CardHeader>
-      <CardContent className="flex flex-col gap-2 flex-grow">
+      <CardContent className="flex flex-col gap-4 flex-grow">
         {isBuiltinVariant
           ? builtinCardContent
           : isPlaywrightVariant


### PR DESCRIPTION
## Summary
- Hide the Logs button on MCP server cards when logs aren't available (remote servers, or local servers with no installations), instead of showing it as disabled/grayed-out
- The Edit button automatically expands to full width when the Logs button is hidden, since both buttons use `flex-1`

## Motivation
Previously, the grayed-out Logs button was confusing for users who didn't understand why it was disabled. Hiding it entirely provides a cleaner UX.