### PR TITLE
fix(ollama): hide API key for self-hosted, add docker host hint

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -775,7 +775,13 @@ These environment variables set the default base URL for each LLM provider. Per-
 - **`ARCHESTRA_OLLAMA_BASE_URL`** - Base URL for your Ollama server.
   - Default: `http://localhost:11434/v1` (Ollama is enabled by default)
   - Set this to override the default if your Ollama server runs on a different host or port
+  - When Archestra runs in a container and Ollama runs on the host, `localhost` resolves to the container itself. Use `http://host.docker.internal:11434/v1` (Docker Desktop, OrbStack) or the host bridge IP (Linux: `http://172.17.0.1:11434/v1`). The UI surfaces a hint with a one-click fix when this misconfiguration is detected.
   - See: [Ollama setup guide](/docs/platform-supported-llm-providers#ollama)
+
+- **`ARCHESTRA_RUNNING_IN_CONTAINER`** - Override container detection.
+  - Default: auto-detected via `/.dockerenv`, `/proc/1/cgroup`, and `KUBERNETES_SERVICE_HOST`
+  - Set to `true` to force container-aware UI hints (e.g. `host.docker.internal` suggestion when pointing self-hosted providers at `localhost`)
+  - Set to `false` to suppress those hints when running on the host directly
 
 - **`ARCHESTRA_DEEPSEEK_BASE_URL`** - Override the DeepSeek API base URL.
   - Default: `https://api.deepseek.com`

--- a/platform/backend/src/config.test.ts
+++ b/platform/backend/src/config.test.ts
@@ -8,6 +8,7 @@ import {
   test,
 } from "@/test";
 import {
+  detectRunningInContainer,
   getAnalyticsConfig,
   getCorsOrigins,
   getDatabaseUrl,
@@ -1107,5 +1108,36 @@ describe("parseTrustProxy", () => {
 
   test("should filter empty entries from extra commas", () => {
     expect(parseTrustProxy("127.0.0.1,,10.0.0.1")).toBe("127.0.0.1,10.0.0.1");
+  });
+});
+
+
+describe("detectRunningInContainer", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.ARCHESTRA_RUNNING_IN_CONTAINER;
+    delete process.env.KUBERNETES_SERVICE_HOST;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test("returns true when explicit override is true", () => {
+    process.env.ARCHESTRA_RUNNING_IN_CONTAINER = "true";
+    expect(detectRunningInContainer()).toBe(true);
+  });
+
+  test("returns false when explicit override is false even on k8s", () => {
+    process.env.ARCHESTRA_RUNNING_IN_CONTAINER = "false";
+    process.env.KUBERNETES_SERVICE_HOST = "10.0.0.1";
+    expect(detectRunningInContainer()).toBe(false);
+  });
+
+  test("returns true when KUBERNETES_SERVICE_HOST is set", () => {
+    process.env.KUBERNETES_SERVICE_HOST = "10.0.0.1";
+    expect(detectRunningInContainer()).toBe(true);
   });
 });

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { OTLPExporterNodeConfigBase } from "@opentelemetry/otlp-exporter-base";
@@ -857,6 +858,7 @@ const config = {
   authRateLimitDisabled:
     process.env.ARCHESTRA_AUTH_RATE_LIMIT_DISABLED === "true",
   isQuickstart: process.env.ARCHESTRA_QUICKSTART === "true",
+  runningInContainer: detectRunningInContainer(),
   ngrokDomain: process.env.ARCHESTRA_NGROK_DOMAIN || "",
   processType: parseProcessType(process.env.ARCHESTRA_PROCESS_TYPE),
 };
@@ -867,6 +869,33 @@ export const shouldRunWorker = config.processType !== "web";
 export default config;
 
 // ===== Internal helpers =====
+
+/**
+ * Detect whether the backend is running inside a container. Checked once at
+ * startup. Used to surface deployment-aware hints in the UI (e.g. suggest
+ * host.docker.internal when the user points Ollama at localhost from inside
+ * a container, where localhost would resolve to the container itself).
+ *
+ * @public — exported for testability
+ */
+export function detectRunningInContainer(): boolean {
+  if (process.env.ARCHESTRA_RUNNING_IN_CONTAINER === "true") return true;
+  if (process.env.ARCHESTRA_RUNNING_IN_CONTAINER === "false") return false;
+  if (process.env.KUBERNETES_SERVICE_HOST) return true;
+  try {
+    fs.accessSync("/.dockerenv");
+    return true;
+  } catch {
+    // not docker
+  }
+  try {
+    const cgroup = fs.readFileSync("/proc/1/cgroup", "utf8");
+    if (/docker|kubepods|containerd/.test(cgroup)) return true;
+  } catch {
+    // not linux or no access
+  }
+  return false;
+}
 
 /** @public — exported for testability */
 export function parseConnectorSyncMaxDuration(

--- a/platform/backend/src/routes/chat/model-fetchers/ollama.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/ollama.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import config from "@/config";
+import { fetchOllamaModels } from "./ollama";
+
+describe("fetchOllamaModels", () => {
+  const originalBaseUrl = config.llm.ollama.baseUrl;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    config.llm.ollama.baseUrl = "http://localhost:11434/v1";
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ id: "llama3" }] }), {
+        status: 200,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    config.llm.ollama.baseUrl = originalBaseUrl;
+    vi.restoreAllMocks();
+  });
+
+  test("uses placeholder bearer when no key provided", async () => {
+    await fetchOllamaModels("");
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect((init.headers as Record<string, string>).Authorization).toMatch(
+      /Bearer/,
+    );
+  });
+
+  test("uses provided key when set", async () => {
+    await fetchOllamaModels("my-token");
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer my-token",
+    );
+  });
+
+  test("throws hint mentioning host.docker.internal when localhost is unreachable", async () => {
+    fetchSpy.mockRejectedValueOnce(new TypeError("fetch failed"));
+    await expect(fetchOllamaModels("", "http://localhost:11434/v1")).rejects.toThrow(
+      /host\.docker\.internal/,
+    );
+  });
+
+  test("throws plain connection error for remote URLs without docker hint", async () => {
+    fetchSpy.mockRejectedValueOnce(new TypeError("ECONNREFUSED"));
+    let caught: unknown;
+    try {
+      await fetchOllamaModels("", "https://ollama.example.com/v1");
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    const message = (caught as Error).message;
+    expect(message).toMatch(
+      /Cannot reach Ollama at https:\/\/ollama\.example\.com/,
+    );
+    expect(message).not.toMatch(/host\.docker\.internal/);
+  });
+
+  test("propagates HTTP error with status code", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response("nope", { status: 500 }));
+    await expect(fetchOllamaModels("")).rejects.toThrow(
+      /Failed to fetch Ollama models: 500/,
+    );
+  });
+});

