### PR TITLE
fix: complete Okta OIDC and OIN SSO support

### DIFF
--- a/docs/pages/platform-identity-providers.md
+++ b/docs/pages/platform-identity-providers.md
@@ -42,7 +42,7 @@ Archestra supports Identity Provider (IdP) configuration for three purposes:
 
 ### Allowed Email Domains
 
-The **Allowed Email Domains** field is the Archestra-side sign-in boundary for an SSO provider. Users can sign in with that provider only when the email returned by the identity provider matches one of the configured domains.
+The **Allowed Email Domains** field is an optional Archestra-side sign-in boundary. When configured, users can sign in with that provider only when the email returned by the identity provider matches one of the configured domains.
 
 Use comma-separated domains for multi-domain SSO, for example:
 
@@ -51,6 +51,8 @@ company.com, subsidiary.com
 ```
 
 Subdomains are included. For example, `engineering.company.com` matches `company.com`.
+
+The current identity provider UI shows this field for Google providers. Other providers can rely on the IdP application's own user and group assignments, plus optional Archestra role mapping and team sync.
 
 ## Disabling Basic Authentication
 
@@ -120,17 +122,21 @@ Okta is an enterprise identity management platform. Archestra supports Okta OIDC
 
 Archestra does not support Okta DPoP for SSO clients. Disable **Require Demonstrating Proof of Possession (DPoP) header in token requests** in the Okta app integration.
 
-#### Okta OIN Fields
+#### Okta OIN App Installation
 
-If you are configuring an Okta Integration Network (OIN) app with integration variables, use:
+When installing Archestra from the Okta Integration Network (OIN), enter your Archestra hostname without the protocol.
 
-| Okta field | Value |
-| --- | --- |
-| Redirect URI | `https://{{app.baseurl}}/api/auth/sso/callback/Okta` |
-| Initiate login URI | `https://{{app.baseurl}}/auth/sign-in` |
-| Post-logout URI | `https://{{app.baseurl}}/auth/sign-in` |
+For example, if your Archestra URL is:
 
-For a manually configured Okta app, replace `{{app.baseurl}}` with your Archestra external domain.
+```
+https://your-archestra-domain.com
+```
+
+enter:
+
+```
+your-archestra-domain.com
+```
 
 #### Configuration Steps
 
@@ -182,12 +188,22 @@ Users can start sign-in from the Archestra sign-in page by selecting **Sign in w
 
 To test, use a private browser window with a user who is assigned to the Okta app and whose email domain is allowed in Archestra.
 
+#### IdP-Initiated SSO
+
+Okta app tile launches should use:
+
+```
+https://your-archestra-domain.com/auth/sso/Okta
+```
+
+This route starts the Okta SSO flow immediately and redirects the user back to Okta with the required authorization request.
+
 #### Troubleshoot
 
 - If setup fails with an issuer mismatch, verify that **Issuer** and **Discovery Endpoint** point to the same Okta org. Do not leave sample values such as `your-domain.okta.com` in either field.
 - If login fails after redirect, verify that the Okta **Sign-in redirect URI** exactly matches the Archestra callback URL, including `Okta` casing.
 - If sign-out returns an Okta error, verify that the Okta **Sign-out redirect URI** is set to `https://your-archestra-domain.com/auth/sign-in`, or disable **Enable RP-Initiated Logout** in Archestra for that provider.
-- If a user is denied after successful Okta authentication, verify that their email domain matches **Allowed Email Domains**.
+- If a user is denied after successful Okta authentication, verify that the user is assigned to the Okta app and matches any configured Archestra role mapping rules.
 
 ### Google
 
@@ -274,7 +290,7 @@ Required information:
 
 - **Provider ID**: A unique identifier (e.g., `azure`, `auth0`)
 - **Issuer**: The OIDC issuer URL
-- **Allowed Email Domains**: Email domains allowed to sign in through this provider. Use comma-separated domains for multi-domain SSO.
+- **Allowed Email Domains**: Optional email domains allowed to sign in through this provider when configured. Use comma-separated domains for multi-domain SSO.
 - **Client ID** and **Client Secret**: From your identity provider
 - **Discovery Endpoint**: The `.well-known/openid-configuration` URL (optional if issuer supports discovery)
 
@@ -296,7 +312,7 @@ Required information:
 
 - **Provider ID**: A unique identifier (e.g., `okta-saml`, `adfs`)
 - **Issuer**: Your organization's identifier
-- **Allowed Email Domains**: Email domains allowed to sign in through this provider. Use comma-separated domains for multi-domain SSO.
+- **Allowed Email Domains**: Optional email domains allowed to sign in through this provider when configured. Use comma-separated domains for multi-domain SSO.
 - **SAML Issuer / Entity ID**: The identity provider's entity ID (from IdP metadata)
 - **SSO Entry Point URL**: The IdP's Single Sign-On URL
 - **IdP Certificate**: The X.509 certificate from your IdP for signature verification

--- a/docs/pages/platform-identity-providers.md
+++ b/docs/pages/platform-identity-providers.md
@@ -120,6 +120,18 @@ Okta is an enterprise identity management platform. Archestra supports Okta OIDC
 
 Archestra does not support Okta DPoP for SSO clients. Disable **Require Demonstrating Proof of Possession (DPoP) header in token requests** in the Okta app integration.
 
+#### Okta OIN Fields
+
+If you are configuring an Okta Integration Network (OIN) app with integration variables, use:
+
+| Okta field | Value |
+| --- | --- |
+| Redirect URI | `https://{{app.baseurl}}/api/auth/sso/callback/Okta` |
+| Initiate login URI | `https://{{app.baseurl}}/auth/sign-in` |
+| Post-logout URI | `https://{{app.baseurl}}/auth/sign-in` |
+
+For a manually configured Okta app, replace `{{app.baseurl}}` with your Archestra external domain.
+
 #### Configuration Steps
 
 1. In the Okta Admin Console, go to **Applications > Applications**.
