### PR TITLE
fix: resolve (more) performance issues

### DIFF
--- a/platform/backend/src/types/chat-api-key.ts
+++ b/platform/backend/src/types/chat-api-key.ts
@@ -45,6 +45,11 @@ export const SelectChatApiKeySchema = createSelectSchema(
 ).extend({
   provider: SupportedChatProviderSchema,
   scope: ChatApiKeyScopeSchema,
+  // baseUrl is nullable in the DB schema (text without .notNull()) but
+  // drizzle-zod's createSelectSchema defaults text columns to z.string().
+  // Override to match the actual DB column nullability so Fastify response
+  // serialization doesn't throw when baseUrl is null.
+  baseUrl: z.string().nullable(),
 });
 
 export const InsertChatApiKeySchema = createInsertSchema(

--- a/platform/frontend/src/lib/chat-settings.query.ts
+++ b/platform/frontend/src/lib/chat-settings.query.ts
@@ -1,7 +1,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { handleApiError } from "./utils";
+import { handleApiError, toApiError } from "./utils";
 
 export type SupportedChatProvider =
   archestraApiTypes.GetChatApiKeysResponses["200"][number]["provider"];
@@ -75,7 +75,7 @@ export function useCreateChatApiKey() {
       });
       if (error) {
         handleApiError(error);
-        throw error;
+        throw toApiError(error);
       }
       return responseData;
     },
@@ -106,7 +106,7 @@ export function useUpdateChatApiKey() {
       });
       if (error) {
         handleApiError(error);
-        throw error;
+        throw toApiError(error);
       }
       return responseData;
     },
@@ -128,7 +128,7 @@ export function useDeleteChatApiKey() {
       });
       if (error) {
         handleApiError(error);
-        throw error;
+        throw toApiError(error);
       }
       return responseData;
     },
@@ -177,7 +177,7 @@ export function useCreateVirtualApiKey() {
       });
       if (error) {
         handleApiError(error);
-        throw error;
+        throw toApiError(error);
       }
       return responseData;
     },
@@ -208,7 +208,7 @@ export function useDeleteVirtualApiKey() {
       });
       if (error) {
         handleApiError(error);
-        throw error;
+        throw toApiError(error);
       }
       return responseData;
     },
@@ -274,7 +274,7 @@ export function useSyncChatModels() {
       const { data: responseData, error } = await syncChatModels();
       if (error) {
         handleApiError(error);
-        throw error;
+        throw toApiError(error);
       }
       return responseData;
     },


### PR DESCRIPTION
## Summary

- **BACKEND-9N**: Fix `SelectChatApiKeySchema` so `baseUrl` is marked as `.nullable()`, matching the actual DB column definition (`text("base_url")` without `.notNull()`). Without this, Fastify's Zod response serialization throws when `baseUrl` is `null` in the DB.
- **FRONTEND-N**: Fix `handleApiError` to wrap API SDK error objects in proper `Error` instances before passing to `Sentry.captureException()`. The SDK returns `{ error: { message, type } }` objects, which Sentry reports as "Object captured as exception with keys: error" when passed directly. Also converts all `throw error` sites in `chat-settings.query.ts` to throw proper `Error` instances via a new `toApiError` helper.