### PR TITLE
fix: set default `ARCHESTRA_AUTH_SECRET` in `.env.example` for local dev

### DIFF
--- a/platform/.env.example
+++ b/platform/.env.example
@@ -97,7 +97,7 @@ ARCHESTRA_ANALYTICS=
 # IMPORTANT: Set ARCHESTRA_AUTH_SECRET to a secure, random value in production.
 # Example: openssl rand -base64 32
 # "better-auth-secret-12345678901234567890" is the default set by better-auth if a secret value is not set
-# https://better-auth.com/docs/reference/options#secret
+# https://github.com/better-auth/better-auth/blob/7a57b61f8ce512e80da3587af8d53b80a153ca45/packages/better-auth/src/utils/constants.ts
 ARCHESTRA_AUTH_SECRET=better-auth-secret-12345678901234567890
 ARCHESTRA_AUTH_ADMIN_EMAIL=admin@example.com
 ARCHESTRA_AUTH_ADMIN_PASSWORD=password

--- a/platform/Tiltfile
+++ b/platform/Tiltfile
@@ -16,7 +16,7 @@ dotenv('./.env')
 
 # Set default ARCHESTRA_AUTH_SECRET for local development if not configured in .env
 # "better-auth-secret-12345678901234567890" is the default set by better-auth when no secret is provided
-# https://better-auth.com/docs/reference/options#secret
+# https://github.com/better-auth/better-auth/blob/7a57b61f8ce512e80da3587af8d53b80a153ca45/packages/better-auth/src/utils/constants.ts
 if not os.getenv('ARCHESTRA_AUTH_SECRET'):
   os.putenv('ARCHESTRA_AUTH_SECRET', 'better-auth-secret-12345678901234567890')
 


### PR DESCRIPTION
## Summary
- Sets `ARCHESTRA_AUTH_SECRET=better-auth-secret-123456789` in `.env.example` so new local dev setups get a working default when `tilt up` copies it to `.env`
- `better-auth-secret-123456789` is better-auth's own internal default ([docs](https://better-auth.com/docs/reference/options#secret)), so existing credentials created before this was required remain compatible

Closes #3077