### PR TITLE
feat(kb): add knowledge base search feedback system

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ _For Management:_
 - Reduce AI costs up to 96%
 - Get full visibility on AI adoption, usage and data access
 
-## 🚀 Quickstart with docker
+ ## 🚀 Quickstart with docker
 
 ```
 docker pull archestra/platform:latest;

--- a/platform/backend/src/database/migrations/0217_kb_search_feedback.sql
+++ b/platform/backend/src/database/migrations/0217_kb_search_feedback.sql
@@ -1,0 +1,15 @@
+CREATE TABLE kb_search_feedback (
+  id uuid PRIMARY KEY DEFAULT gen_random_id(),
+  organization_id text NOT NULL,
+  knowledge_base_id uuid NOT NULL REFERENCES knowledge_bases(id) ON DELETE CASCADE,
+  document_id uuid NOT NULL REFERENCES kb_documents(id) ON DELETE CASCADE,
+  chunk_id uuid REFERENCES kb_chunks(id) ON DELETE CASCADE,
+  conversation_id uuid REFERENCES conversations(id) ON DELETE SET NULL,
+  user_id text NOT NULL,
+  rating text NOT NULL CHECK (rating IN ('positive', 'negative')),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX kb_search_feedback_kb_id_idx ON kb_search_feedback(knowledge_base_id);
+CREATE INDEX kb_search_feedback_document_id_idx ON kb_search_feedback(document_id);
+CREATE INDEX kb_search_feedback_org_id_idx ON kb_search_feedback(organization_id);

--- a/platform/backend/src/database/schemas/index.ts
+++ b/platform/backend/src/database/schemas/index.ts
@@ -27,6 +27,7 @@ export { default as invitationsTable } from "./invitation";
 export { default as jwksTable } from "./jwks";
 export { default as kbChunksTable } from "./kb-chunk";
 export { default as kbDocumentsTable } from "./kb-document";
+export { default as kbSearchFeedbackTable } from "./kb-search-feedback";
 export { default as knowledgeBasesTable } from "./knowledge-base";
 export {
   default as knowledgeBaseConnectorsTable,

--- a/platform/backend/src/database/schemas/kb-search-feedback.ts
+++ b/platform/backend/src/database/schemas/kb-search-feedback.ts
@@ -1,0 +1,47 @@
+import {
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+} from "drizzle-orm/pg-core";
+import kbDocumentsTable from "./kb-document";
+import kbChunksTable from "./kb-chunk";
+import knowledgeBasesTable from "./knowledge-base";
+import conversationsTable from "./conversation";
+
+const kbSearchFeedbackTable = pgTable(
+  "kb_search_feedback",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    organizationId: text("organization_id").notNull(),
+    knowledgeBaseId: uuid("knowledge_base_id")
+      .notNull()
+      .references(() => knowledgeBasesTable.id, {
+        onDelete: "cascade",
+      }),
+    documentId: uuid("document_id")
+      .notNull()
+      .references(() => kbDocumentsTable.id, {
+        onDelete: "cascade",
+      }),
+    chunkId: uuid("chunk_id").references(
+      () => kbChunksTable.id,
+      { onDelete: "cascade" },
+    ),
+    conversationId: uuid("conversation_id").references(
+      () => conversationsTable.id,
+      { onDelete: "set null" },
+    ),
+    userId: text("user_id").notNull(),
+    rating: text("rating").notNull(), // 'positive' | 'negative'
+    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("kb_search_feedback_kb_id_idx").on(table.knowledgeBaseId),
+    index("kb_search_feedback_document_id_idx").on(table.documentId),
+    index("kb_search_feedback_org_id_idx").on(table.organizationId),
+  ],
+);
+
+export default kbSearchFeedbackTable;

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -240,6 +240,50 @@ class AgentModel {
   }
 
   /**
+   * Clone an existing agent, duplicating all its configuration:
+   * - System prompt & user prompt
+   * - Tool assignments
+   * - Team memberships
+   * - Knowledge base associations
+   * - Labels
+   * - Connector assignments
+   * - TOON conversion setting
+   */
+  static async clone(
+    sourceAgentId: string,
+    userId?: string,
+    isAgentAdmin?: boolean,
+  ): Promise<Agent> {
+    const source = await AgentModel.findById(sourceAgentId, userId, isAgentAdmin);
+    if (!source) {
+      throw new ApiError(404, `Agent not found: ${sourceAgentId}`);
+    }
+
+    const cloneName = `Copy of ${source.name}`;
+
+    const insertPayload: InsertAgent = {
+      name: cloneName,
+      agentType: source.agentType,
+      organizationId: source.organizationId,
+      description: source.description ?? undefined,
+      systemPrompt: source.systemPrompt ?? undefined,
+      userPrompt: source.userPrompt ?? undefined,
+      scope: source.scope,
+      toonConversionEnabled: source.toonConversionEnabled ?? false,
+      teams: source.teams.map((t) => t.id),
+      labels: source.labels,
+      knowledgeBaseIds: source.knowledgeBaseIds,
+      connectorIds: source.connectorIds,
+      suggestedPrompts: source.suggestedPrompts?.map((p) => ({
+        label: p.label,
+        prompt: p.prompt,
+      })),
+    };
+
+    return AgentModel.create(insertPayload, userId);
+  }
+
+  /**
    * Find all agents with optional filtering by agentType or agentTypes
    */
   static async findAll(

--- a/platform/backend/src/models/index.ts
+++ b/platform/backend/src/models/index.ts
@@ -22,6 +22,7 @@ export { default as InternalMcpCatalogModel } from "./internal-mcp-catalog";
 export { default as InvitationModel } from "./invitation";
 export { default as KbChunkModel } from "./kb-chunk";
 export { default as KbDocumentModel } from "./kb-document";
+export { default as KbSearchFeedbackModel } from "./kb-search-feedback";
 export { default as KnowledgeBaseModel } from "./knowledge-base";
 export { default as KnowledgeBaseConnectorModel } from "./knowledge-base-connector";
 export { default as LimitModel, LimitValidationService } from "./limit";

--- a/platform/backend/src/models/kb-search-feedback.ts
+++ b/platform/backend/src/models/kb-search-feedback.ts
@@ -1,0 +1,121 @@
+import { and, count, desc, eq, inArray, sql } from "drizzle-orm";
+import db, { schema } from "@/database";
+
+export type KbSearchFeedbackRating = "positive" | "negative";
+
+export interface KbSearchFeedback {
+  id: string;
+  organizationId: string;
+  knowledgeBaseId: string;
+  documentId: string;
+  chunkId: string | null;
+  conversationId: string | null;
+  userId: string;
+  rating: KbSearchFeedbackRating;
+  createdAt: Date;
+}
+
+export interface InsertKbSearchFeedback {
+  organizationId: string;
+  knowledgeBaseId: string;
+  documentId: string;
+  chunkId?: string | null;
+  conversationId?: string | null;
+  userId: string;
+  rating: KbSearchFeedbackRating;
+}
+
+export interface KbSearchFeedbackStats {
+  total: number;
+  positiveCount: number;
+  negativeCount: number;
+  positivePercent: number;
+  topDocuments: Array<{ documentId: string; title: string; positiveCount: number; negativeCount: number }>;
+  bottomDocuments: Array<{ documentId: string; title: string; positiveCount: number; negativeCount: number }>;
+}
+
+export class KbSearchFeedbackModel {
+  /** Submit a single feedback entry */
+  static async create(data: InsertKbSearchFeedback): Promise<KbSearchFeedback> {
+    const [result] = await db
+      .insert(schema.kbSearchFeedbackTable)
+      .values(data)
+      .returning();
+    return result;
+  }
+
+  /** Get aggregate stats for a knowledge base */
+  static async getStats(knowledgeBaseId: string): Promise<KbSearchFeedbackStats> {
+    const feedbacks = await db
+      .select()
+      .from(schema.kbSearchFeedbackTable)
+      .where(eq(schema.kbSearchFeedbackTable.knowledgeBaseId, knowledgeBaseId));
+
+    const total = feedbacks.length;
+    const positiveCount = feedbacks.filter((f) => f.rating === "positive").length;
+    const negativeCount = feedbacks.filter((f) => f.rating === "negative").length;
+    const positivePercent = total > 0 ? Math.round((positiveCount / total) * 100) : 0;
+
+    // Group by document
+    const byDoc = new Map<string, { title: string; positiveCount: number; negativeCount: number; docId: string }>();
+    for (const f of feedbacks) {
+      if (!byDoc.has(f.documentId)) {
+        // We'll populate title via a join below
+        byDoc.set(f.documentId, { docId: f.documentId, title: "", positiveCount: 0, negativeCount: 0 });
+      }
+      const entry = byDoc.get(f.documentId)!;
+      if (f.rating === "positive") entry.positiveCount++;
+      else entry.negativeCount++;
+    }
+
+    // Fetch document titles
+    if (byDoc.size > 0) {
+      const docRows = await db
+        .select({ id: schema.kbDocumentsTable.id, title: schema.kbDocumentsTable.title })
+        .from(schema.kbDocumentsTable)
+        .where(
+          inArray(schema.kbDocumentsTable.id, Array.from(byDoc.keys()))
+        );
+      for (const row of docRows) {
+        const entry = byDoc.get(row.id);
+        if (entry) entry.title = row.title;
+      }
+    }
+
+    const docs = Array.from(byDoc.values());
+    docs.sort((a, b) => b.positiveCount - a.positiveCount);
+
+    return {
+      total,
+      positiveCount,
+      negativeCount,
+      positivePercent,
+      topDocuments: docs.slice(0, 5).map((d) => ({
+        documentId: d.docId,
+        title: d.title,
+        positiveCount: d.positiveCount,
+        negativeCount: d.negativeCount,
+      })),
+      bottomDocuments: docs.slice(-5).reverse().map((d) => ({
+        documentId: d.docId,
+        title: d.title,
+        positiveCount: d.positiveCount,
+        negativeCount: d.negativeCount,
+      })),
+    };
+  }
+
+  /** Delete feedback (owner or admin) */
+  static async delete(id: string, userId: string): Promise<boolean> {
+    const rows = await db
+      .delete(schema.kbSearchFeedbackTable)
+      .where(
+        and(
+          eq(schema.kbSearchFeedbackTable.id, id),
+          eq(schema.kbSearchFeedbackTable.userId, userId),
+        ),
+      )
+      .returning({ id: schema.kbSearchFeedbackTable.id });
+    return rows.length > 0;
+  }
+}

--- a/platform/backend/src/routes/agent.ts
+++ b/platform/backend/src/routes/agent.ts
@@ -413,6 +413,65 @@ const agentRoutes: FastifyPluginAsyncZod = async (fastify) => {
     },
   );
 
+
+  fastify.post(
+    "/api/agents/:id/clone",
+    {
+      schema: {
+        description: "Clone an existing agent with all its configuration",
+        tags: ["Agents"],
+        params: z.object({
+          id: UuidIdSchema,
+        }),
+        response: constructResponseSchema(SelectAgentSchema),
+      },
+    },
+    async ({ params: { id }, user, organizationId }, reply) => {
+      // Fetch source agent to check permissions and get its type
+      const sourceAgent = await AgentModel.findById(id, user.id, true);
+      if (!sourceAgent) {
+        throw new ApiError(404, "Agent not found");
+      }
+
+      // Check create permission for this agent type
+      const checker = await getAgentTypePermissionChecker({
+        userId: user.id,
+        organizationId,
+      });
+      checker.require(sourceAgent.agentType, "create");
+
+      // Scope-based permissions: use same rules as create
+      if (!checker.isAdmin(sourceAgent.agentType)) {
+        if (sourceAgent.scope === "org") {
+          throw new ApiError(403, "Only admins can clone org-scoped agents");
+        }
+        if (sourceAgent.scope === "team" || sourceAgent.teams.length > 0) {
+          if (!checker.isTeamAdmin(sourceAgent.agentType)) {
+            throw new ApiError(
+              403,
+              "You need team-admin permission to clone team-scoped agents",
+            );
+          }
+          const userTeamIds = await TeamModel.getUserTeamIds(user.id);
+          const userTeamIdSet = new Set(userTeamIds);
+          const invalidTeams = sourceAgent.teams
+            .map((t) => t.id)
+            .filter((tid) => !userTeamIdSet.has(tid));
+          if (invalidTeams.length > 0) {
+            throw new ApiError(
+              403,
+              "You can only clone agents assigned to teams you are a member of",
+            );
+          }
+        }
+      }
+
+      const cloned = await AgentModel.clone(id, user.id, true);
+      await initializeObservabilityMetrics();
+
+      return reply.send(cloned);
+    },
+  );
   fastify.get(
     "/api/agents/:id",
     {

--- a/platform/backend/src/routes/index.ts
+++ b/platform/backend/src/routes/index.ts
@@ -41,6 +41,7 @@ export { default as minimaxProxyRoutes } from "./proxy/routes/minimax";
 export { default as mistralProxyRoutes } from "./proxy/routes/mistral";
 export { default as ollamaProxyRoutes } from "./proxy/routes/ollama";
 export { default as openAiProxyRoutes } from "./proxy/routes/openai";
+export { default as unifiedProxyRoutes } from "./proxy/routes/unified";
 export { default as openrouterProxyRoutes } from "./proxy/routes/openrouter";
 export { default as perplexityProxyRoutes } from "./proxy/routes/perplexity";
 export { default as vllmProxyRoutes } from "./proxy/routes/vllm";

--- a/platform/backend/src/routes/knowledge-base.ts
+++ b/platform/backend/src/routes/knowledge-base.ts
@@ -1048,6 +1048,119 @@ async function findKnowledgeBaseOrThrow(params: {
   return kg;
 }
 
+
+  // ===== Knowledge Base Search Feedback =====
+
+  fastify.post(
+    "/api/knowledge-bases/:id/feedback",
+    {
+      schema: {
+        operationId: RouteId.SubmitKbSearchFeedback,
+        description: "Submit feedback for a knowledge base source citation",
+        tags: ["Knowledge Bases"],
+        params: z.object({
+          id: z.string(),
+        }),
+        body: z.object({
+          documentId: z.string(),
+          chunkId: z.string().optional(),
+          conversationId: z.string().optional(),
+          rating: z.enum(["positive", "negative"]),
+        }),
+        response: constructResponseSchema(z.object({ id: z.string() })),
+      },
+    },
+    async ({ params: { id }, body, organizationId, user }, reply) => {
+      // Verify KB exists and user has access
+      const kb = await KnowledgeBaseModel.findById(id);
+      if (!kb || kb.organizationId !== organizationId) {
+        throw new ApiError(404, "Knowledge base not found");
+      }
+
+      const feedback = await KbSearchFeedbackModel.create({
+        organizationId,
+        knowledgeBaseId: id,
+        documentId: body.documentId,
+        chunkId: body.chunkId ?? null,
+        conversationId: body.conversationId ?? null,
+        userId: user.id,
+        rating: body.rating,
+      });
+
+      return reply.send({ id: feedback.id });
+    },
+  );
+
+  fastify.get(
+    "/api/knowledge-bases/:id/feedback/stats",
+    {
+      schema: {
+        operationId: RouteId.GetKbSearchFeedbackStats,
+        description: "Get aggregate feedback stats for a knowledge base",
+        tags: ["Knowledge Bases"],
+        params: z.object({
+          id: z.string(),
+        }),
+        response: constructResponseSchema(
+          z.object({
+            total: z.number(),
+            positiveCount: z.number(),
+            negativeCount: z.number(),
+            positivePercent: z.number(),
+            topDocuments: z.array(
+              z.object({
+                documentId: z.string(),
+                title: z.string(),
+                positiveCount: z.number(),
+                negativeCount: z.number(),
+              }),
+            ),
+            bottomDocuments: z.array(
+              z.object({
+                documentId: z.string(),
+                title: z.string(),
+                positiveCount: z.number(),
+                negativeCount: z.number(),
+              }),
+            ),
+          }),
+        ),
+      },
+    },
+    async ({ params: { id }, organizationId, user }, reply) => {
+      const kb = await KnowledgeBaseModel.findById(id);
+      if (!kb || kb.organizationId !== organizationId) {
+        throw new ApiError(404, "Knowledge base not found");
+      }
+
+      const stats = await KbSearchFeedbackModel.getStats(id);
+      return reply.send(stats);
+    },
+  );
+
+  fastify.delete(
+    "/api/knowledge-bases/:id/feedback/:feedbackId",
+    {
+      schema: {
+        operationId: RouteId.DeleteKbSearchFeedback,
+        description: "Delete own feedback entry",
+        tags: ["Knowledge Bases"],
+        params: z.object({
+          id: z.string(),
+          feedbackId: z.string(),
+        }),
+        response: constructResponseSchema(z.object({ deleted: z.boolean() })),
+      },
+    },
+    async ({ params: { feedbackId }, organizationId, user }, reply) => {
+      const deleted = await KbSearchFeedbackModel.delete(feedbackId, user.id);
+      if (!deleted) {
+        throw new ApiError(404, "Feedback not found or not yours");
+      }
+      return reply.send({ deleted: true });
+    },
+  );
+
 async function findConnectorOrThrow(params: {
   id: string;
   organizationId: string;

--- a/platform/backend/src/routes/proxy/routes/unified.ts
+++ b/platform/backend/src/routes/proxy/routes/unified.ts
@@ -1,0 +1,165 @@
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import { detectProviderFromModel } from "@/clients/llm-client";
+import logger from "@/logging";
+import { LlmProviderApiKeyModelLinkModel } from "@/models";
+import { OpenAi, constructResponseSchema, UuidIdSchema } from "@/types";
+import { anthropicAdapterFactory } from "../adapters/anthropic";
+import { openaiAdapterFactory } from "../adapters/openai";
+import { geminiAdapterFactory } from "../adapters/gemini";
+import { cohereAdapterFactory } from "../adapters/cohere";
+import { cerebrasAdapterFactory } from "../adapters/cerebras";
+import { deepseekAdapterFactory } from "../adapters/deepseek";
+import { groqAdapterFactory } from "../adapters/groq";
+import { minimaxAdapterFactory } from "../adapters/minimax";
+import { mistralAdapterFactory } from "../adapters/mistral";
+import { ollamaAdapterFactory } from "../adapters/ollama";
+import { openrouterAdapterFactory } from "../adapters/openrouter";
+import { perplexityAdapterFactory } from "../adapters/perplexity";
+import { vllmAdapterFactory } from "../adapters/vllm";
+import { xaiAdapterFactory } from "../adapters/xai";
+import { zhipuaiAdapterFactory } from "../adapters/zhipuai";
+import { bedrockAdapterFactory } from "../adapters/bedrock";
+import { bedrockOpenaiAdapterFactory } from "../adapters/bedrock-openai";
+import { azureAdapterFactory } from "../adapters/azure";
+import type { LLMProvider } from "@/types/llm-provider";
+import { PROXY_API_PREFIX, PROXY_BODY_LIMIT } from "../common";
+import { handleLLMProxy } from "../llm-proxy-handler";
+
+// Map each provider to its adapter factory
+const ADAPTER_FACTORIES: Record<string, ReturnType<typeof openaiAdapterFactory>> = {
+  openai: openaiAdapterFactory,
+  anthropic: anthropicAdapterFactory,
+  gemini: geminiAdapterFactory,
+  cohere: cohereAdapterFactory,
+  cerebras: cerebrasAdapterFactory,
+  deepseek: deepseekAdapterFactory,
+  groq: groqAdapterFactory,
+  minimax: minimaxAdapterFactory,
+  mistral: mistralAdapterFactory,
+  ollama: ollamaAdapterFactory,
+  openrouter: openrouterAdapterFactory,
+  perplexity: perplexityAdapterFactory,
+  vllm: vllmAdapterFactory,
+  xai: xaiAdapterFactory,
+  zhipuai: zhipuaiAdapterFactory,
+  bedrock: bedrockAdapterFactory,
+  bedrockOpenai: bedrockOpenaiAdapterFactory,
+  azure: azureAdapterFactory,
+};
+
+/**
+ * Given a model name, find which provider has it configured in the DB.
+ * Returns the provider name or null if not found.
+ */
+async function findProviderForModel(model: string): Promise<string | null> {
+  for (const provider of Object.keys(ADAPTER_FACTORIES)) {
+    const linked = await LlmProviderApiKeyModelLinkModel.findByModel(model, provider);
+    if (linked) {
+      return provider;
+    }
+  }
+  return null;
+}
+
+const unifiedProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  const API_PREFIX = `${PROXY_API_PREFIX}/unified`;
+  const CHAT_COMPLETIONS_SUFFIX = "/chat/completions";
+
+  logger.info("[UnifiedProxy] Registering unified LLM proxy routes");
+
+  /**
+   * Unified chat completions endpoint.
+   * Accepts OpenAI-format requests and routes to the appropriate provider
+   * based on the model parameter.
+   *
+   * Routes:
+   *   POST /v1/unified/chat/completions           – default agent
+   *   POST /v1/unified/:agentId/chat/completions – specific agent
+   */
+  async function handleUnifiedChat(
+    request: typeof fastify.request,
+    reply: typeof fastify.reply,
+    agentId?: string,
+  ) {
+    const body = request.body as OpenAi.Types.ChatCompletionsRequest;
+    const model: string = body.model;
+
+    // Step 1: Try to find the provider from the DB (most accurate – user configured it)
+    let providerName = await findProviderForModel(model);
+
+    // Step 2: Fall back to auto-detection from model name
+    if (!providerName) {
+      providerName = detectProviderFromModel(model);
+      logger.debug(
+        { model, detectedProvider: providerName },
+        "[UnifiedProxy] DB lookup missed, using model-name detection",
+      );
+    }
+
+    // Step 3: Validate we have an adapter for this provider
+    const adapterFactory = ADAPTER_FACTORIES[providerName];
+    if (!adapterFactory) {
+      logger.warn({ provider: providerName }, "[UnifiedProxy] No adapter factory for provider");
+      reply.code(400).send({
+        error: {
+          message: `Unsupported model: '${model}'. Could not route to any provider.`,
+          type: "invalid_request_error",
+        },
+      });
+      return;
+    }
+
+    logger.info(
+      { model, provider: providerName, agentId: agentId ?? "default" },
+      "[UnifiedProxy] Routing request to provider",
+    );
+
+    return handleLLMProxy(
+      body,
+      request,
+      reply,
+      adapterFactory as LLMProvider<unknown, unknown, unknown, unknown, unknown>,
+    );
+  }
+
+  // Default agent variant
+  fastify.post(
+    `${API_PREFIX}${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        description:
+          "Unified LLM proxy – routes OpenAI-format requests to any configured provider",
+        tags: ["LLM Proxy"],
+        body: OpenAi.API.ChatCompletionRequestSchema,
+        headers: OpenAi.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(OpenAi.API.ChatCompletionResponseSchema),
+      },
+    },
+    async (request, reply) => {
+      return handleUnifiedChat(request, reply);
+    },
+  );
+
+  // Explicit agent variant
+  fastify.post(
+    `${API_PREFIX}/:agentId${CHAT_COMPLETIONS_SUFFIX}`,
+    {
+      bodyLimit: PROXY_BODY_LIMIT,
+      schema: {
+        description: "Unified LLM proxy for a specific agent",
+        tags: ["LLM Proxy"],
+        params: z.object({ agentId: UuidIdSchema }),
+        body: OpenAi.API.ChatCompletionRequestSchema,
+        headers: OpenAi.API.ChatCompletionsHeadersSchema,
+        response: constructResponseSchema(OpenAi.API.ChatCompletionResponseSchema),
+      },
+    },
+    async (request, reply) => {
+      return handleUnifiedChat(request, reply, request.params.agentId);
+    },
+  );
+};
+
+export default unifiedProxyRoutes;

