### PR TITLE
fix(ci): restore permissions for platform image build job

### DIFF
--- a/.github/workflows/build-base-mcp-server-docker-image.yml
+++ b/.github/workflows/build-base-mcp-server-docker-image.yml
@@ -57,6 +57,9 @@ jobs:
     name: Build MCP Server Base Image
     needs:
       - python-mcp-lockfile-check
+    permissions:
+      contents: read # Required to checkout the repository and build the image.
+      id-token: write # Required for Workload Identity Federation when pushing images.
     uses: ./.github/workflows/build-native-multi-arch-image.yml
     with:
       image_directory: ./platform/mcp_server_docker_image

--- a/.github/workflows/build-dockerhub-image.yml
+++ b/.github/workflows/build-dockerhub-image.yml
@@ -41,6 +41,9 @@ concurrency:
 jobs:
   build-dockerhub-image:
     name: Build Docker Hub image
+    permissions:
+      contents: read # Required to checkout the repository and build the image.
+      id-token: write # Required for Workload Identity Federation when pushing images.
     uses: ./.github/workflows/build-native-multi-arch-image.yml
     with:
       image_directory: ${{ inputs.image_directory }}

--- a/.github/workflows/deploy-dev-platform-images.yml
+++ b/.github/workflows/deploy-dev-platform-images.yml
@@ -74,6 +74,9 @@ jobs:
     needs:
       - resolve-previous-platform-image
     if: ${{ github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.label.name == 'deploy-dev-platform-images' && github.event.pull_request.head.repo.fork != true) }}
+    permissions:
+      contents: read # Required to checkout the repository and build the image.
+      id-token: write # Required for Workload Identity Federation when pushing images.
     uses: ./.github/workflows/build-native-multi-arch-image.yml
     with:
       image_directory: ./platform


### PR DESCRIPTION
## Summary
- Restores the `permissions` block (`contents: read`, `id-token: write`) on three jobs that call the reusable `build-native-multi-arch-image` workflow but were missing permissions after the refactor in #3741:
  - `publish-dev-platform-image` in `deploy-dev-platform-images.yml`
  - `build-mcp-server-base-image` in `build-base-mcp-server-docker-image.yml`
  - `build-dockerhub-image` in `build-dockerhub-image.yml`
- All three workflows have top-level `permissions: {}`, so jobs without an explicit `permissions` block inherit `none`, causing nested workflow jobs to fail with "requesting contents: read, id-token: write but only allowed none"