### PR TITLE
chore: ignore local Claude scheduler lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ platform/CLAUDE_LOCAL.md
 __pycache__/
 
 .claude/worktrees/
+.claude/*.lock
 .turbo/
 


### PR DESCRIPTION
Adds .claude/*.lock to .gitignore so transient state files from the Claude Code scheduler (e.g. scheduled_tasks.lock) don't show up as untracked changes.