@@ -138,28 +150,37 @@ Archestra does not support Okta DPoP for SSO clients. Disable **Require Demonstr
    ```
 
 6. Assign the users or groups that should access Archestra.
-7. Save the Okta app integration, then copy the **Client ID** and **Client Secret**.
-8. In Archestra, go to **Settings > Identity Providers** and click **Enable** on the Okta card.
-9. Enter your Okta issuer URL, for example:
+7. Save the Okta app integration.
+8. On the app's **Sign On** tab, copy the **Client ID** and **Client Secret**. Keep the Client Secret private and do not commit it to version control.
+9. Find your Okta org issuer in the upper-right profile menu of the Okta Admin Console or from the Admin Console browser URL. It usually looks like:
 
    ```
    https://your-org.okta.com
    ```
 
-10. Enter your allowed email domains, Client ID, and Client Secret.
-11. Keep the discovery endpoint empty unless you need a custom value. Archestra derives it from the issuer as:
+10. In Archestra, go to **Settings > Identity Providers** and click **Enable** on the Okta card.
+11. Enter your Okta issuer URL, for example:
+
+   ```
+   https://your-org.okta.com
+   ```
+
+12. Enter your allowed email domains, Client ID, and Client Secret.
+13. Keep the discovery endpoint empty unless you need a custom value. Archestra derives it from the issuer as:
 
     ```
     https://your-org.okta.com/.well-known/openid-configuration
     ```
 
-12. Click **Create Provider**.
+14. Click **Create Provider**.
 
 If you also use IdP token exchange for downstream MCP calls, configure the exchange client details in the optional **Enterprise-Managed Credentials** section of the OIDC provider form. See [Okta's AI agent token exchange guide](https://developer.okta.com/docs/guides/ai-agent-token-exchange/authserver/main/).
 
 #### SP-Initiated SSO
 
 Users can start sign-in from the Archestra sign-in page by selecting **Sign in with Okta**. After Okta authenticates the user, Archestra checks the returned email against **Allowed Email Domains**, provisions the user if needed, and opens the app.
+
+To test, use a private browser window with a user who is assigned to the Okta app and whose email domain is allowed in Archestra.
 
 #### Troubleshoot
 

--- a/docs/pages/platform-identity-providers.md
+++ b/docs/pages/platform-identity-providers.md
@@ -35,7 +35,7 @@ Archestra supports Identity Provider (IdP) configuration for three purposes:
 1. Admin configures an Identity Provider in **Settings > Identity Providers**
 2. SSO buttons appear on the sign-in page for enabled providers
 3. Users click the SSO button and authenticate with their identity provider
-4. Archestra verifies the authenticated email belongs to the provider's allowed email domains
+4. Archestra applies provider configuration, role mapping, and team sync rules
 5. After successful authentication, users are automatically provisioned and logged in
 
 ![Sign-in with SSO](/docs/automated_screenshots/platform-identity-providers_sign-in-with-sso.webp)
@@ -167,11 +167,11 @@ your-archestra-domain.com
 10. In Archestra, go to **Settings > Identity Providers** and click **Enable** on the Okta card.
 11. Enter your Okta issuer URL, for example:
 
-   ```
-   https://your-org.okta.com
-   ```
+```
+https://your-org.okta.com
+```
 
-12. Enter your allowed email domains, Client ID, and Client Secret.
+12. Enter the Client ID and Client Secret.
 13. Keep the discovery endpoint empty unless you need a custom value. Archestra derives it from the issuer as:
 
     ```
@@ -184,9 +184,9 @@ If you also use IdP token exchange for downstream MCP calls, configure the excha
 
 #### SP-Initiated SSO
 
-Users can start sign-in from the Archestra sign-in page by selecting **Sign in with Okta**. After Okta authenticates the user, Archestra checks the returned email against **Allowed Email Domains**, provisions the user if needed, and opens the app.
+Users can start sign-in from the Archestra sign-in page by selecting **Sign in with Okta**. After Okta authenticates the user, Archestra provisions the user if needed and opens the app.
 
-To test, use a private browser window with a user who is assigned to the Okta app and whose email domain is allowed in Archestra.
+To test, use a private browser window with a user who is assigned to the Okta app.
 
 #### IdP-Initiated SSO
 

--- a/docs/pages/platform-identity-providers.md
+++ b/docs/pages/platform-identity-providers.md
@@ -3,7 +3,7 @@ title: "Identity Providers"
 category: Administration
 description: "Configure Identity Providers for SSO authentication, MCP Gateway JWKS validation, and IdP token exchange for downstream MCP calls"
 order: 2
-lastUpdated: 2026-04-20
+lastUpdated: 2026-04-28
 ---
 
 <!--
@@ -102,21 +102,71 @@ http://localhost:3000/api/auth/sso/saml2/sp/acs/{ProviderId}
 
 ### Okta
 
-Okta is an enterprise identity management platform. To configure Okta SSO:
+Okta is an enterprise identity management platform. Archestra supports Okta OIDC SSO with self-service configuration.
 
-1. In Okta Admin Console, create a new **Web Application**
-2. Set the **Sign-in redirect URI** to your callback URL: `https://your-domain.com/api/auth/sso/callback/Okta`
-3. Copy the **Client ID** and **Client Secret**
-4. In Archestra, click **Enable** on the Okta card
-5. Enter your Okta domain (e.g., `your-org.okta.com`)
-6. Enter the Client ID and Client Secret
-7. Click **Create Provider**
+#### Prerequisites
 
-**Okta-specific requirements:**
+- An Okta admin account with permission to create app integrations
+- An Archestra admin account
+- Your Archestra external URL, for example `https://your-archestra-domain.com`
+- Your Okta org issuer, for example `https://your-org.okta.com`
 
