### PR TITLE
fix(ci): restore dedicated values file for readonly vault e2e

### DIFF
--- a/.github/values-ci-vault-k8s.yaml
+++ b/.github/values-ci-vault-k8s.yaml
@@ -1,0 +1,109 @@
+# CI-specific values for the Archestra Helm chart — Vault K8s auth scenario
+# This file is used during e2e testing in GitHub Actions to validate that the
+# platform starts and runs migrations when the database URL is sourced from
+# Vault via the vault-secrets init container (vault env injector).
+
+archestra:
+  # Image will be set via --set during deployment
+  # image: archestra/platform:ci-test
+
+  # Single replica to avoid concurrent first-boot migration races
+  replicaCount: 1
+
+  worker:
+    replicaCount: 2
+
+  # Environment variables for Vault K8s e2e testing
+  env:
+    ENABLE_E2E_TEST_ENDPOINTS: "true"
+    ARCHESTRA_ANALYTICS: disabled
+    # Dummy LLM proxy base URLs (not tested in this scenario)
+    ARCHESTRA_OPENAI_BASE_URL: "http://localhost:8080/openai/v1"
+    ARCHESTRA_ANTHROPIC_BASE_URL: "http://localhost:8080/anthropic"
+    ARCHESTRA_GEMINI_BASE_URL: "http://localhost:8080/gemini"
+    ARCHESTRA_COHERE_BASE_URL: "http://localhost:8080/cohere"
+    ARCHESTRA_CEREBRAS_BASE_URL: "http://localhost:8080/cerebras/v1"
+    ARCHESTRA_VLLM_BASE_URL: "http://localhost:8080/vllm/v1"
+    ARCHESTRA_OLLAMA_BASE_URL: "http://localhost:8080/ollama/v1"
+    ARCHESTRA_GROQ_BASE_URL: "http://localhost:8080/groq/v1"
+    ARCHESTRA_XAI_BASE_URL: "http://localhost:8080/xai/v1"
+    ARCHESTRA_OPENROUTER_BASE_URL: "http://localhost:8080/openrouter/api/v1"
+    ARCHESTRA_ZHIPUAI_BASE_URL: "http://localhost:8080/zhipuai/v4"
+    ARCHESTRA_MISTRAL_BASE_URL: "http://localhost:8080/mistral/v1"
+    ARCHESTRA_BEDROCK_BASE_URL: "http://localhost:8080/bedrock"
+    ARCHESTRA_PERPLEXITY_BASE_URL: "http://localhost:8080/perplexity/v1"
+    ARCHESTRA_DEEPSEEK_BASE_URL: "http://localhost:8080/deepseek"
+    ARCHESTRA_MINIMAX_BASE_URL: "http://localhost:8080/minimax/v1"
+    ARCHESTRA_AZURE_OPENAI_BASE_URL: "http://localhost:8080/azure/openai/deployments/test-deployment"
+    ARCHESTRA_AZURE_OPENAI_API_VERSION: "2024-02-01"
+    # Dummy chat API keys (not tested in this scenario)
+    ARCHESTRA_CHAT_OPENAI_API_KEY: test-key
+    ARCHESTRA_CHAT_ANTHROPIC_API_KEY: test-key
+    ARCHESTRA_CHAT_GEMINI_API_KEY: test-key
+    ARCHESTRA_CHAT_COHERE_API_KEY: test-key
+    ARCHESTRA_CHAT_CEREBRAS_API_KEY: test-key
+    ARCHESTRA_CHAT_VLLM_API_KEY: test-key
+    ARCHESTRA_CHAT_OLLAMA_API_KEY: test-key
+    ARCHESTRA_CHAT_GROQ_API_KEY: test-key
+    ARCHESTRA_CHAT_XAI_API_KEY: test-key
+    ARCHESTRA_CHAT_OPENROUTER_API_KEY: test-key
+    ARCHESTRA_CHAT_ZHIPUAI_API_KEY: test-key
+    ARCHESTRA_CHAT_MISTRAL_API_KEY: test-key
+    ARCHESTRA_CHAT_BEDROCK_API_KEY: test-key
+    ARCHESTRA_CHAT_PERPLEXITY_API_KEY: test-key
+    ARCHESTRA_CHAT_DEEPSEEK_API_KEY: test-key
+    ARCHESTRA_CHAT_MINIMAX_API_KEY: test-key
+    ARCHESTRA_CHAT_AZURE_OPENAI_API_KEY: test-key
+    ARCHESTRA_METRICS_SECRET: "foo-bar"
+    ARCHESTRA_FRONTEND_URL: "http://localhost:3000"
+    ARCHESTRA_AUTH_SECRET: "e2e-auth-secret-must-be-32-chars-long"
+    ARCHESTRA_ENTERPRISE_LICENSE_ACTIVATED: "true"
+    ARCHESTRA_ENTERPRISE_LICENSE_FULL_WHITE_LABELING: "true"
+    ARCHESTRA_ENTERPRISE_LICENSE_KNOWLEDGE_BASE_ACTIVATED: "true"
+    ARCHESTRA_AUTH_RATE_LIMIT_DISABLED: "true"
+    # Vault K8s auth configuration — readonly vault mode for BYOS testing
+    ARCHESTRA_SECRETS_MANAGER: "READONLY_VAULT"
+    ARCHESTRA_HASHICORP_VAULT_ADDR: "http://vault:8200"
+    ARCHESTRA_HASHICORP_VAULT_AUTH_METHOD: "K8S"
+    ARCHESTRA_HASHICORP_VAULT_K8S_ROLE: "archestra"
+    ARCHESTRA_HASHICORP_VAULT_KV_VERSION: "1"
+
+  # Vault-secrets init container — fetches secrets from Vault and writes them to /vault/secrets/env
+  # The main container sources this file on startup to load secrets as environment variables
+  initContainers:
+    vaultSecrets:
+      enabled: true
+      secrets:
+        - envVar: ARCHESTRA_DATABASE_URL
+          path: kv/archestra/config
+          key: dburl
+        - envVar: TEST_VALUE
+          path: kv/archestra/config
+          key: dummy_var
+
+  # Use NodePort service type to expose services on fixed ports
+  service:
+    type: NodePort
+    nodePorts:
+      backend: 30000
+      metrics: 30050
+      frontend: 30300
+
+# PostgreSQL configuration for CI
+# Vault only provides the connection URL — the DB itself is still deployed via subchart
+postgresql:
+  external_database_url: "from_vault"
+  enabled: true
+  auth:
+    database: archestra_dev
+    username: archestra
+    password: vault_e2e_custom_pw
+  primary:
+    initdb:
+      scripts:
+        grant-superuser.sql: |
+          ALTER USER archestra WITH SUPERUSER;
+    service:
+      type: NodePort
+      nodePorts:
+        postgresql: 30432

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -329,16 +329,15 @@ jobs:
         with:
           kind-config-path: .github/kind.yaml
           kind-cluster-name: archestra-ci-cluster
