### PR TITLE
feat: add DeepSeek provider support

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -44284,6 +44284,7 @@
                           "bedrock",
                           "cerebras",
                           "cohere",
+                          "deepseek",
                           "gemini",
                           "mistral",
                           "openai",
@@ -44622,6 +44623,7 @@
                       "bedrock",
                       "cerebras",
                       "cohere",
+                      "deepseek",
                       "gemini",
                       "mistral",
                       "openai",
@@ -44699,6 +44701,7 @@
                         "bedrock",
                         "cerebras",
                         "cohere",
+                        "deepseek",
                         "gemini",
                         "mistral",
                         "openai",
@@ -44998,6 +45001,7 @@
                 "bedrock",
                 "cerebras",
                 "cohere",
+                "deepseek",
                 "gemini",
                 "mistral",
                 "openai",
@@ -45050,6 +45054,7 @@
                           "bedrock",
                           "cerebras",
                           "cohere",
+                          "deepseek",
                           "gemini",
                           "mistral",
                           "openai",
@@ -45411,6 +45416,7 @@
                         "bedrock",
                         "cerebras",
                         "cohere",
+                        "deepseek",
                         "gemini",
                         "mistral",
                         "openai",
@@ -45818,6 +45824,7 @@
                         "bedrock",
                         "cerebras",
                         "cohere",
+                        "deepseek",
                         "gemini",
                         "mistral",
                         "openai",
@@ -46367,6 +46374,7 @@
                 "bedrock",
                 "cerebras",
                 "cohere",
+                "deepseek",
                 "gemini",
                 "mistral",
                 "openai",
@@ -46404,6 +46412,7 @@
                           "bedrock",
                           "cerebras",
                           "cohere",
+                          "deepseek",
                           "gemini",
                           "mistral",
                           "openai",
@@ -46990,7 +46999,8 @@
                           "perplexity",
                           "vllm",
                           "ollama",
-                          "zhipuai"
+                          "zhipuai",
+                          "deepseek"
                         ]
                       },
                       "modelId": {
@@ -47488,7 +47498,8 @@
                         "perplexity",
                         "vllm",
                         "ollama",
-                        "zhipuai"
+                        "zhipuai",
+                        "deepseek"
                       ]
                     },
                     "modelId": {
@@ -48368,6 +48379,7 @@
                           "bedrock",
                           "cerebras",
                           "cohere",
+                          "deepseek",
                           "gemini",
                           "mistral",
                           "openai",
@@ -48737,6 +48749,7 @@
                       "bedrock",
                       "cerebras",
                       "cohere",
+                      "deepseek",
                       "gemini",
                       "mistral",
                       "openai",
@@ -48806,6 +48819,7 @@
                         "bedrock",
                         "cerebras",
                         "cohere",
+                        "deepseek",
                         "gemini",
                         "mistral",
                         "openai",
@@ -49208,6 +49222,7 @@
                         "bedrock",
                         "cerebras",
                         "cohere",
+                        "deepseek",
                         "gemini",
                         "mistral",
                         "openai",
@@ -49571,6 +49586,7 @@
                       "bedrock",
                       "cerebras",
                       "cohere",
+                      "deepseek",
                       "gemini",
                       "mistral",
                       "openai",
@@ -49657,6 +49673,7 @@
                         "bedrock",
                         "cerebras",
                         "cohere",
+                        "deepseek",
                         "gemini",
                         "mistral",
                         "openai",
@@ -50589,6 +50606,7 @@
                         "bedrock",
                         "cerebras",
                         "cohere",
+                        "deepseek",
                         "gemini",
                         "mistral",
                         "openai",
@@ -51019,6 +51037,7 @@
                         "bedrock",
                         "cerebras",
                         "cohere",
+                        "deepseek",
                         "gemini",
                         "mistral",
                         "openai",
@@ -55274,7 +55293,8 @@
                         "perplexity",
                         "vllm",
                         "ollama",
-                        "zhipuai"
+                        "zhipuai",
+                        "deepseek"
                       ]
                     }
                   },
@@ -86775,7 +86795,8 @@
                           "perplexity",
                           "vllm",
                           "ollama",
-                          "zhipuai"
+                          "zhipuai",
+                          "deepseek"
                         ]
                       },
                       "targetModel": {
@@ -87094,7 +87115,8 @@
                       "perplexity",
                       "vllm",
                       "ollama",
-                      "zhipuai"
+                      "zhipuai",
+                      "deepseek"
                     ]
                   },
                   "targetModel": {
@@ -87188,7 +87210,8 @@
                         "perplexity",
                         "vllm",
                         "ollama",
-                        "zhipuai"
+                        "zhipuai",
+                        "deepseek"
                       ]
                     },
                     "targetModel": {
@@ -87508,7 +87531,8 @@
                       "perplexity",
                       "vllm",
                       "ollama",
-                      "zhipuai"
+                      "zhipuai",
+                      "deepseek"
                     ]
                   },
                   "targetModel": {
@@ -87606,7 +87630,8 @@
                         "perplexity",
                         "vllm",
                         "ollama",
-                        "zhipuai"
+                        "zhipuai",
+                        "deepseek"
                       ]
                     },
                     "targetModel": {

--- a/platform/backend/src/agents/subagents/policy-config-subagent.ts
+++ b/platform/backend/src/agents/subagents/policy-config-subagent.ts
@@ -305,4 +305,5 @@ const PROVIDER_TO_DISCRIMINATOR: Record<
   vllm: "vllm:chatCompletions",
   ollama: "ollama:chatCompletions",
   zhipuai: "zhipuai:chatCompletions",
+  deepseek: "deepseek:chatCompletions",
 };

