### PR TITLE
fix: disappearing chat errors during retries

### DIFF
--- a/platform/frontend/src/lib/chat/chat-utils.test.ts
+++ b/platform/frontend/src/lib/chat/chat-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  conversationStorageKeys,
   getChatExternalAgentId,
   getConversationDisplayTitle,
   preserveNewlines,
@@ -144,6 +145,16 @@ describe("getChatExternalAgentId", () => {
 
   it("handles mixed ASCII and non-ISO-8859-1 characters", () => {
     expect(getChatExternalAgentId("Hello 世界 App")).toBe("Hello App Chat");
+  });
+});
+
+describe("conversationStorageKeys", () => {
+  it("returns all conversation-scoped localStorage keys", () => {
+    expect(conversationStorageKeys("conversation-123")).toEqual({
+      artifactOpen: "archestra-chat-artifact-open-conversation-123",
+      draft: "archestra_chat_draft_conversation-123",
+      error: "archestra_chat_error_conversation-123",
+    });
   });
 });
 

--- a/platform/frontend/src/lib/chat/chat-utils.ts
+++ b/platform/frontend/src/lib/chat/chat-utils.ts
@@ -81,6 +81,7 @@ export function conversationStorageKeys(conversationId: string) {
   return {
     artifactOpen: `archestra-chat-artifact-open-${conversationId}`,
     draft: `archestra_chat_draft_${conversationId}`,
+    error: `archestra_chat_error_${conversationId}`,
   };
 }
 

--- a/platform/frontend/src/lib/chat/chat.query.ts
+++ b/platform/frontend/src/lib/chat/chat.query.ts
@@ -294,6 +294,7 @@ export function useDeleteConversation() {
         const keys = conversationStorageKeys(deletedId);
         localStorage.removeItem(keys.artifactOpen);
         localStorage.removeItem(keys.draft);
+        localStorage.removeItem(keys.error);
       }
 
       toast.success("Conversation deleted");

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -157,6 +157,41 @@ describe("useChatSession", () => {
       localStorage.getItem(conversationStorageKeys(conversationId).error),
     ).toBeNull();
   });
