### PR TITLE
fix: repair chat sharing migration ordering

### DIFF
--- a/platform/backend/src/database/migrations/meta/_journal.json
+++ b/platform/backend/src/database/migrations/meta/_journal.json
@@ -1412,7 +1412,7 @@
     {
       "idx": 201,
       "version": "7",
-      "when": 1775000404682,
+      "when": 1775056755259,
       "tag": "0201_bumpy_red_wolf",
       "breakpoints": true
     }


### PR DESCRIPTION
## Summary
- fix the drizzle migration journal ordering for `0201_bumpy_red_wolf`
- ensure the chat sharing migration sorts after `0200_rename-auto-configure-on-tool-discovery`
- allow staging to apply the existing `0201` migration on the next deploy without rewriting schema SQL

## Why
- the merged PR shipped `0201_bumpy_red_wolf` with an older `when` value than `0200`
- staging deployed the code, but `drizzle-kit migrate` skipped `0201`, leaving `conversation_share_team` and `conversation_share_user` missing
- the share endpoint then 500ed when it tried to load share targets