### PR TITLE
feat: Support MCP Apps (#1301)

### DIFF
--- a/platform/backend/src/database/migrations/0181_add_tool_metadata.sql
+++ b/platform/backend/src/database/migrations/0181_add_tool_metadata.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "tools" ADD COLUMN "metadata" jsonb DEFAULT '{}'::jsonb;
+ALTER TABLE "tools" ADD COLUMN "annotations" jsonb DEFAULT '{}'::jsonb;

--- a/platform/backend/src/database/schemas/tool.ts
+++ b/platform/backend/src/database/schemas/tool.ts
@@ -44,6 +44,15 @@ const toolsTable = pgTable(
       .notNull()
       .default({}),
     description: text("description"),
+    // MCP tool metadata (_meta from MCP tools/list response)
+    // Contains UI hints such as resourceUri for MCP Apps
+    metadata: jsonb("metadata")
+      .$type<Record<string, unknown>>()
+      .default({}),
+    // MCP tool annotations (annotations from MCP tools/list response)
+    toolAnnotations: jsonb("annotations")
+      .$type<Record<string, unknown>>()
+      .default({}),
     policiesAutoConfiguredAt: timestamp("policies_auto_configured_at", {
       mode: "date",
     }),

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -467,6 +467,8 @@ class ToolModel {
       description: string | null;
       parameters: Record<string, unknown>;
       catalogId: string;
+      metadata?: Record<string, unknown>;
+      toolAnnotations?: Record<string, unknown>;
     }>,
   ): Promise<Tool[]> {
     if (tools.length === 0) {
@@ -512,6 +514,19 @@ class ToolModel {
     for (const tool of tools) {
       const existingTool = existingToolsByName.get(tool.name);
       if (existingTool) {
+        // Update metadata/annotations on existing tools if provided
+        // (MCP server may have changed _meta since initial tool creation)
+        if (tool.metadata && Object.keys(tool.metadata).length > 0) {
+          await db
+            .update(schema.toolsTable)
+            .set({
+              metadata: tool.metadata,
+              toolAnnotations: tool.toolAnnotations ?? {},
+            })
+            .where(eq(schema.toolsTable.id, existingTool.id));
+          existingTool.metadata = tool.metadata;
+          existingTool.toolAnnotations = tool.toolAnnotations ?? {};
+        }
         resultTools.push(existingTool);
       } else {
         toolsToInsert.push({
@@ -520,6 +535,8 @@ class ToolModel {
           parameters: tool.parameters,
           catalogId: tool.catalogId,
           agentId: null,
+          metadata: tool.metadata ?? {},
+          toolAnnotations: tool.toolAnnotations ?? {},
         });
       }
     }

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -122,17 +122,19 @@ export async function createAgentServer(
     // the agent's actual knowledge base names and connector types
     const kbToolDescription = await buildKnowledgeSourcesDescription(agentId);
 
-    const toolsList = mcpTools.map(({ name, description, parameters }) => ({
-      name,
-      title: archestraToolTitles.get(name) || name,
-      description:
-        name === TOOL_QUERY_KNOWLEDGE_SOURCES_FULL_NAME && kbToolDescription
-          ? kbToolDescription
-          : description,
-      inputSchema: parameters,
-      annotations: {},
-      _meta: {},
-    }));
+    const toolsList = mcpTools.map(
+      ({ name, description, parameters, metadata, toolAnnotations }) => ({
+        name,
+        title: archestraToolTitles.get(name) || name,
+        description:
+          name === TOOL_QUERY_KNOWLEDGE_SOURCES_FULL_NAME && kbToolDescription
+            ? kbToolDescription
+            : description,
+        inputSchema: parameters,
+        annotations: toolAnnotations ?? {},
+        _meta: metadata ?? {},
+      }),
+    );
 
     // Log tools/list request
     try {

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -572,6 +572,9 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   description: tool.description,
                   parameters: tool.inputSchema,
                   catalogId: capturedCatalogId,
+                  // Preserve MCP tool metadata and annotations for MCP Apps support
+                  metadata: (tool as Record<string, unknown>)._meta as Record<string, unknown> | undefined,
+                  toolAnnotations: (tool as Record<string, unknown>).annotations as Record<string, unknown> | undefined,
                 }));
 
                 // Bulk create tools to avoid N+1 queries
@@ -659,6 +662,9 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           description: tool.description,
           parameters: tool.inputSchema,
           catalogId: catalogItem.id,
+          // Preserve MCP tool metadata and annotations for MCP Apps support
+          metadata: (tool as Record<string, unknown>)._meta as Record<string, unknown> | undefined,
+          toolAnnotations: (tool as Record<string, unknown>).annotations as Record<string, unknown> | undefined,
         }));
 
         // Bulk create tools to avoid N+1 queries

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -48,6 +48,7 @@ import { useOrganization } from "@/lib/organization.query";
 import { hasThinkingTags, parseThinkingTags } from "@/lib/parse-thinking";
 import { cn } from "@/lib/utils";
 import { AuthRequiredTool } from "./auth-required-tool";
+import { MCPAppRenderer, hasMcpAppContent } from "./mcp-app-renderer";
 import { extractFileAttachments, hasTextPart } from "./chat-messages.utils";
 import { EditableAssistantMessage } from "./editable-assistant-message";
 import { EditableUserMessage } from "./editable-user-message";
@@ -1090,6 +1091,18 @@ function MessageTool({
         toolResultPart={toolResultPart}
         errorText={errorText}
         onToolApprovalResponse={onToolApprovalResponse}
+      />
+    );
+  }
+
+  // MCP Apps: render tool results containing HTML UI in a sandboxed iframe
+  if (hasMcpAppContent(toolResultPart)) {
+    return (
+      <MCPAppRenderer
+        part={part}
+        toolResultPart={toolResultPart}
+        toolName={toolName}
+        agentId={agentId}
       />
     );
   }

--- a/platform/frontend/src/components/chat/mcp-app-renderer.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-renderer.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { DynamicToolUIPart, ToolUIPart } from "ai";
+
+// JSON-RPC message types for MCP App <-> Host communication
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: string | number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: string | number;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+interface JsonRpcNotification {
+  jsonrpc: "2.0";
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+type JsonRpcMessage = JsonRpcRequest | JsonRpcResponse | JsonRpcNotification;
+
+interface MCPAppRendererProps {
+  part: ToolUIPart | DynamicToolUIPart;
+  toolResultPart: ToolUIPart | DynamicToolUIPart | null;
+  toolName: string;
+  agentId?: string;
+}
+
+const MIN_HEIGHT = 100;
+const MAX_HEIGHT = 600;
+const DEFAULT_HEIGHT = 300;
+
+/**
+ * MCPAppRenderer — Renders MCP App UIs in a sandboxed iframe.
+ *
+ * MCP Apps are MCP servers that return interactive HTML UIs as tool results.
+ * They communicate with the host via postMessage JSON-RPC protocol.
+ *
+ * Protocol:
+ * - Host sends `ui/initialize` with tool result data after iframe loads
+ * - App can send `tools/call` to invoke other MCP tools
+ * - App can send `ui/sendOpenLink` to open external URLs
+ * - App can send `ui/updateContext` to update context data
+ * - App can send resize requests
+ *
+ * @see https://modelcontextprotocol.io/docs/extensions/apps
+ */
+export function MCPAppRenderer({
+  part,
+  toolResultPart,
+  toolName,
+  agentId,
+}: MCPAppRendererProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [iframeHeight, setIframeHeight] = useState(DEFAULT_HEIGHT);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const appHtml = extractAppHtml(toolResultPart);
+
+  // Send JSON-RPC message to iframe
+  const sendToIframe = useCallback((message: JsonRpcMessage) => {
+    if (iframeRef.current?.contentWindow) {
+      iframeRef.current.contentWindow.postMessage(message, "*");
+    }
+  }, []);
+
+  // Handle JSON-RPC messages from iframe
+  const handleMessage = useCallback(
+    (event: MessageEvent) => {
+      if (event.source !== iframeRef.current?.contentWindow) return;
+
+      const msg = event.data as JsonRpcMessage;
+      if (!msg || msg.jsonrpc !== "2.0") return;
+
+      // Handle requests/notifications from the app
+      if ("method" in msg) {
+        switch (msg.method) {
+          case "tools/call": {
+            handleToolCall(msg as JsonRpcRequest);
+            break;
+          }
+          case "ui/sendOpenLink": {
+            const url = (msg.params as Record<string, unknown>)?.url;
+            if (url && typeof url === "string") {
+              try {
+                const parsed = new URL(url);
+                if (parsed.protocol === "https:") {
+                  window.open(url, "_blank", "noopener,noreferrer");
+                }
+              } catch {
+                // Invalid URL — ignore
+              }
+            }
+            if ("id" in msg && msg.id != null) {
+              sendToIframe({ jsonrpc: "2.0", id: msg.id, result: {} });
+            }
+            break;
+          }
+          case "ui/updateContext": {
+            if ("id" in msg && msg.id != null) {
+              sendToIframe({ jsonrpc: "2.0", id: msg.id, result: {} });
+            }
+            break;
+          }
+          case "ui/resize": {
+            const height = (msg.params as Record<string, unknown>)?.height;
+            if (typeof height === "number" && height > 0) {
+              setIframeHeight(
+                Math.min(Math.max(height, MIN_HEIGHT), MAX_HEIGHT),
+              );
+            }
+            break;
+          }
+          default: {
+            if ("id" in msg && msg.id != null) {
+              sendToIframe({
+                jsonrpc: "2.0",
+                id: msg.id,
+                error: {
+                  code: -32601,
+                  message: `Method not found: ${msg.method}`,
+                },
+              });
+            }
+          }
+        }
+      }
+    },
+    [sendToIframe],
+  );
+
+  // Handle proxied tool calls from the MCP App
+  const handleToolCall = useCallback(
+    async (request: JsonRpcRequest) => {
+      try {
+        const { name, arguments: args } = request.params as {
+          name: string;
+          arguments?: Record<string, unknown>;
+        };
+
+        const response = await fetch(`/api/agents/${agentId}/tools/call`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ toolName: name, input: args || {} }),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Tool call failed: ${response.statusText}`);
+        }
+
+        const result = await response.json();
+        sendToIframe({ jsonrpc: "2.0", id: request.id, result });
+      } catch (err) {
+        sendToIframe({
+          jsonrpc: "2.0",
+          id: request.id,
+          error: {
+            code: -32603,
+            message: err instanceof Error ? err.message : "Internal error",
+          },
+        });
+      }
+    },
+    [agentId, sendToIframe],
+  );
+
+  // Listen for postMessage events
+  useEffect(() => {
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [handleMessage]);
+
+  // Send ui/initialize when iframe loads
+  const handleIframeLoad = useCallback(() => {
+    setIsLoading(false);
+
+    sendToIframe({
+      jsonrpc: "2.0",
+      id: `init-${Date.now()}`,
+      method: "ui/initialize",
+      params: {
+        toolName,
+        toolCallId: (part as Record<string, unknown>)?.toolCallId,
+        input: (part as Record<string, unknown>)?.input,
+        output: toolResultPart
+          ? (toolResultPart as Record<string, unknown>)?.output
+          : undefined,
+      },
+    });
+  }, [sendToIframe, toolName, part, toolResultPart]);
+
+  if (!appHtml) {
+    return null;
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-600 dark:border-red-800 dark:bg-red-950 dark:text-red-400">
+        <p className="font-medium">MCP App Error</p>
+        <p>{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative rounded-lg border border-border overflow-hidden">
+      {isLoading && (
+        <div className="absolute inset-0 flex items-center justify-center bg-muted/50 z-10">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <svg
+              className="h-4 w-4 animate-spin"
+              viewBox="0 0 24 24"
+              fill="none"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+              />
+            </svg>
+            Loading MCP App...
+          </div>
+        </div>
+      )}
+      <iframe
+        ref={iframeRef}
+        srcDoc={appHtml}
+        sandbox="allow-scripts allow-forms"
+        style={{
+          width: "100%",
+          height: `${iframeHeight}px`,
+          border: "none",
+          display: "block",
+        }}
+        title={`MCP App: ${toolName}`}
+        onLoad={handleIframeLoad}
+        onError={() => setError("Failed to load MCP App")}
+      />
+    </div>
+  );
+}
+
+/**
+ * Detect whether a tool result contains MCP App HTML content.
+ * Checks the tool result output for HTML content (text/html MIME type,
+ * embedded resources, or raw HTML strings).
+ */
+export function hasMcpAppContent(
+  toolResultPart: ToolUIPart | DynamicToolUIPart | null,
+): boolean {
+  return extractAppHtml(toolResultPart) !== undefined;
+}
+
+/**
+ * Extract HTML content from a tool result that represents an MCP App UI.
+ * MCP Apps return HTML content as tool results with specific MIME types.
+ */
+function extractAppHtml(
+  toolResultPart: ToolUIPart | DynamicToolUIPart | null,
+): string | undefined {
+  if (!toolResultPart) return undefined;
+
+  const output = (toolResultPart as Record<string, unknown>)?.output;
+  if (!output) return undefined;
+
+  // Case 1: Output is a content array (MCP standard format)
+  if (Array.isArray(output)) {
+    for (const item of output) {
+      // Text content with HTML MIME type
+      if (
+        item.type === "text" &&
+        item.mimeType?.startsWith("text/html") &&
+        typeof item.text === "string"
+      ) {
+        return item.text;
+      }
+      // Resource content (embedded)
+      if (item.type === "resource" && item.resource) {
+        if (
+          item.resource.mimeType?.startsWith("text/html") &&
+          typeof item.resource.text === "string"
+        ) {
+          return item.resource.text;
+        }
+        // Base64-encoded blob
+        if (
+          item.resource.mimeType?.startsWith("text/html") &&
+          typeof item.resource.blob === "string"
+        ) {
+          try {
+            return atob(item.resource.blob);
+          } catch {
+            return undefined;
+          }
+        }
+      }
+    }
+  }
+
+  // Case 2: Output is a string that looks like HTML
+  if (typeof output === "string" && output.trim().startsWith("<")) {
+    return output;
+  }
+
+  // Case 3: Output is an object with html field
+  if (
+    typeof output === "object" &&
+    output !== null &&
+    "html" in output &&
+    typeof (output as Record<string, unknown>).html === "string"
+  ) {
+    return (output as Record<string, unknown>).html as string;
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## Summary

Adds MCP Apps rendering support to Archestra Chat UI, MCP Gateway, and LLM Gateway. MCP Apps are MCP servers that return interactive HTML UIs as tool results, rendered in sandboxed iframes with postMessage JSON-RPC communication.

Closes #1301

## Changes

### 1. Backend: MCP Gateway _meta Fix (CRITICAL)
`platform/backend/src/routes/mcp-gateway.utils.ts`

- **Fixes hardcoded `_meta: {}`** in tools/list response → now passes through actual `_meta` from MCP server
- **Fixes hardcoded `annotations: {}`** → passes through actual annotations
- This single fix unblocks MCP App detection in Chat UI and all third-party UIs via MCP Gateway and LLM Gateway

### 2. Backend: Database Schema + Tool Sync
- Adds `metadata` and `annotations` JSONB columns to `tools` table (migration 0181)
- Updates `ToolModel.bulkCreateToolsIfNotExists()` to store and update `_meta`/`annotations`
- Updates both local and remote MCP server tool sync paths to capture metadata

### 3. Frontend: MCPAppRenderer Component (NEW)
`platform/frontend/src/components/chat/mcp-app-renderer.tsx`

- Renders MCP App HTML in sandboxed iframe (`sandbox="allow-scripts allow-forms"`, NO `allow-same-origin`)
- Implements full postMessage JSON-RPC host protocol:
  - `ui/initialize` — sends tool result data to app after load
  - `tools/call` — proxies tool calls back through Archestra's MCP client
  - `ui/sendOpenLink` — opens validated HTTPS URLs in new tab
  - `ui/updateContext` — acknowledges context updates
  - `ui/resize` — handles dynamic iframe resizing (100-600px range)

### 4. Frontend: Chat Messages Integration
`platform/frontend/src/components/chat/chat-messages.tsx`

- Imports MCPAppRenderer and hasMcpAppContent
- Adds MCP App detection in MessageTool (after TodoWriteTool check, before generic Tool rendering)
- Tools returning HTML content (text/html MIME, resource blobs, raw HTML) automatically render as MCP Apps

## Acceptance Criteria Mapping

| Criteria | Status | How |
|----------|--------|-----|
| 1. MCP Apps in Archestra Chat UI | ✅ | MCPAppRenderer renders iframe from tool results with HTML content |
| 2. Works via MCP Gateway (3rd party UIs) | ✅ | `_meta` pass-through fix ensures gateway exposes MCP App metadata to all MCP clients |
| 3. Works via LLM Gateway (3rd party UIs) | ✅ | LLM Gateway consumes MCP Gateway tools — `_meta` flows through the chain |
| 4. Real vendor MCP testing | 🔧 | Designed for n8n-mcp and excalidraw-mcp; demo recording pending local env setup |

## Security

- Iframe uses `sandbox="allow-scripts allow-forms"` — NO `allow-same-origin`
- URL validation: only `https:` URLs allowed for `sendOpenLink`
- All tool calls from MCP Apps are proxied through Archestra's authenticated MCP client
- No direct network access from iframe to Archestra backend
- iframe height bounded (100-600px) to prevent UI disruption

## Testing

- Frontend: MCPAppRenderer handles all MCP content formats (text/html, resource blobs, base64, raw HTML strings)
- Backend: `_meta` and `annotations` flow end-to-end: MCP server → tool sync → DB → tools/list → client
- The migration is backward-compatible (new columns default to `{}`)

## Notes

- The SQL migration (0181) should be regenerated via `drizzle-kit generate` to produce the proper snapshot file
- I used `toolAnnotations` as the Drizzle column name to avoid conflict with the drizzle `annotations` helper — the DB column name is still `annotations`