### PR TITLE
feat: add OpenAI Responses API support to OpenAI provider

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -75695,18 +75695,146 @@
                                 ]
                               },
                               "request": {
-                                "$ref": "#/components/schemas/XaiChatCompletionRequest"
+                                "anyOf": [
+                                  {
+                                    "$ref": "#/components/schemas/XaiChatCompletionRequest"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "model": {
+                                        "type": "string"
+                                      },
+                                      "input": {},
+                                      "instructions": {
+                                        "type": "string"
+                                      },
+                                      "previous_response_id": {
+                                        "type": "string"
+                                      },
+                                      "store": {
+                                        "type": "boolean"
+                                      },
+                                      "tools": {
+                                        "type": "array",
+                                        "items": {}
+                                      },
+                                      "stream": {
+                                        "nullable": true,
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "model",
+                                      "input"
+                                    ],
+                                    "additionalProperties": {}
+                                  }
+                                ]
                               },
                               "processedRequest": {
                                 "nullable": true,
-                                "allOf": [
+                                "anyOf": [
                                   {
                                     "$ref": "#/components/schemas/XaiChatCompletionRequest"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "model": {
+                                        "type": "string"
+                                      },
+                                      "input": {},
+                                      "instructions": {
+                                        "type": "string"
+                                      },
+                                      "previous_response_id": {
+                                        "type": "string"
+                                      },
+                                      "store": {
+                                        "type": "boolean"
+                                      },
+                                      "tools": {
+                                        "type": "array",
+                                        "items": {}
+                                      },
+                                      "stream": {
+                                        "nullable": true,
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "model",
+                                      "input"
+                                    ],
+                                    "additionalProperties": {}
                                   }
                                 ]
                               },
                               "response": {
-                                "$ref": "#/components/schemas/OpenAiChatCompletionResponse"
+                                "anyOf": [
+                                  {
+                                    "$ref": "#/components/schemas/OpenAiChatCompletionResponse"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "object": {
+                                        "type": "string",
+                                        "enum": [
+                                          "response"
+                                        ]
+                                      },
+                                      "created_at": {
+                                        "type": "number"
+                                      },
+                                      "model": {
+                                        "type": "string"
+                                      },
+                                      "status": {
+                                        "type": "string"
+                                      },
+                                      "output": {
+                                        "type": "array",
+                                        "items": {}
+                                      },
+                                      "usage": {
+                                        "type": "object",
+                                        "properties": {
+                                          "input_tokens": {
+                                            "type": "number"
+                                          },
+                                          "output_tokens": {
+                                            "type": "number"
+                                          },
+                                          "total_tokens": {
+                                            "type": "number"
+                                          },
+                                          "input_tokens_details": {},
+                                          "output_tokens_details": {}
+                                        },
+                                        "required": [
+                                          "input_tokens",
+                                          "output_tokens",
+                                          "total_tokens"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "id",
+                                      "object",
+                                      "created_at",
+                                      "model",
+                                      "status",
+                                      "output"
+                                    ],
+                                    "additionalProperties": {}
+                                  }
+                                ]
                               },
                               "dualLlmAnalyses": {
                                 "nullable": true,
@@ -84618,18 +84746,146 @@
                           ]
                         },
                         "request": {
-                          "$ref": "#/components/schemas/XaiChatCompletionRequest"
+                          "anyOf": [
+                            {
+                              "$ref": "#/components/schemas/XaiChatCompletionRequest"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "model": {
+                                  "type": "string"
+                                },
+                                "input": {},
+                                "instructions": {
+                                  "type": "string"
+                                },
+                                "previous_response_id": {
+                                  "type": "string"
+                                },
+                                "store": {
+                                  "type": "boolean"
+                                },
+                                "tools": {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                "stream": {
+                                  "nullable": true,
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "model",
+                                "input"
+                              ],
+                              "additionalProperties": {}
+                            }
+                          ]
                         },
                         "processedRequest": {
                           "nullable": true,
-                          "allOf": [
+                          "anyOf": [
                             {
                               "$ref": "#/components/schemas/XaiChatCompletionRequest"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "model": {
+                                  "type": "string"
+                                },
+                                "input": {},
+                                "instructions": {
+                                  "type": "string"
+                                },
+                                "previous_response_id": {
+                                  "type": "string"
+                                },
+                                "store": {
+                                  "type": "boolean"
+                                },
+                                "tools": {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                "stream": {
+                                  "nullable": true,
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "model",
+                                "input"
+                              ],
+                              "additionalProperties": {}
                             }
                           ]
                         },
                         "response": {
-                          "$ref": "#/components/schemas/OpenAiChatCompletionResponse"
+                          "anyOf": [
+                            {
+                              "$ref": "#/components/schemas/OpenAiChatCompletionResponse"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "object": {
+                                  "type": "string",
+                                  "enum": [
+                                    "response"
+                                  ]
+                                },
+                                "created_at": {
+                                  "type": "number"
+                                },
+                                "model": {
+                                  "type": "string"
+                                },
+                                "status": {
+                                  "type": "string"
+                                },
+                                "output": {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                "usage": {
+                                  "type": "object",
+                                  "properties": {
+                                    "input_tokens": {
+                                      "type": "number"
+                                    },
+                                    "output_tokens": {
+                                      "type": "number"
+                                    },
+                                    "total_tokens": {
+                                      "type": "number"
+                                    },
+                                    "input_tokens_details": {},
+                                    "output_tokens_details": {}
+                                  },
+                                  "required": [
+                                    "input_tokens",
+                                    "output_tokens",
+                                    "total_tokens"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "object",
+                                "created_at",
+                                "model",
+                                "status",
+                                "output"
+                              ],
+                              "additionalProperties": {}
+                            }
+                          ]
                         },
                         "dualLlmAnalyses": {
                           "nullable": true,
@@ -127693,7 +127949,42 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/XaiChatCompletionRequestInput"
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/XaiChatCompletionRequestInput"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "model": {
+                        "type": "string"
+                      },
+                      "input": {},
+                      "instructions": {
+                        "type": "string"
+                      },
+                      "previous_response_id": {
+                        "type": "string"
+                      },
+                      "store": {
+                        "type": "boolean"
+                      },
+                      "tools": {
+                        "type": "array",
+                        "items": {}
+                      },
+                      "stream": {
+                        "nullable": true,
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "model",
+                      "input"
+                    ],
+                    "additionalProperties": {}
+                  }
+                ]
               }
             }
           }
@@ -127724,7 +128015,69 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/OpenAiChatCompletionResponse"
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/OpenAiChatCompletionResponse"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "object": {
+                          "type": "string",
+                          "enum": [
+                            "response"
+                          ]
+                        },
+                        "created_at": {
+                          "type": "number"
+                        },
+                        "model": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string"
+                        },
+                        "output": {
+                          "type": "array",
+                          "items": {}
+                        },
+                        "usage": {
+                          "type": "object",
+                          "properties": {
+                            "input_tokens": {
+                              "type": "number"
+                            },
+                            "output_tokens": {
+                              "type": "number"
+                            },
+                            "total_tokens": {
+                              "type": "number"
+                            },
+                            "input_tokens_details": {},
+                            "output_tokens_details": {}
+                          },
+                          "required": [
+                            "input_tokens",
+                            "output_tokens",
+                            "total_tokens"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "object",
+                        "created_at",
+                        "model",
+                        "status",
+                        "output"
+                      ],
+                      "additionalProperties": {}
+                    }
+                  ]
                 }
               }
             }
@@ -127954,7 +128307,42 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/XaiChatCompletionRequestInput"
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/XaiChatCompletionRequestInput"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "model": {
+                        "type": "string"
+                      },
+                      "input": {},
+                      "instructions": {
+                        "type": "string"
+                      },
+                      "previous_response_id": {
+                        "type": "string"
+                      },
+                      "store": {
+                        "type": "boolean"
+                      },
+                      "tools": {
+                        "type": "array",
+                        "items": {}
+                      },
+                      "stream": {
+                        "nullable": true,
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "model",
+                      "input"
+                    ],
+                    "additionalProperties": {}
+                  }
+                ]
               }
             }
           }
@@ -127995,7 +128383,69 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/OpenAiChatCompletionResponse"
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/OpenAiChatCompletionResponse"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "object": {
+                          "type": "string",
+                          "enum": [
+                            "response"
+                          ]
+                        },
+                        "created_at": {
+                          "type": "number"
+                        },
+                        "model": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string"
+                        },
+                        "output": {
+                          "type": "array",
+                          "items": {}
+                        },
+                        "usage": {
+                          "type": "object",
+                          "properties": {
+                            "input_tokens": {
+                              "type": "number"
+                            },
+                            "output_tokens": {
+                              "type": "number"
+                            },
+                            "total_tokens": {
+                              "type": "number"
+                            },
+                            "input_tokens_details": {},
+                            "output_tokens_details": {}
+                          },
+                          "required": [
+                            "input_tokens",
+                            "output_tokens",
+                            "total_tokens"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "object",
+                        "created_at",
+                        "model",
+                        "status",
+                        "output"
+                      ],
+                      "additionalProperties": {}
+                    }
+                  ]
                 }
               }
             }

--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -21,7 +21,7 @@ Archestra Platform acts as a security proxy between your AI applications and LLM
 ### Supported OpenAI APIs
 
 - **Chat Completions API** (`/chat/completions`) - ✅ Fully supported
