### PR TITLE
fix: Remove New Chat Session fallback from sidebar title

### DIFF
--- a/platform/frontend/src/lib/chat/chat-utils.ts
+++ b/platform/frontend/src/lib/chat/chat-utils.ts
@@ -80,7 +80,7 @@ export function conversationStorageKeys(conversationId: string) {
 
 /**
  * Extracts a display title for a conversation.
- * Priority: explicit title > first user message > default session name
+ * Priority: explicit title > first user message > neutral placeholder
  */
 export function getConversationDisplayTitle(
   title: string | null,
@@ -102,5 +102,8 @@ export function getConversationDisplayTitle(
     }
   }
 
-  return DEFAULT_SESSION_NAME;
+  // When no title or messages are available (e.g., sidebar list),
+  // show a neutral placeholder instead of "New Chat Session"
+  // to avoid mismatch with the chat page header
+  return "";
 }


### PR DESCRIPTION
## Summary
Fixes #3246 - Chat title mismatch between chat page and sidebar.

## Problem
- Chat page header shows the first user message as title
- Sidebar shows "New Chat Session" instead
- The mismatch occurs because sidebar's `useConversations()` doesn't include messages

## Solution
Modified `getConversationDisplayTitle()` in `chat-utils.ts`:
- When `title` is null and `messages` are undefined (sidebar case), return empty string instead of "New Chat Session"
- This prevents the misleading "New Chat Session" from appearing in the sidebar
- Once the backend generates and saves a title, the sidebar will show it correctly

## Alternative Considered
- Adding messages to the sidebar API call would be a bigger change
- This fix is minimal and addresses the symptom effectively

Fixes #3246
/claim #3246