### PR TITLE
fix: sanitize Bedrock document names

### DIFF
--- a/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
@@ -194,6 +194,74 @@ describe("Bedrock tool name encoding", () => {
     expect(providerToolNames[1]).toMatch(/^server__read_file_[a-f0-9]{8}$/);
   });
 
+  test("sanitizes provider-facing document names for Bedrock validation", () => {
+    const request = createConverseRequest({
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              document: {
+                format: "pdf",
+                name: "customer_report.v2__final!!  copy.pdf",
+                source: { bytes: "ZmFrZQ==" },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const commandInput = getCommandInput(request);
+    const documentBlock = commandInput.messages?.[0]?.content?.[0];
+    const documentName =
+      documentBlock && "document" in documentBlock
+        ? documentBlock.document.name
+        : "";
+
+    expect(documentName).toBe("customer report v2 final copy pdf");
+  });
+
+  test("sanitizes document names nested in tool results", () => {
+    const request = createConverseRequest({
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              toolResult: {
+                toolUseId: "tooluse_123",
+                content: [
+                  {
+                    document: {
+                      format: "txt",
+                      name: "..__",
+                      source: { bytes: "ZmFrZQ==" },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const commandInput = getCommandInput(request);
+    const toolResultBlock = commandInput.messages?.[0]?.content?.[0];
+    const toolResultContent =
+      toolResultBlock && "toolResult" in toolResultBlock
+        ? toolResultBlock.toolResult.content
+        : [];
+    const documentBlock = toolResultContent?.[0];
+    const documentName =
+      documentBlock && "document" in documentBlock
+        ? documentBlock.document.name
+        : "";
+
+    expect(documentName).toBe("Document");
+  });
+
   test("re-encodes streamed tool call events with the original tool name", () => {
     const toolName =
       "splunk_olly_preprod_mcp__olly_get_apm_service_errors_and_requests";

--- a/platform/backend/src/routes/proxy/adapters/bedrock.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.ts
@@ -87,6 +87,7 @@ const PADDING_ALPHABET =
 const BEDROCK_MAX_TOOL_NAME_LENGTH = 64;
 const TOOL_NAME_HASH_LENGTH = 8;
 const TOOL_NAME_HASH_SEPARATOR = "_";
+const BEDROCK_DOCUMENT_NAME_FALLBACK = "Document";
 const bedrockCommandContextCache = new WeakMap<
   BedrockRequest,
   BedrockCommandContext
@@ -285,6 +286,117 @@ function encodeProviderMessageToolNames(params: {
   }) as BedrockMessages;
 }
 
+// Applies all Bedrock provider-facing message rewrites before constructing the
+// AWS command input.
+function prepareProviderMessages(params: {
+  messages: BedrockMessages | undefined;
+  mapping: ToolNameMapping;
+  isNova: boolean;
+}): BedrockMessages | undefined {
+  const messagesWithEncodedToolNames = encodeProviderMessageToolNames(params);
+  return sanitizeProviderDocumentNames(messagesWithEncodedToolNames);
+}
+
+// Walks message content blocks and normalizes document names so Bedrock does
+// not reject otherwise valid file uploads on filename validation.
+function sanitizeProviderDocumentNames(
+  messages: BedrockMessages | undefined,
+): BedrockMessages | undefined {
+  if (!messages) {
+    return messages;
+  }
+
+  return messages.map((message) => {
+    if (!Array.isArray(message.content)) {
+      return message;
+    }
+
+    let changed = false;
+    const content = message.content.map((contentBlock) => {
+      const sanitizedContentBlock =
+        sanitizeDocumentNamesInContentBlock(contentBlock);
+      if (sanitizedContentBlock !== contentBlock) {
+        changed = true;
+      }
+      return sanitizedContentBlock;
+    });
+
+    return changed ? { ...message, content } : message;
+  }) as BedrockMessages;
+}
+
+// Sanitizes direct document blocks and document blocks nested inside tool
+// results while preserving unchanged content by reference.
+function sanitizeDocumentNamesInContentBlock(contentBlock: unknown): unknown {
+  if (isDocumentBlock(contentBlock)) {
+    const sanitizedName = sanitizeBedrockDocumentName(
+      contentBlock.document.name,
+    );
+    if (sanitizedName === contentBlock.document.name) {
+      return contentBlock;
+    }
+
+    return {
+      ...contentBlock,
+      document: {
+        ...contentBlock.document,
+        name: sanitizedName,
+      },
+    };
+  }
+
+  if (!isToolResultBlock(contentBlock)) {
+    return contentBlock;
+  }
+
+  const content = contentBlock.toolResult.content;
+  if (!Array.isArray(content)) {
+    return contentBlock;
+  }
+
+  let changed = false;
+  const sanitizedContent = content.map((item) => {
+    if (!isDocumentBlock(item)) {
+      return item;
+    }
+
+    const sanitizedName = sanitizeBedrockDocumentName(item.document.name);
+    if (sanitizedName === item.document.name) {
+      return item;
+    }
+
+    changed = true;
+    return {
+      ...item,
+      document: {
+        ...item.document,
+        name: sanitizedName,
+      },
+    };
+  });
+
+  return changed
+    ? {
+        ...contentBlock,
+        toolResult: {
+          ...contentBlock.toolResult,
+          content: sanitizedContent,
+        },
+      }
+    : contentBlock;
+}
+
+// Converts arbitrary filenames to Bedrock's document-name character set:
+// alphanumerics, whitespace, hyphens, parentheses, and square brackets.
+function sanitizeBedrockDocumentName(name: string): string {
+  const sanitizedName = name
+    .replace(/[^a-zA-Z0-9\s()[\]-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return sanitizedName || BEDROCK_DOCUMENT_NAME_FALLBACK;
+}
+
 function encodeProviderToolChoiceName(params: {
   toolChoice: Bedrock.Types.ToolChoice | undefined;
   mapping: ToolNameMapping;
@@ -353,6 +465,24 @@ function isToolResultBlock(block: unknown): block is {
     block !== null &&
     "toolResult" in block &&
     (block as { toolResult: unknown }).toolResult !== undefined
+  );
+}
+
+// Narrows a loose Bedrock content item to the document block shape used in
+// messages and tool results.
+function isDocumentBlock(block: unknown): block is {
+  document: { name: string; format?: unknown; source?: unknown };
+} {
+  if (typeof block !== "object" || block === null || !("document" in block)) {
+    return false;
+  }
+
+  const document = (block as { document: unknown }).document;
+  return (
+    typeof document === "object" &&
+    document !== null &&
+    "name" in document &&
+    typeof (document as { name: unknown }).name === "string"
   );
 }
 
@@ -1387,7 +1517,7 @@ function buildBedrockCommandContext(
   const context = {
     commandInput: {
       modelId: request.modelId,
-      messages: encodeProviderMessageToolNames({
+      messages: prepareProviderMessages({
         messages: request.messages,
         mapping: toolNameMapping,
         isNova: shouldEncodeHyphens,


### PR DESCRIPTION
## Summary

Sanitize Bedrock Converse document names before Archestra forwards requests to AWS. Bedrock only accepts alphanumeric characters, whitespace, hyphens, parentheses, and square brackets in `document.name`, and rejects names with repeated whitespace.

This keeps otherwise valid file uploads from failing with provider-side `invalid_request` / `api_validation_error` responses when filenames contain characters that are normal locally but invalid for Bedrock.

## Root Cause

The Bedrock proxy adapter already rewrites tool names for provider compatibility, but it passed `document.name` through unchanged. A user-uploaded filename can still contain Bedrock-invalid characters after AI SDK conversion.

I checked the related upstream issue vercel/ai#11518. That fix landed in `@ai-sdk/amazon-bedrock@4.0.71` and this repo already uses `@ai-sdk/amazon-bedrock@4.0.77`; the upstream fix strips file extensions but does not sanitize the full Bedrock character set or collapse repeated whitespace. This patch adds the remaining Archestra-side guard at the provider boundary.

## Changes

- Normalize provider-facing Bedrock document names in direct message content blocks.
- Normalize document names nested inside tool result content.
- Add fallback name `Document` when sanitization removes all characters.
- Add comments explaining the new Bedrock message/document-name helper functions.
- Add regression tests for invalid document names and nested tool-result documents.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Image" src="https://github.com/user-attachments/assets/1f9497f2-96ad-4334-b3a4-c63ff38abdb9"/>

</a>