### PR TITLE
feat(task-queue): add pg-boss feasibility matrix and gap analysis

### DIFF
--- a/platform/backend/src/task-queue/capabilities.ts
+++ b/platform/backend/src/task-queue/capabilities.ts
@@ -1,0 +1,102 @@
+export type QueueFeature =
+  | "postgres-backed-persistence"
+  | "delayed-scheduling"
+  | "retry-with-backoff"
+  | "dead-letter-state"
+  | "worker-concurrency-limit"
+  | "graceful-shutdown-drain"
+  | "stuck-task-recovery"
+  | "periodic-task-rescheduling"
+  | "periodic-singleton-seeding"
+  | "ack-late-attempt-semantics"
+  | "handler-registration-by-type";
+
+export type CapabilityStatus = "supported" | "partial" | "unsupported";
+
+export type QueueCapability = {
+  feature: QueueFeature;
+  required: boolean;
+  current: CapabilityStatus;
+  pgBoss: CapabilityStatus;
+  notes: string;
+};
+
+export const TASK_QUEUE_CAPABILITY_MATRIX: QueueCapability[] = [
+  {
+    feature: "postgres-backed-persistence",
+    required: true,
+    current: "supported",
+    pgBoss: "supported",
+    notes: "Both implementations persist jobs in Postgres.",
+  },
+  {
+    feature: "delayed-scheduling",
+    required: true,
+    current: "supported",
+    pgBoss: "supported",
+    notes: "Current queue uses scheduledFor; pg-boss supports delayed jobs.",
+  },
+  {
+    feature: "retry-with-backoff",
+    required: true,
+    current: "supported",
+    pgBoss: "supported",
+    notes: "Current queue has exponential backoff; pg-boss supports retry options.",
+  },
+  {
+    feature: "dead-letter-state",
+    required: true,
+    current: "supported",
+    pgBoss: "supported",
+    notes: "Current queue marks tasks dead; pg-boss supports failed/dead-letter handling.",
+  },
+  {
+    feature: "worker-concurrency-limit",
+    required: true,
+    current: "supported",
+    pgBoss: "supported",
+    notes: "Current queue enforces max in-flight tasks; pg-boss supports worker concurrency.",
+  },
+  {
+    feature: "graceful-shutdown-drain",
+    required: true,
+    current: "supported",
+    pgBoss: "supported",
+    notes: "Current queue drains and releases in-flight tasks; pg-boss has worker stop/shutdown controls.",
+  },
+  {
+    feature: "stuck-task-recovery",
+    required: true,
+    current: "supported",
+    pgBoss: "supported",
+    notes: "Current queue periodically resets stuck tasks; pg-boss has job expiration/maintenance semantics.",
+  },
+  {
+    feature: "periodic-task-rescheduling",
+    required: true,
+    current: "supported",
+    pgBoss: "supported",
+    notes: "Current queue re-enqueues periodic definitions; pg-boss supports recurring/scheduled jobs.",
+  },
+  {
+    feature: "periodic-singleton-seeding",
+    required: true,
+    current: "supported",
+    pgBoss: "partial",
+    notes: "Current queue relies on unique constraints and explicit seed checks. pg-boss requires explicit singleton strategy for recurring jobs across replicas.",
+  },
+  {
+    feature: "ack-late-attempt-semantics",
+    required: true,
+    current: "supported",
+    pgBoss: "partial",
+    notes: "Current queue decrements attempts when interrupted tasks are released. Equivalent semantics need validation with pg-boss retry/expire behavior.",
+  },
+  {
+    feature: "handler-registration-by-type",
+    required: true,
+    current: "supported",
+    pgBoss: "supported",
+    notes: "Current queue dispatches by taskType; pg-boss supports named queues/workers.",
+  },
+];

--- a/platform/backend/src/task-queue/index.ts
+++ b/platform/backend/src/task-queue/index.ts
@@ -1,1 +1,6 @@
 export { taskQueueService } from "./task-queue";
