### PR TITLE
fix: sanitize stale custom role permissions

### DIFF
--- a/platform/backend/src/models/organization-role.test.ts
+++ b/platform/backend/src/models/organization-role.test.ts
@@ -58,6 +58,40 @@ describe("OrganizationRoleModel", () => {
     });
   });
 
+  describe("sanitizePermissions", () => {
+    test("returns valid permissions unchanged", () => {
+      const permissions = {
+        agent: ["read", "create"],
+        log: ["read"],
+      };
+
+      expect(OrganizationRoleModel.sanitizePermissions(permissions)).toEqual(
+        permissions,
+      );
+    });
+
+    test("removes invalid actions and unknown resources", () => {
+      expect(
+        OrganizationRoleModel.sanitizePermissions({
+          log: ["read", "create", "update", "delete"],
+          optimizationRule: ["team-admin", "read"],
+          unknownResource: ["read"],
+        }),
+      ).toEqual({
+        log: ["read"],
+        optimizationRule: ["read"],
+      });
+    });
+
+    test("returns empty permissions for malformed input", () => {
+      expect(OrganizationRoleModel.sanitizePermissions("{not-json}")).toEqual(
+        {},
+      );
+      expect(OrganizationRoleModel.sanitizePermissions([])).toEqual({});
+      expect(OrganizationRoleModel.sanitizePermissions(null)).toEqual({});
+    });
+  });
+
   describe("getById", () => {
     test("should return predefined admin role", async ({
       makeOrganization,

--- a/platform/backend/src/models/organization-role.ts
+++ b/platform/backend/src/models/organization-role.ts
@@ -2,13 +2,17 @@ import {
   ADMIN_ROLE_NAME,
   EDITOR_ROLE_NAME,
   MEMBER_ROLE_NAME,
+  type Action,
   type Permissions,
   type PredefinedRoleName,
   PredefinedRoleNameSchema,
   type Resource,
   roleDescriptions,
 } from "@shared";
-import { predefinedPermissionsMap } from "@shared/access-control";
+import {
+  allAvailableActions,
+  predefinedPermissionsMap,
+} from "@shared/access-control";
 import { and, eq, getTableColumns, ilike, sql } from "drizzle-orm";
 import { LRUCacheManager } from "@/cache-manager";
 import db, { schema } from "@/database";
@@ -38,6 +42,34 @@ const generatePredefinedRole = (
 });
 
 class OrganizationRoleModel {
+  static sanitizePermissions(value: unknown): Permissions {
+    const parsedPermissions = parseRolePermissionsValue(value);
+    if (!parsedPermissions) {
+      return {};
+    }
+
+    const sanitizedPermissions: Permissions = {};
+
+    for (const [resource, actions] of Object.entries(parsedPermissions)) {
+      if (!(resource in allAvailableActions) || !Array.isArray(actions)) {
+        continue;
+      }
+
+      const allowedActions = allAvailableActions[resource as Resource];
+      const validActions = actions.filter(
+        (action): action is Action =>
+          typeof action === "string" &&
+          allowedActions.includes(action as Action),
+      );
+
+      if (validActions.length > 0) {
+        sanitizedPermissions[resource as Resource] = validActions;
+      }
+    }
+
+    return sanitizedPermissions;
+  }
+
   static invalidatePermissionsCacheForRole(
     organizationId: string,
     identifier: string,
@@ -270,7 +302,7 @@ class OrganizationRoleModel {
     );
     return {
       ...result,
-      permission: parseRolePermissions(result.permission),
+      permission: OrganizationRoleModel.sanitizePermissions(result.permission),
     };
   }
 
@@ -317,7 +349,7 @@ class OrganizationRoleModel {
     logger.debug({ roleId }, "OrganizationRoleModel.getById: completed");
     return {
       ...result,
-      permission: parseRolePermissions(result.permission),
+      permission: OrganizationRoleModel.sanitizePermissions(result.permission),
     };
   }
 
@@ -414,7 +446,9 @@ class OrganizationRoleModel {
         ...predefinedRoles,
         ...customRoles.map((role) => ({
           ...role,
-          permission: parseRolePermissions(role.permission),
+          permission: OrganizationRoleModel.sanitizePermissions(
+            role.permission,
+          ),
         })),
       ];
     } catch (_error) {
@@ -500,7 +534,9 @@ class OrganizationRoleModel {
         ...takeFromPredefined,
         ...customRoles.map((role) => ({
           ...role,
-          permission: parseRolePermissions(role.permission),
+          permission: OrganizationRoleModel.sanitizePermissions(
+            role.permission,
+          ),
         })),
       ],
       total,
@@ -547,14 +583,33 @@ class OrganizationRoleModel {
 
 export default OrganizationRoleModel;
 
-function parseRolePermissions(value: string): Permissions {
+function parseRolePermissionsValue(
+  value: unknown,
+): Record<string, unknown> | null {
+  if (typeof value !== "string") {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return null;
+    }
+
+    return value as Record<string, unknown>;
+  }
+
   try {
-    return JSON.parse(value) as Permissions;
+    const parsedValue = JSON.parse(value) as unknown;
+    if (
+      !parsedValue ||
+      typeof parsedValue !== "object" ||
+      Array.isArray(parsedValue)
+    ) {
+      return null;
+    }
+
+    return parsedValue as Record<string, unknown>;
   } catch (error) {
     logger.warn(
       { error, permission: value },
       "Failed to parse organization role permissions JSON",
     );
-    return {};
+    return null;
   }
 }

--- a/platform/backend/src/models/organization-role.ts
+++ b/platform/backend/src/models/organization-role.ts
@@ -1,8 +1,8 @@
 import {
+  type Action,
   ADMIN_ROLE_NAME,
   EDITOR_ROLE_NAME,
   MEMBER_ROLE_NAME,
-  type Action,
   type Permissions,
   type PredefinedRoleName,
   PredefinedRoleNameSchema,

--- a/platform/backend/src/routes/custom-role.ee.test.ts
+++ b/platform/backend/src/routes/custom-role.ee.test.ts
@@ -422,6 +422,45 @@ describe("custom role routes", () => {
     expect(role.name).toBe("Analyst");
   });
 
+  test("GET /api/roles/:roleId strips stale invalid permissions from custom roles", async ({
+    makeCustomRole,
+  }) => {
+    const customRole = await makeCustomRole(organizationId, {
+      role: "legacy_analyst",
+      name: "Legacy Analyst",
+      permission: { log: ["read"] },
+    });
+
+    await db
+      .update(schema.organizationRolesTable)
+      .set({
+        permission: JSON.stringify({
+          log: ["read", "create", "update", "delete"],
+          optimizationRule: ["team-admin"],
+          unknownResource: ["read"],
+        }),
+      })
+      .where(
+        and(
+          eq(schema.organizationRolesTable.id, customRole.id),
+          eq(schema.organizationRolesTable.organizationId, organizationId),
+        ),
+      );
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/roles/${customRole.id}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      id: customRole.id,
+      permission: {
+        log: ["read"],
+      },
+    });
+  });
+
   test("GET /api/roles/:roleId returns 404 for non-existent role", async () => {
     const response = await app.inject({
       method: "GET",

--- a/platform/backend/src/routes/custom-role.ee.ts
+++ b/platform/backend/src/routes/custom-role.ee.ts
@@ -306,19 +306,7 @@ function normalizeRoleResponse(roleData: {
 }
 
 function parsePermissions(value: unknown) {
-  if (typeof value === "string") {
-    try {
-      return JSON.parse(value);
-    } catch (error) {
-      logger.warn(
-        { error, permission: value },
-        "Failed to parse custom role permissions JSON",
-      );
-      return {};
-    }
-  }
-
-  return value;
+  return OrganizationRoleModel.sanitizePermissions(value);
 }
 
 function toDate(value: Date | string): Date {


### PR DESCRIPTION
## What changed

- Sanitized custom role permissions when reading them from storage and from the auth layer response.
- Stripped stale or invalid permission entries before they reach the role editor.
- Added a regression test covering legacy invalid permissions like `log:create` and `optimizationRule:team-admin`.

## Why

Some custom roles could contain stale permission keys or actions that are no longer valid in the current RBAC model. When those values were loaded into the edit form and sent back on save, the update could fail even when the user was making an unrelated partial change.

## Impact

- Custom role edits are more resilient when legacy invalid permissions exist in stored role data.
- Invalid permissions are dropped on read instead of being re-submitted and causing save failures.
- No change to valid RBAC permissions.