### PR TITLE
fix: MCP reinstall prompts and config autofill

### DIFF
--- a/platform/backend/src/services/mcp-reinstall.test.ts
+++ b/platform/backend/src/services/mcp-reinstall.test.ts
@@ -247,7 +247,7 @@ describe("mcp-reinstall", () => {
         expect(result).toBe(true);
       });
 
-      test("returns false when only non-prompted config changes (command/args)", () => {
+      test("returns true when command or args change", () => {
         const envVars = [
           {
             key: "API_KEY",
@@ -274,7 +274,40 @@ describe("mcp-reinstall", () => {
 
         const result = requiresNewUserInputForReinstall(oldConfig, newConfig);
 
-        expect(result).toBe(false);
+        expect(result).toBe(true);
+      });
+
+      test("returns true when docker or transport config changes", () => {
+        const oldConfig = {
+          ...createLocalCatalog([]),
+          localConfig: {
+            command: "node",
+            arguments: ["server.js"],
+            dockerImage: "registry.example.com/mcp:1",
+            transportType: "stdio",
+            httpPort: undefined,
+            httpPath: undefined,
+            serviceAccount: "default",
+            environment: [],
+          },
+        } as InternalMcpCatalog;
+        const newConfig = {
+          ...createLocalCatalog([]),
+          localConfig: {
+            command: "node",
+            arguments: ["server.js"],
+            dockerImage: "registry.example.com/mcp:2",
+            transportType: "streamable-http",
+            httpPort: 8080,
+            httpPath: "/mcp",
+            serviceAccount: "custom-sa",
+            environment: [],
+          },
+        } as InternalMcpCatalog;
+
+        const result = requiresNewUserInputForReinstall(oldConfig, newConfig);
+
+        expect(result).toBe(true);
       });
 
       test("returns false when only non-prompted env vars are added", () => {

--- a/platform/backend/src/services/mcp-reinstall.ts
+++ b/platform/backend/src/services/mcp-reinstall.ts
@@ -8,6 +8,7 @@ import type { InternalMcpCatalog, McpServer } from "@/types";
  *
  * Returns true (manual reinstall required) when:
  * - Server name changed (local servers) - affects secret paths
+ * - Local execution config changed (command/args/docker/transport) - restart should be explicit
  * - Prompted env vars changed: added, removed, or key/required/type changed (local servers)
  * - OAuth config changed: added or removed (remote servers)
  * - Required userConfig fields changed: added, removed, or type changed (remote servers)
@@ -46,6 +47,14 @@ export function requiresNewUserInputForReinstall(
       logger.info(
         { catalogId: newCatalogItem.id },
         "Prompted env vars changed - manual reinstall required",
+      );
+      return true;
+    }
+
+    if (localExecutionConfigChanged(oldCatalogItem, newCatalogItem)) {
+      logger.info(
+        { catalogId: newCatalogItem.id },
+        "Local execution config changed - manual reinstall required",
       );
       return true;
     }
@@ -196,6 +205,15 @@ export async function autoReinstallServer(
 // ===== Internal helpers =====
 
 type PromptedEnvVarInfo = { required: boolean; type: string };
+type LocalExecutionConfigInfo = {
+  command: string;
+  arguments: string[];
+  dockerImage: string;
+  transportType: string;
+  httpPort: number | null;
+  httpPath: string;
+  serviceAccount: string;
+};
 
 /**
  * Extract prompted env vars from a catalog item as a map of key -> { required, type }
@@ -234,6 +252,30 @@ function promptedEnvVarsChanged(
   }
 
   return false;
+}
+
+function localExecutionConfigChanged(
+  oldCatalog: InternalMcpCatalog,
+  newCatalog: InternalMcpCatalog,
+): boolean {
+  return (
+    JSON.stringify(getLocalExecutionConfig(oldCatalog)) !==
+    JSON.stringify(getLocalExecutionConfig(newCatalog))
+  );
+}
+
+function getLocalExecutionConfig(
+  catalog: InternalMcpCatalog,
+): LocalExecutionConfigInfo {
+  return {
+    command: catalog.localConfig?.command ?? "",
+    arguments: catalog.localConfig?.arguments ?? [],
+    dockerImage: catalog.localConfig?.dockerImage ?? "",
+    transportType: catalog.localConfig?.transportType ?? "",
+    httpPort: catalog.localConfig?.httpPort ?? null,
+    httpPath: catalog.localConfig?.httpPath ?? "",
+    serviceAccount: catalog.localConfig?.serviceAccount ?? "",
+  };
 }
 
 type UserConfigFieldInfo = { type: string };

--- a/platform/backend/src/services/mcp-reinstall.ts
+++ b/platform/backend/src/services/mcp-reinstall.ts
@@ -272,7 +272,7 @@ function getLocalExecutionConfig(
     command: catalog.localConfig?.command ?? "",
     arguments: catalog.localConfig?.arguments ?? [],
     dockerImage: catalog.localConfig?.dockerImage ?? "",
-    transportType: catalog.localConfig?.transportType ?? "",
+    transportType: catalog.localConfig?.transportType,
     httpPort: catalog.localConfig?.httpPort,
     httpPath: catalog.localConfig?.httpPath ?? "",
     serviceAccount: catalog.localConfig?.serviceAccount ?? "",

--- a/platform/backend/src/services/mcp-reinstall.ts
+++ b/platform/backend/src/services/mcp-reinstall.ts
@@ -1,7 +1,7 @@
 import { McpServerRuntimeManager } from "@/k8s/mcp-server-runtime";
 import logger from "@/logging";
 import { McpServerModel, ToolModel } from "@/models";
-import type { InternalMcpCatalog, McpServer } from "@/types";
+import type { InternalMcpCatalog, LocalConfig, McpServer } from "@/types";
 
 /**
  * Checks if a catalog edit requires new user input for reinstallation.
@@ -205,15 +205,16 @@ export async function autoReinstallServer(
 // ===== Internal helpers =====
 
 type PromptedEnvVarInfo = { required: boolean; type: string };
-type LocalExecutionConfigInfo = {
-  command: string;
-  arguments: string[];
-  dockerImage: string;
-  transportType: string;
-  httpPort: number | null;
-  httpPath: string;
-  serviceAccount: string;
-};
+type ComparableLocalConfig = Pick<
+  LocalConfig,
+  | "command"
+  | "arguments"
+  | "dockerImage"
+  | "transportType"
+  | "httpPort"
+  | "httpPath"
+  | "serviceAccount"
+>;
 
 /**
  * Extract prompted env vars from a catalog item as a map of key -> { required, type }
@@ -266,13 +267,13 @@ function localExecutionConfigChanged(
 
 function getLocalExecutionConfig(
   catalog: InternalMcpCatalog,
-): LocalExecutionConfigInfo {
+): ComparableLocalConfig {
   return {
     command: catalog.localConfig?.command ?? "",
     arguments: catalog.localConfig?.arguments ?? [],
     dockerImage: catalog.localConfig?.dockerImage ?? "",
     transportType: catalog.localConfig?.transportType ?? "",
-    httpPort: catalog.localConfig?.httpPort ?? null,
+    httpPort: catalog.localConfig?.httpPort,
     httpPath: catalog.localConfig?.httpPath ?? "",
     serviceAccount: catalog.localConfig?.serviceAccount ?? "",
   };

--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -857,24 +857,9 @@ export function InternalMCPCatalog({
         setReinstallServerTeamId(installedServer.teamId ?? null);
         openDialog("local-install");
       } else {
-        // No prompted env vars - reinstall directly
-        // Set installing state for immediate UI feedback (progress bar)
-        setInstallingItemId(catalogItem.id);
-        setInstallingServerIds((prev) => new Set(prev).add(installedServer.id));
-        try {
-          await reinstallMutation.mutateAsync({
-            id: installedServer.id,
-            name: catalogItem.name,
-          });
-        } finally {
-          // Clear installing state whether success or error
-          setInstallingItemId(null);
-          setInstallingServerIds((prev) => {
-            const newSet = new Set(prev);
-            newSet.delete(installedServer.id);
-            return newSet;
-          });
-        }
+        // No prompted env vars - still confirm before reinstalling
+        setCatalogItemForReinstall(catalogItem);
+        openDialog("reinstall");
       }
     } else {
       // Remote server - show confirmation dialog (may need OAuth re-auth)
@@ -886,10 +871,16 @@ export function InternalMCPCatalog({
   const handleReinstallConfirm = async () => {
     if (!catalogItemForReinstall) return;
 
-    // Find the installed server for this remote catalog item
-    const installedServer = installedServers?.find(
-      (server) => server.catalogId === catalogItemForReinstall.id,
-    );
+    const installedServer =
+      catalogItemForReinstall.serverType === "local" && currentUserId
+        ? installedServers?.find(
+            (server) =>
+              server.catalogId === catalogItemForReinstall.id &&
+              server.ownerId === currentUserId,
+          )
+        : installedServers?.find(
+            (server) => server.catalogId === catalogItemForReinstall.id,
+          );
 
     if (!installedServer) {
       toast.error("Server not found, cannot reinstall");
@@ -900,8 +891,7 @@ export function InternalMCPCatalog({
 
     closeDialog("reinstall");
 
-    // Remote server - reinstall directly
-    // Set installing state for immediate UI feedback (progress bar)
+    // Reinstall directly after explicit confirmation
     setInstallingItemId(catalogItemForReinstall.id);
     setInstallingServerIds((prev) => new Set(prev).add(installedServer.id));
     try {

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.enterprise.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.enterprise.test.tsx
@@ -78,4 +78,49 @@ describe("McpCatalogForm enterprise gating", () => {
       screen.getByText("Enterprise-managed credentials"),
     ).toBeInTheDocument();
   });
+
+  it("disables browser autofill for MCP config forms and secret fields", () => {
+    const { container } = render(
+      <McpCatalogForm
+        mode="edit"
+        onSubmit={vi.fn()}
+        initialValues={
+          {
+            id: "catalog-1",
+            name: "Remote MCP",
+            description: "",
+            icon: null,
+            serverType: "remote",
+            serverUrl: "https://mcp.example.com",
+            oauthConfig: {
+              name: "Remote MCP",
+              server_url: "https://mcp.example.com",
+              client_id: "client-id",
+              client_secret: "client-secret",
+              redirect_uris: ["https://app.example.com/oauth-callback"],
+              scopes: ["read"],
+              default_scopes: ["read"],
+              supports_resource_metadata: true,
+            },
+            userConfig: {},
+            enterpriseManagedConfig: null,
+            localConfig: null,
+            deploymentSpecYaml: null,
+            scope: "personal",
+            teams: [],
+            labels: [],
+          } as never
+        }
+      />,
+    );
+
+    expect(container.querySelector("form")).toHaveAttribute(
+      "autocomplete",
+      "off",
+    );
+    expect(screen.getByLabelText("Client Secret")).toHaveAttribute(
+      "autocomplete",
+      "new-password",
+    );
+  });
 });

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -71,6 +71,10 @@ import { useHasPermissions } from "@/lib/auth/auth.query";
 import { useEnterpriseFeature, useFeature } from "@/lib/config/config.query";
 import { getVisibleDocsUrl } from "@/lib/docs/docs";
 import { useK8sImagePullSecrets } from "@/lib/mcp/internal-mcp-catalog.query";
+import {
+  MCP_CONFIG_AUTOCOMPLETE,
+  MCP_SECRET_AUTOCOMPLETE,
+} from "@/lib/mcp/mcp-form-autocomplete";
 import { useGetSecret } from "@/lib/secrets.query";
 import { useTeams } from "@/lib/teams/team.query";
 import {
@@ -84,9 +88,6 @@ const ExternalSecretSelector = lazy(
     // biome-ignore lint/style/noRestrictedImports: lazy loading
     import("@/components/external-secret-selector.ee"),
 );
-
-const MCP_CONFIG_AUTOCOMPLETE = "off";
-const MCP_SECRET_AUTOCOMPLETE = "new-password";
 
 interface McpCatalogFormProps {
   mode: "create" | "edit";

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -85,6 +85,9 @@ const ExternalSecretSelector = lazy(
     import("@/components/external-secret-selector.ee"),
 );
 
+const MCP_CONFIG_AUTOCOMPLETE = "off";
+const MCP_SECRET_AUTOCOMPLETE = "new-password";
+
 interface McpCatalogFormProps {
   mode: "create" | "edit";
   initialValues?: archestraApiTypes.GetInternalMcpCatalogResponses["200"][number];
@@ -359,6 +362,8 @@ export function McpCatalogForm({
       <form
         onSubmit={form.handleSubmit(handleSubmit)}
         className="flex min-h-0 flex-1 flex-col"
+        autoComplete={MCP_CONFIG_AUTOCOMPLETE}
+        data-1p-ignore="true"
       >
         <div
           className={`min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-4 ${embedded ? "space-y-4 pt-4 pb-0" : "space-y-4 py-4"}`}
@@ -549,6 +554,7 @@ export function McpCatalogForm({
                       <Input
                         placeholder="https://api.example.com/mcp"
                         className="font-mono"
+                        autoComplete={MCP_CONFIG_AUTOCOMPLETE}
                         {...field}
                       />
                     </FormControl>
@@ -570,6 +576,7 @@ export function McpCatalogForm({
                         <Input
                           placeholder="node"
                           className="font-mono"
+                          autoComplete={MCP_CONFIG_AUTOCOMPLETE}
                           {...field}
                         />
                       </FormControl>
@@ -843,6 +850,7 @@ export function McpCatalogForm({
                             <Input
                               placeholder="e.g. quay.io"
                               className="font-mono"
+                              autoComplete={MCP_CONFIG_AUTOCOMPLETE}
                               value={watchField("server")}
                               onChange={(e) =>
                                 setField("server", e.target.value)
@@ -853,6 +861,7 @@ export function McpCatalogForm({
                             <Label className="text-xs">Username</Label>
                             <Input
                               placeholder="username"
+                              autoComplete={MCP_CONFIG_AUTOCOMPLETE}
                               value={watchField("username")}
                               onChange={(e) =>
                                 setField("username", e.target.value)
@@ -863,6 +872,7 @@ export function McpCatalogForm({
                             <Label className="text-xs">Password</Label>
                             <Input
                               type="password"
+                              autoComplete={MCP_SECRET_AUTOCOMPLETE}
                               placeholder={
                                 mode === "edit" && !watchField("password")
                                   ? "Saved — leave blank to keep"
@@ -878,6 +888,7 @@ export function McpCatalogForm({
                             <Label className="text-xs">Email (optional)</Label>
                             <Input
                               placeholder="email@example.com"
+                              autoComplete={MCP_CONFIG_AUTOCOMPLETE}
                               value={watchField("email")}
                               onChange={(e) =>
                                 setField("email", e.target.value)
@@ -1185,6 +1196,7 @@ export function McpCatalogForm({
                               type="password"
                               placeholder="your-client-secret (optional)"
                               className="font-mono"
+                              autoComplete={MCP_SECRET_AUTOCOMPLETE}
                               {...field}
                             />
                           </FormControl>

--- a/platform/frontend/src/components/environment-variables-form-field.tsx
+++ b/platform/frontend/src/components/environment-variables-form-field.tsx
@@ -50,6 +50,9 @@ const ExternalSecretSelector = lazy(
     import("@/components/external-secret-selector.ee"),
 );
 
+const MCP_CONFIG_AUTOCOMPLETE = "off";
+const MCP_SECRET_AUTOCOMPLETE = "new-password";
+
 interface ExternalSecretValue {
   teamId: string | null;
   secretPath: string | null;
@@ -436,6 +439,11 @@ export function EnvironmentVariablesFormField<
                                     }
                                     placeholder="your-value"
                                     className="font-mono"
+                                    autoComplete={
+                                      envType === "secret"
+                                        ? MCP_SECRET_AUTOCOMPLETE
+                                        : MCP_CONFIG_AUTOCOMPLETE
+                                    }
                                     {...field}
                                   />
                                 </FormControl>
@@ -852,6 +860,7 @@ function AutoResizeSecretTextarea({
         <Textarea
           className="font-mono text-xs resize-none min-h-10 max-h-32 overflow-y-auto"
           rows={1}
+          autoComplete={MCP_SECRET_AUTOCOMPLETE}
           {...field}
           ref={(el) => {
             textareaRef.current = el;

--- a/platform/frontend/src/components/environment-variables-form-field.tsx
+++ b/platform/frontend/src/components/environment-variables-form-field.tsx
@@ -43,15 +43,16 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  MCP_CONFIG_AUTOCOMPLETE,
+  MCP_SECRET_AUTOCOMPLETE,
+} from "@/lib/mcp/mcp-form-autocomplete";
 
 const ExternalSecretSelector = lazy(
   () =>
     // biome-ignore lint/style/noRestrictedImports: lazy loading
     import("@/components/external-secret-selector.ee"),
 );
-
-const MCP_CONFIG_AUTOCOMPLETE = "off";
-const MCP_SECRET_AUTOCOMPLETE = "new-password";
 
 interface ExternalSecretValue {
   teamId: string | null;

--- a/platform/frontend/src/lib/mcp/mcp-form-autocomplete.ts
+++ b/platform/frontend/src/lib/mcp/mcp-form-autocomplete.ts
@@ -1,0 +1,2 @@
+export const MCP_CONFIG_AUTOCOMPLETE = "off";
+export const MCP_SECRET_AUTOCOMPLETE = "new-password";


### PR DESCRIPTION
## What changed

This fixes two MCP registry config dialog issues:

- changing self-hosted MCP execution config such as command, args, docker image, transport, HTTP settings, or service account now marks installations as requiring reinstall instead of silently auto-reinstalling them
- local MCP reinstall flows without prompted env vars now show the reinstall confirmation dialog instead of reinstalling immediately
- MCP server config forms now opt out of browser/password-manager autofill, and secret fields explicitly use `autocomplete="new-password"`

## Why

Argument and runtime config changes affect how the deployed MCP server starts, so the reinstall should be explicit and visible to the user. Separately, Chrome was treating parts of the config dialog as password-like fields and auto-filling them.

## Impact

Admins editing MCP catalog entries will now get a reinstall prompt for runtime config changes, and config fields should no longer be polluted by browser autofill.

## Root cause

The reinstall policy only treated prompted env var and name changes as manual-reinstall triggers for local servers, and the frontend directly reinstalled local servers with no prompted env vars instead of confirming. The config form also did not opt out of browser autofill.
