### PR TITLE
fix: mcp logs filters not resetting pagination

### DIFF
--- a/platform/frontend/src/app/mcp/logs/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/page.client.tsx
@@ -109,9 +109,9 @@ function McpToolCallsTable({
   const handleProfileFilterChange = useCallback(
     (value: string) => {
       setProfileFilter(value);
-      setPagination((prev) => ({ ...prev, pageIndex: 0 })); // Reset to first page
       updateUrlParams({
         profileId: value === "all" ? null : value,
+        page: "1",
       });
     },
     [updateUrlParams],
@@ -121,9 +121,9 @@ function McpToolCallsTable({
   const handleSearchChange = useCallback(
     (value: string) => {
       setSearchFilter(value);
-      setPagination((prev) => ({ ...prev, pageIndex: 0 })); // Reset to first page
       updateUrlParams({
         search: value || null,
+        page: "1",
       });
     },
     [updateUrlParams],
@@ -135,10 +135,10 @@ function McpToolCallsTable({
     endDateFromUrl,
     onDateRangeChange: useCallback(
       ({ startDate, endDate }) => {
-        setPagination((prev) => ({ ...prev, pageIndex: 0 })); // Reset to first page
         updateUrlParams({
           startDate,
           endDate,
+          page: "1",
         });
       },
       [updateUrlParams],


### PR DESCRIPTION
Fixes #3156

Filter changes on /mcp/logs (search, profile, date range) were resetting pagination in local component state but not in the URL params. The API was still fetching from the old page offset, so results looked stale or wrong after filtering.

Added `page: "1"` to the URL update calls, same pattern already used in /llm/logs.

One file, 3 lines changed.