### PR TITLE
fix: Slack setup slash command slugs

### DIFF
--- a/docs/pages/platform-slack.md
+++ b/docs/pages/platform-slack.md
@@ -52,6 +52,7 @@ The bot responds with a list of options to choose which agent will handle messag
 ### Commands
 
 Archestra uses native Slack slash commands — type them directly in the message box without mentioning the bot.
+The command prefix is generated from the Slack app name in the setup wizard. The default app name uses:
 
 | Command | Description |
 |---------|-------------|

--- a/platform/backend/src/agents/chatops/constants.ts
+++ b/platform/backend/src/agents/chatops/constants.ts
@@ -66,21 +66,12 @@ export const CHATOPS_COMMANDS = {
 } as const;
 
 /**
- * Native Slack slash commands.
- * These are registered in the Slack app manifest and handled by a dedicated endpoint.
- * All three share one backend endpoint — the `command` field distinguishes them.
- */
-/**
  * Default connection mode for Slack when not explicitly configured.
  */
 export const SLACK_DEFAULT_CONNECTION_MODE: ChatOpsConnectionMode =
   "socket" as const;
 
-export const SLACK_SLASH_COMMANDS = {
-  SELECT_AGENT: "/archestra-select-agent",
-  STATUS: "/archestra-status",
-  HELP: "/archestra-help",
-} as const;
+export { SLACK_SLASH_COMMANDS } from "@shared";
 
 /**
  * Attachment limits for chatops file downloads.

--- a/platform/backend/src/agents/chatops/constants.ts
+++ b/platform/backend/src/agents/chatops/constants.ts
@@ -46,9 +46,6 @@ export const CHATOPS_TEAM_CACHE = {
 };
 
 /**
- * Bot commands recognized by the chatops system
- */
-/**
  * Channel discovery configuration for auto-populating channel bindings
  */
 export const CHATOPS_CHANNEL_DISCOVERY = {

--- a/platform/backend/src/agents/chatops/slack-provider.test.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.test.ts
@@ -1,5 +1,5 @@
 import { createHmac } from "node:crypto";
-import { SLACK_REQUIRED_BOT_SCOPES } from "@shared";
+import { SLACK_REQUIRED_BOT_SCOPES, SLACK_SLASH_COMMANDS } from "@shared";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { CacheKey, cacheManager } from "@/cache-manager";
 import SlackProvider from "./slack-provider";
@@ -491,6 +491,48 @@ describe("SlackProvider.sendReply", () => {
       ],
       thread_ts: "1111111111.000000",
     });
+  });
+});
+
+// =============================================================================
+// sendAgentSelectionCard
+// =============================================================================
+
+describe("SlackProvider.sendAgentSelectionCard", () => {
+  test("uses shared Slack command names in the welcome card", async () => {
+    const provider = createProvider();
+    const postEphemeral = vi.fn().mockResolvedValue({ ok: true });
+    // biome-ignore lint/suspicious/noExplicitAny: test-only — mock Slack client
+    (provider as any).client = {
+      chat: { postEphemeral },
+    };
+
+    await provider.sendAgentSelectionCard({
+      message: {
+        messageId: "1234567890.123456",
+        channelId: "C12345",
+        workspaceId: "T12345",
+        senderId: "U_SENDER",
+        senderName: "Test User",
+        text: "hello",
+        rawText: "hello",
+        timestamp: new Date(),
+        isThreadReply: false,
+      },
+      agents: [{ id: "agent-1", name: "Sales" }],
+      isWelcome: true,
+    });
+
+    const callArgs = postEphemeral.mock.calls[0][0];
+    expect(JSON.stringify(callArgs.blocks)).toContain(
+      SLACK_SLASH_COMMANDS.SELECT_AGENT,
+    );
+    expect(JSON.stringify(callArgs.blocks)).toContain(
+      SLACK_SLASH_COMMANDS.STATUS,
+    );
+    expect(JSON.stringify(callArgs.blocks)).toContain(
+      SLACK_SLASH_COMMANDS.HELP,
+    );
   });
 });
 

