### PR TITLE
fix: MCP server assignment N+1 queries

### DIFF
--- a/platform/backend/src/models/team.test.ts
+++ b/platform/backend/src/models/team.test.ts
@@ -970,6 +970,88 @@ describe("TeamModel", () => {
     });
   });
 
+  describe("findUserIdsInAnyTeam", () => {
+    test("returns empty array when no team IDs are provided", async ({
+      makeUser,
+    }) => {
+      const user = await makeUser();
+
+      const userIds = await TeamModel.findUserIdsInAnyTeam({
+        teamIds: [],
+        userIds: [user.id],
+      });
+
+      expect(userIds).toEqual([]);
+    });
+
+    test("returns empty array when no user IDs are provided", async ({
+      makeOrganization,
+      makeTeam,
+      makeUser,
+    }) => {
+      const user = await makeUser();
+      const org = await makeOrganization();
+      const team = await makeTeam(org.id, user.id);
+
+      const userIds = await TeamModel.findUserIdsInAnyTeam({
+        teamIds: [team.id],
+        userIds: [],
+      });
+
+      expect(userIds).toEqual([]);
+    });
+
+    test("returns unique user IDs for users in any requested team", async ({
+      makeUser,
+      makeOrganization,
+      makeTeam,
+    }) => {
+      const owner = await makeUser();
+      const member1 = await makeUser({ email: "member-1@test.com" });
+      const member2 = await makeUser({ email: "member-2@test.com" });
+      const nonMember = await makeUser({ email: "non-member@test.com" });
+      const org = await makeOrganization();
+      const team1 = await makeTeam(org.id, owner.id, { name: "Team 1" });
+      const team2 = await makeTeam(org.id, owner.id, { name: "Team 2" });
+
+      await TeamModel.addMember(team1.id, member1.id);
+      await TeamModel.addMember(team1.id, member2.id);
+      await TeamModel.addMember(team2.id, member1.id);
+
+      const userIds = await TeamModel.findUserIdsInAnyTeam({
+        teamIds: [team1.id, team2.id],
+        userIds: [member1.id, member2.id, nonMember.id],
+      });
+
+      expect(userIds.sort()).toEqual([member1.id, member2.id].sort());
+    });
+
+    test("excludes users who only belong to teams outside the requested set", async ({
+      makeUser,
+      makeOrganization,
+      makeTeam,
+    }) => {
+      const owner = await makeUser();
+      const member = await makeUser({ email: "outside-team-member@test.com" });
+      const org = await makeOrganization();
+      const requestedTeam = await makeTeam(org.id, owner.id, {
+        name: "Requested Team",
+      });
+      const otherTeam = await makeTeam(org.id, owner.id, {
+        name: "Other Team",
+      });
+
+      await TeamModel.addMember(otherTeam.id, member.id);
+
+      const userIds = await TeamModel.findUserIdsInAnyTeam({
+        teamIds: [requestedTeam.id],
+        userIds: [member.id],
+      });
+
+      expect(userIds).toEqual([]);
+    });
+  });
+
   describe("syncUserTeams", () => {
     test("should add user to teams based on their SSO groups", async ({
       makeUser,

--- a/platform/backend/src/models/team.ts
+++ b/platform/backend/src/models/team.ts
@@ -544,6 +544,36 @@ class TeamModel {
     return isMember;
   }
 
+  static async findUserIdsInAnyTeam(params: {
+    teamIds: string[];
+    userIds: string[];
+  }): Promise<string[]> {
+    if (params.teamIds.length === 0 || params.userIds.length === 0) {
+      return [];
+    }
+
+    logger.debug(
+      { teamIds: params.teamIds, userCount: params.userIds.length },
+      "TeamModel.findUserIdsInAnyTeam: checking memberships",
+    );
+    const rows = await db
+      .select({ userId: schema.teamMembersTable.userId })
+      .from(schema.teamMembersTable)
+      .where(
+        and(
+          inArray(schema.teamMembersTable.teamId, params.teamIds),
+          inArray(schema.teamMembersTable.userId, params.userIds),
+        ),
+      );
+
+    const userIds = [...new Set(rows.map((row) => row.userId))];
+    logger.debug(
+      { teamIds: params.teamIds, userCount: userIds.length },
+      "TeamModel.findUserIdsInAnyTeam: completed",
+    );
+    return userIds;
+  }
+
   /**
    * Get all team IDs a user is a member of (used for authorization)
    */

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -65,10 +65,12 @@ vi.mock("@/k8s/mcp-server-runtime", () => ({
 describe("mcp server inspect route", () => {
   let app: FastifyInstanceWithZod;
   let user: User;
+  let requestOrganizationId: string | undefined;
   const originalFetch = global.fetch;
 
   beforeEach(async ({ makeUser }) => {
     user = await makeUser();
+    requestOrganizationId = undefined;
     hasPermissionMock.mockResolvedValue({ success: true });
     k8sStartServerMock.mockResolvedValue(undefined);
     k8sRestartServerMock.mockResolvedValue(undefined);
@@ -80,6 +82,9 @@ describe("mcp server inspect route", () => {
     app = createFastifyInstance();
     app.addHook("onRequest", async (request) => {
       (request as typeof request & { user: User }).user = user;
+      (
+        request as typeof request & { organizationId: string | undefined }
+      ).organizationId = requestOrganizationId;
     });
 
     const { default: mcpServerRoutes } = await import("./mcp-server");
@@ -260,6 +265,108 @@ describe("mcp server inspect route", () => {
     expect(response.json().map((server: { id: string }) => server.id)).toEqual([
       ownPersonalServer.id,
     ]);
+  });
+
+  test("filters personal connections by organization membership for org assignment scope", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeMember,
+    makeOrganization,
+    makeUser,
+  }) => {
+    hasPermissionMock.mockResolvedValueOnce({ success: true });
+
+    const organization = await makeOrganization();
+    requestOrganizationId = organization.id;
+    const memberOwner = await makeUser({ email: "member-owner@example.com" });
+    const outsideOwner = await makeUser({ email: "outside-owner@example.com" });
+    await makeMember(memberOwner.id, organization.id, { role: "member" });
+
+    const catalog = await makeInternalMcpCatalog({ serverType: "remote" });
+    const memberOwnedServer = await makeMcpServer({
+      ownerId: memberOwner.id,
+      catalogId: catalog.id,
+    });
+    const orgOwnedServer = await makeMcpServer({
+      catalogId: catalog.id,
+    });
+    await makeMcpServer({
+      ownerId: outsideOwner.id,
+      catalogId: catalog.id,
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/mcp_server?assignmentScope=org",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(
+      response
+        .json()
+        .map((server: { id: string }) => server.id)
+        .sort(),
+    ).toEqual([memberOwnedServer.id, orgOwnedServer.id].sort());
+  });
+
+  test("filters connections for personal assignment scope", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+    makeUser,
+  }) => {
+    hasPermissionMock.mockResolvedValueOnce({ success: true });
+
+    const organization = await makeOrganization();
+    requestOrganizationId = organization.id;
+    const otherUser = await makeUser({ email: "personal-other@example.com" });
+    const authorTeam = await makeTeam(organization.id, user.id, {
+      name: "Author Team",
+    });
+    const otherTeam = await makeTeam(organization.id, user.id, {
+      name: "Other Team",
+    });
+    await makeTeamMember(authorTeam.id, user.id);
+
+    const catalog = await makeInternalMcpCatalog({ serverType: "remote" });
+    const ownPersonalServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    await makeMcpServer({
+      ownerId: otherUser.id,
+      catalogId: catalog.id,
+    });
+    const authorTeamServer = await makeMcpServer({
+      ownerId: otherUser.id,
+      catalogId: catalog.id,
+      teamId: authorTeam.id,
+    });
+    await makeMcpServer({
+      ownerId: otherUser.id,
+      catalogId: catalog.id,
+      teamId: otherTeam.id,
+    });
+    const orgOwnedServer = await makeMcpServer({
+      catalogId: catalog.id,
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/mcp_server?assignmentScope=personal",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(
+      response
+        .json()
+        .map((server: { id: string }) => server.id)
+        .sort(),
+    ).toEqual(
+      [ownPersonalServer.id, authorTeamServer.id, orgOwnedServer.id].sort(),
+    );
   });
 
   test("automatically retries protected remote MCP server installation with the current identity-provider access token", async ({

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -65,12 +65,12 @@ vi.mock("@/k8s/mcp-server-runtime", () => ({
 describe("mcp server inspect route", () => {
   let app: FastifyInstanceWithZod;
   let user: User;
-  let requestOrganizationId: string | undefined;
+  let requestOrganizationId: string;
   const originalFetch = global.fetch;
 
   beforeEach(async ({ makeUser }) => {
     user = await makeUser();
-    requestOrganizationId = undefined;
+    requestOrganizationId = crypto.randomUUID();
     hasPermissionMock.mockResolvedValue({ success: true });
     k8sStartServerMock.mockResolvedValue(undefined);
     k8sRestartServerMock.mockResolvedValue(undefined);
@@ -82,9 +82,8 @@ describe("mcp server inspect route", () => {
     app = createFastifyInstance();
     app.addHook("onRequest", async (request) => {
       (request as typeof request & { user: User }).user = user;
-      (
-        request as typeof request & { organizationId: string | undefined }
-      ).organizationId = requestOrganizationId;
+      (request as typeof request & { organizationId: string }).organizationId =
+        requestOrganizationId;
     });
 
     const { default: mcpServerRoutes } = await import("./mcp-server");

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -18,7 +18,7 @@ import {
   ToolModel,
 } from "@/models";
 import { isByosEnabled, secretManager } from "@/secrets-manager";
-import { isMcpServerAssignableToTarget } from "@/services/agent-tool-assignment";
+import { filterMcpServersAssignableToTarget } from "@/services/agent-tool-assignment";
 import { refreshLinkedIdentityProviderAccessToken } from "@/services/identity-providers/access-token-refresh";
 import { exchangeEnterpriseManagedCredential } from "@/services/identity-providers/enterprise-managed/exchange";
 import {
@@ -80,23 +80,10 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           teamIds: assignmentTeamIds ?? [],
         };
 
-        allServers = (
-          await Promise.all(
-            allServers.map(async (server) =>
-              (await isMcpServerAssignableToTarget({
-                mcpServer: {
-                  ownerId: server.ownerId,
-                  teamId: server.teamId,
-                },
-                target,
-              }))
-                ? server
-                : null,
-            ),
-          )
-        ).filter(
-          (server): server is (typeof allServers)[number] => server != null,
-        );
+        allServers = await filterMcpServersAssignableToTarget({
+          mcpServers: allServers,
+          target,
+        });
       }
 
       return reply.send(allServers);

--- a/platform/backend/src/services/agent-tool-assignment.test.ts
+++ b/platform/backend/src/services/agent-tool-assignment.test.ts
@@ -1,12 +1,153 @@
 import { and, eq } from "drizzle-orm";
+import { vi } from "vitest";
 import db, { schema } from "@/database";
+import MemberModel from "@/models/member";
+import TeamModel from "@/models/team";
 import { describe, expect, test } from "@/test";
 import {
   assignToolToAgent,
+  filterMcpServersAssignableToTarget,
   validateAssignment,
   validateCredentialSource,
   validateExecutionSource,
 } from "./agent-tool-assignment";
+
+describe("filterMcpServersAssignableToTarget", () => {
+  test("uses one organization membership lookup for org-scoped target filtering", async ({
+    makeMember,
+    makeOrganization,
+    makeUser,
+  }) => {
+    const organization = await makeOrganization();
+    const memberOwner = await makeUser();
+    const outsideOwner = await makeUser();
+    await makeMember(memberOwner.id, organization.id, { role: "member" });
+
+    const getByUserIdSpy = vi.spyOn(MemberModel, "getByUserId");
+    const findUserIdsSpy = vi.spyOn(MemberModel, "findUserIdsInOrganization");
+
+    const filtered = await filterMcpServersAssignableToTarget({
+      mcpServers: [
+        { id: "member-owned", ownerId: memberOwner.id, teamId: null },
+        { id: "outside-owned", ownerId: outsideOwner.id, teamId: null },
+        { id: "org-owned", ownerId: null, teamId: null },
+      ],
+      target: {
+        organizationId: organization.id,
+        scope: "org",
+        authorId: null,
+        teamIds: [],
+      },
+    });
+
+    expect(filtered.map((server) => server.id)).toEqual([
+      "member-owned",
+      "org-owned",
+    ]);
+    expect(findUserIdsSpy).toHaveBeenCalledTimes(1);
+    expect(getByUserIdSpy).not.toHaveBeenCalled();
+
+    getByUserIdSpy.mockRestore();
+    findUserIdsSpy.mockRestore();
+  });
+
+  test("uses one team membership lookup for team-scoped personal server filtering", async ({
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+    makeUser,
+  }) => {
+    const organization = await makeOrganization();
+    const requester = await makeUser();
+    const selectedTeam = await makeTeam(organization.id, requester.id, {
+      name: "Selected Team",
+    });
+    const otherTeam = await makeTeam(organization.id, requester.id, {
+      name: "Other Team",
+    });
+    const selectedOwner = await makeUser();
+    const otherOwner = await makeUser();
+    await makeTeamMember(selectedTeam.id, selectedOwner.id);
+    await makeTeamMember(otherTeam.id, otherOwner.id);
+
+    const isUserInAnyTeamSpy = vi.spyOn(TeamModel, "isUserInAnyTeam");
+    const findUserIdsSpy = vi.spyOn(TeamModel, "findUserIdsInAnyTeam");
+
+    const filtered = await filterMcpServersAssignableToTarget({
+      mcpServers: [
+        { id: "selected-owner", ownerId: selectedOwner.id, teamId: null },
+        { id: "other-owner", ownerId: otherOwner.id, teamId: null },
+        { id: "selected-team", ownerId: requester.id, teamId: selectedTeam.id },
+        { id: "other-team", ownerId: requester.id, teamId: otherTeam.id },
+      ],
+      target: {
+        organizationId: organization.id,
+        scope: "team",
+        authorId: requester.id,
+        teamIds: [selectedTeam.id],
+      },
+    });
+
+    expect(filtered.map((server) => server.id)).toEqual([
+      "selected-owner",
+      "selected-team",
+    ]);
+    expect(findUserIdsSpy).toHaveBeenCalledTimes(1);
+    expect(isUserInAnyTeamSpy).not.toHaveBeenCalled();
+
+    isUserInAnyTeamSpy.mockRestore();
+    findUserIdsSpy.mockRestore();
+  });
+
+  test("uses the author's team IDs once for personal target filtering", async ({
+    makeMember,
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+    makeUser,
+  }) => {
+    const organization = await makeOrganization();
+    const author = await makeUser();
+    await makeMember(author.id, organization.id, { role: "member" });
+    const authorTeam = await makeTeam(organization.id, author.id, {
+      name: "Author Team",
+    });
+    const otherTeam = await makeTeam(organization.id, author.id, {
+      name: "Other Team",
+    });
+    await makeTeamMember(authorTeam.id, author.id);
+
+    const getUserTeamIdsSpy = vi.spyOn(TeamModel, "getUserTeamIds");
+    const isUserInAnyTeamSpy = vi.spyOn(TeamModel, "isUserInAnyTeam");
+
+    const filtered = await filterMcpServersAssignableToTarget({
+      mcpServers: [
+        { id: "own-personal", ownerId: author.id, teamId: null },
+        { id: "other-personal", ownerId: crypto.randomUUID(), teamId: null },
+        { id: "author-team", ownerId: null, teamId: authorTeam.id },
+        { id: "other-team", ownerId: null, teamId: otherTeam.id },
+        { id: "org-owned", ownerId: null, teamId: null },
+      ],
+      target: {
+        organizationId: organization.id,
+        scope: "personal",
+        authorId: author.id,
+        teamIds: [],
+      },
+    });
+
+    expect(filtered.map((server) => server.id)).toEqual([
+      "own-personal",
+      "author-team",
+      "org-owned",
+    ]);
+    expect(getUserTeamIdsSpy).toHaveBeenCalledTimes(1);
+    expect(isUserInAnyTeamSpy).not.toHaveBeenCalled();
+
+    getUserTeamIdsSpy.mockRestore();
+    isUserInAnyTeamSpy.mockRestore();
+  });
+});
 
 describe("validateCredentialSource", () => {
   test("returns a validation error when a personal credential owner cannot access the target resource", async ({

--- a/platform/backend/src/services/agent-tool-assignment.ts
+++ b/platform/backend/src/services/agent-tool-assignment.ts
@@ -420,6 +420,82 @@ export async function isMcpServerAssignableToTarget(params: {
   return TeamModel.isUserInAnyTeam(target.teamIds, mcpServer.ownerId);
 }
 
+export async function filterMcpServersAssignableToTarget<
+  TMcpServer extends Pick<PrefetchedMcpServer, "ownerId" | "teamId">,
+>(params: {
+  mcpServers: TMcpServer[];
+  target: {
+    organizationId: string;
+    scope: AgentScope;
+    authorId: string | null;
+    teamIds: string[];
+  };
+}): Promise<TMcpServer[]> {
+  const { mcpServers, target } = params;
+  if (mcpServers.length === 0) {
+    return [];
+  }
+
+  const ownerIds = [
+    ...new Set(
+      mcpServers
+        .map((server) => server.ownerId)
+        .filter((ownerId): ownerId is string => ownerId != null),
+    ),
+  ];
+  const teamServerTeamIds = [
+    ...new Set(
+      mcpServers
+        .map((server) => server.teamId)
+        .filter((teamId): teamId is string => teamId != null),
+    ),
+  ];
+
+  const [orgMemberOwnerIds, targetTeamMemberOwnerIds, authorTeamIds] =
+    await Promise.all([
+      target.scope === "org"
+        ? MemberModel.findUserIdsInOrganization({
+            organizationId: target.organizationId,
+            userIds: ownerIds,
+          })
+        : Promise.resolve([]),
+      target.scope === "team"
+        ? TeamModel.findUserIdsInAnyTeam({
+            teamIds: target.teamIds,
+            userIds: ownerIds,
+          })
+        : Promise.resolve([]),
+      target.scope === "personal" &&
+      target.authorId &&
+      teamServerTeamIds.length > 0
+        ? TeamModel.getUserTeamIds(target.authorId)
+        : Promise.resolve([]),
+    ]);
+
+  const orgMemberOwnerIdSet = new Set(orgMemberOwnerIds);
+  const targetTeamMemberOwnerIdSet = new Set(targetTeamMemberOwnerIds);
+  const authorTeamIdSet = new Set(authorTeamIds);
+  const needsOrgAdminCheck =
+    target.scope === "personal" &&
+    !!target.authorId &&
+    teamServerTeamIds.some((teamId) => !authorTeamIdSet.has(teamId));
+  const authorIsOrgAdmin =
+    needsOrgAdminCheck && target.authorId
+      ? await isOrgAdmin(target.authorId, target.organizationId)
+      : false;
+
+  return mcpServers.filter((mcpServer) =>
+    isMcpServerAssignableToPrefetchedTarget({
+      mcpServer,
+      target,
+      orgMemberOwnerIdSet,
+      targetTeamMemberOwnerIdSet,
+      authorTeamIdSet,
+      authorIsOrgAdmin,
+    }),
+  );
+}
+
 function getAssignmentValidationMessage(
   mcpServer: Pick<PrefetchedMcpServer, "teamId">,
 ) {
@@ -428,4 +504,50 @@ function getAssignmentValidationMessage(
   }
 
   return "The credential owner must be a member of a team that this resource is assigned to";
+}
+
+function isMcpServerAssignableToPrefetchedTarget(params: {
+  mcpServer: Pick<PrefetchedMcpServer, "ownerId" | "teamId">;
+  target: {
+    scope: AgentScope;
+    authorId: string | null;
+    teamIds: string[];
+  };
+  orgMemberOwnerIdSet: Set<string>;
+  targetTeamMemberOwnerIdSet: Set<string>;
+  authorTeamIdSet: Set<string>;
+  authorIsOrgAdmin: boolean;
+}): boolean {
+  const {
+    authorIsOrgAdmin,
+    authorTeamIdSet,
+    mcpServer,
+    orgMemberOwnerIdSet,
+    target,
+    targetTeamMemberOwnerIdSet,
+  } = params;
+
+  if (mcpServer.teamId) {
+    if (target.scope === "team") {
+      return target.teamIds.includes(mcpServer.teamId);
+    }
+    if (target.scope === "personal" && target.authorId) {
+      return authorTeamIdSet.has(mcpServer.teamId) || authorIsOrgAdmin;
+    }
+    return false;
+  }
+
+  if (!mcpServer.ownerId) {
+    return true;
+  }
+
+  if (target.scope === "personal") {
+    return target.authorId === mcpServer.ownerId;
+  }
+
+  if (target.scope === "org") {
+    return orgMemberOwnerIdSet.has(mcpServer.ownerId);
+  }
+
+  return targetTeamMemberOwnerIdSet.has(mcpServer.ownerId);
 }


### PR DESCRIPTION
## Summary
- replace per-server MCP assignment filtering with a batched service path
- add a bulk team-membership lookup for assignment filtering
- add coverage for org, team, and personal assignment filtering without per-server membership lookups

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>