### PR TITLE
feat: support explicit OAuth endpoints without discovery

### DIFF
--- a/.github/actions/build-platform-docker-image/action.yml
+++ b/.github/actions/build-platform-docker-image/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: "Version to pass as VERSION build arg"
     required: false
     default: ""
+  previous-image:
+    description: "Optional previously published platform image to extract static assets from before building"
+    required: false
+    default: ""
   # Secrets must be passed as regular inputs in composite actions
   turbo-team:
     description: "Turborepo remote caching team"
@@ -64,6 +68,29 @@ runs:
       run: mkdir -p "${INPUT_CONTEXT}/prev-static-assets"
       env:
         INPUT_CONTEXT: ${{ inputs.context }}
+
+    - name: Extract previous version static assets
+      if: ${{ inputs.previous-image != '' }}
+      shell: bash
+      run: |
+        echo "Pulling previous image: $INPUT_PREVIOUS_IMAGE"
+        docker pull "$INPUT_PREVIOUS_IMAGE" || {
+          echo "Warning: Failed to pull previous image"
+          exit 0
+        }
+
+        CID=$(docker create "$INPUT_PREVIOUS_IMAGE" 2>/dev/null) || true
+        if [ -n "$CID" ]; then
+          echo "Extracting previous static assets from container $CID"
+          docker cp "${CID}:/static-assets-source/." "${INPUT_CONTEXT}/prev-static-assets/" || echo "Warning: Failed to copy previous assets"
+          docker rm "$CID"
+          echo "Successfully extracted previous static assets"
+        else
+          echo "No previous container created, skipping asset extraction"
+        fi
+      env:
+        INPUT_CONTEXT: ${{ inputs.context }}
+        INPUT_PREVIOUS_IMAGE: ${{ inputs.previous-image }}
 
     - name: Setup Blacksmith Builder
       uses: ./.github/actions/setup-blacksmith-builder

--- a/.github/workflows/build-dockerhub-image.yml
+++ b/.github/workflows/build-dockerhub-image.yml
@@ -71,25 +71,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Extract previous version static assets
-        run: |
-          mkdir -p "${INPUT_IMAGE_DIRECTORY}/prev-static-assets"
-          PREV_IMAGE="docker.io/archestra/${INPUT_IMAGE_NAME}:latest" # supply-chain-policy: allow-latest internal release channel
-          echo "Pulling previous image: $PREV_IMAGE"
-          docker pull "$PREV_IMAGE" || { echo "Warning: Failed to pull previous image"; true; }
-          CID=$(docker create "$PREV_IMAGE" 2>/dev/null) || true
-          if [ -n "$CID" ]; then
-            echo "Extracting previous static assets from container $CID"
-            docker cp "${CID}:/static-assets-source/." "${INPUT_IMAGE_DIRECTORY}/prev-static-assets/" || echo "Warning: Failed to copy previous assets"
-            docker rm "$CID"
-            echo "Successfully extracted previous static assets"
-          else
-            echo "No previous container created, skipping asset extraction"
-          fi
-        env:
-          INPUT_IMAGE_DIRECTORY: ${{ inputs.image_directory }}
-          INPUT_IMAGE_NAME: ${{ inputs.image_name }}
-
       - name: Build Docker image
         id: build
         uses: ./.github/actions/build-platform-docker-image
@@ -98,6 +79,7 @@ jobs:
           push: ${{ inputs.push_image }}
           platforms: ${{ matrix.os_and_arch }}
           version: ${{ inputs.version }}
+          previous-image: docker.io/archestra/${{ inputs.image_name }}:latest
           outputs: type=image,name=docker.io/archestra/${{ inputs.image_name }},push-by-digest=true,name-canonical=true,push=${{ inputs.push_image }}
           turbo-team: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
           turbo-token: ${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}

--- a/.github/workflows/build-dockerhub-image.yml
+++ b/.github/workflows/build-dockerhub-image.yml
@@ -79,6 +79,7 @@ jobs:
           push: ${{ inputs.push_image }}
           platforms: ${{ matrix.os_and_arch }}
           version: ${{ inputs.version }}
+          # supply-chain-policy: allow-latest internal release channel
           previous-image: docker.io/archestra/${{ inputs.image_name }}:latest
           outputs: type=image,name=docker.io/archestra/${{ inputs.image_name }},push-by-digest=true,name-canonical=true,push=${{ inputs.push_image }}
           turbo-team: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}

--- a/.github/workflows/deploy-dev-platform-images.yml
+++ b/.github/workflows/deploy-dev-platform-images.yml
@@ -1,0 +1,101 @@
+name: Deploy Dev Platform Images
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version tag for the Docker images"
+        required: true
+        type: string
+    secrets:
+      DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_SERVICE_ACCOUNT_NAME:
+        required: false
+      DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER:
+        required: false
+      PLATFORM_NEXTJS_SOURCE_MAP_SENTRY_AUTH_TOKEN:
+        required: false
+      TURBOREPO_REMOTE_CACHING_TOKEN:
+        required: false
+      TURBOREPO_REMOTE_CACHING_TEAM:
+        required: false
+  workflow_dispatch:
+  pull_request:
+    types:
+      - labeled
+
+permissions: {}
+
+concurrency:
+  group: deploy-dev-platform-images-${{ github.event.pull_request.number || inputs.version || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-dev-platform-image:
+    name: Build Platform Dev Docker Image
+    permissions:
+      contents: read # Required to checkout the repository and build the platform image.
+      id-token: write # Required for Workload Identity Federation.
+    if: ${{ github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.label.name == 'deploy-dev-platform-images' && github.event.pull_request.head.repo.fork != true) }}
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Authenticate to Google Artifact Registry
+        uses: ./.github/actions/auth-to-gar
+        with:
+          service_account: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_SERVICE_ACCOUNT_NAME }}
+          workload_identity_provider: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER }}
+
+      - name: Install gke-gcloud-auth-plugin
+        run: gcloud components install gke-gcloud-auth-plugin
+
+      - name: Configure kubectl
+        run: |
+          gcloud container clusters get-credentials archestra-staging \
+            --zone us-central1-a --project friendly-path-465518-r6
+
+      - name: Resolve previous platform image
+        id: previous-platform-image
+        run: |
+          PREV_TAG=$(kubectl get deployment archestra-platform -n archestra \
+            -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null \
+            | cut -d: -f2) || true
+
+          if [ -n "$PREV_TAG" ] && [ "$PREV_TAG" != "$IMAGE_VERSION" ]; then
+            echo "previous-image=europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/platform:${PREV_TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "previous-image=" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          IMAGE_VERSION: ${{ inputs.version || github.sha }}
+
+      - name: Build Docker image
+        uses: ./.github/actions/build-platform-docker-image
+        with:
+          context: ./platform
+          push: "true"
+          platforms: linux/amd64
+          version: ${{ inputs.version || github.sha }}
+          previous-image: ${{ steps.previous-platform-image.outputs.previous-image }}
+          tags: europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/platform:${{ inputs.version || github.sha }}
+          turbo-team: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
+          turbo-token: ${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
+          sentry-auth-token: ${{ secrets.PLATFORM_NEXTJS_SOURCE_MAP_SENTRY_AUTH_TOKEN }}
+
+  publish-dev-mcp-server-base-image:
+    name: Build MCP Server Base Dev Image
+    if: ${{ github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.label.name == 'deploy-dev-platform-images' && github.event.pull_request.head.repo.fork != true) }}
+    uses: ./.github/workflows/build-base-mcp-server-docker-image.yml
+    permissions:
+      contents: read # Required to invoke the reusable MCP server base image workflow.
+      id-token: write # Required for Workload Identity Federation.
+    with:
+      push_to_gcr: true
+      version: ${{ inputs.version || github.sha }}
+    secrets:
+      GCP_SERVICE_ACCOUNT_NAME: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_SERVICE_ACCOUNT_NAME }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER }}

