### PR TITLE
fix: make swap_agent work in Slack/MS Teams chatops 

### DIFF
--- a/platform/backend/src/agents/chatops/chatops-manager.test.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.test.ts
@@ -3,6 +3,7 @@ import {
   AgentTeamModel,
   ChatOpsChannelBindingModel,
   ChatOpsConfigModel,
+  ConversationModel,
 } from "@/models";
 import { afterEach, beforeEach, describe, expect, test, vi } from "@/test";
 import type {
@@ -1610,6 +1611,317 @@ describe("ChatOpsManager attachment passthrough", () => {
     expect(executorSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         attachments: [historyImageAttachment],
+      }),
+    );
+  });
+});
+
+describe("ChatOpsManager swap_agent handoff", () => {
+  function createMockProvider(
+    overrides: {
+      getUserEmail?: (userId: string) => Promise<string | null>;
+      sendReply?: (options: ChatReplyOptions) => Promise<string>;
+    } = {},
+  ): ChatOpsProvider {
+    return {
+      providerId: "ms-teams",
+      displayName: "Microsoft Teams",
+      isConfigured: () => true,
+      initialize: async () => {},
+      cleanup: async () => {},
+      validateWebhookRequest: async () => true,
+      handleValidationChallenge: () => null,
+      parseWebhookNotification: async () => null,
+      sendReply: overrides.sendReply ?? (async () => "reply-id"),
+      parseInteractivePayload: () => null,
+      sendAgentSelectionCard: async () => {},
+      getThreadHistory: async () => [],
+      getUserEmail: overrides.getUserEmail ?? (async () => null),
+      getChannelName: async () => null,
+      getWorkspaceId: () => null,
+      getWorkspaceName: () => null,
+      hasMissingScopes: () => false,
+      notifyMissingScopes: async () => {},
+      downloadFiles: async () => [],
+      discoverChannels: async () => null,
+    };
+  }
+
+  function createMockMessage(
+    overrides: Partial<IncomingChatMessage> = {},
+  ): IncomingChatMessage {
+    return {
+      messageId: "test-message-id",
+      channelId: "test-channel-id",
+      workspaceId: "test-workspace-id",
+      senderId: "test-sender-aad-id",
+      senderName: "Test User",
+      text: "Hello agent",
+      rawText: "@Bot Hello agent",
+      timestamp: new Date(),
+      isThreadReply: false,
+      ...overrides,
+    };
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("hands off to swapped agent in the same turn when router produces no reply", async ({
+    makeUser,
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+    makeInternalAgent,
+  }) => {
+    const user = await makeUser({ email: "handoff-same-turn@example.com" });
+    const org = await makeOrganization();
+    const team = await makeTeam(org.id, user.id);
+    await makeTeamMember(team.id, user.id);
+
+    const router = await makeInternalAgent({
+      organizationId: org.id,
+      name: "Router",
+      teams: [team.id],
+    });
+    await AgentTeamModel.assignTeamsToAgent(router.id, [team.id]);
+
+    const worker = await makeInternalAgent({
+      organizationId: org.id,
+      name: "Worker",
+      teams: [team.id],
+    });
+    await AgentTeamModel.assignTeamsToAgent(worker.id, [team.id]);
+
+    await ChatOpsChannelBindingModel.create({
+      organizationId: org.id,
+      provider: "ms-teams",
+      channelId: "test-channel-id",
+      workspaceId: "test-workspace-id",
+      agentId: router.id,
+    });
+
+    // Router runs first. During its turn, swap_agent would update the
+    // conversation row; simulate that by mutating the row directly. Router
+    // produces no text — exercises the same-turn handoff path.
+    const executorSpy = vi
+      .spyOn(a2aExecutor, "executeA2AMessage")
+      .mockImplementation(async (params) => {
+        if (params.agentId === router.id) {
+          if (params.conversationId) {
+            await ConversationModel.update(
+              params.conversationId,
+              params.userId,
+              params.organizationId,
+              { agentId: worker.id },
+            );
+          }
+          return { text: "", messageId: "router-msg", finishReason: "stop" };
+        }
+        if (params.agentId === worker.id) {
+          return {
+            text: "Specialist answer",
+            messageId: "worker-msg",
+            finishReason: "stop",
+          };
+        }
+        throw new Error(`Unexpected agentId: ${params.agentId}`);
+      });
+
+    const sendReplySpy = vi.fn().mockResolvedValue("reply-id");
+    const provider = createMockProvider({
+      getUserEmail: async () => "handoff-same-turn@example.com",
+      sendReply: sendReplySpy,
+    });
+
+    const manager = new ChatOpsManager();
+    (
+      manager as unknown as { msTeamsProvider: ChatOpsProvider }
+    ).msTeamsProvider = provider;
+
+    const result = await manager.processMessage({
+      message: createMockMessage(),
+      provider,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.agentResponse).toBe("Specialist answer");
+    expect(executorSpy).toHaveBeenCalledTimes(2);
+    expect(executorSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ agentId: router.id }),
+    );
+    expect(executorSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ agentId: worker.id }),
+    );
+    expect(sendReplySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Specialist answer",
+        footer: `🤖 ${worker.name}`,
+      }),
+    );
+  });
+
+  test("does not replay when router already replied (persists swap for next turn)", async ({
+    makeUser,
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+    makeInternalAgent,
+  }) => {
+    const user = await makeUser({ email: "handoff-next-turn@example.com" });
+    const org = await makeOrganization();
+    const team = await makeTeam(org.id, user.id);
+    await makeTeamMember(team.id, user.id);
+
+    const router = await makeInternalAgent({
+      organizationId: org.id,
+      name: "Router",
+      teams: [team.id],
+    });
+    await AgentTeamModel.assignTeamsToAgent(router.id, [team.id]);
+
+    const worker = await makeInternalAgent({
+      organizationId: org.id,
+      name: "Worker",
+      teams: [team.id],
+    });
+    await AgentTeamModel.assignTeamsToAgent(worker.id, [team.id]);
+
+    await ChatOpsChannelBindingModel.create({
+      organizationId: org.id,
+      provider: "ms-teams",
+      channelId: "test-channel-id",
+      workspaceId: "test-workspace-id",
+      agentId: router.id,
+    });
+
+    const executorSpy = vi
+      .spyOn(a2aExecutor, "executeA2AMessage")
+      .mockImplementation(async (params) => {
+        if (params.agentId === router.id) {
+          if (params.conversationId) {
+            await ConversationModel.update(
+              params.conversationId,
+              params.userId,
+              params.organizationId,
+              { agentId: worker.id },
+            );
+          }
+          return {
+            text: "Handing you off to Worker.",
+            messageId: "router-msg",
+            finishReason: "stop",
+          };
+        }
+        throw new Error(`Unexpected agentId: ${params.agentId}`);
+      });
+
+    const sendReplySpy = vi.fn().mockResolvedValue("reply-id");
+    const provider = createMockProvider({
+      getUserEmail: async () => "handoff-next-turn@example.com",
+      sendReply: sendReplySpy,
+    });
+
+    const manager = new ChatOpsManager();
+    (
+      manager as unknown as { msTeamsProvider: ChatOpsProvider }
+    ).msTeamsProvider = provider;
+
+    const result = await manager.processMessage({
+      message: createMockMessage(),
+      provider,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.agentResponse).toBe("Handing you off to Worker.");
+    expect(executorSpy).toHaveBeenCalledTimes(1);
+    expect(sendReplySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Handing you off to Worker.",
+        footer: `🤖 ${worker.name}`,
+      }),
+    );
+  });
+
+  test("second message in same thread routes to swapped agent", async ({
+    makeUser,
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+    makeInternalAgent,
+  }) => {
+    const user = await makeUser({ email: "next-turn@example.com" });
+    const org = await makeOrganization();
+    const team = await makeTeam(org.id, user.id);
+    await makeTeamMember(team.id, user.id);
+
+    const router = await makeInternalAgent({
+      organizationId: org.id,
+      name: "Router",
+      teams: [team.id],
+    });
+    await AgentTeamModel.assignTeamsToAgent(router.id, [team.id]);
+
+    const worker = await makeInternalAgent({
+      organizationId: org.id,
+      name: "Worker",
+      teams: [team.id],
+    });
+    await AgentTeamModel.assignTeamsToAgent(worker.id, [team.id]);
+
+    await ChatOpsChannelBindingModel.create({
+      organizationId: org.id,
+      provider: "ms-teams",
+      channelId: "test-channel-id",
+      workspaceId: "test-workspace-id",
+      agentId: router.id,
+    });
+
+    // Pre-seed a prior swap by creating the session's conversation with worker.
+    await ConversationModel.findOrCreateForChatopsSession({
+      sessionId: buildChatOpsSessionId("ms-teams", "test-channel-id"),
+      userId: user.id,
+      organizationId: org.id,
+      agentId: worker.id,
+    });
+
+    const executorSpy = vi
+      .spyOn(a2aExecutor, "executeA2AMessage")
+      .mockResolvedValue({
+        text: "Worker reply",
+        messageId: "worker-msg",
+        finishReason: "stop",
+      });
+
+    const sendReplySpy = vi.fn().mockResolvedValue("reply-id");
+    const provider = createMockProvider({
+      getUserEmail: async () => "next-turn@example.com",
+      sendReply: sendReplySpy,
+    });
+
+    const manager = new ChatOpsManager();
+    (
+      manager as unknown as { msTeamsProvider: ChatOpsProvider }
+    ).msTeamsProvider = provider;
+
+    const result = await manager.processMessage({
+      message: createMockMessage(),
+      provider,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.agentResponse).toBe("Worker reply");
+    expect(executorSpy).toHaveBeenCalledTimes(1);
+    expect(executorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: worker.id }),
+    );
+    expect(sendReplySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Worker reply",
+        footer: `🤖 ${worker.name}`,
       }),
     );
   });

