### PR TITLE
[codex] fix Bedrock tool name encoding

### DIFF
--- a/.github/actions/setup-archestra-platform/action.yml
+++ b/.github/actions/setup-archestra-platform/action.yml
@@ -114,6 +114,14 @@ runs:
         path: /tmp/mcp-jwks-server.tar
         key: mcp-jwks-server-0.0.3-${{ runner.arch }}
 
+    - name: Cache MCP ID-JAG server image
+      if: ${{ inputs.deploy-e2e-dependencies == 'true' }}
+      id: cache-id-jag-image
+      uses: ./.github/actions/github-cache
+      with:
+        path: /tmp/mcp-id-jag-server.tar
+        key: mcp-id-jag-server-0.0.1-${{ runner.arch }}
+
     - name: Pull MCP example OAuth server image
       if: ${{ inputs.deploy-e2e-dependencies == 'true' && steps.cache-oauth-image.outputs.cache-hit != 'true' }}
       shell: bash
@@ -130,6 +138,14 @@ runs:
         docker pull "${MCP_JWKS_IMAGE}"
         docker save "${MCP_JWKS_IMAGE}" > /tmp/mcp-jwks-server.tar
 
+    - name: Pull MCP ID-JAG server image
+      if: ${{ inputs.deploy-e2e-dependencies == 'true' && steps.cache-id-jag-image.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: |
+        MCP_ID_JAG_IMAGE="europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-id-jag:0.0.1"
+        docker pull "${MCP_ID_JAG_IMAGE}"
+        docker save "${MCP_ID_JAG_IMAGE}" > /tmp/mcp-id-jag-server.tar
+
     - name: Load cached MCP example OAuth server image
       if: ${{ inputs.deploy-e2e-dependencies == 'true' && steps.cache-oauth-image.outputs.cache-hit == 'true' }}
       shell: bash
@@ -139,6 +155,11 @@ runs:
       if: ${{ inputs.deploy-e2e-dependencies == 'true' && steps.cache-jwks-image.outputs.cache-hit == 'true' }}
       shell: bash
       run: docker load < /tmp/mcp-jwks-server.tar
+
+    - name: Load cached MCP ID-JAG server image
+      if: ${{ inputs.deploy-e2e-dependencies == 'true' && steps.cache-id-jag-image.outputs.cache-hit == 'true' }}
+      shell: bash
+      run: docker load < /tmp/mcp-id-jag-server.tar
 
     - name: Load all images into Kind in parallel
       shell: bash
@@ -163,12 +184,18 @@ runs:
         if [ "${DEPLOY_E2E_DEPS}" == "true" ]; then
           MCP_OAUTH_IMAGE="europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-example-oauth-server:0.0.1"
           MCP_JWKS_IMAGE="europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-jwks-keycloak:0.0.3"
+          MCP_ID_JAG_IMAGE="europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-id-jag:0.0.1"
+
           echo "Loading MCP example OAuth server image into Kind..."
           kind load docker-image "${MCP_OAUTH_IMAGE}" --name "${KIND_CLUSTER_NAME}" &
           PIDS+=($!)
 
           echo "Loading MCP JWKS server image into Kind..."
           kind load docker-image "${MCP_JWKS_IMAGE}" --name "${KIND_CLUSTER_NAME}" &
+          PIDS+=($!)
+
+          echo "Loading MCP ID-JAG server image into Kind..."
+          kind load docker-image "${MCP_ID_JAG_IMAGE}" --name "${KIND_CLUSTER_NAME}" &
           PIDS+=($!)
         fi
 
@@ -271,6 +298,7 @@ runs:
           echo "Waiting for e2e dependency pods to be ready..."
           kubectl wait --for=condition=Ready pods -l app.kubernetes.io/name=keycloak --timeout=180s
           kubectl wait --for=condition=Ready pods -l app.kubernetes.io/name=wiremock --timeout=60s
+          kubectl wait --for=condition=Ready pods -l app.kubernetes.io/name=mcp-server-id-jag --timeout=60s
 
           echo "Verifying WireMock is accessible and stubs are loaded..."
           for i in $(seq 1 10); do

--- a/.github/kind.yaml
+++ b/.github/kind.yaml
@@ -29,6 +29,9 @@ nodes:
       - containerPort: 30083 # MCP Example OAuth Server
         hostPort: 30083
         protocol: TCP
+      - containerPort: 30084 # MCP Server ID-JAG
+        hostPort: 30084
+        protocol: TCP
       - containerPort: 30200 # Vault
         hostPort: 8200
         protocol: TCP

--- a/platform/backend/src/routes/auth.test.ts
+++ b/platform/backend/src/routes/auth.test.ts
@@ -97,4 +97,64 @@ describe("auth routes", () => {
       new Date((issuedAtSeconds + 604_800) * 1000),
     );
   });
+
+  test("applies MCP token lifetime when resource uses the token endpoint origin", async ({
+    makeAgent,
+    makeOAuthAccessToken,
+    makeOAuthClient,
+    makeOrganization,
+    makeUser,
+  }) => {
+    const user = await makeUser();
+    const organization = await makeOrganization();
+    await OrganizationModel.patch(organization.id, {
+      mcpOauthAccessTokenLifetimeSeconds: 31_536_000,
+    });
+    const agent = await makeAgent({ organizationId: organization.id });
+    const client = await makeOAuthClient({ userId: user.id });
+    const rawAccessToken = "inspector-oauth-access-token";
+    const tokenHash = createHash("sha256")
+      .update(rawAccessToken)
+      .digest("base64url");
+    await makeOAuthAccessToken(client.clientId, user.id, {
+      token: tokenHash,
+      expiresAt: new Date("2026-01-01T01:00:00.000Z"),
+    });
+    vi.mocked(betterAuth.handler).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: rawAccessToken,
+          token_type: "Bearer",
+          expires_in: 3_600,
+          scope: "mcp",
+        }),
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      ),
+    );
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/auth/oauth2/token",
+      headers: {
+        host: "localhost:9000",
+      },
+      payload: {
+        grant_type: "authorization_code",
+        client_id: client.clientId,
+        code: "auth-code",
+        resource: `http://localhost:9000/v1/mcp/${agent.id}`,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      access_token: rawAccessToken,
+      expires_in: 31_536_000,
+    });
+  });
 });

