### PR TITLE
chore: use neutral token prefixes with legacy support

### DIFF
--- a/docs/pages/mcp-authentication.md
+++ b/docs/pages/mcp-authentication.md
@@ -18,7 +18,7 @@ The MCP Gateway supports four client authentication paths. They do not all prese
 
 - **OAuth 2.1** and **ID-JAG** both end with an Archestra-issued OAuth access token being sent to the gateway
 - **JWKS** sends an external IdP JWT directly to the gateway
-- **Bearer token** sends a static `archestra_<token>` directly to the gateway
+- **Bearer token** sends a static platform-managed token directly to the gateway. Newly generated tokens use `arch_<token>`. Legacy `archestra_<token>` values remain valid.
 
 ### OAuth 2.1
 
@@ -43,7 +43,7 @@ Admins can change this in **Settings > MCP**. The setting is organization-wide a
 
 ### Bearer Token
 
-For direct API integrations, clients can authenticate using a static Bearer token with the header `Authorization: Bearer archestra_<token>`. Tokens can be scoped to a specific user, team, or organization. You can create and manage tokens in **Settings > Tokens**.
+For direct API integrations, clients can authenticate using a static Bearer token with the header `Authorization: Bearer arch_<token>`. Legacy `archestra_<token>` values still authenticate correctly. Tokens can be scoped to a specific user, team, or organization. You can create and manage tokens in **Settings > Tokens**.
 
 Bearer tokens authenticate the client to Archestra. They are not enterprise assertions by themselves. If a gateway also needs enterprise-managed upstream credentials, Archestra must still have a usable IdP token for the matched user.
 
@@ -102,7 +102,7 @@ Cursor can reach the gateway through four supported auth paths:
 - **OAuth 2.1**: Cursor completes the standard MCP Authorization flow, receives an Archestra-issued access token, then calls the gateway with that token
 - **ID-JAG**: Cursor sends an ID-JAG to Archestra's token endpoint, receives an Archestra-issued access token, then calls the gateway with that token
 - **JWKS**: Cursor calls the gateway directly with an external IdP JWT, and Archestra validates it against the linked IdP JWKS
-- **Bearer token**: Cursor calls the gateway directly with a static `archestra_<token>` value issued by Archestra
+- **Bearer token**: Cursor calls the gateway directly with a static platform-managed token issued by Archestra
 
 For downstream enterprise-managed credentials, these modes are not equivalent:
 
@@ -154,7 +154,7 @@ This credential resolution enables a powerful workflow: an admin installs upstre
 
 MCP servers that connect to external services like GitHub, Atlassian, or ServiceNow need their own credentials. Archestra manages this with a two-token model:
 
-- **Token A** authenticates the client to the gateway using an Archestra OAuth access token, an external IdP JWT via JWKS, or an `archestra_<token>` bearer token (described above).
+- **Token A** authenticates the client to the gateway using an Archestra OAuth access token, an external IdP JWT via JWKS, or a platform-managed bearer token such as `arch_<token>` (legacy `archestra_<token>` values also work).
 - **Token B** authenticates the gateway to the upstream MCP server. This token is resolved and injected by Archestra at runtime.
 
 The client only ever sends Token A. Archestra resolves Token B behind the scenes.

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -748,7 +748,7 @@ These environment variables set the default base URL for each LLM provider. Per-
 
 - **`ARCHESTRA_LLM_PROXY_MAX_VIRTUAL_KEYS`** - Maximum number of virtual API keys per LLM API key.
   - Default: `10`
-  - Virtual keys are `archestra_`-prefixed tokens used by external LLM Proxy clients
+  - Newly generated virtual keys use the neutral `arch_` prefix. Legacy `archestra_` virtual keys remain valid.
   - See: [LLM Proxy Authentication](/docs/platform-llm-proxy-authentication)
 
 - **`ARCHESTRA_LLM_PROXY_VIRTUAL_KEYS_DEFAULT_EXPIRATION_SECONDS`** - Default expiration time for newly created virtual API keys, in seconds.

--- a/docs/pages/platform-llm-proxy-authentication.md
+++ b/docs/pages/platform-llm-proxy-authentication.md
@@ -28,7 +28,7 @@ This is the simplest approach but means the real provider key is sent with every
 
 ## Virtual API Keys
 
-Virtual API keys are `archestra_`-prefixed tokens that map to a real provider API key stored in Archestra. The real key never leaves Archestra.
+Virtual API keys are platform-managed bearer tokens that map to a real provider API key stored in Archestra. Newly generated virtual keys use the neutral `arch_` prefix. Legacy `archestra_` keys remain valid. The real provider key never leaves Archestra.
 
 ### Benefits
 
@@ -42,7 +42,7 @@ Virtual API keys are `archestra_`-prefixed tokens that map to a real provider AP
 1. Go to **Settings > LLM API Keys**
 2. Click the edit icon on an existing API key
 3. In the **Virtual API Keys** section at the bottom, enter a name and click the add button
-4. Copy the generated `archestra_...` token (shown only once)
+4. Copy the generated token (shown only once)
 
 ### Using Virtual Keys
 
@@ -50,7 +50,7 @@ Use the virtual key in place of the provider key:
 
 ```bash
 curl -X POST "https://archestra.example.com/v1/openai/{proxyId}/chat/completions" \
-  -H "Authorization: Bearer archestra_abc123def456..." \
+  -H "Authorization: Bearer arch_abc123def456..." \
   -H "Content-Type: application/json" \
   -d '{"model": "gpt-4o", "messages": [{"role": "user", "content": "Hello"}]}'
 ```

