### PR TITLE
fix(chat): pad bedrock messages to satisfy Converse content rules

### DIFF
--- a/platform/CLAUDE.md
+++ b/platform/CLAUDE.md
@@ -17,6 +17,7 @@
 7. **No Auto Commits** - Never commit or push changes without explicit user approval. Always ask before running git commit or git push
 8. **No Database Modifications Without Approval** - NEVER run INSERT, UPDATE, DELETE, or any data-modifying SQL queries without explicit user approval. SELECT queries for reading data are allowed. Always ask before modifying database data directly.
 9. **NEVER MENTION REAL CUSTOMER NAMES OR IDENTIFIERS ANYWHERE IN CODE, COMMENTS, TESTS, DOCS, COMMITS, OR PR TEXT!!!!!!!!!!**
+10. **Never copy anything from Sentry into code, comments, tests, docs, commits, or PR text — and do not mention Sentry itself.** Sentry is for diagnosing the problem; describe the bug in neutral terms and cite no IDs, environments, URLs, user info, or stack snippets from there.
 
 ## Docs
 

--- a/platform/backend/src/routes/chat/routes.test.ts
+++ b/platform/backend/src/routes/chat/routes.test.ts
@@ -109,6 +109,130 @@ describe("prepareMessagesForProvider", () => {
 
     expect(messages[0]).toBe(message);
   });
