### PR TITLE
fix: hide connection page

### DIFF
--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -410,15 +410,14 @@ export function AppSidebar() {
   const formattedStarCount = starCount ?? "";
   const permissionMap = usePermissionMap(requiredPagePermissionsMap);
   const appIconLogo = useAppIconLogo();
-  // Connect page requires at least one of these (OR logic)
-  const { data: canReadAgent } = useHasPermissions({ agent: ["read"] });
+  // Connect page requires both MCP gateway and LLM proxy read permissions
   const { data: canReadLlmProxy } = useHasPermissions({
     llmProxy: ["read"],
   });
   const { data: canReadMcpGateway } = useHasPermissions({
     mcpGateway: ["read"],
   });
-  const showConnect = canReadAgent || canReadLlmProxy || canReadMcpGateway;
+  const showConnect = canReadMcpGateway && canReadLlmProxy;
 
   // Filter nav groups based on connect permissions
   const filteredNavGroups = React.useMemo(() => {


### PR DESCRIPTION
Backport of #4151 (commit edde97b) to main.

## Summary
- Hides the connection page in the sidebar.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>