### PR TITLE
feat: add audit log UI

### DIFF
--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -190,7 +190,29 @@ const contentNavGroups: NavGroup[] = [
         url: "/llm/logs",
         icon: MessagesSquare,
         customIsActive: (pathname: string) =>
-          pathname.startsWith("/llm/logs") || pathname.startsWith("/mcp/logs"),
+          pathname.startsWith("/audit-log") ||
+          pathname.startsWith("/llm/logs") ||
+          pathname.startsWith("/mcp/logs"),
+        subItems: [
+          {
+            title: "Audit",
+            url: "/audit-log",
+            customIsActive: (pathname: string) =>
+              pathname.startsWith("/audit-log"),
+          },
+          {
+            title: "LLM",
+            url: "/llm/logs",
+            customIsActive: (pathname: string) =>
+              pathname.startsWith("/llm/logs"),
+          },
+          {
+            title: "MCP",
+            url: "/mcp/logs",
+            customIsActive: (pathname: string) =>
+              pathname.startsWith("/mcp/logs"),
+          },
+        ],
       },
       {
         title: "Connect",

--- a/platform/frontend/src/app/audit-log/_parts/audit-event-type-badge.tsx
+++ b/platform/frontend/src/app/audit-log/_parts/audit-event-type-badge.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import type { AuditEventType } from "./audit-log.types";
+
+const AUDIT_EVENT_TYPE_BADGE_CLASSNAME: Record<AuditEventType, string> = {
+  LLM: "border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-900 dark:bg-sky-950 dark:text-sky-300",
+  MCP: "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-300",
+};
+
+export function AuditEventTypeBadge({ type }: { type: AuditEventType }) {
+  return (
+    <Badge variant="outline" className={AUDIT_EVENT_TYPE_BADGE_CLASSNAME[type]}>
+      {type}
+    </Badge>
+  );
+}

--- a/platform/frontend/src/app/audit-log/_parts/audit-log-columns.tsx
+++ b/platform/frontend/src/app/audit-log/_parts/audit-log-columns.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { formatDate } from "@/lib/utils";
+import { AuditEventTypeBadge } from "./audit-event-type-badge";
+import type { AuditLogEvent } from "./audit-log.types";
+import { AuditStatusBadge } from "./audit-status-badge";
+
+export const auditLogColumns: ColumnDef<AuditLogEvent>[] = [
+  {
+    accessorKey: "createdAt",
+    header: "Date",
+    cell: ({ row }) => (
+      <div className="font-mono text-xs whitespace-nowrap">
+        {formatDate({ date: row.original.createdAt })}
+      </div>
+    ),
+  },
+  {
+    accessorKey: "type",
+    header: "Type",
+    cell: ({ row }) => <AuditEventTypeBadge type={row.original.type} />,
+  },
+  {
+    accessorKey: "actor",
+    header: "Actor",
+    cell: ({ row }) => (
+      <div className="max-w-[220px] truncate font-medium">
+        {row.original.actor}
+      </div>
+    ),
+  },
+  {
+    accessorKey: "action",
+    header: "Action",
+    cell: ({ row }) => (
+      <div className="font-mono text-xs">{row.original.action}</div>
+    ),
+  },
+  {
+    accessorKey: "target",
+    header: "Target",
+    cell: ({ row }) => (
+      <div className="max-w-[220px] truncate">{row.original.target}</div>
+    ),
+  },
+  {
+    accessorKey: "from",
+    header: "From",
+    cell: ({ row }) => (
+      <div className="max-w-[180px] truncate text-muted-foreground">
+        {row.original.from}
+      </div>
+    ),
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ row }) => <AuditStatusBadge status={row.original.status} />,
+  },
+  {
+    accessorKey: "summary",
+    header: "Summary",
+    cell: ({ row }) => (
+      <div className="max-w-[360px] truncate text-muted-foreground">
+        {row.original.summary}
+      </div>
+    ),
+  },
+];

