### PR TITLE
fix: apply MCP OAuth lifetime for inspector resources

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Archestra",
-    "version": "1.2.7"
+    "version": "1.2.8"
   },
   "components": {
     "schemas": {

--- a/platform/backend/src/routes/auth.test.ts
+++ b/platform/backend/src/routes/auth.test.ts
@@ -97,4 +97,64 @@ describe("auth routes", () => {
       new Date((issuedAtSeconds + 604_800) * 1000),
     );
   });
+
+  test("applies MCP token lifetime when resource uses the token endpoint origin", async ({
+    makeAgent,
+    makeOAuthAccessToken,
+    makeOAuthClient,
+    makeOrganization,
+    makeUser,
+  }) => {
+    const user = await makeUser();
+    const organization = await makeOrganization();
+    await OrganizationModel.patch(organization.id, {
+      mcpOauthAccessTokenLifetimeSeconds: 31_536_000,
+    });
+    const agent = await makeAgent({ organizationId: organization.id });
+    const client = await makeOAuthClient({ userId: user.id });
+    const rawAccessToken = "inspector-oauth-access-token";
+    const tokenHash = createHash("sha256")
+      .update(rawAccessToken)
+      .digest("base64url");
+    await makeOAuthAccessToken(client.clientId, user.id, {
+      token: tokenHash,
+      expiresAt: new Date("2026-01-01T01:00:00.000Z"),
+    });
+    vi.mocked(betterAuth.handler).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: rawAccessToken,
+          token_type: "Bearer",
+          expires_in: 3_600,
+          scope: "mcp",
+        }),
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      ),
+    );
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/auth/oauth2/token",
+      headers: {
+        host: "localhost:9000",
+      },
+      payload: {
+        grant_type: "authorization_code",
+        client_id: client.clientId,
+        code: "auth-code",
+        resource: `http://localhost:9000/v1/mcp/${agent.id}`,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      access_token: rawAccessToken,
+      expires_in: 31_536_000,
+    });
+  });
 });

--- a/platform/backend/src/routes/auth.test.ts
+++ b/platform/backend/src/routes/auth.test.ts
@@ -157,4 +157,65 @@ describe("auth routes", () => {
       expires_in: 31_536_000,
     });
   });
+
+  test("applies MCP token lifetime for HTTPS token endpoint origin behind proxy", async ({
+    makeAgent,
+    makeOAuthAccessToken,
+    makeOAuthClient,
+    makeOrganization,
+    makeUser,
+  }) => {
+    const user = await makeUser();
+    const organization = await makeOrganization();
+    await OrganizationModel.patch(organization.id, {
+      mcpOauthAccessTokenLifetimeSeconds: 31_536_000,
+    });
+    const agent = await makeAgent({ organizationId: organization.id });
+    const client = await makeOAuthClient({ userId: user.id });
+    const rawAccessToken = "https-inspector-oauth-access-token";
+    const tokenHash = createHash("sha256")
+      .update(rawAccessToken)
+      .digest("base64url");
+    await makeOAuthAccessToken(client.clientId, user.id, {
+      token: tokenHash,
+      expiresAt: new Date("2026-01-01T01:00:00.000Z"),
+    });
+    vi.mocked(betterAuth.handler).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: rawAccessToken,
+          token_type: "Bearer",
+          expires_in: 3_600,
+          scope: "mcp",
+        }),
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      ),
+    );
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/auth/oauth2/token",
+      headers: {
+        host: "backend.example.com",
+        "x-forwarded-proto": "https",
+      },
+      payload: {
+        grant_type: "authorization_code",
+        client_id: client.clientId,
+        code: "auth-code",
+        resource: `https://backend.example.com/v1/mcp/${agent.id}`,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      access_token: rawAccessToken,
+      expires_in: 31_536_000,
+    });
+  });
 });