-          helm-values-path: .github/values-ci.yaml
+          helm-values-path: .github/values-ci-vault-k8s.yaml
           deploy-e2e-dependencies: "true"
           e2e-dependencies-install-mode: "foreground"
-          e2e-dependencies-extra-helm-set: "vault.k8sAuth.enabled=true,vault.k8sAuth.boundServiceAccountName=archestra-platform,vault.k8sAuth.boundServiceAccountNamespace=default,vault.secrets[0].path=secret/data/archestra/config,vault.secrets[0].data.dburl=postgresql://archestra:vault_e2e_custom_pw@archestra-platform-postgresql:5432/archestra_dev,vault.secrets[0].data.dummy_var=hello-from-vault"
+          e2e-dependencies-extra-helm-set: "vault.k8sAuth.enabled=true,vault.k8sAuth.boundServiceAccountName=archestra-platform,vault.k8sAuth.boundServiceAccountNamespace=default"
           e2e-dependencies-wait-for-vault: "true"
           build-platform-image: "false"
           platform-image-tag: ${{ steps.load-platform-image.outputs.image-tag }}
           platform-context: ./platform
           mcp-server-base-image-tag: ${{ steps.load-mcp-server-base-image.outputs.image-tag }}
-          extra-helm-set: "archestra.env.ARCHESTRA_SECRETS_MANAGER=READONLY_VAULT,archestra.env.ARCHESTRA_HASHICORP_VAULT_KV_VERSION=2,archestra.initContainers.vaultSecrets.secrets[0].path=secret/data/archestra/config,archestra.initContainers.vaultSecrets.secrets[1].path=secret/data/archestra/config"
 
       - name: Run readonly-vault E2E tests
         id: e2e


### PR DESCRIPTION
## Summary

- Restores `values-ci-vault-k8s.yaml` as a dedicated Helm values file for the readonly vault e2e job
- Updates the workflow to use this file instead of `values-ci.yaml` + helm overrides that introduced a KV v1/v2 mismatch

## Problem

The readonly vault e2e job has been failing since #3687 merged the vault config into the shared `values-ci.yaml`. The vault-env-injector init container reads from `kv/archestra/config` (KV v1), but the helm overrides set `ARCHESTRA_HASHICORP_VAULT_KV_VERSION=2`, causing the VaultClient to use the wrong API to read from a v1 engine. The init container crash-loops and the Helm install times out.

## Fix

Restore the dedicated values file that keeps everything consistently on KV v1 — matching the working configuration that existed before the CI consolidation.