### PR TITLE
fix: chat agent defaults and swap tool UI states

### DIFF
--- a/platform/backend/src/archestra-mcp-server/chat.test.ts
+++ b/platform/backend/src/archestra-mcp-server/chat.test.ts
@@ -388,7 +388,7 @@ describe("chat tool execution", () => {
     expect(updatedBinding?.agentId).toBe(testAgent.id);
   });
 
-  test("swap_agent returns error when swapping to same agent", async ({
+  test("swap_agent returns structured state when swapping to same agent", async ({
     makeConversation,
   }) => {
     const conversation = await makeConversation(testAgent.id, {
@@ -406,7 +406,16 @@ describe("chat tool execution", () => {
       { agent_name: testAgent.name },
       contextWithConvo,
     );
-    expect(result.isError).toBe(true);
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toMatchObject({
+      success: false,
+      code: "already_using_agent",
+      archestraError: {
+        type: "tool_state",
+        code: "already_using_agent",
+        toolName: "swap_agent",
+      },
+    });
     expect((result.content[0] as any).text).toContain("Already using agent");
   });
 
@@ -422,7 +431,7 @@ describe("chat tool execution", () => {
     );
   });
 
-  test("swap_to_default_agent returns error when no default agent configured", async ({
+  test("swap_to_default_agent returns structured state when no default agent configured", async ({
     makeConversation,
   }) => {
     const conversation = await makeConversation(testAgent.id, {
@@ -440,7 +449,16 @@ describe("chat tool execution", () => {
       {},
       contextWithConvo,
     );
-    expect(result.isError).toBe(true);
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toMatchObject({
+      success: false,
+      code: "no_default_agent",
+      archestraError: {
+        type: "tool_state",
+        code: "no_default_agent",
+        toolName: "swap_to_default_agent",
+      },
+    });
     expect((result.content[0] as any).text).toContain(
       "No default agent is configured",
     );
@@ -743,11 +761,20 @@ describe("chat tool execution", () => {
       { agent_name: "Inaccessible Agent" },
       memberContext,
     );
-    expect(result.isError).toBe(true);
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toMatchObject({
+      success: false,
+      code: "no_agent_found",
+      archestraError: {
+        type: "tool_state",
+        code: "no_agent_found",
+        toolName: "swap_agent",
+      },
+    });
     expect((result.content[0] as any).text).toContain("No agent found");
   });
 
-  test("swap_to_default_agent returns error when already on default agent", async ({
+  test("swap_to_default_agent returns structured state when already on default agent", async ({
     makeConversation,
   }) => {
     await OrganizationModel.patch(organizationId, {
@@ -769,7 +796,16 @@ describe("chat tool execution", () => {
       {},
       contextWithConvo,
     );
-    expect(result.isError).toBe(true);
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toMatchObject({
+      success: false,
+      code: "already_using_default_agent",
+      archestraError: {
+        type: "tool_state",
+        code: "already_using_default_agent",
+        toolName: "swap_to_default_agent",
+      },
+    });
     expect((result.content[0] as any).text).toContain(
       "Already using the default agent",
     );

--- a/platform/backend/src/archestra-mcp-server/chat.ts
+++ b/platform/backend/src/archestra-mcp-server/chat.ts
@@ -4,6 +4,8 @@ import {
   TOOL_SWAP_AGENT_SHORT_NAME,
   TOOL_SWAP_TO_DEFAULT_AGENT_SHORT_NAME,
   TOOL_TODO_WRITE_SHORT_NAME,
+  type ToolStateMcpToolError,
+  ToolStateMcpToolErrorSchema,
 } from "@shared";
 import { z } from "zod";
 import { isAgentTypeAdmin } from "@/auth/agent-type-permissions";
@@ -24,6 +26,7 @@ import {
   EmptyToolArgsSchema,
   errorResult,
   structuredSuccessResult,
+  structuredToolErrorResult,
 } from "./helpers";
 import type { ArchestraContext } from "./types";
 
@@ -50,11 +53,31 @@ const TodoWriteOutputSchema = z.object({
     .describe("How many todo items were written."),
 });
 
-const SwapAgentOutputSchema = z.object({
-  success: z.literal(true).describe("Whether the swap succeeded."),
-  agent_id: z.string().describe("The agent ID the conversation now uses."),
-  agent_name: z.string().describe("The agent name the conversation now uses."),
-});
+const SwapAgentStateCodeSchema = z.enum([
+  "no_agent_found",
+  "already_using_agent",
+  "no_default_agent",
+  "default_agent_not_found",
+  "already_using_default_agent",
+]);
+
+const SwapAgentOutputSchema = z.discriminatedUnion("success", [
+  z.object({
+    success: z.literal(true).describe("Whether the swap succeeded."),
+    agent_id: z.string().describe("The agent ID the conversation now uses."),
+    agent_name: z
+      .string()
+      .describe("The agent name the conversation now uses."),
+  }),
+  z.object({
+    success: z.literal(false).describe("Whether the swap succeeded."),
+    code: SwapAgentStateCodeSchema.describe("Why the swap was not applied."),
+    message: z.string().describe("Human-readable explanation."),
+    archestraError: ToolStateMcpToolErrorSchema,
+  }),
+]);
+
+type SwapAgentStateCode = z.infer<typeof SwapAgentStateCodeSchema>;
 
 const ArtifactWriteOutputSchema = z.object({
   success: z.literal(true).describe("Whether the artifact write succeeded."),
@@ -217,6 +240,38 @@ export const toolEntries = registry.toolEntries;
 
 export const tools = registry.tools;
 
+function swapAgentStateResult(params: {
+  code: SwapAgentStateCode;
+  message: string;
+  toolName: string;
+}): CallToolResult {
+  const archestraError: ToolStateMcpToolError = {
+    type: "tool_state",
+    code: params.code,
+    message: params.message,
+    toolName: params.toolName,
+  };
+
+  return structuredToolErrorResult({
+    error: archestraError,
+    text: JSON.stringify({
+      success: false,
+      code: params.code,
+      message: params.message,
+      archestraError,
+    }),
+    structuredContent: {
+      success: false,
+      code: params.code,
+      message: params.message,
+    },
+    // These are expected chat-routing states, not MCP transport failures. Keep
+    // isError false so the agent can respond normally instead of surfacing a
+    // global chat error.
+    isError: false,
+  });
+}
+
 async function handleSwapAgent(params: {
   agentName: string;
   context: ArchestraContext;
@@ -275,7 +330,11 @@ async function handleSwapAgent(params: {
     );
 
     if (results.data.length === 0) {
-      return errorResult(`No agent found matching "${agentName}".`);
+      return swapAgentStateResult({
+        code: "no_agent_found",
+        message: `No agent found matching "${agentName}".`,
+        toolName: TOOL_SWAP_AGENT_SHORT_NAME,
+      });
     }
 
     // Pick exact name match if available, otherwise first result
@@ -286,9 +345,11 @@ async function handleSwapAgent(params: {
 
     // Prevent swapping to the same agent
     if (targetAgent.id === contextAgent.id) {
-      return errorResult(
-        `Already using agent "${targetAgent.name}". Choose a different agent.`,
-      );
+      return swapAgentStateResult({
+        code: "already_using_agent",
+        message: `Already using agent "${targetAgent.name}". Choose a different agent.`,
+        toolName: TOOL_SWAP_AGENT_SHORT_NAME,
+      });
     }
 
     // In chatops-triggered A2A runs we can have both:
@@ -417,20 +478,28 @@ async function handleSwapToDefaultAgent(params: {
     const defaultAgentId = org?.defaultAgentId ?? null;
 
     if (!defaultAgentId) {
-      return errorResult(
-        "No default agent is configured for this organization.",
-      );
+      return swapAgentStateResult({
+        code: "no_default_agent",
+        message: "No default agent is configured for this organization.",
+        toolName: TOOL_SWAP_TO_DEFAULT_AGENT_SHORT_NAME,
+      });
     }
 
     const targetAgent = await AgentModel.findById(defaultAgentId);
     if (!targetAgent) {
-      return errorResult("Default agent not found.");
+      return swapAgentStateResult({
+        code: "default_agent_not_found",
+        message: "Default agent not found.",
+        toolName: TOOL_SWAP_TO_DEFAULT_AGENT_SHORT_NAME,
+      });
     }
 
     if (targetAgent.id === contextAgent.id) {
-      return errorResult(
-        `Already using the default agent "${targetAgent.name}".`,
-      );
+      return swapAgentStateResult({
+        code: "already_using_default_agent",
+        message: `Already using the default agent "${targetAgent.name}".`,
+        toolName: TOOL_SWAP_TO_DEFAULT_AGENT_SHORT_NAME,
+      });
     }
 
     // In chatops-triggered A2A runs we can have both:

--- a/platform/backend/src/archestra-mcp-server/helpers.ts
+++ b/platform/backend/src/archestra-mcp-server/helpers.ts
@@ -3,6 +3,7 @@ import {
   type ArchestraToolFullName,
   type ArchestraToolShortName,
   getArchestraToolFullName,
+  type McpToolError,
 } from "@shared";
 import { ZodError, type ZodType, z } from "zod";
 import logger from "@/logging";
@@ -211,6 +212,34 @@ export function structuredSuccessResult(
     content: [{ type: "text" as const, text }],
     structuredContent,
     isError: false,
+  };
+}
+
+export function structuredToolErrorResult(params: {
+  error: McpToolError;
+  text?: string;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+}): CallToolResult {
+  // Keep the structured error in both MCP-native fields and text content:
+  // clients may see only streamed text, persisted output, or structured content.
+  const structuredContent = {
+    ...params.structuredContent,
+    archestraError: params.error,
+  };
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: params.text ?? `Error: ${params.error.message}`,
+      },
+    ],
+    structuredContent,
+    _meta: {
+      archestraError: params.error,
+    },
+    isError: params.isError ?? true,
   };
 }
 

--- a/platform/frontend/src/app/chat/chat-initial-state.test.ts
+++ b/platform/frontend/src/app/chat/chat-initial-state.test.ts
@@ -102,6 +102,30 @@ describe("resolveInitialAgentSelection", () => {
       })?.id,
     ).toBe("member-default");
   });
+
+  test("returns null when no agents are available", () => {
+    expect(
+      resolveInitialAgentSelection({
+        agents: [],
+        organizationDefaultAgentId: "org-default",
+        savedAgentId: "saved-agent",
+        memberDefaultAgentId: "member-default",
+        canUseSavedAgent: true,
+      }),
+    ).toBeNull();
+  });
+
+  test("falls back to the first agent when no defaults match", () => {
+    expect(
+      resolveInitialAgentSelection({
+        agents,
+        organizationDefaultAgentId: null,
+        savedAgentId: "missing-saved-agent",
+        memberDefaultAgentId: "missing-member-default",
+        canUseSavedAgent: true,
+      })?.id,
+    ).toBe("first-agent");
+  });
 });
 
 describe("getProviderForModelId", () => {

--- a/platform/frontend/src/app/chat/chat-initial-state.test.ts
+++ b/platform/frontend/src/app/chat/chat-initial-state.test.ts
@@ -3,6 +3,7 @@ import {
   buildCreateConversationInput,
   getProviderForModelId,
   resolveChatModelState,
+  resolveInitialAgentSelection,
   resolveInitialAgentState,
   resolvePreferredModelForProvider,
   shouldResetInitialChatState,
@@ -55,6 +56,51 @@ describe("resolveInitialAgentState", () => {
       apiKeyId: "key-2",
       modelSource: "agent",
     });
+  });
+});
+
+describe("resolveInitialAgentSelection", () => {
+  const agents = [
+    { id: "first-agent" },
+    { id: "member-default" },
+    { id: "saved-agent" },
+    { id: "org-default" },
+  ];
+
+  test("prefers the organization default over saved and member defaults", () => {
+    expect(
+      resolveInitialAgentSelection({
+        agents,
+        organizationDefaultAgentId: "org-default",
+        savedAgentId: "saved-agent",
+        memberDefaultAgentId: "member-default",
+        canUseSavedAgent: true,
+      })?.id,
+    ).toBe("org-default");
+  });
+
+  test("uses saved agent before member default when the picker is available", () => {
+    expect(
+      resolveInitialAgentSelection({
+        agents,
+        organizationDefaultAgentId: null,
+        savedAgentId: "saved-agent",
+        memberDefaultAgentId: "member-default",
+        canUseSavedAgent: true,
+      })?.id,
+    ).toBe("saved-agent");
+  });
+
+  test("ignores saved agent when the picker is hidden", () => {
+    expect(
+      resolveInitialAgentSelection({
+        agents,
+        organizationDefaultAgentId: null,
+        savedAgentId: "saved-agent",
+        memberDefaultAgentId: "member-default",
+        canUseSavedAgent: false,
+      })?.id,
+    ).toBe("member-default");
   });
 });
 

--- a/platform/frontend/src/app/chat/chat-initial-state.ts
+++ b/platform/frontend/src/app/chat/chat-initial-state.ts
@@ -43,6 +43,42 @@ export type CreateConversationInput = {
   chatApiKeyId?: string | null;
 };
 
+export function resolveInitialAgentSelection<TAgent extends AgentInfo>(params: {
+  agents: TAgent[];
+  organizationDefaultAgentId?: string | null;
+  savedAgentId?: string | null;
+  memberDefaultAgentId?: string | null;
+  canUseSavedAgent: boolean;
+}): TAgent | null {
+  const { agents } = params;
+  if (agents.length === 0) {
+    return null;
+  }
+
+  const organizationDefaultAgent = agents.find(
+    (agent) => agent.id === params.organizationDefaultAgentId,
+  );
+  if (organizationDefaultAgent) {
+    return organizationDefaultAgent;
+  }
+
+  if (params.canUseSavedAgent) {
+    const savedAgent = agents.find((agent) => agent.id === params.savedAgentId);
+    if (savedAgent) {
+      return savedAgent;
+    }
+  }
+
+  const memberDefaultAgent = agents.find(
+    (agent) => agent.id === params.memberDefaultAgentId,
+  );
+  if (memberDefaultAgent) {
+    return memberDefaultAgent;
+  }
+
+  return agents[0];
+}
+
 export function resolveInitialAgentState(params: {
   agent: AgentInfo;
   modelsByProvider: Record<string, LlmModel[]>;

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -134,6 +134,7 @@ import { cn } from "@/lib/utils";
 import {
   buildCreateConversationInput,
   resolveChatModelState,
+  resolveInitialAgentSelection,
   resolveInitialAgentState,
   resolvePreferredModelForProvider,
   shouldResetInitialChatState,
@@ -215,6 +216,10 @@ export function ChatPageContent({
   const { data: canUpdateAgent } = useHasPermissions({
     agent: ["team-admin"],
   });
+  const { data: canSeeAgentPicker, isLoading: isAgentPickerPermissionLoading } =
+    useHasPermissions({
+      chatAgentPicker: ["enable"],
+    });
   const { data: teams } = useTeams({ enabled: !!canReadTeams });
 
   // Non-admin users with no teams cannot create agents
@@ -313,42 +318,26 @@ export function ChatPageContent({
       }
     }
 
-    // Priority: org default > localStorage > member default > first available
+    // Priority: org default > localStorage > member default > first available.
     // Org default always wins when set (admin-configured for the whole org).
-    // localStorage only overrides when no org default is configured.
+    // localStorage only overrides when no org default is configured and the
+    // user can change agents; otherwise a stale hidden picker value can trap
+    // restricted users on a previously swapped agent.
     // Also skip if a URL param was consumed but state hasn't flushed yet.
     if (!initialAgentId && !urlParamsConsumedRef.current) {
-      // Try org's default agent first (admin-configured, takes precedence)
-      if (organization?.defaultAgentId) {
-        const orgDefaultAgent = internalAgents.find(
-          (a) => a.id === organization.defaultAgentId,
-        );
-        if (orgDefaultAgent) {
-          applyInitialAgentSelection(orgDefaultAgent);
-          saveAgent(organization.defaultAgentId);
-          return;
-        }
-      }
-      // Try localStorage (user's previous selection, only when no org default)
-      const savedAgentId = getSavedAgent();
-      const savedAgent = internalAgents.find((a) => a.id === savedAgentId);
-      if (savedAgent) {
-        applyInitialAgentSelection(savedAgent);
-        return;
-      }
-      // Try member's default agent
-      if (defaultAgentId) {
-        const defaultAgent = internalAgents.find(
-          (a) => a.id === defaultAgentId,
-        );
-        if (defaultAgent) {
-          applyInitialAgentSelection(defaultAgent);
-          saveAgent(defaultAgentId);
-          return;
-        }
-      }
-      applyInitialAgentSelection(internalAgents[0]);
-      saveAgent(internalAgents[0].id);
+      if (isAgentPickerPermissionLoading) return;
+
+      const selectedAgent = resolveInitialAgentSelection({
+        agents: internalAgents,
+        organizationDefaultAgentId: organization?.defaultAgentId,
+        savedAgentId: getSavedAgent(),
+        memberDefaultAgentId: defaultAgentId,
+        canUseSavedAgent: canSeeAgentPicker === true,
+      });
+      if (!selectedAgent) return;
+
+      applyInitialAgentSelection(selectedAgent);
+      saveAgent(selectedAgent.id);
     }
   }, [
     applyInitialAgentSelection,
@@ -358,6 +347,8 @@ export function ChatPageContent({
     defaultAgentId,
     organization?.defaultAgentId,
     isOrgLoading,
+    canSeeAgentPicker,
+    isAgentPickerPermissionLoading,
   ]);
 
   // Initialize model and API key once agent is resolved.

--- a/platform/frontend/src/components/chat/chat-messages.test.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.test.tsx
@@ -224,6 +224,51 @@ describe("ChatMessages", () => {
     expect(screen.getByText("Switched to GitHub Agent")).toBeInTheDocument();
   });
 
+  it("deduplicates adjacent swap dividers for the same target", () => {
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-sparky__swap_agent",
+            toolCallId: "call-1",
+            state: "input-available",
+            input: { agent_name: "Jira Agent" },
+          },
+        ],
+      },
+      {
+        id: "assistant-2",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-sparky__swap_agent",
+            toolCallId: "call-1",
+            state: "output-available",
+            input: { agent_name: "Jira Agent" },
+            output: { ok: true },
+          },
+        ],
+      },
+      {
+        id: "assistant-3",
+        role: "assistant",
+        parts: [{ type: "text", text: "I am the Jira Agent." }],
+      },
+    ] as UIMessage[];
+
+    render(
+      <ChatMessages
+        conversationId="conv-1"
+        messages={messages}
+        status="ready"
+      />,
+    );
+
+    expect(screen.getAllByText("Switched to Jira Agent")).toHaveLength(1);
+  });
+
   it("renders persisted chat errors between messages by timestamp", () => {
     const messages = [
       {

--- a/platform/frontend/src/components/chat/chat-messages.test.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.test.tsx
@@ -269,6 +269,56 @@ describe("ChatMessages", () => {
     expect(screen.getAllByText("Switched to Jira Agent")).toHaveLength(1);
   });
 
+  it("renders failed swap tools as compact error indicators instead of swap dividers", () => {
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-sparky__swap_agent",
+            toolCallId: "call-1",
+            state: "output-available",
+            input: { agent_name: "Jira Agent" },
+            output: JSON.stringify({
+              success: false,
+              code: "already_using_agent",
+              message:
+                'Already using agent "Jira Agent". Choose a different agent.',
+              archestraError: {
+                type: "tool_state",
+                code: "already_using_agent",
+                message:
+                  'Already using agent "Jira Agent". Choose a different agent.',
+                toolName: "swap_agent",
+              },
+            }),
+          },
+        ],
+      },
+    ] as UIMessage[];
+
+    render(
+      <ChatMessages
+        conversationId="conv-1"
+        messages={messages}
+        status="ready"
+      />,
+    );
+
+    const toolButtons = screen.getAllByRole("button");
+    expect(toolButtons).toHaveLength(1);
+    expect(
+      screen.queryByText("tool-sparky__swap_agent"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Switched to Jira Agent"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(toolButtons[0]);
+    expect(screen.getByText("tool-sparky__swap_agent")).toBeInTheDocument();
+  });
+
   it("renders persisted chat errors between messages by timestamp", () => {
     const messages = [
       {

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -73,7 +73,10 @@ import {
   resolveToolAuthState,
 } from "@/lib/chat/mcp-error-ui";
 import { hasThinkingTags, parseThinkingTags } from "@/lib/chat/parse-thinking";
-import { getSwapToolShortName } from "@/lib/chat/swap-agent.utils";
+import {
+  getSwapToolShortName,
+  type SwapToolPart,
+} from "@/lib/chat/swap-agent.utils";
 import type { ModelSource } from "@/lib/chat/use-chat-preferences";
 import { useAppIconLogo } from "@/lib/hooks/use-app-name";
 import { useArchestraMcpIdentity } from "@/lib/mcp/archestra-mcp-server";
@@ -105,7 +108,10 @@ import {
   UnsafeContextStartsHereDivider,
 } from "./message-boundary-divider";
 import { PolicyDeniedTool } from "./policy-denied-tool";
-import { SwapAgentBoundaryDivider } from "./swap-agent-boundary";
+import {
+  getSwapAgentBoundaryLabel,
+  SwapAgentBoundaryDivider,
+} from "./swap-agent-boundary";
 import { TodoWriteTool } from "./todo-write-tool";
 import { ToolErrorLogsButton } from "./tool-error-logs-button";
 import { ToolStatusRow } from "./tool-status-row";
@@ -469,6 +475,15 @@ export function ChatMessages({
 
             const isDimmed =
               editingMessageIndex !== -1 && idx > editingMessageIndex;
+            const previousSwapBoundaryLabel =
+              message.role === "assistant"
+                ? getPreviousAssistantSwapBoundaryLabel({
+                    messages,
+                    beforeIndex: idx,
+                    getToolShortName,
+                    hasToolError: hasSwapToolError,
+                  })
+                : null;
 
             return (
               <div
@@ -1174,6 +1189,7 @@ export function ChatMessages({
                     parts={message.parts ?? []}
                     getToolShortName={getToolShortName}
                     hasToolError={hasSwapToolError}
+                    suppressLabel={previousSwapBoundaryLabel}
                   />
                 )}
               </div>
@@ -1793,6 +1809,39 @@ function isSwapAgentPokeMessage(message: UIMessage): boolean {
     text === SWAP_TO_DEFAULT_AGENT_POKE_TEXT ||
     text.startsWith(SWAP_AGENT_POKE_PREFIX)
   );
+}
+
+function getPreviousAssistantSwapBoundaryLabel({
+  messages,
+  beforeIndex,
+  getToolShortName,
+  hasToolError,
+}: {
+  messages: UIMessage[];
+  beforeIndex: number;
+  getToolShortName?: (toolName: string) => ArchestraToolShortName | null;
+  hasToolError: (part: SwapToolPart, allParts: SwapToolPart[]) => boolean;
+}) {
+  for (let i = beforeIndex - 1; i >= 0; i--) {
+    const previousMessage = messages[i];
+    if (previousMessage.role === "user") {
+      return null;
+    }
+    if (previousMessage.role !== "assistant") {
+      continue;
+    }
+
+    const label = getSwapAgentBoundaryLabel({
+      parts: previousMessage.parts ?? [],
+      getToolShortName,
+      hasToolError,
+    });
+    if (label) {
+      return label;
+    }
+  }
+
+  return null;
 }
 
 function renderPartWithUnsafeContextDivider({

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -1489,18 +1489,33 @@ const MessageTool = memo(
       onReauthMcp,
     });
 
-    // swap_agent / swap_to_default_agent are rendered as dividers after all message parts (see SwapAgentDivider below)
-    // Show the raw tool call when the user's name ends with "(debugging)"
+    // Successful swap_agent / swap_to_default_agent calls are rendered as dividers after all message parts.
+    // Failed/no-op swap calls use the compact tool status indicator so they do not render a false divider.
+    // Show the raw tool call when the user's name ends with "(debugging)".
     const swapToolShortName = getSwapToolShortName({
       toolName,
       getToolShortName,
     });
-    if (
-      !isDebugging &&
-      (swapToolShortName === TOOL_SWAP_AGENT_SHORT_NAME ||
-        swapToolShortName === TOOL_SWAP_TO_DEFAULT_AGENT_SHORT_NAME)
-    ) {
-      return null;
+    const isSwapTool =
+      swapToolShortName === TOOL_SWAP_AGENT_SHORT_NAME ||
+      swapToolShortName === TOOL_SWAP_TO_DEFAULT_AGENT_SHORT_NAME;
+    if (!isDebugging && isSwapTool) {
+      return errorText ? (
+        <CompactToolGroup
+          tools={[
+            {
+              key: part.toolCallId ?? toolName,
+              toolName,
+              part,
+              toolResultPart,
+              errorText,
+            },
+          ]}
+          toolIconMap={toolIconMap}
+          canExpandToolCalls={canExpandToolCalls}
+          onToolApprovalResponse={onToolApprovalResponse}
+        />
+      ) : null;
     }
 
     if (getToolShortName(toolName) === TOOL_TODO_WRITE_SHORT_NAME) {

--- a/platform/frontend/src/components/chat/editable-assistant-message.tsx
+++ b/platform/frontend/src/components/chat/editable-assistant-message.tsx
@@ -168,17 +168,19 @@ export function EditableAssistantMessage({
 
   return (
     <Message from="assistant" className="group/message">
-      <div className="relative flex flex-col items-start pb-2 w-full">
-        <MessageContent>
-          <Response isStreaming={isStreaming}>{text}</Response>
-          {citationParts && <KnowledgeGraphCitations parts={citationParts} />}
-        </MessageContent>
+      <div className="flex max-w-[80%] items-center justify-start gap-2">
+        <div className="min-w-0 flex-1">
+          <MessageContent className="max-w-none">
+            <Response isStreaming={isStreaming}>{text}</Response>
+            {citationParts && <KnowledgeGraphCitations parts={citationParts} />}
+          </MessageContent>
+        </div>
         {showActions && (
           <MessageActions
             textToCopy={text}
             onEditClick={handleStartEdit}
             editDisabled={editDisabled}
-            className="absolute -bottom-1 left-0 translate-y-full z-10 opacity-0 group-hover/message:opacity-100 transition-opacity"
+            className="shrink-0 opacity-0 group-hover/message:opacity-100 transition-opacity"
           />
         )}
       </div>

--- a/platform/frontend/src/components/chat/editable-user-message.tsx
+++ b/platform/frontend/src/components/chat/editable-user-message.tsx
@@ -251,25 +251,24 @@ export function EditableUserMessage({
         )}
         {/* Text message bubble - only show if there's text */}
         {text && (
-          <MessageContent>
-            <UserMessageText text={text} />
-          </MessageContent>
-        )}
-        {/* Actions below the message - only show edit for messages with text */}
-        {text && (
-          <MessageActions
-            textToCopy={text}
-            onEditClick={handleStartEdit}
-            onRegenerateClick={handleRegenerateClick}
-            isRegenerateConfirming={isRegenerateConfirming}
-            editDisabled={editDisabled}
-            className={cn(
-              "absolute -bottom-1 right-0 translate-y-full z-10 transition-opacity",
-              isRegenerateConfirming
-                ? "opacity-100"
-                : "opacity-0 group-hover/message:opacity-100",
-            )}
-          />
+          <div className="flex max-w-[80%] items-center justify-end gap-2">
+            <MessageActions
+              textToCopy={text}
+              onEditClick={handleStartEdit}
+              onRegenerateClick={handleRegenerateClick}
+              isRegenerateConfirming={isRegenerateConfirming}
+              editDisabled={editDisabled}
+              className={cn(
+                "shrink-0 transition-opacity",
+                isRegenerateConfirming
+                  ? "opacity-100"
+                  : "opacity-0 group-hover/message:opacity-100",
+              )}
+            />
+            <MessageContent className="max-w-none">
+              <UserMessageText text={text} />
+            </MessageContent>
+          </div>
         )}
       </div>
     </Message>

--- a/platform/frontend/src/components/chat/swap-agent-boundary.tsx
+++ b/platform/frontend/src/components/chat/swap-agent-boundary.tsx
@@ -17,6 +17,30 @@ export function SwapAgentBoundaryDivider({
   parts,
   getToolShortName,
   hasToolError,
+  suppressLabel,
+}: {
+  parts: ToolPart[];
+  getToolShortName?: (toolName: string) => ArchestraToolShortName | null;
+  hasToolError: (part: ToolPart, allParts: ToolPart[]) => boolean;
+  suppressLabel?: string | null;
+}) {
+  const label = getSwapAgentBoundaryLabel({
+    parts,
+    getToolShortName,
+    hasToolError,
+  });
+
+  if (!label || label === suppressLabel) {
+    return null;
+  }
+
+  return <MessageBoundaryDivider label={label} />;
+}
+
+export function getSwapAgentBoundaryLabel({
+  parts,
+  getToolShortName,
+  hasToolError,
 }: {
   parts: ToolPart[];
   getToolShortName?: (toolName: string) => ArchestraToolShortName | null;
@@ -47,7 +71,7 @@ export function SwapAgentBoundaryDivider({
       ? "default agent"
       : (extractSwapTargetAgentName(part) ?? "another agent");
 
-    return <MessageBoundaryDivider label={`Switched to ${agentName}`} />;
+    return `Switched to ${agentName}`;
   }
 
   return null;

--- a/platform/shared/mcp-tool-error.test.ts
+++ b/platform/shared/mcp-tool-error.test.ts
@@ -158,4 +158,24 @@ ${TOOL_INVOCATION_UNTRUSTED_CONTEXT_REASON}`),
       reasonType: "sensitive_context",
     });
   });
+
+  it("extracts tool state errors from structured content", () => {
+    expect(
+      extractMcpToolError({
+        structuredContent: {
+          archestraError: {
+            type: "tool_state",
+            code: "already_using_agent",
+            message: "Already using agent.",
+            toolName: "archestra__swap_agent",
+          },
+        },
+      }),
+    ).toEqual({
+      type: "tool_state",
+      code: "already_using_agent",
+      message: "Already using agent.",
+      toolName: "archestra__swap_agent",
+    });
+  });
 });

--- a/platform/shared/mcp-tool-error.ts
+++ b/platform/shared/mcp-tool-error.ts
@@ -7,6 +7,7 @@ export const McpToolErrorTypeSchema = z.enum([
   "auth_expired",
   "assigned_credential_unavailable",
   "policy_denied",
+  "tool_state",
   "generic",
 ]);
 
@@ -63,12 +64,22 @@ export const PolicyDeniedMcpToolErrorSchema = z
   })
   .strict();
 
+export const ToolStateMcpToolErrorSchema = z
+  .object({
+    type: z.literal("tool_state"),
+    message: z.string(),
+    code: z.string(),
+    toolName: z.string().optional(),
+  })
+  .strict();
+
 export const McpToolErrorSchema = z.discriminatedUnion("type", [
   GenericMcpToolErrorSchema,
   AuthRequiredMcpToolErrorSchema,
   AuthExpiredMcpToolErrorSchema,
   AssignedCredentialUnavailableMcpToolErrorSchema,
   PolicyDeniedMcpToolErrorSchema,
+  ToolStateMcpToolErrorSchema,
 ]);
 
 export type GenericMcpToolError = z.infer<typeof GenericMcpToolErrorSchema>;
@@ -84,6 +95,7 @@ export type AssignedCredentialUnavailableMcpToolError = z.infer<
 export type PolicyDeniedMcpToolError = z.infer<
   typeof PolicyDeniedMcpToolErrorSchema
 >;
+export type ToolStateMcpToolError = z.infer<typeof ToolStateMcpToolErrorSchema>;
 export type PolicyDeniedReasonType = z.infer<
   typeof PolicyDeniedReasonTypeSchema
 >;


### PR DESCRIPTION
## Summary

- Fix new-chat agent selection for users who cannot access the chat agent picker by ignoring stale browser-saved agent IDs and using org/member defaults instead.
- Reuse the existing structured MCP `archestraError` convention for expected swap-agent state outcomes, returning `success: false` with stable codes instead of surfacing them as global chat failures.
- Render failed or no-op `swap_agent` and `swap_to_default_agent` calls with the existing compact tool error indicator instead of a false swap divider or full error card.
- Deduplicate adjacent identical swap-agent dividers in the chat timeline.
- Move chat message copy/edit actions inline beside message bubbles so they do not cover compact tool indicators.

## Root Cause

Restricted users could still inherit `localStorage["selected-chat-agent"]` from a previous chat even though they had no picker access to see or change that selection. Separately, expected swap-tool states such as already being on the requested agent or lacking a configured default agent were returned as MCP execution errors, which could be promoted into large chat error cards even when the assistant handled the tool outcome conversationally.

## Notes

The swap state output intentionally includes structured error metadata in MCP-native fields and persisted text output so streamed, saved, and frontend-rendered messages can all recover the same state. These swap states keep `isError: false` because they are expected routing outcomes rather than MCP transport failures.