### PR TITLE
fix: anthropic virtual key auth

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Archestra",
-    "version": "1.2.13"
+    "version": "1.2.14"
   },
   "components": {
     "schemas": {

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -270,11 +270,11 @@ export async function handleLLMProxy<
     apiKey = provider.extractApiKey(headers);
   }
 
-  // 3. Resolve platform-managed virtual API keys
-  // Strip "Bearer " prefix if present — OpenAI's extractApiKey returns the full
-  // Authorization header value (e.g. "Bearer arch_xxx"), while other providers
-  // return the raw key.
-  const rawApiKey = apiKey?.replace(/^Bearer\s+/i, "") ?? undefined;
+  // 3. Resolve platform-managed virtual API keys.
+  // Some adapters return a standard "Bearer <token>" value while Anthropic uses
+  // a "Bearer:<token>" sentinel so downstream client creation can distinguish
+  // auth tokens from raw API keys. Normalize both forms before virtual-key lookup.
+  const rawApiKey = normalizeVirtualKeyCandidate(apiKey);
   if (
     !wasJwksAuthenticated &&
     rawApiKey &&
@@ -1298,4 +1298,14 @@ async function handleNonStreaming<
   }
 
   return reply.send(responseAdapter.getOriginalResponse());
+}
+
+function normalizeVirtualKeyCandidate(
+  apiKey: string | undefined,
+): string | undefined {
+  if (!apiKey) {
+    return undefined;
+  }
+
+  return apiKey.replace(/^Bearer[:\s]+/i, "");
 }

--- a/platform/backend/src/routes/proxy/routes/anthropic.test.ts
+++ b/platform/backend/src/routes/proxy/routes/anthropic.test.ts
@@ -21,7 +21,7 @@ import {
   type ZodTypeProvider,
 } from "fastify-type-provider-zod";
 import { vi } from "vitest";
-import { ModelModel } from "@/models";
+import { ModelModel, VirtualApiKeyModel } from "@/models";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { createAnthropicTestClient } from "@/test/llm-provider-stubs";
 import { anthropicAdapterFactory } from "../adapters";
@@ -248,6 +248,82 @@ describe("Anthropic streaming mode", () => {
     expect(interaction.outputTokens).toBe(10); // Usage from message_start event
     expect(interaction.cost).toBeTruthy();
     expect(interaction.baselineCost).toBeTruthy();
+  });
+});
+
+describe("Anthropic virtual key auth", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("resolves virtual keys passed via authorization header", async ({
+    makeAgent,
+    makeOrganization,
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    const app = Fastify().withTypeProvider<ZodTypeProvider>();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+
+    let capturedApiKey: string | undefined;
+    vi.spyOn(anthropicAdapterFactory, "createClient").mockImplementation(
+      (apiKey) => {
+        capturedApiKey = apiKey;
+        return createAnthropicTestClient() as never;
+      },
+    );
+
+    try {
+      await app.register(anthropicProxyRoutes);
+
+      const organization = await makeOrganization();
+      const secret = await makeSecret({
+        secret: { apiKey: "sk-anthropic-parent-key" },
+      });
+      const chatApiKey = await makeLlmProviderApiKey(
+        organization.id,
+        secret.id,
+        {
+          provider: "anthropic",
+        },
+      );
+      const { id: virtualKeyId, value } = await VirtualApiKeyModel.create({
+        chatApiKeyId: chatApiKey.id,
+        name: "anthropic-auth-header-vk",
+      });
+
+      const agent = await makeAgent({
+        organizationId: organization.id,
+        name: "Anthropic Virtual Key Agent",
+      });
+
+      const before = await VirtualApiKeyModel.findById(virtualKeyId);
+      expect(before?.lastUsedAt).toBeNull();
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/anthropic/${agent.id}/v1/messages`,
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${value}`,
+          "anthropic-version": "2023-06-01",
+        },
+        payload: {
+          model: "claude-opus-4-20250514",
+          messages: [{ role: "user", content: "Hello!" }],
+          max_tokens: 128,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(capturedApiKey).toBe("sk-anthropic-parent-key");
+
+      const after = await VirtualApiKeyModel.findById(virtualKeyId);
+      expect(after?.lastUsedAt).not.toBeNull();
+    } finally {
+      await app.close();
+    }
   });
 });
 

--- a/platform/backend/src/routes/proxy/routes/anthropic.test.ts
+++ b/platform/backend/src/routes/proxy/routes/anthropic.test.ts
@@ -288,7 +288,10 @@ describe("Anthropic virtual key auth", () => {
           provider: "anthropic",
         },
       );
-      const { id: virtualKeyId, value } = await VirtualApiKeyModel.create({
+      const {
+        virtualKey: { id: virtualKeyId },
+        value,
+      } = await VirtualApiKeyModel.create({
         chatApiKeyId: chatApiKey.id,
         name: "anthropic-auth-header-vk",
       });


### PR DESCRIPTION
## Summary
- normalize Anthropic bearer-style auth tokens before LLM proxy virtual-key lookup
- add a route-level Anthropic regression test that verifies authorization-header virtual keys resolve to the parent provider key and update `lastUsedAt`

## Root cause
Anthropic requests convert `Authorization: Bearer <token>` into an internal `Bearer:<token>` sentinel before client creation. The LLM proxy only stripped the standard `Bearer ` prefix during virtual-key detection, so Anthropic virtual keys passed via the authorization header were skipped and forwarded upstream incorrectly.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img width="1954" height="227" alt="Image" src="https://github.com/user-attachments/assets/1f9497f2-96ad-4334-b3a4-c63ff38abdb9"/>

</a>