### PR TITLE
fix: stabilize e2e CI setup

### DIFF
--- a/platform/e2e-tests/consts.ts
+++ b/platform/e2e-tests/consts.ts
@@ -36,7 +36,7 @@ export const API_BASE_URL =
   process.env.E2E_API_BASE_URL || "http://localhost:9000";
 export const WIREMOCK_BASE_URL =
   process.env.E2E_WIREMOCK_BASE_URL ||
-  (IS_CI ? "http://127.0.0.1:30080" : "http://127.0.0.1:9092");
+  (IS_CI ? "http://127.0.0.1:8080" : "http://127.0.0.1:9092");
 
 // Internal WireMock URL for backend-to-wiremock connections (used when storing URLs in database)
 // In CI, the backend pod needs to use the Kubernetes service DNS name

--- a/platform/e2e-tests/tests/api/mcp-gateway.spec.ts
+++ b/platform/e2e-tests/tests/api/mcp-gateway.spec.ts
@@ -424,40 +424,28 @@ test.describe("MCP Gateway - External MCP Server Tests", () => {
       uninstallMcpServer,
       getTeamByName,
     }) => {
-      // Use the Default MCP Gateway
-      const defaultGatewayResponse = await makeApiRequest({
-        request,
-        method: "get",
-        urlSuffix: "/api/mcp-gateways/default",
-      });
-      const defaultGateway = await defaultGatewayResponse.json();
-      profileId = defaultGateway.id;
-
-      // Get org token using shared utility
-      archestraToken = await getOrgTokenForProfile(request);
-
       // Get the Default Team (required for MCP server installation when Vault is enabled)
       const defaultTeam = await getTeamByName(request, "Default Team");
       if (!defaultTeam) {
         throw new Error("Default Team not found");
       }
 
-      const existingTeamIds = (defaultGateway.teams ?? [])
-        .map((team: string | { id?: string; teamId?: string }) =>
-          typeof team === "string" ? team : (team.id ?? team.teamId),
-        )
-        .filter((teamId: string | undefined): teamId is string =>
-          Boolean(teamId),
-        );
-
-      await makeApiRequest({
+      const gatewayResponse = await makeApiRequest({
         request,
-        method: "put",
-        urlSuffix: `/api/agents/${profileId}`,
+        method: "post",
+        urlSuffix: "/api/agents",
         data: {
-          teams: Array.from(new Set([...existingTeamIds, defaultTeam.id])),
+          name: `External MCP Gateway ${crypto.randomUUID().slice(0, 8)}`,
+          agentType: "mcp_gateway",
+          scope: "team",
+          teams: [defaultTeam.id],
         },
       });
+      const gateway = await gatewayResponse.json();
+      profileId = gateway.id;
+
+      // Get org token using shared utility
+      archestraToken = await getOrgTokenForProfile(request);
 
       // Find the catalog item for internal-dev-test-server
       const catalogItem = await findCatalogItem(
@@ -569,6 +557,10 @@ test.describe("MCP Gateway - External MCP Server Tests", () => {
       }
     },
   );
+
+  test.afterAll(async ({ request, deleteAgent }) => {
+    if (profileId) await deleteAgent(request, profileId);
+  });
 
   const makeMcpGatewayRequestHeaders = () => ({
     Authorization: `Bearer ${archestraToken}`,


### PR DESCRIPTION
## Summary

This follows up after the MCP token lifetime PR was merged and carries only the uncommitted e2e CI fixes.

- Point CI-side WireMock admin calls at `127.0.0.1:8080`, which is the host port mapped by the Kind config.
- Update the external MCP gateway API tests to create a dedicated team-scoped MCP gateway for the Default Team before assigning a team-scoped MCP server connection.
- Clean up the dedicated gateway after the test group.