### PR TITLE
feat 3858: add agent template catalog

### DIFF
--- a/platform/backend/src/routes/agent-templates.test.ts
+++ b/platform/backend/src/routes/agent-templates.test.ts
@@ -1,0 +1,427 @@
+import { vi } from "vitest";
+import type { FastifyInstanceWithZod } from "@/server";
+import { createFastifyInstance } from "@/server";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import { McpServerModel } from "@/models";
+import { ApiError } from "@/types";
+import type { User } from "@/types";
+
+const GENERAL_PURPOSE_TEMPLATE_ID = "general-purpose-agent";
+const TEMPLATE_WITH_TOOLS_ID = "test-template-with-tools";
+const INVALID_TOOLS_TEMPLATE_ID = "test-template-invalid-tools";
+const UNKNOWN_SERVER_TEMPLATE_ID = "test-template-unknown-server";
+const DEDUP_TOOLS_TEMPLATE_ID = "test-template-dedup-tools";
+const MULTI_SERVER_TOOLS_TEMPLATE_ID = "test-template-multi-server-tools";
+
+const templateWithTools = vi.hoisted(() => ({
+  // Must not reference non-hoisted variables here (vi.mock is hoisted).
+  id: "test-template-with-tools",
+  name: "Test Template (tools)",
+  description: "Synthetic test template with tool assignments",
+  type: "test",
+  categories: ["mcp"],
+  systemPrompt: "Test prompt",
+  llmModel: null,
+  tools: ["internal-dev-test-server__print_archestra_test"],
+  labels: [],
+  icon: null,
+}));
+
+const templateWithInvalidTools = vi.hoisted(() => ({
+  id: "test-template-invalid-tools",
+  name: "Test Template (invalid tools)",
+  description: "Synthetic test template with invalid tool full names",
+  type: "test",
+  categories: ["mcp"],
+  systemPrompt: "Test prompt",
+  llmModel: null,
+  tools: ["this_is_not_a_valid_full_tool_name"],
+  labels: [],
+  icon: null,
+}));
+
+const templateWithUnknownServer = vi.hoisted(() => ({
+  id: "test-template-unknown-server",
+  name: "Test Template (unknown server)",
+  description: "Synthetic test template with tools referencing unknown server",
+  type: "test",
+  categories: ["mcp"],
+  systemPrompt: "Test prompt",
+  llmModel: null,
+  tools: ["unknown-server__some_tool"],
+  labels: [],
+  icon: null,
+}));
+
+const templateWithDuplicateToolsSameServer = vi.hoisted(() => ({
+  id: "test-template-dedup-tools",
+  name: "Test Template (dedup tools)",
+  description: "Synthetic test template with multiple tools on same server",
+  type: "test",
+  categories: ["mcp"],
+  systemPrompt: "Test prompt",
+  llmModel: null,
+  tools: [
+    "internal-dev-test-server__tool_a",
+    "internal-dev-test-server__tool_b",
+  ],
+  labels: [],
+  icon: null,
+}));
+
+const templateWithToolsAcrossMultipleServers = vi.hoisted(() => ({
+  id: "test-template-multi-server-tools",
+  name: "Test Template (multi server tools)",
+  description: "Synthetic test template with tools across multiple MCP servers",
+  type: "test",
+  categories: ["mcp"],
+  systemPrompt: "Test prompt",
+  llmModel: null,
+  tools: ["server-a__tool_a", "server-b__tool_b"],
+  labels: [],
+  icon: null,
+}));
+
+const requirePermissionMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/auth")>();
+  return {
+    ...actual,
+    getAgentTypePermissionChecker: async () => ({
+      require: requirePermissionMock,
+    }),
+  };
+});
+
+vi.mock("@shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@shared")>();
+
+  return {
+    ...actual,
+    AGENT_TEMPLATES: [
+      ...actual.AGENT_TEMPLATES,
+      templateWithTools,
+      templateWithInvalidTools,
+      templateWithUnknownServer,
+      templateWithDuplicateToolsSameServer,
+      templateWithToolsAcrossMultipleServers,
+    ],
+    getAgentTemplateById: (id: string) => {
+      if (id === TEMPLATE_WITH_TOOLS_ID) return templateWithTools;
+      if (id === INVALID_TOOLS_TEMPLATE_ID) return templateWithInvalidTools;
+      if (id === UNKNOWN_SERVER_TEMPLATE_ID) return templateWithUnknownServer;
+      if (id === DEDUP_TOOLS_TEMPLATE_ID) return templateWithDuplicateToolsSameServer;
+      if (id === MULTI_SERVER_TOOLS_TEMPLATE_ID) {
+        return templateWithToolsAcrossMultipleServers;
+      }
+      return actual.getAgentTemplateById(id);
+    },
+  };
+});
+
+describe("agent template routes", () => {
+  let app: FastifyInstanceWithZod;
+  let user: User;
+  let organizationId: string;
+
+  beforeEach(async ({ makeOrganization, makeAdmin, makeMember }) => {
+    const organization = await makeOrganization();
+    organizationId = organization.id;
+    user = await makeAdmin();
+    await makeMember(user.id, organizationId, { role: "admin" });
+
+    app = createFastifyInstance();
+    app.addHook("onRequest", async (request) => {
+      (
+        request as typeof request & {
+          user: User;
+          organizationId: string;
+        }
+      ).user = user;
+      (
+        request as typeof request & {
+          user: User;
+          organizationId: string;
+        }
+      ).organizationId = organizationId;
+    });
+
+    const { default: agentTemplateRoutes } = await import("./agent-templates");
+    await app.register(agentTemplateRoutes);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  test("GET /api/agent_templates returns templates with tools field", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/agent_templates",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const templates = response.json() as Array<{ id: string; tools: unknown }>;
+    expect(Array.isArray(templates)).toBe(true);
+    expect(templates.some((t) => t.id === GENERAL_PURPOSE_TEMPLATE_ID)).toBe(
+      true,
+    );
+    for (const t of templates) {
+      expect(Array.isArray(t.tools)).toBe(true);
+    }
+  });
+
+  test("GET /api/agent_templates returns 403 when user lacks agent create permission", async () => {
+    requirePermissionMock.mockImplementationOnce(() => {
+      throw new ApiError(403, "Forbidden");
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/agent_templates",
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
+
+  test("GET /api/agent_templates/:id/requirements returns empty when template has no tools", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/agent_templates/${encodeURIComponent(
+        GENERAL_PURPOSE_TEMPLATE_ID,
+      )}/requirements`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as {
+      templateId: string;
+      missingCatalogIds: string[];
+      missingCatalogs: unknown[];
+    };
+    expect(body.templateId).toBe(GENERAL_PURPOSE_TEMPLATE_ID);
+    expect(body.missingCatalogIds).toEqual([]);
+    expect(body.missingCatalogs).toEqual([]);
+  });
+
+  test("GET /api/agent_templates/:id/requirements returns 404 for unknown template", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/agent_templates/${encodeURIComponent(
+        "does-not-exist-template-id",
+      )}/requirements`,
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  test("GET /api/agent_templates/:id/requirements returns 403 when user lacks agent create permission", async () => {
+    requirePermissionMock.mockImplementationOnce(() => {
+      throw new ApiError(403, "Forbidden");
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/agent_templates/${encodeURIComponent(
+        GENERAL_PURPOSE_TEMPLATE_ID,
+      )}/requirements`,
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
+
+  test("GET /api/agent_templates/:id/requirements returns catalog IDs for template tools", async ({
+    makeInternalMcpCatalog,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      organizationId,
+      name: "internal-dev-test-server",
+      serverType: "local",
+      localConfig: {
+        command: "sh",
+        arguments: ["-c", "echo hi"],
+        transportType: "stdio",
+      },
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/agent_templates/${encodeURIComponent(
+        TEMPLATE_WITH_TOOLS_ID,
+      )}/requirements`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as {
+      templateId: string;
+      missingCatalogIds: string[];
+      missingCatalogs: Array<{ catalogId: string; catalogName: string }>;
+    };
+
+    expect(body.templateId).toBe(TEMPLATE_WITH_TOOLS_ID);
+    expect(body.missingCatalogIds).toContain(catalog.id);
+    expect(body.missingCatalogs.map((c) => c.catalogId)).toContain(catalog.id);
+    expect(body.missingCatalogs.map((c) => c.catalogName)).toContain(
+      "internal-dev-test-server",
+    );
+  });
+
+  test("GET /api/agent_templates/:id/requirements does not include missing catalogs when server is already accessible", async ({
+    makeInternalMcpCatalog,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      organizationId,
+      name: "internal-dev-test-server",
+      serverType: "local",
+      localConfig: {
+        command: "sh",
+        arguments: ["-c", "echo hi"],
+        transportType: "stdio",
+      },
+    });
+
+    vi.spyOn(McpServerModel, "findAll").mockResolvedValueOnce([
+      { catalogId: catalog.id } as never,
+    ]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/agent_templates/${encodeURIComponent(
+        TEMPLATE_WITH_TOOLS_ID,
+      )}/requirements`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as {
+      templateId: string;
+      missingCatalogIds: string[];
+      missingCatalogs: unknown[];
+    };
+
+    expect(body.templateId).toBe(TEMPLATE_WITH_TOOLS_ID);
+    expect(body.missingCatalogIds).toEqual([]);
+    expect(body.missingCatalogs).toEqual([]);
+  });
+
+  test("GET /api/agent_templates/:id/requirements deduplicates catalog IDs when multiple tools use the same server", async ({
+    makeInternalMcpCatalog,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      organizationId,
+      name: "internal-dev-test-server",
+      serverType: "local",
+      localConfig: {
+        command: "sh",
+        arguments: ["-c", "echo hi"],
+        transportType: "stdio",
+      },
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/agent_templates/${encodeURIComponent(
+        DEDUP_TOOLS_TEMPLATE_ID,
+      )}/requirements`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as {
+      templateId: string;
+      missingCatalogIds: string[];
+    };
+
+    expect(body.templateId).toBe(DEDUP_TOOLS_TEMPLATE_ID);
+    expect(body.missingCatalogIds).toEqual([catalog.id]);
+  });
+
+  test("GET /api/agent_templates/:id/requirements ignores tools referencing unknown serverName", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/agent_templates/${encodeURIComponent(
+        UNKNOWN_SERVER_TEMPLATE_ID,
+      )}/requirements`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as {
+      templateId: string;
+      missingCatalogIds: string[];
+      missingCatalogs: unknown[];
+    };
+
+    expect(body.templateId).toBe(UNKNOWN_SERVER_TEMPLATE_ID);
+    expect(body.missingCatalogIds).toEqual([]);
+    expect(body.missingCatalogs).toEqual([]);
+  });
+
+  test("GET /api/agent_templates/:id/requirements ignores invalid tool full names", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/agent_templates/${encodeURIComponent(
+        INVALID_TOOLS_TEMPLATE_ID,
+      )}/requirements`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as {
+      templateId: string;
+      missingCatalogIds: string[];
+      missingCatalogs: unknown[];
+    };
+
+    expect(body.templateId).toBe(INVALID_TOOLS_TEMPLATE_ID);
+    expect(body.missingCatalogIds).toEqual([]);
+    expect(body.missingCatalogs).toEqual([]);
+  });
+
+  test("GET /api/agent_templates/:id/requirements supports tools across multiple MCP servers", async ({
+    makeInternalMcpCatalog,
+  }) => {
+    const catalogA = await makeInternalMcpCatalog({
+      organizationId,
+      name: "server-a",
+      serverType: "local",
+      localConfig: {
+        command: "sh",
+        arguments: ["-c", "echo hi"],
+        transportType: "stdio",
+      },
+    });
+    const catalogB = await makeInternalMcpCatalog({
+      organizationId,
+      name: "server-b",
+      serverType: "local",
+      localConfig: {
+        command: "sh",
+        arguments: ["-c", "echo hi"],
+        transportType: "stdio",
+      },
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/agent_templates/${encodeURIComponent(
+        MULTI_SERVER_TOOLS_TEMPLATE_ID,
+      )}/requirements`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as {
+      templateId: string;
+      missingCatalogIds: string[];
+      missingCatalogs: Array<{ catalogId: string; catalogName: string }>;
+    };
+
+    expect(body.templateId).toBe(MULTI_SERVER_TOOLS_TEMPLATE_ID);
+    expect(body.missingCatalogIds).toEqual(
+      expect.arrayContaining([catalogA.id, catalogB.id]),
+    );
+    expect(body.missingCatalogIds).toHaveLength(2);
+    expect(body.missingCatalogs.map((c) => c.catalogId)).toEqual(
+      expect.arrayContaining([catalogA.id, catalogB.id]),
+    );
+    expect(body.missingCatalogs.map((c) => c.catalogName)).toEqual(
+      expect.arrayContaining(["server-a", "server-b"]),
+    );
+  });
+});

--- a/platform/backend/src/routes/agent-templates.ts
+++ b/platform/backend/src/routes/agent-templates.ts
@@ -1,0 +1,213 @@
+import {
+  AGENT_TEMPLATES,
+  getAgentTemplateById,
+  parseFullToolName,
+  RouteId,
+} from "@shared";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import { getAgentTypePermissionChecker } from "@/auth";
+import logger from "@/logging";
+import { InternalMcpCatalogModel, McpServerModel } from "@/models";
+import { ApiError, constructResponseSchema } from "@/types";
+
+const AgentTemplateSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  type: z.string(),
+  categories: z.array(z.string()),
+  systemPrompt: z.string(),
+  llmModel: z.string().nullable(),
+  tools: z.array(z.string()),
+  labels: z.array(z.object({ key: z.string(), value: z.string() })),
+  icon: z.string().nullable().optional(),
+});
+
+const InstallRequirementFieldSchema = z.object({
+  key: z.string(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  type: z.string(),
+  required: z.boolean().optional(),
+  sensitive: z.boolean().optional(),
+  default: z.unknown().optional(),
+});
+
+const AgentTemplateInstallRequirementsSchema = z.object({
+  templateId: z.string(),
+  missingCatalogIds: z.array(z.string()),
+  missingCatalogs: z.array(
+    z.object({
+      catalogId: z.string(),
+      catalogName: z.string(),
+      serverType: z.string(),
+      requiresOauth: z.boolean(),
+      userConfigFields: z.array(InstallRequirementFieldSchema),
+      environmentFields: z.array(
+        InstallRequirementFieldSchema.extend({
+          mounted: z.boolean().optional(),
+        }),
+      ),
+    }),
+  ),
+});
+
+const agentTemplateRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  fastify.get(
+    "/api/agent_templates",
+    {
+      schema: {
+        operationId: RouteId.GetAgentTemplates,
+        description: "Get available agent templates (code-defined)",
+        tags: ["Agent Templates"],
+        response: constructResponseSchema(z.array(AgentTemplateSchema)),
+      },
+    },
+    async ({ user, organizationId }, reply) => {
+      const checker = await getAgentTypePermissionChecker({
+        userId: user.id,
+        organizationId,
+      });
+      const agentType = "agent" as const;
+      checker.require(agentType, "create");
+
+      return reply.send(AGENT_TEMPLATES);
+    },
+  );
+
+  fastify.get(
+    "/api/agent_templates/:id/requirements",
+    {
+      schema: {
+        operationId: RouteId.GetAgentTemplateInstallRequirements,
+        description: "Get required MCP install inputs to use an agent template",
+        tags: ["Agent Templates"],
+        params: z.object({ id: z.string().min(1) }),
+        response: constructResponseSchema(
+          AgentTemplateInstallRequirementsSchema,
+        ),
+      },
+    },
+    async ({ user, organizationId, params }, reply) => {
+      const checker = await getAgentTypePermissionChecker({
+        userId: user.id,
+        organizationId,
+      });
+      const agentType = "agent" as const;
+      checker.require(agentType, "create");
+
+      const template = getAgentTemplateById(params.id);
+      if (!template) {
+        throw new ApiError(404, "Agent template not found");
+      }
+
+      const catalogIds =
+        (await getCatalogIdsForTemplateTools(template.tools)) ?? [];
+      if (catalogIds.length === 0) {
+        return reply.send({
+          templateId: template.id,
+          missingCatalogIds: [],
+          missingCatalogs: [],
+        });
+      }
+
+      const accessibleServers = await McpServerModel.findAll(user.id, false);
+      const accessibleCatalogIdSet = new Set(
+        accessibleServers.map((s) => s.catalogId).filter(Boolean),
+      );
+      const missingCatalogIds = catalogIds.filter(
+        (catalogId) => !accessibleCatalogIdSet.has(catalogId),
+      );
+
+      const missingCatalogs = [];
+      for (const catalogId of missingCatalogIds) {
+        const item = await InternalMcpCatalogModel.findById(catalogId);
+        if (!item) continue;
+
+        const userConfigFields = Object.entries(item.userConfig ?? {})
+          .filter(([, field]) => field.promptOnInstallation === true)
+          .map(([key, field]) => ({
+            key,
+            title: field.title,
+            description: field.description,
+            type: field.type,
+            required: field.required,
+            sensitive: field.sensitive,
+            default: field.default,
+          }));
+
+        const environmentFields =
+          item.localConfig?.environment
+            ?.filter((env) => env.promptOnInstallation === true)
+            .map((env) => ({
+              key: env.key,
+              title: env.key,
+              description: env.description,
+              type: env.type,
+              required: env.required,
+              sensitive: env.type === "secret",
+              default: env.default,
+              mounted: env.mounted,
+            })) ?? [];
+
+        missingCatalogs.push({
+          catalogId: item.id,
+          catalogName: item.name,
+          serverType: item.serverType,
+          requiresOauth: !!item.oauthConfig,
+          userConfigFields,
+          environmentFields,
+        });
+      }
+
+      logger.info(
+        {
+          userId: user.id,
+          organizationId,
+          agentTemplateId: template.id,
+          resolvedCatalogCount: catalogIds.length,
+          missingCatalogCount: missingCatalogIds.length,
+          missingCatalogIds,
+        },
+        "Computed agent template MCP install requirements",
+      );
+
+      return reply.send({
+        templateId: template.id,
+        missingCatalogIds,
+        missingCatalogs,
+      });
+    },
+  );
+};
+
+export default agentTemplateRoutes;
+
+async function getCatalogIdsForTemplateTools(
+  toolFullNames: string[] | undefined,
+): Promise<string[] | null> {
+  if (!toolFullNames || toolFullNames.length === 0) return null;
+
+  const serverNameSet = new Set<string>();
+  for (const fullName of toolFullNames) {
+    const parsed = parseFullToolName(fullName);
+    if (parsed.serverName) serverNameSet.add(parsed.serverName);
+  }
+  if (serverNameSet.size === 0) return [];
+
+  const catalogIds: string[] = [];
+  for (const serverName of serverNameSet) {
+    const catalogItem = await InternalMcpCatalogModel.findByName(serverName);
+    if (!catalogItem) {
+      logger.warn(
+        { serverName },
+        "Agent template tool assignments reference unknown MCP catalog name",
+      );
+      continue;
+    }
+    catalogIds.push(catalogItem.id);
+  }
+
+  return catalogIds;
+}

--- a/platform/backend/src/routes/index.ts
+++ b/platform/backend/src/routes/index.ts
@@ -1,6 +1,7 @@
 export { default as browserStreamRoutes } from "@/features/browser-stream/routes/browser-stream.routes";
 export { default as a2aRoutes } from "./a2a";
 export { default as agentRoutes } from "./agent";
+export { default as agentTemplateRoutes } from "./agent-templates";
 export { default as agentToolRoutes } from "./agent-tool";
 export { default as apiKeyRoutes } from "./api-key";
 export { default as authRoutes } from "./auth";

--- a/platform/e2e-tests/playwright.config.ts
+++ b/platform/e2e-tests/playwright.config.ts
@@ -37,6 +37,7 @@ const testPatterns = {
 
 const uiTestMatch = [
   "**/agents.spec.ts",
+  "**/agent-templates.spec.ts",
   "**/auth-origin.spec.ts",
   "**/auth-redirect.spec.ts",
   "**/auth.spec.ts",

--- a/platform/e2e-tests/tests/agent-templates.spec.ts
+++ b/platform/e2e-tests/tests/agent-templates.spec.ts
@@ -1,0 +1,64 @@
+import { E2eTestId } from "@shared";
+import { expect, test } from "../fixtures";
+import { clickButton, waitForElementWithReload } from "../utils";
+
+test("can create an agent from template catalog", {
+  tag: ["@firefox", "@webkit"],
+}, async ({ page, makeRandomString, goToPage }) => {
+  test.setTimeout(120_000);
+
+  await goToPage(page, "/agents");
+  await page.waitForLoadState("domcontentloaded");
+
+  const createButton = page.getByTestId(E2eTestId.CreateAgentButton);
+  await waitForElementWithReload(page, createButton);
+  await createButton.click();
+
+  await page
+    .getByRole("button", { name: "Select from Template Catalog" })
+    .click();
+
+  // Template catalog is rendered inside the create dialog
+  await expect(
+    page.getByRole("button", { name: "Use as Template" }).first(),
+  ).toBeVisible({ timeout: 15_000 });
+
+  // Use the general-purpose template (safe in prod, no tools)
+  await page
+    .getByRole("heading", { name: "General Purpose Agent" })
+    .locator("..")
+    .getByRole("button", { name: "Use as Template" })
+    .click();
+
+  // Verify prefills applied
+  const nameInput = page.getByRole("textbox", { name: "Name" });
+  await expect(nameInput).toHaveValue("General Purpose Agent");
+
+  const agentName = makeRandomString(6, "General Purpose Agent");
+  await nameInput.fill(agentName);
+
+  await page.getByRole("button", { name: "Create" }).click();
+
+  // Wait for the create dialog to close
+  await expect(page.getByRole("dialog")).not.toBeVisible({ timeout: 15_000 });
+  await page.waitForLoadState("domcontentloaded");
+
+  // Poll for the agent to appear in the table
+  const agentLocator = page
+    .getByTestId(E2eTestId.AgentsTable)
+    .getByTitle(agentName);
+
+  await waitForElementWithReload(page, agentLocator, {
+    timeout: 30_000,
+    intervals: [2000, 3000, 5000],
+    checkEnabled: false,
+  });
+
+  // Cleanup: delete created agent
+  await page
+    .getByTestId(`${E2eTestId.DeleteAgentButton}-${agentName}`)
+    .click();
+  await clickButton({ page, options: { name: "Delete Agent" } });
+  await expect(agentLocator).not.toBeVisible({ timeout: 10_000 });
+});
+

--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -26,6 +26,7 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import {
   AlertTriangle,
+  ArrowLeft,
   Bot,
   Building2,
   CheckIcon,
@@ -36,6 +37,7 @@ import {
   Loader2,
   Plus,
   RotateCcw,
+  Search,
   User,
   Users,
   X,
@@ -55,6 +57,7 @@ import {
   AgentToolsEditor,
   type AgentToolsEditorRef,
 } from "@/components/agent-tools-editor";
+import { AgentTemplateCatalogPanel } from "@/components/agent-template-catalog-dialog";
 import { ModelSelector } from "@/components/chat/model-selector";
 import { ExternalDocsLink } from "@/components/external-docs-link";
 import {
@@ -636,6 +639,15 @@ export function AgentDialog({
   const [toolExposureMode, setToolExposureMode] =
     useState<ToolExposureMode>("full");
   const [isSaving, setIsSaving] = useState(false);
+  const [createWizardStep, setCreateWizardStep] = useState<
+    "form" | "template-browse"
+  >("form");
+  const [templateToolFullNames, setTemplateToolFullNames] = useState<
+    string[] | null
+  >(null);
+  const [templateSelectionKey, setTemplateSelectionKey] = useState<
+    string | null
+  >(null);
 
   // Determine type-specific visibility based on agentType prop
   const isInternalAgent = agentType === "agent";
@@ -750,6 +762,9 @@ export function AgentDialog({
         setToolExposureMode("full");
         setAutoConfigureOnToolDiscovery(false);
         setDualLlmMaxRounds("5");
+        setCreateWizardStep("form");
+        setTemplateToolFullNames(null);
+        setTemplateSelectionKey(null);
       }
       // Reset counts when dialog opens
       setSelectedToolsCount(0);
@@ -1124,6 +1139,9 @@ export function AgentDialog({
     onOpenChange(false);
   }, [onOpenChange]);
 
+  const isCreateAgentDialog =
+    !agent && !readOnly && agentType === "agent" && !isBuiltIn;
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-5xl h-[90vh] flex flex-col overflow-hidden">
@@ -1131,11 +1149,29 @@ export function AgentDialog({
           <div className="flex items-start justify-between gap-4 pr-6">
             <div className="min-w-0 flex-1">
               <DialogTitle className="flex items-center gap-2">
-                {readOnly
-                  ? `View ${agent?.name ?? "Agent"}`
-                  : isBuiltIn
-                    ? `Edit ${agent?.name ?? "Built-In Agent"}`
-                    : getDialogTitle(agentType, !!agent)}
+                {isCreateAgentDialog &&
+                createWizardStep === "template-browse" ? (
+                  <button
+                    type="button"
+                    onClick={() => setCreateWizardStep("form")}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        setCreateWizardStep("form");
+                      }
+                    }}
+                    className="inline-flex items-center gap-2 text-left"
+                  >
+                    <ArrowLeft className="h-4 w-4" />
+                    <span>Create Agent</span>
+                  </button>
+                ) : readOnly ? (
+                  `View ${agent?.name ?? "Agent"}`
+                ) : isBuiltIn ? (
+                  `Edit ${agent?.name ?? "Built-In Agent"}`
+                ) : (
+                  getDialogTitle(agentType, !!agent)
+                )}
                 {!isBuiltIn && (
                   <AgentBadge type={scope} className="font-normal" />
                 )}
@@ -1179,7 +1215,42 @@ export function AgentDialog({
         >
           <fieldset disabled={readOnly} className="contents">
             <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 pb-4 space-y-4">
-              {agentType === "profile" && (
+              {isCreateAgentDialog && createWizardStep === "template-browse" ? (
+                <AgentTemplateCatalogPanel
+                  enabled
+                  onSelectTemplate={(template) => {
+                    setName(template.name);
+                    setDescription(template.description);
+                    setSystemPrompt(template.systemPrompt);
+                    setLlmModel(template.llmModel);
+                    setTemplateToolFullNames(template.tools ?? []);
+                    setTemplateSelectionKey(template.id);
+                    setLabels(
+                      (template.labels ?? []).map((l) => ({
+                        key: l.key,
+                        value: l.value,
+                      })),
+                    );
+                    setIcon(template.icon ?? null);
+                    setCreateWizardStep("form");
+                  }}
+                  onRequestClose={() => setCreateWizardStep("form")}
+                />
+              ) : (
+                <>
+                  {isCreateAgentDialog ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="w-full"
+                      onClick={() => setCreateWizardStep("template-browse")}
+                    >
+                      <Search className="h-4 w-4 mr-2" />
+                      Select from Template Catalog
+                    </Button>
+                  ) : null}
+
+                  {agentType === "profile" && (
                 <Alert variant="warning">
                   <AlertTriangle className="h-4 w-4" />
                   <AlertDescription>
@@ -1188,7 +1259,7 @@ export function AgentDialog({
                     and Labels.
                   </AlertDescription>
                 </Alert>
-              )}
+                  )}
 
               {/* Section 1: Name, Description, Visibility, LLM Configuration */}
               {showPrimarySettingsCard && (
@@ -1534,6 +1605,14 @@ export function AgentDialog({
                           assignmentTeamIds={assignedTeamIds}
                           onSelectedCountChange={setSelectedToolsCount}
                           openComboboxOnMount={openToolsCombobox}
+                          initialToolFullNames={
+                            !agent
+                              ? (templateToolFullNames ?? undefined)
+                              : undefined
+                          }
+                          initialSelectionKey={
+                            !agent ? templateSelectionKey : null
+                          }
                         />
                       </>
                     ) : agent ? (
@@ -2202,13 +2281,16 @@ export function AgentDialog({
                   </div>
                 </div>
               )}
+                </>
+              )}
             </div>
           </fieldset>
           <DialogStickyFooter className="mt-0">
             <Button type="button" variant="outline" onClick={handleClose}>
               {readOnly ? "Close" : "Cancel"}
             </Button>
-            {!readOnly && (
+            {!readOnly &&
+              !(isCreateAgentDialog && createWizardStep === "template-browse") && (
               <Button
                 type="submit"
                 disabled={

--- a/platform/frontend/src/components/agent-template-catalog-dialog.tsx
+++ b/platform/frontend/src/components/agent-template-catalog-dialog.tsx
@@ -1,0 +1,752 @@
+"use client";
+
+import { parseFullToolName } from "@shared";
+import { useQueries, useQuery } from "@tanstack/react-query";
+import { Info, Search, Server } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { InstallationProgress } from "@/app/mcp/registry/_parts/installation-progress";
+import {
+  LocalServerInstallDialog,
+  type LocalServerInstallResult,
+} from "@/app/mcp/registry/_parts/local-server-install-dialog";
+import {
+  NoAuthInstallDialog,
+  type NoAuthInstallResult,
+} from "@/app/mcp/registry/_parts/no-auth-install-dialog";
+import {
+  RemoteServerInstallDialog,
+  type RemoteServerInstallResult,
+} from "@/app/mcp/registry/_parts/remote-server-install-dialog";
+import { DebouncedInput } from "@/components/debounced-input";
+import { OAuthConfirmationDialog } from "@/components/oauth-confirmation-dialog";
+import { StandardDialog } from "@/components/standard-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  fetchCatalogTools,
+  useInternalMcpCatalog,
+} from "@/lib/mcp/internal-mcp-catalog.query";
+import { useMcpInstallOrchestrator } from "@/lib/mcp/mcp-install-orchestrator.hook";
+import { useMcpServers } from "@/lib/mcp/mcp-server.query";
+
+type AgentTemplate = {
+  id: string;
+  name: string;
+  description: string;
+  type: string;
+  categories: string[];
+  systemPrompt: string;
+  llmModel: string | null;
+  tools: string[];
+  labels: Array<{ key: string; value: string }>;
+  icon?: string | null;
+};
+
+type AgentTemplateInstallRequirements = {
+  templateId: string;
+  missingCatalogIds: string[];
+  missingCatalogs: Array<{
+    catalogId: string;
+    catalogName: string;
+    serverType: string;
+    requiresOauth: boolean;
+    userConfigFields: unknown[];
+    environmentFields: unknown[];
+  }>;
+};
+
+function TemplateDetailsDialog({
+  template,
+  open,
+  onOpenChange,
+}: {
+  template: AgentTemplate | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { data: catalogItems = [] } = useInternalMcpCatalog({});
+
+  const requiredCatalogIds = useMemo(() => {
+    const serverNameSet = new Set<string>();
+    for (const fullName of template?.tools ?? []) {
+      const parsed = parseFullToolName(fullName);
+      if (parsed.serverName) serverNameSet.add(parsed.serverName);
+    }
+
+    const ids: string[] = [];
+    for (const serverName of serverNameSet) {
+      const catalogId = catalogItems.find((c) => c.name === serverName)?.id;
+      if (catalogId) ids.push(catalogId);
+    }
+    return ids;
+  }, [template?.tools, catalogItems]);
+
+  const toolQueries = useQueries({
+    queries: requiredCatalogIds.map((catalogId) => ({
+      queryKey: ["mcp-catalog", catalogId, "tools"] as const,
+      queryFn: () => fetchCatalogTools(catalogId),
+      enabled: open && !!template && requiredCatalogIds.length > 0,
+    })),
+  });
+
+  const toolDescriptionByName = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const q of toolQueries) {
+      for (const t of (q.data ?? []) as Array<{
+        name: string;
+        description: string;
+      }>) {
+        if (t?.name && t?.description) map.set(t.name, t.description);
+      }
+    }
+    return map;
+  }, [toolQueries]);
+
+  if (!template) return null;
+
+  return (
+    <StandardDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Template details"
+      description="Review what this template will configure for the agent."
+      size="large"
+      bodyClassName="space-y-4"
+      footer={
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+          >
+            Close
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-2">
+        <div className="text-sm font-medium">About</div>
+        <div className="text-sm text-muted-foreground">
+          {template.description}
+        </div>
+        <div className="mt-2 flex flex-wrap gap-2">
+          <Badge variant="outline">{template.type}</Badge>
+          {(template.categories ?? []).map((c) => (
+            <Badge key={c} variant="outline">
+              {c}
+            </Badge>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="space-y-2 md:col-span-2">
+          <div className="text-sm font-medium">Agent name</div>
+          <div className="text-sm text-muted-foreground">{template.name}</div>
+        </div>
+        <div className="space-y-2">
+          <div className="text-sm font-medium">Model</div>
+          <div className="text-sm text-muted-foreground">
+            {template.llmModel ? template.llmModel : "Org default"}
+          </div>
+        </div>
+        <div className="space-y-2">
+          <div className="text-sm font-medium">Tools</div>
+          <div className="text-sm text-muted-foreground">
+            {(template.tools ?? []).length} selected
+          </div>
+        </div>
+        <div className="space-y-2 md:col-span-2">
+          <div className="text-sm font-medium">Labels</div>
+          <div className="flex flex-wrap gap-2">
+            {(template.labels ?? []).length === 0 ? (
+              <span className="text-sm text-muted-foreground">None</span>
+            ) : (
+              template.labels.map((l) => (
+                <Badge key={`${l.key}:${l.value}`} variant="outline">
+                  {l.key}:{l.value}
+                </Badge>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+
+      {(template.tools ?? []).length > 0 ? (
+        <div className="space-y-2">
+          <div className="text-sm font-medium">Selected tools</div>
+          <div className="space-y-2">
+            {(template.tools ?? []).map((fullName) => (
+              <div key={fullName} className="rounded-md border p-3">
+                <div className="font-mono text-xs">{fullName}</div>
+                <div className="mt-2 text-sm text-muted-foreground">
+                  {toolDescriptionByName.get(fullName) ??
+                    "Description not available (tool not discovered yet)."}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <div className="space-y-2">
+        <div className="text-sm font-medium">System prompt</div>
+        <pre className="whitespace-pre-wrap rounded-md border bg-muted p-3 text-xs leading-relaxed">
+          {template.systemPrompt}
+        </pre>
+      </div>
+    </StandardDialog>
+  );
+}
+
+export function AgentTemplateCatalogPanel({
+  enabled,
+  onSelectTemplate,
+  onRequestClose,
+}: {
+  enabled: boolean;
+  onSelectTemplate?: (template: AgentTemplate) => void;
+  onRequestClose?: () => void;
+}) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedType, setSelectedType] = useState<string>("all");
+  const [selectedCategory, setSelectedCategory] = useState<string>("all");
+  const [detailsTemplateId, setDetailsTemplateId] = useState<string | null>(
+    null,
+  );
+  const [mcpServersDialogTemplateId, setMcpServersDialogTemplateId] = useState<
+    string | null
+  >(null);
+  const orchestrator = useMcpInstallOrchestrator();
+  const { data: catalogItems } = useInternalMcpCatalog({});
+  const { data: installedServers = [] } = useMcpServers({});
+  const hasInstallingServers = useMemo(
+    () =>
+      installedServers.some(
+        (s) =>
+          s.localInstallationStatus === "pending" ||
+          s.localInstallationStatus === "discovering-tools",
+      ),
+    [installedServers],
+  );
+  const { data: installedServersPolled = [] } = useMcpServers({
+    enabled,
+    hasInstallingServers,
+  });
+
+  const { data: templates = [], isPending } = useQuery({
+    queryKey: ["agent-templates"],
+    queryFn: async (): Promise<AgentTemplate[]> => {
+      const res = await fetch("/api/agent_templates", {
+        method: "GET",
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error("Failed to load templates");
+      return (await res.json()) as AgentTemplate[];
+    },
+    enabled,
+  });
+
+  const mcpServersDialogRequirementsQuery = useQuery({
+    queryKey: [
+      "agent-template-requirements-dialog",
+      mcpServersDialogTemplateId,
+    ],
+    queryFn: async (): Promise<AgentTemplateInstallRequirements> => {
+      if (!mcpServersDialogTemplateId) throw new Error("No template selected");
+      const res = await fetch(
+        `/api/agent_templates/${encodeURIComponent(mcpServersDialogTemplateId)}/requirements`,
+        { method: "GET", credentials: "include" },
+      );
+      if (!res.ok) throw new Error("Failed to load template requirements");
+      return (await res.json()) as AgentTemplateInstallRequirements;
+    },
+    enabled: enabled && !!mcpServersDialogTemplateId,
+  });
+
+  const availableTypes = useMemo(() => {
+    const set = new Set<string>();
+    for (const t of templates) {
+      if (t.type) set.add(t.type);
+    }
+    return ["all", ...Array.from(set).sort()];
+  }, [templates]);
+
+  const availableCategories = useMemo(() => {
+    const set = new Set<string>();
+    for (const t of templates) {
+      for (const c of t.categories ?? []) set.add(c);
+    }
+    return ["all", ...Array.from(set).sort()];
+  }, [templates]);
+
+  const filteredTemplates = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    return templates.filter((t) => {
+      const matchesQuery = !q || t.name.toLowerCase().includes(q);
+      const matchesType = selectedType === "all" || t.type === selectedType;
+      const matchesCategory =
+        selectedCategory === "all" ||
+        (t.categories ?? []).includes(selectedCategory);
+      return matchesQuery && matchesType && matchesCategory;
+    });
+  }, [templates, searchQuery, selectedType, selectedCategory]);
+
+  const effectiveInstalledServers = hasInstallingServers
+    ? installedServersPolled
+    : installedServers;
+
+  const installedCatalogIdSet = useMemo(
+    () =>
+      new Set(
+        effectiveInstalledServers.map((s) => s.catalogId).filter(Boolean),
+      ),
+    [effectiveInstalledServers],
+  );
+
+  const requiredMcpServersByTemplateId = useMemo(() => {
+    const byId = new Map<
+      string,
+      Array<{
+        serverName: string;
+        catalogId: string | null;
+        status:
+          | "installed"
+          | "installing"
+          | "failed"
+          | "not-installed"
+          | "unknown";
+        installationStatus: "pending" | "discovering-tools" | null;
+      }>
+    >();
+
+    const catalogIdByName = new Map<string, string>();
+    for (const item of catalogItems ?? []) {
+      catalogIdByName.set(item.name, item.id);
+    }
+
+    type InstalledServer = (typeof effectiveInstalledServers)[number];
+    const installedByCatalogId = new Map<string, InstalledServer>();
+    for (const s of effectiveInstalledServers) {
+      const catalogId = s.catalogId;
+      if (catalogId && !installedByCatalogId.has(catalogId)) {
+        installedByCatalogId.set(catalogId, s);
+      }
+    }
+
+    for (const t of templates) {
+      const serverNameSet = new Set<string>();
+      for (const fullName of t.tools ?? []) {
+        const parsed = parseFullToolName(fullName);
+        if (parsed.serverName) serverNameSet.add(parsed.serverName);
+      }
+
+      const rows = Array.from(serverNameSet).map((serverName) => {
+        const catalogId = catalogIdByName.get(serverName) ?? null;
+        if (!catalogId) {
+          return {
+            serverName,
+            catalogId,
+            status: "unknown" as const,
+            installationStatus: null,
+          };
+        }
+
+        const installed = installedByCatalogId.get(catalogId);
+        if (!installed) {
+          return {
+            serverName,
+            catalogId,
+            status: "not-installed" as const,
+            installationStatus: null,
+          };
+        }
+
+        const localStatus = installed.localInstallationStatus ?? "idle";
+        if (localStatus === "pending" || localStatus === "discovering-tools") {
+          return {
+            serverName,
+            catalogId,
+            status: "installing" as const,
+            installationStatus: localStatus,
+          };
+        }
+        if (localStatus === "error") {
+          return {
+            serverName,
+            catalogId,
+            status: "failed" as const,
+            installationStatus: null,
+          };
+        }
+        return {
+          serverName,
+          catalogId,
+          status: "installed" as const,
+          installationStatus: null,
+        };
+      });
+
+      byId.set(t.id, rows);
+    }
+
+    return byId;
+  }, [templates, catalogItems, effectiveInstalledServers]);
+
+  const missingCatalogIdCountByTemplateId = useMemo(() => {
+    const byId = new Map<string, number>();
+    const catalogIdByName = new Map<string, string>();
+    for (const item of catalogItems ?? []) {
+      catalogIdByName.set(item.name, item.id);
+    }
+
+    for (const t of templates) {
+      const requiredServerNames = new Set<string>();
+      for (const fullName of t.tools ?? []) {
+        const parsed = parseFullToolName(fullName);
+        if (parsed.serverName) requiredServerNames.add(parsed.serverName);
+      }
+
+      let missing = 0;
+      for (const serverName of requiredServerNames) {
+        const catalogId = catalogIdByName.get(serverName);
+        if (!catalogId) continue;
+        if (!installedCatalogIdSet.has(catalogId)) missing++;
+      }
+      byId.set(t.id, missing);
+    }
+
+    return byId;
+  }, [templates, catalogItems, installedCatalogIdSet]);
+  useEffect(() => {
+    if (!enabled) return;
+    setSearchQuery("");
+    setSelectedType("all");
+    setSelectedCategory("all");
+    setDetailsTemplateId(null);
+    setMcpServersDialogTemplateId(null);
+  }, [enabled]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="ml-1 grid grid-cols-1 items-end gap-4 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,0.5fr)_minmax(0,0.5fr)]">
+        <div className="min-w-0">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <DebouncedInput
+              placeholder="Search templates by name..."
+              initialValue={searchQuery}
+              onChange={setSearchQuery}
+              className="pl-9"
+              autoFocus
+            />
+          </div>
+        </div>
+
+        <div className="min-w-0">
+          <Select value={selectedType} onValueChange={setSelectedType}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="All types" />
+            </SelectTrigger>
+            <SelectContent>
+              {availableTypes.map((t) => (
+                <SelectItem key={t} value={t}>
+                  {t === "all" ? "All types" : t}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="min-w-0">
+          <Select value={selectedCategory} onValueChange={setSelectedCategory}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="All categories" />
+            </SelectTrigger>
+            <SelectContent>
+              {availableCategories.map((c) => (
+                <SelectItem key={c} value={c}>
+                  {c === "all" ? "All categories" : c}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {isPending ? (
+        <div className="grid gap-4 md:grid-cols-2">
+          {Array.from({ length: 4 }, (_, i) => `skeleton-${i}`).map((key) => (
+            <Card key={key}>
+              <CardHeader>
+                <Skeleton className="h-6 w-3/4" />
+                <Skeleton className="h-4 w-1/2 mt-2" />
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-full mt-2" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      ) : (
+        <>
+          <div className="flex items-center justify-between ml-1">
+            <p className="text-sm text-muted-foreground">
+              {filteredTemplates.length}{" "}
+              {filteredTemplates.length === 1 ? "template" : "templates"} found
+            </p>
+          </div>
+
+          {filteredTemplates.length === 0 ? (
+            <div className="text-center py-12">
+              <p className="text-muted-foreground">
+                No templates match your search criteria.
+              </p>
+            </div>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2 overflow-y-auto">
+              {filteredTemplates.map((t) => (
+                <Card key={t.id} className="flex flex-col">
+                  <CardHeader>
+                    <div className="flex items-start">
+                      <div className="flex items-start gap-2 flex-1 min-w-0">
+                        <CardTitle className="text-base">{t.name}</CardTitle>
+                      </div>
+                      <div className="flex flex-wrap gap-1 items-center flex-shrink-0 mt-1">
+                        <Badge variant="outline" className="text-xs">
+                          {t.type}
+                        </Badge>
+                        {(t.categories ?? []).slice(0, 1).map((c) => (
+                          <Badge key={c} variant="outline" className="text-xs">
+                            {c}
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+                    <p className="text-xs text-muted-foreground font-mono">
+                      {t.id}
+                    </p>
+                  </CardHeader>
+                  <CardContent className="flex-1 flex flex-col space-y-3">
+                    {(missingCatalogIdCountByTemplateId.get(t.id) ?? 0) > 0 ? (
+                      <Badge variant="destructive" className="text-xs w-fit">
+                        Install required MCP servers to enable all tools
+                      </Badge>
+                    ) : null}
+
+                    {t.description && (
+                      <p className="text-sm text-muted-foreground line-clamp-2">
+                        {t.description}
+                      </p>
+                    )}
+
+                    <div className="flex flex-col gap-2 mt-auto pt-3 justify-end">
+                      <div className="flex flex-wrap gap-2">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setDetailsTemplateId(t.id)}
+                          className="flex-1"
+                        >
+                          <Info className="h-4 w-4 mr-1" />
+                          Details
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setMcpServersDialogTemplateId(t.id)}
+                          className="flex-1"
+                        >
+                          <Server className="h-4 w-4 mr-1" />
+                          MCP Servers
+                        </Button>
+                      </div>
+                      <Button
+                        type="button"
+                        onClick={() => {
+                          onSelectTemplate?.(t);
+                          onRequestClose?.();
+                        }}
+                        size="sm"
+                        className="w-full"
+                      >
+                        Use as Template
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      <TemplateDetailsDialog
+        template={templates.find((t) => t.id === detailsTemplateId) ?? null}
+        open={!!detailsTemplateId}
+        onOpenChange={(open) => {
+          if (!open) setDetailsTemplateId(null);
+        }}
+      />
+
+      <StandardDialog
+        open={!!mcpServersDialogTemplateId}
+        onOpenChange={(open) => {
+          if (!open) setMcpServersDialogTemplateId(null);
+        }}
+        title="Required MCP servers"
+        description="Install the MCP servers required by this template."
+        bodyClassName="space-y-3"
+        footer={
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => setMcpServersDialogTemplateId(null)}
+            >
+              Close
+            </Button>
+          </div>
+        }
+      >
+        {mcpServersDialogRequirementsQuery.isPending ? (
+          <div className="text-sm text-muted-foreground">Loading…</div>
+        ) : (
+            requiredMcpServersByTemplateId.get(
+              mcpServersDialogTemplateId ?? "",
+            ) ?? []
+          ).length > 0 ? (
+          <div className="space-y-2">
+            {(
+              requiredMcpServersByTemplateId.get(
+                mcpServersDialogTemplateId ?? "",
+              ) ?? []
+            ).map((req) => {
+              const label =
+                req.status === "installed"
+                  ? "Installed"
+                  : req.status === "installing"
+                    ? "Installing…"
+                    : req.status === "failed"
+                      ? "Failed"
+                      : req.status === "not-installed"
+                        ? "Not installed"
+                        : "Unknown";
+              const variant =
+                req.status === "failed"
+                  ? "destructive"
+                  : req.status === "installing"
+                    ? "secondary"
+                    : req.status === "installed"
+                      ? "outline"
+                      : "outline";
+
+              const catalogItem =
+                req.catalogId != null
+                  ? catalogItems?.find((i) => i.id === req.catalogId)
+                  : undefined;
+
+              return (
+                <div key={req.serverName} className="rounded-md border p-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="font-medium truncate">
+                        {req.serverName}
+                      </div>
+                      {catalogItem ? (
+                        <div className="text-xs text-muted-foreground">
+                          {catalogItem.serverType}
+                        </div>
+                      ) : null}
+                    </div>
+                    <Badge variant={variant} className="shrink-0">
+                      {label}
+                    </Badge>
+                  </div>
+
+                  {req.status === "installing" ? (
+                    <div className="mt-3">
+                      <InstallationProgress status={req.installationStatus} />
+                    </div>
+                  ) : req.catalogId && req.status !== "installed" ? (
+                    <div className="mt-3 flex items-center justify-end gap-2">
+                      <Button
+                        type="button"
+                        onClick={() => {
+                          if (!req.catalogId) return;
+                          orchestrator.triggerInstallByCatalogId(req.catalogId);
+                        }}
+                        disabled={!catalogItem}
+                      >
+                        Install…
+                      </Button>
+                    </div>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="text-sm text-muted-foreground">
+            No MCP servers are required for this template.
+          </div>
+        )}
+      </StandardDialog>
+
+      <RemoteServerInstallDialog
+        isOpen={orchestrator.isDialogOpened("remote-install")}
+        onClose={orchestrator.closeRemoteInstall}
+        onConfirm={async (catalogItem, result: RemoteServerInstallResult) => {
+          await orchestrator.handleRemoteServerInstallConfirm(
+            catalogItem,
+            result,
+          );
+        }}
+        catalogItem={orchestrator.selectedCatalogItem}
+        isInstalling={orchestrator.isInstalling}
+        isReauth={orchestrator.isReauth}
+      />
+      <LocalServerInstallDialog
+        isOpen={orchestrator.isDialogOpened("local-install")}
+        onClose={orchestrator.closeLocalInstall}
+        onConfirm={async (result: LocalServerInstallResult) => {
+          await orchestrator.handleLocalServerInstallConfirm(result);
+        }}
+        catalogItem={orchestrator.localServerCatalogItem}
+        isInstalling={orchestrator.isInstalling}
+        isReauth={orchestrator.isReauth}
+      />
+      <NoAuthInstallDialog
+        isOpen={orchestrator.isDialogOpened("no-auth")}
+        onClose={orchestrator.closeNoAuth}
+        onInstall={async (result: NoAuthInstallResult) => {
+          await orchestrator.handleNoAuthConfirm(result);
+        }}
+        catalogItem={orchestrator.noAuthCatalogItem}
+        isInstalling={orchestrator.isInstalling}
+      />
+      <OAuthConfirmationDialog
+        open={orchestrator.isDialogOpened("oauth")}
+        onOpenChange={(next) => {
+          if (!next) orchestrator.closeOAuth();
+        }}
+        serverName={orchestrator.selectedCatalogItem?.name ?? "MCP Server"}
+        catalogId={orchestrator.selectedCatalogItem?.id}
+        onConfirm={orchestrator.handleOAuthConfirm}
+        onCancel={orchestrator.closeOAuth}
+      />
+    </div>
+  );
+}

--- a/platform/frontend/src/components/agent-tools-editor.tsx
+++ b/platform/frontend/src/components/agent-tools-editor.tsx
@@ -91,6 +91,18 @@ interface AgentToolsEditorProps {
   layout?: "pills" | "cards";
   /** When true, the "Add MCP server" combobox starts open. */
   openComboboxOnMount?: boolean;
+  /**
+   * Optional template prefill for create flow (when `agentId` is not set yet).
+   *
+   * These are fully-qualified MCP tool names (e.g. "server-name__tool_name").
+   * The editor will map them to discovered catalog tools and pre-select them.
+   */
+  initialToolFullNames?: string[];
+  /**
+   * Change this when selecting a different template to re-initialize prefill state.
+   * (Example: template id)
+   */
+  initialSelectionKey?: string | null;
 }
 
 export const AgentToolsEditor = forwardRef<
@@ -104,6 +116,8 @@ export const AgentToolsEditor = forwardRef<
     onSelectedCountChange,
     layout = "pills",
     openComboboxOnMount,
+    initialToolFullNames,
+    initialSelectionKey,
   },
   ref,
 ) {
@@ -115,6 +129,8 @@ export const AgentToolsEditor = forwardRef<
       onSelectedCountChange={onSelectedCountChange}
       layout={layout}
       openComboboxOnMount={openComboboxOnMount}
+      initialToolFullNames={initialToolFullNames}
+      initialSelectionKey={initialSelectionKey}
       ref={ref}
     />
   );
@@ -131,6 +147,8 @@ const AgentToolsEditorContent = forwardRef<
     onSelectedCountChange,
     layout = "pills",
     openComboboxOnMount,
+    initialToolFullNames,
+    initialSelectionKey,
   },
   ref,
 ) {
@@ -215,11 +233,23 @@ const AgentToolsEditorContent = forwardRef<
 
   // Track whether default tools have been pre-selected for new agent creation
   const defaultToolsInitializedRef = useRef(false);
+  const templatePrefillInitializedRef = useRef(false);
+  const lastInitialSelectionKeyRef = useRef<string | null>(null);
+  const lastReportedSelectedCountRef = useRef<number | null>(null);
 
-  // Pre-select default Archestra tools when creating a new agent (no agentId)
+  // Pre-select default Archestra tools and/or template tools when creating a new agent (no agentId)
   useEffect(() => {
     if (agentId) return; // Only for new agent creation
-    if (defaultToolsInitializedRef.current) return; // Only initialize once
+    let didMutatePending = false;
+
+    const nextKey = initialSelectionKey ?? null;
+    if (lastInitialSelectionKeyRef.current !== nextKey) {
+      pendingChangesRef.current.clear();
+      defaultToolsInitializedRef.current = false;
+      templatePrefillInitializedRef.current = false;
+      lastInitialSelectionKeyRef.current = nextKey;
+      didMutatePending = true;
+    }
 
     const toolsByCatalogIndex = toolCountQueries.map(
       (q) => (q?.data as CatalogTool[] | undefined) ?? undefined,
@@ -228,21 +258,78 @@ const AgentToolsEditorContent = forwardRef<
       catalogItems,
       toolsByCatalogIndex,
     );
-    if (!result) return;
+    if (!defaultToolsInitializedRef.current && result) {
+      const archestraCatalog = catalogItems[result.catalogIndex];
+      if (archestraCatalog) {
+        defaultToolsInitializedRef.current = true;
+        pendingChangesRef.current.set(ARCHESTRA_MCP_CATALOG_ID, {
+          selectedToolIds: result.toolIds,
+          credentialSourceId: null,
+          catalogItem: archestraCatalog,
+          selectAll: false,
+          isActive: true,
+        });
+        didMutatePending = true;
+      }
+    }
 
-    const archestraCatalog = catalogItems[result.catalogIndex];
-    if (!archestraCatalog) return;
+    if (
+      !templatePrefillInitializedRef.current &&
+      initialToolFullNames?.length
+    ) {
+      const desired = new Set(initialToolFullNames);
+      const found = new Set<string>();
+      const anyToolQueryPending =
+        toolCountQueries.some((q) => q.isPending) ||
+        toolCountQueries.some((q) => q.isFetching);
 
-    defaultToolsInitializedRef.current = true;
-    pendingChangesRef.current.set(ARCHESTRA_MCP_CATALOG_ID, {
-      selectedToolIds: result.toolIds,
-      credentialSourceId: null,
-      catalogItem: archestraCatalog,
-      selectAll: false,
-    });
-    onSelectedCountChange?.(result.toolIds.size);
-    setPendingVersion((v) => v + 1);
-  }, [agentId, catalogItems, toolCountQueries, onSelectedCountChange]);
+      for (let i = 0; i < catalogItems.length; i++) {
+        const catalog = catalogItems[i];
+        const tools = toolsByCatalogIndex[i] ?? [];
+        if (!catalog || tools.length === 0) continue;
+
+        const matchingTools = tools.filter((t) => desired.has(t.name));
+        for (const t of matchingTools) found.add(t.name);
+
+        const selectedToolIds = new Set(matchingTools.map((t) => t.id));
+        if (selectedToolIds.size === 0) continue;
+
+        pendingChangesRef.current.set(catalog.id, {
+          selectedToolIds,
+          credentialSourceId: DYNAMIC_CREDENTIAL_VALUE,
+          catalogItem: catalog,
+          selectAll: false,
+          isActive: true,
+        });
+        didMutatePending = true;
+      }
+
+      const allDesiredFound = found.size >= desired.size;
+      if (allDesiredFound || !anyToolQueryPending) {
+        templatePrefillInitializedRef.current = true;
+      }
+      if (found.size > 0) didMutatePending = true;
+    }
+
+    let total = 0;
+    for (const changes of pendingChangesRef.current.values()) {
+      total += changes.selectedToolIds.size;
+    }
+    if (lastReportedSelectedCountRef.current !== total) {
+      lastReportedSelectedCountRef.current = total;
+      onSelectedCountChange?.(total);
+    }
+    if (didMutatePending) {
+      setPendingVersion((v) => v + 1);
+    }
+  }, [
+    agentId,
+    catalogItems,
+    toolCountQueries,
+    initialToolFullNames,
+    initialSelectionKey,
+    onSelectedCountChange,
+  ]);
 
   // Calculate total selected count from pending changes
   const calculateTotalSelectedCount = useCallback(() => {

--- a/platform/shared/access-control.ts
+++ b/platform/shared/access-control.ts
@@ -401,6 +401,10 @@ export const requiredEndpointPermissionsMap: Partial<
   // Labels are cross-type — any agent-type read permission suffices (checked in handler)
   [RouteId.GetLabelKeys]: {},
   [RouteId.GetLabelValues]: {},
+
+  // Agent templates (permission enforced dynamically in handler)
+  [RouteId.GetAgentTemplates]: {},
+  [RouteId.GetAgentTemplateInstallRequirements]: {},
   [RouteId.GetTokens]: {
     team: ["read"],
   },

--- a/platform/shared/agent-templates.ts
+++ b/platform/shared/agent-templates.ts
@@ -1,0 +1,60 @@
+/**
+ * Code-defined agent templates.
+ *
+ * These templates are not stored in Postgres. They exist purely in code and can
+ * be used to prefill agent creation fields (prompt, model, labels).
+ */
+
+export const AGENT_TEMPLATE_IDS = {
+  GENERAL_PURPOSE: "general-purpose-agent",
+} as const;
+
+export type AgentTemplateId =
+  (typeof AGENT_TEMPLATE_IDS)[keyof typeof AGENT_TEMPLATE_IDS];
+
+export type AgentTemplate = {
+  id: AgentTemplateId;
+  name: string;
+  description: string;
+  /** Used for catalog filtering (e.g. "dev", "security", "support") */
+  type: string;
+  /** Used for catalog filtering (freeform tags, e.g. ["mcp", "testing"]) */
+  categories: string[];
+  systemPrompt: string;
+  llmModel: string | null;
+  /**
+   * Fully-qualified MCP tool names to pre-assign for the agent when using this template.
+   *
+   * Format: `${serverName}__${toolName}` (split on the last "__").
+   * Example: "internal-dev-test-server__print_archestra_test"
+   *
+   * Why names (not IDs): tool IDs are environment-specific (seeded/discovered), but
+   * full tool names are stable and already used throughout the UI/tests.
+   */
+  tools: string[];
+  labels: Array<{ key: string; value: string }>;
+  icon?: string | null;
+};
+
+export const AGENT_TEMPLATES: AgentTemplate[] = [
+  {
+    id: AGENT_TEMPLATE_IDS.GENERAL_PURPOSE,
+    name: "General Purpose Agent",
+    description:
+      "A safe, minimal production template with no preselected tools. Add MCP servers/tools as needed for your environment.",
+    type: "prod",
+    categories: ["production", "general"],
+    systemPrompt:
+      "You are a production assistant. Be concise and reliable. If a request requires actions outside your permissions or missing tools, say what you need and provide a safe alternative. Prefer using available tools when they are relevant, and avoid guessing when data is missing.",
+    // Use org default model unless explicitly chosen by the user
+    llmModel: null,
+    tools: [],
+    labels: [],
+    icon: null,
+  },
+];
+
+export function getAgentTemplateById(id: string): AgentTemplate | null {
+  return AGENT_TEMPLATES.find((t) => t.id === id) ?? null;
+}
+

--- a/platform/shared/index.ts
+++ b/platform/shared/index.ts
@@ -1,6 +1,7 @@
 export * from "./agents";
 export * from "./archestra-mcp-server";
 export * from "./built-in-agents";
+export * from "./agent-templates";
 export * from "./chat";
 export * from "./chat-error";
 export * from "./consts";

--- a/platform/shared/routes.ts
+++ b/platform/shared/routes.ts
@@ -12,6 +12,10 @@ export const RouteId = {
   GetLabelKeys: "getLabelKeys",
   GetLabelValues: "getLabelValues",
 
+  // Agent Template Routes
+  GetAgentTemplates: "getAgentTemplates",
+  GetAgentTemplateInstallRequirements: "getAgentTemplateInstallRequirements",
+
   // Schedule Trigger Routes
   GetScheduleTriggers: "getScheduleTriggers",
   CreateScheduleTrigger: "createScheduleTrigger",


### PR DESCRIPTION
Closes #3858

# Agent Templates Changes (Summary)

https://github.com/user-attachments/assets/96a82601-1258-47ea-83d8-53cbb875e5e4

Added Internal Dev Test Server Agent for demo purposes only.

## Backend API

- Added agent templates API:
  - `GET /api/agent_templates`  
    Returns code-defined templates from `platform/shared/agent-templates.ts`.

- Added requirements API:
  - `GET /api/agent_templates/:id/requirements`  
    Returns missing catalog ids for a chosen template.

- Requirements logic:
  - Computes required MCP servers only from `template.tools`. Use here only registered MCP servers. I think that we can add MCP servers from online catalog also.

- Tool → MCP server resolution:
  - Template tools use fully-qualified names: `server-name__tool_name`.
  - Backend extracts `serverName` via `parseFullToolName()`.
  - Resolves MCP catalog item via `InternalMcpCatalogModel.findByName(serverName)`.

---

## Shared Template Model

- Added production-safe template:
  - **Production Agent (general-purpose)**
    - `system_prompt: You are a production assistant...`
    - `tools: []`
    - `labels: []`
    - `llmModel: null` 
  
We can declare a new templates here. I think that we can move this into config file later.

---

## Frontend (Template Catalog & Create Flow)
I`ve made the same UX/UI experince as for MCP servers installation flow.

### Template Selection

- Selecting a template in  
  `platform/frontend/src/components/agent-dialog.tsx`:
  - Passes `template.tools` into `AgentToolsEditor`.
  - Preselects tools in the create form (when available).

### Tool Prefill Behavior

- Improved resilience in  
  `platform/frontend/src/components/agent-tools-editor.tsx`:
  - Prefill “catches up” after MCP tool discovery.
  - Avoids finalizing too early if tools are not yet discovered.

---

## Template Catalog UI

File: `platform/frontend/src/components/agent-template-catalog-dialog.tsx`

- Template cards:
  - Show warning badge when required MCP servers are missing:
    > "Install required MCP servers to enable all tools"

- **MCP Servers dialog**:
  - Displays required MCP servers with statuses:
    - Installed
    - Installing (with progress bar)
    - Failed
    - Not installed
    - Unknown
    
 Users can configure required params and install MCP servers from this dialog.

---

## Template Details Dialog

- Displays:
  - Name
  - Prompt 
  - Labels
  - Tools
 
---

## Tests

- Added backend route tests
- Added e2e tests