### PR TITLE
fix: Clean up leaked mermaid DOM elements on error

### DIFF
--- a/platform/frontend/src/components/mermaid-diagram.tsx
+++ b/platform/frontend/src/components/mermaid-diagram.tsx
@@ -68,8 +68,16 @@ export function MermaidDiagram({
         } catch (error) {
           console.error("Error rendering mermaid diagram:", error);
           if (ref.current) {
+            // Clean up any mermaid-generated elements that may have leaked into document.body
+            const leakedElements = document.body.querySelectorAll('[id^="mermaid-"]');
+            leakedElements.forEach((el) => el.remove());
+            // Also clean up the injected <div> that mermaid sometimes creates
+            const mermaidDivs = document.body.querySelectorAll('.mermaid');
+            mermaidDivs.forEach((el) => el.remove());
+
             const pre = document.createElement("pre");
             pre.textContent = chart;
+            pre.className = "text-red-500 text-sm p-2 bg-red-50 dark:bg-red-950 rounded border border-red-200 dark:border-red-800 overflow-auto";
             ref.current.replaceChildren(pre);
             setIsLoaded(true);
           }


### PR DESCRIPTION
## Summary
Fixes #3511 - Invalid mermaid diagram errors leaking to other pages.

## Changes
- Clean up any mermaid-generated elements from `document.body` before showing error state
- Style the error display with red border for better visibility
- Error is now properly contained within the component boundary

## Testing
1. Create a message with an invalid mermaid diagram
2. Navigate to a different page
3. Verify the error does not appear on other pages

Fixes #3511
/claim #3511