### PR TITLE
chore: capture raw provider errors in Sentry

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Archestra",
-    "version": "1.2.23"
+    "version": "1.2.24"
   },
   "components": {
     "schemas": {

--- a/platform/backend/src/observability/sentry.ts
+++ b/platform/backend/src/observability/sentry.ts
@@ -28,6 +28,40 @@ const {
   },
 } = config;
 
+export function captureRawProviderErrorInSentry(params: {
+  provider: string;
+  statusCode: number | undefined;
+  parsedError: unknown;
+  errorCode: string;
+  errorMessage: string;
+  errorType: string | undefined;
+  rawErrorJson: string;
+}): void {
+  Sentry.captureMessage("[ChatErrorMapper] rawErrorJson provider error", {
+    level: "error",
+    fingerprint: [
+      "chat-provider-error-raw-error-json",
+      params.provider,
+      String(params.statusCode ?? "unknown"),
+      params.errorCode,
+    ],
+    tags: {
+      provider: params.provider,
+      mapped_code: params.errorCode,
+      raw_error_json: "true",
+      ...(params.statusCode !== undefined
+        ? { status_code: String(params.statusCode) }
+        : {}),
+      ...(params.errorType ? { error_type: params.errorType } : {}),
+    },
+    extra: {
+      parsedError: params.parsedError,
+      errorMessage: params.errorMessage,
+      rawErrorJson: params.rawErrorJson,
+    },
+  });
+}
+
 /**
  * Safely load the profiling integration.
  * The @sentry/profiling-node package contains native bindings that can fail to load

--- a/platform/backend/src/routes/chat/errors.test.ts
+++ b/platform/backend/src/routes/chat/errors.test.ts
@@ -7,12 +7,23 @@ import {
   GeminiErrorReasons,
   OpenAIErrorTypes,
 } from "@shared";
-import { describe, expect, it } from "@/test";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSentryCaptureMessage = vi.hoisted(() => vi.fn());
+
+vi.mock("@sentry/node", () => ({
+  captureMessage: mockSentryCaptureMessage,
+}));
+
 import {
   mapProviderError,
   ProviderError,
   sanitizeChatErrorForFrontend,
 } from "./errors";
+
+beforeEach(() => {
+  mockSentryCaptureMessage.mockClear();
+});
 
 // =============================================================================
 // OpenAI Error Tests
@@ -1185,6 +1196,51 @@ describe("mapProviderError - Fallback behavior", () => {
     const result = mapProviderError("Simple string error", "openai");
 
     expect(result.originalError?.message).toBe("Simple string error");
+  });
+});
+
+// =============================================================================
+// Sentry Capture Tests
+// =============================================================================
+
+describe("mapProviderError - Sentry raw error capture", () => {
+  it("creates a Sentry issue event for rawErrorJson provider error logs", () => {
+    const error = {
+      name: "AI_APICallError",
+      statusCode: 500,
+      responseBody: JSON.stringify({
+        error: {
+          type: OpenAIErrorTypes.SERVER_ERROR,
+          message: "Provider failed",
+        },
+      }),
+      isRetryable: true,
+    };
+
+    mapProviderError(error, "openai");
+
+    expect(mockSentryCaptureMessage).toHaveBeenCalledWith(
+      "[ChatErrorMapper] rawErrorJson provider error",
+      expect.objectContaining({
+        level: "error",
+        fingerprint: [
+          "chat-provider-error-raw-error-json",
+          "openai",
+          "500",
+          ChatErrorCode.ServerError,
+        ],
+        tags: expect.objectContaining({
+          provider: "openai",
+          mapped_code: ChatErrorCode.ServerError,
+          raw_error_json: "true",
+          status_code: "500",
+        }),
+        extra: expect.objectContaining({
+          errorMessage: "Provider failed",
+          rawErrorJson: expect.stringContaining("AI_APICallError"),
+        }),
+      }),
+    );
   });
 });
 

--- a/platform/backend/src/routes/chat/errors.test.ts
+++ b/platform/backend/src/routes/chat/errors.test.ts
@@ -7,7 +7,8 @@ import {
   GeminiErrorReasons,
   OpenAIErrorTypes,
 } from "@shared";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
+import { beforeEach, describe, expect, it } from "@/test";
 
 const mockSentryCaptureMessage = vi.hoisted(() => vi.fn());
 

--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -21,6 +21,7 @@ import {
 import { APICallError, NoOutputGeneratedError, RetryError } from "ai";
 import logger from "@/logging";
 import { getActiveSessionId } from "@/observability/request-context";
+import { captureRawProviderErrorInSentry } from "@/observability/sentry";
 
 // =============================================================================
 // ProviderError — carries a fully-mapped ChatErrorResponse with correct provider
@@ -1502,6 +1503,17 @@ export function mapProviderError(
     (parsedError as ParsedAnthropicError)?.type ||
     (parsedError as ParsedGeminiError)?.status ||
     (error instanceof Error ? error.name : undefined);
+  const rawErrorJson = stringifyRawError(error);
+
+  captureRawProviderErrorInSentry({
+    provider,
+    statusCode,
+    parsedError,
+    errorCode,
+    errorMessage,
+    errorType,
+    rawErrorJson,
+  });
 
   logger.info(
     {
@@ -1510,7 +1522,7 @@ export function mapProviderError(
       parsedError,
       mappedCode: errorCode,
       errorMessage,
-      rawErrorJson: stringifyRawError(error),
+      rawErrorJson,
     },
     "[ChatErrorMapper] Mapped provider error",
   );


### PR DESCRIPTION
## Summary
- add a backend Sentry helper for raw provider error events
- call the helper from chat provider error mapping while preserving the existing rawErrorJson log
- add test coverage for the emitted Sentry message event metadata

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>