### PR TITLE
chore: polish /connection page UX

### DIFF
--- a/platform/frontend/src/app/connection/client-grid.tsx
+++ b/platform/frontend/src/app/connection/client-grid.tsx
@@ -45,7 +45,7 @@ export function ClientPicker({
   const pageItems = filtered.slice(start, start + CLIENT_PICKER_PAGE_SIZE);
 
   return (
-    <section className="border-b pb-5">
+    <section className="pb-5">
       <div className="flex flex-wrap items-center justify-between gap-3 pb-4">
         <h3 className="text-[17px] font-bold tracking-tight text-foreground">
           Select your client

--- a/platform/frontend/src/app/connection/connection-flow.tsx
+++ b/platform/frontend/src/app/connection/connection-flow.tsx
@@ -222,7 +222,7 @@ export function ConnectionFlow({
         metadata={connectionBaseUrls}
         value={baseUrl}
         onChange={setUserBaseUrl}
-        hideWhenSingleAndUnannotated
+        disabled={!clientId}
       />
 
       {/* Step 2 — MCP Gateway */}
@@ -255,6 +255,7 @@ export function ConnectionFlow({
               client={client}
               gatewayId={effectiveMcpId}
               gatewaySlug={selectedMcp.slug ?? effectiveMcpId}
+              gatewayName={selectedMcp.name}
               baseUrl={baseUrl}
             />
           )}

--- a/platform/frontend/src/app/connection/connection-url-step.tsx
+++ b/platform/frontend/src/app/connection/connection-url-step.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type { archestraApiTypes } from "@shared";
-import { CodeText } from "@/components/code-text";
 import {
   Select,
   SelectContent,
@@ -22,8 +21,8 @@ interface ConnectionUrlStepProps {
   /** Currently selected URL (controlled). */
   value: string;
   onChange: (url: string) => void;
-  /** Hide entirely when only one URL is configured AND no description exists. */
-  hideWhenSingleAndUnannotated?: boolean;
+  /** Disable the selector until a client is picked. */
+  disabled?: boolean;
 }
 
 /**
@@ -37,7 +36,7 @@ export function ConnectionUrlStep({
   metadata,
   value,
   onChange,
-  hideWhenSingleAndUnannotated = false,
+  disabled = false,
 }: ConnectionUrlStepProps) {
   const metaByUrl = new Map((metadata ?? []).map((m) => [m.url, m] as const));
   const items = candidateUrls.map((url) => ({
@@ -46,66 +45,51 @@ export function ConnectionUrlStep({
   }));
 
   if (items.length === 0) return null;
+  if (items.length === 1) return null;
 
   const selected = items.find((i) => i.url === value) ?? items[0];
 
-  if (
-    items.length === 1 &&
-    hideWhenSingleAndUnannotated &&
-    !selected.description
-  ) {
-    return null;
-  }
-
   return (
     <section className="border-b pb-5">
-      <h3 className="pb-4 text-[19px] font-bold tracking-tight text-foreground">
+      <h3 className="pb-4 text-[17px] font-bold tracking-tight text-foreground">
         Select an endpoint
       </h3>
 
-      {items.length > 1 ? (
-        <Select value={selected.url} onValueChange={onChange}>
-          <SelectTrigger className="h-12 w-full text-sm [&_svg:not([class*=size-])]:size-5">
-            <SelectValue>
-              <div className="flex min-w-0 flex-1 items-center gap-3 text-left">
-                <CodeText className="shrink-0 text-sm">{selected.url}</CodeText>
-                {selected.description && (
+      <Select value={selected.url} onValueChange={onChange} disabled={disabled}>
+        <SelectTrigger
+          disabled={disabled}
+          className="h-12 w-full bg-white text-sm dark:bg-background [&_svg:not([class*=size-])]:size-5"
+        >
+          <SelectValue>
+            <div className="flex min-w-0 flex-1 items-center gap-3 text-left">
+              <code className="shrink-0 font-mono text-sm">{selected.url}</code>
+              {selected.description && (
+                <span className="min-w-0 truncate text-sm text-muted-foreground">
+                  {selected.description}
+                </span>
+              )}
+            </div>
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent className="min-w-[var(--radix-select-trigger-width)]">
+          {items.map((item) => (
+            <SelectItem
+              key={item.url}
+              value={item.url}
+              className="py-2.5 pl-3 pr-9"
+            >
+              <div className="flex min-w-0 flex-1 items-center gap-3">
+                <code className="shrink-0 font-mono text-sm">{item.url}</code>
+                {item.description && (
                   <span className="min-w-0 truncate text-sm text-muted-foreground">
-                    {selected.description}
+                    {item.description}
                   </span>
                 )}
               </div>
-            </SelectValue>
-          </SelectTrigger>
-          <SelectContent className="min-w-[var(--radix-select-trigger-width)]">
-            {items.map((item) => (
-              <SelectItem
-                key={item.url}
-                value={item.url}
-                className="py-2.5 pl-3 pr-9"
-              >
-                <div className="flex min-w-0 flex-1 items-center gap-3">
-                  <CodeText className="shrink-0 text-sm">{item.url}</CodeText>
-                  {item.description && (
-                    <span className="min-w-0 truncate text-sm text-muted-foreground">
-                      {item.description}
-                    </span>
-                  )}
-                </div>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      ) : (
-        <div className="flex h-12 items-center gap-3 rounded-md border bg-muted/30 px-3">
-          <CodeText className="shrink-0 text-sm">{selected.url}</CodeText>
-          {selected.description && (
-            <span className="min-w-0 truncate text-sm text-muted-foreground">
-              {selected.description}
-            </span>
-          )}
-        </div>
-      )}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
     </section>
   );
 }

--- a/platform/frontend/src/app/connection/mcp-client-instructions.tsx
+++ b/platform/frontend/src/app/connection/mcp-client-instructions.tsx
@@ -40,6 +40,7 @@ interface McpClientInstructionsProps {
   client: ConnectClient;
   gatewayId: string;
   gatewaySlug: string;
+  gatewayName: string;
   /** Connection base URL chosen at the page level (see ConnectionUrlStep). */
   baseUrl: string;
 }
@@ -56,6 +57,7 @@ export function McpClientInstructions({
   client,
   gatewayId,
   gatewaySlug,
+  gatewayName,
   baseUrl,
 }: McpClientInstructionsProps) {
   const supportedAuth =
@@ -74,7 +76,9 @@ export function McpClientInstructions({
   }
 
   const mcpUrl = `${baseUrl}/mcp/${gatewaySlug}`;
-  const serverName = toMcpServerSlug(appName);
+  const serverName = gatewayName.trim()
+    ? gatewayName.trim().toLowerCase().replace(/\s+/g, "_")
+    : toMcpServerSlug(appName);
   const isQuick = client.mcp.kind === "custom" && client.mcp.quick === true;
 
   return (
@@ -211,11 +215,7 @@ function McpBody({
                   )}
                 </div>
                 {s.buildCommand && (
-                  <TerminalBlock
-                    title={s.terminalTitle ?? mcp.configFile}
-                    language={s.language ?? mcp.language}
-                    code={s.buildCommand(ctaParams)}
-                  />
+                  <TerminalBlock code={s.buildCommand(ctaParams)} />
                 )}
               </div>
             </li>
@@ -254,11 +254,7 @@ function McpBody({
           ))}
         </ol>
 
-        <TerminalBlock
-          title={mcp.configFile}
-          language={mcp.language}
-          code={configCode}
-        />
+        <TerminalBlock code={configCode} />
       </div>
     </div>
   );

--- a/platform/frontend/src/app/connection/proxy-client-instructions.tsx
+++ b/platform/frontend/src/app/connection/proxy-client-instructions.tsx
@@ -222,11 +222,7 @@ export function ProxyClientInstructions({
       ) : isCompatible && instruction ? (
         instruction.kind === "snippet" ? (
           <div className="space-y-2">
-            <TerminalBlock
-              title={`${client.label} · ${providerLabel}`}
-              language={instruction.language}
-              code={instruction.code}
-            />
+            <TerminalBlock code={instruction.code} />
             {instruction.note && <ProxyNote note={instruction.note} />}
           </div>
         ) : (

--- a/platform/frontend/src/app/connection/terminal-block.tsx
+++ b/platform/frontend/src/app/connection/terminal-block.tsx
@@ -5,24 +5,11 @@ import { useState } from "react";
 import { toast } from "sonner";
 
 interface TerminalBlockProps {
-  /** Filename or label shown next to the traffic-light dots. */
-  title: string;
-  /** Short language label shown as a pill next to the title. */
-  language: string;
   /** Raw code to render and copy. */
   code: string;
 }
 
-/**
- * Dark GitHub-style terminal block.
- *
- * Matches the code block in the handoff mockup (`instructions.jsx`):
- *  - `#0d1117` canvas, `#111827` title bar, `#1f2937` border
- *  - three macOS traffic-light dots
- *  - filename + language pill on the left
- *  - copy button on the right
- */
-export function TerminalBlock({ title, language, code }: TerminalBlockProps) {
+export function TerminalBlock({ code }: TerminalBlockProps) {
   const [copied, setCopied] = useState(false);
 
   const onCopy = async () => {
@@ -33,31 +20,20 @@ export function TerminalBlock({ title, language, code }: TerminalBlockProps) {
   };
 
   return (
-    <div className="overflow-hidden rounded-xl border border-[#1f2937] bg-[#0d1117] shadow-lg">
-      <div className="flex items-center gap-2.5 border-b border-[#1f2937] bg-[#111827] px-3.5 py-2.5">
-        <span className="size-2.5 rounded-full bg-[#ef4444]" />
-        <span className="size-2.5 rounded-full bg-[#f59e0b]" />
-        <span className="size-2.5 rounded-full bg-[#22c55e]" />
-        <span className="ml-2 truncate font-mono text-xs text-[#9ca3af]">
-          {title}
-        </span>
-        <span className="ml-1 rounded bg-[#1f2937] px-1.5 py-0.5 font-mono text-[10px] uppercase text-[#9ca3af]">
-          {language}
-        </span>
-        <button
-          type="button"
-          onClick={onCopy}
-          aria-label="Copy to clipboard"
-          className="ml-auto flex size-7 items-center justify-center rounded border border-[#1f2937] bg-[#0d1117] text-[#9ca3af] transition-colors hover:text-white"
-        >
-          {copied ? (
-            <Check className="size-3.5 text-[#4ade80]" strokeWidth={2.5} />
-          ) : (
-            <Copy className="size-3.5" strokeWidth={2} />
-          )}
-        </button>
-      </div>
-      <pre className="m-0 max-h-[360px] overflow-auto px-5 py-4 font-mono text-[13px] leading-[1.65] text-[#e5e7eb]">
+    <div className="relative overflow-hidden rounded-xl border border-[#1f2937] bg-[#0d1117] shadow-lg">
+      <button
+        type="button"
+        onClick={onCopy}
+        aria-label="Copy to clipboard"
+        className="absolute right-2 top-2 flex size-7 items-center justify-center rounded border border-[#1f2937] bg-[#0d1117] text-[#9ca3af] transition-colors hover:text-white"
+      >
+        {copied ? (
+          <Check className="size-3.5 text-[#4ade80]" strokeWidth={2.5} />
+        ) : (
+          <Copy className="size-3.5" strokeWidth={2} />
+        )}
+      </button>
+      <pre className="m-0 max-h-[360px] overflow-auto px-5 py-4 pr-12 font-mono text-[13px] leading-[1.65] text-[#e5e7eb]">
         {code}
       </pre>
     </div>

--- a/platform/frontend/src/app/llm/proxies/page.client.tsx
+++ b/platform/frontend/src/app/llm/proxies/page.client.tsx
@@ -432,9 +432,8 @@ function LlmProxies({ initialData }: { initialData?: LlmProxiesInitialData }) {
               onOpenChange={setIsCreateDialogOpen}
               agentType="llm_proxy"
               defaultIconType="llm_proxy"
-              onCreated={(proxy) => {
+              onCreated={() => {
                 setIsCreateDialogOpen(false);
-                navigateToConnection(proxy.id);
               }}
             />
 

--- a/platform/frontend/src/app/mcp/gateways/page.client.tsx
+++ b/platform/frontend/src/app/mcp/gateways/page.client.tsx
@@ -510,9 +510,8 @@ function McpGateways({
               onOpenChange={setIsCreateDialogOpen}
               agentType="mcp_gateway"
               defaultIconType="mcp_gateway"
-              onCreated={(gateway) => {
+              onCreated={() => {
                 setIsCreateDialogOpen(false);
-                navigateToConnection(gateway.id);
               }}
             />
 

--- a/platform/frontend/src/components/a2a-connection-instructions.tsx
+++ b/platform/frontend/src/components/a2a-connection-instructions.tsx
@@ -187,7 +187,6 @@ curl -X GET "${agentCardUrl}" \\
         metadata={connectionBaseUrls}
         value={connectionUrl}
         onChange={setUserBaseUrl}
-        hideWhenSingleAndUnannotated
       />
       {/* A2A Endpoint URL */}
       <div className="space-y-2">


### PR DESCRIPTION
- Stop redirecting to /connection after creating a gateway or LLM proxy; the dialog now just closes (table "Connect" actions still navigate).
- MCP server name in install snippets is derived from the gateway name (lowercased, spaces -> underscores) instead of the app-name slug.
- Strip the terminal-style header (traffic-light dots, title, language pill) from TerminalBlock; keep only the copy button.
- Match "Select an endpoint" heading size to "Select your client".
- Disable the endpoint selector until a client is picked.
- Hide the "Select an endpoint" section entirely when only one visible endpoint is configured.
- Remove the grey code-pill highlight around the endpoint URL.
- Use a white trigger background so the dropdown stands out from the page tint.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>