### PR TITLE
fix: Bedrock tool name encoding

### DIFF
--- a/platform/backend/src/routes/proxy/adapterV2/bedrock.test.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/bedrock.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "@/test";
+import type { Bedrock } from "@/types";
+import { bedrockAdapterFactory, getCommandInput } from "./bedrock";
+
+function createConverseRequest(
+  options?: Partial<Bedrock.Types.ConverseRequest>,
+): Bedrock.Types.ConverseRequest {
+  return {
+    modelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    messages: [{ role: "user", content: [{ text: "Hello" }] }],
+    ...options,
+  };
+}
+
+describe("Bedrock tool name encoding", () => {
+  test("shortens provider-facing tool names that exceed the Bedrock limit", () => {
+    const toolName =
+      "splunk_olly_preprod_mcp__olly_get_apm_service_errors_and_requests";
+    const request = createConverseRequest({
+      messages: [
+        { role: "user", content: [{ text: "Get service errors" }] },
+        {
+          role: "assistant",
+          content: [
+            {
+              toolUse: {
+                toolUseId: "tooluse_123",
+                name: toolName,
+                input: { service: "checkout" },
+              },
+            },
+          ],
+        },
+      ],
+      toolConfig: {
+        tools: [
+          {
+            toolSpec: {
+              name: toolName,
+              description: "Get APM service errors and requests",
+              inputSchema: { json: { type: "object" } },
+            },
+          },
+        ],
+        toolChoice: { tool: { name: toolName } },
+      },
+    });
+
+    const commandInput = getCommandInput(request);
+    const providerToolName =
+      commandInput.toolConfig?.tools?.[0]?.toolSpec?.name ?? "";
+    const toolChoice = commandInput.toolConfig?.toolChoice as
+      | { tool?: { name?: string } }
+      | undefined;
+    const providerToolChoiceName = toolChoice?.tool?.name ?? "";
+    const providerHistoryToolName =
+      commandInput.messages?.[1]?.content?.[0] &&
+      "toolUse" in commandInput.messages[1].content[0]
+        ? commandInput.messages[1].content[0].toolUse.name
+        : "";
+
+    expect(toolName.length).toBeGreaterThan(64);
+    expect(providerToolName).toHaveLength(64);
+    expect(providerToolName).not.toBe(toolName);
+    expect(providerToolChoiceName).toBe(providerToolName);
+    expect(providerHistoryToolName).toBe(providerToolName);
+  });
+
+  test("decodes shortened Bedrock tool call names back to the original name", async () => {
+    const toolName =
+      "splunk_olly_preprod_mcp__olly_get_apm_service_errors_and_requests";
+    const request = createConverseRequest({
+      toolConfig: {
+        tools: [
+          {
+            toolSpec: {
+              name: toolName,
+              description: "Get APM service errors and requests",
+              inputSchema: { json: { type: "object" } },
+            },
+          },
+        ],
+      },
+    });
+    const commandInput = getCommandInput(request);
+    const providerToolName =
+      commandInput.toolConfig?.tools?.[0]?.toolSpec?.name ?? "";
+    const client = {
+      converse: async () => ({
+        $metadata: { requestId: "req_123" },
+        output: {
+          message: {
+            role: "assistant",
+            content: [
+              {
+                toolUse: {
+                  toolUseId: "tooluse_123",
+                  name: providerToolName,
+                  input: { service: "checkout" },
+                },
+              },
+            ],
+          },
+        },
+        stopReason: "tool_use",
+        usage: { inputTokens: 10, outputTokens: 5 },
+      }),
+    };
+
+    const response = await bedrockAdapterFactory.execute(client, request);
+    const adapter = bedrockAdapterFactory.createResponseAdapter(response);
+
+    expect(adapter.getToolCalls()).toEqual([
+      {
+        id: "tooluse_123",
+        name: toolName,
+        arguments: { service: "checkout" },
+      },
+    ]);
+  });
+
+  test("continues to encode hyphens for Nova provider-facing tool names", () => {
+    const request = createConverseRequest({
+      modelId: "amazon.nova-lite-v1:0",
+      toolConfig: {
+        tools: [
+          {
+            toolSpec: {
+              name: "my-server__read-file",
+              inputSchema: { json: { type: "object" } },
+            },
+          },
+        ],
+      },
+    });
+
+    const commandInput = getCommandInput(request);
+
+    expect(commandInput.toolConfig?.tools?.[0]?.toolSpec?.name).toBe(
+      "my_server__read_file",
+    );
+  });
+
+  test("keeps Nova hyphen-normalized tool names unique", () => {
+    const request = createConverseRequest({
+      modelId: "amazon.nova-lite-v1:0",
+      toolConfig: {
+        tools: [
+          {
+            toolSpec: {
+              name: "server__read-file",
+              inputSchema: { json: { type: "object" } },
+            },
+          },
+          {
+            toolSpec: {
+              name: "server__read_file",
+              inputSchema: { json: { type: "object" } },
+            },
+          },
+        ],
+      },
+    });
+
+    const commandInput = getCommandInput(request);
+    const providerToolNames =
+      commandInput.toolConfig?.tools?.map((tool) => tool.toolSpec?.name) ?? [];
+
+    expect(providerToolNames).toHaveLength(2);
+    expect(new Set(providerToolNames).size).toBe(2);
+    expect(providerToolNames[0]).toBe("server__read_file");
+    expect(providerToolNames[1]).toMatch(/^server__read_file_[a-f0-9]{8}$/);
+  });
+});

