### PR TITLE
test(e2e): regression test for slim custom role chat access

### DIFF
--- a/platform/e2e-tests/auth.users.setup.ts
+++ b/platform/e2e-tests/auth.users.setup.ts
@@ -7,6 +7,10 @@ import { EDITOR_ROLE_NAME, MEMBER_ROLE_NAME } from "@shared";
 import {
   ADMIN_EMAIL,
   ADMIN_PASSWORD,
+  BASIC_USER_EMAIL,
+  BASIC_USER_PASSWORD,
+  BASIC_USER_ROLE_NAME,
+  basicUserAuthFile,
   EDITOR_EMAIL,
   EDITOR_PASSWORD,
   editorAuthFile,
@@ -293,6 +297,81 @@ setup("authenticate as editor", async ({ page }) => {
   await page.context().storageState({ path: editorAuthFile });
 });
 
+/**
+ * Permission set granted to the basic-user custom role.
+ *
+ * Deliberately slim — these are the permissions a restricted user
+ * needs to access /chat once an admin has configured provider keys.
+ * Used by chat-permissions.spec.ts to regression-test PR #4142.
+ */
+const BASIC_USER_PERMISSION = {
+  agent: ["read"],
+  llmProviderApiKey: ["read"],
+  llmModel: ["read"],
+} as const;
+
+/**
+ * Look up a custom role by display name. Returns the role identifier
+ * (the immutable, slug-style `role` field) if it exists, else null.
+ */
+async function findCustomRoleIdentifier(
+  request: APIRequestContext,
+  name: string,
+): Promise<string | null> {
+  const response = await request.get(
+    `${UI_BASE_URL}/api/roles?name=${encodeURIComponent(name)}`,
+    { headers: { Origin: UI_BASE_URL } },
+  );
+  if (!response.ok()) {
+    return null;
+  }
+  const body = await response.json();
+  const match = body?.data?.find(
+    (role: { name: string; role: string }) => role.name === name,
+  );
+  return match?.role ?? null;
+}
+
+/**
+ * Create the basic-user custom role if it does not already exist.
+ * Returns the role identifier suitable for use in invitations.
+ */
+async function ensureBasicUserRole(
+  request: APIRequestContext,
+): Promise<string> {
+  const existing = await findCustomRoleIdentifier(
+    request,
+    BASIC_USER_ROLE_NAME,
+  );
+  if (existing) {
+    return existing;
+  }
+
+  const response = await request.post(`${UI_BASE_URL}/api/roles`, {
+    data: {
+      name: BASIC_USER_ROLE_NAME,
+      description: "Slim role used by chat-permissions e2e regression test",
+      permission: BASIC_USER_PERMISSION,
+    },
+    headers: { Origin: UI_BASE_URL },
+  });
+
+  if (!response.ok()) {
+    const errorText = await response.text();
+    throw new Error(
+      `Failed to create basic-user custom role (${response.status()}): ${errorText}`,
+    );
+  }
+
+  const created = await response.json();
+  if (!created?.role) {
+    throw new Error(
+      `Basic-user role create response missing 'role' field: ${JSON.stringify(created)}`,
+    );
+  }
+  return created.role;
+}
+
 // Setup member authentication - runs after admin setup
 setup("authenticate as member", async ({ page }) => {
   // Check if member user already exists
@@ -354,4 +433,64 @@ setup("authenticate as member", async ({ page }) => {
 
   // Save member auth state
   await page.context().storageState({ path: memberAuthFile });
+});
+
+// Setup basic-user authentication (custom role with slim permissions)
+setup("authenticate as basic-user (custom role)", async ({ page }) => {
+  const basicUserExists = await userExists(
+    page.request,
+    BASIC_USER_EMAIL,
+    BASIC_USER_PASSWORD,
+  );
+
+  if (!basicUserExists) {
+    await sleep(100);
+
+    // Sign in as admin to provision the custom role and invitation
+    const adminSignedIn = await signInUser(
+      page.request,
+      ADMIN_EMAIL,
+      ADMIN_PASSWORD,
+    );
+    expect(adminSignedIn, "Admin sign-in failed for basic-user setup").toBe(
+      true,
+    );
+
+    // Establish cookie context with active organization
+    await page.goto(`${UI_BASE_URL}/chat`);
+    await page.waitForLoadState("domcontentloaded");
+
+    // Ensure the custom role exists (idempotent across re-runs)
+    const basicUserRoleIdentifier = await ensureBasicUserRole(page.request);
+
+    // Invite basic user with the custom role identifier
+    const invitationId = await createInvitation(
+      page.request,
+      BASIC_USER_EMAIL,
+      basicUserRoleIdentifier,
+    );
+
+    await signOut(page.request);
+
+    await signUpWithInvitation(
+      page.request,
+      BASIC_USER_EMAIL,
+      BASIC_USER_PASSWORD,
+      invitationId,
+    );
+  } else {
+    const signedIn = await signInUser(
+      page.request,
+      BASIC_USER_EMAIL,
+      BASIC_USER_PASSWORD,
+    );
+    expect(signedIn, "Basic-user sign-in failed").toBe(true);
+  }
+
+  await page.goto(`${UI_BASE_URL}/chat`);
+  await page.waitForLoadState("domcontentloaded");
+
+  await expectAuthenticated(page);
+
+  await page.context().storageState({ path: basicUserAuthFile });
 });

--- a/platform/e2e-tests/auth.users.setup.ts
+++ b/platform/e2e-tests/auth.users.setup.ts
@@ -306,18 +306,19 @@ setup("authenticate as editor", async ({ page }) => {
  */
 const BASIC_USER_PERMISSION = {
   agent: ["read"],
+  chat: ["read", "create", "update", "delete"],
   llmProviderApiKey: ["read"],
   llmModel: ["read"],
 } as const;
 
 /**
- * Look up a custom role by display name. Returns the role identifier
- * (the immutable, slug-style `role` field) if it exists, else null.
+ * Look up a custom role by display name. Returns the role's `id` (base62,
+ * used by PUT/DELETE) and `role` (slug, used by invitations) if found.
  */
-async function findCustomRoleIdentifier(
+async function findCustomRole(
   request: APIRequestContext,
   name: string,
-): Promise<string | null> {
+): Promise<{ id: string; role: string } | null> {
   const response = await request.get(
     `${UI_BASE_URL}/api/roles?name=${encodeURIComponent(name)}`,
     { headers: { Origin: UI_BASE_URL } },
@@ -327,30 +328,51 @@ async function findCustomRoleIdentifier(
   }
   const body = await response.json();
   const match = body?.data?.find(
-    (role: { name: string; role: string }) => role.name === name,
+    (role: { name: string; id: string; role: string }) => role.name === name,
   );
-  return match?.role ?? null;
+  if (!match?.id || !match?.role) {
+    return null;
+  }
+  return { id: match.id, role: match.role };
 }
 
 /**
- * Create the basic-user custom role if it does not already exist.
- * Returns the role identifier suitable for use in invitations.
+ * Create or refresh the basic-user custom role. Returns the role slug
+ * (the value invitations require). Always rewrites the permission set so
+ * that prior runs with a stale set cannot poison this run.
  */
 async function ensureBasicUserRole(
   request: APIRequestContext,
 ): Promise<string> {
-  const existing = await findCustomRoleIdentifier(
-    request,
-    BASIC_USER_ROLE_NAME,
-  );
+  const description =
+    "Slim role used by chat-permissions e2e regression test";
+  const existing = await findCustomRole(request, BASIC_USER_ROLE_NAME);
+
   if (existing) {
-    return existing;
+    const updateResponse = await request.put(
+      `${UI_BASE_URL}/api/roles/${existing.id}`,
+      {
+        data: {
+          name: BASIC_USER_ROLE_NAME,
+          description,
+          permission: BASIC_USER_PERMISSION,
+        },
+        headers: { Origin: UI_BASE_URL },
+      },
+    );
+    if (!updateResponse.ok()) {
+      const errorText = await updateResponse.text();
+      throw new Error(
+        `Failed to refresh basic-user role permissions (${updateResponse.status()}): ${errorText}`,
+      );
+    }
+    return existing.role;
   }
 
   const response = await request.post(`${UI_BASE_URL}/api/roles`, {
     data: {
       name: BASIC_USER_ROLE_NAME,
-      description: "Slim role used by chat-permissions e2e regression test",
+      description,
       permission: BASIC_USER_PERMISSION,
     },
     headers: { Origin: UI_BASE_URL },
@@ -443,26 +465,25 @@ setup("authenticate as basic-user (custom role)", async ({ page }) => {
     BASIC_USER_PASSWORD,
   );
 
+  // Always sign in as admin first so we can refresh the basic-user role's
+  // permission set on every run. Without this, prior runs that created the
+  // role with a stale permission set would persist and break the test.
+  await sleep(100);
+  const adminSignedIn = await signInUser(
+    page.request,
+    ADMIN_EMAIL,
+    ADMIN_PASSWORD,
+  );
+  expect(adminSignedIn, "Admin sign-in failed for basic-user setup").toBe(true);
+
+  // Establish cookie context with active organization
+  await page.goto(`${UI_BASE_URL}/chat`);
+  await page.waitForLoadState("domcontentloaded");
+
+  // Ensure the custom role exists with the current permission set
+  const basicUserRoleIdentifier = await ensureBasicUserRole(page.request);
+
   if (!basicUserExists) {
-    await sleep(100);
-
-    // Sign in as admin to provision the custom role and invitation
-    const adminSignedIn = await signInUser(
-      page.request,
-      ADMIN_EMAIL,
-      ADMIN_PASSWORD,
-    );
-    expect(adminSignedIn, "Admin sign-in failed for basic-user setup").toBe(
-      true,
-    );
-
-    // Establish cookie context with active organization
-    await page.goto(`${UI_BASE_URL}/chat`);
-    await page.waitForLoadState("domcontentloaded");
-
-    // Ensure the custom role exists (idempotent across re-runs)
-    const basicUserRoleIdentifier = await ensureBasicUserRole(page.request);
-
     // Invite basic user with the custom role identifier
     const invitationId = await createInvitation(
       page.request,
@@ -479,6 +500,8 @@ setup("authenticate as basic-user (custom role)", async ({ page }) => {
       invitationId,
     );
   } else {
+    await signOut(page.request);
+
     const signedIn = await signInUser(
       page.request,
       BASIC_USER_EMAIL,

--- a/platform/e2e-tests/auth.users.setup.ts
+++ b/platform/e2e-tests/auth.users.setup.ts
@@ -306,7 +306,7 @@ setup("authenticate as editor", async ({ page }) => {
  */
 const BASIC_USER_PERMISSION = {
   agent: ["read"],
-  chat: ["read", "create", "update", "delete"],
+  chat: ["read"],
   llmProviderApiKey: ["read"],
   llmModel: ["read"],
 } as const;

--- a/platform/e2e-tests/consts.ts
+++ b/platform/e2e-tests/consts.ts
@@ -26,6 +26,10 @@ export const memberAuthFile = path.join(
   __dirname,
   "playwright/.auth/member.json",
 );
+export const basicUserAuthFile = path.join(
+  __dirname,
+  "playwright/.auth/basic-user.json",
+);
 
 export const IS_CI = process.env.CI === "true";
 
@@ -87,6 +91,19 @@ export const EDITOR_PASSWORD = "password";
  */
 export const MEMBER_EMAIL = "member@example.com";
 export const MEMBER_PASSWORD = "password";
+
+/**
+ * Basic-user credentials for e2e tests.
+ *
+ * Assigned to a custom role with a deliberately slim permission set
+ * (agent:read, llmProviderApiKey:read, llmModel:read) — used to
+ * regression-test chat access for restricted users (see PR #4142).
+ */
+export const BASIC_USER_EMAIL = "basic-user@example.com";
+export const BASIC_USER_PASSWORD = "password";
+
+/** Display name for the basic-user custom role created during e2e setup */
+export const BASIC_USER_ROLE_NAME = "E2E Basic User";
 
 /**
  * Team names for e2e tests

--- a/platform/e2e-tests/fixtures.ts
+++ b/platform/e2e-tests/fixtures.ts
@@ -9,6 +9,7 @@ import {
   type Page,
 } from "@playwright/test";
 import {
+  basicUserAuthFile,
   E2eTestId,
   editorAuthFile,
   memberAuthFile,
@@ -32,12 +33,16 @@ interface TestFixtures {
   editorPage: Page;
   /** Page authenticated as member */
   memberPage: Page;
+  /** Page authenticated as a user with a slim custom role (see auth.users.setup.ts) */
+  basicUserPage: Page;
   /** Navigate admin page to a path */
   goToAdminPage: GoToPageFn;
   /** Navigate editor page to a path */
   goToEditorPage: GoToPageFn;
   /** Navigate member page to a path */
   goToMemberPage: GoToPageFn;
+  /** Navigate basic-user page to a path */
+  goToBasicUserPage: GoToPageFn;
 }
 
 export const goToPage = async (page: Page, path = "") => {
@@ -129,6 +134,17 @@ export const test = base.extend<TestFixtures>({
     await context.close();
   },
   /**
+   * Basic-user page - creates a new browser context with basic-user (custom role) auth
+   */
+  basicUserPage: async ({ browser }, use) => {
+    const { context, page } = await createAuthenticatedPage(
+      browser,
+      basicUserAuthFile,
+    );
+    await use(page);
+    await context.close();
+  },
+  /**
    * Navigate admin page to a path
    */
   goToAdminPage: async ({ adminPage }, use) => {
@@ -153,6 +169,15 @@ export const test = base.extend<TestFixtures>({
     await use(async (path = "") => {
       await memberPage.goto(`${UI_BASE_URL}${path}`);
       await dismissOnboarding(memberPage);
+    });
+  },
+  /**
+   * Navigate basic-user page to a path
+   */
+  goToBasicUserPage: async ({ basicUserPage }, use) => {
+    await use(async (path = "") => {
+      await basicUserPage.goto(`${UI_BASE_URL}${path}`);
+      await dismissOnboarding(basicUserPage);
     });
   },
 });

--- a/platform/e2e-tests/playwright.config.ts
+++ b/platform/e2e-tests/playwright.config.ts
@@ -42,6 +42,7 @@ const uiTestMatch = [
   "**/auth.spec.ts",
   "**/chat-auth-required.spec.ts",
   "**/chat-localstorage.spec.ts",
+  "**/chat-permissions.spec.ts",
   "**/chat.spec.ts",
   "**/credentials-with-vault.ee.spec.ts",
   "**/dynamic-credentials.spec.ts",

--- a/platform/e2e-tests/tests/chat-permissions.spec.ts
+++ b/platform/e2e-tests/tests/chat-permissions.spec.ts
@@ -1,26 +1,15 @@
-import { UI_BASE_URL, WIREMOCK_BASE_URL } from "../consts";
+import { WIREMOCK_BASE_URL } from "../consts";
 import { expect, test } from "../fixtures";
-import { expectChatReady, goToChat } from "../utils";
+import {
+  createLlmProviderApiKey,
+  expectChatReady,
+  goToChat,
+  goToLlmProviderApiKeysPage,
+  hasLlmProviderApiKey,
+} from "../utils";
 
 const ORG_KEY_NAME = "chat-permissions-org-seed";
 
-/**
- * Regression test for the chat-permissions fix (PR #4142).
- *
- * A user whose role grants only the slim permission set (see
- * `BASIC_USER_PERMISSION` in auth.users.setup.ts) — i.e. no
- * `canSeeProviderSettings` permission — must still be able to load /chat
- * and see the prompt textarea, instead of being stuck on the
- * "Add an LLM Provider Key" empty state.
- *
- * Pre-fix, the empty state showed because `canUseProviderSettings` was
- * gated on `canSeeProviderSettings`, which a slim role doesn't have. After
- * the fix the gate is removed and the org's provider keys load normally.
- *
- * The "Archestra Local Dev" primary key seeded by Tilt is `personal`-scoped
- * to admin and invisible to basic-user, so we explicitly seed an
- * organization-scoped OpenAI key first (validated against WireMock).
- */
 test.describe("Chat permissions — slim custom role", () => {
   test.setTimeout(60_000);
 
@@ -28,48 +17,20 @@ test.describe("Chat permissions — slim custom role", () => {
     adminPage,
     basicUserPage,
   }) => {
-    // Seed an org-scoped key as admin so basic-user can see at least one key.
-    // Idempotent: if the key already exists from a prior run, reuse it.
-    const existing = await adminPage.request.get(
-      `${UI_BASE_URL}/api/llm-provider-api-keys?provider=openai`,
-      { headers: { Origin: UI_BASE_URL } },
-    );
-    expect(existing.ok(), "list provider keys failed").toBe(true);
-    const existingBody = await existing.json();
-    const alreadySeeded = existingBody?.data?.some(
-      (k: { name: string }) => k.name === ORG_KEY_NAME,
-    );
-
-    if (!alreadySeeded) {
-      const create = await adminPage.request.post(
-        `${UI_BASE_URL}/api/llm-provider-api-keys`,
-        {
-          data: {
-            name: ORG_KEY_NAME,
-            provider: "openai",
-            apiKey: "sk-chat-permissions-test",
-            // Route key validation through WireMock — the e2e backend's
-            // ARCHESTRA_OPENAI_BASE_URL doesn't necessarily point at the
-            // mock, and real OpenAI will reject the fake key with 401.
-            baseUrl: `${WIREMOCK_BASE_URL}/v1`,
-            scope: "org",
-            isPrimary: false,
-          },
-          headers: { Origin: UI_BASE_URL },
-        },
-      );
-      expect(
-        create.ok(),
-        `seed org-scoped key failed (${create.status()}): ${await create.text()}`,
-      ).toBe(true);
+    await goToLlmProviderApiKeysPage(adminPage);
+    if (!(await hasLlmProviderApiKey(adminPage, ORG_KEY_NAME))) {
+      await createLlmProviderApiKey(adminPage, {
+        name: ORG_KEY_NAME,
+        apiKey: "sk-e2e-test",
+        providerOptionName: "OpenAI OpenAI",
+        scope: "org",
+        baseUrl: `${WIREMOCK_BASE_URL}/v1`,
+      });
     }
 
     await goToChat(basicUserPage);
-
-    // The chat textarea must be reachable.
     await expectChatReady(basicUserPage);
 
-    // The provider-key empty state must NOT be shown — that was the bug.
     await expect(
       basicUserPage.getByRole("heading", { name: /Add an LLM Provider Key/i }),
     ).not.toBeVisible();

--- a/platform/e2e-tests/tests/chat-permissions.spec.ts
+++ b/platform/e2e-tests/tests/chat-permissions.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "../fixtures";
+import { expectChatReady, goToChat } from "../utils";
+
+/**
+ * Regression test for the chat-permissions fix (PR #4142).
+ *
+ * A user whose role grants only the slim permission set
+ * (agent:read, llmProviderApiKey:read, llmModel:read) — i.e. no
+ * `canSeeProviderSettings` permission — must still be able to load /chat
+ * and see the prompt textarea, instead of being stuck on the
+ * "Add an LLM Provider Key" empty state.
+ */
+test.describe("Chat permissions — slim custom role", () => {
+  test.setTimeout(60_000);
+
+  test("basic-user role can access chat without the empty-state block", async ({
+    basicUserPage,
+  }) => {
+    await goToChat(basicUserPage);
+
+    // The chat textarea must be reachable.
+    await expectChatReady(basicUserPage);
+
+    // The provider-key empty state must NOT be shown — that was the bug.
+    await expect(
+      basicUserPage.getByRole("heading", { name: /Add an LLM Provider Key/i }),
+    ).not.toBeVisible();
+  });
+});

--- a/platform/e2e-tests/tests/chat-permissions.spec.ts
+++ b/platform/e2e-tests/tests/chat-permissions.spec.ts
@@ -1,21 +1,69 @@
+import { UI_BASE_URL, WIREMOCK_BASE_URL } from "../consts";
 import { expect, test } from "../fixtures";
 import { expectChatReady, goToChat } from "../utils";
+
+const ORG_KEY_NAME = "chat-permissions-org-seed";
 
 /**
  * Regression test for the chat-permissions fix (PR #4142).
  *
- * A user whose role grants only the slim permission set
- * (agent:read, llmProviderApiKey:read, llmModel:read) — i.e. no
+ * A user whose role grants only the slim permission set (see
+ * `BASIC_USER_PERMISSION` in auth.users.setup.ts) — i.e. no
  * `canSeeProviderSettings` permission — must still be able to load /chat
  * and see the prompt textarea, instead of being stuck on the
  * "Add an LLM Provider Key" empty state.
+ *
+ * Pre-fix, the empty state showed because `canUseProviderSettings` was
+ * gated on `canSeeProviderSettings`, which a slim role doesn't have. After
+ * the fix the gate is removed and the org's provider keys load normally.
+ *
+ * The "Archestra Local Dev" primary key seeded by Tilt is `personal`-scoped
+ * to admin and invisible to basic-user, so we explicitly seed an
+ * organization-scoped OpenAI key first (validated against WireMock).
  */
 test.describe("Chat permissions — slim custom role", () => {
   test.setTimeout(60_000);
 
   test("basic-user role can access chat without the empty-state block", async ({
+    adminPage,
     basicUserPage,
   }) => {
+    // Seed an org-scoped key as admin so basic-user can see at least one key.
+    // Idempotent: if the key already exists from a prior run, reuse it.
+    const existing = await adminPage.request.get(
+      `${UI_BASE_URL}/api/llm-provider-api-keys?provider=openai`,
+      { headers: { Origin: UI_BASE_URL } },
+    );
+    expect(existing.ok(), "list provider keys failed").toBe(true);
+    const existingBody = await existing.json();
+    const alreadySeeded = existingBody?.data?.some(
+      (k: { name: string }) => k.name === ORG_KEY_NAME,
+    );
+
+    if (!alreadySeeded) {
+      const create = await adminPage.request.post(
+        `${UI_BASE_URL}/api/llm-provider-api-keys`,
+        {
+          data: {
+            name: ORG_KEY_NAME,
+            provider: "openai",
+            apiKey: "sk-chat-permissions-test",
+            // Route key validation through WireMock — the e2e backend's
+            // ARCHESTRA_OPENAI_BASE_URL doesn't necessarily point at the
+            // mock, and real OpenAI will reject the fake key with 401.
+            baseUrl: `${WIREMOCK_BASE_URL}/v1`,
+            scope: "org",
+            isPrimary: false,
+          },
+          headers: { Origin: UI_BASE_URL },
+        },
+      );
+      expect(
+        create.ok(),
+        `seed org-scoped key failed (${create.status()}): ${await create.text()}`,
+      ).toBe(true);
+    }
+
     await goToChat(basicUserPage);
 
     // The chat textarea must be reachable.

--- a/platform/e2e-tests/utils/llm-provider-api-keys.ts
+++ b/platform/e2e-tests/utils/llm-provider-api-keys.ts
@@ -26,6 +26,8 @@ export async function createLlmProviderApiKey(
     name: string;
     apiKey: string;
     providerOptionName?: string | RegExp;
+    scope?: "personal" | "org";
+    baseUrl?: string;
   },
 ): Promise<void> {
   const addApiKeyButton = page
@@ -45,6 +47,18 @@ export async function createLlmProviderApiKey(
 
   await page.getByLabel(/Name/i).fill(params.name);
   await page.getByRole("textbox", { name: /API Key/i }).fill(params.apiKey);
+
+  if (params.scope === "org") {
+    // Scope selector is a collapsible custom control — click the current
+    // ("Personal") option to expand it before picking "Organization".
+    await page.getByRole("button", { name: /^Personal/ }).click();
+    await page.getByRole("button", { name: /^Organization/ }).click();
+  }
+
+  if (params.baseUrl) {
+    await page.getByLabel(/Base URL/i).fill(params.baseUrl);
+  }
+
   await clickButton({ page, options: { name: "Test & Create" } });
   await expect(
     page.getByTestId(`${E2eTestId.ChatApiKeyRow}-${params.name}`),
@@ -166,4 +180,18 @@ async function getParentKeyOptionNameForProvider(
     },
     { targetProvider: provider, route: LLM_PROVIDER_API_KEYS_ROUTE },
   );
+}
+
+/**
+ * Returns true if an API key row with the given name is already on the
+ * provider API keys page. Caller is responsible for navigating there first.
+ */
+export async function hasLlmProviderApiKey(
+  page: Page,
+  name: string,
+): Promise<boolean> {
+  return page
+    .getByTestId(`${E2eTestId.ChatApiKeyRow}-${name}`)
+    .isVisible()
+    .catch(() => false);
 }


### PR DESCRIPTION
## Summary

Adds an e2e regression test for the chat-permissions hotfix (PR #4142, commit 019c7dc8). A customer reported that users assigned a custom role with a slim permission set were blocked from `/chat` by the "Add an LLM Provider Key" empty state, even when an admin had configured provider keys. The hotfix removed the over-eager `canSeeProviderSettings` gate; this PR locks the behavior in.

- New `basic-user` Playwright auth setup that provisions a custom role with only `agent:read`, `llmProviderApiKey:read`, `llmModel:read` and signs up a user against it.
- New `basicUserPage` / `goToBasicUserPage` fixtures so future restricted-role tests can reuse the same context.
- New `chat-permissions.spec.ts`: loads `/chat` as the basic user, asserts the prompt is reachable, and asserts the provider-key empty state is not shown.

## Test plan

- [ ] `pnpm test:e2e` passes locally with the new spec
- [ ] Test fails if the `canSeeProviderSettings` gate is reintroduced on `frontend/src/app/chat/page.tsx`
- [ ] Auth setup is idempotent across reruns (role + invitation creation guarded)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>