### PR TITLE
fix: sync archestra branding in worker so builtin tools work in scheduled tasks

### DIFF
--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -43,6 +43,7 @@ import {
   PROCESSED_EMAIL_CLEANUP_INTERVAL_MS,
   renewEmailSubscriptionIfNeeded,
 } from "@/agents/incoming-email";
+import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import { fastifyAuthPlugin } from "@/auth";
 import { cacheManager } from "@/cache-manager";
 import config, { shouldRunWebServer, shouldRunWorker } from "@/config";
@@ -961,6 +962,14 @@ const startWorker = async () => {
   try {
     await initializeDatabase();
     cacheManager.start();
+
+    // Sync Archestra MCP branding so the worker recognises branded tool names
+    // (e.g. "archestra_staging__artifact_write") when executing scheduled tasks.
+    // Without this, isToolName() only matches the default "archestra__" prefix
+    // and builtin tools fall through to mcpClient.executeToolCall() which fails
+    // because they have credentialResolutionMode "static" with no mcpServerId.
+    const organization = await OrganizationModel.getFirst();
+    archestraMcpBranding.syncFromOrganization(organization);
 
     // Set OpenMetrics content type to enable exemplar support
     const promClient = await import("prom-client");


### PR DESCRIPTION
## Summary

- The worker process never called `archestraMcpBranding.syncFromOrganization()`, so `isToolName()` only matched the default `archestra__` prefix
- On deployments with a custom app name (e.g. "Archestra Staging"), branded tool names like `archestra_staging__artifact_write` were not recognised as builtin tools
- They fell through to `mcpClient.executeToolCall()` which failed with **"An MCP server installation is required for statically assigned MCP tools"** because builtin tools have `credentialResolutionMode: "static"` with `mcpServerId: null`
- Fix: call `syncFromOrganization()` during worker startup so branded tool names are recognised

## Test plan

- [ ] Deploy to archestra-dev and trigger a scheduled task that uses `artifact_write` or `todo_write`
- [ ] Verify the tools execute successfully instead of returning the MCP server installation error