### PR TITLE
fix: allow members to create/manage personal API keys

### DIFF
--- a/platform/shared/access-control.ts
+++ b/platform/shared/access-control.ts
@@ -91,7 +91,7 @@ export const memberPermissions: Record<Resource, Action[]> = {
   conversation: ["create", "read", "update", "delete"],
   limit: ["read"],
   llmModels: ["read"],
-  chatSettings: ["create", "read", "update", "delete"],
+  chatSettings: ["read"],
   // Empty arrays required for Record<Resource, Action[]> type compatibility
   member: [],
   invitation: [],


### PR DESCRIPTION
Members were getting 403 when trying to create personal API keys because the member role only had `chatSettings: ["read"]`. The RBAC middleware blocked the request before reaching the route handler, which already has proper scope-based authorization.

- Change "Add API Key" button to `PermissionButton` for consistency

Closes #3129