### PR TITLE
fix: avoid duplicate metrics registration in web pods

### DIFF
--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -447,10 +447,9 @@ const startMetricsServer = async () => {
 
   await registerStandaloneMetricsEndpoint({
     fastify: metricsServer,
-    // In local dev, web and worker can run in the same process. Default
-    // Prometheus process/node metrics must only be registered once per process.
-    // In split deployments, the worker-only process registers its own defaults.
-    enableDefaultMetrics: !shouldRunWorker,
+    // The web process already registers default metrics on its main Fastify
+    // instance. The dedicated metrics server must only expose that registry.
+    enableDefaultMetrics: false,
   });
 
   // Start metrics server on dedicated port


### PR DESCRIPTION
## Summary
- keep the dedicated web metrics server in expose-only mode so it does not re-register Prometheus default metrics
- leave worker-only metrics registration unchanged so separate worker processes still expose their own process metrics
- clarify in code that the web process already owns default metrics registration on the main Fastify instance