### PR TITLE
fix: avoid duplicate metrics registration on web startup

### DIFF
--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -447,7 +447,10 @@ const startMetricsServer = async () => {
 
   await registerStandaloneMetricsEndpoint({
     fastify: metricsServer,
-    enableDefaultMetrics: false,
+    // In local dev, web and worker can run in the same process. Default
+    // Prometheus process/node metrics must only be registered once per process.
+    // In split deployments, the worker-only process registers its own defaults.
+    enableDefaultMetrics: !shouldRunWorker,
   });
 
   // Start metrics server on dedicated port


### PR DESCRIPTION
## Summary
- stop the dedicated web metrics server from registering Prometheus default metrics a second time
- keep default metrics enabled for the worker-only mini-server so worker process metrics still appear on its standalone endpoint
- preserve the shared metrics auth and standalone endpoint wiring introduced for worker metrics exposure

## Testing
- pnpm --dir backend run type-check
- pnpm exec biome check backend/src/server.ts