### PR TITLE
[codex] fix chat tool discovery

### DIFF
--- a/platform/backend/src/clients/chat-mcp-client.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.test.ts
@@ -297,17 +297,16 @@ describe("chat-mcp-client health check", () => {
 
       await vi.advanceTimersByTimeAsync(1_001);
 
-      const tools = await chatClient.getChatMcpTools({
-        agentName: agent.name,
-        agentId: agent.id,
-        userId: user.id,
-        organizationId: org.id,
-        conversationId: "conv-1",
-      });
+      const client = await chatClient.getChatMcpClient(
+        agent.id,
+        user.id,
+        org.id,
+        "conv-1",
+      );
 
       expect(expiredClient.ping).not.toHaveBeenCalled();
       expect(expiredClient.close).toHaveBeenCalledTimes(1);
-      expect(tools).toEqual({});
+      expect(client).toBeNull();
 
       chatClient.clearChatMcpClient(agent.id);
       await chatClient.__test.clearToolCache(cacheKey);
@@ -347,15 +346,10 @@ describe("chat-mcp-client health check", () => {
       deadClient as unknown as Client,
     );
 
-    // getChatMcpTools should detect dead client via ping, discard it,
+    // getChatMcpClient should detect dead client via ping, discard it,
     // and attempt to create a fresh client (which will fail in test env,
-    // resulting in empty tools - but the key behavior is ping was called)
-    const tools = await chatClient.getChatMcpTools({
-      agentName: agent.name,
-      agentId: agent.id,
-      userId: user.id,
-      organizationId: org.id,
-    });
+    // resulting in null - but the key behavior is ping was called)
+    const client = await chatClient.getChatMcpClient(agent.id, user.id, org.id);
 
     // Ping should have been called on the dead client
     expect(deadClient.ping).toHaveBeenCalledTimes(1);
@@ -363,8 +357,8 @@ describe("chat-mcp-client health check", () => {
     expect(deadClient.close).toHaveBeenCalledTimes(1);
     // listTools should NOT have been called on the dead client
     expect(deadClient.listTools).not.toHaveBeenCalled();
-    // Tools will be empty since we can't create a real client in tests
-    expect(tools).toEqual({});
+    // Client will be null since we can't create a real connection in tests
+    expect(client).toBeNull();
 
     chatClient.clearChatMcpClient(agent.id);
     await chatClient.__test.clearToolCache(cacheKey);
@@ -402,20 +396,19 @@ describe("chat-mcp-client health check", () => {
         hangingClient as unknown as Client,
       );
 
-      const toolsPromise = chatClient.getChatMcpTools({
-        agentName: agent.name,
-        agentId: agent.id,
-        userId: user.id,
-        organizationId: org.id,
-      });
+      const clientPromise = chatClient.getChatMcpClient(
+        agent.id,
+        user.id,
+        org.id,
+      );
 
       await vi.advanceTimersByTimeAsync(5_000);
-      const tools = await toolsPromise;
+      const client = await clientPromise;
 
       expect(hangingClient.ping).toHaveBeenCalledTimes(1);
       expect(hangingClient.close).toHaveBeenCalledTimes(1);
       expect(hangingClient.listTools).not.toHaveBeenCalled();
-      expect(tools).toEqual({});
+      expect(client).toBeNull();
 
       chatClient.clearChatMcpClient(agent.id);
       await chatClient.__test.clearToolCache(cacheKey);
@@ -635,13 +628,16 @@ describe("executeMcpTool error handling", () => {
   });
 });
 
-describe("chat-mcp-client tool caching", () => {
-  test("reuses cached tool definitions for the same agent and user", async ({
+describe("chat-mcp-client tool discovery", () => {
+  test("discovers assigned MCP tools without listing tools through the cached client", async ({
     makeAgent,
     makeUser,
     makeOrganization,
     makeTeam,
     makeTeamMember,
+    makeTool,
+    makeAgentTool,
+    makeInternalMcpCatalog,
   }) => {
     // Create real test data using fixtures
     const org = await makeOrganization();
@@ -656,6 +652,14 @@ describe("chat-mcp-client tool caching", () => {
 
     // Create team token for the team
     await TeamTokenModel.createTeamToken(team.id, team.name);
+    const catalog = await makeInternalMcpCatalog();
+    const tool = await makeTool({
+      name: "lookup_mcp__lookup_email",
+      description: "Lookup email",
+      parameters: { type: "object", properties: {} },
+      catalogId: catalog.id,
+    });
+    await makeAgentTool(agent.id, tool.id);
 
     const cacheKey = chatClient.__test.getCacheKey(agent.id, user.id);
 
@@ -688,7 +692,7 @@ describe("chat-mcp-client tool caching", () => {
       userId: user.id,
       organizationId: org.id,
     });
-    expect(Object.keys(first)).toEqual(["lookup_email"]);
+    expect(Object.keys(first)).toEqual(["lookup_mcp__lookup_email"]);
 
     const second = await chatClient.getChatMcpTools({
       agentName: agent.name,
@@ -700,12 +704,11 @@ describe("chat-mcp-client tool caching", () => {
     // Check that second call returns the same tool names
     // Note: With cacheManager, functions and symbols cannot be serialized,
     // so we compare the tool names and descriptions rather than full equality
-    expect(Object.keys(second)).toEqual(["lookup_email"]);
-    expect(second.lookup_email.description).toEqual(
-      first.lookup_email.description,
+    expect(Object.keys(second)).toEqual(["lookup_mcp__lookup_email"]);
+    expect(second.lookup_mcp__lookup_email.description).toEqual(
+      first.lookup_mcp__lookup_email.description,
     );
-    // Most importantly, listTools should only be called once due to caching
-    expect(mockClient.listTools).toHaveBeenCalledTimes(1);
+    expect(mockClient.listTools).not.toHaveBeenCalled();
 
     chatClient.clearChatMcpClient(agent.id);
     await chatClient.__test.clearToolCache(cacheKey);

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -18,6 +18,7 @@ import {
   parseFullToolName,
   TimeInMs,
   TOOL_INVOCATION_APPROVAL_REQUIRED_AUTONOMOUS_REASON,
+  TOOL_QUERY_KNOWLEDGE_SOURCES_SHORT_NAME,
 } from "@shared";
 import { type JSONSchema7, jsonSchema, type Tool } from "ai";
 import { evaluateToolExecutionContextTrust } from "@/agents/context-trust";
@@ -25,6 +26,7 @@ import {
   type ArchestraContext,
   archestraMcpBranding,
   executeArchestraTool,
+  filterToolNamesByPermission,
   getAgentTools,
 } from "@/archestra-mcp-server";
 import { CacheKey, LRUCacheManager } from "@/cache-manager";
@@ -47,6 +49,7 @@ import {
   ATTR_MCP_IS_ERROR_RESULT,
   startActiveMcpSpan,
 } from "@/observability/tracing";
+import { buildKnowledgeSourcesDescription } from "@/routes/mcp-gateway.utils";
 import { resolveSessionExternalIdpToken } from "@/services/identity-providers/session-token";
 import type {
   AgentType,
@@ -776,28 +779,39 @@ export async function getChatMcpTools({
     return {};
   }
 
-  // Still use MCP client for listing tools (via MCP Gateway)
-  // Pass conversationId for per-conversation browser isolation.
-  // Forward the already-resolved token to avoid a duplicate selectMCPGatewayToken call.
-  const client = await getChatMcpClient(
-    agentId,
-    userId,
-    organizationId,
-    conversationId,
-    mcpGwToken.tokenValue,
-  );
-
-  if (!client) {
-    logger.warn(
-      { agentId, userId },
-      "No MCP client available, returning empty tools",
-    );
-    return {}; // No tools available
-  }
-
   try {
-    logger.info({ agentId, userId }, "MCP client available, listing tools...");
-    const { tools: mcpTools } = await client.listTools();
+    const [org, agent] = await Promise.all([
+      OrganizationModel.getById(organizationId),
+      AgentModel.findById(agentId),
+    ]);
+
+    archestraMcpBranding.syncFromOrganization(org);
+
+    const [assignedMcpTools, kbToolDescription] = await Promise.all([
+      ToolModel.getMcpToolsByAgent(agentId),
+      buildKnowledgeSourcesDescription(agentId),
+    ]);
+
+    const permittedToolNames = await filterToolNamesByPermission(
+      assignedMcpTools.map((tool) => tool.name),
+      userId === "system" ? undefined : userId,
+      organizationId,
+    );
+
+    const mcpTools = assignedMcpTools
+      .filter((tool) => permittedToolNames.has(tool.name))
+      .map((tool) => ({
+        name: tool.name,
+        description:
+          tool.name ===
+            archestraMcpBranding.getToolName(
+              TOOL_QUERY_KNOWLEDGE_SOURCES_SHORT_NAME,
+            ) && kbToolDescription
+            ? kbToolDescription
+            : (tool.description ?? undefined),
+        inputSchema: tool.parameters,
+        _meta: tool.meta?._meta,
+      }));
 
     // Filter out agent skills and app-only tools.
     // Tools with _meta.ui.visibility that does not include "model" are intended
@@ -817,14 +831,10 @@ export async function getChatMcpTools({
         toolCount: filteredMcpTools.length,
         toolNames: filteredMcpTools.map((t) => t.name),
       },
-      "Fetched tools from MCP Gateway for agent/user",
+      "Fetched chat tools from database for agent/user",
     );
 
     // Fetch globalToolPolicy for approval checks (needed for both chat and autonomous contexts).
-    const [org, agent] = await Promise.all([
-      OrganizationModel.getById(organizationId),
-      AgentModel.findById(agentId),
-    ]);
     const globalToolPolicy: GlobalToolPolicy =
       org?.globalToolPolicy ?? "permissive";
     const considerContextUntrusted = agent?.considerContextUntrusted ?? false;


### PR DESCRIPTION
## Summary

Fixes chat MCP tool discovery so assigned tools are loaded directly from the persisted tool catalog instead of requiring an internal MCP client session to list tools first.

## Root Cause

Chat tool discovery depended on creating or reusing an MCP client connection and calling `tools/list` through the internal gateway. If that connection could not be established, chat returned an empty tool set even when the agent had tools assigned.

## Changes

- Load assigned MCP tools for chat from `ToolModel.getMcpToolsByAgent`.
- Preserve built-in tool RBAC filtering, model/app visibility filtering, and dynamic knowledge-source descriptions.
- Keep gateway token selection for actual tool execution.
- Update chat MCP client tests so client health checks cover `getChatMcpClient` directly and tool discovery verifies it does not call `listTools` on a cached client.

## Validation

- `pnpm --dir ./backend exec vitest src/clients/chat-mcp-client.test.ts --run`
- `pnpm --dir ./backend type-check`
- `pnpm --dir ./backend lint`
- `git diff --check`

## Docs

Audited `../docs/pages`; no documentation changes needed for this internal reliability fix.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Image" src="https://github.com/user-attachments/assets/1f9497f2-96ad-4334-b3a4-c63ff38abdb9"/>

</a>