### PR TITLE
chore: update delete knowledge base dialog wording

### DIFF
--- a/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
@@ -754,9 +754,9 @@ function DeleteKnowledgeBaseDialog({
         <DialogHeader>
           <DialogTitle>Delete Knowledge Base</DialogTitle>
           <DialogDescription>
-            Are you sure you want to delete this knowledge base? Connectors
-            will not be deleted but will be unlinked from this knowledge base.
-            This action cannot be undone.
+            Are you sure you want to delete this knowledge base? Connectors will
+            not be deleted but will be unlinked from this knowledge base. This
+            action cannot be undone.
           </DialogDescription>
         </DialogHeader>
         <DialogForm onSubmit={handleDelete}>


### PR DESCRIPTION
## Summary
- Updated the delete knowledge base confirmation dialog to reflect that connectors are no longer deleted when a knowledge base is removed
- New wording: "Connectors will not be deleted but will be unlinked from this knowledge base."
