### PR TITLE
fix: jira oauth discovery overrides

### DIFF
--- a/docs/pages/mcp-authentication.md
+++ b/docs/pages/mcp-authentication.md
@@ -3,7 +3,7 @@ title: "Authentication"
 category: MCP
 order: 4
 description: "How authentication works for MCP clients and upstream MCP servers"
-lastUpdated: 2026-04-08
+lastUpdated: 2026-04-11
 ---
 
 <!--
@@ -331,6 +331,8 @@ Your server (or its OAuth provider) needs to expose two things:
 - A 401 response with a `WWW-Authenticate` header when tokens are missing or expired
 
 Archestra handles everything else: endpoint discovery, client registration, the authorization code flow with PKCE, token storage, and automatic refresh when tokens expire.
+
+If the MCP server URL is different from the OAuth issuer or metadata host, configure explicit OAuth discovery overrides in the MCP catalog item. Archestra can use a separate authorization server URL, a direct well-known metadata URL, and a direct resource metadata URL instead of deriving discovery from the MCP server URL.
 
 Your server receives an `Authorization: Bearer <access_token>` header with each request from the gateway.
 

--- a/platform/backend/src/routes/oauth.test.ts
+++ b/platform/backend/src/routes/oauth.test.ts
@@ -3,6 +3,7 @@ import { type Mock, vi } from "vitest";
 import { beforeEach, describe, expect, test } from "@/test";
 import {
   buildDiscoveryUrls,
+  discoverOAuthEndpoints,
   discoverScopes,
   generateCodeChallenge,
   generateCodeVerifier,
@@ -247,6 +248,80 @@ describe("OAuth helper functions", () => {
       expect(scopes).toEqual(["mcp:read"]);
       expect(fetchMock).toHaveBeenCalledWith(
         "https://metadata.example.com/.well-known/oauth-protected-resource/mcp",
+        expect.anything(),
+      );
+
+      globalThis.fetch = originalFetch;
+    });
+
+    test("skips default resource metadata discovery when auth server override is set", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          authorization_endpoint: "https://auth.example.com/authorize",
+          token_endpoint: "https://auth.example.com/token",
+          scopes_supported: ["jira:read"],
+        }),
+      }) as Mock;
+
+      globalThis.fetch = fetchMock;
+
+      const scopes = await discoverScopes(
+        "https://tenant.example.com/rest/oauth2/latest/token",
+        true,
+        ["read", "write"],
+        {
+          authServerUrl: "https://auth.example.com",
+          wellKnownUrl:
+            "https://auth.example.com/.well-known/openid-configuration",
+        },
+      );
+
+      expect(scopes).toEqual(["jira:read"]);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://auth.example.com/.well-known/openid-configuration",
+        expect.anything(),
+      );
+
+      globalThis.fetch = originalFetch;
+    });
+  });
+
+  describe("discoverOAuthEndpoints", () => {
+    const originalFetch = globalThis.fetch;
+
+    beforeEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    test("skips default resource metadata discovery when auth server override is set", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          authorization_endpoint: "https://auth.example.com/authorize",
+          token_endpoint: "https://auth.example.com/token",
+        }),
+      }) as Mock;
+
+      globalThis.fetch = fetchMock;
+
+      const endpoints = await discoverOAuthEndpoints({
+        server_url: "https://tenant.example.com/rest/oauth2/latest/token",
+        supports_resource_metadata: true,
+        auth_server_url: "https://auth.example.com",
+        well_known_url:
+          "https://auth.example.com/.well-known/openid-configuration",
+      });
+
+      expect(endpoints).toEqual({
+        authorizationEndpoint: "https://auth.example.com/authorize",
+        tokenEndpoint: "https://auth.example.com/token",
+        registrationEndpoint: undefined,
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://auth.example.com/.well-known/openid-configuration",
         expect.anything(),
       );
 

--- a/platform/backend/src/routes/oauth.test.ts
+++ b/platform/backend/src/routes/oauth.test.ts
@@ -191,5 +191,66 @@ describe("OAuth helper functions", () => {
 
       globalThis.fetch = originalFetch;
     });
+
+    test("uses explicit authorization server metadata URL override", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          authorization_endpoint: "https://auth.example.com/authorize",
+          token_endpoint: "https://auth.example.com/token",
+          scopes_supported: ["jira:read"],
+        }),
+      }) as Mock;
+
+      globalThis.fetch = fetchMock;
+
+      const scopes = await discoverScopes(
+        "https://tenant.example.com/rest/oauth2/latest/token",
+        false,
+        ["read", "write"],
+        {
+          authServerUrl: "https://auth.example.com",
+          wellKnownUrl:
+            "https://auth.example.com/.well-known/openid-configuration",
+        },
+      );
+
+      expect(scopes).toEqual(["jira:read"]);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://auth.example.com/.well-known/openid-configuration",
+        expect.anything(),
+      );
+
+      globalThis.fetch = originalFetch;
+    });
+
+    test("uses explicit resource metadata URL override", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          scopes_supported: ["mcp:read"],
+        }),
+      }) as Mock;
+
+      globalThis.fetch = fetchMock;
+
+      const scopes = await discoverScopes(
+        "https://example.com/mcp",
+        true,
+        ["read", "write"],
+        {
+          resourceMetadataUrl:
+            "https://metadata.example.com/.well-known/oauth-protected-resource/mcp",
+        },
+      );
+
+      expect(scopes).toEqual(["mcp:read"]);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://metadata.example.com/.well-known/oauth-protected-resource/mcp",
+        expect.anything(),
+      );
+
+      globalThis.fetch = originalFetch;
+    });
   });
 });

