### PR TITLE
chore: drop dead declaration flags from tsconfigs

### DIFF
--- a/platform/backend/tsconfig.json
+++ b/platform/backend/tsconfig.json
@@ -5,7 +5,6 @@
     "moduleResolution": "Bundler",
     "resolvePackageJsonExports": true,
     "esModuleInterop": true,
-    "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/platform/shared/tsconfig.base.json
+++ b/platform/shared/tsconfig.base.json
@@ -1,8 +1,6 @@
 {
   "compilerOptions": {
     "composite": false,
-    "declaration": true,
-    "declarationMap": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
`declaration: true` + `declarationMap: true` in shared/tsconfig.base.json and `declaration: true` in backend/tsconfig.json are inert because every consumer runs with `--noEmit` and builds go through tsdown / SWC (not tsc). Removing the dead config.

Discovered while evaluating TS 7 beta (`tsgo`, the new Go-based compiler): tsgo correctly enforces TS4023 ("exported name cannot be named") under `--noEmit` when `declaration: true` is set, whereas tsc 6 silently skipped the check. That surfaced a pre-existing latent error in backend's better-auth export. Lands ahead of the TS 7
migration so the cleanup has its own reviewable commit.

References: https://www.typescriptlang.org/tsconfig/#declaration and https://www.typescriptlang.org/tsconfig/#noEmit