### PR TITLE
fix: OIDC discovery trusted origins for IdP registration

### DIFF
--- a/platform/backend/src/auth/better-auth.test.ts
+++ b/platform/backend/src/auth/better-auth.test.ts
@@ -345,6 +345,28 @@ describe("trustedOrigins", () => {
     );
   });
 
+  test("widens trusted origins for identity provider create requests", async () => {
+    const trustedOriginsOption = auth.options.trustedOrigins;
+
+    expect(typeof trustedOriginsOption).toBe("function");
+
+    const trustedOrigins = await trustedOriginsOption?.(
+      new Request("https://app.example.com/api/identity-providers", {
+        method: "POST",
+      }),
+    );
+
+    expect(trustedOrigins).toEqual(
+      expect.arrayContaining([
+        "https://app.example.com",
+        "http://*:*",
+        "https://*:*",
+        "http://*",
+        "https://*",
+      ]),
+    );
+  });
+
   test("keeps regular auth requests on the configured trusted origins", async () => {
     const trustedOriginsOption = auth.options.trustedOrigins;
 

--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -404,13 +404,15 @@ export type BetterAuth = typeof auth;
  * Archestra admins are explicitly configuring their own IdPs, so we widen
  * origin trust only for provider registration instead of requiring per-IdP
  * allowlisting. Better Auth also invokes this callback with `request`
- * undefined during internal `auth.api` calls, which is the registration path
- * used by `IdentityProviderModel.create()`.
+ * undefined during internal `auth.api` calls, which is one registration path
+ * used by `IdentityProviderModel.create()`. In practice, the same flow can
+ * also inherit the outer `/api/identity-providers` request, so that route
+ * needs the same treatment during provider creation.
  */
 async function getTrustedOriginsForAuthRequest(request?: Request) {
   const trustedOrigins = [...staticTrustedOrigins];
 
-  if (!shouldTrustAllOriginsForSsoRegistration(request)) {
+  if (!shouldTrustAllOriginsForIdentityProviderRegistration(request)) {
     return trustedOrigins;
   }
 
@@ -439,16 +441,23 @@ async function getTrustedAccountLinkingProviderIds(): Promise<string[]> {
 }
 
 /**
- * Keep the wildcard expansion scoped to SSO provider registration so every
- * other auth request still uses the configured trusted origins unchanged.
+ * Keep the wildcard expansion scoped to identity-provider registration so
+ * every other auth request still uses the configured trusted origins
+ * unchanged.
  */
-function shouldTrustAllOriginsForSsoRegistration(request?: Request) {
+function shouldTrustAllOriginsForIdentityProviderRegistration(
+  request?: Request,
+) {
   if (!request) {
     return true;
   }
 
   try {
-    return new URL(request.url).pathname.endsWith("/sso/register");
+    const { pathname } = new URL(request.url);
+    return (
+      pathname.endsWith("/sso/register") ||
+      pathname === "/api/identity-providers"
+    );
   } catch {
     return false;
   }


### PR DESCRIPTION
## What changed
This narrows a recent Better Auth trusted-origin workaround to include the admin identity-provider create flow in addition to the existing `/sso/register` path and internal `auth.api` registration calls.

## Why it changed
There was a report of `Untrusted OIDC discovery URL` while reinstalling a Generic OIDC provider in an environment even though the Okta/Archestraconfiguration matched a working setup. The root cause is that Better Auth can evaluate OIDC discovery trust against the outer `/api/identity-providers` request during provider creation, while our existing workaround only widened trust for `/sso/register` and request-less internal calls.

## Impact
Generic OIDC provider creation and reinstall flows now allow Better Auth's discovery validation to proceed for the admin IdP registration request without widening trusted origins for normal auth traffic.