--- a/platform/backend/src/routes/auth.ts
+++ b/platform/backend/src/routes/auth.ts
@@ -344,6 +344,7 @@ const authRoutes: FastifyPluginAsyncZod = async (fastify) => {
       const responseBody = await applyMcpOauthTokenLifetimeToResponse({
         response,
         resource,
+        tokenEndpointOrigin: url.origin,
       });
 
       reply.status(response.status);
@@ -610,6 +611,7 @@ function shouldSkipForwardedAuthHeader(headerName: string): boolean {
 async function applyMcpOauthTokenLifetimeToResponse(params: {
   response: Response;
   resource: unknown;
+  tokenEndpointOrigin: string;
 }): Promise<string | null> {
   if (!params.response.body) {
     return null;
@@ -639,6 +641,7 @@ async function applyMcpOauthTokenLifetimeToResponse(params: {
   const lifetimeSeconds = await getMcpOauthAccessTokenLifetimeSeconds({
     resource: params.resource,
     referenceId: storedToken?.referenceId,
+    tokenEndpointOrigin: params.tokenEndpointOrigin,
   });
   if (!storedToken || !lifetimeSeconds) {
     return responseText;
@@ -664,10 +667,13 @@ async function applyMcpOauthTokenLifetimeToResponse(params: {
 async function getMcpOauthAccessTokenLifetimeSeconds(params: {
   resource: unknown;
   referenceId: string | null | undefined;
+  tokenEndpointOrigin: string;
 }): Promise<number | null> {
   const profileId =
-    getProfileIdFromResource(params.resource) ??
-    getProfileIdFromReferenceId(params.referenceId);
+    getProfileIdFromResource({
+      resource: params.resource,
+      tokenEndpointOrigin: params.tokenEndpointOrigin,
+    }) ?? getProfileIdFromReferenceId(params.referenceId);
   if (!profileId) {
     return null;
   }
@@ -719,12 +725,32 @@ function getIssuedAtSeconds(tokenBody: Record<string, unknown>): number {
   return Math.floor(Date.now() / 1000);
 }
 
-function getProfileIdFromResource(resource: unknown): string | null {
-  if (typeof resource !== "string") {
+function getProfileIdFromResource(params: {
+  resource: unknown;
+  tokenEndpointOrigin: string;
+}): string | null {
+  if (typeof params.resource !== "string") {
     return null;
   }
 
-  return extractProfileIdFromMcpResource(resource);
+  const profileIdFromIssuerResource = extractProfileIdFromMcpResource(
+    params.resource,
+  );
+  if (profileIdFromIssuerResource) {
+    return profileIdFromIssuerResource;
+  }
+
+  try {
+    const resourceUrl = new URL(params.resource);
+    if (resourceUrl.origin !== params.tokenEndpointOrigin) {
+      return null;
+    }
+
+    const match = resourceUrl.pathname.match(/^\/v1\/mcp\/([0-9a-f-]{36})$/i);
+    return match?.[1] ?? null;
+  } catch {
+    return null;
+  }
 }
 
 function getProfileIdFromReferenceId(

--- a/platform/backend/src/routes/proxy/adapterV2/bedrock.test.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/bedrock.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "@/test";
+import type { Bedrock } from "@/types";
+import { bedrockAdapterFactory, getCommandInput } from "./bedrock";
+
+function createConverseRequest(
+  options?: Partial<Bedrock.Types.ConverseRequest>,
+): Bedrock.Types.ConverseRequest {
+  return {
+    modelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    messages: [{ role: "user", content: [{ text: "Hello" }] }],
+    ...options,
+  };
+}
+
+describe("Bedrock tool name encoding", () => {
+  test("shortens provider-facing tool names that exceed the Bedrock limit", () => {
+    const toolName =
+      "splunk_olly_preprod_mcp__olly_get_apm_service_errors_and_requests";
+    const request = createConverseRequest({
+      messages: [
+        { role: "user", content: [{ text: "Get service errors" }] },
+        {
+          role: "assistant",
+          content: [
+            {
+              toolUse: {
+                toolUseId: "tooluse_123",
+                name: toolName,
+                input: { service: "checkout" },
+              },
+            },
+          ],
+        },
+      ],
+      toolConfig: {
+        tools: [
+          {
+            toolSpec: {
+              name: toolName,
+              description: "Get APM service errors and requests",
+              inputSchema: { json: { type: "object" } },
+            },
+          },
+        ],
+        toolChoice: { tool: { name: toolName } },
+      },
+    });
+
+    const commandInput = getCommandInput(request);
+    const providerToolName =
+      commandInput.toolConfig?.tools?.[0]?.toolSpec?.name ?? "";
+    const toolChoice = commandInput.toolConfig?.toolChoice as
+      | { tool?: { name?: string } }
+      | undefined;
+    const providerToolChoiceName = toolChoice?.tool?.name ?? "";
+    const providerHistoryToolName =
+      commandInput.messages?.[1]?.content?.[0] &&
+      "toolUse" in commandInput.messages[1].content[0]
+        ? commandInput.messages[1].content[0].toolUse.name
+        : "";
+
+    expect(toolName.length).toBeGreaterThan(64);
+    expect(providerToolName).toHaveLength(64);
+    expect(providerToolName).not.toBe(toolName);
+    expect(providerToolChoiceName).toBe(providerToolName);
+    expect(providerHistoryToolName).toBe(providerToolName);
+  });
+
+  test("decodes shortened Bedrock tool call names back to the original name", async () => {
+    const toolName =
+      "splunk_olly_preprod_mcp__olly_get_apm_service_errors_and_requests";
+    const request = createConverseRequest({
+      toolConfig: {
+        tools: [
+          {
+            toolSpec: {
+              name: toolName,
+              description: "Get APM service errors and requests",
+              inputSchema: { json: { type: "object" } },
+            },
+          },
+        ],
+      },
+    });
+    const commandInput = getCommandInput(request);
+    const providerToolName =
+      commandInput.toolConfig?.tools?.[0]?.toolSpec?.name ?? "";
+    const client = {
+      converse: async () => ({
+        $metadata: { requestId: "req_123" },
+        output: {
+          message: {
+            role: "assistant",
+            content: [
+              {
+                toolUse: {
+                  toolUseId: "tooluse_123",
+                  name: providerToolName,
+                  input: { service: "checkout" },
+                },
+              },
+            ],
+          },
+        },
+        stopReason: "tool_use",
+        usage: { inputTokens: 10, outputTokens: 5 },
+      }),
+    };
+
+    const response = await bedrockAdapterFactory.execute(client, request);
+    const adapter = bedrockAdapterFactory.createResponseAdapter(response);
+
+    expect(adapter.getToolCalls()).toEqual([
+      {
+        id: "tooluse_123",
+        name: toolName,
+        arguments: { service: "checkout" },
+      },
+    ]);
+  });
+
+  test("continues to encode hyphens for Nova provider-facing tool names", () => {
+    const request = createConverseRequest({
+      modelId: "amazon.nova-lite-v1:0",
+      toolConfig: {
+        tools: [
+          {
+            toolSpec: {
+              name: "my-server__read-file",
+              inputSchema: { json: { type: "object" } },
+            },
+          },
+        ],
+      },
+    });
+
+    const commandInput = getCommandInput(request);
+
+    expect(commandInput.toolConfig?.tools?.[0]?.toolSpec?.name).toBe(
+      "my_server__read_file",
+    );
+  });
+
+  test("keeps Nova hyphen-normalized tool names unique", () => {
+    const request = createConverseRequest({
+      modelId: "amazon.nova-lite-v1:0",
+      toolConfig: {
+        tools: [
+          {
+            toolSpec: {
+              name: "server__read-file",
+              inputSchema: { json: { type: "object" } },
+            },
+          },
+          {
+            toolSpec: {
+              name: "server__read_file",
+              inputSchema: { json: { type: "object" } },
+            },
+          },
+        ],
+      },
+    });
+
+    const commandInput = getCommandInput(request);
+    const providerToolNames =
+      commandInput.toolConfig?.tools?.map((tool) => tool.toolSpec?.name) ?? [];
+
+    expect(providerToolNames).toHaveLength(2);
+    expect(new Set(providerToolNames).size).toBe(2);
+    expect(providerToolNames[0]).toBe("server__read_file");
+    expect(providerToolNames[1]).toMatch(/^server__read_file_[a-f0-9]{8}$/);
+  });
+});

--- a/platform/backend/src/routes/proxy/adapterV2/bedrock.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/bedrock.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { ConverseStreamOutput } from "@aws-sdk/client-bedrock-runtime";
 import { EventStreamCodec } from "@smithy/eventstream-codec";
 import { fromUtf8, toUtf8 } from "@smithy/util-utf8";
@@ -55,6 +56,9 @@ const eventStreamCodec = new EventStreamCodec(toUtf8, fromUtf8);
 // Padding alphabet used by Bedrock (lowercase + uppercase + digits)
 const PADDING_ALPHABET =
   "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+const BEDROCK_MAX_TOOL_NAME_LENGTH = 64;
+const TOOL_NAME_HASH_LENGTH = 8;
+const TOOL_NAME_HASH_SEPARATOR = "_";
 
 /**
  * Generate padding string to match Bedrock's format.
@@ -104,39 +108,177 @@ function isNovaModel(modelId: string): boolean {
   return modelId.toLowerCase().includes("nova");
 }
 
+type ToolNameMapping = {
+  toProvider: Map<string, string>;
+  toOriginal: Map<string, string>;
+};
+
 /**
- * Nova models faeil with "Model produced invalid sequence as part of ToolUse" when
- * tool names contain hyphens. We replace hyphens with underscores before sending
- * to Bedrock and use a name mapping to restore original names in responses.
+ * Nova models fail with "Model produced invalid sequence as part of ToolUse" when
+ * tool names contain hyphens. Bedrock also rejects names longer than 64 chars.
+ * Encode only the provider-facing names and keep mappings to restore originals.
  */
-function encodeToolName(name: string): string {
-  return name.replaceAll("-", "_");
+function encodeToolName(name: string, options: { isNova: boolean }): string {
+  const normalizedName = options.isNova ? name.replaceAll("-", "_") : name;
+  return truncateToolName(normalizedName, name);
 }
 
 /**
  * Build a mapping from encoded tool names back to original names.
  */
-function buildToolNameMapping(request: BedrockRequest): Map<string, string> {
-  const mapping = new Map<string, string>();
+function buildToolNameMapping(request: BedrockRequest): ToolNameMapping {
+  const isNova = isNovaModel(request.modelId);
+  const toProvider = new Map<string, string>();
+  const toOriginal = new Map<string, string>();
   const tools = request.toolConfig?.tools ?? [];
+
   for (const tool of tools) {
     const originalName = tool.toolSpec?.name;
     if (originalName) {
-      const encodedName = encodeToolName(originalName);
-      mapping.set(encodedName, originalName);
+      const encodedName = getUniqueProviderToolName({
+        originalName,
+        isNova,
+        usedNames: toOriginal,
+      });
+      toProvider.set(originalName, encodedName);
+      toOriginal.set(encodedName, originalName);
     }
   }
-  return mapping;
+
+  return { toProvider, toOriginal };
 }
 
 /**
  * Decode tool name using the mapping (encoded → original).
  */
-function decodeToolName(
-  encodedName: string,
-  mapping: Map<string, string>,
+function decodeToolName(encodedName: string, mapping: ToolNameMapping): string {
+  return mapping.toOriginal.get(encodedName) ?? encodedName;
+}
+
+function getProviderToolName(
+  originalName: string,
+  mapping: ToolNameMapping,
+  options: { isNova: boolean },
 ): string {
-  return mapping.get(encodedName) ?? encodedName;
+  return (
+    mapping.toProvider.get(originalName) ??
+    encodeToolName(originalName, options)
+  );
+}
+
+function createEmptyToolNameMapping(): ToolNameMapping {
+  return {
+    toProvider: new Map(),
+    toOriginal: new Map(),
+  };
+}
+
+function getUniqueProviderToolName(params: {
+  originalName: string;
+  isNova: boolean;
+  usedNames: Map<string, string>;
+}): string {
+  const encodedName = encodeToolName(params.originalName, {
+    isNova: params.isNova,
+  });
+  const existingOriginalName = params.usedNames.get(encodedName);
+
+  if (!existingOriginalName || existingOriginalName === params.originalName) {
+    return encodedName;
+  }
+
+  return appendToolNameHash(encodedName, params.originalName);
+}
+
+function truncateToolName(name: string, hashInput: string): string {
+  if (name.length <= BEDROCK_MAX_TOOL_NAME_LENGTH) {
+    return name;
+  }
+
+  return appendToolNameHash(name, hashInput);
+}
+
+function appendToolNameHash(name: string, hashInput: string): string {
+  const hash = createHash("sha256")
+    .update(hashInput)
+    .digest("hex")
+    .slice(0, TOOL_NAME_HASH_LENGTH);
+  const prefixLength =
+    BEDROCK_MAX_TOOL_NAME_LENGTH -
+    TOOL_NAME_HASH_SEPARATOR.length -
+    TOOL_NAME_HASH_LENGTH;
+
+  return `${name.slice(0, prefixLength)}${TOOL_NAME_HASH_SEPARATOR}${hash}`;
+}
+
+function encodeProviderMessageToolNames(params: {
+  messages: BedrockMessages | undefined;
+  mapping: ToolNameMapping;
+  isNova: boolean;
+}): BedrockMessages | undefined {
+  if (!params.messages) {
+    return params.messages;
+  }
+
+  return params.messages.map((message) => {
+    if (!Array.isArray(message.content)) {
+      return message;
+    }
+
+    const content = message.content.map((contentBlock) => {
+      if (!isToolUseBlock(contentBlock)) {
+        return contentBlock;
+      }
+
+      const name = contentBlock.toolUse.name;
+      if (!name) {
+        return contentBlock;
+      }
+
+      return {
+        ...contentBlock,
+        toolUse: {
+          ...contentBlock.toolUse,
+          name: getProviderToolName(name, params.mapping, {
+            isNova: params.isNova,
+          }),
+        },
+      };
+    });
+
+    return {
+      ...message,
+      content,
+    };
+  }) as BedrockMessages;
+}
+
+function encodeProviderToolChoiceName(params: {
+  toolChoice: Bedrock.Types.ToolChoice | undefined;
+  mapping: ToolNameMapping;
+  isNova: boolean;
+}): Bedrock.Types.ToolChoice | undefined {
+  if (!params.toolChoice || !("tool" in params.toolChoice)) {
+    return params.toolChoice;
+  }
+
+  const toolChoice = params.toolChoice.tool as
+    | { name?: unknown }
+    | null
+    | undefined;
+  if (typeof toolChoice?.name !== "string") {
+    return params.toolChoice;
+  }
+
+  return {
+    ...params.toolChoice,
+    tool: {
+      ...toolChoice,
+      name: getProviderToolName(toolChoice.name, params.mapping, {
+        isNova: params.isNova,
+      }),
+    },
+  };
 }
 
 /**
@@ -200,14 +342,11 @@ class BedrockRequestAdapter
   private request: BedrockRequest;
   private modifiedModel: string | null = null;
   private toolResultUpdates: Record<string, string> = {};
-  private toolNameMapping: Map<string, string>;
+  private toolNameMapping: ToolNameMapping;
 
   constructor(request: BedrockRequest) {
     this.request = request;
-    // Only build mapping for Nova models (which require tool name encoding)
-    this.toolNameMapping = isNovaModel(request.modelId)
-      ? buildToolNameMapping(request)
-      : new Map();
+    this.toolNameMapping = buildToolNameMapping(request);
   }
 
   // ---------------------------------------------------------------------------
@@ -637,7 +776,7 @@ class BedrockStreamAdapter
   readonly provider = "bedrock" as const;
   readonly state: StreamAccumulatorState;
   private currentToolCallIndex = -1;
-  private toolNameMapping: Map<string, string> = new Map();
+  private toolNameMapping: ToolNameMapping = createEmptyToolNameMapping();
 
   // Bedrock-specific extended state
   private bedrockState: {
@@ -671,12 +810,9 @@ class BedrockStreamAdapter
 
   /**
    * Set the tool name mapping from the request for decoding tool names in responses.
-   * Only builds mapping for Nova models (which require tool name encoding).
    */
   setToolNameMapping(request: BedrockRequest): void {
-    if (isNovaModel(request.modelId)) {
-      this.toolNameMapping = buildToolNameMapping(request);
-    }
+    this.toolNameMapping = buildToolNameMapping(request);
   }
 
   processChunk(chunk: BedrockStreamEventWithRaw): ChunkProcessingResult {
@@ -1208,14 +1344,19 @@ export async function convertToolResultsToToon(
 /**
  * Convert BedrockRequest to AWS SDK command input format.
  * Used by both ConverseCommand and ConverseStreamCommand.
- * Only maps tool names for Nova models (which don't support hyphens).
+ * Maps tool names to provider-safe names and decodes them after Bedrock returns.
  */
 export function getCommandInput(request: BedrockRequest) {
-  const shouldEncode = isNovaModel(request.modelId);
+  const shouldEncodeHyphens = isNovaModel(request.modelId);
+  const toolNameMapping = buildToolNameMapping(request);
 
   return {
     modelId: request.modelId,
-    messages: request.messages,
+    messages: encodeProviderMessageToolNames({
+      messages: request.messages,
+      mapping: toolNameMapping,
+      isNova: shouldEncodeHyphens,
+    }),
     system: request.system?.map((s) => {
       if ("text" in s) return { text: s.text };
       return s;
@@ -1226,11 +1367,11 @@ export function getCommandInput(request: BedrockRequest) {
           tools: request.toolConfig.tools?.map((t) => ({
             toolSpec: t.toolSpec
               ? {
-                  // Only encode hyphens for Nova models
-                  name:
-                    t.toolSpec.name && shouldEncode
-                      ? encodeToolName(t.toolSpec.name)
-                      : t.toolSpec.name,
+                  name: t.toolSpec.name
+                    ? getProviderToolName(t.toolSpec.name, toolNameMapping, {
+                        isNova: shouldEncodeHyphens,
+                      })
+                    : t.toolSpec.name,
                   description: t.toolSpec.description,
                   inputSchema: t.toolSpec.inputSchema
                     ? {
@@ -1240,7 +1381,11 @@ export function getCommandInput(request: BedrockRequest) {
                 }
               : undefined,
           })),
-          toolChoice: request.toolConfig.toolChoice,
+          toolChoice: encodeProviderToolChoiceName({
+            toolChoice: request.toolConfig.toolChoice,
+            mapping: toolNameMapping,
+            isNova: shouldEncodeHyphens,
+          }),
         }
       : undefined,
   };
@@ -1335,10 +1480,7 @@ export const bedrockAdapterFactory: LLMProvider<
   ): Promise<BedrockResponse> {
     const bedrockClient = client as BedrockClient;
     const commandInput = getCommandInput(request);
-    // Only build mapping for Nova models (which require tool name encoding)
-    const toolNameMapping = isNovaModel(request.modelId)
-      ? buildToolNameMapping(request)
-      : new Map<string, string>();
+    const toolNameMapping = buildToolNameMapping(request);
 
     // Use fetch-based client.converse()
     const response = await bedrockClient.converse(

--- a/platform/backend/src/services/identity-providers/enterprise-managed/broker.test.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/broker.test.ts
@@ -157,6 +157,118 @@ describe("resolveEnterpriseTransportCredential", () => {
     fetchMock.mockRestore();
   });
 
+  test("exchanges caller-provided ID-JAG at an OAuth protected resource", async ({
+    makeAgent,
+    makeIdentityProvider,
+    makeOrganization,
+  }) => {
+    const organization = await makeOrganization();
+    const identityProvider = await makeIdentityProvider(organization.id, {
+      providerId: "id-jag-demo-idp",
+      issuer: "https://idp.example.com",
+      oidcConfig: {
+        clientId: "gateway-client",
+        tokenEndpoint: "https://idp.example.com/token",
+        enterpriseManagedCredentials: {
+          clientId: "resource-client",
+          tokenEndpointAuthentication: "client_secret_basic",
+          clientSecret: "resource-secret",
+        },
+      },
+    });
+    const agent = await makeAgent({
+      organizationId: organization.id,
+      identityProviderId: identityProvider.id,
+    });
+
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        const url = String(input);
+        if (
+          url ===
+          "https://resource.example.com/.well-known/oauth-protected-resource/mcp"
+        ) {
+          return new Response(
+            JSON.stringify({
+              resource: "https://resource.example.com/mcp",
+              authorization_servers: ["https://resource.example.com"],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+
+        if (
+          url ===
+          "https://resource.example.com/.well-known/oauth-authorization-server"
+        ) {
+          return new Response(
+            JSON.stringify({
+              issuer: "https://resource.example.com",
+              token_endpoint: "https://resource.example.com/token",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+
+        if (url === "https://resource.example.com/token") {
+          return new Response(
+            JSON.stringify({
+              access_token: "mcp-server-access-token",
+              issued_token_type:
+                "urn:ietf:params:oauth:token-type:access_token",
+              expires_in: 300,
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+
+        throw new Error(`Unexpected fetch URL: ${url}`);
+      });
+
+    const result = await resolveEnterpriseTransportCredential({
+      agentId: agent.id,
+      tokenAuth: {
+        tokenId: "external-id-jag",
+        teamId: null,
+        isOrganizationToken: false,
+        userId: "user-1",
+        isExternalIdp: true,
+        rawToken: "caller-id-jag",
+      },
+      enterpriseManagedConfig: {
+        requestedCredentialType: "id_jag",
+        resourceType: "oauth_protected_resource",
+        resourceIdentifier: "https://resource.example.com/mcp",
+        tokenInjectionMode: "authorization_bearer",
+      },
+    });
+
+    expect(result).toEqual({
+      headerName: "Authorization",
+      headerValue: "Bearer mcp-server-access-token",
+      expiresInSeconds: 300,
+    });
+
+    const tokenRequest = fetchMock.mock.calls.find(
+      ([input]) => String(input) === "https://resource.example.com/token",
+    );
+    expect(String(tokenRequest?.[1]?.body)).toContain(
+      "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer",
+    );
+    expect(String(tokenRequest?.[1]?.body)).toContain(
+      "assertion=caller-id-jag",
+    );
+    const tokenRequestHeaders = tokenRequest?.[1]?.headers as
+      | Headers
+      | undefined;
+    expect(tokenRequestHeaders?.get("authorization")).toBe(
+      `Basic ${Buffer.from("resource-client:resource-secret").toString("base64")}`,
+    );
+
+    fetchMock.mockRestore();
+  });
+
   test("exchanges a Keycloak session access token for a brokered downstream bearer token", async ({
     makeAgent,
     makeIdentityProvider,

--- a/platform/backend/src/services/identity-providers/enterprise-managed/broker.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/broker.ts
@@ -1,7 +1,12 @@
 import type { TokenAuthContext } from "@/clients/mcp-client";
 import logger from "@/logging";
 import { resolveEnterpriseAssertion } from "@/services/identity-providers/enterprise-managed/assertion-resolver";
-import { exchangeEnterpriseManagedCredential } from "@/services/identity-providers/enterprise-managed/exchange";
+import {
+  type EnterpriseManagedCredentialResult,
+  exchangeEnterpriseManagedCredential,
+  extractProviderErrorMessage,
+} from "@/services/identity-providers/enterprise-managed/exchange";
+import { findExternalIdentityProviderById } from "@/services/identity-providers/oidc";
 import type { EnterpriseManagedCredentialConfig } from "@/types";
 
 export type ResolvedEnterpriseTransportCredential = {
@@ -9,6 +14,9 @@ export type ResolvedEnterpriseTransportCredential = {
   headerValue: string;
   expiresInSeconds: number | null;
 };
+
+const JWT_BEARER_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
 
 export async function resolveEnterpriseTransportCredential(params: {
   agentId: string;
@@ -37,6 +45,19 @@ export async function resolveEnterpriseTransportCredential(params: {
     return null;
   }
 
+  if (shouldExchangeIdJagAtProtectedResource(config)) {
+    const credential = await exchangeIdJagAtProtectedResource({
+      assertion: assertion.assertion,
+      identityProviderId: assertion.identityProviderId,
+      enterpriseManagedConfig: config,
+    });
+
+    return normalizeEnterpriseTransportCredential({
+      config,
+      credential,
+    });
+  }
+
   const credential = await exchangeEnterpriseManagedCredential({
     identityProviderId: assertion.identityProviderId,
     assertion: assertion.assertion,
@@ -47,6 +68,194 @@ export async function resolveEnterpriseTransportCredential(params: {
     config,
     credential,
   });
+}
+
+async function exchangeIdJagAtProtectedResource(params: {
+  assertion: string;
+  identityProviderId: string;
+  enterpriseManagedConfig: EnterpriseManagedCredentialConfig;
+}): Promise<EnterpriseManagedCredentialResult> {
+  const resourceIdentifier = params.enterpriseManagedConfig.resourceIdentifier;
+  if (!resourceIdentifier) {
+    throw new Error(
+      "ID-JAG protected resource exchange requires resourceIdentifier",
+    );
+  }
+
+  const identityProvider = await findExternalIdentityProviderById(
+    params.identityProviderId,
+  );
+  const enterpriseConfig =
+    identityProvider?.oidcConfig?.enterpriseManagedCredentials;
+  const clientId =
+    params.enterpriseManagedConfig.clientIdOverride ??
+    enterpriseConfig?.clientId ??
+    identityProvider?.oidcConfig?.clientId;
+  if (!clientId) {
+    throw new Error("ID-JAG protected resource exchange client ID is missing");
+  }
+
+  const tokenEndpoint =
+    await discoverProtectedResourceTokenEndpoint(resourceIdentifier);
+  const requestBody = new URLSearchParams({
+    grant_type: JWT_BEARER_GRANT_TYPE,
+    assertion: params.assertion,
+  });
+  const headers = buildProtectedResourceTokenHeaders({
+    clientId,
+    clientSecret:
+      enterpriseConfig?.clientSecret ??
+      identityProvider?.oidcConfig?.clientSecret,
+    tokenEndpointAuthentication:
+      enterpriseConfig?.tokenEndpointAuthentication ?? "client_secret_basic",
+    requestBody,
+  });
+
+  const response = await fetch(tokenEndpoint, {
+    method: "POST",
+    headers,
+    body: requestBody.toString(),
+    signal: AbortSignal.timeout(10_000),
+  });
+  const responseBody = (await response.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+  if (!response.ok || !responseBody) {
+    logger.warn(
+      {
+        status: response.status,
+        body: responseBody,
+        resourceIdentifier,
+      },
+      "ID-JAG protected resource access-token exchange failed",
+    );
+    throw new Error(
+      extractProviderErrorMessage(responseBody) ??
+        "ID-JAG protected resource access-token exchange failed",
+    );
+  }
+
+  const accessToken = responseBody.access_token;
+  if (typeof accessToken !== "string" || accessToken.length === 0) {
+    throw new Error("ID-JAG protected resource did not return an access token");
+  }
+
+  return {
+    credentialType: "bearer_token",
+    expiresInSeconds:
+      typeof responseBody.expires_in === "number"
+        ? responseBody.expires_in
+        : null,
+    value: accessToken,
+    issuedTokenType:
+      typeof responseBody.issued_token_type === "string"
+        ? responseBody.issued_token_type
+        : ACCESS_TOKEN_TYPE,
+  };
+}
+
+async function discoverProtectedResourceTokenEndpoint(
+  resourceIdentifier: string,
+): Promise<string> {
+  const resourceMetadata = await fetchJson(
+    buildProtectedResourceMetadataUrl(resourceIdentifier),
+  );
+  const authorizationServers = resourceMetadata.authorization_servers;
+  if (
+    !Array.isArray(authorizationServers) ||
+    typeof authorizationServers[0] !== "string"
+  ) {
+    throw new Error(
+      "OAuth protected resource metadata did not include an authorization server",
+    );
+  }
+
+  const authServerMetadata = await fetchJson(
+    `${authorizationServers[0].replace(/\/$/, "")}/.well-known/oauth-authorization-server`,
+  );
+  const tokenEndpoint = authServerMetadata.token_endpoint;
+  if (typeof tokenEndpoint !== "string" || tokenEndpoint.length === 0) {
+    throw new Error(
+      "OAuth authorization server metadata did not include a token endpoint",
+    );
+  }
+
+  return tokenEndpoint;
+}
+
+async function fetchJson(url: string): Promise<Record<string, unknown>> {
+  const response = await fetch(url, {
+    headers: {
+      "MCP-Protocol-Version": "2025-06-18",
+      Accept: "application/json",
+    },
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`);
+  }
+
+  return (await response.json()) as Record<string, unknown>;
+}
+
+function buildProtectedResourceMetadataUrl(resourceIdentifier: string): string {
+  const url = new URL(resourceIdentifier);
+  const pathname = url.pathname.endsWith("/")
+    ? url.pathname.slice(0, -1)
+    : url.pathname;
+  return `${url.origin}/.well-known/oauth-protected-resource${pathname}`;
+}
+
+function buildProtectedResourceTokenHeaders(params: {
+  clientId: string;
+  clientSecret?: string;
+  tokenEndpointAuthentication:
+    | "client_secret_post"
+    | "client_secret_basic"
+    | "private_key_jwt";
+  requestBody: URLSearchParams;
+}): Headers {
+  const headers = new Headers({
+    "Content-Type": "application/x-www-form-urlencoded",
+  });
+
+  if (params.tokenEndpointAuthentication === "client_secret_basic") {
+    if (!params.clientSecret) {
+      throw new Error(
+        "ID-JAG protected resource exchange client secret is missing",
+      );
+    }
+    headers.set(
+      "Authorization",
+      `Basic ${Buffer.from(`${params.clientId}:${params.clientSecret}`).toString("base64")}`,
+    );
+    return headers;
+  }
+
+  if (params.tokenEndpointAuthentication === "client_secret_post") {
+    if (!params.clientSecret) {
+      throw new Error(
+        "ID-JAG protected resource exchange client secret is missing",
+      );
+    }
+    params.requestBody.set("client_id", params.clientId);
+    params.requestBody.set("client_secret", params.clientSecret);
+    return headers;
+  }
+
+  throw new Error(
+    "ID-JAG protected resource exchange does not support private_key_jwt in this implementation",
+  );
+}
+
+function shouldExchangeIdJagAtProtectedResource(
+  config: EnterpriseManagedCredentialConfig,
+): boolean {
+  return (
+    config.requestedCredentialType === "id_jag" &&
+    config.resourceType === "oauth_protected_resource"
+  );
 }
 
 function normalizeEnterpriseTransportCredential(params: {

--- a/platform/backend/src/types/llm-providers/bedrock/index.ts
+++ b/platform/backend/src/types/llm-providers/bedrock/index.ts
@@ -38,6 +38,7 @@ namespace Bedrock {
 
     export type Tool = z.infer<typeof BedrockTools.ToolSchema>;
     export type ToolSpec = z.infer<typeof BedrockTools.ToolSpecSchema>;
+    export type ToolChoice = z.infer<typeof BedrockTools.ToolChoiceSchema>;
     export type ToolConfig = z.infer<typeof BedrockTools.ToolConfigSchema>;
 
     export type FoundationModel = z.infer<typeof FoundationModelSchema>;

--- a/platform/e2e-tests/consts.ts
+++ b/platform/e2e-tests/consts.ts
@@ -149,6 +149,15 @@ export const MCP_SERVER_JWKS_BACKEND_URL = IS_CI
   ? "http://e2e-tests-mcp-server-jwks:3456"
   : "http://localhost:30082";
 
+export const MCP_SERVER_ID_JAG_EXTERNAL_URL = "http://localhost:30084";
+export const MCP_SERVER_ID_JAG_BACKEND_URL = IS_CI
+  ? "http://e2e-tests-mcp-server-id-jag:3458"
+  : "http://localhost:30084";
+export const MCP_SERVER_ID_JAG_GATEWAY_AUDIENCE = "id-jag-gateway-client";
+export const MCP_SERVER_ID_JAG_RESOURCE_CLIENT_ID = "id-jag-resource-client";
+export const MCP_SERVER_ID_JAG_RESOURCE_CLIENT_SECRET =
+  "id-jag-resource-secret";
+
 /** Docker image for the JWKS MCP server (used for local K8s deployment tests) */
 export const MCP_SERVER_JWKS_DOCKER_IMAGE =
   "europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-jwks-keycloak:0.0.3";

--- a/platform/e2e-tests/test-mcp-servers/README.md
+++ b/platform/e2e-tests/test-mcp-servers/README.md
@@ -2,5 +2,6 @@ This directory contains standalone MCP servers used by Archestra end-to-end test
 
 - `mcp-example-oauth-server`: OAuth-focused fixture server
 - `mcp-server-jwks-keycloak`: protected server used for JWT propagation and enterprise-managed credential exchange tests
+- `mcp-server-id-jag`: protected server whose authorization server accepts ID-JAG assertions and mints MCP-server access tokens
 
 These are test fixtures, not Helm chart logic, so they live under `e2e-tests/`.

--- a/platform/e2e-tests/test-mcp-servers/mcp-server-id-jag/.dockerignore
+++ b/platform/e2e-tests/test-mcp-servers/mcp-server-id-jag/.dockerignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+npm-debug.log

--- a/platform/e2e-tests/test-mcp-servers/mcp-server-id-jag/.gitignore
+++ b/platform/e2e-tests/test-mcp-servers/mcp-server-id-jag/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/platform/e2e-tests/test-mcp-servers/mcp-server-id-jag/Dockerfile
+++ b/platform/e2e-tests/test-mcp-servers/mcp-server-id-jag/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:24-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:24-alpine AS runtime
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY --from=builder /app/dist ./dist
+
+ENV PORT=3458
+
+EXPOSE 3458
+
+CMD ["npm", "start"]

--- a/platform/e2e-tests/test-mcp-servers/mcp-server-id-jag/Makefile
+++ b/platform/e2e-tests/test-mcp-servers/mcp-server-id-jag/Makefile
@@ -1,0 +1,12 @@
+IMAGE ?= europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-id-jag:0.0.1
+
+.PHONY: build test publish
+
+build:
+	docker build -t $(IMAGE) .
+
+test:
+	npm test
+
+publish: build
+	docker push $(IMAGE)

--- a/platform/e2e-tests/test-mcp-servers/mcp-server-id-jag/README.md
+++ b/platform/e2e-tests/test-mcp-servers/mcp-server-id-jag/README.md
@@ -1,0 +1,23 @@
+# MCP Server ID-JAG Demo
+
+This directory contains the source for a protected MCP server used by e2e tests to validate the ID-JAG flow.
+
+It demonstrates the pattern where the MCP server's authorization server accepts an ID-JAG assertion at `/token`, validates it, and mints an MCP-server-specific bearer access token. The MCP endpoint then accepts only that minted access token, not the original Archestra MCP Gateway token.
+
+## Endpoints
+
+- `GET /.well-known/oauth-protected-resource/mcp`
+- `GET /.well-known/oauth-authorization-server`
+- `POST /token`
+- `POST /mcp`
+- `POST /demo-idp/mint`
+- `GET /demo-idp/jwks`
+
+## Build and publish
+
+```bash
+cd platform/e2e-tests/test-mcp-servers/mcp-server-id-jag
+make publish
+```
+
+The e2e Helm chart references the image configured in `helm/e2e-tests/values.yaml`.

--- a/platform/e2e-tests/test-mcp-servers/mcp-server-id-jag/package-lock.json
+++ b/platform/e2e-tests/test-mcp-servers/mcp-server-id-jag/package-lock.json
@@ -1,0 +1,2207 @@
+{
+  "name": "mcp-server-id-jag",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mcp-server-id-jag",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "express": "^4.21.0",
+        "jose": "^5.9.6",
+        "zod": "^3.24.0"
+      },
+      "devDependencies": {
+        "@types/express": "^5.0.1",
+        "@types/node": "^24.6.0",
+        "tsx": "^4.19.3",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/platform/e2e-tests/test-mcp-servers/mcp-server-id-jag/package.json
+++ b/platform/e2e-tests/test-mcp-servers/mcp-server-id-jag/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "mcp-server-id-jag",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/server.js",
+    "test": "tsx --test src/server.test.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "express": "^4.21.0",
+    "jose": "^5.9.6",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.1",
+    "@types/node": "^24.6.0",
+    "tsx": "^4.19.3",
+    "typescript": "^5.9.3"
+  }
+}

--- a/platform/e2e-tests/test-mcp-servers/mcp-server-id-jag/src/server.test.ts
+++ b/platform/e2e-tests/test-mcp-servers/mcp-server-id-jag/src/server.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import test from "node:test";
+import { createApp } from "./server.js";
+
+test("exchanges an ID-JAG for an MCP-server access token", async () => {
+  const { baseUrl, close } = await startTestServer();
+
+  try {
+    const assertion = await mintIdJag(baseUrl);
+    const accessToken = await exchangeAssertion(baseUrl, assertion);
+    assert.notEqual(accessToken, assertion);
+    assert.match(accessToken, /^mcp-server-at-/);
+
+    const result = await callWhoami(baseUrl, accessToken);
+    assert.equal(result.bearerToken, accessToken);
+    assert.equal(result.accessToken.tokenKind, "mcp_server_access_token");
+    assert.equal(result.accessToken.obtainedVia, "id_jag_jwt_bearer");
+    assert.equal(result.user.email, "admin@example.com");
+  } finally {
+    await close();
+  }
+});
+
+test("does not allow the original ID-JAG as an MCP bearer token", async () => {
+  const { baseUrl, close } = await startTestServer();
+
+  try {
+    const assertion = await mintIdJag(baseUrl);
+    const response = await fetch(`${baseUrl}/mcp`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${assertion}`,
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+      }),
+    });
+
+    assert.equal(response.status, 401);
+  } finally {
+    await close();
+  }
+});
+
+async function startTestServer(): Promise<{
+  baseUrl: string;
+  close: () => Promise<void>;
+}> {
+  const port = await getAvailablePort();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const app = await createApp({ baseUrl, port });
+  const server = http.createServer(app);
+
+  await new Promise<void>((resolve) => {
+    server.listen(port, "127.0.0.1", () => resolve());
+  });
+
+  return {
+    baseUrl,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+async function mintIdJag(baseUrl: string): Promise<string> {
+  const response = await fetch(`${baseUrl}/demo-idp/mint`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      sub: "admin",
+      email: "admin@example.com",
+      name: "Admin User",
+    }),
+  });
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as { assertion: string };
+  return body.assertion;
+}
+
+async function exchangeAssertion(
+  baseUrl: string,
+  assertion: string,
+): Promise<string> {
+  const response = await fetch(`${baseUrl}/token`, {
+    method: "POST",
+    headers: {
+      authorization: `Basic ${Buffer.from("id-jag-resource-client:id-jag-resource-secret").toString("base64")}`,
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion,
+    }),
+  });
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as { access_token: string };
+  return body.access_token;
+}
+
+async function callWhoami(baseUrl: string, accessToken: string) {
+  const response = await fetch(`${baseUrl}/mcp`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${accessToken}`,
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: {
+        name: "whoami",
+        arguments: {},
+      },
+    }),
+  });
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as {
+    result: { content: Array<{ text: string }> };
+  };
+  return JSON.parse(body.result.content[0]!.text) as {
+    user: { email: string };
+    authorizationHeader: string;
+    bearerToken: string;
+    accessToken: {
+      tokenKind: string;
+      obtainedVia: string;
+    };
+  };
+}
+
+async function getAvailablePort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const server = http.createServer();
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Failed to allocate port"));
+        return;
+      }
+
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(address.port);
+      });
+    });
+  });
+}

--- a/platform/e2e-tests/test-mcp-servers/mcp-server-id-jag/src/server.ts
+++ b/platform/e2e-tests/test-mcp-servers/mcp-server-id-jag/src/server.ts
@@ -1,0 +1,546 @@
+import crypto from "node:crypto";
+import express, { type Express, type Request } from "express";
+import {
+  exportJWK,
+  generateKeyPair,
+  importJWK,
+  jwtVerify,
+  type JWK,
+  SignJWT,
+} from "jose";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { z } from "zod";
+
+const JWT_BEARER_GRANT_TYPE =
+  "urn:ietf:params:oauth:grant-type:jwt-bearer";
+const ID_JAG_JWT_TYPE = "oauth-id-jag+jwt";
+const ID_JAG_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:id-jag";
+const ACCESS_TOKEN_TTL_SECONDS = 60 * 10;
+const DEFAULT_PORT = 3458;
+const DEFAULT_BASE_URL = `http://localhost:${DEFAULT_PORT}`;
+const DEFAULT_GATEWAY_AUDIENCE = "id-jag-gateway-client";
+const DEFAULT_CLIENT_ID = "id-jag-resource-client";
+const DEFAULT_CLIENT_SECRET = "id-jag-resource-secret";
+
+type ServerConfig = {
+  port: number;
+  baseUrl: string;
+  gatewayAudience: string;
+  clientId: string;
+  clientSecret: string;
+};
+
+type DemoIdJagClaims = {
+  subject: string;
+  email?: string;
+  name?: string;
+  audience: string[];
+  clientId: string;
+  resource: string;
+  scope: string;
+};
+
+type MintedAccessToken = {
+  bearerToken: string;
+  clientId: string;
+  subject: string;
+  email?: string;
+  name?: string;
+  issuer: string;
+  resource: string;
+  scope: string;
+  assertionJwtId: string;
+  assertionType: typeof ID_JAG_JWT_TYPE;
+  tokenKind: "mcp_server_access_token";
+  obtainedVia: "id_jag_jwt_bearer";
+  expiresAtEpochSeconds: number;
+};
+
+export async function createApp(
+  config: Partial<ServerConfig> = {},
+): Promise<Express> {
+  const resolvedConfig = getServerConfig(config);
+  const demoIdentityProvider = await DemoIdentityProvider.create({
+    issuer: `${resolvedConfig.baseUrl}/demo-idp`,
+  });
+  const accessTokenStore = new AccessTokenStore();
+  const app = express();
+
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
+
+  app.get("/health", (_req, res) => {
+    res.json({ status: "ok" });
+  });
+
+  app.get("/.well-known/oauth-protected-resource/mcp", (_req, res) => {
+    res.json({
+      resource: `${resolvedConfig.baseUrl}/mcp`,
+      authorization_servers: [resolvedConfig.baseUrl],
+      bearer_methods_supported: ["header"],
+      scopes_supported: ["whoami"],
+    });
+  });
+
+  app.get("/.well-known/oauth-authorization-server", (_req, res) => {
+    res.json({
+      issuer: resolvedConfig.baseUrl,
+      token_endpoint: `${resolvedConfig.baseUrl}/token`,
+      jwks_uri: `${demoIdentityProvider.issuer}/jwks`,
+      grant_types_supported: [JWT_BEARER_GRANT_TYPE],
+      token_endpoint_auth_methods_supported: [
+        "client_secret_basic",
+        "client_secret_post",
+      ],
+      id_jag_token_type: ID_JAG_TOKEN_TYPE,
+    });
+  });
+
+  app.get("/demo-idp/.well-known/openid-configuration", (_req, res) => {
+    res.json({
+      issuer: demoIdentityProvider.issuer,
+      jwks_uri: `${demoIdentityProvider.issuer}/jwks`,
+    });
+  });
+
+  app.get("/demo-idp/jwks", (_req, res) => {
+    res.json({
+      keys: [demoIdentityProvider.publicJwk],
+    });
+  });
+
+  app.post("/demo-idp/mint", async (req, res) => {
+    const body = MintIdJagRequestSchema.safeParse(req.body);
+    if (!body.success) {
+      res.status(400).json(oauthError("invalid_request", body.error.message));
+      return;
+    }
+
+    const assertion = await demoIdentityProvider.mintIdJag({
+      subject: body.data.sub,
+      email: body.data.email,
+      name: body.data.name,
+      audience: body.data.audience ?? [
+        resolvedConfig.gatewayAudience,
+        resolvedConfig.baseUrl,
+        `${resolvedConfig.baseUrl}/mcp`,
+      ],
+      clientId: body.data.client_id ?? resolvedConfig.clientId,
+      resource: body.data.resource ?? `${resolvedConfig.baseUrl}/mcp`,
+      scope: body.data.scope ?? "whoami",
+    });
+
+    res.json({
+      assertion,
+      assertion_type: ID_JAG_TOKEN_TYPE,
+      issuer: demoIdentityProvider.issuer,
+      expires_in: 300,
+    });
+  });
+
+  app.post("/token", async (req, res) => {
+    const clientAuth = authenticateClient(req, resolvedConfig);
+    if (!clientAuth) {
+      res
+        .status(401)
+        .setHeader("WWW-Authenticate", 'Basic realm="mcp-server-id-jag"')
+        .json(oauthError("invalid_client", "Client authentication failed"));
+      return;
+    }
+
+    const body = TokenRequestSchema.safeParse(req.body);
+    if (!body.success) {
+      res.status(400).json(oauthError("invalid_request", body.error.message));
+      return;
+    }
+
+    if (body.data.grant_type !== JWT_BEARER_GRANT_TYPE) {
+      res
+        .status(400)
+        .json(
+          oauthError(
+            "unsupported_grant_type",
+            `Only ${JWT_BEARER_GRANT_TYPE} is supported`,
+          ),
+        );
+      return;
+    }
+
+    try {
+      const claims = await demoIdentityProvider.verifyIdJag({
+        assertion: body.data.assertion,
+        audience: resolvedConfig.baseUrl,
+        clientId: resolvedConfig.clientId,
+      });
+
+      const mintedToken = accessTokenStore.issue({
+        clientId: resolvedConfig.clientId,
+        subject: claims.sub,
+        email: claims.email,
+        name: claims.name,
+        issuer: claims.iss,
+        resource: claims.resource,
+        scope: claims.scope,
+        assertionJwtId: claims.jti,
+        assertionType: ID_JAG_JWT_TYPE,
+        tokenKind: "mcp_server_access_token",
+        obtainedVia: "id_jag_jwt_bearer",
+      });
+
+      res.json({
+        access_token: mintedToken.bearerToken,
+        token_type: "Bearer",
+        expires_in: ACCESS_TOKEN_TTL_SECONDS,
+        scope: mintedToken.scope,
+        issued_token_type: "urn:ietf:params:oauth:token-type:access_token",
+      });
+    } catch (error) {
+      res
+        .status(400)
+        .json(
+          oauthError(
+            "invalid_grant",
+            error instanceof Error
+              ? error.message
+              : "The supplied ID-JAG was rejected",
+          ),
+        );
+    }
+  });
+
+  app.post("/mcp", async (req, res) => {
+    const authorizationHeader = req.headers.authorization ?? "";
+    const accessToken = accessTokenStore.read(extractBearerToken(req));
+    if (!accessToken) {
+      res
+        .status(401)
+        .setHeader(
+          "WWW-Authenticate",
+          `Bearer resource_metadata="${resolvedConfig.baseUrl}/.well-known/oauth-protected-resource/mcp"`,
+        )
+        .json(oauthError("invalid_token", "A minted MCP access token is required"));
+      return;
+    }
+
+    const server = new McpServer({
+      name: "id-jag-demo-server",
+      version: "1.0.0",
+    });
+    registerTools(server, {
+      accessToken,
+      authorizationHeader,
+    });
+
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    });
+
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+    await server.close();
+  });
+
+  app.get("/mcp", (_req, res) => {
+    res.status(405).json({ error: "Method not allowed" });
+  });
+
+  app.delete("/mcp", (_req, res) => {
+    res.status(405).json({ error: "Method not allowed" });
+  });
+
+  return app;
+}
+
+export async function startServer(
+  config: Partial<ServerConfig> = {},
+): Promise<void> {
+  const resolvedConfig = getServerConfig(config);
+  const app = await createApp(resolvedConfig);
+  app.listen(resolvedConfig.port, () => {
+    console.log(`MCP ID-JAG server listening on ${resolvedConfig.baseUrl}`);
+    console.log(`Gateway audience: ${resolvedConfig.gatewayAudience}`);
+    console.log(`Resource client ID: ${resolvedConfig.clientId}`);
+  });
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await startServer();
+}
+
+const TokenRequestSchema = z.object({
+  grant_type: z.string(),
+  assertion: z.string().min(1),
+  client_id: z.string().optional(),
+  client_secret: z.string().optional(),
+});
+
+const MintIdJagRequestSchema = z.object({
+  sub: z.string().min(1),
+  email: z.string().email().optional(),
+  name: z.string().optional(),
+  audience: z.array(z.string()).optional(),
+  client_id: z.string().optional(),
+  resource: z.string().url().optional(),
+  scope: z.string().optional(),
+});
+
+const VerifiedIdJagClaimsSchema = z.object({
+  iss: z.string().url(),
+  sub: z.string(),
+  aud: z.union([z.string(), z.array(z.string())]),
+  exp: z.number(),
+  iat: z.number(),
+  jti: z.string(),
+  client_id: z.string(),
+  resource: z.string().url(),
+  scope: z.string(),
+  email: z.string().email().optional(),
+  name: z.string().optional(),
+});
+
+type VerifiedIdJagClaims = z.infer<typeof VerifiedIdJagClaimsSchema>;
+
+class DemoIdentityProvider {
+  public static async create(params: {
+    issuer: string;
+  }): Promise<DemoIdentityProvider> {
+    const { publicKey, privateKey } = await generateKeyPair("RS256");
+    const publicJwk = await exportJWK(publicKey);
+    const privateJwk = await exportJWK(privateKey);
+    const keyId = crypto.randomUUID();
+
+    return new DemoIdentityProvider({
+      issuer: params.issuer,
+      keyId,
+      publicJwk: { ...publicJwk, kid: keyId, use: "sig", alg: "RS256" },
+      privateJwk: { ...privateJwk, kid: keyId, use: "sig", alg: "RS256" },
+    });
+  }
+
+  public readonly issuer: string;
+  public readonly publicJwk: JWK;
+
+  private readonly keyId: string;
+  private readonly privateJwk: JWK;
+
+  private constructor(params: {
+    issuer: string;
+    keyId: string;
+    publicJwk: JWK;
+    privateJwk: JWK;
+  }) {
+    this.issuer = params.issuer;
+    this.keyId = params.keyId;
+    this.publicJwk = params.publicJwk;
+    this.privateJwk = params.privateJwk;
+  }
+
+  public async mintIdJag(claims: DemoIdJagClaims): Promise<string> {
+    const privateKey = await importJWK(this.privateJwk, "RS256");
+
+    return new SignJWT({
+      client_id: claims.clientId,
+      resource: claims.resource,
+      scope: claims.scope,
+      email: claims.email,
+      name: claims.name,
+    })
+      .setProtectedHeader({
+        alg: "RS256",
+        kid: this.keyId,
+        typ: ID_JAG_JWT_TYPE,
+      })
+      .setIssuer(this.issuer)
+      .setSubject(claims.subject)
+      .setAudience(claims.audience)
+      .setJti(crypto.randomUUID())
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(privateKey);
+  }
+
+  public async verifyIdJag(params: {
+    assertion: string;
+    audience: string;
+    clientId: string;
+  }): Promise<VerifiedIdJagClaims> {
+    const publicKey = await importJWK(this.publicJwk, "RS256");
+    const verified = await jwtVerify(params.assertion, publicKey, {
+      issuer: this.issuer,
+      audience: params.audience,
+    });
+
+    if (verified.protectedHeader.typ !== ID_JAG_JWT_TYPE) {
+      throw new Error(`JWT typ must be ${ID_JAG_JWT_TYPE}`);
+    }
+
+    const claims = VerifiedIdJagClaimsSchema.parse(verified.payload);
+    if (claims.client_id !== params.clientId) {
+      throw new Error("ID-JAG client_id does not match the resource client");
+    }
+
+    return claims;
+  }
+}
+
+class AccessTokenStore {
+  private readonly tokens = new Map<string, MintedAccessToken>();
+
+  public issue(
+    params: Omit<MintedAccessToken, "bearerToken" | "expiresAtEpochSeconds">,
+  ): MintedAccessToken {
+    const accessToken: MintedAccessToken = {
+      ...params,
+      bearerToken: `mcp-server-at-${crypto.randomBytes(24).toString("base64url")}`,
+      expiresAtEpochSeconds: Math.floor(Date.now() / 1000) + ACCESS_TOKEN_TTL_SECONDS,
+    };
+
+    this.tokens.set(accessToken.bearerToken, accessToken);
+    return accessToken;
+  }
+
+  public read(token: string | null): MintedAccessToken | null {
+    if (!token) {
+      return null;
+    }
+
+    const accessToken = this.tokens.get(token);
+    if (!accessToken) {
+      return null;
+    }
+
+    if (accessToken.expiresAtEpochSeconds <= Math.floor(Date.now() / 1000)) {
+      this.tokens.delete(token);
+      return null;
+    }
+
+    return accessToken;
+  }
+}
+
+function registerTools(
+  server: McpServer,
+  params: {
+    accessToken: MintedAccessToken;
+    authorizationHeader: string;
+  },
+): void {
+  server.tool(
+    "whoami",
+    "Report the identity and downstream token used by this MCP server",
+    {},
+    async () => ({
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              user: {
+                sub: params.accessToken.subject,
+                email: params.accessToken.email ?? null,
+                name: params.accessToken.name ?? null,
+              },
+              authorizationHeader: params.authorizationHeader,
+              bearerToken: params.accessToken.bearerToken,
+              accessToken: {
+                tokenKind: params.accessToken.tokenKind,
+                obtainedVia: params.accessToken.obtainedVia,
+                issuer: params.accessToken.issuer,
+                clientId: params.accessToken.clientId,
+                resource: params.accessToken.resource,
+                scope: params.accessToken.scope,
+                assertionType: params.accessToken.assertionType,
+                assertionJwtId: params.accessToken.assertionJwtId,
+                expiresAtEpochSeconds: params.accessToken.expiresAtEpochSeconds,
+              },
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    }),
+  );
+}
+
+function getServerConfig(config: Partial<ServerConfig>): ServerConfig {
+  const port = config.port ?? Number(process.env.PORT || DEFAULT_PORT);
+  const baseUrl = config.baseUrl ?? process.env.BASE_URL ?? DEFAULT_BASE_URL;
+
+  return {
+    port,
+    baseUrl,
+    gatewayAudience:
+      config.gatewayAudience ??
+      process.env.GATEWAY_AUDIENCE ??
+      DEFAULT_GATEWAY_AUDIENCE,
+    clientId: config.clientId ?? process.env.CLIENT_ID ?? DEFAULT_CLIENT_ID,
+    clientSecret:
+      config.clientSecret ?? process.env.CLIENT_SECRET ?? DEFAULT_CLIENT_SECRET,
+  };
+}
+
+function authenticateClient(
+  req: Request,
+  config: ServerConfig,
+): { clientId: string } | null {
+  const basicClient = authenticateBasicClient(req, config);
+  if (basicClient) {
+    return basicClient;
+  }
+
+  const body = req.body as { client_id?: unknown; client_secret?: unknown };
+  if (
+    body.client_id === config.clientId &&
+    body.client_secret === config.clientSecret
+  ) {
+    return { clientId: config.clientId };
+  }
+
+  return null;
+}
+
+function authenticateBasicClient(
+  req: Request,
+  config: ServerConfig,
+): { clientId: string } | null {
+  const header = req.headers.authorization;
+  if (!header?.startsWith("Basic ")) {
+    return null;
+  }
+
+  const decoded = Buffer.from(header.slice("Basic ".length), "base64").toString(
+    "utf8",
+  );
+  const separatorIndex = decoded.indexOf(":");
+  if (separatorIndex === -1) {
+    return null;
+  }
+
+  if (
+    decoded.slice(0, separatorIndex) !== config.clientId ||
+    decoded.slice(separatorIndex + 1) !== config.clientSecret
+  ) {
+    return null;
+  }
+
+  return { clientId: config.clientId };
+}
+
+function extractBearerToken(req: Request): string | null {
+  const header = req.headers.authorization;
+  if (!header?.startsWith("Bearer ")) {
+    return null;
+  }
+
+  return header.slice("Bearer ".length);
+}
+
+function oauthError(error: string, errorDescription: string) {
+  return {
+    error,
+    error_description: errorDescription,
+  };
+}

--- a/platform/e2e-tests/test-mcp-servers/mcp-server-id-jag/tsconfig.json
+++ b/platform/e2e-tests/test-mcp-servers/mcp-server-id-jag/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/platform/e2e-tests/tests/api/mcp-enterprise-managed.ee.spec.ts
+++ b/platform/e2e-tests/tests/api/mcp-enterprise-managed.ee.spec.ts
@@ -1,6 +1,11 @@
 import type { APIRequestContext } from "@playwright/test";
 import {
   KEYCLOAK_OIDC,
+  MCP_SERVER_ID_JAG_BACKEND_URL,
+  MCP_SERVER_ID_JAG_EXTERNAL_URL,
+  MCP_SERVER_ID_JAG_GATEWAY_AUDIENCE,
+  MCP_SERVER_ID_JAG_RESOURCE_CLIENT_ID,
+  MCP_SERVER_ID_JAG_RESOURCE_CLIENT_SECRET,
   MCP_SERVER_JWKS_BACKEND_URL,
   MCP_SERVER_JWKS_EXTERNAL_URL,
   MCP_SERVER_TOOL_NAME_SEPARATOR,
@@ -20,6 +25,7 @@ import {
 } from "./mcp-gateway-utils";
 
 const DEBUG_TOOL_SHORT_NAME = "debug-auth-token";
+const WHOAMI_TOOL_SHORT_NAME = "whoami";
 
 test.describe("Enterprise-managed MCP credentials", () => {
   test.skip("installs a protected remote MCP server without a manual access token", async ({
@@ -317,6 +323,110 @@ test.describe("Enterprise-managed MCP credentials", () => {
       await deleteIdentityProvider(request, identityProviderId);
     }
   });
+
+  test("exchanges an ID-JAG at a remote MCP server before gateway tool execution", async ({
+    request,
+    deleteIdentityProvider,
+    deleteMcpCatalogItem,
+    uninstallMcpServer,
+    deleteAgent,
+  }) => {
+    test.slow();
+
+    await expectIdJagDemoServerHealthy(request);
+
+    const providerName = `IdJagGateway${Date.now()}`;
+    const identityProviderId = await createIdJagIdentityProvider({
+      request,
+      providerId: providerName,
+    });
+    const gatewayToken = await mintIdJag({
+      email: "admin@example.com",
+      name: "Admin User",
+      sub: "admin",
+    });
+    const installAccessToken =
+      await exchangeIdJagForMcpServerAccessToken(gatewayToken);
+
+    let gatewayId: string | undefined;
+    let catalogId: string | undefined;
+    let serverId: string | undefined;
+
+    try {
+      gatewayId = await createProfile({
+        request,
+        name: `ID-JAG Gateway ${Date.now()}`,
+        agentType: "mcp_gateway",
+        identityProviderId,
+      });
+
+      const catalogName = `id-jag-resource-${Date.now()}`;
+      catalogId = await createIdJagCatalogItem({
+        request,
+        name: catalogName,
+        identityProviderId,
+      });
+
+      serverId = await installProtectedCatalogServer({
+        request,
+        catalogId,
+        name: catalogName,
+        accessToken: installAccessToken,
+      });
+
+      await waitForServerInstallation(request, serverId);
+
+      const fullToolName = `${catalogName}${MCP_SERVER_TOOL_NAME_SEPARATOR}${WHOAMI_TOOL_SHORT_NAME}`;
+      const toolId = await waitForCatalogTool({
+        request,
+        fullToolName,
+      });
+
+      await assignEnterpriseManagedTool({
+        request,
+        agentId: gatewayId,
+        toolId,
+      });
+
+      await waitForGatewayTool({
+        request,
+        profileId: gatewayId,
+        token: gatewayToken,
+        toolName: fullToolName,
+      });
+
+      const result = await callIdJagWhoamiTool({
+        request,
+        profileId: gatewayId,
+        token: gatewayToken,
+        toolName: fullToolName,
+      });
+
+      expect(result.authorizationHeader).toMatch(/^Bearer mcp-server-at-/);
+      expect(result.bearerToken).toMatch(/^mcp-server-at-/);
+      expect(result.bearerToken).not.toBe(gatewayToken);
+      expect(result.accessToken.tokenKind).toBe("mcp_server_access_token");
+      expect(result.accessToken.obtainedVia).toBe("id_jag_jwt_bearer");
+      expect(result.accessToken.resource).toBe(
+        `${MCP_SERVER_ID_JAG_BACKEND_URL}/mcp`,
+      );
+      expect(result.accessToken.clientId).toBe(
+        MCP_SERVER_ID_JAG_RESOURCE_CLIENT_ID,
+      );
+      expect(result.user.email).toBe("admin@example.com");
+    } finally {
+      if (gatewayId) {
+        await deleteAgent(request, gatewayId);
+      }
+      if (serverId) {
+        await uninstallMcpServer(request, serverId);
+      }
+      if (catalogId) {
+        await deleteMcpCatalogItem(request, catalogId);
+      }
+      await deleteIdentityProvider(request, identityProviderId);
+    }
+  });
 });
 
 async function expectProtectedDemoServerHealthy(
@@ -328,6 +438,18 @@ async function expectProtectedDemoServerHealthy(
     maxAttempts: 20,
     delayMs: 2000,
     description: `Protected demo MCP server at ${MCP_SERVER_JWKS_EXTERNAL_URL}/health`,
+  });
+}
+
+async function expectIdJagDemoServerHealthy(
+  request: APIRequestContext,
+): Promise<void> {
+  await waitForApiEndpointHealthy({
+    request,
+    url: `${MCP_SERVER_ID_JAG_EXTERNAL_URL}/health`,
+    maxAttempts: 20,
+    delayMs: 2000,
+    description: `ID-JAG demo MCP server at ${MCP_SERVER_ID_JAG_EXTERNAL_URL}/health`,
   });
 }
 
@@ -381,6 +503,68 @@ async function createProtectedEnterpriseManagedCatalogItem(params: {
 
   const catalog = (await response.json()) as { id: string };
   return catalog.id;
+}
+
+async function createIdJagCatalogItem(params: {
+  request: APIRequestContext;
+  name: string;
+  identityProviderId: string;
+}): Promise<string> {
+  const response = await makeApiRequest({
+    request: params.request,
+    method: "post",
+    urlSuffix: "/api/internal_mcp_catalog",
+    data: {
+      name: params.name,
+      description:
+        "Protected ID-JAG MCP server for enterprise-managed credential exchange tests",
+      serverType: "remote",
+      serverUrl: `${MCP_SERVER_ID_JAG_BACKEND_URL}/mcp`,
+      authMethod: "enterprise_managed",
+      enterpriseManagedConfig: {
+        identityProviderId: params.identityProviderId,
+        requestedCredentialType: "id_jag",
+        resourceType: "oauth_protected_resource",
+        resourceIdentifier: `${MCP_SERVER_ID_JAG_BACKEND_URL}/mcp`,
+        tokenInjectionMode: "authorization_bearer",
+      },
+    },
+  });
+
+  const catalog = (await response.json()) as { id: string };
+  return catalog.id;
+}
+
+async function createIdJagIdentityProvider(params: {
+  request: APIRequestContext;
+  providerId: string;
+}): Promise<string> {
+  const response = await makeApiRequest({
+    request: params.request,
+    method: "post",
+    urlSuffix: "/api/identity-providers",
+    data: {
+      providerId: params.providerId,
+      issuer: `${MCP_SERVER_ID_JAG_BACKEND_URL}/demo-idp`,
+      domain: "id-jag.example.com",
+      oidcConfig: {
+        issuer: `${MCP_SERVER_ID_JAG_BACKEND_URL}/demo-idp`,
+        pkce: true,
+        clientId: MCP_SERVER_ID_JAG_GATEWAY_AUDIENCE,
+        clientSecret: "unused-gateway-client-secret",
+        discoveryEndpoint: `${MCP_SERVER_ID_JAG_BACKEND_URL}/demo-idp/.well-known/openid-configuration`,
+        jwksEndpoint: `${MCP_SERVER_ID_JAG_BACKEND_URL}/demo-idp/jwks`,
+        enterpriseManagedCredentials: {
+          clientId: MCP_SERVER_ID_JAG_RESOURCE_CLIENT_ID,
+          clientSecret: MCP_SERVER_ID_JAG_RESOURCE_CLIENT_SECRET,
+          tokenEndpointAuthentication: "client_secret_basic",
+        },
+      },
+    },
+  });
+
+  const provider = (await response.json()) as { id: string };
+  return provider.id;
 }
 
 async function installProtectedCatalogServer(params: {
@@ -496,4 +680,94 @@ async function callDebugAuthTool(params: {
   const responseText = result.content[0]?.text;
   expect(responseText).toBeTruthy();
   return JSON.parse(String(responseText));
+}
+
+async function callIdJagWhoamiTool(params: {
+  request: APIRequestContext;
+  profileId: string;
+  token: string;
+  toolName: string;
+}): Promise<{
+  user: {
+    email?: string;
+  };
+  authorizationHeader: string;
+  bearerToken: string;
+  accessToken: {
+    tokenKind: string;
+    obtainedVia: string;
+    resource: string;
+    clientId: string;
+  };
+}> {
+  await initializeMcpSession(params.request, {
+    profileId: params.profileId,
+    token: params.token,
+  });
+
+  const result = await callMcpTool(params.request, {
+    profileId: params.profileId,
+    token: params.token,
+    toolName: params.toolName,
+    timeoutMs: 30000,
+  });
+
+  const responseText = result.content[0]?.text;
+  expect(responseText).toBeTruthy();
+  return JSON.parse(String(responseText));
+}
+
+async function mintIdJag(params: {
+  sub: string;
+  email: string;
+  name: string;
+}): Promise<string> {
+  const response = await fetch(
+    `${MCP_SERVER_ID_JAG_EXTERNAL_URL}/demo-idp/mint`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        sub: params.sub,
+        email: params.email,
+        name: params.name,
+        audience: [
+          MCP_SERVER_ID_JAG_GATEWAY_AUDIENCE,
+          MCP_SERVER_ID_JAG_BACKEND_URL,
+          `${MCP_SERVER_ID_JAG_BACKEND_URL}/mcp`,
+        ],
+        client_id: MCP_SERVER_ID_JAG_RESOURCE_CLIENT_ID,
+        resource: `${MCP_SERVER_ID_JAG_BACKEND_URL}/mcp`,
+        scope: "whoami",
+      }),
+    },
+  );
+
+  expect(response.ok).toBe(true);
+  const body = (await response.json()) as { assertion: string };
+  return body.assertion;
+}
+
+async function exchangeIdJagForMcpServerAccessToken(
+  assertion: string,
+): Promise<string> {
+  const response = await fetch(`${MCP_SERVER_ID_JAG_EXTERNAL_URL}/token`, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${Buffer.from(
+        `${MCP_SERVER_ID_JAG_RESOURCE_CLIENT_ID}:${MCP_SERVER_ID_JAG_RESOURCE_CLIENT_SECRET}`,
+      ).toString("base64")}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion,
+    }),
+  });
+
+  expect(response.ok).toBe(true);
+  const body = (await response.json()) as { access_token: string };
+  return body.access_token;
 }

--- a/platform/helm/e2e-tests/templates/mcp-server-id-jag.yaml
+++ b/platform/helm/e2e-tests/templates/mcp-server-id-jag.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.mcpServerIdJag.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-mcp-server-id-jag
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: mcp-server-id-jag
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: {{ .Values.mcpServerIdJag.service.type }}
+  ports:
+    - port: {{ .Values.mcpServerIdJag.service.port }}
+      targetPort: 3458
+      {{- if and (eq .Values.mcpServerIdJag.service.type "NodePort") .Values.mcpServerIdJag.service.nodePort }}
+      nodePort: {{ .Values.mcpServerIdJag.service.nodePort }}
+      {{- end }}
+      name: http
+  selector:
+    app.kubernetes.io/name: mcp-server-id-jag
+    app.kubernetes.io/instance: {{ .Release.Name }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-mcp-server-id-jag
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: mcp-server-id-jag
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mcp-server-id-jag
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mcp-server-id-jag
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: mcp-server-id-jag
+          image: "{{ .Values.mcpServerIdJag.image.repository }}:{{ .Values.mcpServerIdJag.image.tag }}"
+          imagePullPolicy: {{ .Values.mcpServerIdJag.image.pullPolicy | default "IfNotPresent" }}
+          env:
+            - name: PORT
+              value: "3458"
+            - name: BASE_URL
+              value: "http://{{ .Release.Name }}-mcp-server-id-jag:{{ .Values.mcpServerIdJag.service.port }}"
+            - name: GATEWAY_AUDIENCE
+              value: {{ .Values.mcpServerIdJag.gatewayAudience | quote }}
+            - name: CLIENT_ID
+              value: {{ .Values.mcpServerIdJag.resourceClientId | quote }}
+            - name: CLIENT_SECRET
+              value: {{ .Values.mcpServerIdJag.resourceClientSecret | quote }}
+          ports:
+            - containerPort: 3458
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3458
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+          resources:
+            {{- toYaml .Values.mcpServerIdJag.resources | nindent 12 }}
+{{- end }}

--- a/platform/helm/e2e-tests/values.yaml
+++ b/platform/helm/e2e-tests/values.yaml
@@ -144,6 +144,28 @@ mcpExampleOAuth:
       cpu: 500m
       memory: 512Mi
 
+# MCP Server with ID-JAG authentication for protected-resource exchange testing
+mcpServerIdJag:
+  enabled: true
+  image:
+    repository: europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-id-jag
+    tag: "0.0.1"
+    pullPolicy: IfNotPresent
+  gatewayAudience: "id-jag-gateway-client"
+  resourceClientId: "id-jag-resource-client"
+  resourceClientSecret: "id-jag-resource-secret"
+  service:
+    type: NodePort
+    port: 3458
+    nodePort: 30084
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+
 # HashiCorp Vault configuration for BYOS (Bring Your Own Secrets) testing
 vault:
   enabled: true


### PR DESCRIPTION
## Summary

Fixes Bedrock Converse requests that fail when MCP tool names exceed Bedrock's provider-side tool name limit.

- Adds provider-facing Bedrock tool name encoding that shortens names over 64 characters with a stable hash suffix.
- Applies the encoded name consistently to tool definitions, explicit tool choices, and assistant tool-use history sent back to Bedrock.
- Decodes Bedrock tool call responses back to the original MCP tool names so policy evaluation, logging, and execution continue to use the real tool names.
- Preserves the existing Nova hyphen normalization behavior and adds collision handling for names that normalize to the same provider value.

## Root Cause

Bedrock validates `toolConfig.tools[*].toolSpec.name` before model execution and rejects names longer than its limit. Some fully qualified MCP tool names can exceed that provider limit even though the same tool works through other providers.

## Validation

- `ARCHESTRA_DATABASE_URL=postgres://test:test@localhost:5432/test pnpm --filter @backend exec vitest run src/routes/proxy/adapterV2/bedrock.test.ts`
- `pnpm --filter @backend type-check`
- `pnpm --filter @backend exec biome check src/routes/proxy/adapterV2/bedrock.ts src/routes/proxy/adapterV2/bedrock.test.ts src/types/llm-providers/bedrock/index.ts`
