### PR TITLE
feat: add Google Drive knowledge connector

### DIFF
--- a/platform/backend/package.json
+++ b/platform/backend/package.json
@@ -111,6 +111,7 @@
     "fastify-metrics": "^12.1.0",
     "fastify-plugin": "^5.1.0",
     "fastify-type-provider-zod": "^6.0.0",
+    "googleapis": "^171.4.0",
     "handlebars": "^4.7.9",
     "ipaddr.js": "^2.3.0",
     "jira.js": "^5.3.1",

--- a/platform/backend/src/knowledge-base/connectors/googledrive/googledrive-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/googledrive/googledrive-connector.ts
@@ -1,0 +1,511 @@
+import { google, type drive_v3 } from "googleapis";
+import type { ModelInputModality } from "@shared";
+import mammoth from "mammoth";
+import JSZip from "jszip";
+import type {
+  ConnectorCredentials,
+  ConnectorDocument,
+  ConnectorSyncBatch,
+  GoogleDriveCheckpoint,
+  GoogleDriveConfig,
+} from "@/types";
+import { GoogleDriveConfigSchema } from "@/types";
+import { stripHtmlTags } from "@/utils/strip-html";
+import {
+  BaseConnector,
+  buildCheckpoint,
+  extractErrorMessage,
+} from "../base-connector";
+
+const DEFAULT_BATCH_SIZE = 50;
+const MAX_CONTENT_LENGTH = 500_000; // 500 KB text limit per document
+const MAX_IMAGE_SIZE_BYTES = 4 * 1024 * 1024; // 4 MB image size limit
+const INCREMENTAL_SAFETY_BUFFER_MS = 5 * 60 * 1000;
+const DRIVE_READONLY_SCOPE = "https://www.googleapis.com/auth/drive.readonly";
+
+// Google Workspace MIME types and their export targets
+const GOOGLE_WORKSPACE_EXPORT_MIME: Record<string, string> = {
+  "application/vnd.google-apps.document": "text/plain",
+  "application/vnd.google-apps.spreadsheet": "text/csv",
+  "application/vnd.google-apps.presentation": "text/plain",
+};
+
+// Regular text file MIME types we can read directly
+const SUPPORTED_TEXT_MIME_TYPES = new Set([
+  "text/plain",
+  "text/markdown",
+  "text/csv",
+  "application/json",
+  "application/xml",
+  "text/xml",
+  "text/html",
+  "text/x-log",
+  "application/yaml",
+]);
+
+// File extensions whose MIME types are extractable as binary
+const SUPPORTED_BINARY_EXTENSIONS = new Set([".docx", ".pdf", ".pptx"]);
+
+// Image MIME types supported for multimodal embedding
+const SUPPORTED_IMAGE_MIME_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+]);
+
+export class GoogleDriveConnector extends BaseConnector {
+  type = "googledrive" as const;
+
+  async validateConfig(
+    config: Record<string, unknown>,
+  ): Promise<{ valid: boolean; error?: string }> {
+    const parsed = parseGoogleDriveConfig(config);
+    if (!parsed) {
+      return { valid: false, error: "Invalid Google Drive configuration" };
+    }
+    return { valid: true };
+  }
+
+  async testConnection(params: {
+    config: Record<string, unknown>;
+    credentials: ConnectorCredentials;
+  }): Promise<{ success: boolean; error?: string }> {
+    this.log.debug("Testing Google Drive connection");
+
+    try {
+      const config = parseGoogleDriveConfig(params.config);
+      if (!config) {
+        return { success: false, error: "Invalid configuration" };
+      }
+
+      const drive = buildDriveClient(params.credentials);
+      await drive.files.list({ pageSize: 1, fields: "files(id)" });
+
+      this.log.debug("Google Drive connection test successful");
+      return { success: true };
+    } catch (error) {
+      const message = extractErrorMessage(error);
+      this.log.error({ error: message }, "Google Drive connection test failed");
+      return { success: false, error: `Connection failed: ${message}` };
+    }
+  }
+
+  async *sync(params: {
+    config: Record<string, unknown>;
+    credentials: ConnectorCredentials;
+    checkpoint: Record<string, unknown> | null;
+    startTime?: Date;
+    endTime?: Date;
+    embeddingInputModalities?: ModelInputModality[];
+  }): AsyncGenerator<ConnectorSyncBatch> {
+    const parsed = parseGoogleDriveConfig(params.config);
+    if (!parsed) {
+      throw new Error("Invalid Google Drive configuration");
+    }
+
+    const checkpoint = (params.checkpoint as GoogleDriveCheckpoint | null) ?? {
+      type: "googledrive" as const,
+    };
+
+    const batchSize = parsed.batchSize ?? DEFAULT_BATCH_SIZE;
+    const syncFrom = checkpoint.lastSyncedAt ?? params.startTime?.toISOString();
+    const safetyBufferedSyncFrom = syncFrom
+      ? subtractSafetyBuffer(syncFrom)
+      : undefined;
+    const supportsImages =
+      params.embeddingInputModalities?.includes("image") ?? false;
+
+    const drive = buildDriveClient(params.credentials);
+
+    // Track monotonic high-water mark across all sync phases
+    const progress = {
+      maxLastModified: checkpoint.lastSyncedAt as string | undefined,
+    };
+
+    this.log.debug(
+      {
+        sharedDriveIds: parsed.sharedDriveIds,
+        folderId: parsed.folderId,
+        syncFrom,
+        supportsImages,
+      },
+      "Starting Google Drive sync",
+    );
+
+    // Phase 1: sync My Drive (or folder within it)
+    yield* this.syncDriveFiles({
+      drive,
+      config: parsed,
+      progress,
+      syncFrom: safetyBufferedSyncFrom,
+      batchSize,
+      supportsImages,
+      driveId: undefined,
+    });
+
+    // Phase 2: sync shared drives
+    if (parsed.sharedDriveIds && parsed.sharedDriveIds.length > 0) {
+      for (const sharedDriveId of parsed.sharedDriveIds) {
+        yield* this.syncDriveFiles({
+          drive,
+          config: parsed,
+          progress,
+          syncFrom: safetyBufferedSyncFrom,
+          batchSize,
+          supportsImages,
+          driveId: sharedDriveId,
+        });
+      }
+    }
+  }
+
+  // ===== Private methods =====
+
+  private async *syncDriveFiles(params: {
+    drive: ReturnType<typeof buildDriveClient>;
+    config: GoogleDriveConfig;
+    progress: { maxLastModified: string | undefined };
+    syncFrom: string | undefined;
+    batchSize: number;
+    supportsImages: boolean;
+    driveId: string | undefined;
+  }): AsyncGenerator<ConnectorSyncBatch> {
+    const { drive, config, progress, syncFrom, batchSize, supportsImages, driveId } =
+      params;
+
+    let nextPageToken: string | undefined;
+    let batchIndex = 0;
+
+    do {
+      await this.rateLimit();
+
+      const listParams = buildListParams({
+        batchSize,
+        folderId: config.folderId,
+        syncFrom,
+        driveId,
+        pageToken: nextPageToken,
+      });
+
+      let responseData: drive_v3.Schema$FileList;
+      try {
+        const response = await drive.files.list(listParams);
+        responseData = response.data;
+      } catch (error) {
+        throw new Error(
+          `Google Drive files.list failed: ${extractErrorMessage(error)}`,
+        );
+      }
+
+      const files = responseData.files ?? [];
+      nextPageToken = responseData.nextPageToken ?? undefined;
+      const hasMore = !!nextPageToken;
+
+      const documents: ConnectorDocument[] = [];
+
+      for (const file of files) {
+        if (!file.id || !file.name || !file.mimeType) continue;
+        if (!isSupportedFile(file.mimeType, supportsImages)) continue;
+
+        const doc = await this.safeItemFetch({
+          fetch: async () => {
+            const result = await this.fetchFileData(
+              drive,
+              file.id!,
+              file.name!,
+              file.mimeType!,
+            );
+            if (!result.text.trim() && !result.mediaContent) return null;
+            return buildDocument(file, result.text, result.mediaContent);
+          },
+          fallback: null,
+          itemId: file.id,
+          resource: "driveFile",
+        });
+        if (doc) documents.push(doc);
+
+        const modifiedTime = file.modifiedTime;
+        if (
+          modifiedTime &&
+          (!progress.maxLastModified || modifiedTime > progress.maxLastModified)
+        ) {
+          progress.maxLastModified = modifiedTime;
+        }
+      }
+
+      batchIndex++;
+      this.log.debug(
+        {
+          driveId: driveId ?? "my-drive",
+          batchIndex,
+          fileCount: files.length,
+          documentCount: documents.length,
+          hasMore,
+        },
+        "Google Drive batch done",
+      );
+
+      yield {
+        documents,
+        failures: this.flushFailures(),
+        checkpoint: buildCheckpoint({
+          type: "googledrive",
+          itemUpdatedAt: progress.maxLastModified
+            ? new Date(progress.maxLastModified)
+            : undefined,
+          previousLastSyncedAt: progress.maxLastModified,
+        }),
+        hasMore,
+      };
+    } while (nextPageToken);
+  }
+
+  private async fetchFileData(
+    drive: ReturnType<typeof buildDriveClient>,
+    fileId: string,
+    fileName: string,
+    mimeType: string,
+  ): Promise<{
+    text: string;
+    mediaContent?: { mimeType: string; data: string };
+  }> {
+    // Google Workspace documents: export as text
+    const exportMime = GOOGLE_WORKSPACE_EXPORT_MIME[mimeType];
+    if (exportMime) {
+      try {
+        const response = (await drive.files.export({
+          fileId,
+          mimeType: exportMime,
+        })) as { data: string };
+        const text = String(response.data ?? "");
+        return { text: text.slice(0, MAX_CONTENT_LENGTH) };
+      } catch (error) {
+        throw new Error(
+          `Export failed for ${fileName}: ${extractErrorMessage(error)}`,
+        );
+      }
+    }
+
+    // Image files: download as base64 for multimodal embedding
+    if (SUPPORTED_IMAGE_MIME_TYPES.has(mimeType)) {
+      const buffer = await this.downloadFileBuffer(drive, fileId, fileName);
+      if (buffer.byteLength > MAX_IMAGE_SIZE_BYTES) {
+        this.log.debug(
+          { fileName, sizeBytes: buffer.byteLength },
+          "Google Drive: skipping oversized image",
+        );
+        return { text: "" };
+      }
+      const data = Buffer.from(buffer).toString("base64");
+      return { text: "", mediaContent: { mimeType, data } };
+    }
+
+    // Plain text files: download and read as UTF-8
+    if (SUPPORTED_TEXT_MIME_TYPES.has(mimeType)) {
+      const buffer = await this.downloadFileBuffer(drive, fileId, fileName);
+      const text = Buffer.from(buffer)
+        .toString("utf-8")
+        .slice(0, MAX_CONTENT_LENGTH);
+      return { text };
+    }
+
+    // Binary files (.docx, .pdf, .pptx): extract text
+    const ext = getFileExtension(fileName);
+    if (SUPPORTED_BINARY_EXTENSIONS.has(ext)) {
+      const buffer = await this.downloadFileBuffer(drive, fileId, fileName);
+      const text = await extractTextFromBinary(Buffer.from(buffer), ext);
+      return { text: text.slice(0, MAX_CONTENT_LENGTH) };
+    }
+
+    this.log.debug(
+      { fileName, mimeType },
+      "Google Drive: skipping unsupported file type",
+    );
+    return { text: "" };
+  }
+
+  private async downloadFileBuffer(
+    drive: ReturnType<typeof buildDriveClient>,
+    fileId: string,
+    fileName: string,
+  ): Promise<ArrayBuffer> {
+    try {
+      const response = await drive.files.get(
+        { fileId, alt: "media" },
+        { responseType: "arraybuffer" },
+      );
+      return response.data as ArrayBuffer;
+    } catch (error) {
+      throw new Error(
+        `Download failed for ${fileName}: ${extractErrorMessage(error)}`,
+      );
+    }
+  }
+}
+
+// ===== Module-level helpers =====
+
+function buildDriveClient(credentials: ConnectorCredentials) {
+  const auth = new google.auth.JWT({
+    email: credentials.email,
+    key: credentials.apiToken,
+    scopes: [DRIVE_READONLY_SCOPE],
+  });
+  return google.drive({ version: "v3", auth });
+}
+
+function parseGoogleDriveConfig(
+  config: Record<string, unknown>,
+): GoogleDriveConfig | null {
+  const result = GoogleDriveConfigSchema.safeParse({
+    type: "googledrive",
+    ...config,
+  });
+  return result.success ? result.data : null;
+}
+
+function subtractSafetyBuffer(isoDate: string): string {
+  return new Date(
+    new Date(isoDate).getTime() - INCREMENTAL_SAFETY_BUFFER_MS,
+  ).toISOString();
+}
+
+function buildListParams(params: {
+  batchSize: number;
+  folderId: string | undefined;
+  syncFrom: string | undefined;
+  driveId: string | undefined;
+  pageToken: string | undefined;
+}): drive_v3.Params$Resource$Files$List {
+  const { batchSize, folderId, syncFrom, driveId, pageToken } = params;
+
+  const qParts: string[] = [
+    "trashed=false",
+    "mimeType != 'application/vnd.google-apps.folder'",
+  ];
+
+  if (folderId) {
+    qParts.push(`'${folderId}' in parents`);
+  }
+
+  if (syncFrom) {
+    qParts.push(`modifiedTime >= '${syncFrom}'`);
+  }
+
+  const listParams: drive_v3.Params$Resource$Files$List = {
+    q: qParts.join(" and "),
+    fields:
+      "nextPageToken, files(id, name, mimeType, webViewLink, modifiedTime, createdTime, size, parents)",
+    pageSize: batchSize,
+    orderBy: "modifiedTime",
+  };
+
+  if (pageToken) {
+    listParams.pageToken = pageToken;
+  }
+
+  if (driveId) {
+    listParams.driveId = driveId;
+    listParams.corpora = "drive";
+    listParams.includeItemsFromAllDrives = true;
+    listParams.supportsAllDrives = true;
+  }
+
+  return listParams;
+}
+
+function isSupportedFile(mimeType: string, supportsImages = false): boolean {
+  if (mimeType in GOOGLE_WORKSPACE_EXPORT_MIME) return true;
+  if (SUPPORTED_TEXT_MIME_TYPES.has(mimeType)) return true;
+  if (supportsImages && SUPPORTED_IMAGE_MIME_TYPES.has(mimeType)) return true;
+
+  // Check binary extensions by MIME type
+  const binaryMimes = new Set([
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  ]);
+  return binaryMimes.has(mimeType);
+}
+
+function getFileExtension(name: string): string {
+  const lastDot = name.lastIndexOf(".");
+  if (lastDot < 0) return "";
+  return name.slice(lastDot).toLowerCase();
+}
+
+function buildDocument(
+  file: drive_v3.Schema$File,
+  content: string,
+  mediaContent?: { mimeType: string; data: string },
+): ConnectorDocument {
+  const title = file.name ?? file.id ?? "Untitled";
+  const fullContent = content ? `# ${title}\n\n${content}` : `# ${title}`;
+
+  return {
+    id: file.id ?? "",
+    title,
+    content: mediaContent && !content.trim() ? `# ${title}` : fullContent,
+    sourceUrl: file.webViewLink ?? undefined,
+    metadata: {
+      fileId: file.id,
+      fileName: file.name,
+      mimeType: file.mimeType,
+      size: file.size,
+      modifiedTime: file.modifiedTime,
+      createdTime: file.createdTime,
+      parents: file.parents,
+    },
+    updatedAt: file.modifiedTime ? new Date(file.modifiedTime) : undefined,
+    mediaContent,
+  };
+}
+
+async function extractTextFromBinary(
+  buffer: Buffer,
+  ext: string,
+): Promise<string> {
+  switch (ext) {
+    case ".docx": {
+      const result = await mammoth.extractRawText({ buffer });
+      return result.value;
+    }
+    case ".pdf": {
+      const pdfParse = (await import("pdf-parse")).default;
+      const result = await pdfParse(buffer);
+      return result.text;
+    }
+    case ".pptx": {
+      return extractTextFromPptx(buffer);
+    }
+    default:
+      return "";
+  }
+}
+
+async function extractTextFromPptx(buffer: Buffer): Promise<string> {
+  const zip = await JSZip.loadAsync(buffer);
+  const parts: string[] = [];
+
+  const slideFiles = Object.keys(zip.files)
+    .filter((name) => /^ppt\/slides\/slide\d+\.xml$/.test(name))
+    .sort((a, b) => {
+      const numA = Number.parseInt(a.match(/slide(\d+)/)?.[1] ?? "0", 10);
+      const numB = Number.parseInt(b.match(/slide(\d+)/)?.[1] ?? "0", 10);
+      return numA - numB;
+    });
+
+  for (const slidePath of slideFiles) {
+    const xml = await zip.files[slidePath].async("text");
+    const texts = xml.match(/<a:t[^>]*>([^<]*)<\/a:t>/g);
+    if (texts) {
+      const slideText = texts
+        .map((text: string) => stripHtmlTags(text))
+        .join(" ");
+      if (slideText.trim()) parts.push(slideText.trim());
+    }
+  }
+
+  return parts.join("\n\n");
+}