--- a/platform/backend/src/routes/auth.ts
+++ b/platform/backend/src/routes/auth.ts
@@ -344,6 +344,7 @@ const authRoutes: FastifyPluginAsyncZod = async (fastify) => {
       const responseBody = await applyMcpOauthTokenLifetimeToResponse({
         response,
         resource,
+        tokenEndpointOrigin: url.origin,
       });
 
       reply.status(response.status);
@@ -610,6 +611,7 @@ function shouldSkipForwardedAuthHeader(headerName: string): boolean {
 async function applyMcpOauthTokenLifetimeToResponse(params: {
   response: Response;
   resource: unknown;
+  tokenEndpointOrigin: string;
 }): Promise<string | null> {
   if (!params.response.body) {
     return null;
@@ -639,6 +641,7 @@ async function applyMcpOauthTokenLifetimeToResponse(params: {
   const lifetimeSeconds = await getMcpOauthAccessTokenLifetimeSeconds({
     resource: params.resource,
     referenceId: storedToken?.referenceId,
+    tokenEndpointOrigin: params.tokenEndpointOrigin,
   });
   if (!storedToken || !lifetimeSeconds) {
     return responseText;
@@ -664,10 +667,13 @@ async function applyMcpOauthTokenLifetimeToResponse(params: {
 async function getMcpOauthAccessTokenLifetimeSeconds(params: {
   resource: unknown;
   referenceId: string | null | undefined;
+  tokenEndpointOrigin: string;
 }): Promise<number | null> {
   const profileId =
-    getProfileIdFromResource(params.resource) ??
-    getProfileIdFromReferenceId(params.referenceId);
+    getProfileIdFromResource({
+      resource: params.resource,
+      tokenEndpointOrigin: params.tokenEndpointOrigin,
+    }) ?? getProfileIdFromReferenceId(params.referenceId);
   if (!profileId) {
     return null;
   }
@@ -719,12 +725,32 @@ function getIssuedAtSeconds(tokenBody: Record<string, unknown>): number {
   return Math.floor(Date.now() / 1000);
 }
 
-function getProfileIdFromResource(resource: unknown): string | null {
-  if (typeof resource !== "string") {
+function getProfileIdFromResource(params: {
+  resource: unknown;
+  tokenEndpointOrigin: string;
+}): string | null {
+  if (typeof params.resource !== "string") {
     return null;
   }
 
-  return extractProfileIdFromMcpResource(resource);
+  const profileIdFromIssuerResource = extractProfileIdFromMcpResource(
+    params.resource,
+  );
+  if (profileIdFromIssuerResource) {
+    return profileIdFromIssuerResource;
+  }
+
+  try {
+    const resourceUrl = new URL(params.resource);
+    if (resourceUrl.origin !== params.tokenEndpointOrigin) {
+      return null;
+    }
+
+    const match = resourceUrl.pathname.match(/^\/v1\/mcp\/([0-9a-f-]{36})$/i);
+    return match?.[1] ?? null;
+  } catch {
+    return null;
+  }
 }
 
 function getProfileIdFromReferenceId(

--- a/platform/backend/src/routes/auth.ts
+++ b/platform/backend/src/routes/auth.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import type { IncomingHttpHeaders } from "node:http";
 import { DEFAULT_ADMIN_EMAIL, RouteId } from "@shared";
 import { verifyPassword } from "better-auth/crypto";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
@@ -321,7 +322,11 @@ const authRoutes: FastifyPluginAsyncZod = async (fastify) => {
         delete body.resource;
       }
 
-      const url = new URL(request.url, `http://${request.headers.host}`);
+      const tokenEndpointOrigin = getRequestOrigin({
+        protocol: request.protocol,
+        headers: request.headers,
+      });
+      const url = new URL(request.url, tokenEndpointOrigin);
       const headers = new Headers();
       Object.entries(request.headers).forEach(([key, value]) => {
         if (value) headers.append(key, value.toString());
@@ -344,7 +349,7 @@ const authRoutes: FastifyPluginAsyncZod = async (fastify) => {
       const responseBody = await applyMcpOauthTokenLifetimeToResponse({
         response,
         resource,
-        tokenEndpointOrigin: url.origin,
+        tokenEndpointOrigin,
       });
 
       reply.status(response.status);
@@ -761,6 +766,31 @@ function getProfileIdFromReferenceId(
   }
 
   return referenceId.slice(MCP_RESOURCE_REFERENCE_PREFIX.length) || null;
+}
+
+function getRequestOrigin(params: {
+  protocol: string;
+  headers: IncomingHttpHeaders;
+}): string {
+  const host = Array.isArray(params.headers.host)
+    ? params.headers.host[0]
+    : params.headers.host;
+  const forwardedProto = getFirstHeaderValue(
+    params.headers["x-forwarded-proto"],
+  );
+  const protocol = (forwardedProto || params.protocol || "http").replace(
+    /:$/,
+    "",
+  );
+
+  return `${protocol}://${host}`;
+}
+
+function getFirstHeaderValue(
+  header: string | string[] | undefined,
+): string | undefined {
+  const value = Array.isArray(header) ? header[0] : header;
+  return value?.split(",")[0]?.trim() || undefined;
 }
 
 function hashOAuthAccessTokenForLookup(oauthAccessToken: string): string {


### PR DESCRIPTION
## Summary

Fix MCP OAuth token lifetime handling for clients like MCP Inspector that send the MCP `resource` URL using the backend/token endpoint origin.

The 1.2.8 lifetime override only recognized MCP resource URLs on the frontend issuer origin, so Inspector token responses still showed Better Auth's default `expires_in: 3600`. This now recognizes `/v1/mcp/{gatewayId}` resources on the token endpoint origin and applies the organization setting.