--- a/platform/backend/src/routes/proxy/adapterV2/bedrock.test.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/bedrock.test.ts
@@ -1,6 +1,10 @@
+import { EventStreamCodec } from "@smithy/eventstream-codec";
+import { fromUtf8, toUtf8 } from "@smithy/util-utf8";
 import { describe, expect, test } from "@/test";
 import type { Bedrock } from "@/types";
 import { bedrockAdapterFactory, getCommandInput } from "./bedrock";
+
+const eventStreamCodec = new EventStreamCodec(toUtf8, fromUtf8);
 
 function createConverseRequest(
   options?: Partial<Bedrock.Types.ConverseRequest>,
@@ -10,6 +14,24 @@ function createConverseRequest(
     messages: [{ role: "user", content: [{ text: "Hello" }] }],
     ...options,
   };
+}
+
+function decodeEventStreamJson(bytes: Uint8Array): {
+  headers: Record<string, { value?: unknown }>;
+  body: Record<string, unknown>;
+} {
+  const decoded = eventStreamCodec.decode(bytes);
+  const bodyText =
+    typeof decoded.body === "string" ? decoded.body : toUtf8(decoded.body);
+
+  return {
+    headers: decoded.headers as Record<string, { value?: unknown }>,
+    body: JSON.parse(bodyText) as Record<string, unknown>,
+  };
+}
+
+function asStreamChunk<T>(chunk: unknown): T {
+  return chunk as T;
 }
 
 describe("Bedrock tool name encoding", () => {
@@ -170,5 +192,96 @@ describe("Bedrock tool name encoding", () => {
     expect(new Set(providerToolNames).size).toBe(2);
     expect(providerToolNames[0]).toBe("server__read_file");
     expect(providerToolNames[1]).toMatch(/^server__read_file_[a-f0-9]{8}$/);
+  });
+
+  test("re-encodes streamed tool call events with the original tool name", () => {
+    const toolName =
+      "splunk_olly_preprod_mcp__olly_get_apm_service_errors_and_requests";
+    const request = createConverseRequest({
+      toolConfig: {
+        tools: [
+          {
+            toolSpec: {
+              name: toolName,
+              description: "Get APM service errors and requests",
+              inputSchema: { json: { type: "object" } },
+            },
+          },
+        ],
+      },
+    });
+    const commandInput = getCommandInput(request);
+    const providerToolName =
+      commandInput.toolConfig?.tools?.[0]?.toolSpec?.name ?? "";
+    const adapter = bedrockAdapterFactory.createStreamAdapter(request);
+
+    adapter.processChunk(
+      asStreamChunk<Parameters<typeof adapter.processChunk>[0]>({
+        contentBlockStart: {
+          contentBlockIndex: 0,
+          start: {
+            toolUse: {
+              toolUseId: "tooluse_123",
+              name: providerToolName,
+            },
+          },
+        },
+      }),
+    );
+    adapter.processChunk(
+      asStreamChunk<Parameters<typeof adapter.processChunk>[0]>({
+        contentBlockDelta: {
+          contentBlockIndex: 0,
+          delta: {
+            toolUse: {
+              input: '{"service":"checkout"}',
+            },
+          },
+        },
+      }),
+    );
+    adapter.processChunk(
+      asStreamChunk<Parameters<typeof adapter.processChunk>[0]>({
+        contentBlockStop: {
+          contentBlockIndex: 0,
+        },
+      }),
+    );
+    adapter.processChunk(
+      asStreamChunk<Parameters<typeof adapter.processChunk>[0]>({
+        messageStop: {
+          stopReason: "tool_use",
+        },
+      }),
+    );
+    adapter.processChunk(
+      asStreamChunk<Parameters<typeof adapter.processChunk>[0]>({
+        metadata: {
+          usage: { inputTokens: 10, outputTokens: 5 },
+        },
+      }),
+    );
+
+    expect(adapter.state.toolCalls[0]).toEqual({
+      id: "tooluse_123",
+      name: toolName,
+      arguments: '{"service":"checkout"}',
+    });
+
+    const rawEvents = adapter.getRawToolCallEvents();
+    const decodedStartEvent = decodeEventStreamJson(rawEvents[0] as Uint8Array);
+
+    expect(decodedStartEvent.headers[":event-type"]?.value).toBe(
+      "contentBlockStart",
+    );
+    expect(decodedStartEvent.body).toMatchObject({
+      contentBlockIndex: 0,
+      start: {
+        toolUse: {
+          toolUseId: "tooluse_123",
+          name: toolName,
+        },
+      },
+    });
   });
 });

