### PR TITLE
fix: costs timeframes and surface limit reset settings

### DIFF
--- a/platform/frontend/src/app/llm/(costs)/costs/page.test.tsx
+++ b/platform/frontend/src/app/llm/(costs)/costs/page.test.tsx
@@ -1,0 +1,100 @@
+import type { StatisticsTimeFrame } from "@shared";
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import StatisticsPage from "./page";
+
+const mockRouterPush = vi.fn();
+let mockSearchParams = new URLSearchParams();
+const mockSetCostsAction = vi.fn();
+
+const mockUseTeamStatistics = vi.fn();
+const mockUseProfileStatistics = vi.fn();
+const mockUseModelStatistics = vi.fn();
+const mockUseCostSavingsStatistics = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+vi.mock("@/app/llm/(costs)/layout", () => ({
+  useSetCostsAction: () => mockSetCostsAction,
+}));
+
+vi.mock("@/lib/statistics.query", () => ({
+  useTeamStatistics: (params: { timeframe: StatisticsTimeFrame }) =>
+    mockUseTeamStatistics(params),
+  useProfileStatistics: (params: { timeframe: StatisticsTimeFrame }) =>
+    mockUseProfileStatistics(params),
+  useModelStatistics: (params: { timeframe: StatisticsTimeFrame }) =>
+    mockUseModelStatistics(params),
+  useCostSavingsStatistics: (params: { timeframe: StatisticsTimeFrame }) =>
+    mockUseCostSavingsStatistics(params),
+}));
+
+vi.mock("recharts", () => ({
+  CartesianGrid: () => null,
+  Line: () => null,
+  LineChart: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  XAxis: () => null,
+  YAxis: () => null,
+}));
+
+vi.mock("@/components/ui/chart", () => ({
+  ChartContainer: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ChartLegend: () => null,
+  ChartLegendContent: () => null,
+  ChartTooltip: () => null,
+  ChartTooltipContent: () => null,
+}));
+
+vi.mock("@/components/ui/custom-date-time-range-dialog", () => ({
+  CustomDateTimeRangeDialog: () => null,
+}));
+
+describe("StatisticsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mockSearchParams = new URLSearchParams();
+    mockUseTeamStatistics.mockReturnValue({ data: [] });
+    mockUseProfileStatistics.mockReturnValue({ data: [] });
+    mockUseModelStatistics.mockReturnValue({ data: [] });
+    mockUseCostSavingsStatistics.mockReturnValue({
+      data: { timeSeries: [] },
+    });
+  });
+
+  it("queries statistics with the selected custom timeframe", async () => {
+    const customTimeframe =
+      "custom:2026-07-01T00:00:00.000Z_2026-07-31T23:59:59.999Z";
+    mockSearchParams = new URLSearchParams([["timeframe", customTimeframe]]);
+
+    render(<StatisticsPage />);
+
+    await waitFor(() => {
+      expect(mockUseTeamStatistics).toHaveBeenLastCalledWith({
+        timeframe: customTimeframe,
+      });
+    });
+
+    expect(mockUseProfileStatistics).toHaveBeenLastCalledWith({
+      timeframe: customTimeframe,
+    });
+    expect(mockUseModelStatistics).toHaveBeenLastCalledWith({
+      timeframe: customTimeframe,
+    });
+    expect(mockUseCostSavingsStatistics).toHaveBeenLastCalledWith({
+      timeframe: customTimeframe,
+    });
+    expect(
+      mockUseTeamStatistics.mock.calls.some(
+        ([params]) => params.timeframe === "all",
+      ),
+    ).toBe(false);
+  });
+});

