### PR TITLE
fix: Agents nav item active state to exclude Triggers submenu

### DIFF
--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -93,6 +93,9 @@ const contentNavGroups: NavGroup[] = [
         title: "Agents",
         url: "/agents",
         icon: Bot,
+        customIsActive: (pathname: string) =>
+          pathname.startsWith("/agents") &&
+          !pathname.startsWith("/agents/triggers"),
         subItems: [
           {
             title: "Triggers",


### PR DESCRIPTION
Updated the Agents navigation item to use a custom active state detector that excludes the Triggers submenu path from being highlighted as the parent Agents item.