### PR TITLE
fix: `/llm/costs` table scrolling

### DIFF
--- a/platform/frontend/src/app/llm/(costs)/costs/page.test.tsx
+++ b/platform/frontend/src/app/llm/(costs)/costs/page.test.tsx
@@ -97,4 +97,73 @@ describe("StatisticsPage", () => {
       ),
     ).toBe(false);
   });
+
+  it("renders statistics tables inside capped scroll containers", () => {
+    mockUseTeamStatistics.mockReturnValue({
+      data: [
+        {
+          teamId: "team-1",
+          teamName: "Platform",
+          members: 3,
+          agents: 2,
+          requests: 12,
+          inputTokens: 100,
+          outputTokens: 50,
+          cost: 42,
+          timeSeries: [],
+        },
+      ],
+    });
+    mockUseProfileStatistics.mockReturnValue({
+      data: [
+        {
+          agentId: "agent-1",
+          agentName: "My Assistant",
+          teamName: "Platform",
+          agentType: "agent",
+          requests: 9,
+          inputTokens: 80,
+          outputTokens: 20,
+          cost: 15,
+          timeSeries: [],
+        },
+        {
+          agentId: "proxy-1",
+          agentName: "Default Proxy",
+          teamName: "Platform",
+          agentType: "llm_proxy",
+          requests: 4,
+          inputTokens: 20,
+          outputTokens: 10,
+          cost: 5,
+          timeSeries: [],
+        },
+      ],
+    });
+    mockUseModelStatistics.mockReturnValue({
+      data: [
+        {
+          model: "gpt-5",
+          requests: 7,
+          inputTokens: 70,
+          outputTokens: 30,
+          cost: 9,
+          percentage: 100,
+          timeSeries: [],
+        },
+      ],
+    });
+
+    const { container } = render(<StatisticsPage />);
+
+    const tablePanels = Array.from(
+      container.querySelectorAll(".max-h-\\[280px\\]"),
+    );
+
+    expect(tablePanels).toHaveLength(4);
+    for (const tablePanel of tablePanels) {
+      expect(tablePanel.className).toContain("max-h-[280px]");
+      expect(tablePanel.className).toContain("overflow-auto");
+    }
+  });
 });

--- a/platform/frontend/src/app/llm/(costs)/costs/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/costs/page.tsx
@@ -18,7 +18,6 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 import { CustomDateTimeRangeDialog } from "@/components/ui/custom-date-time-range-dialog";
-import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import {
   Select,
   SelectContent,
@@ -89,6 +88,7 @@ const ChartContainerWrapper = ({
 );
 
 const TIMEFRAME_STORAGE_KEY = "cost-statistics-timeframe";
+const STATISTICS_TABLE_MAX_HEIGHT_CLASS = "max-h-[280px]";
 
 export default function StatisticsPage() {
   const router = useRouter();
@@ -1090,10 +1090,11 @@ export default function StatisticsPage() {
 
 function StatisticsTablePanel({ children }: { children: React.ReactNode }) {
   return (
-    <ScrollArea className="max-h-[360px] rounded-md border">
+    <div
+      className={`${STATISTICS_TABLE_MAX_HEIGHT_CLASS} overflow-auto rounded-md border`}
+    >
       {children}
-      <ScrollBar orientation="horizontal" />
-    </ScrollArea>
+    </div>
   );
 }
 


### PR DESCRIPTION
## What changed
- replaced the `/llm/costs` table wrapper with a capped `overflow-auto` container
- kept the tables compact when they have only a few rows
- preserved internal scrolling once a table grows beyond roughly six visible rows
- added a focused frontend regression test for the capped scroll container behavior

## Why
The previous Radix `ScrollArea` implementation only scrolled correctly when its root had a fixed height. That fixed the overlap, but it also forced sparse tables and empty states to reserve a large blank area. Using a normal overflow container keeps the table height content-driven up to the cap, then scrolls when needed.

## Impact
This keeps `/llm/costs` readable across short and long datasets without pushing later sections down the page or creating oversized empty panels.