--- a/platform/frontend/src/app/audit-log/_parts/audit-log-summary-cards.tsx
+++ b/platform/frontend/src/app/audit-log/_parts/audit-log-summary-cards.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Activity, ShieldCheck, ShieldX } from "lucide-react";
+
+export function AuditLogSummaryCards({
+  totalCount,
+  allowedCount,
+  blockedOrFailedCount,
+}: {
+  totalCount: number;
+  allowedCount: number;
+  blockedOrFailedCount: number;
+}) {
+  return (
+    <div className="mb-4 grid gap-3 md:grid-cols-3">
+      <div className="rounded-md border p-4">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Activity className="h-4 w-4" />
+          Loaded events
+        </div>
+        <div className="mt-2 text-2xl font-semibold">{totalCount}</div>
+      </div>
+      <div className="rounded-md border p-4">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <ShieldCheck className="h-4 w-4" />
+          Allowed
+        </div>
+        <div className="mt-2 text-2xl font-semibold">{allowedCount}</div>
+      </div>
+      <div className="rounded-md border p-4">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <ShieldX className="h-4 w-4" />
+          Blocked or failed
+        </div>
+        <div className="mt-2 text-2xl font-semibold">
+          {blockedOrFailedCount}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/platform/frontend/src/app/audit-log/_parts/audit-log.types.ts
+++ b/platform/frontend/src/app/audit-log/_parts/audit-log.types.ts
@@ -1,0 +1,25 @@
+import type { archestraApiTypes } from "@shared";
+
+export const AUDIT_LOG_SOURCE_LIMIT = 100;
+
+export type AuditEventType = "LLM" | "MCP";
+export type AuditEventTypeFilter = AuditEventType | "all";
+export type AuditEventStatus = "Allowed" | "Denied" | "Failed";
+
+export type LlmInteraction =
+  archestraApiTypes.GetInteractionsResponses["200"]["data"][number];
+export type McpToolCall =
+  archestraApiTypes.GetMcpToolCallsResponses["200"]["data"][number];
+
+export type AuditLogEvent = {
+  id: string;
+  href: string;
+  createdAt: string;
+  type: AuditEventType;
+  actor: string;
+  action: string;
+  target: string;
+  from: string;
+  status: AuditEventStatus;
+  summary: string;
+};

--- a/platform/frontend/src/app/audit-log/_parts/audit-log.utils.test.ts
+++ b/platform/frontend/src/app/audit-log/_parts/audit-log.utils.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@shared")>();
+
+  return {
+    ...actual,
+    DynamicInteraction: class MockDynamicInteraction {
+      private interaction: Record<string, unknown>;
+      modelName?: string;
+
+      constructor(interaction: Record<string, unknown>) {
+        if (interaction.__throwDynamic) {
+          throw new Error("invalid interaction");
+        }
+
+        this.interaction = interaction;
+        this.modelName = interaction.__dynamicModelName as string | undefined;
+      }
+
+      getToolNamesRefused() {
+        return (this.interaction.__blockedTools as string[] | undefined) ?? [];
+      }
+
+      getLastUserMessage() {
+        return this.interaction.__lastUserMessage as string | undefined;
+      }
+    },
+    parseFullToolName: (fullToolName: string) => ({
+      toolName: fullToolName.split("/").at(-1) ?? fullToolName,
+    }),
+  };
+});
+
+import type {
+  AuditLogEvent,
+  LlmInteraction,
+  McpToolCall,
+} from "./audit-log.types";
+import {
+  buildAuditLogEvents,
+  filterAuditLogEvents,
+  getAuditLogSummary,
+  getLlmAuditEvent,
+  getMcpAuditEvent,
+  getValidTypeFilter,
+} from "./audit-log.utils";
+
+describe("audit-log.utils", () => {
+  it("normalizes an invalid type filter to all", () => {
+    expect(getValidTypeFilter("LLM")).toBe("LLM");
+    expect(getValidTypeFilter("bad-value")).toBe("all");
+    expect(getValidTypeFilter(null)).toBe("all");
+  });
+
+  it("maps blocked LLM interactions to denied audit events", () => {
+    const event = getLlmAuditEvent({
+      id: "llm-1",
+      createdAt: "2026-04-20T14:42:18.000Z",
+      type: "openai:responses",
+      model: "gpt-5",
+      userId: "alex@company.com",
+      source: "Web App",
+      __blockedTools: ["postgres.query"],
+    } as unknown as LlmInteraction);
+
+    expect(event).toMatchObject({
+      id: "llm:llm-1",
+      href: "/llm/logs/llm-1",
+      type: "LLM",
+      actor: "alex@company.com",
+      action: "openai.responses",
+      target: "gpt-5",
+      from: "Web App",
+      status: "Denied",
+      summary: "Blocked tools: postgres.query",
+    });
+  });
+
+  it("falls back to dynamic interaction data for allowed LLM events", () => {
+    const event = getLlmAuditEvent({
+      id: "llm-2",
+      createdAt: "2026-04-20T14:31:07.000Z",
+      type: "anthropic:messages",
+      model: null,
+      source: null,
+      sessionSource: "API",
+      __dynamicModelName: "claude-opus-4",
+      __lastUserMessage: "Summarize the quarterly report",
+    } as unknown as LlmInteraction);
+
+    expect(event).toMatchObject({
+      actor: "Unknown",
+      action: "anthropic.messages",
+      target: "claude-opus-4",
+      from: "API",
+      status: "Allowed",
+      summary: "Summarize the quarterly report",
+    });
+  });
+
+  it("maps failed MCP tool calls to failed audit events", () => {
+    const event = getMcpAuditEvent({
+      id: "mcp-1",
+      createdAt: "2026-04-20T14:12:09.000Z",
+      method: "tools/call",
+      mcpServerName: "Google Drive",
+      authMethod: "oauth",
+      userName: "agent:legal-review",
+      toolCall: {
+        name: "google-drive/files.search",
+      },
+      toolResult: { isError: true },
+    } as unknown as McpToolCall);
+
+    expect(event).toMatchObject({
+      id: "mcp:mcp-1",
+      href: "/mcp/logs/mcp-1",
+      type: "MCP",
+      actor: "agent:legal-review",
+      action: "tools/call",
+      target: "files.search",
+      from: "OAuth",
+      status: "Failed",
+      summary: "Called files.search on Google Drive",
+    });
+  });
+
+  it("builds, sorts, filters, and summarizes audit events", () => {
+    const events = buildAuditLogEvents({
+      interactions: [
+        {
+          id: "llm-1",
+          createdAt: "2026-04-20T10:00:00.000Z",
+          type: "openai:responses",
+          model: "gpt-5",
+          userId: "alex@company.com",
+          source: "Web App",
+          __lastUserMessage: "latest forecast",
+        } as unknown as LlmInteraction,
+      ],
+      mcpToolCalls: [
+        {
+          id: "mcp-1",
+          createdAt: "2026-04-20T12:00:00.000Z",
+          method: "tools/call",
+          mcpServerName: "Postgres",
+          authMethod: "org_token",
+          userName: "agent:finance",
+          toolCall: { name: "postgres/query" },
+          toolResult: { isError: false },
+        } as unknown as McpToolCall,
+      ],
+      typeFilter: "all",
+    });
+
+    expect(events.map((event) => event.id)).toEqual(["mcp:mcp-1", "llm:llm-1"]);
+
+    const filteredEvents = filterAuditLogEvents({
+      events: events as AuditLogEvent[],
+      searchQuery: "org token",
+    });
+
+    expect(filteredEvents).toHaveLength(1);
+    expect(filteredEvents[0]?.id).toBe("mcp:mcp-1");
+    expect(getAuditLogSummary(filteredEvents)).toEqual({
+      totalCount: 1,
+      allowedCount: 1,
+      blockedOrFailedCount: 0,
+    });
+  });
+});

