### PR TITLE
chore: add knowledge connector issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-knowledge-connector.md
+++ b/.github/ISSUE_TEMPLATE/add-knowledge-connector.md
@@ -32,34 +32,13 @@ Include clear instructions on how reviewers can create or obtain test credential
 - [ ] Authentication flow is documented
 - [ ] Incremental sync strategy is documented
 
-### 3. Implementation Completeness
+### 3. Implementation Guide
+Follow the [Adding Knowledge Connectors documentation](/docs/platform-adding-knowledge-connectors) for the implementation details, required wiring, testing expectations, and documentation updates.
 
-**Backend:**
-- Connector config and checkpoint Zod schemas
-- Connector implementation (`validateConfig`, `testConnection`, `sync`)
-- Registry wiring
-- Official SDK is used when one is available, or the PR explains why not
+### 4. Demo Evidence
+Please include a short demo video showing the connector being created, connection-tested if applicable, and successfully synced.
 
-**Frontend:**
-- Connector type is selectable in the create connector dialog
-- Connector-specific config fields are implemented
-- Validation and error handling work correctly
-
-### 4. Testing
-- [ ] Connector tests cover `validateConfig`
-- [ ] Connector tests cover `testConnection`
-- [ ] Connector tests cover `sync`, including pagination or incremental sync behavior where relevant
-
-If the connector relies on an external SDK, mock the SDK in tests rather than making live API calls.
-
-### 5. Documentation
-- [ ] Update [Adding Knowledge Connectors](/docs/platform-adding-knowledge-connectors) if the developer workflow changes
-- [ ] Update [Knowledge Connectors](https://archestra.ai/docs/platform-knowledge-connectors) with user-facing setup instructions for the new connector
-
-### 6. Demo Evidence
-Please include screenshots or a short demo video showing the connector being created, connection-tested if applicable, and successfully synced.
-
-**Acceptance Criteria:** We expect the connector to be fully wired through the backend and frontend, covered by tests, documented for users, and to prefer an official SDK over a custom client when the upstream system provides one.
+**Acceptance Criteria:** We expect the connector to follow the [Adding Knowledge Connectors documentation](/docs/platform-adding-knowledge-connectors), include a short demo video, and to prefer an official SDK over a custom client when the upstream system provides one.
 
 ## Additional Context
 

--- a/.github/ISSUE_TEMPLATE/add-knowledge-connector.md
+++ b/.github/ISSUE_TEMPLATE/add-knowledge-connector.md
@@ -1,0 +1,71 @@
+---
+name: Add Knowledge Connector
+about: Request or propose adding a new knowledge connector to Archestra
+title: "[Knowledge Connector] Add <Connector Name> support"
+labels: enhancement, knowledge
+assignees: ''
+
+---
+
+**Connector Name:** <!-- e.g., Linear, Asana, Zendesk -->
+
+**Connector Website:** <!-- Link to the product's main page -->
+
+**API Documentation:** <!-- Link to the API or developer docs -->
+
+**Official SDK:** <!-- Link to the official SDK, if one exists. Prefer official SDKs over hand-rolled clients when available. -->
+
+## Implementation Checklist
+
+Adding a new connector usually requires backend, frontend, documentation, and test updates. For implementation guidance, see our [Adding Knowledge Connectors documentation](/docs/platform-adding-knowledge-connectors).
+
+## Requirements
+
+When submitting a PR to add this connector, please ensure:
+
+### 1. Access and Credential Setup
+Include clear instructions on how reviewers can create or obtain test credentials and what permissions are required. If the connector needs admin consent, special scopes, or a service account, document that in the PR.
+
+### 2. Connector Scope
+- [ ] The sync target is clearly defined (issues, pages, files, tickets, etc.)
+- [ ] Required vs optional config fields are documented
+- [ ] Authentication flow is documented
+- [ ] Incremental sync strategy is documented
+
+### 3. Implementation Completeness
+
+**Backend:**
+- Connector config and checkpoint Zod schemas
+- Connector implementation (`validateConfig`, `testConnection`, `sync`)
+- Registry wiring
+- Official SDK is used when one is available, or the PR explains why not
+
+**Frontend:**
+- Connector type is selectable in the create connector dialog
+- Connector-specific config fields are implemented
+- Validation and error handling work correctly
+
+### 4. Testing
+- [ ] Connector tests cover `validateConfig`
+- [ ] Connector tests cover `testConnection`
+- [ ] Connector tests cover `sync`, including pagination or incremental sync behavior where relevant
+
+If the connector relies on an external SDK, mock the SDK in tests rather than making live API calls.
+
+### 5. Documentation
+- [ ] Update [Adding Knowledge Connectors](/docs/platform-adding-knowledge-connectors) if the developer workflow changes
+- [ ] Update [Knowledge Connectors](https://archestra.ai/docs/platform-knowledge-connectors) with user-facing setup instructions for the new connector
+
+### 6. Demo Evidence
+Please include screenshots or a short demo video showing the connector being created, connection-tested if applicable, and successfully synced.
+
+**Acceptance Criteria:** We expect the connector to be fully wired through the backend and frontend, covered by tests, documented for users, and to prefer an official SDK over a custom client when the upstream system provides one.
+
+## Additional Context
+
+<!--
+Any other information that might be helpful:
+- Are you planning to implement this yourself?
+- Do you already have access to a test instance?
+- Are there any known API limitations, rate limits, or permission constraints?
+-->

--- a/docs/pages/platform-adding-knowledge-connectors.md
+++ b/docs/pages/platform-adding-knowledge-connectors.md
@@ -3,7 +3,7 @@ title: Adding Knowledge Connectors
 category: Development
 order: 3
 description: Developer guide for implementing new knowledge base connectors in Archestra Platform
-lastUpdated: 2026-03-12
+lastUpdated: 2026-04-15
 ---
 
 <!--
@@ -22,7 +22,7 @@ This guide covers how to add a new knowledge connector to Archestra Platform. Co
 4. **Frontend config fields** component for the creation dialog
 5. **User-facing docs update** in `docs/pages/platform-knowledge-connectors.md`
 
-When the external service provides an official SDK, prefer it over raw `fetch` calls. Official SDKs handle pagination, authentication, rate limiting, and type safety out of the box. For example, the GitHub connector uses [`@octokit/rest`](https://www.npmjs.com/package/@octokit/rest) and the GitLab connector uses [`@gitbeaker/rest`](https://www.npmjs.com/package/@gitbeaker/rest).
+When the external service provides an official SDK, prefer it over building a client from scratch with raw `fetch` calls. Use a hand-rolled client only when there is no suitable official SDK or the official SDK is clearly incompatible with the connector's requirements. Official SDKs usually handle pagination, authentication, rate limiting, and type safety out of the box. For example, the GitHub connector uses [`@octokit/rest`](https://www.npmjs.com/package/@octokit/rest) and the GitLab connector uses [`@gitbeaker/rest`](https://www.npmjs.com/package/@gitbeaker/rest).
 
 The walkthrough below uses a hypothetical connector as an example.
 
@@ -233,6 +233,10 @@ export class GithubConnector extends BaseConnector {
 | `rateLimit()`                               | Sleep for the configured delay (default 100ms) between API calls to avoid rate limits           |
 | `joinUrl(base, path)`                       | Normalize and join URL parts                                                                    |
 | `buildBasicAuthHeader(email, token)`        | Build a `Basic` auth header                                                                     |
+
+### SDK selection note
+
+Before writing connector API code, check whether the upstream system publishes an official SDK. If it does, prefer that SDK unless there is a concrete reason not to. If you decide not to use the official SDK, document the reason in the PR so reviewers can evaluate the tradeoff.
 
 ### The async generator pattern
 


### PR DESCRIPTION
## Summary

Adds a new GitHub issue template for proposing Knowledge connector integrations, modeled after the existing LLM provider template.

Also updates the Knowledge connector developer guide to make the SDK preference explicit: when an upstream system offers an official SDK, contributors should prefer it over writing a custom client from scratch unless there is a concrete reason not to.

## Why

We already have contributor guidance for adding LLM providers, but not an equivalent issue template for Knowledge connectors. Adding one makes connector requests more consistent and points contributors to the existing implementation guide.

The docs change reinforces a review expectation that was already implied in the guide, which should reduce hand-rolled integrations when a maintained upstream SDK exists.