### PR TITLE
chore(ci): configure Sentry EU region URL for source map uploads

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -99,12 +99,14 @@ ENV VERSION=${VERSION}
 # https://turborepo.com/docs/guides/tools/docker#example
 #
 # SENTRY_AUTH_TOKEN is used by backend/frontend builds to upload source maps
+# SENTRY_URL points to the EU region where the archestra org is hosted
 #
 # https://docs.docker.com/build/building/secrets/#using-build-secrets
 # https://docs.docker.com/build/building/secrets/#target
 RUN --mount=type=secret,id=turbo_team,env=TURBO_TEAM \
     --mount=type=secret,id=turbo_token,env=TURBO_TOKEN \
     --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN \
+    SENTRY_URL=https://de.sentry.io/ \
     pnpm build
 
 # <----- Final unified stage ----->

--- a/platform/backend/package.json
+++ b/platform/backend/package.json
@@ -27,7 +27,7 @@
     "codegen:access-control-docs": "tsx --tsconfig standalone-scripts.tsconfig.json src/standalone-scripts/codegen-access-control-docs.ts",
     "codegen:openapi": "tsx --tsconfig standalone-scripts.tsconfig.json src/standalone-scripts/codegen-openapi.ts",
     "codegen": "pnpm codegen:openapi && pnpm codegen:access-control-docs",
-    "sentry:sourcemaps": "if [ -n \"$SENTRY_AUTH_TOKEN\" ]; then sentry-cli sourcemaps inject --org archestra --project archestra-platform-backend ./dist && sentry-cli sourcemaps upload --org archestra --project archestra-platform-backend --release \"${VERSION:-dev}\" ./dist; else echo 'Skipping Sentry source map upload (SENTRY_AUTH_TOKEN not set)'; fi"
+    "sentry:sourcemaps": "if [ -n \"$SENTRY_AUTH_TOKEN\" ]; then sentry-cli --url https://de.sentry.io/ sourcemaps inject --org archestra --project archestra-platform-backend ./dist && sentry-cli --url https://de.sentry.io/ sourcemaps upload --org archestra --project archestra-platform-backend --release \"${VERSION:-dev}\" ./dist; else echo 'Skipping Sentry source map upload (SENTRY_AUTH_TOKEN not set)'; fi"
   },
   "dependencies": {
     "@ai-sdk/amazon-bedrock": "^4.0.49",

--- a/platform/frontend/next.config.ts
+++ b/platform/frontend/next.config.ts
@@ -64,6 +64,9 @@ export default withSentryConfig(nextConfig, {
 
   project: "archestra-platform-frontend",
 
+  // The archestra Sentry org is hosted in the EU region
+  sentryUrl: "https://de.sentry.io/",
+
   // Only print logs for uploading source maps in CI
   silent: !process.env.CI,
 


### PR DESCRIPTION
## Summary

Source maps have never been resolving in Sentry because both `sentry-cli` (backend) and `@sentry/nextjs` (frontend) default to `https://sentry.io` (US region), but the `archestra` Sentry org is hosted on `https://de.sentry.io` (EU region). Source maps were being uploaded to the wrong region, so Sentry could never match them to error events.

This is why all Sentry stack traces show minified/bundled paths like `server.mjs:11545` or `_578c906e._.js:28:268766` instead of original source locations.

**Changes (defense-in-depth in 3 places):**
- **Dockerfile**: Set `SENTRY_URL=https://de.sentry.io/` env var during `pnpm build` so both `sentry-cli` and `@sentry/nextjs` target the EU region
- **backend/package.json**: Add `--url https://de.sentry.io/` flag to `sentry-cli` commands
- **frontend/next.config.ts**: Add `sentryUrl: "https://de.sentry.io/"` to `withSentryConfig` options