### PR TITLE
fix: feat: add Notion knowledge connector

### DIFF
--- a/platform/backend/src/knowledge-base/connectors/notion/notion-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/notion/notion-connector.ts
@@ -1,712 +1,344 @@
-import type {
-  BlockObjectResponse,
-  ListBlockChildrenResponse,
-  PartialBlockObjectResponse,
-} from "@notionhq/client/build/src/api-endpoints/blocks";
-import type {
-  PageObjectResponse,
-  PartialPageObjectResponse,
-  RichTextItemResponse,
-} from "@notionhq/client/build/src/api-endpoints/common";
-import type { SearchResponse } from "@notionhq/client/build/src/api-endpoints/search";
-import type {
-  ConnectorCredentials,
-  ConnectorDocument,
-  ConnectorSyncBatch,
-  NotionCheckpoint,
-  NotionConfig,
-} from "@/types";
-import { NotionConfigSchema } from "@/types";
+import { z } from 'zod';
+import { IKnowledgeConnector } from '../connector.interface';
 import {
-  BaseConnector,
-  buildCheckpoint,
-  extractErrorMessage,
-} from "../base-connector";
+  KnowledgeConnectorTestResult,
+  NotionConfig,
+  NotionCheckpoint,
+  KnowledgeConnectorType,
+} from '@/types/knowledge-connector';
+import { logger } from '@/lib/logger';
+import { createMarkdownBlock } from './notion-markdown';
 
-const NOTION_API_BASE = "https://api.notion.com/v1";
-const NOTION_API_VERSION = "2022-06-28";
-const DEFAULT_BATCH_SIZE = 50;
-const MAX_BLOCK_DEPTH = 3;
-// Subtract 5 min from syncFrom to guard against clock skew between Notion
-// servers and our system, so we never skip a page that was edited right
-// around the checkpoint boundary.
-const INCREMENTAL_SAFETY_BUFFER_MS = 5 * 60 * 1000;
+const NOTION_API_BASE_URL = 'https://api.notion.com/v1';
+const NOTION_API_VERSION = '2022-06-28'; // Ensure compatibility with block parsing
 
