### PR TITLE
fix: restore Gemini tool progress

### DIFF
--- a/platform/backend/src/routes/chat/context-trimming.test.ts
+++ b/platform/backend/src/routes/chat/context-trimming.test.ts
@@ -2,6 +2,7 @@ import type { ModelMessage } from "ai";
 import { describe, expect, test } from "vitest";
 import {
   parseMaxInputTokens,
+  shouldProbeTextStreamForContextTrimRetry,
   trimMessagesToTokenLimit,
 } from "./context-trimming";
 
@@ -24,6 +25,17 @@ describe("parseMaxInputTokens", () => {
     expect(parseMaxInputTokens(null)).toBeNull();
     expect(parseMaxInputTokens(undefined)).toBeNull();
     expect(parseMaxInputTokens(42)).toBeNull();
+  });
+});
+
+describe("shouldProbeTextStreamForContextTrimRetry", () => {
+  test("skips the textStream probe for Gemini", () => {
+    expect(shouldProbeTextStreamForContextTrimRetry("gemini")).toBe(false);
+  });
+
+  test("keeps the textStream probe enabled for OpenAI-compatible flows", () => {
+    expect(shouldProbeTextStreamForContextTrimRetry("openai")).toBe(true);
+    expect(shouldProbeTextStreamForContextTrimRetry("vllm")).toBe(true);
   });
 });
 

--- a/platform/backend/src/routes/chat/context-trimming.ts
+++ b/platform/backend/src/routes/chat/context-trimming.ts
@@ -3,9 +3,21 @@
  * When these proxies return a 400 with "maximum input length of N tokens",
  * we parse the limit, trim messages, and retry the request.
  */
+import type { SupportedProvider } from "@shared";
 import { APICallError, type ModelMessage } from "ai";
 
 const CHARS_PER_TOKEN = 4;
+
+/**
+ * Gemini can emit tool-call chunks before any text. Probing textStream to detect
+ * context errors can consume that first tool-call event, which hides the
+ * in-progress tool indicator in chat. Skip the probe there.
+ */
+export function shouldProbeTextStreamForContextTrimRetry(
+  provider: SupportedProvider,
+): boolean {
+  return provider !== "gemini";
+}
 
 /**
  * Parse max input token limit from vLLM/LiteLLM error responses.

--- a/platform/backend/src/routes/chat/routes.chat.ts
+++ b/platform/backend/src/routes/chat/routes.chat.ts
@@ -67,6 +67,7 @@ import {
 import { estimateMessagesSize } from "@/utils/message-size";
 import {
   parseMaxInputTokens,
+  shouldProbeTextStreamForContextTrimRetry,
   trimMessagesToTokenLimit,
 } from "./context-trimming";
 import {
@@ -445,48 +446,50 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 // Try reading the first text chunk to detect immediate provider errors.
                 // Context-length errors fire before any tokens, so this catches them
                 // without blocking normal streaming (first token arrives in ~100-500ms).
-                try {
-                  const reader = result.textStream[Symbol.asyncIterator]();
-                  await reader.next();
-                } catch (error) {
-                  const maxTokens = parseMaxInputTokens(error);
-                  if (maxTokens !== null) {
-                    const trimmed = trimMessagesToTokenLimit(
-                      modelMessages,
-                      maxTokens,
-                    );
-                    logger.info(
-                      {
+                if (shouldProbeTextStreamForContextTrimRetry(provider)) {
+                  try {
+                    const reader = result.textStream[Symbol.asyncIterator]();
+                    await reader.next();
+                  } catch (error) {
+                    const maxTokens = parseMaxInputTokens(error);
+                    if (maxTokens !== null) {
+                      const trimmed = trimMessagesToTokenLimit(
+                        modelMessages,
                         maxTokens,
-                        originalMessages: modelMessages.length,
-                        trimmedMessages: trimmed.length,
-                        conversationId,
-                      },
-                      "[ContextTrimming] retrying with trimmed messages",
-                    );
-                    result = streamText({
-                      ...streamTextConfig,
-                      messages: trimmed,
-                    });
-                  } else {
-                    // Save messages before throwing — this error path runs before
-                    // writer.merge(), so onError/onFinish callbacks won't fire.
-                    if (!messagesPersisted && conversationId) {
-                      messagesPersisted = true;
-                      try {
-                        await persistNewMessages(
+                      );
+                      logger.info(
+                        {
+                          maxTokens,
+                          originalMessages: modelMessages.length,
+                          trimmedMessages: trimmed.length,
                           conversationId,
-                          messages,
-                          "onExecuteError",
-                        );
-                      } catch (persistError) {
-                        logger.error(
-                          { persistError, conversationId },
-                          "Failed to persist messages during execute error",
-                        );
+                        },
+                        "[ContextTrimming] retrying with trimmed messages",
+                      );
+                      result = streamText({
+                        ...streamTextConfig,
+                        messages: trimmed,
+                      });
+                    } else {
+                      // Save messages before throwing — this error path runs before
+                      // writer.merge(), so onError/onFinish callbacks won't fire.
+                      if (!messagesPersisted && conversationId) {
+                        messagesPersisted = true;
+                        try {
+                          await persistNewMessages(
+                            conversationId,
+                            messages,
+                            "onExecuteError",
+                          );
+                        } catch (persistError) {
+                          logger.error(
+                            { persistError, conversationId },
+                            "Failed to persist messages during execute error",
+                          );
+                        }
                       }
+                      throw error;
                     }
-                    throw error;
                   }
                 }
 


### PR DESCRIPTION
## Summary
- restore Gemini in-progress tool indicators in chat
- skip the early `textStream` probe for Gemini because it can consume Gemini tool-call start events before the client renders them
- keep the existing context-trimming retry path for providers that still use that probe