### PR TITLE
fix: remote MCP OAuth client credentials install payload

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -51,7 +51,6 @@ import {
   useMcpCatalogLabelKeys,
   useMcpCatalogLabelValues,
 } from "@/lib/mcp/internal-mcp-catalog.query";
-import { buildRemoteInstallCredentialPayload } from "@/lib/mcp/remote-install-payload";
 import {
   useInstallMcpServer,
   useMcpDeploymentStatuses,
@@ -59,6 +58,7 @@ import {
   useReauthenticateMcpServer,
   useReinstallMcpServer,
 } from "@/lib/mcp/mcp-server.query";
+import { buildRemoteInstallCredentialPayload } from "@/lib/mcp/remote-install-payload";
 import websocketService from "@/lib/websocket/websocket";
 import { CreateCatalogDialog } from "./create-catalog-dialog";
 import { CustomServerRequestDialog } from "./custom-server-request-dialog";

--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -51,6 +51,7 @@ import {
   useMcpCatalogLabelKeys,
   useMcpCatalogLabelValues,
 } from "@/lib/mcp/internal-mcp-catalog.query";
+import { buildRemoteInstallCredentialPayload } from "@/lib/mcp/remote-install-payload";
 import {
   useInstallMcpServer,
   useMcpDeploymentStatuses,
@@ -724,30 +725,14 @@ export function InternalMCPCatalog({
     catalogItem: CatalogItem,
     result: RemoteServerInstallResult,
   ) => {
-    // For non-BYOS mode: Extract access_token from metadata if present and pass as accessToken
-    // For BYOS mode: metadata contains vault references, pass via userConfigValues
-    const accessToken =
-      !result.isByosVault &&
-      result.metadata?.access_token &&
-      typeof result.metadata.access_token === "string"
-        ? result.metadata.access_token
-        : undefined;
+    const credentialPayload = buildRemoteInstallCredentialPayload(result);
 
     // Re-authentication mode: update existing server credentials in-place
     if (reauthServerId) {
       await reauthMutation.mutateAsync({
         id: reauthServerId,
         name: catalogItem.name,
-        ...(accessToken && { accessToken }),
-        ...(result.isByosVault && {
-          userConfigValues: result.metadata as Record<string, string>,
-        }),
-        ...(!result.isByosVault &&
-          !accessToken &&
-          result.metadata && {
-            userConfigValues: result.metadata as Record<string, string>,
-          }),
-        isByosVault: result.isByosVault,
+        ...credentialPayload,
       });
 
       closeDialog("remote-install");
@@ -761,11 +746,7 @@ export function InternalMCPCatalog({
     await installMutation.mutateAsync({
       name: catalogItem.name,
       catalogId: catalogItem.id,
-      ...(accessToken && { accessToken }),
-      ...(result.isByosVault && {
-        userConfigValues: result.metadata as Record<string, string>,
-      }),
-      isByosVault: result.isByosVault,
+      ...credentialPayload,
       teamId: result.teamId ?? undefined,
     });
     setInstallingItemId(null);

--- a/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.ts
+++ b/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.ts
@@ -22,12 +22,12 @@ import {
 } from "@/lib/auth/oauth-session";
 import { useDialogs } from "@/lib/hooks/use-dialog";
 import { useInternalMcpCatalog } from "@/lib/mcp/internal-mcp-catalog.query";
-import { buildRemoteInstallCredentialPayload } from "@/lib/mcp/remote-install-payload";
 import {
   useInstallMcpServer,
   useMcpServers,
   useReauthenticateMcpServer,
 } from "@/lib/mcp/mcp-server.query";
+import { buildRemoteInstallCredentialPayload } from "@/lib/mcp/remote-install-payload";
 import { redirectBrowserToUrl } from "@/lib/utils/browser-redirect";
 
 type DialogKey =

--- a/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.ts
+++ b/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.ts
@@ -22,6 +22,7 @@ import {
 } from "@/lib/auth/oauth-session";
 import { useDialogs } from "@/lib/hooks/use-dialog";
 import { useInternalMcpCatalog } from "@/lib/mcp/internal-mcp-catalog.query";
+import { buildRemoteInstallCredentialPayload } from "@/lib/mcp/remote-install-payload";
 import {
   useInstallMcpServer,
   useMcpServers,
@@ -218,28 +219,14 @@ export function useMcpInstallOrchestrator() {
     catalogItem: CatalogItem,
     result: RemoteServerInstallResult,
   ) => {
+    const credentialPayload = buildRemoteInstallCredentialPayload(result);
+
     // If in reauth mode, call reauthenticate endpoint instead of install
     if (reauthServerId) {
-      const accessToken =
-        !result.isByosVault &&
-        result.metadata?.access_token &&
-        typeof result.metadata.access_token === "string"
-          ? result.metadata.access_token
-          : undefined;
-
       await reauthMutation.mutateAsync({
         id: reauthServerId,
         name: catalogItem.name,
-        ...(accessToken && { accessToken }),
-        ...(result.isByosVault && {
-          userConfigValues: result.metadata as Record<string, string>,
-        }),
-        ...(!result.isByosVault &&
-          !accessToken &&
-          result.metadata && {
-            userConfigValues: result.metadata as Record<string, string>,
-          }),
-        isByosVault: result.isByosVault,
+        ...credentialPayload,
       });
 
       closeDialog("remote-install");
@@ -248,21 +235,10 @@ export function useMcpInstallOrchestrator() {
       return;
     }
 
-    const accessToken =
-      !result.isByosVault &&
-      result.metadata?.access_token &&
-      typeof result.metadata.access_token === "string"
-        ? result.metadata.access_token
-        : undefined;
-
     await installMutation.mutateAsync({
       name: catalogItem.name,
       catalogId: catalogItem.id,
-      ...(accessToken && { accessToken }),
-      ...(result.isByosVault && {
-        userConfigValues: result.metadata as Record<string, string>,
-      }),
-      isByosVault: result.isByosVault,
+      ...credentialPayload,
       teamId: result.teamId ?? undefined,
     });
   };

--- a/platform/frontend/src/lib/mcp/remote-install-payload.test.ts
+++ b/platform/frontend/src/lib/mcp/remote-install-payload.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { buildRemoteInstallCredentialPayload } from "./remote-install-payload";
+
+describe("buildRemoteInstallCredentialPayload", () => {
+  it("forwards client-credentials metadata as userConfigValues for standard installs", () => {
+    expect(
+      buildRemoteInstallCredentialPayload({
+        metadata: {
+          client_id: "client-id",
+          client_secret: "client-secret",
+          audience: "https://api.example.com",
+        },
+        isByosVault: false,
+      }),
+    ).toEqual({
+      userConfigValues: {
+        client_id: "client-id",
+        client_secret: "client-secret",
+        audience: "https://api.example.com",
+      },
+      isByosVault: false,
+    });
+  });
+
+  it("uses accessToken when metadata contains an access token", () => {
+    expect(
+      buildRemoteInstallCredentialPayload({
+        metadata: {
+          access_token: "pat-token",
+          client_id: "ignored-client-id",
+        },
+        isByosVault: false,
+      }),
+    ).toEqual({
+      accessToken: "pat-token",
+      isByosVault: false,
+    });
+  });
+
+  it("preserves BYOS metadata and stringifies scalar values", () => {
+    expect(
+      buildRemoteInstallCredentialPayload({
+        metadata: {
+          client_secret: "vault/path#secret",
+          retries: 3,
+          enabled: true,
+        },
+        isByosVault: true,
+      }),
+    ).toEqual({
+      userConfigValues: {
+        client_secret: "vault/path#secret",
+        retries: "3",
+        enabled: "true",
+      },
+      isByosVault: true,
+    });
+  });
+});

--- a/platform/frontend/src/lib/mcp/remote-install-payload.ts
+++ b/platform/frontend/src/lib/mcp/remote-install-payload.ts
@@ -1,0 +1,40 @@
+import type { RemoteServerInstallResult } from "@/app/mcp/registry/_parts/remote-server-install-dialog";
+
+export function buildRemoteInstallCredentialPayload(
+  result: Pick<RemoteServerInstallResult, "metadata" | "isByosVault">,
+) {
+  const accessToken =
+    !result.isByosVault &&
+    typeof result.metadata?.access_token === "string" &&
+    result.metadata.access_token.length > 0
+      ? result.metadata.access_token
+      : undefined;
+
+  const userConfigValues = accessToken
+    ? undefined
+    : normalizeUserConfigValues(result.metadata);
+
+  return {
+    ...(accessToken ? { accessToken } : {}),
+    ...(userConfigValues ? { userConfigValues } : {}),
+    isByosVault: result.isByosVault,
+  };
+}
+
+function normalizeUserConfigValues(
+  metadata: Record<string, unknown> | undefined,
+): Record<string, string> | undefined {
+  if (!metadata) {
+    return undefined;
+  }
+
+  const entries = Object.entries(metadata)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([key, value]) => [key, String(value)] as const);
+
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(entries);
+}


### PR DESCRIPTION
## What changed
Fixes the remote MCP install and re-auth flows so OAuth 2.0 client-credentials fields are forwarded as `userConfigValues` instead of being dropped unless the metadata contained an `access_token`.

The frontend now builds remote install credential payloads in one shared helper and reuses that logic from both remote install entry points.

## Why
A user configuring a remote MCP server with the OAuth 2.0 client-credentials strategy could fill in `client_id` and `client_secret` in the UI, but those values were not included in the install request payload for the standard non-BYOS path.

The backend already supports persisting and validating `userConfigValues` for remote servers, so the failure was caused by frontend payload shaping.

## Impact
Remote MCP servers using shared OAuth client credentials now send `client_id`, `client_secret`, and optional `audience` during install and re-authentication.

PAT-style flows that use `access_token` continue to use the existing `accessToken` path.

## Root cause
The remote install dialog collected credential metadata correctly, but the frontend handoff only forwarded `userConfigValues` for BYOS installs. In the normal path, any metadata other than `access_token` was discarded before the API call.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Image" src="https://github.com/user-attachments/assets/1f9497f2-96ad-4334-b3a4-c63ff38abdb9"/>

</a>