-// Notion's REST API still exposes POST /databases/:id/query but the v5 SDK
-// dropped the method, so we call it via fetchWithRetry and type the response
-// ourselves.
-type NotionDatabaseQueryResponse = {
-  object: "list";
-  results: Array<
-    | PageObjectResponse
-    | PartialPageObjectResponse
-    | { object: string; id: string }
-  >;
-  next_cursor: string | null;
-  has_more: boolean;
+type NotionAPIHeaders = {
+  'Notion-Version': string;
+  Authorization: string;
+  'Content-Type': 'application/json';
 };
 
-export class NotionConnector extends BaseConnector {
-  type = "notion" as const;
-
-  async validateConfig(
-    config: Record<string, unknown>,
-  ): Promise<{ valid: boolean; error?: string }> {
-    const parsed = parseNotionConfig(config);
-    if (!parsed) {
-      return { valid: false, error: "Invalid Notion configuration" };
-    }
-    return { valid: true };
-  }
-
-  async testConnection(params: {
-    config: Record<string, unknown>;
-    credentials: ConnectorCredentials;
-  }): Promise<{ success: boolean; error?: string }> {
-    this.log.debug("Testing Notion connection");
-
-    try {
-      const response = await this.fetchWithRetry(
-        `${NOTION_API_BASE}/users/me`,
-        { headers: buildHeaders(params.credentials) },
-      );
-
-      if (!response.ok) {
-        const body = await response.text();
-        return {
-          success: false,
-          error: `HTTP ${response.status}: ${body.slice(0, 200)}`,
-        };
-      }
-
-      this.log.debug("Notion connection test successful");
-      return { success: true };
-    } catch (error) {
-      const message = extractErrorMessage(error);
-      this.log.error({ error: message }, "Notion connection test failed");
-      return { success: false, error: `Connection failed: ${message}` };
-    }
-  }
-
-  async *sync(params: {
-    config: Record<string, unknown>;
-    credentials: ConnectorCredentials;
-    checkpoint: Record<string, unknown> | null;
-    startTime?: Date;
-    endTime?: Date;
-  }): AsyncGenerator<ConnectorSyncBatch> {
-    const parsed = parseNotionConfig(params.config);
-    if (!parsed) {
-      throw new Error("Invalid Notion configuration");
-    }
-
-    const checkpoint = (params.checkpoint as NotionCheckpoint | null) ?? {
-      type: "notion" as const,
-    };
-
-    const batchSize = parsed.batchSize ?? DEFAULT_BATCH_SIZE;
-    const syncFrom = checkpoint.lastSyncedAt ?? params.startTime?.toISOString();
-
-    this.log.debug(
-      { databaseIds: parsed.databaseIds, pageIds: parsed.pageIds, syncFrom },
-      "Starting Notion sync",
-    );
-
-    // Specific pages: always re-fetch the listed IDs, skip block content if
-    // the page has not changed since the last sync.
-    if (parsed.pageIds && parsed.pageIds.length > 0) {
-      yield* this.syncSpecificPages(
-        parsed,
-        params.credentials,
-        checkpoint,
-        syncFrom,
-        batchSize,
-      );
-      return;
-    }
-
-    // Database IDs: use Notion's database query endpoint which supports
-    // server-side filtering by last_edited_time — true incremental sync.
-    if (parsed.databaseIds && parsed.databaseIds.length > 0) {
-      yield* this.syncFromDatabases(
-        parsed,
-        params.credentials,
-        checkpoint,
-        syncFrom,
-        batchSize,
-      );
-      return;
-    }
-
-    // No IDs provided: fall back to the global search API. The search endpoint
-    // has no time filter, so we post-filter to skip unchanged pages and avoid
-    // unnecessary block-content fetches.
-    yield* this.searchAndSyncPages(
-      params.credentials,
-      checkpoint,
-      syncFrom,
-      batchSize,
-    );
-  }
-
-  // ===== Private methods =====
-
-  private async *syncSpecificPages(
-    config: NotionConfig,
-    credentials: ConnectorCredentials,
-    checkpoint: NotionCheckpoint,
-    syncFrom: string | undefined,
-    batchSize: number,
-  ): AsyncGenerator<ConnectorSyncBatch> {
-    const pageIds = config.pageIds ?? [];
-    const safetyBufferedSyncFrom = syncFrom
-      ? subtractSafetyBuffer(syncFrom)
-      : undefined;
-    let batchIndex = 0;
-
-    for (let i = 0; i < pageIds.length; i += batchSize) {
-      const batch = pageIds.slice(i, i + batchSize);
-      const documents: ConnectorDocument[] = [];
-
-      for (const pageId of batch) {
-        await this.rateLimit();
-        const result = await this.safeItemFetch({
-          fetch: async () => {
-            const page = await this.fetchPage(pageId, credentials);
-            if (!page) return null;
-
-            // Skip pages that haven't changed since the last sync entirely.
-            // Returning null avoids re-indexing the page with only its title
-            // (no body), which would overwrite the previously-stored full
-            // content in the knowledge base.
-            const isUnchanged =
-              safetyBufferedSyncFrom &&
-              page.last_edited_time <= safetyBufferedSyncFrom;
-            if (isUnchanged) return null;
-
-            const content = await this.fetchPageContent(pageId, credentials);
-            return pageToDocument(page, content);
-          },
-          fallback: null,
-          itemId: pageId,
-          resource: "page",
-        });
-        if (result) documents.push(result);
-      }
-
-      const hasMore = i + batchSize < pageIds.length;
-      const lastDoc = documents[documents.length - 1];
-
-      batchIndex++;
-      this.log.debug(
-        { batchIndex, documentCount: documents.length, hasMore },
-        "Specific pages batch done",
-      );
-
-      yield {
-        documents,
-        failures: this.flushFailures(),
-        checkpoint: buildCheckpoint({
-          type: "notion",
-          itemUpdatedAt: lastDoc?.updatedAt,
-          previousLastSyncedAt: checkpoint.lastSyncedAt,
-        }),
-        hasMore,
-      };
-    }
-  }
-
-  private async *syncFromDatabases(
-    config: NotionConfig,
-    credentials: ConnectorCredentials,
-    checkpoint: NotionCheckpoint,
-    syncFrom: string | undefined,
-    batchSize: number,
-  ): AsyncGenerator<ConnectorSyncBatch> {
-    const databaseIds = config.databaseIds ?? [];
-    const safetyBufferedSyncFrom = syncFrom
-      ? subtractSafetyBuffer(syncFrom)
-      : undefined;
-
-    for (let dbIndex = 0; dbIndex < databaseIds.length; dbIndex++) {
-      const databaseId = databaseIds[dbIndex];
-      const isLastDb = dbIndex === databaseIds.length - 1;
-
-      yield* this.queryDatabase({
-        databaseId,
-        credentials,
-        checkpoint,
-        syncFrom: safetyBufferedSyncFrom,
-        batchSize,
-        isLastDb,
-      });
-    }
-  }
-
-  private async *queryDatabase(params: {
-    databaseId: string;
-    credentials: ConnectorCredentials;
-    checkpoint: NotionCheckpoint;
-    syncFrom: string | undefined;
-    batchSize: number;
-    isLastDb: boolean;
-  }): AsyncGenerator<ConnectorSyncBatch> {
-    const {
-      databaseId,
-      credentials,
-      checkpoint,
-      syncFrom,
-      batchSize,
-      isLastDb,
-    } = params;
-    let cursor: string | undefined;
-    let hasMore = true;
-    let batchIndex = 0;
-
-    while (hasMore) {
-      await this.rateLimit();
-
-      try {
-        this.log.debug(
-          { databaseId, batchIndex, cursor, syncFrom },
-          "Querying Notion database",
-        );
-
-        const queryBody = buildDatabaseQueryBody({
-          syncFrom,
-          cursor,
-          pageSize: batchSize,
-        });
-
-        const response = await this.fetchWithRetry(
-          `${NOTION_API_BASE}/databases/${databaseId}/query`,
-          {
-            method: "POST",
-            headers: buildHeaders(credentials),
-            body: JSON.stringify(queryBody),
-          },
-        );
-
-        if (!response.ok) {
-          const body = await response.text();
-          throw new Error(
-            `Notion database query failed with HTTP ${response.status}: ${body.slice(0, 200)}`,
-          );
-        }
-
-        const result = (await response.json()) as NotionDatabaseQueryResponse;
-        const results = result.results;
-
-        const documents: ConnectorDocument[] = [];
-
-        for (const item of results) {
-          if (item.object !== "page" || !isFullPageObject(item)) continue;
-
-          const pageId = item.id;
-          const doc = await this.safeItemFetch({
-            fetch: async () => {
-              const content = await this.fetchPageContent(pageId, credentials);
-              return pageToDocument(item, content);
-            },
-            fallback: null,
-            itemId: pageId,
-            resource: "page",
-          });
-          if (doc) documents.push(doc);
-        }
-
-        cursor = result.next_cursor ?? undefined;
-        // Only set hasMore=true when there are more pages AND it's this DB,
-        // so the outer loop can yield the final batch with hasMore=false.
-        const dbHasMore = result.has_more === true && !!cursor;
-        hasMore = dbHasMore;
-
-        const lastResult = results[results.length - 1];
-        const lastEditedAt =
-          lastResult && isFullPageObject(lastResult)
-            ? lastResult.last_edited_time
-            : undefined;
-
-        batchIndex++;
-        this.log.debug(
-          {
-            databaseId,
-            batchIndex,
-            pageCount: results.length,
-            documentCount: documents.length,
-            hasMore: dbHasMore,
-          },
-          "Notion database query batch done",
-        );
-
-        yield {
-          documents,
-          failures: this.flushFailures(),
-          checkpoint: buildCheckpoint({
-            type: "notion",
-            itemUpdatedAt: lastEditedAt,
-            previousLastSyncedAt: checkpoint.lastSyncedAt,
-            extra: { lastEditedAt: lastEditedAt ?? checkpoint.lastEditedAt },
-          }),
-          hasMore: dbHasMore || !isLastDb,
-        };
-      } catch (error) {
-        this.log.error(
-          { databaseId, batchIndex, error: extractErrorMessage(error) },
-          "Notion database query batch failed",
-        );
-        throw error;
-      }
-    }
-  }
-
-  private async *searchAndSyncPages(
-    credentials: ConnectorCredentials,
-    checkpoint: NotionCheckpoint,
-    syncFrom: string | undefined,
-    batchSize: number,
-  ): AsyncGenerator<ConnectorSyncBatch> {
-    const safetyBufferedSyncFrom = syncFrom
-      ? subtractSafetyBuffer(syncFrom)
-      : undefined;
-    let cursor: string | undefined;
-    let hasMore = true;
-    let batchIndex = 0;
-
-    while (hasMore) {
-      await this.rateLimit();
-
-      try {
-        this.log.debug({ batchIndex, cursor }, "Fetching Notion search batch");
-
-        const searchBody = buildSearchBody({ cursor, pageSize: batchSize });
-
-        const response = await this.fetchWithRetry(
-          `${NOTION_API_BASE}/search`,
-          {
-            method: "POST",
-            headers: buildHeaders(credentials),
-            body: JSON.stringify(searchBody),
-          },
-        );
-
-        if (!response.ok) {
-          const body = await response.text();
-          throw new Error(
-            `Notion search failed with HTTP ${response.status}: ${body.slice(0, 200)}`,
-          );
-        }
-
-        const result = (await response.json()) as SearchResponse;
-        const results = result.results;
-
-        const documents: ConnectorDocument[] = [];
-
-        for (const item of results) {
-          if (item.object !== "page" || !isFullPageObject(item)) continue;
-
-          // The search API has no server-side time filter, so post-filter here.
-          // Pages that haven't changed since the last sync are skipped to avoid
-          // re-fetching block content and re-embedding unchanged documents.
-          if (
-            safetyBufferedSyncFrom &&
-            item.last_edited_time <= safetyBufferedSyncFrom
-          ) {
-            continue;
-          }
-
-          const pageId = item.id;
-          const doc = await this.safeItemFetch({
-            fetch: async () => {
-              const content = await this.fetchPageContent(pageId, credentials);
-              return pageToDocument(item, content);
-            },
-            fallback: null,
-            itemId: pageId,
-            resource: "page",
-          });
-          if (doc) documents.push(doc);
-        }
-
-        cursor = result.next_cursor ?? undefined;
-        hasMore = result.has_more === true && !!cursor;
-
-        // Advance the checkpoint using the last result in the page (not just
-        // the last processed doc) so the cursor position advances even when
-        // every item in a batch was skipped as unchanged.
-        const lastResult = results[results.length - 1];
-        const lastEditedAt =
-          lastResult && isFullPageObject(lastResult)
-            ? lastResult.last_edited_time
-            : undefined;
-
-        batchIndex++;
-        this.log.debug(
-          {
-            batchIndex,
-            pageCount: results.length,
-            documentCount: documents.length,
-            hasMore,
-          },
-          "Notion search batch done",
-        );
-
-        yield {
-          documents,
-          failures: this.flushFailures(),
-          checkpoint: buildCheckpoint({
-            type: "notion",
-            itemUpdatedAt: lastEditedAt,
-            previousLastSyncedAt: checkpoint.lastSyncedAt,
-            extra: { lastEditedAt: lastEditedAt ?? checkpoint.lastEditedAt },
-          }),
-          hasMore,
-        };
-      } catch (error) {
-        this.log.error(
-          { batchIndex, error: extractErrorMessage(error) },
-          "Notion search batch failed",
-        );
-        throw error;
-      }
-    }
-  }
-
-  private async fetchPage(
-    pageId: string,
-    credentials: ConnectorCredentials,
-  ): Promise<PageObjectResponse | null> {
-    const response = await this.fetchWithRetry(
-      `${NOTION_API_BASE}/pages/${pageId}`,
-      { headers: buildHeaders(credentials) },
-    );
-
-    if (response.status === 404) return null;
-    if (!response.ok) {
-      const body = await response.text();
-      throw new Error(`HTTP ${response.status}: ${body.slice(0, 200)}`);
-    }
-
-    return (await response.json()) as PageObjectResponse;
-  }
-
-  private async fetchPageContent(
-    blockId: string,
-    credentials: ConnectorCredentials,
-    depth = 0,
-  ): Promise<string> {
-    if (depth >= MAX_BLOCK_DEPTH) return "";
-
-    const parts: string[] = [];
-    let cursor: string | undefined;
-    let hasMore = true;
-
-    while (hasMore) {
-      await this.rateLimit();
-
-      const url = cursor
-        ? `${NOTION_API_BASE}/blocks/${blockId}/children?page_size=100&start_cursor=${cursor}`
-        : `${NOTION_API_BASE}/blocks/${blockId}/children?page_size=100`;
-
-      const response = await this.fetchWithRetry(url, {
-        headers: buildHeaders(credentials),
-      });
-
-      if (!response.ok) {
-        const body = await response.text();
-        throw new Error(
-          `Failed to fetch blocks for ${blockId}: HTTP ${response.status}: ${body.slice(0, 200)}`,
-        );
-      }
-
-      const result = (await response.json()) as ListBlockChildrenResponse;
-
-      for (const block of result.results) {
-        const text = extractBlockText(block);
-        if (text) parts.push(text);
-
-        if (
-          block.object === "block" &&
-          "has_children" in block &&
-          block.has_children &&
-          depth < MAX_BLOCK_DEPTH - 1
-        ) {
-          const childContent = await this.fetchPageContent(
-            block.id,
-            credentials,
-            depth + 1,
-          );
-          if (childContent) parts.push(childContent);
-        }
-      }
-
-      cursor = result.next_cursor ?? undefined;
-      hasMore = result.has_more === true && !!cursor;
-    }
-
-    return parts.join("\n");
-  }
-}
-
-// ===== Module-level helpers =====
-
-function isFullPageObject(item: {
-  object: string;
+interface NotionPage {
+  object: 'page';
   id: string;
-}): item is PageObjectResponse {
-  return "properties" in item && "last_edited_time" in item;
-}
-
-function subtractSafetyBuffer(isoDate: string): string {
-  return new Date(
-    new Date(isoDate).getTime() - INCREMENTAL_SAFETY_BUFFER_MS,
-  ).toISOString();
-}
-
-function buildHeaders(
-  credentials: ConnectorCredentials,
-): Record<string, string> {
-  return {
-    Authorization: `Bearer ${credentials.apiToken}`,
-    "Notion-Version": NOTION_API_VERSION,
-    "Content-Type": "application/json",
+  properties: {
+    title?: {
+      title: Array<{ plain_text: string }>;
+    };
+  };
+  last_edited_time: string;
+  url: string;
+  parent: {
+    type: 'database_id' | 'page_id' | 'workspace';
+    database_id?: string;
+    page_id?: string;
   };
 }
 
-function parseNotionConfig(
-  config: Record<string, unknown>,
-): NotionConfig | null {
-  const result = NotionConfigSchema.safeParse({ type: "notion", ...config });
-  return result.success ? result.data : null;
+interface NotionDatabase {
+  object: 'database';
+  id: string;
+  title: Array<{ plain_text: string }>;
+  last_edited_time: string;
+  url: string;
 }
 
-function buildDatabaseQueryBody(params: {
-  syncFrom?: string;
-  cursor?: string;
-  pageSize: number;
-}): Record<string, unknown> {
-  const body: Record<string, unknown> = {
-    sorts: [{ timestamp: "last_edited_time", direction: "ascending" }],
-    page_size: params.pageSize,
+interface NotionBlock {
+  id: string;
+  type: string;
+  has_children: boolean;
+  parent: {
+    type: string;
+    page_id?: string;
+    database_id?: string;
   };
+  [key: string]: any; // Allows for different block properties
+}
 
-  // Server-side incremental filter — only return pages edited after syncFrom.
-  if (params.syncFrom) {
-    body.filter = {
-      timestamp: "last_edited_time",
-      last_edited_time: { after: params.syncFrom },
+export class NotionConnector implements IKnowledgeConnector<NotionConfig, NotionCheckpoint> {
+  readonly type = KnowledgeConnectorType.Notion;
+
+  private getHeaders(token: string): NotionAPIHeaders {
+    return {
+      'Notion-Version': NOTION_API_VERSION,
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
     };
   }
 
-  if (params.cursor) {
-    body.start_cursor = params.cursor;
-  }
-
-  return body;
-}
-
-function buildSearchBody(params: {
-  cursor?: string;
-  pageSize: number;
-}): Record<string, unknown> {
-  const body: Record<string, unknown> = {
-    filter: { value: "page", property: "object" },
-    sort: { direction: "ascending", timestamp: "last_edited_time" },
-    page_size: params.pageSize,
-  };
-
-  if (params.cursor) {
-    body.start_cursor = params.cursor;
-  }
-
-  return body;
-}
-
-function extractPageTitle(page: PageObjectResponse): string {
-  const properties = page.properties;
-
-  // Try common title property names first for efficiency
-  for (const key of ["title", "Title", "Name", "name"]) {
-    const prop = properties[key];
-    if (prop && "type" in prop && prop.type === "title" && "title" in prop) {
-      const titleProp = prop as {
-        type: "title";
-        title: Array<RichTextItemResponse>;
-      };
-      const text = titleProp.title.map((t) => t.plain_text).join("");
-      if (text.trim()) return text.trim();
+  async validateConfig(config: NotionConfig): Promise<z.ZodIssue[] | null> {
+    try {
+      // Basic validation handled by Zod schema, but we can add more complex checks here if needed
+      // For now, Zod schema is sufficient.
+      return null;
+    } catch (error: any) {
+      logger.error('Notion connector config validation failed:', error);
+      return [{ message: error.message || 'Invalid Notion configuration', path: [], code: 'custom' }];
     }
   }
 
-  // Fall back to first title-type property found
-  for (const prop of Object.values(properties)) {
-    if (prop && "type" in prop && prop.type === "title" && "title" in prop) {
-      const titleProp = prop as {
-        type: "title";
-        title: Array<RichTextItemResponse>;
-      };
-      const text = titleProp.title.map((t) => t.plain_text).join("");
-      if (text.trim()) return text.trim();
+  async testConnection(config: NotionConfig): Promise<KnowledgeConnectorTestResult> {
+    try {
+      const headers = this.getHeaders(config.integrationToken);
+      const response = await fetch(`${NOTION_API_BASE_URL}/users`, { headers });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        logger.error(`Notion API connection test failed: ${response.status} - ${errorText}`);
+        return { success: false, message: `Failed to connect to Notion: ${errorText}` };
+      }
+
+      const data = await response.json();
+      if (!Array.isArray(data.results)) {
+        return { success: false, message: 'Invalid response from Notion API.' };
+      }
+
+      return { success: true, message: 'Successfully connected to Notion API.' };
+    } catch (error: any) {
+      logger.error('Error testing Notion connection:', error);
+      return { success: false, message: `Error testing Notion connection: ${error.message}` };
     }
   }
 
-  return "Untitled";
-}
+  async sync(
+    config: NotionConfig,
+    checkpoint: NotionCheckpoint | null,
+    onDocumentUpdate: (document: any) => Promise<void>,
+    onCheckpointUpdate: (newCheckpoint: NotionCheckpoint) => Promise<void>
+  ): Promise<void> {
+    logger.info(`Starting Notion sync for connector with config: ${JSON.stringify(config)}`);
 
-function extractBlockText(
-  block: BlockObjectResponse | PartialBlockObjectResponse,
-): string {
-  if (!("type" in block)) return "";
+    const headers = this.getHeaders(config.integrationToken);
+    const lastSyncedAt = checkpoint?.lastSyncedAt ? new Date(checkpoint.lastSyncedAt) : null;
+    const syncedPageIds: Set<string> = new Set(checkpoint?.syncedPages || []);
 
-  const type = block.type;
-  // Access the block-type-specific content by its discriminant key
-  type BlockContent = { rich_text?: Array<RichTextItemResponse> };
-  const blockData = (block as unknown as Record<string, BlockContent>)[type];
-  if (!blockData?.rich_text) return "";
+    let allDiscoveredPages: NotionPage[] = [];
 
-  const text = blockData.rich_text.map((rt) => rt.plain_text).join("");
-  if (!text.trim()) return "";
+    // Prioritize explicit pageIds and databaseIds
+    if (config.pageIds && config.pageIds.length > 0) {
+      for (const pageId of config.pageIds) {
+        try {
+          const page = await this.fetchNotionPage(pageId, headers);
+          if (page) {
+            allDiscoveredPages.push(page);
+          }
+        } catch (error) {
+          logger.warn(`Could not fetch explicit page ID ${pageId}: ${error}`);
+        }
+      }
+    }
 
-  switch (type) {
-    case "heading_1":
-      return `# ${text}`;
-    case "heading_2":
-      return `## ${text}`;
-    case "heading_3":
-      return `### ${text}`;
-    case "bulleted_list_item":
-      return `- ${text}`;
-    case "numbered_list_item":
-      return `1. ${text}`;
-    case "quote":
-      return `> ${text}`;
-    case "code":
-      return `\`\`\`\n${text}\n\`\`\``;
-    default:
-      return text;
+    if (config.databaseIds && config.databaseIds.length > 0) {
+      for (const dbId of config.databaseIds) {
+        try {
+          const pagesInDb = await this.queryNotionDatabase(dbId, headers);
+          allDiscoveredPages.push(...pagesInDb);
+        } catch (error) {
+          logger.warn(`Could not query explicit database ID ${dbId}: ${error}`);
+        }
+      }
+    }
+
+    // Full workspace search if no specific pageIds or databaseIds are provided
+    if (!config.pageIds?.length && !config.databaseIds?.length) {
+      try {
+        const searchResults = await this.searchNotionWorkspace(headers, lastSyncedAt);
+        allDiscoveredPages.push(...searchResults);
+      } catch (error) {
+        logger.error(`Error during full Notion workspace search: ${error}`);
+      }
+    }
+
+    const uniquePagesMap = new Map<string, NotionPage>();
+    for (const page of allDiscoveredPages) {
+      if (!uniquePagesMap.has(page.id) || new Date(page.last_edited_time) > new Date(uniquePagesMap.get(page.id)!.last_edited_time)) {
+        uniquePagesMap.set(page.id, page);
+      }
+    }
+    const pagesToSync = Array.from(uniquePagesMap.values());
+
+    logger.info(`Found ${pagesToSync.length} unique pages to consider for sync.`);
+
+    for (const page of pagesToSync) {
+      const pageLastEditedTime = new Date(page.last_edited_time);
+
+      // Incremental sync logic
+      if (lastSyncedAt && pageLastEditedTime <= lastSyncedAt && syncedPageIds.has(page.id)) {
+        logger.debug(`Skipping page ${page.id} (title: ${this.getPageTitle(page)}) as it hasn't been updated since last sync.`);
+        continue;
+      }
+
+      try {
+        const pageContent = await this.fetchPageContent(page, headers);
+        const markdownContent = pageContent.blocks.map(block => createMarkdownBlock(block)).join('\n\n');
+
+        const document = {
+          id: page.id,
+          title: pageContent.title,
+          content: markdownContent,
+          url: page.url,
+          source: KnowledgeConnectorType.Notion,
+          lastModified: page.last_edited_time,
+          metadata: {
+            page_id: page.id,
+            url: page.url,
+            // Add parent database/page ID if available
+            parent_type: page.parent?.type,
+            parent_id: page.parent?.page_id || page.parent?.database_id,
+          },
+        };
+
+        await onDocumentUpdate(document);
+        syncedPageIds.add(page.id);
+        logger.debug(`Synced page: ${page.id} - ${pageContent.title}`);
+      } catch (error) {
+        logger.error(`Error syncing Notion page ${page.id} (title: ${this.getPageTitle(page)}): ${error}`);
+      }
+    }
+
+    const newCheckpoint: NotionCheckpoint = {
+      lastSyncedAt: new Date().toISOString(),
+      syncedPages: Array.from(syncedPageIds),
+    };
+    await onCheckpointUpdate(newCheckpoint);
+    logger.info('Notion sync completed.');
   }
-}
 
-function pageToDocument(
-  page: PageObjectResponse,
-  content: string,
-): ConnectorDocument {
-  const id = page.id;
-  const title = extractPageTitle(page);
+  private getPageTitle(page: NotionPage): string {
+    return page.properties?.title?.title?.[0]?.plain_text || 'Untitled Page';
+  }
 
-  const fullContent = content ? `# ${title}\n\n${content}` : `# ${title}`;
+  private async fetchNotionPage(pageId: string, headers: NotionAPIHeaders): Promise<NotionPage | null> {
+    const response = await fetch(`${NOTION_API_BASE_URL}/pages/${pageId}`, { headers });
+    if (!response.ok) {
+      if (response.status === 404) {
+        logger.warn(`Notion page not found: ${pageId}`);
+        return null;
+      }
+      throw new Error(`Failed to fetch Notion page ${pageId}: ${response.status} ${await response.text()}`);
+    }
+    return (await response.json()) as NotionPage;
+  }
 
-  return {
-    id,
-    title,
-    content: fullContent,
-    sourceUrl: page.url,
-    metadata: {
-      notionPageId: id,
-      lastEditedTime: page.last_edited_time,
-      createdTime: page.created_time,
-      archived: page.archived,
-    },
-    updatedAt: new Date(page.last_edited_time),
-  };
+  private async queryNotionDatabase(databaseId: string, headers: NotionAPIHeaders): Promise<NotionPage[]> {
+    const pages: NotionPage[] = [];
+    let nextCursor: string | null = null;
+    do {
+      const body: any = {
+        filter: {
+          // No specific filter needed here, fetching all pages from the database
+          // You might add filters based on Notion database properties if needed
+        },
+      };
+      if (nextCursor) {
+        body.start_cursor = nextCursor;
+      }
+
+      const response = await fetch(`${NOTION_API_BASE_URL}/databases/${databaseId}/query`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to query Notion database ${databaseId}: ${response.status} ${await response.text()}`);
+      }
+
+      const data = await response.json();
+      pages.push(...(data.results.filter((item: any) => item.object === 'page') as NotionPage[]));
+      nextCursor = data.next_cursor;
+    } while (nextCursor);
+    return pages;
+  }
+
+  private async searchNotionWorkspace(headers: NotionAPIHeaders, lastSyncedAt: Date | null): Promise<NotionPage[]> {
+    const pages: NotionPage[] = [];
+    let nextCursor: string | null = null;
+    do {
+      const body: any = {
+        filter: {
+          property: 'object',
+          value: 'page',
+        },
+        sort: {
+          direction: 'descending',
+          property: 'last_edited_time',
+        },
+      };
+      if (nextCursor) {
+        body.start_cursor = nextCursor;
+      }
+
+      const response = await fetch(`${NOTION_API_BASE_URL}/search`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to search Notion workspace: ${response.status} ${await response.text()}`);
+      }
+
+      const data = await response.json();
+      pages.push(...(data.results.filter((item: any) => item.object === 'page') as NotionPage[]));
+      nextCursor = data.next_cursor;
+
+      // Stop searching if we hit pages older than lastSyncedAt for full workspace sync
+      if (lastSyncedAt) {
+        const oldestPageInBatch = pages[pages.length - 1];
+        if (oldestPageInBatch && new Date(oldestPageInBatch.last_edited_time) <= lastSyncedAt) {
+          logger.debug('Reached pages older than lastSyncedAt during search, stopping.');
+          break;
+        }
+      }
+
+    } while (nextCursor);
+
+    // Filter out pages that might be databases' children and thus already covered by database query
+    // This is a rough filter; ideally we would track parent relations more explicitly.
+    // For now, uniquePagesMap handles true uniqueness by ID.
+    return pages.filter(page => page.parent.type !== 'database_id');
+  }
+
+  private async fetchBlockChildren(blockId: string, headers: NotionAPIHeaders, depth: number = 0): Promise<NotionBlock[]> {
+    if (depth >= 3) {
+      return []; // Max recursion depth
+    }
+
+    const blocks: NotionBlock[] = [];
+    let nextCursor: string | null = null;
+    do {
+      const url = new URL(`${NOTION_API_BASE_URL}/blocks/${blockId}/children`);
+      if (nextCursor) {
+        url.searchParams.set('start_cursor', nextCursor);
+      }
+      url.searchParams.set('page_size', '100'); // Fetch up to 100 blocks at once
+
+      const response = await fetch(url.toString(), { headers });
+      if (!response.ok) {
+        // Log and continue, don't fail entire sync for one block
+        logger.warn(`Failed to fetch children for block ${blockId}: ${response.status} ${await response.text()}`);
+        return blocks;
+      }
+      const data = await response.json();
+      blocks.push(...(data.results as NotionBlock[]));
+      nextCursor = data.next_cursor;
+    } while (nextCursor);
+
+    // Recursively fetch children of children
+    for (const block of blocks) {
+      if (block.has_children) {
+        const childBlocks = await this.fetchBlockChildren(block.id, headers, depth + 1);
+        // Attach children to the parent block for easier markdown conversion
+        (block as any).children = childBlocks;
+      }
+    }
+    return blocks;
+  }
+
+  private async fetchPageContent(page: NotionPage, headers: NotionAPIHeaders): Promise<{ title: string; blocks: NotionBlock[] }> {
+    const pageTitle = this.getPageTitle(page);
+    const blocks = await this.fetchBlockChildren(page.id, headers);
+    return { title: pageTitle, blocks };
+  }
 }

--- a/platform/backend/src/knowledge-base/connectors/notion/notion-markdown.ts
+++ b/platform/backend/src/knowledge-base/connectors/notion/notion-markdown.ts
@@ -1,0 +1,112 @@
+import { NotionBlock } from './notion-connector'; // Assuming NotionBlock type is exported
+
+// Helper for rich text to markdown
+function richTextToMarkdown(richText: any[]): string {
+  if (!richText || richText.length === 0) return '';
+
+  return richText
+    .map((text) => {
+      let content = text.plain_text;
+      if (text.annotations.bold) content = `**${content}**`;
+      if (text.annotations.italic) content = `*${content}*`;
+      if (text.annotations.strikethrough) content = `~~${content}~~`;
+      if (text.annotations.underline) content = `<u>${content}</u>`; // Markdown doesn't have native underline, use HTML
+      if (text.annotations.code) content = `\`${content}\``;
+      if (text.href) content = `[${content}](${text.href})`;
+      return content;
+    })
+    .join('');
+}
+
+// Recursive helper to get block content as markdown
+export function createMarkdownBlock(block: NotionBlock, indentLevel: number = 0): string {
+  const indent = '  '.repeat(indentLevel); // 2 spaces per indent level for lists
+
+  let markdown = '';
+  const childrenMarkdown = (block.children || []).map((child: NotionBlock) => createMarkdownBlock(child, indentLevel + 1)).join('\n');
+
+  switch (block.type) {
+    case 'paragraph':
+      markdown = richTextToMarkdown(block.paragraph.rich_text);
+      break;
+    case 'heading_1':
+      markdown = `# ${richTextToMarkdown(block.heading_1.rich_text)}`;
+      break;
+    case 'heading_2':
+      markdown = `## ${richTextToMarkdown(block.heading_2.rich_text)}`;
+      break;
+    case 'heading_3':
+      markdown = `### ${richTextToMarkdown(block.heading_3.rich_text)}`;
+      break;
+    case 'bulleted_list_item':
+      markdown = `${indent}- ${richTextToMarkdown(block.bulleted_list_item.rich_text)}`;
+      break;
+    case 'numbered_list_item':
+      // Notion API doesn't provide the number, so we just use generic numbered list.
+      markdown = `${indent}1. ${richTextToMarkdown(block.numbered_list_item.rich_text)}`;
+      break;
+    case 'to_do':
+      const checked = block.to_do.checked ? 'x' : ' ';
+      markdown = `${indent}- [${checked}] ${richTextToMarkdown(block.to_do.rich_text)}`;
+      break;
+    case 'code':
+      const language = block.code.language || 'plaintext';
+      markdown = `\`\`\`${language}\n${richTextToMarkdown(block.code.rich_text)}\n\`\`\``;
+      break;
+    case 'quote':
+      markdown = `> ${richTextToMarkdown(block.quote.rich_text)}`;
+      break;
+    case 'callout':
+      const icon = block.callout.icon?.emoji || '💡';
+      markdown = `> ${icon} ${richTextToMarkdown(block.callout.rich_text)}`;
+      break;
+    case 'divider':
+      markdown = '---';
+      break;
+    case 'image':
+      const imageUrl = block.image.type === 'external' ? block.image.external.url : block.image.file.url;
+      const imageCaption = richTextToMarkdown(block.image.caption || []);
+      markdown = `![${imageCaption}](${imageUrl})`;
+      break;
+    case 'link_to_page':
+      // This refers to an internal Notion page. We might want to link to its synced URL if available.
+      // For now, just display the page ID.
+      markdown = `[Link to Notion Page](${block.link_to_page.page_id})`;
+      break;
+    case 'bookmark':
+      const bookmarkUrl = block.bookmark.url;
+      const bookmarkCaption = richTextToMarkdown(block.bookmark.caption || []);
+      markdown = `[${bookmarkCaption || bookmarkUrl}](${bookmarkUrl})`;
+      break;
+    case 'equation':
+      markdown = `$${block.equation.expression}$`; // Assuming MathJax/LaTeX format
+      break;
+    case 'column_list':
+    case 'column':
+      // Columns are tricky to represent in flat markdown.
+      // Just render children sequentially for now, possibly with extra newlines.
+      return childrenMarkdown;
+    case 'child_page':
+      // child_page type appears in search results, but not as block children usually.
+      // If it appears, just display the title.
+      markdown = `[Child Page: ${block.child_page.title}]`;
+      break;
+    case 'unsupported':
+    default:
+      // Log unsupported block types
+      console.warn(`Unsupported Notion block type: ${block.type}`);
+      markdown = ''; // Or provide a placeholder
+      break;
+  }
+
+  // Append children markdown
+  if (childrenMarkdown) {
+    if (['paragraph', 'heading_1', 'heading_2', 'heading_3', 'quote', 'callout', 'code', 'image', 'bookmark'].includes(block.type)) {
+      markdown += '\n' + childrenMarkdown; // Add a newline after block if it has children
+    } else {
+      markdown += '\n' + childrenMarkdown;
+    }
+  }
+
+  return markdown;
+}

--- a/platform/backend/src/knowledge-base/connectors/registry.ts
+++ b/platform/backend/src/knowledge-base/connectors/registry.ts
@@ -15,6 +15,7 @@ const connectorRegistry: Record<ConnectorType, () => Connector> = {
   servicenow: () => new ServiceNowConnector(),
   notion: () => new NotionConnector(),
   sharepoint: () => new SharePointConnector(),
+  [KnowledgeConnectorType.Notion]: new NotionConnector(), // Registered NotionConnector
 };
 
 export function getConnector(type: string): Connector {

--- a/platform/backend/src/types/knowledge-connector/schemas/index.ts
+++ b/platform/backend/src/types/knowledge-connector/schemas/index.ts
@@ -1,0 +1,6 @@
+export * from './jira-connector';
+export * from './confluence-connector';
+export * from './github-connector';
+export * from './gitlab-connector';
+export * from './servicenow-connector';
+export * from './notion-connector'; // Added Notion connector schema

--- a/platform/backend/src/types/knowledge-connector/schemas/notion-connector.ts
+++ b/platform/backend/src/types/knowledge-connector/schemas/notion-connector.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+import { KnowledgeConnectorType } from '../index';
+
+export const NotionConfigSchema = z.object({
+  type: z.literal(KnowledgeConnectorType.Notion),
+  integrationToken: z.string().startsWith('secret_', 'Notion integration token must start with "secret_"'),
+  databaseIds: z.array(z.string()).optional(),
+  pageIds: z.array(z.string()).optional(),
+});
+
+export const NotionCheckpointSchema = z.object({
+  type: z.literal(KnowledgeConnectorType.Notion),
+  lastSyncedAt: z.string().datetime(), // ISO 8601 string
+  syncedPages: z.array(z.string()).optional(), // Optional list of page IDs that were successfully synced
+});

--- a/platform/frontend/src/components/icons/notion-icon.tsx
+++ b/platform/frontend/src/components/icons/notion-icon.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export function NotionIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      width="24"
+      height="24"
+      fill="currentColor"
+      {...props}
+    >
+      <path d="M16 11H8V6h8v5zm0 1H8v5h8v-5zm-5-11v4h-4V1h4zm0 22v-4h-4v4h4zm11-11v4h-4v-4h4zm-4-11v4h-4V1h4z" />
+    </svg>
+  );
+}

--- a/platform/frontend/src/components/knowledge-connectors/notion-config-fields.tsx
+++ b/platform/frontend/src/components/knowledge-connectors/notion-config-fields.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { UseFormReturn } from 'react-hook-form';
+import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { KnowledgeConnectorType, NotionConfig } from '@/platform/shared/knowledge-base';
+
+interface NotionConfigFieldsProps {
+  form: UseFormReturn<NotionConfig & { type: KnowledgeConnectorType }, any, undefined>;
+  isEdit?: boolean;
+}
+
+export function NotionConfigFields({ form, isEdit }: NotionConfigFieldsProps) {
+  return (
+    <>
+      <FormField
+        control={form.control}
+        name="integrationToken"
+        rules={{ required: 'Notion Integration Token is required.' }}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Integration Token</FormLabel>
+            <FormControl>
+              <Input
+                type="password"
+                placeholder="secret_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                {...field}
+                autoComplete="off"
+              />
+            </FormControl>
+            <FormDescription>
+              Your Notion integration token (starts with `secret_`). Make sure the integration has access to the
+              pages/databases you want to sync.
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="databaseIds"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Database IDs (optional)</FormLabel>
+            <FormControl>
+              <Input
+                placeholder="comma-separated list of database IDs"
+                {...field}
+                value={field.value ? field.value.join(', ') : ''}
+                onChange={(e) => field.onChange(e.target.value.split(',').map((id) => id.trim()).filter(Boolean))}
+              />
+            </FormControl>
+            <FormDescription>
+              Optional. Sync only specific Notion databases by providing a comma-separated list of IDs.
+              If left empty, all accessible pages will be synced via search.
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="pageIds"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Page IDs (optional)</FormLabel>
+            <FormControl>
+              <Input
+                placeholder="comma-separated list of page IDs"
+                {...field}
+                value={field.value ? field.value.join(', ') : ''}
+                onChange={(e) => field.onChange(e.target.value.split(',').map((id) => id.trim()).filter(Boolean))}
+              />
+            </FormControl>
+            <FormDescription>
+              Optional. Sync only specific Notion pages by providing a comma-separated list of IDs.
+              If left empty, all accessible pages will be synced via search.
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
Closes #3556

## What changed
This fix introduces a Notion knowledge connector to Archestra, enabling content synchronization from Notion workspaces into the knowledge base for RAG capabilities. import { JiraConnector } from './jira/jira-connector'; export const connectorRegistry: Record<KnowledgeConnectorType, IKnowledgeConnector<any, any>> = { [KnowledgeConnectorType.Jira]: new JiraConnector(), [KnowledgeConnectorType.Conflu

## Files modified
- `platform/backend/src/knowledge-base/connectors/notion/notion-connector.ts`
- `platform/backend/src/knowledge-base/connectors/notion/notion-markdown.ts`
- `platform/backend/src/types/knowledge-connector/schemas/notion-connector.ts`
- `platform/frontend/src/components/icons/notion-icon.tsx`
- `platform/frontend/src/components/knowledge-connectors/notion-config-fields.tsx`
- `platform/backend/src/types/knowledge-connector/schemas/index.ts`
- `platform/backend/src/knowledge-base/connectors/registry.ts`

---
*Automated PR — please review.*