### PR TITLE
fix: persist chat errors across page reloads

### DIFF
--- a/platform/backend/src/routes/chat/routes.test.ts
+++ b/platform/backend/src/routes/chat/routes.test.ts
@@ -1,3 +1,4 @@
+import { ChatErrorCode, PERSISTED_CHAT_ERROR_PART_TYPE } from "@shared";
 import { describe, expect, it, vi } from "vitest";
 
 // Mock the ai module before importing chat routes
@@ -193,6 +194,32 @@ describe("getMessagesNotYetPersisted", () => {
 
     expect(newMessages).toHaveLength(1);
     expect(newMessages[0]?.id).toBe("assistant-1");
+  });
+});
+
+describe("createPersistedChatErrorMessage", () => {
+  it("builds a synthetic assistant message that preserves chat errors on reload", () => {
+    const message = __test.createPersistedChatErrorMessage({
+      code: ChatErrorCode.NetworkError,
+      message: "Network error",
+      isRetryable: true,
+      sessionId: "conv-1",
+    });
+
+    expect(message).toEqual({
+      role: "assistant",
+      parts: [
+        {
+          type: PERSISTED_CHAT_ERROR_PART_TYPE,
+          error: {
+            code: ChatErrorCode.NetworkError,
+            message: "Network error",
+            isRetryable: true,
+            sessionId: "conv-1",
+          },
+        },
+      ],
+    });
   });
 });
 

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -2,6 +2,7 @@ import {
   buildUserSystemPromptContext,
   type ChatErrorResponse,
   isSupportedProvider,
+  PERSISTED_CHAT_ERROR_PART_TYPE,
   RouteId,
   type SupportedProvider,
   TimeInMs,
@@ -392,7 +393,11 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
           // saves messages beyond the existing count, so onFinish will only save
           // the assistant response.
           try {
-            await persistNewMessages(conversationId, messages, "earlyUserMsg");
+            await persistNewMessages({
+              conversationId,
+              messages,
+              context: "earlyUserMsg",
+            });
           } catch (error) {
             logger.warn(
               { error, conversationId },
@@ -415,6 +420,14 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 // Persist messages on stream-level errors (e.g. errors thrown
                 // in execute before writer.merge() is reached). Without this,
                 // user messages are lost on refresh after an error.
+                const mapped = mapProviderError(error, provider);
+                const traceContext = getActiveTraceContext();
+                const correlationLogFields =
+                  getCorrelationLogFields(traceContext);
+                const fullError = { ...mapped, ...traceContext };
+                const errorForFrontend = slimChatErrorUi
+                  ? sanitizeChatErrorForFrontend(fullError)
+                  : fullError;
                 const shouldPersist = !messagesPersisted && !!conversationId;
                 if (shouldPersist) {
                   messagesPersisted = true;
@@ -422,11 +435,12 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 (async () => {
                   if (shouldPersist) {
                     try {
-                      await persistNewMessages(
+                      await persistNewMessages({
                         conversationId,
                         messages,
-                        "onStreamError",
-                      );
+                        context: "onStreamError",
+                        persistedError: errorForFrontend,
+                      });
                     } catch (persistError) {
                       logger.error(
                         { persistError, conversationId },
@@ -440,15 +454,6 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                     "Unexpected error in onError async persist handler",
                   );
                 });
-
-                const mapped = mapProviderError(error, provider);
-                const traceContext = getActiveTraceContext();
-                const correlationLogFields =
-                  getCorrelationLogFields(traceContext);
-                const fullError = { ...mapped, ...traceContext };
-                const errorForFrontend = slimChatErrorUi
-                  ? sanitizeChatErrorForFrontend(fullError)
-                  : fullError;
 
                 logger.info(
                   {
@@ -625,14 +630,26 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                     } else {
                       // Save messages before throwing — this error path runs before
                       // writer.merge(), so onError/onFinish callbacks won't fire.
+                      const mappedError = mapProviderError(error, provider);
+                      const traceContext = getActiveTraceContext();
+                      const errorForFrontend = slimChatErrorUi
+                        ? sanitizeChatErrorForFrontend({
+                            ...mappedError,
+                            ...traceContext,
+                          })
+                        : {
+                            ...mappedError,
+                            ...traceContext,
+                          };
                       if (!messagesPersisted && conversationId) {
                         messagesPersisted = true;
                         try {
-                          await persistNewMessages(
+                          await persistNewMessages({
                             conversationId,
                             messages,
-                            "onExecuteError",
-                          );
+                            context: "onExecuteError",
+                            persistedError: errorForFrontend,
+                          });
                         } catch (persistError) {
                           logger.error(
                             { persistError, conversationId },
@@ -656,9 +673,19 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                       if (shouldPersist) {
                         messagesPersisted = true;
                       }
+                      // Use pre-built error from subagent if available (preserves correct provider),
+                      // otherwise map the error with the current provider
+                      const mappedError: ChatErrorResponse =
+                        error instanceof ProviderError
+                          ? error.chatErrorResponse
+                          : mapProviderError(error, provider);
                       const traceContext = getActiveTraceContext();
                       const correlationLogFields =
                         getCorrelationLogFields(traceContext);
+                      const fullError = { ...mappedError, ...traceContext };
+                      const errorForFrontend = slimChatErrorUi
+                        ? sanitizeChatErrorForFrontend(fullError)
+                        : fullError;
 
                       (async () => {
                         logger.error(
@@ -674,11 +701,12 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                         // Persist messages despite error so they have a valid ID for editing
                         if (shouldPersist) {
                           try {
-                            await persistNewMessages(
+                            await persistNewMessages({
                               conversationId,
                               messages,
-                              "onError",
-                            );
+                              context: "onError",
+                              persistedError: errorForFrontend,
+                            });
                           } catch (persistError) {
                             // Log persistence error but don't prevent the error response
                             logger.error(
@@ -694,17 +722,6 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                           "Unexpected error in onError async handler",
                         );
                       });
-
-                      // Use pre-built error from subagent if available (preserves correct provider),
-                      // otherwise map the error with the current provider
-                      const mappedError: ChatErrorResponse =
-                        error instanceof ProviderError
-                          ? error.chatErrorResponse
-                          : mapProviderError(error, provider);
-                      const fullError = { ...mappedError, ...traceContext };
-                      const errorForFrontend = slimChatErrorUi
-                        ? sanitizeChatErrorForFrontend(fullError)
-                        : fullError;
 
                       logger.info(
                         {
@@ -740,11 +757,11 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                       // Only persist if not already persisted by onError
                       if (!messagesPersisted && conversationId) {
                         try {
-                          await persistNewMessages(
+                          await persistNewMessages({
                             conversationId,
-                            finalMessages,
-                            "onFinish",
-                          );
+                            messages: finalMessages,
+                            context: "onFinish",
+                          });
                           messagesPersisted = true;
                         } catch (error) {
                           logger.error(
@@ -1942,16 +1959,23 @@ export async function generateConversationTitle(
  * @param context - Context for logging (e.g., "onFinish", "onError")
  * @returns Promise<number> - Number of messages persisted
  */
-async function persistNewMessages(
-  conversationId: string,
-  messages: unknown[],
-  context: string,
-): Promise<number> {
+async function persistNewMessages(params: {
+  conversationId: string;
+  messages: unknown[];
+  context: string;
+  persistedError?: ChatErrorResponse;
+}): Promise<number> {
+  const { conversationId, messages, context, persistedError } = params;
   try {
     // Get existing messages count to know how many are new
     const existingMessages =
       await MessageModel.findByConversation(conversationId);
-    const uiMessages = messages as ChatMessage[];
+    const uiMessages = [
+      ...(messages as ChatMessage[]),
+      ...(persistedError
+        ? [createPersistedChatErrorMessage(persistedError)]
+        : []),
+    ];
     const newMessages = getMessagesNotYetPersisted({
       existingMessages,
       uiMessages,
@@ -2019,6 +2043,20 @@ async function persistNewMessages(
     );
     throw error;
   }
+}
+
+function createPersistedChatErrorMessage(
+  error: ChatErrorResponse,
+): ChatMessage {
+  return {
+    role: "assistant",
+    parts: [
+      {
+        type: PERSISTED_CHAT_ERROR_PART_TYPE,
+        error,
+      },
+    ],
+  };
 }
 
 function getMessagesNotYetPersisted(params: {
@@ -2232,6 +2270,7 @@ async function validateChatApiKeyAccess(
 }
 
 export const __test = {
+  createPersistedChatErrorMessage,
   getMessagesNotYetPersisted,
   prepareMessagesForProvider,
 };

--- a/platform/frontend/src/components/chat/chat-messages.test.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.test.tsx
@@ -1,4 +1,8 @@
 import type { UIMessage } from "@ai-sdk/react";
+import {
+  PERSISTED_CHAT_ERROR_PART_TYPE,
+  SWAP_AGENT_POKE_TEXT,
+} from "@shared";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -215,6 +219,60 @@ describe("ChatMessages", () => {
     );
 
     expect(screen.getByText("Switched to GitHub Agent")).toBeInTheDocument();
+  });
+
+  it("suppresses a duplicate swap divider after the hidden poke/error turn", () => {
+    const messages = [
+      {
+        id: "assistant-swap",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-sparky__swap_agent",
+            toolCallId: "call-1",
+            state: "output-available",
+            input: { agent_name: "GitHub Agent" },
+            output: { ok: true },
+          },
+        ],
+      },
+      {
+        id: "user-poke",
+        role: "user",
+        parts: [{ type: "text", text: SWAP_AGENT_POKE_TEXT }],
+      },
+      {
+        id: "assistant-error",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-sparky__swap_agent",
+            toolCallId: "call-1",
+            state: "output-available",
+            input: { agent_name: "GitHub Agent" },
+            output: { ok: true },
+          },
+          {
+            type: PERSISTED_CHAT_ERROR_PART_TYPE,
+            error: {
+              code: "invalid_request",
+              message: "Request failed",
+              isRetryable: false,
+            },
+          },
+        ],
+      },
+    ] as UIMessage[];
+
+    render(
+      <ChatMessages
+        conversationId="conv-1"
+        messages={messages}
+        status="ready"
+      />,
+    );
+
+    expect(screen.getAllByText("Switched to GitHub Agent")).toHaveLength(1);
   });
 
   it("renders the unsafe-context divider when a tool result marks the context unsafe", () => {

--- a/platform/frontend/src/components/chat/chat-messages.test.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.test.tsx
@@ -63,7 +63,9 @@ vi.mock("@/components/chat/editable-user-message", () => ({
 }));
 
 vi.mock("@/components/chat/inline-chat-error", () => ({
-  InlineChatError: () => null,
+  InlineChatError: ({ error }: { error: Error }) => (
+    <div>inline-chat-error:{error.message}</div>
+  ),
 }));
 
 vi.mock("@/components/chat/mcp-install-dialogs", () => ({
@@ -701,6 +703,40 @@ describe("ChatMessages", () => {
     expect(
       screen.queryByText("tool-id-jag_test__get_server_info"),
     ).not.toBeInTheDocument();
+  });
+
+  it("renders persisted chat error parts after reload", () => {
+    const messages = [
+      {
+        id: "assistant-error-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "data-chat-error",
+            error: {
+              code: "network_error",
+              message: "Network error",
+              isRetryable: true,
+              sessionId: "conv-1",
+              traceId: "trace-1",
+              spanId: "span-1",
+            },
+          },
+        ],
+      },
+    ] as unknown as UIMessage[];
+
+    render(
+      <ChatMessages
+        conversationId="conv-1"
+        messages={messages}
+        status="ready"
+      />,
+    );
+
+    expect(
+      screen.getByText(/inline-chat-error:\{"code":"network_error"/),
+    ).toBeInTheDocument();
   });
 
   it("renders structured assigned-credential-unavailable tool output as config error UI", () => {

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -2,6 +2,9 @@ import type { UIMessage } from "@ai-sdk/react";
 import {
   type ArchestraToolShortName,
   type archestraApiTypes,
+  type ChatErrorResponse,
+  isChatErrorResponse,
+  PERSISTED_CHAT_ERROR_PART_TYPE,
   parseFullToolName,
   SWAP_AGENT_FAILED_POKE_TEXT,
   SWAP_AGENT_POKE_PREFIX,
@@ -158,6 +161,21 @@ function isToolPart(part: any): part is {
       part.type?.startsWith("data-tool-ui-start") ||
       part.type === "dynamic-tool")
   );
+}
+
+function getPersistedChatError(part: unknown): ChatErrorResponse | undefined {
+  if (
+    typeof part !== "object" ||
+    part === null ||
+    !("type" in part) ||
+    part.type !== PERSISTED_CHAT_ERROR_PART_TYPE ||
+    !("error" in part) ||
+    !isChatErrorResponse(part.error)
+  ) {
+    return undefined;
+  }
+
+  return part.error;
 }
 
 export function ChatMessages({
@@ -1039,6 +1057,29 @@ export function ChatMessages({
                               />
                             ),
                           });
+                        }
+
+                        const persistedChatError = getPersistedChatError(part);
+                        if (persistedChatError) {
+                          return (
+                            <Fragment key={partKey}>
+                              <InlineChatError
+                                error={
+                                  new Error(JSON.stringify(persistedChatError))
+                                }
+                                conversationId={conversationId}
+                                supportMessage={
+                                  organization?.chatErrorSupportMessage
+                                }
+                                slimChatErrorUi={
+                                  organization?.slimChatErrorUi ?? false
+                                }
+                                agentName={agentName}
+                                selectedModel={selectedModel}
+                                modelSource={modelSource}
+                              />
+                            </Fragment>
+                          );
                         }
 
                         // Regular tool-* parts: skip if a data-tool-ui-start already

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -106,7 +106,10 @@ import {
   UnsafeContextStartsHereDivider,
 } from "./message-boundary-divider";
 import { PolicyDeniedTool } from "./policy-denied-tool";
-import { SwapAgentBoundaryDivider } from "./swap-agent-boundary";
+import {
+  getSwapAgentBoundaryLabel,
+  SwapAgentBoundaryDivider,
+} from "./swap-agent-boundary";
 import { TodoWriteTool } from "./todo-write-tool";
 import { ToolErrorLogsButton } from "./tool-error-logs-button";
 import { ToolStatusRow } from "./tool-status-row";
@@ -1164,6 +1167,17 @@ export function ChatMessages({
                     parts={message.parts ?? []}
                     getToolShortName={getToolShortName}
                     hasToolError={hasSwapToolError}
+                    shouldRender={shouldRenderSwapAgentDivider({
+                      messageIndex: idx,
+                      messages,
+                      isDebugging,
+                      currentLabel: getSwapAgentBoundaryLabel({
+                        parts: message.parts ?? [],
+                        getToolShortName,
+                        hasToolError: hasSwapToolError,
+                      }),
+                      getToolShortName,
+                    })}
                   />
                 )}
               </div>
@@ -1739,6 +1753,68 @@ function isSwapAgentPokeMessage(message: UIMessage): boolean {
     text === SWAP_TO_DEFAULT_AGENT_POKE_TEXT ||
     text.startsWith(SWAP_AGENT_POKE_PREFIX)
   );
+}
+
+function shouldRenderSwapAgentDivider(params: {
+  messageIndex: number;
+  messages: UIMessage[];
+  isDebugging: boolean;
+  currentLabel: string | null;
+  getToolShortName: (toolName: string) => ArchestraToolShortName | null;
+}): boolean {
+  const {
+    messageIndex,
+    messages,
+    isDebugging,
+    currentLabel,
+    getToolShortName,
+  } = params;
+  if (!currentLabel) {
+    return false;
+  }
+
+  const previousVisibleAssistantMessage = findPreviousVisibleAssistantMessage({
+    currentIndex: messageIndex,
+    isDebugging,
+    messages,
+  });
+  if (!previousVisibleAssistantMessage) {
+    return true;
+  }
+
+  const previousLabel = getSwapAgentBoundaryLabel({
+    parts: previousVisibleAssistantMessage.parts ?? [],
+    getToolShortName,
+    hasToolError: hasSwapToolError,
+  });
+  return previousLabel !== currentLabel;
+}
+
+function findPreviousVisibleAssistantMessage(params: {
+  currentIndex: number;
+  isDebugging: boolean;
+  messages: UIMessage[];
+}): UIMessage | null {
+  const { currentIndex, isDebugging, messages } = params;
+
+  for (let index = currentIndex - 1; index >= 0; index--) {
+    const previousMessage = messages[index];
+    if (!previousMessage) {
+      continue;
+    }
+
+    if (!isDebugging && isSwapAgentPokeMessage(previousMessage)) {
+      continue;
+    }
+
+    if (previousMessage.role === "assistant") {
+      return previousMessage;
+    }
+
+    return null;
+  }
+
+  return null;
 }
 
 function renderPartWithUnsafeContextDivider({

--- a/platform/frontend/src/components/chat/swap-agent-boundary.tsx
+++ b/platform/frontend/src/components/chat/swap-agent-boundary.tsx
@@ -2,6 +2,7 @@
 
 import {
   type ArchestraToolShortName,
+  PERSISTED_CHAT_ERROR_PART_TYPE,
   TOOL_SWAP_AGENT_SHORT_NAME,
   TOOL_SWAP_TO_DEFAULT_AGENT_SHORT_NAME,
 } from "@shared";
@@ -17,11 +18,45 @@ export function SwapAgentBoundaryDivider({
   parts,
   getToolShortName,
   hasToolError,
+  shouldRender = true,
 }: {
   parts: ToolPart[];
   getToolShortName?: (toolName: string) => ArchestraToolShortName | null;
   hasToolError: (part: ToolPart, allParts: ToolPart[]) => boolean;
+  shouldRender?: boolean;
 }) {
+  if (!shouldRender) {
+    return null;
+  }
+
+  const label = getSwapAgentBoundaryLabel({
+    parts,
+    getToolShortName,
+    hasToolError,
+  });
+
+  return label ? <MessageBoundaryDivider label={label} /> : null;
+}
+
+export function getSwapAgentBoundaryLabel({
+  parts,
+  getToolShortName,
+  hasToolError,
+}: {
+  parts: ToolPart[];
+  getToolShortName?: (toolName: string) => ArchestraToolShortName | null;
+  hasToolError: (part: ToolPart, allParts: ToolPart[]) => boolean;
+}): string | null {
+  if (
+    parts.some(
+      (part) =>
+        typeof part.type === "string" &&
+        part.type === PERSISTED_CHAT_ERROR_PART_TYPE,
+    )
+  ) {
+    return null;
+  }
+
   for (const part of parts) {
     const toolName = getRenderedToolName(part);
     if (!toolName) continue;
@@ -47,7 +82,7 @@ export function SwapAgentBoundaryDivider({
       ? "default agent"
       : (extractSwapTargetAgentName(part) ?? "another agent");
 
-    return <MessageBoundaryDivider label={`Switched to ${agentName}`} />;
+    return `Switched to ${agentName}`;
   }
 
   return null;

--- a/platform/frontend/src/lib/chat/chat-session-utils.test.ts
+++ b/platform/frontend/src/lib/chat/chat-session-utils.test.ts
@@ -139,6 +139,47 @@ describe("restoreRenderableAssistantParts", () => {
     ]);
   });
 
+  test("does not restore tool-rich assistant content onto a re-keyed assistant message", () => {
+    const previousMessages = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "route me somewhere" }],
+      },
+      {
+        id: "assistant-temp-id",
+        role: "assistant",
+        parts: [
+          { type: "step-start" },
+          {
+            type: "tool-archestra__list_agents",
+            toolCallId: "tool-1",
+            state: "output-available",
+            input: {},
+            output: { ok: true },
+          },
+          {
+            type: "text",
+            text: "I'll route you to another agent.",
+          },
+        ],
+      },
+    ] as UIMessage[];
+
+    const nextMessages = [
+      previousMessages[0],
+      {
+        id: "assistant-final-id",
+        role: "assistant",
+        parts: [{ type: "text", text: "" }],
+      },
+    ] as UIMessage[];
+
+    expect(
+      restoreRenderableAssistantParts({ previousMessages, nextMessages }),
+    ).toBe(nextMessages);
+  });
+
   test("does not restore by position when earlier messages changed", () => {
     const previousMessages = [
       {

--- a/platform/frontend/src/lib/chat/chat-session-utils.ts
+++ b/platform/frontend/src/lib/chat/chat-session-utils.ts
@@ -86,6 +86,7 @@ function findPreviousRenderableAssistantMessage(params: {
   if (
     index > 0 &&
     previousMessageAtIndex?.role === "assistant" &&
+    isSafeToRestoreByPosition(previousMessageAtIndex) &&
     nextMessages
       .slice(0, index)
       .every(
@@ -136,4 +137,17 @@ function restoreTruncatedAssistantTail(params: {
 
 function sameMessageIdentity(a: UIMessage, b: UIMessage | undefined): boolean {
   return !!b && a.id === b.id && a.role === b.role;
+}
+
+function isSafeToRestoreByPosition(message: UIMessage): boolean {
+  return (message.parts ?? []).every((part) => {
+    switch (part.type) {
+      case "text":
+      case "reasoning":
+      case "file":
+        return true;
+      default:
+        return false;
+    }
+  });
 }

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -158,6 +158,58 @@ describe("useChatSession", () => {
     ).toBeNull();
   });
 
+  it("clears a persisted error as soon as a new user message is sent", async () => {
+    const conversationId = "conversation-2b";
+
+    const { result } = renderHook(
+      () => useChatSession({ conversationId, enabled: true }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current).not.toBeNull();
+      expect(latestUseChatOptions).toBeDefined();
+    });
+
+    act(() => {
+      latestUseChatOptions?.onError?.(
+        new Error(
+          JSON.stringify({
+            code: "server_error",
+            message: "Temporary backend failure",
+            isRetryable: true,
+          }),
+        ),
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current?.error?.message).toContain(
+        "Temporary backend failure",
+      );
+    });
+
+    act(() => {
+      result.current?.sendMessage({
+        role: "user",
+        parts: [{ type: "text", text: "hello" }],
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current?.error).toBeUndefined();
+    });
+    expect(
+      localStorage.getItem(conversationStorageKeys(conversationId).error),
+    ).toBeNull();
+    expect(useChatState.sendMessage).toHaveBeenCalledWith({
+      role: "user",
+      parts: [{ type: "text", text: "hello" }],
+    });
+  });
+
   it("keeps showing the in-memory error when localStorage persistence fails", async () => {
     const conversationId = "conversation-3";
     const storageSpy = vi

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -2,7 +2,6 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { conversationStorageKeys } from "@/lib/chat/chat-utils";
 import { ChatProvider, useChatSession } from "./global-chat.context";
 
 const useChatMock = vi.fn();
@@ -62,7 +61,6 @@ describe("useChatSession", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    localStorage.clear();
 
     useGenerateConversationTitleMock.mockReturnValue({
       isPending: false,
@@ -78,32 +76,7 @@ describe("useChatSession", () => {
     });
   });
 
-  it("hydrates a persisted conversation error from localStorage", async () => {
-    const conversationId = "conversation-1";
-    localStorage.setItem(
-      conversationStorageKeys(conversationId).error,
-      JSON.stringify({
-        code: "server_error",
-        message: "Persisted provider failure",
-        isRetryable: true,
-      }),
-    );
-
-    const { result } = renderHook(
-      () => useChatSession({ conversationId, enabled: true }),
-      {
-        wrapper: createWrapper(),
-      },
-    );
-
-    await waitFor(() => {
-      expect(result.current?.error?.message).toContain(
-        "Persisted provider failure",
-      );
-    });
-  });
-
-  it("keeps the last error during retries and clears it after a successful finish", async () => {
+  it("keeps the live chat error during retries and clears it after a successful finish", async () => {
     const conversationId = "conversation-2";
 
     const { result } = renderHook(
@@ -119,6 +92,13 @@ describe("useChatSession", () => {
     });
 
     act(() => {
+      useChatState.error = new Error(
+        JSON.stringify({
+          code: "server_error",
+          message: "Temporary backend failure",
+          isRetryable: true,
+        }),
+      );
       latestUseChatOptions?.onError?.(
         new Error(
           JSON.stringify({
@@ -135,9 +115,6 @@ describe("useChatSession", () => {
         "Temporary backend failure",
       );
     });
-    expect(
-      localStorage.getItem(conversationStorageKeys(conversationId).error),
-    ).toContain("Temporary backend failure");
 
     act(() => {
       useChatState.error = undefined;
@@ -153,14 +130,10 @@ describe("useChatSession", () => {
     await waitFor(() => {
       expect(result.current?.error).toBeUndefined();
     });
-    expect(
-      localStorage.getItem(conversationStorageKeys(conversationId).error),
-    ).toBeNull();
   });
 
-  it("clears a persisted error as soon as a new user message is sent", async () => {
-    const conversationId = "conversation-2b";
-
+  it("forwards new user messages without any client-side error persistence layer", async () => {
+    const conversationId = "conversation-3";
     const { result } = renderHook(
       () => useChatSession({ conversationId, enabled: true }),
       {
@@ -171,24 +144,6 @@ describe("useChatSession", () => {
     await waitFor(() => {
       expect(result.current).not.toBeNull();
       expect(latestUseChatOptions).toBeDefined();
-    });
-
-    act(() => {
-      latestUseChatOptions?.onError?.(
-        new Error(
-          JSON.stringify({
-            code: "server_error",
-            message: "Temporary backend failure",
-            isRetryable: true,
-          }),
-        ),
-      );
-    });
-
-    await waitFor(() => {
-      expect(result.current?.error?.message).toContain(
-        "Temporary backend failure",
-      );
     });
 
     act(() => {
@@ -198,51 +153,10 @@ describe("useChatSession", () => {
       });
     });
 
-    await waitFor(() => {
-      expect(result.current?.error).toBeUndefined();
-    });
-    expect(
-      localStorage.getItem(conversationStorageKeys(conversationId).error),
-    ).toBeNull();
     expect(useChatState.sendMessage).toHaveBeenCalledWith({
       role: "user",
       parts: [{ type: "text", text: "hello" }],
     });
-  });
-
-  it("keeps showing the in-memory error when localStorage persistence fails", async () => {
-    const conversationId = "conversation-3";
-    const storageSpy = vi
-      .spyOn(Storage.prototype, "setItem")
-      .mockImplementation(() => {
-        throw new DOMException("Quota exceeded", "QuotaExceededError");
-      });
-
-    const { result } = renderHook(
-      () => useChatSession({ conversationId, enabled: true }),
-      {
-        wrapper: createWrapper(),
-      },
-    );
-
-    await waitFor(() => {
-      expect(result.current).not.toBeNull();
-      expect(latestUseChatOptions).toBeDefined();
-    });
-
-    act(() => {
-      latestUseChatOptions?.onError?.(new Error("Storage-limited failure"));
-    });
-
-    await waitFor(() => {
-      expect(result.current?.error?.message).toBe("Storage-limited failure");
-    });
-    expect(storageSpy).toHaveBeenCalledWith(
-      conversationStorageKeys(conversationId).error,
-      "Storage-limited failure",
-    );
-
-    storageSpy.mockRestore();
   });
 });
 

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -6,6 +6,7 @@ import {
   EXTERNAL_AGENT_ID_HEADER,
   getArchestraToolShortName,
   isChatErrorResponse,
+  PERSISTED_CHAT_ERROR_PART_TYPE,
   makeSwapAgentPokeText,
   SWAP_AGENT_FAILED_POKE_TEXT,
   SWAP_TO_DEFAULT_AGENT_POKE_TEXT,
@@ -431,6 +432,8 @@ function ChatSessionHook({
           `[ChatSession] Auto-retrying (${retryCountRef.current}/${MAX_AUTO_RETRIES})...`,
         );
         retryTimerRef.current = setTimeout(() => {
+          clearPersistedConversationError(conversationId);
+          setPersistedError(undefined);
           regenerate();
         }, AUTO_RETRY_DELAY_MS);
       }
@@ -543,10 +546,32 @@ function ChatSessionHook({
   });
   previousMessagesRef.current = messagesWithRestoredAssistantParts;
 
+  const clearPersistedErrorState = useCallback(() => {
+    clearPersistedConversationError(conversationId);
+    setPersistedError(undefined);
+  }, [conversationId]);
+
+  const sendMessageWithErrorReset = useCallback(
+    (message: Parameters<ReturnType<typeof useChat>["sendMessage"]>[0]) => {
+      clearPersistedErrorState();
+      sendMessage(message);
+    },
+    [clearPersistedErrorState, sendMessage],
+  );
+
   // Keep sendMessageRef up-to-date for onFinish callback
-  sendMessageRef.current = sendMessage;
+  sendMessageRef.current = sendMessageWithErrorReset;
 
   const stableMessages = messagesWithRestoredAssistantParts;
+
+  useEffect(() => {
+    if (!hasPersistedChatErrorMessage(stableMessages)) {
+      return;
+    }
+
+    clearPersistedConversationError(conversationId);
+    setPersistedError(undefined);
+  }, [conversationId, stableMessages]);
 
   // Reset retry counter only when the user sends a genuinely new message.
   // We track the last user message ID to avoid resetting during regenerate(),
@@ -614,7 +639,7 @@ function ChatSessionHook({
   sessionRef.current = {
     conversationId,
     messages: stableMessages,
-    sendMessage,
+    sendMessage: sendMessageWithErrorReset,
     stop,
     status,
     error: error ?? persistedError,
@@ -638,7 +663,7 @@ function ChatSessionHook({
   }, [
     conversationId,
     stableMessages,
-    sendMessage,
+    sendMessageWithErrorReset,
     stop,
     status,
     error,
@@ -742,6 +767,18 @@ function getCurrentArchestraToolShortName(
     fullWhiteLabeling: appConfig.enterpriseFeatures.fullWhiteLabeling,
     includeDefaultPrefix: true,
   });
+}
+
+function hasPersistedChatErrorMessage(messages: UIMessage[]): boolean {
+  return messages.some((message) =>
+    (message.parts ?? []).some(
+      (part) =>
+        typeof part === "object" &&
+        part !== null &&
+        "type" in part &&
+        part.type === PERSISTED_CHAT_ERROR_PART_TYPE,
+    ),
+  );
 }
 
 export function useGlobalChat() {

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -6,7 +6,6 @@ import {
   EXTERNAL_AGENT_ID_HEADER,
   getArchestraToolShortName,
   isChatErrorResponse,
-  PERSISTED_CHAT_ERROR_PART_TYPE,
   makeSwapAgentPokeText,
   SWAP_AGENT_FAILED_POKE_TEXT,
   SWAP_TO_DEFAULT_AGENT_POKE_TEXT,
@@ -35,10 +34,7 @@ import {
 import { filterOptimisticToolCalls } from "@/components/chat/chat-messages.utils";
 import { useGenerateConversationTitle } from "@/lib/chat/chat.query";
 import { restoreRenderableAssistantParts } from "@/lib/chat/chat-session-utils";
-import {
-  conversationStorageKeys,
-  getChatExternalAgentId,
-} from "@/lib/chat/chat-utils";
+import { getChatExternalAgentId } from "@/lib/chat/chat-utils";
 import {
   extractSwapTargetAgentName,
   getRenderedToolName,
@@ -345,9 +341,6 @@ function ChatSessionHook({
   const retryTimerRef = useRef<NodeJS.Timeout | null>(null);
   const lastUserMessageIdRef = useRef<string | null>(null);
   const previousMessagesRef = useRef<UIMessage[]>([]);
-  const [persistedError, setPersistedError] = useState<Error | undefined>(() =>
-    loadPersistedConversationError(conversationId),
-  );
 
   // Track early UI data from data-tool-ui-start events (toolCallId → resource data)
   const [earlyToolUiStarts, setEarlyToolUiStarts] = useState<
@@ -378,8 +371,6 @@ function ChatSessionHook({
     id: conversationId,
     onFinish: ({ message }) => {
       setOptimisticToolCalls([]);
-      clearPersistedConversationError(conversationId);
-      setPersistedError(undefined);
       queryClient.invalidateQueries({
         queryKey: ["conversation", conversationId],
       });
@@ -411,8 +402,6 @@ function ChatSessionHook({
     },
     onError: (chatError) => {
       setOptimisticToolCalls([]);
-      persistConversationError(conversationId, chatError);
-      setPersistedError(chatError);
       console.error("[ChatSession] Error occurred:", {
         conversationId,
         errorName: chatError.name,
@@ -432,8 +421,6 @@ function ChatSessionHook({
           `[ChatSession] Auto-retrying (${retryCountRef.current}/${MAX_AUTO_RETRIES})...`,
         );
         retryTimerRef.current = setTimeout(() => {
-          clearPersistedConversationError(conversationId);
-          setPersistedError(undefined);
           regenerate();
         }, AUTO_RETRY_DELAY_MS);
       }
@@ -546,32 +533,10 @@ function ChatSessionHook({
   });
   previousMessagesRef.current = messagesWithRestoredAssistantParts;
 
-  const clearPersistedErrorState = useCallback(() => {
-    clearPersistedConversationError(conversationId);
-    setPersistedError(undefined);
-  }, [conversationId]);
-
-  const sendMessageWithErrorReset = useCallback(
-    (message: Parameters<ReturnType<typeof useChat>["sendMessage"]>[0]) => {
-      clearPersistedErrorState();
-      sendMessage(message);
-    },
-    [clearPersistedErrorState, sendMessage],
-  );
-
   // Keep sendMessageRef up-to-date for onFinish callback
-  sendMessageRef.current = sendMessageWithErrorReset;
+  sendMessageRef.current = sendMessage;
 
   const stableMessages = messagesWithRestoredAssistantParts;
-
-  useEffect(() => {
-    if (!hasPersistedChatErrorMessage(stableMessages)) {
-      return;
-    }
-
-    clearPersistedConversationError(conversationId);
-    setPersistedError(undefined);
-  }, [conversationId, stableMessages]);
 
   // Reset retry counter only when the user sends a genuinely new message.
   // We track the last user message ID to avoid resetting during regenerate(),
@@ -639,10 +604,10 @@ function ChatSessionHook({
   sessionRef.current = {
     conversationId,
     messages: stableMessages,
-    sendMessage: sendMessageWithErrorReset,
+    sendMessage,
     stop,
     status,
-    error: error ?? persistedError,
+    error,
     setMessages,
     addToolResult,
     addToolApprovalResponse,
@@ -663,11 +628,10 @@ function ChatSessionHook({
   }, [
     conversationId,
     stableMessages,
-    sendMessageWithErrorReset,
+    sendMessage,
     stop,
     status,
     error,
-    persistedError,
     setMessages,
     addToolResult,
     addToolApprovalResponse,
@@ -680,42 +644,6 @@ function ChatSessionHook({
   ]);
 
   return null;
-}
-
-function loadPersistedConversationError(
-  conversationId: string,
-): Error | undefined {
-  if (typeof window === "undefined") {
-    return undefined;
-  }
-
-  const storedMessage = localStorage.getItem(
-    conversationStorageKeys(conversationId).error,
-  );
-  return storedMessage ? new Error(storedMessage) : undefined;
-}
-
-function persistConversationError(conversationId: string, error: Error) {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  try {
-    localStorage.setItem(
-      conversationStorageKeys(conversationId).error,
-      error.message,
-    );
-  } catch {
-    // Storage may be unavailable, but the in-memory session state still shows the error.
-  }
-}
-
-function clearPersistedConversationError(conversationId: string) {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  localStorage.removeItem(conversationStorageKeys(conversationId).error);
 }
 
 function getSwapAgentName(toolCall: unknown): string | null {
@@ -767,18 +695,6 @@ function getCurrentArchestraToolShortName(
     fullWhiteLabeling: appConfig.enterpriseFeatures.fullWhiteLabeling,
     includeDefaultPrefix: true,
   });
-}
-
-function hasPersistedChatErrorMessage(messages: UIMessage[]): boolean {
-  return messages.some((message) =>
-    (message.parts ?? []).some(
-      (part) =>
-        typeof part === "object" &&
-        part !== null &&
-        "type" in part &&
-        part.type === PERSISTED_CHAT_ERROR_PART_TYPE,
-    ),
-  );
 }
 
 export function useGlobalChat() {

--- a/platform/shared/chat.ts
+++ b/platform/shared/chat.ts
@@ -14,6 +14,8 @@ export interface TokenUsage {
   totalTokens: number | undefined;
 }
 
+export const PERSISTED_CHAT_ERROR_PART_TYPE = "data-chat-error" as const;
+
 // ============================================================================
 // Chat Message Part Types
 // ============================================================================


### PR DESCRIPTION
## Summary
- persist synthetic assistant error entries when chat requests fail before a normal assistant message is saved
- render persisted chat error parts through the existing inline error card so reloads preserve the failure state
- add backend/frontend regression coverage for persisted chat error messages
---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img width="1954" height="227" alt="Image" src="https://github.com/user-attachments/assets/1f9497f2-96ad-4334-b3a4-c63ff38abdb9"/>

</a>