### PR TITLE
fix: reduce noisy auth and user model logs to trace level

### DIFF
--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -362,7 +362,7 @@ export async function handleBeforeHook(ctx: HookEndpointContext) {
     return ctx;
   }
 
-  logger.debug({ path, method }, "[auth:beforeHook] Processing auth request");
+  logger.trace({ path, method }, "[auth:beforeHook] Processing auth request");
 
   // Block invitation creation when invitations are disabled
   if (path === "/organization/invite-member" && method === "POST") {
@@ -570,7 +570,7 @@ export async function handleAfterHook(ctx: HookEndpointContext) {
     return ctx;
   }
 
-  logger.debug({ path, method }, "[auth:afterHook] Processing post-auth hook");
+  logger.trace({ path, method }, "[auth:afterHook] Processing post-auth hook");
 
   // Delete invitation from DB when canceled (instead of marking as canceled)
   if (path === "/organization/cancel-invitation" && method === "POST") {

--- a/platform/backend/src/models/user.ts
+++ b/platform/backend/src/models/user.ts
@@ -76,7 +76,7 @@ class UserModel {
    * Get a user by ID with their organization membership
    */
   static async getById(id: string) {
-    logger.debug("UserModel.getById: fetching user");
+    logger.trace("UserModel.getById: fetching user");
     const [user] = await db
       .select({
         ...getTableColumns(schema.usersTable),
@@ -89,7 +89,7 @@ class UserModel {
       )
       .where(eq(schema.usersTable.id, id))
       .limit(1);
-    logger.debug({ found: !!user }, "UserModel.getById: completed");
+    logger.trace({ found: !!user }, "UserModel.getById: completed");
     return user;
   }
 


### PR DESCRIPTION
## Summary
- Bumped `[auth:beforeHook]` and `[auth:afterHook]` log statements from `debug` to `trace` in `better-auth.ts`
- Bumped `UserModel.getById` fetch/complete log statements from `debug` to `trace` in `user.ts`

These logs fire on every request and were flooding debug output. They're still available at `ARCHESTRA_LOGGING_LEVEL=trace`.