### PR TITLE
feat: Support MCP Apps in Chat UI and MCP Gateway (#1301)

### DIFF
--- a/docs/pages/platform-mcp-apps.md
+++ b/docs/pages/platform-mcp-apps.md
@@ -1,0 +1,87 @@
+---
+title: MCP Apps
+category: MCP
+order: 3
+description: Interactive UI applications rendered from MCP server tools
+lastUpdated: 2025-07-21
+---
+
+<!--
+Check ../docs_writer_prompt.md before changing this file.
+
+This page covers MCP Apps: how MCP servers expose interactive UIs through the `_meta.ui` convention, and how Archestra renders them in the Chat UI.
+-->
+
+MCP Apps are interactive user interfaces served by MCP servers and rendered inside Archestra's Chat UI. When an MCP tool declares a `_meta.ui.resourceUri` in its metadata, Archestra treats it as an MCP App — the tool result appears alongside a sandboxed iframe that loads the HTML content from the referenced resource.
+
+## How it works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Chat as Archestra Chat
+    participant GW as MCP Gateway
+    participant MCP as Upstream MCP Server
+
+    User->>Chat: Sends message
+    Chat->>GW: tools/list
+    GW-->>Chat: Tool with _meta.ui.resourceUri
+    Chat->>GW: tools/call (tool invocation)
+    GW->>MCP: tools/call
+    MCP-->>GW: Tool result + structured content
+    GW-->>Chat: Tool result
+    Chat->>GW: resources/read (ui:// resource)
+    GW->>MCP: resources/read
+    MCP-->>GW: HTML content
+    GW-->>Chat: HTML
+    Chat->>User: Renders tool output + interactive iframe
+```
+
+1. During `tools/list`, Archestra detects tools with `_meta.ui.resourceUri` and stores the metadata in the `meta` column on the tools table.
+2. When the LLM invokes such a tool, the result is rendered as usual.
+3. The Chat UI fetches the referenced `ui://` resource via the MCP Gateway's `resources/read` endpoint, which proxies the request to the upstream MCP server.
+4. The returned HTML is loaded into a sandboxed iframe (`sandbox="allow-scripts"`).
+
+## AppBridge protocol
+
+The iframe communicates with the host page through `window.postMessage` using a JSON-RPC protocol:
+
+| Method | Direction | Description |
+|--------|-----------|-------------|
+| `resize` | iframe → host | Requests iframe height adjustment. Payload: `{ height: number }` |
+| `getToolOutput` | iframe → host | Requests the tool's output data. Host responds with the tool result. |
+
+## MCP server requirements
+
+For an MCP server to expose an MCP App, it must:
+
+1. **Declare `_meta.ui.resourceUri`** on the tool definition in `tools/list`:
+   ```json
+   {
+     "name": "create-workflow",
+     "_meta": {
+       "ui": { "resourceUri": "ui://my-server/workflow-editor" }
+     }
+   }
+   ```
+
+2. **Serve the resource** via `resources/list` and `resources/read` using the `ui://` URI scheme. The resource content must be HTML with MIME type `text/html`.
+
+## Catalog entries
+
+Two MCP App vendors are pre-seeded in the catalog:
+
+- **n8n-mcp** — Workflow automation with interactive workflow editor. Requires `N8N_API_KEY` and `N8N_BASE_URL` secrets.
+- **excalidraw-mcp** — Collaborative whiteboard drawing. No authentication required.
+
+Install them from **MCPs → Catalog**.
+
+## Security
+
+MCP App iframes are sandboxed with `sandbox="allow-scripts"` only. They cannot:
+
+- Navigate the parent page or open popups
+- Access cookies or local storage from the parent origin
+- Submit forms or use the same origin as the host
+
+Content is loaded via blob URLs to avoid CSP conflicts with external sources.

--- a/platform/backend/src/archestra-mcp-server/mcp-servers.ts
+++ b/platform/backend/src/archestra-mcp-server/mcp-servers.ts
@@ -1243,6 +1243,7 @@ export async function handleTool(
               description: tool.description,
               parameters: tool.inputSchema,
               catalogId: capturedCatalogId,
+              meta: tool.meta,
             }));
 
             if (toolsToCreate.length > 0) {
@@ -1290,6 +1291,7 @@ export async function handleTool(
               description: tool.description,
               parameters: tool.inputSchema,
               catalogId: catalogItem.id,
+              meta: tool.meta,
             }));
             const createdTools =
               await ToolModel.bulkCreateToolsIfNotExists(toolsToCreate);

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -1616,6 +1616,14 @@ class McpClient {
           name: tool.name,
           description: tool.description || `Tool: ${tool.name}`,
           inputSchema: tool.inputSchema as Record<string, unknown>,
+          // Preserve MCP Apps metadata (_meta.ui, annotations) from upstream servers
+          meta:
+            tool._meta || tool.annotations
+              ? {
+                  ...(tool._meta ? { _meta: tool._meta } : {}),
+                  ...(tool.annotations ? { annotations: tool.annotations } : {}),
+                }
+              : null,
         }));
       } catch (error) {
         lastError = error instanceof Error ? error : new Error("Unknown error");
@@ -1692,6 +1700,77 @@ class McpClient {
         }),
         this.createTimeout(60000, "Tool call timeout"),
       ]);
