### PR TITLE
chore: capture raw provider errors as exceptions

### DIFF
--- a/platform/backend/src/observability/sentry.ts
+++ b/platform/backend/src/observability/sentry.ts
@@ -37,7 +37,10 @@ export function captureRawProviderErrorInSentry(params: {
   errorType: string | undefined;
   rawErrorJson: string;
 }): void {
-  Sentry.captureMessage("[ChatErrorMapper] rawErrorJson provider error", {
+  const error = new Error(params.errorMessage);
+  error.name = "RawProviderError";
+
+  Sentry.captureException(error, {
     level: "error",
     fingerprint: [
       "chat-provider-error-raw-error-json",

--- a/platform/backend/src/routes/chat/errors.test.ts
+++ b/platform/backend/src/routes/chat/errors.test.ts
@@ -11,10 +11,10 @@ import {
 import { vi } from "vitest";
 import { beforeEach, describe, expect, it } from "@/test";
 
-const mockSentryCaptureMessage = vi.hoisted(() => vi.fn());
+const mockSentryCaptureException = vi.hoisted(() => vi.fn());
 
 vi.mock("@sentry/node", () => ({
-  captureMessage: mockSentryCaptureMessage,
+  captureException: mockSentryCaptureException,
 }));
 
 import {
@@ -24,7 +24,7 @@ import {
 } from "./errors";
 
 beforeEach(() => {
-  mockSentryCaptureMessage.mockClear();
+  mockSentryCaptureException.mockClear();
 });
 
 // =============================================================================
@@ -1430,7 +1430,7 @@ describe("mapProviderError - Fallback behavior", () => {
 // =============================================================================
 
 describe("mapProviderError - Sentry raw error capture", () => {
-  it("creates a Sentry issue event for rawErrorJson provider error logs", () => {
+  it("captures a Sentry exception event for rawErrorJson provider errors", () => {
     const error = {
       name: "AI_APICallError",
       statusCode: 500,
@@ -1445,8 +1445,11 @@ describe("mapProviderError - Sentry raw error capture", () => {
 
     mapProviderError(error, "openai");
 
-    expect(mockSentryCaptureMessage).toHaveBeenCalledWith(
-      "[ChatErrorMapper] rawErrorJson provider error",
+    expect(mockSentryCaptureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "RawProviderError",
+        message: "Provider failed",
+      }),
       expect.objectContaining({
         level: "error",
         fingerprint: [


### PR DESCRIPTION
## Summary

Change raw provider error reporting from `Sentry.captureMessage` to `Sentry.captureException` so these events land as exception-backed Sentry issue events while retaining the existing fingerprint, tags, and extra context.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>