### PR TITLE
chore: polish snow metadata

### DIFF
--- a/platform/backend/src/knowledge-base/connectors/servicenow/servicenow-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/servicenow/servicenow-connector.ts
@@ -500,7 +500,6 @@ function dv(field: ServiceNowDisplayValue | undefined): string {
   return field?.display_value ?? field?.value ?? "";
 }
 
-
 function recordToDocument(
   record: ServiceNowRecord,
   instanceUrl: string,


### PR DESCRIPTION
Added 4 metadata fields to ServiceNow incident sync:
- severity — incident severity level
- company — company/customer affected (display name)
- businessService — business service affected (display name)
- problem — linked problem record number (display name)

All fields are only included in metadata when non-empty. No schema changes needed — metadata flows automatically into chunk embeddings and keyword search.