### PR TITLE
fix: normalize model selector override chip behavior (#3491)

### DIFF
--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -351,17 +351,20 @@ export default function ChatPage() {
   // This prevents ModelSelector's auto-select (triggered by apiKeyId changes)
   // from overwriting the agent default or org default.
   const modelSelectorWasOpenRef = useRef(false);
-  const handleInitialModelChange = useCallback((modelId: string) => {
-    if (modelInitializedRef.current && !modelSelectorWasOpenRef.current) {
-      return;
-    }
-    setInitialModel(modelId);
-    if (modelSelectorWasOpenRef.current) {
-      setInitialModelSource("user");
-      saveModelOverride(modelId);
-    }
-    modelSelectorWasOpenRef.current = false;
-  }, []);
+  const handleInitialModelChange = useCallback(
+    (modelId: string, _isUserSelected?: boolean) => {
+      if (modelInitializedRef.current && !modelSelectorWasOpenRef.current) {
+        return;
+      }
+      setInitialModel(modelId);
+      if (modelSelectorWasOpenRef.current) {
+        setInitialModelSource("user");
+        saveModelOverride(modelId);
+      }
+      modelSelectorWasOpenRef.current = false;
+    },
+    [],
+  );
   const handleInitialModelSelectorOpenChange = useCallback((open: boolean) => {
     if (open) {
       modelSelectorWasOpenRef.current = true;
@@ -586,6 +589,9 @@ export default function ChatPage() {
   const updateConversationMutateRef = useRef(updateConversationMutation.mutate);
   updateConversationMutateRef.current = updateConversationMutation.mutate;
 
+  // Track if user explicitly opened model selector (for existing conversations)
+  const conversationModelSelectorOpenRef = useRef(false);
+
   // Handle model change — use refs for chatModels and conversation to keep
   // callback reference stable. A new callback reference would re-trigger
   // ModelSelector's auto-select effect on every chatModels refetch.
@@ -593,19 +599,37 @@ export default function ChatPage() {
   chatModelsRef.current = chatModels;
   const conversationRef = useRef(conversation);
   conversationRef.current = conversation;
-  const handleModelChange = useCallback((model: string) => {
-    if (!conversationRef.current) return;
+  const handleModelChange = useCallback(
+    (model: string, isUserSelected: boolean = false) => {
+      if (!conversationRef.current) return;
 
-    // Find the provider for this model
-    const modelInfo = chatModelsRef.current.find((m) => m.id === model);
-    const provider = modelInfo?.provider;
+      // If user explicitly selected the model (opened selector first), save to localStorage
+      if (isUserSelected) {
+        saveModelOverride(model);
+      }
 
-    updateConversationMutateRef.current({
-      id: conversationRef.current.id,
-      selectedModel: model,
-      selectedProvider: provider,
-    });
-  }, []);
+      // Find the provider for this model
+      const modelInfo = chatModelsRef.current.find((m) => m.id === model);
+      const provider = modelInfo?.provider;
+
+      updateConversationMutateRef.current({
+        id: conversationRef.current.id,
+        selectedModel: model,
+        selectedProvider: provider,
+      });
+    },
+    [],
+  );
+
+  // Handle model selector open state for existing conversations
+  const handleConversationModelSelectorOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        conversationModelSelectorOpenRef.current = true;
+      }
+    },
+    [],
+  );
 
   // Handle API key change - preselect best model for the new key's provider.
   // Combines chatApiKeyId + model selection in a single mutation to avoid
@@ -1767,6 +1791,9 @@ export default function ChatPage() {
                         status={status}
                         selectedModel={conversation?.selectedModel ?? ""}
                         onModelChange={handleModelChange}
+                        onModelSelectorOpenChange={
+                          handleConversationModelSelectorOpenChange
+                        }
                         agentId={promptAgentId ?? activeAgentId}
                         conversationId={conversationId}
                         currentConversationChatApiKeyId={

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -149,6 +149,19 @@ const PromptInputContent = ({
   const controller = usePromptInputController();
   const attachments = usePromptInputAttachments();
 
+  // Track if user explicitly opened model selector (for determining user vs API selection)
+  const modelSelectorUserOpenedRef = useRef(false);
+
+  // Wrap onModelChange to include user selection flag
+  const handleModelChangeWithUserFlag = useCallback(
+    (model: string) => {
+      const isUserSelected = modelSelectorUserOpenedRef.current;
+      modelSelectorUserOpenedRef.current = false;
+      onModelChange(model, isUserSelected);
+    },
+    [onModelChange],
+  );
+
   // Collapsed/expanded state for the model selector (defaults to collapsed = provider icon only)
   const { isCollapsed: showDefaultLogo, expand: expandModelSelector } =
     useModelSelectorDisplay({ conversationId });
@@ -401,7 +414,7 @@ const PromptInputContent = ({
                           </p>
                           <ModelSelector
                             selectedModel={selectedModel}
-                            onModelChange={onModelChange}
+                            onModelChange={handleModelChangeWithUserFlag}
                             onOpenChange={onModelSelectorOpenChange}
                             apiKeyId={
                               conversationId
@@ -539,8 +552,11 @@ const PromptInputContent = ({
                   )}
                   <ModelSelector
                     selectedModel={selectedModel}
-                    onModelChange={onModelChange}
+                    onModelChange={handleModelChangeWithUserFlag}
                     onOpenChange={(open) => {
+                      if (open) {
+                        modelSelectorUserOpenedRef.current = true;
+                      }
                       onModelSelectorOpenChange?.(open);
                       if (!open) {
                         setTimeout(() => {


### PR DESCRIPTION
- Track user vs API-driven model selection using modelSelectorUserOpenedRef
- Pass isUserSelected flag through onModelChange callback to distinguish user explicit selections from API auto-selections
- Save user model selection to localStorage only when user explicitly selects
- Show 'user override' chip only when user manually selects a model
- Show agent/org chip when model matches default (not user-selected)

Before fix:
- User-selected models: no override chip shown (incorrect)
- API auto-selected matching default: showed override (incorrect)

After fix:
- User manually selects: shows 'user override' chip
- API auto-selects matching default: shows 'agent' or 'org' chip
- API auto-selects different: shows null (fallback)