### PR TITLE
fix: checkout release-please PR before local action

### DIFF
--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -204,6 +204,13 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
+      - name: Checkout project for release-please PR
+        if: ${{ steps.check-release-please.outputs.is-release-please == 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
       # Generate a GitHub App token for release-please PRs so pushed generated
       # updates re-trigger workflows. Pushes made with GITHUB_TOKEN do not.
       - name: Generate token for release-please PR


### PR DESCRIPTION
## Summary
- add an initial checkout step for release-please PRs in the Platform Lint and Unit Tests job
- ensure the local composite action at `./.github/actions/github-app-token` exists on disk before GitHub tries to load it
- preserve the follow-up checkout that swaps credentials to the GitHub App token for generated-file pushes

## Root cause
The release-please path skipped the first checkout, then immediately ran `uses: ./.github/actions/github-app-token`. Local actions cannot be loaded until the repository has been checked out, so the job failed with:

`Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/_work/archestra/archestra/.github/actions/github-app-token'`

Fixes the failure on release-please PR #3716.
