### PR TITLE
chore: upgrade TypeScript 5.9 -> 6.x

### DIFF
--- a/platform/frontend/src/app/connection/connection-flow.utils.ts
+++ b/platform/frontend/src/app/connection/connection-flow.utils.ts
@@ -60,7 +60,7 @@ export function resolveEffectiveId(params: {
   return (
     selected ??
     fromUrl ??
-    (skipAdminDefault ? null : (adminDefault ?? null)) ??
+    (skipAdminDefault ? null : adminDefault) ??
     systemDefault ??
     firstAvailable ??
     null

--- a/platform/package.json
+++ b/platform/package.json
@@ -37,10 +37,11 @@
     "husky": "^9.1.7",
     "tsx": "^4.21.0",
     "turbo": "^2.8.13",
-    "typescript": "^5.9.2"
+    "typescript": "^6.0.2"
   },
   "pnpm": {
     "overrides": {
+      "typescript": "^6.0.2",
       "@fastify/reply-from": ">=12.6.2",
       "@fastify/http-proxy": ">=11.4.4",
       "protobufjs": ">=7.5.5",

--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  typescript: ^6
+  typescript: ^6.0.2
   '@fastify/reply-from': '>=12.6.2'
   '@fastify/http-proxy': '>=11.4.4'
   protobufjs: '>=7.5.5'
@@ -67,7 +67,7 @@ importers:
         specifier: ^2.8.13
         version: 2.8.17
       typescript:
-        specifier: ^6
+        specifier: ^6.0.2
         version: 6.0.2
 
   backend:
@@ -422,7 +422,7 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
       typescript:
-        specifier: ^6
+        specifier: ^6.0.2
         version: 6.0.2
       vitest:
         specifier: ^4.1.0
@@ -739,7 +739,7 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       typescript:
-        specifier: ^6
+        specifier: ^6.0.2
         version: 6.0.2
       vite-tsconfig-paths:
         specifier: ^6.1.1
@@ -770,7 +770,7 @@ importers:
         specifier: ^5.85.0
         version: 5.86.0(@types/node@25.5.0)(typescript@6.0.2)
       typescript:
-        specifier: ^6
+        specifier: ^6.0.2
         version: 6.0.2
       vitest:
         specifier: ^4.1.0
@@ -1886,7 +1886,7 @@ packages:
     resolution: {integrity: sha512-nWEyUNbc1O7R5FHMwPh24+127jCbIs6vT89ncHqFSprE0tUVNemGO3cZflZCeGw8XhJAk6O18TcruUbMmwv0Rg==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
-      typescript: ^6
+      typescript: ^6.0.2
 
   '@hey-api/json-schema-ref-parser@1.3.1':
     resolution: {integrity: sha512-7atnpUkT8TyUPHYPLk91j/GyaqMuwTEHanLOe50Dlx0EEvNuQqFD52Yjg8x4KU0UFL1mWlyhE+sUE/wAtQ1N2A==}
@@ -1897,18 +1897,18 @@ packages:
     engines: {node: '>=20.19.0'}
     hasBin: true
     peerDependencies:
-      typescript: ^6
+      typescript: ^6.0.2
 
   '@hey-api/shared@0.2.3':
     resolution: {integrity: sha512-XQsI/VmQeoHJFdZmBshQnMLGRq6kvSIXFgpxsb8k4F8nuKZ+54GAnq0DuTZcgnL6egAO/pN0KBaFbyl/yl9WFg==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
-      typescript: ^6
+      typescript: ^6.0.2
 
   '@hey-api/types@0.1.3':
     resolution: {integrity: sha512-mZaiPOWH761yD4GjDQvtjS2ZYLu5o5pI1TVSvV/u7cmbybv51/FVtinFBeaE1kFQCKZ8OQpn2ezjLBJrKsGATw==}
     peerDependencies:
-      typescript: ^6
+      typescript: ^6.0.2
 
   '@hono/node-server@1.19.11':
     resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
@@ -7576,7 +7576,7 @@ packages:
     hasBin: true
     peerDependencies:
       '@types/node': '>=18'
-      typescript: ^6
+      typescript: ^6.0.2
 
   kysely@0.28.14:
     resolution: {integrity: sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA==}
@@ -8775,7 +8775,7 @@ packages:
       '@ts-macro/tsc': ^0.3.6
       '@typescript/native-preview': '>=7.0.0-dev.20250601.1'
       rolldown: ^1.0.0-rc.3
-      typescript: ^6
+      typescript: ^6.0.2
       vue-tsc: ~3.2.0
     peerDependenciesMeta:
       '@ts-macro/tsc':
@@ -9253,7 +9253,7 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:
-      typescript: ^6
+      typescript: ^6.0.2
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -9268,7 +9268,7 @@ packages:
       '@tsdown/exe': 0.21.3
       '@vitejs/devtools': '*'
       publint: ^0.3.0
-      typescript: ^6
+      typescript: ^6.0.2
       unplugin-unused: ^0.5.0
     peerDependenciesMeta:
       '@arethetypeswrong/core':

--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  typescript: ^6
   '@fastify/reply-from': '>=12.6.2'
   '@fastify/http-proxy': '>=11.4.4'
   protobufjs: '>=7.5.5'
@@ -66,8 +67,8 @@ importers:
         specifier: ^2.8.13
         version: 2.8.17
       typescript:
-        specifier: ^5.9.2
-        version: 5.9.3
+        specifier: ^6
+        version: 6.0.2
 
   backend:
     dependencies:
@@ -413,16 +414,16 @@ importers:
         version: 8.18.1
       knip:
         specifier: ^5.85.0
-        version: 5.86.0(@types/node@25.5.0)(typescript@5.9.3)
+        version: 5.86.0(@types/node@25.5.0)(typescript@6.0.2)
       tsdown:
         specifier: ^0.21.0
-        version: 0.21.3(oxc-resolver@11.19.1)(typescript@5.9.3)
+        version: 0.21.3(oxc-resolver@11.19.1)(typescript@6.0.2)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
       typescript:
-        specifier: ^5.9.2
-        version: 5.9.3
+        specifier: ^6
+        version: 6.0.2
       vitest:
         specifier: ^4.1.0
         version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@29.0.0(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -447,7 +448,7 @@ importers:
         version: 25.5.0
       knip:
         specifier: ^5.85.0
-        version: 5.86.0(@types/node@25.5.0)(typescript@5.9.3)
+        version: 5.86.0(@types/node@25.5.0)(typescript@6.0.2)
 
   frontend:
     dependencies:
@@ -727,7 +728,7 @@ importers:
         version: 29.0.0(@noble/hashes@2.0.1)
       knip:
         specifier: ^5.85.0
-        version: 5.86.0(@types/node@25.5.0)(typescript@5.9.3)
+        version: 5.86.0(@types/node@25.5.0)(typescript@6.0.2)
       semver:
         specifier: ^7.7.4
         version: 7.7.4
@@ -738,11 +739,11 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       typescript:
-        specifier: ^5
-        version: 5.9.3
+        specifier: ^6
+        version: 6.0.2
       vite-tsconfig-paths:
         specifier: ^6.1.1
-        version: 6.1.1(typescript@5.9.3)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 6.1.1(typescript@6.0.2)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: ^4.1.0
         version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@29.0.0(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -761,16 +762,16 @@ importers:
     devDependencies:
       '@hey-api/openapi-ts':
         specifier: ^0.94.0
-        version: 0.94.1(typescript@5.9.3)
+        version: 0.94.1(typescript@6.0.2)
       '@types/node':
         specifier: ^25
         version: 25.5.0
       knip:
         specifier: ^5.85.0
-        version: 5.86.0(@types/node@25.5.0)(typescript@5.9.3)
+        version: 5.86.0(@types/node@25.5.0)(typescript@6.0.2)
       typescript:
-        specifier: ^5.9.2
-        version: 5.9.3
+        specifier: ^6
+        version: 6.0.2
       vitest:
         specifier: ^4.1.0
         version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@29.0.0(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -1885,7 +1886,7 @@ packages:
     resolution: {integrity: sha512-nWEyUNbc1O7R5FHMwPh24+127jCbIs6vT89ncHqFSprE0tUVNemGO3cZflZCeGw8XhJAk6O18TcruUbMmwv0Rg==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
-      typescript: '>=5.5.3'
+      typescript: ^6
 
   '@hey-api/json-schema-ref-parser@1.3.1':
     resolution: {integrity: sha512-7atnpUkT8TyUPHYPLk91j/GyaqMuwTEHanLOe50Dlx0EEvNuQqFD52Yjg8x4KU0UFL1mWlyhE+sUE/wAtQ1N2A==}
@@ -1896,18 +1897,18 @@ packages:
     engines: {node: '>=20.19.0'}
     hasBin: true
     peerDependencies:
-      typescript: '>=5.5.3'
+      typescript: ^6
 
   '@hey-api/shared@0.2.3':
     resolution: {integrity: sha512-XQsI/VmQeoHJFdZmBshQnMLGRq6kvSIXFgpxsb8k4F8nuKZ+54GAnq0DuTZcgnL6egAO/pN0KBaFbyl/yl9WFg==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
-      typescript: '>=5.5.3'
+      typescript: ^6
 
   '@hey-api/types@0.1.3':
     resolution: {integrity: sha512-mZaiPOWH761yD4GjDQvtjS2ZYLu5o5pI1TVSvV/u7cmbybv51/FVtinFBeaE1kFQCKZ8OQpn2ezjLBJrKsGATw==}
     peerDependencies:
-      typescript: '>=5.5.3'
+      typescript: ^6
 
   '@hono/node-server@1.19.11':
     resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
@@ -7575,7 +7576,7 @@ packages:
     hasBin: true
     peerDependencies:
       '@types/node': '>=18'
-      typescript: '>=5.0.4 <7'
+      typescript: ^6
 
   kysely@0.28.14:
     resolution: {integrity: sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA==}
@@ -8774,7 +8775,7 @@ packages:
       '@ts-macro/tsc': ^0.3.6
       '@typescript/native-preview': '>=7.0.0-dev.20250601.1'
       rolldown: ^1.0.0-rc.3
-      typescript: ^5.0.0 || ^6.0.0-beta
+      typescript: ^6
       vue-tsc: ~3.2.0
     peerDependenciesMeta:
       '@ts-macro/tsc':
@@ -9252,7 +9253,7 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: ^6
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -9267,7 +9268,7 @@ packages:
       '@tsdown/exe': 0.21.3
       '@vitejs/devtools': '*'
       publint: ^0.3.0
-      typescript: ^5.0.0
+      typescript: ^6
       unplugin-unused: ^0.5.0
     peerDependenciesMeta:
       '@arethetypeswrong/core':
@@ -9349,8 +9350,8 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -11282,13 +11283,13 @@ snapshots:
 
   '@hexagon/base64@1.1.28': {}
 
-  '@hey-api/codegen-core@0.7.2(typescript@5.9.3)':
+  '@hey-api/codegen-core@0.7.2(typescript@6.0.2)':
     dependencies:
-      '@hey-api/types': 0.1.3(typescript@5.9.3)
+      '@hey-api/types': 0.1.3(typescript@6.0.2)
       ansi-colors: 4.1.3
       c12: 3.3.3
       color-support: 1.1.3
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - magicast
 
@@ -11298,35 +11299,35 @@ snapshots:
       '@types/json-schema': 7.0.15
       js-yaml: 4.1.1
 
-  '@hey-api/openapi-ts@0.94.1(typescript@5.9.3)':
+  '@hey-api/openapi-ts@0.94.1(typescript@6.0.2)':
     dependencies:
-      '@hey-api/codegen-core': 0.7.2(typescript@5.9.3)
+      '@hey-api/codegen-core': 0.7.2(typescript@6.0.2)
       '@hey-api/json-schema-ref-parser': 1.3.1
-      '@hey-api/shared': 0.2.3(typescript@5.9.3)
-      '@hey-api/types': 0.1.3(typescript@5.9.3)
+      '@hey-api/shared': 0.2.3(typescript@6.0.2)
+      '@hey-api/types': 0.1.3(typescript@6.0.2)
       ansi-colors: 4.1.3
       color-support: 1.1.3
       commander: 14.0.3
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - magicast
 
-  '@hey-api/shared@0.2.3(typescript@5.9.3)':
+  '@hey-api/shared@0.2.3(typescript@6.0.2)':
     dependencies:
-      '@hey-api/codegen-core': 0.7.2(typescript@5.9.3)
+      '@hey-api/codegen-core': 0.7.2(typescript@6.0.2)
       '@hey-api/json-schema-ref-parser': 1.3.1
-      '@hey-api/types': 0.1.3(typescript@5.9.3)
+      '@hey-api/types': 0.1.3(typescript@6.0.2)
       ansi-colors: 4.1.3
       cross-spawn: 7.0.6
       open: 11.0.0
       semver: 7.7.3
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - magicast
 
-  '@hey-api/types@0.1.3(typescript@5.9.3)':
+  '@hey-api/types@0.1.3(typescript@6.0.2)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   '@hono/node-server@1.19.11(hono@4.12.9)':
     dependencies:
@@ -17422,7 +17423,7 @@ snapshots:
 
   khroma@2.1.0: {}
 
-  knip@5.86.0(@types/node@25.5.0)(typescript@5.9.3):
+  knip@5.86.0(@types/node@25.5.0)(typescript@6.0.2):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
       '@types/node': 25.5.0
@@ -17435,7 +17436,7 @@ snapshots:
       picomatch: 4.0.4
       smol-toml: 1.6.0
       strip-json-comments: 5.0.3
-      typescript: 5.9.3
+      typescript: 6.0.2
       unbash: 2.2.0
       yaml: 2.8.2
       zod: 4.3.6
@@ -18921,7 +18922,7 @@ snapshots:
 
   robust-predicates@3.0.2: {}
 
-  rolldown-plugin-dts@0.22.5(oxc-resolver@11.19.1)(rolldown@1.0.0-rc.9)(typescript@5.9.3):
+  rolldown-plugin-dts@0.22.5(oxc-resolver@11.19.1)(rolldown@1.0.0-rc.9)(typescript@6.0.2):
     dependencies:
       '@babel/generator': 8.0.0-rc.2
       '@babel/helper-validator-identifier': 8.0.0-rc.2
@@ -18934,7 +18935,7 @@ snapshots:
       obug: 2.1.1
       rolldown: 1.0.0-rc.9
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -19519,11 +19520,11 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  tsconfck@3.1.6(typescript@5.9.3):
+  tsconfck@3.1.6(typescript@6.0.2):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
-  tsdown@0.21.3(oxc-resolver@11.19.1)(typescript@5.9.3):
+  tsdown@0.21.3(oxc-resolver@11.19.1)(typescript@6.0.2):
     dependencies:
       ansis: 4.2.0
       cac: 7.0.0
@@ -19534,7 +19535,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.4
       rolldown: 1.0.0-rc.9
-      rolldown-plugin-dts: 0.22.5(oxc-resolver@11.19.1)(rolldown@1.0.0-rc.9)(typescript@5.9.3)
+      rolldown-plugin-dts: 0.22.5(oxc-resolver@11.19.1)(rolldown@1.0.0-rc.9)(typescript@6.0.2)
       semver: 7.7.4
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
@@ -19542,7 +19543,7 @@ snapshots:
       unconfig-core: 7.5.0
       unrun: 0.2.32
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
@@ -19604,7 +19605,7 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   ua-parser-js@1.0.41: {}
 
@@ -19772,11 +19773,11 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vite-tsconfig-paths@6.1.1(typescript@6.0.2)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@5.9.3)
+      tsconfck: 3.1.6(typescript@6.0.2)
       vite: 7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
and fix an issue detected by stricter TS:

Remove no-op ?? null from adminDefault in resolveEffectiveId

adminDefault ?? null was intended to normalize undefined to null, but in a ?? chain both null and undefined already fall through to the next operand — so the conversion had no effect. TypeScript 6's new syntactic nullish-coalescing check caught this as a code smell (TS2871)

🚂  depends on https://github.com/archestra-ai/archestra/pull/4027