### PR TITLE
fix(ci): don’t cancel in-flight release-please runs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,7 +11,9 @@ permissions: {}
 
 concurrency:
   group: release-please-${{ github.ref }}
-  cancel-in-progress: true
+  # Never preempt an in-flight release for the same branch. Subsequent pushes queue
+  # behind the active run so artifact publishing can complete atomically.
+  cancel-in-progress: false
 
 jobs:
   release-please:


### PR DESCRIPTION
## Summary
- stop `release-please.yml` from cancelling an in-flight run for the same branch
- keep the existing branch-level concurrency group so later pushes queue instead
- document why release publication must complete atomically once a tag/release draft already exists

## Root cause
The release run for `chore(main): release platform 1.2.16 (#3872)` was not failing. It was cancelled by GitHub Actions concurrency.

- Cancelled run: `24571175877`
- Started: `2026-04-17T14:46:28Z`
- Newer push/run that preempted it: `ci: drop contributor-onboard label step (#3902)` / run `24571344901`
- Newer run created at: `2026-04-17T14:50:04Z`

`release-please.yml` currently uses:

```yaml
concurrency:
  group: release-please-${{ github.ref }}
  cancel-in-progress: true
```

Because both runs were on `refs/heads/main`, the later push cancelled the in-flight release after `Release Please` had already created the draft/tag and after some downstream publish jobs had already started. That left the release pipeline in a partially completed state.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Image" src="https://github.com/user-attachments/assets/1f9497f2-96ad-4334-b3a4-c63ff38abdb9"/>

</a>