### PR TITLE
fix: render user chat messages as plain text

### DIFF
--- a/platform/frontend/src/components/chat/editable-user-message.tsx
+++ b/platform/frontend/src/components/chat/editable-user-message.tsx
@@ -9,8 +9,8 @@ import {
   useState,
 } from "react";
 import { Message, MessageContent } from "@/components/ai-elements/message";
-import { Response } from "@/components/ai-elements/response";
 import { MessageActions } from "@/components/chat/message-actions";
+import { UserMessageText } from "@/components/chat/user-message-text";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -18,7 +18,6 @@ import {
   isCsvAttachment,
   isPlainTextAttachment,
 } from "@/lib/chat/chat-attachment-display";
-import { preserveNewlines } from "@/lib/chat/chat-utils";
 import { cn } from "@/lib/utils";
 
 export interface FileAttachment {
@@ -248,7 +247,7 @@ export function EditableUserMessage({
         {/* Text message bubble - only show if there's text */}
         {text && (
           <MessageContent>
-            <Response>{preserveNewlines(text)}</Response>
+            <UserMessageText text={text} />
           </MessageContent>
         )}
         {/* Actions below the message - only show edit for messages with text */}

--- a/platform/frontend/src/components/chat/user-message-text.test.tsx
+++ b/platform/frontend/src/components/chat/user-message-text.test.tsx
@@ -1,0 +1,25 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { UserMessageText } from "./user-message-text";
+
+describe("UserMessageText", () => {
+  it("renders markdown-looking pasted text as literal text", () => {
+    const text =
+      "TASK-1001 - Runbook wiki page write\nstatus: keep **Open**\nComment:\n\n_Deployitized_ html_page";
+
+    const { container } = render(<UserMessageText text={text} />);
+
+    expect(screen.getByText(/\*\*Open\*\*/)).toBeInTheDocument();
+    expect(screen.getByText(/_Deployitized_/)).toBeInTheDocument();
+    expect(container.querySelector("strong")).not.toBeInTheDocument();
+    expect(container.querySelector("em")).not.toBeInTheDocument();
+  });
+
+  it("preserves user-entered line breaks with CSS instead of markdown hard breaks", () => {
+    const { container } = render(<UserMessageText text={"first\nsecond"} />);
+
+    expect(container.firstElementChild?.textContent).toBe("first\nsecond");
+    expect(container.firstElementChild).toHaveClass("whitespace-pre-wrap");
+  });
+});

--- a/platform/frontend/src/components/chat/user-message-text.tsx
+++ b/platform/frontend/src/components/chat/user-message-text.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import type { HTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+
+interface UserMessageTextProps extends HTMLAttributes<HTMLDivElement> {
+  text: string;
+}
+
+export function UserMessageText({
+  className,
+  text,
+  ...props
+}: UserMessageTextProps) {
+  return (
+    <div
+      className={cn("whitespace-pre-wrap break-words", className)}
+      {...props}
+    >
+      {text}
+    </div>
+  );
+}

--- a/platform/frontend/src/components/message-thread.tsx
+++ b/platform/frontend/src/components/message-thread.tsx
@@ -58,10 +58,10 @@ import {
 } from "@/components/chat/message-boundary-divider";
 import { PolicyDeniedTool } from "@/components/chat/policy-denied-tool";
 import { SwapAgentBoundaryDivider } from "@/components/chat/swap-agent-boundary";
+import { UserMessageText } from "@/components/chat/user-message-text";
 import Divider from "@/components/divider";
 import { Button } from "@/components/ui/button";
 import { getToolNameFromPart } from "@/lib/chat/chat-tools-display.utils";
-import { preserveNewlines } from "@/lib/chat/chat-utils";
 import { parsePolicyDenied } from "@/lib/chat/mcp-error-ui";
 import {
   getRenderedToolName,
@@ -307,11 +307,11 @@ const MessageThread = ({
                                       System Prompt
                                     </div>
                                   )}
-                                  <Response>
-                                    {message.role === "user"
-                                      ? preserveNewlines(part.text)
-                                      : part.text}
-                                  </Response>
+                                  {message.role === "user" ? (
+                                    <UserMessageText text={part.text} />
+                                  ) : (
+                                    <Response>{part.text}</Response>
+                                  )}
                                   {citationParts && (
                                     <KnowledgeGraphCitations
                                       parts={citationParts}

--- a/platform/frontend/src/lib/chat/chat-utils.test.ts
+++ b/platform/frontend/src/lib/chat/chat-utils.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   getChatExternalAgentId,
   getConversationDisplayTitle,
-  preserveNewlines,
 } from "./chat-utils";
 
 const DEFAULT_SESSION_NAME = "New Chat Session";
@@ -144,95 +143,5 @@ describe("getChatExternalAgentId", () => {
 
   it("handles mixed ASCII and non-ISO-8859-1 characters", () => {
     expect(getChatExternalAgentId("Hello 世界 App")).toBe("Hello App Chat");
-  });
-});
-
-describe("preserveNewlines", () => {
-  it("returns empty string for empty input", () => {
-    expect(preserveNewlines("")).toBe("");
-  });
-
-  it("returns the input as-is for falsy values", () => {
-    expect(preserveNewlines("")).toBe("");
-  });
-
-  it("returns single-line text unchanged", () => {
-    expect(preserveNewlines("Hello world")).toBe("Hello world");
-  });
-
-  it("appends two trailing spaces to preserve single newlines", () => {
-    expect(preserveNewlines("line 1\nline 2")).toBe("line 1  \nline 2");
-  });
-
-  it("preserves multiple consecutive newlines as paragraph breaks", () => {
-    expect(preserveNewlines("line 1\n\nline 2")).toBe("line 1  \n\nline 2");
-  });
-
-  it("handles three or more lines", () => {
-    expect(preserveNewlines("line 1\nline 2\nline 3")).toBe(
-      "line 1  \nline 2  \nline 3",
-    );
-  });
-
-  it("does not add trailing spaces to the last line", () => {
-    const result = preserveNewlines("line 1\nline 2");
-    expect(result.endsWith("line 2")).toBe(true);
-    expect(result.endsWith("line 2  ")).toBe(false);
-  });
-
-  it("does not double-add trailing spaces to lines already ending with two spaces", () => {
-    expect(preserveNewlines("line 1  \nline 2")).toBe("line 1  \nline 2");
-  });
-
-  it("leaves empty lines unchanged (they create paragraph breaks in markdown)", () => {
-    expect(preserveNewlines("line 1\n\nline 3")).toBe("line 1  \n\nline 3");
-  });
-
-  it("preserves text inside fenced code blocks with backticks", () => {
-    const input = "before\n```\ncode line 1\ncode line 2\n```\nafter";
-    const expected = "before  \n```\ncode line 1\ncode line 2\n```\nafter";
-    expect(preserveNewlines(input)).toBe(expected);
-  });
-
-  it("preserves text inside fenced code blocks with tildes", () => {
-    const input = "before\n~~~\ncode line 1\ncode line 2\n~~~\nafter";
-    const expected = "before  \n~~~\ncode line 1\ncode line 2\n~~~\nafter";
-    expect(preserveNewlines(input)).toBe(expected);
-  });
-
-  it("preserves text inside fenced code blocks with language specifier", () => {
-    const input =
-      "before\n```python\nprint('hello')\nprint('world')\n```\nafter";
-    const expected =
-      "before  \n```python\nprint('hello')\nprint('world')\n```\nafter";
-    expect(preserveNewlines(input)).toBe(expected);
-  });
-
-  it("handles mixed content with code blocks and regular text", () => {
-    const input = "line 1\nline 2\n```\ncode\n```\nline 3\nline 4";
-    const expected = "line 1  \nline 2  \n```\ncode\n```\nline 3  \nline 4";
-    expect(preserveNewlines(input)).toBe(expected);
-  });
-
-  it("handles text with trailing newline", () => {
-    expect(preserveNewlines("line 1\nline 2\n")).toBe("line 1  \nline 2  \n");
-  });
-
-  it("handles text with only newlines", () => {
-    expect(preserveNewlines("\n\n")).toBe("\n\n");
-  });
-
-  it("handles text with indented code block fences", () => {
-    const input = "before\n  ```\n  code\n  ```\nafter";
-    const expected = "before  \n  ```\n  code\n  ```\nafter";
-    expect(preserveNewlines(input)).toBe(expected);
-  });
-
-  it("handles a single newline", () => {
-    expect(preserveNewlines("\n")).toBe("\n");
-  });
-
-  it("handles multiple empty lines between text", () => {
-    expect(preserveNewlines("a\n\n\nb")).toBe("a  \n\n\nb");
   });
 });

--- a/platform/frontend/src/lib/chat/chat-utils.ts
+++ b/platform/frontend/src/lib/chat/chat-utils.ts
@@ -19,60 +19,6 @@ export function getChatExternalAgentId(appName: string): string {
 }
 
 /**
- * Preserves newlines in user message text for markdown rendering.
- *
- * Markdown treats single newlines as soft breaks (collapsed into spaces).
- * This function converts single newlines into markdown hard line breaks
- * (two trailing spaces + newline) so that user-typed line breaks are
- * visually preserved when rendered through a markdown renderer.
- *
- * Lines inside fenced code blocks (``` or ~~~) are left untouched since
- * code blocks already preserve whitespace.
- */
-export function preserveNewlines(text: string): string {
-  if (!text || typeof text !== "string") return text;
-
-  const lines = text.split("\n");
-  const result: string[] = [];
-  let inCodeBlock = false;
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    const trimmedLine = line.trimStart();
-
-    // Toggle code block state on fenced code block delimiters
-    if (trimmedLine.startsWith("```") || trimmedLine.startsWith("~~~")) {
-      inCodeBlock = !inCodeBlock;
-      result.push(line);
-      continue;
-    }
-
-    // Inside code blocks, preserve lines as-is
-    if (inCodeBlock) {
-      result.push(line);
-      continue;
-    }
-
-    // For the last line, don't append trailing spaces
-    if (i === lines.length - 1) {
-      result.push(line);
-      continue;
-    }
-
-    // Append two trailing spaces for a markdown hard line break,
-    // but only if the line doesn't already end with two+ spaces
-    // and the line is not empty (empty lines already create paragraph breaks)
-    if (line === "" || line.endsWith("  ")) {
-      result.push(line);
-    } else {
-      result.push(`${line}  `);
-    }
-  }
-
-  return result.join("\n");
-}
-
-/**
  * Generates localStorage keys scoped to a specific conversation.
  * Use this everywhere conversation-specific keys are read/written/removed
  * so that key formats stay in sync (especially for cleanup on deletion).


### PR DESCRIPTION
## What changed

- Added a dedicated `UserMessageText` renderer for user-authored chat content.
- Updated the current chat message bubble and legacy message thread path to use plain-text rendering for user messages.
- Added tests covering markdown-looking pasted text and preserved line breaks.

## Why

User-authored content was rendered through the markdown response component. Pasted update lists from tools like issue trackers can contain underscores, asterisks, indentation, and other markdown-like syntax, which caused unintended emphasis and low-contrast colors inside the user bubble.

## Impact

User messages now display exactly as typed or pasted while preserving line breaks. Assistant and system markdown rendering remains unchanged.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Image" src="https://github.com/user-attachments/assets/1f9497f2-96ad-4334-b3a4-c63ff38abdb9"/>

</a>