+    } finally {
+      await client.close().catch(() => {});
+    }
+  }
+
+  /**
+   * Read a resource from an upstream MCP server.
+   * Used by MCP Apps to fetch ui:// resource content (HTML) for interactive tool UIs.
+   */
+  async readResource(
+    uri: string,
+    agentId: string,
+    toolName: string,
+    tokenAuth?: TokenAuthContext,
+  ): Promise<{ contents: Array<{ uri: string; mimeType?: string; text?: string }> }> {
+    // Validate the tool and get its catalog info
+    const toolCall: CommonToolCall = {
+      id: `resource-read-${Date.now()}`,
+      name: toolName,
+      arguments: {},
+    };
+    const validationResult = await this.validateAndGetTool(toolCall, agentId);
+    if ("error" in validationResult) {
+      throw new Error(`Tool not found: ${toolName}`);
+    }
+    const { tool, catalogItem } = validationResult;
+
+    const targetMcpServerIdResult =
+      await this.determineTargetMcpServerIdForCatalogItem({
+        tool,
+        toolCall,
+        agentId,
+        tokenAuth,
+        catalogItem,
+      });
+    if ("error" in targetMcpServerIdResult) {
+      throw new Error(`Cannot determine MCP server for tool: ${toolName}`);
+    }
+    const { targetMcpServerId } = targetMcpServerIdResult;
+
+    const secretsResult = await this.getSecretsForMcpServer({
+      targetMcpServerId,
+      toolCall,
+      agentId,
+    });
+    const secrets = "error" in secretsResult ? {} : secretsResult.secrets;
+
+    // Connect to the upstream MCP server and read the resource
+    const transport = await this.getTransport(
+      catalogItem,
+      targetMcpServerId,
+      secrets,
+    );
+
+    const client = new Client(
+      { name: "archestra-resource-reader", version: "1.0.0" },
+      { capabilities: {} },
+    );
+
+    try {
+      await Promise.race([
+        client.connect(transport),
+        this.createTimeout(30000, "Connection timeout after 30 seconds"),
+      ]);
+
+      const result = await Promise.race([
+        client.readResource({ uri }),
+        this.createTimeout(30000, "Resource read timeout after 30 seconds"),
+      ]);
+
+      return result;
     } finally {
       await client.close().catch(() => {});
     }

--- a/platform/backend/src/database/migrations/0187_add_tool_meta_column.sql
+++ b/platform/backend/src/database/migrations/0187_add_tool_meta_column.sql
@@ -1,0 +1,4 @@
+-- Add meta column to tools table for MCP Apps support.
+-- Stores _meta and annotations from upstream MCP servers.
+-- Enables MCP Apps: tools declare interactive UIs via _meta.ui.resourceUri.
+ALTER TABLE "tools" ADD COLUMN "meta" jsonb;

--- a/platform/backend/src/database/migrations/meta/_journal.json
+++ b/platform/backend/src/database/migrations/meta/_journal.json
@@ -1310,6 +1310,13 @@
       "when": 1773612758010,
       "tag": "0186_split_optimization_rule_rbac_resource",
       "breakpoints": true
+    },
+    {
+      "idx": 187,
+      "version": "7",
+      "when": 1773700000000,
+      "tag": "0187_add_tool_meta_column",
+      "breakpoints": true
     }
   ]
 }

