### PR TITLE
fix: probe Vertex Gemini fallback models when list only returns live audio

### DIFF
--- a/platform/backend/src/routes/chat/routes.models.test.ts
+++ b/platform/backend/src/routes/chat/routes.models.test.ts
@@ -491,6 +491,102 @@ describe("chat-models", () => {
         },
       ]);
     });
+
+    test("probes fallback models when list only returns live audio Gemini", async () => {
+      const mockModels = [
+        {
+          name: "publishers/google/models/text-multilingual-embedding-002",
+          version: "default",
+          tunedModelInfo: {},
+        },
+        {
+          name: "publishers/google/models/text-embedding-005",
+          version: "default",
+          tunedModelInfo: {},
+        },
+        {
+          name: "publishers/google/models/imagen-4.0-generate-001",
+          version: "default",
+          tunedModelInfo: {},
+        },
+        {
+          name: "publishers/google/models/gemini-live-2.5-flash-native-audio",
+          version: "default",
+          tunedModelInfo: {},
+        },
+      ];
+
+      const mockPager = {
+        [Symbol.asyncIterator]: async function* () {
+          for (const model of mockModels) {
+            yield model;
+          }
+        },
+      };
+
+      const mockGet = vi.fn(async ({ model }: { model: string }) => {
+        if (
+          model === "gemini-2.5-pro" ||
+          model === "gemini-2.5-flash" ||
+          model === "gemini-2.5-flash-lite" ||
+          model === "gemini-2.0-flash-001" ||
+          model === "gemini-2.0-flash-lite-001"
+        ) {
+          return {
+            name: `publishers/google/models/${model}`,
+            displayName: null,
+          };
+        }
+
+        throw new Error("Not found");
+      });
+
+      const mockClient = {
+        models: {
+          list: vi.fn().mockResolvedValue(mockPager),
+          get: mockGet,
+        },
+      } as unknown as GoogleGenAI;
+
+      mockCreateGoogleGenAIClient.mockReturnValue(mockClient);
+
+      const models = await fetchGeminiModelsViaVertexAi();
+
+      expect(models).toEqual([
+        {
+          id: "gemini-live-2.5-flash-native-audio",
+          displayName: "Gemini Live 2.5 Flash Native Audio",
+          provider: "gemini",
+        },
+        {
+          id: "gemini-2.5-pro",
+          displayName: "Gemini 2.5 Pro",
+          provider: "gemini",
+        },
+        {
+          id: "gemini-2.5-flash",
+          displayName: "Gemini 2.5 Flash",
+          provider: "gemini",
+        },
+        {
+          id: "gemini-2.5-flash-lite",
+          displayName: "Gemini 2.5 Flash Lite",
+          provider: "gemini",
+        },
+        {
+          id: "gemini-2.0-flash-001",
+          displayName: "Gemini 2.0 Flash 001",
+          provider: "gemini",
+        },
+        {
+          id: "gemini-2.0-flash-lite-001",
+          displayName: "Gemini 2.0 Flash Lite 001",
+          provider: "gemini",
+        },
+      ]);
+      expect(mockGet).toHaveBeenCalledWith({ model: "gemini-2.5-pro" });
+      expect(mockGet).toHaveBeenCalledWith({ model: "gemini-2.5-flash" });
+    });
   });
 
   describe("isVertexAiEnabled", () => {

--- a/platform/backend/src/routes/chat/routes.models.ts
+++ b/platform/backend/src/routes/chat/routes.models.ts
@@ -1470,7 +1470,7 @@ function formatVertexGeminiDisplayName(modelId: string): string {
 }
 
 function isPrimaryVertexGeminiModel(modelId: string): boolean {
-  return modelId.includes("flash") || modelId.includes("pro");
+  return VERTEX_GEMINI_FALLBACK_MODEL_IDS.includes(modelId);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- fix Vertex Gemini fallback detection so `gemini-live-2.5-flash-native-audio` does not suppress probing of the canonical Gemini chat model IDs
- add a regression test covering the exact partial `models.list()` shape observed in customer environments where only the live-audio Gemini model is returned

## Root cause
The Vertex discovery path treated any model ID containing `flash` or `pro` as a "primary" Gemini chat model. That incorrectly classified `gemini-live-2.5-flash-native-audio` as sufficient discovery, so fallback `models.get()` probes for `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, and the `2.0` fallback models never ran.

In environments where `models.list()` is incomplete, Archestra could then sync only the live-audio Gemini model into the database, which is what the chat model selector later returned.

## Testing
- `pnpm --filter @backend exec vitest run src/routes/chat/routes.models.test.ts`