+export {
+	type FeasibilityReport,
+	PG_BOSS_FEASIBILITY_REPORT,
+	analyzePgBossFeasibility,
+} from "./pg-boss-feasibility";

--- a/platform/backend/src/task-queue/pg-boss-feasibility.test.ts
+++ b/platform/backend/src/task-queue/pg-boss-feasibility.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "@/test";
+import { TASK_QUEUE_CAPABILITY_MATRIX } from "./capabilities";
+import {
+  PG_BOSS_FEASIBILITY_REPORT,
+  analyzePgBossFeasibility,
+} from "./pg-boss-feasibility";
+
+describe("analyzePgBossFeasibility", () => {
+  test("reports counts that match matrix size", () => {
+    const report = analyzePgBossFeasibility();
+    const total =
+      report.supportedCount + report.partialCount + report.unsupportedCount;
+    expect(total).toBe(TASK_QUEUE_CAPABILITY_MATRIX.length);
+  });
+
+  test("flags required partial/unsupported items as blocking gaps", () => {
+    const report = analyzePgBossFeasibility();
+    const requiredGaps = TASK_QUEUE_CAPABILITY_MATRIX.filter(
+      (item) =>
+        item.required && (item.pgBoss === "partial" || item.pgBoss === "unsupported"),
+    );
+
+    expect(report.blockingGaps.map((g) => g.feature).sort()).toEqual(
+      requiredGaps.map((g) => g.feature).sort(),
+    );
+  });
+
+  test("exports a stable default report", () => {
+    expect(PG_BOSS_FEASIBILITY_REPORT.partialCount).toBeGreaterThanOrEqual(0);
+    expect(PG_BOSS_FEASIBILITY_REPORT.supportedCount).toBeGreaterThan(0);
+  });
+});

--- a/platform/backend/src/task-queue/pg-boss-feasibility.ts
+++ b/platform/backend/src/task-queue/pg-boss-feasibility.ts
@@ -1,0 +1,40 @@
+import {
+  type QueueCapability,
+  TASK_QUEUE_CAPABILITY_MATRIX,
+} from "./capabilities";
+
+export type FeasibilityReport = {
+  isViableReplacement: boolean;
+  blockingGaps: QueueCapability[];
+  nonBlockingGaps: QueueCapability[];
+  supportedCount: number;
+  partialCount: number;
+  unsupportedCount: number;
+};
+
+export function analyzePgBossFeasibility(
+  matrix: QueueCapability[] = TASK_QUEUE_CAPABILITY_MATRIX,
+): FeasibilityReport {
+  const supportedCount = matrix.filter((item) => item.pgBoss === "supported").length;
+  const partial = matrix.filter((item) => item.pgBoss === "partial");
+  const unsupported = matrix.filter((item) => item.pgBoss === "unsupported");
+
+  const blockingGaps = [...partial, ...unsupported].filter(
+    (item) => item.required,
+  );
+
+  const nonBlockingGaps = [...partial, ...unsupported].filter(
+    (item) => !item.required,
+  );
+
+  return {
+    isViableReplacement: blockingGaps.length === 0,
+    blockingGaps,
+    nonBlockingGaps,
+    supportedCount,
+    partialCount: partial.length,
+    unsupportedCount: unsupported.length,
+  };
+}
+
+export const PG_BOSS_FEASIBILITY_REPORT = analyzePgBossFeasibility();


### PR DESCRIPTION
## Summary
- add a typed capability matrix for the current TaskQueue vs pg-boss
- add a feasibility analyzer that reports blocking vs non-blocking gaps
- export a default feasibility report for runtime/inspection usage
- add unit tests for matrix/report consistency

## Why
Issue #3796 asks for a concrete analysis of whether pg-boss can replace the current Postgres-backed task queue. This PR makes that analysis explicit, typed, and testable so migration decisions are based on codified requirements.

## Notes
- no behavior change to the existing task queue yet
- highlights two required parity points to validate before full migration:
  - periodic singleton seeding strategy across replicas
  - ack-late attempt semantics for interrupted tasks

/claim #3796