--- a/platform/frontend/src/app/llm/(costs)/costs/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/costs/page.tsx
@@ -18,6 +18,7 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 import { CustomDateTimeRangeDialog } from "@/components/ui/custom-date-time-range-dialog";
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import {
   Select,
   SelectContent,
@@ -100,18 +101,17 @@ export default function StatisticsPage() {
   const [isCustomDialogOpen, setIsCustomDialogOpen] = useState(false);
 
   // Statistics data fetching hooks
-  const currentTimeframe = timeframe.startsWith("custom:") ? "all" : timeframe;
   const { data: teamStatistics = [] } = useTeamStatistics({
-    timeframe: currentTimeframe,
+    timeframe,
   });
   const { data: agentStatistics = [] } = useProfileStatistics({
-    timeframe: currentTimeframe,
+    timeframe,
   });
   const { data: modelStatistics = [] } = useModelStatistics({
-    timeframe: currentTimeframe,
+    timeframe,
   });
   const { data: costSavingsData } = useCostSavingsStatistics({
-    timeframe: currentTimeframe,
+    timeframe,
   });
 
   /**
@@ -127,8 +127,13 @@ export default function StatisticsPage() {
     );
     if (success) {
       setTimeframe(data);
+      const customRange = parseCustomTimeframe(data);
+      setCustomFrom(customRange?.from);
+      setCustomTo(customRange?.to);
     } else {
       setTimeframe("1h");
+      setCustomFrom(undefined);
+      setCustomTo(undefined);
     }
   }, [searchParams]);
 
@@ -629,8 +634,8 @@ export default function StatisticsPage() {
           <CardTitle>Teams</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-            <div className="order-2 lg:order-1">
+          <div className="space-y-4">
+            <div className="space-y-3">
               <ChartContainerWrapper
                 config={teamChartConfig}
                 data={teamChartData}
@@ -680,16 +685,28 @@ export default function StatisticsPage() {
               )}
             </div>
 
-            <div className="order-1 lg:order-2">
+            <StatisticsTablePanel>
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Team Name</TableHead>
-                    <TableHead>Members</TableHead>
-                    <TableHead>Profiles</TableHead>
-                    <TableHead>Requests</TableHead>
-                    <TableHead>Tokens</TableHead>
-                    <TableHead className="text-right">Cost</TableHead>
+                    <TableHead className="bg-card sticky top-0 z-10">
+                      Team Name
+                    </TableHead>
+                    <TableHead className="bg-card sticky top-0 z-10">
+                      Members
+                    </TableHead>
+                    <TableHead className="bg-card sticky top-0 z-10">
+                      Profiles
+                    </TableHead>
+                    <TableHead className="bg-card sticky top-0 z-10">
+                      Requests
+                    </TableHead>
+                    <TableHead className="bg-card sticky top-0 z-10">
+                      Tokens
+                    </TableHead>
+                    <TableHead className="bg-card sticky top-0 z-10 text-right">
+                      Cost
+                    </TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -724,7 +741,7 @@ export default function StatisticsPage() {
                   )}
                 </TableBody>
               </Table>
-            </div>
+            </StatisticsTablePanel>
           </div>
         </CardContent>
       </Card>
@@ -734,8 +751,8 @@ export default function StatisticsPage() {
           <CardTitle>Agents</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-            <div className="order-2 lg:order-1">
+          <div className="space-y-4">
+            <div className="space-y-3">
               <ChartContainerWrapper
                 config={agentChartConfig}
                 data={agentChartData}
@@ -785,15 +802,25 @@ export default function StatisticsPage() {
               )}
             </div>
 
-            <div className="order-1 lg:order-2">
+            <StatisticsTablePanel>
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Name</TableHead>
-                    <TableHead>Team</TableHead>
-                    <TableHead>Requests</TableHead>
-                    <TableHead>Tokens</TableHead>
-                    <TableHead className="text-right">Cost</TableHead>
+                    <TableHead className="bg-card sticky top-0 z-10">
+                      Name
+                    </TableHead>
+                    <TableHead className="bg-card sticky top-0 z-10">
+                      Team
+                    </TableHead>
+                    <TableHead className="bg-card sticky top-0 z-10">
+                      Requests
+                    </TableHead>
+                    <TableHead className="bg-card sticky top-0 z-10">
+                      Tokens
+                    </TableHead>
+                    <TableHead className="bg-card sticky top-0 z-10 text-right">
+                      Cost
+                    </TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -827,7 +854,7 @@ export default function StatisticsPage() {
                   )}
                 </TableBody>
               </Table>
-            </div>
+            </StatisticsTablePanel>
           </div>
         </CardContent>
       </Card>
@@ -837,8 +864,8 @@ export default function StatisticsPage() {
           <CardTitle>LLM Proxies</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-            <div className="order-2 lg:order-1">
+          <div className="space-y-4">
+            <div className="space-y-3">
               <ChartContainerWrapper
                 config={llmProxyChartConfig}
                 data={llmProxyChartData}
@@ -888,15 +915,25 @@ export default function StatisticsPage() {
               )}
             </div>
 
-            <div className="order-1 lg:order-2">
+            <StatisticsTablePanel>
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Name</TableHead>
-                    <TableHead>Team</TableHead>
-                    <TableHead>Requests</TableHead>
-                    <TableHead>Tokens</TableHead>
-                    <TableHead className="text-right">Cost</TableHead>
+                    <TableHead className="bg-card sticky top-0 z-10">
+                      Name
+                    </TableHead>
+                    <TableHead className="bg-card sticky top-0 z-10">
+                      Team
+                    </TableHead>
+                    <TableHead className="bg-card sticky top-0 z-10">
+                      Requests
+                    </TableHead>
+                    <TableHead className="bg-card sticky top-0 z-10">
+                      Tokens
+                    </TableHead>
+                    <TableHead className="bg-card sticky top-0 z-10 text-right">
+                      Cost
+                    </TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -930,7 +967,7 @@ export default function StatisticsPage() {
                   )}
                 </TableBody>
               </Table>
-            </div>
+            </StatisticsTablePanel>
           </div>
         </CardContent>
       </Card>
@@ -940,8 +977,8 @@ export default function StatisticsPage() {
           <CardTitle>Models</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-            <div className="order-2 lg:order-1">
+          <div className="space-y-4">
+            <div className="space-y-3">
               <ChartContainerWrapper
                 config={modelChartConfig}
                 data={modelChartData}
@@ -991,15 +1028,25 @@ export default function StatisticsPage() {
               )}
             </div>
 
-            <div className="order-1 lg:order-2">
+            <StatisticsTablePanel>
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Model</TableHead>
-                    <TableHead>Requests</TableHead>
-                    <TableHead>Tokens Used</TableHead>
-                    <TableHead>Cost</TableHead>
-                    <TableHead className="text-right">% of Total</TableHead>
+                    <TableHead className="bg-card sticky top-0 z-10">
+                      Model
+                    </TableHead>
+                    <TableHead className="bg-card sticky top-0 z-10">
+                      Requests
+                    </TableHead>
+                    <TableHead className="bg-card sticky top-0 z-10">
+                      Tokens Used
+                    </TableHead>
+                    <TableHead className="bg-card sticky top-0 z-10">
+                      Cost
+                    </TableHead>
+                    <TableHead className="bg-card sticky top-0 z-10 text-right">
+                      % of Total
+                    </TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -1033,10 +1080,43 @@ export default function StatisticsPage() {
                   )}
                 </TableBody>
               </Table>
-            </div>
+            </StatisticsTablePanel>
           </div>
         </CardContent>
       </Card>
     </div>
   );
+}
+
+function StatisticsTablePanel({ children }: { children: React.ReactNode }) {
+  return (
+    <ScrollArea className="max-h-[360px] rounded-md border">
+      {children}
+      <ScrollBar orientation="horizontal" />
+    </ScrollArea>
+  );
+}
+
+function parseCustomTimeframe(timeframe: StatisticsTimeFrame):
+  | {
+      from: Date;
+      to: Date;
+    }
+  | undefined {
+  if (!timeframe.startsWith("custom:")) {
+    return undefined;
+  }
+
+  const [from, to] = timeframe.replace("custom:", "").split("_");
+  if (!from || !to) {
+    return undefined;
+  }
+
+  const fromDate = new Date(from);
+  const toDate = new Date(to);
+  if (Number.isNaN(fromDate.getTime()) || Number.isNaN(toDate.getTime())) {
+    return undefined;
+  }
+
+  return { from: fromDate, to: toDate };
 }

--- a/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import LimitsPage from "./page";
+
+const mockSetCostsAction = vi.fn();
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/app/llm/(costs)/layout", () => ({
+  useSetCostsAction: () => mockSetCostsAction,
+}));
+
+vi.mock("@/lib/limits.query", () => ({
+  useLimits: () => ({ data: [], isPending: false }),
+  useCreateLimit: () => ({ mutateAsync: vi.fn() }),
+  useUpdateLimit: () => ({ mutateAsync: vi.fn() }),
+  useDeleteLimit: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock("@/lib/teams/team.query", () => ({
+  useTeams: () => ({ data: [] }),
+}));
+
+vi.mock("@/lib/organization.query", () => ({
+  useOrganization: () => ({
+    data: { id: "org-1", limitCleanupInterval: "1m" },
+  }),
+}));
+
+vi.mock("@/lib/llm-models.query", () => ({
+  useModelsWithApiKeys: () => ({ data: [] }),
+}));
+
+vi.mock("@/lib/hooks/use-data-table-query-params", () => ({
+  useDataTableQueryParams: () => ({
+    searchParams: new URLSearchParams(),
+    updateQueryParams: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/loading", () => ({
+  LoadingSpinner: () => <div>Loading</div>,
+  LoadingWrapper: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("@/components/ui/data-table", () => ({
+  DataTable: () => <div>Limits table</div>,
+}));
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectItem: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/components/ui/permission-button", () => ({
+  PermissionButton: ({ children }: { children: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}));
+
+vi.mock("@/components/llm-model-select", () => ({
+  LlmModelSearchableSelect: () => <div>Model filter</div>,
+}));
+
+vi.mock("@/components/form-dialog", () => ({
+  FormDialog: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  DialogBody: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogForm: ({ children }: { children: React.ReactNode }) => (
+    <form>{children}</form>
+  ),
+  DialogStickyFooter: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/components/delete-confirm-dialog", () => ({
+  DeleteConfirmDialog: () => null,
+}));
+
+vi.mock("@/components/table-row-actions", () => ({
+  TableRowActions: () => null,
+}));
+
+vi.mock("@/components/ui/progress", () => ({
+  Progress: () => <div />,
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: () => <input />,
+}));
+
+vi.mock("@/components/ui/label", () => ({
+  Label: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children }: { children: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+
+describe("LimitsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the active cleanup interval and links to LLM settings", () => {
+    render(<LimitsPage />);
+
+    expect(
+      screen.getByText(
+        /expired or exceeded limits reset on the current cleanup schedule/i,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Every month")).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("link", { name: /change it in llm settings/i }),
+    ).toHaveAttribute("href", "/settings/llm");
+  });
+});

--- a/platform/frontend/src/app/llm/(costs)/limits/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.tsx
@@ -353,6 +353,24 @@ export default function LimitsPage() {
 
   return (
     <div className="space-y-4">
+      <Alert variant="info">
+        <CircleHelp />
+        <AlertDescription className="sm:flex sm:flex-wrap sm:items-center sm:gap-1">
+          <span>
+            Expired or exceeded limits reset on the current cleanup schedule:
+          </span>
+          <span className="font-medium text-foreground">
+            {cleanupIntervalLabel}
+          </span>
+          <Link
+            href="/settings/llm"
+            className="font-medium underline underline-offset-4"
+          >
+            Change it in LLM settings
+          </Link>
+        </AlertDescription>
+      </Alert>
+
       <div className="flex flex-wrap gap-3">
         <Select
           value={statusFilter}
@@ -400,24 +418,6 @@ export default function LimitsPage() {
           allLabel="All models"
         />
       </div>
-
-      <Alert variant="info">
-        <CircleHelp />
-        <AlertDescription>
-          Expired or exceeded limits reset on the current cleanup schedule:{" "}
-          <span className="font-medium text-foreground">
-            {cleanupIntervalLabel}
-          </span>
-          .{" "}
-          <Link
-            href="/settings/llm"
-            className="font-medium underline underline-offset-4"
-          >
-            Change it in LLM settings
-          </Link>
-          .
-        </AlertDescription>
-      </Alert>
 
       <LoadingWrapper
         isPending={isPending}

--- a/platform/frontend/src/app/llm/(costs)/limits/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.tsx
@@ -2,7 +2,8 @@
 
 import type { archestraApiTypes } from "@shared";
 import type { ColumnDef } from "@tanstack/react-table";
-import { Edit, Plus, Trash2, X } from "lucide-react";
+import { CircleHelp, Edit, Plus, Trash2, X } from "lucide-react";
+import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSetCostsAction } from "@/app/llm/(costs)/layout";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
@@ -10,6 +11,7 @@ import { FormDialog } from "@/components/form-dialog";
 import { LlmModelSearchableSelect } from "@/components/llm-model-select";
 import { LoadingSpinner, LoadingWrapper } from "@/components/loading";
 import { TableRowActions } from "@/components/table-row-actions";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
@@ -43,6 +45,11 @@ import { useTeams } from "@/lib/teams/team.query";
 type LimitData = archestraApiTypes.GetLimitsResponses["200"][number];
 type LimitEntityType = archestraApiTypes.CreateLimitData["body"]["entityType"];
 type UsageStatus = "safe" | "warning" | "danger";
+type LimitCleanupInterval = NonNullable<
+  NonNullable<
+    archestraApiTypes.UpdateLlmSettingsData["body"]
+  >["limitCleanupInterval"]
+>;
 
 type LimitFormState = {
   entityType: LimitEntityType;
@@ -56,6 +63,14 @@ const DEFAULT_FORM_STATE: LimitFormState = {
   entityId: "",
   limitValue: "",
   model: [],
+};
+
+const CLEANUP_INTERVAL_LABELS: Record<LimitCleanupInterval, string> = {
+  "1h": "Every hour",
+  "12h": "Every 12 hours",
+  "24h": "Every 24 hours",
+  "1w": "Every week",
+  "1m": "Every month",
 };
 
 function formatCurrencyWhole(value: number) {
@@ -290,6 +305,10 @@ export default function LimitsPage() {
     statusFilter !== "all" ||
     appliedToFilter !== "all" ||
     modelFilter !== "all";
+  const cleanupIntervalLabel =
+    CLEANUP_INTERVAL_LABELS[
+      (organization?.limitCleanupInterval as LimitCleanupInterval) ?? "1h"
+    ];
 
   async function handleSubmit() {
     const body = {
@@ -381,6 +400,24 @@ export default function LimitsPage() {
           allLabel="All models"
         />
       </div>
+
+      <Alert variant="info">
+        <CircleHelp />
+        <AlertDescription>
+          Expired or exceeded limits reset on the current cleanup schedule:{" "}
+          <span className="font-medium text-foreground">
+            {cleanupIntervalLabel}
+          </span>
+          .{" "}
+          <Link
+            href="/settings/llm"
+            className="font-medium underline underline-offset-4"
+          >
+            Change it in LLM settings
+          </Link>
+          .
+        </AlertDescription>
+      </Alert>
 
       <LoadingWrapper
         isPending={isPending}


### PR DESCRIPTION
## Summary

- Fix `/llm/costs` so custom timeframes are sent to the statistics API instead of falling back to all-time data.
- Initialize the custom timeframe dialog from the currently selected custom range so edits are consistent.
- Rework the Teams, Agents, LLM Proxies, and Models breakdowns so charts are followed by bounded, scrollable detail tables with sticky headers.
- Add a visible cleanup-interval hint on `/llm/limits` that shows the active reset cadence and links to LLM settings.
- Add regression tests for the custom timeframe query behavior and the limits-page settings hint.

## Root Cause

The costs page converted every `custom:*` timeframe to `all` before invoking the statistics queries, so future custom ranges continued showing all-time data instead of an empty range. Separately, the limit reset cadence lived only under LLM settings, which made it easy to miss when working from the limits page.

## User Impact

- Custom date ranges on `/llm/costs` now drive the charts and summaries correctly, including future ranges.
- Long cost breakdown tables are easier to scan without overwhelming the chart layout.
- Users can discover and navigate to the limit reset interval setting directly from `/llm/limits`.

## Validation

- `pnpm install`
- `pnpm --filter @frontend test -- 'src/app/llm/(costs)/costs/page.test.tsx' --run`
- `pnpm --filter @frontend test -- 'src/app/llm/(costs)/limits/page.test.tsx' --run`
- `pnpm --filter @frontend type-check`
- `pnpm exec biome check 'frontend/src/app/llm/(costs)/costs/page.tsx' 'frontend/src/app/llm/(costs)/costs/page.test.tsx'`
- `pnpm exec biome check 'frontend/src/app/llm/(costs)/limits/page.tsx' 'frontend/src/app/llm/(costs)/limits/page.test.tsx'`
