### PR TITLE
fix(deps): update fastify proxy packages

### DIFF
--- a/platform/backend/package.json
+++ b/platform/backend/package.json
@@ -54,7 +54,7 @@
     "@chonkiejs/core": "^0.0.7",
     "@fastify/cors": "^11.1.0",
     "@fastify/formbody": "^8.0.2",
-    "@fastify/http-proxy": "fastify/fastify-http-proxy#bbe97fb55de3f7e3d15f57791142f7d84abf5a96",
+    "@fastify/http-proxy": "11.4.4",
     "@fastify/otel": "^0.17.1",
     "@fastify/swagger": "^9.7.0",
     "@gitbeaker/rest": "^43.8.0",


### PR DESCRIPTION
## Summary

Updates `@fastify/http-proxy` to `11.4.4`, which pulls the patched `@fastify/reply-from@12.6.2`.

This addresses the public Fastify proxy advisory:
- [GHSA-gwhp-pf74-vj37](https://github.com/advisories/GHSA-gwhp-pf74-vj37)
- [CVE-2026-33805](https://nvd.nist.gov/vuln/detail/CVE-2026-33805)

## Criticality

This advisory is marked **Critical** by GitHub Advisory Database, and NVD/OpenJS lists it as **CVSS 4.0: 9.0 Critical**.

Relevant references:
- [GitHub Advisory: Critical severity](https://github.com/advisories/GHSA-gwhp-pf74-vj37)
- [NVD: CVSS 4.0 9.0 Critical](https://nvd.nist.gov/vuln/detail/CVE-2026-33805)

## Release links

- [`@fastify/http-proxy@11.4.4` release](https://github.com/fastify/fastify-http-proxy/releases/tag/v11.4.4)
- [`@fastify/reply-from@12.6.2` release](https://github.com/fastify/fastify-reply-from/releases/tag/v12.6.2)

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm audit --prod` no longer reports `GHSA-gwhp-pf74-vj37`
- `pnpm -r why @fastify/http-proxy @fastify/reply-from` resolves to patched versions
- Focused Vitest check passed locally
