### PR TITLE
fix(chat): Add expandable input for mobile devices

### DIFF
--- a/platform/frontend/src/components/ai-elements/prompt-input.tsx
+++ b/platform/frontend/src/components/ai-elements/prompt-input.tsx
@@ -5,7 +5,9 @@ import {
   CornerDownLeftIcon,
   ImageIcon,
   Loader2Icon,
+  Maximize2Icon,
   MicIcon,
+  Minimize2Icon,
   PaperclipIcon,
   PlusIcon,
   SquareIcon,
@@ -905,6 +907,8 @@ export const PromptInputTextarea = ({
   const controller = useOptionalPromptInputController();
   const attachments = usePromptInputAttachments();
   const [isComposing, setIsComposing] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
     if (e.key === "Enter") {
@@ -983,17 +987,37 @@ export const PromptInputTextarea = ({
       };
 
   return (
-    <InputGroupTextarea
-      className={cn("field-sizing-content max-h-48 min-h-16", className)}
-      name="message"
-      onCompositionEnd={() => setIsComposing(false)}
-      onCompositionStart={() => setIsComposing(true)}
-      onKeyDown={handleKeyDown}
-      onPaste={handlePaste}
-      placeholder={placeholder}
-      {...props}
-      {...controlledProps}
-    />
+    <div className="relative flex w-full items-end">
+      <InputGroupTextarea
+        className={cn(
+          "field-sizing-content min-h-16 pr-10",
+          isExpanded ? "max-h-[80vh]" : "max-h-48",
+          className,
+        )}
+        name="message"
+        onCompositionEnd={() => setIsComposing(false)}
+        onCompositionStart={() => setIsComposing(true)}
+        onKeyDown={handleKeyDown}
+        onPaste={handlePaste}
+        placeholder={placeholder}
+        ref={textareaRef}
+        {...props}
+        {...controlledProps}
+      />
+      <Button
+        aria-label={isExpanded ? "Collapse input" : "Expand input"}
+        className="absolute bottom-2 right-2 size-8 cursor-pointer p-0 opacity-60 hover:opacity-100"
+        onClick={() => setIsExpanded(!isExpanded)}
+        type="button"
+        variant="ghost"
+      >
+        {isExpanded ? (
+          <Minimize2Icon className="size-4" />
+        ) : (
+          <Maximize2Icon className="size-4" />
+        )}
+      </Button>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary

Fix for #3244: Mobile input field truncates long messages - need expandable editor for better readability and editing.

## Changes

- Added expand/collapse button to chat input textarea
- When expanded, the textarea allows up to 80vh height for comfortable editing
- When collapsed, maintains the original 48 (192px) max height
- Uses Lucide's Maximize2Icon and Minimize2Icon for clear visual affordance

## Testing

1. Type a long message in the chat input on mobile
2. Click the expand button (bottom-right corner of textarea)
3. Textarea should expand to show full content
4. Click again to collapse back to compact mode

## Screenshots

### Before (collapsed)
Text is truncated after reaching max height

### After (expanded)
Full message visible with expand button in corner

/claim #3244
