### PR TITLE
feat(chat): support MCP Apps with UIResource rendering

### DIFF
--- a/docs/pages/platform-mcp-apps.md
+++ b/docs/pages/platform-mcp-apps.md
@@ -1,0 +1,83 @@
+---
+title: MCP Apps
+category: MCP
+order: 4
+description: Interactive UI rendering for MCP tool outputs
+lastUpdated: 2026-03-22
+---
+
+<!--
+Check ../docs_writer_prompt.md before changing this file.
+-->
+
+MCP Apps allow MCP servers to return interactive UI alongside their tool outputs. When a tool result contains a UIResource, the Chat UI renders it in a sandboxed iframe instead of showing raw JSON.
+
+## How It Works
+
+1. An MCP server returns a tool result containing a `UIResource` object.
+2. The Chat UI detects the UIResource in the tool output.
+3. Instead of rendering JSON, an iframe displays the interactive content.
+
+## UIResource Format
+
+Tool results can include a UIResource in two ways:
+
+**Top-level:**
+```json
+{
+  "uri": "ui://weather-widget",
+  "mimeType": "text/html",
+  "text": "<html>...</html>"
+}
+```
+
+**Nested in `_meta`:**
+```json
+{
+  "data": { "temperature": 22 },
+  "_meta": {
+    "ui": {
+      "uri": "ui://weather-widget",
+      "mimeType": "text/html",
+      "text": "<html>...</html>"
+    }
+  }
+}
+```
+
+## Supported MIME Types
+
+| MIME Type | Behavior |
+|-----------|----------|
+| `text/html` | Renders HTML content via iframe `srcdoc` |
+| `text/uri-list` | Loads remote URL in iframe `src` |
+| `application/remote-dom+json` | Reserved for future remote DOM support |
+
+## Security
+
+All MCP App content renders in a sandboxed iframe with restricted permissions:
+
+- `allow-scripts` - JavaScript execution
+- `allow-forms` - Form submission
+- `allow-popups` - Opening new windows
+
+The iframe cannot access the parent page's DOM, cookies, or storage.
+
+## Communication Protocol
+
+MCP Apps can communicate with the parent page via `postMessage`:
+
+**Iframe to parent:**
+- `ui-lifecycle-iframe-ready` - Iframe has loaded and is ready
+- `ui-size-change` - Request height change: `{ type: "ui-size-change", height: 400 }`
+
+**Parent to iframe:**
+- `ui-lifecycle-auth` - Authentication nonce for handshake
+
+## MCP Gateway Compatibility
+
+UIResource metadata passes through the MCP Gateway transparently. External clients consuming tool results via the gateway will receive UIResource objects as-is and can implement their own rendering.
+
+## LLM Gateway Compatibility
+
+The LLM proxy preserves UIResource metadata in tool results during format conversion between providers (OpenAI, Anthropic, Gemini).

