### PR TITLE
chore: log raw chat provider errors

### DIFF
--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -90,6 +90,18 @@ function safeSerialize(obj: unknown): unknown {
   }
 }
 
+function stringifyRawError(error: unknown): string {
+  try {
+    return JSON.stringify(error, Object.getOwnPropertyNames(error));
+  } catch {
+    try {
+      return JSON.stringify(safeSerialize(error));
+    } catch {
+      return String(error);
+    }
+  }
+}
+
 // =============================================================================
 // Parsed Error Types
 // =============================================================================
@@ -1498,6 +1510,7 @@ export function mapProviderError(
       parsedError,
       mappedCode: errorCode,
       errorMessage,
+      rawErrorJson: stringifyRawError(error),
     },
     "[ChatErrorMapper] Mapped provider error",
   );


### PR DESCRIPTION
## Summary

Adds a provider-agnostic `rawErrorJson` field to the existing `[ChatErrorMapper] Mapped provider error` log. This gives Sentry a direct stringified view of the raw error object that reached the shared chat error mapper, without adding provider-specific handling or logging request payloads.

## Why

A Bedrock chat stream failure was mapped to `unknown` because the mapper only surfaced the normalized error fields. Keeping the raw error JSON in the shared mapper log should make future provider failures easier to inspect across all providers.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>