### PR TITLE
fix: chat access and role permission hints

### DIFF
--- a/docs/pages/platform-access-control.md
+++ b/docs/pages/platform-access-control.md
@@ -3,7 +3,7 @@ title: "Access Control"
 category: Administration
 description: "Role-based access control (RBAC) system for managing user permissions in Archestra"
 order: 1
-lastUpdated: 2026-04-10
+lastUpdated: 2026-04-16
 ---
 <!--
 Check ../docs_writer_prompt.md before changing this file.
@@ -256,6 +256,17 @@ Examples:
 - Organization-wide records require the resource-specific admin permission such as `llmProviderApiKey:admin` or `llmVirtualKey:admin`
 
 These resources do **not** use `:team-admin`.
+
+### Chat Access And Optional UI Controls
+
+Chat access is controlled separately from optional chat UI controls:
+
+- `chat:read` allows access to chat itself
+- `agent:read` is also required because chat is agent-backed and a user must be able to access at least one agent/profile context to start or use chat
+- `chatAgentPicker:enable` controls whether the agent picker is visible
+- `chatProviderSettings:enable` controls whether model and API key selectors are visible
+
+The selector visibility permissions are UI toggles. They should be treated independently from core chat access and should not be assumed to grant access to provider credentials or model catalogs on their own.
 
 ### MCP Registry And Installation Records
 

