### PR TITLE
fix: filter empty-content messages to prevent Bedrock Converse 400 errors

### DIFF
--- a/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
+++ b/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
@@ -49,6 +49,66 @@ describe("normalizeChatMessages", () => {
     ).toHaveLength(1);
   });
 
+  test("drops assistant messages left empty after stripping dangling tool calls", () => {
+    const messages = [
+      {
+        id: "msg1",
+        role: "user" as const,
+        parts: [{ type: "text", text: "Do something" }],
+      },
+      {
+        id: "msg2",
+        role: "assistant" as const,
+        parts: [
+          {
+            type: "tool-call",
+            toolCallId: "dangling_call_1",
+            toolName: "some_tool",
+            state: "input-available",
+            args: {},
+          },
+        ],
+      },
+      {
+        id: "msg3",
+        role: "user" as const,
+        parts: [{ type: "text", text: "What happened?" }],
+      },
+    ];
+
+    const result = normalizeChatMessages(messages);
+
+    // The assistant message with only a dangling tool call should be removed
+    expect(result).toHaveLength(2);
+    expect(result.map((m) => m.id)).toEqual(["msg1", "msg3"]);
+  });
+
+  test("keeps assistant messages with remaining parts after stripping dangling tool calls", () => {
+    const messages = [
+      {
+        id: "msg1",
+        role: "assistant" as const,
+        parts: [
+          { type: "text", text: "I'll use a tool." },
+          {
+            type: "tool-call",
+            toolCallId: "dangling_call_1",
+            toolName: "some_tool",
+            state: "input-available",
+            args: {},
+          },
+        ],
+      },
+    ];
+
+    const result = normalizeChatMessages(messages);
+
+    // The message should remain because it still has the text part
+    expect(result).toHaveLength(1);
+    expect(result[0].parts).toHaveLength(1);
+    expect(result[0].parts![0]).toMatchObject({ type: "text" });
+  });
+
   test("preserves distinct tool parts when toolCallIds differ", () => {
     const messages = [
       {

--- a/platform/backend/src/routes/chat/normalization/normalize-chat-messages.ts
+++ b/platform/backend/src/routes/chat/normalization/normalize-chat-messages.ts
@@ -4,9 +4,11 @@ import type { ChatMessage, ChatMessagePart } from "@/types";
 import { stripImagesFromMessages } from "./strip-images-from-messages";
 
 export function normalizeChatMessages(messages: ChatMessage[]): ChatMessage[] {
-  return stripImagesFromMessages(
+  const normalized = stripImagesFromMessages(
     stripDanglingToolCallsFromMessages(dedupeToolPartsFromMessages(messages)),
   );
+
+  return filterEmptyMessages(normalized);
 }
 
 function dedupeToolPartsFromMessages(messages: ChatMessage[]): ChatMessage[] {
@@ -106,4 +108,26 @@ function getToolPartSignature(part: NonNullable<ChatMessage["parts"]>[number]) {
 }
 function getToolPartState(part: ChatMessagePart) {
   return typeof part.state === "string" ? part.state : "unknown";
+}
+
+/**
+ * Remove messages whose parts array became empty after normalization.
+ *
+ * `stripDanglingToolCalls` can strip every part from an assistant message
+ * when all its tool-call parts were dangling (no matching tool-result).
+ * Sending a message with an empty content array to the LLM provider causes
+ * a 400 error (e.g. Bedrock Converse "content field is empty").
+ */
+function filterEmptyMessages(messages: ChatMessage[]): ChatMessage[] {
+  return messages.filter((message) => {
+    if (!message.parts || message.parts.length > 0) {
+      return true;
+    }
+
+    logger.warn(
+      { messageId: message.id, role: message.role },
+      "[normalizeChatMessages] Dropping message with empty parts",
+    );
+    return false;
+  });
 }

--- a/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
@@ -34,6 +34,68 @@ function asStreamChunk<T>(chunk: unknown): T {
   return chunk as T;
 }
 
+describe("Bedrock empty content filtering", () => {
+  test("filters out messages with empty content arrays", () => {
+    const request = createConverseRequest({
+      messages: [
+        { role: "user", content: [{ text: "Do something" }] },
+        { role: "assistant", content: [] },
+        { role: "user", content: [{ text: "What happened?" }] },
+      ],
+    });
+
+    const adapter = bedrockAdapterFactory.createRequestAdapter(request);
+    const result = adapter.toProviderRequest();
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages![0]).toMatchObject({
+      role: "user",
+      content: [{ text: "Do something" }],
+    });
+    expect(result.messages![1]).toMatchObject({
+      role: "user",
+      content: [{ text: "What happened?" }],
+    });
+  });
+
+  test("keeps messages with non-empty content", () => {
+    const request = createConverseRequest({
+      messages: [
+        { role: "user", content: [{ text: "Hello" }] },
+        { role: "assistant", content: [{ text: "Hi there!" }] },
+      ],
+    });
+
+    const adapter = bedrockAdapterFactory.createRequestAdapter(request);
+    const result = adapter.toProviderRequest();
+
+    expect(result.messages).toHaveLength(2);
+  });
+
+  test("filters out assistant message whose only toolUse was removed upstream", () => {
+    const request = createConverseRequest({
+      messages: [
+        { role: "user", content: [{ text: "Run a query" }] },
+        { role: "assistant", content: [] as Bedrock.Types.ContentBlock[] },
+        {
+          role: "user",
+          content: [{ text: "That didn't work, try again" }],
+        },
+        {
+          role: "assistant",
+          content: [{ text: "Sure, let me try a different approach." }],
+        },
+      ],
+    });
+
+    const adapter = bedrockAdapterFactory.createRequestAdapter(request);
+    const result = adapter.toProviderRequest();
+
+    expect(result.messages).toHaveLength(3);
+    expect(result.messages!.every((m) => m.content!.length > 0)).toBe(true);
+  });
+});
+
 describe("Bedrock tool name encoding", () => {
   test("shortens provider-facing tool names that exceed the Bedrock limit", () => {
     const toolName =

--- a/platform/backend/src/routes/proxy/adapters/bedrock.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.ts
@@ -511,6 +511,25 @@ class BedrockRequestAdapter
       messages = this.applyUpdates(messages, this.toolResultUpdates);
     }
 
+    // Filter out messages with empty content arrays — Bedrock Converse API
+    // rejects them with "The content field in the Message object is empty".
+    // This can happen when upstream normalization (e.g. stripDanglingToolCalls)
+    // removes all content blocks from a message.
+    const originalCount = messages.length;
+    messages = messages.filter(
+      (msg) => Array.isArray(msg.content) && msg.content.length > 0,
+    );
+    if (messages.length < originalCount) {
+      logger.warn(
+        {
+          originalCount,
+          filteredCount: messages.length,
+          removedCount: originalCount - messages.length,
+        },
+        "[BedrockAdapter] Filtered out messages with empty content",
+      );
+    }
+
     return {
       ...this.request,
       modelId: this.getModel(),


### PR DESCRIPTION
## Summary

- Fixes Bedrock Converse API 400 error: `"The content field in the Message object at messages.N is empty"`
- Root cause: `stripDanglingToolCalls` can remove all parts from an assistant message when every tool-call part is dangling (no matching tool-result), producing `parts: []` which becomes `content: []` in the Bedrock request
- Two layers of defense:
  - `normalizeChatMessages` now drops messages whose parts became empty after normalization
  - Bedrock adapter filters messages with empty content arrays before sending (matching existing behavior in Cohere and Gemini adapters)

## Context

Observed in a long chat conversation (189 messages, 14% context used) going through the LLM proxy to Bedrock. The conversation had interrupted tool calls mid-execution, leaving dangling tool-call parts. After `stripDanglingToolCalls` stripped them, assistant messages with only those parts ended up with empty content. Bedrock rejected the request; refreshing the page cleaned up the problematic messages.

Error trace: `cdecffaa-ee9c-4d23-89a5-51ddce06c95c` / `8697d132a7bd08440e813c5f85351858`

## Test plan

- [x] Unit test: assistant message with only dangling tool calls is dropped after normalization
- [x] Unit test: assistant message with text + dangling tool call retains the text part
- [x] Unit test: Bedrock adapter filters messages with empty content arrays
- [x] Unit test: Bedrock adapter keeps messages with non-empty content unchanged
- [x] Type check passes

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Image" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>