### PR TITLE
chore: trust proxy in staging backend

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -33,6 +33,7 @@ archestra:
     ARCHESTRA_BEDROCK_INFERENCE_PROFILE_PREFIX: "eu"
     ARCHESTRA_AUTH_COOKIE_DOMAIN: ".archestra.dev"
     ARCHESTRA_FRONTEND_URL: "https://frontend.archestra.dev"
+    ARCHESTRA_TRUST_PROXY: "true"
     ARCHESTRA_SENTRY_ENVIRONMENT: "archestra.dev"
     ARCHESTRA_AGENTS_INCOMING_EMAIL_PROVIDER: "outlook"
     ARCHESTRA_AGENTS_INCOMING_EMAIL_OUTLOOK_MAILBOX_ADDRESS: "agents@archestraai.onmicrosoft.com"


### PR DESCRIPTION
## Summary

- set `ARCHESTRA_TRUST_PROXY: "true"` in staging Helm values
- ensure backend OAuth protected-resource metadata and `WWW-Authenticate` headers advertise `https://backend.archestra.dev/...` behind the TLS-terminating proxy

## Root Cause

Staging was serving MCP OAuth protected-resource metadata with `http://backend.archestra.dev/...` while clients connect over `https://backend.archestra.dev/...`. Claude rejects that mismatch during SDK auth.

Fastify only derives the external HTTPS scheme from `X-Forwarded-Proto` when `trustProxy` is enabled, so the backend needed `ARCHESTRA_TRUST_PROXY=true` in staging.