### PR TITLE
fix: sanitize OpenAI tool schemas

### DIFF
--- a/platform/backend/src/routes/proxy/adapters/openai.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai.test.ts
@@ -664,6 +664,58 @@ describe("OpenAIRequestAdapter", () => {
         { type: "text", text: "[Image omitted due to size]" },
       ]);
     });
+
+    test("sanitizes array tool schemas before forwarding to OpenAI", () => {
+      const request = createMockRequest([{ role: "user", content: "Search" }], {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "redis_ctx__search_policy_by_content_embedding_similarity",
+              description: "Vector search",
+              parameters: {
+                type: "object",
+                properties: {
+                  vector: {
+                    type: "array",
+                    description: "The content_embedding vector to search for",
+                  },
+                  k: {
+                    type: "number",
+                  },
+                },
+                required: ["vector"],
+              },
+            },
+          },
+        ],
+      });
+
+      const adapter = openaiAdapterFactory.createRequestAdapter(request);
+      const result = adapter.toProviderRequest();
+
+      expect(result.tools?.[0]).toEqual({
+        type: "function",
+        function: {
+          name: "redis_ctx__search_policy_by_content_embedding_similarity",
+          description: "Vector search",
+          parameters: {
+            type: "object",
+            properties: {
+              vector: {
+                type: "array",
+                description: "The content_embedding vector to search for",
+                items: { type: "number" },
+              },
+              k: {
+                type: "number",
+              },
+            },
+            required: ["vector"],
+          },
+        },
+      });
+    });
   });
 });
 

--- a/platform/backend/src/routes/proxy/adapters/openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai.ts
@@ -70,6 +70,91 @@ type OpenAiToolResultContentBlock =
 
 type OpenAiToolResultContent = string | OpenAiToolResultContentBlock[];
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function defaultArrayItemsSchema(
+  schema: Record<string, unknown>,
+  fieldName?: string,
+): Record<string, unknown> {
+  const description =
+    typeof schema.description === "string" ? schema.description : "";
+  const hint = `${fieldName ?? ""} ${description}`.toLowerCase();
+
+  if (hint.includes("vector") || hint.includes("embedding")) {
+    return { type: "number" };
+  }
+
+  return {};
+}
+
+function sanitizeJsonSchema(
+  schema: unknown,
+  fieldName?: string,
+): Record<string, unknown> {
+  if (!isRecord(schema)) {
+    return { type: "object", properties: {} };
+  }
+
+  const sanitized: Record<string, unknown> = { ...schema };
+
+  if (sanitized.type === "array") {
+    const items = sanitized.items;
+    sanitized.items = isRecord(items)
+      ? sanitizeJsonSchema(items)
+      : defaultArrayItemsSchema(sanitized, fieldName);
+  }
+
+  if (isRecord(sanitized.properties)) {
+    sanitized.properties = Object.fromEntries(
+      Object.entries(sanitized.properties).map(([name, value]) => [
+        name,
+        sanitizeJsonSchema(value, name),
+      ]),
+    );
+  }
+
+  if (isRecord(sanitized.additionalProperties)) {
+    sanitized.additionalProperties = sanitizeJsonSchema(
+      sanitized.additionalProperties,
+    );
+  }
+
+  for (const key of ["allOf", "anyOf", "oneOf", "prefixItems"] as const) {
+    const value = sanitized[key];
+    if (Array.isArray(value)) {
+      sanitized[key] = value.map((item) =>
+        isRecord(item) ? sanitizeJsonSchema(item) : item,
+      );
+    }
+  }
+
+  if (isRecord(sanitized.not)) {
+    sanitized.not = sanitizeJsonSchema(sanitized.not);
+  }
+
+  return sanitized;
+}
+
+function sanitizeOpenAiTools(
+  tools: OpenAiRequest["tools"],
+): OpenAiRequest["tools"] {
+  return tools?.map((tool) => {
+    if (tool.type !== "function") {
+      return tool;
+    }
+
+    return {
+      ...tool,
+      function: {
+        ...tool.function,
+        parameters: sanitizeJsonSchema(tool.function.parameters),
+      },
+    };
+  });
+}
+
 // =============================================================================
 // REQUEST ADAPTER
 // =============================================================================
@@ -386,6 +471,7 @@ export class OpenAIRequestAdapter
       ...this.request,
       model: this.getModel(),
       messages,
+      tools: sanitizeOpenAiTools(this.request.tools),
     };
   }
 


### PR DESCRIPTION
## Summary

OpenAI-compatible requests routed through Archestra can fail before execution when an MCP-derived function tool schema contains an array property without an items definition.

In the local repro, the failing tool was a Redis Context Surface vector search tool exposed as either:
- `redis_ctx__search_policy_by_content_embedding_similarity`
- `redis__search_policy_by_content_embedding_similarity`

OpenAI rejects the request with:

`Invalid schema for function '...search_policy_by_content_embedding_similarity': In context=('properties', 'vector'), array schema missing items.`

## Root Cause

Archestra forwards `request.tools` upstream without normalizing incomplete JSON Schema.

For the affected MCP tool, the forwarded function schema contains a `vector` property like:
- `type: array`
- `description: The content_embedding vector to search for`
- missing `items`

OpenAI requires array schemas to include `items`, so the proxy request is rejected before model execution.

## Expected Behavior

Before forwarding OpenAI function tools upstream, Archestra should sanitize MCP-derived schemas so malformed array schemas become valid JSON Schema.

For this case, the array should be forwarded as:
- `type: array`
- `items.type: number`

## Proposed Fix

In the OpenAI proxy adapter, recursively sanitize outbound tool schemas before returning the provider request:
- repair array schemas missing `items`
- recurse through `properties`, `additionalProperties`, `allOf`, `anyOf`, `oneOf`, `prefixItems`, and `not`
- infer `items.type = number` for vector or embedding arrays when the upstream schema omits it

## Local Patch and Validation

Local patch files:
- `platform/backend/src/routes/proxy/adapters/openai.ts`
- `platform/backend/src/routes/proxy/adapters/openai.test.ts`

Focused validation command:
`DATABASE_URL=postgresql://test:test@localhost:5432/test /Applications/Codex.app/Contents/Resources/node /opt/homebrew/bin/pnpm --dir /Users/albert.wong/sandbox/archestra/platform/backend exec vitest run src/routes/proxy/adapters/openai.test.ts`

Result:
- `1` file passed
- `31` tests passed

## Related Context

This surfaced while testing `redis/context-engine-demos` issue #11, but the actual failure happens in Archestra's `/v1/openai/.../chat/completions` proxy layer rather than in the demo app itself.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img width="1954" height="227" alt="Image" src="https://github.com/user-attachments/assets/1f9497f2-96ad-4334-b3a4-c63ff38abdb9"/>

</a>