### PR TITLE
Add copy button to code blocks

### DIFF
--- a/platform/frontend/src/components/chat/conversation-artifact.tsx
+++ b/platform/frontend/src/components/chat/conversation-artifact.tsx
@@ -2,7 +2,6 @@
 
 import DOMPurify from "dompurify";
 import { Copy, Download, FileText, GripVertical, X } from "lucide-react";
-import { CopyButton } from "@/components/copy-button";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
@@ -234,27 +233,6 @@ export function ConversationArtifactPanel({
         <code className={className} {...props}>
           {children}
         </code>
-      );
-    },
-    pre({ children, ...props }) {
-      // Extract the text content from the code element inside <pre>
-      const extractText = (node: React.ReactNode): string => {
-        if (typeof node === "string") return node;
-        if (Array.isArray(node)) return node.map(extractText).join("");
-        if (node && typeof node === "object" && "props" in node) {
-          return extractText((node as React.ReactElement<{ children?: React.ReactNode }>).props.children);
-        }
-        return "";
-      };
-      const codeText = extractText(children).replace(/\n$/, "");
-
-      return (
-        <div className="relative group">
-          <pre {...props}>{children}</pre>
-          <div className="absolute top-2 right-2">
-            <CopyButton text={codeText} size={14} />
-          </div>
-        </div>
       );
     },
   };


### PR DESCRIPTION
Added a copy button in Code Blocks for easy copy of code.

Additionally shifted the title inside the code block for better understanding and improving UI.

#3243 

<img width="577" height="564" alt="image" src="https://github.com/user-attachments/assets/da23a564-3637-49e5-8a00-2dbfba29a55a" />
