### PR TITLE
fix(ci): allow all non-PR triggers in deploy-dev-platform-images

### DIFF
--- a/.github/workflows/deploy-dev-platform-images.yml
+++ b/.github/workflows/deploy-dev-platform-images.yml
@@ -35,7 +35,7 @@ jobs:
     permissions:
       contents: read # Required to checkout the repository and build the platform image.
       id-token: write # Required for Workload Identity Federation.
-    if: ${{ github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.label.name == 'deploy-dev-platform-images' && github.event.pull_request.head.repo.fork != true) }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.label.name == 'deploy-dev-platform-images' && github.event.pull_request.head.repo.fork != true) }}
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - name: Checkout repository
@@ -88,7 +88,7 @@ jobs:
 
   publish-dev-mcp-server-base-image:
     name: Build MCP Server Base Dev Image
-    if: ${{ github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.label.name == 'deploy-dev-platform-images' && github.event.pull_request.head.repo.fork != true) }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.label.name == 'deploy-dev-platform-images' && github.event.pull_request.head.repo.fork != true) }}
     uses: ./.github/workflows/build-base-mcp-server-docker-image.yml
     permissions:
       contents: read # Required to invoke the reusable MCP server base image workflow.

--- a/.github/workflows/deploy-dev-platform-images.yml
+++ b/.github/workflows/deploy-dev-platform-images.yml
@@ -35,7 +35,7 @@ jobs:
     permissions:
       contents: read # Required to checkout the repository and build the platform image.
       id-token: write # Required for Workload Identity Federation.
-    if: ${{ github.event_name != 'pull_request' || (github.event.label.name == 'deploy-dev-platform-images' && github.event.pull_request.head.repo.fork != true) }}
+    if: ${{ github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.label.name == 'deploy-dev-platform-images' && github.event.pull_request.head.repo.fork != true) }}
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - name: Checkout repository
@@ -88,7 +88,7 @@ jobs:
 
   publish-dev-mcp-server-base-image:
     name: Build MCP Server Base Dev Image
-    if: ${{ github.event_name != 'pull_request' || (github.event.label.name == 'deploy-dev-platform-images' && github.event.pull_request.head.repo.fork != true) }}
+    if: ${{ github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.label.name == 'deploy-dev-platform-images' && github.event.pull_request.head.repo.fork != true) }}
     uses: ./.github/workflows/build-base-mcp-server-docker-image.yml
     permissions:
       contents: read # Required to invoke the reusable MCP server base image workflow.


### PR DESCRIPTION
## Summary

- Fixes the `if` condition on both jobs in `deploy-dev-platform-images.yml` (lines 38 and 91)
- The previous condition explicitly allowed `workflow_call`, `workflow_dispatch`, and labeled PRs — but missed `push`, which is what `github.event_name` evaluates to when called from `on-commits-to-main.yml`
- New condition: `github.event_name != 'pull_request' || (label check)` — allows all triggers except unlabeled/fork PRs
- This has been blocking all staging deploys since `005835d29`
