### PR TITLE
fix: apply MCP OAuth lifetime for gateway slugs

### DIFF
--- a/platform/backend/src/routes/auth.test.ts
+++ b/platform/backend/src/routes/auth.test.ts
@@ -218,4 +218,76 @@ describe("auth routes", () => {
       expires_in: 31_536_000,
     });
   });
+
+  test("applies MCP token lifetime when resource uses the gateway slug", async ({
+    makeAgent,
+    makeOAuthAccessToken,
+    makeOAuthClient,
+    makeOrganization,
+    makeUser,
+  }) => {
+    const user = await makeUser();
+    const organization = await makeOrganization();
+    await OrganizationModel.patch(organization.id, {
+      mcpOauthAccessTokenLifetimeSeconds: 300,
+    });
+    const agent = await makeAgent({
+      agentType: "mcp_gateway",
+      name: "Default MCP Gateway",
+      organizationId: organization.id,
+    });
+    const client = await makeOAuthClient({ userId: user.id });
+    const rawAccessToken = "cursor-oauth-access-token";
+    const tokenHash = createHash("sha256")
+      .update(rawAccessToken)
+      .digest("base64url");
+    await makeOAuthAccessToken(client.clientId, user.id, {
+      token: tokenHash,
+      expiresAt: new Date("2026-01-01T01:00:00.000Z"),
+    });
+    const issuedAtSeconds = 1_767_225_600;
+    vi.mocked(betterAuth.handler).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: rawAccessToken,
+          token_type: "Bearer",
+          expires_in: 3_600,
+          expires_at: issuedAtSeconds + 3_600,
+          scope: "mcp",
+        }),
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      ),
+    );
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/auth/oauth2/token",
+      headers: {
+        host: "localhost:9000",
+      },
+      payload: {
+        grant_type: "authorization_code",
+        client_id: client.clientId,
+        code: "auth-code",
+        resource: `http://localhost:9000/v1/mcp/${agent.slug}`,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      access_token: rawAccessToken,
+      expires_in: 300,
+      expires_at: issuedAtSeconds + 300,
+    });
+
+    const storedToken = await OAuthAccessTokenModel.getByTokenHash(tokenHash);
+    expect(storedToken?.expiresAt).toEqual(
+      new Date((issuedAtSeconds + 300) * 1000),
+    );
+  });
 });

--- a/platform/backend/src/routes/auth.ts
+++ b/platform/backend/src/routes/auth.ts
@@ -19,8 +19,8 @@ import {
   UserTokenModel,
 } from "@/models";
 import {
+  buildOAuthIssuer,
   exchangeIdentityAssertionForAccessToken,
-  extractProfileIdFromMcpResource,
   JWT_BEARER_GRANT_TYPE,
   MCP_RESOURCE_REFERENCE_PREFIX,
 } from "@/services/identity-providers/enterprise-managed/authorization";
@@ -675,10 +675,10 @@ async function getMcpOauthAccessTokenLifetimeSeconds(params: {
   tokenEndpointOrigin: string;
 }): Promise<number | null> {
   const profileId =
-    getProfileIdFromResource({
+    (await getProfileIdFromResource({
       resource: params.resource,
       tokenEndpointOrigin: params.tokenEndpointOrigin,
-    }) ?? getProfileIdFromReferenceId(params.referenceId);
+    })) ?? getProfileIdFromReferenceId(params.referenceId);
   if (!profileId) {
     return null;
   }
@@ -730,29 +730,25 @@ function getIssuedAtSeconds(tokenBody: Record<string, unknown>): number {
   return Math.floor(Date.now() / 1000);
 }
 
-function getProfileIdFromResource(params: {
+async function getProfileIdFromResource(params: {
   resource: unknown;
   tokenEndpointOrigin: string;
-}): string | null {
+}): Promise<string | null> {
   if (typeof params.resource !== "string") {
     return null;
   }
 
-  const profileIdFromIssuerResource = extractProfileIdFromMcpResource(
-    params.resource,
-  );
-  if (profileIdFromIssuerResource) {
-    return profileIdFromIssuerResource;
-  }
-
   try {
     const resourceUrl = new URL(params.resource);
-    if (resourceUrl.origin !== params.tokenEndpointOrigin) {
+    const issuerOrigin = new URL(buildOAuthIssuer()).origin;
+    const allowedOrigins = new Set([issuerOrigin, params.tokenEndpointOrigin]);
+    if (!allowedOrigins.has(resourceUrl.origin)) {
       return null;
     }
 
-    const match = resourceUrl.pathname.match(/^\/v1\/mcp\/([0-9a-f-]{36})$/i);
-    return match?.[1] ?? null;
+    const match = resourceUrl.pathname.match(/^\/v1\/mcp\/([^/]+)$/);
+    const idOrSlug = match?.[1] ? decodeURIComponent(match[1]) : null;
+    return idOrSlug ? AgentModel.resolveIdFromIdOrSlug(idOrSlug) : null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- Resolve MCP OAuth resource URLs by UUID or gateway slug when applying org token lifetime settings
- Covers Cursor-style `/v1/mcp/default-mcp-gateway` resource URLs so `expires_in` and persisted `oauth_access_token.expires_at` use the configured lifetime
- Add regression test for a 300-second org lifetime with a gateway slug resource