### PR TITLE
fix: atomic rate limiting to prevent bypass under concurrent requests

### DIFF
--- a/platform/backend/src/agents/utils.test.ts
+++ b/platform/backend/src/agents/utils.test.ts
@@ -3,17 +3,34 @@ import { type AllowedCacheKey, CacheKey } from "@/cache-manager";
 import { beforeEach, describe, expect, test } from "@/test";
 import { isRateLimited, type RateLimitEntry } from "./utils";
 
-// Mock cacheManager while preserving other exports (like LRUCacheManager, CacheKey)
+// Simulate atomic rate limiting with an in-memory store
 const mockCache = new Map<string, RateLimitEntry>();
 vi.mock("@/cache-manager", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/cache-manager")>();
   return {
     ...actual,
     cacheManager: {
-      get: vi.fn(async (key: string) => mockCache.get(key)),
-      set: vi.fn(async (key: string, value: RateLimitEntry) => {
-        mockCache.set(key, value);
-      }),
+      atomicRateLimitCheck: vi.fn(
+        async (key: string, windowMs: number, maxRequests: number) => {
+          const now = Date.now();
+          const entry = mockCache.get(key);
+
+          if (!entry || now - entry.windowStart > windowMs) {
+            // Start new window
+            mockCache.set(key, { count: 1, windowStart: now });
+            return false;
+          }
+
+          if (entry.count >= maxRequests) {
+            return true;
+          }
+
+          // Increment count
+          entry.count += 1;
+          mockCache.set(key, entry);
+          return false;
+        },
+      ),
     },
   };
 });

--- a/platform/backend/src/agents/utils.ts
+++ b/platform/backend/src/agents/utils.ts
@@ -39,29 +39,5 @@ export async function isRateLimited(
   config: RateLimitConfig,
 ): Promise<boolean> {
   const { windowMs, maxRequests } = config;
-  const now = Date.now();
-  const entry = await cacheManager.get<RateLimitEntry>(cacheKey);
-
-  if (!entry || now - entry.windowStart > windowMs) {
-    // Start new window
-    await cacheManager.set(
-      cacheKey,
-      { count: 1, windowStart: now },
-      // TTL is 2x window to ensure cleanup even if requests stop
-      windowMs * 2,
-    );
-    return false;
-  }
-
-  if (entry.count >= maxRequests) {
-    return true;
-  }
-
-  // Increment count
-  await cacheManager.set(
-    cacheKey,
-    { count: entry.count + 1, windowStart: entry.windowStart },
-    windowMs * 2,
-  );
-  return false;
+  return cacheManager.atomicRateLimitCheck(cacheKey, windowMs, maxRequests);
 }

