### PR TITLE
chore(ci): remove unused vitest CI flag

### DIFF
--- a/platform/frontend/vitest.config.ts
+++ b/platform/frontend/vitest.config.ts
@@ -2,8 +2,6 @@ import path from "node:path";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
 
-const isCI = process.env.CI === "true";
-
 export default defineConfig({
   plugins: [tsconfigPaths()],
   resolve: {


### PR DESCRIPTION
## Summary

Remove an unused `isCI` constant from the frontend Vitest config.

## Validation

- `pnpm exec biome check --write frontend/vitest.config.ts`
- `pnpm --filter @frontend type-check`
