### PR TITLE
fix: MCP reauth cache invalidation

### DIFF
--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -439,6 +439,46 @@ describe("McpClient", () => {
       expect(mockConnect).toHaveBeenCalledTimes(2);
     });
 
+    test("reuses cached client when MCP server row changes without secret rotation", async () => {
+      const tool = await ToolModel.createToolIfNotExists({
+        name: "github-mcp-server__metadata_update_reuse",
+        description: "Reuse after metadata update",
+        parameters: {},
+        catalogId,
+      });
+
+      await AgentToolModel.create(agentId, tool.id, {
+        mcpServerId,
+        credentialResolutionMode: "static",
+      });
+
+      mockConnect.mockResolvedValue(undefined);
+      mockPing.mockResolvedValue(undefined);
+      mockCallTool.mockResolvedValue({
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      });
+
+      const toolCall = {
+        id: "call_metadata_update_reuse",
+        name: tool.name,
+        arguments: {},
+      };
+
+      const firstResult = await mcpClient.executeToolCall(toolCall, agentId);
+      expect(firstResult.isError).toBe(false);
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+
+      await McpServerModel.update(mcpServerId, {
+        oauthRefreshError: "refresh_failed",
+      });
+
+      const secondResult = await mcpClient.executeToolCall(toolCall, agentId);
+      expect(secondResult.isError).toBe(false);
+      expect(mockClose).toHaveBeenCalledTimes(0);
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+    });
+
     describe("Concurrency limiter", () => {
       test("limits HTTP concurrency to 4", async () => {
         const clientWithInternals = mcpClient as unknown as {

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -340,7 +340,9 @@ describe("McpClient", () => {
           { access_token: "fresh-github-token-456" },
           "rotatedmcptoken",
         );
-        await McpServerModel.update(mcpServerId, { secretId: rotatedSecret.id });
+        await McpServerModel.update(mcpServerId, {
+          secretId: rotatedSecret.id,
+        });
 
         const secondResult = await mcpClient.executeToolCall(toolCall, agentId);
         expect(secondResult.isError).toBe(false);

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -306,6 +306,48 @@ describe("McpClient", () => {
 
         getSecretSpy.mockRestore();
       });
+
+      test("reloads cached secrets after server credentials are re-authenticated", async () => {
+        const tool = await ToolModel.createToolIfNotExists({
+          name: "github-mcp-server__rotated_secret",
+          description: "Rotated secret tool",
+          parameters: {},
+          catalogId,
+        });
+
+        await AgentToolModel.create(agentId, tool.id, {
+          mcpServerId,
+          credentialResolutionMode: "static",
+        });
+
+        mockCallTool.mockResolvedValue({
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+        });
+
+        const getSecretSpy = vi.spyOn(secretManager(), "getSecret");
+        const toolCall = {
+          id: "call_rotated_secret",
+          name: tool.name,
+          arguments: {},
+        };
+
+        const firstResult = await mcpClient.executeToolCall(toolCall, agentId);
+        expect(firstResult.isError).toBe(false);
+        expect(getSecretSpy).toHaveBeenCalledTimes(1);
+
+        const rotatedSecret = await secretManager().createSecret(
+          { access_token: "fresh-github-token-456" },
+          "rotatedmcptoken",
+        );
+        await McpServerModel.update(mcpServerId, { secretId: rotatedSecret.id });
+
+        const secondResult = await mcpClient.executeToolCall(toolCall, agentId);
+        expect(secondResult.isError).toBe(false);
+        expect(getSecretSpy).toHaveBeenCalledTimes(2);
+
+        getSecretSpy.mockRestore();
+      });
     });
 
     test("expires idle active connections and recreates them on the next tool call", async () => {
@@ -351,6 +393,48 @@ describe("McpClient", () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    test("recreates cached client after server credentials change", async () => {
+      const tool = await ToolModel.createToolIfNotExists({
+        name: "github-mcp-server__reauth_reconnect",
+        description: "Reconnect after reauth",
+        parameters: {},
+        catalogId,
+      });
+
+      await AgentToolModel.create(agentId, tool.id, {
+        mcpServerId,
+        credentialResolutionMode: "static",
+      });
+
+      mockConnect.mockResolvedValue(undefined);
+      mockPing.mockResolvedValue(undefined);
+      mockCallTool.mockResolvedValue({
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      });
+
+      const toolCall = {
+        id: "call_reauth_reconnect",
+        name: tool.name,
+        arguments: {},
+      };
+
+      const firstResult = await mcpClient.executeToolCall(toolCall, agentId);
+      expect(firstResult.isError).toBe(false);
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+
+      const rotatedSecret = await secretManager().createSecret(
+        { access_token: "fresh-github-token-789" },
+        "reauthreconnecttoken",
+      );
+      await McpServerModel.update(mcpServerId, { secretId: rotatedSecret.id });
+
+      const secondResult = await mcpClient.executeToolCall(toolCall, agentId);
+      expect(secondResult.isError).toBe(false);
+      expect(mockClose).toHaveBeenCalledTimes(1);
+      expect(mockConnect).toHaveBeenCalledTimes(2);
     });
 
     describe("Concurrency limiter", () => {

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -196,7 +196,6 @@ type CachedResource = {
 
 type CachedServerState = {
   secretId: string | null;
-  updatedAtMs: number;
 };
 
 class McpClient {
@@ -810,7 +809,7 @@ class McpClient {
             cachedSecretId: cachedServerState?.secretId ?? null,
             currentSecretId: currentServerState.secretId,
           },
-          "Discarding cached MCP client after server credentials changed",
+          "Discarding cached MCP client after MCP server secret changed",
         );
         try {
           await existingClient.close();
@@ -1079,45 +1078,23 @@ class McpClient {
       this.secretsCache.delete(targetMcpServerId);
     }
 
-    const result = await this.fetchSecretsForLoadedMcpServer(
-      mcpServer,
-      toolCall,
-      agentId,
-    );
+    const result = await this.fetchSecretsForLoadedMcpServer(mcpServer);
 
-    // Only cache successful results (not errors) so transient failures can be retried
-    if (!("error" in result)) {
-      this.secretsCache.set(targetMcpServerId, {
-        secrets: result.secrets,
-        secretId: result.secretId,
-      });
-    }
+    this.secretsCache.set(targetMcpServerId, {
+      secrets: result.secrets,
+      secretId: result.secretId,
+    });
 
     return result;
   }
 
   private async fetchSecretsForLoadedMcpServer(
-    mcpServer: Awaited<ReturnType<typeof McpServerModel.findById>>,
-    toolCall: CommonToolCall,
-    agentId: string,
-  ): Promise<
-    | {
-        secrets: Record<string, unknown>;
-        secretId?: string;
-        serverState: CachedServerState;
-      }
-    | { error: CommonToolResult }
-  > {
-    if (!mcpServer) {
-      return {
-        error: await this.createErrorResult(
-          toolCall,
-          agentId,
-          "MCP server not found when getting secrets for MCP server",
-          "unknown",
-        ),
-      };
-    }
+    mcpServer: NonNullable<Awaited<ReturnType<typeof McpServerModel.findById>>>,
+  ): Promise<{
+    secrets: Record<string, unknown>;
+    secretId?: string;
+    serverState: CachedServerState;
+  }> {
     const serverState = this.toCachedServerState(mcpServer);
     if (mcpServer.secretId) {
       const secret = await secretManager().getSecret(mcpServer.secretId);
@@ -2712,9 +2689,7 @@ class McpClient {
     left: CachedServerState,
     right: CachedServerState,
   ): boolean {
-    return (
-      left.secretId === right.secretId && left.updatedAtMs === right.updatedAtMs
-    );
+    return left.secretId === right.secretId;
   }
 
   private toCachedServerState(
@@ -2722,7 +2697,6 @@ class McpClient {
   ): CachedServerState {
     return {
       secretId: mcpServer.secretId ?? null,
-      updatedAtMs: mcpServer.updatedAt.getTime(),
     };
   }
 }

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -194,6 +194,11 @@ type CachedResource = {
   ttl: number;
 };
 
+type CachedServerState = {
+  secretId: string | null;
+  updatedAtMs: number;
+};
+
 class McpClient {
   private static readonly TOOL_NAME_CACHE_MAX_ENTRIES = 1_000;
   private static readonly SECRETS_CACHE_MAX_ENTRIES = 1_000;
@@ -213,10 +218,12 @@ class McpClient {
           "Error closing evicted active MCP connection",
         );
       });
+      this.activeConnectionServerState.delete(key);
       this.toolNameCache.delete(key);
       this.pendingHttpSessionMetadata.delete(key);
     },
   });
+  private activeConnectionServerState = new Map<string, CachedServerState>();
   private connectionLimiter = new ConnectionLimiter();
   // Cache of actual tool names per connection key: lowercased name -> original cased name
   private toolNameCache = new LRUCacheManager<Map<string, string>>({
@@ -285,6 +292,7 @@ class McpClient {
         );
       }
       this.activeConnections.delete(connectionKey);
+      this.activeConnectionServerState.delete(connectionKey);
       this.toolNameCache.delete(connectionKey);
       this.pendingHttpSessionMetadata.delete(connectionKey);
       logger.info({ connectionKey }, "Closed cached MCP session");
@@ -391,7 +399,7 @@ class McpClient {
     if ("error" in secretsResult) {
       return secretsResult.error;
     }
-    const { secrets, secretId } = secretsResult;
+    const { secrets, secretId, serverState } = secretsResult;
 
     // Build connection cache key using the resolved target server ID.
     // When conversationId is provided, each (agent, conversation) gets its own connection
@@ -454,7 +462,12 @@ class McpClient {
         const transport = await getTransport();
 
         // Get or create client
-        const client = await this.getOrCreateClient(connectionKey, transport);
+        const client = await this.getOrCreateClient(
+          connectionKey,
+          transport,
+          targetMcpServerId,
+          serverState,
+        );
 
         // Determine the actual tool name by stripping the server/catalog prefix.
         // We prioritize the `catalogName` prefix, which is standard for local MCP servers.
@@ -611,6 +624,7 @@ class McpClient {
               }
             }
             this.activeConnections.delete(connectionKey);
+            this.activeConnectionServerState.delete(connectionKey);
             this.toolNameCache.delete(connectionKey);
             this.pendingHttpSessionMetadata.delete(connectionKey);
             return await executeToolCall(getTransport, currentSecrets, true);
@@ -777,19 +791,54 @@ class McpClient {
   private async getOrCreateClient(
     connectionKey: string,
     transport: Transport,
+    targetMcpServerId: string,
+    currentServerState: CachedServerState,
   ): Promise<Client> {
     // Check if we already have an active connection
     const existingClient = this.activeConnections.get(connectionKey);
     if (existingClient) {
+      const cachedServerState =
+        this.activeConnectionServerState.get(connectionKey);
+      if (
+        !cachedServerState ||
+        !this.hasMatchingServerState(cachedServerState, currentServerState)
+      ) {
+        logger.info(
+          {
+            connectionKey,
+            targetMcpServerId,
+            cachedSecretId: cachedServerState?.secretId ?? null,
+            currentSecretId: currentServerState.secretId,
+          },
+          "Discarding cached MCP client after server credentials changed",
+        );
+        try {
+          await existingClient.close();
+        } catch (error) {
+          logger.warn(
+            { connectionKey, targetMcpServerId, error },
+            "Error closing stale cached MCP client after credential change",
+          );
+        }
+        this.activeConnections.delete(connectionKey);
+        this.activeConnectionServerState.delete(connectionKey);
+        this.toolNameCache.delete(connectionKey);
+        this.pendingHttpSessionMetadata.delete(connectionKey);
+      }
+    }
+
+    const reusableClient = this.activeConnections.get(connectionKey);
+    if (reusableClient) {
       // Health check: ping the client to verify connection is still alive
       try {
-        await existingClient.ping();
+        await reusableClient.ping();
         logger.debug(
           { connectionKey },
           "Client ping successful, reusing cached client",
         );
-        this.activeConnections.set(connectionKey, existingClient);
-        return existingClient;
+        this.activeConnections.set(connectionKey, reusableClient);
+        this.activeConnectionServerState.set(connectionKey, currentServerState);
+        return reusableClient;
       } catch (error) {
         // Connection is dead, invalidate cache and create fresh client
         logger.warn(
@@ -800,6 +849,7 @@ class McpClient {
           "Client ping failed, creating fresh client",
         );
         this.activeConnections.delete(connectionKey);
+        this.activeConnectionServerState.delete(connectionKey);
         this.toolNameCache.delete(connectionKey);
         this.pendingHttpSessionMetadata.delete(connectionKey);
         // If the transport carries a stored session ID the session is likely
@@ -879,6 +929,7 @@ class McpClient {
     // This prevents a race where a second request creates a duplicate connection
     // while the upsert is in flight.
     this.activeConnections.set(connectionKey, client);
+    this.activeConnectionServerState.set(connectionKey, currentServerState);
 
     // Persist the MCP session ID so other backend pods can reuse it.
     // With --isolated, each Mcp-Session-Id maps to a separate browser context;
@@ -999,34 +1050,11 @@ class McpClient {
     toolCall: CommonToolCall;
     agentId: string;
   }): Promise<
-    | { secrets: Record<string, unknown>; secretId?: string }
-    | { error: CommonToolResult }
-  > {
-    const cached = this.secretsCache.get(targetMcpServerId);
-    if (cached) {
-      return cached;
-    }
-
-    const result = await this.fetchSecretsForMcpServer(
-      targetMcpServerId,
-      toolCall,
-      agentId,
-    );
-
-    // Only cache successful results (not errors) so transient failures can be retried
-    if (!("error" in result)) {
-      this.secretsCache.set(targetMcpServerId, result);
-    }
-
-    return result;
-  }
-
-  private async fetchSecretsForMcpServer(
-    targetMcpServerId: string,
-    toolCall: CommonToolCall,
-    agentId: string,
-  ): Promise<
-    | { secrets: Record<string, unknown>; secretId?: string }
+    | {
+        secrets: Record<string, unknown>;
+        secretId?: string;
+        serverState: CachedServerState;
+      }
     | { error: CommonToolResult }
   > {
     const mcpServer = await McpServerModel.findById(targetMcpServerId);
@@ -1040,20 +1068,75 @@ class McpClient {
         ),
       };
     }
+
+    const currentServerState = this.toCachedServerState(mcpServer);
+    const cached = this.secretsCache.get(targetMcpServerId);
+    if (cached?.secretId === currentServerState.secretId) {
+      return { ...cached, serverState: currentServerState };
+    }
+
+    if (cached) {
+      this.secretsCache.delete(targetMcpServerId);
+    }
+
+    const result = await this.fetchSecretsForLoadedMcpServer(
+      mcpServer,
+      toolCall,
+      agentId,
+    );
+
+    // Only cache successful results (not errors) so transient failures can be retried
+    if (!("error" in result)) {
+      this.secretsCache.set(targetMcpServerId, {
+        secrets: result.secrets,
+        secretId: result.secretId,
+      });
+    }
+
+    return result;
+  }
+
+  private async fetchSecretsForLoadedMcpServer(
+    mcpServer: Awaited<ReturnType<typeof McpServerModel.findById>>,
+    toolCall: CommonToolCall,
+    agentId: string,
+  ): Promise<
+    | {
+        secrets: Record<string, unknown>;
+        secretId?: string;
+        serverState: CachedServerState;
+      }
+    | { error: CommonToolResult }
+  > {
+    if (!mcpServer) {
+      return {
+        error: await this.createErrorResult(
+          toolCall,
+          agentId,
+          "MCP server not found when getting secrets for MCP server",
+          "unknown",
+        ),
+      };
+    }
+    const serverState = this.toCachedServerState(mcpServer);
     if (mcpServer.secretId) {
       const secret = await secretManager().getSecret(mcpServer.secretId);
       if (secret?.secret) {
         logger.info(
           {
-            targetMcpServerId,
+            targetMcpServerId: mcpServer.id,
             secretId: mcpServer.secretId,
           },
-          `Found secrets for MCP server ${targetMcpServerId}`,
+          `Found secrets for MCP server ${mcpServer.id}`,
         );
-        return { secrets: secret.secret, secretId: mcpServer.secretId };
+        return {
+          secrets: secret.secret,
+          secretId: mcpServer.secretId,
+          serverState,
+        };
       }
     }
-    return { secrets: {} };
+    return { secrets: {}, serverState };
   }
 
   // Determines the target MCP server ID for a local catalog item
@@ -1790,6 +1873,7 @@ class McpClient {
           // Ignore close errors during refresh teardown.
         }
         this.activeConnections.delete(connectionKey);
+        this.activeConnectionServerState.delete(connectionKey);
         this.pendingHttpSessionMetadata.delete(connectionKey);
       }
 
@@ -2161,6 +2245,7 @@ class McpClient {
 
     await Promise.all([...disconnectPromises, ...activeDisconnectPromises]);
     this.activeConnections.clear();
+    this.activeConnectionServerState.clear();
     this.pendingHttpSessionMetadata.clear();
   }
 
@@ -2189,6 +2274,7 @@ class McpClient {
         }
 
         this.activeConnections.delete(connectionKey);
+        this.activeConnectionServerState.delete(connectionKey);
         this.toolNameCache.delete(connectionKey);
         this.pendingHttpSessionMetadata.delete(connectionKey);
         await McpHttpSessionModel.deleteStaleSession(connectionKey).catch(
@@ -2365,7 +2451,12 @@ class McpClient {
       tokenAuth,
     );
     const connectionKey = `${catalogItem.id}:${server.id}:${agentId}`;
-    const client = await this.getOrCreateClient(connectionKey, transport);
+    const client = await this.getOrCreateClient(
+      connectionKey,
+      transport,
+      server.id,
+      secretResult.serverState,
+    );
 
     const result = await client.readResource({ uri });
     return result;
@@ -2448,7 +2539,12 @@ class McpClient {
           secretResult.secrets,
         );
         const connectionKey = `${catalogItem.id}:${server.id}`;
-        const client = await this.getOrCreateClient(connectionKey, transport);
+        const client = await this.getOrCreateClient(
+          connectionKey,
+          transport,
+          server.id,
+          secretResult.serverState,
+        );
         clients.push(client);
       } catch (error) {
         logger.warn(
@@ -2610,6 +2706,24 @@ class McpClient {
     }
 
     return McpClient.ENTERPRISE_CREDENTIAL_CACHE_FALLBACK_TTL_MS;
+  }
+
+  private hasMatchingServerState(
+    left: CachedServerState,
+    right: CachedServerState,
+  ): boolean {
+    return (
+      left.secretId === right.secretId && left.updatedAtMs === right.updatedAtMs
+    );
+  }
+
+  private toCachedServerState(
+    mcpServer: NonNullable<Awaited<ReturnType<typeof McpServerModel.findById>>>,
+  ): CachedServerState {
+    return {
+      secretId: mcpServer.secretId ?? null,
+      updatedAtMs: mcpServer.updatedAt.getTime(),
+    };
   }
 }
 

--- a/platform/frontend/src/lib/mcp/mcp-server.query.ts
+++ b/platform/frontend/src/lib/mcp/mcp-server.query.ts
@@ -261,7 +261,10 @@ export function useReauthenticateMcpServer() {
       }
       return response.data;
     },
-    onSuccess: async (_, variables) => {
+    onSuccess: async (updatedServer, variables) => {
+      if (!updatedServer) {
+        return;
+      }
       await queryClient.refetchQueries({ queryKey: ["mcp-servers"] });
       invalidateToolAssignmentQueries(queryClient);
       toast.success(`Successfully re-authenticated ${variables.name}`);


### PR DESCRIPTION
## What changed
- validate cached MCP secrets against the current `mcp_server` row before reuse, so a re-auth that swaps `secret_id` is observed even on other platform replicas
- track the server auth state for cached MCP clients and force a reconnect when the server's credentials change
- add backend regression coverage for secret rotation and cached-client reuse after re-authentication
- stop showing a successful re-auth toast in the frontend when the API actually returned an error payload

## Why
Re-authentication previously invalidated in-memory client and secret caches only inside the pod that handled the `PATCH /api/mcp_server/:id/reauthenticate` request. In staging, later tool calls could land on a different replica that still held the old secret/client in memory, so the agent kept reporting the MCP server as unauthenticated even after the user supplied a fresh PAT.

## Impact
- re-authenticated MCP credentials converge correctly across multi-replica platform deployments
- users no longer get a misleading success toast when re-authentication failed