### PR TITLE
fix: vault-secrets init container crash due to config.ts import

### DIFF
--- a/platform/backend/src/secrets-manager/secrets-manager.test.ts
+++ b/platform/backend/src/secrets-manager/secrets-manager.test.ts
@@ -563,18 +563,10 @@ describe("SecretsManager", async () => {
     });
 
     describe("KV version configuration", () => {
-      // Helper to set vaultKvVersion on the imported config object.
-      // Needed because tests use `const config = getVaultConfigFromEnv()` which
-      // shadows the import, making direct `config.secretsManager` access hit TDZ.
-      const setKvVersion = (v: string) => {
-        config.secretsManager.vaultKvVersion = v;
-      };
-
       test("should default to KV v2 when ARCHESTRA_HASHICORP_VAULT_KV_VERSION is not set", () => {
         process.env.ARCHESTRA_HASHICORP_VAULT_ADDR = "http://localhost:8200";
         process.env.ARCHESTRA_HASHICORP_VAULT_TOKEN = "dev-root-token";
         delete process.env.ARCHESTRA_HASHICORP_VAULT_KV_VERSION;
-        setKvVersion("2");
         delete process.env.ARCHESTRA_HASHICORP_VAULT_SECRET_PATH;
 
         const config = getVaultConfigFromEnv();
@@ -587,7 +579,6 @@ describe("SecretsManager", async () => {
         process.env.ARCHESTRA_HASHICORP_VAULT_ADDR = "http://localhost:8200";
         process.env.ARCHESTRA_HASHICORP_VAULT_TOKEN = "dev-root-token";
         process.env.ARCHESTRA_HASHICORP_VAULT_KV_VERSION = "1";
-        setKvVersion("1");
         delete process.env.ARCHESTRA_HASHICORP_VAULT_SECRET_PATH;
 
         const config = getVaultConfigFromEnv();
@@ -600,7 +591,6 @@ describe("SecretsManager", async () => {
         process.env.ARCHESTRA_HASHICORP_VAULT_ADDR = "http://localhost:8200";
         process.env.ARCHESTRA_HASHICORP_VAULT_TOKEN = "dev-root-token";
         process.env.ARCHESTRA_HASHICORP_VAULT_KV_VERSION = "2";
-        setKvVersion("2");
         delete process.env.ARCHESTRA_HASHICORP_VAULT_SECRET_PATH;
 
         const config = getVaultConfigFromEnv();
@@ -613,7 +603,6 @@ describe("SecretsManager", async () => {
         process.env.ARCHESTRA_HASHICORP_VAULT_ADDR = "http://localhost:8200";
         process.env.ARCHESTRA_HASHICORP_VAULT_TOKEN = "dev-root-token";
         process.env.ARCHESTRA_HASHICORP_VAULT_KV_VERSION = "3";
-        setKvVersion("3");
 
         expect(() => getVaultConfigFromEnv()).toThrow(
           SecretsManagerConfigurationError,
@@ -627,7 +616,6 @@ describe("SecretsManager", async () => {
         process.env.ARCHESTRA_HASHICORP_VAULT_ADDR = "http://localhost:8200";
         process.env.ARCHESTRA_HASHICORP_VAULT_TOKEN = "dev-root-token";
         process.env.ARCHESTRA_HASHICORP_VAULT_KV_VERSION = "1";
-        setKvVersion("1");
         process.env.ARCHESTRA_HASHICORP_VAULT_SECRET_PATH = "custom/secrets";
 
         const config = getVaultConfigFromEnv();
@@ -641,7 +629,6 @@ describe("SecretsManager", async () => {
         process.env.ARCHESTRA_HASHICORP_VAULT_AUTH_METHOD = "K8S";
         process.env.ARCHESTRA_HASHICORP_VAULT_K8S_ROLE = "archestra";
         process.env.ARCHESTRA_HASHICORP_VAULT_KV_VERSION = "1";
-        setKvVersion("1");
         delete process.env.ARCHESTRA_HASHICORP_VAULT_SECRET_PATH;
         delete process.env.ARCHESTRA_HASHICORP_VAULT_K8S_TOKEN_PATH;
         delete process.env.ARCHESTRA_HASHICORP_VAULT_K8S_MOUNT_POINT;
@@ -657,7 +644,6 @@ describe("SecretsManager", async () => {
         process.env.ARCHESTRA_HASHICORP_VAULT_AUTH_METHOD = "AWS";
         process.env.ARCHESTRA_HASHICORP_VAULT_AWS_ROLE = "archestra-role";
         process.env.ARCHESTRA_HASHICORP_VAULT_KV_VERSION = "1";
-        setKvVersion("1");
         delete process.env.ARCHESTRA_HASHICORP_VAULT_SECRET_PATH;
         delete process.env.ARCHESTRA_HASHICORP_VAULT_AWS_MOUNT_POINT;
         delete process.env.ARCHESTRA_HASHICORP_VAULT_AWS_REGION;

--- a/platform/backend/src/secrets-manager/vault-config.ts
+++ b/platform/backend/src/secrets-manager/vault-config.ts
@@ -1,4 +1,3 @@
-import config from "@/config";
 import type { VaultConfig, VaultKvVersion } from "@/types";
 
 export class SecretsManagerConfigurationError extends Error {
@@ -43,7 +42,11 @@ export function getVaultConfigFromEnv(): VaultConfig {
   const errors: string[] = [];
 
   // Parse KV version first (needed for default secret path)
-  const kvVersionEnv = config.secretsManager.vaultKvVersion;
+  // Read directly from process.env instead of importing config to avoid
+  // triggering config.ts module evaluation (which requires DATABASE_URL).
+  // This is critical because vault-env-injector imports this module and runs
+  // BEFORE the database URL is available.
+  const kvVersionEnv = process.env.ARCHESTRA_HASHICORP_VAULT_KV_VERSION || "2";
   let kvVersion: VaultKvVersion = DEFAULT_KV_VERSION;
 
   if (kvVersionEnv === "1" || kvVersionEnv === "2") {

--- a/platform/backend/src/standalone-scripts/vault-env-injector.test.ts
+++ b/platform/backend/src/standalone-scripts/vault-env-injector.test.ts
@@ -1,6 +1,29 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 // biome-ignore lint/style/noRestrictedImports: test file for .ee module
 import { escapeForShell } from "./vault-env-injector.ee";
+
+describe("vault-env-injector import safety", () => {
+  it("vault-config.ts must not import @/config to avoid crashing the vault-secrets init container", () => {
+    // The vault-env-injector runs as a K8s init container BEFORE the database URL
+    // is available (it's the one that fetches it from Vault). If vault-config.ts
+    // imports @/config, it triggers config.ts module evaluation which calls
+    // getDatabaseUrl() and throws "Database URL is not set".
+    const vaultConfigSource = readFileSync(
+      resolve(__dirname, "../secrets-manager/vault-config.ts"),
+      "utf-8",
+    );
+
+    const hasConfigImport = /import\s+.*from\s+["']@\/config["']/.test(
+      vaultConfigSource,
+    );
+    expect(
+      hasConfigImport,
+      "vault-config.ts must NOT import @/config — it would crash the vault-secrets init container which runs before DATABASE_URL is available",
+    ).toBe(false);
+  });
+});
 
 describe("escapeForShell", () => {
   it("should wrap simple values in single quotes", () => {


### PR DESCRIPTION
## Summary

- Fixed vault-secrets init container `CrashLoopBackOff` caused by `vault-config.ts` importing `@/config`, which eagerly calls `getDatabaseUrl()` at module load time. The vault-secrets init container runs **before** `ARCHESTRA_DATABASE_URL` is available (it's the one fetching it from Vault), so this threw: `"Database URL is not set"`
- Changed `vault-config.ts` to read `ARCHESTRA_HASHICORP_VAULT_KV_VERSION` directly from `process.env` instead of importing the full config module
- Added a regression test that verifies `vault-config.ts` never imports `@/config`

## Root Cause

Commit `590102a32` (knowledge base feature) changed `vault-config.ts` to `import config from "@/config"` for reading `vaultKvVersion`. This created a transitive dependency chain: `vault-env-injector.ee.ts` → `vault-config.ts` → `config.ts` → `getDatabaseUrl()` → crash.
