### PR TITLE
fix: persist approval responses to DB so they survive page refresh

### DIFF
--- a/platform/backend/src/models/message.ts
+++ b/platform/backend/src/models/message.ts
@@ -105,6 +105,16 @@ class MessageModel {
     return MessageModel.findByContentId(id);
   }
 
+  static async updateContent(
+    messageId: string,
+    content: unknown,
+  ): Promise<void> {
+    await db
+      .update(schema.messagesTable)
+      .set({ content, updatedAt: new Date() })
+      .where(eq(schema.messagesTable.id, messageId));
+  }
+
   static async updateTextPart(
     messageId: string,
     partIndex: number,

--- a/platform/backend/src/routes/chat/routes.test.ts
+++ b/platform/backend/src/routes/chat/routes.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock the ai module before importing chat routes
 const mockGenerateText = vi.hoisted(() => vi.fn());
@@ -23,6 +23,12 @@ vi.mock("@/clients/llm-client", async (importOriginal) => {
 const mockGetFastestModel = vi.hoisted(() => vi.fn());
 vi.mock("@/models/llm-provider-api-key-model", () => ({
   default: { getFastestModel: mockGetFastestModel },
+}));
+
+// Mock MessageModel for updateModifiedMessages tests
+const mockUpdateContent = vi.hoisted(() => vi.fn());
+vi.mock("@/models/message", () => ({
+  default: { updateContent: mockUpdateContent },
 }));
 
 import { archestraMcpBranding } from "@/archestra-mcp-server";
@@ -553,5 +559,159 @@ describe("title generation integration", () => {
     expect(prompt).toContain(
       "Assistant: I can help you debug that. What error are you seeing?",
     );
+  });
+});
+
+describe("getPartsArray", () => {
+  it("extracts parts from valid content", () => {
+    const parts = __test.getPartsArray({
+      parts: [{ type: "text", text: "hello" }],
+    });
+    expect(parts).toEqual([{ type: "text", text: "hello" }]);
+  });
+
+  it("returns empty array for content without parts", () => {
+    expect(__test.getPartsArray({})).toEqual([]);
+    expect(__test.getPartsArray(null)).toEqual([]);
+    expect(__test.getPartsArray("string")).toEqual([]);
+  });
+});
+
+describe("updateModifiedMessages", () => {
+  beforeEach(() => {
+    mockUpdateContent.mockReset();
+  });
+
+  it("updates an existing message when new parts are added (approval response)", async () => {
+    await __test.updateModifiedMessages({
+      existingMessages: [
+        {
+          id: "db-uuid-1",
+          content: {
+            id: "assistant-1",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-invocation",
+                toolCallId: "call-1",
+                toolName: "read_file",
+                state: "approval-requested",
+              },
+            ],
+          },
+        },
+      ],
+      uiMessages: [
+        {
+          id: "db-uuid-1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-invocation",
+              toolCallId: "call-1",
+              toolName: "read_file",
+              state: "output-available",
+            },
+            {
+              type: "tool-result",
+              toolCallId: "call-1",
+              output: "file contents",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(mockUpdateContent).toHaveBeenCalledTimes(1);
+    expect(mockUpdateContent).toHaveBeenCalledWith(
+      "db-uuid-1",
+      expect.objectContaining({ role: "assistant" }),
+    );
+  });
+
+  it("does not update when parts count is unchanged", async () => {
+    await __test.updateModifiedMessages({
+      existingMessages: [
+        {
+          id: "db-uuid-1",
+          content: {
+            id: "assistant-1",
+            role: "assistant",
+            parts: [{ type: "text", text: "hello" }],
+          },
+        },
+      ],
+      uiMessages: [
+        {
+          id: "db-uuid-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "hello" }],
+        },
+      ],
+    });
+
+    expect(mockUpdateContent).not.toHaveBeenCalled();
+  });
+
+  it("matches messages by content id when frontend sends AI SDK ids", async () => {
+    await __test.updateModifiedMessages({
+      existingMessages: [
+        {
+          id: "db-uuid-1",
+          content: {
+            id: "temp-assistant-1",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-invocation",
+                toolCallId: "call-1",
+                toolName: "read_file",
+                state: "approval-requested",
+              },
+            ],
+          },
+        },
+      ],
+      uiMessages: [
+        {
+          id: "temp-assistant-1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-invocation",
+              toolCallId: "call-1",
+              toolName: "read_file",
+              state: "output-available",
+            },
+            {
+              type: "tool-result",
+              toolCallId: "call-1",
+              output: "approved",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(mockUpdateContent).toHaveBeenCalledTimes(1);
+    expect(mockUpdateContent).toHaveBeenCalledWith(
+      "db-uuid-1",
+      expect.objectContaining({ role: "assistant" }),
+    );
+  });
+
+  it("skips messages that are not in the existing set", async () => {
+    await __test.updateModifiedMessages({
+      existingMessages: [],
+      uiMessages: [
+        {
+          id: "new-msg-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "hello" }],
+        },
+      ],
+    });
+
+    expect(mockUpdateContent).not.toHaveBeenCalled();
   });
 });

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -1961,6 +1961,13 @@ async function persistNewMessages(
     const existingMessages =
       await MessageModel.findByConversation(conversationId);
     const uiMessages = messages as ChatMessage[];
+
+    // Update existing messages whose content has changed (e.g. tool approval
+    // responses added after the user approves/declines an MCP tool call).
+    // Without this, the DB retains the old version of the message and the
+    // approval state is lost on page refresh.
+    await updateModifiedMessages({ existingMessages, uiMessages });
+
     const newMessages = getMessagesNotYetPersisted({
       existingMessages,
       uiMessages,
@@ -2088,6 +2095,60 @@ function getMessagesNotYetPersisted(params: {
 
     return !existingIds.has(message.id);
   });
+}
+
+async function updateModifiedMessages(params: {
+  existingMessages: Array<{ id: string; content: unknown }>;
+  uiMessages: ChatMessage[];
+}): Promise<void> {
+  const existingById = new Map<string, { id: string; content: unknown }>();
+  for (const msg of params.existingMessages) {
+    existingById.set(msg.id, msg);
+
+    const contentId =
+      typeof msg.content === "object" &&
+      msg.content !== null &&
+      "id" in msg.content &&
+      typeof msg.content.id === "string"
+        ? msg.content.id
+        : null;
+    if (contentId) {
+      existingById.set(contentId, msg);
+    }
+  }
+
+  for (const uiMsg of params.uiMessages) {
+    if (!uiMsg.id) continue;
+    const existing = existingById.get(uiMsg.id);
+    if (!existing) continue;
+
+    const existingParts = getPartsArray(existing.content);
+    const currentParts = uiMsg.parts ?? [];
+    if (currentParts.length <= existingParts.length) continue;
+
+    const normalized = normalizeChatMessages([uiMsg])[0];
+    await MessageModel.updateContent(existing.id, normalized);
+    logger.info(
+      {
+        messageId: existing.id,
+        previousParts: existingParts.length,
+        updatedParts: currentParts.length,
+      },
+      "[Chat] Updated existing message with new parts (approval response)",
+    );
+  }
+}
+
+function getPartsArray(content: unknown): ChatMessagePart[] {
+  if (
+    typeof content === "object" &&
+    content !== null &&
+    "parts" in content &&
+    Array.isArray(content.parts)
+  ) {
+    return content.parts;
+  }
+  return [];
 }
 
 function prepareMessagesForProvider(params: {
@@ -2267,7 +2328,9 @@ async function validateChatApiKeyAccess(
 
 export const __test = {
   getMessagesNotYetPersisted,
+  getPartsArray,
   prepareMessagesForProvider,
+  updateModifiedMessages,
 };
 
 export default chatRoutes;


### PR DESCRIPTION
## Summary
- When a user approves/declines an MCP tool call in chat, the assistant message gains new tool-result parts. The existing `persistNewMessages` logic only inserts new messages by ID, so the modified assistant message was never updated in the database. On page refresh the old version loaded, showing the tool call as still awaiting approval.
- Added `updateModifiedMessages` to detect existing messages that gained new parts and update their content in the DB before inserting new messages.
- Added `MessageModel.updateContent` for targeted JSONB content updates.

## Changes
- `backend/src/models/message.ts`: Added `updateContent` method to update a message's JSONB content column
- `backend/src/routes/chat/routes.ts`: Added `updateModifiedMessages` and `getPartsArray` helpers, called from `persistNewMessages` before computing new messages
- `backend/src/routes/chat/routes.test.ts`: Added tests for `getPartsArray`, `updateModifiedMessages` (4 test cases covering approval update, no-op, content-id matching, and skip-new-messages)

## Test plan
- [x] All existing tests pass (46/46)
- [x] Type-check passes across all 4 workspaces
- [x] Biome lint passes with no issues
- [ ] Manual verification: approve a tool call in chat, refresh the page, verify the approval state and follow-up response persist

Closes #4030