### PR TITLE
fix: stop endless retry loop on provider error

### DIFF
--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -320,6 +320,14 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
             ...(supportsToolCalling && { tools: mcpTools }),
             stopWhen: buildChatStopConditions(),
             abortSignal: chatAbortController.signal,
+            // Disable the AI SDK's built-in retry logic so that error
+            // classification and retry decisions are handled exclusively by
+            // the frontend (see global-chat.context.tsx MAX_AUTO_RETRIES).
+            // Without this, a provider connection error (e.g. Ollama down)
+            // triggers AI SDK retries (default: 2) AND frontend retries,
+            // multiplying the number of requests and causing an apparent
+            // endless retry loop.
+            maxRetries: 0,
             onFinish: async ({ usage, finishReason }) => {
               removeAbortListeners();
               logger.info(

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -39,26 +39,27 @@ import { useAppName } from "@/lib/hooks/use-app-name";
 const SESSION_CLEANUP_TIMEOUT = 10 * 60 * 1000; // 10 min
 const MAX_AUTO_RETRIES = 2;
 const AUTO_RETRY_DELAY_MS = 1500;
-/** Network-level errors that never reach the backend */
-const RETRYABLE_CLIENT_ERRORS = [
-  "Failed to fetch",
-  "NetworkError",
-  "No output generated",
-  "network",
-];
+/**
+ * Network-level error strings that indicate a pure client-side failure
+ * (i.e., the request never reached the backend at all).
+ * Keep this list narrow and exact to avoid matching structured backend
+ * error messages that contain substrings like "network" (e.g. "network_error").
+ */
+const RETRYABLE_CLIENT_ERRORS = ["Failed to fetch"];
 
 function isRetryableError(error: Error): boolean {
   const msg = error.message;
-  // Check client-side patterns
-  if (RETRYABLE_CLIENT_ERRORS.some((p) => msg.includes(p))) return true;
-  // Check structured backend error
+  // First, try to parse a structured backend ChatErrorResponse.
+  // This takes priority to avoid false-positive string matches on payloads
+  // that contain words like "network" or "server" as part of an error code.
   try {
     const parsed = JSON.parse(msg);
     if (isChatErrorResponse(parsed)) return parsed.isRetryable;
   } catch {
-    // not JSON
+    // not JSON — fall through to client-side string checks
   }
-  return false;
+  // Only retry pure client-side transport failures that never reached the backend.
+  return RETRYABLE_CLIENT_ERRORS.some((p) => msg.includes(p));
 }
 
 interface ChatSession {


### PR DESCRIPTION
## Summary

Fixes #3476 — endless retry loop when a provider (e.g. Ollama) is unavailable.

### Root causes

**1. Over-broad string matching in `isRetryableError()` (frontend)**

`RETRYABLE_CLIENT_ERRORS` contained broad patterns like `"network"` and `"NetworkError"`. These matched the backend's serialised `ChatErrorCode` string `"network_error"` inside the JSON error payload **before** the JSON was parsed. As a result, any error whose code contained those substrings bypassed the `MAX_AUTO_RETRIES` cap and retried indefinitely.

**2. AI SDK internal retries stacking on top of frontend retries (backend)**

`streamText()` was called without `maxRetries: 0`. The AI SDK defaults to 2 internal retries per call. When a provider is down this means:
- 2 AI SDK retries inside the backend → failure surface to frontend
- Frontend `onError` schedules up to 2 more `regenerate()` calls
- Each `regenerate()` triggers another 2 AI SDK retries

Total: up to **6 requests** for a single user message, creating the visible "endless" loop in the video.

### Fix

**`platform/frontend/src/lib/chat/global-chat.context.tsx`**
- Restructured `isRetryableError()` to parse the structured `ChatErrorResponse` JSON **first**; the `isRetryable` field is the authoritative source.
- Removed the broad string patterns (`"network"`, `"NetworkError"`, `"No output generated"`) from the plain-string fallback; only `"Failed to fetch"` remains (a genuine transport error that never reaches the backend).

**`platform/backend/src/routes/chat/routes.ts`**
- Added `maxRetries: 0` to `streamTextConfig` so the AI SDK never retries internally. Retry strategy is now owned exclusively by the frontend (`MAX_AUTO_RETRIES = 2`), giving a predictable, visible failure state after at most 2 requests.

### Testing

1. Start the app with Ollama configured as the provider.
2. Shut down Ollama to simulate a provider error.
3. Send a chat message.
4. **Before fix:** the loading indicator spins forever (endless retries).
5. **After fix:** the request fails cleanly after at most 2 attempts (≤3 seconds) and shows an error card.

/claim #3476
