### PR TITLE
fix: add UUID validation to MCP server tool handlers

### DIFF
--- a/platform/backend/src/archestra-mcp-server/agents.ts
+++ b/platform/backend/src/archestra-mcp-server/agents.ts
@@ -17,6 +17,7 @@ import {
   assignSubAgentDelegations,
   deduplicateLabels,
   formatAssignmentSummary,
+  validateUuid,
 } from "./helpers";
 import type { ArchestraContext } from "./types";
 
@@ -204,17 +205,20 @@ export const tools: Tool[] = [
   {
     name: TOOL_GET_AGENT_FULL_NAME,
     title: "Get Agent",
-    description: "Get a specific agent by ID or name.",
+    description:
+      "Get a specific agent by ID or name. Use 'name' if you only know the agent's name — do NOT put a name string into the 'id' field. When searching by name, only your personal agents are matched.",
     inputSchema: {
       type: "object",
       properties: {
         id: {
           type: "string",
-          description: "The ID of the agent to retrieve",
+          description:
+            "The UUID of the agent to retrieve. Must be a valid UUID (e.g. '123e4567-e89b-12d3-a456-426614174000'). If you only have a name, use the 'name' parameter instead.",
         },
         name: {
           type: "string",
-          description: "Search by name (partial match).",
+          description:
+            "Search by name (partial match). Use this when you know the agent's name but not its UUID. Only returns your personal agents.",
         },
       },
     },
@@ -225,18 +229,19 @@ export const tools: Tool[] = [
     name: TOOL_GET_LLM_PROXY_FULL_NAME,
     title: "Get LLM Proxy",
     description:
-      "Get a specific LLM proxy by ID or name. When searching by name, only your personal proxies are matched.",
+      "Get a specific LLM proxy by ID or name. Use 'name' if you only know the proxy's name — do NOT put a name string into the 'id' field. When searching by name, only your personal proxies are matched.",
     inputSchema: {
       type: "object",
       properties: {
         id: {
           type: "string",
-          description: "The ID of the LLM proxy to retrieve",
+          description:
+            "The UUID of the LLM proxy to retrieve. Must be a valid UUID (e.g. '123e4567-e89b-12d3-a456-426614174000'). If you only have a name, use the 'name' parameter instead.",
         },
         name: {
           type: "string",
           description:
-            "Search by name (partial match). Only returns your personal proxies.",
+            "Search by name (partial match). Use this when you know the proxy's name but not its UUID. Only returns your personal proxies.",
         },
       },
     },
@@ -247,18 +252,19 @@ export const tools: Tool[] = [
     name: TOOL_GET_MCP_GATEWAY_FULL_NAME,
     title: "Get MCP Gateway",
     description:
-      "Get a specific MCP gateway by ID or name. When searching by name, only your personal gateways are matched.",
+      "Get a specific MCP gateway by ID or name. Use 'name' if you only know the gateway's name — do NOT put a name string into the 'id' field. When searching by name, only your personal gateways are matched.",
     inputSchema: {
       type: "object",
       properties: {
         id: {
           type: "string",
-          description: "The ID of the MCP gateway to retrieve",
+          description:
+            "The UUID of the MCP gateway to retrieve. Must be a valid UUID (e.g. '123e4567-e89b-12d3-a456-426614174000'). If you only have a name, use the 'name' parameter instead.",
         },
         name: {
           type: "string",
           description:
-            "Search by name (partial match). Only returns your personal gateways.",
+            "Search by name (partial match). Use this when you know the gateway's name but not its UUID. Only returns your personal gateways.",
         },
       },
     },
@@ -550,6 +556,12 @@ export async function handleTool(
           : false;
 
       if (id) {
+        if (!validateUuid(id)) {
+          return {
+            content: [{ type: "text", text: "Error: id must be a valid UUID" }],
+            isError: true,
+          };
+        }
         record = await AgentModel.findById(id, context.userId, isAdmin);
       } else if (name) {
         const results = await AgentModel.findAllPaginated(
@@ -718,6 +730,12 @@ export async function handleTool(
       if (!id) {
         return {
           content: [{ type: "text", text: "Error: agent id is required." }],
+          isError: true,
+        };
+      }
+      if (!validateUuid(id)) {
+        return {
+          content: [{ type: "text", text: "Error: id must be a valid UUID" }],
           isError: true,
         };
       }

--- a/platform/backend/src/archestra-mcp-server/helpers.ts
+++ b/platform/backend/src/archestra-mcp-server/helpers.ts
@@ -116,3 +116,14 @@ export function deduplicateLabels(
 ): Array<{ key: string; value: string }> {
   return Array.from(new Map(rawLabels.map((l) => [l.key, l])).values());
 }
+
+const UUID_REGEX =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+/**
+ * Validates if the given string is a valid UUID format
+ */
+export function validateUuid(id: string | undefined | null): boolean {
+  if (!id) return false;
+  return UUID_REGEX.test(id);
+}

--- a/platform/backend/src/archestra-mcp-server/mcp-servers.ts
+++ b/platform/backend/src/archestra-mcp-server/mcp-servers.ts
@@ -14,7 +14,7 @@ import {
   ToolModel,
 } from "@/models";
 import type { InternalMcpCatalog } from "@/types";
-import { deduplicateLabels } from "./helpers";
+import { deduplicateLabels, validateUuid } from "./helpers";
 import type { ArchestraContext } from "./types";
 
 // === Constants ===
@@ -967,6 +967,13 @@ export async function handleTool(
           content: [
             { type: "text", text: "Error: MCP server catalog id is required." },
           ],
+          isError: true,
+        };
+      }
+
+      if (!validateUuid(id)) {
+        return {
+          content: [{ type: "text", text: "Error: id must be a valid UUID." }],
           isError: true,
         };
       }

--- a/platform/backend/src/archestra-mcp-server/policies.ts
+++ b/platform/backend/src/archestra-mcp-server/policies.ts
@@ -10,6 +10,7 @@ import {
   type ToolInvocation,
   type TrustedData,
 } from "@/types";
+import { validateUuid } from "./helpers";
 import type { ArchestraContext } from "./types";
 
 // === Constants ===
@@ -564,6 +565,13 @@ export async function handleTool(
         };
       }
 
+      if (!validateUuid(id)) {
+        return {
+          content: [{ type: "text", text: "Error: id must be a valid UUID" }],
+          isError: true,
+        };
+      }
+
       const policy = await ToolInvocationPolicyModel.findById(id);
       if (!policy) {
         return {
@@ -619,6 +627,13 @@ export async function handleTool(
               text: "Error: id parameter is required",
             },
           ],
+          isError: true,
+        };
+      }
+
+      if (!validateUuid(id)) {
+        return {
+          content: [{ type: "text", text: "Error: id must be a valid UUID" }],
           isError: true,
         };
       }
@@ -688,6 +703,13 @@ export async function handleTool(
               text: "Error: id parameter is required",
             },
           ],
+          isError: true,
+        };
+      }
+
+      if (!validateUuid(id)) {
+        return {
+          content: [{ type: "text", text: "Error: id must be a valid UUID" }],
           isError: true,
         };
       }
@@ -823,6 +845,13 @@ export async function handleTool(
         };
       }
 
+      if (!validateUuid(id)) {
+        return {
+          content: [{ type: "text", text: "Error: id must be a valid UUID" }],
+          isError: true,
+        };
+      }
+
       const policy = await TrustedDataPolicyModel.findById(id);
       if (!policy) {
         return {
@@ -878,6 +907,13 @@ export async function handleTool(
               text: "Error: id parameter is required",
             },
           ],
+          isError: true,
+        };
+      }
+
+      if (!validateUuid(id)) {
+        return {
+          content: [{ type: "text", text: "Error: id must be a valid UUID" }],
           isError: true,
         };
       }
@@ -947,6 +983,13 @@ export async function handleTool(
               text: "Error: id parameter is required",
             },
           ],
+          isError: true,
+        };
+      }
+
+      if (!validateUuid(id)) {
+        return {
+          content: [{ type: "text", text: "Error: id must be a valid UUID" }],
           isError: true,
         };
       }


### PR DESCRIPTION
### Summary
This PR implements a UUID validator to prevent database crashes caused by passing non-UUID strings into tool `id` parameters.

Closes #3214

### Changes

- Added `validateUuid()` helper: A new regex-based utility function to quickly verify correct UUID formatting.
- Added validation to tool handlers: Applied the `validateUuid()`check to all tools that accept an `id` parameter.
- Updated tool descriptions: Updated `get_agent`, `get_llm_proxy`, and `get_mcp_gateway` descriptions to guide the LLM to prefer the `name` parameter rather than the `id` field.

### Demos
**1. ID/UUID Validation Test:**


https://github.com/user-attachments/assets/55159564-9d59-4172-8654-b014b3dd82c7

**2. Testing all archestra__ tools:**

https://github.com/user-attachments/assets/c3183bd8-901d-4eb5-81d4-2339c145ca3f

/claim #3214