### PR TITLE
ci(contrib): re-attribute mjkvyjn5wn-ctrl

### DIFF
--- a/EXTERNAL_CONTRIBUTORS.md
+++ b/EXTERNAL_CONTRIBUTORS.md
@@ -91,7 +91,6 @@ To unblock real contributors without re-opening the floodgates, sign in via GitH
 - @gentlementlegen
 - @janfaiengineer
 - @Aqil-Ahmad
-- @mjkvyjn5wn-ctrl
 - @xenohunter
 - @mohitjeswani01
 - @reverb256
@@ -141,3 +140,4 @@ To unblock real contributors without re-opening the floodgates, sign in via GitH
 - @AbdellahBouarguan
 - @rajanarahul93
 - @WarmSpark
+- @mjkvyjn5wn-ctrl


### PR DESCRIPTION
Re-add @mjkvyjn5wn-ctrl with their own author email so GitHub recognizes them as a contributor. Original entry was committed by the CI bot.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>