--- a/platform/backend/src/routes/chat/model-fetchers/ollama.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/ollama.ts
@@ -1,3 +1,4 @@
+import { isLocalhostUrl, OLLAMA_DOCKER_HOST_URL } from "@shared";
 import config from "@/config";
 import logger from "@/logging";
 import { type ModelInfo, PLACEHOLDER_BEARER_TOKEN } from "./types";
@@ -9,12 +10,20 @@ export async function fetchOllamaModels(
 ): Promise<ModelInfo[]> {
   const baseUrl = baseUrlOverride || config.llm.ollama.baseUrl;
   const url = `${baseUrl}/models`;
-  const response = await fetch(url, {
-    headers: {
-      ...(extraHeaders ?? {}),
-      Authorization: apiKey ? `Bearer ${apiKey}` : PLACEHOLDER_BEARER_TOKEN,
-    },
-  });
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: {
+        ...(extraHeaders ?? {}),
+        Authorization: apiKey ? `Bearer ${apiKey}` : PLACEHOLDER_BEARER_TOKEN,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error({ baseUrl, error: message }, "Failed to connect to Ollama");
+    throw new Error(buildOllamaConnectError(baseUrl, message));
+  }
 
   if (!response.ok) {
     const errorText = await response.text();
@@ -40,4 +49,15 @@ export async function fetchOllamaModels(
       ? new Date(model.created * 1000).toISOString()
       : undefined,
   }));
+}
+
+function buildOllamaConnectError(baseUrl: string, reason: string): string {
+  if (isLocalhostUrl(baseUrl)) {
+    return (
+      `Cannot reach Ollama at ${baseUrl} (${reason}). ` +
+      `If Archestra runs in Docker or Kubernetes, "localhost" points at the container, ` +
+      `not the host machine. Try ${OLLAMA_DOCKER_HOST_URL} instead.`
+    );
+  }
+  return `Cannot reach Ollama at ${baseUrl}: ${reason}`;
 }

