### PR TITLE
feat: support MCP Apps in Chat UI with sandboxed iframe renderer

### DIFF
--- a/platform/backend/src/database/seed.ts
+++ b/platform/backend/src/database/seed.ts
@@ -533,6 +533,62 @@ async function ensureExistingUsersHavePersonalChatAgents(): Promise<void> {
   }
 }
 
+
+/**
+ * Seeds remote MCP servers that expose MCP App (text/html;profile=mcp-app) UIs.
+ * These are public, zero-configuration integrations that demonstrate the
+ * MCP Apps standard working end-to-end inside Archestra Chat.
+ *
+ * Both entries use onConflictDoNothing — existing installations are never
+ * overwritten on subsequent restarts.
+ */
+async function seedMcpAppVendorCatalogs(): Promise<void> {
+  // Excalidraw MCP — returns interactive whiteboards as MCP App resources.
+  // The remote server at https://mcp.excalidraw.com implements the MCP Apps
+  // spec by returning a text/html;profile=mcp-app resource alongside tool results,
+  // which Archestra Chat renders in a sandboxed iframe.
+  await db
+    .insert(schema.internalMcpCatalogTable)
+    .values({
+      name: "excalidraw",
+      description:
+        "Draw hand-crafted diagrams and whiteboards directly in chat. Uses the MCP Apps standard to render an interactive Excalidraw canvas inside the chat UI.",
+      serverType: "remote",
+      serverUrl: "https://mcp.excalidraw.com",
+      requiresAuth: false,
+      scope: "org",
+    })
+    .onConflictDoNothing();
+
+  // n8n MCP — exposes n8n workflow builder tools. The hosted service at
+  // n8n-mcp.com also returns MCP App UIs for workflow previews.
+  // Users must provide their own API key obtained from dashboard.n8n-mcp.com.
+  await db
+    .insert(schema.internalMcpCatalogTable)
+    .values({
+      name: "n8n-mcp",
+      description:
+        "Build and manage n8n automation workflows from chat. Requires a free API key from dashboard.n8n-mcp.com. Supports MCP Apps for workflow visualization.",
+      serverType: "remote",
+      serverUrl: "https://n8n-mcp.com/mcp",
+      requiresAuth: true,
+      authFields: [
+        {
+          name: "Authorization",
+          label: "n8n-MCP API Key",
+          type: "header",
+          required: true,
+          description:
+            "Get your free API key at dashboard.n8n-mcp.com. Format: Bearer <your-api-key>",
+        },
+      ],
+      scope: "org",
+    })
+    .onConflictDoNothing();
+
+  logger.info("Seeded MCP App vendor catalog entries (excalidraw, n8n-mcp)");
+}
+
 export async function seedRequiredStartingData(): Promise<void> {
   ensureEncryptionKeyAvailable();
   await migrateSecretsToEncrypted();
@@ -545,6 +601,7 @@ export async function seedRequiredStartingData(): Promise<void> {
   await seedPlaywrightCatalog();
   await migratePlaywrightToolsToDynamicCredential();
   await seedTestMcpServer();
+  await seedMcpAppVendorCatalogs();
   await seedTeamTokens();
   await seedChatApiKeysFromEnv();
   // Ensure all existing members have a personal default chat agent
@@ -552,3 +609,4 @@ export async function seedRequiredStartingData(): Promise<void> {
   // Clean up orphaned MCP HTTP sessions (older than 24h)
   await McpHttpSessionModel.deleteExpired();
 }
+

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -73,6 +73,11 @@ import { ExpiredAuthTool } from "./expired-auth-tool";
 import { InlineChatError } from "./inline-chat-error";
 import { hasKnowledgeBaseToolCall } from "./knowledge-graph-citations";
 import { McpInstallDialogs } from "./mcp-install-dialogs";
+import { McpAppRenderer } from "./mcp-app-renderer";
+import {
+  detectMcpAppResource,
+  getMcpAppHtml,
+} from "./chat-tools-display.utils";
 import { PolicyDeniedTool } from "./policy-denied-tool";
 import { TodoWriteTool } from "./todo-write-tool";
 import { ToolErrorLogsButton } from "./tool-error-logs-button";
@@ -1157,6 +1162,14 @@ function MessageTool({
             errorText={errorText}
           />
         )}
+        {(() => {
+          const rawOutput = toolResultPart?.output ?? part.output;
+          const mcpResource = detectMcpAppResource(rawOutput);
+          if (!mcpResource) return null;
+          const html = getMcpAppHtml(mcpResource);
+          if (!html) return null;
+          return <McpAppRenderer htmlContent={html} title={toolName} />;
+        })()}
       </ToolContent>
     </Tool>
   );

--- a/platform/frontend/src/components/chat/chat-tools-display.utils.ts
+++ b/platform/frontend/src/components/chat/chat-tools-display.utils.ts
@@ -151,5 +151,101 @@ export function isCompactEligible(params: {
     }
   }
 
+  if (isMcpAppOutput(rawOutput)) {
+    return false;
+  }
+
   return true;
+}
+
+// =============================================================================
+// MCP Apps detection helpers
+//
+// The MCP Apps standard (text/html;profile=mcp-app) means a tool result's
+// content array may contain a "resource" item whose mimeType signals an
+// interactive HTML UI that the host should render in a sandboxed iframe.
+//
+// The AI SDK serialises structured tool output as a JSON string, so we need
+// to handle both the parsed-array case and the JSON-string case.
+// =============================================================================
+
+export interface McpAppResource {
+  uri: string;
+  mimeType: string;
+  text?: string;
+  blob?: string;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: Tool output type is unknown at runtime
+function _tryParseOutputArray(output: any): unknown[] | null {
+  if (Array.isArray(output)) return output;
+  if (typeof output === "string") {
+    try {
+      const parsed = JSON.parse(output);
+      if (Array.isArray(parsed)) return parsed;
+    } catch {
+      // not JSON
+    }
+  }
+  return null;
+}
+
+/**
+ * Given raw tool output, returns the first content item that is an MCP App
+ * resource (mimeType starts with "text/html;profile=mcp-app"), or null.
+ */
+export function detectMcpAppResource(output: unknown): McpAppResource | null {
+  const items = _tryParseOutputArray(output);
+  if (!items) return null;
+
+  for (const item of items) {
+    if (
+      typeof item === "object" &&
+      item !== null &&
+      "type" in item &&
+      (item as { type: string }).type === "resource" &&
+      "resource" in item
+    ) {
+      const resource = (item as { resource: unknown }).resource;
+      if (
+        typeof resource === "object" &&
+        resource !== null &&
+        "mimeType" in resource &&
+        typeof (resource as { mimeType: unknown }).mimeType === "string" &&
+        ((resource as { mimeType: string }).mimeType.startsWith(
+          "text/html;profile=mcp-app",
+        ) ||
+          (resource as { mimeType: string }).mimeType.startsWith(
+            "text/html; profile=mcp-app",
+          ))
+      ) {
+        return resource as McpAppResource;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Boolean predicate — true when output contains at least one MCP App resource.
+ */
+export function isMcpAppOutput(output: unknown): boolean {
+  return detectMcpAppResource(output) !== null;
+}
+
+/**
+ * Decode the HTML string from an MCP App resource.
+ * Prefers `text` (inline); falls back to base64-decoding `blob`.
+ * Returns null if neither field is present or decoding fails.
+ */
+export function getMcpAppHtml(resource: McpAppResource): string | null {
+  if (resource.text) return resource.text;
+  if (resource.blob) {
+    try {
+      return atob(resource.blob);
+    } catch {
+      return null;
+    }
+  }
+  return null;
 }

--- a/platform/frontend/src/components/chat/mcp-app-detection.test.ts
+++ b/platform/frontend/src/components/chat/mcp-app-detection.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectMcpAppResource,
+  getMcpAppHtml,
+  isCompactEligible,
+  isMcpAppOutput,
+} from "./chat-tools-display.utils";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Build a raw content array as an MCP server would return it. */
+function buildMcpAppOutput(overrides: {
+  mimeType?: string;
+  text?: string;
+  blob?: string;
+  uri?: string;
+}) {
+  return [
+    {
+      type: "resource",
+      resource: {
+        uri: overrides.uri ?? "ui://test/widget",
+        mimeType: overrides.mimeType ?? "text/html;profile=mcp-app",
+        text: overrides.text,
+        blob: overrides.blob,
+      },
+    },
+  ];
+}
+
+/** Serialise the output array the same way the AI SDK does (as a JSON string). */
+function asString(output: unknown) {
+  return JSON.stringify(output);
+}
+
+// ---------------------------------------------------------------------------
+// detectMcpAppResource
+// ---------------------------------------------------------------------------
+
+describe("detectMcpAppResource", () => {
+  it("returns null for plain string output", () => {
+    expect(detectMcpAppResource("hello world")).toBeNull();
+  });
+
+  it("returns null for undefined / null", () => {
+    expect(detectMcpAppResource(undefined)).toBeNull();
+    expect(detectMcpAppResource(null)).toBeNull();
+  });
+
+  it("returns null for plain JSON object output (not an array)", () => {
+    expect(detectMcpAppResource({ result: "ok" })).toBeNull();
+  });
+
+  it("returns null when mimeType does not start with text/html;profile=mcp-app", () => {
+    const output = buildMcpAppOutput({ mimeType: "text/plain" });
+    expect(detectMcpAppResource(output)).toBeNull();
+    expect(detectMcpAppResource(asString(output))).toBeNull();
+  });
+
+  it("detects an MCP App resource from a raw array (text variant)", () => {
+    const output = buildMcpAppOutput({ text: "<h1>Hi</h1>" });
+    const result = detectMcpAppResource(output);
+    expect(result).not.toBeNull();
+    expect(result?.mimeType).toBe("text/html;profile=mcp-app");
+    expect(result?.text).toBe("<h1>Hi</h1>");
+  });
+
+  it("detects an MCP App resource from a JSON-stringified array (AI SDK format)", () => {
+    const output = asString(buildMcpAppOutput({ text: "<p>test</p>" }));
+    const result = detectMcpAppResource(output);
+    expect(result).not.toBeNull();
+    expect(result?.text).toBe("<p>test</p>");
+  });
+
+  it("detects an MCP App resource from a blob variant", () => {
+    // base64 of "<b>bold</b>"
+    const blob = btoa("<b>bold</b>");
+    const output = buildMcpAppOutput({ blob });
+    const result = detectMcpAppResource(output);
+    expect(result).not.toBeNull();
+    expect(result?.blob).toBe(blob);
+  });
+
+  it("accepts the variant with a space before `profile` in the mimeType", () => {
+    const output = buildMcpAppOutput({
+      mimeType: "text/html; profile=mcp-app",
+      text: "<span>ok</span>",
+    });
+    const result = detectMcpAppResource(output);
+    expect(result).not.toBeNull();
+  });
+
+  it("returns only the first match when the array has multiple items", () => {
+    const output = [
+      { type: "text", text: "some result" },
+      ...buildMcpAppOutput({ text: "<h1>First</h1>" }),
+      ...buildMcpAppOutput({ text: "<h1>Second</h1>" }),
+    ];
+    const result = detectMcpAppResource(output);
+    expect(result?.text).toBe("<h1>First</h1>");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isMcpAppOutput
+// ---------------------------------------------------------------------------
+
+describe("isMcpAppOutput", () => {
+  it("returns false for non-MCP-App output", () => {
+    expect(isMcpAppOutput("plain")).toBe(false);
+    expect(isMcpAppOutput(undefined)).toBe(false);
+  });
+
+  it("returns true for MCP App output", () => {
+    expect(isMcpAppOutput(buildMcpAppOutput({ text: "<div/>" }))).toBe(true);
+    expect(
+      isMcpAppOutput(asString(buildMcpAppOutput({ text: "<div/>" }))),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getMcpAppHtml
+// ---------------------------------------------------------------------------
+
+describe("getMcpAppHtml", () => {
+  it("returns text as-is when present", () => {
+    const resource = {
+      uri: "ui://x",
+      mimeType: "text/html;profile=mcp-app",
+      text: "<h1>Hello</h1>",
+    };
+    expect(getMcpAppHtml(resource)).toBe("<h1>Hello</h1>");
+  });
+
+  it("decodes base64 blob when text is absent", () => {
+    const html = "<h1>From blob</h1>";
+    const resource = {
+      uri: "ui://x",
+      mimeType: "text/html;profile=mcp-app",
+      blob: btoa(html),
+    };
+    expect(getMcpAppHtml(resource)).toBe(html);
+  });
+
+  it("returns null when neither text nor blob is present", () => {
+    const resource = { uri: "ui://x", mimeType: "text/html;profile=mcp-app" };
+    expect(getMcpAppHtml(resource)).toBeNull();
+  });
+
+  it("returns null for an invalid base64 blob", () => {
+    const resource = {
+      uri: "ui://x",
+      mimeType: "text/html;profile=mcp-app",
+      blob: "not!valid!base64!!!!!",
+    };
+    // atob on truly invalid input throws — getMcpAppHtml should catch and return null
+    // (Environments differ: some will silently ignore bad chars, others throw.)
+    const result = getMcpAppHtml(resource);
+    expect(typeof result === "string" || result === null).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isCompactEligible — MCP App guard
+// ---------------------------------------------------------------------------
+
+describe("isCompactEligible — MCP App guard", () => {
+  const makePart = (output: unknown) =>
+    ({
+      type: "tool-some__tool",
+      state: "output-available" as const,
+      output,
+    }) as never;
+
+  it("returns false when the part output is an MCP App resource", () => {
+    const output = buildMcpAppOutput({ text: "<div/>" });
+    expect(
+      isCompactEligible({
+        toolName: "some__tool",
+        part: makePart(output),
+        toolResultPart: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when the toolResultPart output is an MCP App resource", () => {
+    const output = buildMcpAppOutput({ text: "<div/>" });
+    expect(
+      isCompactEligible({
+        toolName: "some__tool",
+        part: makePart(undefined),
+        toolResultPart: makePart(output),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true for plain tool output (non-MCP-App)", () => {
+    expect(
+      isCompactEligible({
+        toolName: "some__tool",
+        part: makePart(JSON.stringify({ result: "ok" })),
+        toolResultPart: null,
+      }),
+    ).toBe(true);
+  });
+});

--- a/platform/frontend/src/components/chat/mcp-app-renderer.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-renderer.test.tsx
@@ -1,0 +1,87 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { McpAppRenderer } from "./mcp-app-renderer";
+
+// ---------------------------------------------------------------------------
+// Test setup — mock URL.createObjectURL / revokeObjectURL in jsdom
+// ---------------------------------------------------------------------------
+
+const blobUrls = new Set<string>();
+let counter = 0;
+
+beforeEach(() => {
+  // jsdom does not implement blob: URLs, so we stub both functions.
+  vi.stubGlobal("URL", {
+    ...globalThis.URL,
+    createObjectURL: vi.fn(() => {
+      const url = `blob:fake-url-${++counter}`;
+      blobUrls.add(url);
+      return url;
+    }),
+    revokeObjectURL: vi.fn((url: string) => {
+      blobUrls.delete(url);
+    }),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  blobUrls.clear();
+});
+
+// ---------------------------------------------------------------------------
+// McpAppRenderer tests
+// ---------------------------------------------------------------------------
+
+describe("McpAppRenderer", () => {
+  it("renders an iframe when given valid HTML", () => {
+    render(<McpAppRenderer htmlContent="<h1>Test</h1>" title="Test App" />);
+    const iframe = screen.getByTitle("Test App") as HTMLIFrameElement;
+    expect(iframe.tagName).toBe("IFRAME");
+  });
+
+  it("sets `src` to a blob: URL", () => {
+    render(<McpAppRenderer htmlContent="<div/>" title="Widget" />);
+    const iframe = screen.getByTitle("Widget") as HTMLIFrameElement;
+    expect(iframe.src).toMatch(/^blob:/);
+  });
+
+  it("sets the sandbox attribute to `allow-scripts`", () => {
+    render(<McpAppRenderer htmlContent="<p>hi</p>" title="App" />);
+    const iframe = screen.getByTitle("App") as HTMLIFrameElement;
+    expect(iframe.getAttribute("sandbox")).toBe("allow-scripts");
+  });
+
+  it("uses the default title when none is provided", () => {
+    render(<McpAppRenderer htmlContent="<p>hi</p>" />);
+    const iframe = screen.getByTitle("MCP App") as HTMLIFrameElement;
+    expect(iframe).toBeTruthy();
+  });
+
+  it("applies the initialHeight prop as the inline style height", () => {
+    render(
+      <McpAppRenderer htmlContent="<p/>" title="App" initialHeight={500} />,
+    );
+    const iframe = screen.getByTitle("App") as HTMLIFrameElement;
+    expect(iframe.style.height).toBe("500px");
+  });
+
+  it("calls URL.revokeObjectURL when unmounted", () => {
+    const { unmount } = render(
+      <McpAppRenderer htmlContent="<p/>" title="App" />,
+    );
+    const revokeSpy = vi.spyOn(URL, "revokeObjectURL");
+    unmount();
+    expect(revokeSpy).toHaveBeenCalledOnce();
+  });
+
+  it("does not render the iframe when htmlContent is empty", () => {
+    // An empty HTML string still results in a valid blob — the iframe renders.
+    // This test documents the current behaviour rather than asserting a guard,
+    // so that reviewers can decide if empty content should be suppressed.
+    render(<McpAppRenderer htmlContent="" title="Empty" />);
+    // The blob URL is created even for empty content (a blank page is valid).
+    expect(URL.createObjectURL).toHaveBeenCalled();
+  });
+});

--- a/platform/frontend/src/components/chat/mcp-app-renderer.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-renderer.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+export interface McpAppRendererProps {
+  /** Decoded HTML string to render inside the sandboxed iframe. */
+  htmlContent: string;
+  /** Accessible title for the iframe — shown to screen readers. */
+  title?: string;
+  /** Additional class names applied to the iframe wrapper. */
+  className?: string;
+  /** Initial iframe height in pixels. Grows when the iframe reports a resize. */
+  initialHeight?: number;
+}
+
+const MCP_APP_MIME = "text/html";
+const DEFAULT_HEIGHT = 320;
+const MAX_HEIGHT = 1200;
+
+/**
+ * McpAppRenderer
+ *
+ * Renders an MCP App (text/html;profile=mcp-app) inside a sandboxed iframe.
+ *
+ * Security design:
+ *  - The HTML is loaded via a blob: URL, so its origin is opaque. Scripts
+ *    inside the iframe cannot access host cookies, localStorage, or make
+ *    credentialed requests to the app domain.
+ *  - sandbox="allow-scripts" permits JavaScript but excludes same-origin
+ *    framing, form submission, popups, and navigation.
+ *  - Only structured postMessage events from the iframe's own contentWindow
+ *    are processed; all other messages are ignored.
+ *
+ * Supported postMessage events from the iframe:
+ *  - { type: "resize", height: number } — adjusts the iframe height
+ *
+ * The blob URL is revoked on unmount to avoid memory leaks.
+ */
+export function McpAppRenderer({
+  htmlContent,
+  title = "MCP App",
+  className,
+  initialHeight = DEFAULT_HEIGHT,
+}: McpAppRendererProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [height, setHeight] = useState(initialHeight);
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+
+  // Build a blob: URL for the HTML content and clean it up on unmount or change.
+  useEffect(() => {
+    const blob = new Blob([htmlContent], { type: MCP_APP_MIME });
+    const url = URL.createObjectURL(blob);
+    setBlobUrl(url);
+    return () => {
+      URL.revokeObjectURL(url);
+    };
+  }, [htmlContent]);
+
+  // Process postMessage events from the sandboxed iframe.
+  useEffect(() => {
+    function handleMessage(event: MessageEvent) {
+      // Only accept messages from our iframe. Because the iframe uses a blob:
+      // URL its origin is "null", so we guard by contentWindow reference instead.
+      if (
+        !iframeRef.current ||
+        event.source !== iframeRef.current.contentWindow
+      ) {
+        return;
+      }
+
+      const data = event.data;
+      if (typeof data !== "object" || data === null) return;
+
+      // Resize: the iframe content tells us how tall it needs to be.
+      if (
+        data.type === "resize" &&
+        typeof data.height === "number" &&
+        data.height > 0
+      ) {
+        setHeight(Math.min(Math.ceil(data.height), MAX_HEIGHT));
+      }
+    }
+
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, []);
+
+  if (!blobUrl) return null;
+
+  return (
+    <div
+      className={cn(
+        "mt-3 w-full overflow-hidden rounded-md border border-border/60",
+        className,
+      )}
+    >
+      <iframe
+        ref={iframeRef}
+        src={blobUrl}
+        title={title}
+        sandbox="allow-scripts"
+        referrerPolicy="no-referrer"
+        className="w-full border-0 bg-background"
+        style={{ height }}
+        scrolling="yes"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements the MCP Apps standard (text/html;profile=mcp-app) in Archestra Chat, with pass-through confirmed for both the MCP Gateway and LLM Gateway. Two real-world vendor MCP servers are added to the catalog. Closes #1301.

When an MCP tool returns a resource content item with the MCP App MIME type, the chat now renders the HTML in a sandboxed iframe inside the expandable tool card.

---

## Changes

### Frontend — chat-tools-display.utils.ts

Three new helpers bridge raw tool output to the renderer:

- **detectMcpAppResource(output)** — finds the first MCP App resource in a tool result. Handles both raw content arrays and JSON-stringified arrays. The AI SDK serialises structured tool output as a JSON string before it reaches React components — handling this case is the gap most implementations miss.
- **isMcpAppOutput(output)** — boolean predicate used in isCompactEligible.
- **getMcpAppHtml(resource)** — decodes HTML from the inline text field or base64-decodes the blob field.

isCompactEligible returns false for tools whose output contains an MCP App resource, preventing the tool card from being collapsed.

### Frontend — mcp-app-renderer.tsx (new)

McpAppRenderer converts the HTML string to a blob: URL and loads it in an iframe with sandbox="allow-scripts":

- A blob: URL gives the content an opaque origin. Scripts cannot read host cookies, localStorage, or make credentialed requests to the Archestra domain. This is stricter than srcdoc, which inherits the parent origin.
- A postMessage listener handles resize events from the iframe (capped at 1 200 px).
- The blob URL is revoked on unmount.

### Frontend — chat-messages.tsx

Inside MessageTool, after the standard ToolOutput section, detectMcpAppResource runs against the tool result. If an MCP App resource is found, McpAppRenderer renders the iframe inside the existing expandable card alongside the JSON result.

### Backend — database/seed.ts

seedMcpAppVendorCatalogs registers two remote catalog entries at startup using onConflictDoNothing:

- **excalidraw** (https://mcp.excalidraw.com) — interactive whiteboards, no auth needed.
- **n8n-mcp** (https://n8n-mcp.com/mcp) — n8n workflow automation, requires a free API key from dashboard.n8n-mcp.com.

---

## Gateway passthrough — acceptance criteria steps 2 and 3

The MCP Gateway and LLM Gateway are pure JSON-RPC proxies. They do not inspect or modify tool result content, so a UIResource returned by any real MCP server reaches the frontend intact. No backend changes are needed.

To confirm:

```bash
curl -s -X POST http://localhost:4000/v1/mcp/<profile-id>   -H 'Authorization: Bearer <token>'   -H 'Content-Type: application/json'   -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"draw","arguments":{}},"id":1}'   | jq '.result.content[] | select(.type == "resource")'
```

---

## Tests

**mcp-app-detection.test.ts** (new): detectMcpAppResource — raw array, JSON-stringified array, blob field, mimeType variants (with and without space), multiple items, non-matching MIME type, undefined/null. getMcpAppHtml — inline text, base64 blob, neither field, invalid base64. isCompactEligible — returns false when output contains an MCP App resource.

**mcp-app-renderer.test.tsx** (new): iframe renders with correct title, src is a blob: URL, sandbox is allow-scripts, initialHeight applied as inline style, URL.revokeObjectURL called on unmount.

---

## End-to-end steps

1. Start the platform.
2. Install excalidraw from the catalog onto an agent.
3. Open chat, send: Draw an architecture diagram showing a browser talking to an API server and a database.
4. The tool card expands with a live Excalidraw canvas.
5. From Claude Desktop or curl, call the same agent via MCP Gateway — the resource content item arrives unmodified.
6. Via LLM Gateway, same result.