### PR TITLE
docs: clarify enterprise-managed credential setup

### DIFF
--- a/docs/pages/mcp-authentication.md
+++ b/docs/pages/mcp-authentication.md
@@ -263,6 +263,8 @@ Configure all three of the following:
 - **MCP catalog item**: In the server's multitenant authorization settings, choose either **Identity Provider Token Exchange** to exchange the caller's IdP token for a downstream token, or **Identity Provider JWT / JWKS** to forward the caller's IdP JWT directly.
 - **Tool assignment**: Assign the tool with **Resolve at call time** so Archestra resolves credentials per caller when the tool runs.
 
+See [Identity Providers - Using Enterprise-Managed Credentials for Downstream MCP Calls](/docs/platform-identity-providers#using-enterprise-managed-credentials-for-downstream-mcp-calls) for the Identity Provider form fields and where this is configured in the UI.
+
 This works best when the gateway auth path gives Archestra a user-specific identity it can reuse for downstream access, such as **JWKS** or **ID-JAG**.
 
 #### Token Exchange Configuration

--- a/docs/pages/mcp-authentication.md
+++ b/docs/pages/mcp-authentication.md
@@ -263,9 +263,9 @@ Configure all three of the following:
 - **MCP catalog item**: In the server's multitenant authorization settings, choose either **Identity Provider Token Exchange** to exchange the caller's IdP token for a downstream token, or **Identity Provider JWT / JWKS** to forward the caller's IdP JWT directly.
 - **Tool assignment**: Assign the tool with **Resolve at call time** so Archestra resolves credentials per caller when the tool runs.
 
-See [Identity Providers - Using Enterprise-Managed Credentials for Downstream MCP Calls](/docs/platform-identity-providers#using-enterprise-managed-credentials-for-downstream-mcp-calls) for the Identity Provider form fields and where this is configured in the UI.
+See [Identity Providers - Using Enterprise-Managed Credentials for Downstream MCP Calls](/docs/platform-identity-providers#using-enterprise-managed-credentials-for-downstream-mcp-calls) for related setup details.
 
-This works best when the gateway auth path gives Archestra a user-specific identity it can reuse for downstream access, such as **JWKS** or **ID-JAG**.
+This works with any gateway auth method that lets Archestra resolve a specific user and a usable IdP token for that user. In practice, **JWKS** and **ID-JAG** are the clearest options, **OAuth 2.1** also works when the authenticated Archestra user has a linked session with the same IdP, and personal user bearer tokens can work when they map to a specific user with a linked IdP session. Team and organization bearer tokens do not carry enough user identity for per-user downstream token exchange.
 
 #### Token Exchange Configuration
 

--- a/docs/pages/platform-identity-providers.md
+++ b/docs/pages/platform-identity-providers.md
@@ -224,6 +224,18 @@ Provider defaults:
 - **RFC 8693 token exchange** defaults to client secret POST and access token exchange
 - **Microsoft Entra OBO** defaults to client secret POST and access token exchange
 
+#### Using Enterprise-Managed Credentials for Downstream MCP Calls
+
+To use this with an MCP server, you need to configure three places:
+
+1. **Identity Provider**: In **Settings > Identity Providers**, open the OIDC provider and complete the **Enterprise-Managed Credentials** section. The main fields are **Exchange Client ID**, **Exchange Client Secret**, **Exchange Token Endpoint**, **Exchange Client Authentication**, and **User Token To Exchange**.
+2. **MCP catalog item**: In the server's multitenant authorization settings, choose **Identity Provider Token Exchange**. Then set the **Requested Credential**, **Injection Mode**, and the **Managed Resource Identifier** or scopes for the downstream API.
+3. **Tool assignment**: Assign the tool with **Resolve at call time** so Archestra resolves the downstream credential for the caller when the tool runs.
+
+This works best when the gateway auth path gives Archestra a user-specific identity, usually **JWKS** or **ID-JAG**. **OAuth 2.1** also works when the authenticated Archestra user has a linked session with the same IdP.
+
+For local MCP servers, this requires HTTP transport. Local `stdio` servers do not support per-request token exchange and injection. See [MCP Authentication - Upstream Identity Provider Token Exchange](/docs/mcp-authentication#upstream-identity-provider-token-exchange) for the downstream credential flow.
+
 ### Generic SAML
 
 Archestra supports SAML 2.0 for enterprise identity providers that don't support OIDC.

--- a/docs/pages/platform-identity-providers.md
+++ b/docs/pages/platform-identity-providers.md
@@ -232,7 +232,7 @@ To use this with an MCP server, you need to configure three places:
 2. **MCP catalog item**: In the server's multitenant authorization settings, choose **Identity Provider Token Exchange**. Then set the **Requested Credential**, **Injection Mode**, and the **Managed Resource Identifier** or scopes for the downstream API.
 3. **Tool assignment**: Assign the tool with **Resolve at call time** so Archestra resolves the downstream credential for the caller when the tool runs.
 
-This works best when the gateway auth path gives Archestra a user-specific identity, usually **JWKS** or **ID-JAG**. **OAuth 2.1** also works when the authenticated Archestra user has a linked session with the same IdP.
+This works with any gateway auth method that lets Archestra resolve a specific user and a usable IdP token for that user. In practice, **JWKS** and **ID-JAG** are the clearest options, **OAuth 2.1** also works when the authenticated Archestra user has a linked session with the same IdP, and personal user bearer tokens can work when they map to a specific user with a linked IdP session. Team and organization bearer tokens do not carry enough user identity for per-user downstream token exchange.
 
 For local MCP servers, this requires HTTP transport. Local `stdio` servers do not support per-request token exchange and injection. See [MCP Authentication - Upstream Identity Provider Token Exchange](/docs/mcp-authentication#upstream-identity-provider-token-exchange) for the downstream credential flow.
 


### PR DESCRIPTION
## Summary
- add a dedicated Identity Providers subsection for enterprise-managed credentials on downstream MCP calls
- cross-link that subsection with the MCP Authentication token exchange section
- clarify the three places customers need to configure this flow

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Image" src="https://github.com/user-attachments/assets/1f9497f2-96ad-4334-b3a4-c63ff38abdb9"/>

</a>