--- a/.github/workflows/on-commits-to-main.yml
+++ b/.github/workflows/on-commits-to-main.yml
@@ -16,93 +16,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-staging-image:
-    name: Build Platform Staging Docker Image
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+  deploy-dev-platform-images:
+    name: Build Platform Staging and MCP Server Base Images
+    uses: ./.github/workflows/deploy-dev-platform-images.yml
     permissions:
-      contents: read # Required to checkout the repository and build the staging image.
-      id-token: write # Required for Workload Identity Federation.
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          fetch-depth: 1
-
-      - name: Authenticate to Google Artifact Registry
-        uses: ./.github/actions/auth-to-gar
-        with:
-          service_account: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_SERVICE_ACCOUNT_NAME }}
-          workload_identity_provider: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER }}
-
-      - name: Install gke-gcloud-auth-plugin
-        run: gcloud components install gke-gcloud-auth-plugin
-
-      - name: Configure kubectl
-        run: |
-          gcloud container clusters get-credentials archestra-staging \
-            --zone us-central1-a --project friendly-path-465518-r6
-
-      - name: Extract previous version static assets
-        run: |
-          PREV_TAG=$(kubectl get deployment archestra-platform -n archestra \
-            -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null \
-            | cut -d: -f2) || true
-
-          mkdir -p platform/prev-static-assets
-          if [ -n "$PREV_TAG" ] && [ "$PREV_TAG" != "$GITHUB_SHA_VALUE" ]; then
-            PREV_IMAGE="europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/platform:${PREV_TAG}"
-            echo "Pulling previous image: $PREV_IMAGE"
-            docker pull "$PREV_IMAGE" || { echo "Warning: Failed to pull previous image"; true; }
-            CID=$(docker create "$PREV_IMAGE" 2>/dev/null) || true
-            if [ -n "$CID" ]; then
-              # Extract from /static-assets-source/ which has ONLY that build's chunks (not accumulated)
-              echo "Extracting previous static assets from container $CID"
-              docker cp "${CID}:/static-assets-source/." platform/prev-static-assets/ || echo "Warning: Failed to copy previous assets"
-              docker rm "$CID"
-              echo "Successfully extracted previous static assets"
-            else
-              echo "No previous container created, skipping asset extraction"
-            fi
-          else
-            echo "No previous version to extract (PREV_TAG: $PREV_TAG)"
-          fi
-        env:
-          GITHUB_SHA_VALUE: ${{ github.sha }}
-
-      # NOTE: only build on amd64 for now as our staging environment runs on amd64
-      # if we will need to support arm64, we should follow the pattern we do in
-      # .github/workflows/build-dockerhub-image.yml and do a matrix build so that we are build
-      # on both amd64 and arm64 using native arch (to massively speed up the builds)
-      - name: Build Docker image
-        uses: ./.github/actions/build-platform-docker-image
-        with:
-          context: ./platform
-          push: "true"
-          platforms: linux/amd64
-          version: ${{ github.sha }}
-          tags: europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/platform:${{ github.sha }}
-          turbo-team: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
-          turbo-token: ${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
-          sentry-auth-token: ${{ secrets.PLATFORM_NEXTJS_SOURCE_MAP_SENTRY_AUTH_TOKEN }}
-
-  build-mcp-server-base-image:
-    name: Build MCP Server Base Image
-    uses: ./.github/workflows/build-base-mcp-server-docker-image.yml
-    permissions:
-      contents: read # Required to invoke the reusable MCP server base image workflow.
+      contents: read # Required to invoke the reusable image publishing workflow.
       id-token: write # Required for Workload Identity Federation.
     with:
-      push_to_gcr: true
       version: ${{ github.sha }}
     secrets:
-      GCP_SERVICE_ACCOUNT_NAME: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_SERVICE_ACCOUNT_NAME }}
-      GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER }}
+      DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_SERVICE_ACCOUNT_NAME: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_SERVICE_ACCOUNT_NAME }}
+      DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER }}
+      PLATFORM_NEXTJS_SOURCE_MAP_SENTRY_AUTH_TOKEN: ${{ secrets.PLATFORM_NEXTJS_SOURCE_MAP_SENTRY_AUTH_TOKEN }}
+      TURBOREPO_REMOTE_CACHING_TOKEN: ${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
+      TURBOREPO_REMOTE_CACHING_TEAM: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
 
   deploy-to-staging:
     name: Deploy to staging
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    needs: [build-staging-image, build-mcp-server-base-image]
+    needs: [deploy-dev-platform-images]
     permissions:
       contents: read # Required to checkout the repository and deploy the chart.
       id-token: write # Required for Workload Identity Federation.

--- a/.github/workflows/pr-title-linter.yml
+++ b/.github/workflows/pr-title-linter.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - edited
       - reopened
+      - synchronize
   # This check can be required with merge queue enabled. The actual title lint
   # only needs PR metadata, but required checks must also post on merge_group.
   merge_group:

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Archestra",
-    "version": "1.2.9"
+    "version": "1.2.10"
   },
   "components": {
     "schemas": {
@@ -93829,6 +93829,9 @@
                           "auth_server_url": {
                             "type": "string"
                           },
+                          "authorization_endpoint": {
+                            "type": "string"
+                          },
                           "resource_metadata_url": {
                             "type": "string"
                           },
@@ -94675,6 +94678,9 @@
                       "auth_server_url": {
                         "type": "string"
                       },
+                      "authorization_endpoint": {
+                        "type": "string"
+                      },
                       "resource_metadata_url": {
                         "type": "string"
                       },
@@ -95252,6 +95258,9 @@
                           "type": "string"
                         },
                         "auth_server_url": {
+                          "type": "string"
+                        },
+                        "authorization_endpoint": {
                           "type": "string"
                         },
                         "resource_metadata_url": {
@@ -96124,6 +96133,9 @@
                         "auth_server_url": {
                           "type": "string"
                         },
+                        "authorization_endpoint": {
+                          "type": "string"
+                        },
                         "resource_metadata_url": {
                           "type": "string"
                         },
@@ -96964,6 +96976,9 @@
                       "auth_server_url": {
                         "type": "string"
                       },
+                      "authorization_endpoint": {
+                        "type": "string"
+                      },
                       "resource_metadata_url": {
                         "type": "string"
                       },
@@ -97549,6 +97564,9 @@
                           "type": "string"
                         },
                         "auth_server_url": {
+                          "type": "string"
+                        },
+                        "authorization_endpoint": {
                           "type": "string"
                         },
                         "resource_metadata_url": {
@@ -114781,6 +114799,9 @@
                                   "auth_server_url": {
                                     "type": "string"
                                   },
+                                  "authorization_endpoint": {
+                                    "type": "string"
+                                  },
                                   "resource_metadata_url": {
                                     "type": "string"
                                   },
@@ -115435,6 +115456,9 @@
                               "auth_server_url": {
                                 "type": "string"
                               },
+                              "authorization_endpoint": {
+                                "type": "string"
+                              },
                               "resource_metadata_url": {
                                 "type": "string"
                               },
@@ -115806,6 +115830,9 @@
                                   "type": "string"
                                 },
                                 "auth_server_url": {
+                                  "type": "string"
+                                },
+                                "authorization_endpoint": {
                                   "type": "string"
                                 },
                                 "resource_metadata_url": {
@@ -116492,6 +116519,9 @@
                                 "auth_server_url": {
                                   "type": "string"
                                 },
+                                "authorization_endpoint": {
+                                  "type": "string"
+                                },
                                 "resource_metadata_url": {
                                   "type": "string"
                                 },
@@ -117149,6 +117179,9 @@
                               "auth_server_url": {
                                 "type": "string"
                               },
+                              "authorization_endpoint": {
+                                "type": "string"
+                              },
                               "resource_metadata_url": {
                                 "type": "string"
                               },
@@ -117571,6 +117604,9 @@
                                   "type": "string"
                                 },
                                 "auth_server_url": {
+                                  "type": "string"
+                                },
+                                "authorization_endpoint": {
                                   "type": "string"
                                 },
                                 "resource_metadata_url": {
@@ -118528,6 +118564,9 @@
                                 "auth_server_url": {
                                   "type": "string"
                                 },
+                                "authorization_endpoint": {
+                                  "type": "string"
+                                },
                                 "resource_metadata_url": {
                                   "type": "string"
                                 },
@@ -119225,6 +119264,9 @@
                                   "type": "string"
                                 },
                                 "auth_server_url": {
+                                  "type": "string"
+                                },
+                                "authorization_endpoint": {
                                   "type": "string"
                                 },
                                 "resource_metadata_url": {
@@ -119928,6 +119970,9 @@
                                   "type": "string"
                                 },
                                 "auth_server_url": {
+                                  "type": "string"
+                                },
+                                "authorization_endpoint": {
                                   "type": "string"
                                 },
                                 "resource_metadata_url": {

--- a/docs/pages/mcp-authentication.md
+++ b/docs/pages/mcp-authentication.md
@@ -332,7 +332,9 @@ Your server (or its OAuth provider) needs to expose two things:
 
 Archestra handles everything else: endpoint discovery, client registration, the authorization code flow with PKCE, token storage, and automatic refresh when tokens expire.
 
-If the MCP server URL is different from the OAuth issuer or metadata host, configure explicit OAuth discovery overrides in the MCP catalog item. Archestra can use a separate authorization server URL, a direct well-known metadata URL, and a direct resource metadata URL instead of deriving discovery from the MCP server URL.
+If the MCP server URL is different from the OAuth issuer or metadata host, configure explicit OAuth overrides in the MCP catalog item. Archestra can use a separate authorization server URL, a direct well-known metadata URL, a direct resource metadata URL, or direct authorization and token endpoints instead of deriving everything from the MCP server URL.
+
+Direct authorization and token endpoints are useful for legacy or self-hosted OAuth providers that expose fixed OAuth URLs but do not publish any `/.well-known` metadata.
 
 Your server receives an `Authorization: Bearer <access_token>` header with each request from the gateway.
 

--- a/docs/pages/mcp-authentication.md
+++ b/docs/pages/mcp-authentication.md
@@ -334,7 +334,7 @@ Archestra handles everything else: endpoint discovery, client registration, the 
 
 If the MCP server URL is different from the OAuth issuer or metadata host, configure explicit OAuth overrides in the MCP catalog item. Archestra can use a separate authorization server URL, a direct well-known metadata URL, a direct resource metadata URL, or direct authorization and token endpoints instead of deriving everything from the MCP server URL.
 
-Direct authorization and token endpoints are useful for legacy or self-hosted OAuth providers that expose fixed OAuth URLs but do not publish any `/.well-known` metadata.
+Direct authorization and token endpoints act as explicit overrides when configured, and are useful for legacy or self-hosted OAuth providers that expose fixed OAuth URLs but do not publish any `/.well-known` metadata.
 
 Your server receives an `Authorization: Bearer <access_token>` header with each request from the gateway.
 

--- a/platform/backend/src/routes/oauth.test.ts
+++ b/platform/backend/src/routes/oauth.test.ts
@@ -327,5 +327,52 @@ describe("OAuth helper functions", () => {
 
       globalThis.fetch = originalFetch;
     });
+
+    test("falls back to explicit endpoints when discovery fails", async () => {
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error("404")) as Mock;
+
+      const endpoints = await discoverOAuthEndpoints({
+        server_url: "https://legacy-idp.example.com/mcp",
+        supports_resource_metadata: false,
+        authorization_endpoint:
+          "https://legacy-idp.example.com/oauth/authorize",
+        token_endpoint: "https://legacy-idp.example.com/oauth/token",
+      });
+
+      expect(endpoints).toEqual({
+        authorizationEndpoint: "https://legacy-idp.example.com/oauth/authorize",
+        tokenEndpoint: "https://legacy-idp.example.com/oauth/token",
+        registrationEndpoint: undefined,
+      });
+
+      globalThis.fetch = originalFetch;
+    });
+
+    test("prefers explicit endpoints over discovered metadata", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          authorization_endpoint: "https://auth.example.com/authorize",
+          token_endpoint: "https://auth.example.com/token",
+          registration_endpoint: "https://auth.example.com/register",
+        }),
+      }) as Mock;
+
+      const endpoints = await discoverOAuthEndpoints({
+        server_url: "https://mcp.example.com",
+        supports_resource_metadata: false,
+        authorization_endpoint:
+          "https://legacy-idp.example.com/oauth/authorize",
+        token_endpoint: "https://legacy-idp.example.com/oauth/token",
+      });
+
+      expect(endpoints).toEqual({
+        authorizationEndpoint: "https://legacy-idp.example.com/oauth/authorize",
+        tokenEndpoint: "https://legacy-idp.example.com/oauth/token",
+        registrationEndpoint: "https://auth.example.com/register",
+      });
+
+      globalThis.fetch = originalFetch;
+    });
   });
 });