--- a/platform/backend/src/clients/dual-llm-client.ts
+++ b/platform/backend/src/clients/dual-llm-client.ts
@@ -1085,6 +1085,136 @@ Return only the JSON object, no other text.`;
 }
 
 /**
+ * DeepSeek implementation of DualLlmClient
+ * DeepSeek exposes an OpenAI-compatible API, so we use the OpenAI SDK with DeepSeek's base URL
+ */
+export class DeepSeekDualLlmClient implements DualLlmClient {
+  private client: OpenAI;
+  private model: string;
+
+  constructor(apiKey: string, model = "deepseek-chat") {
+    logger.debug({ model }, "[dualLlmClient] DeepSeek: initializing client");
+    this.client = new OpenAI({
+      apiKey,
+      baseURL: config.llm.deepseek.baseUrl,
+    });
+    this.model = model;
+  }
+
+  async chat(messages: DualLlmMessage[], temperature = 0): Promise<string> {
+    logger.debug(
+      { model: this.model, messageCount: messages.length, temperature },
+      "[dualLlmClient] DeepSeek: starting chat completion",
+    );
+    const response = await this.client.chat.completions.create({
+      model: this.model,
+      messages,
+      temperature,
+    });
+
+    const content = response.choices[0].message.content?.trim() || "";
+    logger.debug(
+      { model: this.model, responseLength: content.length },
+      "[dualLlmClient] DeepSeek: chat completion complete",
+    );
+    return content;
+  }
+
+  async chatWithSchema<T>(
+    messages: DualLlmMessage[],
+    schema: {
+      name: string;
+      schema: {
+        type: string;
+        properties: Record<string, unknown>;
+        required: string[];
+        additionalProperties: boolean;
+      };
+    },
+    temperature = 0,
+  ): Promise<T> {
+    logger.debug(
+      {
+        model: this.model,
+        schemaName: schema.name,
+        messageCount: messages.length,
+        temperature,
+      },
+      "[dualLlmClient] DeepSeek: starting chat with schema",
+    );
+
+    // DeepSeek supports JSON schema via response_format for some models
+    // Try OpenAI-compatible structured output first
+    try {
+      const response = await this.client.chat.completions.create({
+        model: this.model,
+        messages,
+        response_format: {
+          type: "json_schema",
+          json_schema: schema,
+        },
+        temperature,
+      });
+
+      const content = response.choices[0].message.content || "";
+      logger.debug(
+        { model: this.model, responseLength: content.length },
+        "[dualLlmClient] DeepSeek: chat with schema complete, parsing response",
+      );
+      return JSON.parse(content) as T;
+    } catch (error) {
+      // Fallback to prompt-based approach if structured output not supported
+      logger.debug(
+        {
+          model: this.model,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "[dualLlmClient] DeepSeek: structured output not supported, using prompt fallback",
+      );
+
+      const systemPrompt = `You must respond with valid JSON matching this schema:
+${JSON.stringify(schema.schema, null, 2)}
+
+Return only the JSON object, no other text.`;
+
+      const enhancedMessages: DualLlmMessage[] = messages.map((msg, idx) => {
+        if (idx === 0 && msg.role === "user") {
+          return {
+            ...msg,
+            content: `${systemPrompt}\n\n${msg.content}`,
+          };
+        }
+        return msg;
+      });
+
+      const response = await this.client.chat.completions.create({
+        model: this.model,
+        messages: enhancedMessages,
+        temperature,
+      });
+
+      const content = response.choices[0].message.content || "";
+      // Strip markdown code blocks if present
+      const jsonMatch = content.match(/```(?:json)?\s*([\s\S]*?)```/) || [
+        null,
+        content,
+      ];
+      const jsonText = jsonMatch[1].trim();
+
+      try {
+        return JSON.parse(jsonText) as T;
+      } catch (parseError) {
+        logger.error(
+          { model: this.model, content: jsonText, parseError },
+          "[dualLlmClient] DeepSeek: failed to parse JSON response",
+        );
+        throw parseError;
+      }
+    }
+  }
+}
+
+/**
  * Bedrock implementation of DualLlmClient
  * Uses AWS Bedrock Converse API for chat completions
  */
@@ -1308,6 +1438,10 @@ const dualLlmClientFactories: Record<SupportedProvider, DualLlmClientFactory> =
     zhipuai: (apiKey, model) => {
       if (!apiKey) throw new Error("API key required for Zhipuai dual LLM");
       return new ZhipuaiDualLlmClient(apiKey, model);
+    },
+    deepseek: (apiKey, model) => {
+      if (!apiKey) throw new Error("API key required for DeepSeek dual LLM");
+      return new DeepSeekDualLlmClient(apiKey, model);
     },
     bedrock: (apiKey, model) => {
       if (!model) throw new Error("Model name required for Bedrock dual LLM");

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -85,6 +85,7 @@ const envApiKeyGetters: Record<
   bedrock: () => config.chat.bedrock.apiKey,
   cerebras: () => config.chat.cerebras.apiKey,
   cohere: () => config.chat.cohere.apiKey,
+  deepseek: () => config.chat.deepseek.apiKey,
   gemini: () => config.chat.gemini.apiKey,
   mistral: () => config.chat.mistral.apiKey,
   ollama: () => config.chat.ollama.apiKey,
@@ -222,6 +223,7 @@ export const FAST_MODELS: Record<SupportedChatProvider, string> = {
   bedrock: "amazon.nova-lite-v1:0", // Bedrock's fast model, available in all regions for on-demand inference
   mistral: "mistral-small-latest", // Mistral's fast model
   perplexity: "sonar", // Perplexity's fast model
+  deepseek: "deepseek-chat", // DeepSeek's fast model
 };
 
 /**
@@ -397,6 +399,23 @@ const directModelCreators: Record<SupportedChatProvider, DirectModelCreator> = {
     const client = createOpenAI({
       apiKey,
       baseURL: baseUrl ?? config.llm.zhipuai.baseUrl,
+    });
+    return client.chat(modelName);
+  },
+
+  deepseek: ({ apiKey, modelName, baseUrl }) => {
+    if (!apiKey) {
+      throw new ApiError(
+        400,
+        "DeepSeek API key is required. Please configure DEEPSEEK_API_KEY.",
+      );
+    }
+    // DeepSeek uses OpenAI-compatible API
+    // Use client.chat() to force the Chat Completions API (/chat/completions)
+    // instead of the default Responses API (/responses)
+    const client = createOpenAI({
+      apiKey,
+      baseURL: baseUrl ?? config.llm.deepseek.baseUrl,
     });
     return client.chat(modelName);
   },
@@ -614,6 +633,18 @@ const proxiedModelCreators: Record<SupportedChatProvider, ProxiedModelCreator> =
       const client = createOpenAI({
         apiKey,
         baseURL: buildProxyBaseUrl("zhipuai", agentId),
+        headers,
+        fetch: createTracedFetch(),
+      });
+      return client.chat(modelName);
+    },
+
+    deepseek: ({ apiKey, agentId, modelName, headers }) => {
+      // URL format: /v1/deepseek/:agentId (SDK appends /chat/completions)
+      // DeepSeek is OpenAI-compatible, so we use the OpenAI SDK with custom baseURL
+      const client = createOpenAI({
+        apiKey,
+        baseURL: buildProxyBaseUrl("deepseek", agentId),
         headers,
         fetch: createTracedFetch(),
       });

--- a/platform/backend/src/clients/models-dev-client.ts
+++ b/platform/backend/src/clients/models-dev-client.ts
@@ -49,10 +49,11 @@ const MODELS_DEV_PROVIDER_MAP: Record<string, SupportedProvider | null> = {
   mistral: "mistral",
   // These providers use OpenAI-compatible API in Archestra
   llama: "openai",
-  deepseek: "openai",
   groq: "openai",
   "fireworks-ai": "openai",
   togetherai: "openai",
+  // DeepSeek now has native provider support
+  deepseek: "deepseek",
   // Explicitly unsupported providers (return null to skip)
   perplexity: null,
   xai: null,
@@ -402,7 +403,8 @@ class ModelsDevClient {
     // provider (e.g., "google/gemini-2.5-flash" vs "google-vertex/gemini-2.5-flash").
     const preferredSourcePrefixes: Record<SupportedProvider, string[]> = {
       gemini: ["google/"], // Prefer google over google-vertex
-      openai: ["openai/", "deepseek/"], // Prefer direct providers over aggregators
+      openai: ["openai/"], // Prefer direct openai over aggregators
+      deepseek: ["deepseek/"],
       anthropic: ["anthropic/"],
       cohere: ["cohere/"],
       cerebras: ["cerebras/"],

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -572,6 +572,11 @@ export default {
         process.env.ARCHESTRA_ZHIPUAI_BASE_URL ||
         "https://api.z.ai/api/paas/v4",
     },
+    deepseek: {
+      baseUrl:
+        process.env.ARCHESTRA_DEEPSEEK_BASE_URL ||
+        "https://api.deepseek.com/v1",
+    },
     bedrock: {
       enabled: Boolean(process.env.ARCHESTRA_BEDROCK_BASE_URL),
       baseUrl: process.env.ARCHESTRA_BEDROCK_BASE_URL || "",
@@ -610,6 +615,9 @@ export default {
     },
     zhipuai: {
       apiKey: process.env.ARCHESTRA_CHAT_ZHIPUAI_API_KEY || "",
+    },
+    deepseek: {
+      apiKey: process.env.ARCHESTRA_CHAT_DEEPSEEK_API_KEY || "",
     },
     bedrock: {
       apiKey: process.env.ARCHESTRA_CHAT_BEDROCK_API_KEY || "",

--- a/platform/backend/src/database/seed.ts
+++ b/platform/backend/src/database/seed.ts
@@ -440,6 +440,7 @@ async function seedChatApiKeysFromEnv(): Promise<void> {
     vllm: config.chat.vllm.apiKey,
     zhipuai: config.chat.zhipuai.apiKey,
     bedrock: config.chat.bedrock.apiKey,
+    deepseek: config.chat.deepseek.apiKey,
   };
 
   for (const [provider, apiKeyValue] of Object.entries(providerEnvVars)) {
@@ -529,6 +530,7 @@ function getProviderDisplayName(provider: SupportedProvider): string {
     vllm: "vLLM",
     zhipuai: "ZhipuAI",
     bedrock: "AWS Bedrock",
+    deepseek: "DeepSeek",
   };
   return displayNames[provider];
 }

--- a/platform/backend/src/models/optimization-rule.ts
+++ b/platform/backend/src/models/optimization-rule.ts
@@ -285,6 +285,7 @@ class OptimizationRuleModel {
         ollama: [], // Ollama optimization rules are deployment-specific, no defaults
         zhipuai: [],
         bedrock: [], // Bedrock optimization rules are deployment-specific, no defaults
+        deepseek: [], // DeepSeek optimization rules are deployment-specific, no defaults
       };
 
     // Filter by provider if specified, otherwise get providers from interactions

--- a/platform/backend/src/observability/metrics/llm.ts
+++ b/platform/backend/src/observability/metrics/llm.ts
@@ -37,6 +37,7 @@ const fetchUsageExtractors: Record<SupportedProvider, UsageExtractor> = {
   ollama: getOpenAIUsage,
   mistral: getOpenAIUsage,
   perplexity: getOpenAIUsage,
+  deepseek: getOpenAIUsage,
   anthropic: getAnthropicUsage,
   cohere: getCohereUsage,
   zhipuai: getZhipuaiUsage,

--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -1128,6 +1128,7 @@ const providerParsers: Record<SupportedProvider, ErrorParser> = {
   vllm: parseVllmError,
   ollama: parseOllamaError,
   zhipuai: parseZhipuaiError,
+  deepseek: parseOpenAIError, // DeepSeek uses OpenAI-compatible API
 };
 
 /**
@@ -1147,6 +1148,7 @@ const providerMappers: Record<SupportedProvider, ErrorMapper> = {
   vllm: mapVllmErrorWrapper,
   ollama: mapOllamaErrorWrapper,
   zhipuai: mapZhipuaiErrorWrapper,
+  deepseek: mapOpenAIErrorWrapper, // DeepSeek uses OpenAI-compatible API
 };
 
 // =============================================================================

--- a/platform/backend/src/routes/chat/routes.chat.ts
+++ b/platform/backend/src/routes/chat/routes.chat.ts
@@ -81,6 +81,7 @@ const DEFAULT_MODELS: Record<SupportedProvider, string> = {
   perplexity: "sonar-pro",
   zhipuai: "glm-4-plus",
   bedrock: "anthropic.claude-opus-4-1-20250805-v1:0",
+  deepseek: "deepseek-chat",
 };
 
 /**

--- a/platform/backend/src/routes/chat/routes.models.ts
+++ b/platform/backend/src/routes/chat/routes.models.ts
@@ -537,6 +537,46 @@ async function fetchZhipuaiModels(apiKey: string): Promise<ModelInfo[]> {
 }
 
 /**
+ * Fetch models from DeepSeek API
+ * DeepSeek exposes an OpenAI-compatible API
+ */
+async function fetchDeepSeekModels(apiKey: string): Promise<ModelInfo[]> {
+  const baseUrl = config.llm.deepseek.baseUrl;
+  const url = `${baseUrl}/models`;
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    logger.error(
+      { status: response.status, error: errorText },
+      "Failed to fetch DeepSeek models",
+    );
+    throw new Error(`Failed to fetch DeepSeek models: ${response.status}`);
+  }
+
+  const data = (await response.json()) as {
+    data: Array<{
+      id: string;
+      created: number;
+      owned_by: string;
+    }>;
+  };
+
+  // DeepSeek returns chat models, no filtering needed
+  return data.data.map((model) => ({
+    id: model.id,
+    displayName: model.id,
+    provider: "deepseek" as const,
+    createdAt: new Date(model.created * 1000).toISOString(),
+  }));
+}
+
+/**
  * Fetch models from AWS Bedrock API
  * Uses Bearer token authentication (proxy handles AWS credentials)
  */
@@ -763,6 +803,7 @@ async function getProviderApiKey({
     vllm: () => config.chat.vllm.apiKey || "", // vLLM typically doesn't require API keys
     zhipuai: () => config.chat.zhipuai?.apiKey || null,
     bedrock: () => config.chat.bedrock.apiKey || null,
+    deepseek: () => config.chat.deepseek?.apiKey || null,
   };
 
   return envApiKeyFallbacks[provider]();
@@ -784,6 +825,7 @@ const modelFetchers: Record<
   ollama: fetchOllamaModels,
   cohere: fetchCohereModels,
   zhipuai: fetchZhipuaiModels,
+  deepseek: fetchDeepSeekModels,
 };
 
 // Register all model fetchers with the sync service

--- a/platform/backend/src/routes/config.ts
+++ b/platform/backend/src/routes/config.ts
@@ -89,6 +89,7 @@ const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
           vllm: config.llm.vllm.baseUrl || null,
           ollama: config.llm.ollama.baseUrl || null,
           zhipuai: config.llm.zhipuai.baseUrl || null,
+          deepseek: config.llm.deepseek.baseUrl || null,
         },
       });
     },

--- a/platform/backend/src/services/model-sync.ts
+++ b/platform/backend/src/services/model-sync.ts
@@ -214,10 +214,11 @@ const MODELS_DEV_PROVIDER_MAP: Record<string, SupportedProvider | null> = {
   cerebras: "cerebras",
   mistral: "mistral",
   llama: "openai",
-  deepseek: "openai",
   groq: "openai",
   "fireworks-ai": "openai",
   togetherai: "openai",
+  // DeepSeek now has native provider support
+  deepseek: "deepseek",
   perplexity: null,
   xai: null,
   nvidia: null,

--- a/platform/backend/src/tokenizers/index.ts
+++ b/platform/backend/src/tokenizers/index.ts
@@ -23,6 +23,7 @@ const tokenizerFactories: Record<SupportedProvider, () => Tokenizer> = {
   zhipuai: () => new TiktokenTokenizer(),
   gemini: () => new TiktokenTokenizer(),
   bedrock: () => new TiktokenTokenizer(),
+  deepseek: () => new TiktokenTokenizer(),
 };
 
 /**

--- a/platform/backend/src/types/chat-api-key.ts
+++ b/platform/backend/src/types/chat-api-key.ts
@@ -13,6 +13,7 @@ export const SupportedChatProviderSchema = z.enum([
   "bedrock",
   "cerebras",
   "cohere",
+  "deepseek",
   "gemini",
   "mistral",
   "openai",

--- a/platform/e2e-tests/tests/api/llm-proxy/execution-metrics.spec.ts
+++ b/platform/e2e-tests/tests/api/llm-proxy/execution-metrics.spec.ts
@@ -168,6 +168,22 @@ const zhipuaiConfig: ExecutionMetricsTestConfig = {
   }),
 };
 
+const deepseekConfig: ExecutionMetricsTestConfig = {
+  providerName: "DeepSeek",
+
+  endpoint: (agentId) => `/v1/deepseek/${agentId}/chat/completions`,
+
+  headers: (wiremockStub) => ({
+    Authorization: `Bearer ${wiremockStub}`,
+    "Content-Type": "application/json",
+  }),
+
+  buildRequest: (content) => ({
+    model: "deepseek-chat",
+    messages: [{ role: "user", content }],
+  }),
+};
+
 const bedrockConfig: ExecutionMetricsTestConfig = {
   providerName: "Bedrock",
 
@@ -199,6 +215,7 @@ const testConfigsMap = {
   vllm: vllmConfig,
   ollama: ollamaConfig,
   zhipuai: zhipuaiConfig,
+  deepseek: deepseekConfig,
   bedrock: bedrockConfig,
   perplexity: null, // Perplexity has no tool calling - execution metrics require tool call flows
 } satisfies Record<SupportedProvider, ExecutionMetricsTestConfig | null>;

--- a/platform/e2e-tests/tests/api/llm-proxy/model-optimization.spec.ts
+++ b/platform/e2e-tests/tests/api/llm-proxy/model-optimization.spec.ts
@@ -413,6 +413,41 @@ const zhipuaiConfig: ModelOptimizationTestConfig = {
   getModelFromResponse: (response) => response.model,
 };
 
+const deepseekConfig: ModelOptimizationTestConfig = {
+  providerName: "DeepSeek",
+  provider: "deepseek",
+
+  endpoint: (agentId) => `/v1/deepseek/${agentId}/chat/completions`,
+
+  headers: (wiremockStub) => ({
+    Authorization: `Bearer ${wiremockStub}`,
+    "Content-Type": "application/json",
+  }),
+
+  buildRequest: (content, tools) => {
+    const request: Record<string, unknown> = {
+      model: "e2e-test-deepseek-baseline",
+      messages: [{ role: "user", content }],
+    };
+    if (tools && tools.length > 0) {
+      request.tools = tools.map((t) => ({
+        type: "function",
+        function: {
+          name: t.name,
+          description: t.description,
+          parameters: t.parameters,
+        },
+      }));
+    }
+    return request;
+  },
+
+  baselineModel: "e2e-test-deepseek-baseline",
+  optimizedModel: "e2e-test-deepseek-optimized",
+
+  getModelFromResponse: (response) => response.model,
+};
+
 // =============================================================================
 // Helper Functions
 // =============================================================================
@@ -449,6 +484,7 @@ const testConfigsMap = {
   vllm: vllmConfig,
   ollama: ollamaConfig,
   zhipuai: zhipuaiConfig,
+  deepseek: deepseekConfig,
   bedrock: null, // Bedrock messages use nested content arrays that the tokenizer doesn't count correctly
 } satisfies Record<SupportedProvider, ModelOptimizationTestConfig | null>;
 

--- a/platform/e2e-tests/tests/api/llm-proxy/streaming-tool-calls.spec.ts
+++ b/platform/e2e-tests/tests/api/llm-proxy/streaming-tool-calls.spec.ts
@@ -223,6 +223,18 @@ const zhipuaiConfig: StreamingToolCallTestConfig = {
   expectedToolName: "read_file",
 };
 
+const deepseekConfig: StreamingToolCallTestConfig = {
+  providerName: "DeepSeek",
+  endpoint: (agentId) => `/v1/deepseek/${agentId}/chat/completions`,
+  headers: (wiremockStub) => ({
+    Authorization: `Bearer ${wiremockStub}`,
+    "Content-Type": "application/json",
+  }),
+  buildStreamingRequest: (content, tools) =>
+    buildOpenAIStreamingRequest("deepseek-chat", content, tools),
+  expectedToolName: "read_file",
+};
+
 // =============================================================================
 // Test Suite
 // =============================================================================
@@ -238,6 +250,7 @@ const testConfigsMap = {
   vllm: vllmConfig,
   ollama: ollamaConfig,
   zhipuai: zhipuaiConfig,
+  deepseek: deepseekConfig,
   bedrock: null, // Bedrock uses binary AWS EventStream format which cannot be mocked via WireMock SSE
   perplexity: null, // Perplexity does not support tool calling
 } satisfies Record<SupportedProvider, StreamingToolCallTestConfig | null>;

--- a/platform/e2e-tests/tests/api/llm-proxy/token-cost-limits.spec.ts
+++ b/platform/e2e-tests/tests/api/llm-proxy/token-cost-limits.spec.ts
@@ -169,6 +169,12 @@ const zhipuaiConfig = makeOpenAiCompatibleCostConfig({
   provider: "zhipuai",
 });
 
+const deepseekConfig = makeOpenAiCompatibleCostConfig({
+  providerName: "DeepSeek",
+  modelName: "test-deepseek-cost-limit",
+  provider: "deepseek",
+});
+
 const cohereConfig: TokenCostLimitTestConfig = {
   providerName: "Cohere",
 
@@ -239,6 +245,7 @@ const testConfigsMap = {
   vllm: vllmConfig,
   ollama: ollamaConfig,
   zhipuai: zhipuaiConfig,
+  deepseek: deepseekConfig,
   bedrock: bedrockConfig,
 } satisfies Record<SupportedProvider, TokenCostLimitTestConfig>;
 

--- a/platform/e2e-tests/tests/api/llm-proxy/tool-invocation.spec.ts
+++ b/platform/e2e-tests/tests/api/llm-proxy/tool-invocation.spec.ts
@@ -445,6 +445,12 @@ const zhipuaiConfig = makeOpenAiCompatibleToolConfig({
   model: "glm-4.5-flash",
 });
 
+const deepseekConfig = makeOpenAiCompatibleToolConfig({
+  providerName: "DeepSeek",
+  endpoint: (agentId) => `/v1/deepseek/${agentId}/chat/completions`,
+  model: "deepseek-chat",
+});
+
 const bedrockConfig: ToolInvocationTestConfig = {
   providerName: "Bedrock",
 
@@ -541,6 +547,7 @@ const testConfigsMap = {
   vllm: vllmConfig,
   ollama: ollamaConfig,
   zhipuai: zhipuaiConfig,
+  deepseek: deepseekConfig,
   bedrock: bedrockConfig,
   perplexity: null, // Perplexity does not support tool calling
 } satisfies Record<SupportedProvider, ToolInvocationTestConfig | null>;

--- a/platform/e2e-tests/tests/api/llm-proxy/tool-persistence.spec.ts
+++ b/platform/e2e-tests/tests/api/llm-proxy/tool-persistence.spec.ts
@@ -223,6 +223,30 @@ const zhipuaiConfig: ToolPersistenceTestConfig = {
   }),
 };
 
+const deepseekConfig: ToolPersistenceTestConfig = {
+  providerName: "DeepSeek",
+
+  endpoint: (agentId) => `/v1/deepseek/${agentId}/chat/completions`,
+
+  headers: (wiremockStub) => ({
+    Authorization: `Bearer ${wiremockStub}`,
+    "Content-Type": "application/json",
+  }),
+
+  buildRequest: (content, tools) => ({
+    model: "deepseek-chat",
+    messages: [{ role: "user", content }],
+    tools: tools.map((t) => ({
+      type: "function",
+      function: {
+        name: t.name,
+        description: t.description,
+        parameters: t.parameters,
+      },
+    })),
+  }),
+};
+
 const cohereConfig: ToolPersistenceTestConfig = {
   providerName: "Cohere",
 
@@ -287,6 +311,7 @@ const testConfigsMap = {
   vllm: vllmConfig,
   ollama: ollamaConfig,
   zhipuai: zhipuaiConfig,
+  deepseek: deepseekConfig,
   bedrock: bedrockConfig,
   perplexity: null, // Perplexity does not support tool calling
 } satisfies Record<SupportedProvider, ToolPersistenceTestConfig | null>;

--- a/platform/e2e-tests/tests/api/llm-proxy/tool-result-compression.spec.ts
+++ b/platform/e2e-tests/tests/api/llm-proxy/tool-result-compression.spec.ts
@@ -398,6 +398,44 @@ const zhipuaiConfig: CompressionTestConfig = {
   }),
 };
 
+const deepseekConfig: CompressionTestConfig = {
+  providerName: "DeepSeek",
+
+  endpoint: (profileId) => `/v1/deepseek/${profileId}/chat/completions`,
+
+  headers: (wiremockStub) => ({
+    Authorization: `Bearer ${wiremockStub}`,
+    "Content-Type": "application/json",
+  }),
+
+  // DeepSeek uses similar format to OpenAI
+  buildRequestWithToolResult: () => ({
+    model: "deepseek-chat",
+    messages: [
+      { role: "user", content: "What files are in the current directory?" },
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: "call_123",
+            type: "function",
+            function: {
+              name: "list_files",
+              arguments: '{"directory": "."}',
+            },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        tool_call_id: "call_123",
+        content: JSON.stringify(TOOL_RESULT_DATA),
+      },
+    ],
+  }),
+};
+
 const bedrockConfig: CompressionTestConfig = {
   providerName: "Bedrock",
 
@@ -458,6 +496,7 @@ const testConfigsMap = {
   vllm: vllmConfig,
   ollama: ollamaConfig,
   zhipuai: zhipuaiConfig,
+  deepseek: deepseekConfig,
   bedrock: bedrockConfig,
   perplexity: null, // Perplexity does not support tool calling (has built-in web search instead)
 } satisfies Record<SupportedProvider, CompressionTestConfig | null>;

--- a/platform/frontend/src/components/chat-api-key-form.tsx
+++ b/platform/frontend/src/components/chat-api-key-form.tsx
@@ -151,6 +151,14 @@ const PROVIDER_CONFIG: Record<
     consoleUrl: "https://z.ai/model-api",
     consoleName: "Zhipu AI Platform",
   },
+  deepseek: {
+    name: "DeepSeek",
+    icon: "/icons/deepseek.png",
+    placeholder: "sk-...",
+    enabled: true,
+    consoleUrl: "https://platform.deepseek.com/api_keys",
+    consoleName: "DeepSeek Platform",
+  },
   bedrock: {
     name: "AWS Bedrock",
     icon: "/icons/bedrock.png",

--- a/platform/frontend/src/components/chat/model-selector.tsx
+++ b/platform/frontend/src/components/chat/model-selector.tsx
@@ -104,6 +104,7 @@ const providerToLogoProvider: Record<SupportedProvider, string> = {
   vllm: "vllm",
   ollama: "ollama-cloud", // models.dev uses ollama-cloud for the Ollama provider
   zhipuai: "zhipuai",
+  deepseek: "deepseek",
 };
 
 /**

--- a/platform/frontend/src/components/proxy-connection-instructions.tsx
+++ b/platform/frontend/src/components/proxy-connection-instructions.tsx
@@ -64,6 +64,10 @@ const PROVIDER_CONFIG: Record<
     label: providerDisplayNames.zhipuai,
     originalUrl: "https://open.bigmodel.cn/api/",
   },
+  deepseek: {
+    label: providerDisplayNames.deepseek,
+    originalUrl: "https://api.deepseek.com/v1/",
+  },
   bedrock: {
     label: providerDisplayNames.bedrock,
     originalUrl: "https://bedrock-runtime.your-region.amazonaws.com/",

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -12850,7 +12850,7 @@ export type GetChatApiKeysResponses = {
         id: string;
         organizationId: string;
         name: string;
-        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'deepseek' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
         secretId: string | null;
         scope: 'personal' | 'team' | 'org_wide';
         userId: string | null;
@@ -12875,7 +12875,7 @@ export type GetChatApiKeysResponse = GetChatApiKeysResponses[keyof GetChatApiKey
 export type CreateChatApiKeyData = {
     body: {
         name: string;
-        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'deepseek' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
         apiKey?: string;
         baseUrl?: string | null;
         scope?: 'personal' | 'team' | 'org_wide';
@@ -12956,7 +12956,7 @@ export type CreateChatApiKeyResponses = {
         id: string;
         organizationId: string;
         name: string;
-        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'deepseek' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
         secretId: string | null;
         scope: 'personal' | 'team' | 'org_wide';
         userId: string | null;
@@ -12975,7 +12975,7 @@ export type GetAvailableChatApiKeysData = {
     body?: never;
     path?: never;
     query?: {
-        provider?: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        provider?: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'deepseek' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
         includeKeyId?: string;
     };
     url: '/api/chat-api-keys/available';
@@ -13048,7 +13048,7 @@ export type GetAvailableChatApiKeysResponses = {
         id: string;
         organizationId: string;
         name: string;
-        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'deepseek' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
         secretId: string | null;
         scope: 'personal' | 'team' | 'org_wide';
         userId: string | null;
@@ -13225,7 +13225,7 @@ export type GetChatApiKeyResponses = {
         id: string;
         organizationId: string;
         name: string;
-        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'deepseek' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
         secretId: string | null;
         scope: 'personal' | 'team' | 'org_wide';
         userId: string | null;
@@ -13332,7 +13332,7 @@ export type UpdateChatApiKeyResponses = {
         id: string;
         organizationId: string;
         name: string;
-        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'deepseek' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
         secretId: string | null;
         scope: 'personal' | 'team' | 'org_wide';
         userId: string | null;
@@ -13351,7 +13351,7 @@ export type GetChatModelsData = {
     body?: never;
     path?: never;
     query?: {
-        provider?: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        provider?: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'deepseek' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
     };
     url: '/api/chat/models';
 };
@@ -13422,7 +13422,7 @@ export type GetChatModelsResponses = {
     200: Array<{
         id: string;
         displayName: string;
-        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'deepseek' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
         createdAt?: string;
         capabilities?: {
             contextLength: number | null;
@@ -13589,7 +13589,7 @@ export type GetModelsWithApiKeysResponses = {
     200: Array<{
         id: string;
         externalId: string;
-        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek';
         modelId: string;
         description: string | null;
         contextLength: number | null;
@@ -13705,7 +13705,7 @@ export type UpdateModelPricingResponses = {
     200: {
         id: string;
         externalId: string;
-        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek';
         modelId: string;
         description: string | null;
         contextLength: number | null;
@@ -13953,7 +13953,7 @@ export type GetChatConversationsResponses = {
         chatApiKeyId: string | null;
         title: string | null;
         selectedModel: string;
-        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'deepseek' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
         hasCustomToolSelection: boolean;
         todoList: string | number | boolean | null | {
             [key: string]: unknown;
@@ -13980,7 +13980,7 @@ export type CreateChatConversationData = {
         agentId: string;
         title?: string | null;
         selectedModel?: string;
-        selectedProvider?: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        selectedProvider?: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'deepseek' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
         chatApiKeyId?: string | null;
     };
     path?: never;
@@ -14059,7 +14059,7 @@ export type CreateChatConversationResponses = {
         chatApiKeyId: string | null;
         title: string | null;
         selectedModel: string;
-        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'deepseek' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
         hasCustomToolSelection: boolean;
         todoList: string | number | boolean | null | {
             [key: string]: unknown;
@@ -14240,7 +14240,7 @@ export type GetChatConversationResponses = {
         chatApiKeyId: string | null;
         title: string | null;
         selectedModel: string;
-        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'deepseek' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
         hasCustomToolSelection: boolean;
         todoList: string | number | boolean | null | {
             [key: string]: unknown;
@@ -14266,7 +14266,7 @@ export type UpdateChatConversationData = {
     body?: {
         title?: string | null;
         selectedModel?: string;
-        selectedProvider?: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        selectedProvider?: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'deepseek' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
         chatApiKeyId?: string | null;
         agentId?: string;
         artifact?: string | null;
@@ -14349,7 +14349,7 @@ export type UpdateChatConversationResponses = {
         chatApiKeyId: string | null;
         title: string | null;
         selectedModel: string;
-        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'deepseek' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
         hasCustomToolSelection: boolean;
         todoList: string | number | boolean | null | {
             [key: string]: unknown;
@@ -14539,7 +14539,7 @@ export type GenerateChatConversationTitleResponses = {
         chatApiKeyId: string | null;
         title: string | null;
         selectedModel: string;
-        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'deepseek' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
         hasCustomToolSelection: boolean;
         todoList: string | number | boolean | null | {
             [key: string]: unknown;
@@ -14645,7 +14645,7 @@ export type UpdateChatMessageResponses = {
         chatApiKeyId: string | null;
         title: string | null;
         selectedModel: string;
-        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        selectedProvider: 'anthropic' | 'bedrock' | 'cerebras' | 'cohere' | 'deepseek' | 'gemini' | 'mistral' | 'openai' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
         hasCustomToolSelection: boolean;
         todoList: string | number | boolean | null | {
             [key: string]: unknown;
@@ -24353,7 +24353,7 @@ export type GetOptimizationRulesResponses = {
         } | {
             hasTools: boolean;
         }>;
-        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek';
         targetModel: string;
         enabled: boolean;
         createdAt: string;
@@ -24373,7 +24373,7 @@ export type CreateOptimizationRuleData = {
         } | {
             hasTools: boolean;
         }>;
-        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek';
         targetModel: string;
         enabled?: boolean;
         createdAt?: unknown;
@@ -24456,7 +24456,7 @@ export type CreateOptimizationRuleResponses = {
         } | {
             hasTools: boolean;
         }>;
-        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek';
         targetModel: string;
         enabled: boolean;
         createdAt: string;
@@ -24555,7 +24555,7 @@ export type UpdateOptimizationRuleData = {
         } | {
             hasTools: boolean;
         }>;
-        provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek';
         targetModel?: string;
         enabled?: boolean;
         createdAt?: unknown;
@@ -24640,7 +24640,7 @@ export type UpdateOptimizationRuleResponses = {
         } | {
             hasTools: boolean;
         }>;
-        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai';
+        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek';
         targetModel: string;
         enabled: boolean;
         createdAt: string;

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -15,6 +15,7 @@ export const SupportedProvidersSchema = z.enum([
   "vllm",
   "ollama",
   "zhipuai",
+  "deepseek",
 ]);
 
 export const SupportedProvidersDiscriminatorSchema = z.enum([
@@ -29,6 +30,7 @@ export const SupportedProvidersDiscriminatorSchema = z.enum([
   "vllm:chatCompletions",
   "ollama:chatCompletions",
   "zhipuai:chatCompletions",
+  "deepseek:chatCompletions",
 ]);
 
 export const SupportedProviders = Object.values(SupportedProvidersSchema.enum);
@@ -49,6 +51,7 @@ export const providerDisplayNames: Record<SupportedProvider, string> = {
   vllm: "vLLM",
   ollama: "Ollama",
   zhipuai: "Zhipu AI",
+  deepseek: "DeepSeek",
 };
 
 /**
@@ -80,6 +83,7 @@ export const DEFAULT_PROVIDER_BASE_URLS: Record<SupportedProvider, string> = {
   vllm: "",
   ollama: "http://localhost:11434/v1",
   zhipuai: "https://api.z.ai/api/paas/v4",
+  deepseek: "https://api.deepseek.com/v1",
 };
 
 /**
@@ -143,5 +147,9 @@ export const MODEL_MARKER_PATTERNS: Record<
   bedrock: {
     fastest: ["nova-lite", "nova-micro", "haiku"],
     best: ["nova-pro", "sonnet", "opus"],
+  },
+  deepseek: {
+    fastest: ["deepseek-chat"],
+    best: ["deepseek-chat", "deepseek-reasoner"],
   },
 };


### PR DESCRIPTION
## Summary

This PR implements DeepSeek as a first-class LLM provider in Archestra.

## Changes

### Backend
- Added `deepseek` to `SupportedChatProviderSchema` and `SupportedProvidersSchema`
- Added DeepSeek configuration (`ARCHESTRA_DEEPSEEK_BASE_URL` and `ARCHESTRA_CHAT_DEEPSEEK_API_KEY`)
- Implemented DeepSeek provider in `llm-client.ts` (direct and proxied model creators)
- Added DeepSeek dual LLM client support
- Added DeepSeek tokenizer support (using Tiktoken for OpenAI-compatible tokenization)
- Added DeepSeek error handling and metrics extraction
- Updated models.dev sync to map deepseek provider correctly

### Frontend
- Added DeepSeek to provider settings UI
- Added DeepSeek to model selector
- Added DeepSeek to proxy connection instructions

### Tests
- Added DeepSeek e2e test configurations for all LLM proxy test suites

## Configuration

To use DeepSeek, set the following environment variables:
- `ARCHESTRA_CHAT_DEEPSEEK_API_KEY`: Your DeepSeek API key
- `ARCHESTRA_DEEPSEEK_BASE_URL`: DeepSeek API base URL (default: https://api.deepseek.com/v1)

## Technical Details

DeepSeek uses an OpenAI-compatible API, so the implementation follows the same pattern as other OpenAI-compatible providers (Zhipu AI, Cerebras, etc.):
- Uses `createOpenAI` from `@ai-sdk/openai` with custom base URL
- Uses OpenAI-compatible tokenization via Tiktoken
- Uses OpenAI-compatible error parsing

Fixes #1846