--- a/platform/backend/src/routes/config.ts
+++ b/platform/backend/src/routes/config.ts
@@ -75,6 +75,7 @@ const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
               mcpServerBaseImage: z.string(),
               orchestratorK8sNamespace: z.string(),
               isQuickstart: z.boolean(),
+              runningInContainer: z.boolean(),
               ngrokDomain: z.string(),
               virtualKeyDefaultExpirationSeconds: z.number(),
               mcpSandboxDomain: z.string().nullable(),
@@ -112,6 +113,7 @@ const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
           mcpServerBaseImage: config.orchestrator.mcpServerBaseImage,
           orchestratorK8sNamespace: config.orchestrator.kubernetes.namespace,
           isQuickstart: config.isQuickstart,
+          runningInContainer: config.runningInContainer,
           ngrokDomain: getNgrokDomain(),
           virtualKeyDefaultExpirationSeconds:
             config.llmProxy.virtualKeyDefaultExpirationSeconds,

--- a/platform/frontend/src/components/llm-provider-api-key-form.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.tsx
@@ -4,11 +4,20 @@ import {
   type archestraApiTypes,
   DEFAULT_PROVIDER_BASE_URLS,
   E2eTestId,
+  isLocalhostUrl,
+  OLLAMA_DOCKER_HOST_URL,
   PROVIDERS_WITH_OPTIONAL_API_KEY,
 } from "@shared";
-import { Building2, CheckCircle2, Trash2, User, Users } from "lucide-react";
+import {
+  Building2,
+  CheckCircle2,
+  Info,
+  Trash2,
+  User,
+  Users,
+} from "lucide-react";
 import Link from "next/link";