--- a/platform/backend/src/routes/oauth.test.ts
+++ b/platform/backend/src/routes/oauth.test.ts
@@ -348,6 +348,21 @@ describe("OAuth helper functions", () => {
       globalThis.fetch = originalFetch;
     });
 
+    test("throws when discovery fails and only one explicit endpoint is configured", async () => {
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error("404")) as Mock;
+
+      await expect(
+        discoverOAuthEndpoints({
+          server_url: "https://legacy-idp.example.com/mcp",
+          supports_resource_metadata: false,
+          authorization_endpoint:
+            "https://legacy-idp.example.com/oauth/authorize",
+        }),
+      ).rejects.toThrow("404");
+
+      globalThis.fetch = originalFetch;
+    });
+
     test("prefers explicit endpoints over discovered metadata", async () => {
       globalThis.fetch = vi.fn().mockResolvedValue({
         ok: true,

--- a/platform/backend/src/routes/oauth.ts
+++ b/platform/backend/src/routes/oauth.ts
@@ -293,6 +293,23 @@ export async function discoverOAuthEndpoints(
         wellKnownUrl: oauthConfig.well_known_url,
       },
     );
+    if (
+      (explicitEndpoints.authorizationEndpoint &&
+        explicitEndpoints.authorizationEndpoint !==
+          metadata.authorization_endpoint) ||
+      (explicitEndpoints.tokenEndpoint &&
+        explicitEndpoints.tokenEndpoint !== metadata.token_endpoint)
+    ) {
+      log?.warn(
+        {
+          discoveredAuthorizationEndpoint: metadata.authorization_endpoint,
+          discoveredTokenEndpoint: metadata.token_endpoint,
+          authorizationEndpoint: explicitEndpoints.authorizationEndpoint,
+          tokenEndpoint: explicitEndpoints.tokenEndpoint,
+        },
+        "Using explicitly configured OAuth endpoint overrides instead of discovered metadata",
+      );
+    }
     log?.info(
       {
         authorizationEndpoint:
@@ -717,16 +734,7 @@ const oauthRoutes: FastifyPluginAsyncZod = async (fastify) => {
           registrationEndpoint = endpoints.registrationEndpoint;
         } catch (error) {
           fastify.log.error({ error }, "Authorization server discovery failed");
-          if (oauthConfig.authorization_endpoint) {
-            authorizationEndpoint = oauthConfig.authorization_endpoint;
-            registrationEndpoint = undefined;
-            fastify.log.warn(
-              { authorizationEndpoint },
-              "Using explicitly configured authorization endpoint after discovery failure",
-            );
-          } else {
-            throw new ApiError(500, "Failed to discover OAuth endpoints");
-          }
+          throw new ApiError(500, "Failed to discover OAuth endpoints");
         }
       }
 

--- a/platform/backend/src/routes/oauth.ts
+++ b/platform/backend/src/routes/oauth.ts
@@ -221,6 +221,11 @@ interface DiscoveredEndpoints {
   registrationEndpoint?: string;
 }
 
+interface ExplicitOAuthEndpoints {
+  authorizationEndpoint?: string;
+  tokenEndpoint?: string;
+}
+
 /**
  * Discover OAuth endpoints via resource metadata → auth server metadata chain.
  * Shared by the initiate, callback, and refresh flows to avoid duplicated discovery logic.
@@ -230,14 +235,17 @@ export async function discoverOAuthEndpoints(
     server_url: string;
     supports_resource_metadata: boolean;
     auth_server_url?: string;
+    authorization_endpoint?: string;
     resource_metadata_url?: string;
     well_known_url?: string;
+    token_endpoint?: string;
   },
   log?: {
     info: (...args: unknown[]) => void;
     warn: (...args: unknown[]) => void;
   },
 ): Promise<DiscoveredEndpoints> {
+  const explicitEndpoints = getExplicitOAuthEndpoints(oauthConfig);
   let discoveryServerUrl =
     oauthConfig.auth_server_url || oauthConfig.server_url;
   const shouldDiscoverResourceMetadata =
@@ -276,28 +284,55 @@ export async function discoverOAuthEndpoints(
     }
   }
 
-  const metadata = await discoverAuthorizationServerMetadataWithOverrides(
-    discoveryServerUrl,
-    {
-      authServerUrl: oauthConfig.auth_server_url,
-      resourceMetadataUrl: oauthConfig.resource_metadata_url,
-      wellKnownUrl: oauthConfig.well_known_url,
-    },
-  );
-  log?.info(
-    {
-      authorizationEndpoint: metadata.authorization_endpoint,
-      tokenEndpoint: metadata.token_endpoint,
-      registrationEndpoint: metadata.registration_endpoint,
-    },
-    "Discovery successful",
-  );
+  try {
+    const metadata = await discoverAuthorizationServerMetadataWithOverrides(
+      discoveryServerUrl,
+      {
+        authServerUrl: oauthConfig.auth_server_url,
+        resourceMetadataUrl: oauthConfig.resource_metadata_url,
+        wellKnownUrl: oauthConfig.well_known_url,
+      },
+    );
+    log?.info(
+      {
+        authorizationEndpoint:
+          explicitEndpoints.authorizationEndpoint ??
+          metadata.authorization_endpoint,
+        tokenEndpoint:
+          explicitEndpoints.tokenEndpoint ?? metadata.token_endpoint,
+        registrationEndpoint: metadata.registration_endpoint,
+      },
+      "Discovery successful",
+    );
 
-  return {
-    authorizationEndpoint: metadata.authorization_endpoint,
-    tokenEndpoint: metadata.token_endpoint,
-    registrationEndpoint: metadata.registration_endpoint,
-  };
+    return {
+      authorizationEndpoint:
+        explicitEndpoints.authorizationEndpoint ??
+        metadata.authorization_endpoint,
+      tokenEndpoint: explicitEndpoints.tokenEndpoint ?? metadata.token_endpoint,
+      registrationEndpoint: metadata.registration_endpoint,
+    };
+  } catch (error) {
+    if (
+      explicitEndpoints.authorizationEndpoint &&
+      explicitEndpoints.tokenEndpoint
+    ) {
+      log?.warn(
+        {
+          error,
+          authorizationEndpoint: explicitEndpoints.authorizationEndpoint,
+          tokenEndpoint: explicitEndpoints.tokenEndpoint,
+        },
+        "Authorization server discovery failed; using explicitly configured OAuth endpoints",
+      );
+      return {
+        authorizationEndpoint: explicitEndpoints.authorizationEndpoint,
+        tokenEndpoint: explicitEndpoints.tokenEndpoint,
+      };
+    }
+
+    throw error;
+  }
 }
 
 /**
@@ -682,7 +717,16 @@ const oauthRoutes: FastifyPluginAsyncZod = async (fastify) => {
           registrationEndpoint = endpoints.registrationEndpoint;
         } catch (error) {
           fastify.log.error({ error }, "Authorization server discovery failed");
-          throw new ApiError(500, "Failed to discover OAuth endpoints");
+          if (oauthConfig.authorization_endpoint) {
+            authorizationEndpoint = oauthConfig.authorization_endpoint;
+            registrationEndpoint = undefined;
+            fastify.log.warn(
+              { authorizationEndpoint },
+              "Using explicitly configured authorization endpoint after discovery failure",
+            );
+          } else {
+            throw new ApiError(500, "Failed to discover OAuth endpoints");
+          }
         }
       }
 
@@ -990,5 +1034,15 @@ const oauthRoutes: FastifyPluginAsyncZod = async (fastify) => {
     },
   );
 };
+
+function getExplicitOAuthEndpoints(oauthConfig: {
+  authorization_endpoint?: string;
+  token_endpoint?: string;
+}): ExplicitOAuthEndpoints {
+  return {
+    authorizationEndpoint: oauthConfig.authorization_endpoint,
+    tokenEndpoint: oauthConfig.token_endpoint,
+  };
+}
 
 export default oauthRoutes;

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.test.ts
@@ -299,6 +299,28 @@ describe("formSchema", () => {
       expect(formSchema.parse(data)).toEqual(data);
     });
 
+    it("should reject OAuth config when only one explicit endpoint is set", () => {
+      const data = {
+        ...baseValidData,
+        authMethod: "oauth" as const,
+        serverType: "remote" as const,
+        serverUrl: "https://api.example.com/mcp",
+        oauthConfig: {
+          client_id: "test-client-id",
+          client_secret: "test-secret",
+          redirect_uris: "https://localhost:3000/oauth-callback",
+          scopes: "read,write",
+          supports_resource_metadata: true,
+          authorizationEndpoint: "https://auth.example.com/oauth/authorize",
+        },
+        localConfig: undefined,
+      };
+
+      expect(() => formSchema.parse(data)).toThrow(
+        "Authorization and token endpoints must be set together",
+      );
+    });
+
     it("should reject OAuth config with empty redirect_uris", () => {
       const data = {
         ...baseValidData,

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -1064,6 +1064,7 @@ export function McpCatalogForm({
                         <FormDescription>
                           Optional direct authorization endpoint override for
                           providers that do not publish well-known metadata.
+                          Set together with Token Endpoint.
                         </FormDescription>
                         <FormMessage />
                       </FormItem>
@@ -1130,6 +1131,7 @@ export function McpCatalogForm({
                         <FormDescription>
                           Optional direct token endpoint override for providers
                           that use fixed OAuth endpoints instead of discovery.
+                          Set together with Authorization Endpoint.
                         </FormDescription>
                         <FormMessage />
                       </FormItem>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -1063,8 +1063,8 @@ export function McpCatalogForm({
                         </FormControl>
                         <FormDescription>
                           Optional direct authorization endpoint override for
-                          providers that do not publish well-known metadata.
-                          Set together with Token Endpoint.
+                          providers that do not publish well-known metadata. Set
+                          together with Token Endpoint.
                         </FormDescription>
                         <FormMessage />
                       </FormItem>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -1062,9 +1062,9 @@ export function McpCatalogForm({
                           />
                         </FormControl>
                         <FormDescription>
-                          Optional direct authorization endpoint override for
-                          providers that do not publish well-known metadata. Set
-                          together with Token Endpoint.
+                          Optional direct authorization endpoint override.
+                          When set, it overrides discovery. Set together with
+                          Token Endpoint.
                         </FormDescription>
                         <FormMessage />
                       </FormItem>
@@ -1129,9 +1129,9 @@ export function McpCatalogForm({
                           />
                         </FormControl>
                         <FormDescription>
-                          Optional direct token endpoint override for providers
-                          that use fixed OAuth endpoints instead of discovery.
-                          Set together with Authorization Endpoint.
+                          Optional direct token endpoint override. When set, it
+                          overrides discovery. Set together with Authorization
+                          Endpoint.
                         </FormDescription>
                         <FormMessage />
                       </FormItem>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -1062,9 +1062,9 @@ export function McpCatalogForm({
                           />
                         </FormControl>
                         <FormDescription>
-                          Optional direct authorization endpoint override.
-                          When set, it overrides discovery. Set together with
-                          Token Endpoint.
+                          Optional direct authorization endpoint override. When
+                          set, it overrides discovery. Set together with Token
+                          Endpoint.
                         </FormDescription>
                         <FormMessage />
                       </FormItem>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -151,8 +151,10 @@ export function McpCatalogForm({
             scopes: "read, write",
             supports_resource_metadata: true,
             authServerUrl: "",
+            authorizationEndpoint: "",
             wellKnownUrl: "",
             resourceMetadataUrl: "",
+            tokenEndpoint: "",
           },
           localConfig: {
             command: "",
@@ -1048,6 +1050,28 @@ export function McpCatalogForm({
 
                   <FormField
                     control={form.control}
+                    name="oauthConfig.authorizationEndpoint"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Authorization Endpoint</FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder="https://auth.example.com/oauth/authorize"
+                            className="font-mono"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          Optional direct authorization endpoint override for
+                          providers that do not publish well-known metadata.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
                     name="oauthConfig.wellKnownUrl"
                     render={({ field }) => (
                       <FormItem>
@@ -1084,6 +1108,28 @@ export function McpCatalogForm({
                         <FormDescription>
                           Optional override for OAuth protected resource
                           metadata discovery.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="oauthConfig.tokenEndpoint"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Token Endpoint</FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder="https://auth.example.com/oauth/token"
+                            className="font-mono"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          Optional direct token endpoint override for providers
+                          that use fixed OAuth endpoints instead of discovery.
                         </FormDescription>
                         <FormMessage />
                       </FormItem>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.types.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.types.ts
@@ -80,8 +80,7 @@ export const oauthConfigSchema = z
   })
   .superRefine((value, ctx) => {
     if (Boolean(value.authorizationEndpoint) !== Boolean(value.tokenEndpoint)) {
-      const message =
-        "Authorization and token endpoints must be set together";
+      const message = "Authorization and token endpoints must be set together";
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message,

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.types.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.types.ts
@@ -16,6 +16,14 @@ export const oauthConfigSchema = z.object({
     })
     .optional()
     .or(z.literal("")),
+  authorizationEndpoint: z
+    .string()
+    .url({ error: "Must be a valid URL" })
+    .refine((val) => val.startsWith("http://") || val.startsWith("https://"), {
+      message: "Must be an HTTP or HTTPS URL",
+    })
+    .optional()
+    .or(z.literal("")),
   wellKnownUrl: z
     .string()
     .url({ error: "Must be a valid URL" })
@@ -25,6 +33,14 @@ export const oauthConfigSchema = z.object({
     .optional()
     .or(z.literal("")),
   resourceMetadataUrl: z
+    .string()
+    .url({ error: "Must be a valid URL" })
+    .refine((val) => val.startsWith("http://") || val.startsWith("https://"), {
+      message: "Must be an HTTP or HTTPS URL",
+    })
+    .optional()
+    .or(z.literal("")),
+  tokenEndpoint: z
     .string()
     .url({ error: "Must be a valid URL" })
     .refine((val) => val.startsWith("http://") || val.startsWith("https://"), {

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.types.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.types.ts
@@ -2,63 +2,98 @@ import { LocalConfigFormSchema } from "@shared";
 import { z } from "zod";
 
 // Simplified OAuth config schema
-export const oauthConfigSchema = z.object({
-  client_id: z.string().optional().or(z.literal("")),
-  client_secret: z.string().optional().or(z.literal("")),
-  redirect_uris: z.string().min(1, "At least one redirect URI is required"),
-  scopes: z.string().optional().or(z.literal("")),
-  supports_resource_metadata: z.boolean(),
-  authServerUrl: z
-    .string()
-    .url({ error: "Must be a valid URL" })
-    .refine((val) => val.startsWith("http://") || val.startsWith("https://"), {
-      message: "Must be an HTTP or HTTPS URL",
-    })
-    .optional()
-    .or(z.literal("")),
-  authorizationEndpoint: z
-    .string()
-    .url({ error: "Must be a valid URL" })
-    .refine((val) => val.startsWith("http://") || val.startsWith("https://"), {
-      message: "Must be an HTTP or HTTPS URL",
-    })
-    .optional()
-    .or(z.literal("")),
-  wellKnownUrl: z
-    .string()
-    .url({ error: "Must be a valid URL" })
-    .refine((val) => val.startsWith("http://") || val.startsWith("https://"), {
-      message: "Must be an HTTP or HTTPS URL",
-    })
-    .optional()
-    .or(z.literal("")),
-  resourceMetadataUrl: z
-    .string()
-    .url({ error: "Must be a valid URL" })
-    .refine((val) => val.startsWith("http://") || val.startsWith("https://"), {
-      message: "Must be an HTTP or HTTPS URL",
-    })
-    .optional()
-    .or(z.literal("")),
-  tokenEndpoint: z
-    .string()
-    .url({ error: "Must be a valid URL" })
-    .refine((val) => val.startsWith("http://") || val.startsWith("https://"), {
-      message: "Must be an HTTP or HTTPS URL",
-    })
-    .optional()
-    .or(z.literal("")),
-  // OAuth Server URL for local servers (since they don't have a serverUrl field)
-  // Used for OAuth discovery/authorization, NOT for tool execution
-  oauthServerUrl: z
-    .string()
-    .url({ error: "Must be a valid URL" })
-    .refine((val) => val.startsWith("http://") || val.startsWith("https://"), {
-      message: "Must be an HTTP or HTTPS URL",
-    })
-    .optional()
-    .or(z.literal("")),
-});
+export const oauthConfigSchema = z
+  .object({
+    client_id: z.string().optional().or(z.literal("")),
+    client_secret: z.string().optional().or(z.literal("")),
+    redirect_uris: z.string().min(1, "At least one redirect URI is required"),
+    scopes: z.string().optional().or(z.literal("")),
+    supports_resource_metadata: z.boolean(),
+    authServerUrl: z
+      .string()
+      .url({ error: "Must be a valid URL" })
+      .refine(
+        (val) => val.startsWith("http://") || val.startsWith("https://"),
+        {
+          message: "Must be an HTTP or HTTPS URL",
+        },
+      )
+      .optional()
+      .or(z.literal("")),
+    authorizationEndpoint: z
+      .string()
+      .url({ error: "Must be a valid URL" })
+      .refine(
+        (val) => val.startsWith("http://") || val.startsWith("https://"),
+        {
+          message: "Must be an HTTP or HTTPS URL",
+        },
+      )
+      .optional()
+      .or(z.literal("")),
+    wellKnownUrl: z
+      .string()
+      .url({ error: "Must be a valid URL" })
+      .refine(
+        (val) => val.startsWith("http://") || val.startsWith("https://"),
+        {
+          message: "Must be an HTTP or HTTPS URL",
+        },
+      )
+      .optional()
+      .or(z.literal("")),
+    resourceMetadataUrl: z
+      .string()
+      .url({ error: "Must be a valid URL" })
+      .refine(
+        (val) => val.startsWith("http://") || val.startsWith("https://"),
+        {
+          message: "Must be an HTTP or HTTPS URL",
+        },
+      )
+      .optional()
+      .or(z.literal("")),
+    tokenEndpoint: z
+      .string()
+      .url({ error: "Must be a valid URL" })
+      .refine(
+        (val) => val.startsWith("http://") || val.startsWith("https://"),
+        {
+          message: "Must be an HTTP or HTTPS URL",
+        },
+      )
+      .optional()
+      .or(z.literal("")),
+    // OAuth Server URL for local servers (since they don't have a serverUrl field)
+    // Used for OAuth discovery/authorization, NOT for tool execution
+    oauthServerUrl: z
+      .string()
+      .url({ error: "Must be a valid URL" })
+      .refine(
+        (val) => val.startsWith("http://") || val.startsWith("https://"),
+        {
+          message: "Must be an HTTP or HTTPS URL",
+        },
+      )
+      .optional()
+      .or(z.literal("")),
+  })
+  .superRefine((value, ctx) => {
+    if (Boolean(value.authorizationEndpoint) !== Boolean(value.tokenEndpoint)) {
+      const message =
+        "Authorization and token endpoints must be set together";
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message,
+        path: ["authorizationEndpoint"],
+      });
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message,
+        path: ["tokenEndpoint"],
+      });
+    }
+  });
 
 const enterpriseManagedConfigSchema = z.object({
   resourceIdentifier: z.string().optional(),

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
@@ -1,10 +1,14 @@
 import type { McpCatalogFormValues } from "./mcp-catalog-form.types";
-import { transformFormToApiData } from "./mcp-catalog-form.utils";
+import {
+  transformCatalogItemToFormValues,
+  transformExternalCatalogToFormValues,
+  transformFormToApiData,
+} from "./mcp-catalog-form.utils";
 
 describe("transformFormToApiData", () => {
   it("includes OAuth discovery overrides in the API payload", () => {
     const values: McpCatalogFormValues = {
-      name: "Jira MCP",
+      name: "Direct OAuth MCP",
       description: "",
       icon: null,
       serverType: "local",
@@ -18,10 +22,12 @@ describe("transformFormToApiData", () => {
         supports_resource_metadata: true,
         oauthServerUrl: "https://mcp.example.com",
         authServerUrl: "https://auth.example.com",
+        authorizationEndpoint: "https://legacy-idp.example.com/oauth/authorize",
         wellKnownUrl:
           "https://auth.example.com/.well-known/openid-configuration",
         resourceMetadataUrl:
           "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+        tokenEndpoint: "https://legacy-idp.example.com/oauth/token",
       },
       enterpriseManagedConfig: null,
       localConfig: {
@@ -50,16 +56,18 @@ describe("transformFormToApiData", () => {
     expect(transformFormToApiData(values).oauthConfig).toMatchObject({
       server_url: "https://mcp.example.com",
       auth_server_url: "https://auth.example.com",
+      authorization_endpoint: "https://legacy-idp.example.com/oauth/authorize",
       well_known_url:
         "https://auth.example.com/.well-known/openid-configuration",
       resource_metadata_url:
         "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+      token_endpoint: "https://legacy-idp.example.com/oauth/token",
     });
   });
 
   it("uses the remote server URL as the OAuth server URL for remote servers", () => {
     const values: McpCatalogFormValues = {
-      name: "Remote Jira MCP",
+      name: "Remote Direct OAuth MCP",
       description: "",
       icon: null,
       serverType: "remote",
@@ -73,10 +81,12 @@ describe("transformFormToApiData", () => {
         supports_resource_metadata: true,
         oauthServerUrl: "",
         authServerUrl: "https://auth.example.com",
+        authorizationEndpoint: "https://legacy-idp.example.com/oauth/authorize",
         wellKnownUrl:
           "https://auth.example.com/.well-known/openid-configuration",
         resourceMetadataUrl:
           "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+        tokenEndpoint: "https://legacy-idp.example.com/oauth/token",
       },
       enterpriseManagedConfig: null,
       localConfig: undefined,
@@ -94,10 +104,93 @@ describe("transformFormToApiData", () => {
     expect(transformFormToApiData(values).oauthConfig).toMatchObject({
       server_url: "https://mcp.example.com",
       auth_server_url: "https://auth.example.com",
+      authorization_endpoint: "https://legacy-idp.example.com/oauth/authorize",
       well_known_url:
         "https://auth.example.com/.well-known/openid-configuration",
       resource_metadata_url:
         "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+      token_endpoint: "https://legacy-idp.example.com/oauth/token",
     });
+  });
+
+  it("hydrates explicit OAuth endpoints from internal catalog items", () => {
+    const values = transformCatalogItemToFormValues({
+      id: "catalog-1",
+      name: "Direct OAuth MCP",
+      description: "",
+      icon: null,
+      serverType: "remote",
+      serverUrl: "https://mcp.example.com",
+      oauthConfig: {
+        client_id: "client-id",
+        client_secret: "client-secret",
+        redirect_uris: ["https://app.example.com/oauth-callback"],
+        scopes: ["read"],
+        default_scopes: ["read", "write"],
+        supports_resource_metadata: false,
+        server_url: "https://mcp.example.com",
+        auth_server_url: "https://auth.example.com",
+        authorization_endpoint:
+          "https://legacy-idp.example.com/oauth/authorize",
+        well_known_url:
+          "https://auth.example.com/.well-known/openid-configuration",
+        resource_metadata_url:
+          "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+        token_endpoint: "https://legacy-idp.example.com/oauth/token",
+        name: "Direct OAuth MCP",
+      },
+      enterpriseManagedConfig: null,
+      localConfig: null,
+      deploymentSpecYaml: null,
+      userConfig: {},
+      scope: "personal",
+      teams: [],
+      labels: [],
+    } as never);
+
+    expect(values.oauthConfig?.authorizationEndpoint).toBe(
+      "https://legacy-idp.example.com/oauth/authorize",
+    );
+    expect(values.oauthConfig?.tokenEndpoint).toBe(
+      "https://legacy-idp.example.com/oauth/token",
+    );
+  });
+
+  it("hydrates explicit OAuth endpoints from external catalog manifests", () => {
+    const values = transformExternalCatalogToFormValues({
+      name: "direct-oauth-mcp",
+      display_name: "Direct OAuth MCP",
+      description: "",
+      icon: null,
+      server: {
+        type: "remote",
+        url: "https://mcp.example.com",
+      },
+      oauth_config: {
+        client_id: "client-id",
+        client_secret: "client-secret",
+        redirect_uris: ["https://app.example.com/oauth-callback"],
+        scopes: ["read"],
+        default_scopes: ["read", "write"],
+        supports_resource_metadata: false,
+        server_url: "https://mcp.example.com",
+        auth_server_url: "https://auth.example.com",
+        authorization_endpoint:
+          "https://legacy-idp.example.com/oauth/authorize",
+        well_known_url:
+          "https://auth.example.com/.well-known/openid-configuration",
+        resource_metadata_url:
+          "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+        token_endpoint: "https://legacy-idp.example.com/oauth/token",
+        name: "Direct OAuth MCP",
+      },
+    } as never);
+
+    expect(values.oauthConfig?.authorizationEndpoint).toBe(
+      "https://legacy-idp.example.com/oauth/authorize",
+    );
+    expect(values.oauthConfig?.tokenEndpoint).toBe(
+      "https://legacy-idp.example.com/oauth/token",
+    );
   });
 });

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
@@ -438,7 +438,11 @@ export function transformExternalCatalogToFormValues(
       supports_resource_metadata:
         server.oauth_config.supports_resource_metadata ?? true,
       authServerUrl: server.oauth_config.auth_server_url || "",
-      authorizationEndpoint: server.oauth_config.authorization_endpoint || "",
+      authorizationEndpoint:
+        getOptionalStringProperty(
+          server.oauth_config,
+          "authorization_endpoint",
+        ) || "",
       wellKnownUrl: server.oauth_config.well_known_url || "",
       resourceMetadataUrl: server.oauth_config.resource_metadata_url || "",
       tokenEndpoint: server.oauth_config.token_endpoint || "",
@@ -602,6 +606,18 @@ export function transformExternalCatalogToFormValues(
     scope: "personal",
     teams: [],
   } as McpCatalogFormValues;
+}
+
+function getOptionalStringProperty(
+  value: unknown,
+  key: string,
+): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  const propertyValue = (value as Record<string, unknown>)[key];
+  return typeof propertyValue === "string" ? propertyValue : undefined;
 }
 
 /**

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
@@ -94,9 +94,12 @@ export function transformFormToApiData(
       name: values.name, // Use name as OAuth provider name
       server_url: oauthServerUrl, // OAuth server URL for discovery/authorization
       auth_server_url: values.oauthConfig.authServerUrl || undefined,
+      authorization_endpoint:
+        values.oauthConfig.authorizationEndpoint || undefined,
       well_known_url: values.oauthConfig.wellKnownUrl || undefined,
       resource_metadata_url:
         values.oauthConfig.resourceMetadataUrl || undefined,
+      token_endpoint: values.oauthConfig.tokenEndpoint || undefined,
       client_id: values.oauthConfig.client_id || "",
       // Only include client_secret if no BYOS vault path is set
       client_secret: values.oauthClientSecretVaultPath
@@ -225,8 +228,10 @@ export function transformCatalogItemToFormValues(
         scopes: string;
         supports_resource_metadata: boolean;
         authServerUrl?: string;
+        authorizationEndpoint?: string;
         wellKnownUrl?: string;
         resourceMetadataUrl?: string;
+        tokenEndpoint?: string;
         oauthServerUrl?: string;
       }
     | undefined;
@@ -242,8 +247,10 @@ export function transformCatalogItemToFormValues(
       supports_resource_metadata:
         item.oauthConfig.supports_resource_metadata ?? true,
       authServerUrl: item.oauthConfig.auth_server_url || "",
+      authorizationEndpoint: item.oauthConfig.authorization_endpoint || "",
       wellKnownUrl: item.oauthConfig.well_known_url || "",
       resourceMetadataUrl: item.oauthConfig.resource_metadata_url || "",
+      tokenEndpoint: item.oauthConfig.token_endpoint || "",
       // For local servers, populate oauthServerUrl from server_url
       oauthServerUrl:
         item.serverType === "local"
@@ -431,8 +438,10 @@ export function transformExternalCatalogToFormValues(
       supports_resource_metadata:
         server.oauth_config.supports_resource_metadata ?? true,
       authServerUrl: server.oauth_config.auth_server_url || "",
+      authorizationEndpoint: server.oauth_config.authorization_endpoint || "",
       wellKnownUrl: server.oauth_config.well_known_url || "",
       resourceMetadataUrl: server.oauth_config.resource_metadata_url || "",
+      tokenEndpoint: server.oauth_config.token_endpoint || "",
       oauthServerUrl:
         server.server.type === "local"
           ? server.oauth_config.server_url || ""
@@ -573,8 +582,10 @@ export function transformExternalCatalogToFormValues(
       scopes: "read, write",
       supports_resource_metadata: true,
       authServerUrl: "",
+      authorizationEndpoint: "",
       wellKnownUrl: "",
       resourceMetadataUrl: "",
+      tokenEndpoint: "",
     },
     localConfig: localConfig ?? {
       command: "",

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -24808,6 +24808,7 @@ export type GetInternalMcpCatalogResponses = {
             name: string;
             server_url: string;
             auth_server_url?: string;
+            authorization_endpoint?: string;
             resource_metadata_url?: string;
             client_id: string;
             client_secret?: string;
@@ -24939,6 +24940,7 @@ export type CreateInternalMcpCatalogItemData = {
             name: string;
             server_url: string;
             auth_server_url?: string;
+            authorization_endpoint?: string;
             resource_metadata_url?: string;
             client_id: string;
             client_secret?: string;
@@ -25129,6 +25131,7 @@ export type CreateInternalMcpCatalogItemResponses = {
             name: string;
             server_url: string;
             auth_server_url?: string;
+            authorization_endpoint?: string;
             resource_metadata_url?: string;
             client_id: string;
             client_secret?: string;
@@ -25410,6 +25413,7 @@ export type GetInternalMcpCatalogItemResponses = {
             name: string;
             server_url: string;
             auth_server_url?: string;
+            authorization_endpoint?: string;
             resource_metadata_url?: string;
             client_id: string;
             client_secret?: string;
@@ -25540,6 +25544,7 @@ export type UpdateInternalMcpCatalogItemData = {
             name: string;
             server_url: string;
             auth_server_url?: string;
+            authorization_endpoint?: string;
             resource_metadata_url?: string;
             client_id: string;
             client_secret?: string;
@@ -25732,6 +25737,7 @@ export type UpdateInternalMcpCatalogItemResponses = {
             name: string;
             server_url: string;
             auth_server_url?: string;
+            authorization_endpoint?: string;
             resource_metadata_url?: string;
             client_id: string;
             client_secret?: string;
@@ -30197,6 +30203,7 @@ export type GetMcpServerInstallationRequestsResponses = {
                 name: string;
                 server_url: string;
                 auth_server_url?: string;
+                authorization_endpoint?: string;
                 resource_metadata_url?: string;
                 client_id: string;
                 client_secret?: string;
@@ -30293,6 +30300,7 @@ export type CreateMcpServerInstallationRequestData = {
                 name: string;
                 server_url: string;
                 auth_server_url?: string;
+                authorization_endpoint?: string;
                 resource_metadata_url?: string;
                 client_id: string;
                 client_secret?: string;
@@ -30443,6 +30451,7 @@ export type CreateMcpServerInstallationRequestResponses = {
                 name: string;
                 server_url: string;
                 auth_server_url?: string;
+                authorization_endpoint?: string;
                 resource_metadata_url?: string;
                 client_id: string;
                 client_secret?: string;
@@ -30692,6 +30701,7 @@ export type GetMcpServerInstallationRequestResponses = {
                 name: string;
                 server_url: string;
                 auth_server_url?: string;
+                authorization_endpoint?: string;
                 resource_metadata_url?: string;
                 client_id: string;
                 client_secret?: string;
@@ -30788,6 +30798,7 @@ export type UpdateMcpServerInstallationRequestData = {
                 name: string;
                 server_url: string;
                 auth_server_url?: string;
+                authorization_endpoint?: string;
                 resource_metadata_url?: string;
                 client_id: string;
                 client_secret?: string;
@@ -30950,6 +30961,7 @@ export type UpdateMcpServerInstallationRequestResponses = {
                 name: string;
                 server_url: string;
                 auth_server_url?: string;
+                authorization_endpoint?: string;
                 resource_metadata_url?: string;
                 client_id: string;
                 client_secret?: string;
@@ -31122,6 +31134,7 @@ export type ApproveMcpServerInstallationRequestResponses = {
                 name: string;
                 server_url: string;
                 auth_server_url?: string;
+                authorization_endpoint?: string;
                 resource_metadata_url?: string;
                 client_id: string;
                 client_secret?: string;
@@ -31294,6 +31307,7 @@ export type DeclineMcpServerInstallationRequestResponses = {
                 name: string;
                 server_url: string;
                 auth_server_url?: string;
+                authorization_endpoint?: string;
                 resource_metadata_url?: string;
                 client_id: string;
                 client_secret?: string;
@@ -31466,6 +31480,7 @@ export type AddMcpServerInstallationRequestNoteResponses = {
                 name: string;
                 server_url: string;
                 auth_server_url?: string;
+                authorization_endpoint?: string;
                 resource_metadata_url?: string;
                 client_id: string;
                 client_secret?: string;

--- a/platform/shared/mcp-server-config.test.ts
+++ b/platform/shared/mcp-server-config.test.ts
@@ -30,8 +30,6 @@ describe("OAuthConfigSchema", () => {
         authorization_endpoint:
           "https://legacy-idp.example.com/oauth/authorize",
       }),
-    ).toThrow(
-      "authorization_endpoint and token_endpoint must be set together",
-    );
+    ).toThrow("authorization_endpoint and token_endpoint must be set together");
   });
 });

--- a/platform/shared/mcp-server-config.test.ts
+++ b/platform/shared/mcp-server-config.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { OAuthConfigSchema } from "./mcp-server-config";
+
+describe("OAuthConfigSchema", () => {
+  const baseOAuthConfig = {
+    name: "Direct OAuth MCP",
+    server_url: "https://mcp.example.com",
+    client_id: "client-id",
+    redirect_uris: ["https://app.example.com/oauth-callback"],
+    scopes: ["read"],
+    default_scopes: ["read", "write"],
+    supports_resource_metadata: false,
+  };
+
+  it("accepts explicit authorization and token endpoints when both are set", () => {
+    expect(() =>
+      OAuthConfigSchema.parse({
+        ...baseOAuthConfig,
+        authorization_endpoint:
+          "https://legacy-idp.example.com/oauth/authorize",
+        token_endpoint: "https://legacy-idp.example.com/oauth/token",
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects configs where only one explicit endpoint is set", () => {
+    expect(() =>
+      OAuthConfigSchema.parse({
+        ...baseOAuthConfig,
+        authorization_endpoint:
+          "https://legacy-idp.example.com/oauth/authorize",
+      }),
+    ).toThrow(
+      "authorization_endpoint and token_endpoint must be set together",
+    );
+  });
+});

--- a/platform/shared/mcp-server-config.ts
+++ b/platform/shared/mcp-server-config.ts
@@ -4,6 +4,7 @@ export const OAuthConfigSchema = z.object({
   name: z.string(),
   server_url: z.string(),
   auth_server_url: z.string().optional(),
+  authorization_endpoint: z.string().optional(),
   resource_metadata_url: z.string().optional(),
   client_id: z.string(),
   client_secret: z.string().optional(),

--- a/platform/shared/mcp-server-config.ts
+++ b/platform/shared/mcp-server-config.ts
@@ -1,34 +1,53 @@
 import { z } from "zod";
 
-export const OAuthConfigSchema = z.object({
-  name: z.string(),
-  server_url: z.string(),
-  auth_server_url: z.string().optional(),
-  authorization_endpoint: z.string().optional(),
-  resource_metadata_url: z.string().optional(),
-  client_id: z.string(),
-  client_secret: z.string().optional(),
-  redirect_uris: z.array(z.string()),
-  scopes: z.array(z.string()),
-  description: z.string().optional(),
-  well_known_url: z.string().optional(),
-  default_scopes: z.array(z.string()),
-  supports_resource_metadata: z.boolean(),
-  generic_oauth: z.boolean().optional(),
-  token_endpoint: z.string().optional(),
-  access_token_env_var: z
-    .string()
-    .regex(
-      /^[A-Za-z_][A-Za-z0-9_]*$/,
-      "Must be a valid environment variable name (letters, digits, underscores)",
-    )
-    .optional(),
-  requires_proxy: z.boolean().optional(),
-  provider_name: z.string().optional(),
-  browser_auth: z.boolean().optional(),
-  streamable_http_url: z.string().optional(),
-  streamable_http_port: z.number().optional(),
-});
+export const OAuthConfigSchema = z
+  .object({
+    name: z.string(),
+    server_url: z.string(),
+    auth_server_url: z.string().optional(),
+    authorization_endpoint: z.string().optional(),
+    resource_metadata_url: z.string().optional(),
+    client_id: z.string(),
+    client_secret: z.string().optional(),
+    redirect_uris: z.array(z.string()),
+    scopes: z.array(z.string()),
+    description: z.string().optional(),
+    well_known_url: z.string().optional(),
+    default_scopes: z.array(z.string()),
+    supports_resource_metadata: z.boolean(),
+    generic_oauth: z.boolean().optional(),
+    token_endpoint: z.string().optional(),
+    access_token_env_var: z
+      .string()
+      .regex(
+        /^[A-Za-z_][A-Za-z0-9_]*$/,
+        "Must be a valid environment variable name (letters, digits, underscores)",
+      )
+      .optional(),
+    requires_proxy: z.boolean().optional(),
+    provider_name: z.string().optional(),
+    browser_auth: z.boolean().optional(),
+    streamable_http_url: z.string().optional(),
+    streamable_http_port: z.number().optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (
+      Boolean(value.authorization_endpoint) !== Boolean(value.token_endpoint)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "authorization_endpoint and token_endpoint must be set together",
+        path: ["authorization_endpoint"],
+      });
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "authorization_endpoint and token_endpoint must be set together",
+        path: ["token_endpoint"],
+      });
+    }
+  });
 
 export const EnvironmentVariableSchema = z.object({
   key: z.string().min(1, "Key is required"),


### PR DESCRIPTION
## Summary
- add explicit `authorization_endpoint` support alongside `token_endpoint`
- fall back to configured OAuth endpoints when `.well-known` discovery is unavailable
- expose the explicit endpoint fields in the MCP registry form and wire them through the form transforms