+
+  it("keeps showing the in-memory error when localStorage persistence fails", async () => {
+    const conversationId = "conversation-3";
+    const storageSpy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new DOMException("Quota exceeded", "QuotaExceededError");
+      });
+
+    const { result } = renderHook(
+      () => useChatSession({ conversationId, enabled: true }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current).not.toBeNull();
+      expect(latestUseChatOptions).toBeDefined();
+    });
+
+    act(() => {
+      latestUseChatOptions?.onError?.(new Error("Storage-limited failure"));
+    });
+
+    await waitFor(() => {
+      expect(result.current?.error?.message).toBe("Storage-limited failure");
+    });
+    expect(storageSpy).toHaveBeenCalledWith(
+      conversationStorageKeys(conversationId).error,
+      "Storage-limited failure",
+    );
+
+    storageSpy.mockRestore();
+  });
 });
 
 function createWrapper() {

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -1,0 +1,188 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { conversationStorageKeys } from "@/lib/chat/chat-utils";
+import { ChatProvider, useChatSession } from "./global-chat.context";
+
+const useChatMock = vi.fn();
+const useGenerateConversationTitleMock = vi.fn();
+const invalidateQueriesMock = vi.fn();
+
+vi.mock("@ai-sdk/react", () => ({
+  useChat: (...args: unknown[]) => useChatMock(...args),
+}));
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual = await vi.importActual("@tanstack/react-query");
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      invalidateQueries: invalidateQueriesMock,
+    }),
+  };
+});
+
+vi.mock("@/lib/chat/chat.query", () => ({
+  useGenerateConversationTitle: () => useGenerateConversationTitleMock(),
+}));
+
+vi.mock("@/lib/chat/chat-session-utils", () => ({
+  restoreRenderableAssistantParts: ({
+    nextMessages,
+  }: {
+    nextMessages: unknown[];
+  }) => nextMessages,
+}));
+
+vi.mock("@/lib/chat/swap-agent.utils", () => ({
+  extractSwapTargetAgentName: () => null,
+  getRenderedToolName: () => null,
+  getSwapToolShortName: () => null,
+  hasSwapToolErrorInPart: () => false,
+}));
+
+vi.mock("@/lib/config/config", () => ({
+  default: {
+    enterpriseFeatures: {
+      fullWhiteLabeling: false,
+    },
+  },
+}));
+
+vi.mock("@/lib/hooks/use-app-name", () => ({
+  useAppName: () => "Archestra",
+}));
+
+type UseChatOptions = Parameters<typeof useChatMock>[0];
+
+describe("useChatSession", () => {
+  let latestUseChatOptions: UseChatOptions | undefined;
+  let useChatState: ReturnType<typeof createUseChatState>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+
+    useGenerateConversationTitleMock.mockReturnValue({
+      isPending: false,
+      mutate: vi.fn(),
+    });
+
+    useChatState = createUseChatState();
+    latestUseChatOptions = undefined;
+
+    useChatMock.mockImplementation((options: UseChatOptions) => {
+      latestUseChatOptions = options;
+      return useChatState;
+    });
+  });
+
+  it("hydrates a persisted conversation error from localStorage", async () => {
+    const conversationId = "conversation-1";
+    localStorage.setItem(
+      conversationStorageKeys(conversationId).error,
+      JSON.stringify({
+        code: "server_error",
+        message: "Persisted provider failure",
+        isRetryable: true,
+      }),
+    );
+
+    const { result } = renderHook(
+      () => useChatSession({ conversationId, enabled: true }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current?.error?.message).toContain(
+        "Persisted provider failure",
+      );
+    });
+  });
+
+  it("keeps the last error during retries and clears it after a successful finish", async () => {
+    const conversationId = "conversation-2";
+
+    const { result } = renderHook(
+      () => useChatSession({ conversationId, enabled: true }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current).not.toBeNull();
+      expect(latestUseChatOptions).toBeDefined();
+    });
+
+    act(() => {
+      latestUseChatOptions?.onError?.(
+        new Error(
+          JSON.stringify({
+            code: "server_error",
+            message: "Temporary backend failure",
+            isRetryable: true,
+          }),
+        ),
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current?.error?.message).toContain(
+        "Temporary backend failure",
+      );
+    });
+    expect(
+      localStorage.getItem(conversationStorageKeys(conversationId).error),
+    ).toContain("Temporary backend failure");
+
+    act(() => {
+      useChatState.error = undefined;
+      latestUseChatOptions?.onFinish?.({
+        message: {
+          id: "assistant-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "Recovered" }],
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current?.error).toBeUndefined();
+    });
+    expect(
+      localStorage.getItem(conversationStorageKeys(conversationId).error),
+    ).toBeNull();
+  });
+});
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <ChatProvider>{children}</ChatProvider>
+    </QueryClientProvider>
+  );
+}
+
+function createUseChatState() {
+  return {
+    messages: [],
+    sendMessage: vi.fn(),
+    regenerate: vi.fn(),
+    status: "ready" as const,
+    setMessages: vi.fn(),
+    stop: vi.fn(),
+    error: undefined as Error | undefined,
+    addToolResult: vi.fn(),
+    addToolApprovalResponse: vi.fn(),
+  };
+}

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -34,7 +34,10 @@ import {
 import { filterOptimisticToolCalls } from "@/components/chat/chat-messages.utils";
 import { useGenerateConversationTitle } from "@/lib/chat/chat.query";
 import { restoreRenderableAssistantParts } from "@/lib/chat/chat-session-utils";
-import { getChatExternalAgentId } from "@/lib/chat/chat-utils";
+import {
+  conversationStorageKeys,
+  getChatExternalAgentId,
+} from "@/lib/chat/chat-utils";
 import {
   extractSwapTargetAgentName,
   getRenderedToolName,
@@ -341,6 +344,9 @@ function ChatSessionHook({
   const retryTimerRef = useRef<NodeJS.Timeout | null>(null);
   const lastUserMessageIdRef = useRef<string | null>(null);
   const previousMessagesRef = useRef<UIMessage[]>([]);
+  const [persistedError, setPersistedError] = useState<Error | undefined>(() =>
+    loadPersistedConversationError(conversationId),
+  );
 
   // Track early UI data from data-tool-ui-start events (toolCallId → resource data)
   const [earlyToolUiStarts, setEarlyToolUiStarts] = useState<
@@ -371,6 +377,8 @@ function ChatSessionHook({
     id: conversationId,
     onFinish: ({ message }) => {
       setOptimisticToolCalls([]);
+      clearPersistedConversationError(conversationId);
+      setPersistedError(undefined);
       queryClient.invalidateQueries({
         queryKey: ["conversation", conversationId],
       });
@@ -402,6 +410,8 @@ function ChatSessionHook({
     },
     onError: (chatError) => {
       setOptimisticToolCalls([]);
+      persistConversationError(conversationId, chatError);
+      setPersistedError(new Error(chatError.message));
       console.error("[ChatSession] Error occurred:", {
         conversationId,
         errorName: chatError.name,
@@ -607,7 +617,7 @@ function ChatSessionHook({
     sendMessage,
     stop,
     status,
-    error,
+    error: error ?? persistedError,
     setMessages,
     addToolResult,
     addToolApprovalResponse,
@@ -632,6 +642,7 @@ function ChatSessionHook({
     stop,
     status,
     error,
+    persistedError,
     setMessages,
     addToolResult,
     addToolApprovalResponse,
@@ -644,6 +655,38 @@ function ChatSessionHook({
   ]);
 
   return null;
+}
+
+function loadPersistedConversationError(
+  conversationId: string,
+): Error | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
+  const storedMessage = localStorage.getItem(
+    conversationStorageKeys(conversationId).error,
+  );
+  return storedMessage ? new Error(storedMessage) : undefined;
+}
+
+function persistConversationError(conversationId: string, error: Error) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  localStorage.setItem(
+    conversationStorageKeys(conversationId).error,
+    error.message,
+  );
+}
+
+function clearPersistedConversationError(conversationId: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  localStorage.removeItem(conversationStorageKeys(conversationId).error);
 }
 
 function getSwapAgentName(toolCall: unknown): string | null {

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -411,7 +411,7 @@ function ChatSessionHook({
     onError: (chatError) => {
       setOptimisticToolCalls([]);
       persistConversationError(conversationId, chatError);
-      setPersistedError(new Error(chatError.message));
+      setPersistedError(chatError);
       console.error("[ChatSession] Error occurred:", {
         conversationId,
         errorName: chatError.name,
@@ -675,10 +675,14 @@ function persistConversationError(conversationId: string, error: Error) {
     return;
   }
 
-  localStorage.setItem(
-    conversationStorageKeys(conversationId).error,
-    error.message,
-  );
+  try {
+    localStorage.setItem(
+      conversationStorageKeys(conversationId).error,
+      error.message,
+    );
+  } catch {
+    // Storage may be unavailable, but the in-memory session state still shows the error.
+  }
 }
 
 function clearPersistedConversationError(conversationId: string) {


### PR DESCRIPTION
## Summary
Fixes #3860.

This change persists the latest chat error per conversation in frontend local storage so the inline error card does not disappear when the page refreshes or while the client retries a transient failure. The persisted error is cleared after the next successful response and when the conversation is deleted.

## Root Cause
The chat UI only rendered `chatSession.error`, which lived in the in-memory `useChat` session state. Refreshing the page or retrying a send could recreate or clear that session state, so the error banner vanished even though the conversation was still in an error state from the user’s perspective.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img width="1954" height="227" alt="Image" src="https://github.com/user-attachments/assets/1f9497f2-96ad-4334-b3a4-c63ff38abdb9"/>

</a>