### PR TITLE
chore: Fix chat OAuth re-authentication flow

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Archestra",
-    "version": "1.2.9"
+    "version": "1.2.10"
   },
   "components": {
     "schemas": {

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -145,6 +145,53 @@ describe("McpClient", () => {
     mockListTools.mockResolvedValue({ tools: [] });
   });
 
+  test("invalidateConnectionsForServer closes cached active connections for the server", async () => {
+    const tool = await ToolModel.createToolIfNotExists({
+      name: "github-mcp-server__list_repos",
+      description: "List repos",
+      parameters: {},
+      catalogId,
+    });
+
+    await AgentToolModel.create(agentId, tool.id, {
+      mcpServerId,
+    });
+
+    mockCallTool.mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+      isError: false,
+    });
+
+    await mcpClient.executeToolCall(
+      {
+        id: "call_invalidate_connection",
+        name: "github-mcp-server__list_repos",
+        arguments: {},
+      },
+      agentId,
+    );
+
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+
+    await mcpClient.invalidateConnectionsForServer(mcpServerId);
+
+    expect(mockClose).toHaveBeenCalled();
+    expect(McpHttpSessionModel.deleteStaleSession).toHaveBeenCalled();
+
+    mockConnect.mockClear();
+
+    await mcpClient.executeToolCall(
+      {
+        id: "call_invalidate_connection_after",
+        name: "github-mcp-server__list_repos",
+        arguments: {},
+      },
+      agentId,
+    );
+
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+  });
+
   describe("executeToolCall", () => {
     test("returns error when tool not found for agent", async () => {
       const toolCall = {

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -2008,6 +2008,52 @@ class McpClient {
     this.pendingHttpSessionMetadata.clear();
   }
 
+  async invalidateConnectionsForServer(
+    targetMcpServerId: string,
+  ): Promise<void> {
+    const matchingConnectionKeys = Array.from(
+      this.activeConnections.keys(),
+    ).filter((connectionKey) => {
+      const parts = connectionKey.split(":");
+      return parts[1] === targetMcpServerId;
+    });
+
+    await Promise.all(
+      matchingConnectionKeys.map(async (connectionKey) => {
+        const client = this.activeConnections.get(connectionKey);
+        if (client) {
+          try {
+            await client.close();
+          } catch (error) {
+            logger.warn(
+              { connectionKey, targetMcpServerId, error },
+              "Error closing active MCP connection during server invalidation",
+            );
+          }
+        }
+
+        this.activeConnections.delete(connectionKey);
+        this.toolNameCache.delete(connectionKey);
+        this.pendingHttpSessionMetadata.delete(connectionKey);
+        await McpHttpSessionModel.deleteStaleSession(connectionKey).catch(
+          (error) => {
+            logger.warn(
+              { connectionKey, targetMcpServerId, error },
+              "Failed to delete stale MCP HTTP session during server invalidation",
+            );
+          },
+        );
+      }),
+    );
+
+    const matchingSecretKeys = Array.from(this.secretsCache.keys()).filter(
+      (cacheKey) => cacheKey === targetMcpServerId,
+    );
+    for (const cacheKey of matchingSecretKeys) {
+      this.secretsCache.delete(cacheKey);
+    }
+  }
+
   /**
    * Read a resource from its assigned MCP server
    */

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -11,6 +11,7 @@ const {
   connectAndGetToolsMock,
   exchangeEnterpriseManagedCredentialMock,
   hasPermissionMock,
+  invalidateConnectionsForServerMock,
   inspectServerMock,
   MockMcpServerConnectionTimeoutError,
   MockMcpServerNotReadyError,
@@ -18,6 +19,7 @@ const {
   connectAndGetToolsMock: vi.fn(),
   exchangeEnterpriseManagedCredentialMock: vi.fn(),
   hasPermissionMock: vi.fn(),
+  invalidateConnectionsForServerMock: vi.fn(),
   inspectServerMock: vi.fn(),
   MockMcpServerNotReadyError: class MockMcpServerNotReadyError extends Error {},
   MockMcpServerConnectionTimeoutError: class MockMcpServerConnectionTimeoutError extends Error {},
@@ -28,6 +30,7 @@ vi.mock("@/clients/mcp-client", () => ({
   McpServerConnectionTimeoutError: MockMcpServerConnectionTimeoutError,
   default: {
     connectAndGetTools: connectAndGetToolsMock,
+    invalidateConnectionsForServer: invalidateConnectionsForServerMock,
     inspectServer: inspectServerMock,
   },
 }));
@@ -62,6 +65,7 @@ describe("mcp server inspect route", () => {
     connectAndGetToolsMock.mockReset();
     exchangeEnterpriseManagedCredentialMock.mockReset();
     hasPermissionMock.mockReset();
+    invalidateConnectionsForServerMock.mockReset();
     inspectServerMock.mockReset();
     global.fetch = originalFetch;
     await app.close();

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -1005,6 +1005,10 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
         oauthRefreshFailedAt: null,
       });
 
+      // Re-auth swaps the secret behind the same MCP server ID. Cached MCP clients
+      // are keyed by server ID and can otherwise keep reusing the stale auth/session.
+      await mcpClient.invalidateConnectionsForServer(id);
+
       // For local servers, trigger pod restart to pick up new credentials
       if (mcpServer.serverType === "local") {
         try {

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -82,6 +82,10 @@ import { TypingText } from "@/components/ui/typing-text";
 import { Version } from "@/components/version";
 import { useDefaultAgentId, useInternalAgents } from "@/lib/agent.query";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
+import {
+  clearOAuthReauthChatResume,
+  getOAuthReauthChatResume,
+} from "@/lib/auth/oauth-session";
 import { useRecentlyGeneratedTitles } from "@/lib/chat/chat.hook";
 import {
   fetchConversationEnabledTools,
@@ -167,6 +171,7 @@ export function ChatPageContent({
   );
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const autoSendTriggeredRef = useRef(false);
+  const oauthReauthResumeTriggeredRef = useRef(false);
   // Store pending URL for browser navigation after conversation is created
   const [pendingBrowserUrl, setPendingBrowserUrl] = useState<
     string | undefined
@@ -1374,6 +1379,26 @@ export function ChatPageContent({
     selectConversation,
     createConversationMutation.isPending,
   ]);
+
+  useEffect(() => {
+    const pendingReauthResume = getOAuthReauthChatResume();
+    if (
+      oauthReauthResumeTriggeredRef.current ||
+      !pendingReauthResume ||
+      pendingReauthResume.conversationId !== conversationId ||
+      !sendMessage ||
+      status !== "ready"
+    ) {
+      return;
+    }
+
+    oauthReauthResumeTriggeredRef.current = true;
+    clearOAuthReauthChatResume();
+    sendMessage({
+      role: "user",
+      parts: [{ type: "text", text: pendingReauthResume.message }],
+    });
+  }, [conversationId, sendMessage, status]);
 
   // Check if the conversation's agent was deleted
   const isAgentDeleted = conversationId && conversation && !conversation.agent;

--- a/platform/frontend/src/app/oauth-callback/page.tsx
+++ b/platform/frontend/src/app/oauth-callback/page.tsx
@@ -15,6 +15,7 @@ import { useHandleOAuthCallback } from "@/lib/auth/oauth.query";
 import {
   clearCallbackProcessing,
   clearInstallContext,
+  clearOAuthReauthChatResume,
   clearOAuthReturnUrl,
   clearReauthContext,
   getOAuthEnvironmentValues,
@@ -26,11 +27,13 @@ import {
   isCallbackProcessed,
   markCallbackProcessing,
   setOAuthInstallationCompleteCatalogId,
+  setOAuthReauthChatResume,
 } from "@/lib/auth/oauth-session";
 import {
   useInstallMcpServer,
   useReauthenticateMcpServer,
 } from "@/lib/mcp/mcp-server.query";
+import { replaceBrowserUrl } from "@/lib/utils/browser-redirect";
 
 function OAuthCallbackContent() {
   const searchParams = useSearchParams();
@@ -87,7 +90,8 @@ function OAuthCallbackContent() {
 
           // Redirect back to where the user was (e.g. chat page)
           if (returnUrl) {
-            router.push(returnUrl);
+            setOAuthReauthChatResume({ returnUrl, serverName: name });
+            replaceBrowserUrl(returnUrl);
             return;
           }
         } else {
@@ -123,6 +127,7 @@ function OAuthCallbackContent() {
         router.push("/mcp/registry");
       } catch (error) {
         console.error("OAuth completion error:", error);
+        clearOAuthReauthChatResume();
         // The mutation's onError handler will show the error toast
         // Redirect back to catalog
         router.push("/mcp/registry");

--- a/platform/frontend/src/components/chat/auth-error-tool.tsx
+++ b/platform/frontend/src/components/chat/auth-error-tool.tsx
@@ -1,6 +1,11 @@
 import { ExternalLink, KeyRound } from "lucide-react";
 import type { ReactNode } from "react";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface AuthErrorToolProps {
   title: string;
@@ -9,6 +14,7 @@ interface AuthErrorToolProps {
   buttonUrl: string;
   /** When provided, renders an inline button instead of an external link */
   onAction?: () => void;
+  actionTooltipText?: string;
 }
 
 export function AuthErrorTool({
@@ -17,6 +23,7 @@ export function AuthErrorTool({
   buttonText,
   buttonUrl,
   onAction,
+  actionTooltipText,
 }: AuthErrorToolProps) {
   return (
     <div className="mt-3 rounded-xl border border-border px-5 py-4">
@@ -27,9 +34,16 @@ export function AuthErrorTool({
           <span>{description}</span>
         </div>
         {onAction ? (
-          <Button variant="secondary" size="sm" onClick={onAction}>
-            {buttonText}
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button variant="secondary" size="sm" onClick={onAction}>
+                {buttonText}
+              </Button>
+            </TooltipTrigger>
+            {actionTooltipText ? (
+              <TooltipContent>{actionTooltipText}</TooltipContent>
+            ) : null}
+          </Tooltip>
         ) : (
           <Button variant="secondary" size="sm" asChild>
             <a href={buttonUrl} target="_blank" rel="noopener noreferrer">

--- a/platform/frontend/src/components/chat/expired-auth-tool.test.tsx
+++ b/platform/frontend/src/components/chat/expired-auth-tool.test.tsx
@@ -1,7 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { ExpiredAuthTool } from "./expired-auth-tool";
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
 
 describe("ExpiredAuthTool", () => {
   const defaultProps = {

--- a/platform/frontend/src/components/chat/expired-auth-tool.tsx
+++ b/platform/frontend/src/components/chat/expired-auth-tool.tsx
@@ -28,6 +28,11 @@ export function ExpiredAuthTool({
       buttonText={onReauth ? "Re-authenticate" : "Manage credentials"}
       buttonUrl={reauthUrl}
       onAction={onReauth}
+      actionTooltipText={
+        onReauth
+          ? `This will redirect you to ${displayName} to authorize access, then return you to this chat.`
+          : undefined
+      }
     />
   );
 }

--- a/platform/frontend/src/lib/auth/oauth-session.test.ts
+++ b/platform/frontend/src/lib/auth/oauth-session.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearOAuthReauthChatResume,
+  getOAuthReauthChatResume,
+  setOAuthReauthChatResume,
+} from "./oauth-session";
+
+describe("oauth-session reauth chat resume", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("stores a pending chat resume message for chat return URLs", () => {
+    setOAuthReauthChatResume({
+      returnUrl: "http://localhost:3000/chat/conv_123",
+      serverName: "PostHog",
+    });
+
+    expect(getOAuthReauthChatResume()).toEqual({
+      conversationId: "conv_123",
+      message:
+        'I re-authenticated the "PostHog" connection. Please retry the last failed tool call and continue from where we left off.',
+    });
+  });
+
+  it("ignores non-chat return URLs", () => {
+    setOAuthReauthChatResume({
+      returnUrl: "http://localhost:3000/mcp/registry",
+      serverName: "PostHog",
+    });
+
+    expect(getOAuthReauthChatResume()).toBeNull();
+  });
+
+  it("clears the pending chat resume message", () => {
+    setOAuthReauthChatResume({
+      returnUrl: "http://localhost:3000/chat/conv_123",
+      serverName: "PostHog",
+    });
+
+    clearOAuthReauthChatResume();
+
+    expect(getOAuthReauthChatResume()).toBeNull();
+  });
+});

--- a/platform/frontend/src/lib/auth/oauth-session.ts
+++ b/platform/frontend/src/lib/auth/oauth-session.ts
@@ -24,6 +24,7 @@ const OAUTH_SERVER_TYPE = "oauth_server_type";
 const OAUTH_ENVIRONMENT_VALUES = "oauth_environment_values";
 const OAUTH_PENDING_AFTER_ENV_VARS = "oauth_pending_after_env_vars";
 const OAUTH_RETURN_URL = "oauth_return_url";
+const OAUTH_REAUTH_CHAT_RESUME = "oauth_reauth_chat_resume";
 
 // Dynamic key prefix (combined with code + state to deduplicate callbacks)
 const OAUTH_PROCESSING_PREFIX = "oauth_processing_";
@@ -158,6 +159,58 @@ export function clearOAuthReturnUrl() {
   sessionStorage.removeItem(OAUTH_RETURN_URL);
 }
 
+export function setOAuthReauthChatResume(params: {
+  returnUrl: string;
+  serverName: string;
+}) {
+  const conversationId = extractConversationIdFromChatUrl(params.returnUrl);
+  if (!conversationId) {
+    return;
+  }
+
+  sessionStorage.setItem(
+    OAUTH_REAUTH_CHAT_RESUME,
+    JSON.stringify({
+      conversationId,
+      message: `I re-authenticated the "${params.serverName}" connection. Please retry the last failed tool call and continue from where we left off.`,
+    }),
+  );
+}
+
+export function getOAuthReauthChatResume(): {
+  conversationId: string;
+  message: string;
+} | null {
+  const json = sessionStorage.getItem(OAUTH_REAUTH_CHAT_RESUME);
+  if (!json) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(json) as {
+      conversationId?: unknown;
+      message?: unknown;
+    };
+    if (
+      typeof parsed.conversationId !== "string" ||
+      typeof parsed.message !== "string"
+    ) {
+      return null;
+    }
+
+    return {
+      conversationId: parsed.conversationId,
+      message: parsed.message,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function clearOAuthReauthChatResume() {
+  sessionStorage.removeItem(OAUTH_REAUTH_CHAT_RESUME);
+}
+
 // ─── Cleanup ─────────────────────────────────────────────────────────
 
 /** Remove re-authentication context. */
@@ -184,4 +237,14 @@ export function clearInstallationCompleteCatalogId() {
 /** Remove the "pending after env vars" flag. */
 export function clearPendingAfterEnvVars() {
   sessionStorage.removeItem(OAUTH_PENDING_AFTER_ENV_VARS);
+}
+
+function extractConversationIdFromChatUrl(url: string): string | null {
+  try {
+    const parsedUrl = new URL(url, window.location.origin);
+    const match = parsedUrl.pathname.match(/^\/chat\/([^/]+)$/);
+    return match?.[1] ?? null;
+  } catch {
+    return null;
+  }
 }

--- a/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.test.tsx
+++ b/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.test.tsx
@@ -1,0 +1,114 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useMcpInstallOrchestrator } from "./mcp-install-orchestrator.hook";
+
+const {
+  mutateAsyncMock,
+  openDialogMock,
+  redirectBrowserToUrlMock,
+  setOAuthCatalogIdMock,
+  setOAuthMcpServerIdMock,
+  setOAuthReturnUrlMock,
+  setOAuthStateMock,
+  setOAuthTeamIdMock,
+} = vi.hoisted(() => ({
+  mutateAsyncMock: vi.fn(),
+  openDialogMock: vi.fn(),
+  redirectBrowserToUrlMock: vi.fn(),
+  setOAuthCatalogIdMock: vi.fn(),
+  setOAuthMcpServerIdMock: vi.fn(),
+  setOAuthReturnUrlMock: vi.fn(),
+  setOAuthStateMock: vi.fn(),
+  setOAuthTeamIdMock: vi.fn(),
+}));
+
+vi.mock("@/lib/mcp/internal-mcp-catalog.query", () => ({
+  useInternalMcpCatalog: () => ({
+    data: [
+      {
+        id: "catalog-posthog",
+        name: "PostHog",
+        serverType: "remote",
+        oauthConfig: { clientId: "client-123" },
+      },
+    ],
+  }),
+}));
+
+vi.mock("@/lib/mcp/mcp-server.query", () => ({
+  useMcpServers: () => ({ data: [] }),
+  useInstallMcpServer: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useReauthenticateMcpServer: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/lib/auth/oauth.query", () => ({
+  useInitiateOAuth: () => ({
+    mutateAsync: mutateAsyncMock,
+  }),
+}));
+
+vi.mock("@/lib/hooks/use-dialog", () => ({
+  useDialogs: () => ({
+    isDialogOpened: () => false,
+    openDialog: openDialogMock,
+    closeDialog: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/utils/browser-redirect", () => ({
+  redirectBrowserToUrl: redirectBrowserToUrlMock,
+}));
+
+vi.mock("@/lib/auth/oauth-session", () => ({
+  clearPendingAfterEnvVars: vi.fn(),
+  getOAuthPendingAfterEnvVars: vi.fn(() => false),
+  setOAuthCatalogId: setOAuthCatalogIdMock,
+  setOAuthEnvironmentValues: vi.fn(),
+  setOAuthIsFirstInstallation: vi.fn(),
+  setOAuthMcpServerId: setOAuthMcpServerIdMock,
+  setOAuthPendingAfterEnvVars: vi.fn(),
+  setOAuthReturnUrl: setOAuthReturnUrlMock,
+  setOAuthServerType: vi.fn(),
+  setOAuthState: setOAuthStateMock,
+  setOAuthTeamId: setOAuthTeamIdMock,
+}));
+
+describe("useMcpInstallOrchestrator", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mutateAsyncMock.mockResolvedValue({
+      authorizationUrl: "https://posthog.example.com/oauth/authorize",
+      state: "oauth-state-123",
+    });
+  });
+
+  it("starts OAuth immediately for pure OAuth re-authentication", async () => {
+    const { result } = renderHook(() => useMcpInstallOrchestrator());
+
+    act(() => {
+      result.current.triggerReauthByCatalogIdAndServerId(
+        "catalog-posthog",
+        "server-123",
+      );
+    });
+
+    await waitFor(() => {
+      expect(mutateAsyncMock).toHaveBeenCalledWith({
+        catalogId: "catalog-posthog",
+      });
+    });
+
+    expect(openDialogMock).not.toHaveBeenCalled();
+    expect(setOAuthStateMock).toHaveBeenCalledWith("oauth-state-123");
+    expect(setOAuthCatalogIdMock).toHaveBeenCalledWith("catalog-posthog");
+    expect(setOAuthTeamIdMock).toHaveBeenCalledWith(null);
+    expect(setOAuthMcpServerIdMock).toHaveBeenCalledWith("server-123");
+    expect(setOAuthReturnUrlMock).toHaveBeenCalledWith(window.location.href);
+    expect(redirectBrowserToUrlMock).toHaveBeenCalledWith(
+      "https://posthog.example.com/oauth/authorize",
+    );
+  });
+});

--- a/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.ts
+++ b/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.ts
@@ -26,6 +26,7 @@ import {
   useMcpServers,
   useReauthenticateMcpServer,
 } from "@/lib/mcp/mcp-server.query";
+import { redirectBrowserToUrl } from "@/lib/utils/browser-redirect";
 
 type DialogKey =
   | "remote-install"
@@ -59,6 +60,41 @@ export function useMcpInstallOrchestrator() {
   const findCatalogItem = useCallback(
     (catalogId: string) => catalogItems?.find((item) => item.id === catalogId),
     [catalogItems],
+  );
+
+  const initiateOAuthRedirect = useCallback(
+    async (params: {
+      catalogItem: CatalogItem;
+      teamId?: string | null;
+      reauthServerId?: string | null;
+    }) => {
+      try {
+        const { authorizationUrl, state } =
+          await initiateOAuthMutation.mutateAsync({
+            catalogId: params.catalogItem.id,
+          });
+
+        setOAuthState(state);
+        setOAuthCatalogId(params.catalogItem.id);
+        setOAuthTeamId(params.teamId ?? null);
+
+        if (params.reauthServerId) {
+          setOAuthMcpServerId(params.reauthServerId);
+          setOAuthReturnUrl(window.location.href);
+          setReauthServerId(null);
+        } else {
+          const isFirstInstallation = !installedServers?.some(
+            (server) => server.catalogId === params.catalogItem.id,
+          );
+          setOAuthIsFirstInstallation(isFirstInstallation);
+        }
+
+        redirectBrowserToUrl(authorizationUrl);
+      } catch {
+        toast.error("Failed to initiate OAuth flow");
+      }
+    },
+    [initiateOAuthMutation, installedServers],
   );
 
   const handleInstallRemoteServer = useCallback(
@@ -150,11 +186,10 @@ export function useMcpInstallOrchestrator() {
           Object.keys(catalogItem.userConfig).length > 0;
 
         if (!hasUserConfig) {
-          // Pure OAuth — set reauth context and open OAuth confirmation
-          setOAuthMcpServerId(serverId);
-          setOAuthReturnUrl(window.location.href);
-          setSelectedCatalogItem(catalogItem);
-          openDialog("oauth");
+          void initiateOAuthRedirect({
+            catalogItem,
+            reauthServerId: serverId,
+          });
           return;
         }
 
@@ -173,7 +208,7 @@ export function useMcpInstallOrchestrator() {
         openDialog("remote-install");
       }
     },
-    [findCatalogItem, openDialog],
+    [findCatalogItem, initiateOAuthRedirect, openDialog],
   );
 
   // --- Confirm handlers ---
@@ -309,32 +344,11 @@ export function useMcpInstallOrchestrator() {
   const handleOAuthConfirm = async (result: OAuthInstallResult) => {
     if (!selectedCatalogItem) return;
 
-    try {
-      const { authorizationUrl, state } =
-        await initiateOAuthMutation.mutateAsync({
-          catalogId: selectedCatalogItem.id,
-        });
-
-      setOAuthState(state);
-      setOAuthCatalogId(selectedCatalogItem.id);
-      setOAuthTeamId(result.teamId ?? null);
-
-      // If re-authenticating via OAuth, store reauth context
-      if (reauthServerId) {
-        setOAuthMcpServerId(reauthServerId);
-        setOAuthReturnUrl(window.location.href);
-        setReauthServerId(null);
-      } else {
-        const isFirstInstallation = !installedServers?.some(
-          (s) => s.catalogId === selectedCatalogItem.id,
-        );
-        setOAuthIsFirstInstallation(isFirstInstallation);
-      }
-
-      window.location.href = authorizationUrl;
-    } catch {
-      toast.error("Failed to initiate OAuth flow");
-    }
+    await initiateOAuthRedirect({
+      catalogItem: selectedCatalogItem,
+      teamId: result.teamId,
+      reauthServerId,
+    });
   };
 
   const handleManageDialogClose = useCallback(() => {

--- a/platform/frontend/src/lib/utils/browser-redirect.ts
+++ b/platform/frontend/src/lib/utils/browser-redirect.ts
@@ -1,0 +1,7 @@
+export function redirectBrowserToUrl(url: string) {
+  window.location.assign(url);
+}
+
+export function replaceBrowserUrl(url: string) {
+  window.location.replace(url);
+}


### PR DESCRIPTION
## What changed
- start pure OAuth re-authentication directly from the chat error block instead of opening the generic OAuth installation dialog
- preserve the exact return URL for the failed chat so the user lands back on the same `/chat/<id>` after OAuth completes
- queue a one-time resume message after successful re-authentication so the agent can continue and retry the failed tool path
- add hover copy on the inline re-auth button explaining the redirect
- add focused tests for the direct re-auth path and chat resume session state

## Why
Expired chat credentials were reusing the install flow, which forced the user to pick an installation/team even though the failing MCP server installation was already known. That interrupted recovery and made re-auth feel like a new install instead of a credential refresh.

## User impact
Users can click `Re-authenticate` directly in chat, complete OAuth, land back in the same conversation, and have the model resume automatically.