### PR TITLE
feat: add remote MCP client credentials auth mode

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -90968,6 +90968,13 @@
                           "server_url": {
                             "type": "string"
                           },
+                          "grant_type": {
+                            "type": "string",
+                            "enum": [
+                              "authorization_code",
+                              "client_credentials"
+                            ]
+                          },
                           "auth_server_url": {
                             "type": "string"
                           },
@@ -90981,6 +90988,9 @@
                             "type": "string"
                           },
                           "client_secret": {
+                            "type": "string"
+                          },
+                          "audience": {
                             "type": "string"
                           },
                           "redirect_uris": {
@@ -91830,6 +91840,13 @@
                       "server_url": {
                         "type": "string"
                       },
+                      "grant_type": {
+                        "type": "string",
+                        "enum": [
+                          "authorization_code",
+                          "client_credentials"
+                        ]
+                      },
                       "auth_server_url": {
                         "type": "string"
                       },
@@ -91843,6 +91860,9 @@
                         "type": "string"
                       },
                       "client_secret": {
+                        "type": "string"
+                      },
+                      "audience": {
                         "type": "string"
                       },
                       "redirect_uris": {
@@ -92425,6 +92445,13 @@
                         "server_url": {
                           "type": "string"
                         },
+                        "grant_type": {
+                          "type": "string",
+                          "enum": [
+                            "authorization_code",
+                            "client_credentials"
+                          ]
+                        },
                         "auth_server_url": {
                           "type": "string"
                         },
@@ -92438,6 +92465,9 @@
                           "type": "string"
                         },
                         "client_secret": {
+                          "type": "string"
+                        },
+                        "audience": {
                           "type": "string"
                         },
                         "redirect_uris": {
@@ -93311,6 +93341,13 @@
                         "server_url": {
                           "type": "string"
                         },
+                        "grant_type": {
+                          "type": "string",
+                          "enum": [
+                            "authorization_code",
+                            "client_credentials"
+                          ]
+                        },
                         "auth_server_url": {
                           "type": "string"
                         },
@@ -93324,6 +93361,9 @@
                           "type": "string"
                         },
                         "client_secret": {
+                          "type": "string"
+                        },
+                        "audience": {
                           "type": "string"
                         },
                         "redirect_uris": {
@@ -94167,6 +94207,13 @@
                       "server_url": {
                         "type": "string"
                       },
+                      "grant_type": {
+                        "type": "string",
+                        "enum": [
+                          "authorization_code",
+                          "client_credentials"
+                        ]
+                      },
                       "auth_server_url": {
                         "type": "string"
                       },
@@ -94180,6 +94227,9 @@
                         "type": "string"
                       },
                       "client_secret": {
+                        "type": "string"
+                      },
+                      "audience": {
                         "type": "string"
                       },
                       "redirect_uris": {
@@ -94770,6 +94820,13 @@
                         "server_url": {
                           "type": "string"
                         },
+                        "grant_type": {
+                          "type": "string",
+                          "enum": [
+                            "authorization_code",
+                            "client_credentials"
+                          ]
+                        },
                         "auth_server_url": {
                           "type": "string"
                         },
@@ -94783,6 +94840,9 @@
                           "type": "string"
                         },
                         "client_secret": {
+                          "type": "string"
+                        },
+                        "audience": {
                           "type": "string"
                         },
                         "redirect_uris": {
@@ -112314,6 +112374,13 @@
                                   "server_url": {
                                     "type": "string"
                                   },
+                                  "grant_type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "authorization_code",
+                                      "client_credentials"
+                                    ]
+                                  },
                                   "auth_server_url": {
                                     "type": "string"
                                   },
@@ -112327,6 +112394,9 @@
                                     "type": "string"
                                   },
                                   "client_secret": {
+                                    "type": "string"
+                                  },
+                                  "audience": {
                                     "type": "string"
                                   },
                                   "redirect_uris": {
@@ -112971,6 +113041,13 @@
                               "server_url": {
                                 "type": "string"
                               },
+                              "grant_type": {
+                                "type": "string",
+                                "enum": [
+                                  "authorization_code",
+                                  "client_credentials"
+                                ]
+                              },
                               "auth_server_url": {
                                 "type": "string"
                               },
@@ -112984,6 +113061,9 @@
                                 "type": "string"
                               },
                               "client_secret": {
+                                "type": "string"
+                              },
+                              "audience": {
                                 "type": "string"
                               },
                               "redirect_uris": {
@@ -113347,6 +113427,13 @@
                                 "server_url": {
                                   "type": "string"
                                 },
+                                "grant_type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "authorization_code",
+                                    "client_credentials"
+                                  ]
+                                },
                                 "auth_server_url": {
                                   "type": "string"
                                 },
@@ -113360,6 +113447,9 @@
                                   "type": "string"
                                 },
                                 "client_secret": {
+                                  "type": "string"
+                                },
+                                "audience": {
                                   "type": "string"
                                 },
                                 "redirect_uris": {
@@ -114034,6 +114124,13 @@
                                 "server_url": {
                                   "type": "string"
                                 },
+                                "grant_type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "authorization_code",
+                                    "client_credentials"
+                                  ]
+                                },
                                 "auth_server_url": {
                                   "type": "string"
                                 },
@@ -114047,6 +114144,9 @@
                                   "type": "string"
                                 },
                                 "client_secret": {
+                                  "type": "string"
+                                },
+                                "audience": {
                                   "type": "string"
                                 },
                                 "redirect_uris": {
@@ -114694,6 +114794,13 @@
                               "server_url": {
                                 "type": "string"
                               },
+                              "grant_type": {
+                                "type": "string",
+                                "enum": [
+                                  "authorization_code",
+                                  "client_credentials"
+                                ]
+                              },
                               "auth_server_url": {
                                 "type": "string"
                               },
@@ -114707,6 +114814,9 @@
                                 "type": "string"
                               },
                               "client_secret": {
+                                "type": "string"
+                              },
+                              "audience": {
                                 "type": "string"
                               },
                               "redirect_uris": {
@@ -115121,6 +115231,13 @@
                                 "server_url": {
                                   "type": "string"
                                 },
+                                "grant_type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "authorization_code",
+                                    "client_credentials"
+                                  ]
+                                },
                                 "auth_server_url": {
                                   "type": "string"
                                 },
@@ -115134,6 +115251,9 @@
                                   "type": "string"
                                 },
                                 "client_secret": {
+                                  "type": "string"
+                                },
+                                "audience": {
                                   "type": "string"
                                 },
                                 "redirect_uris": {
@@ -116079,6 +116199,13 @@
                                 "server_url": {
                                   "type": "string"
                                 },
+                                "grant_type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "authorization_code",
+                                    "client_credentials"
+                                  ]
+                                },
                                 "auth_server_url": {
                                   "type": "string"
                                 },
@@ -116092,6 +116219,9 @@
                                   "type": "string"
                                 },
                                 "client_secret": {
+                                  "type": "string"
+                                },
+                                "audience": {
                                   "type": "string"
                                 },
                                 "redirect_uris": {
@@ -116781,6 +116911,13 @@
                                 "server_url": {
                                   "type": "string"
                                 },
+                                "grant_type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "authorization_code",
+                                    "client_credentials"
+                                  ]
+                                },
                                 "auth_server_url": {
                                   "type": "string"
                                 },
@@ -116794,6 +116931,9 @@
                                   "type": "string"
                                 },
                                 "client_secret": {
+                                  "type": "string"
+                                },
+                                "audience": {
                                   "type": "string"
                                 },
                                 "redirect_uris": {
@@ -117487,6 +117627,13 @@
                                 "server_url": {
                                   "type": "string"
                                 },
+                                "grant_type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "authorization_code",
+                                    "client_credentials"
+                                  ]
+                                },
                                 "auth_server_url": {
                                   "type": "string"
                                 },
