### PR TITLE
chore(staging): set postgres PVC size to 20Gi

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -105,3 +105,8 @@ archestra:
           - path: /
             port: 9000
             pathType: Prefix
+
+postgresql:
+  primary:
+    persistence:
+      size: 20Gi


### PR DESCRIPTION
## Summary
- Default Bitnami PostgreSQL PVC size (8Gi) filled up on staging, causing Postgres to crashloop (couldn't write WAL during recovery).
- Live PVC already expanded to 20Gi via `kubectl patch` (StatefulSet volumeClaimTemplates are immutable, so Helm can't do it).
- This change brings `values-staging.yaml` in line with reality so future fresh installs request 20Gi.


---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Image" src="https://github.com/user-attachments/assets/1f9497f2-96ad-4334-b3a4-c63ff38abdb9"/>

</a>