### PR TITLE
fix: treat UUID search input as sessionId filter on sessions list

### DIFF
--- a/platform/frontend/src/lib/interactions/interaction.query.ts
+++ b/platform/frontend/src/lib/interactions/interaction.query.ts
@@ -17,6 +17,12 @@ const {
   getUniqueUserIds,
 } = archestraApiSdk;
 
+function isUuid(value: string): boolean {
+  const uuidRegex =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  return uuidRegex.test(value);
+}
+
 export function useInteractions({
   profileId,
   externalAgentId,
@@ -190,6 +196,12 @@ export function useInteractionSessions({
   offset?: number;
   initialData?: archestraApiTypes.GetInteractionSessionsResponses["200"];
 } = {}) {
+  // If the search value is a UUID, treat it as an exact sessionId filter instead
+  // of a free-text search. Explicit sessionId from the caller always wins.
+  const searchIsUuid = !!search && isUuid(search);
+  const effectiveSessionId = sessionId ?? (searchIsUuid ? search : undefined);
+  const effectiveSearch = searchIsUuid ? undefined : search;
+
   return useQuery({
     queryKey: [
       "interactions",
@@ -197,10 +209,10 @@ export function useInteractionSessions({
       profileId,
       userId,
       source,
-      sessionId,
+      effectiveSessionId,
       startDate,
       endDate,
-      search,
+      effectiveSearch,
       limit,
       offset,
     ],
@@ -210,10 +222,10 @@ export function useInteractionSessions({
           ...(profileId ? { profileId } : {}),
           ...(userId ? { userId } : {}),
           ...(source ? { source } : {}),
-          ...(sessionId ? { sessionId } : {}),
+          ...(effectiveSessionId ? { sessionId: effectiveSessionId } : {}),
           ...(startDate ? { startDate } : {}),
           ...(endDate ? { endDate } : {}),
-          ...(search ? { search } : {}),
+          ...(effectiveSearch ? { search: effectiveSearch } : {}),
           limit,
           offset,
         },
@@ -242,11 +254,12 @@ export function useInteractionSessions({
       !profileId &&
       !userId &&
       !source &&
-      !sessionId &&
+      !effectiveSessionId &&
       !startDate &&
       !endDate &&
-      !search
+      !effectiveSearch
         ? initialData
         : undefined,
   });
 }
+

--- a/platform/frontend/src/lib/interactions/interaction.query.ts
+++ b/platform/frontend/src/lib/interactions/interaction.query.ts
@@ -262,4 +262,3 @@ export function useInteractionSessions({
         : undefined,
   });
 }
-


### PR DESCRIPTION
## Summary

- On the sessions list page, `useInteractionSessions` now detects when the `search` value is a UUID and routes it through the API's exact-match `sessionId` query param instead of the free-text `search` param.
- An explicit `sessionId` passed by the caller always takes precedence over the UUID-shaped search.
- Query key and `initialData` guard use the effective (post-detection) values so cache correctness is preserved.

## Why

Users pasting a session UUID into the search box were hitting the backend's `search` path (free-text ILIKE/trigram scan) instead of the indexed exact-match path on `interactions.session_id`. The backend API already exposes a separate `sessionId` filter — this change keeps the backend contract clean and puts the UI-only UUID detection where it belongs.

## Test plan

- [x] Paste a full UUID into the sessions search input → request should send `sessionId=<uuid>` (no `search` param). Verify in Network tab.
- [x] Type a non-UUID string → request should send `search=<text>` (no `sessionId`). Verify in Network tab.
- [x] With an explicit `sessionId` passed to the hook and a UUID in `search`, the explicit `sessionId` wins.
- [x] Switching between UUID and non-UUID search values does not serve stale data (cache key is based on effective values).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Image" src="https://github.com/user-attachments/assets/1f9497f2-96ad-4334-b3a4-c63ff38abdb9"/>

</a>