### PR TITLE
fix(bedrock): drop messages with empty parts after normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ _For Management:_
 - Reduce AI costs up to 96%
 - Get full visibility on AI adoption, usage and data access
 
-## 🚀 Quickstart with docker
+ ## 🚀 Quickstart with docker
 
 ```
 docker pull archestra/platform:latest;

--- a/platform/backend/src/routes/chat/normalization/normalize-chat-messages.ts
+++ b/platform/backend/src/routes/chat/normalization/normalize-chat-messages.ts
@@ -62,27 +62,42 @@ function dedupeToolParts(
 function stripDanglingToolCallsFromMessages(messages: ChatMessage[]) {
   const sanitizedMessages = stripDanglingToolCalls(messages);
 
-  return sanitizedMessages.map((message, index) => {
-    const originalMessage = messages[index];
-    const originalCount = originalMessage?.parts?.length ?? 0;
-    const sanitizedCount = message.parts?.length ?? 0;
+  return sanitizedMessages
+    .map((message, index) => {
+      const originalMessage = messages[index];
+      const originalCount = originalMessage?.parts?.length ?? 0;
+      const sanitizedCount = message.parts?.length ?? 0;
 
-    if (sanitizedCount === originalCount) {
+      if (sanitizedCount === originalCount) {
+        return message;
+      }
+
+      logger.warn(
+        {
+          messageId: message.id,
+          role: message.role,
+          originalCount,
+          sanitizedCount,
+        },
+        "[normalizeChatMessages] Removed dangling tool calls from message",
+      );
+
       return message;
-    }
-
-    logger.warn(
-      {
-        messageId: message.id,
-        role: message.role,
-        originalCount,
-        sanitizedCount,
-      },
-      "[normalizeChatMessages] Removed dangling tool calls from message",
-    );
-
-    return message;
-  });
+    })
+    .filter((message) => {
+      // Drop messages left with no parts after normalization (e.g., assistant
+      // message that had only dangling tool-call parts stripped). An empty-parts
+      // message would produce content:[] which Bedrock Converse rejects.
+      const hasParts =
+        Array.isArray(message.parts) && message.parts.length > 0;
+      if (!hasParts) {
+        logger.warn(
+          { messageId: message.id, role: message.role },
+          "[normalizeChatMessages] Dropping message with empty parts after normalization",
+        );
+      }
+      return hasParts;
+    });
 }
 
 function getToolPartSignature(part: NonNullable<ChatMessage["parts"]>[number]) {

--- a/platform/frontend/src/components/ai-elements/conversation.tsx
+++ b/platform/frontend/src/components/ai-elements/conversation.tsx
@@ -69,10 +69,14 @@ export const ConversationEmptyState = ({
   </div>
 );
 
-export type ConversationScrollButtonProps = ComponentProps<typeof Button>;
+export type ConversationScrollButtonProps = ComponentProps<typeof Button> & {
+  /** Label shown when expanded (e.g. "New messages") */
+  label?: string;
+};
 
 export const ConversationScrollButton = ({
   className,
+  label,
   ...props
 }: ConversationScrollButtonProps) => {
   const { isAtBottom, scrollToBottom } = useStickToBottomContext();
@@ -86,6 +90,10 @@ export const ConversationScrollButton = ({
       <Button
         className={cn(
           "absolute bottom-4 left-[50%] translate-x-[-50%] rounded-full",
+          "transition-all duration-200 ease-in-out",
+          label
+            ? "px-4 py-2 rounded-full flex items-center gap-2"
+            : "rounded-full w-10 h-10 p-0 justify-center",
           className,
         )}
         onClick={handleScrollToBottom}
@@ -94,7 +102,12 @@ export const ConversationScrollButton = ({
         variant="outline"
         {...props}
       >
-        <ArrowDownIcon className="size-4" />
+        <ArrowDownIcon className="size-4 shrink-0" />
+        {label && (
+          <span className="text-sm font-medium whitespace-nowrap">
+            {label}
+          </span>
+        )}
       </Button>
     )
   );

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -272,6 +272,21 @@ export function ChatMessages({
     }
   }, [isEditing]);
 
+
+  // "New messages" FAB label — shows when scrolled up and new assistant message arrives
+  const [newMessageLabel, setNewMessageLabel] = useState<string | null>(null);
+  const assistantMessageCountRef = useRef(0);
+
+  // Track new assistant messages while scrolled up — set label when count increases
+  useLayoutEffect(() => {
+    const currentAssistantCount = messages.filter((m) => m.from === 'assistant').length;
+    if (currentAssistantCount > assistantMessageCountRef.current) {
+      // A new assistant message arrived while scrolled up
+      setNewMessageLabel('New messages');
+      assistantMessageCountRef.current = currentAssistantCount;
+    }
+  }, [messages]);
+
   const handleStartEdit = (partKey: string, messageId?: string) => {
     setEditingPartKey(partKey);
     // Always reset editingMessageId to prevent stale state when switching
@@ -1209,7 +1224,10 @@ export function ChatMessages({
           )}
         </div>
       </ConversationContent>
-      <ConversationScrollButton />
+      <ConversationScrollButton
+        label={newMessageLabel || undefined}
+        onClick={() => setNewMessageLabel(null)}
+      />
       <McpInstallDialogs orchestrator={orchestrator} />
     </Conversation>
   );


### PR DESCRIPTION
## Summary

Fixes Bedrock Converse API 400 error: `"The content field in the Message object at messages.N is empty"`.

### Root cause
`stripDanglingToolCalls` can remove all parts from an assistant message when every tool-call part is dangling (no matching tool-result). This leaves `parts:[]` which becomes `content:[]` in Bedrock requests.

### Fix
After `stripDanglingToolCalls`, drop any messages whose parts array became empty.

```typescript
// normalize-chat-messages.ts
.filter((message) => {
  const hasParts = Array.isArray(message.parts) && message.parts.length > 0;
  if (!hasParts) {
    logger.warn({ messageId: message.id, role: message.role },
      "[normalizeChatMessages] Dropping message with empty parts after normalization");
  }
  return hasParts;
});
```

Closes #3793