### PR TITLE
fix: allow to attach team scoped mcps credentials to org

### DIFF
--- a/platform/backend/src/services/agent-tool-assignment.test.ts
+++ b/platform/backend/src/services/agent-tool-assignment.test.ts
@@ -886,7 +886,7 @@ describe("isMcpServerAssignableToTarget", () => {
     expect(assignable).toBe(false);
   });
 
-  test("team-scoped server is not assignable to org-scoped target", async () => {
+  test("team-scoped server is assignable to org-scoped target", async () => {
     const assignable = await isMcpServerAssignableToTarget({
       mcpServer: {
         ownerId: "owner-1",
@@ -901,7 +901,7 @@ describe("isMcpServerAssignableToTarget", () => {
       },
     });
 
-    expect(assignable).toBe(false);
+    expect(assignable).toBe(true);
   });
 
   test("team-scoped server with no teamId is not assignable", async () => {

--- a/platform/backend/src/services/agent-tool-assignment.test.ts
+++ b/platform/backend/src/services/agent-tool-assignment.test.ts
@@ -198,6 +198,37 @@ describe("filterMcpServersAssignableToTarget", () => {
     getUserTeamIdsSpy.mockRestore();
     isUserInAnyTeamSpy.mockRestore();
   });
+
+  test("includes team-scoped servers when filtering for an org-scoped target", async ({
+    makeOrganization,
+    makeTeam,
+    makeUser,
+  }) => {
+    const organization = await makeOrganization();
+    const requester = await makeUser();
+    const team = await makeTeam(organization.id, requester.id, {
+      name: "Some Team",
+    });
+
+    const filtered = await filterMcpServersAssignableToTarget({
+      mcpServers: [
+        {
+          id: "team-server",
+          ownerId: requester.id,
+          teamId: team.id,
+          scope: "team",
+        },
+      ],
+      target: {
+        organizationId: organization.id,
+        scope: "org",
+        authorId: null,
+        teamIds: [],
+      },
+    });
+
+    expect(filtered.map((server) => server.id)).toEqual(["team-server"]);
+  });
 });
 
 describe("validateCredentialSource", () => {
@@ -346,6 +377,52 @@ describe("validateCredentialSource", () => {
         type: "validation_error",
       },
     });
+  });
+
+  test("allows a team-installed MCP server when the target resource is org-scoped", async ({
+    makeAgent,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeMember,
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+    makeTool,
+    makeUser,
+  }) => {
+    const organization = await makeOrganization();
+    const owner = await makeUser();
+    const author = await makeUser();
+
+    await makeMember(owner.id, organization.id, { role: "member" });
+    await makeMember(author.id, organization.id, { role: "admin" });
+
+    const team = await makeTeam(organization.id, author.id, {
+      name: "Some Team",
+    });
+    await makeTeamMember(team.id, owner.id);
+
+    const agent = await makeAgent({
+      organizationId: organization.id,
+      authorId: author.id,
+      scope: "org",
+    });
+    const catalog = await makeInternalMcpCatalog({ serverType: "remote" });
+    const tool = await makeTool({ catalogId: catalog.id, name: "remote_tool" });
+    const mcpServer = await makeMcpServer({
+      scope: "team",
+      teamId: team.id,
+      ownerId: owner.id,
+      catalogId: catalog.id,
+    });
+
+    const result = await validateCredentialSource({
+      agentId: agent.id,
+      mcpServerId: mcpServer.id,
+      toolId: tool.id,
+    });
+
+    expect(result).toBeNull();
   });
 
   test("rejects a personal credential for an org-scoped resource when the owner is outside the organization", async ({

--- a/platform/backend/src/services/agent-tool-assignment.ts
+++ b/platform/backend/src/services/agent-tool-assignment.ts
@@ -541,6 +541,9 @@ function isMcpServerAssignableToPrefetchedTarget(params: {
   }
 
   if (mcpServer.teamId) {
+    if (target.scope === "org") {
+      return true;
+    }
     if (target.scope === "team") {
       return target.teamIds.includes(mcpServer.teamId);
     }

--- a/platform/backend/src/services/agent-tool-assignment.ts
+++ b/platform/backend/src/services/agent-tool-assignment.ts
@@ -393,6 +393,9 @@ export async function isMcpServerAssignableToTarget(params: {
   }
 
   if (mcpServer.teamId) {
+    if (target.scope === "org") {
+      return true;
+    }
     if (target.scope === "team") {
       return target.teamIds.includes(mcpServer.teamId);
     }

--- a/platform/e2e-tests/tests/static-credentials-management.spec.ts
+++ b/platform/e2e-tests/tests/static-credentials-management.spec.ts
@@ -190,12 +190,7 @@ test.describe("Custom Self-hosted MCP Server - installation and static credentia
           catalogItemName,
           gatewayName: gatewayNameForAssignment,
         });
-        const expectedAssignableCredentials =
-          user === "Admin"
-            ? expectedCredentials.filter(
-                (credential) => credential !== DEFAULT_TEAM_NAME,
-              )
-            : expectedCredentials;
+        const expectedAssignableCredentials = expectedCredentials;
         const visibleStaticCredentials =
           await getVisibleStaticCredentials(page);
         for (const credential of expectedAssignableCredentials) {


### PR DESCRIPTION
**What**

Make team-scoped mcp credentials assignable to org-wide agents.

**Why**

Existing installations relied on this behaviour, which we recently changed. It resulted in mcp tools assignments "missing" in the "Edit Agent" Modal. This fix should make them visible back.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>