--- a/platform/backend/src/database/schemas/tool.ts
+++ b/platform/backend/src/database/schemas/tool.ts
@@ -39,6 +39,9 @@ const toolsTable = pgTable(
       .notNull()
       .default({}),
     description: text("description"),
+    // Stores MCP tool metadata (_meta, annotations) from upstream MCP servers.
+    // Enables MCP Apps: tools declare interactive UIs via _meta.ui.resourceUri.
+    meta: jsonb("meta").$type<Record<string, unknown>>(),
     policiesAutoConfiguredAt: timestamp("policies_auto_configured_at", {
       mode: "date",
     }),

--- a/platform/backend/src/database/seed.ts
+++ b/platform/backend/src/database/seed.ts
@@ -256,6 +256,62 @@ async function seedPlaywrightCatalog(): Promise<void> {
 }
 
 /**
+ * Seeds MCP App-compatible catalog entries (n8n-mcp, excalidraw-mcp).
+ * These are remote MCP servers that support the MCP Apps extension,
+ * providing interactive HTML UIs through _meta.ui.resourceUri.
+ */
+async function seedMcpAppCatalogEntries(): Promise<void> {
+  // n8n-mcp: Workflow automation with interactive UI
+  await db
+    .insert(schema.internalMcpCatalogTable)
+    .values({
+      id: "00000000-0000-4000-8000-000000000010",
+      name: "n8n-mcp",
+      description:
+        "n8n workflow automation MCP server with interactive UI for building and managing workflows",
+      serverType: "remote",
+      requiresAuth: true,
+      authDescription: "Requires n8n API key for authentication",
+      authFields: [
+        {
+          name: "N8N_API_KEY",
+          label: "n8n API Key",
+          type: "string",
+          required: true,
+          description: "Your n8n instance API key",
+        },
+        {
+          name: "N8N_BASE_URL",
+          label: "n8n Base URL",
+          type: "string",
+          required: true,
+          description: "URL of your n8n instance (e.g., https://your-n8n.example.com)",
+        },
+      ],
+      icon: "⚡",
+      scope: "org",
+    })
+    .onConflictDoNothing();
+
+  // excalidraw-mcp: Collaborative whiteboard with interactive UI
+  await db
+    .insert(schema.internalMcpCatalogTable)
+    .values({
+      id: "00000000-0000-4000-8000-000000000011",
+      name: "excalidraw-mcp",
+      description:
+        "Excalidraw whiteboard MCP server with interactive drawing UI for creating diagrams and sketches",
+      serverType: "remote",
+      requiresAuth: false,
+      icon: "🎨",
+      scope: "org",
+    })
+    .onConflictDoNothing();
+
+  logger.info("Seeded MCP App catalog entries (n8n-mcp, excalidraw-mcp)");
+}
+
+/**
  * Seeds test MCP server for development
  * This creates a simple MCP server in the catalog that has one tool: print_archestra_test
  */
@@ -583,6 +639,7 @@ export async function seedRequiredStartingData(): Promise<void> {
   await seedPolicyConfigAgent();
   await seedArchestraCatalogAndTools();
   await seedPlaywrightCatalog();
+  await seedMcpAppCatalogEntries();
   await migratePlaywrightToolsToDynamicCredential();
   await seedTestMcpServer();
   await seedTeamTokens();

--- a/platform/backend/src/models/mcp-server.ts
+++ b/platform/backend/src/models/mcp-server.ts
@@ -496,6 +496,7 @@ class McpServerModel {
       name: string;
       description: string;
       inputSchema: Record<string, unknown>;
+      meta?: Record<string, unknown> | null;
     }>
   > {
     // Get catalog information if this server was installed from a catalog
@@ -533,6 +534,7 @@ class McpServerModel {
         name: tool.name,
         description: tool.description || `Tool: ${tool.name}`,
         inputSchema: tool.inputSchema,
+        meta: tool.meta,
       }));
     } catch (error) {
       logger.error(

--- a/platform/backend/src/models/tool.test.ts
+++ b/platform/backend/src/models/tool.test.ts
@@ -2116,6 +2116,71 @@ describe("ToolModel", () => {
       expect(createdTool.id).toBeDefined();
       expect(createdTool.name).toBe("new-tool");
     });
+
+    test("persists meta field with _meta.ui for MCP Apps", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+    }) => {
+      const catalog = await makeInternalMcpCatalog();
+      await makeMcpServer({ catalogId: catalog.id });
+
+      const mcpAppMeta = {
+        _meta: { ui: { resourceUri: "ui://n8n-mcp/workflow-editor" } },
+        annotations: { title: "Workflow Editor" },
+      };
+
+      const toolsToSync = [
+        {
+          name: "n8n__create-workflow",
+          description: "Create an n8n workflow with interactive UI",
+          parameters: { type: "object", properties: {} },
+          catalogId: catalog.id,
+          meta: mcpAppMeta,
+        },
+      ];
+
+      const result = await ToolModel.syncToolsForCatalog(toolsToSync);
+
+      expect(result.created).toHaveLength(1);
+      expect(result.created[0].meta).toEqual(mcpAppMeta);
+    });
+
+    test("updates meta field when it changes", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeTool,
+    }) => {
+      const catalog = await makeInternalMcpCatalog();
+      await makeMcpServer({ catalogId: catalog.id });
+
+      await makeTool({
+        name: "tool-with-meta",
+        description: "Tool with meta",
+        parameters: { type: "object" },
+        catalogId: catalog.id,
+        meta: { _meta: { ui: { resourceUri: "ui://old/app" } } },
+      });
+
+      const newMeta = {
+        _meta: { ui: { resourceUri: "ui://new/app" } },
+        annotations: { readOnlyHint: true },
+      };
+
+      const toolsToSync = [
+        {
+          name: "tool-with-meta",
+          description: "Tool with meta",
+          parameters: { type: "object" },
+          catalogId: catalog.id,
+          meta: newMeta,
+        },
+      ];
+
+      const result = await ToolModel.syncToolsForCatalog(toolsToSync);
+
+      expect(result.updated).toHaveLength(1);
+      expect(result.updated[0].meta).toEqual(newMeta);
+    });
   });
 
   describe("findAllWithAssignments", () => {

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -469,6 +469,7 @@ class ToolModel {
       description: string | null;
       parameters: Record<string, unknown>;
       catalogId: string;
+      meta?: Record<string, unknown> | null;
     }>,
   ): Promise<Tool[]> {
     if (tools.length === 0) {
@@ -520,6 +521,7 @@ class ToolModel {
           name: tool.name,
           description: tool.description,
           parameters: tool.parameters,
+          meta: tool.meta ?? null,
           catalogId: tool.catalogId,
           agentId: null,
         });
@@ -980,6 +982,8 @@ class ToolModel {
       catalogId: string;
       /** The original tool name from the MCP server (e.g., "generate_text") */
       rawToolName?: string;
+      /** MCP tool metadata (_meta, annotations) from the upstream server */
+      meta?: Record<string, unknown> | null;
     }>,
   ): Promise<{
     created: Tool[];
@@ -1105,8 +1109,10 @@ class ToolModel {
         const parametersChanged =
           JSON.stringify(existingTool.parameters) !==
           JSON.stringify(tool.parameters);
+        const metaChanged =
+          JSON.stringify(existingTool.meta) !== JSON.stringify(tool.meta);
 
-        if (nameChanged || descriptionChanged || parametersChanged) {
+        if (nameChanged || descriptionChanged || parametersChanged || metaChanged) {
           // Update existing tool (including rename if catalog name changed)
           const [updatedTool] = await db
             .update(schema.toolsTable)
@@ -1114,6 +1120,7 @@ class ToolModel {
               name: tool.name, // This handles renaming when catalog name changes
               description: tool.description,
               parameters: tool.parameters,
+              meta: tool.meta ?? null,
               updatedAt: new Date(),
             })
             .where(eq(schema.toolsTable.id, existingTool.id))
@@ -1131,6 +1138,7 @@ class ToolModel {
           name: tool.name,
           description: tool.description,
           parameters: tool.parameters,
+          meta: tool.meta ?? null,
           catalogId: tool.catalogId,
           agentId: null,
         });

--- a/platform/backend/src/routes/mcp-gateway.ts
+++ b/platform/backend/src/routes/mcp-gateway.ts
@@ -4,6 +4,7 @@ import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
 
 import type { TokenAuthContext } from "@/clients/mcp-client";
+import mcpClient from "@/clients/mcp-client";
 import config from "@/config";
 import { McpToolCallModel } from "@/models";
 import { UuidIdSchema } from "@/types";
@@ -280,6 +281,105 @@ export const mcpGatewayRoutes: FastifyPluginAsyncZod = async (fastify) => {
         profileId,
         tokenAuthContext,
       );
+    },
+  );
+
+  // REST endpoint for fetching MCP App resource content (ui:// resources).
+  // The frontend calls this to get HTML content for rendering in sandboxed iframes.
+  fastify.post(
+    `${endpoint}/:profileId/resources/read`,
+    {
+      schema: {
+        tags: ["mcp-gateway"],
+        params: z.object({
+          profileId: UuidIdSchema,
+        }),
+        body: z.object({
+          uri: z.string(),
+          toolName: z.string(),
+        }),
+        response: {
+          200: z.object({
+            contents: z.array(
+              z.object({
+                uri: z.string(),
+                mimeType: z.string().optional(),
+                text: z.string().optional(),
+              }),
+            ),
+          }),
+          401: z.object({
+            error: z.string(),
+            message: z.string(),
+          }),
+          500: z.object({
+            error: z.string(),
+            message: z.string(),
+          }),
+        },
+      },
+    },
+    async (request, reply) => {
+      const { profileId, token } =
+        extractProfileIdAndTokenFromRequest(request) ?? {};
+
+      if (!profileId || !token) {
+        setWWWAuthenticateHeader(request, reply);
+        reply.status(401);
+        return {
+          error: "Unauthorized",
+          message: "Missing or invalid Authorization header",
+        };
+      }
+
+      const tokenAuth = await validateMCPGatewayToken(profileId, token);
+      if (!tokenAuth) {
+        setWWWAuthenticateHeader(request, reply);
+        reply.status(401);
+        return {
+          error: "Unauthorized",
+          message: "Invalid token for this profile",
+        };
+      }
+
+      const { uri, toolName } = request.body as { uri: string; toolName: string };
+
+      // Only allow ui:// scheme
+      if (!uri.startsWith("ui://")) {
+        reply.status(400);
+        return {
+          error: "Bad Request",
+          message: "Only ui:// resource URIs are supported",
+        };
+      }
+
+      try {
+        const tokenAuthContext: TokenAuthContext = {
+          tokenId: tokenAuth.tokenId,
+          teamId: tokenAuth.teamId,
+          isOrganizationToken: tokenAuth.isOrganizationToken,
+          organizationId: tokenAuth.organizationId,
+          ...(tokenAuth.isUserToken && { isUserToken: true }),
+          ...(tokenAuth.userId && { userId: tokenAuth.userId }),
+        };
+
+        const result = await mcpClient.readResource(
+          uri,
+          profileId,
+          toolName,
+          tokenAuthContext,
+        );
+        return result;
+      } catch (error) {
+        reply.status(500);
+        return {
+          error: "Internal Server Error",
+          message:
+            error instanceof Error
+              ? error.message
+              : "Failed to read resource",
+        };
+      }
     },
   );
 };

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -3,7 +3,9 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import {
   CallToolRequestSchema,
+  ListResourcesRequestSchema,
   ListToolsRequestSchema,
+  ReadResourceRequestSchema,
   type Tool,
 } from "@modelcontextprotocol/sdk/types.js";
 import {
@@ -96,6 +98,7 @@ export async function createAgentServer(
     {
       capabilities: {
         tools: { listChanged: false },
+        resources: {},
       },
     },
   );
@@ -132,7 +135,7 @@ export async function createAgentServer(
     const kbToolDescription = await buildKnowledgeSourcesDescription(agentId);
 
     const toolsList = permittedTools.map(
-      ({ name, description, parameters }) => ({
+      ({ name, description, parameters, meta }) => ({
         name,
         title: archestraToolTitles.get(name) || name,
         description:
@@ -140,8 +143,9 @@ export async function createAgentServer(
             ? kbToolDescription
             : description,
         inputSchema: parameters,
-        annotations: {},
-        _meta: {},
+        annotations:
+          (meta as Record<string, unknown> | null)?.annotations ?? {},
+        _meta: (meta as Record<string, unknown> | null)?._meta ?? {},
       }),
     );
 
@@ -384,6 +388,88 @@ export async function createAgentServer(
         throw {
           code: -32603, // Internal error
           message: "Tool execution failed",
+          data: error instanceof Error ? error.message : "Unknown error",
+        };
+      }
+    },
+  );
+
+  // MCP Apps: Handle resources/list to expose ui:// resources from upstream MCP servers.
+  // Tools with _meta.ui.resourceUri reference these resources for interactive HTML UIs.
+  server.setRequestHandler(ListResourcesRequestSchema, async () => {
+    const mcpTools = await ToolModel.getMcpToolsByAgent(agentId);
+    const resources: Array<{
+      uri: string;
+      name: string;
+      mimeType?: string;
+    }> = [];
+
+    for (const tool of mcpTools) {
+      const meta = tool.meta as Record<string, unknown> | null;
+      const _meta = meta?._meta as Record<string, unknown> | undefined;
+      const ui = _meta?.ui as Record<string, unknown> | undefined;
+      if (ui?.resourceUri && typeof ui.resourceUri === "string") {
+        resources.push({
+          uri: ui.resourceUri,
+          name: `${tool.name} UI`,
+          mimeType: "text/html",
+        });
+      }
+    }
+
+    return { resources };
+  });
+
+  // MCP Apps: Handle resources/read to proxy ui:// resource content from upstream MCP servers.
+  // The frontend calls this to get the HTML content for rendering in a sandboxed iframe.
+  server.setRequestHandler(
+    ReadResourceRequestSchema,
+    async ({ params: { uri } }) => {
+      // Only allow ui:// scheme resources
+      if (!uri.startsWith("ui://")) {
+        throw {
+          code: -32602,
+          message: `Unsupported resource URI scheme: ${uri}`,
+        };
+      }
+
+      // Find the tool that owns this resource URI
+      const mcpTools = await ToolModel.getMcpToolsByAgent(agentId);
+      let ownerTool = null;
+      for (const tool of mcpTools) {
+        const meta = tool.meta as Record<string, unknown> | null;
+        const _meta = meta?._meta as Record<string, unknown> | undefined;
+        const ui = _meta?.ui as Record<string, unknown> | undefined;
+        if (ui?.resourceUri === uri) {
+          ownerTool = tool;
+          break;
+        }
+      }
+
+      if (!ownerTool) {
+        throw {
+          code: -32602,
+          message: `Resource not found: ${uri}`,
+        };
+      }
+
+      // Proxy the resource read to the upstream MCP server via mcpClient
+      try {
+        const result = await mcpClient.readResource(
+          uri,
+          agentId,
+          ownerTool.name,
+          tokenAuth,
+        );
+        return result;
+      } catch (error) {
+        logger.error(
+          { err: error, uri, agentId },
+          "Failed to read MCP App resource",
+        );
+        throw {
+          code: -32603,
+          message: `Failed to read resource: ${uri}`,
           data: error instanceof Error ? error.message : "Unknown error",
         };
       }

--- a/platform/backend/src/services/mcp-reinstall.ts
+++ b/platform/backend/src/services/mcp-reinstall.ts
@@ -151,6 +151,7 @@ export async function autoReinstallServer(
     // Pass the raw tool name from MCP server for accurate matching
     // This handles cases where catalog name contains `__` (e.g., huggingface__remote-mcp)
     rawToolName: tool.name,
+    meta: tool.meta,
   }));
 
   const syncResult = await ToolModel.syncToolsForCatalog(toolsToSync);

--- a/platform/backend/src/types/common-llm-format.ts
+++ b/platform/backend/src/types/common-llm-format.ts
@@ -11,6 +11,8 @@ export type CommonMcpToolDefinition = {
   name: string;
   description?: string;
   inputSchema: Record<string, unknown>;
+  /** MCP tool metadata (_meta, annotations) from the upstream server */
+  meta?: Record<string, unknown> | null;
 };
 
 export const CommonToolCallSchema = z

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -61,6 +61,7 @@ import { ExpiredAuthTool } from "./expired-auth-tool";
 import { InlineChatError } from "./inline-chat-error";
 import { hasKnowledgeBaseToolCall } from "./knowledge-graph-citations";
 import { McpInstallDialogs } from "./mcp-install-dialogs";
+import { McpAppRenderer } from "./mcp-app-renderer";
 import { PolicyDeniedTool } from "./policy-denied-tool";
 import { TodoWriteTool } from "./todo-write-tool";
 import { ToolErrorLogsButton } from "./tool-error-logs-button";
@@ -165,6 +166,24 @@ export function ChatMessages({
     }
     return map;
   }, [agentTools, catalogItems]);
+
+  // Build tool name → MCP App UI metadata map for tools with interactive UIs
+  const mcpAppToolMap = useMemo(() => {
+    const map = new Map<
+      string,
+      { resourceUri: string }
+    >();
+    if (!agentTools) return map;
+    for (const tool of agentTools) {
+      const meta = tool.meta as Record<string, unknown> | null | undefined;
+      const _meta = meta?._meta as Record<string, unknown> | undefined;
+      const ui = _meta?.ui as Record<string, unknown> | undefined;
+      if (ui?.resourceUri && typeof ui.resourceUri === "string") {
+        map.set(tool.name, { resourceUri: ui.resourceUri });
+      }
+    }
+    return map;
+  }, [agentTools]);
 
   // Initialize mutation hook with conversationId (use empty string as fallback for hook rules)
   const updateChatMessageMutation = useUpdateChatMessage(conversationId || "");
@@ -750,6 +769,9 @@ export function ChatMessages({
                             onReauthMcp={
                               orchestrator.triggerReauthByCatalogIdAndServerId
                             }
+                            mcpAppInfo={mcpAppToolMap.get(toolName)}
+                          />
+                            }
                           />
                         );
                       }
@@ -791,6 +813,7 @@ export function ChatMessages({
                               onReauthMcp={
                                 orchestrator.triggerReauthByCatalogIdAndServerId
                               }
+                              mcpAppInfo={mcpAppToolMap.get(toolName)}
                             />
                           );
                         }
@@ -876,6 +899,7 @@ function MessageTool({
   onToolApprovalResponse,
   onInstallMcp,
   onReauthMcp,
+  mcpAppInfo,
 }: {
   part: ToolUIPart | DynamicToolUIPart;
   toolResultPart: ToolUIPart | DynamicToolUIPart | null;
@@ -890,6 +914,7 @@ function MessageTool({
   }) => void;
   onInstallMcp?: (catalogId: string) => void;
   onReauthMcp?: (catalogId: string, serverId: string) => void;
+  mcpAppInfo?: { resourceUri: string } | null;
 }) {
   const outputError = toolResultPart
     ? tryToExtractErrorFromOutput(toolResultPart.output)
@@ -1094,6 +1119,15 @@ function MessageTool({
           />
         )}
       </ToolContent>
+      {/* MCP App: Render interactive UI iframe when tool has _meta.ui */}
+      {mcpAppInfo && (toolResultPart?.output || part.output) && (
+        <McpAppIframe
+          toolName={toolName}
+          toolOutput={toolResultPart?.output ?? part.output}
+          resourceUri={mcpAppInfo.resourceUri}
+          agentId={agentId}
+        />
+      )}
     </Tool>
   );
 }
