### PR TITLE
chore(e2e): skip currently-failing tests

### DIFF
--- a/platform/e2e-tests/tests/agents.spec.ts
+++ b/platform/e2e-tests/tests/agents.spec.ts
@@ -46,6 +46,7 @@ test("can create and delete an agent", {
 test("can create and delete an LLM proxy", {
   tag: ["@firefox", "@webkit"],
 }, async ({ page, makeRandomString, goToPage }) => {
+  test.skip(true, "Currently failing: 'Connect via ...' dialog not visible after create (agents.spec.ts:65)");
   test.setTimeout(120_000);
 
   const PROXY_NAME = makeRandomString(10, "Test LLM Proxy");
@@ -95,6 +96,7 @@ test("can create and delete an LLM proxy", {
 test("can create and delete an MCP gateway", {
   tag: ["@firefox", "@webkit"],
 }, async ({ page, makeRandomString, goToPage }) => {
+  test.skip(true, "Currently failing in CI (agents.spec.ts:95 MCP gateway create/delete)");
   test.setTimeout(120_000);
 
   const GATEWAY_NAME = makeRandomString(10, "Test MCP Gateway");

--- a/platform/e2e-tests/tests/chat-auth-required.spec.ts
+++ b/platform/e2e-tests/tests/chat-auth-required.spec.ts
@@ -181,6 +181,7 @@ test.describe("Chat - Auth Required Tool", () => {
     memberPage,
     goToMemberPage,
   }) => {
+    test.skip(true, "Currently failing in CI (chat-auth-required.spec.ts:180)");
     // Navigate directly to chat with the test agent selected. The chat page
     // supports agentId in the URL, which is more stable than driving the
     // selector UI and keeps this test focused on the auth-required flow.

--- a/platform/e2e-tests/tests/credentials-with-vault.ee.spec.ts
+++ b/platform/e2e-tests/tests/credentials-with-vault.ee.spec.ts
@@ -258,6 +258,7 @@ test.describe("Test self-hosted MCP server with Readonly Vault", () => {
     extractCookieHeaders,
     makeRandomString,
   }) => {
+    test.skip(true, "Currently failing: readonly-vault tool assign returns 'team connection not shared with selected team'");
     test.skip(!byosEnabled, "BYOS Vault is not enabled in this environment.");
     const cookieHeaders = await extractCookieHeaders(adminPage);
     const catalogItemName = makeRandomString(10, "mcp");

--- a/platform/e2e-tests/tests/identity-providers.ee.spec.ts
+++ b/platform/e2e-tests/tests/identity-providers.ee.spec.ts
@@ -970,6 +970,7 @@ test.describe("Identity Provider SAML E2E Flow with Keycloak", () => {
     browser,
     goToPage,
   }) => {
+    test.skip(true, "Currently failing in CI (identity-providers.ee.spec.ts:968 SAML/Keycloak flow)");
     test.slow();
 
     // Fetch IdP metadata dynamically (Keycloak regenerates certs on restart)

--- a/platform/e2e-tests/tests/mcp-install.spec.ts
+++ b/platform/e2e-tests/tests/mcp-install.spec.ts
@@ -136,6 +136,7 @@ test.describe("MCP Install", () => {
     });
 
     test("Bearer Token", async ({ adminPage, extractCookieHeaders }) => {
+      test.skip(true, "Currently failing in CI (mcp-install.spec.ts:138 Custom remote Bearer Token)");
       await deleteCatalogItem(
         adminPage,
         extractCookieHeaders,


### PR DESCRIPTION
## Summary

Marks several e2e tests as skipped (with `test.skip(true, ...)` and a comment) while they are being investigated/fixed. Identified from failures on run [24779010024](https://github.com/archestra-ai/archestra/actions/runs/24779010024).

## Tests skipped

- `platform/e2e-tests/tests/agents.spec.ts:46` — `can create and delete an LLM proxy` (chromium/firefox/webkit). Locator assertion at line 65 (`Connect via ...` dialog) not visible after create.
- `platform/e2e-tests/tests/agents.spec.ts:95` — `can create and delete an MCP gateway` (chromium/firefox/webkit).
- `platform/e2e-tests/tests/chat-auth-required.spec.ts:180` — `surfaces missing credentials guidance when tool call fails due to missing credentials`.
- `platform/e2e-tests/tests/mcp-install.spec.ts:138` — `MCP Install › Custom remote › Bearer Token`.
- `platform/e2e-tests/tests/identity-providers.ee.spec.ts:968` — `Identity Provider SAML E2E Flow with Keycloak › should configure SAML provider, login via SSO, update, and delete`.
- `platform/e2e-tests/tests/credentials-with-vault.ee.spec.ts:256` — `Test self-hosted MCP server with Vault - without prompt on installation`. Readonly-vault tool assign returns `This team connection is not shared with the selected team`.
---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Image" src="https://github.com/user-attachments/assets/1f9497f2-96ad-4334-b3a4-c63ff38abdb9"/>

</a>