### PR TITLE
fix(ci): add missing checkout step to resolve-previous-platform-image job

### DIFF
--- a/.github/workflows/deploy-dev-platform-images.yml
+++ b/.github/workflows/deploy-dev-platform-images.yml
@@ -40,6 +40,12 @@ jobs:
     outputs:
       previous_image: ${{ steps.previous-platform-image.outputs.previous-image }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
       - name: Authenticate to Google Artifact Registry
         uses: ./.github/actions/auth-to-gar
         with:


### PR DESCRIPTION
## Summary
- Adds the missing `actions/checkout` step to the `resolve-previous-platform-image` job in `deploy-dev-platform-images.yml`
- The job uses the local action `.github/actions/auth-to-gar` which requires the repo to be checked out first — the checkout step was lost when the job was extracted from the original `publish-dev-platform-image` job in #3741