### PR TITLE
feat: display Organization badge with globe icon in MCP logs dialog

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-logs-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-logs-dialog.tsx
@@ -7,12 +7,14 @@ import {
   type McpLogsEndedMessage,
   type McpLogsErrorMessage,
   type McpLogsMessage,
+  type ResourceVisibilityScope,
 } from "@shared";
 import {
   ArrowDown,
   Check,
   ChevronsUpDown,
   Copy,
+  Globe,
   RefreshCw,
   Terminal,
 } from "lucide-react";
@@ -56,6 +58,7 @@ interface McpLogsDialogProps {
     name: string;
     ownerEmail?: string | null;
     teamDetails?: { teamId: string; name: string } | null;
+    scope?: ResourceVisibilityScope | null;
   }[];
   deploymentStatuses: Record<string, McpDeploymentStatusEntry>;
   /** Hide the installation dropdown selector */
@@ -717,7 +720,10 @@ function InstanceSelector({
             : selectedStatus.state) as DeploymentState,
         )
       : null;
-  const owner = selected?.teamDetails?.name ?? selected?.ownerEmail;
+  const isOrgScope = selected?.scope === "org";
+  const owner = isOrgScope
+    ? "Organization"
+    : (selected?.teamDetails?.name ?? selected?.ownerEmail);
   const ownerInitials = (
     selected?.teamDetails?.name ||
     selected?.ownerEmail ||
@@ -779,15 +785,21 @@ function InstanceSelector({
         {/* Stats — separated by hairlines */}
         {owner && (
           <div className="hidden md:flex items-center gap-2 px-4 py-3 border-l border-border/40">
-            <span
-              className={`flex items-center justify-center size-6 rounded-full text-[10px] font-medium ${
-                selected?.teamDetails
-                  ? "bg-accent text-accent-foreground"
-                  : "bg-muted text-muted-foreground"
-              }`}
-            >
-              {ownerInitials}
-            </span>
+            {isOrgScope ? (
+              <span className="flex items-center justify-center size-6 rounded-full bg-accent text-accent-foreground">
+                <Globe className="h-3 w-3" />
+              </span>
+            ) : (
+              <span
+                className={`flex items-center justify-center size-6 rounded-full text-[10px] font-medium ${
+                  selected?.teamDetails
+                    ? "bg-accent text-accent-foreground"
+                    : "bg-muted text-muted-foreground"
+                }`}
+              >
+                {ownerInitials}
+              </span>
+            )}
             <span className="text-xs text-foreground/80 max-w-[140px] truncate">
               {owner}
             </span>
@@ -863,7 +875,10 @@ function InstanceSelector({
                   ? "running"
                   : (s?.state ?? "pending")
               ) as DeploymentState;
-              const io = install.teamDetails?.name ?? install.ownerEmail;
+              const io =
+                install.scope === "org"
+                  ? "Organization"
+                  : (install.teamDetails?.name ?? install.ownerEmail);
               const age = s?.podAge;
               const isActive = install.id === serverId;
 


### PR DESCRIPTION
fixes [#3790](https://github.com/archestra-ai/archestra/issues/3790)

Use '🌐 Organization' instead of owner name

Before:

<img width="1197" height="478" alt="Screenshot 2026-05-01 at 16 30 56" src="https://github.com/user-attachments/assets/a06f53c4-9aea-47c4-98b3-826555648302" />

After:

<img width="1186" height="502" alt="Screenshot 2026-05-01 at 16 30 34" src="https://github.com/user-attachments/assets/df0ed7b7-0e92-445a-8472-81e526a873c0" />