--- a/platform/frontend/src/app/audit-log/_parts/audit-log.utils.ts
+++ b/platform/frontend/src/app/audit-log/_parts/audit-log.utils.ts
@@ -1,0 +1,168 @@
+import { DynamicInteraction, parseFullToolName } from "@shared";
+import { formatAuthMethod } from "@/lib/mcp/mcp-tool-call.query";
+import type {
+  AuditEventStatus,
+  AuditEventTypeFilter,
+  AuditLogEvent,
+  LlmInteraction,
+  McpToolCall,
+} from "./audit-log.types";
+
+export function getValidTypeFilter(value: string | null): AuditEventTypeFilter {
+  if (value === "LLM" || value === "MCP") {
+    return value;
+  }
+  return "all";
+}
+
+function getDynamicInteraction(interaction: LlmInteraction) {
+  try {
+    return new DynamicInteraction(interaction);
+  } catch {
+    return null;
+  }
+}
+
+export function getLlmAuditEvent(interaction: LlmInteraction): AuditLogEvent {
+  const dynamicInteraction = getDynamicInteraction(interaction);
+  const blockedTools = dynamicInteraction?.getToolNamesRefused() ?? [];
+  const lastUserMessage = dynamicInteraction?.getLastUserMessage();
+  const [provider, endpoint] = interaction.type.split(":");
+  const model = interaction.model ?? dynamicInteraction?.modelName;
+  const externalAgentIdLabel =
+    "externalAgentIdLabel" in interaction
+      ? interaction.externalAgentIdLabel
+      : null;
+  const actor =
+    externalAgentIdLabel ??
+    interaction.userId ??
+    interaction.externalAgentId ??
+    interaction.source ??
+    "Unknown";
+  const status: AuditEventStatus =
+    blockedTools.length > 0 ||
+    interaction.unsafeContextBoundary?.reason === "tool_result_blocked"
+      ? "Denied"
+      : "Allowed";
+
+  return {
+    id: `llm:${interaction.id}`,
+    href: `/llm/logs/${interaction.id}`,
+    createdAt: interaction.createdAt,
+    type: "LLM",
+    actor,
+    action: `${provider ?? "llm"}.${endpoint ?? "request"}`,
+    target: model ?? "Unknown model",
+    from: interaction.source ?? interaction.sessionSource ?? "API",
+    status,
+    summary:
+      blockedTools.length > 0
+        ? `Blocked tools: ${blockedTools.join(", ")}`
+        : lastUserMessage || `Processed ${model ?? "LLM"} request`,
+  };
+}
+
+export function isMcpToolCallFailed(toolCall: McpToolCall) {
+  if (toolCall.method !== "tools/call") {
+    return false;
+  }
+
+  const result = toolCall.toolResult;
+  return (
+    result !== null &&
+    typeof result === "object" &&
+    "isError" in result &&
+    Boolean((result as { isError?: unknown }).isError)
+  );
+}
+
+export function getMcpTarget(toolCall: McpToolCall) {
+  const rawToolName = toolCall.toolCall?.name;
+  if (!rawToolName) {
+    return toolCall.mcpServerName;
+  }
+
+  const { toolName } = parseFullToolName(rawToolName);
+  return toolName || rawToolName;
+}
+
+export function getMcpAuditEvent(toolCall: McpToolCall): AuditLogEvent {
+  const target = getMcpTarget(toolCall);
+  const actor =
+    toolCall.userName ??
+    toolCall.userId ??
+    formatAuthMethod(toolCall.authMethod) ??
+    "Unknown";
+  const failed = isMcpToolCallFailed(toolCall);
+
+  return {
+    id: `mcp:${toolCall.id}`,
+    href: `/mcp/logs/${toolCall.id}`,
+    createdAt: toolCall.createdAt,
+    type: "MCP",
+    actor,
+    action: toolCall.method || "tools/call",
+    target,
+    from: formatAuthMethod(toolCall.authMethod),
+    status: failed ? "Failed" : "Allowed",
+    summary: toolCall.toolCall
+      ? `Called ${target} on ${toolCall.mcpServerName}`
+      : `${toolCall.method} on ${toolCall.mcpServerName}`,
+  };
+}
+
+export function buildAuditLogEvents({
+  interactions,
+  mcpToolCalls,
+  typeFilter,
+}: {
+  interactions: LlmInteraction[];
+  mcpToolCalls: McpToolCall[];
+  typeFilter: AuditEventTypeFilter;
+}) {
+  const llmEvents =
+    typeFilter === "MCP" ? [] : interactions.map(getLlmAuditEvent);
+  const mcpEvents =
+    typeFilter === "LLM" ? [] : mcpToolCalls.map(getMcpAuditEvent);
+
+  return [...llmEvents, ...mcpEvents].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+}
+
+export function filterAuditLogEvents({
+  events,
+  searchQuery,
+}: {
+  events: AuditLogEvent[];
+  searchQuery: string;
+}) {
+  const normalizedSearch = searchQuery.trim().toLowerCase();
+  if (!normalizedSearch) {
+    return events;
+  }
+
+  return events.filter((event) =>
+    [
+      event.actor,
+      event.action,
+      event.target,
+      event.from,
+      event.status,
+      event.summary,
+      event.type,
+    ].some((value) => value.toLowerCase().includes(normalizedSearch)),
+  );
+}
+
+export function getAuditLogSummary(events: AuditLogEvent[]) {
+  const allowedCount = events.filter(
+    (event) => event.status === "Allowed",
+  ).length;
+
+  return {
+    totalCount: events.length,
+    allowedCount,
+    blockedOrFailedCount: events.length - allowedCount,
+  };
+}

