### PR TITLE
fix: prioritize current agent over personal agent in selector sort

### DIFF
--- a/platform/frontend/src/components/chat/initial-agent-selector.utils.test.ts
+++ b/platform/frontend/src/components/chat/initial-agent-selector.utils.test.ts
@@ -53,7 +53,7 @@ describe("filterAndSortInitialAgents", () => {
     expect(result.map((agent) => agent.id)).toEqual(["mine", "shared"]);
   });
 
-  it("prioritizes the current user's personal agent over the selected shared agent", () => {
+  it("puts the current agent first even if it is a shared agent", () => {
     const agents = [
       makeAgent({
         id: "shared",
@@ -75,7 +75,7 @@ describe("filterAndSortInitialAgents", () => {
       userId,
     });
 
-    expect(result.map((agent) => agent.id)).toEqual(["personal", "shared"]);
+    expect(result.map((agent) => agent.id)).toEqual(["shared", "personal"]);
   });
 
   it("keeps the selected non-personal agent first after the personal-agent priority", () => {

--- a/platform/frontend/src/components/chat/initial-agent-selector.utils.ts
+++ b/platform/frontend/src/components/chat/initial-agent-selector.utils.ts
@@ -32,6 +32,9 @@ export function filterAndSortInitialAgents(params: {
   }
 
   return [...result].sort((a, b) => {
+    if (a.id === currentAgentId) return -1;
+    if (b.id === currentAgentId) return 1;
+
     const aIsMyPersonalAgent =
       a.scope === "personal" && a.authorId === userId ? 1 : 0;
     const bIsMyPersonalAgent =
@@ -40,8 +43,6 @@ export function filterAndSortInitialAgents(params: {
     if (aIsMyPersonalAgent !== bIsMyPersonalAgent) {
       return bIsMyPersonalAgent - aIsMyPersonalAgent;
     }
-    if (a.id === currentAgentId) return -1;
-    if (b.id === currentAgentId) return 1;
     if (getScopeOrder(a.scope) !== getScopeOrder(b.scope)) {
       return getScopeOrder(a.scope) - getScopeOrder(b.scope);
     }


### PR DESCRIPTION
Current agent now always appears first in the initial agent selector, regardless of whether it's a personal or shared agent.