--- a/platform/backend/src/routes/proxy/adapterV2/bedrock.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/bedrock.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { ConverseStreamOutput } from "@aws-sdk/client-bedrock-runtime";
 import { EventStreamCodec } from "@smithy/eventstream-codec";
 import { fromUtf8, toUtf8 } from "@smithy/util-utf8";
@@ -55,6 +56,9 @@ const eventStreamCodec = new EventStreamCodec(toUtf8, fromUtf8);
 // Padding alphabet used by Bedrock (lowercase + uppercase + digits)
 const PADDING_ALPHABET =
   "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+const BEDROCK_MAX_TOOL_NAME_LENGTH = 64;
+const TOOL_NAME_HASH_LENGTH = 8;
+const TOOL_NAME_HASH_SEPARATOR = "_";
 
 /**
  * Generate padding string to match Bedrock's format.
@@ -104,39 +108,177 @@ function isNovaModel(modelId: string): boolean {
   return modelId.toLowerCase().includes("nova");
 }
 
+type ToolNameMapping = {
+  toProvider: Map<string, string>;
+  toOriginal: Map<string, string>;
+};
+
 /**
- * Nova models faeil with "Model produced invalid sequence as part of ToolUse" when
- * tool names contain hyphens. We replace hyphens with underscores before sending
- * to Bedrock and use a name mapping to restore original names in responses.
+ * Nova models fail with "Model produced invalid sequence as part of ToolUse" when
+ * tool names contain hyphens. Bedrock also rejects names longer than 64 chars.
+ * Encode only the provider-facing names and keep mappings to restore originals.
  */
