### PR TITLE
fix: include all e2e job failures in Playwright report comment

### DIFF
--- a/.github/workflows/platform-linting-and-tests.yml
+++ b/.github/workflows/platform-linting-and-tests.yml
@@ -345,6 +345,9 @@ jobs:
             artifact: blob-report-vault
             extra_helm_set: "archestra.env.ARCHESTRA_SECRETS_MANAGER=READONLY_VAULT"
     steps:
+      # REVERT: Force failure to test check-jobs step
+      - name: Force failure for testing
+        run: exit 1
       - name: Checkout repository
         if: ${{ inputs.should-skip-running-and-always-succeed != true }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -442,6 +445,9 @@ jobs:
       contents: read
       packages: read
     steps:
+      # REVERT: Force failure to test check-jobs step
+      - name: Force failure for testing
+        run: exit 1
       - name: Checkout repository
         if: ${{ inputs.should-skip-running-and-always-succeed != true }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -634,6 +640,9 @@ jobs:
       contents: read
       packages: read
     steps:
+      # REVERT: Force failure to test check-jobs step
+      - name: Force failure for testing
+        run: exit 1
       - name: Checkout repository
         if: ${{ inputs.should-skip-running-and-always-succeed != true }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Summary

- When an e2e job fails at infrastructure level (e.g. init container crash, helm deploy timeout) before Playwright tests run, no blob report is produced. The merged Playwright report comment on the PR would still show green, hiding the failure
- The `Merge E2E Test Reports` job now checks all upstream e2e job results (`platform-e2e-tests`, `platform-quickstart-e2e-tests`, `platform-vault-k8s-e2e-tests`) and:
  1. Adds a `[!CAUTION]` banner to the PR comment via `custom-info` listing which jobs failed
  2. Fails itself if any upstream job failed, so the overall check status is red

## Test plan

- [ ] Trigger a CI run where all e2e jobs pass — report should show no caution banner
- [ ] If a job fails (e.g. Vault K8s), the PR comment should include the caution banner and the merge-reports job should be red