### PR TITLE
fix: enforce SSO allowed email domains

### DIFF
--- a/docs/pages/platform-identity-providers.md
+++ b/docs/pages/platform-identity-providers.md
@@ -35,10 +35,22 @@ Archestra supports Identity Provider (IdP) configuration for three purposes:
 1. Admin configures an Identity Provider in **Settings > Identity Providers**
 2. SSO buttons appear on the sign-in page for enabled providers
 3. Users click the SSO button and authenticate with their identity provider
-4. Archestra verifies the authenticated email belongs to the provider's configured domain
+4. Archestra verifies the authenticated email belongs to the provider's allowed email domains
 5. After successful authentication, users are automatically provisioned and logged in
 
 ![Sign-in with SSO](/docs/automated_screenshots/platform-identity-providers_sign-in-with-sso.webp)
+
+### Allowed Email Domains
+
+The **Allowed Email Domains** field is the Archestra-side sign-in boundary for an SSO provider. Users can sign in with that provider only when the email returned by the identity provider matches one of the configured domains.
+
+Use comma-separated domains for multi-domain SSO, for example:
+
+```
+company.com, subsidiary.com
+```
+
+Subdomains are included. For example, `engineering.company.com` matches `company.com`.
 
 ## Disabling Basic Authentication
 
@@ -117,13 +129,13 @@ Google OAuth allows users to sign in with their Google accounts.
 5. Add your callback URL: `https://your-domain.com/api/auth/sso/callback/Google`
 6. Copy the **Client ID** and **Client Secret**
 7. In Archestra, click **Enable** on the Google card
-8. Enter your domain and the credentials
+8. Enter the allowed email domains and the credentials
 
 **Google-specific notes:**
 
 - Users must have a Google Workspace or personal Google account
 - The discovery endpoint is automatically configured
-- Optional: set **Hosted Domain Hint** to pass Google's `hd` parameter and prefer account selection for a specific Google Workspace domain (for example `example.com`). Archestra still enforces the configured provider domain after Google returns the authenticated email.
+- Optional: set **Hosted Domain Hint** to pass Google's `hd` parameter and prefer account selection for a specific Google Workspace domain (for example `example.com`). Archestra still enforces **Allowed Email Domains** after Google returns the authenticated email.
 
 ### GitHub
 
@@ -134,7 +146,7 @@ GitHub OAuth allows users to sign in with their GitHub accounts.
 3. Set the **Authorization callback URL** to: `https://your-domain.com/api/auth/sso/callback/GitHub`
 4. Copy the **Client ID** and generate a **Client Secret**
 5. In Archestra, click **Enable** on the GitHub card
-6. Enter your domain and the credentials
+6. Enter the allowed email domains and the credentials
 
 **GitHub limitations:**
 
