### PR TITLE
fix: format playwright.config.ts to pass biome CI

### DIFF
--- a/platform/e2e-tests/playwright.config.ts
+++ b/platform/e2e-tests/playwright.config.ts
@@ -69,7 +69,7 @@ export default defineConfig({
   forbidOnly: IS_CI,
   /* Retry on CI only */
   retries: IS_CI ? 2 : 0,
-  workers: IS_CI ? '90%' : 3,
+  workers: IS_CI ? "90%" : 3,
   /* Global timeout for each test */
   timeout: 60_000,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */


### PR DESCRIPTION
## Summary
- Fixes biome formatting in `platform/e2e-tests/playwright.config.ts` (single quotes → double quotes) introduced by #3618
- This was breaking CI for all open PRs

## Test plan
- [ ] CI passes on this PR