### PR TITLE
feat: add platform HPA defaults and scaling guidance

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -285,7 +285,6 @@ Recommended approach:
 Two good KEDA patterns for workers:
 
 - Use KEDA's PostgreSQL scaler against the `tasks` table with a query that counts ready work, for example `SELECT COUNT(*) FROM tasks WHERE status = 'pending' AND scheduled_for <= NOW()`
-- Add a Prometheus gauge for ready backlog and let a KEDA Prometheus scaler target that metric. Archestra does not expose a ready-backlog metric today; the built-in `task_queue_active_tasks` metric only covers in-flight work, not queued work.
 
 Practical starting point for worker autoscaling:
 

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -242,6 +242,65 @@ Chart-managed diagnostics PVCs are validated conservatively. If more than one di
 - `archestra.tolerations` - Tolerations for scheduling pods on nodes with specific taints (e.g., dedicated nodes, GPU nodes, spot instances). These values are also inherited by MCP server pods as defaults. See [Kubernetes docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
 - `archestra.deploymentStrategy` - Deployment strategy configuration (default: RollingUpdate with `maxUnavailable: 25%` and `maxSurge: 25%`)
 - `archestra.resources` - CPU and memory requests/limits for the container (default: 2Gi request, 3Gi limit for memory)
+- `archestra.horizontalPodAutoscaler` - Optional HPA for the main `archestra-platform` Deployment. When enabled, the chart defaults to `minReplicas: 2`, `maxReplicas: 10`, a memory utilization target of 70%, immediate scale-up, and a 5-minute scale-down stabilization window.
+- `archestra.worker.replicaCount` - Manual replica count for the separate worker Deployment
+- `archestra.worker.resources` - Resource requests/limits for worker pods (default: 1Gi request, 2Gi limit for memory)
+- `archestra.worker.deploymentStrategy` - Rolling update strategy for worker pods (default: `maxUnavailable: 25%`, `maxSurge: 25%`)
+
+#### HorizontalPodAutoscaler
+
+The Helm chart can optionally create a Kubernetes `HorizontalPodAutoscaler` for the main `archestra-platform` Deployment. It does not autoscale the separate worker Deployment.
+
+Default behavior when enabled:
+
+- Maintains at least 2 web pods
+- Scales up to 10 web pods
+- Uses memory utilization because the chart defines memory requests by default
+- Scales up aggressively (up to 100% or 2 pods per minute)
+- Scales down conservatively with a 5-minute stabilization window
+
+Example:
+
+```yaml
+archestra:
+  horizontalPodAutoscaler:
+    enabled: true
+```
+
+If your cluster has reliable CPU requests for the platform pods and you prefer request-rate-driven scaling, override `archestra.horizontalPodAutoscaler.metrics` with a CPU target instead.
+
+#### Existing Scaling Controls
+
+The chart already exposes a few scaling-related controls, even without autoscaling:
+
+- `archestra.replicaCount` sets the manual replica count for web pods when HPA is disabled
+- `archestra.worker.replicaCount` sets the manual replica count for worker pods
+- `archestra.deploymentStrategy` and `archestra.worker.deploymentStrategy` control rollout overlap (`maxSurge` and `maxUnavailable`), which affects rollout capacity but not steady-state scaling
+- `archestra.podDisruptionBudget` protects availability during voluntary disruptions, but it is not an autoscaler
+
+The chart does not currently create worker HPAs, KEDA `ScaledObject`s, or a VerticalPodAutoscaler.
+
+#### Worker Scaling Recommendations
+
+Worker throughput is driven by a Postgres-backed task queue, so resource-based autoscaling is usually the wrong first signal. The worker currently polls the `tasks` table for rows where `status = 'pending'` and `scheduled_for <= NOW()`, and each pod processes up to `ARCHESTRA_KNOWLEDGE_BASE_TASK_WORKER_MAX_CONCURRENT` tasks at once (default: `2`).
+
+Recommended approach:
+
+- Keep the platform HPA focused on web traffic and leave workers on manual replicas until you have queue metrics
+- Tune `archestra.worker.replicaCount` together with `ARCHESTRA_KNOWLEDGE_BASE_TASK_WORKER_MAX_CONCURRENT`; increasing concurrency per pod is often cheaper than adding pods for modest backlog
+- If your customer has KEDA, scale workers from queue backlog instead of CPU or memory
+
+Two good KEDA patterns for workers:
+
+- Use KEDA's PostgreSQL scaler against the `tasks` table with a query that counts ready work, for example `SELECT COUNT(*) FROM tasks WHERE status = 'pending' AND scheduled_for <= NOW()`
+- Add a Prometheus gauge for ready backlog, such as `task_queue_ready_tasks`, and let a KEDA Prometheus scaler target that metric
+
+Practical starting point for worker autoscaling:
+
+- Start with `minReplicaCount: 1`
+- Set a low activation threshold so scale-from-zero or scale-from-one happens only when real backlog exists
+- Target roughly 5 to 10 ready tasks per worker pod, then tune based on average task duration
+- Keep `maxReplicaCount` aligned with database capacity, embedding provider rate limits, and downstream connector quotas
 
 **Service Settings**:
 

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -259,14 +259,6 @@ Default behavior when enabled:
 - Scales up aggressively (up to 100% or 2 pods per minute)
 - Scales down conservatively with a 5-minute stabilization window
 
-Example:
-
-```yaml
-archestra:
-  horizontalPodAutoscaler:
-    enabled: true
-```
-
 If your cluster has reliable CPU requests for the platform pods and you prefer request-rate-driven scaling, override `archestra.horizontalPodAutoscaler.metrics` with a CPU target instead.
 
 #### Existing Scaling Controls
@@ -293,13 +285,13 @@ Recommended approach:
 Two good KEDA patterns for workers:
 
 - Use KEDA's PostgreSQL scaler against the `tasks` table with a query that counts ready work, for example `SELECT COUNT(*) FROM tasks WHERE status = 'pending' AND scheduled_for <= NOW()`
-- Add a Prometheus gauge for ready backlog, such as `task_queue_ready_tasks`, and let a KEDA Prometheus scaler target that metric
+- Add a Prometheus gauge for ready backlog and let a KEDA Prometheus scaler target that metric. Archestra does not expose a ready-backlog metric today; the built-in `task_queue_active_tasks` metric only covers in-flight work, not queued work.
 
 Practical starting point for worker autoscaling:
 
 - Start with `minReplicaCount: 1`
-- Set a low activation threshold so scale-from-zero or scale-from-one happens only when real backlog exists
-- Target roughly 5 to 10 ready tasks per worker pod, then tune based on average task duration
+- Set `activationQueryValue: "1"` so KEDA stays idle when there is no ready work
+- With the default `ARCHESTRA_KNOWLEDGE_BASE_TASK_WORKER_MAX_CONCURRENT=2`, start with `targetQueryValue: "4"` so each worker pod is asked to absorb about two waves of ready tasks before KEDA adds another pod
 - Keep `maxReplicaCount` aligned with database capacity, embedding provider rate limits, and downstream connector quotas
 
 **Service Settings**:

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -280,11 +280,11 @@ Recommended approach:
 
 - Keep the platform HPA focused on web traffic and leave workers on manual replicas until you have queue metrics
 - Tune `archestra.worker.replicaCount` together with `ARCHESTRA_KNOWLEDGE_BASE_TASK_WORKER_MAX_CONCURRENT`; increasing concurrency per pod is often cheaper than adding pods for modest backlog
-- If your customer has KEDA, scale workers from queue backlog instead of CPU or memory
+- If you use KEDA, scale workers from queue backlog instead of CPU or memory
 
-Two good KEDA patterns for workers:
+For KEDA-backed worker autoscaling, use KEDA's PostgreSQL scaler against the `tasks` table with a query that counts ready work, for example:
 
-- Use KEDA's PostgreSQL scaler against the `tasks` table with a query that counts ready work, for example `SELECT COUNT(*) FROM tasks WHERE status = 'pending' AND scheduled_for <= NOW()`
+- `SELECT COUNT(*) FROM tasks WHERE status = 'pending' AND scheduled_for <= NOW()`
 
 Practical starting point for worker autoscaling:
 

--- a/platform/helm/archestra/tests/archestra_platform_hpa_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_hpa_test.yaml
@@ -61,10 +61,68 @@ tests:
     asserts:
       - equal:
           path: spec.minReplicas
-          value: 1
+          value: 2
       - equal:
           path: spec.maxReplicas
           value: 10
+
+  - it: should configure default memory utilization metric
+    set:
+      archestra.horizontalPodAutoscaler.enabled: true
+    asserts:
+      - equal:
+          path: spec.metrics[0].type
+          value: Resource
+      - equal:
+          path: spec.metrics[0].resource.name
+          value: memory
+      - equal:
+          path: spec.metrics[0].resource.target.type
+          value: Utilization
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 70
+
+  - it: should configure default scaling behavior
+    set:
+      archestra.horizontalPodAutoscaler.enabled: true
+    asserts:
+      - equal:
+          path: spec.behavior.scaleUp.stabilizationWindowSeconds
+          value: 0
+      - equal:
+          path: spec.behavior.scaleUp.selectPolicy
+          value: Max
+      - equal:
+          path: spec.behavior.scaleUp.policies[0].type
+          value: Percent
+      - equal:
+          path: spec.behavior.scaleUp.policies[0].value
+          value: 100
+      - equal:
+          path: spec.behavior.scaleUp.policies[1].type
+          value: Pods
+      - equal:
+          path: spec.behavior.scaleUp.policies[1].value
+          value: 2
+      - equal:
+          path: spec.behavior.scaleDown.stabilizationWindowSeconds
+          value: 300
+      - equal:
+          path: spec.behavior.scaleDown.selectPolicy
+          value: Min
+      - equal:
+          path: spec.behavior.scaleDown.policies[0].type
+          value: Percent
+      - equal:
+          path: spec.behavior.scaleDown.policies[0].value
+          value: 25
+      - equal:
+          path: spec.behavior.scaleDown.policies[1].type
+          value: Pods
+      - equal:
+          path: spec.behavior.scaleDown.policies[1].value
+          value: 1
 
   - it: should configure custom minReplicas
     set:
@@ -186,7 +244,7 @@ tests:
       archestra.horizontalPodAutoscaler.enabled: true
       archestra.horizontalPodAutoscaler.minReplicas: 1
       archestra.horizontalPodAutoscaler.maxReplicas: 10
-      archestra.horizontalPodAutoscaler.behavior: {}
+      archestra.horizontalPodAutoscaler.behavior: null
     asserts:
       - isNull:
           path: spec.behavior

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -496,14 +496,16 @@ archestra:
     spec: {}
 
   # HorizontalPodAutoscaler configuration
-  # Automatically scales the number of pod replicas based on observed metrics
+  # Automatically scales the number of replicas for the main archestra-platform Deployment
+  # based on observed metrics. This does not apply to the separate worker Deployment.
   # See: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
   horizontalPodAutoscaler:
     # Enable or disable HorizontalPodAutoscaler creation
     enabled: false
 
     # Minimum number of replicas the autoscaler can scale down to
-    minReplicas: 1
+    # Default keeps two web pods available when autoscaling is enabled.
+    minReplicas: 2
 
     # Maximum number of replicas the autoscaler can scale up to
     maxReplicas: 10
@@ -518,7 +520,15 @@ archestra:
     #         target:
     #           type: Utilization
     #           averageUtilization: 80
-    metrics: []
+    # Default uses memory utilization because the chart already defines memory
+    # requests by default, while CPU requests are optional.
+    metrics:
+      - type: Resource
+        resource:
+          name: memory
+          target:
+            type: Utilization
+            averageUtilization: 70
 
     # Scaling behavior configuration for scale up and scale down
     # Allows fine-grained control over scaling speed and stabilization
@@ -536,7 +546,27 @@ archestra:
     #         - type: Percent
     #           value: 100
     #           periodSeconds: 15
-    behavior: {}
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 0
+        selectPolicy: Max
+        policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 60
+          - type: Pods
+            value: 2
+            periodSeconds: 60
+      scaleDown:
+        stabilizationWindowSeconds: 300
+        selectPolicy: Min
+        policies:
+          - type: Percent
+            value: 25
+            periodSeconds: 60
+          - type: Pods
+            value: 1
+            periodSeconds: 60
 
   # PodDisruptionBudget configuration
   # Limits the number of pods that can be down simultaneously during voluntary disruptions


### PR DESCRIPTION
## Summary
- add useful default values for the optional `archestra.horizontalPodAutoscaler` on the main platform deployment
- extend Helm unit coverage for default HPA metrics and behavior
- document existing chart scaling controls and add worker scaling guidance for queue-depth-based KEDA setups

## Why
The chart already rendered an HPA for `archestra-platform`, but enabling it required every deployment to define its own metrics and behavior. Staging also showed there is currently no HPA or KEDA object in place, and the web deployment only has memory requests by default, so the safest built-in autoscaling default is memory-based.

## Impact
- users can enable platform HPA with `archestra.horizontalPodAutoscaler.enabled=true` and get a sensible default without extra values
- the chart remains worker-manual by default, with docs steering users toward queue backlog signals instead of CPU or memory for worker autoscaling
- no change is made to steady-state behavior unless HPA is explicitly enabled