--- a/platform/backend/src/agents/chatops/slack-provider.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.ts
@@ -1,5 +1,10 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
-import { SLACK_REQUIRED_BOT_SCOPES, TimeInMs } from "@shared";
+import {
+  buildSlackSlashCommandsForCommand,
+  getSlackSlashCommandAction,
+  SLACK_REQUIRED_BOT_SCOPES,
+  TimeInMs,
+} from "@shared";
 import { SocketModeClient } from "@slack/socket-mode";
 import { WebClient } from "@slack/web-api";
 import {
@@ -32,7 +37,6 @@ import {
   CHATOPS_ATTACHMENT_LIMITS,
   CHATOPS_THREAD_HISTORY,
   SLACK_DEFAULT_CONNECTION_MODE,
-  SLACK_SLASH_COMMANDS,
 } from "./constants";
 import { EventDedupMap, errorMessage, isSlackDmChannel } from "./utils";
 
@@ -677,6 +681,8 @@ class SlackProvider implements ChatOpsProvider {
     trigger_id?: string;
   }): Promise<{ response_type: string; text: string } | null> {
     const command = body.command;
+    const commandAction = getSlackSlashCommandAction(command);
+    const slashCommands = buildSlackSlashCommandsForCommand(command);
     const channelId = body.channel_id || "";
     const workspaceId = body.team_id || null;
     const userId = body.user_id || "unknown";
@@ -724,19 +730,19 @@ class SlackProvider implements ChatOpsProvider {
       }
     }
 
