### PR TITLE
fix: update PostgreSQL 17 pin from 17.8-r0 to 17.9-r0

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -135,8 +135,8 @@ ENV ARCHESTRA_SENTRY_ENVIRONMENT=""
 ENV NODE_EXTRA_CA_CERTS="/etc/ssl/certs/cloud-database-ca-bundle.pem"
 
 RUN apk --no-cache upgrade && \
-    # Install PostgreSQL 17 (pin 17.8-r0 for CVE-2026-2004..2007), pgvector, supervisord, and wget
-    apk add --no-cache postgresql17=17.8-r0 postgresql17-contrib=17.8-r0 postgresql-pgvector su-exec wget && \
+    # Install PostgreSQL 17, pgvector, supervisord, and wget
+    apk add --no-cache postgresql17=17.9-r0 postgresql17-contrib=17.9-r0 postgresql-pgvector su-exec wget && \
     # Download cloud database CA bundles for SSL certificate validation
     # AWS RDS global CA bundle
     wget -qO /tmp/aws-rds-ca.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem && \


### PR DESCRIPTION
## Summary
- Alpine released `postgresql17` `17.9-r0`, removing `17.8-r0` from the package index
- The Docker build runs `apk --no-cache upgrade` first (refreshing the index to 17.9), then tries to install the pinned `17.8-r0` which no longer exists, causing a version conflict
- Updates the pin from `17.8-r0` → `17.9-r0` to fix the staging Docker build

## Test plan
- [ ] Verify the staging Docker build passes in CI