### PR TITLE
chore: human-readable labels in dashboard Source filter

### DIFF
--- a/platform/dev/grafana/dashboards/genai-observability.json
+++ b/platform/dev/grafana/dashboards/genai-observability.json
@@ -3710,7 +3710,7 @@
             "value": "knowledge:reranker"
           }
         ],
-        "query": "api,chat,chatops:slack,chatops:ms-teams,email,knowledge:embedding,knowledge:reranker",
+        "query": "API : api,Chat : chat,Slack : chatops:slack,MS Teams : chatops:ms-teams,Email : email,Knowledge - Embedding : knowledge:embedding,Knowledge - Reranker : knowledge:reranker",
         "type": "custom"
       },
       {


### PR DESCRIPTION
## Summary

- Fix Source filter dropdown in GenAI Observability dashboard to show human-readable labels (API, Chat, Slack, MS Teams, etc.) instead of raw metric values (api, chat, chatops:slack, chatops:ms-teams, etc.)
- Grafana custom variables require `Text : value` format in the `query` field — the `options` array `text` fields alone are not sufficient