### PR TITLE
fix(mermaid): prevent error SVG from leaking to other pages

### DIFF
--- a/platform/frontend/src/components/mermaid-diagram.test.tsx
+++ b/platform/frontend/src/components/mermaid-diagram.test.tsx
@@ -58,14 +58,10 @@ describe("MermaidDiagram", () => {
   it("shows inline error and skips render when parse returns false", async () => {
     mockParse.mockResolvedValue(false);
 
-    const { container } = render(
-      <MermaidDiagram chart="not valid mermaid" />,
-    );
+    const { container } = render(<MermaidDiagram chart="not valid mermaid" />);
 
     await waitFor(() =>
-      expect(container.textContent).toContain(
-        "Invalid mermaid diagram syntax",
-      ),
+      expect(container.textContent).toContain("Invalid mermaid diagram syntax"),
     );
     expect(mockRender).not.toHaveBeenCalled();
     // Original chart text is still surfaced for debugging
@@ -78,9 +74,7 @@ describe("MermaidDiagram", () => {
     const { container } = render(<MermaidDiagram chart="???" />);
 
     await waitFor(() =>
-      expect(container.textContent).toContain(
-        "Invalid mermaid diagram syntax",
-      ),
+      expect(container.textContent).toContain("Invalid mermaid diagram syntax"),
     );
     expect(mockRender).not.toHaveBeenCalled();
   });
@@ -89,9 +83,7 @@ describe("MermaidDiagram", () => {
     mockParse.mockResolvedValue({ diagramType: "flowchart", config: {} });
     mockRender.mockRejectedValue(new Error("render blew up"));
 
-    const { container } = render(
-      <MermaidDiagram chart="graph TD; A-->B" />,
-    );
+    const { container } = render(<MermaidDiagram chart="graph TD; A-->B" />);
 
     await waitFor(() =>
       expect(container.textContent).toContain(

--- a/platform/frontend/src/components/mermaid-diagram.test.tsx
+++ b/platform/frontend/src/components/mermaid-diagram.test.tsx
@@ -1,0 +1,102 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockUseTheme, mockInitialize, mockParse, mockRender } = vi.hoisted(
+  () => ({
+    mockUseTheme: vi.fn(() => ({ theme: "light" })),
+    mockInitialize: vi.fn(),
+    mockParse: vi.fn(),
+    mockRender: vi.fn(),
+  }),
+);
+
+vi.mock("next-themes", () => ({
+  useTheme: () => mockUseTheme(),
+}));
+
+vi.mock("mermaid", () => ({
+  default: {
+    initialize: mockInitialize,
+    parse: mockParse,
+    render: mockRender,
+  },
+}));
+
+import { MermaidDiagram } from "./mermaid-diagram";
+
+describe("MermaidDiagram", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.replaceChildren();
+  });
+
+  it("initializes mermaid with suppressErrorRendering enabled", async () => {
+    mockParse.mockResolvedValue({ diagramType: "flowchart", config: {} });
+    mockRender.mockResolvedValue({ svg: "<svg></svg>" });
+
+    render(<MermaidDiagram chart="graph TD; A-->B" />);
+
+    await waitFor(() => expect(mockInitialize).toHaveBeenCalled());
+    const config = mockInitialize.mock.calls[0]?.[0];
+    expect(config).toMatchObject({ suppressErrorRendering: true });
+  });
+
+  it("validates with mermaid.parse before rendering", async () => {
+    mockParse.mockResolvedValue({ diagramType: "flowchart", config: {} });
+    mockRender.mockResolvedValue({ svg: "<svg></svg>" });
+
+    render(<MermaidDiagram chart="graph TD; A-->B" />);
+
+    await waitFor(() =>
+      expect(mockParse).toHaveBeenCalledWith("graph TD; A-->B", {
+        suppressErrors: true,
+      }),
+    );
+    await waitFor(() => expect(mockRender).toHaveBeenCalled());
+  });
+
+  it("shows inline error and skips render when parse returns false", async () => {
+    mockParse.mockResolvedValue(false);
+
+    const { container } = render(
+      <MermaidDiagram chart="not valid mermaid" />,
+    );
+
+    await waitFor(() =>
+      expect(container.textContent).toContain(
+        "Invalid mermaid diagram syntax",
+      ),
+    );
+    expect(mockRender).not.toHaveBeenCalled();
+    // Original chart text is still surfaced for debugging
+    expect(container.textContent).toContain("not valid mermaid");
+  });
+
+  it("shows inline error when parse throws", async () => {
+    mockParse.mockRejectedValue(new Error("parse blew up"));
+
+    const { container } = render(<MermaidDiagram chart="???" />);
+
+    await waitFor(() =>
+      expect(container.textContent).toContain(
+        "Invalid mermaid diagram syntax",
+      ),
+    );
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it("shows inline error when render throws after a successful parse", async () => {
+    mockParse.mockResolvedValue({ diagramType: "flowchart", config: {} });
+    mockRender.mockRejectedValue(new Error("render blew up"));
+
+    const { container } = render(
+      <MermaidDiagram chart="graph TD; A-->B" />,
+    );
+
+    await waitFor(() =>
+      expect(container.textContent).toContain(
+        "Failed to render mermaid diagram",
+      ),
+    );
+  });
+});

--- a/platform/frontend/src/components/mermaid-diagram.tsx
+++ b/platform/frontend/src/components/mermaid-diagram.tsx
@@ -23,6 +23,11 @@ export function MermaidDiagram({
 
     mermaid.initialize({
       startOnLoad: false,
+      // When render fails, mermaid creates a temporary container div in
+      // document.body and renders an error SVG inside it. Without this flag
+      // that container is never removed, so it outlives the React component
+      // and shows up as a stale error on unrelated pages. See #3511.
+      suppressErrorRendering: true,
       theme: isDark ? "dark" : "neutral",
       themeVariables: isDark
         ? {
@@ -51,29 +56,57 @@ export function MermaidDiagram({
           },
     });
 
+    const renderInlineError = (message: string) => {
+      if (!ref.current) return;
+      const wrapper = document.createElement("div");
+      wrapper.className =
+        "w-full rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-left";
+      const heading = document.createElement("p");
+      heading.className = "font-medium text-destructive";
+      heading.textContent = message;
+      const pre = document.createElement("pre");
+      pre.className = "mt-2 overflow-x-auto text-xs opacity-70";
+      pre.textContent = chart;
+      wrapper.appendChild(heading);
+      wrapper.appendChild(pre);
+      ref.current.replaceChildren(wrapper);
+      setIsLoaded(true);
+    };
+
     const renderDiagram = async () => {
-      if (ref.current) {
-        ref.current.replaceChildren();
-        try {
-          // Generate a unique ID to avoid conflicts
-          const uniqueId = `${id}-${Date.now()}`;
-          const { svg } = await mermaid.render(uniqueId, chart);
-          if (ref.current) {
-            // Parse SVG string via DOMParser to avoid innerHTML
-            const doc = new DOMParser().parseFromString(svg, "image/svg+xml");
-            const svgElement = doc.documentElement;
-            ref.current.replaceChildren(svgElement);
-            requestAnimationFrame(() => setIsLoaded(true));
-          }
-        } catch (error) {
-          console.error("Error rendering mermaid diagram:", error);
-          if (ref.current) {
-            const pre = document.createElement("pre");
-            pre.textContent = chart;
-            ref.current.replaceChildren(pre);
-            setIsLoaded(true);
-          }
+      if (!ref.current) return;
+      ref.current.replaceChildren();
+
+      // Belt-and-suspenders: suppressErrorRendering handles cleanup if render()
+      // fails, but pre-validating avoids calling render() at all for bad input.
+      try {
+        const parseResult = await mermaid.parse(chart, {
+          suppressErrors: true,
+        });
+        if (parseResult === false) {
+          renderInlineError("Invalid mermaid diagram syntax");
+          return;
         }
+      } catch (error) {
+        console.error("Error parsing mermaid diagram:", error);
+        renderInlineError("Invalid mermaid diagram syntax");
+        return;
+      }
+
+      try {
+        // Generate a unique ID to avoid conflicts
+        const uniqueId = `${id}-${Date.now()}`;
+        const { svg } = await mermaid.render(uniqueId, chart);
+        if (ref.current) {
+          // Parse SVG string via DOMParser to avoid innerHTML
+          const doc = new DOMParser().parseFromString(svg, "image/svg+xml");
+          const svgElement = doc.documentElement;
+          ref.current.replaceChildren(svgElement);
+          requestAnimationFrame(() => setIsLoaded(true));
+        }
+      } catch (error) {
+        console.error("Error rendering mermaid diagram:", error);
+        renderInlineError("Failed to render mermaid diagram");
       }
     };
 


### PR DESCRIPTION
Closes #3511

## Problem
When chart syntax is invalid, mermaid.render() creates a temporary
container div in document.body with an error SVG inside it. Without
the suppressErrorRendering flag that container is never cleaned up,
so it persists after the React component unmounts and appears as a
stale error on unrelated pages.

## Fix
- Set suppressErrorRendering: true in mermaid.initialize so mermaid
  removes temp elements on failure instead of rendering error SVGs
- Pre-validate with mermaid.parse(chart, { suppressErrors: true })
  to short-circuit before render() for invalid input
- Show an inline error box inside the component on failure

## Test plan
- New unit tests (5 cases): init config, parse success, parse returns
  false, parse throws, render throws after successful parse
- Verified with real mermaid v11.13.0: without the flag, 1 orphan node
  leaks into document.body; with the flag, 0 nodes leak