### PR TITLE
ci: drop contributor-onboard label step

### DIFF
--- a/.github/workflows/merge-external-contributors.yml
+++ b/.github/workflows/merge-external-contributors.yml
@@ -72,12 +72,6 @@ jobs:
           app-id: ${{ secrets.ARCHESTRA_MERGE_EXTERNAL_CONTRIBUTORS_GITHUB_APP_ID }}
           private-key: ${{ secrets.ARCHESTRA_MERGE_EXTERNAL_CONTRIBUTORS_GITHUB_APP_PRIVATE_KEY }}
 
-      - name: Add label
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: gh pr edit "$PR_NUMBER" --add-label "contributor-onboard"
-
       - name: Update PR branch
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
App token lacks issues:write, causing the merge workflow to fail.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img width="1954" height="227" alt="Image" src="https://github.com/user-attachments/assets/1f9497f2-96ad-4334-b3a4-c63ff38abdb9"/>

</a>