### PR TITLE
feat: add automatic retry for transient database connection errors

### DIFF
--- a/platform/backend/src/database/index.ts
+++ b/platform/backend/src/database/index.ts
@@ -86,6 +86,13 @@ export function getDb() {
  *
  * Uses a 3-second timeout to prevent hanging probes under high load.
  * This is called every 10 seconds by K8s readiness probes (per Helm config).
+ *
+ * Note: pool.query() is wrapped with retry logic (see {@link wrapPoolWithRetry}).
+ * This is intentional for health checks — a single transient blip (e.g.
+ * ECONNREFUSED during a brief network hiccup) will be retried rather than
+ * immediately marking the pod as unhealthy and causing unnecessary restarts.
+ * The 3-second Promise.race timeout still caps the total wall-clock time,
+ * so hanging connections are detected promptly regardless of retries.
  */
 export async function isDatabaseHealthy(): Promise<boolean> {
   if (!pool) {

--- a/platform/backend/src/database/retry.test.ts
+++ b/platform/backend/src/database/retry.test.ts
@@ -111,6 +111,15 @@ describe("isTransientDbError", () => {
     });
     expect(isTransientDbError(outerError)).toBe(true);
   });
+
+  test("returns false when cause chain exceeds max depth", () => {
+    // Build a chain deeper than MAX_CAUSE_DEPTH (5)
+    let error: Error = new Error("ECONNREFUSED");
+    for (let i = 0; i < 7; i++) {
+      error = new Error(`wrapper ${i}`, { cause: error });
+    }
+    expect(isTransientDbError(error)).toBe(false);
+  });
 });
 
 describe("withDbRetry", () => {
@@ -298,5 +307,21 @@ describe("wrapPoolWithRetry", () => {
     const result = await pool.query("SELECT count(*) FROM users");
     expect(result).toEqual({ rows: [{ count: 5 }], rowCount: 1 });
     expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  test("calling wrapPoolWithRetry twice does not double-wrap", async () => {
+    const mockQuery = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("connect ECONNREFUSED 10.2.124.50:5432"))
+      .mockResolvedValue({ rows: [{ id: 1 }], rowCount: 1 });
+
+    const pool = { query: mockQuery };
+    wrapPoolWithRetry(pool);
+    wrapPoolWithRetry(pool); // second call should be a no-op
+
+    const result = await pool.query("SELECT 1");
+    expect(result).toEqual({ rows: [{ id: 1 }], rowCount: 1 });
+    // Should be 2 (1 initial + 1 retry), NOT 4+ from double-wrapped retries
+    expect(mockQuery).toHaveBeenCalledTimes(2);
   });
 });

--- a/platform/backend/src/database/retry.ts
+++ b/platform/backend/src/database/retry.ts
@@ -52,14 +52,18 @@ const TRANSIENT_ERROR_PATTERNS = [
   "timeout expired",
 ];
 
+/** Maximum depth for cause-chain traversal to guard against circular references */
+const MAX_CAUSE_DEPTH = 5;
+
 /**
  * Determine whether a database error is transient (i.e. retrying may succeed).
  *
  * Checks the error itself and, for DrizzleQueryError wrappers, recursively
- * checks the underlying cause.
+ * checks the underlying cause (bounded to {@link MAX_CAUSE_DEPTH} levels).
  */
-export function isTransientDbError(error: unknown): boolean {
+export function isTransientDbError(error: unknown, depth = 0): boolean {
   if (!(error instanceof Error)) return false;
+  if (depth > MAX_CAUSE_DEPTH) return false;
 
   // Check PostgreSQL error code (set by node-postgres on query errors)
   const pgCode = (error as Error & { code?: string }).code;
@@ -73,7 +77,7 @@ export function isTransientDbError(error: unknown): boolean {
 
   // DrizzleQueryError wraps the underlying pg error as `cause`
   const cause = (error as Error & { cause?: unknown }).cause;
-  if (cause) return isTransientDbError(cause);
+  if (cause) return isTransientDbError(cause, depth + 1);
 
   return false;
 }
@@ -139,6 +143,9 @@ export async function withDbRetry<T>(
   throw new Error("withDbRetry: unreachable");
 }
 
+/** Symbol marker to prevent double-wrapping the same pool */
+const RETRY_WRAPPED = Symbol("retryWrapped");
+
 /**
  * Wrap a pg.Pool instance so that its `query()` method automatically retries
  * transient connection errors.
@@ -149,10 +156,15 @@ export async function withDbRetry<T>(
  *
  * Transaction queries (via a checked-out PoolClient) are NOT affected by this
  * wrapper; callers should use {@link withDbRetry} around the entire transaction.
+ *
+ * Calling this function multiple times on the same pool is a no-op (guarded
+ * by a Symbol marker to prevent compounding retries).
  */
 export function wrapPoolWithRetry(pool: {
   query: (...args: unknown[]) => unknown;
 }): void {
+  if ((pool as Record<symbol, unknown>)[RETRY_WRAPPED]) return;
+
   const originalQuery = pool.query.bind(pool);
 
   pool.query = ((...args: unknown[]) => {
@@ -165,4 +177,6 @@ export function wrapPoolWithRetry(pool: {
     // Promise-style call: wrap with retry logic
     return withDbRetry(() => originalQuery(...args) as Promise<unknown>);
   }) as typeof pool.query;
+
+  (pool as Record<symbol, unknown>)[RETRY_WRAPPED] = true;
 }


### PR DESCRIPTION
## Summary
- Adds `withDbRetry()` utility and `wrapPoolWithRetry()` for automatic retry of transient database connection errors (ECONNREFUSED, connection timeout, connection terminated unexpectedly, etc.)
- Uses exponential backoff with jitter (100ms base, 2s max, up to 3 retries)
- Wraps `pg.Pool.query()` transparently — all non-transaction Drizzle queries get automatic retry without any call-site changes
- Detects transient errors by PostgreSQL SQLSTATE codes (08xxx, 57Pxx) and error message patterns, including through DrizzleQueryError cause chains
- Also exports `withDbRetry()` for callers who need retry around full transactions

## How it works
`pool.query()` internally checks out a client, runs the query, and releases it — so each retry gets a fresh connection from the pool. Transaction queries (via a checked-out `PoolClient`) are not affected by the pool-level wrapper.

Transient errors detected:
- TCP/socket: `ECONNREFUSED`, `ECONNRESET`, `EPIPE`, `ETIMEDOUT`
- node-postgres: `Connection terminated`, `Connection terminated unexpectedly`, `timeout expired`
- PostgreSQL SQLSTATE: `08000`–`08006` (connection exception class), `57P01`–`57P03` (operator intervention class)
