### PR TITLE
fix: hide default credentials warning when basic auth disabled

### DIFF
--- a/platform/frontend/src/app/auth/[path]/auth-page-with-invitation-check.test.tsx
+++ b/platform/frontend/src/app/auth/[path]/auth-page-with-invitation-check.test.tsx
@@ -22,11 +22,21 @@ vi.mock("@/lib/backend-connectivity", () => ({
 }));
 
 // Mock config
+const mockConfig = {
+  disableBasicAuth: false,
+  enterpriseLicenseActivated: false,
+};
+
 vi.mock("@/lib/config", () => ({
-  default: {
-    disableBasicAuth: false,
-    enterpriseLicenseActivated: false,
-  },
+  default: new Proxy(
+    {},
+    {
+      get: (_target, prop) =>
+        prop in mockConfig
+          ? mockConfig[prop as keyof typeof mockConfig]
+          : undefined,
+    },
+  ),
 }));
 
 // Mock AuthViewWithErrorHandling
@@ -68,6 +78,8 @@ const mockRetry = vi.fn();
 describe("AuthPageWithInvitationCheck", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockConfig.disableBasicAuth = false;
+    mockConfig.enterpriseLicenseActivated = false;
     vi.mocked(useRouter).mockReturnValue({
       push: mockRouterPush,
     } as unknown as ReturnType<typeof useRouter>);
@@ -118,6 +130,23 @@ describe("AuthPageWithInvitationCheck", () => {
       } as unknown as ReturnType<typeof useSearchParams>);
       vi.mocked(useInvitationCheck).mockReturnValue({
         data: { userExists: true },
+        isLoading: false,
+      } as ReturnType<typeof useInvitationCheck>);
+
+      render(<AuthPageWithInvitationCheck path="sign-in" />);
+
+      expect(
+        screen.queryByTestId("default-credentials-warning"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should not show default credentials warning when basic auth is disabled", () => {
+      mockConfig.disableBasicAuth = true;
+      vi.mocked(useSearchParams).mockReturnValue({
+        get: vi.fn().mockReturnValue(null),
+      } as unknown as ReturnType<typeof useSearchParams>);
+      vi.mocked(useInvitationCheck).mockReturnValue({
+        data: undefined,
         isLoading: false,
       } as ReturnType<typeof useInvitationCheck>);
 

--- a/platform/frontend/src/components/sidebar-warnings.test.tsx
+++ b/platform/frontend/src/components/sidebar-warnings.test.tsx
@@ -21,6 +21,22 @@ vi.mock("@/lib/config.query", () => ({
   useFeatures: (...args: unknown[]) => mockUseFeatures(...args),
 }));
 
+const mockConfig = {
+  disableBasicAuth: false,
+};
+
+vi.mock("@/lib/config", () => ({
+  default: new Proxy(
+    {},
+    {
+      get: (_target, prop) =>
+        prop in mockConfig
+          ? mockConfig[prop as keyof typeof mockConfig]
+          : undefined,
+    },
+  ),
+}));
+
 vi.mock("@shared", () => ({
   DEFAULT_ADMIN_EMAIL: "admin@example.com",
   DEFAULT_ADMIN_PASSWORD: "admin",
@@ -40,6 +56,7 @@ import { SidebarWarnings } from "./sidebar-warnings";
 describe("SidebarWarnings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockConfig.disableBasicAuth = false;
 
     // Default: no session, no warnings
     mockUseSession.mockReturnValue({ data: null });
@@ -148,6 +165,22 @@ describe("SidebarWarnings", () => {
 
       const { container } = render(<SidebarWarnings />);
       expect(container.firstChild).toBeNull();
+    });
+
+    it("does not show when basic auth is disabled", () => {
+      mockConfig.disableBasicAuth = true;
+      mockUseSession.mockReturnValue({
+        data: { user: { email: "admin@example.com" } },
+      });
+      mockUseDefaultCredentialsEnabled.mockReturnValue({
+        data: true,
+        isLoading: false,
+      });
+
+      const { container } = render(<SidebarWarnings />);
+      expect(
+        screen.queryByTestId("default-credentials-warning"),
+      ).not.toBeInTheDocument();
     });
 
     it("does not show when credentials are not default", () => {

--- a/platform/frontend/src/components/sidebar-warnings.tsx
+++ b/platform/frontend/src/components/sidebar-warnings.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { DefaultCredentialsWarning } from "@/components/default-credentials-warning";
 import { useDefaultCredentialsEnabled } from "@/lib/auth.query";
 import { authClient } from "@/lib/clients/auth/auth-client";
+import config from "@/lib/config";
 import { useFeatures } from "@/lib/config.query";
 
 export function SidebarWarnings() {
@@ -21,6 +22,7 @@ export function SidebarWarnings() {
   const showSecurityEngineWarning =
     !!session && !isLoadingFeatures && features !== undefined && isPermissive;
   const showDefaultCredsWarning =
+    !config.disableBasicAuth &&
     !isLoadingCreds &&
     defaultCredentialsEnabled !== undefined &&
     defaultCredentialsEnabled &&


### PR DESCRIPTION
## Summary
- The sidebar's `DefaultCredentialsWarning` was still shown even when basic auth was disabled via `ARCHESTRA_AUTH_DISABLE_BASIC_AUTH`. The sign-in page already had the correct `!isBasicAuthDisabled` guard but the sidebar (`SidebarWarnings`) was missing it.
- Added `!config.disableBasicAuth` check to `showDefaultCredsWarning` in `SidebarWarnings`