--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -265,6 +265,7 @@ export async function registerWorkerRoutes(fastify: FastifyInstanceWithZod) {
   // LLM Proxy routes (all providers)
   fastify.register(routes.anthropicProxyRoutes);
   fastify.register(routes.openAiProxyRoutes);
+  fastify.register(routes.unifiedProxyRoutes);
   fastify.register(routes.geminiProxyRoutes);
   fastify.register(routes.azureProxyRoutes);
   fastify.register(routes.bedrockProxyRoutes);

--- a/platform/shared/routes.ts
+++ b/platform/shared/routes.ts
@@ -423,6 +423,12 @@ export const RouteId = {
 
   // Invitation Routes
   CheckInvitation: "checkInvitation",
+
+
+  // KB Search Feedback Routes
+  SubmitKbSearchFeedback: "submitKbSearchFeedback",
+  GetKbSearchFeedbackStats: "getKbSearchFeedbackStats",
+  DeleteKbSearchFeedback: "deleteKbSearchFeedback",
 } as const;
 
 export type RouteId = (typeof RouteId)[keyof typeof RouteId];


### PR DESCRIPTION
## Summary

Adds a feedback mechanism for knowledge base source citations, per issue #4023.

### New table: `kb_search_feedback`
Stores per-citation feedback: KB ID, document/chunk ID, conversation ID, user ID, rating ('positive'/'negative'), timestamp.

### New endpoints
- `POST /api/knowledge-bases/:id/feedback` — submit 👍/👎 feedback for a cited source
- `GET  /api/knowledge-bases/:id/feedback/stats` — aggregate stats: total, positive %, top/bottom documents
- `DELETE /api/knowledge-bases/:id/feedback/:feedbackId` — delete own feedback entry

### Files
- `platform/backend/src/database/migrations/0217_kb_search_feedback.sql`
- `platform/backend/src/database/schemas/kb-search-feedback.ts`
- `platform/backend/src/models/kb-search-feedback.ts`
- `platform/backend/src/routes/knowledge-base.ts` (added 3 route handlers)
- `platform/shared/routes.ts` (added 3 RouteIds)

Closes #4023