### PR TITLE
fix: OAuth consent redirect through SSO sign-in

### DIFF
--- a/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.tsx
+++ b/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.tsx
@@ -331,7 +331,10 @@ export function AuthViewWithErrorHandling({
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <IdentityProviderSelector showDivider={false} />
+            <IdentityProviderSelector
+              showDivider={false}
+              callbackURL={callbackURL}
+            />
           </CardContent>
         </Card>
       </div>
@@ -439,7 +442,10 @@ export function AuthViewWithErrorHandling({
           />
         )}
         {isSignInPage && config.enterpriseFeatures.core && (
-          <IdentityProviderSelector showDivider={!isBasicAuthDisabled} />
+          <IdentityProviderSelector
+            showDivider={!isBasicAuthDisabled}
+            callbackURL={callbackURL}
+          />
         )}
       </div>
     </>

--- a/platform/frontend/src/components/identity-provider-selector.ee.test.tsx
+++ b/platform/frontend/src/components/identity-provider-selector.ee.test.tsx
@@ -62,6 +62,27 @@ describe("IdentityProviderSelector", () => {
   });
 
   describe("callbackURL handling", () => {
+    it("should prefer an explicit callback URL override", async () => {
+      mockSearchParams.get.mockReturnValue(
+        encodeURIComponent("/oauth/consent?client_id=test"),
+      );
+      const user = userEvent.setup();
+
+      render(
+        <IdentityProviderSelector
+          callbackURL={`${mockOrigin}/oauth/consent?client_id=test&scope=mcp`}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: /sign in with/i }));
+
+      expect(authClient.signIn.sso).toHaveBeenCalledWith(
+        expect.objectContaining({
+          callbackURL: `${mockOrigin}/oauth/consent?client_id=test&scope=mcp`,
+        }),
+      );
+    });
+
     it("should use home URL when no redirectTo param is present", async () => {
       mockSearchParams.get.mockReturnValue(null);
       const user = userEvent.setup();

--- a/platform/frontend/src/components/identity-provider-selector.ee.tsx
+++ b/platform/frontend/src/components/identity-provider-selector.ee.tsx
@@ -17,10 +17,12 @@ interface IdentityProviderSelectorProps {
    * Defaults to true.
    */
   showDivider?: boolean;
+  callbackURL?: string;
 }
 
 export function IdentityProviderSelector({
   showDivider = true,
+  callbackURL: callbackURLOverride,
 }: IdentityProviderSelectorProps) {
   const searchParams = useSearchParams();
   const { data: identityProviders = [], isLoading } =
@@ -29,9 +31,13 @@ export function IdentityProviderSelector({
   // Get the redirectTo URL from search params, defaulting to "/"
   // Validates that the path is safe (relative path, no protocol) to prevent open redirect attacks
   const callbackURL = useMemo(() => {
+    if (callbackURLOverride) {
+      return callbackURLOverride;
+    }
+
     const redirectTo = searchParams.get("redirectTo");
     return getValidatedCallbackURLWithDefault(redirectTo);
-  }, [searchParams]);
+  }, [callbackURLOverride, searchParams]);
 
   const handleSsoSignIn = useCallback(
     async (providerId: string) => {


### PR DESCRIPTION
## What changed
- pass the auth page's computed `callbackURL` into the Google/SSO selector instead of having the selector rebuild it from `redirectTo`
- make `IdentityProviderSelector` prefer that explicit callback URL when provided
- add a frontend test covering the override path

## Why
When an unauthenticated user hits `/oauth/consent`, `WithAuthCheck` sends them through `/auth/sign-in?redirectTo=...` first. The auth page already computes the correct callback URL for returning to the original consent route, but the SSO selector was reconstructing its own callback from the raw query param. In the MCP OAuth flow that could drop the intended `/oauth/consent?...` destination and fall back to `/`, which then redirects to `/chat`.

## User impact
Users who start the MCP OAuth flow without an active Archestra session should now return to the consent screen and see the Allow dialog after Google sign-in instead of landing on `/chat`.