-- Disable **DPoP** (Demonstrating Proof of Possession) in your Okta application settings. Archestra does not support DPoP.
-- The issuer URL is automatically set to `https://your-domain.okta.com`
-- If you also use IdP token exchange for downstream MCP calls, configure the exchange client details in the optional **Enterprise-Managed Credentials** section of the OIDC provider form. See [Okta's AI agent token exchange guide](https://developer.okta.com/docs/guides/ai-agent-token-exchange/authserver/main/).
+#### Supported Features
+
+- SP-initiated SSO
+- IdP-initiated SSO through Okta's OIDC app tile
+- Just-In-Time user provisioning
+- SP-initiated logout when Okta publishes an `end_session_endpoint`
+
+Archestra does not support Okta DPoP for SSO clients. Disable **Require Demonstrating Proof of Possession (DPoP) header in token requests** in the Okta app integration.
+
+#### Configuration Steps
+
+1. In the Okta Admin Console, go to **Applications > Applications**.
+2. Click **Create App Integration**.
+3. Select **OIDC - OpenID Connect** and **Web Application**.
+4. Set **Sign-in redirect URIs** to:
+
+   ```
+   https://your-archestra-domain.com/api/auth/sso/callback/Okta
+   ```
+
+5. Set **Sign-out redirect URIs** to:
+
+   ```
+   https://your-archestra-domain.com/auth/sign-in
+   ```
+
+6. Assign the users or groups that should access Archestra.
+7. Save the Okta app integration, then copy the **Client ID** and **Client Secret**.
+8. In Archestra, go to **Settings > Identity Providers** and click **Enable** on the Okta card.
+9. Enter your Okta issuer URL, for example:
+
+   ```
+   https://your-org.okta.com
+   ```
+
+10. Enter your allowed email domains, Client ID, and Client Secret.
+11. Keep the discovery endpoint empty unless you need a custom value. Archestra derives it from the issuer as:
+
+    ```
+    https://your-org.okta.com/.well-known/openid-configuration
+    ```
+
+12. Click **Create Provider**.
+
+If you also use IdP token exchange for downstream MCP calls, configure the exchange client details in the optional **Enterprise-Managed Credentials** section of the OIDC provider form. See [Okta's AI agent token exchange guide](https://developer.okta.com/docs/guides/ai-agent-token-exchange/authserver/main/).
+
+#### SP-Initiated SSO
+
+Users can start sign-in from the Archestra sign-in page by selecting **Sign in with Okta**. After Okta authenticates the user, Archestra checks the returned email against **Allowed Email Domains**, provisions the user if needed, and opens the app.
+
+#### Troubleshoot
+
+- If setup fails with an issuer mismatch, verify that **Issuer** and **Discovery Endpoint** point to the same Okta org. Do not leave sample values such as `your-domain.okta.com` in either field.
+- If login fails after redirect, verify that the Okta **Sign-in redirect URI** exactly matches the Archestra callback URL, including `Okta` casing.
+- If sign-out returns an Okta error, verify that the Okta **Sign-out redirect URI** is set to `https://your-archestra-domain.com/auth/sign-in`, or disable **Enable RP-Initiated Logout** in Archestra for that provider.
+- If a user is denied after successful Okta authentication, verify that their email domain matches **Allowed Email Domains**.
 
 ### Google
 

--- a/platform/backend/src/models/identity-provider.ee.test.ts
+++ b/platform/backend/src/models/identity-provider.ee.test.ts
@@ -229,6 +229,111 @@ describe("IdentityProviderModel", () => {
       ).toBe("urn:ietf:params:oauth:token-type:access_token");
     });
 
+    test("clears persisted allowed email domains for non-Google API submissions", async ({
+      makeOrganization,
+      makeUser,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+
+      const registerSSOProvider = vi.fn(async ({ body }) => {
+        await db.insert(schema.identityProvidersTable).values({
+          id: crypto.randomUUID(),
+          providerId: body.providerId,
+          issuer: body.issuer,
+          domain: body.domain,
+          organizationId: org.id,
+          userId: user.id,
+          oidcConfig: JSON.stringify(
+            body.oidcConfig,
+          ) as unknown as typeof schema.identityProvidersTable.$inferInsert.oidcConfig,
+        });
+      });
+
+      const created = await IdentityProviderModel.create(
+        {
+          providerId: "Okta",
+          issuer: "https://integrator-8514409.okta.com",
+          domain: "example.com",
+          userId: user.id,
+          oidcConfig: {
+            issuer: "https://integrator-8514409.okta.com",
+            skipDiscovery: true,
+            pkce: true,
+            clientId: "okta-client-id",
+            clientSecret: "okta-client-secret",
+            discoveryEndpoint:
+              "https://integrator-8514409.okta.com/.well-known/openid-configuration",
+          },
+        },
+        org.id,
+        new Headers(),
+        {
+          api: {
+            registerSSOProvider,
+          },
+        } as unknown as Parameters<typeof IdentityProviderModel.create>[3],
+      );
+
+      expect(registerSSOProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            domain: "sso-placeholder.example.com",
+          }),
+        }),
+      );
+      expect(created.domain).toBe("");
+    });
+
+    test("keeps persisted allowed email domains for Google API submissions", async ({
+      makeOrganization,
+      makeUser,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+
+      const registerSSOProvider = vi.fn(async ({ body }) => {
+        await db.insert(schema.identityProvidersTable).values({
+          id: crypto.randomUUID(),
+          providerId: body.providerId,
+          issuer: body.issuer,
+          domain: body.domain,
+          organizationId: org.id,
+          userId: user.id,
+          oidcConfig: JSON.stringify(
+            body.oidcConfig,
+          ) as unknown as typeof schema.identityProvidersTable.$inferInsert.oidcConfig,
+        });
+      });
+
+      const created = await IdentityProviderModel.create(
+        {
+          providerId: "Google",
+          issuer: "https://accounts.google.com",
+          domain: "example.com",
+          userId: user.id,
+          oidcConfig: {
+            issuer: "https://accounts.google.com",
+            skipDiscovery: true,
+            pkce: true,
+            clientId: "google-client-id",
+            clientSecret: "google-client-secret",
+            discoveryEndpoint:
+              "https://accounts.google.com/.well-known/openid-configuration",
+          },
+        },
+        org.id,
+        new Headers(),
+        {
+          api: {
+            registerSSOProvider,
+          },
+        } as unknown as Parameters<typeof IdentityProviderModel.create>[3],
+      );
+
+      expect(created.domain).toBe("example.com");
+    });
+
     test("rejects registration when discovery fetch returns a non-2xx response", async ({
       makeOrganization,
       makeUser,
@@ -1023,8 +1128,29 @@ describe("IdentityProviderModel", () => {
 
       expect(updated).not.toBeNull();
       expect(updated?.issuer).toBe("https://new-issuer.com");
-      expect(updated?.domain).toBe("new.example.com");
+      expect(updated?.domain).toBe("");
       expect(updated?.providerId).toBe("Okta"); // Unchanged
+    });
+
+    test("keeps updated allowed email domains for Google providers", async ({
+      makeOrganization,
+      makeIdentityProvider,
+    }) => {
+      const org = await makeOrganization();
+
+      const inserted = await makeIdentityProvider(org.id, {
+        providerId: "Google",
+        issuer: "https://accounts.google.com",
+        domain: "old.example.com",
+      });
+
+      const updated = await IdentityProviderModel.update(
+        inserted.id,
+        { domain: "new.example.com" },
+        org.id,
+      );
+
+      expect(updated?.domain).toBe("new.example.com");
     });
 
     test("can update oidcConfig", async ({

--- a/platform/backend/src/models/identity-provider.ee.ts
+++ b/platform/backend/src/models/identity-provider.ee.ts
@@ -855,7 +855,10 @@ async function hydrateOidcConfigForRegistration<
     return data;
   }
 
-  const hydratedOidcConfig = await discoverOidcConfig(data.oidcConfig);
+  const hydratedOidcConfig = await discoverOidcConfig({
+    ...data.oidcConfig,
+    issuer: data.issuer,
+  });
 
   logger.info(
     {

--- a/platform/backend/src/models/identity-provider.ee.ts
+++ b/platform/backend/src/models/identity-provider.ee.ts
@@ -1,6 +1,10 @@
 import type { SSOOptions } from "@better-auth/sso";
 import type { IdentityProviderOidcConfig, IdpRoleMappingConfig } from "@shared";
-import { IDENTITY_TRUSTED_PROVIDER_IDS, MEMBER_ROLE_NAME } from "@shared";
+import {
+  IDENTITY_PROVIDER_ID,
+  IDENTITY_TRUSTED_PROVIDER_IDS,
+  MEMBER_ROLE_NAME,
+} from "@shared";
 import { APIError } from "better-auth";
 import { and, eq } from "drizzle-orm";
 import { jwtDecode } from "jwt-decode";
@@ -571,7 +575,11 @@ class IdentityProviderModel {
     const parsedData = {
       providerId: data.providerId,
       issuer: data.issuer,
-      domain: data.domain,
+      domain:
+        normalizePersistedAllowedEmailDomain({
+          providerId: data.providerId,
+          domain: data.domain,
+        }) || SSO_REGISTRATION_PLACEHOLDER_DOMAIN,
       organizationId,
       ...(data.oidcConfig && {
         oidcConfig:
@@ -635,9 +643,14 @@ class IdentityProviderModel {
     const samlConfigJson = serializeConfigValue(data.samlConfig);
     const roleMappingJson = serializeConfigValue(data.roleMapping);
     const teamSyncConfigJson = serializeConfigValue(data.teamSyncConfig);
+    const persistedDomain = normalizePersistedAllowedEmailDomain({
+      providerId: data.providerId,
+      domain: data.domain,
+    });
     const [updatedProvider] = await db
       .update(schema.identityProvidersTable)
       .set({
+        domain: persistedDomain,
         domainVerified: true,
         ...(oidcConfigJson !== undefined && {
           oidcConfig: oidcConfigJson as unknown as typeof data.oidcConfig,
@@ -700,6 +713,11 @@ class IdentityProviderModel {
     const samlConfigJson = serializeConfigValue(samlConfig);
     const roleMappingJson = serializeConfigValue(roleMapping);
     const teamSyncConfigJson = serializeConfigValue(teamSyncConfig);
+    const nextProviderId = restData.providerId ?? existingProvider.providerId;
+    const nextDomain = normalizePersistedAllowedEmailDomain({
+      providerId: nextProviderId,
+      domain: restData.domain ?? existingProvider.domain,
+    });
 
     // Update in database
     // WORKAROUND: Always ensure domainVerified is true to enable account linking
@@ -708,6 +726,7 @@ class IdentityProviderModel {
       .update(schema.identityProvidersTable)
       .set({
         ...restData,
+        domain: nextDomain,
         domainVerified: true,
         ...(oidcConfigJson !== undefined && {
           oidcConfig: oidcConfigJson as unknown as typeof oidcConfig,
@@ -827,6 +846,7 @@ class IdentityProviderModel {
 export default IdentityProviderModel;
 
 const OIDC_DISCOVERY_TIMEOUT_MS = 10_000;
+const SSO_REGISTRATION_PLACEHOLDER_DOMAIN = "sso-placeholder.example.com";
 
 function serializeConfigValue(
   value: string | object | null | undefined,
@@ -840,6 +860,17 @@ function serializeConfigValue(
   }
 
   return JSON.stringify(value);
+}
+
+function normalizePersistedAllowedEmailDomain(params: {
+  providerId: string;
+  domain: string;
+}): string {
+  if (params.providerId === IDENTITY_PROVIDER_ID.GOOGLE) {
+    return params.domain;
+  }
+
+  return "";
 }
 
 async function hydrateOidcConfigForRegistration<

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -309,10 +309,10 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
     expect(capturedInnerOnError).toBeDefined();
 
     const stage1Error = new Error("Upstream provider error");
-    const payload1 = capturedInnerOnError!(stage1Error);
+    const payload1 = capturedInnerOnError?.(stage1Error);
 
     const stage2Error = new Error(payload1);
-    const payload2 = capturedInnerOnError!(stage2Error);
+    const payload2 = capturedInnerOnError?.(stage2Error);
 
     expect(payload2).toBe(payload1);
 

--- a/platform/frontend/next.config.ts
+++ b/platform/frontend/next.config.ts
@@ -9,6 +9,7 @@ const platformPkg = JSON.parse(
 ) as { name: string; version: string };
 
 const nextConfig: NextConfig = {
+  allowedDevOrigins: getAllowedDevOrigins(),
   env: {
     NEXT_PUBLIC_APP_VERSION: platformPkg.version,
   },
@@ -75,6 +76,21 @@ const nextConfig: NextConfig = {
     ];
   },
 };
+
+function getAllowedDevOrigins(): string[] {
+  return [
+    process.env.ARCHESTRA_FRONTEND_URL,
+    process.env.ARCHESTRA_NGROK_DOMAIN,
+  ]
+    .filter((value): value is string => !!value)
+    .map((value) => {
+      try {
+        return new URL(value).host;
+      } catch {
+        return value;
+      }
+    });
+}
 
 export default withSentryConfig(nextConfig, {
   // For all available options, see:

--- a/platform/frontend/src/app/_parts/with-auth-check.test.tsx
+++ b/platform/frontend/src/app/_parts/with-auth-check.test.tsx
@@ -160,6 +160,19 @@ describe("WithAuthCheck", () => {
       expect(mockRouterPush).not.toHaveBeenCalled();
       expect(screen.getByTestId("protected-content")).toBeInTheDocument();
     });
+
+    it("should allow access to IdP-initiated SSO route without adding redirectTo", () => {
+      vi.mocked(usePathname).mockReturnValue("/auth/sso/Okta");
+
+      render(
+        <WithAuthCheck>
+          <MockChild />
+        </WithAuthCheck>,
+      );
+
+      expect(mockRouterPush).not.toHaveBeenCalled();
+      expect(screen.getByTestId("protected-content")).toBeInTheDocument();
+    });
   });
 
   describe("when user is authenticated", () => {

--- a/platform/frontend/src/app/_parts/with-auth-check.tsx
+++ b/platform/frontend/src/app/_parts/with-auth-check.tsx
@@ -21,6 +21,7 @@ const pathCorrespondsToAnAuthPage = (pathname: string) => {
   return (
     pathname?.startsWith("/auth/sign-in") ||
     pathname?.startsWith("/auth/sign-up") ||
+    pathname?.startsWith("/auth/sso") ||
     pathname?.startsWith("/auth/sign-out")
   );
 };
@@ -35,6 +36,7 @@ const pathCorrespondsToAnAuthPage = (pathname: string) => {
 const isSpecialAuthPage = (pathname: string) => {
   return (
     pathname?.startsWith("/auth/two-factor") ||
+    pathname?.startsWith("/auth/sso") ||
     pathname?.startsWith("/auth/sign-out")
   );
 };

--- a/platform/frontend/src/app/auth/_components/sign-out-with-idp-logout.test.tsx
+++ b/platform/frontend/src/app/auth/_components/sign-out-with-idp-logout.test.tsx
@@ -1,0 +1,46 @@
+import { archestraApiSdk } from "@shared";
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  hasSsoSignInAttempt,
+  recordSsoSignInAttempt,
+} from "@/lib/auth/sso-sign-in-attempt";
+import { SignOutWithIdpLogout } from "./sign-out-with-idp-logout";
+
+vi.mock("@shared", () => ({
+  archestraApiSdk: {
+    getIdentityProviderIdpLogoutUrl: vi.fn(),
+  },
+}));
+
+describe("SignOutWithIdpLogout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.sessionStorage.clear();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 200 })),
+    );
+    Object.defineProperty(window, "location", {
+      value: { href: "" },
+      writable: true,
+    });
+    vi.mocked(
+      archestraApiSdk.getIdentityProviderIdpLogoutUrl,
+    ).mockResolvedValue({
+      data: { url: null },
+    } as Awaited<
+      ReturnType<typeof archestraApiSdk.getIdentityProviderIdpLogoutUrl>
+    >);
+  });
+
+  it("clears stale SSO sign-in attempts during logout", async () => {
+    recordSsoSignInAttempt();
+
+    render(<SignOutWithIdpLogout />);
+
+    await waitFor(() => {
+      expect(hasSsoSignInAttempt()).toBe(false);
+    });
+  });
+});

--- a/platform/frontend/src/app/auth/_components/sign-out-with-idp-logout.tsx
+++ b/platform/frontend/src/app/auth/_components/sign-out-with-idp-logout.tsx
@@ -3,6 +3,7 @@
 import { archestraApiSdk } from "@shared";
 import { Loader2 } from "lucide-react";
 import { useEffect, useRef } from "react";
+import { clearSsoSignInAttempt } from "@/lib/auth/sso-sign-in-attempt";
 
 export function SignOutWithIdpLogout() {
   const hasStarted = useRef(false);
@@ -23,6 +24,8 @@ export function SignOutWithIdpLogout() {
 }
 
 async function performSignOut() {
+  clearSsoSignInAttempt();
+
   // Fetch IdP logout URL while still authenticated
   let idpLogoutUrl: string | null = null;
   try {

--- a/platform/frontend/src/app/auth/sso/[providerId]/page.test.tsx
+++ b/platform/frontend/src/app/auth/sso/[providerId]/page.test.tsx
@@ -1,4 +1,5 @@
-import { render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { useParams, useSearchParams } from "next/navigation";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { hasSsoSignInAttempt } from "@/lib/auth/sso-sign-in-attempt";
@@ -67,6 +68,27 @@ describe("IdpInitiatedSsoPage", () => {
           callbackURL: "https://app.example.com/chat",
         }),
       );
+    });
+  });
+
+  it("retries SSO when the initial request fails", async () => {
+    const user = userEvent.setup();
+    vi.mocked(authClient.signIn.sso)
+      .mockRejectedValueOnce(new Error("SSO failed"))
+      .mockResolvedValueOnce(
+        undefined as Awaited<ReturnType<typeof authClient.signIn.sso>>,
+      );
+
+    render(<IdpInitiatedSsoPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Try Again" })).toBeVisible();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Try Again" }));
+
+    await waitFor(() => {
+      expect(authClient.signIn.sso).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/platform/frontend/src/app/auth/sso/[providerId]/page.test.tsx
+++ b/platform/frontend/src/app/auth/sso/[providerId]/page.test.tsx
@@ -1,0 +1,72 @@
+import { render, waitFor } from "@testing-library/react";
+import { useParams, useSearchParams } from "next/navigation";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { hasSsoSignInAttempt } from "@/lib/auth/sso-sign-in-attempt";
+import { authClient } from "@/lib/clients/auth/auth-client";
+import IdpInitiatedSsoPage from "./page";
+
+vi.mock("next/navigation", () => ({
+  useParams: vi.fn(),
+  useSearchParams: vi.fn(),
+}));
+
+vi.mock("@/components/app-logo", () => ({
+  AppLogo: () => <div data-testid="app-logo" />,
+}));
+
+vi.mock("@/lib/clients/auth/auth-client", () => ({
+  authClient: {
+    signIn: {
+      sso: vi.fn(),
+    },
+  },
+}));
+
+describe("IdpInitiatedSsoPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.sessionStorage.clear();
+    Object.defineProperty(window, "location", {
+      value: { origin: "https://app.example.com" },
+      writable: true,
+    });
+    vi.mocked(useParams).mockReturnValue({ providerId: "Okta" });
+    vi.mocked(useSearchParams).mockReturnValue({
+      get: vi.fn().mockReturnValue(null),
+    } as unknown as ReturnType<typeof useSearchParams>);
+    vi.mocked(authClient.signIn.sso).mockResolvedValue(
+      undefined as Awaited<ReturnType<typeof authClient.signIn.sso>>,
+    );
+  });
+
+  it("starts SSO for the provider in the route", async () => {
+    render(<IdpInitiatedSsoPage />);
+
+    await waitFor(() => {
+      expect(authClient.signIn.sso).toHaveBeenCalledWith({
+        providerId: "Okta",
+        callbackURL: "https://app.example.com/",
+        errorCallbackURL: "https://app.example.com/auth/sign-in",
+      });
+    });
+    expect(hasSsoSignInAttempt()).toBe(true);
+  });
+
+  it("uses a safe redirectTo value as callback URL", async () => {
+    vi.mocked(useSearchParams).mockReturnValue({
+      get: vi.fn((key: string) =>
+        key === "redirectTo" ? encodeURIComponent("/chat") : null,
+      ),
+    } as unknown as ReturnType<typeof useSearchParams>);
+
+    render(<IdpInitiatedSsoPage />);
+
+    await waitFor(() => {
+      expect(authClient.signIn.sso).toHaveBeenCalledWith(
+        expect.objectContaining({
+          callbackURL: "https://app.example.com/chat",
+        }),
+      );
+    });
+  });
+});

--- a/platform/frontend/src/app/auth/sso/[providerId]/page.tsx
+++ b/platform/frontend/src/app/auth/sso/[providerId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useParams, useSearchParams } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { AppLogo } from "@/components/app-logo";
 import { LoadingSpinner } from "@/components/loading";
@@ -25,9 +25,10 @@ export default function IdpInitiatedSsoPage() {
 
   const providerId = params.providerId;
 
-  useEffect(() => {
+  const startSso = useCallback(() => {
     if (hasStarted.current) return;
     hasStarted.current = true;
+    setFailed(false);
 
     const redirectTo = searchParams.get("redirectTo");
     const callbackURL = getValidatedCallbackURLWithDefault(redirectTo);
@@ -45,6 +46,15 @@ export default function IdpInitiatedSsoPage() {
       });
   }, [providerId, searchParams]);
 
+  useEffect(() => {
+    startSso();
+  }, [startSso]);
+
+  const retrySso = useCallback(() => {
+    hasStarted.current = false;
+    startSso();
+  }, [startSso]);
+
   return (
     <main className="h-full flex items-center justify-center p-4">
       <div className="space-y-4 w-full max-w-md">
@@ -58,13 +68,7 @@ export default function IdpInitiatedSsoPage() {
           </CardHeader>
           <CardContent className="flex flex-col items-center gap-4">
             {failed ? (
-              <Button
-                type="button"
-                onClick={() => {
-                  hasStarted.current = false;
-                  setFailed(false);
-                }}
-              >
+              <Button type="button" onClick={retrySso}>
                 Try Again
               </Button>
             ) : (

--- a/platform/frontend/src/app/auth/sso/[providerId]/page.tsx
+++ b/platform/frontend/src/app/auth/sso/[providerId]/page.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useParams, useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { AppLogo } from "@/components/app-logo";
+import { LoadingSpinner } from "@/components/loading";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { recordSsoSignInAttempt } from "@/lib/auth/sso-sign-in-attempt";
+import { authClient } from "@/lib/clients/auth/auth-client";
+import { getValidatedCallbackURLWithDefault } from "@/lib/utils/redirect-validation";
+
+export default function IdpInitiatedSsoPage() {
+  const params = useParams<{ providerId: string }>();
+  const searchParams = useSearchParams();
+  const hasStarted = useRef(false);
+  const [failed, setFailed] = useState(false);
+
+  const providerId = params.providerId;
+
+  useEffect(() => {
+    if (hasStarted.current) return;
+    hasStarted.current = true;
+
+    const redirectTo = searchParams.get("redirectTo");
+    const callbackURL = getValidatedCallbackURLWithDefault(redirectTo);
+
+    recordSsoSignInAttempt();
+    authClient.signIn
+      .sso({
+        providerId,
+        callbackURL,
+        errorCallbackURL: `${window.location.origin}/auth/sign-in`,
+      })
+      .catch(() => {
+        setFailed(true);
+        toast.error("Failed to initiate SSO sign-in");
+      });
+  }, [providerId, searchParams]);
+
+  return (
+    <main className="h-full flex items-center justify-center p-4">
+      <div className="space-y-4 w-full max-w-md">
+        <AppLogo />
+        <Card>
+          <CardHeader>
+            <CardTitle>Redirecting to SSO</CardTitle>
+            <CardDescription>
+              Continue sign-in with your identity provider.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col items-center gap-4">
+            {failed ? (
+              <Button
+                type="button"
+                onClick={() => {
+                  hasStarted.current = false;
+                  setFailed(false);
+                }}
+              >
+                Try Again
+              </Button>
+            ) : (
+              <LoadingSpinner />
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.test.ts
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.test.ts
@@ -25,6 +25,53 @@ function makeOidcFormValues(
 }
 
 describe("normalizeIdentityProviderFormValues", () => {
+  it("syncs the nested OIDC issuer with the visible issuer field", () => {
+    const normalized = normalizeIdentityProviderFormValues(
+      makeOidcFormValues({
+        issuer: "https://integrator-8514409.okta.com",
+        providerId: "Okta",
+        oidcConfig: {
+          issuer: "https://your-domain.okta.com",
+          pkce: true,
+          clientId: "client-id",
+          clientSecret: "client-secret",
+          discoveryEndpoint:
+            "https://your-domain.okta.com/.well-known/openid-configuration",
+          mapping: { id: "sub", email: "email", name: "name" },
+        },
+      }),
+    );
+
+    expect(normalized.oidcConfig?.issuer).toBe(
+      "https://integrator-8514409.okta.com",
+    );
+    expect(normalized.oidcConfig?.discoveryEndpoint).toBe(
+      "https://integrator-8514409.okta.com/.well-known/openid-configuration",
+    );
+  });
+
+  it("keeps a custom discovery endpoint while syncing the nested OIDC issuer", () => {
+    const normalized = normalizeIdentityProviderFormValues(
+      makeOidcFormValues({
+        issuer: "https://login.example.com",
+        oidcConfig: {
+          issuer: "https://old-login.example.com",
+          pkce: true,
+          clientId: "client-id",
+          clientSecret: "client-secret",
+          discoveryEndpoint:
+            "https://discovery.example.com/.well-known/openid-configuration",
+          mapping: { id: "sub", email: "email", name: "name" },
+        },
+      }),
+    );
+
+    expect(normalized.oidcConfig?.issuer).toBe("https://login.example.com");
+    expect(normalized.oidcConfig?.discoveryEndpoint).toBe(
+      "https://discovery.example.com/.well-known/openid-configuration",
+    );
+  });
+
   it("fills inferred Keycloak enterprise-managed defaults when the section is used", () => {
     const normalized = normalizeIdentityProviderFormValues(
       makeOidcFormValues({

--- a/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.test.ts
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.test.ts
@@ -25,6 +25,28 @@ function makeOidcFormValues(
 }
 
 describe("normalizeIdentityProviderFormValues", () => {
+  it("clears allowed email domains for non-Google OIDC providers", () => {
+    const normalized = normalizeIdentityProviderFormValues(
+      makeOidcFormValues({
+        providerId: "Okta",
+        domain: "example.com",
+      }),
+    );
+
+    expect(normalized.domain).toBe("");
+  });
+
+  it("keeps allowed email domains for Google providers", () => {
+    const normalized = normalizeIdentityProviderFormValues(
+      makeOidcFormValues({
+        providerId: "Google",
+        domain: "example.com",
+      }),
+    );
+
+    expect(normalized.domain).toBe("example.com");
+  });
+
   it("syncs the nested OIDC issuer with the visible issuer field", () => {
     const normalized = normalizeIdentityProviderFormValues(
       makeOidcFormValues({

--- a/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.ts
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.ts
@@ -11,10 +11,14 @@ export function normalizeIdentityProviderFormValues(
     return data;
   }
 
+  const oidcConfig = normalizeOidcIssuerFields(data);
   const enterpriseManagedCredentials =
-    data.oidcConfig.enterpriseManagedCredentials;
+    oidcConfig.enterpriseManagedCredentials;
   if (!enterpriseManagedCredentials) {
-    return data;
+    return {
+      ...data,
+      oidcConfig,
+    };
   }
 
   const inferredExchangeType = inferEnterpriseExchangeType({
@@ -33,13 +37,16 @@ export function normalizeIdentityProviderFormValues(
   });
 
   if (!hasConfiguredEnterpriseManagedFields) {
-    return data;
+    return {
+      ...data,
+      oidcConfig,
+    };
   }
 
   return {
     ...data,
     oidcConfig: {
-      ...data.oidcConfig,
+      ...oidcConfig,
       enterpriseManagedCredentials: {
         exchangeStrategy: enterpriseManagedCredentials.exchangeStrategy
           ? enterpriseManagedCredentials.exchangeStrategy
@@ -53,6 +60,32 @@ export function normalizeIdentityProviderFormValues(
           getDefaultSubjectTokenType(inferredExchangeType),
       },
     },
+  };
+}
+
+export function normalizeOidcIssuerFields(
+  data: IdentityProviderFormValues,
+): NonNullable<IdentityProviderFormValues["oidcConfig"]> {
+  const oidcConfig = data.oidcConfig;
+  if (!oidcConfig) {
+    throw new Error("OIDC configuration is required");
+  }
+
+  const issuer = data.issuer.trim();
+  const previousIssuer = oidcConfig.issuer?.trim() ?? "";
+  const discoveryEndpoint = oidcConfig.discoveryEndpoint?.trim() ?? "";
+  const defaultPreviousDiscoveryEndpoint = previousIssuer
+    ? getDefaultDiscoveryEndpoint(previousIssuer)
+    : "";
+
+  return {
+    ...oidcConfig,
+    issuer,
+    discoveryEndpoint:
+      !discoveryEndpoint ||
+      discoveryEndpoint === defaultPreviousDiscoveryEndpoint
+        ? getDefaultDiscoveryEndpoint(issuer)
+        : discoveryEndpoint,
   };
 }
 
@@ -92,6 +125,10 @@ function tryParseIssuerUrl(issuer: string): URL | null {
   } catch {
     return null;
   }
+}
+
+function getDefaultDiscoveryEndpoint(issuer: string): string {
+  return `${issuer.replace(/\/$/, "")}/.well-known/openid-configuration`;
 }
 
 export function getDefaultTokenEndpointAuthentication(

--- a/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.ts
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.ts
@@ -1,4 +1,5 @@
 import {
+  IDENTITY_PROVIDER_ID,
   type IdentityProviderFormValues,
   isEntraHostname,
   isOktaHostname,
@@ -8,21 +9,22 @@ export function normalizeIdentityProviderFormValues(
   data: IdentityProviderFormValues,
 ): IdentityProviderFormValues {
   if (data.providerType !== "oidc" || !data.oidcConfig) {
-    return data;
+    return normalizeAllowedEmailDomains(data);
   }
 
-  const oidcConfig = normalizeOidcIssuerFields(data);
+  const normalizedData = normalizeAllowedEmailDomains(data);
+  const oidcConfig = normalizeOidcIssuerFields(normalizedData);
   const enterpriseManagedCredentials = oidcConfig.enterpriseManagedCredentials;
   if (!enterpriseManagedCredentials) {
     return {
-      ...data,
+      ...normalizedData,
       oidcConfig,
     };
   }
 
   const inferredExchangeType = inferEnterpriseExchangeType({
-    issuer: data.issuer,
-    providerId: data.providerId,
+    issuer: normalizedData.issuer,
+    providerId: normalizedData.providerId,
   });
 
   const hasConfiguredEnterpriseManagedFields = Object.values(
@@ -37,13 +39,13 @@ export function normalizeIdentityProviderFormValues(
 
   if (!hasConfiguredEnterpriseManagedFields) {
     return {
-      ...data,
+      ...normalizedData,
       oidcConfig,
     };
   }
 
   return {
-    ...data,
+    ...normalizedData,
     oidcConfig: {
       ...oidcConfig,
       enterpriseManagedCredentials: {
@@ -59,6 +61,19 @@ export function normalizeIdentityProviderFormValues(
           getDefaultSubjectTokenType(inferredExchangeType),
       },
     },
+  };
+}
+
+export function normalizeAllowedEmailDomains(
+  data: IdentityProviderFormValues,
+): IdentityProviderFormValues {
+  if (data.providerId === IDENTITY_PROVIDER_ID.GOOGLE) {
+    return data;
+  }
+
+  return {
+    ...data,
+    domain: "",
   };
 }
 

--- a/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.ts
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.ts
@@ -12,8 +12,7 @@ export function normalizeIdentityProviderFormValues(
   }
 
   const oidcConfig = normalizeOidcIssuerFields(data);
-  const enterpriseManagedCredentials =
-    oidcConfig.enterpriseManagedCredentials;
+  const enterpriseManagedCredentials = oidcConfig.enterpriseManagedCredentials;
   if (!enterpriseManagedCredentials) {
     return {
       ...data,

--- a/platform/frontend/src/app/settings/identity-providers/_parts/identity-providers-page.ee.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/identity-providers-page.ee.tsx
@@ -81,9 +81,8 @@ const IDP_CONFIGS: IdpConfig[] = [
     hideProviderId: true,
     providerType: "oidc",
     defaultOidcConfig: {
-      issuer: "https://your-domain.okta.com",
-      discoveryEndpoint:
-        "https://your-domain.okta.com/.well-known/openid-configuration",
+      issuer: "",
+      discoveryEndpoint: "",
       scopes: ["openid", "email", "profile"],
       mapping: {
         id: "sub",

--- a/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.test.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.test.tsx
@@ -94,8 +94,16 @@ describe("OidcConfigForm", () => {
     );
   });
 
-  it("explains that allowed email domains gate SSO sign-in", () => {
+  it("hides allowed email domains for non-Google providers", () => {
     render(<TestWrapper />);
+
+    expect(
+      screen.queryByLabelText("Allowed Email Domains"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("explains that allowed email domains gate Google SSO sign-in", () => {
+    render(<TestWrapper providerId="Google" />);
 
     expect(screen.getByLabelText("Allowed Email Domains")).toBeInTheDocument();
     expect(

--- a/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.tsx
@@ -66,6 +66,7 @@ export function OidcConfigForm({
   const scopes = form.watch("oidcConfig.scopes") || [];
   const issuer = form.watch("issuer") || "";
   const providerId = form.watch("providerId") || "";
+  const showAllowedEmailDomains = providerId === "Google";
 
   const inferredEnterpriseExchangeType = inferEnterpriseExchangeType({
     issuer,
@@ -135,24 +136,26 @@ export function OidcConfigForm({
           )}
         />
 
-        <FormField
-          control={form.control}
-          name="domain"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Allowed Email Domains</FormLabel>
-              <FormControl>
-                <Input placeholder="company.com, subsidiary.com" {...field} />
-              </FormControl>
-              <FormDescription>
-                Users can sign in with this provider only when their returned
-                email matches one of these domains. Separate multiple domains
-                with commas.
-              </FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+        {showAllowedEmailDomains && (
+          <FormField
+            control={form.control}
+            name="domain"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Allowed Email Domains</FormLabel>
+                <FormControl>
+                  <Input placeholder="company.com, subsidiary.com" {...field} />
+                </FormControl>
+                <FormDescription>
+                  Users can sign in with this provider only when their returned
+                  email matches one of these domains. Separate multiple domains
+                  with commas.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
 
         <Separator />
 

--- a/platform/frontend/src/app/settings/identity-providers/_parts/saml-config-form.ee.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/saml-config-form.ee.tsx
@@ -63,25 +63,6 @@ export function SamlConfigForm({ form, hideProviderId }: SamlConfigFormProps) {
           )}
         />
 
-        <FormField
-          control={form.control}
-          name="domain"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Allowed Email Domains</FormLabel>
-              <FormControl>
-                <Input placeholder="company.com, subsidiary.com" {...field} />
-              </FormControl>
-              <FormDescription>
-                Users can sign in with this provider only when their returned
-                email matches one of these domains. Separate multiple domains
-                with commas.
-              </FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
         <Separator />
 
         <div>

--- a/platform/shared/identity-provider.test.ts
+++ b/platform/shared/identity-provider.test.ts
@@ -104,6 +104,15 @@ describe("IdentityProviderFormSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts empty allowed email domains", () => {
+    const result = IdentityProviderFormSchema.safeParse({
+      ...validBase,
+      domain: "",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
   it("rejects invalid allowed email domains", () => {
     const result = IdentityProviderFormSchema.safeParse({
       ...validBase,

--- a/platform/shared/identity-provider.ts
+++ b/platform/shared/identity-provider.ts
@@ -230,12 +230,11 @@ export const IdentityProviderFormSchema = z
     issuer: z.string().min(1, "Issuer is required"),
     domain: z
       .string()
-      .min(1, "Allowed email domains are required")
       .refine(
         (value) => {
           const domains = parseAllowedIdentityProviderDomains(value);
           return (
-            domains.length > 0 &&
+            domains.length === 0 ||
             domains.every((domain) => DOMAIN_VALIDATION_REGEX.test(domain))
           );
         },


### PR DESCRIPTION
## Summary

Fixes and completes the Okta OIDC/O IN SSO flow:

- Keeps the submitted OIDC issuer in sync with the visible Issuer field and derives the default discovery endpoint from that issuer.
- Removes the Okta placeholder issuer defaults so admins must enter their real Okta org issuer.
- Adds `/auth/sso/[providerId]` for IdP-initiated SSO launches from Okta app tiles and OIN tests.
- Allows unauthenticated access to `/auth/sso/*` in the frontend auth guard so the route can start SSO instead of redirecting to the generic sign-in page.
- Clears stale SSO-attempt state during logout so an Okta logout return does not show a false "Sign-In Failed" alert.
- Makes Allowed Email Domains optional and only shown/preserved for Google; API/model-level normalization clears the persisted domain gate for non-Google IdPs so Okta OIN/JIT test users are not rejected by Archestra domain filtering.
- Adds local ngrok support for Next dev resources through `allowedDevOrigins`.
- Updates Okta docs for customer OIN installation, IdP-initiated SSO, JIT/SP/logout behavior, troubleshooting, and optional email-domain behavior.

## Why

Okta OIN testing exercises both SP-initiated and IdP-initiated OIDC flows. The existing setup could fail because Okta issuer/discovery values could drift from the UI input, the Okta app tile had no route that auto-started SSO, and optional test users could be blocked by Archestra's email-domain gate. Logout could also surface a stale SSO failure message after a successful session.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
