### PR TITLE
docs: add Okta Archestra setup step

### DIFF
--- a/docs/pages/platform-identity-providers.md
+++ b/docs/pages/platform-identity-providers.md
@@ -140,7 +140,8 @@ Okta is an enterprise identity management platform. Archestra supports Okta OIDC
 
 5. Complete the Okta app setup.
 6. Assign the users or groups that should access Archestra.
-7. Users can sign in from the Archestra sign-in page or from the Archestra tile on their Okta End-User Dashboard.
+7. In Archestra, go to **Settings > Identity Providers**, enable Okta, and enter the Okta issuer URL, client ID, and client secret from the Okta app integration.
+8. Users can sign in from the Archestra sign-in page or from the Archestra tile on their Okta End-User Dashboard.
 
 For Okta's general catalog installation flow, see [Add existing app integrations](https://help.okta.com/oie/en-us/Content/Topics/Apps/apps-add-applications.htm).
 


### PR DESCRIPTION
## Summary
- Add the missing Archestra-side Okta setup step after Okta user/group assignment.
- Keep the customer-facing OIN flow concise while noting the required issuer URL, client ID, and client secret entry in Archestra.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>