--- a/docs/pages/platform-mcp-gateway.md
+++ b/docs/pages/platform-mcp-gateway.md
@@ -74,7 +74,7 @@ Archestra's MCP Gateways support three authentication methods:
 
 - **OAuth 2.1** — MCP-native clients (Claude Desktop, Cursor, Open WebUI) authenticate automatically via the [MCP Authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization). Supports both DCR and CIMD client registration.
 
-- **Bearer Token** — For direct API integrations. Use `Authorization: Bearer archestra_<token>`. Tokens can be scoped to a user, team, or organization. Create tokens in **Settings → Tokens**.
+- **Bearer Token** — For direct API integrations. Use `Authorization: Bearer arch_<token>`. Tokens can be scoped to a user, team, or organization. Create tokens in **Settings → Tokens**.
 
 - **External Identity Provider (JWKS)** — For MCP clients that authenticate with an external IdP (Keycloak, Okta, Entra ID, Auth0, etc.). The gateway validates JWT bearer tokens directly against the IdP's JWKS endpoint, allowing external users to access MCP tools without an Archestra account. Configure in **Settings → Identity Providers**, then select in the MCP Gateway's **Identity Provider (JWKS Auth)** dropdown.
 

--- a/docs/pages/platform-quickstart.md
+++ b/docs/pages/platform-quickstart.md
@@ -80,7 +80,7 @@ graph LR
     "archestra": {
       "url": "http://localhost:9000/v1/mcp/e1b0272c-3839-4575-a49d-aabb864d638d",
       "headers": {
-        "Authorization": "Bearer archestra_119220a7bfc485d66b678d3e9fb2db36"
+        "Authorization": "Bearer arch_119220a7bfc485d66b678d3e9fb2db36"
       }
     }
   }
@@ -90,7 +90,7 @@ graph LR
 I converted it to the command for claude:
 
 ```
-claude mcp add archestra "http://localhost:9000/v1/mcp/e1b0272c-3839-4575-a49d-aabb864d638d" --transport http --header "Authorization: Bearer archestra_119220a7bfc485d66b678d3e9fb2db36"
+claude mcp add archestra "http://localhost:9000/v1/mcp/e1b0272c-3839-4575-a49d-aabb864d638d" --transport http --header "Authorization: Bearer arch_119220a7bfc485d66b678d3e9fb2db36"
 ```
 
 Now ask Claude:

--- a/platform/backend/src/models/team-token.test.ts
+++ b/platform/backend/src/models/team-token.test.ts
@@ -1,10 +1,22 @@
+import {
+  ARCHESTRA_TOKEN_PREFIX,
+  LEGACY_ARCHESTRA_TOKEN_PREFIXES,
+} from "@shared";
 import { describe, expect, test } from "@/test";
 import TeamTokenModel, { isArchestraPrefixedToken } from "./team-token";
 
 describe("TeamTokenModel", () => {
   describe("isArchestraPrefixedToken", () => {
-    test("returns true for archestra_ prefixed tokens", () => {
-      expect(isArchestraPrefixedToken("archestra_abc123")).toBe(true);
+    test("returns true for current platform token prefix", () => {
+      expect(isArchestraPrefixedToken(`${ARCHESTRA_TOKEN_PREFIX}abc123`)).toBe(
+        true,
+      );
+    });
+
+    test("returns true for legacy token prefixes", () => {
+      expect(
+        isArchestraPrefixedToken(`${LEGACY_ARCHESTRA_TOKEN_PREFIXES[0]}abc123`),
+      ).toBe(true);
     });
 
     test("returns false for non-prefixed tokens", () => {
@@ -29,7 +41,9 @@ describe("TeamTokenModel", () => {
       expect(token.name).toBe("Test Token");
       expect(token.organizationId).toBe(org.id);
       expect(token.teamId).toBeNull();
-      expect(value).toMatch(/^archestra_[a-f0-9]{32}$/);
+      expect(value).toMatch(
+        new RegExp(`^${ARCHESTRA_TOKEN_PREFIX}[a-f0-9]{32}$`),
+      );
       expect(token.tokenStart).toBe(value.substring(0, 14));
     });
 
@@ -49,7 +63,7 @@ describe("TeamTokenModel", () => {
       });
 
       expect(token.teamId).toBe(team.id);
-      expect(value.startsWith("archestra_")).toBe(true);
+      expect(value.startsWith(ARCHESTRA_TOKEN_PREFIX)).toBe(true);
     });
   });
 
@@ -169,7 +183,7 @@ describe("TeamTokenModel", () => {
       const result = await TeamTokenModel.rotate(token.id);
       expect(result?.value).toBeDefined();
       expect(result?.value).not.toBe(originalValue);
-      expect(result?.value.startsWith("archestra_")).toBe(true);
+      expect(result?.value.startsWith(ARCHESTRA_TOKEN_PREFIX)).toBe(true);
 
       const updated = await TeamTokenModel.findById(token.id);
       expect(updated?.tokenStart).toBe(result?.value.substring(0, 14));
@@ -198,7 +212,7 @@ describe("TeamTokenModel", () => {
 
     test("returns null for invalid token", async () => {
       const validated = await TeamTokenModel.validateToken(
-        "archestra_invalidtoken12345",
+        `${LEGACY_ARCHESTRA_TOKEN_PREFIXES[0]}invalidtoken12345`,
       );
       expect(validated).toBeNull();
     });
@@ -241,7 +255,7 @@ describe("TeamTokenModel", () => {
 
     test("returns null when no tokens exist", async () => {
       const validated = await TeamTokenModel.validateToken(
-        "archestra_nonexistent0000000000000",
+        `${LEGACY_ARCHESTRA_TOKEN_PREFIXES[0]}nonexistent0000000000000`,
       );
       expect(validated).toBeNull();
     });

--- a/platform/backend/src/models/team-token.ts
+++ b/platform/backend/src/models/team-token.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { ARCHESTRA_TOKEN_PREFIX } from "@shared";
+import { ARCHESTRA_TOKEN_PREFIX, hasArchestraTokenPrefix } from "@shared";
 import { desc, eq } from "drizzle-orm";
 import db, { schema } from "@/database";
 import SecretModel from "@/models/secret";
@@ -38,8 +38,7 @@ const TOKEN_RANDOM_LENGTH = 16;
 const TOKEN_START_LENGTH = 14;
 
 /**
- * Generate a secure random token with archestra_ prefix
- * Format: archestra_<32 hex characters>
+ * Generate a secure random token with the current platform token prefix.
  * Total length: 42 characters
  */
 function generateToken(): string {
@@ -55,10 +54,10 @@ function getTokenStart(token: string): string {
 }
 
 /**
- * Check if a value looks like a team token (starts with archestra_)
+ * Check if a value looks like a platform-managed team token.
  */
 export function isArchestraPrefixedToken(value: string): boolean {
-  return value.startsWith(ARCHESTRA_TOKEN_PREFIX);
+  return hasArchestraTokenPrefix(value);
 }
 
 class TeamTokenModel {

--- a/platform/backend/src/models/user-token.test.ts
+++ b/platform/backend/src/models/user-token.test.ts
@@ -1,3 +1,7 @@
+import {
+  ARCHESTRA_TOKEN_PREFIX,
+  LEGACY_ARCHESTRA_TOKEN_PREFIXES,
+} from "@shared";
 import { describe, expect, test } from "@/test";
 import UserTokenModel from "./user-token";
 
@@ -21,7 +25,9 @@ describe("UserTokenModel", () => {
       expect(token.name).toBe("Test Token");
       expect(token.organizationId).toBe(org.id);
       expect(token.userId).toBe(user.id);
-      expect(value).toMatch(/^archestra_[a-f0-9]{32}$/);
+      expect(value).toMatch(
+        new RegExp(`^${ARCHESTRA_TOKEN_PREFIX}[a-f0-9]{32}$`),
+      );
       expect(token.tokenStart).toBe(value.substring(0, 14));
     });
 
@@ -134,7 +140,7 @@ describe("UserTokenModel", () => {
       const result = await UserTokenModel.rotate(token.id);
       expect(result?.value).toBeDefined();
       expect(result?.value).not.toBe(originalValue);
-      expect(result?.value.startsWith("archestra_")).toBe(true);
+      expect(result?.value.startsWith(ARCHESTRA_TOKEN_PREFIX)).toBe(true);
 
       const updated = await UserTokenModel.findById(token.id);
       expect(updated?.tokenStart).toBe(result?.value.substring(0, 14));
@@ -166,7 +172,7 @@ describe("UserTokenModel", () => {
 
     test("returns null for invalid token", async () => {
       const validated = await UserTokenModel.validateToken(
-        "archestra_invalidtoken1234567890",
+        `${LEGACY_ARCHESTRA_TOKEN_PREFIXES[0]}invalidtoken1234567890`,
       );
       expect(validated).toBeNull();
     });
@@ -220,7 +226,7 @@ describe("UserTokenModel", () => {
 
     test("returns null when no tokens exist", async () => {
       const validated = await UserTokenModel.validateToken(
-        "archestra_0000000000000000000000000000",
+        `${LEGACY_ARCHESTRA_TOKEN_PREFIXES[0]}0000000000000000000000000000`,
       );
       expect(validated).toBeNull();
     });

--- a/platform/backend/src/models/user-token.ts
+++ b/platform/backend/src/models/user-token.ts
@@ -21,8 +21,7 @@ const TOKEN_RANDOM_LENGTH = 16;
 const TOKEN_START_LENGTH = 14;
 
 /**
- * Generate a secure random token with archestra_ prefix
- * Format: archestra_<32 hex characters>
+ * Generate a secure random token with the current platform token prefix.
  * Total length: 42 characters
  */
 function generateToken(): string {
@@ -200,7 +199,7 @@ class UserTokenModel {
     tokenValue: string,
   ): Promise<SelectUserToken | null> {
     // Use tokenStart (first 14 chars) to narrow candidates instead of scanning all tokens.
-    // tokenStart has very low collision rate (archestra_ prefix + 4 hex chars), so this
+    // tokenStart has very low collision rate (prefix + leading random chars), so this
     // typically returns 0-1 candidates.
     const tokenStart = getTokenStart(tokenValue);
     const candidates = await db

--- a/platform/backend/src/models/virtual-api-key.test.ts
+++ b/platform/backend/src/models/virtual-api-key.test.ts
@@ -1,3 +1,7 @@
+import {
+  ARCHESTRA_TOKEN_PREFIX,
+  LEGACY_ARCHESTRA_TOKEN_PREFIXES,
+} from "@shared";
 import { describe } from "vitest";
 import { expect, test } from "@/test";
 import VirtualApiKeyModel from "./virtual-api-key";
@@ -25,7 +29,9 @@ describe("VirtualApiKeyModel", () => {
     expect(virtualKey.chatApiKeyId).toBe(chatApiKey.id);
     expect(virtualKey.name).toBe("Test Virtual Key");
     expect(virtualKey.expiresAt).toBeNull();
-    expect(value).toMatch(/^archestra_[a-f0-9]{64}$/);
+    expect(value).toMatch(
+      new RegExp(`^${ARCHESTRA_TOKEN_PREFIX}[a-f0-9]{64}$`),
+    );
     expect(virtualKey.tokenStart).toBe(value.substring(0, 14));
   });
 
@@ -258,12 +264,12 @@ describe("VirtualApiKeyModel", () => {
 
   test("validateToken: returns null for invalid token", async () => {
     const result = await VirtualApiKeyModel.validateToken(
-      "archestra_0000000000000000000000000000",
+      `${LEGACY_ARCHESTRA_TOKEN_PREFIXES[0]}0000000000000000000000000000`,
     );
     expect(result).toBeNull();
   });
 
-  test("validateToken: returns null for non-archestra token", async () => {
+  test("validateToken: returns null for non-platform token", async () => {
     const result = await VirtualApiKeyModel.validateToken("sk-some-random-key");
     expect(result).toBeNull();
   });

--- a/platform/backend/src/routes/a2a.ts
+++ b/platform/backend/src/routes/a2a.ts
@@ -126,7 +126,7 @@ const a2aRoutes: FastifyPluginAsyncZod = async (fastify) => {
       if (!token) {
         throw new ApiError(
           401,
-          "Authorization header required. Use: Bearer <archestra_token>",
+          "Authorization header required. Use: Bearer <platform_token>",
         );
       }
 
@@ -230,7 +230,7 @@ const a2aRoutes: FastifyPluginAsyncZod = async (fastify) => {
           error: {
             code: -32600,
             message:
-              "Authorization header required. Use: Bearer <archestra_token>",
+              "Authorization header required. Use: Bearer <platform_token>",
           },
         });
       }

--- a/platform/backend/src/routes/api-key.test.ts
+++ b/platform/backend/src/routes/api-key.test.ts
@@ -1,3 +1,4 @@
+import { ARCHESTRA_TOKEN_PREFIX } from "@shared";
 import { vi } from "vitest";
 import db, { schema } from "@/database";
 import type { FastifyInstanceWithZod } from "@/server";
@@ -168,12 +169,15 @@ describe("api key routes", () => {
   });
 
   test("normalizes a successful create response", async () => {
+    const tokenStart = `${ARCHESTRA_TOKEN_PREFIX}abcd`;
+    const tokenValue = `${ARCHESTRA_TOKEN_PREFIX}abcd1234`;
+
     createApiKeyMock.mockResolvedValue({
       id: "key-1",
       configId: "default",
       name: "CLI Key",
-      start: "archestra_abcd",
-      prefix: "archestra_",
+      start: tokenStart,
+      prefix: ARCHESTRA_TOKEN_PREFIX,
       referenceId: userId,
       enabled: true,
       refillInterval: null,
@@ -190,7 +194,7 @@ describe("api key routes", () => {
       updatedAt: "2026-03-15T00:00:00.000Z",
       metadata: { scope: "cli" },
       permissions: { apiKey: ["read"] },
-      key: "archestra_abcd1234",
+      key: tokenValue,
     });
 
     const response = await app.inject({
@@ -206,21 +210,24 @@ describe("api key routes", () => {
     expect(response.json()).toMatchObject({
       id: "key-1",
       name: "CLI Key",
-      start: "archestra_abcd",
-      prefix: "archestra_",
-      key: "archestra_abcd1234",
+      start: tokenStart,
+      prefix: ARCHESTRA_TOKEN_PREFIX,
+      key: tokenValue,
       metadata: { scope: "cli" },
       permissions: { apiKey: ["read"] },
     });
   });
 
   test("omits a null name before calling better-auth createApiKey", async () => {
+    const tokenStart = `${ARCHESTRA_TOKEN_PREFIX}abcd`;
+    const tokenValue = `${ARCHESTRA_TOKEN_PREFIX}abcd1234`;
+
     createApiKeyMock.mockResolvedValue({
       id: "key-1",
       configId: "default",
       name: null,
-      start: "archestra_abcd",
-      prefix: "archestra_",
+      start: tokenStart,
+      prefix: ARCHESTRA_TOKEN_PREFIX,
       referenceId: userId,
       enabled: true,
       refillInterval: null,
@@ -237,7 +244,7 @@ describe("api key routes", () => {
       updatedAt: "2026-03-15T00:00:00.000Z",
       metadata: null,
       permissions: null,
-      key: "archestra_abcd1234",
+      key: tokenValue,
     });
 
     const response = await app.inject({

--- a/platform/backend/src/routes/mcp-gateway.ts
+++ b/platform/backend/src/routes/mcp-gateway.ts
@@ -148,7 +148,7 @@ async function handleMcpPostRequest(
 // =============================================================================
 // MCP Gateway endpoints with token authentication (stateless)
 // /v1/mcp/<profile_id>
-// Authorization header: Bearer <archestra_token>
+// Authorization header: Bearer <platform_token>
 // =============================================================================
 export const mcpGatewayRoutes: FastifyPluginAsyncZod = async (fastify) => {
   const { endpoint } = config.mcpGateway;
@@ -199,7 +199,7 @@ export const mcpGatewayRoutes: FastifyPluginAsyncZod = async (fastify) => {
         return {
           error: "Unauthorized",
           message:
-            "Missing or invalid Authorization header. Expected: Bearer <archestra_token> or Bearer <agent-id>",
+            "Missing or invalid Authorization header. Expected: Bearer <platform_token> or Bearer <agent-id>",
         };
       }
 
@@ -228,7 +228,7 @@ export const mcpGatewayRoutes: FastifyPluginAsyncZod = async (fastify) => {
   );
 
   // POST endpoint for JSON-RPC requests with profile ID in URL
-  // New auth: Validates archestra token for the profile
+  // New auth: Validates a platform-managed token for the profile
   fastify.post(
     `${endpoint}/:profileId`,
     {
@@ -253,7 +253,7 @@ export const mcpGatewayRoutes: FastifyPluginAsyncZod = async (fastify) => {
           error: {
             code: -32000,
             message:
-              "Unauthorized: Missing or invalid Authorization header. Expected: Bearer <archestra_token> or Bearer <agent-id>",
+              "Unauthorized: Missing or invalid Authorization header. Expected: Bearer <platform_token> or Bearer <agent-id>",
           },
           id: null,
         };

--- a/platform/backend/src/routes/mcp-gateway.utils.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.test.ts
@@ -1,5 +1,9 @@
 import { createHash } from "node:crypto";
-import { OAUTH_TOKEN_ID_PREFIX } from "@shared";
+import {
+  ARCHESTRA_TOKEN_PREFIX,
+  LEGACY_ARCHESTRA_TOKEN_PREFIXES,
+  OAUTH_TOKEN_ID_PREFIX,
+} from "@shared";
 import { vi } from "vitest";
 import { archestraMcpBranding } from "@/archestra-mcp-server";
 import type * as originalConfigModule from "@/config";
@@ -44,7 +48,7 @@ describe("validateMCPGatewayToken", () => {
     test("returns null for invalid token", async () => {
       const result = await validateMCPGatewayToken(
         crypto.randomUUID(),
-        "archestra_invalidtoken1234567890ab",
+        `${LEGACY_ARCHESTRA_TOKEN_PREFIXES[0]}invalidtoken1234567890ab`,
       );
       expect(result).toBeNull();
     });
@@ -397,19 +401,26 @@ describe("validateMCPGatewayToken", () => {
       expect(result).toBeNull();
     });
 
-    test("validateMCPGatewayToken skips OAuth validation for archestra_ prefixed tokens", async () => {
-      // archestra_ prefixed tokens should never reach validateOAuthToken
+    test("validateMCPGatewayToken skips OAuth validation for legacy prefixed tokens", async () => {
       const result = await validateMCPGatewayToken(
         crypto.randomUUID(),
-        "archestra_fake_token_that_does_not_exist",
+        `${LEGACY_ARCHESTRA_TOKEN_PREFIXES[0]}fake_token_that_does_not_exist`,
       );
-      // Returns null because the archestra_ token is invalid, but importantly
+      // Returns null because the legacy token is invalid, but importantly
       // it should NOT have tried OAuth token validation
       expect(result).toBeNull();
     });
 
-    test("validateMCPGatewayToken tries OAuth validation for non-archestra tokens", async () => {
-      // A non-archestra token should try OAuth validation path and return null
+    test("validateMCPGatewayToken skips OAuth validation for current prefixed tokens", async () => {
+      const result = await validateMCPGatewayToken(
+        crypto.randomUUID(),
+        `${ARCHESTRA_TOKEN_PREFIX}fake_token_that_does_not_exist`,
+      );
+      expect(result).toBeNull();
+    });
+
+    test("validateMCPGatewayToken tries OAuth validation for non-platform tokens", async () => {
+      // A non-platform token should try OAuth validation path and return null
       const result = await validateMCPGatewayToken(
         crypto.randomUUID(),
         "some-random-bearer-token",

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -11,7 +11,7 @@ import {
   type Tool,
 } from "@modelcontextprotocol/sdk/types.js";
 import {
-  ARCHESTRA_TOKEN_PREFIX,
+  hasArchestraTokenPrefix,
   isAgentTool,
   MCP_APPS_SERVER_EXTENSION_CAPABILITIES,
   MCP_ENTERPRISE_AUTH_EXTENSION_CAPABILITIES,
@@ -581,7 +581,7 @@ export function extractPassthroughHeaders(
 }
 
 /**
- * Validate an archestra_ prefixed token for a specific profile
+ * Validate a platform-managed token for a specific profile
  * Returns token auth info if valid, null otherwise
  *
  * Validates that:
@@ -908,7 +908,7 @@ export async function validateMCPGatewayToken(
     };
 
   // Try external IdP JWKS validation first (if profile has an IdP configured)
-  if (!tokenValue.startsWith(ARCHESTRA_TOKEN_PREFIX)) {
+  if (!hasArchestraTokenPrefix(tokenValue)) {
     const externalIdpResult = await validateExternalIdpToken(
       profileId,
       tokenValue,
@@ -919,7 +919,7 @@ export async function validateMCPGatewayToken(
     }
   }
 
-  if (tokenValue.startsWith(ARCHESTRA_TOKEN_PREFIX)) {
+  if (hasArchestraTokenPrefix(tokenValue)) {
     const resolvedToken = await resolveArchestraToken(
       tokenValue,
       tokenHashes.rawTokenHash,

--- a/platform/backend/src/routes/proxy/llm-proxy-auth.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-auth.test.ts
@@ -1,3 +1,7 @@
+import {
+  ARCHESTRA_TOKEN_PREFIX,
+  LEGACY_ARCHESTRA_TOKEN_PREFIXES,
+} from "@shared";
 import type { FastifyRequest } from "fastify";
 import { vi } from "vitest";
 import { VirtualApiKeyModel } from "@/models";
@@ -61,7 +65,10 @@ describe("resolveAgent", () => {
 describe("validateVirtualApiKey", () => {
   test("throws 401 for invalid/non-existent token", async () => {
     await expect(
-      validateVirtualApiKey("archestra_nonexistent", "openai"),
+      validateVirtualApiKey(
+        `${LEGACY_ARCHESTRA_TOKEN_PREFIXES[0]}nonexistent`,
+        "openai",
+      ),
     ).rejects.toThrow("Invalid virtual API key");
   });
 
@@ -172,7 +179,7 @@ describe("validateVirtualApiKey", () => {
           id: "vk-1",
           chatApiKeyId: "ck-1",
           name: "test",
-          tokenStart: "archestra_",
+          tokenStart: ARCHESTRA_TOKEN_PREFIX,
           secretId: "secret-1",
           expiresAt: null,
           lastUsedAt: null,
@@ -187,7 +194,7 @@ describe("validateVirtualApiKey", () => {
       } as never);
 
     const result = await validateVirtualApiKey(
-      "archestra_test_token",
+      `${LEGACY_ARCHESTRA_TOKEN_PREFIXES[0]}test_token`,
       "openai",
     );
     expect(result.apiKey).toBeUndefined();
@@ -270,7 +277,7 @@ describe("attemptJwksAuth", () => {
     expect(result).toBeNull();
   });
 
-  test("returns null when bearer token is a virtual key", async ({
+  test("returns null when bearer token uses a legacy virtual-key prefix", async ({
     makeOrganization,
     makeAgent,
     makeIdentityProvider,
@@ -283,7 +290,29 @@ describe("attemptJwksAuth", () => {
     });
 
     const result = await attemptJwksAuth(
-      makeFakeRequest("Bearer archestra_abc123def456"),
+      makeFakeRequest(
+        `Bearer ${LEGACY_ARCHESTRA_TOKEN_PREFIXES[0]}abc123def456`,
+      ),
+      agent,
+      "openai",
+    );
+    expect(result).toBeNull();
+  });
+
+  test("returns null when bearer token uses the current virtual-key prefix", async ({
+    makeOrganization,
+    makeAgent,
+    makeIdentityProvider,
+  }) => {
+    const org = await makeOrganization();
+    const idp = await makeIdentityProvider(org.id);
+    const agent = await makeAgent({
+      organizationId: org.id,
+      identityProviderId: idp.id,
+    });
+
+    const result = await attemptJwksAuth(
+      makeFakeRequest(`Bearer ${ARCHESTRA_TOKEN_PREFIX}abc123def456`),
       agent,
       "openai",
     );

--- a/platform/backend/src/routes/proxy/llm-proxy-auth.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-auth.ts
@@ -5,7 +5,7 @@
  * request/response orchestration. Each function is independently testable.
  */
 
-import { ARCHESTRA_TOKEN_PREFIX, isSupportedProvider } from "@shared";
+import { hasArchestraTokenPrefix, isSupportedProvider } from "@shared";
 import type { FastifyRequest } from "fastify";
 import { type AllowedCacheKey, CacheKey, cacheManager } from "@/cache-manager";
 import logger from "@/logging";
@@ -51,7 +51,7 @@ export interface VirtualKeyValidationResult {
 }
 
 /**
- * Validate an `archestra_` prefixed virtual API key.
+ * Validate a platform-managed virtual API key.
  * Checks: token validity, expiration, provider match, parent key health.
  * Returns the resolved real API key and optional base URL.
  *
@@ -143,8 +143,7 @@ export async function attemptJwksAuth(
   const rawAuthHeader = request.raw.headers.authorization;
   const tokenMatch = rawAuthHeader?.match(/^Bearer\s+(.+)$/i);
   const bearerToken = tokenMatch?.[1] ?? null;
-  if (!bearerToken || bearerToken.startsWith(ARCHESTRA_TOKEN_PREFIX))
-    return null;
+  if (!bearerToken || hasArchestraTokenPrefix(bearerToken)) return null;
 
   let jwksResult: Awaited<ReturnType<typeof validateExternalIdpToken>>;
   try {
@@ -227,7 +226,7 @@ export function assertAuthenticatedForKeylessProvider(
   if (!isLoopbackAddress(requestIp)) {
     throw new ApiError(
       401,
-      "Authentication required. Use a virtual API key (archestra_...) or pass a provider API key.",
+      "Authentication required. Use a platform virtual API key or pass a provider API key.",
     );
   }
 }

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -11,7 +11,7 @@ import {
   propagation,
 } from "@opentelemetry/api";
 import {
-  ARCHESTRA_TOKEN_PREFIX,
+  hasArchestraTokenPrefix,
   type InteractionSource,
   InteractionSourceSchema,
   SOURCE_HEADER,
@@ -270,12 +270,16 @@ export async function handleLLMProxy<
     apiKey = provider.extractApiKey(headers);
   }
 
-  // 3. Resolve virtual API key (archestra_ prefixed)
+  // 3. Resolve platform-managed virtual API keys
   // Strip "Bearer " prefix if present — OpenAI's extractApiKey returns the full
-  // Authorization header value (e.g. "Bearer archestra_xxx"), while other providers
+  // Authorization header value (e.g. "Bearer arch_xxx"), while other providers
   // return the raw key.
   const rawApiKey = apiKey?.replace(/^Bearer\s+/i, "") ?? undefined;
-  if (!wasJwksAuthenticated && rawApiKey?.startsWith(ARCHESTRA_TOKEN_PREFIX)) {
+  if (
+    !wasJwksAuthenticated &&
+    rawApiKey &&
+    hasArchestraTokenPrefix(rawApiKey)
+  ) {
     await virtualKeyRateLimiter.check(request.ip);
     try {
       const virtualResult = await validateVirtualApiKey(

--- a/platform/backend/src/routes/proxy/routesv2/gemini.ts
+++ b/platform/backend/src/routes/proxy/routesv2/gemini.ts
@@ -1,5 +1,5 @@
 import fastifyHttpProxy from "@fastify/http-proxy";
-import { ARCHESTRA_TOKEN_PREFIX } from "@shared";
+import { hasArchestraTokenPrefix } from "@shared";
 import type { FastifyReply, FastifyRequest } from "fastify";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
@@ -263,7 +263,7 @@ function createGeminiProxyPreHandler() {
 /**
  * Resolves virtual API keys in Gemini's ?key= query parameter.
  * Gemini uses ?key= for auth (unlike OpenAI which uses Authorization header).
- * If the key is a virtual key (starts with ARCHESTRA_TOKEN_PREFIX), resolve it
+ * If the key is a platform virtual key, resolve it
  * to the real provider API key and rewrite the URL. Real Gemini keys pass through unchanged.
  */
 async function resolveGeminiVirtualQueryKey(request: FastifyRequest) {
@@ -274,7 +274,7 @@ async function resolveGeminiVirtualQueryKey(request: FastifyRequest) {
   if (!keyMatch) return;
 
   const keyValue = keyMatch[1];
-  if (!keyValue.startsWith(ARCHESTRA_TOKEN_PREFIX)) return;
+  if (!hasArchestraTokenPrefix(keyValue)) return;
 
   try {
     const resolved = await validateVirtualApiKey(keyValue, "gemini");

--- a/platform/backend/src/routes/user-token.test.ts
+++ b/platform/backend/src/routes/user-token.test.ts
@@ -1,3 +1,4 @@
+import { ARCHESTRA_TOKEN_PREFIX } from "@shared";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
@@ -42,7 +43,9 @@ describe("user token routes", () => {
     expect(firstResponse.json()).toMatchObject({
       id: expect.any(String),
       name: "Personal Token",
-      tokenStart: expect.stringMatching(/^archestra_/),
+      tokenStart: expect.stringMatching(
+        new RegExp(`^${ARCHESTRA_TOKEN_PREFIX}`),
+      ),
       createdAt: expect.any(String),
     });
 
@@ -71,7 +74,9 @@ describe("user token routes", () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
-      value: expect.stringMatching(/^archestra_[a-f0-9]{32}$/),
+      value: expect.stringMatching(
+        new RegExp(`^${ARCHESTRA_TOKEN_PREFIX}[a-f0-9]{32}$`),
+      ),
     });
   });
 
@@ -107,8 +112,12 @@ describe("user token routes", () => {
     expect(rotateResponse.json()).toMatchObject({
       id: initialToken.id,
       name: "Personal Token",
-      tokenStart: expect.stringMatching(/^archestra_/),
-      value: expect.stringMatching(/^archestra_[a-f0-9]{32}$/),
+      tokenStart: expect.stringMatching(
+        new RegExp(`^${ARCHESTRA_TOKEN_PREFIX}`),
+      ),
+      value: expect.stringMatching(
+        new RegExp(`^${ARCHESTRA_TOKEN_PREFIX}[a-f0-9]{32}$`),
+      ),
     });
     expect(rotateResponse.json().value).not.toBe(initialValue);
     expect(rotateResponse.json().tokenStart).toBe(

--- a/platform/backend/src/types/team-token.ts
+++ b/platform/backend/src/types/team-token.ts
@@ -1,4 +1,4 @@
-import { ARCHESTRA_TOKEN_PREFIX } from "@shared";
+import { hasArchestraTokenPrefix } from "@shared";
 import {
   createInsertSchema,
   createSelectSchema,
@@ -83,7 +83,7 @@ export const TokensListResponseSchema = z.object({
 
 export type TokensListResponse = z.infer<typeof TokensListResponseSchema>;
 
-// Helper function to check if a token has the archestra prefix
+// Helper function to check if a token has a platform-managed prefix
 export function isArchestraPrefixedToken(value: string): boolean {
-  return value.startsWith(ARCHESTRA_TOKEN_PREFIX);
+  return hasArchestraTokenPrefix(value);
 }

--- a/platform/frontend/src/app/settings/api-keys/page.utils.test.ts
+++ b/platform/frontend/src/app/settings/api-keys/page.utils.test.ts
@@ -1,3 +1,4 @@
+import { ARCHESTRA_TOKEN_PREFIX } from "@shared";
 import { describe, expect, it } from "vitest";
 import { shouldSkipCreateApiKeySubmit } from "./page.utils";
 
@@ -27,7 +28,7 @@ describe("shouldSkipCreateApiKeySubmit", () => {
       shouldSkipCreateApiKeySubmit({
         hasSubmittedForCurrentDialogOpen: true,
         isCreatePending: false,
-        createdApiKeyValue: "archestra_123",
+        createdApiKeyValue: `${ARCHESTRA_TOKEN_PREFIX}123`,
       }),
     ).toBe(true);
   });

--- a/platform/frontend/src/components/settings/personal-token-card.tsx
+++ b/platform/frontend/src/components/settings/personal-token-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { archestraApiSdk } from "@shared";
+import { ARCHESTRA_TOKEN_PREFIX, archestraApiSdk } from "@shared";
 import { useQueryClient } from "@tanstack/react-query";
 import { Check, Copy, RefreshCw } from "lucide-react";
 import { useState } from "react";
@@ -111,7 +111,7 @@ export function PersonalTokenCard() {
           <div className="flex gap-2">
             <Input
               readOnly
-              value={`${token?.tokenStart || "archestra_"}***`}
+              value={`${token?.tokenStart || ARCHESTRA_TOKEN_PREFIX}***`}
               className="font-mono"
             />
             <Button

--- a/platform/shared/consts.test.ts
+++ b/platform/shared/consts.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+import {
+  ALL_ARCHESTRA_TOKEN_PREFIXES,
+  ARCHESTRA_TOKEN_PREFIX,
+  getArchestraTokenPrefix,
+  hasArchestraTokenPrefix,
+  LEGACY_ARCHESTRA_TOKEN_PREFIXES,
+} from "./consts";
+
+describe("token prefix helpers", () => {
+  test("uses a neutral prefix for newly generated tokens", () => {
+    expect(ARCHESTRA_TOKEN_PREFIX).toBe("arch_");
+  });
+
+  test("keeps legacy prefixes in the accepted prefix list", () => {
+    expect(ALL_ARCHESTRA_TOKEN_PREFIXES).toContain(
+      LEGACY_ARCHESTRA_TOKEN_PREFIXES[0],
+    );
+  });
+
+  test("matches the current token prefix", () => {
+    expect(getArchestraTokenPrefix(`${ARCHESTRA_TOKEN_PREFIX}abc123`)).toBe(
+      ARCHESTRA_TOKEN_PREFIX,
+    );
+    expect(hasArchestraTokenPrefix(`${ARCHESTRA_TOKEN_PREFIX}abc123`)).toBe(
+      true,
+    );
+  });
+
+  test("matches legacy token prefixes", () => {
+    expect(
+      getArchestraTokenPrefix(`${LEGACY_ARCHESTRA_TOKEN_PREFIXES[0]}abc123`),
+    ).toBe(LEGACY_ARCHESTRA_TOKEN_PREFIXES[0]);
+    expect(
+      hasArchestraTokenPrefix(`${LEGACY_ARCHESTRA_TOKEN_PREFIXES[0]}abc123`),
+    ).toBe(true);
+  });
+
+  test("returns null for non-platform prefixes", () => {
+    expect(getArchestraTokenPrefix("sk-abc123")).toBeNull();
+    expect(hasArchestraTokenPrefix("sk-abc123")).toBe(false);
+  });
+});

--- a/platform/shared/consts.ts
+++ b/platform/shared/consts.ts
@@ -4,8 +4,24 @@ export const DEFAULT_APP_FULL_NAME = "Archestra.AI";
 export const DEFAULT_APP_DESCRIPTION =
   "Enterprise MCP-native Secure AI Platform";
 
-/** Prefix for all Archestra-generated tokens (team tokens, user tokens, virtual API keys, API keys) */
-export const ARCHESTRA_TOKEN_PREFIX = "archestra_";
+/**
+ * Prefix used for newly generated platform-managed tokens (team tokens, user
+ * tokens, virtual API keys, API keys). Keep this branding-neutral.
+ */
+export const ARCHESTRA_TOKEN_PREFIX = "arch_";
+
+/**
+ * Legacy token prefixes that must remain valid for backwards compatibility.
+ */
+export const LEGACY_ARCHESTRA_TOKEN_PREFIXES = ["archestra_"] as const;
+
+/**
+ * All accepted platform-managed token prefixes, ordered from current to legacy.
+ */
+export const ALL_ARCHESTRA_TOKEN_PREFIXES = [
+  ARCHESTRA_TOKEN_PREFIX,
+  ...LEGACY_ARCHESTRA_TOKEN_PREFIXES,
+] as const;
 
 export const DEFAULT_ADMIN_EMAIL = "admin@example.com";
 export const DEFAULT_ADMIN_PASSWORD = "password";
@@ -106,3 +122,14 @@ export const TimeInMs = {
 } as const;
 
 export const AUTO_PROVISIONED_INVITATION_STATUS = "auto-provisioned";
+
+export function getArchestraTokenPrefix(value: string): string | null {
+  return (
+    ALL_ARCHESTRA_TOKEN_PREFIXES.find((prefix) => value.startsWith(prefix)) ??
+    null
+  );
+}
+
+export function hasArchestraTokenPrefix(value: string): boolean {
+  return getArchestraTokenPrefix(value) !== null;
+}


### PR DESCRIPTION
## What changed
- switched newly generated platform-managed API, MCP gateway, A2A, and virtual-key token prefixes from `archestra_` to the neutral `arch_` prefix
- centralized token-prefix matching in shared helpers and updated the gateway and LLM proxy auth paths to accept both current and legacy prefixes
- updated token-related UI/tests and the main authentication docs to reflect the new default prefix and explicit backwards compatibility

## Why
- white-label deployments should not expose an `archestra_` token prefix in newly issued credentials
- making the prefix follow mutable organization app names would create long-term compatibility and rename-migration problems
- this keeps the rollout simple: new tokens are neutral, old `archestra_` tokens continue to work unchanged

## Impact
- newly created user tokens, team tokens, virtual API keys, and Better Auth API keys now default to `arch_`
- existing `archestra_` tokens remain valid for MCP Gateway, A2A, and LLM proxy authentication
- docs now describe `arch_` as the default and call out legacy support

## Root cause
The platform treated `archestra_` as both the branding choice and the token-type discriminator. That hardcoded product name leaked into issued credentials and into auth routing logic.