--- a/platform/frontend/src/components/ai-elements/mcp-app-renderer.test.tsx
+++ b/platform/frontend/src/components/ai-elements/mcp-app-renderer.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import {
+  McpAppRenderer,
+  extractUIResource,
+  hasUIResource,
+} from "./mcp-app-renderer";
+
+describe("extractUIResource", () => {
+  it("returns null for non-object output", () => {
+    expect(extractUIResource(null)).toBeNull();
+    expect(extractUIResource(undefined)).toBeNull();
+    expect(extractUIResource(42)).toBeNull();
+    expect(extractUIResource("plain text")).toBeNull();
+  });
+
+  it("extracts from top-level uri + mimeType", () => {
+    const output = {
+      uri: "ui://weather",
+      mimeType: "text/html",
+      text: "<h1>Weather</h1>",
+    };
+    const result = extractUIResource(output);
+    expect(result).toEqual(output);
+  });
+
+  it("extracts from _meta.ui pattern", () => {
+    const resource = {
+      uri: "ui://chart",
+      mimeType: "text/html",
+      text: "<canvas></canvas>",
+    };
+    const output = {
+      data: [1, 2, 3],
+      _meta: { ui: resource },
+    };
+    const result = extractUIResource(output);
+    expect(result).toEqual(resource);
+  });
+
+  it("extracts from JSON string output", () => {
+    const resource = {
+      uri: "https://app.example.com",
+      mimeType: "text/uri-list",
+    };
+    const result = extractUIResource(JSON.stringify(resource));
+    expect(result).toEqual(resource);
+  });
+
+  it("returns null for invalid mimeType", () => {
+    const output = {
+      uri: "ui://widget",
+      mimeType: "application/json",
+    };
+    expect(extractUIResource(output)).toBeNull();
+  });
+
+  it("returns null for missing uri", () => {
+    const output = { mimeType: "text/html", text: "<div>test</div>" };
+    expect(extractUIResource(output)).toBeNull();
+  });
+});
+
+describe("hasUIResource", () => {
+  it("returns true for valid UIResource output", () => {
+    expect(
+      hasUIResource({ uri: "ui://x", mimeType: "text/html" }),
+    ).toBe(true);
+  });
+
+  it("returns false for plain object output", () => {
+    expect(hasUIResource({ result: "ok" })).toBe(false);
+  });
+});
+
+describe("McpAppRenderer", () => {
+  it("renders an iframe for text/html content", () => {
+    render(
+      <McpAppRenderer
+        resource={{
+          uri: "ui://test",
+          mimeType: "text/html",
+          text: "<h1>Hello</h1>",
+        }}
+      />,
+    );
+    const iframe = screen.getByTitle("MCP App");
+    expect(iframe).toBeDefined();
+    expect(iframe.getAttribute("sandbox")).toBe(
+      "allow-scripts allow-forms allow-popups",
+    );
+  });
+
+  it("renders an iframe with src for text/uri-list", () => {
+    render(
+      <McpAppRenderer
+        resource={{
+          uri: "https://example.com/app",
+          mimeType: "text/uri-list",
+        }}
+      />,
+    );
+    const iframe = screen.getByTitle("MCP App");
+    expect(iframe.getAttribute("src")).toBe("https://example.com/app");
+  });
+
+  it("shows unsupported message for remote-dom+json", () => {
+    render(
+      <McpAppRenderer
+        resource={{
+          uri: "ui://remote",
+          mimeType: "application/remote-dom+json",
+        }}
+      />,
+    );
+    expect(
+      screen.getByText("Remote DOM rendering is not yet supported."),
+    ).toBeDefined();
+  });
+
+  it("renders external link button for uri-list type", () => {
+    render(
+      <McpAppRenderer
+        resource={{
+          uri: "https://example.com/app",
+          mimeType: "text/uri-list",
+        }}
+      />,
+    );
+    const link = screen.getByRole("link");
+    expect(link.getAttribute("href")).toBe("https://example.com/app");
+    expect(link.getAttribute("target")).toBe("_blank");
+  });
+
+  it("renders expand/collapse button", async () => {
+    const user = userEvent.setup();
+    render(
+      <McpAppRenderer
+        resource={{
+          uri: "ui://test",
+          mimeType: "text/html",
+          text: "<p>Content</p>",
+        }}
+      />,
+    );
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+});

--- a/platform/frontend/src/components/ai-elements/mcp-app-renderer.tsx
+++ b/platform/frontend/src/components/ai-elements/mcp-app-renderer.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import type { UIResource } from "@shared";
+import { AlertTriangleIcon, ExternalLinkIcon, MaximizeIcon, MinimizeIcon } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type McpAppRendererProps = {
+  resource: UIResource;
+  className?: string;
+};
+
+/**
+ * Renders an MCP App UI resource inside a sandboxed iframe.
+ *
+ * Supports three content types:
+ * - `text/html`: inline HTML rendered via srcdoc
+ * - `text/uri-list`: remote URL loaded in iframe src
+ * - `application/remote-dom+json`: reserved for future remote DOM support
+ *
+ * Communication between the iframe and parent uses postMessage with a
+ * nonce-based handshake for authentication.
+ */
+export function McpAppRenderer({ resource, className }: McpAppRendererProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const nonceRef = useRef(crypto.randomUUID());
+  const [height, setHeight] = useState(300);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleMessage = useCallback(
+    (event: MessageEvent) => {
+      const iframe = iframeRef.current;
+      if (!iframe?.contentWindow || event.source !== iframe.contentWindow) {
+        return;
+      }
+
+      const data = event.data;
+      if (typeof data !== "object" || data === null) return;
+
+      switch (data.type) {
+        case "ui-lifecycle-iframe-ready": {
+          iframe.contentWindow.postMessage(
+            { type: "ui-lifecycle-auth", nonce: nonceRef.current },
+            "*",
+          );
+          break;
+        }
+        case "ui-size-change": {
+          if (typeof data.height === "number" && data.height > 0) {
+            setHeight(Math.min(data.height, 800));
+          }
+          break;
+        }
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [handleMessage]);
+
+  if (resource.mimeType === "application/remote-dom+json") {
+    return (
+      <div className={cn("flex items-center gap-2 rounded-md border p-3 text-muted-foreground text-xs", className)}>
+        <AlertTriangleIcon className="size-4" />
+        <span>Remote DOM rendering is not yet supported.</span>
+      </div>
+    );
+  }
+
+  const sandbox = "allow-scripts allow-forms allow-popups";
+
+  const iframeSrc =
+    resource.mimeType === "text/uri-list" ? resource.uri : undefined;
+
+  const iframeSrcDoc =
+    resource.mimeType === "text/html" ? (resource.text ?? "") : undefined;
+
+  if (!iframeSrc && !iframeSrcDoc) {
+    return (
+      <div className={cn("flex items-center gap-2 rounded-md border p-3 text-muted-foreground text-xs", className)}>
+        <AlertTriangleIcon className="size-4" />
+        <span>No content available for this MCP App.</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("space-y-1", className)}>
+      <div className="flex items-center justify-between">
+        <span className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+          MCP App
+        </span>
+        <div className="flex items-center gap-1">
+          {resource.mimeType === "text/uri-list" && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 px-1"
+              asChild
+            >
+              <a
+                href={resource.uri}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <ExternalLinkIcon className="size-3" />
+              </a>
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-1"
+            onClick={() => setIsExpanded(!isExpanded)}
+          >
+            {isExpanded ? (
+              <MinimizeIcon className="size-3" />
+            ) : (
+              <MaximizeIcon className="size-3" />
+            )}
+          </Button>
+        </div>
+      </div>
+      {error ? (
+        <div className="rounded-md border border-destructive/20 bg-destructive/10 p-3 text-destructive text-xs">
+          {error}
+        </div>
+      ) : (
+        <iframe
+          ref={iframeRef}
+          title="MCP App"
+          sandbox={sandbox}
+          src={iframeSrc}
+          srcDoc={iframeSrcDoc}
+          className={cn(
+            "w-full rounded-md border bg-background transition-[height] duration-200",
+            isExpanded ? "h-[80vh]" : "",
+          )}
+          style={isExpanded ? undefined : { height: `${height}px` }}
+          onError={() => setError("Failed to load MCP App content.")}
+        />
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// UIResource detection helpers
+// ============================================================================
+
+/**
+ * Checks if a tool output contains a UIResource.
+ */
+export function hasUIResource(output: unknown): boolean {
+  return extractUIResource(output) !== null;
+}
+
+/**
+ * Extracts the first UIResource from a tool output.
+ * Looks for the standard `_meta.ui` or top-level `uri` + `mimeType` pattern.
+ */
+export function extractUIResource(output: unknown): UIResource | null {
+  if (!output || typeof output !== "object") return null;
+
+  const obj = output as Record<string, unknown>;
+
+  // Pattern 1: { _meta: { ui: UIResource } }
+  if (obj._meta && typeof obj._meta === "object") {
+    const meta = obj._meta as Record<string, unknown>;
+    if (meta.ui && typeof meta.ui === "object") {
+      const ui = meta.ui as Record<string, unknown>;
+      if (isValidUIResource(ui)) {
+        return ui as unknown as UIResource;
+      }
+    }
+  }
+
+  // Pattern 2: { uri, mimeType } at top level
+  if (isValidUIResource(obj)) {
+    return obj as unknown as UIResource;
+  }
+
+  // Pattern 3: string output that looks like JSON containing UIResource
+  if (typeof output === "string") {
+    try {
+      const parsed = JSON.parse(output);
+      return extractUIResource(parsed);
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function isValidUIResource(obj: Record<string, unknown>): boolean {
+  const validMimeTypes = [
+    "text/html",
+    "text/uri-list",
+    "application/remote-dom+json",
+  ];
+  return (
+    typeof obj.uri === "string" &&
+    typeof obj.mimeType === "string" &&
+    validMimeTypes.includes(obj.mimeType)
+  );
+}

--- a/platform/frontend/src/components/ai-elements/tool.tsx
+++ b/platform/frontend/src/components/ai-elements/tool.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import { CodeBlock } from "./code-block";
+import { McpAppRenderer, extractUIResource } from "./mcp-app-renderer";
 
 export type ToolProps = ComponentProps<typeof Collapsible>;
 
@@ -230,6 +231,16 @@ export const ToolOutput = ({
 
   if (!(output || errorText || conversations)) {
     return null;
+  }
+
+  // Render MCP App UI if output contains a UIResource
+  const uiResource = output ? extractUIResource(output) : null;
+  if (uiResource && !errorText) {
+    return (
+      <div className={cn("space-y-2 p-4", className)} {...props}>
+        <McpAppRenderer resource={uiResource} />
+      </div>
+    );
   }
 
   // Render conversations as chat bubbles if provided

--- a/platform/shared/chat.ts
+++ b/platform/shared/chat.ts
@@ -1,6 +1,26 @@
 import { z } from "zod";
 
 // ============================================================================
+// MCP UI Resource Types (MCP Apps)
+// ============================================================================
+
+/**
+ * A UI resource returned by an MCP tool in its output.
+ * When present, the chat renders an interactive iframe instead of raw JSON.
+ */
+export interface UIResource {
+  uri: string;
+  mimeType: UIResourceMimeType;
+  text?: string;
+  _meta?: Record<string, unknown>;
+}
+
+export type UIResourceMimeType =
+  | "text/html"
+  | "text/uri-list"
+  | "application/remote-dom+json";
+
+// ============================================================================
 // Token Usage Types
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- Add `UIResource` type to `shared/chat.ts` for MCP App UI resources
- Create `McpAppRenderer` component that renders interactive MCP App content in sandboxed iframes
- Integrate UIResource detection into `ToolOutput` so tool results with UI automatically render as apps instead of JSON
- Support `text/html` (inline via srcdoc), `text/uri-list` (remote URL), and `application/remote-dom+json` (reserved)
- Nonce-based postMessage handshake for iframe authentication
- Dynamic iframe height via `ui-size-change` messages
- Comprehensive unit tests for UIResource extraction and component rendering
- Documentation for MCP Apps feature

## Test plan

- [ ] Verify UIResource detection from tool outputs (top-level, `_meta.ui`, JSON string)
- [ ] Test `text/html` rendering via srcdoc in sandboxed iframe
- [ ] Test `text/uri-list` rendering via iframe src with external link button
- [ ] Verify `application/remote-dom+json` shows unsupported message
- [ ] Confirm expand/collapse toggle works for iframe resize
- [ ] Run `pnpm test` to verify all unit tests pass
- [ ] Test with n8n-mcp and excalidraw-mcp servers that return UIResource
- [ ] Verify MCP Gateway passes UIResource metadata through transparently

Resolves #1301

🤖 Generated with [Claude Code](https://claude.com/claude-code)