### PR TITLE
fix: handle non-UUID id in get_mcp_gateway and related get tools

### DIFF
--- a/platform/backend/src/archestra-mcp-server.ts
+++ b/platform/backend/src/archestra-mcp-server.ts
@@ -1711,8 +1711,28 @@ export async function executeArchestraTool(
 
       let record: Agent | null | undefined;
 
-      if (id) {
+      const UUID_REGEX =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+      if (id && UUID_REGEX.test(id)) {
         record = await AgentModel.findById(id);
+      } else if (id && !UUID_REGEX.test(id)) {
+        // id looks like a name — fall through to name search
+        const results = await AgentModel.findAllPaginated(
+          { limit: 1, offset: 0 },
+          undefined,
+          {
+            name: id,
+            agentType: expectedType,
+            scope: "personal",
+            authorIds: context.userId ? [context.userId] : [],
+          },
+          context.userId,
+          true,
+        );
+        if (results.data.length > 0) {
+          record = results.data[0];
+        }
       } else if (name) {
         // Search by name, only matching personal agents owned by the current user
         const results = await AgentModel.findAllPaginated(


### PR DESCRIPTION
**Problem**

When Claude calls archestra__get_mcp_gateway (or get_agent get_llm_proxy) with a descriptive name as the id parameter instead of a UUID, PostgreSQL throws a cast error and it surfaces as an unhandled crash.

As shown in #3214, Claude naturally tries id: 'n8n workflow: Grafana exporter' a valid human intent but not a UUID.

**Fix**

Added UUID format validation before calling indById. If the id parameter doesn't match UUID format, the handler now falls back to a name search (same logic as the existing 
ame parameter path rather than crashing.

^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\$

This fix applies to all three tools that share this handler: get_mcp_gateway, get_agent, and get_llm_proxy.

/claim #3214