### PR TITLE
chore: remove deprecated downlevelIteration from tsconfig

### DIFF
--- a/platform/shared/tsconfig.base.json
+++ b/platform/shared/tsconfig.base.json
@@ -17,8 +17,7 @@
     "strict": true,
     "noEmit": true,
     "strictNullChecks": true,
-    "target": "ES2020",
-    "downlevelIteration": true
+    "target": "ES2020"
   },
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
`downlevelIteration` only ever had an effect when targeting ES5. Since we already target ES2020, it's been a no-op. As of TypeScript 6.0, setting it at all raises a deprecation error — so we just remove it.

See [TypeScript release docs](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html#deprecated---downleveliteration) and the original addition here https://github.com/archestra-ai/archestra/pull/1003/changes#diff-4c1ae6c32b408ef56be877ff61d21b6fac0c4a04b05f633f294c7ad78c23ab5bR21