-function encodeToolName(name: string): string {
-  return name.replaceAll("-", "_");
+function encodeToolName(name: string, options: { isNova: boolean }): string {
+  const normalizedName = options.isNova ? name.replaceAll("-", "_") : name;
+  return truncateToolName(normalizedName, name);
 }
 
 /**
  * Build a mapping from encoded tool names back to original names.
  */
-function buildToolNameMapping(request: BedrockRequest): Map<string, string> {
-  const mapping = new Map<string, string>();
+function buildToolNameMapping(request: BedrockRequest): ToolNameMapping {
+  const isNova = isNovaModel(request.modelId);
+  const toProvider = new Map<string, string>();
+  const toOriginal = new Map<string, string>();
   const tools = request.toolConfig?.tools ?? [];
+
   for (const tool of tools) {
     const originalName = tool.toolSpec?.name;
     if (originalName) {
-      const encodedName = encodeToolName(originalName);
-      mapping.set(encodedName, originalName);
+      const encodedName = getUniqueProviderToolName({
+        originalName,
+        isNova,
+        usedNames: toOriginal,
+      });
+      toProvider.set(originalName, encodedName);
+      toOriginal.set(encodedName, originalName);
     }
   }
-  return mapping;
+
+  return { toProvider, toOriginal };
 }
 
 /**
  * Decode tool name using the mapping (encoded → original).
  */
-function decodeToolName(
-  encodedName: string,
-  mapping: Map<string, string>,
+function decodeToolName(encodedName: string, mapping: ToolNameMapping): string {
+  return mapping.toOriginal.get(encodedName) ?? encodedName;
+}
+
+function getProviderToolName(
+  originalName: string,
+  mapping: ToolNameMapping,
+  options: { isNova: boolean },
 ): string {
-  return mapping.get(encodedName) ?? encodedName;
+  return (
+    mapping.toProvider.get(originalName) ??
+    encodeToolName(originalName, options)
+  );
+}
+
+function createEmptyToolNameMapping(): ToolNameMapping {
+  return {
+    toProvider: new Map(),
+    toOriginal: new Map(),
+  };
+}
+
+function getUniqueProviderToolName(params: {
+  originalName: string;
+  isNova: boolean;
+  usedNames: Map<string, string>;
+}): string {
+  const encodedName = encodeToolName(params.originalName, {
+    isNova: params.isNova,
+  });
+  const existingOriginalName = params.usedNames.get(encodedName);
+
+  if (!existingOriginalName || existingOriginalName === params.originalName) {
+    return encodedName;
+  }
+
+  return appendToolNameHash(encodedName, params.originalName);
+}
+
+function truncateToolName(name: string, hashInput: string): string {
+  if (name.length <= BEDROCK_MAX_TOOL_NAME_LENGTH) {
+    return name;
+  }
+
+  return appendToolNameHash(name, hashInput);
+}
+
+function appendToolNameHash(name: string, hashInput: string): string {
+  const hash = createHash("sha256")
+    .update(hashInput)
+    .digest("hex")
+    .slice(0, TOOL_NAME_HASH_LENGTH);
+  const prefixLength =
+    BEDROCK_MAX_TOOL_NAME_LENGTH -
+    TOOL_NAME_HASH_SEPARATOR.length -
+    TOOL_NAME_HASH_LENGTH;
+
+  return `${name.slice(0, prefixLength)}${TOOL_NAME_HASH_SEPARATOR}${hash}`;
+}
+
+function encodeProviderMessageToolNames(params: {
+  messages: BedrockMessages | undefined;
+  mapping: ToolNameMapping;
+  isNova: boolean;
+}): BedrockMessages | undefined {
+  if (!params.messages) {
+    return params.messages;
+  }
+
+  return params.messages.map((message) => {
+    if (!Array.isArray(message.content)) {
+      return message;
+    }
+
+    const content = message.content.map((contentBlock) => {
+      if (!isToolUseBlock(contentBlock)) {
+        return contentBlock;
+      }
+
+      const name = contentBlock.toolUse.name;
+      if (!name) {
+        return contentBlock;
+      }
+
+      return {
+        ...contentBlock,
+        toolUse: {
+          ...contentBlock.toolUse,
+          name: getProviderToolName(name, params.mapping, {
+            isNova: params.isNova,
+          }),
+        },
+      };
+    });
+
+    return {
+      ...message,
+      content,
+    };
+  }) as BedrockMessages;
+}
+
+function encodeProviderToolChoiceName(params: {
+  toolChoice: Bedrock.Types.ToolChoice | undefined;
+  mapping: ToolNameMapping;
+  isNova: boolean;
+}): Bedrock.Types.ToolChoice | undefined {
+  if (!params.toolChoice || !("tool" in params.toolChoice)) {
+    return params.toolChoice;
+  }
+
+  const toolChoice = params.toolChoice.tool as
+    | { name?: unknown }
+    | null
+    | undefined;
+  if (typeof toolChoice?.name !== "string") {
+    return params.toolChoice;
+  }
+
+  return {
+    ...params.toolChoice,
+    tool: {
+      ...toolChoice,
+      name: getProviderToolName(toolChoice.name, params.mapping, {
+        isNova: params.isNova,
+      }),
+    },
+  };
 }
 
 /**
@@ -200,14 +342,11 @@ class BedrockRequestAdapter
   private request: BedrockRequest;
   private modifiedModel: string | null = null;
   private toolResultUpdates: Record<string, string> = {};
-  private toolNameMapping: Map<string, string>;
+  private toolNameMapping: ToolNameMapping;
 
   constructor(request: BedrockRequest) {
     this.request = request;
-    // Only build mapping for Nova models (which require tool name encoding)
-    this.toolNameMapping = isNovaModel(request.modelId)
-      ? buildToolNameMapping(request)
-      : new Map();
+    this.toolNameMapping = buildToolNameMapping(request);
   }
 
   // ---------------------------------------------------------------------------
@@ -637,7 +776,7 @@ class BedrockStreamAdapter
   readonly provider = "bedrock" as const;
   readonly state: StreamAccumulatorState;
   private currentToolCallIndex = -1;
-  private toolNameMapping: Map<string, string> = new Map();
+  private toolNameMapping: ToolNameMapping = createEmptyToolNameMapping();
 
   // Bedrock-specific extended state
   private bedrockState: {
@@ -671,12 +810,9 @@ class BedrockStreamAdapter
 
   /**
    * Set the tool name mapping from the request for decoding tool names in responses.
-   * Only builds mapping for Nova models (which require tool name encoding).
    */
   setToolNameMapping(request: BedrockRequest): void {
-    if (isNovaModel(request.modelId)) {
-      this.toolNameMapping = buildToolNameMapping(request);
-    }
+    this.toolNameMapping = buildToolNameMapping(request);
   }
 
   processChunk(chunk: BedrockStreamEventWithRaw): ChunkProcessingResult {
@@ -1208,14 +1344,19 @@ export async function convertToolResultsToToon(
 /**
  * Convert BedrockRequest to AWS SDK command input format.
  * Used by both ConverseCommand and ConverseStreamCommand.
- * Only maps tool names for Nova models (which don't support hyphens).
+ * Maps tool names to provider-safe names and decodes them after Bedrock returns.
  */
 export function getCommandInput(request: BedrockRequest) {
-  const shouldEncode = isNovaModel(request.modelId);
+  const shouldEncodeHyphens = isNovaModel(request.modelId);
+  const toolNameMapping = buildToolNameMapping(request);
 
   return {
     modelId: request.modelId,
-    messages: request.messages,
+    messages: encodeProviderMessageToolNames({
+      messages: request.messages,
+      mapping: toolNameMapping,
+      isNova: shouldEncodeHyphens,
+    }),
     system: request.system?.map((s) => {
       if ("text" in s) return { text: s.text };
       return s;
@@ -1226,11 +1367,11 @@ export function getCommandInput(request: BedrockRequest) {
           tools: request.toolConfig.tools?.map((t) => ({
             toolSpec: t.toolSpec
               ? {
-                  // Only encode hyphens for Nova models
-                  name:
-                    t.toolSpec.name && shouldEncode
-                      ? encodeToolName(t.toolSpec.name)
-                      : t.toolSpec.name,
+                  name: t.toolSpec.name
+                    ? getProviderToolName(t.toolSpec.name, toolNameMapping, {
+                        isNova: shouldEncodeHyphens,
+                      })
+                    : t.toolSpec.name,
                   description: t.toolSpec.description,
                   inputSchema: t.toolSpec.inputSchema
                     ? {
@@ -1240,7 +1381,11 @@ export function getCommandInput(request: BedrockRequest) {
                 }
               : undefined,
           })),
-          toolChoice: request.toolConfig.toolChoice,
+          toolChoice: encodeProviderToolChoiceName({
+            toolChoice: request.toolConfig.toolChoice,
+            mapping: toolNameMapping,
+            isNova: shouldEncodeHyphens,
+          }),
         }
       : undefined,
   };
@@ -1335,10 +1480,7 @@ export const bedrockAdapterFactory: LLMProvider<
   ): Promise<BedrockResponse> {
     const bedrockClient = client as BedrockClient;
     const commandInput = getCommandInput(request);
-    // Only build mapping for Nova models (which require tool name encoding)
-    const toolNameMapping = isNovaModel(request.modelId)
-      ? buildToolNameMapping(request)
-      : new Map<string, string>();
+    const toolNameMapping = buildToolNameMapping(request);
 
     // Use fetch-based client.converse()
     const response = await bedrockClient.converse(

--- a/platform/backend/src/routes/proxy/adapterV2/bedrock.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/bedrock.ts
@@ -41,9 +41,34 @@ type BedrockRequest = Bedrock.Types.ConverseRequest;
 type BedrockResponse = Bedrock.Types.ConverseResponse;
 type BedrockMessages = Bedrock.Types.Message[];
 type BedrockHeaders = Bedrock.Types.ConverseHeaders;
-type BedrockCommandInput = ReturnType<
-  typeof buildBedrockCommandContext
->["commandInput"];
+type BedrockCommandContext = {
+  commandInput: {
+    modelId: string;
+    messages: BedrockMessages | undefined;
+    system:
+      | Array<{ text?: string; guardContent?: unknown; cachePoint?: unknown }>
+      | undefined;
+    inferenceConfig: BedrockRequest["inferenceConfig"];
+    toolConfig:
+      | {
+          tools:
+            | Array<{
+                toolSpec:
+                  | {
+                      name?: string;
+                      description?: string;
+                      inputSchema?: { json: Record<string, unknown> };
+                    }
+                  | undefined;
+              }>
+            | undefined;
+          toolChoice: Bedrock.Types.ToolChoice | undefined;
+        }
+      | undefined;
+  };
+  toolNameMapping: ToolNameMapping;
+};
+type BedrockCommandInput = BedrockCommandContext["commandInput"];
 
 // Stream event types from the SDK
 type BedrockStreamEvent = ConverseStreamOutput;
@@ -62,6 +87,10 @@ const PADDING_ALPHABET =
 const BEDROCK_MAX_TOOL_NAME_LENGTH = 64;
 const TOOL_NAME_HASH_LENGTH = 8;
 const TOOL_NAME_HASH_SEPARATOR = "_";
+const bedrockCommandContextCache = new WeakMap<
+  BedrockRequest,
+  BedrockCommandContext
+>();
 
 /**
  * Generate padding string to match Bedrock's format.
@@ -814,8 +843,8 @@ class BedrockStreamAdapter
   /**
    * Set the tool name mapping from the request for decoding tool names in responses.
    */
-  setToolNameMapping(request: BedrockRequest): void {
-    this.toolNameMapping = buildToolNameMapping(request);
+  setToolNameMapping(toolNameMapping: ToolNameMapping): void {
+    this.toolNameMapping = toolNameMapping;
   }
 
   processChunk(chunk: BedrockStreamEventWithRaw): ChunkProcessingResult {
@@ -1344,37 +1373,18 @@ export async function convertToolResultsToToon(
 // HELPER: Build Command Input
 // =============================================================================
 
-function buildBedrockCommandContext(request: BedrockRequest): {
-  commandInput: {
-    modelId: string;
-    messages: BedrockMessages | undefined;
-    system:
-      | Array<{ text?: string; guardContent?: unknown; cachePoint?: unknown }>
-      | undefined;
-    inferenceConfig: BedrockRequest["inferenceConfig"];
-    toolConfig:
-      | {
-          tools:
-            | Array<{
-                toolSpec:
-                  | {
-                      name?: string;
-                      description?: string;
-                      inputSchema?: { json: Record<string, unknown> };
-                    }
-                  | undefined;
-              }>
-            | undefined;
-          toolChoice: Bedrock.Types.ToolChoice | undefined;
-        }
-      | undefined;
-  };
-  toolNameMapping: ToolNameMapping;
-} {
+function buildBedrockCommandContext(
+  request: BedrockRequest,
+): BedrockCommandContext {
+  const cachedContext = bedrockCommandContextCache.get(request);
+  if (cachedContext) {
+    return cachedContext;
+  }
+
   const shouldEncodeHyphens = isNovaModel(request.modelId);
   const toolNameMapping = buildToolNameMapping(request);
 
-  return {
+  const context = {
     commandInput: {
       modelId: request.modelId,
       messages: encodeProviderMessageToolNames({
@@ -1416,6 +1426,9 @@ function buildBedrockCommandContext(request: BedrockRequest): {
     },
     toolNameMapping,
   };
+
+  bedrockCommandContextCache.set(request, context);
+  return context;
 }
 
 /**
@@ -1458,7 +1471,8 @@ export const bedrockAdapterFactory: LLMProvider<
   ): LLMStreamAdapter<BedrockStreamEvent, BedrockResponse> {
     const adapter = new BedrockStreamAdapter();
     if (request) {
-      adapter.setToolNameMapping(request);
+      const { toolNameMapping } = buildBedrockCommandContext(request);
+      adapter.setToolNameMapping(toolNameMapping);
     }
     return adapter;
   },

--- a/platform/backend/src/routes/proxy/adapterV2/bedrock.ts
+++ b/platform/backend/src/routes/proxy/adapterV2/bedrock.ts
@@ -41,6 +41,9 @@ type BedrockRequest = Bedrock.Types.ConverseRequest;
 type BedrockResponse = Bedrock.Types.ConverseResponse;
 type BedrockMessages = Bedrock.Types.Message[];
 type BedrockHeaders = Bedrock.Types.ConverseHeaders;
+type BedrockCommandInput = ReturnType<
+  typeof buildBedrockCommandContext
+>["commandInput"];
 
 // Stream event types from the SDK
 type BedrockStreamEvent = ConverseStreamOutput;
@@ -1341,54 +1344,87 @@ export async function convertToolResultsToToon(
 // HELPER: Build Command Input
 // =============================================================================
 
+function buildBedrockCommandContext(request: BedrockRequest): {
+  commandInput: {
+    modelId: string;
+    messages: BedrockMessages | undefined;
+    system:
+      | Array<{ text?: string; guardContent?: unknown; cachePoint?: unknown }>
+      | undefined;
+    inferenceConfig: BedrockRequest["inferenceConfig"];
+    toolConfig:
+      | {
+          tools:
+            | Array<{
+                toolSpec:
+                  | {
+                      name?: string;
+                      description?: string;
+                      inputSchema?: { json: Record<string, unknown> };
+                    }
+                  | undefined;
+              }>
+            | undefined;
+          toolChoice: Bedrock.Types.ToolChoice | undefined;
+        }
+      | undefined;
+  };
+  toolNameMapping: ToolNameMapping;
+} {
+  const shouldEncodeHyphens = isNovaModel(request.modelId);
+  const toolNameMapping = buildToolNameMapping(request);
+
+  return {
+    commandInput: {
+      modelId: request.modelId,
+      messages: encodeProviderMessageToolNames({
+        messages: request.messages,
+        mapping: toolNameMapping,
+        isNova: shouldEncodeHyphens,
+      }),
+      system: request.system?.map((s) => {
+        if ("text" in s) return { text: s.text };
+        return s;
+      }),
+      inferenceConfig: request.inferenceConfig,
+      toolConfig: request.toolConfig
+        ? {
+            tools: request.toolConfig.tools?.map((t) => ({
+              toolSpec: t.toolSpec
+                ? {
+                    name: t.toolSpec.name
+                      ? getProviderToolName(t.toolSpec.name, toolNameMapping, {
+                          isNova: shouldEncodeHyphens,
+                        })
+                      : t.toolSpec.name,
+                    description: t.toolSpec.description,
+                    inputSchema: t.toolSpec.inputSchema
+                      ? {
+                          json: t.toolSpec.inputSchema.json,
+                        }
+                      : undefined,
+                  }
+                : undefined,
+            })),
+            toolChoice: encodeProviderToolChoiceName({
+              toolChoice: request.toolConfig.toolChoice,
+              mapping: toolNameMapping,
+              isNova: shouldEncodeHyphens,
+            }),
+          }
+        : undefined,
+    },
+    toolNameMapping,
+  };
+}
+
 /**
  * Convert BedrockRequest to AWS SDK command input format.
  * Used by both ConverseCommand and ConverseStreamCommand.
  * Maps tool names to provider-safe names and decodes them after Bedrock returns.
  */
-export function getCommandInput(request: BedrockRequest) {
-  const shouldEncodeHyphens = isNovaModel(request.modelId);
-  const toolNameMapping = buildToolNameMapping(request);
-
-  return {
-    modelId: request.modelId,
-    messages: encodeProviderMessageToolNames({
-      messages: request.messages,
-      mapping: toolNameMapping,
-      isNova: shouldEncodeHyphens,
-    }),
-    system: request.system?.map((s) => {
-      if ("text" in s) return { text: s.text };
-      return s;
-    }),
-    inferenceConfig: request.inferenceConfig,
-    toolConfig: request.toolConfig
-      ? {
-          tools: request.toolConfig.tools?.map((t) => ({
-            toolSpec: t.toolSpec
-              ? {
-                  name: t.toolSpec.name
-                    ? getProviderToolName(t.toolSpec.name, toolNameMapping, {
-                        isNova: shouldEncodeHyphens,
-                      })
-                    : t.toolSpec.name,
-                  description: t.toolSpec.description,
-                  inputSchema: t.toolSpec.inputSchema
-                    ? {
-                        json: t.toolSpec.inputSchema.json,
-                      }
-                    : undefined,
-                }
-              : undefined,
-          })),
-          toolChoice: encodeProviderToolChoiceName({
-            toolChoice: request.toolConfig.toolChoice,
-            mapping: toolNameMapping,
-            isNova: shouldEncodeHyphens,
-          }),
-        }
-      : undefined,
-  };
+export function getCommandInput(request: BedrockRequest): BedrockCommandInput {
+  return buildBedrockCommandContext(request).commandInput;
 }
 
 // =============================================================================
@@ -1479,8 +1515,8 @@ export const bedrockAdapterFactory: LLMProvider<
     request: BedrockRequest,
   ): Promise<BedrockResponse> {
     const bedrockClient = client as BedrockClient;
-    const commandInput = getCommandInput(request);
-    const toolNameMapping = buildToolNameMapping(request);
+    const { commandInput, toolNameMapping } =
+      buildBedrockCommandContext(request);
 
     // Use fetch-based client.converse()
     const response = await bedrockClient.converse(
@@ -1545,7 +1581,7 @@ export const bedrockAdapterFactory: LLMProvider<
     request: BedrockRequest,
   ): Promise<AsyncIterable<BedrockStreamEventWithRaw>> {
     const bedrockClient = client as BedrockClient;
-    const commandInput = getCommandInput(request);
+    const { commandInput } = buildBedrockCommandContext(request);
 
     // Use fetch-based client.converseStream() - returns events with __rawBytes already set
     return bedrockClient.converseStream(request.modelId, commandInput);

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -200,7 +200,7 @@ export async function handleLLMProxy<
   );
 
   const requestAdapter = provider.createRequestAdapter(body);
-  const streamAdapter = provider.createStreamAdapter();
+  const streamAdapter = provider.createStreamAdapter(body);
   const providerMessages = requestAdapter.getProviderMessages();
   const messagesCount = getProviderMessagesCount(providerMessages);
 

--- a/platform/backend/src/types/llm-providers/bedrock/index.ts
+++ b/platform/backend/src/types/llm-providers/bedrock/index.ts
@@ -38,6 +38,7 @@ namespace Bedrock {
 
     export type Tool = z.infer<typeof BedrockTools.ToolSchema>;
     export type ToolSpec = z.infer<typeof BedrockTools.ToolSpecSchema>;
+    export type ToolChoice = z.infer<typeof BedrockTools.ToolChoiceSchema>;
     export type ToolConfig = z.infer<typeof BedrockTools.ToolConfigSchema>;
 
     export type FoundationModel = z.infer<typeof FoundationModelSchema>;


### PR DESCRIPTION
## Summary

Fixes Bedrock Converse requests that fail when MCP tool names exceed Bedrock's provider-side tool name limit.

- Adds provider-facing Bedrock tool name encoding that shortens names over 64 characters with a stable hash suffix.
- Applies the encoded name consistently to tool definitions, explicit tool choices, and assistant tool-use history sent back to Bedrock.
- Decodes Bedrock tool call responses back to the original MCP tool names so policy evaluation, logging, and execution continue to use the real tool names.
- Preserves the existing Nova hyphen normalization behavior and adds collision handling for names that normalize to the same provider value.

## Root Cause

Bedrock validates `toolConfig.tools[*].toolSpec.name` before model execution and rejects names longer than its limit. Some fully qualified MCP tool names can exceed that provider limit even though the same tool works through other providers.