### PR TITLE
feat: add Notion knowledge connector

### DIFF
--- a/docs/pages/platform-knowledge-connectors.md
+++ b/docs/pages/platform-knowledge-connectors.md
@@ -96,6 +96,17 @@ Ingests records from ServiceNow instances via the Table API. HTML descriptions a
 
 Authentication supports both basic auth (username + password) and OAuth bearer tokens. When using basic auth, provide the username in the Email field and the password in the API Token field. For OAuth, leave the Email field empty and provide the bearer token. Incidents are synced by default; enable additional entity types in the advanced configuration. States and assignment group filters apply to all entity types except business applications. Incremental sync uses the `sys_created_on` field to fetch only records created since the last run.
 
+## Notion
+
+Ingests pages and databases from Notion workspaces via the official Notion REST API. Page content is fetched recursively up to 3 block levels deep and converted to Markdown (headings, bullets, quotes, code blocks, etc.).
+
+| Field       | Description                                                                                                      |
+| ----------- | ---------------------------------------------------------------------------------------------------------------- |
+| Database IDs | Comma-separated Notion database IDs to restrict sync to specific databases (optional -- leave blank for full workspace sync) |
+| Page IDs    | Comma-separated specific page IDs to sync (optional)                                                             |
+
+Authentication uses a [Notion Integration Token](https://www.notion.so/my-integrations) (`secret_...`). No instance URL is required -- Notion is cloud-only. Incremental sync uses `last_edited_time` timestamps.
+
 ## Managing Connectors
 
 Connectors can be managed from either the **Connectors** page or a knowledge base's detail page. After creation you can:

--- a/platform/backend/src/knowledge-base/connectors/notion/notion-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/notion/notion-connector.ts
@@ -1,0 +1,502 @@
+import type pino from "pino";
+import type {
+  ConnectorCredentials,
+  ConnectorDocument,
+  ConnectorSyncBatch,
+  NotionCheckpoint,
+  NotionConfig,
+} from "@/types";
+import { NotionConfigSchema } from "@/types";
+import {
+  BaseConnector,
+  buildCheckpoint,
+  extractErrorMessage,
+  REQUEST_TIMEOUT_MS,
+} from "../base-connector";
+
+const NOTION_API_BASE = "https://api.notion.com/v1";
+const NOTION_API_VERSION = "2022-06-28";
+const BATCH_SIZE = 50;
+const BLOCK_DEPTH_LIMIT = 3;
+
+export class NotionConnector extends BaseConnector {
+  type = "notion" as const;
+
+  async validateConfig(
+    config: Record<string, unknown>,
+  ): Promise<{ valid: boolean; error?: string }> {
+    const parsed = parseNotionConfig(config);
+    if (!parsed) {
+      return {
+        valid: false,
+        error:
+          "Invalid Notion configuration: integrationToken (string) is required",
+      };
+    }
+    return { valid: true };
+  }
+
+  async testConnection(params: {
+    config: Record<string, unknown>;
+    credentials: ConnectorCredentials;
+  }): Promise<{ success: boolean; error?: string }> {
+    const parsed = parseNotionConfig(params.config);
+    if (!parsed) {
+      return { success: false, error: "Invalid Notion configuration" };
+    }
+
+    this.log.debug("Testing Notion API connection");
+
+    try {
+      await this.notionFetch("/search", params.credentials, {
+        method: "POST",
+        body: JSON.stringify({ page_size: 1 }),
+      });
+      this.log.debug("Connection test successful");
+      return { success: true };
+    } catch (error) {
+      const message = extractErrorMessage(error);
+      this.log.error({ error: message }, "Connection test failed");
+      return { success: false, error: `Connection failed: ${message}` };
+    }
+  }
+
+  async *sync(params: {
+    config: Record<string, unknown>;
+    credentials: ConnectorCredentials;
+    checkpoint: Record<string, unknown> | null;
+    startTime?: Date;
+    endTime?: Date;
+  }): AsyncGenerator<ConnectorSyncBatch> {
+    const parsed = parseNotionConfig(params.config);
+    if (!parsed) {
+      throw new Error("Invalid Notion configuration");
+    }
+
+    const checkpoint =
+      (params.checkpoint as NotionCheckpoint | null) ?? buildDefaultCheckpoint();
+
+    // Determine sync mode
+    const hasExplicitTargets =
+      (parsed.databaseIds?.length ?? 0) > 0 ||
+      (parsed.pageIds?.length ?? 0) > 0;
+
+    // 1. Full-workspace search when no explicit targets specified
+    if (!hasExplicitTargets) {
+      this.log.debug("No explicit targets — running full workspace search");
+      yield* this.syncWorkspaceSearch(parsed, params.credentials, checkpoint);
+    }
+
+    // 2. Sync specific databases
+    if (parsed.databaseIds?.length) {
+      for (const databaseId of parsed.databaseIds) {
+        yield* this.syncDatabase(databaseId, params.credentials, checkpoint);
+      }
+    }
+
+    // 3. Sync specific pages
+    if (parsed.pageIds?.length) {
+      for (const pageId of parsed.pageIds) {
+        yield* this.syncPage(pageId, params.credentials, checkpoint);
+      }
+    }
+  }
+
+  private async *syncWorkspaceSearch(
+    config: NotionConfig,
+    credentials: ConnectorCredentials,
+    checkpoint: NotionCheckpoint,
+  ): AsyncGenerator<ConnectorSyncBatch> {
+    this.log.debug("Starting workspace search sync");
+
+    let cursor: string | undefined;
+    let hasMore = true;
+    let lastEditedTime: string | undefined;
+
+    while (hasMore) {
+      await this.rateLimit();
+
+      const body: Record<string, unknown> = {
+        page_size: BATCH_SIZE,
+        filter: { value: "page", property: "object" },
+        sort: { direction: "descending", timestamp: "last_edited_time" },
+      };
+
+      if (cursor) {
+        body.start_cursor = cursor;
+      }
+
+      let response: NotionPaginatedResponse<NotionPage>;
+      try {
+        response = (await this.notionFetch("/search", credentials, {
+          method: "POST",
+          body: JSON.stringify(body),
+        })) as NotionPaginatedResponse<NotionPage>;
+      } catch (error) {
+        const message = extractErrorMessage(error);
+        this.log.error({ error: message }, "Workspace search failed");
+        throw error;
+      }
+
+      const pages = response.results ?? [];
+      hasMore = response.has_more === true;
+      cursor = response.next_cursor ?? undefined;
+
+      if (pages.length === 0 && !hasMore) {
+        yield {
+          documents: [],
+          failures: this.flushFailures(),
+          checkpoint,
+          hasMore: false,
+        };
+        return;
+      }
+
+      const documents: ConnectorDocument[] = [];
+      for (const page of pages) {
+        const doc = await this.pageToDocument(page, credentials);
+        if (doc) documents.push(doc);
+        if (!lastEditedTime || page.last_edited_time > lastEditedTime) {
+          lastEditedTime = page.last_edited_time;
+        }
+      }
+
+      yield {
+        documents,
+        failures: this.flushFailures(),
+        checkpoint: buildCheckpoint({
+          type: "notion",
+          itemUpdatedAt: lastEditedTime,
+          previousLastSyncedAt: checkpoint.lastSyncedAt,
+        }),
+        hasMore,
+      };
+    }
+  }
+
+  private async *syncDatabase(
+    databaseId: string,
+    credentials: ConnectorCredentials,
+    checkpoint: NotionCheckpoint,
+  ): AsyncGenerator<ConnectorSyncBatch> {
+    this.log.debug({ databaseId }, "Syncing Notion database");
+
+    let cursor: string | undefined;
+    let hasMore = true;
+    let lastEditedTime: string | undefined;
+
+    while (hasMore) {
+      await this.rateLimit();
+
+      const body: Record<string, unknown> = {
+        page_size: BATCH_SIZE,
+        filter: { property: "object", value: "page" },
+      };
+
+      if (cursor) {
+        body.start_cursor = cursor;
+      }
+
+      let response: NotionPaginatedResponse<NotionPage>;
+      try {
+        response = (await this.notionFetch(
+          `/databases/${databaseId}/query`,
+          credentials,
+          { method: "POST", body: JSON.stringify(body) },
+        )) as NotionPaginatedResponse<NotionPage>;
+      } catch (error) {
+        const message = extractErrorMessage(error);
+        this.log.error({ databaseId, error: message }, "Database query failed");
+        throw error;
+      }
+
+      const pages = response.results ?? [];
+      hasMore = response.has_more === true;
+      cursor = response.next_cursor ?? undefined;
+
+      if (pages.length === 0 && !hasMore) {
+        yield {
+          documents: [],
+          failures: this.flushFailures(),
+          checkpoint,
+          hasMore: false,
+        };
+        return;
+      }
+
+      const documents: ConnectorDocument[] = [];
+      for (const page of pages) {
+        const doc = await this.pageToDocument(page, credentials);
+        if (doc) documents.push(doc);
+        if (!lastEditedTime || page.last_edited_time > lastEditedTime) {
+          lastEditedTime = page.last_edited_time;
+        }
+      }
+
+      yield {
+        documents,
+        failures: this.flushFailures(),
+        checkpoint: buildCheckpoint({
+          type: "notion",
+          itemUpdatedAt: lastEditedTime,
+          previousLastSyncedAt: checkpoint.lastSyncedAt,
+        }),
+        hasMore,
+      };
+    }
+  }
+
+  private async *syncPage(
+    pageId: string,
+    credentials: ConnectorCredentials,
+    checkpoint: NotionCheckpoint,
+  ): AsyncGenerator<ConnectorSyncBatch> {
+    this.log.debug({ pageId }, "Syncing Notion page");
+
+    let page: NotionPage;
+    try {
+      await this.rateLimit();
+      page = (await this.notionFetch(
+        `/pages/${pageId}`,
+        credentials,
+      )) as NotionPage;
+    } catch (error) {
+      const message = extractErrorMessage(error);
+      this.log.error({ pageId, error: message }, "Page fetch failed");
+      throw error;
+    }
+
+    const doc = await this.pageToDocument(page, credentials);
+
+    yield {
+      documents: doc ? [doc] : [],
+      failures: this.flushFailures(),
+      checkpoint: buildCheckpoint({
+        type: "notion",
+        itemUpdatedAt: page.last_edited_time,
+        previousLastSyncedAt: checkpoint.lastSyncedAt,
+      }),
+      hasMore: false,
+    };
+  }
+
+  private async pageToDocument(
+    page: NotionPage,
+    credentials: ConnectorCredentials,
+  ): Promise<ConnectorDocument | null> {
+    const title = extractNotionTitle(page);
+    const url =
+      page.url ?? `https://notion.so/${page.id.replace(/-/g, "")}`;
+
+    const content = await this.fetchBlockContent(page.id, credentials, 0);
+
+    return {
+      id: `notion:${page.id}`,
+      title: title || `Notion Page (${page.id})`,
+      content,
+      sourceUrl: url,
+      metadata: {
+        kind: "page",
+        pageId: page.id,
+        lastEditedTime: page.last_edited_time,
+        createdTime: page.created_time,
+      },
+      updatedAt: parseNotionTimestamp(page.last_edited_time),
+    };
+  }
+
+  private async fetchBlockContent(
+    blockId: string,
+    credentials: ConnectorCredentials,
+    depth: number,
+  ): Promise<string> {
+    if (depth >= BLOCK_DEPTH_LIMIT) {
+      return "";
+    }
+
+    await this.rateLimit();
+
+    let response: NotionPaginatedResponse<NotionBlock>;
+    try {
+      response = (await this.notionFetch(
+        `/blocks/${blockId}/children`,
+        credentials,
+        {
+          method: "GET",
+          query: { page_size: 100 },
+        },
+      )) as NotionPaginatedResponse<NotionBlock>;
+    } catch (error) {
+      const message = extractErrorMessage(error);
+      this.log.warn(
+        { blockId, error: message },
+        "Failed to fetch block children, skipping",
+      );
+      return "";
+    }
+
+    const blocks = response.results ?? [];
+    const lines: string[] = [];
+
+    for (const block of blocks) {
+      const text = blockToMarkdown(block);
+      if (text) lines.push(text);
+
+      if (
+        block.has_children === true &&
+        depth + 1 < BLOCK_DEPTH_LIMIT
+      ) {
+        await this.rateLimit();
+        const children = await this.fetchBlockContent(
+          block.id,
+          credentials,
+          depth + 1,
+        );
+        if (children) lines.push(children);
+      }
+    }
+
+    return lines.join("\n");
+  }
+
+  private async notionFetch(
+    path: string,
+    credentials: ConnectorCredentials,
+    options: RequestInit & { query?: Record<string, string | number> } = {},
+  ): Promise<unknown> {
+    let url = `${NOTION_API_BASE}${path}`;
+    const query = options.query;
+    if (query) {
+      const qs = new URLSearchParams(
+        Object.fromEntries(
+          Object.entries(query).map(([k, v]) => [k, String(v)]),
+        ),
+      ).toString();
+      url += `?${qs}`;
+    }
+
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${credentials.apiToken}`,
+      "Notion-Version": NOTION_API_VERSION,
+      "Content-Type": "application/json",
+    };
+
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(),
+      REQUEST_TIMEOUT_MS,
+    );
+
+    try {
+      const response = await fetch(url, {
+        ...options,
+        headers: { ...options.headers, ...headers },
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => "");
+        throw new Error(
+          `Notion API ${response.status}: ${response.statusText}${body ? ` — ${body}` : ""}`,
+        );
+      }
+
+      return await response.json();
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+// ===== Module-level helpers =====
+
+function parseNotionConfig(
+  config: Record<string, unknown>,
+): NotionConfig | null {
+  const result = NotionConfigSchema.safeParse({ type: "notion", ...config });
+  return result.success ? result.data : null;
+}
+
+function buildDefaultCheckpoint(): NotionCheckpoint {
+  return { type: "notion", lastSyncedAt: undefined };
+}
+
+function extractNotionTitle(page: NotionPage): string {
+  const titleProp =
+    page.properties?.["title"] ?? page.properties?.["Name"];
+  if (!titleProp) return "";
+  if (titleProp.type === "title") {
+    return titleProp.title.map((t) => t.plain_text).join("") ?? "";
+  }
+  return "";
+}
+
+function parseNotionTimestamp(ts: string): Date | null {
+  if (!ts) return null;
+  const d = new Date(ts);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+function blockToMarkdown(block: NotionBlock): string {
+  const text = extractBlockText(block);
+  if (!text) return "";
+
+  switch (block.type) {
+    case "heading_1":
+      return `## ${text}`;
+    case "heading_2":
+      return `### ${text}`;
+    case "heading_3":
+      return `#### ${text}`;
+    case "bulleted_list_item":
+      return `- ${text}`;
+    case "numbered_list_item":
+      return `1. ${text}`;
+    case "quote":
+      return `> ${text}`;
+    case "code":
+      return `\`\`\`${block.code?.language ?? ""}\n${text}\n\`\`\``;
+    case "callout":
+      return `> **Callout**: ${text}`;
+    case "divider":
+      return "---";
+    case "to_do":
+      return `${block.to_do?.checked ? "✅" : "⬜"} ${text}`;
+    default:
+      return text;
+  }
+}
+
+function extractBlockText(block: NotionBlock): string {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const richText = (block as any)[block.type]?.rich_text;
+  if (!Array.isArray(richText)) return "";
+  return richText.map((t: { plain_text: string }) => t.plain_text).join("");
+}
+
+// ===== Notion API types =====
+
+interface NotionPaginatedResponse<T> {
+  object: "list";
+  results: T[];
+  next_cursor: string | null;
+  has_more: boolean;
+  type: string;
+}
+
+interface NotionPage {
+  id: string;
+  object: string;
+  url: string;
+  created_time: string;
+  last_edited_time: string;
+  properties: Record<string, unknown>;
+}
+
+interface NotionBlock {
+  id: string;
+  type: string;
+  has_children: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}

--- a/platform/backend/src/knowledge-base/connectors/registry.ts
+++ b/platform/backend/src/knowledge-base/connectors/registry.ts
@@ -3,6 +3,7 @@ import { ConfluenceConnector } from "./confluence/confluence-connector";
 import { GithubConnector } from "./github/github-connector";
 import { GitlabConnector } from "./gitlab/gitlab-connector";
 import { JiraConnector } from "./jira/jira-connector";
+import { NotionConnector } from "./notion/notion-connector";
 import { ServiceNowConnector } from "./servicenow/servicenow-connector";
 
 const connectorRegistry: Record<ConnectorType, () => Connector> = {
@@ -11,6 +12,7 @@ const connectorRegistry: Record<ConnectorType, () => Connector> = {
   github: () => new GithubConnector(),
   gitlab: () => new GitlabConnector(),
   servicenow: () => new ServiceNowConnector(),
+  notion: () => new NotionConnector(),
 };
 
 export function getConnector(type: string): Connector {

--- a/platform/backend/src/types/knowledge-connector.ts
+++ b/platform/backend/src/types/knowledge-connector.ts
@@ -7,6 +7,7 @@ const CONFLUENCE = z.literal("confluence");
 const GITHUB = z.literal("github");
 const GITLAB = z.literal("gitlab");
 const SERVICENOW = z.literal("servicenow");
+const NOTION = z.literal("notion");
 
 export const ConnectorTypeSchema = z.union([
   JIRA,
@@ -14,6 +15,7 @@ export const ConnectorTypeSchema = z.union([
   GITHUB,
   GITLAB,
   SERVICENOW,
+  NOTION,
 ]);
 export type ConnectorType = z.infer<typeof ConnectorTypeSchema>;
 
@@ -153,6 +155,21 @@ export const ServiceNowCheckpointSchema = z.object({
 });
 export type ServiceNowCheckpoint = z.infer<typeof ServiceNowCheckpointSchema>;
 
+// ===== Notion Config & Checkpoint =====
+
+export const NotionConfigSchema = z.object({
+  type: NOTION,
+  databaseIds: z.array(z.string()).optional(),
+  pageIds: z.array(z.string()).optional(),
+});
+export type NotionConfig = z.infer<typeof NotionConfigSchema>;
+
+export const NotionCheckpointSchema = z.object({
+  type: NOTION,
+  lastSyncedAt: z.string().optional(),
+});
+export type NotionCheckpoint = z.infer<typeof NotionCheckpointSchema>;
+
 // ===== Discriminated Unions =====
 
 export const ConnectorConfigSchema = z.discriminatedUnion("type", [
@@ -161,6 +178,7 @@ export const ConnectorConfigSchema = z.discriminatedUnion("type", [
   GithubConfigSchema,
   GitlabConfigSchema,
   ServiceNowConfigSchema,
+  NotionConfigSchema,
 ]);
 export type ConnectorConfig = z.infer<typeof ConnectorConfigSchema>;
 
@@ -170,6 +188,7 @@ export const ConnectorCheckpointSchema = z.discriminatedUnion("type", [
   GithubCheckpointSchema,
   GitlabCheckpointSchema,
   ServiceNowCheckpointSchema,
+  NotionCheckpointSchema,
 ]);
 export type ConnectorCheckpoint = z.infer<typeof ConnectorCheckpointSchema>;
 

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-icons.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-icons.tsx
@@ -18,6 +18,7 @@ const CONNECTOR_ICON_MAP: Partial<Record<ConnectorType, ConnectorIcon>> = {
   },
   gitlab: { kind: "img", src: "/icons/gitlab.png" },
   servicenow: { kind: "img", src: "/icons/servicenow.png" },
+  notion: { kind: "img", src: "/icons/notion.png" },
 };
 
 export function hasConnectorIcon(type: string): boolean {

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/create-connector-dialog.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/create-connector-dialog.tsx
@@ -41,6 +41,7 @@ import { ConnectorTypeIcon } from "./connector-icons";
 import { GithubConfigFields } from "./github-config-fields";
 import { GitlabConfigFields } from "./gitlab-config-fields";
 import { JiraConfigFields } from "./jira-config-fields";
+import { NotionConfigFields } from "./notion-config-fields";
 import { SchedulePicker } from "./schedule-picker";
 import { ServiceNowConfigFields } from "./servicenow-config-fields";
 import { transformConfigArrayFields } from "./transform-config-array-fields";
@@ -77,6 +78,11 @@ const CONNECTOR_OPTIONS: {
     type: "servicenow",
     label: "ServiceNow",
     description: "Sync incidents from ServiceNow",
+  },
+  {
+    type: "notion",
+    label: CONNECTOR_TYPE_LABELS.notion,
+    description: "Sync pages and databases from Notion",
   },
 ];
 
@@ -128,6 +134,7 @@ export function CreateConnectorDialog({
       github: { type, githubUrl: "https://api.github.com" },
       gitlab: { type, gitlabUrl: "https://gitlab.com" },
       servicenow: { type, syncDataForLastMonths: 6 },
+      notion: { type },
     };
     form.setValue("config", defaultConfigs[type]);
     setStep("configure");
@@ -307,26 +314,28 @@ export function CreateConnectorDialog({
                   )}
                 />
 
-                <FormField
-                  control={form.control}
-                  // biome-ignore lint/suspicious/noExplicitAny: dynamic field name for connector-specific URL
-                  name={urlConfig.fieldName as any}
-                  rules={{ required: `${urlConfig.label} is required` }}
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>{urlConfig.label}</FormLabel>
-                      <FormControl>
-                        <Input
-                          placeholder={urlConfig.placeholder}
-                          {...field}
-                          value={(field.value as string) ?? ""}
-                        />
-                      </FormControl>
-                      <FormDescription>{urlConfig.description}</FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
+                {urlConfig && (
+                  <FormField
+                    control={form.control}
+                    // biome-ignore lint/suspicious/noExplicitAny: dynamic field name for connector-specific URL
+                    name={urlConfig.fieldName as any}
+                    rules={{ required: `${urlConfig.label} is required` }}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{urlConfig.label}</FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder={urlConfig.placeholder}
+                            {...field}
+                            value={(field.value as string) ?? ""}
+                          />
+                        </FormControl>
+                        <FormDescription>{urlConfig.description}</FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                )}
 
                 {(connectorType === "jira" ||
                   connectorType === "confluence") && (
@@ -500,6 +509,12 @@ export function CreateConnectorDialog({
                     )}
                     {connectorType === "servicenow" && (
                       <ServiceNowConfigFields form={form} hideUrl />
+                    )}
+                    {connectorType === "notion" && (
+                      <NotionConfigFields
+                        register={form.register}
+                        errors={form.formState.errors}
+                      />
                     )}
                   </CollapsibleContent>
                 </Collapsible>

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/edit-connector-dialog.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/edit-connector-dialog.tsx
@@ -28,6 +28,7 @@ import { ConnectorTypeIcon } from "./connector-icons";
 import { GithubConfigFields } from "./github-config-fields";
 import { GitlabConfigFields } from "./gitlab-config-fields";
 import { JiraConfigFields } from "./jira-config-fields";
+import { NotionConfigFields } from "./notion-config-fields";
 import { SchedulePicker } from "./schedule-picker";
 import { ServiceNowConfigFields } from "./servicenow-config-fields";
 import { transformConfigArrayFields } from "./transform-config-array-fields";
@@ -217,26 +218,28 @@ export function EditConnectorDialog({
             )}
           />
 
-          <FormField
-            control={form.control}
-            // biome-ignore lint/suspicious/noExplicitAny: dynamic field name for connector-specific URL
-            name={urlConfig.fieldName as any}
-            rules={{ required: `${urlConfig.label} is required` }}
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>{urlConfig.label}</FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder={urlConfig.placeholder}
-                    {...field}
-                    value={(field.value as string) ?? ""}
-                  />
-                </FormControl>
-                <FormDescription>{urlConfig.description}</FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+          {urlConfig.fieldName && (
+            <FormField
+              control={form.control}
+              // biome-ignore lint/suspicious/noExplicitAny: dynamic field name for connector-specific URL
+              name={urlConfig.fieldName as any}
+              rules={{ required: `${urlConfig.label} is required` }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{urlConfig.label}</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder={urlConfig.placeholder}
+                      {...field}
+                      value={(field.value as string) ?? ""}
+                    />
+                  </FormControl>
+                  <FormDescription>{urlConfig.description}</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          )}
 
           {(connectorType === "jira" || connectorType === "confluence") && (
             <FormField
@@ -363,6 +366,12 @@ export function EditConnectorDialog({
               {connectorType === "servicenow" && (
                 <ServiceNowConfigFields form={form} hideUrl />
               )}
+              {connectorType === "notion" && (
+                <NotionConfigFields
+                  register={form.register}
+                  errors={form.formState.errors}
+                />
+              )}
             </CollapsibleContent>
           </Collapsible>
         </div>
@@ -422,6 +431,14 @@ function getEditUrlConfig(type: ConnectorType): {
         placeholder: "https://your-instance.service-now.com",
         description: "Your ServiceNow instance URL.",
         typeLabel: "ServiceNow",
+      };
+    case "notion":
+      return {
+        fieldName: "",
+        label: "",
+        placeholder: "",
+        description: "",
+        typeLabel: "Notion",
       };
     default:
       return {

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/notion-config-fields.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/notion-config-fields.tsx
@@ -1,0 +1,65 @@
+import type { FieldErrors, UseFormRegister } from "react-hook-form";
+import type { ConnectorFormData } from "./create-connector-dialog";
+
+interface NotionConfigFieldsProps {
+  register: UseFormRegister<ConnectorFormData>;
+  errors: FieldErrors<ConnectorFormData>;
+}
+
+export function NotionConfigFields({
+  register,
+}: NotionConfigFieldsProps) {
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Provide a{" "}
+        <a
+          href="https://www.notion.so/my-integrations"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary underline"
+        >
+          Notion Integration Token
+        </a>{" "}
+        (starts with <code>secret_</code>). No instance URL is required — Notion
+        is cloud-only.
+      </p>
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium leading-none">
+          Database IDs{" "}
+          <span className="text-xs font-normal text-muted-foreground">
+            (optional — leave empty to sync entire workspace)
+          </span>
+        </label>
+        <textarea
+          {...register("notion.databaseIds")}
+          placeholder={"Enter Notion database IDs, comma-separated"}
+          rows={3}
+          className="flex min-h-[60px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+        />
+        <p className="text-xs text-muted-foreground">
+          When specified, only pages from these databases will be synced. Comma-separated.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium leading-none">
+          Page IDs{" "}
+          <span className="text-xs font-normal text-muted-foreground">
+            (optional)
+          </span>
+        </label>
+        <textarea
+          {...register("notion.pageIds")}
+          placeholder={"Enter specific page IDs, comma-separated"}
+          rows={3}
+          className="flex min-h-[60px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+        />
+        <p className="text-xs text-muted-foreground">
+          When specified, only these specific pages will be synced. Comma-separated.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/transform-config-array-fields.ts
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/transform-config-array-fields.ts
@@ -33,5 +33,22 @@ export function transformConfigArrayFields(
       .filter((n) => !Number.isNaN(n));
   }
 
+  // Notion nested array fields
+  if (
+    result.notion &&
+    typeof result.notion === "object" &&
+    !Array.isArray(result.notion)
+  ) {
+    const notion = result.notion as Record<string, unknown>;
+    const notionArrayFields = ["databaseIds", "pageIds"] as const;
+    for (const key of notionArrayFields) {
+      if (typeof notion[key] === "string") {
+        const value = notion[key] as string;
+        notion[key] = value.split(",").map((s) => s.trim()).filter(Boolean);
+      }
+    }
+    result.notion = notion;
+  }
+
   return result;
 }

--- a/platform/shared/knowledge-base.ts
+++ b/platform/shared/knowledge-base.ts
@@ -77,6 +77,7 @@ export const CONNECTOR_TYPE_LABELS: Record<string, string> = {
   confluence: "Confluence",
   github: "GitHub",
   gitlab: "GitLab",
+  notion: "Notion",
 };
 
 const CONNECTOR_PLACEHOLDER_DEPARTMENTS = [


### PR DESCRIPTION
Implements a Notion knowledge connector for the Archestra knowledge base.

## Summary
Adds a Notion connector that syncs pages and databases from a Notion workspace via the official Notion REST API (no third-party SDK dependency).

## Key capabilities
- Full-workspace sync via `/search` API — discovers all accessible pages
- Filtered sync by `databaseIds` — restrict to specific Notion databases
- Targeted sync by explicit `pageIds` — sync only specified pages
- Incremental sync via `lastSyncedAt` checkpoint to avoid redundant re-syncing
- Block content fetched recursively up to 3 levels deep and converted to Markdown
- Authentication via Notion Integration Token (`secret_...`)

## Changes
- `platform/backend/src/knowledge-base/connectors/notion/notion-connector.ts` — NotionConnector with validateConfig, testConnection, and sync
- `platform/backend/src/types/knowledge-connector.ts` — NotionConfigSchema, NotionCheckpointSchema, discriminated union registration
- `platform/backend/src/knowledge-base/connectors/registry.ts` — connector registered
- `platform/frontend/...` — create/edit dialogs, config fields, icon
- `platform/shared/knowledge-base.ts` — `notion: "Notion"` label
- `docs/pages/platform-knowledge-connectors.md` — updated

## Issue
Closes #3556