### PR TITLE
fix: gate team vault-folder queries on byosEnabled flag

### DIFF
--- a/platform/frontend/src/lib/teams/team-vault-folder.query.ee.ts
+++ b/platform/frontend/src/lib/teams/team-vault-folder.query.ee.ts
@@ -1,6 +1,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { useFeature } from "@/lib/config/config.query";
 import { handleApiError } from "@/lib/utils";
 
 const {
@@ -21,6 +22,7 @@ export type VaultSecretListItem =
  * Hook to get a team's Vault folder configuration
  */
 export function useTeamVaultFolder(teamId: string | null) {
+  const byosEnabled = useFeature("byosEnabled");
   return useQuery({
     queryKey: ["team-vault-folder", teamId],
     queryFn: async () => {
@@ -34,7 +36,7 @@ export function useTeamVaultFolder(teamId: string | null) {
       }
       return data;
     },
-    enabled: !!teamId,
+    enabled: byosEnabled && !!teamId,
     throwOnError: false, // Handle errors gracefully in the component instead of crashing
   });
 }
@@ -127,6 +129,7 @@ export function useCheckTeamVaultFolderConnectivity() {
  * Hook to list secrets in a team's Vault folder
  */
 export function useTeamVaultFolderSecrets(teamId: string | null) {
+  const byosEnabled = useFeature("byosEnabled");
   return useQuery({
     queryKey: ["team-vault-folder-secrets", teamId],
     queryFn: async () => {
@@ -140,7 +143,7 @@ export function useTeamVaultFolderSecrets(teamId: string | null) {
       }
       return data ?? [];
     },
-    enabled: !!teamId,
+    enabled: byosEnabled && !!teamId,
     throwOnError: false, // Handle errors gracefully in the component instead of crashing
   });
 }
@@ -152,6 +155,7 @@ export function useTeamVaultSecretKeys(
   teamId: string | null,
   secretPath: string | null,
 ) {
+  const byosEnabled = useFeature("byosEnabled");
   return useQuery({
     queryKey: ["team-vault-secret-keys", teamId, secretPath],
     queryFn: async () => {
@@ -166,7 +170,7 @@ export function useTeamVaultSecretKeys(
       }
       return data ?? { keys: [] };
     },
-    enabled: !!teamId && !!secretPath,
+    enabled: byosEnabled && !!teamId && !!secretPath,
     retry: false, // Don't retry on 403/404 errors
     throwOnError: false, // Handle errors gracefully in the component instead of crashing
   });

--- a/platform/frontend/src/lib/teams/team.query.ts
+++ b/platform/frontend/src/lib/teams/team.query.ts
@@ -1,5 +1,6 @@
 import { archestraApiSdk, type archestraApiTypes } from "@shared";
 import { useQueries, useQuery } from "@tanstack/react-query";
+import { useFeature } from "@/lib/config/config.query";
 
 const { getTeams, getTeamVaultFolder } = archestraApiSdk;
 
@@ -49,6 +50,7 @@ export function useTeamsPaginated(params: TeamsPaginatedParams) {
  * Fetches teams first, then fetches vault folders for each team in parallel
  */
 export function useTeamsWithVaultFolders() {
+  const byosEnabled = useFeature("byosEnabled");
   const { data: teams, isLoading: isLoadingTeams } = useTeams();
 
   const vaultFolderQueries = useQueries({
@@ -60,7 +62,7 @@ export function useTeamsWithVaultFolders() {
         });
         return { teamId: team.id, vaultPath: data?.vaultPath ?? null };
       },
-      enabled: !!teams,
+      enabled: byosEnabled && !!teams,
     })),
   });
 


### PR DESCRIPTION
## Summary

- `useTeamVaultFolder`, `useTeamVaultFolderSecrets`, `useTeamVaultSecretKeys`, and the per-team queries inside `useTeamsWithVaultFolders` fire on mount without consulting the `byosEnabled` feature flag. With `ARCHESTRA_SECRETS_MANAGER` set to `VAULT` or `DB`, each request hits the BYOS-only endpoint and gets a 403 `"Readonly Vault is not enabled"` — visible both as failed network requests on pages like `/mcp/registry` and as noise in backend logs.
- Pass `byosEnabled` into each query's `enabled` option. In `READONLY_VAULT` mode the flag is `true` so behavior is unchanged; in other modes the queries stay idle and no requests are sent.
- The existing UI gates (`if (!byosEnabled) return null` in `ExternalSecretSelector`, the `byosEnabled && ...` branches in the install dialogs) hide UI but run after the hooks, so they can't prevent the fetch.
---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Image" src="https://github.com/user-attachments/assets/1f9497f2-96ad-4334-b3a4-c63ff38abdb9"/>

</a>