### PR TITLE
fix: prehydrate OIDC discovery during IdP registration

### DIFF
--- a/platform/CLAUDE.md
+++ b/platform/CLAUDE.md
@@ -16,6 +16,7 @@
 6. **Enterprise Edition Imports** - NEVER directly import from `.ee.ts` files unless the importing file is itself an `.ee.ts` file. Use runtime conditional logic with `config.enterpriseFeatures.core` checks instead to avoid bundling enterprise code into free builds
 7. **No Auto Commits** - Never commit or push changes without explicit user approval. Always ask before running git commit or git push
 8. **No Database Modifications Without Approval** - NEVER run INSERT, UPDATE, DELETE, or any data-modifying SQL queries without explicit user approval. SELECT queries for reading data are allowed. Always ask before modifying database data directly.
+9. **NEVER MENTION REAL CUSTOMER NAMES OR IDENTIFIERS ANYWHERE IN CODE, COMMENTS, TESTS, DOCS, COMMITS, OR PR TEXT!!!!!!!!!!**
 
 ## Docs
 

--- a/platform/backend/src/models/identity-provider.ee.test.ts
+++ b/platform/backend/src/models/identity-provider.ee.test.ts
@@ -66,6 +66,97 @@ function createParams(
 
 describe("IdentityProviderModel", () => {
   describe("create", () => {
+    test("hydrates OIDC discovery before registering with Better Auth", async ({
+      makeOrganization,
+      makeUser,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+
+      const registerSSOProvider = vi.fn(async ({ body }) => {
+        await db.insert(schema.identityProvidersTable).values({
+          id: crypto.randomUUID(),
+          providerId: body.providerId,
+          issuer: body.issuer,
+          domain: body.domain,
+          organizationId: org.id,
+          userId: user.id,
+          oidcConfig: JSON.stringify(
+            body.oidcConfig,
+          ) as unknown as typeof schema.identityProvidersTable.$inferInsert.oidcConfig,
+        });
+      });
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          issuer: "https://idp.example.com/oauth2/example",
+          authorization_endpoint:
+            "https://idp.example.com/oauth2/example/v1/authorize",
+          token_endpoint: "https://idp.example.com/oauth2/example/v1/token",
+          token_endpoint_auth_methods_supported: [
+            "client_secret_post",
+            "client_secret_basic",
+          ],
+          jwks_uri: "https://idp.example.com/oauth2/example/v1/keys",
+          userinfo_endpoint:
+            "https://idp.example.com/oauth2/example/v1/userinfo",
+        }),
+      });
+
+      try {
+        const created = await IdentityProviderModel.create(
+          {
+            providerId: "example-idp",
+            issuer: "https://idp.example.com/oauth2/example",
+            domain: "example.com",
+            userId: user.id,
+            oidcConfig: {
+              issuer: "https://idp.example.com/oauth2/example",
+              pkce: true,
+              clientId: "load-spark-platform",
+              clientSecret: "secret",
+              discoveryEndpoint:
+                "https://idp.example.com/oauth2/example/.well-known/openid-configuration",
+              scopes: ["openid", "email", "profile"],
+            },
+          },
+          org.id,
+          new Headers(),
+          {
+            api: {
+              registerSSOProvider,
+            },
+          } as unknown as Parameters<typeof IdentityProviderModel.create>[3],
+        );
+
+        expect(registerSSOProvider).toHaveBeenCalledWith(
+          expect.objectContaining({
+            body: expect.objectContaining({
+              oidcConfig: expect.objectContaining({
+                skipDiscovery: true,
+                authorizationEndpoint:
+                  "https://idp.example.com/oauth2/example/v1/authorize",
+                tokenEndpoint:
+                  "https://idp.example.com/oauth2/example/v1/token",
+                jwksEndpoint: "https://idp.example.com/oauth2/example/v1/keys",
+                userInfoEndpoint:
+                  "https://idp.example.com/oauth2/example/v1/userinfo",
+                tokenEndpointAuthentication: "client_secret_basic",
+              }),
+            }),
+          }),
+        );
+        expect(created.oidcConfig?.skipDiscovery).toBe(true);
+        expect(created.oidcConfig?.authorizationEndpoint).toBe(
+          "https://idp.example.com/oauth2/example/v1/authorize",
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
     test("persists enterprise-managed credentials inside oidcConfig", async ({
       makeOrganization,
       makeUser,
@@ -90,21 +181,22 @@ describe("IdentityProviderModel", () => {
       const created = await IdentityProviderModel.create(
         {
           providerId: "keycloak",
-          issuer: "http://localhost:30081/realms/archestra",
+          issuer: "https://keycloak.example.com/realms/archestra",
           domain: "example.com",
           userId: user.id,
           oidcConfig: {
-            issuer: "http://localhost:30081/realms/archestra",
+            issuer: "https://keycloak.example.com/realms/archestra",
+            skipDiscovery: true,
             pkce: true,
             clientId: "archestra-oidc",
             clientSecret: "archestra-oidc-secret",
             discoveryEndpoint:
-              "http://localhost:30081/realms/archestra/.well-known/openid-configuration",
+              "https://keycloak.example.com/realms/archestra/.well-known/openid-configuration",
             enterpriseManagedCredentials: {
               clientId: "archestra-oidc",
               clientSecret: "archestra-oidc-secret",
               tokenEndpoint:
-                "http://localhost:30081/realms/archestra/protocol/openid-connect/token",
+                "https://keycloak.example.com/realms/archestra/protocol/openid-connect/token",
               tokenEndpointAuthentication: "client_secret_post",
               subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
             },
@@ -126,11 +218,160 @@ describe("IdentityProviderModel", () => {
       expect(
         created.oidcConfig?.enterpriseManagedCredentials?.tokenEndpoint,
       ).toBe(
-        "http://localhost:30081/realms/archestra/protocol/openid-connect/token",
+        "https://keycloak.example.com/realms/archestra/protocol/openid-connect/token",
       );
       expect(
         created.oidcConfig?.enterpriseManagedCredentials?.subjectTokenType,
       ).toBe("urn:ietf:params:oauth:token-type:access_token");
+    });
+
+    test("rejects registration when discovery fetch returns a non-2xx response", async ({
+      makeOrganization,
+      makeUser,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      const registerSSOProvider = vi.fn();
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+      });
+
+      try {
+        await expect(
+          IdentityProviderModel.create(
+            {
+              providerId: "example-idp-404",
+              issuer: "https://idp.example.com/oauth2/example",
+              domain: "example.com",
+              userId: user.id,
+              oidcConfig: {
+                issuer: "https://idp.example.com/oauth2/example",
+                pkce: true,
+                clientId: "load-spark-platform",
+                clientSecret: "secret",
+                discoveryEndpoint:
+                  "https://idp.example.com/oauth2/example/.well-known/openid-configuration",
+              },
+            },
+            org.id,
+            new Headers(),
+            {
+              api: {
+                registerSSOProvider,
+              },
+            } as unknown as Parameters<typeof IdentityProviderModel.create>[3],
+          ),
+        ).rejects.toThrow(
+          'OIDC discovery request to "https://idp.example.com/oauth2/example/.well-known/openid-configuration" failed with status 404.',
+        );
+
+        expect(registerSSOProvider).not.toHaveBeenCalled();
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    test("rejects registration when discovery issuer does not match the configured issuer", async ({
+      makeOrganization,
+      makeUser,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      const registerSSOProvider = vi.fn();
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          issuer: "https://idp.example.com/oauth2/different",
+          authorization_endpoint:
+            "https://idp.example.com/oauth2/example/v1/authorize",
+          token_endpoint: "https://idp.example.com/oauth2/example/v1/token",
+          jwks_uri: "https://idp.example.com/oauth2/example/v1/keys",
+        }),
+      });
+
+      try {
+        await expect(
+          IdentityProviderModel.create(
+            {
+              providerId: "example-idp-mismatch",
+              issuer: "https://idp.example.com/oauth2/example",
+              domain: "example.com",
+              userId: user.id,
+              oidcConfig: {
+                issuer: "https://idp.example.com/oauth2/example",
+                pkce: true,
+                clientId: "load-spark-platform",
+                clientSecret: "secret",
+                discoveryEndpoint:
+                  "https://idp.example.com/oauth2/example/.well-known/openid-configuration",
+              },
+            },
+            org.id,
+            new Headers(),
+            {
+              api: {
+                registerSSOProvider,
+              },
+            } as unknown as Parameters<typeof IdentityProviderModel.create>[3],
+          ),
+        ).rejects.toThrow(
+          'OIDC discovery issuer "https://idp.example.com/oauth2/different" did not match configured issuer "https://idp.example.com/oauth2/example".',
+        );
+
+        expect(registerSSOProvider).not.toHaveBeenCalled();
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    test("rejects registration when the discovery endpoint is not HTTPS", async ({
+      makeOrganization,
+      makeUser,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      const registerSSOProvider = vi.fn();
+      const fetchSpy = vi.fn();
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = fetchSpy;
+
+      try {
+        await expect(
+          IdentityProviderModel.create(
+            {
+              providerId: "example-idp-http",
+              issuer: "https://idp.example.com/oauth2/example",
+              domain: "example.com",
+              userId: user.id,
+              oidcConfig: {
+                issuer: "https://idp.example.com/oauth2/example",
+                pkce: true,
+                clientId: "load-spark-platform",
+                clientSecret: "secret",
+                discoveryEndpoint:
+                  "http://localhost:30081/realms/archestra/.well-known/openid-configuration",
+              },
+            },
+            org.id,
+            new Headers(),
+            {
+              api: {
+                registerSSOProvider,
+              },
+            } as unknown as Parameters<typeof IdentityProviderModel.create>[3],
+          ),
+        ).rejects.toThrow("OIDC discovery endpoint must use HTTPS.");
+
+        expect(fetchSpy).not.toHaveBeenCalled();
+        expect(registerSSOProvider).not.toHaveBeenCalled();
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
     });
   });
 

--- a/platform/backend/src/models/identity-provider.ee.ts
+++ b/platform/backend/src/models/identity-provider.ee.ts
@@ -1,5 +1,5 @@
 import type { SSOOptions } from "@better-auth/sso";
-import type { IdpRoleMappingConfig } from "@shared";
+import type { IdentityProviderOidcConfig, IdpRoleMappingConfig } from "@shared";
 import { IDENTITY_TRUSTED_PROVIDER_IDS, MEMBER_ROLE_NAME } from "@shared";
 import { APIError } from "better-auth";
 import { and, eq } from "drizzle-orm";
@@ -18,6 +18,8 @@ import type {
   PublicIdentityProvider,
   UpdateIdentityProvider,
 } from "@/types";
+import { ApiError } from "@/types";
+import { isPrivateOrLoopbackHostname } from "@/utils/network";
 import AccountModel from "./account";
 import MemberModel from "./member";
 
@@ -594,9 +596,11 @@ class IdentityProviderModel {
       };
     }
 
+    const registrationData = await hydrateOidcConfigForRegistration(parsedData);
+
     // Register with Better Auth
     await auth.api.registerSSOProvider({
-      body: parsedData,
+      body: registrationData,
       headers: new Headers(headers),
     });
 
@@ -626,7 +630,7 @@ class IdentityProviderModel {
      */
     // Also store roleMapping and teamSyncConfig if provided (Better Auth doesn't handle these fields)
     // Note: These are stored as JSON text but typed as objects in Drizzle schema
-    const oidcConfigJson = serializeConfigValue(data.oidcConfig);
+    const oidcConfigJson = serializeConfigValue(registrationData.oidcConfig);
     const samlConfigJson = serializeConfigValue(data.samlConfig);
     const roleMappingJson = serializeConfigValue(data.roleMapping);
     const teamSyncConfigJson = serializeConfigValue(data.teamSyncConfig);
@@ -821,6 +825,8 @@ class IdentityProviderModel {
 
 export default IdentityProviderModel;
 
+const OIDC_DISCOVERY_TIMEOUT_MS = 10_000;
+
 function serializeConfigValue(
   value: string | object | null | undefined,
 ): string | null | undefined {
@@ -833,4 +839,188 @@ function serializeConfigValue(
   }
 
   return JSON.stringify(value);
+}
+
+async function hydrateOidcConfigForRegistration<
+  T extends {
+    providerId: string;
+    issuer: string;
+    domain: string;
+    oidcConfig?: IdentityProviderOidcConfig;
+    samlConfig?: InsertIdentityProvider["samlConfig"];
+  },
+>(data: T): Promise<T> {
+  if (!data.oidcConfig || data.samlConfig) {
+    return data;
+  }
+
+  const hydratedOidcConfig = await discoverOidcConfig(data.oidcConfig);
+
+  logger.info(
+    {
+      providerId: data.providerId,
+      issuer: data.issuer,
+      discoveryEndpoint: hydratedOidcConfig.discoveryEndpoint,
+    },
+    "Hydrated OIDC configuration before Better Auth registration",
+  );
+
+  return {
+    ...data,
+    oidcConfig: hydratedOidcConfig,
+  };
+}
+
+async function discoverOidcConfig(
+  oidcConfig: IdentityProviderOidcConfig,
+): Promise<IdentityProviderOidcConfig> {
+  if (oidcConfig.skipDiscovery) {
+    return oidcConfig;
+  }
+
+  const discoveryEndpoint =
+    oidcConfig.discoveryEndpoint ||
+    `${normalizeIssuer(oidcConfig.issuer)}/.well-known/openid-configuration`;
+  assertValidOidcDiscoveryEndpoint(discoveryEndpoint);
+
+  try {
+    const response = await fetch(discoveryEndpoint, {
+      headers: {
+        Accept: "application/json",
+      },
+      signal: AbortSignal.timeout(OIDC_DISCOVERY_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      logger.error(
+        { discoveryEndpoint, status: response.status },
+        "OIDC discovery fetch failed during IdP registration",
+      );
+      throw new ApiError(
+        400,
+        `OIDC discovery request to "${discoveryEndpoint}" failed with status ${response.status}.`,
+      );
+    }
+
+    const discoveryDocument = (await response.json()) as Partial<OidcDiscovery>;
+    const validationError = getOidcDiscoveryValidationError(
+      discoveryDocument,
+      oidcConfig.issuer,
+    );
+    if (validationError) {
+      logger.error(
+        {
+          discoveryEndpoint,
+          issuer: oidcConfig.issuer,
+          validationError,
+        },
+        "OIDC discovery document was incomplete or issuer mismatched during IdP registration",
+      );
+      throw new ApiError(400, validationError);
+    }
+
+    return {
+      ...oidcConfig,
+      skipDiscovery: true,
+      authorizationEndpoint: discoveryDocument.authorization_endpoint,
+      tokenEndpoint: discoveryDocument.token_endpoint,
+      jwksEndpoint: discoveryDocument.jwks_uri,
+      userInfoEndpoint:
+        discoveryDocument.userinfo_endpoint ?? oidcConfig.userInfoEndpoint,
+      tokenEndpointAuthentication:
+        oidcConfig.tokenEndpointAuthentication ||
+        selectTokenEndpointAuthentication(
+          discoveryDocument.token_endpoint_auth_methods_supported,
+        ),
+    };
+  } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
+
+    logger.error(
+      {
+        discoveryEndpoint,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "OIDC discovery request failed during IdP registration",
+    );
+    throw new ApiError(
+      400,
+      `OIDC discovery request to "${discoveryEndpoint}" failed before registration could complete.`,
+    );
+  }
+}
+
+function getOidcDiscoveryValidationError(
+  document: Partial<OidcDiscovery>,
+  configuredIssuer: string,
+): string | null {
+  if (
+    typeof document.issuer !== "string" ||
+    typeof document.authorization_endpoint !== "string" ||
+    typeof document.token_endpoint !== "string" ||
+    typeof document.jwks_uri !== "string"
+  ) {
+    return "OIDC discovery document is missing one or more required endpoints.";
+  }
+
+  if (normalizeIssuer(document.issuer) !== normalizeIssuer(configuredIssuer)) {
+    return `OIDC discovery issuer "${document.issuer}" did not match configured issuer "${configuredIssuer}".`;
+  }
+
+  return null;
+}
+
+function normalizeIssuer(issuer: string): string {
+  return issuer.replace(/\/$/, "");
+}
+
+function selectTokenEndpointAuthentication(
+  methods: string[] | undefined,
+): IdentityProviderOidcConfig["tokenEndpointAuthentication"] | undefined {
+  if (!methods?.length) {
+    return undefined;
+  }
+
+  if (methods.includes("client_secret_basic")) {
+    return "client_secret_basic";
+  }
+
+  if (methods.includes("client_secret_post")) {
+    return "client_secret_post";
+  }
+
+  return undefined;
+}
+
+function assertValidOidcDiscoveryEndpoint(discoveryEndpoint: string): void {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(discoveryEndpoint);
+  } catch {
+    throw new ApiError(
+      400,
+      `OIDC discovery endpoint "${discoveryEndpoint}" is not a valid URL.`,
+    );
+  }
+
+  if (parsedUrl.protocol !== "https:") {
+    throw new ApiError(400, "OIDC discovery endpoint must use HTTPS.");
+  }
+
+  if (isPrivateOrLoopbackHostname(parsedUrl.hostname)) {
+    throw new ApiError(
+      400,
+      `OIDC discovery endpoint host "${parsedUrl.hostname}" is not allowed.`,
+    );
+  }
+}
+
+interface OidcDiscovery {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  jwks_uri: string;
+  userinfo_endpoint?: string;
+  token_endpoint_auth_methods_supported?: string[];
 }

--- a/platform/backend/src/utils/network.test.ts
+++ b/platform/backend/src/utils/network.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   isLoopbackAddress,
   isLoopbackRedirectUri,
+  isPrivateOrLoopbackHostname,
   loopbackRedirectUriMatchesIgnoringPort,
 } from "./network";
 
@@ -179,5 +180,41 @@ describe("loopbackRedirectUriMatchesIgnoringPort", () => {
         "http://127.0.0.1:3000/callback",
       ]),
     ).toBe(false);
+  });
+});
+
+describe("isPrivateOrLoopbackHostname", () => {
+  test("returns true for localhost hostnames", () => {
+    expect(isPrivateOrLoopbackHostname("localhost")).toBe(true);
+    expect(isPrivateOrLoopbackHostname("idp.localhost")).toBe(true);
+  });
+
+  test("returns true for loopback and private IPv4 addresses", () => {
+    expect(isPrivateOrLoopbackHostname("127.0.0.1")).toBe(true);
+    expect(isPrivateOrLoopbackHostname("10.0.0.1")).toBe(true);
+    expect(isPrivateOrLoopbackHostname("172.16.0.10")).toBe(true);
+    expect(isPrivateOrLoopbackHostname("192.168.1.20")).toBe(true);
+    expect(isPrivateOrLoopbackHostname("169.254.10.5")).toBe(true);
+  });
+
+  test("returns true for loopback and private IPv6 addresses", () => {
+    expect(isPrivateOrLoopbackHostname("::1")).toBe(true);
+    expect(isPrivateOrLoopbackHostname("::")).toBe(true);
+    expect(isPrivateOrLoopbackHostname("fc00::1")).toBe(true);
+    expect(isPrivateOrLoopbackHostname("fd12::1")).toBe(true);
+    expect(isPrivateOrLoopbackHostname("fe80::1")).toBe(true);
+    expect(isPrivateOrLoopbackHostname("::ffff:10.0.0.1")).toBe(true);
+  });
+
+  test("returns false for public hostnames and IP addresses", () => {
+    expect(isPrivateOrLoopbackHostname("example.com")).toBe(false);
+    expect(isPrivateOrLoopbackHostname("idp.example.net")).toBe(false);
+    expect(isPrivateOrLoopbackHostname("8.8.8.8")).toBe(false);
+    expect(isPrivateOrLoopbackHostname("2001:4860:4860::8888")).toBe(false);
+  });
+
+  test("returns false for invalid hostname input", () => {
+    expect(isPrivateOrLoopbackHostname("")).toBe(false);
+    expect(isPrivateOrLoopbackHostname("not a host")).toBe(false);
   });
 });

--- a/platform/backend/src/utils/network.ts
+++ b/platform/backend/src/utils/network.ts
@@ -1,4 +1,4 @@
-import { isIPv4 } from "node:net";
+import { isIP, isIPv4 } from "node:net";
 
 /**
  * Check whether an IP address string is a loopback (localhost) address.
@@ -37,6 +37,42 @@ export function isLoopbackRedirectUri(uri: string): boolean {
 }
 
 /**
+ * Check whether a hostname is an explicit loopback/private target.
+ *
+ * This is intentionally limited to cases we can determine locally without DNS:
+ *  - localhost / *.localhost
+ *  - literal IP addresses in loopback, RFC1918, link-local, or unspecified ranges
+ */
+export function isPrivateOrLoopbackHostname(hostname: string): boolean {
+  const normalizedHostname = hostname
+    .trim()
+    .toLowerCase()
+    .replace(/^\[(.*)\]$/, "$1");
+
+  if (
+    normalizedHostname === "localhost" ||
+    normalizedHostname.endsWith(".localhost")
+  ) {
+    return true;
+  }
+
+  if (isLoopbackAddress(normalizedHostname)) {
+    return true;
+  }
+
+  const ipVersion = isIP(normalizedHostname);
+  if (ipVersion === 4) {
+    return isPrivateIpv4Address(normalizedHostname);
+  }
+
+  if (ipVersion === 6) {
+    return isPrivateIpv6Address(normalizedHostname);
+  }
+
+  return false;
+}
+
+/**
  * Check if a requested loopback redirect URI matches any registered URI,
  * ignoring the port component. Returns true when scheme, host, and path
  * match but the port differs.
@@ -69,4 +105,39 @@ export function loopbackRedirectUriMatchesIgnoringPort(
       return false;
     }
   });
+}
+
+function isPrivateIpv4Address(ipAddress: string): boolean {
+  const octets = ipAddress.split(".").map((segment) => Number(segment));
+  const [firstOctet, secondOctet] = octets;
+
+  return (
+    firstOctet === 10 ||
+    firstOctet === 0 ||
+    (firstOctet === 169 && secondOctet === 254) ||
+    (firstOctet === 172 && secondOctet >= 16 && secondOctet <= 31) ||
+    (firstOctet === 192 && secondOctet === 168)
+  );
+}
+
+function isPrivateIpv6Address(ipAddress: string): boolean {
+  const normalizedIpAddress = ipAddress.toLowerCase();
+
+  if (normalizedIpAddress === "::") {
+    return true;
+  }
+
+  if (
+    normalizedIpAddress.startsWith("fc") ||
+    normalizedIpAddress.startsWith("fd") ||
+    normalizedIpAddress.startsWith("fe80:")
+  ) {
+    return true;
+  }
+
+  if (normalizedIpAddress.startsWith("::ffff:")) {
+    return isPrivateIpv4Address(normalizedIpAddress.slice(7));
+  }
+
+  return false;
 }


### PR DESCRIPTION
## What changed
This follow-up bypasses Better Auth's OIDC discovery-origin gate during identity-provider creation by hydrating the discovery document in Archestra first, then registering the provider with `skipDiscovery: true` and the resolved OIDC endpoints.

## Why it changed
The earlier fix widened Better Auth trusted origins for the registration flow, but someone reported still hitting `Untrusted OIDC discovery URL` in load after deploying it. Rather than continuing to depend on Better Auth's internal discovery trust path, this patch resolves the discovery document server-side and persists the hydrated OIDC configuration that Better Auth needs.

## Impact
Generic OIDC provider creation should no longer fail on Better Auth's discovery-origin trust check when the discovery document itself is valid. The created provider also keeps the hydrated authorization, token, JWKS, and userinfo endpoints in the stored config.