@@ -117500,6 +117647,9 @@
                                   "type": "string"
                                 },
                                 "client_secret": {
+                                  "type": "string"
+                                },
+                                "audience": {
                                   "type": "string"
                                 },
                                 "redirect_uris": {

--- a/docs/pages/mcp-authentication.md
+++ b/docs/pages/mcp-authentication.md
@@ -165,16 +165,29 @@ graph LR
     style CR fill:#fff,stroke:#0066cc,stroke-width:1px
 ```
 
-Credentials are configured when you install a server from the [MCP Catalog](/docs/platform-private-registry). There are four types of upstream credentials:
+Credentials are configured when you install a server from the [MCP Catalog](/docs/platform-private-registry). There are five types of upstream credentials:
 
 - **Static secrets**: API keys or personal access tokens that are set once at install time and used for all requests.
 - **OAuth tokens**: Obtained by running an OAuth flow against the upstream provider during installation. Archestra stores both the access token and refresh token.
+- **OAuth client credentials**: Shared client credentials stored on the MCP connection and exchanged for a short-lived bearer token when a tool call runs.
 - **Upstream ID-JAG**: Retrieved at tool-call time by exchanging the caller's enterprise assertion for the downstream credential the MCP server needs.
 - **Upstream Identity Provider JWT / JWKS**: Retrieved at tool-call time by forwarding the caller's IdP JWT to the upstream MCP server for direct JWKS-based validation.
 
 How credentials are delivered to the upstream server depends on the server type. For **passthrough** (remote) servers, Archestra sends the credential over HTTP. The primary auth header defaults to `Authorization`, but you can configure a different header name such as `x-api-key` when the upstream server expects the token outside the standard authorization header. Additional headers are available for tenant IDs and other non-auth upstream requirements, and non-sensitive static values are stored directly in the catalog item. For **hosted** (local) servers running in Kubernetes, the gateway connects via stdio transport within the cluster and no auth headers are needed.
 
 Auth credentials are stored in the secrets backend, which uses the database by default. For enterprise deployments, you can configure an [external secrets manager](/docs/platform-secrets-management).
+
+### OAuth Client Credentials
+
+Use this mode when a remote MCP server expects Archestra to obtain a short-lived bearer token from an OAuth 2.0 token endpoint using `grant_type=client_credentials`.
+
+Archestra stores the shared `client_id`, `client_secret`, and optional `audience` on the installed MCP connection. At runtime it exchanges those values for an access token, injects that token as `Authorization: Bearer <token>`, and reuses it until the configured refresh window is reached.
+
+This is a shared connection pattern, not a per-user identity pattern:
+
+- install one connection per team or shared scope
+- assign tools to that installed connection directly
+- do not use `Resolve at call time` unless you want Archestra to choose among multiple installed shared credentials
 
 ### Dynamic Credential Resolution
 

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -3972,6 +3972,265 @@ describe("McpClient", () => {
       });
     });
 
+    describe("oauth client credentials", () => {
+      test("exchanges stored client credentials for a bearer token on remote MCP calls", async ({
+        makeUser,
+      }) => {
+        const user = await makeUser({
+          email: "client-credentials@example.com",
+        });
+
+        const secret = await secretManager().createSecret(
+          {
+            client_id: "shared-client-id",
+            client_secret: "shared-client-secret",
+            audience: "https://service.example.com",
+          },
+          "client-credentials-secret",
+        );
+
+        const oauthCatalog = await InternalMcpCatalogModel.create({
+          name: "shared-client-credentials-server",
+          serverType: "remote",
+          serverUrl: "https://api.example.com/mcp/",
+          oauthConfig: {
+            name: "Shared Client Credentials",
+            server_url: "https://api.example.com/mcp/",
+            grant_type: "client_credentials",
+            client_id: "",
+            redirect_uris: [],
+            scopes: [],
+            default_scopes: [],
+            supports_resource_metadata: false,
+            token_endpoint: "https://auth.example.com/oauth/token",
+          },
+          userConfig: {
+            client_id: {
+              type: "string",
+              title: "Client ID",
+              description: "Client ID",
+              required: true,
+              sensitive: false,
+            },
+            client_secret: {
+              type: "string",
+              title: "Client Secret",
+              description: "Client Secret",
+              required: true,
+              sensitive: true,
+            },
+            audience: {
+              type: "string",
+              title: "Audience",
+              description: "Audience",
+              required: true,
+              sensitive: false,
+            },
+          },
+        });
+
+        const oauthServer = await McpServerModel.create({
+          name: "shared-client-credentials-server",
+          catalogId: oauthCatalog.id,
+          secretId: secret.id,
+          serverType: "remote",
+          ownerId: user.id,
+        });
+
+        const tool = await ToolModel.createToolIfNotExists({
+          name: "shared-client-credentials-server__list_projects",
+          description: "List projects",
+          parameters: {},
+          catalogId: oauthCatalog.id,
+        });
+
+        await AgentToolModel.create(agentId, tool.id, {
+          mcpServerId: oauthServer.id,
+        });
+
+        const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              access_token: createJwt({ exp: futureExpSeconds() }),
+              expires_in: 3600,
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        );
+
+        mockCallTool.mockResolvedValue({
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+        });
+
+        const result = await mcpClient.executeToolCall(
+          {
+            id: "call_client_credentials_1",
+            name: "shared-client-credentials-server__list_projects",
+            arguments: {},
+          },
+          agentId,
+          {
+            tokenId: "token-1",
+            teamId: null,
+            isOrganizationToken: false,
+            userId: user.id,
+          },
+        );
+
+        expect(result.isError).toBe(false);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock.mock.calls[0]?.[0]).toBe(
+          "https://auth.example.com/oauth/token",
+        );
+        expect(String(fetchMock.mock.calls[0]?.[1]?.body)).toContain(
+          '"grant_type":"client_credentials"',
+        );
+
+        const { StreamableHTTPClientTransport } = await import(
+          "@modelcontextprotocol/sdk/client/streamableHttp.js"
+        );
+        const [, options] =
+          vi.mocked(StreamableHTTPClientTransport).mock.calls.at(-1) ?? [];
+        const headers =
+          options?.requestInit?.headers instanceof Headers
+            ? options.requestInit.headers
+            : new Headers(options?.requestInit?.headers);
+        expect(headers.get("Authorization")).toMatch(/^Bearer /);
+
+        fetchMock.mockRestore();
+      });
+
+      test("reuses cached client credentials tokens until refresh time", async ({
+        makeUser,
+      }) => {
+        const user = await makeUser({
+          email: "client-credentials-cache@example.com",
+        });
+
+        const secret = await secretManager().createSecret(
+          {
+            client_id: "shared-client-id",
+            client_secret: "shared-client-secret",
+            audience: "https://service.example.com",
+          },
+          "client-credentials-cache-secret",
+        );
+
+        const oauthCatalog = await InternalMcpCatalogModel.create({
+          name: "shared-client-credentials-cache-server",
+          serverType: "remote",
+          serverUrl: "https://api.example.com/mcp/",
+          oauthConfig: {
+            name: "Shared Client Credentials Cache",
+            server_url: "https://api.example.com/mcp/",
+            grant_type: "client_credentials",
+            client_id: "",
+            redirect_uris: [],
+            scopes: [],
+            default_scopes: [],
+            supports_resource_metadata: false,
+            token_endpoint: "https://auth.example.com/oauth/token",
+          },
+          userConfig: {
+            client_id: {
+              type: "string",
+              title: "Client ID",
+              description: "Client ID",
+              required: true,
+              sensitive: false,
+            },
+            client_secret: {
+              type: "string",
+              title: "Client Secret",
+              description: "Client Secret",
+              required: true,
+              sensitive: true,
+            },
+            audience: {
+              type: "string",
+              title: "Audience",
+              description: "Audience",
+              required: true,
+              sensitive: false,
+            },
+          },
+        });
+
+        const oauthServer = await McpServerModel.create({
+          name: "shared-client-credentials-cache-server",
+          catalogId: oauthCatalog.id,
+          secretId: secret.id,
+          serverType: "remote",
+          ownerId: user.id,
+        });
+
+        const tool = await ToolModel.createToolIfNotExists({
+          name: "shared-client-credentials-cache-server__list_projects",
+          description: "List projects",
+          parameters: {},
+          catalogId: oauthCatalog.id,
+        });
+
+        await AgentToolModel.create(agentId, tool.id, {
+          mcpServerId: oauthServer.id,
+        });
+
+        const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              access_token: createJwt({ exp: futureExpSeconds() }),
+              expires_in: 3600,
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        );
+
+        mockCallTool.mockResolvedValue({
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+        });
+
+        await mcpClient.executeToolCall(
+          {
+            id: "call_client_credentials_cache_1",
+            name: "shared-client-credentials-cache-server__list_projects",
+            arguments: {},
+          },
+          agentId,
+          {
+            tokenId: "token-1",
+            teamId: null,
+            isOrganizationToken: false,
+            userId: user.id,
+          },
+        );
+        await mcpClient.executeToolCall(
+          {
+            id: "call_client_credentials_cache_2",
+            name: "shared-client-credentials-cache-server__list_projects",
+            arguments: {},
+          },
+          agentId,
+          {
+            tokenId: "token-1",
+            teamId: null,
+            isOrganizationToken: false,
+            userId: user.id,
+          },
+        );
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        fetchMock.mockRestore();
+      });
+    });
+
     describe("_meta and structuredContent passthrough", () => {
       test("passes _meta from callTool result into CommonToolResult", async () => {
         const tool = await ToolModel.createToolIfNotExists({

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -4023,7 +4023,7 @@ describe("McpClient", () => {
               type: "string",
               title: "Audience",
               description: "Audience",
-              required: true,
+              required: false,
               sensitive: false,
             },
           },
@@ -4086,9 +4086,17 @@ describe("McpClient", () => {
         expect(fetchMock.mock.calls[0]?.[0]).toBe(
           "https://auth.example.com/oauth/token",
         );
-        expect(String(fetchMock.mock.calls[0]?.[1]?.body)).toContain(
-          '"grant_type":"client_credentials"',
-        );
+        const requestOptions = fetchMock.mock.calls[0]?.[1];
+        expect(requestOptions?.headers).toMatchObject({
+          "Content-Type": "application/x-www-form-urlencoded",
+          Accept: "application/json",
+        });
+        expect(requestOptions?.body).toBeInstanceOf(URLSearchParams);
+        const requestBody = requestOptions?.body as URLSearchParams;
+        expect(requestBody.get("grant_type")).toBe("client_credentials");
+        expect(requestBody.get("client_id")).toBe("shared-client-id");
+        expect(requestBody.get("client_secret")).toBe("shared-client-secret");
+        expect(requestBody.get("audience")).toBe("https://service.example.com");
 
         const { StreamableHTTPClientTransport } = await import(
           "@modelcontextprotocol/sdk/client/streamableHttp.js"
@@ -4154,7 +4162,7 @@ describe("McpClient", () => {
               type: "string",
               title: "Audience",
               description: "Audience",
-              required: true,
+              required: false,
               sensitive: false,
             },
           },
@@ -4227,6 +4235,122 @@ describe("McpClient", () => {
         );
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
+        fetchMock.mockRestore();
+      });
+
+      test("omits audience when the shared credential does not provide one", async ({
+        makeUser,
+      }) => {
+        const user = await makeUser({
+          email: "client-credentials-no-audience@example.com",
+        });
+
+        const secret = await secretManager().createSecret(
+          {
+            client_id: "shared-client-id",
+            client_secret: "shared-client-secret",
+          },
+          "client-credentials-no-audience-secret",
+        );
+
+        const oauthCatalog = await InternalMcpCatalogModel.create({
+          name: "shared-client-credentials-no-audience-server",
+          serverType: "remote",
+          serverUrl: "https://api.example.com/mcp/",
+          oauthConfig: {
+            name: "Shared Client Credentials No Audience",
+            server_url: "https://api.example.com/mcp/",
+            grant_type: "client_credentials",
+            client_id: "",
+            redirect_uris: [],
+            scopes: [],
+            default_scopes: [],
+            supports_resource_metadata: false,
+            token_endpoint: "https://auth.example.com/oauth/token",
+          },
+          userConfig: {
+            client_id: {
+              type: "string",
+              title: "Client ID",
+              description: "Client ID",
+              required: true,
+              sensitive: false,
+            },
+            client_secret: {
+              type: "string",
+              title: "Client Secret",
+              description: "Client Secret",
+              required: true,
+              sensitive: true,
+            },
+            audience: {
+              type: "string",
+              title: "Audience",
+              description: "Audience",
+              required: false,
+              sensitive: false,
+            },
+          },
+        });
+
+        const oauthServer = await McpServerModel.create({
+          name: "shared-client-credentials-no-audience-server",
+          catalogId: oauthCatalog.id,
+          secretId: secret.id,
+          serverType: "remote",
+          ownerId: user.id,
+        });
+
+        const tool = await ToolModel.createToolIfNotExists({
+          name: "shared-client-credentials-no-audience-server__list_projects",
+          description: "List projects",
+          parameters: {},
+          catalogId: oauthCatalog.id,
+        });
+
+        await AgentToolModel.create(agentId, tool.id, {
+          mcpServerId: oauthServer.id,
+        });
+
+        const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              access_token: createJwt({ exp: futureExpSeconds() }),
+              expires_in: 3600,
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        );
+
+        mockCallTool.mockResolvedValue({
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+        });
+
+        const result = await mcpClient.executeToolCall(
+          {
+            id: "call_client_credentials_no_audience_1",
+            name: "shared-client-credentials-no-audience-server__list_projects",
+            arguments: {},
+          },
+          agentId,
+          {
+            tokenId: "token-1",
+            teamId: null,
+            isOrganizationToken: false,
+            userId: user.id,
+          },
+        );
+
+        expect(result.isError).toBe(false);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const requestBody = fetchMock.mock.calls[0]?.[1]?.body as URLSearchParams;
+        expect(requestBody.get("grant_type")).toBe("client_credentials");
+        expect(requestBody.get("audience")).toBeNull();
+
         fetchMock.mockRestore();
       });
     });

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -4347,7 +4347,8 @@ describe("McpClient", () => {
 
         expect(result.isError).toBe(false);
         expect(fetchMock).toHaveBeenCalledTimes(1);
-        const requestBody = fetchMock.mock.calls[0]?.[1]?.body as URLSearchParams;
+        const requestBody = fetchMock.mock.calls[0]?.[1]
+          ?.body as URLSearchParams;
         expect(requestBody.get("grant_type")).toBe("client_credentials");
         expect(requestBody.get("audience")).toBeNull();
 

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -4692,6 +4692,6 @@ function base64UrlEncode(value: unknown): string {
   return Buffer.from(JSON.stringify(value)).toString("base64url");
 }
 
-function futureExpSeconds(): number {
-  return Math.floor(Date.now() / 1000) + 3600;
+function futureExpSeconds(secondsFromNow: number = 3600): number {
+  return Math.floor(Date.now() / 1000) + secondsFromNow;
 }

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -4354,6 +4354,264 @@ describe("McpClient", () => {
 
         fetchMock.mockRestore();
       });
+
+      test("retries with a fresh token after the upstream MCP call returns UnauthorizedError", async ({
+        makeUser,
+      }) => {
+        const user = await makeUser({
+          email: "client-credentials-retry@example.com",
+        });
+
+        const secret = await secretManager().createSecret(
+          {
+            client_id: "shared-client-id",
+            client_secret: "shared-client-secret",
+            audience: "https://service.example.com",
+          },
+          "client-credentials-retry-secret",
+        );
+
+        const oauthCatalog = await InternalMcpCatalogModel.create({
+          name: "shared-client-credentials-retry-server",
+          serverType: "remote",
+          serverUrl: "https://api.example.com/mcp/",
+          oauthConfig: {
+            name: "Shared Client Credentials Retry",
+            server_url: "https://api.example.com/mcp/",
+            grant_type: "client_credentials",
+            client_id: "",
+            redirect_uris: [],
+            scopes: [],
+            default_scopes: [],
+            supports_resource_metadata: false,
+            token_endpoint: "https://auth.example.com/oauth/token",
+          },
+          userConfig: {
+            client_id: {
+              type: "string",
+              title: "Client ID",
+              description: "Client ID",
+              required: true,
+              sensitive: false,
+            },
+            client_secret: {
+              type: "string",
+              title: "Client Secret",
+              description: "Client Secret",
+              required: true,
+              sensitive: true,
+            },
+            audience: {
+              type: "string",
+              title: "Audience",
+              description: "Audience",
+              required: false,
+              sensitive: false,
+            },
+          },
+        });
+
+        const oauthServer = await McpServerModel.create({
+          name: "shared-client-credentials-retry-server",
+          catalogId: oauthCatalog.id,
+          secretId: secret.id,
+          serverType: "remote",
+          ownerId: user.id,
+        });
+
+        const tool = await ToolModel.createToolIfNotExists({
+          name: "shared-client-credentials-retry-server__list_projects",
+          description: "List projects",
+          parameters: {},
+          catalogId: oauthCatalog.id,
+        });
+
+        await AgentToolModel.create(agentId, tool.id, {
+          mcpServerId: oauthServer.id,
+        });
+
+        const firstAccessToken = createJwt({ exp: futureExpSeconds() });
+        const secondAccessToken = createJwt({ exp: futureExpSeconds(7200) });
+        const fetchMock = vi
+          .spyOn(globalThis, "fetch")
+          .mockResolvedValueOnce(
+            new Response(
+              JSON.stringify({
+                access_token: firstAccessToken,
+                expires_in: 3600,
+              }),
+              {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              },
+            ),
+          )
+          .mockResolvedValueOnce(
+            new Response(
+              JSON.stringify({
+                access_token: secondAccessToken,
+                expires_in: 3600,
+              }),
+              {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              },
+            ),
+          );
+
+        const { UnauthorizedError } = await import(
+          "@modelcontextprotocol/sdk/client/auth.js"
+        );
+        mockCallTool
+          .mockRejectedValueOnce(new UnauthorizedError())
+          .mockResolvedValueOnce({
+            content: [{ type: "text", text: "ok" }],
+            isError: false,
+          });
+
+        const result = await mcpClient.executeToolCall(
+          {
+            id: "call_client_credentials_retry_1",
+            name: "shared-client-credentials-retry-server__list_projects",
+            arguments: {},
+          },
+          agentId,
+          {
+            tokenId: "token-1",
+            teamId: null,
+            isOrganizationToken: false,
+            userId: user.id,
+          },
+        );
+
+        expect(result.isError).toBe(false);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(mockCallTool).toHaveBeenCalledTimes(2);
+
+        const { StreamableHTTPClientTransport } = await import(
+          "@modelcontextprotocol/sdk/client/streamableHttp.js"
+        );
+        const transportCalls = vi.mocked(StreamableHTTPClientTransport).mock
+          .calls;
+        const firstHeaders =
+          transportCalls[0]?.[1]?.requestInit?.headers instanceof Headers
+            ? transportCalls[0][1].requestInit.headers
+            : new Headers(transportCalls[0]?.[1]?.requestInit?.headers);
+        const secondHeaders =
+          transportCalls[1]?.[1]?.requestInit?.headers instanceof Headers
+            ? transportCalls[1][1].requestInit.headers
+            : new Headers(transportCalls[1]?.[1]?.requestInit?.headers);
+        expect(firstHeaders.get("Authorization")).toBe(
+          `Bearer ${firstAccessToken}`,
+        );
+        expect(secondHeaders.get("Authorization")).toBe(
+          `Bearer ${secondAccessToken}`,
+        );
+
+        const updatedSecret = await secretManager().getSecret(secret.id);
+        expect(updatedSecret?.secret).toMatchObject({
+          access_token: secondAccessToken,
+        });
+
+        fetchMock.mockRestore();
+      });
+
+      test("includes the token endpoint in client credential exchange failures", async ({
+        makeUser,
+      }) => {
+        const user = await makeUser({
+          email: "client-credentials-error@example.com",
+        });
+
+        const secret = await secretManager().createSecret(
+          {
+            client_id: "shared-client-id",
+            client_secret: "shared-client-secret",
+          },
+          "client-credentials-error-secret",
+        );
+
+        const oauthCatalog = await InternalMcpCatalogModel.create({
+          name: "shared-client-credentials-error-server",
+          serverType: "remote",
+          serverUrl: "https://api.example.com/mcp/",
+          oauthConfig: {
+            name: "Shared Client Credentials Error",
+            server_url: "https://api.example.com/mcp/",
+            grant_type: "client_credentials",
+            client_id: "",
+            redirect_uris: [],
+            scopes: [],
+            default_scopes: [],
+            supports_resource_metadata: false,
+            token_endpoint: "https://auth.example.com/oauth/token",
+          },
+          userConfig: {
+            client_id: {
+              type: "string",
+              title: "Client ID",
+              description: "Client ID",
+              required: true,
+              sensitive: false,
+            },
+            client_secret: {
+              type: "string",
+              title: "Client Secret",
+              description: "Client Secret",
+              required: true,
+              sensitive: true,
+            },
+          },
+        });
+
+        const oauthServer = await McpServerModel.create({
+          name: "shared-client-credentials-error-server",
+          catalogId: oauthCatalog.id,
+          secretId: secret.id,
+          serverType: "remote",
+          ownerId: user.id,
+        });
+
+        const tool = await ToolModel.createToolIfNotExists({
+          name: "shared-client-credentials-error-server__list_projects",
+          description: "List projects",
+          parameters: {},
+          catalogId: oauthCatalog.id,
+        });
+
+        await AgentToolModel.create(agentId, tool.id, {
+          mcpServerId: oauthServer.id,
+        });
+
+        const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response("invalid_client", {
+            status: 401,
+            headers: { "Content-Type": "text/plain" },
+          }),
+        );
+
+        const result = await mcpClient.executeToolCall(
+          {
+            id: "call_client_credentials_error_1",
+            name: "shared-client-credentials-error-server__list_projects",
+            arguments: {},
+          },
+          agentId,
+          {
+            tokenId: "token-1",
+            teamId: null,
+            isOrganizationToken: false,
+            userId: user.id,
+          },
+        );
+
+        expect(result.isError).toBe(true);
+        expect(result.error).toContain(
+          "Client credentials token request to https://auth.example.com/oauth/token failed: 401 invalid_client",
+        );
+
+        fetchMock.mockRestore();
+      });
     });
 
     describe("_meta and structuredContent passthrough", () => {

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -1616,6 +1616,11 @@ class McpClient {
     }
 
     const oauthConfig = params.catalogItem.oauthConfig;
+    if (!oauthConfig) {
+      throw new Error(
+        "OAuth client credentials configuration is missing oauthConfig",
+      );
+    }
     const clientId =
       getOptionalSecretString(params.secrets, "client_id") ||
       oauthConfig.client_id;
@@ -1669,6 +1674,11 @@ class McpClient {
     audience?: string;
   }): Promise<Record<string, unknown>> {
     const oauthConfig = params.catalogItem.oauthConfig;
+    if (!oauthConfig) {
+      throw new Error(
+        "OAuth client credentials configuration is missing oauthConfig",
+      );
+    }
     let tokenEndpoint = oauthConfig.token_endpoint;
     if (!tokenEndpoint) {
       const endpoints = await discoverOAuthEndpoints(oauthConfig);

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -1703,7 +1703,7 @@ class McpClient {
     if (!tokenResponse.ok) {
       const errorText = await tokenResponse.text();
       throw new Error(
-        `Client credentials token request failed: ${tokenResponse.status} ${errorText}`,
+        `Client credentials token request to ${tokenEndpoint} failed: ${tokenResponse.status} ${errorText}`,
       );
     }
 

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -38,7 +38,7 @@ import {
   TeamModel,
   ToolModel,
 } from "@/models";
-import { refreshOAuthToken } from "@/routes/oauth";
+import { discoverOAuthEndpoints, refreshOAuthToken } from "@/routes/oauth";
 import { secretManager } from "@/secrets-manager";
 import {
   type ResolvedEnterpriseTransportCredential,
@@ -177,6 +177,7 @@ type TransportKind = "stdio" | "http";
 
 const HTTP_CONCURRENCY_LIMIT = 4;
 const OAUTH_TOKEN_REFRESH_BUFFER_MS = 5 * TimeInMs.Minute;
+const CLIENT_CREDENTIALS_FALLBACK_TTL_MS = 5 * TimeInMs.Minute;
 // Idle TTL for shared MCP active connections. These clients can retain HTTP
 // session affinity, tool-name caches, and browser-backed remote state, so we
 // want them to age out after inactivity instead of accumulating forever.
@@ -269,6 +270,10 @@ class McpClient {
       maxSize: McpClient.ENTERPRISE_CREDENTIAL_CACHE_MAX_ENTRIES,
       defaultTtl: McpClient.ENTERPRISE_CREDENTIAL_CACHE_FALLBACK_TTL_MS,
     });
+  private clientCredentialsLocks = new Map<
+    string,
+    Promise<Record<string, unknown>>
+  >();
 
   /**
    * Close a cached session for a specific (catalogId, targetMcpServerId, agentId, conversationId).
@@ -647,6 +652,7 @@ class McpClient {
 
         // Only attempt token refresh for OAuth servers with a refresh token
         const isOAuthServer = !!catalogItem.oauthConfig;
+        const usesClientCredentials = usesOAuthClientCredentials(catalogItem);
         const hasRefreshToken = !!(currentSecrets as { refresh_token?: string })
           .refresh_token;
 
@@ -655,7 +661,8 @@ class McpClient {
           isAuthError &&
           isOAuthServer &&
           targetMcpServerId &&
-          !hasRefreshToken
+          !hasRefreshToken &&
+          !usesClientCredentials
         ) {
           await McpServerModel.update(targetMcpServerId, {
             oauthRefreshError: "no_refresh_token",
@@ -696,6 +703,39 @@ class McpClient {
             return retryToolCallResult;
           }
           // If recovery returned null, the error was already recorded in attemptTokenRefreshAndRetry
+        }
+
+        if (!isRetry && isAuthError && usesClientCredentials && secretId) {
+          const resetSecrets = {
+            ...currentSecrets,
+            access_token: null,
+            client_credentials_expires_at: null,
+            client_credentials_refresh_at: null,
+          };
+          await secretManager().updateSecret(secretId, resetSecrets);
+          this.secretsCache.set(targetMcpServerId, {
+            secrets: resetSecrets,
+            secretId,
+          });
+          this.activeConnections.delete(connectionKey);
+          this.activeConnectionServerState.delete(connectionKey);
+          this.toolNameCache.delete(connectionKey);
+          this.pendingHttpSessionMetadata.delete(connectionKey);
+
+          return await executeToolCall(
+            () =>
+              this.getTransport(
+                catalogItem,
+                targetMcpServerId,
+                resetSecrets,
+                secretId,
+                connectionKey,
+                tokenAuth,
+                enterpriseTransportCredential ?? undefined,
+              ),
+            resetSecrets,
+            true,
+          );
         }
 
         // For auth errors, return an actionable message with re-auth URL
@@ -772,6 +812,7 @@ class McpClient {
             catalogItem,
             targetMcpServerId,
             secrets,
+            secretId,
             connectionKey,
             tokenAuth,
             enterpriseTransportCredential ?? undefined,
@@ -790,19 +831,29 @@ class McpClient {
       connectionKey,
       concurrencyLimit,
       () =>
-        executeToolCall(
-          () =>
-            this.getTransportWithKind(
-              catalogItem,
-              targetMcpServerId,
-              secrets,
-              transportKind,
-              connectionKey,
-              tokenAuth,
-              enterpriseTransportCredential ?? undefined,
-            ),
-          secrets,
-        ),
+        executeToolCall(async () => {
+          const resolvedSecrets = await this.resolveSecretsForTransport({
+            catalogItem,
+            secrets,
+            secretId,
+          });
+          if (resolvedSecrets !== secrets) {
+            this.secretsCache.set(targetMcpServerId, {
+              secrets: resolvedSecrets,
+              ...(secretId ? { secretId } : {}),
+            });
+          }
+
+          return this.getTransportWithKind(
+            catalogItem,
+            targetMcpServerId,
+            resolvedSecrets,
+            transportKind,
+            connectionKey,
+            tokenAuth,
+            enterpriseTransportCredential ?? undefined,
+          );
+        }, secrets),
     );
   }
 
@@ -1551,10 +1602,155 @@ class McpClient {
     throw new Error(`Unsupported transport kind: ${transportKind}`);
   }
 
+  private async resolveSecretsForTransport(params: {
+    catalogItem: InternalMcpCatalog;
+    secrets: Record<string, unknown>;
+    secretId?: string;
+  }): Promise<Record<string, unknown>> {
+    if (!usesOAuthClientCredentials(params.catalogItem)) {
+      return params.secrets;
+    }
+
+    if (hasUsableClientCredentialsToken(params.secrets)) {
+      return params.secrets;
+    }
+
+    const oauthConfig = params.catalogItem.oauthConfig;
+    if (!oauthConfig) {
+      return params.secrets;
+    }
+
+    const clientId =
+      getOptionalSecretString(params.secrets, "client_id") ||
+      oauthConfig.client_id;
+    const clientSecret =
+      getOptionalSecretString(params.secrets, "client_secret") ||
+      oauthConfig.client_secret;
+    const audience =
+      getOptionalSecretString(params.secrets, "audience") ||
+      oauthConfig.audience;
+
+    if (!clientId || !clientSecret || !audience) {
+      throw new Error(
+        "OAuth client credentials configuration requires client_id, client_secret, and audience",
+      );
+    }
+
+    const cacheKey =
+      params.secretId ||
+      [
+        params.catalogItem.id,
+        clientId,
+        audience,
+        oauthConfig.token_endpoint || oauthConfig.auth_server_url || "",
+      ].join(":");
+    const existingLock = this.clientCredentialsLocks.get(cacheKey);
+    if (existingLock) {
+      return await existingLock;
+    }
+
+    const resolutionPromise = this.fetchClientCredentialsAccessToken({
+      catalogItem: params.catalogItem,
+      existingSecrets: params.secrets,
+      secretId: params.secretId,
+      clientId,
+      clientSecret,
+      audience,
+    }).finally(() => {
+      this.clientCredentialsLocks.delete(cacheKey);
+    });
+
+    this.clientCredentialsLocks.set(cacheKey, resolutionPromise);
+    return await resolutionPromise;
+  }
+
+  private async fetchClientCredentialsAccessToken(params: {
+    catalogItem: InternalMcpCatalog;
+    existingSecrets: Record<string, unknown>;
+    secretId?: string;
+    clientId: string;
+    clientSecret: string;
+    audience: string;
+  }): Promise<Record<string, unknown>> {
+    const oauthConfig = params.catalogItem.oauthConfig;
+    if (!oauthConfig) {
+      return params.existingSecrets;
+    }
+
+    let tokenEndpoint = oauthConfig.token_endpoint;
+    if (!tokenEndpoint) {
+      const endpoints = await discoverOAuthEndpoints(oauthConfig);
+      tokenEndpoint = endpoints.tokenEndpoint;
+    }
+
+    const configuredScopes =
+      oauthConfig.scopes.length > 0
+        ? oauthConfig.scopes
+        : oauthConfig.default_scopes;
+    const requestBody: Record<string, string> = {
+      grant_type: "client_credentials",
+      client_id: params.clientId,
+      client_secret: params.clientSecret,
+      audience: params.audience,
+    };
+    if (configuredScopes.length > 0) {
+      requestBody.scope = configuredScopes.join(" ");
+    }
+
+    const tokenResponse = await fetch(tokenEndpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    if (!tokenResponse.ok) {
+      const errorText = await tokenResponse.text();
+      throw new Error(
+        `Client credentials token request failed: ${tokenResponse.status} ${errorText}`,
+      );
+    }
+
+    const tokenData = (await tokenResponse.json()) as {
+      access_token?: string;
+      expires_in?: number;
+    };
+    if (!tokenData.access_token) {
+      throw new Error(
+        "Client credentials token response did not include access_token",
+      );
+    }
+
+    const timing = buildClientCredentialsTokenTiming(
+      tokenData.access_token,
+      tokenData.expires_in,
+    );
+    const resolvedSecrets = {
+      ...params.existingSecrets,
+      client_id: params.clientId,
+      client_secret: params.clientSecret,
+      audience: params.audience,
+      access_token: tokenData.access_token,
+      ...(timing.expiresAt
+        ? { client_credentials_expires_at: timing.expiresAt }
+        : {}),
+      client_credentials_refresh_at: timing.refreshAt,
+    };
+
+    if (params.secretId) {
+      await secretManager().updateSecret(params.secretId, resolvedSecrets);
+    }
+
+    return resolvedSecrets;
+  }
+
   private async getTransport(
     catalogItem: InternalMcpCatalog,
     targetMcpServerId: string,
     secrets: Record<string, unknown>,
+    secretId?: string,
     connectionKey?: string,
     tokenAuth?: TokenAuthContext,
     enterpriseTransportCredential?: {
@@ -1562,6 +1758,17 @@ class McpClient {
       headerValue: string;
     },
   ): Promise<Transport> {
+    const resolvedSecrets = await this.resolveSecretsForTransport({
+      catalogItem,
+      secrets,
+      secretId,
+    });
+    if (resolvedSecrets !== secrets) {
+      this.secretsCache.set(targetMcpServerId, {
+        secrets: resolvedSecrets,
+        ...(secretId ? { secretId } : {}),
+      });
+    }
     const transportKind = await this.getTransportKind(
       catalogItem,
       targetMcpServerId,
@@ -1569,7 +1776,7 @@ class McpClient {
     return this.getTransportWithKind(
       catalogItem,
       targetMcpServerId,
-      secrets,
+      resolvedSecrets,
       transportKind,
       connectionKey,
       tokenAuth,
@@ -1799,7 +2006,12 @@ class McpClient {
 
       // Create new transport with updated secrets
       const getUpdatedTransport = () =>
-        this.getTransport(catalogItem, targetMcpServerId, updatedSecret);
+        this.getTransport(
+          catalogItem,
+          targetMcpServerId,
+          updatedSecret,
+          secretId,
+        );
 
       return await executeRetry(getUpdatedTransport, updatedSecret);
     } catch (retryError) {
@@ -2083,8 +2295,9 @@ class McpClient {
     catalogItem: InternalMcpCatalog;
     mcpServerId: string;
     secrets: Record<string, unknown>;
+    secretId?: string;
   }): Promise<CommonMcpToolDefinition[]> {
-    const { catalogItem, mcpServerId, secrets } = params;
+    const { catalogItem, mcpServerId, secrets, secretId } = params;
 
     // For local servers, retry connection a few times since the MCP server process
     // may need time to initialize even after the pod is ready
@@ -2100,6 +2313,7 @@ class McpClient {
           catalogItem,
           mcpServerId,
           secrets,
+          secretId,
         );
 
         const capabilities: ClientCapabilitiesWithExtensions = {
@@ -2182,6 +2396,7 @@ class McpClient {
       catalogItem,
       mcpServerId,
       secrets,
+      undefined,
     );
 
     const client = new Client(buildMcpClientInfo("archestra-inspector"), {
@@ -2456,12 +2671,13 @@ class McpClient {
     if ("error" in secretResult) {
       throw new Error(`Secret resolution failed: ${secretResult.error}`);
     }
-    const { secrets } = secretResult;
+    const { secrets, secretId } = secretResult;
 
     const transport = await this.getTransport(
       catalogItem,
       server.id,
       secrets,
+      secretId,
       undefined,
       tokenAuth,
     );
@@ -2552,6 +2768,7 @@ class McpClient {
           catalogItem,
           server.id,
           secretResult.secrets,
+          secretResult.secretId,
         );
         const connectionKey = `${catalogItem.id}:${server.id}`;
         const client = await this.getOrCreateClient(
@@ -2921,6 +3138,107 @@ function buildStaticCredentialHeaders(params: {
   }
 
   return buildDefaultAuthorizationHeaders(headers, secrets);
+}
+
+function usesOAuthClientCredentials(catalogItem: InternalMcpCatalog): boolean {
+  return catalogItem.oauthConfig?.grant_type === "client_credentials";
+}
+
+function getOptionalSecretString(
+  secrets: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = secrets[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function hasUsableClientCredentialsToken(
+  secrets: Record<string, unknown>,
+): boolean {
+  const accessToken = getOptionalSecretString(secrets, "access_token");
+  if (!accessToken) {
+    return false;
+  }
+
+  const refreshAt = toOptionalTimestamp(secrets.client_credentials_refresh_at);
+  if (refreshAt) {
+    return Date.now() < refreshAt;
+  }
+
+  const expiresAt = toOptionalTimestamp(secrets.client_credentials_expires_at);
+  if (expiresAt) {
+    return Date.now() + TimeInMs.Minute < expiresAt;
+  }
+
+  return false;
+}
+
+function buildClientCredentialsTokenTiming(
+  accessToken: string,
+  expiresIn?: number,
+): {
+  expiresAt?: number;
+  refreshAt: number;
+} {
+  const now = Date.now();
+  const jwtExpiration = getJwtExpirationMs(accessToken);
+  if (jwtExpiration && jwtExpiration > now) {
+    const lifetimeMs = jwtExpiration - now;
+    return {
+      expiresAt: jwtExpiration,
+      refreshAt: now + Math.max(lifetimeMs / 2, TimeInMs.Minute),
+    };
+  }
+
+  if (
+    typeof expiresIn === "number" &&
+    Number.isFinite(expiresIn) &&
+    expiresIn > 0
+  ) {
+    const lifetimeMs = expiresIn * 1000;
+    return {
+      expiresAt: now + lifetimeMs,
+      refreshAt: now + Math.max(lifetimeMs / 2, TimeInMs.Minute),
+    };
+  }
+
+  return {
+    refreshAt: now + CLIENT_CREDENTIALS_FALLBACK_TTL_MS,
+  };
+}
+
+function toOptionalTimestamp(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return value;
+  }
+  return undefined;
+}
+
+function getJwtExpirationMs(token: string): number | undefined {
+  const [, payload] = token.split(".");
+  if (!payload) {
+    return undefined;
+  }
+
+  try {
+    const normalizedPayload = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const paddedPayload =
+      normalizedPayload + "=".repeat((4 - (normalizedPayload.length % 4)) % 4);
+    const decoded = JSON.parse(
+      Buffer.from(paddedPayload, "base64").toString("utf8"),
+    ) as { exp?: number };
+    if (
+      typeof decoded.exp === "number" &&
+      Number.isFinite(decoded.exp) &&
+      decoded.exp > 0
+    ) {
+      return decoded.exp * 1000;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
 }
 
 function hasStaticAuthorizationCredential(

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -1616,10 +1616,6 @@ class McpClient {
     }
 
     const oauthConfig = params.catalogItem.oauthConfig;
-    if (!oauthConfig) {
-      return params.secrets;
-    }
-
     const clientId =
       getOptionalSecretString(params.secrets, "client_id") ||
       oauthConfig.client_id;
@@ -1630,9 +1626,9 @@ class McpClient {
       getOptionalSecretString(params.secrets, "audience") ||
       oauthConfig.audience;
 
-    if (!clientId || !clientSecret || !audience) {
+    if (!clientId || !clientSecret) {
       throw new Error(
-        "OAuth client credentials configuration requires client_id, client_secret, and audience",
+        "OAuth client credentials configuration requires client_id and client_secret",
       );
     }
 
@@ -1670,13 +1666,9 @@ class McpClient {
     secretId?: string;
     clientId: string;
     clientSecret: string;
-    audience: string;
+    audience?: string;
   }): Promise<Record<string, unknown>> {
     const oauthConfig = params.catalogItem.oauthConfig;
-    if (!oauthConfig) {
-      return params.existingSecrets;
-    }
-
     let tokenEndpoint = oauthConfig.token_endpoint;
     if (!tokenEndpoint) {
       const endpoints = await discoverOAuthEndpoints(oauthConfig);
@@ -1691,8 +1683,10 @@ class McpClient {
       grant_type: "client_credentials",
       client_id: params.clientId,
       client_secret: params.clientSecret,
-      audience: params.audience,
     };
+    if (params.audience) {
+      requestBody.audience = params.audience;
+    }
     if (configuredScopes.length > 0) {
       requestBody.scope = configuredScopes.join(" ");
     }
@@ -1700,10 +1694,10 @@ class McpClient {
     const tokenResponse = await fetch(tokenEndpoint, {
       method: "POST",
       headers: {
-        "Content-Type": "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
         Accept: "application/json",
       },
-      body: JSON.stringify(requestBody),
+      body: new URLSearchParams(requestBody),
     });
 
     if (!tokenResponse.ok) {
@@ -1731,7 +1725,7 @@ class McpClient {
       ...params.existingSecrets,
       client_id: params.clientId,
       client_secret: params.clientSecret,
-      audience: params.audience,
+      ...(params.audience ? { audience: params.audience } : {}),
       access_token: tokenData.access_token,
       ...(timing.expiresAt
         ? { client_credentials_expires_at: timing.expiresAt }

--- a/platform/backend/src/models/mcp-server.ts
+++ b/platform/backend/src/models/mcp-server.ts
@@ -528,6 +528,7 @@ class McpServerModel {
         catalogItem,
         mcpServerId: mcpServer.id,
         secrets,
+        secretId: mcpServer.secretId ?? undefined,
       });
 
       // Transform to ensure description is always a string
@@ -682,6 +683,7 @@ class McpServerModel {
             catalogItem,
             mcpServerId: "validation",
             secrets,
+            secretId,
           });
           return {
             isValid: tools.length > 0,

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -1790,6 +1790,7 @@ async function connectAndGetToolsForInstallation(params: {
       catalogItem,
       mcpServerId: params.mcpServerId,
       secrets,
+      secretId: params.secretId,
     });
   } catch (error) {
     if (
@@ -1823,6 +1824,7 @@ async function connectAndGetToolsForInstallation(params: {
         ...secrets,
         access_token: accessToken,
       },
+      secretId: params.secretId,
     });
   }
 }

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.enterprise.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.enterprise.test.tsx
@@ -222,6 +222,7 @@ describe("McpCatalogForm enterprise gating", () => {
               server_url: "https://mcp.example.com",
               client_id: "client-id",
               client_secret: "client-secret",
+              grant_type: "authorization_code",
               redirect_uris: ["https://app.example.com/oauth-callback"],
               scopes: ["read"],
               default_scopes: ["read"],

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.test.ts
@@ -334,9 +334,11 @@ describe("formSchema", () => {
         oauthConfig: {
           client_id: "test-client-id",
           client_secret: "test-secret",
+          audience: "",
           redirect_uris: "https://localhost:3000/oauth-callback",
           scopes: "read,write",
           supports_resource_metadata: true,
+          grantType: "authorization_code",
           authServerUrl: "https://auth.example.com",
           wellKnownUrl:
             "https://auth.example.com/.well-known/openid-configuration",
@@ -358,9 +360,11 @@ describe("formSchema", () => {
         oauthConfig: {
           client_id: "test-client-id",
           client_secret: "test-secret",
+          audience: "",
           redirect_uris: "https://localhost:3000/oauth-callback",
           scopes: "read,write",
           supports_resource_metadata: true,
+          grantType: "authorization_code",
           authorizationEndpoint: "https://auth.example.com/oauth/authorize",
         },
         localConfig: undefined,
@@ -380,9 +384,11 @@ describe("formSchema", () => {
         oauthConfig: {
           client_id: "test-client-id",
           client_secret: "test-secret",
+          audience: "",
           redirect_uris: "",
           scopes: "read,write",
           supports_resource_metadata: true,
+          grantType: "authorization_code",
         },
         localConfig: undefined,
       };
@@ -390,6 +396,33 @@ describe("formSchema", () => {
       expect(() => formSchema.parse(data)).toThrow(
         "At least one redirect URI is required",
       );
+    });
+
+    it("should validate OAuth client credentials without redirect URIs", () => {
+      const data = {
+        ...baseValidData,
+        authMethod: "oauth_client_credentials" as const,
+        serverType: "remote" as const,
+        serverUrl: "https://api.example.com/mcp",
+        oauthConfig: {
+          client_id: "",
+          client_secret: "",
+          audience: "https://api.example.com",
+          redirect_uris: "",
+          scopes: "",
+          supports_resource_metadata: false,
+          grantType: "client_credentials" as const,
+          authServerUrl: "",
+          authorizationEndpoint: "",
+          wellKnownUrl: "",
+          resourceMetadataUrl: "",
+          tokenEndpoint: "https://auth.example.com/oauth/token",
+          oauthServerUrl: "",
+        },
+        localConfig: undefined,
+      };
+
+      expect(formSchema.parse(data)).toEqual(data);
     });
   });
 });

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -1316,6 +1316,29 @@ export function McpCatalogForm({
                                     </FormItem>
                                   )}
                                 />
+
+                                <FormField
+                                  control={form.control}
+                                  name="oauthConfig.scopes"
+                                  render={({ field }) => (
+                                    <FormItem>
+                                      <FormLabel>Scopes</FormLabel>
+                                      <FormControl>
+                                        <Input
+                                          placeholder="read, write"
+                                          className="font-mono"
+                                          {...field}
+                                        />
+                                      </FormControl>
+                                      <FormDescription>
+                                        Optional comma-separated OAuth scopes to
+                                        include in the client credentials token
+                                        request.
+                                      </FormDescription>
+                                      <FormMessage />
+                                    </FormItem>
+                                  )}
+                                />
                               </div>
                             )}
                           </div>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -1210,7 +1210,7 @@ export function McpCatalogForm({
                                 <div className="bg-muted p-4 rounded-lg">
                                   <p className="text-sm text-muted-foreground">
                                     Installations will prompt for a shared
-                                    client ID, client secret, and audience.
+                                    client ID, client secret, and audience.{" "}
                                     {appName} will exchange them for a
                                     short-lived bearer token at runtime and
                                     refresh it automatically.

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -189,12 +189,14 @@ export function McpCatalogForm({
           oauthConfig: {
             client_id: "",
             client_secret: "",
+            audience: "",
             redirect_uris:
               typeof window !== "undefined"
                 ? `${window.location.origin}/oauth-callback`
                 : "",
             scopes: "read, write",
             supports_resource_metadata: true,
+            grantType: "authorization_code",
             authServerUrl: "",
             authorizationEndpoint: "",
             wellKnownUrl: "",
@@ -239,6 +241,19 @@ export function McpCatalogForm({
     nextAuthMethod: McpCatalogFormValues["authMethod"],
   ) => {
     form.setValue("authMethod", nextAuthMethod, { shouldDirty: true });
+
+    if (
+      nextAuthMethod === "oauth" ||
+      nextAuthMethod === "oauth_client_credentials"
+    ) {
+      form.setValue(
+        "oauthConfig.grantType",
+        nextAuthMethod === "oauth"
+          ? "authorization_code"
+          : "client_credentials",
+        { shouldDirty: true },
+      );
+    }
 
     if (nextAuthMethod === "enterprise_managed") {
       form.setValue(
@@ -1171,6 +1186,136 @@ export function McpCatalogForm({
                                     )}
                                   />
                                 </div>
+                              </div>
+                            )}
+                          </div>
+                        )}
+                        {currentServerType === "remote" && (
+                          <div className="space-y-2">
+                            <div className="flex items-center space-x-2">
+                              <RadioGroupItem
+                                value="oauth_client_credentials"
+                                id="auth-oauth-client-credentials"
+                              />
+                              <FormLabel
+                                htmlFor="auth-oauth-client-credentials"
+                                className="font-normal cursor-pointer"
+                              >
+                                OAuth 2.0 Client Credentials
+                              </FormLabel>
+                            </div>
+
+                            {authMethod === "oauth_client_credentials" && (
+                              <div className="space-y-4 pl-6 border-l-2">
+                                <div className="bg-muted p-4 rounded-lg">
+                                  <p className="text-sm text-muted-foreground">
+                                    Installations will prompt for a shared
+                                    client ID, client secret, and audience.
+                                    {appName} will exchange them for a
+                                    short-lived bearer token at runtime and
+                                    refresh it automatically.
+                                  </p>
+                                </div>
+
+                                <FormField
+                                  control={form.control}
+                                  name="oauthConfig.authServerUrl"
+                                  render={({ field }) => (
+                                    <FormItem>
+                                      <FormLabel>
+                                        Authorization Server URL
+                                      </FormLabel>
+                                      <FormControl>
+                                        <Input
+                                          placeholder="https://auth.example.com"
+                                          className="font-mono"
+                                          {...field}
+                                        />
+                                      </FormControl>
+                                      <FormDescription>
+                                        Optional discovery base URL when the
+                                        token endpoint is derived from an auth
+                                        server instead of entered directly.
+                                      </FormDescription>
+                                      <FormMessage />
+                                    </FormItem>
+                                  )}
+                                />
+
+                                <FormField
+                                  control={form.control}
+                                  name="oauthConfig.wellKnownUrl"
+                                  render={({ field }) => (
+                                    <FormItem>
+                                      <FormLabel>
+                                        Well-Known Metadata URL
+                                      </FormLabel>
+                                      <FormControl>
+                                        <Input
+                                          placeholder="https://auth.example.com/.well-known/openid-configuration"
+                                          className="font-mono"
+                                          {...field}
+                                        />
+                                      </FormControl>
+                                      <FormDescription>
+                                        Optional direct metadata endpoint
+                                        override when discovery is non-standard.
+                                      </FormDescription>
+                                      <FormMessage />
+                                    </FormItem>
+                                  )}
+                                />
+
+                                <FormField
+                                  control={form.control}
+                                  name="oauthConfig.tokenEndpoint"
+                                  render={({ field }) => (
+                                    <FormItem>
+                                      <FormLabel>
+                                        Token Endpoint{" "}
+                                        <span className="text-destructive">
+                                          *
+                                        </span>
+                                      </FormLabel>
+                                      <FormControl>
+                                        <Input
+                                          placeholder="https://auth.example.com/oauth/token"
+                                          className="font-mono"
+                                          {...field}
+                                        />
+                                      </FormControl>
+                                      <FormDescription>
+                                        Endpoint used to exchange the stored
+                                        client credentials for a short-lived
+                                        bearer token.
+                                      </FormDescription>
+                                      <FormMessage />
+                                    </FormItem>
+                                  )}
+                                />
+
+                                <FormField
+                                  control={form.control}
+                                  name="oauthConfig.audience"
+                                  render={({ field }) => (
+                                    <FormItem>
+                                      <FormLabel>Default Audience</FormLabel>
+                                      <FormControl>
+                                        <Input
+                                          placeholder="https://api.example.com"
+                                          className="font-mono"
+                                          {...field}
+                                        />
+                                      </FormControl>
+                                      <FormDescription>
+                                        Optional default audience shown during
+                                        installation. Teams can override it per
+                                        shared connection.
+                                      </FormDescription>
+                                      <FormMessage />
+                                    </FormItem>
+                                  )}
+                                />
                               </div>
                             )}
                           </div>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.types.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.types.ts
@@ -27,7 +27,8 @@ export const oauthConfigSchema = z
   .object({
     client_id: z.string().optional().or(z.literal("")),
     client_secret: z.string().optional().or(z.literal("")),
-    redirect_uris: z.string().min(1, "At least one redirect URI is required"),
+    audience: z.string().optional().or(z.literal("")),
+    redirect_uris: z.string().optional().or(z.literal("")),
     scopes: z.string().optional().or(z.literal("")),
     supports_resource_metadata: z.boolean(),
     authServerUrl: z
@@ -98,9 +99,13 @@ export const oauthConfigSchema = z
       )
       .optional()
       .or(z.literal("")),
+    grantType: z.enum(["authorization_code", "client_credentials"]),
   })
   .superRefine((value, ctx) => {
-    if (Boolean(value.authorizationEndpoint) !== Boolean(value.tokenEndpoint)) {
+    if (
+      value.grantType === "authorization_code" &&
+      Boolean(value.authorizationEndpoint) !== Boolean(value.tokenEndpoint)
+    ) {
       const message = "Authorization and token endpoints must be set together";
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -110,6 +115,31 @@ export const oauthConfigSchema = z
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message,
+        path: ["tokenEndpoint"],
+      });
+    }
+
+    if (
+      value.grantType === "authorization_code" &&
+      !value.redirect_uris?.trim()
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "At least one redirect URI is required",
+        path: ["redirect_uris"],
+      });
+    }
+
+    if (
+      value.grantType === "client_credentials" &&
+      !value.tokenEndpoint?.trim() &&
+      !value.authServerUrl?.trim() &&
+      !value.wellKnownUrl?.trim()
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "Provide a token endpoint, authorization server URL, or well-known URL for client credentials",
         path: ["tokenEndpoint"],
       });
     }
@@ -157,6 +187,7 @@ export const formSchema = z
       "none",
       "bearer",
       "oauth",
+      "oauth_client_credentials",
       "enterprise_managed",
       "idp_jwt",
     ]),

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
@@ -326,7 +326,7 @@ describe("transformFormToApiData", () => {
         client_secret: "",
         audience: "https://api.example.com",
         redirect_uris: "",
-        scopes: "",
+        scopes: "read, write",
         supports_resource_metadata: false,
         grantType: "client_credentials",
         oauthServerUrl: "",
@@ -356,8 +356,8 @@ describe("transformFormToApiData", () => {
       token_endpoint: "https://auth.example.com/oauth/token",
       audience: "https://api.example.com",
       redirect_uris: [],
-      scopes: [],
-      default_scopes: [],
+      scopes: ["read", "write"],
+      default_scopes: ["read", "write"],
     });
     expect(result.userConfig).toMatchObject({
       client_id: expect.objectContaining({ required: true }),

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
@@ -68,9 +68,11 @@ describe("transformFormToApiData", () => {
       oauthConfig: {
         client_id: "client-id",
         client_secret: "client-secret",
+        audience: "",
         redirect_uris: "https://app.example.com/oauth-callback",
         scopes: "read:jira-work",
         supports_resource_metadata: true,
+        grantType: "authorization_code",
         oauthServerUrl: "https://mcp.example.com",
         authServerUrl: "https://auth.example.com",
         authorizationEndpoint: "https://legacy-idp.example.com/oauth/authorize",
@@ -132,9 +134,11 @@ describe("transformFormToApiData", () => {
       oauthConfig: {
         client_id: "client-id",
         client_secret: "client-secret",
+        audience: "",
         redirect_uris: "https://app.example.com/oauth-callback",
         scopes: "read:jira-work",
         supports_resource_metadata: true,
+        grantType: "authorization_code",
         oauthServerUrl: "",
         authServerUrl: "https://auth.example.com",
         authorizationEndpoint: "https://legacy-idp.example.com/oauth/authorize",
@@ -185,9 +189,11 @@ describe("transformFormToApiData", () => {
       oauthConfig: {
         client_id: "client-id",
         client_secret: "client-secret",
+        audience: "",
         redirect_uris: "https://app.example.com/oauth-callback",
         scopes: "",
         supports_resource_metadata: false,
+        grantType: "authorization_code",
         oauthServerUrl: "",
         authServerUrl: "",
         authorizationEndpoint: "",
@@ -228,9 +234,11 @@ describe("transformFormToApiData", () => {
       oauthConfig: {
         client_id: "client-id",
         client_secret: "client-secret",
+        audience: "",
         redirect_uris: "https://app.example.com/oauth-callback",
         scopes: " , ",
         supports_resource_metadata: false,
+        grantType: "authorization_code",
         oauthServerUrl: "",
         authServerUrl: "",
         authorizationEndpoint: "",
@@ -268,10 +276,12 @@ describe("transformFormToApiData", () => {
       oauthConfig: {
         client_id: "client-id",
         client_secret: "client-secret",
+        audience: "",
         redirect_uris: ["https://app.example.com/oauth-callback"],
         scopes: ["read"],
         default_scopes: ["read", "write"],
         supports_resource_metadata: false,
+        grant_type: "authorization_code",
         server_url: "https://mcp.example.com",
         auth_server_url: "https://auth.example.com",
         authorization_endpoint:
@@ -300,6 +310,64 @@ describe("transformFormToApiData", () => {
     );
   });
 
+  it("maps OAuth client credentials auth into install-time shared fields", () => {
+    const values: McpCatalogFormValues = {
+      name: "Shared OAuth MCP",
+      description: "",
+      icon: null,
+      serverType: "remote",
+      serverUrl: "https://mcp.example.com",
+      authMethod: "oauth_client_credentials",
+      includeBearerPrefix: true,
+      authHeaderName: "",
+      additionalHeaders: [],
+      oauthConfig: {
+        client_id: "",
+        client_secret: "",
+        audience: "https://api.example.com",
+        redirect_uris: "",
+        scopes: "",
+        supports_resource_metadata: false,
+        grantType: "client_credentials",
+        oauthServerUrl: "",
+        authServerUrl: "",
+        authorizationEndpoint: "",
+        wellKnownUrl: "",
+        resourceMetadataUrl: "",
+        tokenEndpoint: "https://auth.example.com/oauth/token",
+      },
+      enterpriseManagedConfig: null,
+      localConfig: undefined,
+      deploymentSpecYaml: "",
+      originalDeploymentSpecYaml: "",
+      oauthClientSecretVaultPath: "",
+      oauthClientSecretVaultKey: "",
+      localConfigVaultPath: "",
+      localConfigVaultKey: "",
+      labels: [],
+      scope: "team",
+      teams: ["team-1"],
+    };
+
+    const result = transformFormToApiData(values);
+
+    expect(result.oauthConfig).toMatchObject({
+      grant_type: "client_credentials",
+      token_endpoint: "https://auth.example.com/oauth/token",
+      audience: "https://api.example.com",
+      redirect_uris: [],
+      scopes: [],
+      default_scopes: [],
+    });
+    expect(result.userConfig).toMatchObject({
+      client_id: expect.objectContaining({ required: true }),
+      client_secret: expect.objectContaining({ sensitive: true }),
+      audience: expect.objectContaining({
+        default: "https://api.example.com",
+      }),
+    });
+  });
+
   it("hydrates explicit OAuth endpoints from external catalog manifests", () => {
     const values = transformExternalCatalogToFormValues({
       name: "direct-oauth-mcp",
@@ -317,6 +385,7 @@ describe("transformFormToApiData", () => {
         scopes: ["read"],
         default_scopes: ["read", "write"],
         supports_resource_metadata: false,
+        grant_type: "authorization_code",
         server_url: "https://mcp.example.com",
         auth_server_url: "https://auth.example.com",
         authorization_endpoint:

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
@@ -363,6 +363,7 @@ describe("transformFormToApiData", () => {
       client_id: expect.objectContaining({ required: true }),
       client_secret: expect.objectContaining({ sensitive: true }),
       audience: expect.objectContaining({
+        required: false,
         default: "https://api.example.com",
       }),
     });

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
@@ -243,13 +243,7 @@ export function transformCatalogItemToFormValues(
   } | null,
 ): McpCatalogFormValues {
   // Determine auth method
-  let authMethod:
-    | "none"
-    | "bearer"
-    | "oauth"
-    | "oauth_client_credentials"
-    | "enterprise_managed"
-    | "idp_jwt" = "none";
+  let authMethod: McpCatalogFormValues["authMethod"] = "none";
   let includeBearerPrefix = true;
   if (item.enterpriseManagedConfig) {
     authMethod =
@@ -500,8 +494,7 @@ export function transformExternalCatalogToFormValues(
   };
 
   // Determine auth method
-  let authMethod: "none" | "bearer" | "oauth" | "oauth_client_credentials" =
-    "none";
+  let authMethod: McpCatalogFormValues["authMethod"] = "none";
   let includeBearerPrefix = true;
   const staticHeaderFields = getHeaderMappedUserConfigEntries(
     server.user_config,

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
@@ -70,19 +70,30 @@ export function transformFormToApiData(
   }
 
   // Handle OAuth configuration
-  if (values.authMethod === "oauth" && values.oauthConfig) {
-    const redirectUrisList = values.oauthConfig.redirect_uris
-      .split(",")
-      .map((uri) => uri.trim())
-      .filter((uri) => uri.length > 0);
-
+  if (
+    (values.authMethod === "oauth" ||
+      values.authMethod === "oauth_client_credentials") &&
+    values.oauthConfig
+  ) {
+    const isClientCredentials =
+      values.authMethod === "oauth_client_credentials";
+    const redirectUrisList = isClientCredentials
+      ? []
+      : (values.oauthConfig.redirect_uris ?? "")
+          .split(",")
+          .map((uri) => uri.trim())
+          .filter((uri) => uri.length > 0);
     const explicitScopes = values.oauthConfig.scopes?.trim() ?? "";
     const parsedScopes = explicitScopes
       .split(",")
       .map((scope) => scope.trim())
       .filter((scope) => scope.length > 0);
     const hasExplicitScopes = parsedScopes.length > 0;
-    const scopesList = hasExplicitScopes ? parsedScopes : ["read", "write"];
+    const scopesList = hasExplicitScopes
+      ? parsedScopes
+      : isClientCredentials
+        ? []
+        : ["read", "write"];
 
     // For local servers, use oauthServerUrl; for remote servers, use serverUrl
     const oauthServerUrl =
@@ -93,23 +104,34 @@ export function transformFormToApiData(
     data.oauthConfig = {
       name: values.name, // Use name as OAuth provider name
       server_url: oauthServerUrl, // OAuth server URL for discovery/authorization
+      grant_type: isClientCredentials
+        ? "client_credentials"
+        : "authorization_code",
       auth_server_url: values.oauthConfig.authServerUrl || undefined,
-      authorization_endpoint:
-        values.oauthConfig.authorizationEndpoint || undefined,
+      authorization_endpoint: isClientCredentials
+        ? undefined
+        : values.oauthConfig.authorizationEndpoint || undefined,
       well_known_url: values.oauthConfig.wellKnownUrl || undefined,
       resource_metadata_url:
         values.oauthConfig.resourceMetadataUrl || undefined,
       token_endpoint: values.oauthConfig.tokenEndpoint || undefined,
-      client_id: values.oauthConfig.client_id || "",
+      client_id: isClientCredentials ? "" : values.oauthConfig.client_id || "",
       // Only include client_secret if no BYOS vault path is set
       client_secret: values.oauthClientSecretVaultPath
         ? undefined
-        : values.oauthConfig.client_secret || undefined,
+        : isClientCredentials
+          ? undefined
+          : values.oauthConfig.client_secret || undefined,
+      audience: values.oauthConfig.audience || undefined,
       redirect_uris: redirectUrisList,
       scopes: scopesList,
       // Keep fallback scopes aligned with explicit scopes because the backend
       // skips discovery entirely when scopes are configured.
-      default_scopes: hasExplicitScopes ? scopesList : ["read", "write"],
+      default_scopes: hasExplicitScopes
+        ? scopesList
+        : isClientCredentials
+          ? []
+          : ["read", "write"],
       supports_resource_metadata: values.oauthConfig.supports_resource_metadata,
     };
 
@@ -119,8 +141,39 @@ export function transformFormToApiData(
       data.oauthClientSecretVaultKey = values.oauthClientSecretVaultKey;
     }
 
-    // Clear userConfig when using OAuth
-    data.userConfig = {};
+    data.userConfig = isClientCredentials
+      ? {
+          client_id: {
+            type: "string",
+            title: "Client ID",
+            description:
+              "OAuth client ID used to fetch a client-credentials token for this remote MCP server.",
+            promptOnInstallation: true,
+            required: true,
+            default: values.oauthConfig.client_id || undefined,
+            sensitive: false,
+          },
+          client_secret: {
+            type: "string",
+            title: "Client Secret",
+            description:
+              "OAuth client secret used to fetch a client-credentials token for this remote MCP server.",
+            promptOnInstallation: true,
+            required: true,
+            sensitive: true,
+          },
+          audience: {
+            type: "string",
+            title: "Audience",
+            description:
+              "Audience included when requesting the client-credentials token.",
+            promptOnInstallation: true,
+            required: true,
+            default: values.oauthConfig.audience || undefined,
+            sensitive: false,
+          },
+        }
+      : {};
     data.enterpriseManagedConfig = null;
   } else if (values.authMethod === "enterprise_managed") {
     data.userConfig = {};
@@ -194,6 +247,7 @@ export function transformCatalogItemToFormValues(
     | "none"
     | "bearer"
     | "oauth"
+    | "oauth_client_credentials"
     | "enterprise_managed"
     | "idp_jwt" = "none";
   let includeBearerPrefix = true;
@@ -203,7 +257,10 @@ export function transformCatalogItemToFormValues(
         ? "idp_jwt"
         : "enterprise_managed";
   } else if (item.oauthConfig) {
-    authMethod = "oauth";
+    authMethod =
+      item.oauthConfig.grant_type === "client_credentials"
+        ? "oauth_client_credentials"
+        : "oauth";
   } else if (item.userConfig?.raw_access_token) {
     authMethod = "bearer";
     includeBearerPrefix = false;
@@ -232,9 +289,11 @@ export function transformCatalogItemToFormValues(
     | {
         client_id: string;
         client_secret: string;
+        audience: string;
         redirect_uris: string;
         scopes: string;
         supports_resource_metadata: boolean;
+        grantType: "authorization_code" | "client_credentials";
         authServerUrl?: string;
         authorizationEndpoint?: string;
         wellKnownUrl?: string;
@@ -250,10 +309,15 @@ export function transformCatalogItemToFormValues(
       client_secret: oauthClientSecretVaultPath
         ? ""
         : item.oauthConfig.client_secret || "",
+      audience:
+        typeof item.userConfig?.audience?.default === "string"
+          ? item.userConfig.audience.default
+          : item.oauthConfig.audience || "",
       redirect_uris: item.oauthConfig.redirect_uris?.join(", ") || "",
       scopes: item.oauthConfig.scopes?.join(", ") || "",
       supports_resource_metadata:
         item.oauthConfig.supports_resource_metadata ?? true,
+      grantType: item.oauthConfig.grant_type ?? "authorization_code",
       authServerUrl: item.oauthConfig.auth_server_url || "",
       authorizationEndpoint: item.oauthConfig.authorization_endpoint || "",
       wellKnownUrl: item.oauthConfig.well_known_url || "",
@@ -436,7 +500,8 @@ export function transformExternalCatalogToFormValues(
   };
 
   // Determine auth method
-  let authMethod: "none" | "bearer" | "oauth" = "none";
+  let authMethod: "none" | "bearer" | "oauth" | "oauth_client_credentials" =
+    "none";
   let includeBearerPrefix = true;
   const staticHeaderFields = getHeaderMappedUserConfigEntries(
     server.user_config,
@@ -462,7 +527,11 @@ export function transformExternalCatalogToFormValues(
   // Rewrite redirect URIs to prefer platform callback
   let oauthConfig: McpCatalogFormValues["oauthConfig"] | undefined;
   if (server.oauth_config && !server.oauth_config.requires_proxy) {
-    authMethod = "oauth";
+    const oauthGrantType = getOAuthGrantType(server.oauth_config);
+    authMethod =
+      oauthGrantType === "client_credentials"
+        ? "oauth_client_credentials"
+        : "oauth";
     const redirectUris =
       server.oauth_config.redirect_uris
         ?.map((u) =>
@@ -474,6 +543,7 @@ export function transformExternalCatalogToFormValues(
     oauthConfig = {
       client_id: server.oauth_config.client_id || "",
       client_secret: server.oauth_config.client_secret || "",
+      audience: "",
       redirect_uris:
         redirectUris ||
         (typeof window !== "undefined"
@@ -482,6 +552,10 @@ export function transformExternalCatalogToFormValues(
       scopes: server.oauth_config.scopes?.join(", ") || "read, write",
       supports_resource_metadata:
         server.oauth_config.supports_resource_metadata ?? true,
+      grantType:
+        oauthGrantType === "client_credentials"
+          ? "client_credentials"
+          : "authorization_code",
       authServerUrl: server.oauth_config.auth_server_url || "",
       authorizationEndpoint:
         getOptionalStringProperty(
@@ -642,12 +716,14 @@ export function transformExternalCatalogToFormValues(
     oauthConfig: oauthConfig ?? {
       client_id: "",
       client_secret: "",
+      audience: "",
       redirect_uris:
         typeof window !== "undefined"
           ? `${window.location.origin}/oauth-callback`
           : "",
       scopes: "read, write",
       supports_resource_metadata: true,
+      grantType: "authorization_code",
       authServerUrl: "",
       authorizationEndpoint: "",
       wellKnownUrl: "",
@@ -805,6 +881,15 @@ function getOptionalStringProperty(
 
   const propertyValue = (value as Record<string, unknown>)[key];
   return typeof propertyValue === "string" ? propertyValue : undefined;
+}
+
+function getOAuthGrantType(
+  oauthConfig: unknown,
+): "authorization_code" | "client_credentials" {
+  return getOptionalStringProperty(oauthConfig, "grant_type") ===
+    "client_credentials"
+    ? "client_credentials"
+    : "authorization_code";
 }
 
 /**

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
@@ -168,7 +168,7 @@ export function transformFormToApiData(
             description:
               "Audience included when requesting the client-credentials token.",
             promptOnInstallation: true,
-            required: true,
+            required: false,
             default: values.oauthConfig.audience || undefined,
             sensitive: false,
           },

--- a/platform/frontend/src/app/mcp/registry/_parts/remote-server-install-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/remote-server-install-dialog.tsx
@@ -216,6 +216,8 @@ export function RemoteServerInstallDialog({
   );
   const hasConfig = Object.keys(promptableUserConfig).length > 0;
   const hasOAuth = !!catalogItem.oauthConfig;
+  const usesBrowserOAuth =
+    catalogItem.oauthConfig?.grant_type !== "client_credentials";
 
   // Get sensitive and non-sensitive required fields
   const sensitiveRequiredFields = Object.entries(promptableUserConfig).filter(
@@ -338,12 +340,23 @@ export function RemoteServerInstallDialog({
         </div>
       )}
 
-      {canInstall && hasOAuth && (
+      {canInstall && hasOAuth && usesBrowserOAuth && (
         <Alert>
           <Info className="h-4 w-4" />
           <AlertDescription>
             This server requires OAuth authentication. You'll be redirected to
             complete the authentication flow after clicking Install.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {canInstall && hasOAuth && !usesBrowserOAuth && (
+        <Alert>
+          <Info className="h-4 w-4" />
+          <AlertDescription>
+            This server uses shared OAuth client credentials. The values below
+            are stored with the installation, and {catalogItem.name} will fetch
+            short-lived bearer tokens automatically when tools run.
           </AlertDescription>
         </Alert>
       )}

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -24823,11 +24823,13 @@ export type GetInternalMcpCatalogResponses = {
         oauthConfig: {
             name: string;
             server_url: string;
+            grant_type?: 'authorization_code' | 'client_credentials';
             auth_server_url?: string;
             authorization_endpoint?: string;
             resource_metadata_url?: string;
             client_id: string;
             client_secret?: string;
+            audience?: string;
             redirect_uris: Array<string>;
             scopes: Array<string>;
             description?: string;
@@ -24958,11 +24960,13 @@ export type CreateInternalMcpCatalogItemData = {
         oauthConfig?: {
             name: string;
             server_url: string;
+            grant_type?: 'authorization_code' | 'client_credentials';
             auth_server_url?: string;
             authorization_endpoint?: string;
             resource_metadata_url?: string;
             client_id: string;
             client_secret?: string;
+            audience?: string;
             redirect_uris: Array<string>;
             scopes: Array<string>;
             description?: string;
@@ -25152,11 +25156,13 @@ export type CreateInternalMcpCatalogItemResponses = {
         oauthConfig: {
             name: string;
             server_url: string;
+            grant_type?: 'authorization_code' | 'client_credentials';
             auth_server_url?: string;
             authorization_endpoint?: string;
             resource_metadata_url?: string;
             client_id: string;
             client_secret?: string;
+            audience?: string;
             redirect_uris: Array<string>;
             scopes: Array<string>;
             description?: string;
@@ -25437,11 +25443,13 @@ export type GetInternalMcpCatalogItemResponses = {
         oauthConfig: {
             name: string;
             server_url: string;
+            grant_type?: 'authorization_code' | 'client_credentials';
             auth_server_url?: string;
             authorization_endpoint?: string;
             resource_metadata_url?: string;
             client_id: string;
             client_secret?: string;
+            audience?: string;
             redirect_uris: Array<string>;
             scopes: Array<string>;
             description?: string;
@@ -25571,11 +25579,13 @@ export type UpdateInternalMcpCatalogItemData = {
         oauthConfig?: {
             name: string;
             server_url: string;
+            grant_type?: 'authorization_code' | 'client_credentials';
             auth_server_url?: string;
             authorization_endpoint?: string;
             resource_metadata_url?: string;
             client_id: string;
             client_secret?: string;
+            audience?: string;
             redirect_uris: Array<string>;
             scopes: Array<string>;
             description?: string;
@@ -25767,11 +25777,13 @@ export type UpdateInternalMcpCatalogItemResponses = {
         oauthConfig: {
             name: string;
             server_url: string;
+            grant_type?: 'authorization_code' | 'client_credentials';
             auth_server_url?: string;
             authorization_endpoint?: string;
             resource_metadata_url?: string;
             client_id: string;
             client_secret?: string;
+            audience?: string;
             redirect_uris: Array<string>;
             scopes: Array<string>;
             description?: string;
@@ -30288,11 +30300,13 @@ export type GetMcpServerInstallationRequestsResponses = {
             oauthConfig?: {
                 name: string;
                 server_url: string;
+                grant_type?: 'authorization_code' | 'client_credentials';
                 auth_server_url?: string;
                 authorization_endpoint?: string;
                 resource_metadata_url?: string;
                 client_id: string;
                 client_secret?: string;
+                audience?: string;
                 redirect_uris: Array<string>;
                 scopes: Array<string>;
                 description?: string;
@@ -30385,11 +30399,13 @@ export type CreateMcpServerInstallationRequestData = {
             oauthConfig?: {
                 name: string;
                 server_url: string;
+                grant_type?: 'authorization_code' | 'client_credentials';
                 auth_server_url?: string;
                 authorization_endpoint?: string;
                 resource_metadata_url?: string;
                 client_id: string;
                 client_secret?: string;
+                audience?: string;
                 redirect_uris: Array<string>;
                 scopes: Array<string>;
                 description?: string;
@@ -30536,11 +30552,13 @@ export type CreateMcpServerInstallationRequestResponses = {
             oauthConfig?: {
                 name: string;
                 server_url: string;
+                grant_type?: 'authorization_code' | 'client_credentials';
                 auth_server_url?: string;
                 authorization_endpoint?: string;
                 resource_metadata_url?: string;
                 client_id: string;
                 client_secret?: string;
+                audience?: string;
                 redirect_uris: Array<string>;
                 scopes: Array<string>;
                 description?: string;
@@ -30786,11 +30804,13 @@ export type GetMcpServerInstallationRequestResponses = {
             oauthConfig?: {
                 name: string;
                 server_url: string;
+                grant_type?: 'authorization_code' | 'client_credentials';
                 auth_server_url?: string;
                 authorization_endpoint?: string;
                 resource_metadata_url?: string;
                 client_id: string;
                 client_secret?: string;
+                audience?: string;
                 redirect_uris: Array<string>;
                 scopes: Array<string>;
                 description?: string;
@@ -30883,11 +30903,13 @@ export type UpdateMcpServerInstallationRequestData = {
             oauthConfig?: {
                 name: string;
                 server_url: string;
+                grant_type?: 'authorization_code' | 'client_credentials';
                 auth_server_url?: string;
                 authorization_endpoint?: string;
                 resource_metadata_url?: string;
                 client_id: string;
                 client_secret?: string;
+                audience?: string;
                 redirect_uris: Array<string>;
                 scopes: Array<string>;
                 description?: string;
@@ -31046,11 +31068,13 @@ export type UpdateMcpServerInstallationRequestResponses = {
             oauthConfig?: {
                 name: string;
                 server_url: string;
+                grant_type?: 'authorization_code' | 'client_credentials';
                 auth_server_url?: string;
                 authorization_endpoint?: string;
                 resource_metadata_url?: string;
                 client_id: string;
                 client_secret?: string;
+                audience?: string;
                 redirect_uris: Array<string>;
                 scopes: Array<string>;
                 description?: string;
@@ -31219,11 +31243,13 @@ export type ApproveMcpServerInstallationRequestResponses = {
             oauthConfig?: {
                 name: string;
                 server_url: string;
+                grant_type?: 'authorization_code' | 'client_credentials';
                 auth_server_url?: string;
                 authorization_endpoint?: string;
                 resource_metadata_url?: string;
                 client_id: string;
                 client_secret?: string;
+                audience?: string;
                 redirect_uris: Array<string>;
                 scopes: Array<string>;
                 description?: string;
@@ -31392,11 +31418,13 @@ export type DeclineMcpServerInstallationRequestResponses = {
             oauthConfig?: {
                 name: string;
                 server_url: string;
+                grant_type?: 'authorization_code' | 'client_credentials';
                 auth_server_url?: string;
                 authorization_endpoint?: string;
                 resource_metadata_url?: string;
                 client_id: string;
                 client_secret?: string;
+                audience?: string;
                 redirect_uris: Array<string>;
                 scopes: Array<string>;
                 description?: string;
@@ -31565,11 +31593,13 @@ export type AddMcpServerInstallationRequestNoteResponses = {
             oauthConfig?: {
                 name: string;
                 server_url: string;
+                grant_type?: 'authorization_code' | 'client_credentials';
                 auth_server_url?: string;
                 authorization_endpoint?: string;
                 resource_metadata_url?: string;
                 client_id: string;
                 client_secret?: string;
+                audience?: string;
                 redirect_uris: Array<string>;
                 scopes: Array<string>;
                 description?: string;

--- a/platform/shared/mcp-server-config.test.ts
+++ b/platform/shared/mcp-server-config.test.ts
@@ -32,4 +32,15 @@ describe("OAuthConfigSchema", () => {
       }),
     ).toThrow("authorization_endpoint and token_endpoint must be set together");
   });
+
+  it("accepts client credentials configs without redirect URIs", () => {
+    expect(() =>
+      OAuthConfigSchema.parse({
+        ...baseOAuthConfig,
+        grant_type: "client_credentials",
+        redirect_uris: [],
+        token_endpoint: "https://legacy-idp.example.com/oauth/token",
+      }),
+    ).not.toThrow();
+  });
 });

--- a/platform/shared/mcp-server-config.ts
+++ b/platform/shared/mcp-server-config.ts
@@ -4,11 +4,13 @@ export const OAuthConfigSchema = z
   .object({
     name: z.string(),
     server_url: z.string(),
+    grant_type: z.enum(["authorization_code", "client_credentials"]).optional(),
     auth_server_url: z.string().optional(),
     authorization_endpoint: z.string().optional(),
     resource_metadata_url: z.string().optional(),
     client_id: z.string(),
     client_secret: z.string().optional(),
+    audience: z.string().optional(),
     redirect_uris: z.array(z.string()),
     scopes: z.array(z.string()),
     description: z.string().optional(),
@@ -31,7 +33,11 @@ export const OAuthConfigSchema = z
     streamable_http_port: z.number().optional(),
   })
   .superRefine((value, ctx) => {
+    const grantType = value.grant_type ?? "authorization_code";
+    const requiresAuthorizationEndpoint = grantType !== "client_credentials";
+
     if (
+      requiresAuthorizationEndpoint &&
       Boolean(value.authorization_endpoint) !== Boolean(value.token_endpoint)
     ) {
       ctx.addIssue({
@@ -44,6 +50,19 @@ export const OAuthConfigSchema = z
         code: z.ZodIssueCode.custom,
         message:
           "authorization_endpoint and token_endpoint must be set together",
+        path: ["token_endpoint"],
+      });
+    }
+
+    if (
+      grantType === "client_credentials" &&
+      value.authorization_endpoint &&
+      !value.token_endpoint
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "token_endpoint is required when authorization_endpoint is set for client credentials",
         path: ["token_endpoint"],
       });
     }


### PR DESCRIPTION
## Summary
- add a dedicated remote MCP OAuth client credentials auth mode in the catalog form and install flow
- exchange shared client credentials for short-lived upstream bearer tokens at runtime with cache-aware refresh handling
- document the new upstream auth pattern and extend backend/frontend/shared test coverage
---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img width="1954" height="227" alt="Image" src="https://github.com/user-attachments/assets/1f9497f2-96ad-4334-b3a4-c63ff38abdb9"/>

</a>