### PR TITLE
fix: MCP OAuth discovery rewrite

### DIFF
--- a/platform/frontend/next.config.ts
+++ b/platform/frontend/next.config.ts
@@ -57,6 +57,10 @@ const nextConfig: NextConfig = {
         destination: `${backendUrl}/v1/:path*`,
       },
       {
+        source: "/.well-known/:path*",
+        destination: `${backendUrl}/.well-known/:path*`,
+      },
+      {
         source: "/health",
         destination: `${backendUrl}/health`,
       },

--- a/platform/frontend/src/next-config.test.ts
+++ b/platform/frontend/src/next-config.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@sentry/nextjs", () => ({
+  withSentryConfig: (config: unknown) => config,
+}));
+
+describe("next config rewrites", () => {
+  beforeEach(() => {
+    delete process.env.ARCHESTRA_INTERNAL_API_BASE_URL;
+  });
+
+  it("proxies well-known oauth discovery routes to the backend by default", async () => {
+    const { default: nextConfig } = await import("../next.config");
+
+    const rewrites = await nextConfig.rewrites?.();
+
+    expect(rewrites).toEqual(
+      expect.arrayContaining([
+        {
+          source: "/.well-known/:path*",
+          destination: "http://localhost:9000/.well-known/:path*",
+        },
+      ]),
+    );
+  });
+
+  it("uses the configured backend URL for well-known oauth discovery routes", async () => {
+    process.env.ARCHESTRA_INTERNAL_API_BASE_URL = "https://api.example.com";
+
+    const { default: nextConfig } = await import("../next.config");
+
+    const rewrites = await nextConfig.rewrites?.();
+
+    expect(rewrites).toEqual(
+      expect.arrayContaining([
+        {
+          source: "/.well-known/:path*",
+          destination: "https://api.example.com/.well-known/:path*",
+        },
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## What changed
- Added a Next.js rewrite for `/.well-known/:path*` so OAuth discovery endpoints are forwarded from the frontend to the backend just like `/api/*` and `/v1/*`
- Added a focused frontend regression test covering the default backend URL and a custom `ARCHESTRA_INTERNAL_API_BASE_URL`

## Why
A deployment that fronts Archestra through the frontend port on a single domain could return a Next.js 404 for MCP OAuth discovery endpoints such as `/.well-known/oauth-authorization-server`. Operators had to work around that with an ingress rule that routed `/.well-known/*` directly to the backend. The frontend proxy should handle this itself.

## Impact
- MCP clients can discover gateway OAuth metadata through the same public hostname without extra ingress routing
- Reduces deployment friction for single-domain frontend-backed installs