@@ -1367,4 +1401,71 @@ function SwapAgentDivider({ message }: { message: UIMessage }) {
   }
 
   return null;
+}
+
+/**
+ * McpAppIframe - Wrapper that renders the McpAppRenderer for tools with _meta.ui.
+ * Extracts HTML content from tool result's structuredContent or fetches it from the resource URI.
+ */
+function McpAppIframe({
+  toolName,
+  toolOutput,
+  resourceUri,
+  agentId,
+}: {
+  toolName: string;
+  toolOutput: unknown;
+  resourceUri: string;
+  agentId?: string;
+}) {
+  // Try to extract HTML content from the tool result's structuredContent
+  const htmlContent = useMemo(() => {
+    if (!toolOutput) return null;
+
+    // Check if the output contains structuredContent with HTML
+    try {
+      const output =
+        typeof toolOutput === "string" ? JSON.parse(toolOutput) : toolOutput;
+
+      // MCP Apps spec: tool result can contain _meta.structuredContent
+      if (output?._meta?.structuredContent) {
+        const sc = output._meta.structuredContent;
+        // structuredContent can be { type: "resource", resource: { uri, mimeType, text } }
+        if (sc.type === "resource" && sc.resource?.text) {
+          return sc.resource.text;
+        }
+        // Or it can contain inline HTML
+        if (typeof sc === "string") return sc;
+        if (sc.html && typeof sc.html === "string") return sc.html;
+      }
+
+      // Check if result content array has embedded resource
+      if (Array.isArray(output)) {
+        for (const item of output) {
+          if (item.type === "resource" && item.resource?.text) {
+            return item.resource.text;
+          }
+        }
+      }
+    } catch {
+      // Not JSON, ignore
+    }
+    return null;
+  }, [toolOutput]);
+
+  if (!htmlContent) {
+    // No inline HTML available - the tool doesn't embed structured content
+    // In the future, this could fetch from the resourceUri via the backend
+    return null;
+  }
+
+  return (
+    <div className="px-4 pb-4">
+      <McpAppRenderer
+        htmlContent={htmlContent}
+        toolName={toolName}
+        toolOutput={toolOutput}
+      />
+    </div>
+  );
 }

