### PR TITLE
fix: chat blinking

### DIFF
--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -883,9 +883,9 @@ function getMessagePartSignature(part: UIMessage["parts"][number]): string {
 
   switch (part.type) {
     case "text":
-      return `text:${part.text}`;
+      return "text";
     case "reasoning":
-      return `reasoning:${part.text}`;
+      return "reasoning";
     case "file":
       return `file:${part.url}:${part.mediaType}:${part.filename ?? ""}`;
     default:


### PR DESCRIPTION
                                                                                                                                                                                                                                                                           
  The getMessagePartSignature() function (introduced in #3324) included the full text content in the React key for text and reasoning parts. During streaming, every new chunk changed part.text, producing a new key, which caused React to unmount and remount the entire message component tree on     
  every update — resulting in visible blinking/flickering.                         
                                                                                                                                                                                                                                                                                                          
  Key generation before #3324:                                                                                                                                                                                                                                                                            
  ${message.id}-${partIndex}
  → "msg123-0", "msg123-1", "msg123-2"                                                                                                                                                                                                                                                                    
  Stable during streaming — keys never change as text grows.                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                          
  Key generation after #3324 (broken):                                                                                                                                                                                                                                                                    
  ${messageId}-text:${part.text}-${occurrence}                                                                                                                                                                                                                                                            
  → "msg123-text:Hello-0"                                                                                                                                                                                                                                                                                 
  → "msg123-text:Hello world-0"                                                                                                                                                                                                                                                                           
  → "msg123-text:Hello world, how are-0"                                                                                                                                                                                                                                                                  
  Key changes on every streaming chunk → React unmounts/remounts the entire EditableAssistantMessage → Response → Streamdown component tree each time → visible blinking.                                                                                                                                 
                                                                                                                                                                                                                                                                                                          
  Key generation after this fix:                                                                                                                                                                                                                                                                          
  ${messageId}-text-${occurrence}                                                                                                                                                                                                                                                                         
  → "msg123-text-0", "msg123-text-1"    