--- a/platform/backend/src/agents/chatops/chatops-manager.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.ts
@@ -9,6 +9,7 @@ import {
   ChatOpsChannelBindingModel,
   ChatOpsConfigModel,
   ChatOpsProcessedMessageModel,
+  ConversationModel,
   OrganizationModel,
   UserModel,
 } from "@/models";
@@ -1240,13 +1241,54 @@ export class ChatOpsManager {
       const chatOpsUser =
         userId !== "system" ? await UserModel.getById(userId) : null;
 
+      // Stable id per Slack/Teams thread — used for logs and as the
+      // lookup key for the backing conversation row.
+      const sessionId = buildChatOpsSessionId(
+        provider.providerId,
+        message.channelId,
+        message.threadId,
+      );
+
+      const source =
+        provider.providerId === "slack" ? "chatops:slack" : "chatops:ms-teams";
+
+      const attachments =
+        message.attachments && message.attachments.length > 0
+          ? message.attachments
+          : undefined;
+
+      // Get or create the conversation row that backs this thread.
+      // swap_agent needs a real row to update.
+      const conversation =
+        userId !== "system"
+          ? await ConversationModel.findOrCreateForChatopsSession({
+              sessionId,
+              userId,
+              organizationId: binding.organizationId,
+              agentId: agent.id,
+            })
+          : null;
+
+      // If an earlier turn already swapped this thread, use that agent now.
+      let effectiveAgent = agent;
+      if (
+        conversation &&
+        conversation.agentId &&
+        conversation.agentId !== agent.id
+      ) {
+        const swappedAgent = await AgentModel.findById(conversation.agentId);
+        if (swappedAgent && swappedAgent.agentType === "agent") {
+          effectiveAgent = { id: swappedAgent.id, name: swappedAgent.name };
+        }
+      }
+
       // Wrap A2A execution with a parent span so all LLM and MCP tool calls
       // appear as children of a single unified trace. The provider ID (e.g.
       // "ms-teams", "slack") is recorded as archestra.trigger.source so traces
       // can be filtered by invocation channel.
-      const result = await startActiveChatSpan({
-        agentName: agent.name,
-        agentId: agent.id,
+      const execution = await startActiveChatSpan({
+        agentName: effectiveAgent.name,
+        agentId: effectiveAgent.id,
         routeCategory: RouteCategory.CHATOPS,
         triggerSource: provider.providerId,
         user: chatOpsUser
@@ -1257,39 +1299,79 @@ export class ChatOpsManager {
             }
           : null,
         callback: async () => {
-          // Use thread ID (or channel ID for non-threaded messages) as session ID
-          // so all messages in the same thread are grouped together in logs
-          const sessionId = buildChatOpsSessionId(
-            provider.providerId,
-            message.channelId,
-            message.threadId,
-          );
-
-          return executeA2AMessage({
-            agentId: agent.id,
+          // First run: the current agent handles the message.
+          const initialResult = await executeA2AMessage({
+            agentId: effectiveAgent.id,
             organizationId: binding.organizationId,
             message: fullMessage,
             userId,
             sessionId,
-            source:
-              provider.providerId === "slack"
-                ? "chatops:slack"
-                : "chatops:ms-teams",
-            attachments:
-              message.attachments && message.attachments.length > 0
-                ? message.attachments
-                : undefined,
+            conversationId: conversation?.id,
+            source,
+            attachments,
           });
+
+          const initialText = stripThinkingBlocks(initialResult.text || "");
+
+          if (!conversation) {
+            return { result: initialResult, responseAgent: effectiveAgent };
+          }
+
+          // Did swap_agent change the agent on this conversation?
+          const latest = await ConversationModel.getAgentId(conversation.id);
+          if (!latest || latest === effectiveAgent.id) {
+            return { result: initialResult, responseAgent: effectiveAgent };
+          }
+
+          // Load the new agent.
+          const swappedAgent = await AgentModel.findById(latest);
+          if (!swappedAgent || swappedAgent.agentType !== "agent") {
+            return { result: initialResult, responseAgent: effectiveAgent };
+          }
+
+          const responseAgent = {
+            id: swappedAgent.id,
+            name: swappedAgent.name,
+          };
+
+          // The old agent already replied — keep its reply, swap takes
+          // effect on the next message. (Re-running now could loop.)
+          if (initialText) {
+            return { result: initialResult, responseAgent };
+          }
+
+          // Same turn: let the new agent answer the user's message now.
+          logger.info(
+            {
+              sessionId,
+              previousAgentId: effectiveAgent.id,
+              swappedAgentId: swappedAgent.id,
+            },
+            "[ChatOps] swap_agent invoked mid-turn; handing off to swapped agent",
+          );
+
+          const handoffResult = await executeA2AMessage({
+            agentId: swappedAgent.id,
+            organizationId: binding.organizationId,
+            message: fullMessage,
+            userId,
+            sessionId,
+            conversationId: conversation.id,
+            source,
+            attachments,
+          });
+
+          return { result: handoffResult, responseAgent };
         },
       });
 
-      const agentResponse = stripThinkingBlocks(result.text || "");
+      const agentResponse = stripThinkingBlocks(execution.result.text || "");
 
       if (sendReply && agentResponse) {
         await provider.sendReply({
           originalMessage: message,
           text: agentResponse,
-          footer: `🤖 ${agent.name}`,
+          footer: `🤖 ${execution.responseAgent.name}`,
           conversationReference: message.metadata?.conversationReference,
         });
       } else if (
@@ -1309,7 +1391,7 @@ export class ChatOpsManager {
       return {
         success: true,
         agentResponse,
-        interactionId: result.messageId,
+        interactionId: execution.result.messageId,
       };
     } catch (error) {
       logger.error(

--- a/platform/backend/src/models/conversation.test.ts
+++ b/platform/backend/src/models/conversation.test.ts
@@ -6,6 +6,76 @@ import ConversationShareModel from "./conversation-share";
 import MessageModel from "./message";
 
 describe("ConversationModel", () => {
+  test("findOrCreateForChatopsSession creates once and reuses on subsequent calls", async ({
+    makeUser,
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const user = await makeUser();
+    const org = await makeOrganization();
+    const agent = await makeAgent({ name: "Router", teams: [] });
+    const sessionId = "chatops:slack:C123:T456";
+
+    const first = await ConversationModel.findOrCreateForChatopsSession({
+      sessionId,
+      userId: user.id,
+      organizationId: org.id,
+      agentId: agent.id,
+    });
+    expect(first.id).toBeDefined();
+    expect(first.agentId).toBe(agent.id);
+
+    const second = await ConversationModel.findOrCreateForChatopsSession({
+      sessionId,
+      userId: user.id,
+      organizationId: org.id,
+      agentId: agent.id,
+    });
+    expect(second.id).toBe(first.id);
+    expect(second.agentId).toBe(agent.id);
+
+    const conversation = await ConversationModel.findById({
+      id: first.id,
+      userId: user.id,
+      organizationId: org.id,
+    });
+    expect(conversation?.title).toBe(sessionId);
+    expect(conversation?.agentId).toBe(agent.id);
+  });
+
+  test("findOrCreateForChatopsSession surfaces swapped agentId on subsequent calls", async ({
+    makeUser,
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const user = await makeUser();
+    const org = await makeOrganization();
+    const router = await makeAgent({ name: "Router", teams: [] });
+    const worker = await makeAgent({ name: "Worker", teams: [] });
+    const sessionId = "chatops:slack:C999:T999";
+
+    const first = await ConversationModel.findOrCreateForChatopsSession({
+      sessionId,
+      userId: user.id,
+      organizationId: org.id,
+      agentId: router.id,
+    });
+    expect(first.agentId).toBe(router.id);
+
+    await ConversationModel.update(first.id, user.id, org.id, {
+      agentId: worker.id,
+    });
+
+    const after = await ConversationModel.findOrCreateForChatopsSession({
+      sessionId,
+      userId: user.id,
+      organizationId: org.id,
+      agentId: router.id,
+    });
+    expect(after.id).toBe(first.id);
+    expect(after.agentId).toBe(worker.id);
+  });
+
   test("can create a conversation", async ({
     makeUser,
     makeOrganization,

--- a/platform/backend/src/models/conversation.ts
+++ b/platform/backend/src/models/conversation.ts
@@ -359,6 +359,51 @@ class ConversationModel {
     });
   }
 
+  // Find or create the conversation row that backs a Slack/Teams thread.
+  // swap_agent updates a conversations row — chatops has none by default,
+  // so we create one keyed by sessionId and return its current agentId
+  // so callers can detect a prior swap.
+  static async findOrCreateForChatopsSession(params: {
+    sessionId: string;
+    userId: string;
+    organizationId: string;
+    agentId: string;
+  }): Promise<{ id: string; agentId: string | null }> {
+    // Look for an existing row for this user + thread.
+    const [existing] = await db
+      .select({
+        id: schema.conversationsTable.id,
+        agentId: schema.conversationsTable.agentId,
+      })
+      .from(schema.conversationsTable)
+      .where(
+        and(
+          eq(schema.conversationsTable.userId, params.userId),
+          eq(schema.conversationsTable.organizationId, params.organizationId),
+          eq(schema.conversationsTable.title, params.sessionId),
+        ),
+      )
+      .limit(1);
+
+    if (existing) return existing;
+
+    // First message in this thread — create a fresh row.
+    const [created] = await db
+      .insert(schema.conversationsTable)
+      .values({
+        userId: params.userId,
+        organizationId: params.organizationId,
+        agentId: params.agentId,
+        title: params.sessionId,
+      })
+      .returning({
+        id: schema.conversationsTable.id,
+        agentId: schema.conversationsTable.agentId,
+      });
+
+    return created;
+  }
+
   static async update(
     id: string,
     userId: string,


### PR DESCRIPTION
/claim #4011 

## Summary

The `swap_agent` built-in MCP tool returned `"Failed to update conversation agent"` when invoked through Slack or MS Teams, so router-style agents could never hand off to a specialist.

Root cause: `swap_agent` at `backend/src/archestra-mcp-server/chat.ts:293` updates a `conversations` row by id. Chatops had no conversation lifecycle — `a2a-executor.ts:108` generated a random in-memory UUID as the `conversationId`, so the UPDATE matched zero rows and the tool errored out.

## Approach: per-user, per-thread conversation

This PR materializes a real `conversations` row keyed by `(userId, organizationId, sessionId)` on every chatops message, where `sessionId` is `chatops:<provider>:<threadId or channelId>` (already a stable key). The existing `swap_agent` DB logic then works as-is.

`ChatOpsManager.executeAndReply` now:

1. Gets or creates the conversation row for this user + thread.
2. If a previous turn already swapped the row's `agentId`, uses that swapped agent for the new turn (next-turn persistence).
3. Runs the initial A2A execution.
4. If `swap_agent` mutated the row mid-turn AND the old agent produced no visible reply, re-invokes A2A with the new agent in the **same** Slack turn so the user sees the specialist's answer inline (same-turn handoff).
5. If the old agent already replied, keeps that reply and lets the swap take effect on the next message (prevents replaying the same user text into the new agent and triggering swap loops).

## Why per-user, per-thread

A Slack channel is usually shared by many people, and the same channel can hold many threads. If two users are talking to the bot in the same channel — or the same user is working in two different threads — each of those flows should stay independent. One person routing their question to a specialist should not silently change what happens the next time someone else messages the bot in that channel.

Keying the state on `(userId, organizationId, sessionId)` gives each user their own routing memory inside each thread. A swap only affects the thread where it happened, and only for the person who asked for it. The channel's configured default agent (set through `/archestra-select-agent`) is untouched, so that command stays the one source of truth for "what this channel does by default."

It also keeps `swap_agent`'s behavior simple and the same everywhere: whether the call comes from the web chat UI or from Slack/Teams, the tool just updates the conversation's current agent. No special chatops branch, no second storage location, nothing extra for future readers of the code to keep in sync.


https://github.com/user-attachments/assets/31ecd117-615c-4979-9164-f7f9fea7a7a5