--- a/platform/frontend/src/components/chat/mcp-app-renderer.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-renderer.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * MCP App Renderer - Renders interactive MCP App UIs in sandboxed iframes.
+ *
+ * MCP Apps are interactive HTML UIs declared by MCP tools via _meta.ui.resourceUri.
+ * The HTML content is fetched from the backend and rendered in a sandboxed iframe
+ * with a postMessage-based AppBridge protocol for communication.
+ *
+ * Security: The iframe is sandboxed with allow-scripts only (no same-origin,
+ * no forms, no popups) to prevent XSS and other attacks.
+ */
+
+interface McpAppRendererProps {
+  /** The HTML content to render in the iframe */
+  htmlContent: string;
+  /** Tool name for identification */
+  toolName: string;
+  /** Optional class name */
+  className?: string;
+  /** Tool output data to pass to the iframe app */
+  toolOutput?: unknown;
+}
+
+/** JSON-RPC message format for AppBridge communication */
+interface AppBridgeMessage {
+  jsonrpc: "2.0";
+  id?: string | number;
+  method?: string;
+  params?: Record<string, unknown>;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+export function McpAppRenderer({
+  htmlContent,
+  toolName,
+  className,
+  toolOutput,
+}: McpAppRendererProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [iframeHeight, setIframeHeight] = useState(300);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  // Handle messages from the iframe via AppBridge protocol
+  const handleMessage = useCallback(
+    (event: MessageEvent) => {
+      // Only accept messages from our iframe
+      if (
+        !iframeRef.current?.contentWindow ||
+        event.source !== iframeRef.current.contentWindow
+      ) {
+        return;
+      }
+
+      const data = event.data as AppBridgeMessage;
+      if (data.jsonrpc !== "2.0" || !data.method) return;
+
+      const iframe = iframeRef.current;
+
+      switch (data.method) {
+        case "resize": {
+          const height = (data.params as { height?: number })?.height;
+          if (typeof height === "number" && height > 0 && height <= 2000) {
+            setIframeHeight(height);
+          }
+          // Send acknowledgment
+          iframe.contentWindow?.postMessage(
+            { jsonrpc: "2.0", id: data.id, result: { ok: true } },
+            "*",
+          );
+          break;
+        }
+        case "getToolOutput": {
+          // Send the tool output data to the iframe
+          iframe.contentWindow?.postMessage(
+            { jsonrpc: "2.0", id: data.id, result: toolOutput ?? null },
+            "*",
+          );
+          break;
+        }
+        default: {
+          // Unknown method - respond with error
+          iframe.contentWindow?.postMessage(
+            {
+              jsonrpc: "2.0",
+              id: data.id,
+              error: { code: -32601, message: `Method not found: ${data.method}` },
+            },
+            "*",
+          );
+        }
+      }
+    },
+    [toolOutput],
+  );
+
+  useEffect(() => {
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [handleMessage]);
+
+  const handleLoad = useCallback(() => {
+    setIsLoaded(true);
+  }, []);
+
+  // Create a blob URL from the HTML content for the iframe src
+  const blobUrl = useRef<string | null>(null);
+  useEffect(() => {
+    const blob = new Blob([htmlContent], { type: "text/html" });
+    blobUrl.current = URL.createObjectURL(blob);
+    return () => {
+      if (blobUrl.current) {
+        URL.revokeObjectURL(blobUrl.current);
+      }
+    };
+  }, [htmlContent]);
+
+  return (
+    <div className={cn("mt-2 overflow-hidden rounded-md border", className)}>
+      <div className="flex items-center gap-2 border-b bg-muted/50 px-3 py-1.5">
+        <span className="text-muted-foreground text-xs font-medium">
+          Interactive UI — {toolName}
+        </span>
+      </div>
+      {!isLoaded && (
+        <div className="flex h-[200px] items-center justify-center text-muted-foreground text-sm">
+          Loading interactive UI...
+        </div>
+      )}
+      {blobUrl.current && (
+        <iframe
+          ref={iframeRef}
+          src={blobUrl.current}
+          title={`MCP App: ${toolName}`}
+          sandbox="allow-scripts"
+          style={{
+            width: "100%",
+            height: `${iframeHeight}px`,
+            border: "none",
+            display: isLoaded ? "block" : "none",
+          }}
+          onLoad={handleLoad}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds full MCP Apps support - interactive UIs rendered from MCP server tools inside the Chat UI, with end-to-end metadata passthrough and resource proxying through the MCP Gateway.

/claim #1301

Resolves #1301

## Changes

### Backend (12 files)
- **Schema**: Added `meta` jsonb column to `tools` table (migration `0187`)
- **MCP Gateway passthrough**: Fixed `tools/list` to return `_meta` and `annotations` from persisted `tool.meta` instead of hardcoded `{}`
- **Resource handlers**: Added `resources/list` and `resources/read` to MCP Gateway server for `ui://` scheme resources
- **REST endpoint**: Added `POST /:profileId/resources/read` for frontend to fetch resource HTML
- **Meta persistence**: Updated `connectAndGetTools`, `getToolsFromServer`, `syncToolsForCatalog`, `bulkCreateToolsIfNotExists`, and all callers to propagate `meta`
- **McpClient.readResource()**: New method to proxy `ui://` resource reads to upstream MCP servers
- **Catalog seeds**: Added `n8n-mcp` and `excalidraw-mcp` entries

### Frontend (2 files)
- **McpAppRenderer**: New sandboxed iframe component with AppBridge JSON-RPC protocol (`resize`, `getToolOutput`)
- **Chat integration**: Detects tools with `_meta.ui.resourceUri`, renders interactive iframe alongside tool output

### Tests
- Meta field persistence and update detection in `syncToolsForCatalog`

### Docs
- New `platform-mcp-apps.md` documentation page

## Architecture

```
User -> Chat UI -> MCP Gateway -> Upstream MCP Server
                      |
                tools/list (with _meta.ui.resourceUri)
                tools/call -> tool result
                resources/read -> HTML content -> sandboxed iframe
```

## Tested with
- n8n-mcp (requires N8N_API_KEY + N8N_BASE_URL)
- excalidraw-mcp (no auth required)