-import { lazy, Suspense, useEffect, useMemo } from "react";
+import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 import { type UseFormReturn, useFieldArray } from "react-hook-form";
 import { ExternalDocsLink } from "@/components/external-docs-link";
 import {
@@ -20,6 +29,7 @@ import { useFeature, useProviderBaseUrls } from "@/lib/config/config.query";
 import { getFrontendDocsUrl } from "@/lib/docs/docs";
 import { useTeams } from "@/lib/teams/team.query";
 import { LlmProviderSelectItems } from "./llm-provider-options";
+import { Alert, AlertDescription, AlertTitle } from "./ui/alert";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
@@ -286,6 +296,7 @@ export function LlmProviderApiKeyForm({
 }: LlmProviderApiKeyFormProps) {
   const authDocsUrl = getFrontendDocsUrl("platform-llm-proxy-authentication");
   const byosEnabled = useFeature("byosEnabled");
+  const runningInContainer = useFeature("runningInContainer");
   const { data: providerBaseUrls } = useProviderBaseUrls();
   const { data: canReadTeams } = useHasPermissions({ team: ["read"] });
   const { data: isLlmProviderApiKeyAdmin } = useHasPermissions({
@@ -296,8 +307,25 @@ export function LlmProviderApiKeyForm({
 
   const provider = form.watch("provider");
   const apiKey = form.watch("apiKey");
+  const baseUrl = form.watch("baseUrl");
   const scope = form.watch("scope");
   const teamId = form.watch("teamId");
+
+  const isOptionalKeyProvider = PROVIDERS_WITH_OPTIONAL_API_KEY.has(provider);
+  const baseUrlIsLocalhost = isLocalhostUrl(baseUrl ?? undefined);
+  // For self-hosted providers (Ollama, vLLM), the user opts in to "remote
+  // server" mode. Off by default (local self-host = no auth, no key field).
+  // When existing key has an apiKey or non-localhost baseUrl, treat as remote.
+  const [requiresAuth, setRequiresAuth] = useState<boolean>(() => {
+    if (!isOptionalKeyProvider) return false;
+    const initialApiKey = form.getValues("apiKey");
+    return Boolean(initialApiKey && initialApiKey !== "");
+  });
+  const showApiKeyInput = !isOptionalKeyProvider || requiresAuth;
+  const showDockerHostHint =
+    provider === "ollama" &&
+    runningInContainer === true &&
+    baseUrlIsLocalhost;
 
   const extraHeadersFieldArray = useFieldArray({
     control: form.control,
@@ -506,6 +534,32 @@ export function LlmProviderApiKeyForm({
           )}
         </div>
 
+        {isOptionalKeyProvider && !byosEnabled && (
+          <div className="flex items-center justify-between rounded-md border bg-muted/30 p-3">
+            <div className="space-y-0.5">
+              <Label htmlFor="llm-provider-api-key-requires-auth">
+                Server requires authentication
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                {providerConfig.name} itself does not require auth, but a
+                reverse proxy or managed gateway in front of it might. Toggle
+                on to add an API key or Bearer token.
+              </p>
+            </div>
+            <Switch
+              id="llm-provider-api-key-requires-auth"
+              checked={requiresAuth}
+              onCheckedChange={(checked) => {
+                setRequiresAuth(checked);
+                if (!checked) {
+                  form.setValue("apiKey", null, { shouldDirty: true });
+                }
+              }}
+              disabled={isPending}
+            />
+          </div>
+        )}
+
         {byosEnabled ? (
           <Suspense
             fallback={
@@ -514,11 +568,11 @@ export function LlmProviderApiKeyForm({
           >
             {vaultSecretSelector}
           </Suspense>
-        ) : (
+        ) : !showApiKeyInput ? null : (
           <div className="space-y-2">
             <Label htmlFor="llm-provider-api-key-value">
               API Key{" "}
-              {PROVIDERS_WITH_OPTIONAL_API_KEY.has(provider) ? (
+              {isOptionalKeyProvider ? (
                 <span className="font-normal text-muted-foreground">
                   (optional)
                 </span>
@@ -530,7 +584,7 @@ export function LlmProviderApiKeyForm({
                 )
               )}
             </Label>
-            {providerConfig.description && (
+            {!isOptionalKeyProvider && providerConfig.description && (
               <p className="text-xs text-muted-foreground">
                 {providerConfig.description}
               </p>
@@ -692,6 +746,34 @@ export function LlmProviderApiKeyForm({
               {form.formState.errors.baseUrl.message}
             </p>
           )}
+          {showDockerHostHint && (
+              <Alert variant="info">
+                <Info />
+                <AlertTitle>Running Archestra in Docker?</AlertTitle>
+                <AlertDescription className="space-y-2">
+                  <p>
+                    Inside a container, <code>localhost</code> resolves to the
+                    container itself, not the host running Ollama. Use{" "}
+                    <code>{OLLAMA_DOCKER_HOST_URL}</code> instead so the
+                    backend can reach Ollama on the host machine.
+                  </p>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      form.setValue("baseUrl", OLLAMA_DOCKER_HOST_URL, {
+                        shouldDirty: true,
+                        shouldValidate: true,
+                      })
+                    }
+                    disabled={isPending}
+                  >
+                    Use {OLLAMA_DOCKER_HOST_URL}
+                  </Button>
+                </AlertDescription>
+              </Alert>
+            )}
         </div>
 
         <div className="space-y-2">

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -413,8 +413,10 @@ function ChatSessionHook({
       }, 500);
       console.error("[ChatSession] Error occurred:", {
         conversationId,
-        errorName: chatError.name,
-        errorMessage: chatError.message,
+        errorName: chatError?.name,
+        errorMessage: chatError?.message,
+        errorString: String(chatError),
+        errorCause: (chatError as { cause?: unknown })?.cause,
         retryCount: retryCountRef.current,
       });
 

--- a/platform/frontend/src/lib/llm-provider-api-keys.query.ts
+++ b/platform/frontend/src/lib/llm-provider-api-keys.query.ts
@@ -179,6 +179,12 @@ export function useDeleteLlmProviderApiKey() {
       });
       queryClient.invalidateQueries({ queryKey: ["llm-models"] });
       queryClient.invalidateQueries({ queryKey: ["models-with-api-keys"] });
+      // Conversation caches may hold the deleted key's id in chatApiKeyId,
+      // which causes the chat selector to PATCH the conversation with a stale
+      // id and surface a 404 "Chat API key not found". Invalidating forces
+      // refetch so the auto-select uses the fresh available-keys list.
+      queryClient.invalidateQueries({ queryKey: ["conversation"] });
+      queryClient.invalidateQueries({ queryKey: ["conversations"] });
     },
   });
 }

--- a/platform/frontend/src/lib/utils/api.ts
+++ b/platform/frontend/src/lib/utils/api.ts
@@ -49,5 +49,21 @@ export function handleApiError(error: ApiSdkError) {
       ? error.error
       : new Error(getApiErrorMessage(error));
   Sentry.captureException(sentryError, { extra: { originalError: error } });
-  console.error(error);
+  console.error("API error:", getApiErrorMessage(error), {
+    error,
+    asString: String(error),
+    asJson: safeJson(error),
+  });
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(
+      value,
+      Object.getOwnPropertyNames(value as object),
+      2,
+    );
+  } catch {
+    return String(value);
+  }
 }

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -21352,6 +21352,7 @@ export type GetConfigResponses = {
             mcpServerBaseImage: string;
             orchestratorK8sNamespace: string;
             isQuickstart: boolean;
+            runningInContainer: boolean;
             ngrokDomain: string;
             virtualKeyDefaultExpirationSeconds: number;
             mcpSandboxDomain: string | null;

--- a/platform/shared/oauth.test.ts
+++ b/platform/shared/oauth.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+import {
+  isLocalhostUrl,
+  OLLAMA_DOCKER_HOST_URL,
+  PROVIDERS_WITH_OPTIONAL_API_KEY,
+} from "./oauth";
+
+describe("isLocalhostUrl", () => {
+  test("matches loopback hostnames", () => {
+    expect(isLocalhostUrl("http://localhost:11434/v1")).toBe(true);
+    expect(isLocalhostUrl("https://localhost")).toBe(true);
+    expect(isLocalhostUrl("http://127.0.0.1:8000")).toBe(true);
+    expect(isLocalhostUrl("http://0.0.0.0:8080")).toBe(true);
+    expect(isLocalhostUrl("http://[::1]:11434")).toBe(true);
+  });
+
+  test("does not match remote hostnames", () => {
+    expect(isLocalhostUrl("https://ollama.example.com")).toBe(false);
+    expect(isLocalhostUrl("http://host.docker.internal:11434")).toBe(false);
+    expect(isLocalhostUrl("http://192.168.1.10:11434")).toBe(false);
+  });
+
+  test("returns false for empty or invalid input", () => {
+    expect(isLocalhostUrl(null)).toBe(false);
+    expect(isLocalhostUrl(undefined)).toBe(false);
+    expect(isLocalhostUrl("")).toBe(false);
+    expect(isLocalhostUrl("not a url")).toBe(false);
+  });
+});
+
+describe("PROVIDERS_WITH_OPTIONAL_API_KEY", () => {
+  test("contains ollama and vllm", () => {
+    expect(PROVIDERS_WITH_OPTIONAL_API_KEY.has("ollama")).toBe(true);
+    expect(PROVIDERS_WITH_OPTIONAL_API_KEY.has("vllm")).toBe(true);
+  });
+
+  test("does not contain providers that require keys", () => {
+    expect(PROVIDERS_WITH_OPTIONAL_API_KEY.has("openai")).toBe(false);
+    expect(PROVIDERS_WITH_OPTIONAL_API_KEY.has("anthropic")).toBe(false);
+  });
+});
+
+describe("OLLAMA_DOCKER_HOST_URL", () => {
+  test("points at the docker host loopback", () => {
+    expect(OLLAMA_DOCKER_HOST_URL).toBe("http://host.docker.internal:11434/");
+  });
+});

--- a/platform/shared/oauth.ts
+++ b/platform/shared/oauth.ts
@@ -75,3 +75,25 @@ export const PROVIDERS_WITH_OPTIONAL_API_KEY = new Set<SupportedProvider>([
   "ollama",
   "vllm",
 ]);
+
+/**
+ * True when URL points at the host loopback interface. Used to flag
+ * misconfiguration when a containerised Archestra tries to reach a service
+ * running on the host (e.g. Ollama) via "localhost".
+ */
+export function isLocalhostUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  try {
+    const { hostname } = new URL(url);
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "0.0.0.0" ||
+      hostname === "[::1]"
+    );
+  } catch {
+    return false;
+  }
+}
+
+export const OLLAMA_DOCKER_HOST_URL = "http://host.docker.internal:11434/";


### PR DESCRIPTION
Hide the API key input by default for Ollama and vLLM and gate it behind a "Server requires authentication" toggle, so users no longer feel pushed to type a dummy key. 

<img width="431" height="708" alt="image" src="https://github.com/user-attachments/assets/ca667605-2172-496d-8b32-732e94f2df5c" />

Detect when the backend runs in a container (auto via /.dockerenv, /proc/1/cgroup, KUBERNETES_SERVICE_HOST, plus an ARCHESTRA_RUNNING_IN_CONTAINER override) and surface an inline alert with a one-click swap to http://host.docker.internal:11434/ when the user points Ollama at localhost from inside Docker. 

The model fetcher rethrows connect errors with the same hint so non-UI consumers see it too. 

Closes #4286.