--- a/platform/backend/src/routes/oauth.ts
+++ b/platform/backend/src/routes/oauth.ts
@@ -98,7 +98,7 @@ export async function discoverScopes(
 
   // Try authorization server metadata discovery
   try {
-    const metadata = await discoverAuthorizationServerMetadata(
+    const metadata = await discoverAuthorizationServerMetadataWithOverrides(
       serverUrl,
       overrides,
     );
@@ -121,11 +121,7 @@ export async function discoverScopes(
  * Build discovery URLs to try for authorization server metadata
  * Implements the same fallback strategy as MCP SDK
  */
-export function buildDiscoveryUrls(serverUrl: string): string[] {
-  return buildDiscoveryUrlsWithOverride(serverUrl);
-}
-
-function buildDiscoveryUrlsWithOverride(
+export function buildDiscoveryUrls(
   serverUrl: string,
   wellKnownUrl?: string,
 ): string[] {
@@ -163,18 +159,6 @@ function buildDiscoveryUrlsWithOverride(
  * Discover OAuth authorization server metadata with fallback support
  * Tries multiple discovery URLs like the MCP SDK does
  */
-async function discoverAuthorizationServerMetadata(
-  serverUrl: string,
-  overrides?: OAuthDiscoveryOverrides,
-): Promise<{
-  authorization_endpoint: string;
-  token_endpoint: string;
-  registration_endpoint?: string;
-  scopes_supported?: string[];
-}> {
-  return discoverAuthorizationServerMetadataWithOverrides(serverUrl, overrides);
-}
-
 async function discoverAuthorizationServerMetadataWithOverrides(
   serverUrl: string,
   overrides?: OAuthDiscoveryOverrides,
@@ -185,10 +169,7 @@ async function discoverAuthorizationServerMetadataWithOverrides(
   scopes_supported?: string[];
 }> {
   const discoveryUrl = overrides?.authServerUrl || serverUrl;
-  const urls = buildDiscoveryUrlsWithOverride(
-    discoveryUrl,
-    overrides?.wellKnownUrl,
-  );
+  const urls = buildDiscoveryUrls(discoveryUrl, overrides?.wellKnownUrl);
 
   for (const url of urls) {
     try {
@@ -265,9 +246,7 @@ export async function discoverOAuthEndpoints(
       const resourceMetadata = await discoverOAuthResourceMetadata(
         oauthConfig.server_url,
         {
-          authServerUrl: oauthConfig.auth_server_url,
           resourceMetadataUrl: oauthConfig.resource_metadata_url,
-          wellKnownUrl: oauthConfig.well_known_url,
         },
       );
       if (

--- a/platform/backend/src/routes/oauth.ts
+++ b/platform/backend/src/routes/oauth.ts
@@ -78,7 +78,11 @@ export async function discoverScopes(
   overrides?: OAuthDiscoveryOverrides,
 ): Promise<string[]> {
   // Try resource metadata discovery first if supported
-  if (supportsResourceMetadata) {
+  const shouldDiscoverResourceMetadata =
+    supportsResourceMetadata &&
+    (!overrides?.authServerUrl || !!overrides.resourceMetadataUrl);
+
+  if (shouldDiscoverResourceMetadata) {
     try {
       const resourceMetadata = await discoverOAuthResourceMetadata(
         serverUrl,
@@ -236,8 +240,11 @@ export async function discoverOAuthEndpoints(
 ): Promise<DiscoveredEndpoints> {
   let discoveryServerUrl =
     oauthConfig.auth_server_url || oauthConfig.server_url;
+  const shouldDiscoverResourceMetadata =
+    oauthConfig.supports_resource_metadata &&
+    (!oauthConfig.auth_server_url || !!oauthConfig.resource_metadata_url);
 
-  if (oauthConfig.supports_resource_metadata) {
+  if (shouldDiscoverResourceMetadata) {
     try {
       log?.info(
         { serverUrl: oauthConfig.server_url },

--- a/platform/backend/src/routes/oauth.ts
+++ b/platform/backend/src/routes/oauth.ts
@@ -23,11 +23,20 @@ export function generateCodeChallenge(verifier: string): string {
   return createHash("sha256").update(verifier).digest("base64url");
 }
 
+interface OAuthDiscoveryOverrides {
+  authServerUrl?: string;
+  resourceMetadataUrl?: string;
+  wellKnownUrl?: string;
+}
+
 /**
  * Discover OAuth resource metadata (for MCP servers)
  * Sends MCP-Protocol-Version header for MCP-aware servers
  */
-async function discoverOAuthResourceMetadata(serverUrl: string) {
+async function discoverOAuthResourceMetadata(
+  serverUrl: string,
+  overrides?: OAuthDiscoveryOverrides,
+) {
   try {
     // MCP SDK uses "path-aware discovery": /.well-known/{type}{pathname}
     // For https://huggingface.co/mcp -> https://huggingface.co/.well-known/oauth-protected-resource/mcp
@@ -35,7 +44,9 @@ async function discoverOAuthResourceMetadata(serverUrl: string) {
     const pathname = url.pathname.endsWith("/")
       ? url.pathname.slice(0, -1)
       : url.pathname;
-    const wellKnownUrl = `${url.origin}/.well-known/oauth-protected-resource${pathname}`;
+    const wellKnownUrl =
+      overrides?.resourceMetadataUrl ||
+      `${url.origin}/.well-known/oauth-protected-resource${pathname}`;
 
     const response = await fetch(wellKnownUrl, {
       headers: {
@@ -64,11 +75,15 @@ export async function discoverScopes(
   serverUrl: string,
   supportsResourceMetadata: boolean,
   defaultScopes: string[],
+  overrides?: OAuthDiscoveryOverrides,
 ): Promise<string[]> {
   // Try resource metadata discovery first if supported
   if (supportsResourceMetadata) {
     try {
-      const resourceMetadata = await discoverOAuthResourceMetadata(serverUrl);
+      const resourceMetadata = await discoverOAuthResourceMetadata(
+        serverUrl,
+        overrides,
+      );
       if (
         resourceMetadata?.scopes_supported &&
         Array.isArray(resourceMetadata.scopes_supported) &&
@@ -83,7 +98,10 @@ export async function discoverScopes(
 
   // Try authorization server metadata discovery
   try {
-    const metadata = await discoverAuthorizationServerMetadata(serverUrl);
+    const metadata = await discoverAuthorizationServerMetadata(
+      serverUrl,
+      overrides,
+    );
     if (
       metadata.scopes_supported &&
       Array.isArray(metadata.scopes_supported) &&
@@ -104,6 +122,17 @@ export async function discoverScopes(
  * Implements the same fallback strategy as MCP SDK
  */
 export function buildDiscoveryUrls(serverUrl: string): string[] {
+  return buildDiscoveryUrlsWithOverride(serverUrl);
+}
+
+function buildDiscoveryUrlsWithOverride(
+  serverUrl: string,
+  wellKnownUrl?: string,
+): string[] {
+  if (wellKnownUrl) {
+    return [wellKnownUrl];
+  }
+
   const url = new URL(serverUrl);
   const hasPath = url.pathname !== "/" && url.pathname !== "";
   const urls: string[] = [];
@@ -134,13 +163,32 @@ export function buildDiscoveryUrls(serverUrl: string): string[] {
  * Discover OAuth authorization server metadata with fallback support
  * Tries multiple discovery URLs like the MCP SDK does
  */
-async function discoverAuthorizationServerMetadata(serverUrl: string): Promise<{
+async function discoverAuthorizationServerMetadata(
+  serverUrl: string,
+  overrides?: OAuthDiscoveryOverrides,
+): Promise<{
   authorization_endpoint: string;
   token_endpoint: string;
   registration_endpoint?: string;
   scopes_supported?: string[];
 }> {
-  const urls = buildDiscoveryUrls(serverUrl);
+  return discoverAuthorizationServerMetadataWithOverrides(serverUrl, overrides);
+}
+
+async function discoverAuthorizationServerMetadataWithOverrides(
+  serverUrl: string,
+  overrides?: OAuthDiscoveryOverrides,
+): Promise<{
+  authorization_endpoint: string;
+  token_endpoint: string;
+  registration_endpoint?: string;
+  scopes_supported?: string[];
+}> {
+  const discoveryUrl = overrides?.authServerUrl || serverUrl;
+  const urls = buildDiscoveryUrlsWithOverride(
+    discoveryUrl,
+    overrides?.wellKnownUrl,
+  );
 
   for (const url of urls) {
     try {
@@ -193,13 +241,20 @@ interface DiscoveredEndpoints {
  * Shared by the initiate, callback, and refresh flows to avoid duplicated discovery logic.
  */
 export async function discoverOAuthEndpoints(
-  oauthConfig: { server_url: string; supports_resource_metadata: boolean },
+  oauthConfig: {
+    server_url: string;
+    supports_resource_metadata: boolean;
+    auth_server_url?: string;
+    resource_metadata_url?: string;
+    well_known_url?: string;
+  },
   log?: {
     info: (...args: unknown[]) => void;
     warn: (...args: unknown[]) => void;
   },
 ): Promise<DiscoveredEndpoints> {
-  let discoveryServerUrl = oauthConfig.server_url;
+  let discoveryServerUrl =
+    oauthConfig.auth_server_url || oauthConfig.server_url;
 
   if (oauthConfig.supports_resource_metadata) {
     try {
@@ -209,8 +264,14 @@ export async function discoverOAuthEndpoints(
       );
       const resourceMetadata = await discoverOAuthResourceMetadata(
         oauthConfig.server_url,
+        {
+          authServerUrl: oauthConfig.auth_server_url,
+          resourceMetadataUrl: oauthConfig.resource_metadata_url,
+          wellKnownUrl: oauthConfig.well_known_url,
+        },
       );
       if (
+        !oauthConfig.auth_server_url &&
         resourceMetadata.authorization_servers &&
         Array.isArray(resourceMetadata.authorization_servers) &&
         resourceMetadata.authorization_servers.length > 0
@@ -229,8 +290,14 @@ export async function discoverOAuthEndpoints(
     }
   }
 
-  const metadata =
-    await discoverAuthorizationServerMetadata(discoveryServerUrl);
+  const metadata = await discoverAuthorizationServerMetadataWithOverrides(
+    discoveryServerUrl,
+    {
+      authServerUrl: oauthConfig.auth_server_url,
+      resourceMetadataUrl: oauthConfig.resource_metadata_url,
+      wellKnownUrl: oauthConfig.well_known_url,
+    },
+  );
   log?.info(
     {
       authorizationEndpoint: metadata.authorization_endpoint,
@@ -574,6 +641,11 @@ const oauthRoutes: FastifyPluginAsyncZod = async (fastify) => {
         oauthConfig.server_url,
         oauthConfig.supports_resource_metadata || false,
         oauthConfig.default_scopes || oauthConfig.scopes,
+        {
+          authServerUrl: oauthConfig.auth_server_url,
+          resourceMetadataUrl: oauthConfig.resource_metadata_url,
+          wellKnownUrl: oauthConfig.well_known_url,
+        },
       );
 
       // Use discovered scopes if different from configured

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.test.ts
@@ -287,6 +287,11 @@ describe("formSchema", () => {
           redirect_uris: "https://localhost:3000/oauth-callback",
           scopes: "read,write",
           supports_resource_metadata: true,
+          authServerUrl: "https://auth.example.com",
+          wellKnownUrl:
+            "https://auth.example.com/.well-known/openid-configuration",
+          resourceMetadataUrl:
+            "https://api.example.com/.well-known/oauth-protected-resource",
         },
         localConfig: undefined,
       };

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -150,6 +150,9 @@ export function McpCatalogForm({
                 : "",
             scopes: "read, write",
             supports_resource_metadata: true,
+            authServerUrl: "",
+            wellKnownUrl: "",
+            resourceMetadataUrl: "",
           },
           localConfig: {
             command: "",
@@ -1011,15 +1014,81 @@ export function McpCatalogForm({
                             />
                           </FormControl>
                           <FormDescription>
-                            The OAuth server endpoint used for authorization and
-                            token exchange. This is separate from the
-                            K8s-deployed server.
+                            Base URL used for OAuth discovery. Use the issuer or
+                            auth server base URL here, not the token endpoint.
+                            This is separate from the K8s-deployed server.
                           </FormDescription>
                           <FormMessage />
                         </FormItem>
                       )}
                     />
                   )}
+
+                  <FormField
+                    control={form.control}
+                    name="oauthConfig.authServerUrl"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Authorization Server URL</FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder="https://auth.example.com"
+                            className="font-mono"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          Optional override for discovery when the MCP server
+                          URL is not the OAuth issuer.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="oauthConfig.wellKnownUrl"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Well-Known Metadata URL</FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder="https://auth.example.com/.well-known/openid-configuration"
+                            className="font-mono"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          Optional direct metadata endpoint override when
+                          provider discovery is non-standard.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="oauthConfig.resourceMetadataUrl"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Resource Metadata URL</FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder="https://mcp.example.com/.well-known/oauth-protected-resource"
+                            className="font-mono"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          Optional override for OAuth protected resource
+                          metadata discovery.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
 
                   <FormField
                     control={form.control}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.types.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.types.ts
@@ -8,6 +8,30 @@ export const oauthConfigSchema = z.object({
   redirect_uris: z.string().min(1, "At least one redirect URI is required"),
   scopes: z.string().optional().or(z.literal("")),
   supports_resource_metadata: z.boolean(),
+  authServerUrl: z
+    .string()
+    .url({ error: "Must be a valid URL" })
+    .refine((val) => val.startsWith("http://") || val.startsWith("https://"), {
+      message: "Must be an HTTP or HTTPS URL",
+    })
+    .optional()
+    .or(z.literal("")),
+  wellKnownUrl: z
+    .string()
+    .url({ error: "Must be a valid URL" })
+    .refine((val) => val.startsWith("http://") || val.startsWith("https://"), {
+      message: "Must be an HTTP or HTTPS URL",
+    })
+    .optional()
+    .or(z.literal("")),
+  resourceMetadataUrl: z
+    .string()
+    .url({ error: "Must be a valid URL" })
+    .refine((val) => val.startsWith("http://") || val.startsWith("https://"), {
+      message: "Must be an HTTP or HTTPS URL",
+    })
+    .optional()
+    .or(z.literal("")),
   // OAuth Server URL for local servers (since they don't have a serverUrl field)
   // Used for OAuth discovery/authorization, NOT for tool execution
   oauthServerUrl: z

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
@@ -1,0 +1,59 @@
+import type { McpCatalogFormValues } from "./mcp-catalog-form.types";
+import { transformFormToApiData } from "./mcp-catalog-form.utils";
+
+describe("transformFormToApiData", () => {
+  it("includes OAuth discovery overrides in the API payload", () => {
+    const values: McpCatalogFormValues = {
+      name: "Jira MCP",
+      description: "",
+      icon: null,
+      serverType: "local",
+      serverUrl: "",
+      authMethod: "oauth",
+      oauthConfig: {
+        client_id: "client-id",
+        client_secret: "client-secret",
+        redirect_uris: "https://app.example.com/oauth-callback",
+        scopes: "read:jira-work",
+        supports_resource_metadata: true,
+        oauthServerUrl: "https://mcp.example.com",
+        authServerUrl: "https://auth.example.com",
+        wellKnownUrl:
+          "https://auth.example.com/.well-known/openid-configuration",
+        resourceMetadataUrl:
+          "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+      },
+      enterpriseManagedConfig: null,
+      localConfig: {
+        command: "node",
+        arguments: "server.js",
+        environment: [],
+        envFrom: [],
+        dockerImage: "",
+        transportType: "streamable-http",
+        httpPort: "8080",
+        httpPath: "/mcp",
+        serviceAccount: "",
+        imagePullSecrets: [],
+      },
+      deploymentSpecYaml: "",
+      originalDeploymentSpecYaml: "",
+      oauthClientSecretVaultPath: "",
+      oauthClientSecretVaultKey: "",
+      localConfigVaultPath: "",
+      localConfigVaultKey: "",
+      labels: [],
+      scope: "personal",
+      teams: [],
+    };
+
+    expect(transformFormToApiData(values).oauthConfig).toMatchObject({
+      server_url: "https://mcp.example.com",
+      auth_server_url: "https://auth.example.com",
+      well_known_url:
+        "https://auth.example.com/.well-known/openid-configuration",
+      resource_metadata_url:
+        "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+    });
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
@@ -56,4 +56,48 @@ describe("transformFormToApiData", () => {
         "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
     });
   });
+
+  it("uses the remote server URL as the OAuth server URL for remote servers", () => {
+    const values: McpCatalogFormValues = {
+      name: "Remote Jira MCP",
+      description: "",
+      icon: null,
+      serverType: "remote",
+      serverUrl: "https://mcp.example.com",
+      authMethod: "oauth",
+      oauthConfig: {
+        client_id: "client-id",
+        client_secret: "client-secret",
+        redirect_uris: "https://app.example.com/oauth-callback",
+        scopes: "read:jira-work",
+        supports_resource_metadata: true,
+        oauthServerUrl: "",
+        authServerUrl: "https://auth.example.com",
+        wellKnownUrl:
+          "https://auth.example.com/.well-known/openid-configuration",
+        resourceMetadataUrl:
+          "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+      },
+      enterpriseManagedConfig: null,
+      localConfig: undefined,
+      deploymentSpecYaml: "",
+      originalDeploymentSpecYaml: "",
+      oauthClientSecretVaultPath: "",
+      oauthClientSecretVaultKey: "",
+      localConfigVaultPath: "",
+      localConfigVaultKey: "",
+      labels: [],
+      scope: "personal",
+      teams: [],
+    };
+
+    expect(transformFormToApiData(values).oauthConfig).toMatchObject({
+      server_url: "https://mcp.example.com",
+      auth_server_url: "https://auth.example.com",
+      well_known_url:
+        "https://auth.example.com/.well-known/openid-configuration",
+      resource_metadata_url:
+        "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+    });
+  });
 });

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
@@ -93,6 +93,10 @@ export function transformFormToApiData(
     data.oauthConfig = {
       name: values.name, // Use name as OAuth provider name
       server_url: oauthServerUrl, // OAuth server URL for discovery/authorization
+      auth_server_url: values.oauthConfig.authServerUrl || undefined,
+      well_known_url: values.oauthConfig.wellKnownUrl || undefined,
+      resource_metadata_url:
+        values.oauthConfig.resourceMetadataUrl || undefined,
       client_id: values.oauthConfig.client_id || "",
       // Only include client_secret if no BYOS vault path is set
       client_secret: values.oauthClientSecretVaultPath
@@ -220,6 +224,9 @@ export function transformCatalogItemToFormValues(
         redirect_uris: string;
         scopes: string;
         supports_resource_metadata: boolean;
+        authServerUrl?: string;
+        wellKnownUrl?: string;
+        resourceMetadataUrl?: string;
         oauthServerUrl?: string;
       }
     | undefined;
@@ -234,6 +241,9 @@ export function transformCatalogItemToFormValues(
       scopes: item.oauthConfig.scopes?.join(", ") || "",
       supports_resource_metadata:
         item.oauthConfig.supports_resource_metadata ?? true,
+      authServerUrl: item.oauthConfig.auth_server_url || "",
+      wellKnownUrl: item.oauthConfig.well_known_url || "",
+      resourceMetadataUrl: item.oauthConfig.resource_metadata_url || "",
       // For local servers, populate oauthServerUrl from server_url
       oauthServerUrl:
         item.serverType === "local"
@@ -420,6 +430,9 @@ export function transformExternalCatalogToFormValues(
       scopes: server.oauth_config.scopes?.join(", ") || "read, write",
       supports_resource_metadata:
         server.oauth_config.supports_resource_metadata ?? true,
+      authServerUrl: server.oauth_config.auth_server_url || "",
+      wellKnownUrl: server.oauth_config.well_known_url || "",
+      resourceMetadataUrl: server.oauth_config.resource_metadata_url || "",
       oauthServerUrl:
         server.server.type === "local"
           ? server.oauth_config.server_url || ""
@@ -559,6 +572,9 @@ export function transformExternalCatalogToFormValues(
           : "",
       scopes: "read, write",
       supports_resource_metadata: true,
+      authServerUrl: "",
+      wellKnownUrl: "",
+      resourceMetadataUrl: "",
     },
     localConfig: localConfig ?? {
       command: "",


### PR DESCRIPTION
## Summary
- honor explicit OAuth discovery overrides in backend OAuth initiation and callback flows
- expose authorization server and metadata override fields in the MCP registry form
- add regression coverage for backend discovery overrides and frontend form serialization

## Root cause
The MCP catalog schema already had `auth_server_url`, `well_known_url`, and `resource_metadata_url`, but the runtime OAuth discovery path ignored them and always derived discovery URLs from `server_url`. For Jira-style setups where the MCP server URL is not the OAuth issuer, that led Archestra to fetch HTML from the wrong endpoint and fail discovery before the OAuth flow could start.

## Impact
- self-hosted MCP servers can now use explicit OAuth issuer and metadata endpoints when discovery is not co-located with the MCP server URL
- the registry UI now makes those overrides configurable instead of requiring manual payload editing
- the local-server OAuth field copy now clarifies that the value should be the issuer or discovery base URL, not the token endpoint