### PR TITLE
test: validate org zizmor enforcement

### DIFF
--- a/.github/workflows/zizmor-org-ruleset-test.yml
+++ b/.github/workflows/zizmor-org-ruleset-test.yml
@@ -1,0 +1,21 @@
+name: Zizmor Org Ruleset Test
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+
+jobs:
+  test-zizmor:
+    name: Trigger Zizmor Finding
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout pull request head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Run shell from pull request contents
+        run: |
+          echo "This workflow intentionally exists to trigger zizmor for org ruleset verification."


### PR DESCRIPTION
## Summary
- add an intentionally insecure workflow to validate the org-level `zizmor` ruleset
- exercise `pull_request_target` plus checkout of the PR head SHA so `zizmor` should raise findings

## Expected result
- the org-managed `Org Zizmor` workflow should upload a `zizmor` code scanning finding for this PR
- the org ruleset should block merge based on that finding

## Do not merge
This PR exists only to verify the enforcement path.
