### PR TITLE
fix: reranker model dropdown labels

### DIFF
--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -364,6 +364,7 @@ function RerankerModelSelector({
       className={cn("w-full", pulse && "animate-pulse ring-2 ring-primary/40")}
       popoverContentClassName={KNOWLEDGE_MODEL_POPOVER_CLASS}
       popoverSide="bottom"
+      popoverAvoidCollisions={false}
       truncateOptionLabels={false}
       disabled={disabled}
     />
@@ -618,6 +619,7 @@ function KnowledgeSettingsContent() {
                     )}
                     popoverContentClassName={KNOWLEDGE_MODEL_POPOVER_CLASS}
                     popoverSide="bottom"
+                    popoverAvoidCollisions={false}
                     truncateOptionLabels={false}
                     disabled={
                       !hasPermission ||

--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -79,6 +79,8 @@ const EMBEDDING_DEFAULT_FORM_VALUES: LlmProviderApiKeyFormValues = {
 const KNOWLEDGE_SETTINGS_CONTROL_CLASS = "w-full max-w-[28rem]";
 const KNOWLEDGE_MODEL_POPOVER_CLASS =
   "w-max min-w-[var(--radix-popover-trigger-width)] max-w-[min(32rem,calc(100vw-2rem))]";
+const KNOWLEDGE_MODEL_POPOVER_LIST_CLASS =
+  "max-h-[min(220px,calc(var(--radix-popover-content-available-height)-3rem))]";
 
 function AddApiKeyDialog({
   open,
@@ -363,6 +365,7 @@ function RerankerModelSelector({
       placeholder="Select reranking model..."
       className={cn("w-full", pulse && "animate-pulse ring-2 ring-primary/40")}
       popoverContentClassName={KNOWLEDGE_MODEL_POPOVER_CLASS}
+      popoverListClassName={KNOWLEDGE_MODEL_POPOVER_LIST_CLASS}
       popoverSide="bottom"
       popoverAlign="end"
       truncateOptionLabels={false}
@@ -618,6 +621,7 @@ function KnowledgeSettingsContent() {
                         "animate-pulse ring-2 ring-primary/40",
                     )}
                     popoverContentClassName={KNOWLEDGE_MODEL_POPOVER_CLASS}
+                    popoverListClassName={KNOWLEDGE_MODEL_POPOVER_LIST_CLASS}
                     popoverSide="bottom"
                     popoverAlign="end"
                     truncateOptionLabels={false}

--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -360,6 +360,8 @@ function RerankerModelSelector({
       options={rerankerItems}
       placeholder="Select reranking model..."
       className={cn("w-full", pulse && "animate-pulse ring-2 ring-primary/40")}
+      popoverContentClassName="w-[min(520px,calc(100vw-2rem))]"
+      truncateOptionLabels={false}
       disabled={disabled}
     />
   );

--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -364,7 +364,6 @@ function RerankerModelSelector({
       className={cn("w-full", pulse && "animate-pulse ring-2 ring-primary/40")}
       popoverContentClassName={KNOWLEDGE_MODEL_POPOVER_CLASS}
       popoverSide="bottom"
-      popoverAvoidCollisions={false}
       truncateOptionLabels={false}
       disabled={disabled}
     />
@@ -619,7 +618,6 @@ function KnowledgeSettingsContent() {
                     )}
                     popoverContentClassName={KNOWLEDGE_MODEL_POPOVER_CLASS}
                     popoverSide="bottom"
-                    popoverAvoidCollisions={false}
                     truncateOptionLabels={false}
                     disabled={
                       !hasPermission ||

--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -363,6 +363,7 @@ function RerankerModelSelector({
       placeholder="Select reranking model..."
       className={cn("w-full", pulse && "animate-pulse ring-2 ring-primary/40")}
       popoverContentClassName={KNOWLEDGE_MODEL_POPOVER_CLASS}
+      popoverSide="bottom"
       truncateOptionLabels={false}
       disabled={disabled}
     />
@@ -616,6 +617,7 @@ function KnowledgeSettingsContent() {
                         "animate-pulse ring-2 ring-primary/40",
                     )}
                     popoverContentClassName={KNOWLEDGE_MODEL_POPOVER_CLASS}
+                    popoverSide="bottom"
                     truncateOptionLabels={false}
                     disabled={
                       !hasPermission ||

--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -364,6 +364,7 @@ function RerankerModelSelector({
       className={cn("w-full", pulse && "animate-pulse ring-2 ring-primary/40")}
       popoverContentClassName={KNOWLEDGE_MODEL_POPOVER_CLASS}
       popoverSide="bottom"
+      popoverAlign="end"
       truncateOptionLabels={false}
       disabled={disabled}
     />
@@ -618,6 +619,7 @@ function KnowledgeSettingsContent() {
                     )}
                     popoverContentClassName={KNOWLEDGE_MODEL_POPOVER_CLASS}
                     popoverSide="bottom"
+                    popoverAlign="end"
                     truncateOptionLabels={false}
                     disabled={
                       !hasPermission ||

--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -77,6 +77,8 @@ const EMBEDDING_DEFAULT_FORM_VALUES: LlmProviderApiKeyFormValues = {
   ...DEFAULT_FORM_VALUES,
 };
 const KNOWLEDGE_SETTINGS_CONTROL_CLASS = "w-full max-w-[28rem]";
+const KNOWLEDGE_MODEL_POPOVER_CLASS =
+  "w-max min-w-[var(--radix-popover-trigger-width)] max-w-[min(32rem,calc(100vw-2rem))]";
 
 function AddApiKeyDialog({
   open,
@@ -360,7 +362,7 @@ function RerankerModelSelector({
       options={rerankerItems}
       placeholder="Select reranking model..."
       className={cn("w-full", pulse && "animate-pulse ring-2 ring-primary/40")}
-      popoverContentClassName="w-[min(520px,calc(100vw-2rem))]"
+      popoverContentClassName={KNOWLEDGE_MODEL_POPOVER_CLASS}
       truncateOptionLabels={false}
       disabled={disabled}
     />
@@ -613,6 +615,8 @@ function KnowledgeSettingsContent() {
                       embeddingSetupStep === "select-model" &&
                         "animate-pulse ring-2 ring-primary/40",
                     )}
+                    popoverContentClassName={KNOWLEDGE_MODEL_POPOVER_CLASS}
+                    truncateOptionLabels={false}
                     disabled={
                       !hasPermission ||
                       isEmbeddingModelLocked ||

--- a/platform/frontend/src/components/llm-model-select.test.tsx
+++ b/platform/frontend/src/components/llm-model-select.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { LlmModelSearchableSelect } from "./llm-model-select";
+
+vi.mock("next/image", () => ({
+  default: ({ alt, src }: { alt: string; src: string }) => (
+    <img alt={alt} src={src} />
+  ),
+}));
+
+describe("LlmModelSearchableSelect", () => {
+  it("can render wider dropdown content with full option labels", async () => {
+    const user = userEvent.setup();
+    const modelName =
+      "gemini-2.5-pro-preview-05-06-very-long-model-name-for-reranking";
+
+    render(
+      <LlmModelSearchableSelect
+        value=""
+        onValueChange={vi.fn()}
+        options={[
+          {
+            value: "gemini-2.5-pro-preview-05-06",
+            model: modelName,
+            provider: "gemini",
+          },
+        ]}
+        popoverContentClassName="w-[min(520px,calc(100vw-2rem))]"
+        truncateOptionLabels={false}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+
+    expect(
+      screen
+        .getByPlaceholderText("Search models...")
+        .closest("[data-slot='popover-content']"),
+    ).toHaveClass("w-[min(520px,calc(100vw-2rem))]");
+    expect(screen.getByText(modelName)).toHaveClass(
+      "whitespace-normal",
+      "break-words",
+    );
+    expect(screen.getByText(modelName)).not.toHaveClass("truncate");
+  });
+});

--- a/platform/frontend/src/components/llm-model-select.test.tsx
+++ b/platform/frontend/src/components/llm-model-select.test.tsx
@@ -10,7 +10,7 @@ vi.mock("next/image", () => ({
 }));
 
 describe("LlmModelSearchableSelect", () => {
-  it("can render wider dropdown content with full option labels", async () => {
+  it("can render fit-content dropdown content with full option labels", async () => {
     const user = userEvent.setup();
     const modelName =
       "gemini-2.5-pro-preview-05-06-very-long-model-name-for-reranking";
@@ -26,7 +26,7 @@ describe("LlmModelSearchableSelect", () => {
             provider: "gemini",
           },
         ]}
-        popoverContentClassName="w-[min(520px,calc(100vw-2rem))]"
+        popoverContentClassName="w-max min-w-[var(--radix-popover-trigger-width)] max-w-[min(32rem,calc(100vw-2rem))]"
         truncateOptionLabels={false}
       />,
     );
@@ -37,7 +37,11 @@ describe("LlmModelSearchableSelect", () => {
       screen
         .getByPlaceholderText("Search models...")
         .closest("[data-slot='popover-content']"),
-    ).toHaveClass("w-[min(520px,calc(100vw-2rem))]");
+    ).toHaveClass(
+      "w-max",
+      "min-w-[var(--radix-popover-trigger-width)]",
+      "max-w-[min(32rem,calc(100vw-2rem))]",
+    );
     expect(screen.getByText(modelName)).toHaveClass(
       "whitespace-normal",
       "break-words",

--- a/platform/frontend/src/components/llm-model-select.tsx
+++ b/platform/frontend/src/components/llm-model-select.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { PopoverContentProps } from "@radix-ui/react-popover";
 import { providerDisplayNames, type SupportedProvider } from "@shared";
 import Image from "next/image";
 import { SearchableSelect } from "@/components/ui/searchable-select";
@@ -133,6 +134,7 @@ export function LlmModelSearchableSelect({
   emptyMessage,
   popoverContentClassName,
   truncateOptionLabels = true,
+  popoverSide,
 }: {
   value: string;
   onValueChange: (value: string) => void;
@@ -148,6 +150,7 @@ export function LlmModelSearchableSelect({
   emptyMessage?: string;
   popoverContentClassName?: string;
   truncateOptionLabels?: boolean;
+  popoverSide?: PopoverContentProps["side"];
 }) {
   return (
     <SearchableSelect
@@ -161,6 +164,7 @@ export function LlmModelSearchableSelect({
       allowCustom={allowCustom}
       emptyMessage={emptyMessage}
       contentClassName={popoverContentClassName}
+      contentSide={popoverSide}
       items={[
         ...(includeAllOption
           ? [{ value: "all", label: allLabel, searchText: allLabel }]

--- a/platform/frontend/src/components/llm-model-select.tsx
+++ b/platform/frontend/src/components/llm-model-select.tsx
@@ -133,6 +133,7 @@ export function LlmModelSearchableSelect({
   allowCustom = false,
   emptyMessage,
   popoverContentClassName,
+  popoverListClassName,
   truncateOptionLabels = true,
   popoverSide,
   popoverAlign,
@@ -151,6 +152,7 @@ export function LlmModelSearchableSelect({
   allowCustom?: boolean;
   emptyMessage?: string;
   popoverContentClassName?: string;
+  popoverListClassName?: string;
   truncateOptionLabels?: boolean;
   popoverSide?: PopoverContentProps["side"];
   popoverAlign?: PopoverContentProps["align"];
@@ -168,6 +170,7 @@ export function LlmModelSearchableSelect({
       allowCustom={allowCustom}
       emptyMessage={emptyMessage}
       contentClassName={popoverContentClassName}
+      listClassName={popoverListClassName}
       contentSide={popoverSide}
       contentAlign={popoverAlign}
       contentAvoidCollisions={popoverAvoidCollisions}

--- a/platform/frontend/src/components/llm-model-select.tsx
+++ b/platform/frontend/src/components/llm-model-select.tsx
@@ -135,6 +135,7 @@ export function LlmModelSearchableSelect({
   popoverContentClassName,
   truncateOptionLabels = true,
   popoverSide,
+  popoverAlign,
   popoverAvoidCollisions,
 }: {
   value: string;
@@ -152,6 +153,7 @@ export function LlmModelSearchableSelect({
   popoverContentClassName?: string;
   truncateOptionLabels?: boolean;
   popoverSide?: PopoverContentProps["side"];
+  popoverAlign?: PopoverContentProps["align"];
   popoverAvoidCollisions?: PopoverContentProps["avoidCollisions"];
 }) {
   return (
@@ -167,6 +169,7 @@ export function LlmModelSearchableSelect({
       emptyMessage={emptyMessage}
       contentClassName={popoverContentClassName}
       contentSide={popoverSide}
+      contentAlign={popoverAlign}
       contentAvoidCollisions={popoverAvoidCollisions}
       items={[
         ...(includeAllOption

--- a/platform/frontend/src/components/llm-model-select.tsx
+++ b/platform/frontend/src/components/llm-model-select.tsx
@@ -37,9 +37,11 @@ export type LlmModelSelectOption = {
 export function LlmModelOptionLabel({
   option,
   showPricing = false,
+  truncateModelName = true,
 }: {
   option: LlmModelSelectOption;
   showPricing?: boolean;
+  truncateModelName?: boolean;
 }) {
   return (
     <div className="flex min-w-0 items-center gap-2">
@@ -51,7 +53,13 @@ export function LlmModelOptionLabel({
         className="shrink-0 rounded dark:invert"
       />
       <div className="min-w-0">
-        <div className="truncate">{option.model}</div>
+        <div
+          className={cn(
+            truncateModelName ? "truncate" : "whitespace-normal break-words",
+          )}
+        >
+          {option.model}
+        </div>
         {showPricing && (
           <div className="truncate text-xs text-muted-foreground">
             {formatPricing(option)}
@@ -123,6 +131,8 @@ export function LlmModelSearchableSelect({
   searchPlaceholder = "Search models...",
   allowCustom = false,
   emptyMessage,
+  popoverContentClassName,
+  truncateOptionLabels = true,
 }: {
   value: string;
   onValueChange: (value: string) => void;
@@ -136,6 +146,8 @@ export function LlmModelSearchableSelect({
   searchPlaceholder?: string;
   allowCustom?: boolean;
   emptyMessage?: string;
+  popoverContentClassName?: string;
+  truncateOptionLabels?: boolean;
 }) {
   return (
     <SearchableSelect
@@ -148,6 +160,7 @@ export function LlmModelSearchableSelect({
       multiline={showPricing}
       allowCustom={allowCustom}
       emptyMessage={emptyMessage}
+      contentClassName={popoverContentClassName}
       items={[
         ...(includeAllOption
           ? [{ value: "all", label: allLabel, searchText: allLabel }]
@@ -158,7 +171,11 @@ export function LlmModelSearchableSelect({
           searchText: `${providerDisplayNames[option.provider]} ${option.model}`,
           description: option.description,
           content: (
-            <LlmModelOptionLabel option={option} showPricing={showPricing} />
+            <LlmModelOptionLabel
+              option={option}
+              showPricing={showPricing}
+              truncateModelName={truncateOptionLabels}
+            />
           ),
           selectedContent: (
             <LlmModelSelectedValue option={option} showPricing={showPricing} />

--- a/platform/frontend/src/components/llm-model-select.tsx
+++ b/platform/frontend/src/components/llm-model-select.tsx
@@ -135,6 +135,7 @@ export function LlmModelSearchableSelect({
   popoverContentClassName,
   truncateOptionLabels = true,
   popoverSide,
+  popoverAvoidCollisions,
 }: {
   value: string;
   onValueChange: (value: string) => void;
@@ -151,6 +152,7 @@ export function LlmModelSearchableSelect({
   popoverContentClassName?: string;
   truncateOptionLabels?: boolean;
   popoverSide?: PopoverContentProps["side"];
+  popoverAvoidCollisions?: PopoverContentProps["avoidCollisions"];
 }) {
   return (
     <SearchableSelect
@@ -165,6 +167,7 @@ export function LlmModelSearchableSelect({
       emptyMessage={emptyMessage}
       contentClassName={popoverContentClassName}
       contentSide={popoverSide}
+      contentAvoidCollisions={popoverAvoidCollisions}
       items={[
         ...(includeAllOption
           ? [{ value: "all", label: allLabel, searchText: allLabel }]

--- a/platform/frontend/src/components/ui/searchable-select.test.tsx
+++ b/platform/frontend/src/components/ui/searchable-select.test.tsx
@@ -43,4 +43,31 @@ describe("SearchableSelect", () => {
     await user.click(screen.getByRole("button", { name: /Available User/i }));
     expect(onValueChange).toHaveBeenCalledWith("available");
   });
+
+  it("respects a custom popover side", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SearchableSelect
+        value=""
+        onValueChange={vi.fn()}
+        placeholder="Select a model"
+        contentSide="top"
+        items={[
+          {
+            value: "model-a",
+            label: "Model A",
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+
+    expect(
+      screen
+        .getByPlaceholderText("Search...")
+        .closest("[data-slot='popover-content']"),
+    ).toHaveAttribute("data-side", "top");
+  });
 });

--- a/platform/frontend/src/components/ui/searchable-select.test.tsx
+++ b/platform/frontend/src/components/ui/searchable-select.test.tsx
@@ -97,4 +97,29 @@ describe("SearchableSelect", () => {
         .closest("[data-slot='popover-content']"),
     ).toHaveAttribute("data-align", "end");
   });
+
+  it("applies a custom list class", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SearchableSelect
+        value=""
+        onValueChange={vi.fn()}
+        placeholder="Select a model"
+        listClassName="max-h-[220px]"
+        items={[
+          {
+            value: "model-a",
+            label: "Model A",
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+
+    expect(
+      screen.getByRole("button", { name: /Model A/i }).parentElement,
+    ).toHaveClass("max-h-[220px]");
+  });
 });

--- a/platform/frontend/src/components/ui/searchable-select.test.tsx
+++ b/platform/frontend/src/components/ui/searchable-select.test.tsx
@@ -70,4 +70,31 @@ describe("SearchableSelect", () => {
         .closest("[data-slot='popover-content']"),
     ).toHaveAttribute("data-side", "top");
   });
+
+  it("respects a custom popover alignment", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SearchableSelect
+        value=""
+        onValueChange={vi.fn()}
+        placeholder="Select a model"
+        contentAlign="end"
+        items={[
+          {
+            value: "model-a",
+            label: "Model A",
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+
+    expect(
+      screen
+        .getByPlaceholderText("Search...")
+        .closest("[data-slot='popover-content']"),
+    ).toHaveAttribute("data-align", "end");
+  });
 });

--- a/platform/frontend/src/components/ui/searchable-select.tsx
+++ b/platform/frontend/src/components/ui/searchable-select.tsx
@@ -38,6 +38,7 @@ interface SearchableSelectProps {
   contentSide?: PopoverContentProps["side"];
   contentAlign?: PopoverContentProps["align"];
   contentAvoidCollisions?: PopoverContentProps["avoidCollisions"];
+  listClassName?: string;
 }
 
 export function SearchableSelect({
@@ -58,6 +59,7 @@ export function SearchableSelect({
   contentSide,
   contentAlign,
   contentAvoidCollisions,
+  listClassName,
 }: SearchableSelectProps) {
   const [open, setOpen] = React.useState(false);
   const [searchQuery, setSearchQuery] = React.useState("");
@@ -140,7 +142,10 @@ export function SearchableSelect({
           </div>
         )}
         <div
-          className="max-h-[min(300px,calc(var(--radix-popover-content-available-height)-3rem))] overflow-y-auto p-1"
+          className={cn(
+            "max-h-[min(300px,calc(var(--radix-popover-content-available-height)-3rem))] overflow-y-auto p-1",
+            listClassName,
+          )}
           onWheelCapture={(event) => event.stopPropagation()}
         >
           {filteredItems.length === 0 ? (

--- a/platform/frontend/src/components/ui/searchable-select.tsx
+++ b/platform/frontend/src/components/ui/searchable-select.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { PopoverContentProps } from "@radix-ui/react-popover";
 import { Check, ChevronDown, Search } from "lucide-react";
 import * as React from "react";
 import { Button } from "@/components/ui/button";
@@ -34,6 +35,7 @@ interface SearchableSelectProps {
   emptyMessage?: string;
   multiline?: boolean;
   contentClassName?: string;
+  contentSide?: PopoverContentProps["side"];
 }
 
 export function SearchableSelect({
@@ -51,6 +53,7 @@ export function SearchableSelect({
   emptyMessage = "No results found.",
   multiline = false,
   contentClassName,
+  contentSide,
 }: SearchableSelectProps) {
   const [open, setOpen] = React.useState(false);
   const [searchQuery, setSearchQuery] = React.useState("");
@@ -105,10 +108,11 @@ export function SearchableSelect({
       </PopoverTrigger>
       <PopoverContent
         className={cn(
-          "w-[var(--radix-popover-trigger-width)] p-0",
+          "max-h-[var(--radix-popover-content-available-height)] w-[var(--radix-popover-trigger-width)] overflow-hidden p-0",
           contentClassName,
         )}
         align="start"
+        side={contentSide}
       >
         <div className="flex items-center border-b px-3 py-2">
           {showSearchIcon && (
@@ -131,7 +135,7 @@ export function SearchableSelect({
           </div>
         )}
         <div
-          className="max-h-[300px] overflow-y-auto p-1"
+          className="max-h-[min(300px,calc(var(--radix-popover-content-available-height)-3rem))] overflow-y-auto p-1"
           onWheelCapture={(event) => event.stopPropagation()}
         >
           {filteredItems.length === 0 ? (

--- a/platform/frontend/src/components/ui/searchable-select.tsx
+++ b/platform/frontend/src/components/ui/searchable-select.tsx
@@ -36,6 +36,7 @@ interface SearchableSelectProps {
   multiline?: boolean;
   contentClassName?: string;
   contentSide?: PopoverContentProps["side"];
+  contentAvoidCollisions?: PopoverContentProps["avoidCollisions"];
 }
 
 export function SearchableSelect({
@@ -54,6 +55,7 @@ export function SearchableSelect({
   multiline = false,
   contentClassName,
   contentSide,
+  contentAvoidCollisions,
 }: SearchableSelectProps) {
   const [open, setOpen] = React.useState(false);
   const [searchQuery, setSearchQuery] = React.useState("");
@@ -113,6 +115,7 @@ export function SearchableSelect({
         )}
         align="start"
         side={contentSide}
+        avoidCollisions={contentAvoidCollisions}
       >
         <div className="flex items-center border-b px-3 py-2">
           {showSearchIcon && (

--- a/platform/frontend/src/components/ui/searchable-select.tsx
+++ b/platform/frontend/src/components/ui/searchable-select.tsx
@@ -36,6 +36,7 @@ interface SearchableSelectProps {
   multiline?: boolean;
   contentClassName?: string;
   contentSide?: PopoverContentProps["side"];
+  contentAlign?: PopoverContentProps["align"];
   contentAvoidCollisions?: PopoverContentProps["avoidCollisions"];
 }
 
@@ -55,6 +56,7 @@ export function SearchableSelect({
   multiline = false,
   contentClassName,
   contentSide,
+  contentAlign,
   contentAvoidCollisions,
 }: SearchableSelectProps) {
   const [open, setOpen] = React.useState(false);
@@ -113,7 +115,7 @@ export function SearchableSelect({
           "max-h-[var(--radix-popover-content-available-height)] w-[var(--radix-popover-trigger-width)] overflow-hidden p-0",
           contentClassName,
         )}
-        align="start"
+        align={contentAlign ?? "start"}
         side={contentSide}
         avoidCollisions={contentAvoidCollisions}
       >

--- a/platform/frontend/src/components/ui/searchable-select.tsx
+++ b/platform/frontend/src/components/ui/searchable-select.tsx
@@ -33,6 +33,7 @@ interface SearchableSelectProps {
   onSearchQueryChange?: (value: string) => void;
   emptyMessage?: string;
   multiline?: boolean;
+  contentClassName?: string;
 }
 
 export function SearchableSelect({
@@ -49,6 +50,7 @@ export function SearchableSelect({
   onSearchQueryChange,
   emptyMessage = "No results found.",
   multiline = false,
+  contentClassName,
 }: SearchableSelectProps) {
   const [open, setOpen] = React.useState(false);
   const [searchQuery, setSearchQuery] = React.useState("");
@@ -102,7 +104,10 @@ export function SearchableSelect({
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-[var(--radix-popover-trigger-width)] p-0"
+        className={cn(
+          "w-[var(--radix-popover-trigger-width)] p-0",
+          contentClassName,
+        )}
         align="start"
       >
         <div className="flex items-center border-b px-3 py-2">


### PR DESCRIPTION
## Summary

- Adds opt-in popover width control to the shared searchable select.
- Lets the LLM model selector render untruncated, wrapping option labels when requested.
- Applies the wider, non-truncating behavior to the Settings > Knowledge reranker model dropdown so long model names are visible.