### PR TITLE
fix: version footer incorrectly shows "new" for commit-hash dev builds

### DIFF
--- a/platform/frontend/src/lib/version-utils.test.ts
+++ b/platform/frontend/src/lib/version-utils.test.ts
@@ -42,6 +42,15 @@ describe("hasNewerVersion", () => {
     expect(hasNewerVersion("abc1234", "platform-v1.0.38")).toBe(false);
   });
 
+  it("returns false when current version is a full commit hash starting with a digit", () => {
+    expect(
+      hasNewerVersion(
+        "1fb94dd9badfb738525eaa3a4fe23fd7d6aacb1d",
+        "platform-v1.0.57",
+      ),
+    ).toBe(false);
+  });
+
   it("returns false when latest tag is not semver", () => {
     expect(hasNewerVersion("1.0.37", "latest")).toBe(false);
   });

--- a/platform/frontend/src/lib/version-utils.ts
+++ b/platform/frontend/src/lib/version-utils.ts
@@ -20,7 +20,7 @@ export function hasNewerVersion(
   const current = cleanVersionString(currentVersion);
   const latest = cleanVersionString(latestTagName);
 
-  const parsedCurrent = semver.valid(semver.coerce(current));
+  const parsedCurrent = semver.valid(current);
   const parsedLatest = semver.valid(semver.coerce(latest));
 
   if (!parsedCurrent || !parsedLatest) {


### PR DESCRIPTION
## Summary

- `semver.coerce()` extracts digits from any string, so a commit hash like `1fb94dd9badfb738525eaa3a4fe23fd7d6aacb1d` gets coerced to `1.0.0`, which is less than the latest release (`1.0.57`), incorrectly showing a "new version available" link in the footer
- Fix: use `semver.valid()` (strict parsing) for the current version instead of `semver.coerce()`. Commit hashes correctly return `null` from strict parsing
- Added test case for commit hashes starting with a digit