-- **Responses API** (`/responses`) - ⚠️ Not yet supported ([GitHub Issue #720](https://github.com/archestra-ai/archestra/issues/720))
+- **Responses API** - ✅ Fully supported (auto-detected, see notes below)
 
 ### OpenAI Connection Details
 
@@ -30,7 +30,8 @@ Archestra Platform acts as a security proxy between your AI applications and LLM
 
 ### Important Notes
 
-- **Use Chat Completions API**: Ensure your application uses the `/chat/completions` endpoint (not `/responses`). Many frameworks default to this, but some like Vercel AI SDK require explicit configuration (add `.chat` to the provider instance).
+- **Single endpoint, two API shapes**: Archestra exposes one OpenAI route at `/v1/openai/{profile-id}/chat/completions`. Requests are auto-detected by body shape: a `messages` array routes to Chat Completions, while an `input` field routes to the Responses API. No client configuration change is required.
+- **Responses API via Chat UI**: The Archestra chat UI currently uses Chat Completions API. To use Responses API, call the proxy endpoint directly (e.g., via SDK, REST client, or curl) and send requests with an `input` field instead of `messages`.
 - **Streaming**: OpenAI streaming responses require your cloud provider's load balancer to support long-lived connections. See [Cloud Provider Configuration](/docs/platform-deployment#cloud-provider-configuration-streaming-timeout-settings) for more details.
 
 ## Anthropic

--- a/platform/backend/src/models/interaction.test.ts
+++ b/platform/backend/src/models/interaction.test.ts
@@ -86,6 +86,51 @@ describe("InteractionModel", () => {
       const parsed = SelectInteractionSchema.safeParse(interaction);
       expect(parsed.success).toBe(true);
     });
+
+    test("can create and serialize an OpenAI Responses interaction", async () => {
+      const interaction = await InteractionModel.create({
+        profileId,
+        request: {
+          model: "gpt-4.1",
+          input: "Hello Responses",
+        },
+        processedRequest: {
+          model: "gpt-4.1",
+          input: "Hello Responses",
+        },
+        response: {
+          id: "resp-test-openai",
+          object: "response",
+          created_at: Date.now(),
+          model: "gpt-4.1",
+          status: "completed",
+          output: [
+            {
+              id: "msg-test-openai-responses",
+              type: "message",
+              role: "assistant",
+              status: "completed",
+              content: [
+                {
+                  type: "output_text",
+                  text: "Hi from Responses",
+                  annotations: [],
+                },
+              ],
+            },
+          ],
+          usage: {
+            input_tokens: 10,
+            output_tokens: 5,
+            total_tokens: 15,
+          },
+        },
+        type: "openai:chatCompletions",
+      });
+
+      const parsed = SelectInteractionSchema.safeParse(interaction);
+      expect(parsed.success).toBe(true);
+    });
   });
 
   describe("create - null byte sanitization", () => {

--- a/platform/backend/src/routes/proxy/adapters/openai-responses.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-responses.test.ts
@@ -1,0 +1,444 @@
+import { describe, expect, test } from "@/test";
+import { openaiAdapterFactory } from "./openai";
+
+describe("openaiAdapterFactory (Responses API dispatch)", () => {
+  // ===========================================================================
+  // Request Adapter — Responses API input format
+  // ===========================================================================
+
+  test("maps tools and tool outputs from Responses API request", () => {
+    const adapter = openaiAdapterFactory.createRequestAdapter({
+      model: "gpt-4.1",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "hello" }],
+        },
+        {
+          type: "function_call",
+          id: "fc_1",
+          call_id: "call_1",
+          name: "read_file",
+          arguments: '{"path":"/tmp"}',
+          status: "completed",
+        },
+        {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: '{"value":1}',
+        },
+      ],
+      tools: [
+        {
+          type: "function",
+          name: "read_file",
+          description: "Read a file",
+          strict: true,
+          parameters: {
+            type: "object",
+            properties: { path: { type: "string" } },
+          },
+        },
+      ],
+    } as unknown as Parameters<
+      typeof openaiAdapterFactory.createRequestAdapter
+    >[0]);
+
+    expect(adapter.getMessages()).toEqual([
+      { role: "user", content: "hello" },
+      {
+        role: "tool",
+        content: '{"value":1}',
+        toolCalls: [
+          {
+            id: "call_1",
+            name: "read_file",
+            content: { value: 1 },
+            isError: false,
+          },
+        ],
+      },
+    ]);
+    expect(adapter.getToolResults()).toEqual([
+      {
+        id: "call_1",
+        name: "read_file",
+        content: '{"value":1}',
+        isError: false,
+      },
+    ]);
+    expect(adapter.getTools()).toEqual([
+      {
+        name: "read_file",
+        description: "Read a file",
+        inputSchema: {
+          type: "object",
+          properties: { path: { type: "string" } },
+        },
+      },
+    ]);
+    expect(adapter.hasTools()).toBe(true);
+    expect(adapter.getProviderMessages()).toEqual([]);
+  });
+
+  test("handles string input in Responses request", () => {
+    const adapter = openaiAdapterFactory.createRequestAdapter({
+      model: "gpt-4.1",
+      input: "Hello world",
+    } as unknown as Parameters<
+      typeof openaiAdapterFactory.createRequestAdapter
+    >[0]);
+
+    expect(adapter.getMessages()).toEqual([
+      { role: "user", content: "Hello world" },
+    ]);
+    expect(adapter.getToolResults()).toEqual([]);
+  });
+
+  test("falls back to unknown when function_call_output has no matching function_call", () => {
+    const adapter = openaiAdapterFactory.createRequestAdapter({
+      model: "gpt-4.1",
+      input: [
+        {
+          type: "function_call_output",
+          call_id: "call_missing",
+          output: '{"value":1}',
+        },
+      ],
+    } as unknown as Parameters<
+      typeof openaiAdapterFactory.createRequestAdapter
+    >[0]);
+
+    expect(adapter.getToolResults()).toEqual([
+      {
+        id: "call_missing",
+        name: "unknown",
+        content: '{"value":1}',
+        isError: false,
+      },
+    ]);
+  });
+
+  test("applyToonCompression is a no-op", async () => {
+    const adapter = openaiAdapterFactory.createRequestAdapter({
+      model: "gpt-4.1",
+      input: [
+        {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: '{"value":1}',
+        },
+      ],
+    } as unknown as Parameters<
+      typeof openaiAdapterFactory.createRequestAdapter
+    >[0]);
+
+    const stats = await adapter.applyToonCompression("gpt-4.1");
+
+    expect(stats.hadToolResults).toBe(false);
+    expect(stats.wasEffective).toBe(false);
+    expect(stats.tokensBefore).toBe(0);
+    expect(stats.tokensAfter).toBe(0);
+    expect(stats.costSavings).toBe(0);
+  });
+
+  test("toProviderRequest applies tool result updates", () => {
+    const adapter = openaiAdapterFactory.createRequestAdapter({
+      model: "gpt-4.1",
+      input: [
+        {
+          type: "function_call",
+          id: "fc_1",
+          call_id: "call_1",
+          name: "read_file",
+          arguments: '{"path":"/tmp"}',
+          status: "completed",
+        },
+        {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: "original output",
+        },
+      ],
+    } as unknown as Parameters<
+      typeof openaiAdapterFactory.createRequestAdapter
+    >[0]);
+
+    adapter.applyToolResultUpdates({ call_1: "updated output" });
+
+    const providerRequest = adapter.toProviderRequest() as unknown as {
+      input: Array<{ type: string; call_id?: string; output?: string }>;
+    };
+
+    const outputItem = providerRequest.input.find(
+      (item) =>
+        item.type === "function_call_output" && item.call_id === "call_1",
+    );
+    expect(outputItem?.output).toBe("updated output");
+  });
+
+  // ===========================================================================
+  // Response Adapter — Responses API payload
+  // ===========================================================================
+
+  test("extracts text and tool calls from a Responses payload", () => {
+    const adapter = openaiAdapterFactory.createResponseAdapter({
+      id: "resp_123",
+      object: "response",
+      created_at: 123,
+      model: "gpt-4.1",
+      status: "completed",
+      output: [
+        {
+          type: "function_call",
+          id: "fc_1",
+          call_id: "call_1",
+          name: "read_file",
+          arguments: '{"path":"/tmp"}',
+          status: "completed",
+        },
+        {
+          id: "msg_1",
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "output_text", text: "Done", annotations: [] }],
+        },
+      ],
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+        total_tokens: 15,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens_details: { reasoning_tokens: 0 },
+      },
+    } as unknown as Parameters<
+      typeof openaiAdapterFactory.createResponseAdapter
+    >[0]);
+
+    expect(adapter.getText()).toBe("Done");
+    expect(adapter.getToolCalls()).toEqual([
+      { id: "call_1", name: "read_file", arguments: { path: "/tmp" } },
+    ]);
+    expect(adapter.getUsage()).toEqual({ inputTokens: 10, outputTokens: 5 });
+    expect(adapter.getFinishReasons()).toEqual(["tool_calls"]);
+  });
+
+  // ===========================================================================
+  // Stream Adapter — Responses API streaming events
+  // ===========================================================================
+
+  test("processes streaming events and completes on response.completed", () => {
+    const adapter = openaiAdapterFactory.createStreamAdapter({
+      model: "gpt-4.1",
+      input: "test",
+      instructions: "be helpful",
+    } as unknown as Parameters<
+      typeof openaiAdapterFactory.createStreamAdapter
+    >[0]);
+
+    const deltaResult = adapter.processChunk({
+      type: "response.output_text.delta",
+      item_id: "msg_1",
+      output_index: 0,
+      content_index: 0,
+      sequence_number: 1,
+      delta: "Hello",
+      logprobs: [],
+    } as unknown as Parameters<typeof adapter.processChunk>[0]);
+
+    expect(deltaResult.isFinal).toBe(false);
+    expect(deltaResult.sseData).toContain(
+      '"type":"response.output_text.delta"',
+    );
+
+    const completedResult = adapter.processChunk({
+      type: "response.completed",
+      sequence_number: 2,
+      response: {
+        id: "resp_123",
+        object: "response",
+        created_at: 123,
+        model: "gpt-4.1",
+        status: "completed",
+        output: [
+          {
+            id: "msg_1",
+            type: "message",
+            role: "assistant",
+            status: "completed",
+            content: [{ type: "output_text", text: "Hello", annotations: [] }],
+          },
+        ],
+        usage: {
+          input_tokens: 4,
+          output_tokens: 1,
+          total_tokens: 5,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+      },
+    } as unknown as Parameters<typeof adapter.processChunk>[0]);
+
+    expect(completedResult.isFinal).toBe(true);
+    expect(adapter.state.text).toBe("Hello");
+    expect(adapter.formatEndSSE()).toBe("data: [DONE]\n\n");
+  });
+
+  test("accumulates streamed function call arguments across delta events", () => {
+    const adapter = openaiAdapterFactory.createStreamAdapter({
+      model: "gpt-4.1",
+      input: "test",
+    } as unknown as Parameters<
+      typeof openaiAdapterFactory.createStreamAdapter
+    >[0]);
+
+    adapter.processChunk({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: {
+        id: "fc_1",
+        type: "function_call",
+        call_id: "call_1",
+        name: "read_file",
+        arguments: "",
+        status: "in_progress",
+      },
+    } as unknown as Parameters<typeof adapter.processChunk>[0]);
+
+    adapter.processChunk({
+      type: "response.function_call_arguments.delta",
+      item_id: "fc_1",
+      output_index: 0,
+      delta: '{"path',
+      sequence_number: 1,
+    } as unknown as Parameters<typeof adapter.processChunk>[0]);
+
+    adapter.processChunk({
+      type: "response.function_call_arguments.delta",
+      item_id: "fc_1",
+      output_index: 0,
+      delta: '":"/tmp"}',
+      sequence_number: 2,
+    } as unknown as Parameters<typeof adapter.processChunk>[0]);
+
+    expect(
+      (adapter.toProviderResponse() as unknown as { output: unknown[] }).output,
+    ).toContainEqual(
+      expect.objectContaining({
+        type: "function_call",
+        call_id: "call_1",
+        name: "read_file",
+        arguments: '{"path":"/tmp"}',
+      }),
+    );
+  });
+  // Guardrail path — getMessages() must populate toolCalls so trusted-data
+  // evaluation can detect untrusted context and block subsequent tool calls
+  //
+
+  test("getMessages populates toolCalls on function_call_output so trusted-data evaluation detects untrusted context", () => {
+    const adapter = openaiAdapterFactory.createRequestAdapter({
+      model: "gpt-4o",
+      input: [
+        { type: "message", role: "user", content: "Search for open issues." },
+        {
+          type: "function_call",
+          id: "fc_1",
+          call_id: "call_abc",
+          name: "search_issues",
+          arguments: '{"q":"repo:acme/app is:open"}',
+          status: "completed",
+        },
+        {
+          type: "function_call_output",
+          call_id: "call_abc",
+          output: '[{"number":1,"title":"Bug","state":"open"}]',
+        },
+        {
+          type: "message",
+          role: "user",
+          content: "Now search for closed ones.",
+        },
+      ],
+      tools: [
+        {
+          type: "function",
+          name: "search_issues",
+          description: "Search GitHub issues",
+          parameters: { type: "object", properties: { q: { type: "string" } } },
+        },
+      ],
+    } as unknown as Parameters<
+      typeof openaiAdapterFactory.createRequestAdapter
+    >[0]);
+
+    const messages = adapter.getMessages();
+
+    // The function_call_output message must carry toolCalls so that
+    // evaluateIfContextIsTrusted finds tool results and can mark the context
+    // as untrusted before checking tool invocation policies.
+    const toolMessage = messages.find((m) => m.role === "tool");
+    expect(toolMessage).toBeDefined();
+    expect(toolMessage?.toolCalls).toHaveLength(1);
+    expect(toolMessage?.toolCalls?.[0]).toEqual({
+      id: "call_abc",
+      name: "search_issues",
+      content: [{ number: 1, title: "Bug", state: "open" }],
+      isError: false,
+    });
+
+    // function_call items are not exposed as messages
+    expect(messages.filter((m) => m.role === "assistant")).toHaveLength(0);
+    // user messages are preserved
+    expect(messages.filter((m) => m.role === "user")).toHaveLength(2);
+  });
+
+  test("getMessages resolves name as unknown when function_call_output has no matching function_call", () => {
+    const adapter = openaiAdapterFactory.createRequestAdapter({
+      model: "gpt-4o",
+      input: [
+        {
+          type: "function_call_output",
+          call_id: "call_orphan",
+          output: '{"value":1}',
+        },
+      ],
+    } as unknown as Parameters<
+      typeof openaiAdapterFactory.createRequestAdapter
+    >[0]);
+
+    const messages = adapter.getMessages();
+    expect(messages[0].toolCalls?.[0].name).toBe("unknown");
+    expect(messages[0].toolCalls?.[0].id).toBe("call_orphan");
+  });
+
+  // ===========================================================================
+  // Factory dispatch — detects format from request shape
+  // ===========================================================================
+
+  test("routes ChatCompletions request to ChatCompletions adapter", () => {
+    const adapter = openaiAdapterFactory.createRequestAdapter({
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    expect(adapter.getMessages()).toEqual([{ role: "user", content: "hello" }]);
+    expect(Array.isArray(adapter.getProviderMessages())).toBe(true);
+    expect((adapter.getProviderMessages() as unknown[]).length).toBe(1);
+  });
+
+  test("routes Responses API request to Responses adapter", () => {
+    const adapter = openaiAdapterFactory.createRequestAdapter({
+      model: "gpt-4.1",
+      input: "Hello",
+      instructions: "Be helpful",
+    } as unknown as Parameters<
+      typeof openaiAdapterFactory.createRequestAdapter
+    >[0]);
+
+    expect(adapter.getMessages()).toEqual([{ role: "user", content: "Hello" }]);
+    expect(adapter.getProviderMessages()).toEqual([]);
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/openai-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-responses.ts
@@ -1,0 +1,826 @@
+import type {
+  ResponseFunctionCallArgumentsDeltaEvent,
+  ResponseFunctionCallArgumentsDoneEvent,
+  ResponseInputItem,
+  ResponseOutputItem,
+  ResponseStreamEvent,
+} from "openai/resources/responses/responses";
+import type {
+  ChunkProcessingResult,
+  CommonMcpToolDefinition,
+  CommonMessage,
+  CommonToolCall,
+  CommonToolResult,
+  LLMRequestAdapter,
+  LLMResponseAdapter,
+  LLMStreamAdapter,
+  OpenAi,
+  ToolCompressionStats,
+  UsageView,
+} from "@/types";
+import { createStreamAccumulatorState } from "@/types";
+
+// =============================================================================
+// TYPE ALIASES
+// =============================================================================
+
+type OpenAiRequest = OpenAi.Types.ChatCompletionsRequest;
+type OpenAiResponse = OpenAi.Types.ChatCompletionsResponse;
+type OpenAiMessages = OpenAi.Types.ChatCompletionsRequest["messages"];
+type OpenAiStreamChunk = OpenAi.Types.ChatCompletionChunk;
+
+type OpenAiResponsesRequest = {
+  model: string;
+  input?: string | ResponseInputItem[];
+  instructions?: string;
+  stream?: boolean | null;
+  tools?: Array<{
+    type: "function";
+    name: string;
+    description?: string;
+    parameters?: Record<string, unknown>;
+    strict?: boolean;
+  }>;
+  previous_response_id?: string;
+  store?: boolean;
+  [key: string]: unknown;
+};
+
+type OpenAiResponsesResponse = {
+  id: string;
+  object: string;
+  created_at: number;
+  model: string;
+  status: string;
+  output: ResponseOutputItem[];
+  usage?: {
+    input_tokens: number;
+    output_tokens: number;
+    total_tokens: number;
+    input_tokens_details?: { cached_tokens: number };
+    output_tokens_details?: { reasoning_tokens: number };
+  };
+};
+
+// =============================================================================
+// REQUEST ADAPTER
+// =============================================================================
+
+export class OpenAIResponsesRequestAdapter
+  implements LLMRequestAdapter<OpenAiRequest, OpenAiMessages>
+{
+  readonly provider = "openai" as const;
+  private request: OpenAiResponsesRequest;
+  private modifiedModel: string | null = null;
+  private toolResultUpdates: Record<string, string> = {};
+
+  constructor(request: OpenAiRequest) {
+    this.request = request as unknown as OpenAiResponsesRequest;
+  }
+
+  getModel(): string {
+    return this.modifiedModel ?? this.request.model;
+  }
+
+  isStreaming(): boolean {
+    return this.request.stream === true;
+  }
+
+  getMessages(): CommonMessage[] {
+    if (typeof this.request.input === "string") {
+      return [{ role: "user", content: this.request.input }];
+    }
+
+    if (!Array.isArray(this.request.input)) {
+      return [];
+    }
+
+    const toolNamesByCallId = getToolNamesByCallId(this.request.input);
+    return this.request.input.flatMap((item) =>
+      toCommonMessages(item, toolNamesByCallId),
+    );
+  }
+
+  getToolResults(): CommonToolResult[] {
+    if (!Array.isArray(this.request.input)) {
+      return [];
+    }
+
+    const toolNamesByCallId = getToolNamesByCallId(this.request.input);
+
+    return this.request.input.flatMap((item) => {
+      if (!isFunctionCallOutputItem(item)) {
+        return [];
+      }
+
+      return [
+        {
+          id: item.call_id,
+          name: toolNamesByCallId.get(item.call_id) ?? "unknown",
+          content: item.output,
+          isError: false,
+        },
+      ];
+    });
+  }
+
+  getTools(): CommonMcpToolDefinition[] {
+    if (!Array.isArray(this.request.tools)) {
+      return [];
+    }
+
+    return this.request.tools.flatMap((tool) => {
+      if (tool.type !== "function") {
+        return [];
+      }
+
+      return [
+        {
+          name: tool.name,
+          description: tool.description ?? undefined,
+          inputSchema: tool.parameters ?? {},
+        },
+      ];
+    });
+  }
+
+  hasTools(): boolean {
+    return (this.request.tools?.length ?? 0) > 0;
+  }
+
+  getProviderMessages(): OpenAiMessages {
+    // Responses API has no messages array; return empty array cast to the
+    // expected type so the rest of the pipeline has something to work with.
+    return [] as unknown as OpenAiMessages;
+  }
+
+  getOriginalRequest(): OpenAiRequest {
+    return this.request as unknown as OpenAiRequest;
+  }
+
+  setModel(model: string): void {
+    this.modifiedModel = model;
+  }
+
+  updateToolResult(toolCallId: string, newContent: string): void {
+    this.toolResultUpdates[toolCallId] = newContent;
+  }
+
+  applyToolResultUpdates(updates: Record<string, string>): void {
+    Object.assign(this.toolResultUpdates, updates);
+  }
+
+  async applyToonCompression(_model: string): Promise<ToolCompressionStats> {
+    // Responses API tool outputs are already structured as function_call_output
+    // items, so there is no JSON blob to compress with TOON before forwarding
+    // upstream.
+    return createEmptyToolCompressionStats();
+  }
+
+  convertToolResultContent(messages: OpenAiMessages): OpenAiMessages {
+    // OpenAI Responses API accepts tool results in their native
+    // function_call_output shape, so the proxy should pass them through
+    // unchanged.
+    return messages;
+  }
+
+  toProviderRequest(): OpenAiRequest {
+    if (!Array.isArray(this.request.input)) {
+      return {
+        ...this.request,
+        model: this.getModel(),
+      } as unknown as OpenAiRequest;
+    }
+
+    return {
+      ...this.request,
+      model: this.getModel(),
+      input: this.request.input.map((item) => {
+        if (!isFunctionCallOutputItem(item)) {
+          return item;
+        }
+
+        const updatedOutput = this.toolResultUpdates[item.call_id];
+        if (!updatedOutput) {
+          return item;
+        }
+
+        return {
+          ...item,
+          output: updatedOutput,
+        };
+      }),
+    } as unknown as OpenAiRequest;
+  }
+}
+
+// =============================================================================
+// RESPONSE ADAPTER
+// =============================================================================
+
+export class OpenAIResponsesResponseAdapter
+  implements LLMResponseAdapter<OpenAiResponse>
+{
+  readonly provider = "openai" as const;
+  private response: OpenAiResponsesResponse;
+
+  constructor(response: OpenAiResponse) {
+    this.response = response as unknown as OpenAiResponsesResponse;
+  }
+
+  getId(): string {
+    return this.response.id;
+  }
+
+  getModel(): string {
+    return this.response.model;
+  }
+
+  getText(): string {
+    return this.response.output
+      .flatMap((item) => {
+        if (!isResponseMessage(item)) {
+          return [];
+        }
+
+        return item.content.flatMap((contentPart) => {
+          if (contentPart.type === "output_text") {
+            return [contentPart.text];
+          }
+
+          if (contentPart.type === "refusal") {
+            return [contentPart.refusal];
+          }
+
+          return [];
+        });
+      })
+      .join("\n");
+  }
+
+  getToolCalls(): CommonToolCall[] {
+    return this.response.output.flatMap((item) => {
+      if (!isResponseFunctionCall(item)) {
+        return [];
+      }
+
+      return [
+        {
+          id: item.call_id,
+          name: item.name,
+          arguments: tryParseJsonObject(item.arguments),
+        },
+      ];
+    });
+  }
+
+  hasToolCalls(): boolean {
+    return this.getToolCalls().length > 0;
+  }
+
+  getUsage(): UsageView {
+    return {
+      inputTokens: this.response.usage?.input_tokens ?? 0,
+      outputTokens: this.response.usage?.output_tokens ?? 0,
+    };
+  }
+
+  getOriginalResponse(): OpenAiResponse {
+    return this.response as unknown as OpenAiResponse;
+  }
+
+  getFinishReasons(): string[] {
+    if (this.hasToolCalls()) {
+      return ["tool_calls"];
+    }
+
+    return [this.response.status ?? "completed"];
+  }
+
+  toRefusalResponse(
+    refusalMessage: string,
+    contentMessage: string,
+  ): OpenAiResponse {
+    return {
+      id: this.response.id,
+      object: "response",
+      created_at: Math.floor(Date.now() / 1000),
+      model: this.response.model,
+      status: "completed",
+      output: [
+        {
+          id: `msg_${Date.now()}`,
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: [
+            {
+              type: "refusal",
+              refusal: refusalMessage,
+            },
+            {
+              type: "output_text",
+              text: contentMessage,
+              annotations: [],
+            },
+          ],
+        },
+      ],
+      usage: this.response.usage,
+    } as unknown as OpenAiResponse;
+  }
+}
+
+// =============================================================================
+// STREAM ADAPTER
+// =============================================================================
+
+export class OpenAIResponsesStreamAdapter
+  implements LLMStreamAdapter<OpenAiStreamChunk, OpenAiResponse>
+{
+  readonly provider = "openai" as const;
+  readonly state = createStreamAccumulatorState();
+  private completedResponse: OpenAiResponsesResponse | null = null;
+  private toolCallsByItemId = new Map<
+    string,
+    { id: string; name: string; arguments: string }
+  >();
+
+  processChunk(chunk: OpenAiStreamChunk): ChunkProcessingResult {
+    if (this.state.timing.firstChunkTime === null) {
+      this.state.timing.firstChunkTime = Date.now();
+    }
+
+    const event = chunk as unknown as ResponseStreamEvent;
+
+    if ("response" in event) {
+      const response = (event as { response: OpenAiResponsesResponse })
+        .response;
+      this.state.responseId = response.id;
+      this.state.model = response.model;
+      if (response.usage) {
+        this.state.usage = {
+          inputTokens: response.usage.input_tokens ?? 0,
+          outputTokens: response.usage.output_tokens ?? 0,
+        };
+      }
+    }
+
+    if (event.type === "response.output_text.delta") {
+      this.state.text += event.delta;
+      return {
+        sseData: toSse(event),
+        isToolCallChunk: false,
+        isFinal: false,
+      };
+    }
+
+    if (isResponsesToolCallChunk(event)) {
+      this.captureToolCallChunk(event);
+      this.state.rawToolCallEvents.push(event);
+      return {
+        sseData: null,
+        isToolCallChunk: true,
+        isFinal: false,
+      };
+    }
+
+    if (event.type === "response.completed") {
+      this.completedResponse =
+        event.response as unknown as OpenAiResponsesResponse;
+      this.state.stopReason =
+        this.state.toolCalls.length > 0 ? "tool_calls" : "stop";
+
+      return {
+        sseData: toSse(event),
+        isToolCallChunk: false,
+        isFinal: true,
+      };
+    }
+
+    if (
+      event.type === "response.failed" ||
+      event.type === "response.incomplete"
+    ) {
+      this.state.stopReason = "length";
+      return {
+        sseData: toSse(event),
+        isToolCallChunk: false,
+        isFinal: true,
+      };
+    }
+
+    return {
+      sseData: toSse(event),
+      isToolCallChunk: false,
+      isFinal: false,
+    };
+  }
+
+  getSSEHeaders(): Record<string, string> {
+    return {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    };
+  }
+
+  formatTextDeltaSSE(text: string): string {
+    const responseId = this.state.responseId || `resp_${Date.now()}`;
+    const itemId = `msg_${Date.now()}`;
+
+    return [
+      toSse({
+        type: "response.output_item.added",
+        output_index: 0,
+        sequence_number: Date.now(),
+        item: {
+          id: itemId,
+          type: "message",
+          role: "assistant",
+          status: "in_progress",
+          content: [],
+        },
+      }),
+      toSse({
+        type: "response.content_part.added",
+        item_id: itemId,
+        output_index: 0,
+        content_index: 0,
+        sequence_number: Date.now() + 1,
+        part: {
+          type: "output_text",
+          text: "",
+          annotations: [],
+        },
+      }),
+      toSse({
+        type: "response.output_text.delta",
+        item_id: itemId,
+        output_index: 0,
+        content_index: 0,
+        sequence_number: Date.now() + 2,
+        delta: text,
+        logprobs: [],
+      }),
+      toSse({
+        type: "response.output_text.done",
+        item_id: itemId,
+        output_index: 0,
+        content_index: 0,
+        sequence_number: Date.now() + 3,
+        text,
+        logprobs: [],
+      }),
+      toSse({
+        type: "response.content_part.done",
+        item_id: itemId,
+        output_index: 0,
+        content_index: 0,
+        sequence_number: Date.now() + 4,
+        part: {
+          type: "output_text",
+          text,
+          annotations: [],
+        },
+      }),
+      toSse({
+        type: "response.output_item.done",
+        output_index: 0,
+        sequence_number: Date.now() + 5,
+        item: {
+          id: itemId,
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: [
+            {
+              type: "output_text",
+              text,
+              annotations: [],
+            },
+          ],
+        },
+      }),
+      toSse({
+        type: "response.completed",
+        sequence_number: Date.now() + 6,
+        response: {
+          id: responseId,
+          object: "response",
+          created_at: Math.floor(Date.now() / 1000),
+          model: this.state.model,
+          status: "completed",
+          output: [
+            {
+              id: itemId,
+              type: "message",
+              role: "assistant",
+              status: "completed",
+              content: [
+                {
+                  type: "output_text",
+                  text,
+                  annotations: [],
+                },
+              ],
+            },
+          ],
+          usage: {
+            input_tokens: 0,
+            input_tokens_details: { cached_tokens: 0 },
+            output_tokens: 0,
+            output_tokens_details: { reasoning_tokens: 0 },
+            total_tokens: 0,
+          },
+        },
+      }),
+    ].join("");
+  }
+
+  getRawToolCallEvents(): string[] {
+    return this.state.rawToolCallEvents.map((event) => toSse(event));
+  }
+
+  formatCompleteTextSSE(text: string): string[] {
+    return [this.formatTextDeltaSSE(text)];
+  }
+
+  formatEndSSE(): string {
+    return "data: [DONE]\n\n";
+  }
+
+  toProviderResponse(): OpenAiResponse {
+    if (this.completedResponse) {
+      return this.completedResponse as unknown as OpenAiResponse;
+    }
+
+    const outputItems: OpenAiResponsesResponse["output"] = [];
+
+    if (this.state.text) {
+      outputItems.push({
+        id: `msg_${Date.now()}`,
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: [
+          {
+            type: "output_text",
+            text: this.state.text,
+            annotations: [],
+          },
+        ],
+      } as OpenAiResponsesResponse["output"][number]);
+    }
+
+    outputItems.push(
+      ...this.state.toolCalls.map((toolCall) => ({
+        id: toolCall.id,
+        call_id: toolCall.id,
+        type: "function_call" as const,
+        name: toolCall.name,
+        arguments: toolCall.arguments,
+        status: "completed" as const,
+      })),
+    );
+
+    return {
+      id: this.state.responseId || `resp_${Date.now()}`,
+      object: "response",
+      created_at: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      status: "completed",
+      output: outputItems,
+      usage: this.state.usage
+        ? {
+            input_tokens: this.state.usage.inputTokens,
+            input_tokens_details: { cached_tokens: 0 },
+            output_tokens: this.state.usage.outputTokens,
+            output_tokens_details: { reasoning_tokens: 0 },
+            total_tokens:
+              this.state.usage.inputTokens + this.state.usage.outputTokens,
+          }
+        : undefined,
+    } as unknown as OpenAiResponse;
+  }
+
+  private captureToolCallChunk(chunk: ResponseStreamEvent): void {
+    if (chunk.type === "response.output_item.added") {
+      const item = chunk.item;
+      if (!isResponseFunctionCall(item)) {
+        return;
+      }
+
+      this.toolCallsByItemId.set(item.id ?? item.call_id, {
+        id: item.call_id,
+        name: item.name,
+        arguments: item.arguments,
+      });
+      this.state.toolCalls = Array.from(this.toolCallsByItemId.values());
+      return;
+    }
+
+    if (chunk.type === "response.function_call_arguments.delta") {
+      const toolCall = this.toolCallsByItemId.get(chunk.item_id) ?? {
+        id: chunk.item_id,
+        name: "",
+        arguments: "",
+      };
+      toolCall.arguments += chunk.delta;
+      this.toolCallsByItemId.set(chunk.item_id, toolCall);
+      this.state.toolCalls = Array.from(this.toolCallsByItemId.values());
+      return;
+    }
+
+    if (chunk.type === "response.function_call_arguments.done") {
+      this.updateToolCallArguments(chunk);
+    }
+  }
+
+  private updateToolCallArguments(
+    chunk:
+      | ResponseFunctionCallArgumentsDoneEvent
+      | ResponseFunctionCallArgumentsDeltaEvent,
+  ): void {
+    const toolCall = this.toolCallsByItemId.get(chunk.item_id) ?? {
+      id: chunk.item_id,
+      name: "name" in chunk ? chunk.name : "",
+      arguments: "",
+    };
+
+    if ("name" in chunk) {
+      toolCall.name = chunk.name;
+      toolCall.arguments = chunk.arguments;
+    }
+
+    this.toolCallsByItemId.set(chunk.item_id, toolCall);
+    this.state.toolCalls = Array.from(this.toolCallsByItemId.values());
+  }
+}
+
+// =============================================================================
+// PRIVATE HELPERS
+// =============================================================================
+
+function createEmptyToolCompressionStats(): ToolCompressionStats {
+  return {
+    tokensBefore: 0,
+    tokensAfter: 0,
+    costSavings: 0,
+    wasEffective: false,
+    hadToolResults: false,
+  };
+}
+
+function toCommonMessages(
+  item: ResponseInputItem,
+  toolNamesByCallId: Map<string, string>,
+): CommonMessage[] {
+  if (item.type === "message") {
+    return [
+      {
+        role: normalizeResponseMessageRole(item.role),
+        content: extractResponseInputText(item.content),
+      },
+    ];
+  }
+
+  if (item.type === "function_call_output") {
+    const content =
+      typeof item.output === "string"
+        ? item.output
+        : JSON.stringify(item.output);
+    let toolResult: unknown;
+    try {
+      toolResult =
+        typeof item.output === "string" ? JSON.parse(item.output) : item.output;
+    } catch {
+      toolResult = item.output;
+    }
+    return [
+      {
+        role: "tool",
+        content,
+        toolCalls: [
+          {
+            id: item.call_id,
+            name: toolNamesByCallId.get(item.call_id) ?? "unknown",
+            content: toolResult,
+            isError: false,
+          },
+        ],
+      },
+    ];
+  }
+
+  return [];
+}
+
+function extractResponseInputText(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  return content
+    .flatMap((part) => {
+      if (!part || typeof part !== "object" || !("type" in part)) {
+        return [];
+      }
+
+      if (part.type === "input_text" && "text" in part) {
+        return typeof part.text === "string" ? [part.text] : [];
+      }
+
+      if (part.type === "output_text" && "text" in part) {
+        return typeof part.text === "string" ? [part.text] : [];
+      }
+
+      return [];
+    })
+    .join("\n");
+}
+
+function isFunctionCallOutputItem(
+  item: unknown,
+): item is Extract<ResponseInputItem, { type: "function_call_output" }> {
+  return (
+    !!item &&
+    typeof item === "object" &&
+    "type" in item &&
+    item.type === "function_call_output"
+  );
+}
+
+function isResponseMessage(
+  item: ResponseOutputItem,
+): item is Extract<ResponseOutputItem, { type: "message" }> {
+  return item.type === "message";
+}
+
+function isResponseFunctionCall(
+  item: ResponseOutputItem | { type?: string },
+): item is Extract<ResponseOutputItem, { type: "function_call" }> {
+  return item.type === "function_call";
+}
+
+function isResponseInputFunctionCall(
+  item: ResponseInputItem,
+): item is Extract<ResponseInputItem, { type: "function_call" }> {
+  return item.type === "function_call";
+}
+
+function isResponsesToolCallChunk(
+  chunk: ResponseStreamEvent,
+): chunk is
+  | Extract<ResponseStreamEvent, { type: "response.output_item.added" }>
+  | Extract<ResponseStreamEvent, { type: "response.output_item.done" }>
+  | ResponseFunctionCallArgumentsDeltaEvent
+  | ResponseFunctionCallArgumentsDoneEvent {
+  return (
+    (chunk.type === "response.output_item.added" &&
+      isResponseFunctionCall(chunk.item)) ||
+    (chunk.type === "response.output_item.done" &&
+      isResponseFunctionCall(chunk.item)) ||
+    chunk.type === "response.function_call_arguments.delta" ||
+    chunk.type === "response.function_call_arguments.done"
+  );
+}
+
+function getToolNamesByCallId(input: ResponseInputItem[]): Map<string, string> {
+  return new Map(
+    input.flatMap((item) => {
+      if (!isResponseInputFunctionCall(item)) {
+        return [];
+      }
+
+      return [[item.call_id, item.name] as const];
+    }),
+  );
+}
+
+function tryParseJsonObject(value: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeResponseMessageRole(
+  role: "user" | "system" | "assistant" | "developer",
+): CommonMessage["role"] {
+  return role === "developer" ? "system" : role;
+}
+
+function toSse(event: unknown): string {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}

--- a/platform/backend/src/routes/proxy/adapters/openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai.ts
@@ -5,6 +5,10 @@ import type {
   ChatCompletionCreateParamsNonStreaming,
   ChatCompletionCreateParamsStreaming,
 } from "openai/resources/chat/completions/completions";
+import type {
+  ResponseCreateParamsNonStreaming,
+  ResponseCreateParamsStreaming,
+} from "openai/resources/responses/responses";
 import config from "@/config";
 import logger from "@/logging";
 import { ModelModel } from "@/models";
@@ -40,6 +44,11 @@ import {
 } from "../utils/mcp-image";
 import { stripBrowserToolsResults } from "../utils/summarize-tool-results";
 import { unwrapToolContent } from "../utils/unwrap-tool-content";
+import {
+  OpenAIResponsesRequestAdapter,
+  OpenAIResponsesResponseAdapter,
+  OpenAIResponsesStreamAdapter,
+} from "./openai-responses";
 
 // =============================================================================
 // TYPE ALIASES
@@ -1113,6 +1122,18 @@ export async function convertToolResultsToToon(
 }
 
 // =============================================================================
+// RESPONSES API DETECTION
+// =============================================================================
+
+function isResponsesRequest(request: OpenAiRequest): boolean {
+  return "input" in request;
+}
+
+function isResponsesResponse(response: OpenAiResponse): boolean {
+  return "output" in (response as unknown as Record<string, unknown>);
+}
+
+// =============================================================================
 // ADAPTER FACTORY
 // =============================================================================
 
@@ -1140,16 +1161,34 @@ export const openaiAdapterFactory: LLMProvider<
   createRequestAdapter(
     request: OpenAiRequest,
   ): LLMRequestAdapter<OpenAiRequest, OpenAiMessages> {
+    if (isResponsesRequest(request)) {
+      return new OpenAIResponsesRequestAdapter(
+        request,
+      ) as unknown as LLMRequestAdapter<OpenAiRequest, OpenAiMessages>;
+    }
     return new OpenAIRequestAdapter(request);
   },
 
   createResponseAdapter(
     response: OpenAiResponse,
   ): LLMResponseAdapter<OpenAiResponse> {
+    if (isResponsesResponse(response)) {
+      return new OpenAIResponsesResponseAdapter(
+        response,
+      ) as unknown as LLMResponseAdapter<OpenAiResponse>;
+    }
     return new OpenAIResponseAdapter(response);
   },
 
-  createStreamAdapter(): LLMStreamAdapter<OpenAiStreamChunk, OpenAiResponse> {
+  createStreamAdapter(
+    request?: OpenAiRequest,
+  ): LLMStreamAdapter<OpenAiStreamChunk, OpenAiResponse> {
+    if (request && isResponsesRequest(request)) {
+      return new OpenAIResponsesStreamAdapter() as unknown as LLMStreamAdapter<
+        OpenAiStreamChunk,
+        OpenAiResponse
+      >;
+    }
     return new OpenAIStreamAdapter();
   },
 
@@ -1242,6 +1281,12 @@ export const openaiAdapterFactory: LLMProvider<
     request: OpenAiRequest,
   ): Promise<OpenAiResponse> {
     const openaiClient = client as OpenAIProvider;
+    if (isResponsesRequest(request)) {
+      return (await openaiClient.responses.create({
+        ...request,
+        stream: false,
+      } as unknown as ResponseCreateParamsNonStreaming)) as unknown as OpenAiResponse;
+    }
     const openaiRequest = {
       ...request,
       stream: false,
@@ -1256,6 +1301,12 @@ export const openaiAdapterFactory: LLMProvider<
     request: OpenAiRequest,
   ): Promise<AsyncIterable<OpenAiStreamChunk>> {
     const openaiClient = client as OpenAIProvider;
+    if (isResponsesRequest(request)) {
+      return (await openaiClient.responses.create({
+        ...request,
+        stream: true,
+      } as unknown as ResponseCreateParamsStreaming)) as unknown as AsyncIterable<OpenAiStreamChunk>;
+    }
     const openaiRequest = {
       ...request,
       stream: true,

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
@@ -14,7 +14,7 @@ import {
 } from "fastify-type-provider-zod";
 import { vi } from "vitest";
 import type { PolicyBlockResult } from "@/guardrails/tool-invocation";
-import { ModelModel } from "@/models";
+import { InteractionModel, ModelModel } from "@/models";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import {
   createAnthropicTestClient,
@@ -87,7 +87,10 @@ import openAiProxyRoutes from "./routes/openai";
 describe("LLM Proxy Handler Prometheus Metrics", () => {
   let app: FastifyInstance;
   let testAgent: Agent;
-  let openAiStubOptions: { interruptAtChunk?: number };
+  let openAiStubOptions: {
+    interruptAtChunk?: number;
+    responsesToolCall?: boolean;
+  };
   let anthropicStubOptions: {
     includeToolUse?: boolean;
     interruptAtChunk?: number;
@@ -559,7 +562,10 @@ describe("LLM Proxy Handler Prometheus Metrics", () => {
 describe("LLM Proxy Handler — recordBlockedToolSpans", () => {
   let app: FastifyInstance;
   let testAgent: Agent;
-  let openAiStubOptions: { interruptAtChunk?: number };
+  let openAiStubOptions: {
+    interruptAtChunk?: number;
+    responsesToolCall?: boolean;
+  };
   let anthropicStubOptions: {
     includeToolUse?: boolean;
     interruptAtChunk?: number;
@@ -706,6 +712,99 @@ describe("LLM Proxy Handler — recordBlockedToolSpans", () => {
       expect(mockRecordBlockedToolSpans).toHaveBeenCalledOnce();
       const callArg = mockRecordBlockedToolSpans.mock.calls[0][0];
       expect(callArg.agentType).toBeDefined();
+    });
+  });
+
+  describe("streaming (OpenAI Responses)", () => {
+    beforeEach(async () => {
+      await app.register(openAiProxyRoutes);
+
+      await ModelModel.upsert({
+        externalId: "openai/gpt-4.1",
+        provider: "openai",
+        modelId: "gpt-4.1",
+        inputModalities: null,
+        outputModalities: null,
+        customPricePerMillionInput: "2.00",
+        customPricePerMillionOutput: "8.00",
+        lastSyncedAt: new Date(),
+      });
+    });
+
+    test("records refusal response when policy blocks streamed tool calls", async () => {
+      openAiStubOptions.responsesToolCall = true;
+
+      const blockResult: PolicyBlockResult = {
+        refusalMessage: "Tool blocked by policy",
+        contentMessage: "Tool list_files was blocked",
+        reason: "Tool invocation blocked: always block",
+        blockedToolName: "list_files",
+        allToolCallNames: ["list_files"],
+      };
+      mockEvaluatePolicies.mockResolvedValue(blockResult);
+
+      const initialInteractions =
+        await InteractionModel.getAllInteractionsForProfile(testAgent.id);
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/openai/${testAgent.id}/chat/completions`,
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer test-key",
+          "user-agent": "test-client",
+        },
+        payload: {
+          model: "gpt-4.1",
+          input: "List files with Responses streaming",
+          stream: true,
+          tools: [
+            {
+              type: "function",
+              name: "list_files",
+              description: "List files",
+              parameters: {
+                type: "object",
+                properties: { path: { type: "string" } },
+              },
+            },
+          ],
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toContain("Tool list_files was blocked");
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(mockRecordBlockedToolSpans).toHaveBeenCalledOnce();
+
+      const interactions = await InteractionModel.getAllInteractionsForProfile(
+        testAgent.id,
+      );
+      expect(interactions.length).toBe(initialInteractions.length + 1);
+
+      const interaction = interactions[interactions.length - 1];
+      expect(interaction.response).toMatchObject({
+        object: "response",
+        status: "completed",
+        output: [
+          expect.objectContaining({
+            type: "message",
+            content: expect.arrayContaining([
+              expect.objectContaining({
+                type: "output_text",
+                text: "Tool list_files was blocked",
+              }),
+            ]),
+          }),
+        ],
+      });
+      expect(
+        (
+          interaction.response as { output: Array<{ type: string }> }
+        ).output.some((item) => item.type === "function_call"),
+      ).toBe(false);
     });
   });
 

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -706,6 +706,7 @@ async function handleStreaming<
   // Once a blocking tool is encountered, buffer all subsequent tool call chunks
   // to prevent streaming data for tools that appear after a blocked tool.
   let bufferAllToolCalls = false;
+  let responseForInteraction: TResponse | null = null;
 
   logger.debug(
     { model: actualModel },
@@ -898,7 +899,7 @@ async function handleStreaming<
     }
 
     if (toolInvocationRefusal) {
-      const { contentMessage, reason, allToolCallNames } =
+      const { refusalMessage, contentMessage, reason, allToolCallNames } =
         toolInvocationRefusal;
 
       // When not buffering, tool call chunks were already streamed — append
@@ -910,6 +911,10 @@ async function handleStreaming<
       for (const event of refusalEvents) {
         reply.raw.write(event);
       }
+
+      responseForInteraction = provider
+        .createResponseAdapter(streamAdapter.toProviderResponse())
+        .toRefusalResponse(refusalMessage, contentMessage);
 
       recordBlockedToolCallMetrics({
         allToolCallNames,
@@ -1012,7 +1017,8 @@ async function handleStreaming<
             providerType: provider.interactionType,
             request: originalRequest,
             processedRequest: request,
-            response: streamAdapter.toProviderResponse(),
+            response:
+              responseForInteraction ?? streamAdapter.toProviderResponse(),
             actualModel,
             baselineModel,
             usage,

--- a/platform/backend/src/routes/proxy/routes/openai.test.ts
+++ b/platform/backend/src/routes/proxy/routes/openai.test.ts
@@ -385,6 +385,130 @@ describe("OpenAI streaming mode", () => {
   });
 });
 
+describe("OpenAI Responses API", () => {
+  let openAiStubOptions: { interruptAtChunk?: number };
+
+  beforeEach(async () => {
+    openAiStubOptions = {};
+    vi.spyOn(openaiAdapterFactory, "createClient").mockImplementation(
+      () => createOpenAiTestClient(openAiStubOptions) as never,
+    );
+
+    await ModelModel.upsert({
+      externalId: "openai/gpt-4.1",
+      provider: "openai",
+      modelId: "gpt-4.1",
+      inputModalities: null,
+      outputModalities: null,
+      customPricePerMillionInput: "2.00",
+      customPricePerMillionOutput: "8.00",
+      lastSyncedAt: new Date(),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("non-streaming mode records interaction", async ({ makeAgent }) => {
+    const app = Fastify().withTypeProvider<ZodTypeProvider>();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+
+    await app.register(openAiProxyRoutes);
+
+    const agent = await makeAgent({ name: "Test Responses Agent" });
+    const { InteractionModel } = await import("@/models");
+    const initialInteractions =
+      await InteractionModel.getAllInteractionsForProfile(agent.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/openai/${agent.id}/chat/completions`,
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer test-key",
+        "user-agent": "test-client",
+      },
+      payload: {
+        model: "gpt-4.1",
+        input: "Hello from the Responses API",
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toMatchObject({
+      object: "response",
+      model: "gpt-4.1",
+      status: "completed",
+    });
+
+    const interactions = await InteractionModel.getAllInteractionsForProfile(
+      agent.id,
+    );
+    expect(interactions.length).toBe(initialInteractions.length + 1);
+
+    const interaction = interactions[interactions.length - 1];
+    expect(interaction.type).toBe("openai:chatCompletions");
+    expect(interaction.model).toBe("gpt-4.1");
+    expect(interaction.inputTokens).toBe(12);
+    expect(interaction.outputTokens).toBe(10);
+    expect(interaction.response).toMatchObject({
+      object: "response",
+      status: "completed",
+    });
+  });
+
+  test("streaming mode records interaction", async ({ makeAgent }) => {
+    const app = Fastify().withTypeProvider<ZodTypeProvider>();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+
+    await app.register(openAiProxyRoutes);
+
+    const agent = await makeAgent({ name: "Test Streaming Responses Agent" });
+    const { InteractionModel } = await import("@/models");
+    const initialInteractions =
+      await InteractionModel.getAllInteractionsForProfile(agent.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/openai/${agent.id}/chat/completions`,
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer test-key",
+        "user-agent": "test-client",
+      },
+      payload: {
+        model: "gpt-4.1",
+        input: "Hello from the streaming Responses API",
+        stream: true,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toContain('"type":"response.output_text.delta"');
+    expect(response.body).toContain("data: [DONE]");
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const interactions = await InteractionModel.getAllInteractionsForProfile(
+      agent.id,
+    );
+    expect(interactions.length).toBe(initialInteractions.length + 1);
+
+    const interaction = interactions[interactions.length - 1];
+    expect(interaction.type).toBe("openai:chatCompletions");
+    expect(interaction.model).toBe("gpt-4.1");
+    expect(interaction.inputTokens).toBe(12);
+    expect(interaction.outputTokens).toBe(10);
+    expect(interaction.response).toMatchObject({
+      object: "response",
+      status: "completed",
+    });
+  });
+});
+
 describe("OpenAI proxy routing", () => {
   let app: FastifyInstance;
   let mockUpstream: FastifyInstance;

--- a/platform/backend/src/routes/proxy/routes/openai.ts
+++ b/platform/backend/src/routes/proxy/routes/openai.ts
@@ -37,10 +37,10 @@ const openAiProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
         description:
           "Create a chat completion with OpenAI (uses default agent)",
         tags: ["LLM Proxy"],
-        body: OpenAi.API.ChatCompletionRequestSchema,
+        body: OpenAi.API.ChatCompletionOrResponsesRequestSchema,
         headers: OpenAi.API.ChatCompletionsHeadersSchema,
         response: constructResponseSchema(
-          OpenAi.API.ChatCompletionResponseSchema,
+          OpenAi.API.ChatCompletionOrResponsesResponseSchema,
         ),
       },
     },
@@ -65,10 +65,10 @@ const openAiProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
         params: z.object({
           agentId: UuidIdSchema,
         }),
-        body: OpenAi.API.ChatCompletionRequestSchema,
+        body: OpenAi.API.ChatCompletionOrResponsesRequestSchema,
         headers: OpenAi.API.ChatCompletionsHeadersSchema,
         response: constructResponseSchema(
-          OpenAi.API.ChatCompletionResponseSchema,
+          OpenAi.API.ChatCompletionOrResponsesResponseSchema,
         ),
       },
     },

--- a/platform/backend/src/test/llm-provider-stubs.ts
+++ b/platform/backend/src/test/llm-provider-stubs.ts
@@ -4,6 +4,7 @@ import type OpenAI from "openai";
 
 export interface OpenAiStubOptions {
   interruptAtChunk?: number;
+  responsesToolCall?: boolean;
 }
 
 export interface AnthropicStubOptions {
@@ -60,6 +61,15 @@ export function createOpenAiTestClient(options: OpenAiStubOptions = {}) {
             },
           } satisfies OpenAI.Chat.Completions.ChatCompletion;
         },
+      },
+    },
+    responses: {
+      create: async (params: { stream?: boolean | null }) => {
+        if (params.stream) {
+          return createOpenAiResponsesStream(options);
+        }
+
+        return createOpenAiResponsesResponse(options);
       },
     },
   };
@@ -195,6 +205,153 @@ function createOpenAiStream(options: OpenAiStubOptions) {
       },
     },
   ];
+
+  return {
+    [Symbol.asyncIterator]() {
+      let index = 0;
+
+      return {
+        async next() {
+          if (
+            options.interruptAtChunk !== undefined &&
+            index === options.interruptAtChunk
+          ) {
+            return { done: true, value: undefined };
+          }
+
+          if (index < chunks.length) {
+            return { done: false, value: chunks[index++] };
+          }
+
+          return { done: true, value: undefined };
+        },
+      };
+    },
+  };
+}
+
+function createOpenAiResponsesResponse(options: OpenAiStubOptions) {
+  const output = options.responsesToolCall
+    ? [
+        {
+          id: "fc_list_files",
+          type: "function_call",
+          call_id: "call_list_files",
+          name: "list_files",
+          arguments: '{"path":"."}',
+          status: "completed",
+        },
+      ]
+    : [
+        {
+          id: "msg-test-openai-responses",
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: [
+            {
+              type: "output_text",
+              text: "Hello! How can I help you today?",
+              annotations: [],
+            },
+          ],
+        },
+      ];
+
+  return {
+    id: "resp-test-openai",
+    object: "response",
+    created_at: Math.floor(Date.now() / 1000),
+    model: "gpt-4.1",
+    status: "completed",
+    output,
+    usage: {
+      input_tokens: 12,
+      output_tokens: 10,
+      total_tokens: 22,
+      input_tokens_details: { cached_tokens: 0 },
+      output_tokens_details: { reasoning_tokens: 0 },
+    },
+  };
+}
+
+function createOpenAiResponsesStream(options: OpenAiStubOptions) {
+  const chunks = options.responsesToolCall
+    ? [
+        {
+          type: "response.created",
+          sequence_number: 0,
+          response: {
+            id: "resp-test-openai",
+            object: "response",
+            created_at: Math.floor(Date.now() / 1000),
+            model: "gpt-4.1",
+            status: "in_progress",
+            output: [],
+          },
+        },
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          sequence_number: 1,
+          item: {
+            id: "fc_list_files",
+            type: "function_call",
+            call_id: "call_list_files",
+            name: "list_files",
+            arguments: "",
+            status: "in_progress",
+          },
+        },
+        {
+          type: "response.function_call_arguments.delta",
+          item_id: "fc_list_files",
+          output_index: 0,
+          sequence_number: 2,
+          delta: '{"path":"."}',
+        },
+        {
+          type: "response.function_call_arguments.done",
+          item_id: "fc_list_files",
+          output_index: 0,
+          sequence_number: 3,
+          name: "list_files",
+          arguments: '{"path":"."}',
+        },
+        {
+          type: "response.completed",
+          sequence_number: 4,
+          response: createOpenAiResponsesResponse(options),
+        },
+      ]
+    : [
+        {
+          type: "response.created",
+          sequence_number: 0,
+          response: {
+            id: "resp-test-openai",
+            object: "response",
+            created_at: Math.floor(Date.now() / 1000),
+            model: "gpt-4.1",
+            status: "in_progress",
+            output: [],
+          },
+        },
+        {
+          type: "response.output_text.delta",
+          item_id: "msg-test-openai-responses",
+          output_index: 0,
+          content_index: 0,
+          sequence_number: 1,
+          delta: "Hello from Responses",
+          logprobs: [],
+        },
+        {
+          type: "response.completed",
+          sequence_number: 2,
+          response: createOpenAiResponsesResponse(options),
+        },
+      ];
 
   return {
     [Symbol.asyncIterator]() {

--- a/platform/backend/src/types/interaction.ts
+++ b/platform/backend/src/types/interaction.ts
@@ -40,7 +40,7 @@ export const UserInfoSchema = z.object({
  * These are used for the database schema definition
  */
 export const InteractionRequestSchema = z.union([
-  OpenAi.API.ChatCompletionRequestSchema,
+  OpenAi.API.ChatCompletionOrResponsesRequestSchema,
   OpenAi.API.EmbeddingRequestSchema,
   Gemini.API.GenerateContentRequestSchema,
   Anthropic.API.MessagesRequestSchema,
@@ -62,7 +62,7 @@ export const InteractionRequestSchema = z.union([
 ]);
 
 export const InteractionResponseSchema = z.union([
-  OpenAi.API.ChatCompletionResponseSchema,
+  OpenAi.API.ChatCompletionOrResponsesResponseSchema,
   OpenAi.API.EmbeddingResponseSchema,
   Gemini.API.GenerateContentResponseSchema,
   Anthropic.API.MessagesResponseSchema,
@@ -113,10 +113,10 @@ export const RequestTypeSchema = z.enum(["main", "subagent"]);
 export const SelectInteractionSchema = z.discriminatedUnion("type", [
   BaseSelectInteractionSchema.extend({
     type: z.enum(["openai:chatCompletions"]),
-    request: OpenAi.API.ChatCompletionRequestSchema,
+    request: OpenAi.API.ChatCompletionOrResponsesRequestSchema,
     processedRequest:
-      OpenAi.API.ChatCompletionRequestSchema.nullable().optional(),
-    response: OpenAi.API.ChatCompletionResponseSchema,
+      OpenAi.API.ChatCompletionOrResponsesRequestSchema.nullable().optional(),
+    response: OpenAi.API.ChatCompletionOrResponsesResponseSchema,
     requestType: RequestTypeSchema.optional(),
     /** Resolved prompt name if externalAgentId matches a prompt ID */
     externalAgentIdLabel: z.string().nullable().optional(),

--- a/platform/backend/src/types/llm-providers/openai/api.ts
+++ b/platform/backend/src/types/llm-providers/openai/api.ts
@@ -79,6 +79,27 @@ export const ChatCompletionRequestSchema = z
     `https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L1487`,
   );
 
+// Loose schema for the OpenAI Responses API. The route accepts both
+// ChatCompletions and Responses request shapes via union; the adapter factory
+// dispatches based on whether `input` is present. Detailed validation happens
+// inside the adapter and at the OpenAI SDK call site.
+export const ResponsesRequestSchema = z
+  .object({
+    model: z.string(),
+    input: z.unknown(),
+    instructions: z.string().optional(),
+    previous_response_id: z.string().optional(),
+    store: z.boolean().optional(),
+    tools: z.array(z.unknown()).optional(),
+    stream: z.boolean().nullable().optional(),
+  })
+  .passthrough();
+
+export const ChatCompletionOrResponsesRequestSchema = z.union([
+  ChatCompletionRequestSchema,
+  ResponsesRequestSchema,
+]);
+
 export const ChatCompletionResponseSchema = z
   .object({
     id: z.string(),
@@ -93,6 +114,31 @@ export const ChatCompletionResponseSchema = z
   .describe(
     `https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L248`,
   );
+
+export const ResponsesResponseSchema = z
+  .object({
+    id: z.string(),
+    object: z.literal("response"),
+    created_at: z.number(),
+    model: z.string(),
+    status: z.string(),
+    output: z.array(z.unknown()),
+    usage: z
+      .object({
+        input_tokens: z.number(),
+        output_tokens: z.number(),
+        total_tokens: z.number(),
+        input_tokens_details: z.unknown().optional(),
+        output_tokens_details: z.unknown().optional(),
+      })
+      .optional(),
+  })
+  .passthrough();
+
+export const ChatCompletionOrResponsesResponseSchema = z.union([
+  ChatCompletionResponseSchema,
+  ResponsesResponseSchema,
+]);
 
 // ===== Embeddings API =====
 

--- a/platform/e2e-tests/tests/llm-proxy/tool-invocation.spec.ts
+++ b/platform/e2e-tests/tests/llm-proxy/tool-invocation.spec.ts
@@ -205,6 +205,97 @@ const openaiConfig = makeOpenAiCompatibleToolConfig({
   model: "gpt-4",
 });
 
+const openaiResponsesConfig: ToolInvocationTestConfig = {
+  providerName: "OpenAI Responses",
+  providerSlug: "openai-responses",
+
+  // Auto-detected at the OpenAI adapter layer based on request shape.
+  // Same endpoint as ChatCompletions; the proxy dispatches to the
+  // Responses adapter when `input` is present in the body.
+  endpoint: (agentId) => `/v1/openai/${agentId}/chat/completions`,
+
+  headers: (wiremockStub) => ({
+    Authorization: `Bearer ${wiremockStub}`,
+    "Content-Type": "application/json",
+  }),
+
+  buildRequest: (content, tools) => ({
+    model: "gpt-4.1",
+    input: [
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: content }],
+      },
+    ],
+    tools: tools.map((t) => ({
+      type: "function",
+      name: t.name,
+      description: t.description,
+      parameters: t.parameters,
+    })),
+  }),
+
+  trustedDataPolicyAttributePath: "$.content[0].text",
+
+  assertToolCallBlocked: (response) => {
+    expect(response.output).toBeDefined();
+
+    const functionCalls = response.output.filter(
+      (item: { type: string }) => item.type === "function_call",
+    );
+    expect(functionCalls.length).toBe(0);
+
+    const assistantMessage = response.output.find(
+      (item: { type: string }) => item.type === "message",
+    );
+    expect(assistantMessage).toBeDefined();
+
+    const combinedText = assistantMessage.content
+      .map(
+        (part: { text?: string; refusal?: string }) =>
+          part.text ?? part.refusal,
+      )
+      .filter(Boolean)
+      .join("\n");
+
+    expect(combinedText).toContain("read_file");
+    expect(combinedText).toContain("denied");
+  },
+
+  assertToolCallsPresent: (response, expectedTools) => {
+    expect(response.output).toBeDefined();
+
+    const functionCalls = response.output.filter(
+      (item: { type: string }) => item.type === "function_call",
+    );
+    expect(functionCalls.length).toBe(expectedTools.length);
+
+    for (const toolName of expectedTools) {
+      const found = functionCalls.find(
+        (item: { name: string }) => item.name === toolName,
+      );
+      expect(found).toBeDefined();
+    }
+  },
+
+  assertToolArgument: (response, toolName, argName, matcher) => {
+    const functionCalls = response.output.filter(
+      (item: { type: string }) => item.type === "function_call",
+    );
+    const toolCall = functionCalls.find(
+      (item: { name: string }) => item.name === toolName,
+    );
+    const args = JSON.parse(toolCall.arguments);
+    matcher(args[argName]);
+  },
+
+  findInteractionByContent: (interactions, content) =>
+    interactions.find((interaction) =>
+      interactionContainsContent(interaction, content),
+    ),
+};
+
 const azureResponsesConfig: ToolInvocationTestConfig = {
   providerName: "Azure Responses",
   providerSlug: "azure-responses",
@@ -779,6 +870,7 @@ const testConfigs = [
     (c): c is ToolInvocationTestConfig => c !== null,
   ),
   azureResponsesConfig,
+  openaiResponsesConfig,
 ];
 
 for (const config of testConfigs) {

--- a/platform/helm/e2e-tests/mappings/openai-responses-allows-archestra-untrusted-context 2.json
+++ b/platform/helm/e2e-tests/mappings/openai-responses-allows-archestra-untrusted-context 2.json
@@ -1,0 +1,49 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/openai/v1/responses",
+    "headers": {
+      "Authorization": {
+        "contains": "openai-responses-allows-archestra-untrusted-context"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "id": "resp_openai_archestra_mixed",
+      "object": "response",
+      "created_at": 1234567890,
+      "status": "completed",
+      "model": "gpt-4.1",
+      "output": [
+        {
+          "id": "fc_read",
+          "type": "function_call",
+          "call_id": "call_read",
+          "name": "read_file",
+          "arguments": "{\"file_path\":\"/etc/passwd\"}",
+          "status": "completed"
+        },
+        {
+          "id": "fc_archestra",
+          "type": "function_call",
+          "call_id": "call_archestra",
+          "name": "archestra__whoami",
+          "arguments": "{}",
+          "status": "completed"
+        }
+      ],
+      "usage": {
+        "input_tokens": 100,
+        "input_tokens_details": { "cached_tokens": 0 },
+        "output_tokens": 20,
+        "output_tokens_details": { "reasoning_tokens": 0 },
+        "total_tokens": 120
+      }
+    }
+  }
+}

--- a/platform/helm/e2e-tests/mappings/openai-responses-allows-archestra-untrusted-context.json
+++ b/platform/helm/e2e-tests/mappings/openai-responses-allows-archestra-untrusted-context.json
@@ -1,0 +1,49 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/openai/v1/responses",
+    "headers": {
+      "Authorization": {
+        "contains": "openai-responses-allows-archestra-untrusted-context"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "id": "resp_openai_archestra_mixed",
+      "object": "response",
+      "created_at": 1234567890,
+      "status": "completed",
+      "model": "gpt-4.1",
+      "output": [
+        {
+          "id": "fc_read",
+          "type": "function_call",
+          "call_id": "call_read",
+          "name": "read_file",
+          "arguments": "{\"file_path\":\"/etc/passwd\"}",
+          "status": "completed"
+        },
+        {
+          "id": "fc_archestra",
+          "type": "function_call",
+          "call_id": "call_archestra",
+          "name": "archestra__whoami",
+          "arguments": "{}",
+          "status": "completed"
+        }
+      ],
+      "usage": {
+        "input_tokens": 100,
+        "input_tokens_details": { "cached_tokens": 0 },
+        "output_tokens": 20,
+        "output_tokens_details": { "reasoning_tokens": 0 },
+        "total_tokens": 120
+      }
+    }
+  }
+}

--- a/platform/helm/e2e-tests/mappings/openai-responses-allows-regular-after-archestra 2.json
+++ b/platform/helm/e2e-tests/mappings/openai-responses-allows-regular-after-archestra 2.json
@@ -1,0 +1,49 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/openai/v1/responses",
+    "headers": {
+      "Authorization": {
+        "contains": "openai-responses-allows-regular-after-archestra"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "id": "resp_openai_archestra_sequence",
+      "object": "response",
+      "created_at": 1234567890,
+      "status": "completed",
+      "model": "gpt-4.1",
+      "output": [
+        {
+          "id": "fc_archestra",
+          "type": "function_call",
+          "call_id": "call_archestra",
+          "name": "archestra__whoami",
+          "arguments": "{}",
+          "status": "completed"
+        },
+        {
+          "id": "fc_regular",
+          "type": "function_call",
+          "call_id": "call_regular",
+          "name": "read_file",
+          "arguments": "{\"file_path\":\"/tmp/test\"}",
+          "status": "completed"
+        }
+      ],
+      "usage": {
+        "input_tokens": 100,
+        "input_tokens_details": { "cached_tokens": 0 },
+        "output_tokens": 20,
+        "output_tokens_details": { "reasoning_tokens": 0 },
+        "total_tokens": 120
+      }
+    }
+  }
+}

--- a/platform/helm/e2e-tests/mappings/openai-responses-allows-regular-after-archestra.json
+++ b/platform/helm/e2e-tests/mappings/openai-responses-allows-regular-after-archestra.json
@@ -1,0 +1,49 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/openai/v1/responses",
+    "headers": {
+      "Authorization": {
+        "contains": "openai-responses-allows-regular-after-archestra"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "id": "resp_openai_archestra_sequence",
+      "object": "response",
+      "created_at": 1234567890,
+      "status": "completed",
+      "model": "gpt-4.1",
+      "output": [
+        {
+          "id": "fc_archestra",
+          "type": "function_call",
+          "call_id": "call_archestra",
+          "name": "archestra__whoami",
+          "arguments": "{}",
+          "status": "completed"
+        },
+        {
+          "id": "fc_regular",
+          "type": "function_call",
+          "call_id": "call_regular",
+          "name": "read_file",
+          "arguments": "{\"file_path\":\"/tmp/test\"}",
+          "status": "completed"
+        }
+      ],
+      "usage": {
+        "input_tokens": 100,
+        "input_tokens_details": { "cached_tokens": 0 },
+        "output_tokens": 20,
+        "output_tokens_details": { "reasoning_tokens": 0 },
+        "total_tokens": 120
+      }
+    }
+  }
+}

--- a/platform/helm/e2e-tests/mappings/openai-responses-blocks-tool-untrusted-data 2.json
+++ b/platform/helm/e2e-tests/mappings/openai-responses-blocks-tool-untrusted-data 2.json
@@ -1,0 +1,41 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/openai/v1/responses",
+    "headers": {
+      "Authorization": {
+        "contains": "openai-responses-blocks-tool-untrusted-data"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "id": "resp_openai_tool_invocation_blocked",
+      "object": "response",
+      "created_at": 1234567890,
+      "status": "completed",
+      "model": "gpt-4.1",
+      "output": [
+        {
+          "id": "fc_test_123",
+          "type": "function_call",
+          "call_id": "call_test_123",
+          "name": "e2e_read_file_openai-responses",
+          "arguments": "{\"file_path\":\"/etc/passwd\"}",
+          "status": "completed"
+        }
+      ],
+      "usage": {
+        "input_tokens": 100,
+        "input_tokens_details": { "cached_tokens": 0 },
+        "output_tokens": 20,
+        "output_tokens_details": { "reasoning_tokens": 0 },
+        "total_tokens": 120
+      }
+    }
+  }
+}

--- a/platform/helm/e2e-tests/mappings/openai-responses-blocks-tool-untrusted-data.json
+++ b/platform/helm/e2e-tests/mappings/openai-responses-blocks-tool-untrusted-data.json
@@ -1,0 +1,41 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/openai/v1/responses",
+    "headers": {
+      "Authorization": {
+        "contains": "openai-responses-blocks-tool-untrusted-data"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "id": "resp_openai_tool_invocation_blocked",
+      "object": "response",
+      "created_at": 1234567890,
+      "status": "completed",
+      "model": "gpt-4.1",
+      "output": [
+        {
+          "id": "fc_test_123",
+          "type": "function_call",
+          "call_id": "call_test_123",
+          "name": "e2e_read_file_openai-responses",
+          "arguments": "{\"file_path\":\"/etc/passwd\"}",
+          "status": "completed"
+        }
+      ],
+      "usage": {
+        "input_tokens": 100,
+        "input_tokens_details": { "cached_tokens": 0 },
+        "output_tokens": 20,
+        "output_tokens_details": { "reasoning_tokens": 0 },
+        "total_tokens": 120
+      }
+    }
+  }
+}

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -21969,9 +21969,42 @@ export type GetInteractionsResponses = {
             sessionId: string | null;
             sessionSource: string | null;
             source?: 'api' | 'chat' | 'chatops:slack' | 'chatops:ms-teams' | 'email' | 'schedule-trigger' | 'knowledge:embedding' | 'knowledge:reranker' | 'knowledge:query-expansion';
-            request: XaiChatCompletionRequest;
-            processedRequest?: XaiChatCompletionRequest | null;
-            response: OpenAiChatCompletionResponse;
+            request: XaiChatCompletionRequest | {
+                model: string;
+                input: unknown;
+                instructions?: string;
+                previous_response_id?: string;
+                store?: boolean;
+                tools?: Array<unknown>;
+                stream?: boolean | null;
+                [key: string]: unknown;
+            };
+            processedRequest?: XaiChatCompletionRequest | {
+                model: string;
+                input: unknown;
+                instructions?: string;
+                previous_response_id?: string;
+                store?: boolean;
+                tools?: Array<unknown>;
+                stream?: boolean | null;
+                [key: string]: unknown;
+            } | null;
+            response: OpenAiChatCompletionResponse | {
+                id: string;
+                object: 'response';
+                created_at: number;
+                model: string;
+                status: string;
+                output: Array<unknown>;
+                usage?: {
+                    input_tokens: number;
+                    output_tokens: number;
+                    total_tokens: number;
+                    input_tokens_details?: unknown;
+                    output_tokens_details?: unknown;
+                };
+                [key: string]: unknown;
+            };
             dualLlmAnalyses?: Array<{
                 toolCallId: string;
                 conversations: Array<{
@@ -23734,9 +23767,42 @@ export type GetInteractionResponses = {
         sessionId: string | null;
         sessionSource: string | null;
         source?: 'api' | 'chat' | 'chatops:slack' | 'chatops:ms-teams' | 'email' | 'schedule-trigger' | 'knowledge:embedding' | 'knowledge:reranker' | 'knowledge:query-expansion';
-        request: XaiChatCompletionRequest;
-        processedRequest?: XaiChatCompletionRequest | null;
-        response: OpenAiChatCompletionResponse;
+        request: XaiChatCompletionRequest | {
+            model: string;
+            input: unknown;
+            instructions?: string;
+            previous_response_id?: string;
+            store?: boolean;
+            tools?: Array<unknown>;
+            stream?: boolean | null;
+            [key: string]: unknown;
+        };
+        processedRequest?: XaiChatCompletionRequest | {
+            model: string;
+            input: unknown;
+            instructions?: string;
+            previous_response_id?: string;
+            store?: boolean;
+            tools?: Array<unknown>;
+            stream?: boolean | null;
+            [key: string]: unknown;
+        } | null;
+        response: OpenAiChatCompletionResponse | {
+            id: string;
+            object: 'response';
+            created_at: number;
+            model: string;
+            status: string;
+            output: Array<unknown>;
+            usage?: {
+                input_tokens: number;
+                output_tokens: number;
+                total_tokens: number;
+                input_tokens_details?: unknown;
+                output_tokens_details?: unknown;
+            };
+            [key: string]: unknown;
+        };
         dualLlmAnalyses?: Array<{
             toolCallId: string;
             conversations: Array<{
@@ -34190,7 +34256,16 @@ export type OllamaChatCompletionsWithAgentResponses = {
 export type OllamaChatCompletionsWithAgentResponse = OllamaChatCompletionsWithAgentResponses[keyof OllamaChatCompletionsWithAgentResponses];
 
 export type OpenAiChatCompletionsWithDefaultAgentData = {
-    body: XaiChatCompletionRequestInput;
+    body: XaiChatCompletionRequestInput | {
+        model: string;
+        input: unknown;
+        instructions?: string;
+        previous_response_id?: string;
+        store?: boolean;
+        tools?: Array<unknown>;
+        stream?: boolean | null;
+        [key: string]: unknown;
+    };
     headers: {
         /**
          * The user agent of the client
@@ -34269,13 +34344,37 @@ export type OpenAiChatCompletionsWithDefaultAgentResponses = {
     /**
      * Default Response
      */
-    200: OpenAiChatCompletionResponse;
+    200: OpenAiChatCompletionResponse | {
+        id: string;
+        object: 'response';
+        created_at: number;
+        model: string;
+        status: string;
+        output: Array<unknown>;
+        usage?: {
+            input_tokens: number;
+            output_tokens: number;
+            total_tokens: number;
+            input_tokens_details?: unknown;
+            output_tokens_details?: unknown;
+        };
+        [key: string]: unknown;
+    };
 };
 
 export type OpenAiChatCompletionsWithDefaultAgentResponse = OpenAiChatCompletionsWithDefaultAgentResponses[keyof OpenAiChatCompletionsWithDefaultAgentResponses];
 
 export type OpenAiChatCompletionsWithAgentData = {
-    body: XaiChatCompletionRequestInput;
+    body: XaiChatCompletionRequestInput | {
+        model: string;
+        input: unknown;
+        instructions?: string;
+        previous_response_id?: string;
+        store?: boolean;
+        tools?: Array<unknown>;
+        stream?: boolean | null;
+        [key: string]: unknown;
+    };
     headers: {
         /**
          * The user agent of the client
@@ -34356,7 +34455,22 @@ export type OpenAiChatCompletionsWithAgentResponses = {
     /**
      * Default Response
      */
-    200: OpenAiChatCompletionResponse;
+    200: OpenAiChatCompletionResponse | {
+        id: string;
+        object: 'response';
+        created_at: number;
+        model: string;
+        status: string;
+        output: Array<unknown>;
+        usage?: {
+            input_tokens: number;
+            output_tokens: number;
+            total_tokens: number;
+            input_tokens_details?: unknown;
+            output_tokens_details?: unknown;
+        };
+        [key: string]: unknown;
+    };
 };
 
 export type OpenAiChatCompletionsWithAgentResponse = OpenAiChatCompletionsWithAgentResponses[keyof OpenAiChatCompletionsWithAgentResponses];

--- a/platform/shared/interactions/llmProviders/openai.ts
+++ b/platform/shared/interactions/llmProviders/openai.ts
@@ -2,6 +2,43 @@ import { type archestraApiTypes, parseArchestraToolRefusal } from "../../index";
 import type { PartialUIMessage } from "../types";
 import type { DualLlmAnalysis, Interaction, InteractionUtils } from "./common";
 
+type RequestMessage =
+  archestraApiTypes.OpenAiChatCompletionRequest["messages"][number];
+type ResponseChoice =
+  archestraApiTypes.OpenAiChatCompletionResponse["choices"][number];
+
+// Responses API item shapes (runtime only — these requests share the
+// "openai:chatCompletions" interaction type but carry input/output instead
+// of messages/choices).
+type ResponsesInputItem =
+  | { type: "message"; role: string; content: unknown }
+  | {
+      type: "function_call";
+      id?: string;
+      call_id: string;
+      name: string;
+      arguments: string;
+    }
+  | { type: "function_call_output"; call_id: string; output: string };
+
+type ResponsesOutputTextPart = { type: "output_text"; text: string };
+type ResponsesOutputRefusalPart = { type: "refusal"; refusal: string };
+type ResponsesOutputItem =
+  | {
+      type: "message";
+      id: string;
+      role: "assistant";
+      content: Array<ResponsesOutputTextPart | ResponsesOutputRefusalPart>;
+    }
+  | {
+      type: "function_call";
+      id: string;
+      call_id: string;
+      name: string;
+      arguments: string;
+      status?: string;
+    };
+
 class OpenAiChatCompletionInteraction implements InteractionUtils {
   private request: archestraApiTypes.OpenAiChatCompletionRequest;
   private response: archestraApiTypes.OpenAiChatCompletionResponse;
@@ -16,32 +53,41 @@ class OpenAiChatCompletionInteraction implements InteractionUtils {
   }
 
   isLastMessageToolCall(): boolean {
-    const messages = this.request.messages;
-
-    if (messages.length === 0) {
-      return false;
+    if (this.isResponsesApi()) {
+      const input = this.responsesInput();
+      if (input.length === 0) return false;
+      return input[input.length - 1].type === "function_call_output";
     }
-
-    const lastMessage = messages[messages.length - 1];
-    return lastMessage.role === "tool";
+    const messages = this.requestMessages;
+    if (messages.length === 0) return false;
+    return messages[messages.length - 1].role === "tool";
   }
 
   getLastToolCallId(): string | null {
-    const messages = this.request.messages;
-    if (messages.length === 0) {
+    if (this.isResponsesApi()) {
+      const input = this.responsesInput();
+      const last = input[input.length - 1];
+      if (last?.type === "function_call_output") return last.call_id;
       return null;
     }
-
+    const messages = this.requestMessages;
+    if (messages.length === 0) return null;
     const lastMessage = messages[messages.length - 1];
-    if (lastMessage.role === "tool") {
-      return lastMessage.tool_call_id;
-    }
+    if (lastMessage.role === "tool") return lastMessage.tool_call_id;
     return null;
   }
 
   getToolNamesUsed(): string[] {
     const toolsUsed = new Set<string>();
-    for (const message of this.request.messages) {
+    if (this.isResponsesApi()) {
+      for (const item of this.responsesInput()) {
+        if (item.type === "function_call") {
+          toolsUsed.add(item.name);
+        }
+      }
+      return Array.from(toolsUsed);
+    }
+    for (const message of this.requestMessages) {
       if (message.role === "assistant" && message.tool_calls) {
         for (const toolCall of message.tool_calls) {
           if ("function" in toolCall) {
@@ -55,25 +101,33 @@ class OpenAiChatCompletionInteraction implements InteractionUtils {
 
   getToolNamesRefused(): string[] {
     const toolsRefused = new Set<string>();
-    for (const message of this.request.messages) {
+    if (this.isResponsesApi()) {
+      for (const item of this.responsesOutput()) {
+        if (item.type === "message") {
+          for (const part of item.content) {
+            if (part.type === "refusal") {
+              const toolName = parseArchestraToolRefusal(part.refusal).toolName;
+              if (toolName) toolsRefused.add(toolName);
+            }
+          }
+        }
+      }
+      return Array.from(toolsRefused);
+    }
+    for (const message of this.requestMessages) {
       if (message.role === "assistant") {
         const refusal = message.refusal;
         if (refusal && refusal.length > 0) {
           const toolName = parseArchestraToolRefusal(refusal).toolName;
-          if (toolName) {
-            toolsRefused.add(toolName);
-          }
+          if (toolName) toolsRefused.add(toolName);
         }
       }
     }
-
-    for (const message of this.response.choices) {
+    for (const message of this.responseChoices) {
       const refusal = message.message.refusal;
       if (refusal && refusal.length > 0) {
         const toolName = parseArchestraToolRefusal(refusal).toolName;
-        if (toolName) {
-          toolsRefused.add(toolName);
-        }
+        if (toolName) toolsRefused.add(toolName);
       }
     }
     return Array.from(toolsRefused);
@@ -81,9 +135,15 @@ class OpenAiChatCompletionInteraction implements InteractionUtils {
 
   getToolNamesRequested(): string[] {
     const toolsRequested = new Set<string>();
-
-    // Check the response for tool calls (tools that LLM wants to execute)
-    for (const choice of this.response.choices) {
+    if (this.isResponsesApi()) {
+      for (const item of this.responsesOutput()) {
+        if (item.type === "function_call") {
+          toolsRequested.add(item.name);
+        }
+      }
+      return Array.from(toolsRequested);
+    }
+    for (const choice of this.responseChoices) {
       if (Array.isArray(choice.message.tool_calls)) {
         for (const toolCall of choice.message.tool_calls) {
           if ("function" in toolCall) {
@@ -92,52 +152,91 @@ class OpenAiChatCompletionInteraction implements InteractionUtils {
         }
       }
     }
-
     return Array.from(toolsRequested);
   }
 
   getLastUserMessage(): string {
-    const reversedMessages = [...this.request.messages].reverse();
+    if (this.isResponsesApi()) {
+      const raw = (this.request as unknown as Record<string, unknown>).input;
+      if (typeof raw === "string") return raw;
+      const input = this.responsesInput();
+      for (let i = input.length - 1; i >= 0; i--) {
+        const item = input[i];
+        if (item.type === "message" && item.role === "user") {
+          return extractResponsesInputText(item.content);
+        }
+      }
+      return "";
+    }
+    const reversedMessages = [...this.requestMessages].reverse();
     for (const message of reversedMessages) {
-      if (message.role !== "user") {
-        continue;
-      }
-      if (typeof message.content === "string") {
-        return message.content;
-      }
-      if (message.content?.[0]?.type === "text") {
-        return message.content[0].text;
-      }
+      if (message.role !== "user") continue;
+      if (typeof message.content === "string") return message.content;
+      if (message.content?.[0]?.type === "text") return message.content[0].text;
     }
     return "";
   }
 
   getLastAssistantResponse(): string {
-    return this.response.choices[0]?.message?.content ?? "";
+    if (this.isResponsesApi()) {
+      for (let i = this.responsesOutput().length - 1; i >= 0; i--) {
+        const item = this.responsesOutput()[i];
+        if (item.type === "message") {
+          for (const part of item.content) {
+            if (part.type === "output_text") return part.text;
+          }
+        }
+      }
+      return "";
+    }
+    return this.responseChoices[0]?.message?.content ?? "";
   }
 
   getToolRefusedCount(): number {
     let count = 0;
-    for (const message of this.request.messages) {
-      if (message.role === "assistant") {
-        const refusal = message.refusal;
-        if (refusal && refusal.length > 0) {
-          count++;
+    if (this.isResponsesApi()) {
+      for (const item of this.responsesOutput()) {
+        if (item.type === "message") {
+          for (const part of item.content) {
+            if (part.type === "refusal") count++;
+          }
         }
       }
+      return count;
     }
-    for (const message of this.response.choices) {
-      const refusal = message.message.refusal;
-      if (refusal && refusal.length > 0) {
-        count++;
+    for (const message of this.requestMessages) {
+      if (message.role === "assistant") {
+        const refusal = message.refusal;
+        if (refusal && refusal.length > 0) count++;
       }
+    }
+    for (const message of this.responseChoices) {
+      const refusal = message.message.refusal;
+      if (refusal && refusal.length > 0) count++;
     }
     return count;
   }
 
+  mapToUiMessages(dualLlmAnalyses?: DualLlmAnalysis[]): PartialUIMessage[] {
+    if (this.isResponsesApi()) {
+      return [
+        ...this.mapResponsesInputToUiMessages(dualLlmAnalyses),
+        ...this.mapResponsesOutputToUiMessages(),
+      ];
+    }
+    return [
+      ...this.mapRequestToUiMessages(dualLlmAnalyses),
+      ...this.mapResponseToUiMessages(),
+    ];
+  }
+
+  // ==========================================================================
+  // PRIVATE — Chat Completions rendering
+  // ==========================================================================
+
   private mapToUiMessage(
     message:
-      | archestraApiTypes.OpenAiChatCompletionRequest["messages"][number]
+      | RequestMessage
       | archestraApiTypes.OpenAiChatCompletionResponse["choices"][number]["message"],
   ): PartialUIMessage {
     const parts: PartialUIMessage["parts"] = [];
@@ -148,9 +247,6 @@ class OpenAiChatCompletionInteraction implements InteractionUtils {
       const refusal = message.refusal;
 
       if (Array.isArray(toolCalls)) {
-        // Handle assistant messages with tool calls
-
-        // Add text content if present
         if (typeof content === "string" && content) {
           parts.push({ type: "text", text: content });
         } else if (Array.isArray(content)) {
@@ -162,8 +258,6 @@ class OpenAiChatCompletionInteraction implements InteractionUtils {
             }
           }
         }
-
-        // Add tool invocation parts
         for (const toolCall of toolCalls) {
           if (toolCall.type === "function") {
             parts.push({
@@ -184,10 +278,8 @@ class OpenAiChatCompletionInteraction implements InteractionUtils {
           }
         }
       } else if (refusal) {
-        // Push as text - parsePolicyDenied in message-thread will handle policy denials
         parts.push({ type: "text", text: refusal });
       } else {
-        // Plain text assistant message (no tool calls, no refusal)
         if (typeof content === "string" && content) {
           parts.push({ type: "text", text: content });
         } else if (Array.isArray(content)) {
@@ -201,13 +293,11 @@ class OpenAiChatCompletionInteraction implements InteractionUtils {
         }
       }
     } else if (message.role === "tool") {
-      // Handle tool response messages
       const toolContent = message.content;
       const toolCallId = message.tool_call_id;
 
-      // Resolve the tool name from the corresponding assistant tool call
       let resolvedToolName = "tool-result";
-      for (const m of this.request.messages) {
+      for (const m of this.requestMessages) {
         if ("tool_calls" in m && Array.isArray(m.tool_calls)) {
           const tc = m.tool_calls.find((t) => t.id === toolCallId);
           if (tc) {
@@ -222,7 +312,6 @@ class OpenAiChatCompletionInteraction implements InteractionUtils {
         }
       }
 
-      // Parse the tool output
       let output: unknown;
       try {
         output =
@@ -242,7 +331,6 @@ class OpenAiChatCompletionInteraction implements InteractionUtils {
         output,
       });
     } else {
-      // Handle regular content
       if (typeof content === "string") {
         parts.push({ type: "text", text: content });
       } else if (Array.isArray(content)) {
@@ -256,12 +344,10 @@ class OpenAiChatCompletionInteraction implements InteractionUtils {
               url: part.image_url.url,
             });
           }
-          // Note: input_audio and file types from API would need additional handling
         }
       }
     }
 
-    // Map role to UIMessage role (only system, user, assistant are allowed)
     const openAiRoleToUIMessageRoleMap: Record<
       archestraApiTypes.OpenAiChatCompletionRequest["messages"][number]["role"],
       PartialUIMessage["role"]
@@ -283,26 +369,19 @@ class OpenAiChatCompletionInteraction implements InteractionUtils {
   private mapRequestToUiMessages(
     dualLlmAnalyses?: DualLlmAnalysis[],
   ): PartialUIMessage[] {
-    const messages = this.request.messages;
+    const messages = this.requestMessages;
     const uiMessages: PartialUIMessage[] = [];
 
     for (let i = 0; i < messages.length; i++) {
       const msg = messages[i];
-
-      // Skip tool messages - they'll be merged with their assistant message
-      if (msg.role === "tool") {
-        continue;
-      }
+      if (msg.role === "tool") continue;
 
       const uiMessage = this.mapToUiMessage(msg);
 
-      // If this is an assistant message with tool_calls, look ahead for tool results
       if (msg.role === "assistant" && "tool_calls" in msg && msg.tool_calls) {
         const toolCallParts: PartialUIMessage["parts"] = [...uiMessage.parts];
 
-        // For each tool call, find its corresponding tool result
         for (const toolCall of msg.tool_calls) {
-          // Find the tool result message
           const toolResultMsg = messages
             .slice(i + 1)
             .find(
@@ -313,17 +392,14 @@ class OpenAiChatCompletionInteraction implements InteractionUtils {
             );
 
           if (toolResultMsg && toolResultMsg.role === "tool") {
-            // Map the tool result to a UI part
             const toolResultUiMsg = this.mapToUiMessage(toolResultMsg);
             toolCallParts.push(...toolResultUiMsg.parts);
 
-            // Check if there's a dual LLM result for this tool call
             const dualLlmResultForTool = dualLlmAnalyses?.find(
               (result) => result.toolCallId === toolCall.id,
             );
-
             if (dualLlmResultForTool) {
-              const dualLlmPart = {
+              toolCallParts.push({
                 type: "dual-llm-analysis" as const,
                 toolCallId: dualLlmResultForTool.toolCallId,
                 safeResult: dualLlmResultForTool.result,
@@ -333,16 +409,12 @@ class OpenAiChatCompletionInteraction implements InteractionUtils {
                       content: string | unknown;
                     }>)
                   : [],
-              };
-              toolCallParts.push(dualLlmPart);
+              });
             }
           }
         }
 
-        uiMessages.push({
-          ...uiMessage,
-          parts: toolCallParts,
-        });
+        uiMessages.push({ ...uiMessage, parts: toolCallParts });
       } else {
         uiMessages.push(uiMessage);
       }
@@ -352,17 +424,233 @@ class OpenAiChatCompletionInteraction implements InteractionUtils {
   }
 
   private mapResponseToUiMessages(): PartialUIMessage[] {
-    return this.response.choices.map((choice) =>
+    return this.responseChoices.map((choice) =>
       this.mapToUiMessage(choice.message),
     );
   }
 
-  mapToUiMessages(dualLlmAnalyses?: DualLlmAnalysis[]): PartialUIMessage[] {
-    return [
-      ...this.mapRequestToUiMessages(dualLlmAnalyses),
-      ...this.mapResponseToUiMessages(),
-    ];
+  // ==========================================================================
+  // PRIVATE — Responses API rendering
+  // ==========================================================================
+
+  private mapResponsesInputToUiMessages(
+    dualLlmAnalyses?: DualLlmAnalysis[],
+  ): PartialUIMessage[] {
+    const input = this.responsesInput();
+    const uiMessages: PartialUIMessage[] = [];
+
+    // Build a call_id → name map for resolving tool result names
+    const callIdToName = new Map<string, string>(
+      input.flatMap((item) =>
+        item.type === "function_call" ? [[item.call_id, item.name]] : [],
+      ),
+    );
+
+    for (let i = 0; i < input.length; i++) {
+      const item = input[i];
+
+      if (item.type === "message") {
+        const role =
+          item.role === "assistant"
+            ? "assistant"
+            : item.role === "user"
+              ? "user"
+              : "system";
+        const text = extractResponsesInputText(item.content);
+        uiMessages.push({ role, parts: [{ type: "text", text }] });
+        continue;
+      }
+
+      if (item.type === "function_call") {
+        let args: unknown = {};
+        try {
+          args = JSON.parse(item.arguments);
+        } catch {
+          args = item.arguments;
+        }
+
+        const callId = item.call_id;
+        const parts: PartialUIMessage["parts"] = [
+          {
+            type: "dynamic-tool",
+            toolName: item.name,
+            toolCallId: callId,
+            state: "input-available",
+            input: args,
+          },
+        ];
+
+        // Look ahead for the matching function_call_output
+        const outputItem = input
+          .slice(i + 1)
+          .find(
+            (
+              m,
+            ): m is Extract<
+              ResponsesInputItem,
+              { type: "function_call_output" }
+            > => m.type === "function_call_output" && m.call_id === callId,
+          );
+
+        if (outputItem) {
+          let output: unknown;
+          try {
+            output = JSON.parse(outputItem.output);
+          } catch {
+            output = outputItem.output;
+          }
+          parts.push({
+            type: "dynamic-tool",
+            toolName: item.name,
+            toolCallId: callId,
+            state: "output-available",
+            input: args,
+            output,
+          });
+
+          const dualLlm = dualLlmAnalyses?.find((r) => r.toolCallId === callId);
+          if (dualLlm) {
+            parts.push({
+              type: "dual-llm-analysis",
+              toolCallId: dualLlm.toolCallId,
+              safeResult: dualLlm.result,
+              conversations: Array.isArray(dualLlm.conversations)
+                ? (dualLlm.conversations as Array<{
+                    role: "user" | "assistant";
+                    content: string | unknown;
+                  }>)
+                : [],
+            });
+          }
+        }
+
+        uiMessages.push({ role: "assistant", parts });
+        continue;
+      }
+
+      // function_call_output without a preceding function_call (edge case)
+      if (item.type === "function_call_output") {
+        const toolName = callIdToName.get(item.call_id) ?? "tool-result";
+        let output: unknown;
+        try {
+          output = JSON.parse(item.output);
+        } catch {
+          output = item.output;
+        }
+        uiMessages.push({
+          role: "assistant",
+          parts: [
+            {
+              type: "dynamic-tool",
+              toolName,
+              toolCallId: item.call_id,
+              state: "output-available",
+              input: {},
+              output,
+            },
+          ],
+        });
+      }
+    }
+
+    return uiMessages;
   }
+
+  private mapResponsesOutputToUiMessages(): PartialUIMessage[] {
+    return this.responsesOutput().flatMap((item): PartialUIMessage[] => {
+      if (item.type === "message") {
+        const parts: PartialUIMessage["parts"] = [];
+        for (const part of item.content) {
+          if (part.type === "output_text") {
+            parts.push({ type: "text", text: part.text });
+          } else if (part.type === "refusal") {
+            parts.push({ type: "text", text: part.refusal });
+          }
+        }
+        return parts.length > 0 ? [{ role: "assistant", parts }] : [];
+      }
+      if (item.type === "function_call") {
+        let args: unknown = {};
+        try {
+          args = JSON.parse(item.arguments);
+        } catch {
+          args = item.arguments;
+        }
+        return [
+          {
+            role: "assistant",
+            parts: [
+              {
+                type: "dynamic-tool",
+                toolName: item.name,
+                toolCallId: item.call_id,
+                state: "input-available",
+                input: args,
+              },
+            ],
+          },
+        ];
+      }
+      return [];
+    });
+  }
+
+  // ==========================================================================
+  // PRIVATE — shape detection + normalized accessors
+  // ==========================================================================
+
+  private isResponsesApi(): boolean {
+    return (
+      "input" in (this.request as unknown as Record<string, unknown>) &&
+      !("messages" in (this.request as unknown as Record<string, unknown>))
+    );
+  }
+
+  private get requestMessages(): RequestMessage[] {
+    return (
+      (this.request as unknown as { messages?: RequestMessage[] }).messages ??
+      []
+    );
+  }
+
+  private get responseChoices(): ResponseChoice[] {
+    return (
+      (this.response as unknown as { choices?: ResponseChoice[] }).choices ?? []
+    );
+  }
+
+  private responsesInput(): ResponsesInputItem[] {
+    const raw = (this.request as unknown as Record<string, unknown>).input;
+    if (typeof raw === "string") {
+      return [{ type: "message", role: "user", content: raw }];
+    }
+    if (Array.isArray(raw)) return raw as ResponsesInputItem[];
+    return [];
+  }
+
+  private responsesOutput(): ResponsesOutputItem[] {
+    const raw = (this.response as unknown as Record<string, unknown>).output;
+    if (Array.isArray(raw)) return raw as ResponsesOutputItem[];
+    return [];
+  }
+}
+
+function extractResponsesInputText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .flatMap((part) => {
+      if (!part || typeof part !== "object" || !("type" in part)) return [];
+      if (
+        (part.type === "input_text" || part.type === "output_text") &&
+        "text" in part &&
+        typeof part.text === "string"
+      ) {
+        return [part.text];
+      }
+      return [];
+    })
+    .join("\n");
 }
 
 export default OpenAiChatCompletionInteraction;


### PR DESCRIPTION
## Change Log

### Backend
- `types/llm-providers/openai/api.ts` - add `ResponsesRequestSchema`, `ResponsesResponseSchema`, and union schemas
- `types/interaction.ts` — widen interaction request/response schemas to include Responses API shapes
- `routes/proxy/routes/openai.ts` — accept `ChatCompletionOrResponsesRequestSchema` on both OpenAI routes
- `routes/proxy/adapters/openai-responses.ts` — new `OpenAIResponsesRequestAdapter`, `OpenAIResponsesResponseAdapter`, `OpenAIResponsesStreamAdapter`; fix `toCommonMessages` to populate `toolCalls` on `function_call_output` items for trusted-data evaluation
- `routes/proxy/adapters/openai.ts` — wire Responses API adapters into the factory; dispatch `openaiClient.responses.create()` for Responses-shaped requests
- `routes/proxy/llm-proxy-handler.ts` — capture refusal response for interaction logging in the streaming path

### Shared
- `shared/interactions/llmProviders/openai.ts` — handle Responses API shape in log detail rendering (`request.messages` undefined guard, dedicated `input`/`output` render paths)
- `shared/hey-api/clients/api/types.gen.ts` — regenerated

### Tests
- `adapters/openai-responses.test.ts` — 12 unit tests (request, response, stream adapters; guardrail path; factory dispatch)
- `llm-proxy-handler.test.ts`, `routes/openai.test.ts`, `models/interaction.test.ts` — updated with Responses API fixtures
- `e2e-tests/tests/llm-proxy/tool-invocation.spec.ts` — `openaiResponsesConfig` covering allow/block/archestra-trusted cases
- `helm/e2e-tests/mappings/` — 3 WireMock mappings for the above e2e cases

### Docs
- `docs/pages/platform-supported-llm-providers.md` — Responses API marked supported under OpenAI

## Demo video

https://github.com/user-attachments/assets/1343cde2-d521-4db4-a2cc-d4ad867ed845



Ref #720

cc @Konstantinov-Innokentii @joeyorlando