### PR TITLE
fix: session logs loading state

### DIFF
--- a/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.test.tsx
+++ b/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useInteractionSessions,
+  useInteractions,
+} from "@/lib/interactions/interaction.query";
+import SessionDetailPage from "./page.client";
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(),
+  useSearchParams: vi.fn(),
+}));
+
+vi.mock("@/lib/interactions/interaction.query", () => ({
+  useInteractions: vi.fn(),
+  useInteractionSessions: vi.fn(),
+}));
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return {
+    ...actual,
+    use: () => ({ sessionId: "test-session" }),
+  };
+});
+
+describe("SessionDetailPage", () => {
+  beforeEach(() => {
+    vi.mocked(useRouter).mockReturnValue({
+      push: vi.fn(),
+    } as unknown as ReturnType<typeof useRouter>);
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams() as unknown as ReturnType<typeof useSearchParams>,
+    );
+    vi.mocked(useInteractionSessions).mockReturnValue({
+      data: undefined,
+    } as unknown as ReturnType<typeof useInteractionSessions>);
+  });
+
+  it("shows a loading state while session interactions are loading", async () => {
+    vi.mocked(useInteractions).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as unknown as ReturnType<typeof useInteractions>);
+
+    renderSessionDetailPage();
+
+    expect(await screen.findByText("Loading session logs...")).toBeVisible();
+    expect(
+      screen.queryByText("No interactions found for this session"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the empty state after session interactions finish loading empty", async () => {
+    vi.mocked(useInteractions).mockReturnValue({
+      data: {
+        data: [],
+        pagination: {
+          currentPage: 1,
+          limit: 50,
+          total: 0,
+          totalPages: 0,
+          hasNext: false,
+          hasPrev: false,
+        },
+      },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useInteractions>);
+
+    renderSessionDetailPage();
+
+    expect(
+      await screen.findByText("No interactions found for this session"),
+    ).toBeVisible();
+    expect(
+      screen.queryByText("Loading session logs..."),
+    ).not.toBeInTheDocument();
+  });
+});
+
+function renderSessionDetailPage() {
+  return render(
+    <SessionDetailPage
+      paramsPromise={Promise.resolve({ sessionId: "test-session" })}
+    />,
+  );
+}

--- a/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.tsx
+++ b/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { ArrowLeft, Bot, ExternalLink, Layers, User } from "lucide-react";
+import {
+  ArrowLeft,
+  Bot,
+  ExternalLink,
+  Layers,
+  Loader2,
+  User,
+} from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { use, useCallback } from "react";
@@ -44,13 +51,14 @@ export default function SessionDetailPage({
   const pageIndex = Number(pageFromUrl || "1") - 1;
   const pageSize = DEFAULT_TABLE_LIMIT;
 
-  const { data: interactionsResponse } = useInteractions({
-    sessionId: sessionId,
-    limit: pageSize,
-    offset: pageIndex * pageSize,
-    sortBy: "createdAt",
-    sortDirection: "desc",
-  });
+  const { data: interactionsResponse, isLoading: interactionsLoading } =
+    useInteractions({
+      sessionId: sessionId,
+      limit: pageSize,
+      offset: pageIndex * pageSize,
+      sortBy: "createdAt",
+      sortDirection: "desc",
+    });
 
   // Fetch session metadata (profile name, user names, etc.)
   const { data: sessionResponse } = useInteractionSessions({
@@ -264,7 +272,19 @@ export default function SessionDetailPage({
             </TableRow>
           </TableHeader>
           <TableBody>
-            {interactions.length === 0 ? (
+            {interactionsLoading ? (
+              <TableRow>
+                <TableCell
+                  colSpan={6}
+                  className="text-center text-muted-foreground"
+                >
+                  <div className="flex items-center justify-center gap-2 py-6">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Loading session logs...
+                  </div>
+                </TableCell>
+              </TableRow>
+            ) : interactions.length === 0 ? (
               <TableRow>
                 <TableCell
                   colSpan={6}


### PR DESCRIPTION
## What changed

- Added an explicit loading row to `/llm/logs/session/[sessionId]` while the session interactions query is pending.
- Added a focused frontend test covering both pending and completed-empty interaction states.

## Why

Long-running session log requests previously defaulted the pending query result to an empty array, so the page could briefly show "No interactions found for this session" before logs finished loading.