### PR TITLE
feat: Support MCP Apps in Chat UI and MCP Gateway (#1301)

### DIFF
--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -310,6 +310,7 @@ class McpClient {
           mcpServerName,
           result.content,
           !!result.isError,
+          result._meta,
           authInfo,
         );
       } catch (error) {
@@ -1281,6 +1282,7 @@ class McpClient {
     mcpServerName: string,
     content: unknown,
     isError: boolean,
+    _meta?: unknown,
     authInfo?: {
       userId?: string;
       authMethod?: MCPGatewayAuthMethod;
@@ -1291,6 +1293,7 @@ class McpClient {
       name: toolCall.name,
       content,
       isError,
+      _meta,
     };
 
     await this.persistToolCall(

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -362,6 +362,7 @@ export async function createAgentServer(
             ? result.content
             : [{ type: "text", text: JSON.stringify(result.content) }],
           isError: result.isError,
+          _meta: result._meta,
         };
       } catch (error) {
         const durationSeconds = (Date.now() - startTime) / 1000;

--- a/platform/backend/src/types/common-llm-format.ts
+++ b/platform/backend/src/types/common-llm-format.ts
@@ -29,6 +29,7 @@ export type CommonToolResult = {
   content: unknown;
   isError: boolean;
   error?: string;
+  _meta?: unknown;
 };
 
 /**

--- a/platform/frontend/package.json
+++ b/platform/frontend/package.json
@@ -23,6 +23,7 @@
     "@daveyplate/better-auth-ui": "github:archestra-ai/better-auth-ui#516664e",
     "@ferrucc-io/emoji-picker": "^0.0.48",
     "@hookform/resolvers": "^5.2.2",
+    "@mcp-ui/client": "^0.1.0",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -1,4 +1,5 @@
 import type { UIMessage } from "@ai-sdk/react";
+import { AppRenderer } from "@mcp-ui/client";
 import {
   SWAP_AGENT_POKE_PREFIX,
   SWAP_AGENT_POKE_TEXT,
@@ -1080,19 +1081,41 @@ function MessageTool({
           )}
         {errorText ? <ToolErrorDetails errorText={errorText} /> : null}
         {toolResultPart && (
-          <ToolOutput
-            label={errorText ? "Error" : "Result"}
-            output={toolResultPart.output}
-            errorText={errorText}
-          />
+          (toolResultPart.output as any)?._meta?.ui?.resourceUri ? (
+            <div className="px-4 pb-4">
+              <AppRenderer
+                resourceUri={
+                  (toolResultPart.output as any)._meta.ui.resourceUri
+                }
+                toolInput={part.input}
+                toolResult={toolResultPart.output}
+              />
+            </div>
+          ) : (
+            <ToolOutput
+              label={errorText ? "Error" : "Result"}
+              output={toolResultPart.output}
+              errorText={errorText}
+            />
+          )
         )}
-        {!toolResultPart && Boolean(part.output) && (
-          <ToolOutput
-            label={errorText ? "Error" : "Result"}
-            output={part.output}
-            errorText={errorText}
-          />
-        )}
+        {!toolResultPart &&
+          Boolean(part.output) &&
+          ((part.output as any)?._meta?.ui?.resourceUri ? (
+            <div className="px-4 pb-4">
+              <AppRenderer
+                resourceUri={(part.output as any)._meta.ui.resourceUri}
+                toolInput={part.input}
+                toolResult={part.output}
+              />
+            </div>
+          ) : (
+            <ToolOutput
+              label={errorText ? "Error" : "Result"}
+              output={part.output}
+              errorText={errorText}
+            />
+          ))}
       </ToolContent>
     </Tool>
   );


### PR DESCRIPTION
## Description

This PR implements support for [MCP Apps](https://modelcontextprotocol.io/docs/extensions/apps) (formerly known as 'mcp-ui') in the Archestra platform.

### Changes:

- **Backend/Gateways:** Added support for persisting and passing the '_meta' field from MCP tool results through the tool execution pipeline.
- **Frontend:** Integrated '@mcp-ui/client' and added 'AppRenderer' to 'ChatMessageTool' to render interactive UI components when 'resourceUri' is present in the tool output '_meta'.

### Verification:

1. Integrated '@mcp-ui/client' into 'platform/frontend/package.json'.
2. Verified tool execution correctly captures and passes '_meta'.
3. Verified 'AppRenderer' correctly detects 'resourceUri' and renders the sandboxed iframe for interactive tools.

/claim #1301