@@ -153,7 +165,7 @@ GitLab OAuth allows users to sign in with their GitLab accounts (both GitLab.com
 5. Click **Save application**
 6. Copy the **Application ID** (Client ID) and **Secret** (Client Secret)
 7. In Archestra, click **Enable** on the GitLab card
-8. Enter your domain and the credentials
+8. Enter the allowed email domains and the credentials
 
 **GitLab-specific notes:**
 
@@ -174,7 +186,7 @@ Microsoft Entra ID (formerly Azure AD) allows users to sign in with their Micros
 7. Note your **Directory (tenant) ID** from the Overview page
 8. In Archestra, click **Enable** on the Microsoft Entra ID card
 9. Replace `{tenant-id}` in all URLs with your actual tenant ID
-10. Enter your domain and the credentials
+10. Enter the allowed email domains and the credentials
 
 **Entra ID-specific notes:**
 
@@ -191,7 +203,7 @@ Required information:
 
 - **Provider ID**: A unique identifier (e.g., `azure`, `auth0`)
 - **Issuer**: The OIDC issuer URL
-- **Domain**: Your organization's domain
+- **Allowed Email Domains**: Email domains allowed to sign in through this provider. Use comma-separated domains for multi-domain SSO.
 - **Client ID** and **Client Secret**: From your identity provider
 - **Discovery Endpoint**: The `.well-known/openid-configuration` URL (optional if issuer supports discovery)
 
@@ -213,7 +225,7 @@ Required information:
 
 - **Provider ID**: A unique identifier (e.g., `okta-saml`, `adfs`)
 - **Issuer**: Your organization's identifier
-- **Domain**: Your organization's domain
+- **Allowed Email Domains**: Email domains allowed to sign in through this provider. Use comma-separated domains for multi-domain SSO.
 - **SAML Issuer / Entity ID**: The identity provider's entity ID (from IdP metadata)
 - **SSO Entry Point URL**: The IdP's Single Sign-On URL
 - **IdP Certificate**: The X.509 certificate from your IdP for signature verification

--- a/docs/pages/platform-identity-providers.md
+++ b/docs/pages/platform-identity-providers.md
@@ -3,7 +3,7 @@ title: "Identity Providers"
 category: Administration
 description: "Configure Identity Providers for SSO authentication, MCP Gateway JWKS validation, and IdP token exchange for downstream MCP calls"
 order: 2
-lastUpdated: 2026-04-17
+lastUpdated: 2026-04-20
 ---
 
 <!--
@@ -35,7 +35,8 @@ Archestra supports Identity Provider (IdP) configuration for three purposes:
 1. Admin configures an Identity Provider in **Settings > Identity Providers**
 2. SSO buttons appear on the sign-in page for enabled providers
 3. Users click the SSO button and authenticate with their identity provider
-4. After successful authentication, users are automatically provisioned and logged in
+4. Archestra verifies the authenticated email belongs to the provider's configured domain
+5. After successful authentication, users are automatically provisioned and logged in
 
 ![Sign-in with SSO](/docs/automated_screenshots/platform-identity-providers_sign-in-with-sso.webp)
 
@@ -122,7 +123,7 @@ Google OAuth allows users to sign in with their Google accounts.
 
 - Users must have a Google Workspace or personal Google account
 - The discovery endpoint is automatically configured
-- Optional: set **Hosted Domain Hint** to pass Google's `hd` parameter and prefer or restrict account selection to a specific Google Workspace domain (for example `example.com`)
+- Optional: set **Hosted Domain Hint** to pass Google's `hd` parameter and prefer account selection for a specific Google Workspace domain (for example `example.com`). Archestra still enforces the configured provider domain after Google returns the authenticated email.
 
 ### GitHub
 

--- a/platform/backend/src/auth/better-auth.test.ts
+++ b/platform/backend/src/auth/better-auth.test.ts
@@ -3,7 +3,7 @@ import { APIError } from "better-auth";
 import { vi } from "vitest";
 import { cacheManager } from "@/cache-manager";
 import type * as originalConfigModule from "@/config";
-import { MemberModel, TeamModel } from "@/models";
+import { MemberModel, SessionModel, TeamModel } from "@/models";
 import { beforeEach, describe, expect, test } from "@/test";
 
 // Create a hoisted ref to control disableInvitations in tests
@@ -552,6 +552,80 @@ describe("handleAfterHook", () => {
       });
 
       await expect(handleAfterHook(ctx)).resolves.toBeUndefined();
+    });
+
+    test("should reject SSO login when user email does not match provider domain", async ({
+      makeUser,
+      makeOrganization,
+      makeMember,
+      makeIdentityProvider,
+      makeSession,
+    }) => {
+      const user = await makeUser({ email: "person@other.com" });
+      const org = await makeOrganization();
+      await makeMember(user.id, org.id, { role: "member" });
+      await makeIdentityProvider(org.id, {
+        providerId: "google-workspace",
+        domain: "example.com",
+      });
+      const session = await makeSession(user.id, {
+        activeOrganizationId: org.id,
+      });
+
+      const ctx = createMockContext({
+        path: "/sso/callback/google-workspace",
+        method: "GET",
+        body: {},
+        context: {
+          newSession: {
+            user: { id: user.id, email: user.email },
+            session: { id: session.id, activeOrganizationId: org.id },
+          },
+        },
+      });
+
+      await expect(handleAfterHook(ctx)).rejects.toMatchObject({
+        status: "FORBIDDEN",
+        body: {
+          message:
+            "Your email domain is not allowed for this identity provider.",
+        },
+      });
+      expect(await SessionModel.getById(session.id)).toHaveLength(0);
+    });
+
+    test("should allow SSO login when user email matches provider domain", async ({
+      makeUser,
+      makeOrganization,
+      makeMember,
+      makeIdentityProvider,
+      makeSession,
+    }) => {
+      const user = await makeUser({ email: "person@example.com" });
+      const org = await makeOrganization();
+      await makeMember(user.id, org.id, { role: "member" });
+      await makeIdentityProvider(org.id, {
+        providerId: "google-workspace-allowed",
+        domain: "example.com",
+      });
+      const session = await makeSession(user.id, {
+        activeOrganizationId: org.id,
+      });
+
+      const ctx = createMockContext({
+        path: "/sso/callback/google-workspace-allowed",
+        method: "GET",
+        body: {},
+        context: {
+          newSession: {
+            user: { id: user.id, email: user.email },
+            session: { id: session.id, activeOrganizationId: org.id },
+          },
+        },
+      });
+
+      await expect(handleAfterHook(ctx)).resolves.toBeUndefined();
+      expect(await SessionModel.getById(session.id)).toHaveLength(1);
     });
 
     test("should handle user without any memberships", async ({ makeUser }) => {

--- a/platform/backend/src/auth/better-auth.test.ts
+++ b/platform/backend/src/auth/better-auth.test.ts
@@ -3,7 +3,13 @@ import { APIError } from "better-auth";
 import { vi } from "vitest";
 import { cacheManager } from "@/cache-manager";
 import type * as originalConfigModule from "@/config";
-import { MemberModel, SessionModel, TeamModel } from "@/models";
+import {
+  AccountModel,
+  MemberModel,
+  SessionModel,
+  TeamModel,
+  UserModel,
+} from "@/models";
 import { beforeEach, describe, expect, test } from "@/test";
 
 // Create a hoisted ref to control disableInvitations in tests
@@ -560,14 +566,17 @@ describe("handleAfterHook", () => {
       makeMember,
       makeIdentityProvider,
       makeSession,
+      makeAccount,
     }) => {
       const user = await makeUser({ email: "person@other.com" });
       const org = await makeOrganization();
       await makeMember(user.id, org.id, { role: "member" });
+      await makeAccount(user.id, { providerId: "credential" });
       await makeIdentityProvider(org.id, {
         providerId: "google-workspace",
         domain: "example.com",
       });
+      await makeAccount(user.id, { providerId: "google-workspace" });
       const session = await makeSession(user.id, {
         activeOrganizationId: org.id,
       });
@@ -592,6 +601,55 @@ describe("handleAfterHook", () => {
         },
       });
       expect(await SessionModel.getById(session.id)).toHaveLength(0);
+      expect(
+        await AccountModel.getLatestSsoAccountByUserIdAndProviderId(
+          user.id,
+          "google-workspace",
+        ),
+      ).toBeUndefined();
+      expect(await MemberModel.getByUserId(user.id, org.id)).toBeDefined();
+      expect(await UserModel.findByEmail(user.email)).toBeDefined();
+    });
+
+    test("should clean up rows created by a rejected first-time SSO login", async ({
+      makeUser,
+      makeOrganization,
+      makeMember,
+      makeIdentityProvider,
+      makeSession,
+      makeAccount,
+    }) => {
+      const user = await makeUser({ email: "new-person@other.com" });
+      const org = await makeOrganization();
+      await makeMember(user.id, org.id, { role: "member" });
+      await makeIdentityProvider(org.id, {
+        providerId: "google-workspace-new-user",
+        domain: "example.com",
+      });
+      await makeAccount(user.id, { providerId: "google-workspace-new-user" });
+      const session = await makeSession(user.id, {
+        activeOrganizationId: org.id,
+      });
+
+      const ctx = createMockContext({
+        path: "/sso/callback/google-workspace-new-user",
+        method: "GET",
+        body: {},
+        context: {
+          newSession: {
+            user: { id: user.id, email: user.email },
+            session: { id: session.id, activeOrganizationId: org.id },
+          },
+        },
+      });
+
+      await expect(handleAfterHook(ctx)).rejects.toMatchObject({
+        status: "FORBIDDEN",
+      });
+      expect(await SessionModel.getById(session.id)).toHaveLength(0);
+      expect(await AccountModel.getAllByUserId(user.id)).toHaveLength(0);
+      expect(await MemberModel.getByUserId(user.id, org.id)).toBeUndefined();
+      expect(await UserModel.findByEmail(user.email)).toBeUndefined();
     });
 
     test("should allow SSO login when user email matches provider domain", async ({

--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -27,10 +27,12 @@ import db, { schema } from "@/database";
 import logger from "@/logging";
 import { LOG_LEVEL } from "@/logging/log-level";
 // Import directly from files to avoid circular dependency through barrel export
+import AccountModel from "@/models/account";
 import AgentModel from "@/models/agent";
 import InvitationModel from "@/models/invitation";
 import MemberModel from "@/models/member";
 import SessionModel from "@/models/session";
+import UserModel from "@/models/user";
 
 const { ssoConfig, syncSsoRole, syncSsoTeams } = config.enterpriseFeatures.core
   ? // biome-ignore lint/style/noRestrictedImports: EE-only SSO config
@@ -786,6 +788,7 @@ export async function handleAfterHook(ctx: HookEndpointContext) {
         await assertSsoEmailDomainAllowed({
           providerId: providerIdHint,
           userEmail: user.email,
+          userId,
           sessionId,
         });
       }
@@ -917,6 +920,7 @@ function getSsoCallbackProviderId(params: {
 async function assertSsoEmailDomainAllowed(params: {
   providerId: string;
   userEmail: string;
+  userId: string;
   sessionId: string;
 }) {
   if (!config.enterpriseFeatures.core) {
@@ -939,7 +943,12 @@ async function assertSsoEmailDomainAllowed(params: {
     return;
   }
 
-  await SessionModel.deleteById(params.sessionId);
+  await cleanupRejectedSsoLogin({
+    providerId: params.providerId,
+    organizationId: provider.organizationId,
+    userId: params.userId,
+    sessionId: params.sessionId,
+  });
   logger.warn(
     {
       providerId: params.providerId,
@@ -952,6 +961,34 @@ async function assertSsoEmailDomainAllowed(params: {
   throw new APIError("FORBIDDEN", {
     message: "Your email domain is not allowed for this identity provider.",
   });
+}
+
+async function cleanupRejectedSsoLogin(params: {
+  providerId: string;
+  organizationId: string | null;
+  userId: string;
+  sessionId: string;
+}) {
+  await SessionModel.deleteById(params.sessionId);
+  await AccountModel.deleteByUserIdAndProviderId({
+    userId: params.userId,
+    providerId: params.providerId,
+  });
+
+  const accounts = await AccountModel.getAllByUserId(params.userId);
+
+  if (accounts.length === 0 && params.organizationId) {
+    await MemberModel.deleteByMemberOrUserId(
+      params.userId,
+      params.organizationId,
+    );
+  }
+
+  const hasMembership = await MemberModel.hasAnyMembership(params.userId);
+
+  if (accounts.length === 0 && !hasMembership) {
+    await UserModel.delete(params.userId);
+  }
 }
 
 function emailMatchesIdentityProviderDomain(

--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -1004,5 +1004,7 @@ function emailMatchesIdentityProviderDomain(
     .split(",")
     .map((domain) => domain.trim().toLowerCase())
     .filter(Boolean)
-    .some((domain) => emailDomain === domain);
+    .some(
+      (domain) => emailDomain === domain || emailDomain.endsWith(`.${domain}`),
+    );
 }

--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -775,6 +775,21 @@ export async function handleAfterHook(ctx: HookEndpointContext) {
         "[auth:afterHook] Processing sign-in/SSO callback",
       );
 
+      const providerIdHint = path.startsWith("/sso/callback")
+        ? getSsoCallbackProviderId({
+            path,
+            requestUrl: request?.url,
+          })
+        : undefined;
+
+      if (providerIdHint) {
+        await assertSsoEmailDomainAllowed({
+          providerId: providerIdHint,
+          userEmail: user.email,
+          sessionId,
+        });
+      }
+
       // Auto-accept any pending invitations for this user's email
       try {
         const pendingInvitation = await InvitationModel.findPendingByEmail(
@@ -849,11 +864,6 @@ export async function handleAfterHook(ctx: HookEndpointContext) {
       // SSO Role & Team Sync: Synchronize role and team memberships based on SSO claims
       // Only applies to SSO logins (not regular email/password logins)
       if (path.startsWith("/sso/callback")) {
-        const providerIdHint = getSsoCallbackProviderId({
-          path,
-          requestUrl: request?.url,
-        });
-
         logger.debug(
           { userId, email: user.email, providerIdHint },
           "[auth:afterHook] Processing SSO role and team sync",
@@ -902,4 +912,60 @@ function getSsoCallbackProviderId(params: {
   }
 
   return providerId || undefined;
+}
+
+async function assertSsoEmailDomainAllowed(params: {
+  providerId: string;
+  userEmail: string;
+  sessionId: string;
+}) {
+  if (!config.enterpriseFeatures.core) {
+    return;
+  }
+
+  const { default: IdentityProviderModel } = await import(
+    // biome-ignore lint/style/noRestrictedImports: runtime-gated EE model import
+    "@/models/identity-provider.ee"
+  );
+  const provider = await IdentityProviderModel.findByProviderId(
+    params.providerId,
+  );
+
+  if (!provider?.domain) {
+    return;
+  }
+
+  if (emailMatchesIdentityProviderDomain(params.userEmail, provider.domain)) {
+    return;
+  }
+
+  await SessionModel.deleteById(params.sessionId);
+  logger.warn(
+    {
+      providerId: params.providerId,
+      userEmail: params.userEmail,
+      providerDomain: provider.domain,
+    },
+    "[auth:afterHook] SSO login denied because user email domain does not match identity provider domain",
+  );
+
+  throw new APIError("FORBIDDEN", {
+    message: "Your email domain is not allowed for this identity provider.",
+  });
+}
+
+function emailMatchesIdentityProviderDomain(
+  email: string,
+  providerDomain: string,
+) {
+  const emailDomain = email.split("@")[1]?.trim().toLowerCase();
+  if (!emailDomain) {
+    return false;
+  }
+
+  return providerDomain
+    .split(",")
+    .map((domain) => domain.trim().toLowerCase())
+    .filter(Boolean)
+    .some((domain) => emailDomain === domain);
 }

--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -6,6 +6,8 @@ import {
   ARCHESTRA_TOKEN_PREFIX,
   AUTO_PROVISIONED_INVITATION_STATUS,
   DEFAULT_APP_NAME,
+  emailMatchesAllowedIdentityProviderDomains,
+  getEmailDomain,
   IDENTITY_TRUSTED_PROVIDER_IDS,
   OAUTH_PAGES,
   OAUTH_SCOPES,
@@ -939,7 +941,12 @@ async function assertSsoEmailDomainAllowed(params: {
     return;
   }
 
-  if (emailMatchesIdentityProviderDomain(params.userEmail, provider.domain)) {
+  if (
+    emailMatchesAllowedIdentityProviderDomains(
+      params.userEmail,
+      provider.domain,
+    )
+  ) {
     return;
   }
 
@@ -952,7 +959,7 @@ async function assertSsoEmailDomainAllowed(params: {
   logger.warn(
     {
       providerId: params.providerId,
-      userEmail: params.userEmail,
+      emailDomain: getEmailDomain(params.userEmail),
       providerDomain: provider.domain,
     },
     "[auth:afterHook] SSO login denied because user email domain does not match identity provider domain",
@@ -969,42 +976,28 @@ async function cleanupRejectedSsoLogin(params: {
   userId: string;
   sessionId: string;
 }) {
-  await SessionModel.deleteById(params.sessionId);
-  await AccountModel.deleteByUserIdAndProviderId({
-    userId: params.userId,
-    providerId: params.providerId,
+  await db.transaction(async (tx) => {
+    await SessionModel.deleteById(params.sessionId, tx);
+    await AccountModel.deleteByUserIdAndProviderId({
+      userId: params.userId,
+      providerId: params.providerId,
+      tx,
+    });
+
+    const accounts = await AccountModel.getAllByUserId(params.userId, tx);
+
+    if (accounts.length === 0 && params.organizationId) {
+      await MemberModel.deleteByMemberOrUserId(
+        params.userId,
+        params.organizationId,
+        tx,
+      );
+    }
+
+    const hasMembership = await MemberModel.hasAnyMembership(params.userId, tx);
+
+    if (accounts.length === 0 && !hasMembership) {
+      await UserModel.delete(params.userId, tx);
+    }
   });
-
-  const accounts = await AccountModel.getAllByUserId(params.userId);
-
-  if (accounts.length === 0 && params.organizationId) {
-    await MemberModel.deleteByMemberOrUserId(
-      params.userId,
-      params.organizationId,
-    );
-  }
-
-  const hasMembership = await MemberModel.hasAnyMembership(params.userId);
-
-  if (accounts.length === 0 && !hasMembership) {
-    await UserModel.delete(params.userId);
-  }
-}
-
-function emailMatchesIdentityProviderDomain(
-  email: string,
-  providerDomain: string,
-) {
-  const emailDomain = email.split("@")[1]?.trim().toLowerCase();
-  if (!emailDomain) {
-    return false;
-  }
-
-  return providerDomain
-    .split(",")
-    .map((domain) => domain.trim().toLowerCase())
-    .filter(Boolean)
-    .some(
-      (domain) => emailDomain === domain || emailDomain.endsWith(`.${domain}`),
-    );
 }

--- a/platform/backend/src/models/account.ts
+++ b/platform/backend/src/models/account.ts
@@ -24,12 +24,13 @@ class AccountModel {
    * Get all accounts for a user ordered by updatedAt DESC (most recent first)
    * Used to find the most recently used SSO account for team sync
    */
-  static async getAllByUserId(userId: string) {
+  static async getAllByUserId(userId: string, tx?: Transaction) {
     logger.debug(
       { userId },
       "AccountModel.getAllByUserId: fetching all accounts",
     );
-    const accounts = await db
+    const dbOrTx = tx ?? db;
+    const accounts = await dbOrTx
       .select()
       .from(schema.accountsTable)
       .where(eq(schema.accountsTable.userId, userId))
@@ -140,12 +141,18 @@ class AccountModel {
   static async deleteByUserIdAndProviderId(params: {
     userId: string;
     providerId: string;
+    tx?: Transaction;
   }) {
+    const logContext = {
+      userId: params.userId,
+      providerId: params.providerId,
+    };
     logger.debug(
-      params,
+      logContext,
       "AccountModel.deleteByUserIdAndProviderId: deleting account",
     );
-    const deleted = await db
+    const dbOrTx = params.tx ?? db;
+    const deleted = await dbOrTx
       .delete(schema.accountsTable)
       .where(
         and(
@@ -155,7 +162,7 @@ class AccountModel {
       )
       .returning({ id: schema.accountsTable.id });
     logger.debug(
-      { ...params, count: deleted.length },
+      { ...logContext, count: deleted.length },
       "AccountModel.deleteByUserIdAndProviderId: completed",
     );
     return deleted.length;

--- a/platform/backend/src/models/account.ts
+++ b/platform/backend/src/models/account.ts
@@ -137,6 +137,30 @@ class AccountModel {
     return account ?? null;
   }
 
+  static async deleteByUserIdAndProviderId(params: {
+    userId: string;
+    providerId: string;
+  }) {
+    logger.debug(
+      params,
+      "AccountModel.deleteByUserIdAndProviderId: deleting account",
+    );
+    const deleted = await db
+      .delete(schema.accountsTable)
+      .where(
+        and(
+          eq(schema.accountsTable.userId, params.userId),
+          eq(schema.accountsTable.providerId, params.providerId),
+        ),
+      )
+      .returning({ id: schema.accountsTable.id });
+    logger.debug(
+      { ...params, count: deleted.length },
+      "AccountModel.deleteByUserIdAndProviderId: completed",
+    );
+    return deleted.length;
+  }
+
   /**
    * Delete all accounts with a specific providerId.
    * This is used to clean up SSO accounts when an SSO provider is deleted,

--- a/platform/backend/src/models/member.ts
+++ b/platform/backend/src/models/member.ts
@@ -1,6 +1,6 @@
 import type { AnyRoleName } from "@shared";
 import { and, count, eq, ilike, inArray, or } from "drizzle-orm";
-import db, { schema } from "@/database";
+import db, { schema, type Transaction } from "@/database";
 import { createPaginatedResult } from "@/database/utils/pagination";
 import logger from "@/logging";
 
@@ -101,9 +101,13 @@ class MemberModel {
    * Count memberships for a user across all organizations
    * Used to check if user should be deleted after member removal
    */
-  static async countByUserId(userId: string): Promise<number> {
+  static async countByUserId(
+    userId: string,
+    tx?: Transaction,
+  ): Promise<number> {
     logger.debug({ userId }, "MemberModel.countByUserId: counting memberships");
-    const [result] = await db
+    const dbOrTx = tx ?? db;
+    const [result] = await dbOrTx
       .select({ count: count() })
       .from(schema.membersTable)
       .where(eq(schema.membersTable.userId, userId));
@@ -118,12 +122,15 @@ class MemberModel {
   /**
    * Check if a user has any memberships remaining
    */
-  static async hasAnyMembership(userId: string): Promise<boolean> {
+  static async hasAnyMembership(
+    userId: string,
+    tx?: Transaction,
+  ): Promise<boolean> {
     logger.debug(
       { userId },
       "MemberModel.hasAnyMembership: checking for memberships",
     );
-    const memberCount = await MemberModel.countByUserId(userId);
+    const memberCount = await MemberModel.countByUserId(userId, tx);
     const hasMembership = memberCount > 0;
     logger.debug(
       { userId, hasMembership },
@@ -312,20 +319,22 @@ class MemberModel {
   static async deleteByMemberOrUserId(
     memberIdOrUserId: string,
     organizationId: string,
+    tx?: Transaction,
   ) {
     logger.debug(
       { memberIdOrUserId, organizationId },
       "MemberModel.deleteByMemberOrUserId: deleting member",
     );
+    const dbOrTx = tx ?? db;
     // Try to delete by member ID first
-    let deleted = await db
+    let deleted = await dbOrTx
       .delete(schema.membersTable)
       .where(eq(schema.membersTable.id, memberIdOrUserId))
       .returning();
 
     // If not found, try by user ID + organization ID
     if (!deleted[0] && organizationId) {
-      deleted = await db
+      deleted = await dbOrTx
         .delete(schema.membersTable)
         .where(
           and(

--- a/platform/backend/src/models/session.test.ts
+++ b/platform/backend/src/models/session.test.ts
@@ -93,6 +93,26 @@ describe("SessionModel", () => {
   });
 
   describe("deleteAllByUserId", () => {
+    test("should delete a session by ID", async () => {
+      await SessionModel.deleteById(testSessionId);
+
+      const deletedSession = await SessionModel.getById(testSessionId);
+      expect(deletedSession).toHaveLength(0);
+
+      const otherUserSessions = await SessionModel.getByUserId(testUser2Id);
+      expect(otherUserSessions).toHaveLength(1);
+      expect(otherUserSessions[0]?.id).toBe(testSession3Id);
+    });
+
+    test("should handle non-existent session ID gracefully", async () => {
+      await expect(
+        SessionModel.deleteById(crypto.randomUUID()),
+      ).resolves.not.toThrow();
+
+      const existingSessions = await SessionModel.getAll();
+      expect(existingSessions).toHaveLength(3);
+    });
+
     test("should delete all sessions for a user", async () => {
       // Verify sessions exist before deletion
       const sessionsBefore = await SessionModel.getByUserId(testUserId);

--- a/platform/backend/src/models/session.ts
+++ b/platform/backend/src/models/session.ts
@@ -1,5 +1,5 @@
 import { eq } from "drizzle-orm";
-import db, { schema } from "@/database";
+import db, { schema, type Transaction } from "@/database";
 import logger from "@/logging";
 import type { InsertSession, UpdateSession } from "@/types";
 
@@ -82,9 +82,10 @@ class SessionModel {
   /**
    * Delete a session by ID
    */
-  static async deleteById(id: string) {
+  static async deleteById(id: string, tx?: Transaction) {
     logger.debug({ id }, "SessionModel.deleteById: deleting session");
-    const result = await db
+    const dbOrTx = tx ?? db;
+    const result = await dbOrTx
       .delete(schema.sessionsTable)
       .where(eq(schema.sessionsTable.id, id));
     logger.debug({ id }, "SessionModel.deleteById: completed");

--- a/platform/backend/src/models/session.ts
+++ b/platform/backend/src/models/session.ts
@@ -80,6 +80,18 @@ class SessionModel {
   }
 
   /**
+   * Delete a session by ID
+   */
+  static async deleteById(id: string) {
+    logger.debug({ id }, "SessionModel.deleteById: deleting session");
+    const result = await db
+      .delete(schema.sessionsTable)
+      .where(eq(schema.sessionsTable.id, id));
+    logger.debug({ id }, "SessionModel.deleteById: completed");
+    return result;
+  }
+
+  /**
    * Delete all sessions for a user
    */
   static async deleteAllByUserId(userId: string) {

--- a/platform/backend/src/models/user.ts
+++ b/platform/backend/src/models/user.ts
@@ -7,7 +7,7 @@ import {
 import { eq, getTableColumns } from "drizzle-orm";
 import { betterAuth } from "@/auth";
 import config from "@/config";
-import db, { schema } from "@/database";
+import db, { schema, type Transaction } from "@/database";
 import logger from "@/logging";
 import type { UpdateUser } from "@/types";
 import MemberModel from "./member";
@@ -176,9 +176,10 @@ class UserModel {
   /**
    * Delete a user by ID
    */
-  static async delete(userId: string): Promise<boolean> {
+  static async delete(userId: string, tx?: Transaction): Promise<boolean> {
     logger.debug("UserModel.delete: deleting user");
-    const result = await db
+    const dbOrTx = tx ?? db;
+    const result = await dbOrTx
       .delete(schema.usersTable)
       .where(eq(schema.usersTable.id, userId))
       .returning();

--- a/platform/backend/src/test/fixtures.ts
+++ b/platform/backend/src/test/fixtures.ts
@@ -819,7 +819,7 @@ async function makeIdentityProvider(
       providerId,
       issuer:
         overrides.issuer ?? `https://issuer-${id.substring(0, 8)}.example.com`,
-      domain: overrides.domain ?? `domain-${id.substring(0, 8)}.example.com`,
+      domain: overrides.domain ?? "example.com",
       organizationId,
       oidcConfig: overrides.oidcConfig
         ? (JSON.stringify(overrides.oidcConfig) as unknown as undefined)

--- a/platform/frontend/src/app/auth/[path]/auth-page-with-invitation-check.test.tsx
+++ b/platform/frontend/src/app/auth/[path]/auth-page-with-invitation-check.test.tsx
@@ -282,6 +282,7 @@ describe("AuthPageWithInvitationCheck", () => {
         get: vi.fn((key: string) =>
           key === "redirectTo" ? "%2Fdashboard" : null,
         ),
+        toString: vi.fn(() => "redirectTo=%2Fdashboard"),
       } as unknown as ReturnType<typeof useSearchParams>);
       vi.mocked(useInvitationCheck).mockReturnValue({
         data: undefined,
@@ -295,11 +296,41 @@ describe("AuthPageWithInvitationCheck", () => {
       );
     });
 
+    it("should preserve OAuth authorize params for MCP client auth redirects", () => {
+      const params = new URLSearchParams({
+        response_type: "code",
+        client_id: "https://claude.ai/oauth/claude-code-client-metadata",
+        redirect_uri: "http://localhost:54022/callback",
+        scope: "mcp offline_access",
+        state: "state123",
+        code_challenge: "challenge",
+        code_challenge_method: "S256",
+        resource: "http://localhost:9000/v1/mcp/default-mcp-gateway",
+        exp: "123",
+        sig: "abc",
+      });
+      vi.mocked(useSearchParams).mockReturnValue({
+        get: vi.fn((key: string) => params.get(key)),
+        toString: vi.fn(() => params.toString()),
+      } as unknown as ReturnType<typeof useSearchParams>);
+      vi.mocked(useInvitationCheck).mockReturnValue({
+        data: undefined,
+        isLoading: false,
+      } as ReturnType<typeof useInvitationCheck>);
+
+      render(<AuthPageWithInvitationCheck path="sign-in" />);
+
+      expect(screen.getByTestId("auth-callback").textContent).toBe(
+        `/api/auth/oauth2/authorize?${params.toString()}`,
+      );
+    });
+
     it("should fallback to / for invalid redirectTo", () => {
       vi.mocked(useSearchParams).mockReturnValue({
         get: vi.fn((key: string) =>
           key === "redirectTo" ? encodeURIComponent("https://evil.com") : null,
         ),
+        toString: vi.fn(() => "redirectTo=https%3A%2F%2Fevil.com"),
       } as unknown as ReturnType<typeof useSearchParams>);
       vi.mocked(useInvitationCheck).mockReturnValue({
         data: undefined,
@@ -314,6 +345,7 @@ describe("AuthPageWithInvitationCheck", () => {
     it("should fallback to / when redirectTo is not provided", () => {
       vi.mocked(useSearchParams).mockReturnValue({
         get: vi.fn().mockReturnValue(null),
+        toString: vi.fn(() => ""),
       } as unknown as ReturnType<typeof useSearchParams>);
       vi.mocked(useInvitationCheck).mockReturnValue({
         data: undefined,
@@ -331,6 +363,9 @@ describe("AuthPageWithInvitationCheck", () => {
           key === "redirectTo"
             ? "%2Fsearch%3Fq%3Dhello%26filter%3Dactive"
             : null,
+        ),
+        toString: vi.fn(
+          () => "redirectTo=%2Fsearch%3Fq%3Dhello%26filter%3Dactive",
         ),
       } as unknown as ReturnType<typeof useSearchParams>);
       vi.mocked(useInvitationCheck).mockReturnValue({
@@ -350,6 +385,7 @@ describe("AuthPageWithInvitationCheck", () => {
         get: vi.fn((key: string) =>
           key === "redirectTo" ? encodeURIComponent("//evil.com") : null,
         ),
+        toString: vi.fn(() => "redirectTo=%2F%2Fevil.com"),
       } as unknown as ReturnType<typeof useSearchParams>);
       vi.mocked(useInvitationCheck).mockReturnValue({
         data: undefined,

--- a/platform/frontend/src/app/auth/[path]/auth-page-with-invitation-check.tsx
+++ b/platform/frontend/src/app/auth/[path]/auth-page-with-invitation-check.tsx
@@ -140,17 +140,61 @@ export function AuthPageWithInvitationCheck({ path }: { path: string }) {
           */}
           <AuthViewWithErrorHandling
             path={path}
-            callbackURL={
-              invitationId
-                ? `${
-                    path === "sign-in" ? "/auth/sign-in" : "/auth/sign-up"
-                  }?invitationId=${invitationId}`
-                : getValidatedRedirectPath(redirectTo)
-            }
+            callbackURL={getAuthCallbackURL({
+              invitationId,
+              path,
+              redirectTo,
+              searchParams,
+            })}
           />
           {isSignInOrSignUp && <CommunityLinks />}
         </div>
       </main>
     </BackendConnectivityStatus>
   );
+}
+
+const OAUTH_AUTHORIZE_REQUIRED_PARAMS = [
+  "response_type",
+  "client_id",
+  "redirect_uri",
+  "scope",
+  "state",
+] as const;
+
+function getAuthCallbackURL(params: {
+  invitationId: string | null;
+  path: string;
+  redirectTo: string | null;
+  searchParams: ReturnType<typeof useSearchParams>;
+}) {
+  const { invitationId, path, redirectTo, searchParams } = params;
+
+  if (invitationId) {
+    return `${
+      path === "sign-in" ? "/auth/sign-in" : "/auth/sign-up"
+    }?invitationId=${invitationId}`;
+  }
+
+  const oauthAuthorizeCallbackURL = getOAuthAuthorizeCallbackURL(searchParams);
+  if (oauthAuthorizeCallbackURL) {
+    return oauthAuthorizeCallbackURL;
+  }
+
+  return getValidatedRedirectPath(redirectTo);
+}
+
+function getOAuthAuthorizeCallbackURL(
+  searchParams: ReturnType<typeof useSearchParams>,
+) {
+  const hasOAuthAuthorizeParams = OAUTH_AUTHORIZE_REQUIRED_PARAMS.every(
+    (param) => searchParams.get(param) !== null,
+  );
+
+  if (!hasOAuthAuthorizeParams) {
+    return null;
+  }
+
+  const queryString = searchParams.toString();
+  return queryString ? `/api/auth/oauth2/authorize?${queryString}` : null;
 }

--- a/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.test.tsx
+++ b/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.test.tsx
@@ -64,7 +64,7 @@ describe("AuthViewWithErrorHandling", () => {
   it("shows a generic failed SSO message when the attempted callback returns to sign-in without an error query", async () => {
     const callbackURL =
       "/api/auth/oauth2/authorize?response_type=code&client_id=test&state=abc&exp=123&sig=old";
-    recordSsoSignInAttempt(callbackURL);
+    recordSsoSignInAttempt();
     mockSearchParams.get.mockReturnValue(null);
 
     render(
@@ -81,10 +81,8 @@ describe("AuthViewWithErrorHandling", () => {
     ).toBeInTheDocument();
   });
 
-  it("matches a failed SSO callback when Better Auth regenerates exp and sig", async () => {
-    recordSsoSignInAttempt(
-      "/api/auth/oauth2/authorize?response_type=code&client_id=test&state=abc&exp=123&sig=old",
-    );
+  it("shows the failed SSO message when Better Auth regenerates exp and sig", async () => {
+    recordSsoSignInAttempt();
     mockSearchParams.get.mockReturnValue(null);
 
     render(
@@ -102,7 +100,7 @@ describe("AuthViewWithErrorHandling", () => {
   it("keeps the generic failed SSO message visible under React Strict Mode", async () => {
     const callbackURL =
       "/api/auth/oauth2/authorize?response_type=code&client_id=test&state=strict";
-    recordSsoSignInAttempt(callbackURL);
+    recordSsoSignInAttempt();
     mockSearchParams.get.mockReturnValue(null);
 
     render(

--- a/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.test.tsx
+++ b/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { useSearchParams } from "next/navigation";
+import { StrictMode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { recordSsoSignInAttempt } from "@/lib/auth/sso-sign-in-attempt";
 import { usePublicConfig } from "@/lib/config/config.query";
@@ -78,5 +79,22 @@ describe("AuthViewWithErrorHandling", () => {
         "Single sign-on could not be completed. Please try again or contact your administrator.",
       ),
     ).toBeInTheDocument();
+  });
+
+  it("keeps the generic failed SSO message visible under React Strict Mode", async () => {
+    const callbackURL =
+      "/api/auth/oauth2/authorize?response_type=code&client_id=test&state=strict";
+    recordSsoSignInAttempt(callbackURL);
+    mockSearchParams.get.mockReturnValue(null);
+
+    render(
+      <StrictMode>
+        <AuthViewWithErrorHandling path="sign-in" callbackURL={callbackURL} />
+      </StrictMode>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Sign-In Failed")).toBeInTheDocument();
+    });
   });
 });

--- a/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.test.tsx
+++ b/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.test.tsx
@@ -63,7 +63,7 @@ describe("AuthViewWithErrorHandling", () => {
 
   it("shows a generic failed SSO message when the attempted callback returns to sign-in without an error query", async () => {
     const callbackURL =
-      "/api/auth/oauth2/authorize?response_type=code&client_id=test&state=abc";
+      "/api/auth/oauth2/authorize?response_type=code&client_id=test&state=abc&exp=123&sig=old";
     recordSsoSignInAttempt(callbackURL);
     mockSearchParams.get.mockReturnValue(null);
 
@@ -79,6 +79,24 @@ describe("AuthViewWithErrorHandling", () => {
         "Single sign-on could not be completed. Please try again or contact your administrator.",
       ),
     ).toBeInTheDocument();
+  });
+
+  it("matches a failed SSO callback when Better Auth regenerates exp and sig", async () => {
+    recordSsoSignInAttempt(
+      "/api/auth/oauth2/authorize?response_type=code&client_id=test&state=abc&exp=123&sig=old",
+    );
+    mockSearchParams.get.mockReturnValue(null);
+
+    render(
+      <AuthViewWithErrorHandling
+        path="sign-in"
+        callbackURL="/api/auth/oauth2/authorize?response_type=code&client_id=test&state=abc&exp=456&sig=new"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Sign-In Failed")).toBeInTheDocument();
+    });
   });
 
   it("keeps the generic failed SSO message visible under React Strict Mode", async () => {

--- a/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.test.tsx
+++ b/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.test.tsx
@@ -2,7 +2,10 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { useSearchParams } from "next/navigation";
 import { StrictMode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { recordSsoSignInAttempt } from "@/lib/auth/sso-sign-in-attempt";
+import {
+  hasSsoSignInAttempt,
+  recordSsoSignInAttempt,
+} from "@/lib/auth/sso-sign-in-attempt";
 import { usePublicConfig } from "@/lib/config/config.query";
 import { AuthViewWithErrorHandling } from "./auth-view-with-error-handling";
 
@@ -79,6 +82,7 @@ describe("AuthViewWithErrorHandling", () => {
         "Single sign-on could not be completed. Please try again or contact your administrator.",
       ),
     ).toBeInTheDocument();
+    expect(hasSsoSignInAttempt()).toBe(false);
   });
 
   it("shows the failed SSO message when Better Auth regenerates exp and sig", async () => {

--- a/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.test.tsx
+++ b/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { useSearchParams } from "next/navigation";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { recordSsoSignInAttempt } from "@/lib/auth/sso-sign-in-attempt";
+import { usePublicConfig } from "@/lib/config/config.query";
+import { AuthViewWithErrorHandling } from "./auth-view-with-error-handling";
+
+vi.mock("@daveyplate/better-auth-ui", () => ({
+  AuthView: () => <div data-testid="auth-view" />,
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: vi.fn(),
+}));
+
+vi.mock("@/lib/config/config", () => ({
+  default: {
+    enterpriseFeatures: { core: false },
+  },
+}));
+
+vi.mock("@/lib/config/config.query", () => ({
+  usePublicConfig: vi.fn(),
+}));
+
+vi.mock("@/lib/hooks/use-app-name", () => ({
+  useAppName: () => "Test App",
+}));
+
+vi.mock("./sign-out-with-idp-logout", () => ({
+  SignOutWithIdpLogout: () => <div data-testid="sign-out" />,
+}));
+
+describe("AuthViewWithErrorHandling", () => {
+  const mockSearchParams = {
+    get: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.sessionStorage.clear();
+    vi.mocked(useSearchParams).mockReturnValue(
+      mockSearchParams as unknown as ReturnType<typeof useSearchParams>,
+    );
+    vi.mocked(usePublicConfig).mockReturnValue({
+      data: {
+        disableBasicAuth: false,
+        disableInvitations: false,
+      },
+      isLoading: false,
+    } as ReturnType<typeof usePublicConfig>);
+  });
+
+  it("does not show a failed SSO message on first sign-in page load", () => {
+    mockSearchParams.get.mockReturnValue(null);
+
+    render(<AuthViewWithErrorHandling path="sign-in" callbackURL="/" />);
+
+    expect(screen.queryByText("Sign-In Failed")).not.toBeInTheDocument();
+    expect(screen.getByTestId("auth-view")).toBeInTheDocument();
+  });
+
+  it("shows a generic failed SSO message when the attempted callback returns to sign-in without an error query", async () => {
+    const callbackURL =
+      "/api/auth/oauth2/authorize?response_type=code&client_id=test&state=abc";
+    recordSsoSignInAttempt(callbackURL);
+    mockSearchParams.get.mockReturnValue(null);
+
+    render(
+      <AuthViewWithErrorHandling path="sign-in" callbackURL={callbackURL} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Sign-In Failed")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(
+        "Single sign-on could not be completed. Please try again or contact your administrator.",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.tsx
+++ b/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.tsx
@@ -20,7 +20,10 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { consumeSsoSignInAttempt } from "@/lib/auth/sso-sign-in-attempt";
+import {
+  clearSsoSignInAttempt,
+  hasSsoSignInAttempt,
+} from "@/lib/auth/sso-sign-in-attempt";
 import config from "@/lib/config/config";
 import { usePublicConfig } from "@/lib/config/config.query";
 import { useAppName } from "@/lib/hooks/use-app-name";
@@ -186,7 +189,7 @@ export function AuthViewWithErrorHandling({
       return;
     }
 
-    if (path === "sign-in" && consumeSsoSignInAttempt(callbackURL)) {
+    if (path === "sign-in" && hasSsoSignInAttempt(callbackURL)) {
       setSsoError(GENERIC_SSO_SIGN_IN_FAILED);
     }
   }, [callbackURL, path, searchParams]);
@@ -311,6 +314,7 @@ export function AuthViewWithErrorHandling({
           variant="ghost"
           onClick={() => {
             setSsoError(null);
+            clearSsoSignInAttempt();
             // Clear the error params from URL without page reload
             const url = new URL(window.location.href);
             url.searchParams.delete("error");

--- a/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.tsx
+++ b/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.tsx
@@ -189,10 +189,10 @@ export function AuthViewWithErrorHandling({
       return;
     }
 
-    if (path === "sign-in" && hasSsoSignInAttempt(callbackURL)) {
+    if (path === "sign-in" && hasSsoSignInAttempt()) {
       setSsoError(GENERIC_SSO_SIGN_IN_FAILED);
     }
-  }, [callbackURL, path, searchParams]);
+  }, [path, searchParams]);
 
   useEffect(() => {
     // Intercept fetch to detect 500 errors from auth endpoints

--- a/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.tsx
+++ b/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.tsx
@@ -20,6 +20,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { consumeSsoSignInAttempt } from "@/lib/auth/sso-sign-in-attempt";
 import config from "@/lib/config/config";
 import { usePublicConfig } from "@/lib/config/config.query";
 import { useAppName } from "@/lib/hooks/use-app-name";
@@ -120,6 +121,12 @@ const SSO_ERROR_MESSAGES: Record<string, { title: string; message: string }> = {
   },
 };
 
+const GENERIC_SSO_SIGN_IN_FAILED = {
+  title: "Sign-In Failed",
+  message:
+    "Single sign-on could not be completed. Please try again or contact your administrator.",
+};
+
 interface AuthViewWithErrorHandlingProps {
   path: string;
   callbackURL?: string;
@@ -176,8 +183,13 @@ export function AuthViewWithErrorHandling({
             : `An error occurred during sign-in: ${decodeURIComponent(errorParam)}. Please try again or contact your administrator.`,
         });
       }
+      return;
     }
-  }, [searchParams]);
+
+    if (path === "sign-in" && consumeSsoSignInAttempt(callbackURL)) {
+      setSsoError(GENERIC_SSO_SIGN_IN_FAILED);
+    }
+  }, [callbackURL, path, searchParams]);
 
   useEffect(() => {
     // Intercept fetch to detect 500 errors from auth endpoints

--- a/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.tsx
+++ b/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.tsx
@@ -191,6 +191,7 @@ export function AuthViewWithErrorHandling({
 
     if (path === "sign-in" && hasSsoSignInAttempt()) {
       setSsoError(GENERIC_SSO_SIGN_IN_FAILED);
+      clearSsoSignInAttempt();
     }
   }, [path, searchParams]);
 

--- a/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.test.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.test.tsx
@@ -94,11 +94,25 @@ describe("OidcConfigForm", () => {
     );
   });
 
+  it("explains that allowed email domains gate SSO sign-in", () => {
+    render(<TestWrapper />);
+
+    expect(screen.getByLabelText("Allowed Email Domains")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Users can sign in with this provider only when their returned email matches one of these domains/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("shows the hosted domain field for Google providers", () => {
     render(<TestWrapper providerId="Google" />);
 
     expect(
       screen.getByLabelText("Hosted Domain Hint (Optional)"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/This is a Google hint, not the security boundary/i),
     ).toBeInTheDocument();
   });
 

--- a/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.tsx
@@ -140,12 +140,14 @@ export function OidcConfigForm({
           name="domain"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Domain</FormLabel>
+              <FormLabel>Allowed Email Domains</FormLabel>
               <FormControl>
-                <Input placeholder="company.com" {...field} />
+                <Input placeholder="company.com, subsidiary.com" {...field} />
               </FormControl>
               <FormDescription>
-                Email domain for automatic provider detection.
+                Users can sign in with this provider only when their returned
+                email matches one of these domains. Separate multiple domains
+                with commas.
               </FormDescription>
               <FormMessage />
             </FormItem>
@@ -206,8 +208,10 @@ export function OidcConfigForm({
                   <Input placeholder="example.com" {...field} />
                 </FormControl>
                 <FormDescription>
-                  Passes Google&apos;s `hd` parameter to prefer or restrict
-                  account selection to a specific Workspace domain.
+                  Passes Google&apos;s `hd` parameter to prefer account
+                  selection for a Workspace domain. This is a Google hint, not
+                  the security boundary; sign-in is enforced by Allowed Email
+                  Domains.
                 </FormDescription>
                 <FormMessage />
               </FormItem>

--- a/platform/frontend/src/app/settings/identity-providers/_parts/saml-config-form.ee.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/saml-config-form.ee.tsx
@@ -68,12 +68,14 @@ export function SamlConfigForm({ form, hideProviderId }: SamlConfigFormProps) {
           name="domain"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Domain</FormLabel>
+              <FormLabel>Allowed Email Domains</FormLabel>
               <FormControl>
-                <Input placeholder="company.com" {...field} />
+                <Input placeholder="company.com, subsidiary.com" {...field} />
               </FormControl>
               <FormDescription>
-                Email domain for automatic provider detection.
+                Users can sign in with this provider only when their returned
+                email matches one of these domains. Separate multiple domains
+                with commas.
               </FormDescription>
               <FormMessage />
             </FormItem>

--- a/platform/frontend/src/components/identity-provider-selector.ee.test.tsx
+++ b/platform/frontend/src/components/identity-provider-selector.ee.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { useSearchParams } from "next/navigation";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { usePublicIdentityProviders } from "@/lib/auth/identity-provider.query.ee";
+import { consumeSsoSignInAttempt } from "@/lib/auth/sso-sign-in-attempt";
 import { authClient } from "@/lib/clients/auth/auth-client";
 import config from "@/lib/config/config";
 import { IdentityProviderSelector } from "./identity-provider-selector.ee";
@@ -52,6 +53,7 @@ describe("IdentityProviderSelector", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    window.sessionStorage.clear();
     vi.mocked(useSearchParams).mockReturnValue(
       mockSearchParams as unknown as ReturnType<typeof useSearchParams>,
     );
@@ -81,6 +83,11 @@ describe("IdentityProviderSelector", () => {
           callbackURL: `${mockOrigin}/oauth/consent?client_id=test&scope=mcp`,
         }),
       );
+      expect(
+        consumeSsoSignInAttempt(
+          `${mockOrigin}/oauth/consent?client_id=test&scope=mcp`,
+        ),
+      ).toBe(true);
     });
 
     it("should use home URL when no redirectTo param is present", async () => {

--- a/platform/frontend/src/components/identity-provider-selector.ee.test.tsx
+++ b/platform/frontend/src/components/identity-provider-selector.ee.test.tsx
@@ -83,11 +83,7 @@ describe("IdentityProviderSelector", () => {
           callbackURL: `${mockOrigin}/oauth/consent?client_id=test&scope=mcp`,
         }),
       );
-      expect(
-        hasSsoSignInAttempt(
-          `${mockOrigin}/oauth/consent?client_id=test&scope=mcp`,
-        ),
-      ).toBe(true);
+      expect(hasSsoSignInAttempt()).toBe(true);
     });
 
     it("should use home URL when no redirectTo param is present", async () => {

--- a/platform/frontend/src/components/identity-provider-selector.ee.test.tsx
+++ b/platform/frontend/src/components/identity-provider-selector.ee.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { useSearchParams } from "next/navigation";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { usePublicIdentityProviders } from "@/lib/auth/identity-provider.query.ee";
-import { consumeSsoSignInAttempt } from "@/lib/auth/sso-sign-in-attempt";
+import { hasSsoSignInAttempt } from "@/lib/auth/sso-sign-in-attempt";
 import { authClient } from "@/lib/clients/auth/auth-client";
 import config from "@/lib/config/config";
 import { IdentityProviderSelector } from "./identity-provider-selector.ee";
@@ -84,7 +84,7 @@ describe("IdentityProviderSelector", () => {
         }),
       );
       expect(
-        consumeSsoSignInAttempt(
+        hasSsoSignInAttempt(
           `${mockOrigin}/oauth/consent?client_id=test&scope=mcp`,
         ),
       ).toBe(true);

--- a/platform/frontend/src/components/identity-provider-selector.ee.tsx
+++ b/platform/frontend/src/components/identity-provider-selector.ee.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { IdentityProviderIcon } from "@/components/identity-provider-icons.ee";
 import { Button } from "@/components/ui/button";
 import { usePublicIdentityProviders } from "@/lib/auth/identity-provider.query.ee";
+import { recordSsoSignInAttempt } from "@/lib/auth/sso-sign-in-attempt";
 import { authClient } from "@/lib/clients/auth/auth-client";
 import config from "@/lib/config/config";
 import { getValidatedCallbackURLWithDefault } from "@/lib/utils/redirect-validation";
@@ -42,6 +43,7 @@ export function IdentityProviderSelector({
   const handleSsoSignIn = useCallback(
     async (providerId: string) => {
       try {
+        recordSsoSignInAttempt(callbackURL);
         await authClient.signIn.sso({
           providerId,
           callbackURL,

--- a/platform/frontend/src/components/identity-provider-selector.ee.tsx
+++ b/platform/frontend/src/components/identity-provider-selector.ee.tsx
@@ -43,7 +43,7 @@ export function IdentityProviderSelector({
   const handleSsoSignIn = useCallback(
     async (providerId: string) => {
       try {
-        recordSsoSignInAttempt(callbackURL);
+        recordSsoSignInAttempt();
         await authClient.signIn.sso({
           providerId,
           callbackURL,

--- a/platform/frontend/src/lib/auth/sso-sign-in-attempt.ts
+++ b/platform/frontend/src/lib/auth/sso-sign-in-attempt.ts
@@ -2,7 +2,10 @@ const SSO_SIGN_IN_ATTEMPT_KEY = "archestra:sso-sign-in-attempt";
 
 export function recordSsoSignInAttempt(callbackURL: string) {
   try {
-    window.sessionStorage.setItem(SSO_SIGN_IN_ATTEMPT_KEY, callbackURL);
+    window.sessionStorage.setItem(
+      SSO_SIGN_IN_ATTEMPT_KEY,
+      normalizeCallbackURL(callbackURL),
+    );
   } catch {
     // Ignore storage failures. SSO still works; only the fallback error UI is lost.
   }
@@ -18,7 +21,7 @@ export function hasSsoSignInAttempt(callbackURL?: string) {
       SSO_SIGN_IN_ATTEMPT_KEY,
     );
 
-    if (attemptedCallbackURL !== callbackURL) {
+    if (attemptedCallbackURL !== normalizeCallbackURL(callbackURL)) {
       return false;
     }
 
@@ -34,4 +37,12 @@ export function clearSsoSignInAttempt() {
   } catch {
     // Ignore storage failures.
   }
+}
+
+function normalizeCallbackURL(callbackURL: string) {
+  const url = new URL(callbackURL, window.location.origin);
+  url.searchParams.delete("exp");
+  url.searchParams.delete("sig");
+
+  return url.pathname + url.search;
 }

--- a/platform/frontend/src/lib/auth/sso-sign-in-attempt.ts
+++ b/platform/frontend/src/lib/auth/sso-sign-in-attempt.ts
@@ -8,7 +8,7 @@ export function recordSsoSignInAttempt(callbackURL: string) {
   }
 }
 
-export function consumeSsoSignInAttempt(callbackURL?: string) {
+export function hasSsoSignInAttempt(callbackURL?: string) {
   if (!callbackURL) {
     return false;
   }
@@ -22,9 +22,16 @@ export function consumeSsoSignInAttempt(callbackURL?: string) {
       return false;
     }
 
-    window.sessionStorage.removeItem(SSO_SIGN_IN_ATTEMPT_KEY);
     return true;
   } catch {
     return false;
+  }
+}
+
+export function clearSsoSignInAttempt() {
+  try {
+    window.sessionStorage.removeItem(SSO_SIGN_IN_ATTEMPT_KEY);
+  } catch {
+    // Ignore storage failures.
   }
 }

--- a/platform/frontend/src/lib/auth/sso-sign-in-attempt.ts
+++ b/platform/frontend/src/lib/auth/sso-sign-in-attempt.ts
@@ -1,31 +1,23 @@
 const SSO_SIGN_IN_ATTEMPT_KEY = "archestra:sso-sign-in-attempt";
+const SSO_SIGN_IN_ATTEMPT_VALUE = "pending";
 
-export function recordSsoSignInAttempt(callbackURL: string) {
+export function recordSsoSignInAttempt() {
   try {
     window.sessionStorage.setItem(
       SSO_SIGN_IN_ATTEMPT_KEY,
-      normalizeCallbackURL(callbackURL),
+      SSO_SIGN_IN_ATTEMPT_VALUE,
     );
   } catch {
     // Ignore storage failures. SSO still works; only the fallback error UI is lost.
   }
 }
 
-export function hasSsoSignInAttempt(callbackURL?: string) {
-  if (!callbackURL) {
-    return false;
-  }
-
+export function hasSsoSignInAttempt() {
   try {
-    const attemptedCallbackURL = window.sessionStorage.getItem(
-      SSO_SIGN_IN_ATTEMPT_KEY,
+    return (
+      window.sessionStorage.getItem(SSO_SIGN_IN_ATTEMPT_KEY) ===
+      SSO_SIGN_IN_ATTEMPT_VALUE
     );
-
-    if (attemptedCallbackURL !== normalizeCallbackURL(callbackURL)) {
-      return false;
-    }
-
-    return true;
   } catch {
     return false;
   }
@@ -37,12 +29,4 @@ export function clearSsoSignInAttempt() {
   } catch {
     // Ignore storage failures.
   }
-}
-
-function normalizeCallbackURL(callbackURL: string) {
-  const url = new URL(callbackURL, window.location.origin);
-  url.searchParams.delete("exp");
-  url.searchParams.delete("sig");
-
-  return url.pathname + url.search;
 }

--- a/platform/frontend/src/lib/auth/sso-sign-in-attempt.ts
+++ b/platform/frontend/src/lib/auth/sso-sign-in-attempt.ts
@@ -1,0 +1,30 @@
+const SSO_SIGN_IN_ATTEMPT_KEY = "archestra:sso-sign-in-attempt";
+
+export function recordSsoSignInAttempt(callbackURL: string) {
+  try {
+    window.sessionStorage.setItem(SSO_SIGN_IN_ATTEMPT_KEY, callbackURL);
+  } catch {
+    // Ignore storage failures. SSO still works; only the fallback error UI is lost.
+  }
+}
+
+export function consumeSsoSignInAttempt(callbackURL?: string) {
+  if (!callbackURL) {
+    return false;
+  }
+
+  try {
+    const attemptedCallbackURL = window.sessionStorage.getItem(
+      SSO_SIGN_IN_ATTEMPT_KEY,
+    );
+
+    if (attemptedCallbackURL !== callbackURL) {
+      return false;
+    }
+
+    window.sessionStorage.removeItem(SSO_SIGN_IN_ATTEMPT_KEY);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/platform/shared/identity-provider.test.ts
+++ b/platform/shared/identity-provider.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  emailMatchesAllowedIdentityProviderDomains,
   IdentityProviderFormSchema,
   IdentityProviderOidcConfigSchema,
 } from "./identity-provider";
@@ -113,5 +114,52 @@ describe("IdentityProviderFormSchema", () => {
     expect(result.error?.issues[0]?.message).toBe(
       "Enter valid comma-separated domains, for example company.com, subsidiary.com",
     );
+  });
+});
+
+describe("emailMatchesAllowedIdentityProviderDomains", () => {
+  it("matches exact allowed domains", () => {
+    expect(
+      emailMatchesAllowedIdentityProviderDomains(
+        "user@example.com",
+        "example.com",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches subdomains of allowed domains", () => {
+    expect(
+      emailMatchesAllowedIdentityProviderDomains(
+        "user@engineering.example.com",
+        "example.com",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches comma-separated allowed domains", () => {
+    expect(
+      emailMatchesAllowedIdentityProviderDomains(
+        "user@subsidiary.com",
+        "example.com, subsidiary.com",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects unrelated domains", () => {
+    expect(
+      emailMatchesAllowedIdentityProviderDomains(
+        "user@other.com",
+        "example.com",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match sibling suffixes", () => {
+    expect(
+      emailMatchesAllowedIdentityProviderDomains(
+        "user@badexample.com",
+        "example.com",
+      ),
+    ).toBe(false);
   });
 });

--- a/platform/shared/identity-provider.test.ts
+++ b/platform/shared/identity-provider.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, test } from "vitest";
-import { IdentityProviderOidcConfigSchema } from "./identity-provider";
+import { describe, expect, it } from "vitest";
+import {
+  IdentityProviderFormSchema,
+  IdentityProviderOidcConfigSchema,
+} from "./identity-provider";
 
 describe("IdentityProviderOidcConfigSchema", () => {
-  test("accepts skipDiscovery with explicit endpoints", () => {
+  it("accepts skipDiscovery with explicit endpoints", () => {
     const result = IdentityProviderOidcConfigSchema.parse({
       issuer: "http://id-jag.example.com/demo-idp",
       skipDiscovery: true,
@@ -20,5 +23,47 @@ describe("IdentityProviderOidcConfigSchema", () => {
     expect(result.skipDiscovery).toBe(true);
     expect(result.hd).toBe("example.com");
     expect(result.tokenEndpoint).toBe("http://id-jag.example.com/token");
+  });
+});
+
+describe("IdentityProviderFormSchema", () => {
+  const validBase = {
+    providerId: "Google",
+    issuer: "https://accounts.google.com",
+    providerType: "oidc" as const,
+    oidcConfig: {
+      issuer: "https://accounts.google.com",
+      pkce: true,
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      discoveryEndpoint:
+        "https://accounts.google.com/.well-known/openid-configuration",
+      mapping: {
+        id: "sub",
+        email: "email",
+        name: "name",
+      },
+    },
+  };
+
+  it("accepts comma-separated allowed email domains", () => {
+    const result = IdentityProviderFormSchema.safeParse({
+      ...validBase,
+      domain: "example.com, subsidiary.example.com",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid allowed email domains", () => {
+    const result = IdentityProviderFormSchema.safeParse({
+      ...validBase,
+      domain: "example.com, https://evil.com/path",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(
+      "Enter valid comma-separated domains, for example company.com, subsidiary.com",
+    );
   });
 });

--- a/platform/shared/identity-provider.test.ts
+++ b/platform/shared/identity-provider.test.ts
@@ -24,6 +24,54 @@ describe("IdentityProviderOidcConfigSchema", () => {
     expect(result.hd).toBe("example.com");
     expect(result.tokenEndpoint).toBe("http://id-jag.example.com/token");
   });
+
+  it("accepts a single hosted domain hint", () => {
+    const result = IdentityProviderOidcConfigSchema.safeParse({
+      issuer: "https://accounts.google.com",
+      pkce: true,
+      hd: "example.com",
+      clientId: "gateway-client",
+      clientSecret: "gateway-secret",
+      discoveryEndpoint:
+        "https://accounts.google.com/.well-known/openid-configuration",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects comma-separated hosted domain hints", () => {
+    const result = IdentityProviderOidcConfigSchema.safeParse({
+      issuer: "https://accounts.google.com",
+      pkce: true,
+      hd: "example.com, subsidiary.example.com",
+      clientId: "gateway-client",
+      clientSecret: "gateway-secret",
+      discoveryEndpoint:
+        "https://accounts.google.com/.well-known/openid-configuration",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(
+      "Enter a single valid domain, for example company.com",
+    );
+  });
+
+  it("rejects malformed hosted domain hints", () => {
+    const result = IdentityProviderOidcConfigSchema.safeParse({
+      issuer: "https://accounts.google.com",
+      pkce: true,
+      hd: "https://example.com/path",
+      clientId: "gateway-client",
+      clientSecret: "gateway-secret",
+      discoveryEndpoint:
+        "https://accounts.google.com/.well-known/openid-configuration",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(
+      "Enter a single valid domain, for example company.com",
+    );
+  });
 });
 
 describe("IdentityProviderFormSchema", () => {

--- a/platform/shared/identity-provider.ts
+++ b/platform/shared/identity-provider.ts
@@ -28,7 +28,14 @@ export const IdentityProviderOidcConfigSchema = z
     skipDiscovery: z.boolean().optional(),
     pkce: z.boolean(),
     enableRpInitiatedLogout: z.boolean().optional(),
-    hd: z.string().optional(),
+    hd: z
+      .string()
+      .trim()
+      .optional()
+      .refine(
+        (value) => !value || DOMAIN_VALIDATION_REGEX.test(value),
+        "Enter a single valid domain, for example company.com",
+      ),
     clientId: z.string(),
     clientSecret: z.string(),
     authorizationEndpoint: z.string().optional(),

--- a/platform/shared/identity-provider.ts
+++ b/platform/shared/identity-provider.ts
@@ -22,6 +22,31 @@ export type IdentityProviderId =
 export const IDENTITY_TRUSTED_PROVIDER_IDS =
   Object.values(IDENTITY_PROVIDER_ID);
 
+export function emailMatchesAllowedIdentityProviderDomains(
+  email: string,
+  allowedDomains: string,
+) {
+  const emailDomain = getEmailDomain(email);
+  if (!emailDomain) {
+    return false;
+  }
+
+  return parseAllowedIdentityProviderDomains(allowedDomains).some(
+    (domain) => emailDomain === domain || emailDomain.endsWith(`.${domain}`),
+  );
+}
+
+export function parseAllowedIdentityProviderDomains(allowedDomains: string) {
+  return allowedDomains
+    .split(",")
+    .map((domain) => domain.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function getEmailDomain(email: string) {
+  return email.split("@")[1]?.trim().toLowerCase() ?? null;
+}
+
 export const IdentityProviderOidcConfigSchema = z
   .object({
     issuer: z.string(),
@@ -207,11 +232,13 @@ export const IdentityProviderFormSchema = z
       .string()
       .min(1, "Allowed email domains are required")
       .refine(
-        (value) =>
-          value
-            .split(",")
-            .map((domain) => domain.trim())
-            .every((domain) => DOMAIN_VALIDATION_REGEX.test(domain)),
+        (value) => {
+          const domains = parseAllowedIdentityProviderDomains(value);
+          return (
+            domains.length > 0 &&
+            domains.every((domain) => DOMAIN_VALIDATION_REGEX.test(domain))
+          );
+        },
         {
           message:
             "Enter valid comma-separated domains, for example company.com, subsidiary.com",

--- a/platform/shared/identity-provider.ts
+++ b/platform/shared/identity-provider.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { DOMAIN_VALIDATION_REGEX } from "./incoming-email";
 
 /**
  * Identity provider IDs - these are the canonical built-in provider identifiers used for:
@@ -195,7 +196,20 @@ export const IdentityProviderFormSchema = z
   .object({
     providerId: z.string().min(1, "Provider ID is required"),
     issuer: z.string().min(1, "Issuer is required"),
-    domain: z.string().min(1, "Domain is required"),
+    domain: z
+      .string()
+      .min(1, "Allowed email domains are required")
+      .refine(
+        (value) =>
+          value
+            .split(",")
+            .map((domain) => domain.trim())
+            .every((domain) => DOMAIN_VALIDATION_REGEX.test(domain)),
+        {
+          message:
+            "Enter valid comma-separated domains, for example company.com, subsidiary.com",
+        },
+      ),
     providerType: z.enum(["oidc", "saml"]),
     oidcConfig: IdentityProviderOidcConfigSchema.optional(),
     samlConfig: IdentityProviderSamlConfigSchema.optional(),


### PR DESCRIPTION
## Summary

Fixes SSO authentication issues around MCP OAuth callback preservation and identity-provider email-domain enforcement:

- Preserve OAuth authorize parameters when an unauthenticated MCP client auth request lands on `/auth/sign-in`, so completing SSO resumes `/api/auth/oauth2/authorize?...` instead of falling through to `/chat`.
- Enforce identity-provider **Allowed Email Domains** after SSO callback by rejecting returned emails outside the configured domains, using shared domain parsing/matching logic for schema validation and backend enforcement.
- Clean up rows created before Better Auth reaches the after-hook inside one database transaction: rejected first-time SSO logins remove the session, SSO account, member, and throwaway user; rejected existing users keep existing user/member data but remove the failed SSO account.
- Show a generic sign-in failure message when a denied SSO callback returns to sign-in without `error` query params.
- Track pending SSO attempts with a constant session-storage marker instead of storing OAuth callback URLs or query parameters, consume the marker after showing the fallback failure, and avoid logging full denied user emails in the domain-enforcement warning.
- Rename the IdP form field from `Domain` to `Allowed Email Domains`, validate comma-separated allowed domains, validate Google `hd` as a single hosted-domain hint, document subdomain matching, and clarify that Google `hd` is only an account-selection hint.

## Root Cause

Better Auth redirects unauthenticated OAuth authorize requests to `/auth/sign-in` with the authorize parameters directly in the query string. The auth page only preserved `redirectTo` or invitation callbacks, so SSO defaulted back to `/`, which then routed users to `/chat` instead of resuming the OAuth consent flow.

The identity-provider domain field was not explicit enough in UI/docs and was not consistently treated as an Archestra-side sign-in boundary. Better Auth used provider domain metadata for trusted account-linking behavior, but Archestra also needs to explicitly block provider logins when the returned email domain is outside the configured allowlist.

Better Auth creates the user/account/session, and may create organization membership, before Archestra's after-hook runs. Rejecting in the after-hook without cleanup left partial rows behind. The hook now performs explicit cleanup before rejecting.

For some after-hook SSO failures, Better Auth returns to the sign-in URL without preserving a user-facing `error` parameter. The frontend records that an SSO attempt is pending and shows a generic failure alert if the user returns to sign-in without an explicit error. The marker intentionally does not store the OAuth callback URL because that URL can contain OAuth state, client, redirect, resource, and PKCE query data.