### PR TITLE
fix: Preserve narrower-scoped MCP credentials when widening agent scope

### DIFF
--- a/platform/frontend/src/components/agent-tools-editor.tsx
+++ b/platform/frontend/src/components/agent-tools-editor.tsx
@@ -137,11 +137,10 @@ const AgentToolsEditorContent = forwardRef<
   // Fetch catalog items (MCP servers in registry)
   const { data: catalogItems = [], isPending } = useInternalMcpCatalog();
 
-  // Fetch all credentials grouped by catalog (for default credential on toggle)
-  const allCredentials = useMcpServersGroupedByCatalog({
-    assignmentScope,
-    assignmentTeamIds,
-  });
+  // Fetch all credentials grouped by catalog (for default credential on toggle).
+  // Show every credential regardless of agent scope — the user picks what to bind,
+  // and runtime resolution determines accessibility per invoking user.
+  const allCredentials = useMcpServersGroupedByCatalog();
 
   // Fetch tool counts for all catalog items to enable sorting
   const toolCountQueries = useQueries({
@@ -686,11 +685,9 @@ function McpServerPill({
     catalogItem.id,
   );
 
-  // Fetch available credentials for this catalog
+  // Fetch available credentials for this catalog (no scope filter — see parent)
   const credentials = useMcpServersGroupedByCatalog({
     catalogId: catalogItem.id,
-    assignmentScope,
-    assignmentTeamIds,
   });
   const mcpServers = credentials?.[catalogItem.id] ?? [];
   const prefersEnterpriseManaged = catalogItem.enterpriseManagedConfig != null;


### PR DESCRIPTION
## Summary

- Stop filtering the agent tools editor's credential picker by agent scope.
- Fixes silent loss of team-scoped credentials when an agent is widened (e.g. personal → org) and then any further tool change is saved.

## Repro before fix

1. Personal agent, tool bound to a team-scoped MCP credential.
2. Switch agent scope to org → save.
3. Open dialog again, change anything tool-related → save.
4. Original team-scoped credential is silently rebound to an org-scoped one.

Root cause: the credential picker was scoped via `useMcpServersGroupedByCatalog({ assignmentScope, assignmentTeamIds })`. After widening, the originally-bound credential dropped out of the list, triggering an on-mount auto-swap effect that registered pending changes and rebound the tool on the next save.

## Test plan

- [ ] Repro the steps above; confirm the team-scoped credential survives the scope change and any subsequent save.
- [ ] Org-scoped agent still shows personal/team/org credentials in the picker.
- [ ] Picking a narrower credential explicitly continues to work.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>