--- a/platform/backend/src/knowledge-base/connectors/registry.ts
+++ b/platform/backend/src/knowledge-base/connectors/registry.ts
@@ -2,6 +2,7 @@ import type { Connector, ConnectorType } from "@/types";
 import { ConfluenceConnector } from "./confluence/confluence-connector";
 import { GithubConnector } from "./github/github-connector";
 import { GitlabConnector } from "./gitlab/gitlab-connector";
+import { GoogleDriveConnector } from "./googledrive/googledrive-connector";
 import { JiraConnector } from "./jira/jira-connector";
 import { NotionConnector } from "./notion/notion-connector";
 import { ServiceNowConnector } from "./servicenow/servicenow-connector";
@@ -15,6 +16,7 @@ const connectorRegistry: Record<ConnectorType, () => Connector> = {
   servicenow: () => new ServiceNowConnector(),
   notion: () => new NotionConnector(),
   sharepoint: () => new SharePointConnector(),
+  googledrive: () => new GoogleDriveConnector(),
 };
 
 export function getConnector(type: string): Connector {

--- a/platform/backend/src/types/knowledge-connector.ts
+++ b/platform/backend/src/types/knowledge-connector.ts
@@ -10,6 +10,7 @@ const GITLAB = z.literal("gitlab");
 const SERVICENOW = z.literal("servicenow");
 const NOTION = z.literal("notion");
 const SHAREPOINT = z.literal("sharepoint");
+const GOOGLEDRIVE = z.literal("googledrive");
 
 export const ConnectorTypeSchema = z.union([
   JIRA,
@@ -19,6 +20,7 @@ export const ConnectorTypeSchema = z.union([
   SERVICENOW,
   NOTION,
   SHAREPOINT,
+  GOOGLEDRIVE,
 ]);
 export type ConnectorType = z.infer<typeof ConnectorTypeSchema>;
 
@@ -194,6 +196,22 @@ export const SharePointCheckpointSchema = z.object({
 });
 export type SharePointCheckpoint = z.infer<typeof SharePointCheckpointSchema>;
 
+// ===== Google Drive Config & Checkpoint =====
+
+export const GoogleDriveConfigSchema = z.object({
+  type: GOOGLEDRIVE,
+  sharedDriveIds: z.array(z.string()).optional(),
+  folderId: z.string().optional(),
+  batchSize: z.number().optional(),
+});
+export type GoogleDriveConfig = z.infer<typeof GoogleDriveConfigSchema>;
+
+export const GoogleDriveCheckpointSchema = z.object({
+  type: GOOGLEDRIVE,
+  lastSyncedAt: z.string().optional(),
+});
+export type GoogleDriveCheckpoint = z.infer<typeof GoogleDriveCheckpointSchema>;
+
 // ===== Discriminated Unions =====
 
 export const ConnectorConfigSchema = z.discriminatedUnion("type", [
@@ -204,6 +222,7 @@ export const ConnectorConfigSchema = z.discriminatedUnion("type", [
   ServiceNowConfigSchema,
   NotionConfigSchema,
   SharePointConfigSchema,
+  GoogleDriveConfigSchema,
 ]);
 export type ConnectorConfig = z.infer<typeof ConnectorConfigSchema>;
 
@@ -215,6 +234,7 @@ export const ConnectorCheckpointSchema = z.discriminatedUnion("type", [
   ServiceNowCheckpointSchema,
   NotionCheckpointSchema,
   SharePointCheckpointSchema,
+  GoogleDriveCheckpointSchema,
 ]);
 export type ConnectorCheckpoint = z.infer<typeof ConnectorCheckpointSchema>;
 

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-icons.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-icons.tsx
@@ -20,6 +20,7 @@ const CONNECTOR_ICON_MAP: Partial<Record<ConnectorType, ConnectorIcon>> = {
   servicenow: { kind: "img", src: "/icons/servicenow.png" },
   notion: { kind: "img", src: "/icons/notion.png" },
   sharepoint: { kind: "img", src: "/icons/sharepoint.png" },
+  googledrive: { kind: "img", src: "/icons/google.png" },
 };
 
 export function hasConnectorIcon(type: string): boolean {

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/create-connector-dialog.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/create-connector-dialog.tsx
@@ -46,6 +46,7 @@ import { GithubConfigFields } from "./github-config-fields";
 import { GitlabConfigFields } from "./gitlab-config-fields";
 import { JiraConfigFields } from "./jira-config-fields";
 import { NotionConfigFields } from "./notion-config-fields";
+import { GoogleDriveConfigFields } from "./googledrive-config-fields";
 import { SchedulePicker } from "./schedule-picker";
 import { ServiceNowConfigFields } from "./servicenow-config-fields";
 import { SharePointConfigFields } from "./sharepoint-config-fields";
@@ -93,6 +94,11 @@ const CONNECTOR_OPTIONS: {
     type: "sharepoint",
     label: CONNECTOR_TYPE_LABELS.sharepoint,
     description: "Sync documents and pages from SharePoint",
+  },
+  {
+    type: "googledrive",
+    label: CONNECTOR_TYPE_LABELS.googledrive,
+    description: "Sync files and documents from Google Drive",
   },
 ];
 
@@ -152,6 +158,7 @@ export function CreateConnectorDialog({
       servicenow: { type, syncDataForLastMonths: 6 },
       notion: { type },
       sharepoint: { type, includePages: true },
+      googledrive: { type },
     };
     form.setValue("config", defaultConfigs[type]);
     setStep("configure");
@@ -535,6 +542,31 @@ export function CreateConnectorDialog({
                   />
                 )}
 
+                {connectorType === "googledrive" && (
+                  <FormField
+                    control={form.control}
+                    name="email"
+                    rules={{ required: "Service account email is required" }}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Service Account Email</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="email"
+                            placeholder="my-sa@my-project.iam.gserviceaccount.com"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          The email address of the Google service account with
+                          Drive read access.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                )}
+
                 <FormField
                   control={form.control}
                   name="apiToken"
@@ -549,7 +581,9 @@ export function CreateConnectorDialog({
                           ? "Integration token is required"
                           : connectorType === "sharepoint"
                             ? "Client secret is required"
-                            : "Personal access token is required",
+                            : connectorType === "googledrive"
+                              ? "Private key is required"
+                              : "Personal access token is required",
                   }}
                   render={({ field }) => (
                     <FormItem>
@@ -560,11 +594,13 @@ export function CreateConnectorDialog({
                             ? "Integration Token"
                             : connectorType === "sharepoint"
                               ? "Client Secret"
-                              : needsEmail
-                                ? emailRequired
-                                  ? "API Token"
-                                  : "API Token / Personal Access Token"
-                                : "Personal Access Token"}
+                              : connectorType === "googledrive"
+                                ? "Private Key"
+                                : needsEmail
+                                  ? emailRequired
+                                    ? "API Token"
+                                    : "API Token / Personal Access Token"
+                                  : "Personal Access Token"}
                       </FormLabel>
                       <FormControl>
                         <Input
@@ -576,11 +612,13 @@ export function CreateConnectorDialog({
                                 ? "secret_..."
                                 : connectorType === "sharepoint"
                                   ? "Your Azure AD client secret"
-                                  : needsEmail
-                                    ? emailRequired
-                                      ? "Your API token"
-                                      : "Your API token or personal access token"
-                                    : "Your personal access token"
+                                  : connectorType === "googledrive"
+                                    ? "-----BEGIN RSA PRIVATE KEY-----..."
+                                    : needsEmail
+                                      ? emailRequired
+                                        ? "Your API token"
+                                        : "Your API token or personal access token"
+                                      : "Your personal access token"
                           }
                           {...field}
                         />
@@ -597,6 +635,14 @@ export function CreateConnectorDialog({
                           The Azure AD app registration requires the{" "}
                           <code>Sites.Read.All</code> permission on Microsoft
                           Graph.
+                        </p>
+                      )}
+                      {connectorType === "googledrive" && (
+                        <p className="text-[0.8rem] text-muted-foreground">
+                          The service account requires the{" "}
+                          <code>drive.readonly</code> OAuth scope. Paste the PEM
+                          private key from your service account JSON credentials
+                          file.
                         </p>
                       )}
                       <FormMessage />
@@ -631,6 +677,9 @@ export function CreateConnectorDialog({
                     )}
                     {connectorType === "sharepoint" && (
                       <SharePointConfigFields form={form} />
+                    )}
+                    {connectorType === "googledrive" && (
+                      <GoogleDriveConfigFields form={form} />
                     )}
                   </CollapsibleContent>
                 </Collapsible>
@@ -706,6 +755,8 @@ function getUrlConfig(type: ConnectorType): {
         placeholder: "https://your-tenant.sharepoint.com/sites/your-site",
         description: "Your SharePoint site URL.",
       };
+    case "googledrive":
+      return null;
   }
 }
 

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/edit-connector-dialog.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/edit-connector-dialog.tsx
@@ -36,6 +36,7 @@ import { GithubConfigFields } from "./github-config-fields";
 import { GitlabConfigFields } from "./gitlab-config-fields";
 import { JiraConfigFields } from "./jira-config-fields";
 import { NotionConfigFields } from "./notion-config-fields";
+import { GoogleDriveConfigFields } from "./googledrive-config-fields";
 import { SchedulePicker } from "./schedule-picker";
 import { ServiceNowConfigFields } from "./servicenow-config-fields";
 import { SharePointConfigFields } from "./sharepoint-config-fields";
@@ -392,6 +393,30 @@ export function EditConnectorDialog({
             />
           )}
 
+          {connectorType === "googledrive" && (
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Service Account Email</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      placeholder="Leave empty to keep existing credentials"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    The email address of the Google service account with Drive
+                    read access.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          )}
+
           <FormField
             control={form.control}
             name="apiToken"
@@ -404,11 +429,13 @@ export function EditConnectorDialog({
                       ? "Integration Token"
                       : connectorType === "sharepoint"
                         ? "Client Secret"
-                        : needsEmail
-                          ? emailRequired
-                            ? "API Token"
-                            : "API Token / Personal Access Token"
-                          : "Personal Access Token"}
+                        : connectorType === "googledrive"
+                          ? "Private Key"
+                          : needsEmail
+                            ? emailRequired
+                              ? "API Token"
+                              : "API Token / Personal Access Token"
+                            : "Personal Access Token"}
                 </FormLabel>
                 <FormControl>
                   <Input
@@ -428,6 +455,13 @@ export function EditConnectorDialog({
                   <p className="text-[0.8rem] text-muted-foreground">
                     The Azure AD app registration requires the{" "}
                     <code>Sites.Read.All</code> permission on Microsoft Graph.
+                  </p>
+                )}
+                {connectorType === "googledrive" && (
+                  <p className="text-[0.8rem] text-muted-foreground">
+                    The service account requires the{" "}
+                    <code>drive.readonly</code> OAuth scope. Paste the PEM
+                    private key from your service account JSON credentials file.
                   </p>
                 )}
                 <FormMessage />
@@ -460,6 +494,9 @@ export function EditConnectorDialog({
               {connectorType === "notion" && <NotionConfigFields form={form} />}
               {connectorType === "sharepoint" && (
                 <SharePointConfigFields form={form} />
+              )}
+              {connectorType === "googledrive" && (
+                <GoogleDriveConfigFields form={form} />
               )}
             </CollapsibleContent>
           </Collapsible>
@@ -545,6 +582,8 @@ function getEditUrlConfig(type: ConnectorType): {
           description: "Your SharePoint site URL.",
         },
       };
+    case "googledrive":
+      return { typeLabel: "Google Drive", urlFields: null };
     default:
       return {
         typeLabel: type,

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/googledrive-config-fields.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/googledrive-config-fields.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import type { UseFormReturn } from "react-hook-form";
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+
+interface GoogleDriveConfigFieldsProps {
+  // biome-ignore lint/suspicious/noExplicitAny: form type is generic across different form schemas
+  form: UseFormReturn<any>;
+  prefix?: string;
+}
+
+export function GoogleDriveConfigFields({
+  form,
+  prefix = "config",
+}: GoogleDriveConfigFieldsProps) {
+  return (
+    <div className="space-y-4">
+      <FormField
+        control={form.control}
+        name={`${prefix}.sharedDriveIds`}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Shared Drive IDs (optional)</FormLabel>
+            <FormControl>
+              <Input
+                placeholder="0ABCxyz123, 0DEFabc456"
+                {...field}
+                value={(field.value as string) ?? ""}
+              />
+            </FormControl>
+            <FormDescription>
+              Comma-separated list of shared (Team) Drive IDs to sync. Leave
+              blank to sync only My Drive.
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name={`${prefix}.folderId`}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Folder ID (optional)</FormLabel>
+            <FormControl>
+              <Input
+                placeholder="1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms"
+                {...field}
+                value={(field.value as string) ?? ""}
+              />
+            </FormControl>
+            <FormDescription>
+              Restrict sync to files within a specific folder. Use the folder ID
+              from the Google Drive URL.
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </div>
+  );
+}

--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -301,6 +301,9 @@ importers:
       fastify-type-provider-zod:
         specifier: ^6.0.0
         version: 6.1.0(@fastify/swagger@9.7.0)(fastify@5.8.3)(openapi-types@12.1.3)(zod@4.3.6)
+      googleapis:
+        specifier: ^171.4.0
+        version: 171.4.0
       handlebars:
         specifier: ^4.7.9
         version: 4.7.9
@@ -6927,6 +6930,14 @@ packages:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
 
+  googleapis-common@8.0.1:
+    resolution: {integrity: sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==}
+    engines: {node: '>=18.0.0'}
+
+  googleapis@171.4.0:
+    resolution: {integrity: sha512-xybFL2SmmUgIifgsbsRQYRdNrSAYwxWZDmkZTGjUIaRnX5jPqR8el/cEvo6rCqh7iaZx6MfEPS/lrDgZ0bymkg==}
+    engines: {node: '>=18'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -9189,6 +9200,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  url-template@2.0.8:
+    resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -16536,6 +16550,23 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
+  googleapis-common@8.0.1:
+    dependencies:
+      extend: 3.0.2
+      gaxios: 7.1.3
+      google-auth-library: 10.5.0
+      qs: 6.14.2
+      url-template: 2.0.8
+    transitivePeerDependencies:
+      - supports-color
+
+  googleapis@171.4.0:
+    dependencies:
+      google-auth-library: 10.5.0
+      googleapis-common: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -19256,6 +19287,8 @@ snapshots:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  url-template@2.0.8: {}
 
   use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
     dependencies:

--- a/platform/shared/knowledge-base.ts
+++ b/platform/shared/knowledge-base.ts
@@ -41,6 +41,7 @@ export const CONNECTOR_TYPE_LABELS: Record<string, string> = {
   gitlab: "GitLab",
   notion: "Notion",
   sharepoint: "SharePoint",
+  googledrive: "Google Drive",
 };
 
 const CONNECTOR_PLACEHOLDER_DEPARTMENTS = [


### PR DESCRIPTION
Fixes https://github.com/archestra-ai/archestra/issues/3689

## Approach

Follows the same pattern as the SharePoint connector. Uses Google service account JWT auth via the `googleapis` npm package.

### Backend
- Added `googledrive` to `ConnectorTypeSchema`, config and checkpoint schemas
- Created `googledrive-connector.ts` implementing `BaseConnector` with JWT auth, My Drive + shared drives sync, Google Workspace export, binary file extraction, incremental sync via `modifiedTime`
- Registered in `registry.ts`
- Added `googleapis` dependency

### Frontend
- Added label, icon, config fields (sharedDriveIds, folderId)
- Wired into create and edit connector dialogs with service account credentials