### PR TITLE
fix: Enter key in Delete modal triggers delete instead of closing (#3098, #3099)

### DIFF
--- a/platform/frontend/src/app/agents/page.client.tsx
+++ b/platform/frontend/src/app/agents/page.client.tsx
@@ -729,6 +729,7 @@ function DeleteAgentDialog({
               type="submit"
               variant="destructive"
               disabled={deleteAgent.isPending}
+              autoFocus
             >
               {deleteAgent.isPending ? "Deleting..." : "Delete Agent"}
             </Button>

--- a/platform/frontend/src/components/agents-canvas/agents-canvas-view.tsx
+++ b/platform/frontend/src/components/agents-canvas/agents-canvas-view.tsx
@@ -753,6 +753,7 @@ function AgentsCanvasViewInner() {
             <AlertDialogAction
               onClick={confirmDelete}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              autoFocus
             >
               Delete
             </AlertDialogAction>


### PR DESCRIPTION
## Summary

- Fixes the Enter key behavior in both Delete Agent modals (Agents Table and Agent Builder)
- Both modals auto-focused the Cancel/Close button when opened, so pressing Enter dismissed the dialog instead of confirming deletion
- Added `autoFocus` to the destructive action buttons so Enter triggers the expected delete action

## Changes

- `platform/frontend/src/app/agents/page.client.tsx` — Added `autoFocus` to the Delete Agent submit button in `DeleteAgentDialog`
- `platform/frontend/src/components/agents-canvas/agents-canvas-view.tsx` — Added `autoFocus` to the `AlertDialogAction` delete button

## Testing

1. Navigate to `/agents` → click delete on any agent → press Enter → agent should be deleted (not dialog dismissed)
2. Navigate to Agent Builder → click delete on any agent → press Enter → agent should be deleted (not dialog dismissed)

Fixes #3098
Fixes #3099