### PR TITLE
fix: scroll to bottom when user sends a message

### DIFF
--- a/platform/frontend/src/components/chat/chat-messages.test.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.test.tsx
@@ -12,6 +12,10 @@ vi.mock("@/components/ai-elements/conversation", () => ({
   ConversationScrollButton: () => null,
 }));
 
+vi.mock("use-stick-to-bottom", () => ({
+  useStickToBottomContext: () => ({ scrollToBottom: vi.fn() }),
+}));
+
 vi.mock("@/components/ai-elements/message", () => ({
   Message: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -26,6 +26,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { useStickToBottomContext } from "use-stick-to-bottom";
 import {
   Conversation,
   ConversationContent,
@@ -425,6 +426,7 @@ export function ChatMessages({
       resize={instantResize || initialLoad ? "instant" : "smooth"}
       targetScrollTop={isResponseInProgress ? undefined : preventResizeScroll}
     >
+      <ScrollToBottomOnSubmit status={status} />
       <ConversationContent>
         <div className="max-w-4xl mx-auto relative pb-8">
           <SensitiveContextStickyIndicator
@@ -1261,6 +1263,21 @@ function useStreamingStallDetection(
   }, [status]);
 
   return isStreamingStalled;
+}
+
+// Re-engage stick-to-bottom when the user sends a new message.
+// If the user has scrolled up, the library keeps state.isAtBottom=false and
+// won't auto-scroll on content resize — this resets it on the submit transition.
+function ScrollToBottomOnSubmit({ status }: { status: ChatStatus }) {
+  const { scrollToBottom } = useStickToBottomContext();
+  const prevStatusRef = useRef(status);
+  useEffect(() => {
+    if (status === "submitted" && prevStatusRef.current !== "submitted") {
+      scrollToBottom();
+    }
+    prevStatusRef.current = status;
+  }, [status, scrollToBottom]);
+  return null;
 }
 
 const MessageTool = memo(

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -1261,12 +1261,15 @@ function useStreamingStallDetection(
 function ScrollToBottomOnSubmit({ status }: { status: ChatStatus }) {
   const { scrollToBottom } = useStickToBottomContext();
   const prevStatusRef = useRef(status);
+
   useEffect(() => {
     if (status === "submitted" && prevStatusRef.current !== "submitted") {
       scrollToBottom();
     }
+
     prevStatusRef.current = status;
   }, [status, scrollToBottom]);
+
   return null;
 }
 


### PR DESCRIPTION
## Summary

- When the user has scrolled up and sends a new message, the view now scrolls back to the bottom to follow the response
- Previously, `use-stick-to-bottom` kept `state.isAtBottom=false` after the user scrolled up and skipped the resize-triggered auto-scroll, so new messages rendered off-screen with no visual feedback
## Change

Adds a `ScrollToBottomOnSubmit` effect component rendered inside `<Conversation>` that watches `status` and calls `scrollToBottom()` on the `ready → submitted` transition. This re-engages sticky mode so the user follows the response until they scroll up again.

The component must live inside `<Conversation>` because `useStickToBottomContext()` requires the `StickToBottom` provider — the same reason `ConversationScrollButton` is rendered there.

## Test plan

- [x] Open an existing conversation with many messages, scroll up, send a new message → view scrolls to bottom
- [x] Already-at-bottom send still works (no visual regression)
- [x] While streaming, scrolling up still "escapes the lock" (user can read history without being snapped back)
- [x] Starting a brand-new conversation still auto-scrolls from the first message

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Image" src="https://github.com/user-attachments/assets/1f9497f2-96ad-4334-b3a4-c63ff38abdb9"/>

</a>