### PR TITLE
ci: fix Blacksmith builder secret handling and bump setup action

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -94,6 +94,32 @@ runs:
         INPUT_CONTEXT: ${{ inputs.context }}
         INPUT_PREVIOUS_IMAGE: ${{ inputs.previous-image }}
 
+    - name: Prepare build secrets
+      id: prepare-secrets
+      shell: bash
+      run: |
+        {
+          echo "value<<EOF"
+
+          if [ -n "${INPUT_TURBO_TEAM}" ]; then
+            echo "turbo_team=${INPUT_TURBO_TEAM}"
+          fi
+
+          if [ -n "${INPUT_TURBO_TOKEN}" ]; then
+            echo "turbo_token=${INPUT_TURBO_TOKEN}"
+          fi
+
+          if [ -n "${INPUT_SENTRY_AUTH_TOKEN}" ]; then
+            echo "sentry_auth_token=${INPUT_SENTRY_AUTH_TOKEN}"
+          fi
+
+          echo "EOF"
+        } >> "${GITHUB_OUTPUT}"
+      env:
+        INPUT_SENTRY_AUTH_TOKEN: ${{ inputs.sentry-auth-token }}
+        INPUT_TURBO_TEAM: ${{ inputs.turbo-team }}
+        INPUT_TURBO_TOKEN: ${{ inputs.turbo-token }}
+
     - name: Setup Blacksmith Builder
       uses: ./.github/actions/setup-blacksmith-builder
 
@@ -110,7 +136,4 @@ runs:
         outputs: ${{ inputs.outputs }}
         network: host
         build-args: ${{ inputs.version != '' && format('VERSION={0}', inputs.version) || '' }}
-        secrets: |
-          turbo_team=${{ inputs.turbo-team }}
-          turbo_token=${{ inputs.turbo-token }}
-          ${{ inputs.sentry-auth-token != '' && format('sentry_auth_token={0}', inputs.sentry-auth-token) || '' }}
+        secrets: ${{ steps.prepare-secrets.outputs.value }}

--- a/.github/actions/setup-blacksmith-builder/action.yml
+++ b/.github/actions/setup-blacksmith-builder/action.yml
@@ -4,4 +4,4 @@ runs:
   using: composite
   steps:
     - name: Setup Blacksmith Builder
-      uses: useblacksmith/setup-docker-builder@ef12d5b165b596e3aa44ea8198d8fde563eab402 # v1.4.0
+      uses: useblacksmith/setup-docker-builder@ac083cc84672d01c60d5e8561d0a939b697de542 # v1.7.0


### PR DESCRIPTION
## Summary
- bump `.github/actions/setup-blacksmith-builder` from `useblacksmith/setup-docker-builder` `v1.4.0` to `v1.7.0`
- make `.github/actions/build-docker-image` construct its `secrets` payload dynamically so empty `turbo_team` and `turbo_token` values are omitted instead of forwarded as invalid `key=` entries

## Root Cause
`build-native-multi-arch-image.yml` is a shared reusable workflow. Some callers pass `TURBOREPO_REMOTE_CACHING_TEAM` and `TURBOREPO_REMOTE_CACHING_TOKEN`, but `build-base-mcp-server-docker-image.yml` does not. The composite action still emitted:

- `turbo_team=`
- `turbo_token=`

Those lines were forwarded to the Blacksmith build action and rejected as invalid secrets, which is why the failure only showed up on jobs where the Turborepo secrets were unset.

## Impact
Build jobs that do not provide Turborepo remote cache secrets should stop failing with `is not a valid secret`, while jobs that do provide those secrets continue to pass them through.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Image" src="https://github.com/user-attachments/assets/1f9497f2-96ad-4334-b3a4-c63ff38abdb9"/>

</a>