### PR TITLE
fix: prevent release-please from creating ghost PRs

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -4,7 +4,6 @@
   "changelog-type": "default",
   "pull-request-footer": "",
   "include-v-in-tag": true,
-  "draft": true,
   "separate-pull-requests": true,
   "changelog-sections": [
     {

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -53,6 +53,18 @@ jobs:
         run: |
           echo "$OUTPUTS"
 
+      # Re-draft the release so it's not visible until all artifacts are built.
+      # We removed "draft: true" from release-please-config.json because draft releases
+      # don't create git tags, and release-please needs the tag to exist when calculating
+      # the next version (otherwise it creates bogus PRs with stale versions).
+      - name: Re-draft release until artifacts are ready
+        if: steps.release-please.outputs['platform--release_created']
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG_NAME: ${{ steps.release-please.outputs['platform--tag_name'] }}
+        run: gh release edit "$TAG_NAME" --draft=true
+
   build-and-push-mcp-server-docker-image:
     name: Build and push MCP Server Docker image
     if: needs.release-please.outputs.platform_release_created


### PR DESCRIPTION
## Summary

- Removes `"draft": true` from `release-please-config.json` so releases create git tags immediately
- Adds a "Re-draft release" step in the release-please workflow to set the release back to draft until all artifacts (Docker, Helm) are built
- The existing `publish-github-release` job still un-drafts when everything is ready

## Root Cause

`"draft": true` caused release-please to create **draft** GitHub releases, which **don't create git tags**. In the same action step, release-please then tries to calculate the next release PR — but without the tag for the just-released version, it miscalculates and creates bogus PRs (the recurring "release platform 1.0.48" ghost PRs #2982 and #3001).