### PR TITLE
fix: allow personal agents to use team credentials the author can access

### DIFF
--- a/platform/backend/src/services/agent-tool-assignment.test.ts
+++ b/platform/backend/src/services/agent-tool-assignment.test.ts
@@ -199,6 +199,100 @@ describe("validateCredentialSource", () => {
     });
   });
 
+  test("accepts a team-installed MCP server for a personal agent when the author is a member of that team", async ({
+    makeAgent,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeMember,
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+    makeTool,
+    makeUser,
+  }) => {
+    const organization = await makeOrganization();
+    const owner = await makeUser();
+    const author = await makeUser();
+
+    await makeMember(owner.id, organization.id, { role: "member" });
+    await makeMember(author.id, organization.id, { role: "member" });
+
+    const sharedTeam = await makeTeam(organization.id, author.id, {
+      name: "Shared Team",
+    });
+    await makeTeamMember(sharedTeam.id, author.id);
+
+    const agent = await makeAgent({
+      organizationId: organization.id,
+      authorId: author.id,
+      scope: "personal",
+    });
+    const catalog = await makeInternalMcpCatalog({ serverType: "remote" });
+    const tool = await makeTool({ catalogId: catalog.id, name: "remote_tool" });
+    const mcpServer = await makeMcpServer({
+      teamId: sharedTeam.id,
+      ownerId: owner.id,
+      catalogId: catalog.id,
+    });
+
+    const result = await validateCredentialSource({
+      agentId: agent.id,
+      mcpServerId: mcpServer.id,
+      toolId: tool.id,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("rejects a team-installed MCP server for a personal agent when the author is not a member of that team", async ({
+    makeAgent,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeMember,
+    makeOrganization,
+    makeTeam,
+    makeTool,
+    makeUser,
+  }) => {
+    const organization = await makeOrganization();
+    const owner = await makeUser();
+    const author = await makeUser();
+
+    await makeMember(owner.id, organization.id, { role: "member" });
+    await makeMember(author.id, organization.id, { role: "member" });
+
+    const otherTeam = await makeTeam(organization.id, author.id, {
+      name: "Other Team",
+    });
+
+    const agent = await makeAgent({
+      organizationId: organization.id,
+      authorId: author.id,
+      scope: "personal",
+    });
+    const catalog = await makeInternalMcpCatalog({ serverType: "remote" });
+    const tool = await makeTool({ catalogId: catalog.id, name: "remote_tool" });
+    const mcpServer = await makeMcpServer({
+      teamId: otherTeam.id,
+      ownerId: owner.id,
+      catalogId: catalog.id,
+    });
+
+    const result = await validateCredentialSource({
+      agentId: agent.id,
+      mcpServerId: mcpServer.id,
+      toolId: tool.id,
+    });
+
+    expect(result).toEqual({
+      code: "validation_error",
+      error: {
+        message: "This team connection is not shared with the selected team",
+        type: "validation_error",
+      },
+    });
+  });
+
   test("accepts a personal credential for a team-scoped resource when the owner is a team member", async ({
     makeAgent,
     makeInternalMcpCatalog,

--- a/platform/backend/src/services/agent-tool-assignment.test.ts
+++ b/platform/backend/src/services/agent-tool-assignment.test.ts
@@ -293,6 +293,49 @@ describe("validateCredentialSource", () => {
     });
   });
 
+  test("accepts a team-installed MCP server for a personal agent when the author is an org admin", async ({
+    makeAgent,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeMember,
+    makeOrganization,
+    makeTeam,
+    makeTool,
+    makeUser,
+  }) => {
+    const organization = await makeOrganization();
+    const owner = await makeUser();
+    const author = await makeUser();
+
+    await makeMember(owner.id, organization.id, { role: "member" });
+    await makeMember(author.id, organization.id, { role: "admin" });
+
+    const otherTeam = await makeTeam(organization.id, owner.id, {
+      name: "Eng Team",
+    });
+
+    const agent = await makeAgent({
+      organizationId: organization.id,
+      authorId: author.id,
+      scope: "personal",
+    });
+    const catalog = await makeInternalMcpCatalog({ serverType: "remote" });
+    const tool = await makeTool({ catalogId: catalog.id, name: "remote_tool" });
+    const mcpServer = await makeMcpServer({
+      teamId: otherTeam.id,
+      ownerId: owner.id,
+      catalogId: catalog.id,
+    });
+
+    const result = await validateCredentialSource({
+      agentId: agent.id,
+      mcpServerId: mcpServer.id,
+      toolId: tool.id,
+    });
+
+    expect(result).toBeNull();
+  });
+
   test("accepts a personal credential for a team-scoped resource when the owner is a team member", async ({
     makeAgent,
     makeInternalMcpCatalog,

--- a/platform/backend/src/services/agent-tool-assignment.ts
+++ b/platform/backend/src/services/agent-tool-assignment.ts
@@ -379,7 +379,16 @@ export async function isMcpServerAssignableToTarget(params: {
   const { mcpServer, target } = params;
 
   if (mcpServer.teamId) {
-    return target.scope === "team" && target.teamIds.includes(mcpServer.teamId);
+    if (target.scope === "team") {
+      return target.teamIds.includes(mcpServer.teamId);
+    }
+    if (target.scope === "personal" && target.authorId) {
+      return TeamModel.isUserInAnyTeam(
+        [mcpServer.teamId],
+        target.authorId,
+      );
+    }
+    return false;
   }
 
   if (!mcpServer.ownerId) {

--- a/platform/backend/src/services/agent-tool-assignment.ts
+++ b/platform/backend/src/services/agent-tool-assignment.ts
@@ -367,6 +367,14 @@ async function getAssignmentTargetContext(agentId: string): Promise<{
   };
 }
 
+async function isOrgAdmin(
+  userId: string,
+  organizationId: string,
+): Promise<boolean> {
+  const membership = await MemberModel.getByUserId(userId, organizationId);
+  return membership?.role === "admin";
+}
+
 export async function isMcpServerAssignableToTarget(params: {
   mcpServer: Pick<PrefetchedMcpServer, "ownerId" | "teamId">;
   target: {
@@ -383,10 +391,12 @@ export async function isMcpServerAssignableToTarget(params: {
       return target.teamIds.includes(mcpServer.teamId);
     }
     if (target.scope === "personal" && target.authorId) {
-      return TeamModel.isUserInAnyTeam(
-        [mcpServer.teamId],
-        target.authorId,
-      );
+      if (
+        await TeamModel.isUserInAnyTeam([mcpServer.teamId], target.authorId)
+      ) {
+        return true;
+      }
+      return isOrgAdmin(target.authorId, target.organizationId);
     }
     return false;
   }


### PR DESCRIPTION
## Summary

Personal agents couldn't be assigned team-scoped credentials, even when the agent's author was a member of that team. `isMcpServerAssignableToTarget` rejected any team credential whose target wasn't itself team-scoped.

Now: a personal agent can use a team credential iff the agent's author is a member of that team. Team and org agent behavior is unchanged — team agents still only accept credentials from teams the agent is assigned to (preserves the invariant that every user who can run the agent has access to the credential).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>