--- a/platform/backend/src/standalone-scripts/codegen-access-control-docs.ts
+++ b/platform/backend/src/standalone-scripts/codegen-access-control-docs.ts
@@ -143,6 +143,17 @@ Examples:
 
 These resources do **not** use \`:team-admin\`.
 
+### Chat Access And Optional UI Controls
+
+Chat access is controlled separately from optional chat UI controls:
+
+- \`chat:read\` allows access to chat itself
+- \`agent:read\` is still required to use agents in chat
+- \`chatAgentPicker:enable\` controls whether the agent picker is visible
+- \`chatProviderSettings:enable\` controls whether model and API key selectors are visible
+
+The selector visibility permissions are UI toggles. They should be treated independently from core chat access and should not be assumed to grant access to provider credentials or model catalogs on their own.
+
 ### MCP Registry And Installation Records
 
 Some MCP-related resources also apply runtime scope checks in addition to RBAC, but their rules differ from agents, MCP gateways, and LLM proxies:

--- a/platform/backend/src/standalone-scripts/codegen-access-control-docs.ts
+++ b/platform/backend/src/standalone-scripts/codegen-access-control-docs.ts
@@ -148,7 +148,7 @@ These resources do **not** use \`:team-admin\`.
 Chat access is controlled separately from optional chat UI controls:
 
 - \`chat:read\` allows access to chat itself
-- \`agent:read\` is still required to use agents in chat
+- \`agent:read\` is also required because chat is agent-backed and a user must be able to access at least one agent/profile context to start or use chat
 - \`chatAgentPicker:enable\` controls whether the agent picker is visible
 - \`chatProviderSettings:enable\` controls whether model and API key selectors are visible
 

--- a/platform/frontend/src/app/chat/chat-initial-state.test.ts
+++ b/platform/frontend/src/app/chat/chat-initial-state.test.ts
@@ -135,6 +135,22 @@ describe("buildCreateConversationInput", () => {
     });
   });
 
+  test("builds a minimal payload when model selectors are unavailable", () => {
+    expect(
+      buildCreateConversationInput({
+        agentId: "agent-1",
+        modelId: "",
+        chatApiKeyId: null,
+        chatModels: [],
+      }),
+    ).toEqual({
+      agentId: "agent-1",
+      selectedModel: undefined,
+      selectedProvider: undefined,
+      chatApiKeyId: undefined,
+    });
+  });
+
   test("returns null when the initial selection is incomplete", () => {
     expect(
       buildCreateConversationInput({

--- a/platform/frontend/src/app/chat/chat-initial-state.ts
+++ b/platform/frontend/src/app/chat/chat-initial-state.ts
@@ -38,9 +38,9 @@ export type ResolvedChatModelState = {
 
 export type CreateConversationInput = {
   agentId: string;
-  selectedModel: string;
-  selectedProvider: SupportedProvider | undefined;
-  chatApiKeyId: string | null;
+  selectedModel?: string;
+  selectedProvider?: SupportedProvider;
+  chatApiKeyId?: string | null;
 };
 
 export function resolveInitialAgentState(params: {
@@ -140,18 +140,22 @@ export function buildCreateConversationInput(params: {
   chatApiKeyId: string | null;
   chatModels: LlmModel[];
 }): CreateConversationInput | null {
-  if (!params.agentId || !params.modelId) {
+  if (!params.agentId) {
     return null;
   }
 
+  const selectedProvider = params.modelId
+    ? getProviderForModelId({
+        modelId: params.modelId,
+        chatModels: params.chatModels,
+      })
+    : undefined;
+
   return {
     agentId: params.agentId,
-    selectedModel: params.modelId,
-    selectedProvider: getProviderForModelId({
-      modelId: params.modelId,
-      chatModels: params.chatModels,
-    }),
-    chatApiKeyId: params.chatApiKeyId,
+    selectedModel: params.modelId || undefined,
+    selectedProvider,
+    chatApiKeyId: params.chatApiKeyId ?? undefined,
   };
 }
 

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -1411,8 +1411,6 @@ export function ChatPageContent({
   // If user lacks permission to read agents, show access denied
   // Must check before loading state since disabled queries stay in pending state
   if (!conversationId && canReadAgent === false) {
-    const missingPermissions: string[] = [];
-    if (canReadAgent === false) missingPermissions.push("agent:read");
     return (
       <Empty className="h-full">
         <EmptyHeader>
@@ -1426,16 +1424,9 @@ export function ChatPageContent({
           </EmptyDescription>
         </EmptyHeader>
         <EmptyContent>
-          <div className="flex flex-col items-center gap-1">
-            {missingPermissions.map((p) => (
-              <code
-                key={p}
-                className="rounded bg-muted px-2 py-1 text-sm font-mono"
-              >
-                {p}
-              </code>
-            ))}
-          </div>
+          <code className="rounded bg-muted px-2 py-1 text-sm font-mono">
+            agent:read
+          </code>
         </EmptyContent>
       </Empty>
     );

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -205,6 +205,12 @@ export function ChatPageContent({
   const { data: canReadLlmProvider } = useHasPermissions({
     llmProviderApiKey: ["read"],
   });
+  const { data: canReadLlmModels } = useHasPermissions({
+    llmModel: ["read"],
+  });
+  const { data: canSeeProviderSettings } = useHasPermissions({
+    chatProviderSettings: ["enable"],
+  });
   const { data: canReadTeams } = useHasPermissions({
     team: ["read"],
   });
@@ -227,7 +233,11 @@ export function ChatPageContent({
     return false;
   });
 
-  const hasChatAccess = canReadAgent !== false && canReadLlmProvider !== false;
+  const hasChatAccess = canReadAgent !== false;
+  const canUseProviderSettings =
+    canSeeProviderSettings === true &&
+    canReadLlmProvider === true &&
+    canReadLlmModels === true;
 
   // Fetch internal agents for dialog editing
   const { data: internalAgents = [], isPending: isLoadingAgents } =
@@ -236,9 +246,9 @@ export function ChatPageContent({
 
   // Fetch profiles and models for initial chat (no conversation)
   const { modelsByProvider, isPending: isModelsLoading } =
-    useLlmModelsByProvider();
+    useLlmModelsByProvider({ enabled: canUseProviderSettings });
   const { data: chatApiKeys = [], isLoading: isLoadingApiKeys } =
-    useLlmProviderApiKeys({ enabled: hasChatAccess });
+    useLlmProviderApiKeys({ enabled: hasChatAccess && canUseProviderSettings });
   const { data: organization, isPending: isOrgLoading } = useOrganization();
 
   // State for initial chat (when no conversation exists yet)
@@ -1265,7 +1275,6 @@ export function ChatPageContent({
       if (
         (!hasText && !hasFiles) ||
         !initialAgentId ||
-        !initialModel ||
         createConversationMutation.isPending
       ) {
         return;
@@ -1328,7 +1337,6 @@ export function ChatPageContent({
     [
       isPlaywrightSetupVisible,
       initialAgentId,
-      initialModel,
       createInitialConversation,
       updateEnabledToolsMutation,
       selectConversation,
@@ -1356,8 +1364,6 @@ export function ChatPageContent({
 
     // Wait for agent to be ready.
     if (!initialAgentId) return;
-    if (!initialModel) return;
-
     // Skip if mutation is already in progress
     if (createConversationMutation.isPending) return;
 
@@ -1374,7 +1380,6 @@ export function ChatPageContent({
     initialUserPrompt,
     conversationId,
     initialAgentId,
-    initialModel,
     createInitialConversation,
     selectConversation,
     createConversationMutation.isPending,
@@ -1403,16 +1408,11 @@ export function ChatPageContent({
   // Check if the conversation's agent was deleted
   const isAgentDeleted = conversationId && conversation && !conversation.agent;
 
-  // If user lacks permission to read agents or LLM providers, show access denied
+  // If user lacks permission to read agents, show access denied
   // Must check before loading state since disabled queries stay in pending state
-  if (
-    !conversationId &&
-    (canReadAgent === false || canReadLlmProvider === false)
-  ) {
+  if (!conversationId && canReadAgent === false) {
     const missingPermissions: string[] = [];
     if (canReadAgent === false) missingPermissions.push("agent:read");
-    if (canReadLlmProvider === false)
-      missingPermissions.push("llmProviderApiKey:read");
     return (
       <Empty className="h-full">
         <EmptyHeader>

--- a/platform/frontend/src/components/roles/role-permission-builder.ee.test.tsx
+++ b/platform/frontend/src/components/roles/role-permission-builder.ee.test.tsx
@@ -10,7 +10,9 @@ global.ResizeObserver = class ResizeObserver {
 } as typeof ResizeObserver;
 
 vi.mock("@/components/ui/tooltip", () => ({
-  Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
   TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),

--- a/platform/frontend/src/components/roles/role-permission-builder.ee.test.tsx
+++ b/platform/frontend/src/components/roles/role-permission-builder.ee.test.tsx
@@ -1,5 +1,5 @@
 import type { Permissions } from "@shared";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -90,9 +90,11 @@ describe("RolePermissionBuilder", () => {
 
     const createCheckbox = screen.getByLabelText("Create");
     expect(createCheckbox).toBeDisabled();
+    const createRow = createCheckbox.closest("div");
+    expect(createRow).not.toBeNull();
 
     expect(
-      screen.getByText(
+      within(createRow as HTMLElement).getByText(
         "You can only grant permissions that you currently have yourself.",
       ),
     ).toBeInTheDocument();

--- a/platform/frontend/src/components/roles/role-permission-builder.ee.test.tsx
+++ b/platform/frontend/src/components/roles/role-permission-builder.ee.test.tsx
@@ -2,13 +2,24 @@ import type { Permissions } from "@shared";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { RolePermissionBuilder } from "./role-permission-builder.ee";
 
-global.ResizeObserver = vi.fn().mockImplementation(() => ({
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-  disconnect: vi.fn(),
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as typeof ResizeObserver;
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
 }));
+
+import { RolePermissionBuilder } from "./role-permission-builder.ee";
 
 describe("RolePermissionBuilder", () => {
   it("shows indeterminate state for preloaded partial permissions", async () => {
@@ -80,10 +91,8 @@ describe("RolePermissionBuilder", () => {
     const createCheckbox = screen.getByLabelText("Create");
     expect(createCheckbox).toBeDisabled();
 
-    await user.hover(screen.getByText("Create"));
-
     expect(
-      await screen.findByText(
+      screen.getByText(
         "You can only grant permissions that you currently have yourself.",
       ),
     ).toBeInTheDocument();

--- a/platform/frontend/src/components/roles/role-permission-builder.ee.test.tsx
+++ b/platform/frontend/src/components/roles/role-permission-builder.ee.test.tsx
@@ -10,7 +10,7 @@ global.ResizeObserver = class ResizeObserver {
 } as typeof ResizeObserver;
 
 vi.mock("@/components/ui/tooltip", () => ({
-  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),

--- a/platform/frontend/src/components/roles/role-permission-builder.ee.test.tsx
+++ b/platform/frontend/src/components/roles/role-permission-builder.ee.test.tsx
@@ -4,6 +4,12 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { RolePermissionBuilder } from "./role-permission-builder.ee";
 
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
 describe("RolePermissionBuilder", () => {
   it("shows indeterminate state for preloaded partial permissions", async () => {
     const user = userEvent.setup();
@@ -74,7 +80,7 @@ describe("RolePermissionBuilder", () => {
     const createCheckbox = screen.getByLabelText("Create");
     expect(createCheckbox).toBeDisabled();
 
-    await user.hover(createCheckbox);
+    await user.hover(screen.getByText("Create"));
 
     expect(
       await screen.findByText(

--- a/platform/frontend/src/components/roles/role-permission-builder.ee.test.tsx
+++ b/platform/frontend/src/components/roles/role-permission-builder.ee.test.tsx
@@ -55,4 +55,31 @@ describe("RolePermissionBuilder", () => {
       }),
     ).toHaveAttribute("data-state", "indeterminate");
   });
+
+  it("shows ungrantable permissions as disabled with an explanation", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <RolePermissionBuilder
+        permission={{}}
+        onChange={vi.fn()}
+        userPermissions={{
+          knowledgeSource: ["read"],
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Knowledge" }));
+
+    const createCheckbox = screen.getByLabelText("Create");
+    expect(createCheckbox).toBeDisabled();
+
+    await user.hover(createCheckbox);
+
+    expect(
+      await screen.findByText(
+        "You can only grant permissions that you currently have yourself.",
+      ),
+    ).toBeInTheDocument();
+  });
 });

--- a/platform/frontend/src/components/roles/role-permission-builder.ee.test.tsx
+++ b/platform/frontend/src/components/roles/role-permission-builder.ee.test.tsx
@@ -1,5 +1,5 @@
 import type { Permissions } from "@shared";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -92,13 +92,11 @@ describe("RolePermissionBuilder", () => {
 
     const createCheckbox = screen.getByLabelText("Create");
     expect(createCheckbox).toBeDisabled();
-    const createRow = createCheckbox.closest("div");
-    expect(createRow).not.toBeNull();
 
     expect(
-      within(createRow as HTMLElement).getByText(
+      screen.getAllByText(
         "You can only grant permissions that you currently have yourself.",
-      ),
-    ).toBeInTheDocument();
+      ).length,
+    ).toBeGreaterThan(0);
   });
 });

--- a/platform/frontend/src/components/roles/role-permission-builder.ee.tsx
+++ b/platform/frontend/src/components/roles/role-permission-builder.ee.tsx
@@ -314,125 +314,121 @@ export function RolePermissionBuilder({
 
               {expandedCategories.has(category) && (
                 <div className="mt-2 space-y-2">
-                  {resources
-                    .map((resource) => {
-                      const availableActions = userPermissions[resource] || [];
-                      const allActions = allAvailableActions[resource] || [];
-                      const selectedActions = permission[resource] || [];
-                      const resourceCheckState =
-                        getResourceCheckState(resource);
-                      const isPartiallySelected =
-                        resourceCheckState === "indeterminate";
+                  {resources.map((resource) => {
+                    const availableActions = userPermissions[resource] || [];
+                    const allActions = allAvailableActions[resource] || [];
+                    const selectedActions = permission[resource] || [];
+                    const resourceCheckState = getResourceCheckState(resource);
+                    const isPartiallySelected =
+                      resourceCheckState === "indeterminate";
 
-                      return (
-                        <div
-                          key={resource}
-                          className="rounded-md border bg-card p-3"
-                        >
-                          <div className="flex items-center justify-between mb-2">
-                            <div className="flex items-center gap-2">
-                              <Checkbox
-                                aria-label={`${
-                                  resourceLabels[resource] || resource
-                                } permissions`}
-                                id={`${resource}-all`}
-                                checked={resourceCheckState}
-                                disabled={readOnly}
-                                onCheckedChange={(checked) => {
-                                  if (checked) {
-                                    selectAllForResource(resource);
-                                  } else {
-                                    deselectAllForResource(resource);
-                                  }
-                                }}
-                                className={
-                                  isPartiallySelected ? "opacity-50" : ""
+                    return (
+                      <div
+                        key={resource}
+                        className="rounded-md border bg-card p-3"
+                      >
+                        <div className="flex items-center justify-between mb-2">
+                          <div className="flex items-center gap-2">
+                            <Checkbox
+                              aria-label={`${
+                                resourceLabels[resource] || resource
+                              } permissions`}
+                              id={`${resource}-all`}
+                              checked={resourceCheckState}
+                              disabled={readOnly}
+                              onCheckedChange={(checked) => {
+                                if (checked) {
+                                  selectAllForResource(resource);
+                                } else {
+                                  deselectAllForResource(resource);
                                 }
-                              />
-                              <div>
-                                <Label
-                                  htmlFor={`${resource}-all`}
-                                  className="font-medium cursor-pointer"
-                                >
-                                  {resourceLabels[resource] || resource}
-                                  {isPartiallySelected && (
-                                    <span className="text-xs text-muted-foreground ml-1">
-                                      (Partial)
-                                    </span>
-                                  )}
-                                </Label>
-                                {resourceDescriptions[resource] && (
-                                  <p className="text-xs text-muted-foreground mt-1">
-                                    {resourceDescriptions[resource]}
-                                  </p>
+                              }}
+                              className={
+                                isPartiallySelected ? "opacity-50" : ""
+                              }
+                            />
+                            <div>
+                              <Label
+                                htmlFor={`${resource}-all`}
+                                className="font-medium cursor-pointer"
+                              >
+                                {resourceLabels[resource] || resource}
+                                {isPartiallySelected && (
+                                  <span className="text-xs text-muted-foreground ml-1">
+                                    (Partial)
+                                  </span>
                                 )}
-                              </div>
+                              </Label>
+                              {resourceDescriptions[resource] && (
+                                <p className="text-xs text-muted-foreground mt-1">
+                                  {resourceDescriptions[resource]}
+                                </p>
+                              )}
                             </div>
-                            {selectedActions.length > 0 && (
-                              <span className="text-xs text-muted-foreground">
-                                {selectedActions.length}/
-                                {allActions.length}
-                              </span>
-                            )}
                           </div>
-
-                          <Separator className="my-3" />
-
-                          <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
-                            {allActions.map((action) => {
-                              const isSelected =
-                                selectedActions.includes(action);
-                              const canGrantAction =
-                                availableActions.includes(action);
-                              const shouldDisableAction =
-                                readOnly || (!canGrantAction && !isSelected);
-
-                              return (
-                                <div
-                                  key={action}
-                                  className="flex items-center gap-2"
-                                >
-                                  <Tooltip>
-                                    <TooltipTrigger asChild>
-                                      <div className="flex items-center gap-2">
-                                        <Checkbox
-                                          id={`${resource}-${action}`}
-                                          checked={isSelected}
-                                          disabled={shouldDisableAction}
-                                          onCheckedChange={() => {
-                                            toggleAction(resource, action);
-                                          }}
-                                        />
-                                        <Label
-                                          htmlFor={`${resource}-${action}`}
-                                          className={`text-sm ${
-                                            shouldDisableAction
-                                              ? "cursor-not-allowed text-muted-foreground"
-                                              : "cursor-pointer"
-                                          }`}
-                                        >
-                                          {actionLabels[action]}
-                                          {isSelected && (
-                                            <Check className="ml-1 inline h-3 w-3" />
-                                          )}
-                                        </Label>
-                                      </div>
-                                    </TooltipTrigger>
-                                    {shouldDisableAction &&
-                                      !readOnly &&
-                                      !canGrantAction && (
-                                        <TooltipContent>
-                                          {UNGRANTABLE_PERMISSION_TOOLTIP}
-                                        </TooltipContent>
-                                      )}
-                                  </Tooltip>
-                                </div>
-                              );
-                            })}
-                          </div>
+                          {selectedActions.length > 0 && (
+                            <span className="text-xs text-muted-foreground">
+                              {selectedActions.length}/{allActions.length}
+                            </span>
+                          )}
                         </div>
-                      );
-                    })}
+
+                        <Separator className="my-3" />
+
+                        <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
+                          {allActions.map((action) => {
+                            const isSelected = selectedActions.includes(action);
+                            const canGrantAction =
+                              availableActions.includes(action);
+                            const shouldDisableAction =
+                              readOnly || (!canGrantAction && !isSelected);
+
+                            return (
+                              <div
+                                key={action}
+                                className="flex items-center gap-2"
+                              >
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <div className="flex items-center gap-2">
+                                      <Checkbox
+                                        id={`${resource}-${action}`}
+                                        checked={isSelected}
+                                        disabled={shouldDisableAction}
+                                        onCheckedChange={() => {
+                                          toggleAction(resource, action);
+                                        }}
+                                      />
+                                      <Label
+                                        htmlFor={`${resource}-${action}`}
+                                        className={`text-sm ${
+                                          shouldDisableAction
+                                            ? "cursor-not-allowed text-muted-foreground"
+                                            : "cursor-pointer"
+                                        }`}
+                                      >
+                                        {actionLabels[action]}
+                                        {isSelected && (
+                                          <Check className="ml-1 inline h-3 w-3" />
+                                        )}
+                                      </Label>
+                                    </div>
+                                  </TooltipTrigger>
+                                  {shouldDisableAction &&
+                                    !readOnly &&
+                                    !canGrantAction && (
+                                      <TooltipContent>
+                                        {UNGRANTABLE_PERMISSION_TOOLTIP}
+                                      </TooltipContent>
+                                    )}
+                                </Tooltip>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    );
+                  })}
                 </div>
               )}
             </Card>

--- a/platform/frontend/src/components/roles/role-permission-builder.ee.tsx
+++ b/platform/frontend/src/components/roles/role-permission-builder.ee.tsx
@@ -368,7 +368,8 @@ export function RolePermissionBuilder({
                           </div>
                           {selectedActions.length > 0 && (
                             <span className="text-xs text-muted-foreground">
-                              {selectedActions.length}/{allActions.length}
+                              {selectedActions.length}/
+                              {availableActions.length}
                             </span>
                           )}
                         </div>

--- a/platform/frontend/src/components/roles/role-permission-builder.ee.tsx
+++ b/platform/frontend/src/components/roles/role-permission-builder.ee.tsx
@@ -368,8 +368,7 @@ export function RolePermissionBuilder({
                           </div>
                           {selectedActions.length > 0 && (
                             <span className="text-xs text-muted-foreground">
-                              {selectedActions.length}/
-                              {availableActions.length}
+                              {selectedActions.length}/{availableActions.length}
                             </span>
                           )}
                         </div>

--- a/platform/frontend/src/components/roles/role-permission-builder.ee.tsx
+++ b/platform/frontend/src/components/roles/role-permission-builder.ee.tsx
@@ -8,6 +8,7 @@ import {
   resourceDescriptions,
   resourceLabels,
 } from "@shared";
+import { allAvailableActions } from "@shared/access-control";
 import { Check, ChevronDown, ChevronRight } from "lucide-react";
 import { useCallback, useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -41,6 +42,9 @@ const actionLabels: Record<Action, string> = {
   enable: "Enable",
   query: "Query",
 };
+
+const UNGRANTABLE_PERMISSION_TOOLTIP =
+  "You can only grant permissions that you currently have yourself.";
 
 export function RolePermissionBuilder({
   permission,
@@ -311,9 +315,9 @@ export function RolePermissionBuilder({
               {expandedCategories.has(category) && (
                 <div className="mt-2 space-y-2">
                   {resources
-                    .filter((resource) => userPermissions[resource]) // Only show resources user has permission for
                     .map((resource) => {
                       const availableActions = userPermissions[resource] || [];
+                      const allActions = allAvailableActions[resource] || [];
                       const selectedActions = permission[resource] || [];
                       const resourceCheckState =
                         getResourceCheckState(resource);
@@ -367,7 +371,7 @@ export function RolePermissionBuilder({
                             {selectedActions.length > 0 && (
                               <span className="text-xs text-muted-foreground">
                                 {selectedActions.length}/
-                                {availableActions.length}
+                                {allActions.length}
                               </span>
                             )}
                           </div>
@@ -375,32 +379,53 @@ export function RolePermissionBuilder({
                           <Separator className="my-3" />
 
                           <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
-                            {availableActions.map((action) => {
+                            {allActions.map((action) => {
                               const isSelected =
                                 selectedActions.includes(action);
+                              const canGrantAction =
+                                availableActions.includes(action);
+                              const shouldDisableAction =
+                                readOnly || (!canGrantAction && !isSelected);
 
                               return (
                                 <div
                                   key={action}
                                   className="flex items-center gap-2"
                                 >
-                                  <Checkbox
-                                    id={`${resource}-${action}`}
-                                    checked={isSelected}
-                                    disabled={readOnly}
-                                    onCheckedChange={() => {
-                                      toggleAction(resource, action);
-                                    }}
-                                  />
-                                  <Label
-                                    htmlFor={`${resource}-${action}`}
-                                    className="text-sm cursor-pointer"
-                                  >
-                                    {actionLabels[action]}
-                                    {isSelected && (
-                                      <Check className="ml-1 inline h-3 w-3" />
-                                    )}
-                                  </Label>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <div className="flex items-center gap-2">
+                                        <Checkbox
+                                          id={`${resource}-${action}`}
+                                          checked={isSelected}
+                                          disabled={shouldDisableAction}
+                                          onCheckedChange={() => {
+                                            toggleAction(resource, action);
+                                          }}
+                                        />
+                                        <Label
+                                          htmlFor={`${resource}-${action}`}
+                                          className={`text-sm ${
+                                            shouldDisableAction
+                                              ? "cursor-not-allowed text-muted-foreground"
+                                              : "cursor-pointer"
+                                          }`}
+                                        >
+                                          {actionLabels[action]}
+                                          {isSelected && (
+                                            <Check className="ml-1 inline h-3 w-3" />
+                                          )}
+                                        </Label>
+                                      </div>
+                                    </TooltipTrigger>
+                                    {shouldDisableAction &&
+                                      !readOnly &&
+                                      !canGrantAction && (
+                                        <TooltipContent>
+                                          {UNGRANTABLE_PERMISSION_TOOLTIP}
+                                        </TooltipContent>
+                                      )}
+                                  </Tooltip>
                                 </div>
                               );
                             })}


### PR DESCRIPTION
## What changed

- Removed the hard chat access dependency on `llmProviderApiKey:read` when provider/model selectors are not available.
- Let new chat conversations be created with just `agentId`, allowing the backend to apply smart defaults when model and API key selectors are hidden.
- Updated the role editor to show non-grantable permissions as disabled instead of hiding them, with a hover explanation.
- Added a small access-control docs generator note describing the difference between core chat access and optional chat UI controls.

## Why

Chat was incorrectly blocked for users who should be allowed to use chat but should not be allowed to see provider or model selectors. Separately, the role editor made it hard to understand why some permissions could not be granted because those options were hidden rather than explained.

## Impact

- Users can use chat without `llmProviderApiKey:read` when provider settings are intentionally hidden.
- Provider and model selectors remain gated by their own UI permission plus the underlying read permissions.
- Role editors now get clearer feedback about permissions they cannot grant.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img width="1954" height="227" alt="Image" src="https://github.com/user-attachments/assets/1f9497f2-96ad-4334-b3a4-c63ff38abdb9"/>

</a>