--- a/platform/backend/src/cache-manager.ts
+++ b/platform/backend/src/cache-manager.ts
@@ -243,6 +243,117 @@ class CacheManager {
   }
 
   /**
+   * Atomically check and increment a rate limit counter.
+   *
+   * Uses a single SQL upsert (INSERT ... ON CONFLICT UPDATE) to atomically
+   * read, check, and increment the counter in one database operation.
+   * This prevents the race condition where concurrent requests could read the
+   * same counter value before any of them increments it.
+   *
+   * @param key - Cache key for the rate limit entry
+   * @param windowMs - Rate limit window in milliseconds
+   * @param maxRequests - Maximum requests allowed per window
+   * @returns true if rate limited (counter already at or above max), false if request is allowed
+   */
+  async atomicRateLimitCheck(
+    key: AllowedCacheKey,
+    windowMs: number,
+    maxRequests: number,
+  ): Promise<boolean> {
+    if (!this.keyv) {
+      logger.warn(
+        "CacheManager: Not started, allowing request for atomicRateLimitCheck",
+      );
+      return false;
+    }
+
+    try {
+      const keyvKey = `keyv:${key}`;
+      const now = Date.now();
+      const expiresAt = now + windowMs * 2;
+      // Keyv stores values as JSON: {"value": <actual>, "expires": <timestamp>}
+      // Our actual value is: {"count": N, "windowStart": T}
+      const newEntry = JSON.stringify({
+        value: { count: 1, windowStart: now },
+        expires: expiresAt,
+      });
+
+      const result = await db.execute<{
+        prev_value: string | null;
+        was_inserted: boolean;
+      }>(
+        sql`INSERT INTO keyv_cache (key, value)
+            VALUES (${keyvKey}, ${newEntry})
+            ON CONFLICT (key)
+            DO UPDATE SET value = (
+              CASE
+                -- If expired or window elapsed, start a new window
+                WHEN (keyv_cache.value::jsonb->'expires')::bigint <= ${now}
+                  OR ${now} - (keyv_cache.value::jsonb->'value'->>'windowStart')::bigint > ${windowMs}
+                THEN ${newEntry}::text
+                -- Otherwise increment the count
+                ELSE jsonb_set(
+                  jsonb_set(
+                    keyv_cache.value::jsonb,
+                    '{value,count}',
+                    to_jsonb(((keyv_cache.value::jsonb->'value'->>'count')::int + 1))
+                  ),
+                  '{expires}',
+                  to_jsonb(${expiresAt})
+                )::text
+              END
+            )
+            RETURNING
+              (xmax = 0) AS was_inserted,
+              CASE WHEN xmax != 0
+                THEN (
+                  SELECT old.value FROM keyv_cache old WHERE old.key = ${keyvKey}
+                )
+              END AS prev_value`,
+      );
+
+      if (result.rows.length === 0) {
+        return false;
+      }
+
+      const row = result.rows[0];
+
+      // If freshly inserted, this is the first request in a new window
+      if (row.was_inserted) {
+        return false;
+      }
+
+      // Parse the previous value to check if the limit was already reached
+      // The UPDATE already happened, so we check the pre-update count
+      if (row.prev_value) {
+        const parsed =
+          typeof row.prev_value === "string"
+            ? JSON.parse(row.prev_value)
+            : row.prev_value;
+        const prevCount: number = parsed?.value?.count ?? 0;
+        const prevWindowStart: number = parsed?.value?.windowStart ?? 0;
+        const prevExpires: number = parsed?.expires ?? 0;
+
+        // If the previous entry was expired or window elapsed, we reset (count=1)
+        if (prevExpires <= now || now - prevWindowStart > windowMs) {
+          return false;
+        }
+
+        // Rate limited if previous count was already at or above max
+        return prevCount >= maxRequests;
+      }
+
+      return false;
+    } catch (error) {
+      logger.error(
+        { error, key },
+        "CacheManager: Error in atomicRateLimitCheck, allowing request",
+      );
+      return false;
+    }
+  }
+
+  /**
    * Delete all entries with keys matching a prefix.
    * Useful for invalidating related cache entries (e.g., all chat models cache).
    *


### PR DESCRIPTION
## Summary

Fixes #3650 — rate limiting can be bypassed under concurrent requests due to non-atomic updates.

### Problem

The `isRateLimited` function used separate `cacheManager.get()` and `cacheManager.set()` calls, creating a classic TOCTOU race condition. Under concurrent requests, multiple handlers could read the same counter value before any of them incremented it, allowing more requests through than configured.

### Solution

Added `atomicRateLimitCheck()` to `CacheManager` that uses a single SQL `INSERT ... ON CONFLICT DO UPDATE` (upsert) to atomically:

1. **Insert** a new rate limit window if the key doesn't exist
2. **Reset** the window if the previous one has expired
3. **Increment** the counter if within an active window
4. **Return** the previous state to determine if the request should be blocked

All of this happens in one database round trip with no separate read step, eliminating the race condition entirely.

### Changes

- `cache-manager.ts` — new `atomicRateLimitCheck()` method using raw SQL upsert
- `agents/utils.ts` — `isRateLimited()` now delegates to the atomic method
- `agents/utils.test.ts` — updated mock to match the new interface

### Design Notes

- Follows the existing pattern in the codebase: `getAndDelete()` already uses raw SQL for atomicity
- The upsert handles window expiration inline, so no separate cleanup is needed
- TTL is set to 2x the window (same as before) for natural cleanup via Keyv
- On error, the method allows the request through (fail-open) consistent with existing cache behavior