### PR TITLE
fix(ci): disable cancel-in-progress for staging deploys

### DIFF
--- a/.github/workflows/on-commits-to-main.yml
+++ b/.github/workflows/on-commits-to-main.yml
@@ -13,7 +13,7 @@ permissions: {}
 
 concurrency:
   group: on-commits-to-main-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   deploy-dev-platform-images:


### PR DESCRIPTION
## Summary

- Changes `cancel-in-progress` from `true` to `false` in the `on-commits-to-main` workflow
- `cancel-in-progress: true` was causing two issues:
  1. Killing CI runners mid-`helm upgrade` left Helm releases stuck in `pending-upgrade` state, blocking all subsequent deploys
  2. Release-please commits triggered concurrent `on-commits-to-main` runs that cancelled the original deploy, causing it to be skipped
- With `false`, concurrent runs will queue instead of cancelling each other, ensuring deploys complete safely

## Test plan

- [ ] Merge and verify the next push to main triggers a successful staging deploy
- [ ] Push two commits in quick succession and verify both deploy (queued, not cancelled)