--- a/platform/frontend/src/app/audit-log/_parts/audit-status-badge.tsx
+++ b/platform/frontend/src/app/audit-log/_parts/audit-status-badge.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { ShieldCheck, ShieldX } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { AuditEventStatus } from "./audit-log.types";
+
+export function AuditStatusBadge({ status }: { status: AuditEventStatus }) {
+  if (status === "Allowed") {
+    return (
+      <Badge
+        variant="outline"
+        className="border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-300"
+      >
+        <ShieldCheck className="h-3 w-3" />
+        Allowed
+      </Badge>
+    );
+  }
+
+  if (status === "Denied") {
+    return (
+      <Badge
+        variant="outline"
+        className="border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300"
+      >
+        <ShieldX className="h-3 w-3" />
+        Denied
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge variant="destructive">
+      <ShieldX className="h-3 w-3" />
+      Failed
+    </Badge>
+  );
+}

--- a/platform/frontend/src/app/audit-log/page.client.test.tsx
+++ b/platform/frontend/src/app/audit-log/page.client.test.tsx
@@ -1,0 +1,438 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useRouter } from "next/navigation";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
+import { useDateTimeRangePicker } from "@/lib/hooks/use-date-time-range-picker";
+import { useInteractions } from "@/lib/interactions/interaction.query";
+import { useMcpToolCalls } from "@/lib/mcp/mcp-tool-call.query";
+import AuditLogPage from "./page.client";
+
+vi.mock("@shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@shared")>();
+
+  return {
+    ...actual,
+    DynamicInteraction: class MockDynamicInteraction {
+      private interaction: Record<string, unknown>;
+      modelName?: string;
+
+      constructor(interaction: Record<string, unknown>) {
+        this.interaction = interaction;
+        this.modelName = interaction.__dynamicModelName as string | undefined;
+      }
+
+      getToolNamesRefused() {
+        return (this.interaction.__blockedTools as string[] | undefined) ?? [];
+      }
+
+      getLastUserMessage() {
+        return this.interaction.__lastUserMessage as string | undefined;
+      }
+    },
+    parseFullToolName: (fullToolName: string) => ({
+      toolName: fullToolName.split("/").at(-1) ?? fullToolName,
+    }),
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(),
+}));
+
+vi.mock("@/lib/hooks/use-data-table-query-params", () => ({
+  useDataTableQueryParams: vi.fn(),
+}));
+
+vi.mock("@/lib/hooks/use-date-time-range-picker", () => ({
+  useDateTimeRangePicker: vi.fn(),
+}));
+
+vi.mock("@/lib/interactions/interaction.query", () => ({
+  useInteractions: vi.fn(),
+}));
+
+vi.mock("@/lib/mcp/mcp-tool-call.query", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/mcp/mcp-tool-call.query")>();
+
+  return {
+    ...actual,
+    useMcpToolCalls: vi.fn(),
+  };
+});
+
+vi.mock("@/components/page-layout", () => ({
+  PageLayout: ({
+    title,
+    description,
+    tabs,
+    children,
+  }: {
+    title: string;
+    description: ReactNode;
+    tabs: Array<{ label: string; href: string }>;
+    children: ReactNode;
+  }) => (
+    <section>
+      <h1>{title}</h1>
+      <div>{description}</div>
+      <nav>
+        {tabs.map((tab) => (
+          <span key={tab.href}>{tab.label}</span>
+        ))}
+      </nav>
+      {children}
+    </section>
+  ),
+}));
+
+vi.mock("@/components/table-filters", () => ({
+  TableFilters: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/components/search-input", () => ({
+  SearchInput: ({
+    placeholder,
+    value,
+    onSearchChange,
+  }: {
+    placeholder: string;
+    value: string;
+    onSearchChange: (value: string) => void;
+  }) => (
+    <input
+      aria-label="Search audit events"
+      defaultValue={value}
+      placeholder={placeholder}
+      onChange={(event) => onSearchChange(event.target.value)}
+    />
+  ),
+}));
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string;
+    onValueChange: (value: string) => void;
+    children: ReactNode;
+  }) => (
+    <select
+      aria-label="Audit type filter"
+      value={value}
+      onChange={(event) => onValueChange(event.target.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+}));
+
+vi.mock("@/components/ui/date-time-range-picker", () => ({
+  DateTimeRangePicker: ({ displayText }: { displayText: string | null }) => (
+    <div>{displayText ?? "All dates"}</div>
+  ),
+}));
+
+vi.mock("@/components/ui/data-table", () => ({
+  DataTable: ({
+    data,
+    emptyMessage,
+    filteredEmptyMessage,
+    hasActiveFilters,
+    isLoading,
+    onClearFilters,
+    onRowClick,
+  }: {
+    data: Array<{
+      id: string;
+      type: string;
+      actor: string;
+      status: string;
+      summary: string;
+      href: string;
+    }>;
+    emptyMessage: string;
+    filteredEmptyMessage: string;
+    hasActiveFilters: boolean;
+    isLoading: boolean;
+    onClearFilters: () => void;
+    onRowClick?: (row: {
+      id: string;
+      type: string;
+      actor: string;
+      status: string;
+      summary: string;
+      href: string;
+    }) => void;
+  }) => {
+    if (isLoading) {
+      return <div>Loading table</div>;
+    }
+
+    if (data.length === 0) {
+      return (
+        <div>
+          <div>{hasActiveFilters ? filteredEmptyMessage : emptyMessage}</div>
+          <button type="button" onClick={onClearFilters}>
+            Clear filters
+          </button>
+        </div>
+      );
+    }
+
+    return (
+      <div>
+        <button type="button" onClick={onClearFilters}>
+          Clear filters
+        </button>
+        {data.map((row) => (
+          <button key={row.id} type="button" onClick={() => onRowClick?.(row)}>
+            {`${row.type}:${row.actor}:${row.status}:${row.summary}`}
+          </button>
+        ))}
+      </div>
+    );
+  },
+}));
+
+const mockRouterPush = vi.fn();
+const mockUpdateQueryParams = vi.fn();
+const mockClearDateRange = vi.fn();
+
+describe("AuditLogPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(useRouter).mockReturnValue({
+      push: mockRouterPush,
+    } as unknown as ReturnType<typeof useRouter>);
+
+    vi.mocked(useDataTableQueryParams).mockReturnValue({
+      ...createDataTableQueryParams(),
+    });
+
+    vi.mocked(useDateTimeRangePicker).mockReturnValue({
+      startDate: undefined,
+      endDate: undefined,
+      isDateDialogOpen: false,
+      tempStartDate: undefined,
+      tempEndDate: undefined,
+      setIsDateDialogOpen: vi.fn(),
+      setTempStartDate: vi.fn(),
+      setTempEndDate: vi.fn(),
+      openDateDialog: vi.fn(),
+      handleApplyDateRange: vi.fn(),
+      clearDateRange: mockClearDateRange,
+      getDateRangeDisplay: () => null,
+      startDateParam: undefined,
+      endDateParam: undefined,
+    });
+
+    vi.mocked(useInteractions).mockReturnValue(
+      createQueryResult([
+        {
+          id: "llm-1",
+          createdAt: "2026-04-20T10:00:00.000Z",
+          type: "openai:responses",
+          model: "gpt-5",
+          userId: "alex@company.com",
+          source: "Web App",
+          __lastUserMessage: "Sent chat completion request",
+        },
+        {
+          id: "llm-2",
+          createdAt: "2026-04-20T09:00:00.000Z",
+          type: "openai:responses",
+          model: "gpt-5-mini",
+          userId: "maria@company.com",
+          source: "Web App",
+          __blockedTools: ["postgres.query"],
+        },
+      ]) as unknown as ReturnType<typeof useInteractions>,
+    );
+
+    vi.mocked(useMcpToolCalls).mockReturnValue(
+      createQueryResult([
+        {
+          id: "mcp-1",
+          createdAt: "2026-04-20T11:00:00.000Z",
+          method: "tools/call",
+          mcpServerName: "Postgres",
+          authMethod: "oauth",
+          userName: "agent:finance",
+          toolCall: { name: "postgres/query" },
+          toolResult: { isError: true },
+        },
+      ]) as unknown as ReturnType<typeof useMcpToolCalls>,
+    );
+  });
+
+  it("renders combined audit events with summary counts", () => {
+    render(<AuditLogPage />);
+
+    expect(screen.getByText("Audit Log")).toBeVisible();
+    expect(screen.getByText("Loaded events")).toBeVisible();
+    expect(screen.getByText("3")).toBeVisible();
+    expect(screen.getByText("1")).toBeVisible();
+    expect(screen.getByText("2")).toBeVisible();
+    expect(
+      screen.getByRole("button", {
+        name: "MCP:agent:finance:Failed:Called query on Postgres",
+      }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", {
+        name: "LLM:alex@company.com:Allowed:Sent chat completion request",
+      }),
+    ).toBeVisible();
+  });
+
+  it("updates query params when search and type filters change", async () => {
+    const user = userEvent.setup();
+
+    render(<AuditLogPage />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Search audit events" }),
+      "postgres",
+    );
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Audit type filter" }),
+      "MCP",
+    );
+
+    expect(mockUpdateQueryParams).toHaveBeenCalledWith({
+      search: "postgres",
+    });
+    expect(mockUpdateQueryParams).toHaveBeenCalledWith({
+      type: "MCP",
+    });
+  });
+
+  it("clears all filters and date range from the table action", async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(useDataTableQueryParams).mockReturnValue({
+      ...createDataTableQueryParams(
+        new URLSearchParams(
+          "search=postgres&type=MCP&startDate=2026-04-20T00%3A00%3A00.000Z&endDate=2026-04-20T23%3A59%3A59.999Z",
+        ),
+      ),
+    });
+
+    vi.mocked(useDateTimeRangePicker).mockReturnValue({
+      startDate: new Date("2026-04-20T00:00:00.000Z"),
+      endDate: new Date("2026-04-20T23:59:59.999Z"),
+      isDateDialogOpen: false,
+      tempStartDate: undefined,
+      tempEndDate: undefined,
+      setIsDateDialogOpen: vi.fn(),
+      setTempStartDate: vi.fn(),
+      setTempEndDate: vi.fn(),
+      openDateDialog: vi.fn(),
+      handleApplyDateRange: vi.fn(),
+      clearDateRange: mockClearDateRange,
+      getDateRangeDisplay: () => "Apr 20, 2026",
+      startDateParam: "2026-04-20T00:00:00.000Z",
+      endDateParam: "2026-04-20T23:59:59.999Z",
+    });
+
+    render(<AuditLogPage />);
+
+    await user.click(screen.getByRole("button", { name: "Clear filters" }));
+
+    expect(mockClearDateRange).toHaveBeenCalledTimes(1);
+    expect(mockUpdateQueryParams).toHaveBeenCalledWith({
+      search: null,
+      type: null,
+      startDate: null,
+      endDate: null,
+    });
+  });
+
+  it("navigates to the underlying log detail page when a row is clicked", async () => {
+    const user = userEvent.setup();
+
+    render(<AuditLogPage />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "MCP:agent:finance:Failed:Called query on Postgres",
+      }),
+    );
+
+    expect(mockRouterPush).toHaveBeenCalledWith("/mcp/logs/mcp-1");
+  });
+
+  it("disables the LLM query when the MCP filter is active", () => {
+    vi.mocked(useDataTableQueryParams).mockReturnValue({
+      ...createDataTableQueryParams(new URLSearchParams("type=MCP")),
+    });
+
+    render(<AuditLogPage />);
+
+    expect(vi.mocked(useInteractions)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+      }),
+    );
+    expect(vi.mocked(useMcpToolCalls)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true,
+      }),
+    );
+    expect(
+      screen.getByRole("button", {
+        name: "MCP:agent:finance:Failed:Called query on Postgres",
+      }),
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("button", {
+        name: "LLM:alex@company.com:Allowed:Sent chat completion request",
+      }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+function createQueryResult<T extends Record<string, unknown>>(data: T[]) {
+  return {
+    data: {
+      data,
+      pagination: {
+        currentPage: 1,
+        limit: 100,
+        total: data.length,
+        totalPages: 1,
+        hasNext: false,
+        hasPrev: false,
+      },
+    },
+    isFetching: false,
+  } as const;
+}
+
+function createDataTableQueryParams(searchParams = new URLSearchParams()) {
+  return {
+    searchParams: searchParams as unknown as ReturnType<
+      typeof useDataTableQueryParams
+    >["searchParams"],
+    pathname: "/audit-log",
+    pageIndex: 0,
+    pageSize: 100,
+    offset: 0,
+    updateQueryParams: mockUpdateQueryParams,
+    setPagination: vi.fn(),
+  } as ReturnType<typeof useDataTableQueryParams>;
+}

--- a/platform/frontend/src/app/audit-log/page.client.tsx
+++ b/platform/frontend/src/app/audit-log/page.client.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import type { archestraApiTypes } from "@shared";
+import { useRouter } from "next/navigation";
+import { useCallback, useMemo } from "react";
+import { PageLayout } from "@/components/page-layout";
+import { SearchInput } from "@/components/search-input";
+import { TableFilters } from "@/components/table-filters";
+import { DataTable } from "@/components/ui/data-table";
+import { DateTimeRangePicker } from "@/components/ui/date-time-range-picker";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
+import { useDateTimeRangePicker } from "@/lib/hooks/use-date-time-range-picker";
+import { useInteractions } from "@/lib/interactions/interaction.query";
+import { useMcpToolCalls } from "@/lib/mcp/mcp-tool-call.query";
+import { ErrorBoundary } from "../_parts/error-boundary";
+import { AUDIT_LOG_SOURCE_LIMIT } from "./_parts/audit-log.types";
+import {
+  buildAuditLogEvents,
+  filterAuditLogEvents,
+  getAuditLogSummary,
+  getValidTypeFilter,
+} from "./_parts/audit-log.utils";
+import { auditLogColumns } from "./_parts/audit-log-columns";
+import { AuditLogSummaryCards } from "./_parts/audit-log-summary-cards";
+
+type AuditLogInitialData = {
+  interactions: archestraApiTypes.GetInteractionsResponses["200"];
+  mcpToolCalls: archestraApiTypes.GetMcpToolCallsResponses["200"];
+};
+
+export default function AuditLogPage({
+  initialData,
+}: {
+  initialData?: AuditLogInitialData;
+}) {
+  return (
+    <div>
+      <ErrorBoundary>
+        <AuditLogTable initialData={initialData} />
+      </ErrorBoundary>
+    </div>
+  );
+}
+
+function AuditLogTable({ initialData }: { initialData?: AuditLogInitialData }) {
+  const router = useRouter();
+  const { searchParams, updateQueryParams } = useDataTableQueryParams();
+  const typeFilter = getValidTypeFilter(searchParams.get("type"));
+  const searchQuery = searchParams.get("search") ?? "";
+  const startDateFromUrl = searchParams.get("startDate");
+  const endDateFromUrl = searchParams.get("endDate");
+
+  const dateTimePicker = useDateTimeRangePicker({
+    startDateFromUrl,
+    endDateFromUrl,
+    onDateRangeChange: useCallback(
+      ({ startDate, endDate }) => {
+        updateQueryParams({ startDate, endDate });
+      },
+      [updateQueryParams],
+    ),
+  });
+
+  const { data: interactionsResponse, isFetching: isFetchingInteractions } =
+    useInteractions({
+      limit: AUDIT_LOG_SOURCE_LIMIT,
+      offset: 0,
+      sortBy: "createdAt",
+      sortDirection: "desc",
+      startDate: dateTimePicker.startDateParam,
+      endDate: dateTimePicker.endDateParam,
+      initialData: initialData?.interactions,
+      enabled: typeFilter === "all" || typeFilter === "LLM",
+    });
+
+  const { data: mcpToolCallsResponse, isFetching: isFetchingMcpToolCalls } =
+    useMcpToolCalls({
+      limit: AUDIT_LOG_SOURCE_LIMIT,
+      offset: 0,
+      sortBy: "createdAt",
+      sortDirection: "desc",
+      startDate: dateTimePicker.startDateParam,
+      endDate: dateTimePicker.endDateParam,
+      initialData: initialData?.mcpToolCalls,
+      enabled: typeFilter === "all" || typeFilter === "MCP",
+    });
+
+  const interactions =
+    interactionsResponse?.data ?? initialData?.interactions.data ?? [];
+  const mcpToolCalls =
+    mcpToolCallsResponse?.data ?? initialData?.mcpToolCalls.data ?? [];
+
+  const auditEvents = useMemo(() => {
+    return buildAuditLogEvents({
+      interactions,
+      mcpToolCalls,
+      typeFilter,
+    });
+  }, [interactions, mcpToolCalls, typeFilter]);
+
+  const filteredEvents = useMemo(() => {
+    return filterAuditLogEvents({ events: auditEvents, searchQuery });
+  }, [auditEvents, searchQuery]);
+
+  const { totalCount, allowedCount, blockedOrFailedCount } = useMemo(
+    () => getAuditLogSummary(filteredEvents),
+    [filteredEvents],
+  );
+  const hasActiveFilters =
+    searchQuery.length > 0 ||
+    typeFilter !== "all" ||
+    dateTimePicker.startDate !== undefined;
+
+  const clearFilters = useCallback(() => {
+    dateTimePicker.clearDateRange();
+    updateQueryParams({
+      search: null,
+      type: null,
+      startDate: null,
+      endDate: null,
+    });
+  }, [dateTimePicker, updateQueryParams]);
+
+  return (
+    <PageLayout
+      title="Audit Log"
+      description="Review security-relevant platform activity across LLM and MCP events."
+      tabs={[
+        { label: "Audit", href: "/audit-log" },
+        { label: "LLM", href: "/llm/logs" },
+        { label: "MCP", href: "/mcp/logs" },
+      ]}
+    >
+      <TableFilters>
+        <SearchInput
+          placeholder="Search audit events..."
+          value={searchQuery}
+          onSearchChange={(value) =>
+            updateQueryParams({ search: value || null })
+          }
+          syncQueryParams={false}
+        />
+        <Select
+          value={typeFilter}
+          onValueChange={(value) => updateQueryParams({ type: value })}
+        >
+          <SelectTrigger className="w-[160px]">
+            <SelectValue placeholder="Event type" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All types</SelectItem>
+            <SelectItem value="LLM">LLM</SelectItem>
+            <SelectItem value="MCP">MCP</SelectItem>
+          </SelectContent>
+        </Select>
+        <DateTimeRangePicker
+          startDate={dateTimePicker.startDate}
+          endDate={dateTimePicker.endDate}
+          isDialogOpen={dateTimePicker.isDateDialogOpen}
+          tempStartDate={dateTimePicker.tempStartDate}
+          tempEndDate={dateTimePicker.tempEndDate}
+          displayText={dateTimePicker.getDateRangeDisplay()}
+          onDialogOpenChange={dateTimePicker.setIsDateDialogOpen}
+          onTempStartDateChange={dateTimePicker.setTempStartDate}
+          onTempEndDateChange={dateTimePicker.setTempEndDate}
+          onOpenDialog={dateTimePicker.openDateDialog}
+          onApply={dateTimePicker.handleApplyDateRange}
+        />
+      </TableFilters>
+      <AuditLogSummaryCards
+        totalCount={totalCount}
+        allowedCount={allowedCount}
+        blockedOrFailedCount={blockedOrFailedCount}
+      />
+      <DataTable
+        columns={auditLogColumns}
+        data={filteredEvents}
+        emptyMessage="No audit events found. LLM requests and MCP tool calls will appear here when activity is recorded."
+        hasActiveFilters={hasActiveFilters}
+        filteredEmptyMessage="No audit events match your filters."
+        hidePaginationWhenSinglePage
+        isLoading={isFetchingInteractions || isFetchingMcpToolCalls}
+        onClearFilters={clearFilters}
+        onRowClick={(row) => {
+          router.push(row.href);
+        }}
+      />
+    </PageLayout>
+  );
+}

--- a/platform/frontend/src/app/audit-log/page.tsx
+++ b/platform/frontend/src/app/audit-log/page.tsx
@@ -1,0 +1,88 @@
+import {
+  archestraApiSdk,
+  type archestraApiTypes,
+  type ErrorExtended,
+} from "@shared";
+import { ServerErrorFallback } from "@/components/error-fallback";
+import { handleApiError } from "@/lib/utils";
+import { getServerApiHeaders } from "@/lib/utils/server";
+import { AUDIT_LOG_SOURCE_LIMIT } from "./_parts/audit-log.types";
+import AuditLogPage from "./page.client";
+
+export const dynamic = "force-dynamic";
+
+function createEmptyPaginatedResponse<T>(limit: number) {
+  return {
+    data: [] as T[],
+    pagination: {
+      currentPage: 1,
+      limit,
+      total: 0,
+      totalPages: 0,
+      hasNext: false,
+      hasPrev: false,
+    },
+  };
+}
+
+export default async function AuditLogPageServer() {
+  let initialData: {
+    interactions: archestraApiTypes.GetInteractionsResponses["200"];
+    mcpToolCalls: archestraApiTypes.GetMcpToolCallsResponses["200"];
+  } = {
+    interactions: createEmptyPaginatedResponse<
+      archestraApiTypes.GetInteractionsResponses["200"]["data"][number]
+    >(AUDIT_LOG_SOURCE_LIMIT),
+    mcpToolCalls: createEmptyPaginatedResponse<
+      archestraApiTypes.GetMcpToolCallsResponses["200"]["data"][number]
+    >(AUDIT_LOG_SOURCE_LIMIT),
+  };
+
+  try {
+    const headers = await getServerApiHeaders();
+    const [interactionsResponse, mcpToolCallsResponse] = await Promise.all([
+      archestraApiSdk.getInteractions({
+        headers,
+        query: {
+          limit: AUDIT_LOG_SOURCE_LIMIT,
+          offset: 0,
+          sortBy: "createdAt",
+          sortDirection: "desc",
+        },
+      }),
+      archestraApiSdk.getMcpToolCalls({
+        headers,
+        query: {
+          limit: AUDIT_LOG_SOURCE_LIMIT,
+          offset: 0,
+          sortBy: "createdAt",
+          sortDirection: "desc",
+        },
+      }),
+    ]);
+
+    if (interactionsResponse.error) {
+      handleApiError(interactionsResponse.error);
+    }
+    if (mcpToolCallsResponse.error) {
+      handleApiError(mcpToolCallsResponse.error);
+    }
+
+    initialData = {
+      interactions:
+        interactionsResponse.data ??
+        createEmptyPaginatedResponse<
+          archestraApiTypes.GetInteractionsResponses["200"]["data"][number]
+        >(AUDIT_LOG_SOURCE_LIMIT),
+      mcpToolCalls:
+        mcpToolCallsResponse.data ??
+        createEmptyPaginatedResponse<
+          archestraApiTypes.GetMcpToolCallsResponses["200"]["data"][number]
+        >(AUDIT_LOG_SOURCE_LIMIT),
+    };
+  } catch (error) {
+    return <ServerErrorFallback error={error as ErrorExtended} />;
+  }
+
+  return <AuditLogPage initialData={initialData} />;
+}

--- a/platform/frontend/src/lib/mcp/mcp-tool-call.query.ts
+++ b/platform/frontend/src/lib/mcp/mcp-tool-call.query.ts
@@ -37,6 +37,7 @@ export function useMcpToolCalls({
   sortBy,
   sortDirection = "desc",
   initialData,
+  enabled = true,
 }: {
   agentId?: string;
   startDate?: string;
@@ -51,6 +52,7 @@ export function useMcpToolCalls({
     archestraApiTypes.GetMcpToolCallsData["query"]
   >["sortDirection"];
   initialData?: archestraApiTypes.GetMcpToolCallsResponses["200"];
+  enabled?: boolean;
 } = {}) {
   return useQuery({
     queryKey: [
@@ -117,6 +119,7 @@ export function useMcpToolCalls({
       !search
         ? initialData
         : undefined,
+    enabled,
   });
 }
 

--- a/platform/shared/access-control.ts
+++ b/platform/shared/access-control.ts
@@ -1052,6 +1052,7 @@ export const requiredPagePermissionsMap: Record<string, Permissions> = {
   },
 
   // Logs
+  "/audit-log": { log: ["read"] },
   "/llm/logs": { log: ["read"] },
   "/mcp/logs": { log: ["read"] },
 


### PR DESCRIPTION
- add a new `/audit-log` page under Logs
- aggregate existing LLM interactions and MCP tool calls into a unified audit log view
- add filtering, summary cards, and navigation to underlying log entries
- add unit and UI tests for audit log utilities and page behavior