### PR TITLE
feat: allow basic users to access chat agent picker and provider settings

### DIFF
--- a/docs/pages/platform-access-control.md
+++ b/docs/pages/platform-access-control.md
@@ -3,7 +3,7 @@ title: "Access Control"
 category: Administration
 description: "Role-based access control (RBAC) system for managing user permissions in Archestra"
 order: 1
-lastUpdated: 2026-04-16
+lastUpdated: 2026-04-28
 ---
 <!--
 Check ../docs_writer_prompt.md before changing this file.
@@ -90,6 +90,8 @@ Can manage agents, tools, and chat, with read-only access to most other resource
 | API Keys | `read`, `create`, `delete` |
 | Teams | `read` |
 | Simple View | `enable` |
+| Chat Agent Picker | `enable` |
+| Chat Provider Settings | `enable` |
 | Chat Expand Tool Calls | `enable` |
 
 

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -309,10 +309,10 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
     expect(capturedInnerOnError).toBeDefined();
 
     const stage1Error = new Error("Upstream provider error");
-    const payload1 = capturedInnerOnError!(stage1Error);
+    const payload1 = capturedInnerOnError?.(stage1Error);
 
     const stage2Error = new Error(payload1);
-    const payload2 = capturedInnerOnError!(stage2Error);
+    const payload2 = capturedInnerOnError?.(stage2Error);
 
     expect(payload2).toBe(payload1);
 

--- a/platform/shared/access-control.ts
+++ b/platform/shared/access-control.ts
@@ -171,8 +171,8 @@ export const memberPermissions: Record<Resource, Action[]> = {
 
   // UI behavior resources
   simpleView: ["enable"],
-  chatAgentPicker: [],
-  chatProviderSettings: [],
+  chatAgentPicker: ["enable"],
+  chatProviderSettings: ["enable"],
   chatExpandToolCalls: ["enable"],
 
   // better-auth internal resource — not exposed to users, kept for ACL compatibility


### PR DESCRIPTION
## Summary
- Grants the `member` (basic user) role the `enable` action for the `chatAgentPicker` and `chatProviderSettings` UI resources in `shared/access-control.ts`, so basic users see the agent picker and provider settings in the chat prompt input (matching `editor`/`admin` roles).
