### PR TITLE
chore: remove whitespace-only line from .env.example

### DIFF
--- a/platform/.env.example
+++ b/platform/.env.example
@@ -246,7 +246,6 @@ LIGHTRAG_QDRANT_API_KEY=
 LIGHTRAG_LLM_MODEL=gpt-4o-mini
 LIGHTRAG_EMBEDDING_MODEL=text-embedding-3-small
 LIGHTRAG_EMBEDDING_DIM=1536
- 
 
- # Quickstart mode
+# Quickstart mode
 ARCHESTRA_QUICKSTART=false


### PR DESCRIPTION

This change removes a whitespace-only line in `.env.example`. Tilt copies `.env.example` to `.env` on first run, and Tilt’s dotenv parser fails on whitespace-only lines. This prevents `tilt up` from failing for fresh setups.

addresses https://github.com/archestra-ai/archestra/issues/3063