+
+  const pdfFilePart = {
+    type: "file",
+    mediaType: "application/pdf",
+    filename: "report.pdf",
+    url: "data:application/pdf;base64,JVBERi0=",
+  };
+
+  it("prepends placeholder text for bedrock user messages with only a file part", () => {
+    const messages = __test.prepareMessagesForProvider({
+      provider: "bedrock",
+      messages: [{ role: "user", parts: [pdfFilePart] }],
+    });
+
+    expect(messages[0].parts).toEqual([
+      { type: "text", text: expect.stringMatching(/\S/) },
+      pdfFilePart,
+    ]);
+  });
+
+  it("prepends placeholder when the only existing text part is whitespace", () => {
+    const messages = __test.prepareMessagesForProvider({
+      provider: "bedrock",
+      messages: [
+        {
+          role: "user",
+          parts: [{ type: "text", text: "   " }, pdfFilePart],
+        },
+      ],
+    });
+
+    expect(messages[0].parts?.[0]).toMatchObject({
+      type: "text",
+      text: expect.stringMatching(/\S/),
+    });
+  });
+
+  it("leaves bedrock user messages with text and file untouched", () => {
+    const message = {
+      role: "user" as const,
+      parts: [{ type: "text", text: "Summarize this" }, pdfFilePart],
+    };
+
+    const messages = __test.prepareMessagesForProvider({
+      provider: "bedrock",
+      messages: [message],
+    });
+
+    expect(messages[0]).toBe(message);
+  });
+
+  it("pads bedrock assistant messages whose only text part is whitespace", () => {
+    const messages = __test.prepareMessagesForProvider({
+      provider: "bedrock",
+      messages: [{ role: "assistant", parts: [{ type: "text", text: "" }] }],
+    });
+
+    expect(messages[0].parts).toContainEqual(
+      expect.objectContaining({
+        type: "text",
+        text: expect.stringMatching(/\S/),
+      }),
+    );
+  });
+
+  it("pads bedrock messages whose reasoning lacks a bedrock signature", () => {
+    const messages = __test.prepareMessagesForProvider({
+      provider: "bedrock",
+      messages: [
+        {
+          role: "assistant",
+          parts: [{ type: "reasoning", text: "thinking..." }],
+        },
+      ],
+    });
+
+    expect(messages[0].parts).toContainEqual(
+      expect.objectContaining({
+        type: "text",
+        text: expect.stringMatching(/\S/),
+      }),
+    );
+  });
+
+  it("leaves bedrock assistant messages with a tool-call part untouched", () => {
+    const message = {
+      role: "assistant" as const,
+      parts: [
+        {
+          type: "tool-call",
+          toolCallId: "call_123",
+          toolName: "search",
+          input: { q: "x" },
+        },
+      ],
+    };
+
+    const messages = __test.prepareMessagesForProvider({
+      provider: "bedrock",
+      messages: [message],
+    });
+
+    expect(messages[0]).toBe(message);
+  });
+
+  it("leaves bedrock messages with reasoning that carries a bedrock signature", () => {
+    const message = {
+      role: "assistant" as const,
+      parts: [
+        {
+          type: "reasoning",
+          text: "thinking...",
+          providerOptions: { bedrock: { signature: "sig-abc" } },
+        },
+      ],
+    };
+
+    const messages = __test.prepareMessagesForProvider({
+      provider: "bedrock",
+      messages: [message],
+    });
+
+    expect(messages[0]).toBe(message);
+  });
 });
 
 describe("getMessagesNotYetPersisted", () => {

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -2127,9 +2127,7 @@ function prepareMessagesForProvider(params: {
   return messages;
 }
 
-function normalizeAnthropicMessageFileParts(
-  message: ChatMessage,
-): ChatMessage {
+function normalizeAnthropicMessageFileParts(message: ChatMessage): ChatMessage {
   if (!message.parts?.length) {
     return message;
   }

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -2112,32 +2112,118 @@ function prepareMessagesForProvider(params: {
 }): ChatMessage[] {
   const { messages, provider } = params;
 
-  if (provider !== "anthropic") {
-    return messages;
+  if (provider === "anthropic") {
+    return messages.map(normalizeAnthropicMessageFileParts);
   }
 
-  return messages.map((message) => {
-    if (!message.parts?.length) {
-      return message;
-    }
+  if (provider === "bedrock") {
+    return messages.map((message) =>
+      ensureBedrockMessageHasContent(
+        ensureBedrockUserMessageHasTextPart(message),
+      ),
+    );
+  }
 
-    let changed = false;
-    const parts = message.parts.map((part) => {
-      const normalizedPart = normalizeAnthropicFilePart(part);
-      if (normalizedPart !== part) {
-        changed = true;
-      }
-      return normalizedPart;
-    });
-
-    return changed
-      ? {
-          ...message,
-          parts,
-        }
-      : message;
-  });
+  return messages;
 }
+
+function normalizeAnthropicMessageFileParts(
+  message: ChatMessage,
+): ChatMessage {
+  if (!message.parts?.length) {
+    return message;
+  }
+
+  let changed = false;
+  const parts = message.parts.map((part) => {
+    const normalizedPart = normalizeAnthropicFilePart(part);
+    if (normalizedPart !== part) {
+      changed = true;
+    }
+    return normalizedPart;
+  });
+
+  return changed ? { ...message, parts } : message;
+}
+
+// Bedrock rejects user messages that contain a file/document block but no text
+// block ("A text block must be included when using documents."). When the user
+// sends a file with an empty prompt, prepend a placeholder so the request is
+// accepted.
+function ensureBedrockUserMessageHasTextPart(
+  message: ChatMessage,
+): ChatMessage {
+  if (message.role !== "user" || !message.parts?.length) {
+    return message;
+  }
+
+  let hasFilePart = false;
+  let hasNonEmptyTextPart = false;
+  for (const part of message.parts) {
+    if (part.type === "file") {
+      hasFilePart = true;
+    } else if (
+      part.type === "text" &&
+      typeof part.text === "string" &&
+      part.text.trim().length > 0
+    ) {
+      hasNonEmptyTextPart = true;
+    }
+  }
+
+  if (!hasFilePart || hasNonEmptyTextPart) {
+    return message;
+  }
+
+  return {
+    ...message,
+    parts: [
+      { type: "text", text: BEDROCK_DOCUMENT_PLACEHOLDER_TEXT },
+      ...message.parts,
+    ],
+  };
+}
+
+// Bedrock also rejects messages whose content array is empty after the AI SDK
+// drops empty text blocks and reasoning blocks without a signature ("The
+// content field in the Message object at messages.N is empty"). Pad with
+// placeholder text so turn alternation is preserved.
+function ensureBedrockMessageHasContent(message: ChatMessage): ChatMessage {
+  if (message.role === "system" || message.role === "tool") {
+    return message;
+  }
+  if (message.parts?.some(producesBedrockContentBlock)) {
+    return message;
+  }
+
+  const placeholder = {
+    type: "text",
+    text: BEDROCK_EMPTY_CONTENT_PLACEHOLDER_TEXT,
+  };
+  return {
+    ...message,
+    parts: message.parts ? [...message.parts, placeholder] : [placeholder],
+  };
+}
+
+// Mirrors the AI SDK's bedrock converter: text/reasoning blocks without usable
+// payload are silently dropped; everything else (tool-call, tool-result, file,
+// image) always produces a content block.
+function producesBedrockContentBlock(part: ChatMessagePart): boolean {
+  if (part.type === "text") {
+    return typeof part.text === "string" && part.text.trim().length > 0;
+  }
+  if (part.type === "reasoning") {
+    const bedrock = (part.providerOptions as { bedrock?: unknown } | undefined)
+      ?.bedrock as { signature?: unknown; redactedData?: unknown } | undefined;
+    return Boolean(bedrock?.signature || bedrock?.redactedData);
+  }
+  return true;
+}
+
+const BEDROCK_DOCUMENT_PLACEHOLDER_TEXT =
+  "Please review the attached document.";
+const BEDROCK_EMPTY_CONTENT_PLACEHOLDER_TEXT = "(no content)";
 
 function normalizeAnthropicFilePart(part: ChatMessagePart): ChatMessagePart {
   if (


### PR DESCRIPTION
## Summary
- Fixes two related Bedrock 400s on `POST /api/chat` seen in production:
  - *"A text block must be included when using documents."* — user attached a file with no text prompt; Bedrock requires both.
  - *"The content field in the Message object at messages.N is empty."* — a persisted message reached Bedrock with `content: []` after the AI SDK silently dropped empty text blocks and reasoning blocks lacking a bedrock signature.
- `prepareMessagesForProvider` now runs two passes for the bedrock branch: inject a placeholder text part on user file-only messages, then pad any non-system/non-tool message whose parts would all be filtered out by the AI SDK's bedrock converter. Anthropic path is unchanged.

