### PR TITLE
fix: persist empty OAuth scopes from catalog form

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -1362,8 +1362,7 @@ export function McpCatalogForm({
                                       />
                                     </FormControl>
                                     <FormDescription>
-                                      Comma-separated list of OAuth scopes
-                                      (defaults to read, write)
+                                      Comma-separated list of OAuth scopes.
                                     </FormDescription>
                                     <FormMessage />
                                   </FormItem>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
@@ -175,7 +175,7 @@ describe("transformFormToApiData", () => {
     });
   });
 
-  it('uses ["read", "write"] as defaults only when the scopes field is blank', () => {
+  it("persists empty scopes when the scopes field is blank, but keeps ['read','write'] as default_scopes fallback", () => {
     const values: McpCatalogFormValues = {
       name: "Default Scope OAuth MCP",
       description: "",
@@ -215,12 +215,12 @@ describe("transformFormToApiData", () => {
     };
 
     expect(transformFormToApiData(values).oauthConfig).toMatchObject({
-      scopes: ["read", "write"],
+      scopes: [],
       default_scopes: ["read", "write"],
     });
   });
 
-  it('treats comma-only scopes input as blank and falls back to ["read", "write"]', () => {
+  it("treats comma-only scopes input as blank (persists empty scopes with read/write fallback)", () => {
     const values: McpCatalogFormValues = {
       name: "Comma Scope OAuth MCP",
       description: "",
@@ -260,7 +260,7 @@ describe("transformFormToApiData", () => {
     };
 
     expect(transformFormToApiData(values).oauthConfig).toMatchObject({
-      scopes: ["read", "write"],
+      scopes: [],
       default_scopes: ["read", "write"],
     });
   });
@@ -458,6 +458,31 @@ describe("transformFormToApiData", () => {
         description: "Tenant ID",
       },
     ]);
+  });
+
+  it("leaves the scopes field empty when external catalog oauth_config has no scopes", () => {
+    const values = transformExternalCatalogToFormValues({
+      name: "empty-scopes-server",
+      display_name: "Empty Scopes Server",
+      description: "",
+      icon: null,
+      server: {
+        type: "remote",
+        url: "https://mcp.example.com",
+      },
+      oauth_config: {
+        client_id: "client-id",
+        client_secret: "client-secret",
+        redirect_uris: ["https://app.example.com/oauth-callback"],
+        scopes: [],
+        default_scopes: ["read", "write"],
+        supports_resource_metadata: true,
+        grant_type: "authorization_code",
+        server_url: "https://mcp.example.com",
+      },
+    } as never);
+
+    expect(values.oauthConfig?.scopes).toBe("");
   });
 
   it("detects default bearer auth from external catalog manifests without an explicit headerName", () => {

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
@@ -88,12 +88,7 @@ export function transformFormToApiData(
       .split(",")
       .map((scope) => scope.trim())
       .filter((scope) => scope.length > 0);
-    const hasExplicitScopes = parsedScopes.length > 0;
-    const scopesList = hasExplicitScopes
-      ? parsedScopes
-      : isClientCredentials
-        ? []
-        : ["read", "write"];
+    const scopesList = parsedScopes;
 
     // For local servers, use oauthServerUrl; for remote servers, use serverUrl
     const oauthServerUrl =
@@ -125,13 +120,21 @@ export function transformFormToApiData(
       audience: values.oauthConfig.audience || undefined,
       redirect_uris: redirectUrisList,
       scopes: scopesList,
-      // Keep fallback scopes aligned with explicit scopes because the backend
-      // skips discovery entirely when scopes are configured.
-      default_scopes: hasExplicitScopes
-        ? scopesList
-        : isClientCredentials
-          ? []
-          : ["read", "write"],
+      // default_scopes is the fallback used by the backend's scope resolution:
+      //   1. If `scopes` is non-empty, discovery is skipped and `scopes` is sent verbatim.
+      //   2. If `scopes` is empty, backend tries .well-known discovery
+      //      (oauth-protected-resource, then oauth-authorization-server).
+      //   3. If discovery yields nothing, backend falls back to `default_scopes`.
+      // When the user configures explicit scopes, mirror them into default_scopes so
+      // the fallback matches intent. When the field is blank, keep the generic
+      // ["read","write"] fallback — some proxy MCP servers (e.g. Atlassian) accept
+      // those literal values and translate them to real provider scopes.
+      default_scopes:
+        scopesList.length > 0
+          ? scopesList
+          : isClientCredentials
+            ? []
+            : ["read", "write"],
       supports_resource_metadata: values.oauthConfig.supports_resource_metadata,
     };
 
@@ -542,7 +545,7 @@ export function transformExternalCatalogToFormValues(
         (typeof window !== "undefined"
           ? `${window.location.origin}/oauth-callback`
           : ""),
-      scopes: server.oauth_config.scopes?.join(", ") || "read, write",
+      scopes: server.oauth_config.scopes?.join(", ") ?? "",
       supports_resource_metadata:
         server.oauth_config.supports_resource_metadata ?? true,
       grantType:


### PR DESCRIPTION
## Summary

- Clearing the scopes field in the MCP catalog form now persists `scopes: []` instead of silently rewriting back to `["read","write"]`.
- It's needed because if scopes are not null,  mcp (such as huggingface) will never do scopes discovery and wil fail. cause default "read,write" scopes are invalid for it.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>