-    switch (command) {
-      case SLACK_SLASH_COMMANDS.HELP:
+    switch (commandAction) {
+      case "HELP":
         return {
           response_type: "ephemeral",
           text:
             "*Available commands:*\n" +
-            "`/archestra-select-agent` — Change the default agent\n" +
-            "`/archestra-status` — Show current agent binding\n" +
-            "`/archestra-help` — Show this help message\n\n" +
+            `\`${slashCommands.SELECT_AGENT}\` — Change the default agent\n` +
+            `\`${slashCommands.STATUS}\` — Show current agent binding\n` +
+            `\`${slashCommands.HELP}\` — Show this help message\n\n` +
             "Or just send a message to interact with the assigned agent.",
         };
 
-      case SLACK_SLASH_COMMANDS.STATUS: {
+      case "STATUS": {
         const binding = await ChatOpsChannelBindingModel.findByChannel({
           provider: "slack",
           channelId,
@@ -750,7 +756,7 @@ class SlackProvider implements ChatOpsProvider {
             text:
               `This channel is assigned to agent: *${agent?.name || binding.agentId}*\n\n` +
               "*Tip:* You can use other agents with the syntax *AgentName >* (e.g., @Archestra Sales > what's the status?).\n\n" +
-              "Use `/archestra-select-agent` to change the default agent.",
+              `Use \`${slashCommands.SELECT_AGENT}\` to change the default agent.`,
           };
         }
 
@@ -760,7 +766,7 @@ class SlackProvider implements ChatOpsProvider {
         };
       }
 
-      case SLACK_SLASH_COMMANDS.SELECT_AGENT: {
+      case "SELECT_AGENT": {
         // Send agent selection card (visible to all in channel)
         const isDm = isSlackDmChannel(channelId);
         const message: IncomingChatMessage = {
@@ -801,7 +807,7 @@ class SlackProvider implements ChatOpsProvider {
       default:
         return {
           response_type: "ephemeral",
-          text: "Unknown command. Use `/archestra-help` to see available commands.",
+          text: `Unknown command. Use \`${slashCommands.HELP}\` to see available commands.`,
         };
     }
   }

--- a/platform/backend/src/agents/chatops/slack-provider.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.ts
@@ -3,6 +3,7 @@ import {
   buildSlackSlashCommandsForCommand,
   getSlackSlashCommandAction,
   SLACK_REQUIRED_BOT_SCOPES,
+  SLACK_SLASH_COMMANDS,
   TimeInMs,
 } from "@shared";
 import { SocketModeClient } from "@slack/socket-mode";
@@ -381,7 +382,11 @@ class SlackProvider implements ChatOpsProvider {
             type: "section",
             text: {
               type: "mrkdwn",
-              text: "*Available commands:*\n`/archestra-select-agent` — Change the default agent handling requests in the channel\n`/archestra-status` — Check the current agent handling requests in the channel\n`/archestra-help` — Show available commands",
+              text:
+                "*Available commands:*\n" +
+                `\`${SLACK_SLASH_COMMANDS.SELECT_AGENT}\` — Change the default agent handling requests in the channel\n` +
+                `\`${SLACK_SLASH_COMMANDS.STATUS}\` — Check the current agent handling requests in the channel\n` +
+                `\`${SLACK_SLASH_COMMANDS.HELP}\` — Show available commands`,
             },
           },
           { type: "divider" },

--- a/platform/backend/src/routes/chatops-slash-command.test.ts
+++ b/platform/backend/src/routes/chatops-slash-command.test.ts
@@ -182,6 +182,21 @@ describe("POST /api/webhooks/chatops/slack/slash-command", () => {
     await app.close();
   });
 
+  test("slugified app-name slash commands are accepted", async () => {
+    const app = await createApp();
+
+    const response = await injectSlashCommand(app, "/archestra-staging-help");
+
+    expect(response.statusCode).toBe(200);
+    const json = response.json();
+    expect(json.response_type).toBe("ephemeral");
+    expect(json.text).toContain("/archestra-staging-select-agent");
+    expect(json.text).toContain("/archestra-staging-status");
+    expect(json.text).toContain("/archestra-staging-help");
+
+    await app.close();
+  });
+
   test("/archestra-status returns ephemeral status when no binding", async () => {
     const app = await createApp();
 

--- a/platform/frontend/src/app/agents/triggers/slack/page.tsx
+++ b/platform/frontend/src/app/agents/triggers/slack/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { archestraApiTypes } from "@shared";
+import { type archestraApiTypes, buildSlackSlashCommands } from "@shared";
 import { AlertTriangle, Info } from "lucide-react";
 import { useEffect, useState } from "react";
 import { CopyButton } from "@/components/copy-button";
@@ -40,7 +40,7 @@ function useSlackProviderConfig(): ProviderConfig {
     providerIcon: "/icons/slack.png",
     webhookPath: "/api/webhooks/chatops/slack",
     docsUrl: getFrontendDocsUrl("platform-slack"),
-    slashCommand: `/${appName.toLowerCase()}-select-agent`,
+    slashCommand: buildSlackSlashCommands(appName).SELECT_AGENT,
     buildDeepLink: (binding) => {
       if (binding.workspaceId) {
         return `slack://channel?team=${binding.workspaceId}&id=${binding.channelId}`;

--- a/platform/frontend/src/components/slack-setup-dialog.tsx
+++ b/platform/frontend/src/components/slack-setup-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type archestraApiTypes, SLACK_REQUIRED_BOT_SCOPES } from "@shared";
+import type { archestraApiTypes } from "@shared";
 import { ExternalLink } from "lucide-react";
 import * as React from "react";
 import { useState } from "react";
@@ -16,6 +16,7 @@ import { usePublicBaseUrl } from "@/lib/config/config.query";
 import { getFrontendDocsUrl } from "@/lib/docs/docs";
 import { useAppName } from "@/lib/hooks/use-app-name";
 import { useOrganization } from "@/lib/organization.query";
+import { buildSlackManifest } from "@/lib/slack/slack-manifest";
 
 type ConnectionMode = NonNullable<
   NonNullable<
@@ -411,112 +412,6 @@ function StepAppLevelToken({
       />
     </div>
   );
-}
-
-function buildSlackManifest(params: {
-  appName: string;
-  connectionMode: ConnectionMode;
-  webhookUrl: string;
-  interactiveUrl: string;
-  slashCommandUrl: string;
-}): string {
-  const {
-    appName,
-    connectionMode,
-    webhookUrl,
-    interactiveUrl,
-    slashCommandUrl,
-  } = params;
-  const isSocket = connectionMode === "socket";
-
-  // biome-ignore lint/suspicious/noExplicitAny: Manifest shape varies by mode
-  const manifest: any = {
-    display_information: {
-      name: appName,
-      description: `${appName} AI Agent`,
-    },
-    features: {
-      app_home: {
-        messages_tab_enabled: true,
-        messages_tab_read_only_enabled: false,
-      },
-      bot_user: {
-        display_name: appName,
-        always_online: true,
-      },
-      assistant_view: {
-        assistant_description: `Your AI-powered ${appName} assistant`,
-      },
-      slash_commands: isSocket
-        ? [
-            {
-              command: `/${appName.toLowerCase()}-select-agent`,
-              description: "Change which agent handles this channel",
-            },
-            {
-              command: `/${appName.toLowerCase()}-status`,
-              description: "Show current agent for this channel",
-            },
-            {
-              command: `/${appName.toLowerCase()}-help`,
-              description: "Show available commands",
-            },
-          ]
-        : [
-            {
-              command: `/${appName.toLowerCase()}-select-agent`,
-              description: "Change which agent handles this channel",
-              url: slashCommandUrl,
-            },
-            {
-              command: `/${appName.toLowerCase()}-status`,
-              description: "Show current agent for this channel",
-              url: slashCommandUrl,
-            },
-            {
-              command: `/${appName.toLowerCase()}-help`,
-              description: "Show available commands",
-              url: slashCommandUrl,
-            },
-          ],
-    },
-    oauth_config: {
-      scopes: {
-        bot: SLACK_REQUIRED_BOT_SCOPES,
-      },
-    },
-    settings: {
-      event_subscriptions: isSocket
-        ? {
-            bot_events: [
-              "app_mention",
-              "assistant_thread_started",
-              "assistant_thread_context_changed",
-              "message.channels",
-              "message.groups",
-              "message.im",
-            ],
-          }
-        : {
-            request_url: webhookUrl,
-            bot_events: [
-              "app_mention",
-              "assistant_thread_started",
-              "assistant_thread_context_changed",
-              "message.channels",
-              "message.groups",
-              "message.im",
-            ],
-          },
-      interactivity: isSocket
-        ? { is_enabled: true }
-        : { is_enabled: true, request_url: interactiveUrl },
-      org_deploy_enabled: false,
-      socket_mode_enabled: isSocket,
-      token_rotation_enabled: false,
-    },
-  };
-  return JSON.stringify(manifest, null, 2);
 }
 
 function StepManifestWebhook({

--- a/platform/frontend/src/lib/slack/slack-manifest.test.ts
+++ b/platform/frontend/src/lib/slack/slack-manifest.test.ts
@@ -1,0 +1,80 @@
+import { SLACK_REQUIRED_BOT_SCOPES } from "@shared";
+import { describe, expect, it } from "vitest";
+import { buildSlackManifest } from "./slack-manifest";
+
+describe("buildSlackManifest", () => {
+  it("slugifies Slack slash commands when the app name contains spaces", () => {
+    const manifest = JSON.parse(
+      buildSlackManifest({
+        appName: "Archestra Staging",
+        connectionMode: "socket",
+        webhookUrl: "",
+        interactiveUrl: "",
+        slashCommandUrl: "",
+      }),
+    );
+
+    expect(manifest.display_information.name).toBe("Archestra Staging");
+    expect(manifest.features.bot_user.display_name).toBe("Archestra Staging");
+    expect(manifest.features.slash_commands).toEqual([
+      {
+        command: "/archestra-staging-select-agent",
+        description: "Change which agent handles this channel",
+      },
+      {
+        command: "/archestra-staging-status",
+        description: "Show current agent for this channel",
+      },
+      {
+        command: "/archestra-staging-help",
+        description: "Show available commands",
+      },
+    ]);
+  });
+
+  it("adds webhook slash command URLs for webhook mode", () => {
+    const manifest = JSON.parse(
+      buildSlackManifest({
+        appName: "Archestra",
+        connectionMode: "webhook",
+        webhookUrl: "https://example.test/api/webhooks/chatops/slack",
+        interactiveUrl:
+          "https://example.test/api/webhooks/chatops/slack/interactive",
+        slashCommandUrl:
+          "https://example.test/api/webhooks/chatops/slack/slash-command",
+      }),
+    );
+
+    expect(manifest.features.slash_commands).toEqual([
+      {
+        command: "/archestra-select-agent",
+        description: "Change which agent handles this channel",
+        url: "https://example.test/api/webhooks/chatops/slack/slash-command",
+      },
+      {
+        command: "/archestra-status",
+        description: "Show current agent for this channel",
+        url: "https://example.test/api/webhooks/chatops/slack/slash-command",
+      },
+      {
+        command: "/archestra-help",
+        description: "Show available commands",
+        url: "https://example.test/api/webhooks/chatops/slack/slash-command",
+      },
+    ]);
+  });
+
+  it("uses the shared Slack bot scopes", () => {
+    const manifest = JSON.parse(
+      buildSlackManifest({
+        appName: "Archestra",
+        connectionMode: "socket",
+        webhookUrl: "",
+        interactiveUrl: "",
+        slashCommandUrl: "",
+      }),
+    );
+
+    expect(manifest.oauth_config.scopes.bot).toEqual(SLACK_REQUIRED_BOT_SCOPES);
+  });
+});

--- a/platform/frontend/src/lib/slack/slack-manifest.ts
+++ b/platform/frontend/src/lib/slack/slack-manifest.ts
@@ -1,0 +1,95 @@
+import { buildSlackSlashCommands, SLACK_REQUIRED_BOT_SCOPES } from "@shared";
+
+export type SlackConnectionMode = "socket" | "webhook";
+
+export function buildSlackManifest(params: {
+  appName: string;
+  connectionMode: SlackConnectionMode;
+  webhookUrl: string;
+  interactiveUrl: string;
+  slashCommandUrl: string;
+}): string {
+  const {
+    appName,
+    connectionMode,
+    webhookUrl,
+    interactiveUrl,
+    slashCommandUrl,
+  } = params;
+  const isSocket = connectionMode === "socket";
+  const slackSlashCommands = buildSlackSlashCommands(appName);
+
+  const slashCommands = [
+    {
+      command: slackSlashCommands.SELECT_AGENT,
+      description: "Change which agent handles this channel",
+    },
+    {
+      command: slackSlashCommands.STATUS,
+      description: "Show current agent for this channel",
+    },
+    {
+      command: slackSlashCommands.HELP,
+      description: "Show available commands",
+    },
+  ].map((command) =>
+    isSocket ? command : { ...command, url: slashCommandUrl },
+  );
+
+  const manifest = {
+    display_information: {
+      name: appName,
+      description: `${appName} AI Agent`,
+    },
+    features: {
+      app_home: {
+        messages_tab_enabled: true,
+        messages_tab_read_only_enabled: false,
+      },
+      bot_user: {
+        display_name: appName,
+        always_online: true,
+      },
+      assistant_view: {
+        assistant_description: `Your AI-powered ${appName} assistant`,
+      },
+      slash_commands: slashCommands,
+    },
+    oauth_config: {
+      scopes: {
+        bot: SLACK_REQUIRED_BOT_SCOPES,
+      },
+    },
+    settings: {
+      event_subscriptions: isSocket
+        ? {
+            bot_events: [
+              "app_mention",
+              "assistant_thread_started",
+              "assistant_thread_context_changed",
+              "message.channels",
+              "message.groups",
+              "message.im",
+            ],
+          }
+        : {
+            request_url: webhookUrl,
+            bot_events: [
+              "app_mention",
+              "assistant_thread_started",
+              "assistant_thread_context_changed",
+              "message.channels",
+              "message.groups",
+              "message.im",
+            ],
+          },
+      interactivity: isSocket
+        ? { is_enabled: true }
+        : { is_enabled: true, request_url: interactiveUrl },
+      org_deploy_enabled: false,
+      socket_mode_enabled: isSocket,
+      token_rotation_enabled: false,
+    },
+  };
+  return JSON.stringify(manifest, null, 2);
+}

--- a/platform/frontend/src/lib/slack/slack-manifest.ts
+++ b/platform/frontend/src/lib/slack/slack-manifest.ts
@@ -1,10 +1,10 @@
 import { buildSlackSlashCommands, SLACK_REQUIRED_BOT_SCOPES } from "@shared";
 
-export type SlackConnectionMode = "socket" | "webhook";
+type SlackManifestConnectionMode = "socket" | "webhook";
 
 export function buildSlackManifest(params: {
   appName: string;
-  connectionMode: SlackConnectionMode;
+  connectionMode: SlackManifestConnectionMode;
   webhookUrl: string;
   interactiveUrl: string;
   slashCommandUrl: string;

--- a/platform/shared/slack.test.ts
+++ b/platform/shared/slack.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildSlackSlashCommands,
+  buildSlackSlashCommandsForCommand,
+  getSlackSlashCommandAction,
+  SLACK_SLASH_COMMANDS,
+} from "./slack";
+
+describe("Slack slash commands", () => {
+  test("builds default Archestra commands", () => {
+    expect(SLACK_SLASH_COMMANDS).toEqual({
+      SELECT_AGENT: "/archestra-select-agent",
+      STATUS: "/archestra-status",
+      HELP: "/archestra-help",
+    });
+  });
+
+  test("slugifies app names with hyphens", () => {
+    expect(buildSlackSlashCommands("Archestra Staging")).toEqual({
+      SELECT_AGENT: "/archestra-staging-select-agent",
+      STATUS: "/archestra-staging-status",
+      HELP: "/archestra-staging-help",
+    });
+  });
+
+  test("detects command actions from any app-name prefix", () => {
+    expect(getSlackSlashCommandAction("/archestra-staging-select-agent")).toBe(
+      "SELECT_AGENT",
+    );
+    expect(getSlackSlashCommandAction("/archestra-staging-status")).toBe(
+      "STATUS",
+    );
+    expect(getSlackSlashCommandAction("/archestra-staging-help")).toBe("HELP");
+    expect(getSlackSlashCommandAction("/archestra-staging-unknown")).toBeNull();
+  });
+
+  test("rebuilds sibling commands from a received command prefix", () => {
+    expect(
+      buildSlackSlashCommandsForCommand("/archestra-staging-help"),
+    ).toEqual({
+      SELECT_AGENT: "/archestra-staging-select-agent",
+      STATUS: "/archestra-staging-status",
+      HELP: "/archestra-staging-help",
+    });
+  });
+});

--- a/platform/shared/slack.ts
+++ b/platform/shared/slack.ts
@@ -42,9 +42,7 @@ export const SLACK_SLASH_COMMAND_SUFFIXES = {
 
 export type SlackSlashCommandAction = keyof typeof SLACK_SLASH_COMMAND_SUFFIXES;
 
-export const SLACK_SLASH_COMMANDS = {
-  ...buildSlackSlashCommands("Archestra"),
-};
+export const SLACK_SLASH_COMMANDS = buildSlackSlashCommands("Archestra");
 
 export function buildSlackSlashCommands(
   appName: string,

--- a/platform/shared/slack.ts
+++ b/platform/shared/slack.ts
@@ -1,3 +1,5 @@
+import { urlSlugify } from "./utils";
+
 /**
  * Slack bot scopes required by the Archestra Slack app.
  *
@@ -24,3 +26,70 @@ export const SLACK_REQUIRED_BOT_SCOPES = [
   "users:read",
   "users:read.email",
 ] as const;
+
+/**
+ * Native Slack slash commands.
+ *
+ * Slack command names are generated from the app name in the setup manifest,
+ * but the command suffixes are stable so the backend can route any app-name
+ * prefix to the right action.
+ */
+export const SLACK_SLASH_COMMAND_SUFFIXES = {
+  SELECT_AGENT: "-select-agent",
+  STATUS: "-status",
+  HELP: "-help",
+} as const;
+
+export type SlackSlashCommandAction = keyof typeof SLACK_SLASH_COMMAND_SUFFIXES;
+
+export const SLACK_SLASH_COMMANDS = {
+  ...buildSlackSlashCommands("Archestra"),
+};
+
+export function buildSlackSlashCommands(
+  appName: string,
+): Record<SlackSlashCommandAction, string> {
+  const commandPrefix = urlSlugify(appName) || "archestra";
+
+  return {
+    SELECT_AGENT: `/${commandPrefix}${SLACK_SLASH_COMMAND_SUFFIXES.SELECT_AGENT}`,
+    STATUS: `/${commandPrefix}${SLACK_SLASH_COMMAND_SUFFIXES.STATUS}`,
+    HELP: `/${commandPrefix}${SLACK_SLASH_COMMAND_SUFFIXES.HELP}`,
+  };
+}
+
+export function getSlackSlashCommandAction(
+  command: string | undefined,
+): SlackSlashCommandAction | null {
+  const normalizedCommand = command?.trim().toLowerCase();
+  if (!normalizedCommand?.startsWith("/")) return null;
+
+  for (const [action, suffix] of Object.entries(SLACK_SLASH_COMMAND_SUFFIXES)) {
+    const hasPrefix = normalizedCommand.length > suffix.length + 1;
+    if (hasPrefix && normalizedCommand.endsWith(suffix)) {
+      return action as SlackSlashCommandAction;
+    }
+  }
+
+  return null;
+}
+
+export function buildSlackSlashCommandsForCommand(
+  command: string | undefined,
+): Record<SlackSlashCommandAction, string> {
+  const normalizedCommand = command?.trim().toLowerCase();
+  const suffix = Object.values(SLACK_SLASH_COMMAND_SUFFIXES).find((value) =>
+    normalizedCommand?.endsWith(value),
+  );
+
+  if (!normalizedCommand?.startsWith("/") || !suffix) {
+    return SLACK_SLASH_COMMANDS;
+  }
+
+  const commandPrefix = normalizedCommand.slice(0, -suffix.length);
+  return {
+    SELECT_AGENT: `${commandPrefix}${SLACK_SLASH_COMMAND_SUFFIXES.SELECT_AGENT}`,
+    STATUS: `${commandPrefix}${SLACK_SLASH_COMMAND_SUFFIXES.STATUS}`,
+    HELP: `${commandPrefix}${SLACK_SLASH_COMMAND_SUFFIXES.HELP}`,
+  };
+}


### PR DESCRIPTION
## Summary

Fixes Slack app setup manifest generation when the entered app name contains spaces or other non-alphanumeric characters.

## What changed

- Generate Slack slash commands from the setup app name with the shared hyphen-based `urlSlugify()` helper.
- Move Slack manifest generation into a tested frontend utility.
- Add shared Slack command helpers so frontend and backend use the same command naming rules.
- Update Slack slash command handling to route by stable suffixes, allowing app-name prefixes such as `/archestra-staging-help`.
- Clarify Slack docs that command prefixes come from the setup app name.

## Root cause

The setup dialog lowercased the raw app name when building command names, so `Archestra Staging` produced invalid command strings containing spaces. The backend also only matched the default `/archestra-*` command names directly, which would reject valid custom app-name prefixes.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Image" src="https://github.com/user-attachments/assets/1f9497f2-96ad-4334-b3a4-c63ff38abdb9"/>

</a>