### PR TITLE
chore: render existing secret envs as **** instead of empty value

### DIFF
--- a/platform/backend/src/routes/internal-mcp-catalog.secrets-preservation.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.secrets-preservation.test.ts
@@ -1,0 +1,346 @@
+import { type Mock, vi } from "vitest";
+import { InternalMcpCatalogModel } from "@/models";
+import { secretManager } from "@/secrets-manager";
+import type { FastifyInstanceWithZod } from "@/server";
+import { createFastifyInstance } from "@/server";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import type { User } from "@/types";
+
+vi.mock("@/auth", () => ({
+  hasPermission: vi.fn(),
+}));
+
+import { hasPermission } from "@/auth";
+
+const mockHasPermission = hasPermission as Mock;
+
+describe("Internal MCP Catalog - Local Config Secret Preservation on PUT", () => {
+  let app: FastifyInstanceWithZod;
+  let user: User;
+  let organizationId: string;
+
+  beforeEach(async ({ makeOrganization, makeUser }) => {
+    vi.clearAllMocks();
+    mockHasPermission.mockResolvedValue({ success: true, error: null });
+
+    user = await makeUser();
+    const organization = await makeOrganization();
+    organizationId = organization.id;
+
+    app = createFastifyInstance();
+    app.addHook("onRequest", async (request) => {
+      (request as typeof request & { user: unknown }).user = user;
+      (request as typeof request & { organizationId: string }).organizationId =
+        organizationId;
+    });
+
+    const { default: routes } = await import("./internal-mcp-catalog");
+    await app.register(routes);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await app.close();
+  });
+
+  test("1. PUT with env var entry but no value preserves the stored secret value", async ({
+    makeSecret,
+  }) => {
+    const existingSecret = await makeSecret({
+      name: "preserve-no-value",
+      secret: { API_KEY: "kept-value-1" },
+    });
+    const catalog = await InternalMcpCatalogModel.create(
+      {
+        name: "preserve-no-value-catalog",
+        serverType: "local",
+        localConfigSecretId: existingSecret.id,
+        localConfig: {
+          command: "node",
+          arguments: ["server.js"],
+          environment: [
+            {
+              key: "API_KEY",
+              type: "secret",
+              promptOnInstallation: false,
+            },
+          ],
+        },
+      },
+      { organizationId, authorId: user.id },
+    );
+
+    const response = await app.inject({
+      method: "PUT",
+      url: `/api/internal_mcp_catalog/${catalog.id}`,
+      payload: {
+        name: catalog.name,
+        serverType: "local",
+        localConfig: {
+          command: "node",
+          arguments: ["server.js"],
+          environment: [
+            {
+              key: "API_KEY",
+              type: "secret",
+              promptOnInstallation: false,
+              // value omitted entirely (masked, unedited row)
+            },
+          ],
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const stored = await secretManager().getSecret(existingSecret.id);
+    expect(stored?.secret).toEqual({ API_KEY: "kept-value-1" });
+  });
+
+  test("2. PUT with env var entry and empty-string value preserves the stored secret value", async ({
+    makeSecret,
+  }) => {
+    const existingSecret = await makeSecret({
+      name: "preserve-empty-string",
+      secret: { API_KEY: "kept-value-2" },
+    });
+    const catalog = await InternalMcpCatalogModel.create(
+      {
+        name: "preserve-empty-string-catalog",
+        serverType: "local",
+        localConfigSecretId: existingSecret.id,
+        localConfig: {
+          command: "node",
+          arguments: ["server.js"],
+          environment: [
+            {
+              key: "API_KEY",
+              type: "secret",
+              promptOnInstallation: false,
+            },
+          ],
+        },
+      },
+      { organizationId, authorId: user.id },
+    );
+
+    const response = await app.inject({
+      method: "PUT",
+      url: `/api/internal_mcp_catalog/${catalog.id}`,
+      payload: {
+        name: catalog.name,
+        serverType: "local",
+        localConfig: {
+          command: "node",
+          arguments: ["server.js"],
+          environment: [
+            {
+              key: "API_KEY",
+              type: "secret",
+              promptOnInstallation: false,
+              value: "",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const stored = await secretManager().getSecret(existingSecret.id);
+    expect(stored?.secret).toEqual({ API_KEY: "kept-value-2" });
+  });
+
+  test("3. PUT updates one secret while preserving the other", async ({
+    makeSecret,
+  }) => {
+    const existingSecret = await makeSecret({
+      name: "preserve-mixed",
+      secret: {
+        EDITED_KEY: "old-edited",
+        UNTOUCHED_KEY: "old-untouched",
+      },
+    });
+    const catalog = await InternalMcpCatalogModel.create(
+      {
+        name: "preserve-mixed-catalog",
+        serverType: "local",
+        localConfigSecretId: existingSecret.id,
+        localConfig: {
+          command: "node",
+          arguments: ["server.js"],
+          environment: [
+            {
+              key: "EDITED_KEY",
+              type: "secret",
+              promptOnInstallation: false,
+            },
+            {
+              key: "UNTOUCHED_KEY",
+              type: "secret",
+              promptOnInstallation: false,
+            },
+          ],
+        },
+      },
+      { organizationId, authorId: user.id },
+    );
+
+    const response = await app.inject({
+      method: "PUT",
+      url: `/api/internal_mcp_catalog/${catalog.id}`,
+      payload: {
+        name: catalog.name,
+        serverType: "local",
+        localConfig: {
+          command: "node",
+          arguments: ["server.js"],
+          environment: [
+            {
+              key: "EDITED_KEY",
+              type: "secret",
+              promptOnInstallation: false,
+              value: "new-edited",
+            },
+            {
+              key: "UNTOUCHED_KEY",
+              type: "secret",
+              promptOnInstallation: false,
+              // value omitted: untouched stored value should remain
+            },
+          ],
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const stored = await secretManager().getSecret(existingSecret.id);
+    expect(stored?.secret).toEqual({
+      EDITED_KEY: "new-edited",
+      UNTOUCHED_KEY: "old-untouched",
+    });
+  });
+
+  test("4. PUT removing an env var entry drops its stored secret value", async ({
+    makeSecret,
+  }) => {
+    const existingSecret = await makeSecret({
+      name: "preserve-removed",
+      secret: {
+        KEPT_KEY: "kept-value",
+        DROPPED_KEY: "dropped-value",
+      },
+    });
+    const catalog = await InternalMcpCatalogModel.create(
+      {
+        name: "preserve-removed-catalog",
+        serverType: "local",
+        localConfigSecretId: existingSecret.id,
+        localConfig: {
+          command: "node",
+          arguments: ["server.js"],
+          environment: [
+            {
+              key: "KEPT_KEY",
+              type: "secret",
+              promptOnInstallation: false,
+            },
+            {
+              key: "DROPPED_KEY",
+              type: "secret",
+              promptOnInstallation: false,
+            },
+          ],
+        },
+      },
+      { organizationId, authorId: user.id },
+    );
+
+    const response = await app.inject({
+      method: "PUT",
+      url: `/api/internal_mcp_catalog/${catalog.id}`,
+      payload: {
+        name: catalog.name,
+        serverType: "local",
+        localConfig: {
+          command: "node",
+          arguments: ["server.js"],
+          environment: [
+            {
+              key: "KEPT_KEY",
+              type: "secret",
+              promptOnInstallation: false,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const stored = await secretManager().getSecret(existingSecret.id);
+    expect(stored?.secret).toEqual({ KEPT_KEY: "kept-value" });
+    expect(stored?.secret).not.toHaveProperty("DROPPED_KEY");
+  });
+
+  test("5. PUT adding a new secret entry without a value does not insert an empty secret", async ({
+    makeSecret,
+  }) => {
+    const existingSecret = await makeSecret({
+      name: "preserve-new-empty",
+      secret: { EXISTING_KEY: "existing-value" },
+    });
+    const catalog = await InternalMcpCatalogModel.create(
+      {
+        name: "preserve-new-empty-catalog",
+        serverType: "local",
+        localConfigSecretId: existingSecret.id,
+        localConfig: {
+          command: "node",
+          arguments: ["server.js"],
+          environment: [
+            {
+              key: "EXISTING_KEY",
+              type: "secret",
+              promptOnInstallation: false,
+            },
+          ],
+        },
+      },
+      { organizationId, authorId: user.id },
+    );
+
+    const response = await app.inject({
+      method: "PUT",
+      url: `/api/internal_mcp_catalog/${catalog.id}`,
+      payload: {
+        name: catalog.name,
+        serverType: "local",
+        localConfig: {
+          command: "node",
+          arguments: ["server.js"],
+          environment: [
+            {
+              key: "EXISTING_KEY",
+              type: "secret",
+              promptOnInstallation: false,
+            },
+            {
+              key: "BRAND_NEW_KEY",
+              type: "secret",
+              promptOnInstallation: false,
+              // user added the row but did not type a value
+            },
+          ],
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const stored = await secretManager().getSecret(existingSecret.id);
+    expect(stored?.secret).toEqual({ EXISTING_KEY: "existing-value" });
+    expect(stored?.secret).not.toHaveProperty("BRAND_NEW_KEY");
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -146,6 +146,18 @@ export function McpCatalogForm({
   // Fetch local config secrets only for local MCP catalog items.
   const { data: localConfigSecret } = useGetSecret(localConfigSecretId);
 
+  // Pre-existing secret env-var keys, used to render a `••••••••` placeholder.
+  const storedSecretKeys = useMemo(() => {
+    if (initialValues?.serverType !== "local" || !initialValues.localConfig) {
+      return new Set<string>();
+    }
+    return new Set(
+      (initialValues.localConfig.environment ?? [])
+        .filter((env) => env.type === "secret")
+        .map((env) => env.key),
+    );
+  }, [initialValues]);
+
   // Get MCP server base image from backend features endpoint
   const mcpServerBaseImage = useFeature("mcpServerBaseImage") ?? "";
 
@@ -983,6 +995,7 @@ export function McpCatalogForm({
                 fieldNamePrefix="localConfig.environment"
                 form={form}
                 useExternalSecretsManager={showByosOption}
+                secretKeysWithStoredValue={storedSecretKeys}
                 disablePromptOnInstallation={isMultitenant}
                 disablePromptOnInstallationReason="Multi-tenant servers share one deployment, so env vars are set once at deploy time and cannot be prompted per install."
                 envFrom={{

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
@@ -670,3 +670,120 @@ describe("transformFormToApiData", () => {
     expect(values.authHeaderName).toBe("");
   });
 });
+
+describe("transformFormToApiData - secret env var preservation", () => {
+  type LocalEnvironment = NonNullable<
+    McpCatalogFormValues["localConfig"]
+  >["environment"];
+
+  function buildLocalFormValues(
+    environment: LocalEnvironment,
+  ): McpCatalogFormValues {
+    return {
+      name: "secret-preservation-mcp",
+      description: "",
+      icon: null,
+      serverType: "local",
+      serverUrl: "",
+      authMethod: "none",
+      includeBearerPrefix: true,
+      authHeaderName: "",
+      additionalHeaders: [],
+      oauthConfig: undefined,
+      enterpriseManagedConfig: null,
+      localConfig: {
+        command: "node",
+        arguments: "server.js",
+        environment,
+        envFrom: [],
+        dockerImage: "",
+        transportType: "stdio",
+        httpPort: "",
+        httpPath: "",
+        serviceAccount: "",
+        imagePullSecrets: [],
+      },
+      deploymentSpecYaml: "",
+      originalDeploymentSpecYaml: "",
+      oauthClientSecretVaultPath: "",
+      oauthClientSecretVaultKey: "",
+      localConfigVaultPath: "",
+      localConfigVaultKey: "",
+      labels: [],
+      scope: "personal",
+      teams: [],
+    };
+  }
+
+  it("emits empty value (not a mask sentinel) for an unedited secret row", () => {
+    const result = transformFormToApiData(
+      buildLocalFormValues([
+        {
+          key: "API_KEY",
+          type: "secret",
+          value: "",
+          promptOnInstallation: false,
+          required: false,
+          description: "",
+        },
+      ]),
+    );
+
+    const envVar = result.localConfig?.environment?.[0];
+    expect(envVar?.key).toBe("API_KEY");
+    expect(envVar?.type).toBe("secret");
+    // The form must NOT round-trip the masked placeholder back to the API.
+    // Backend preserves stored value when value is empty/undefined.
+    const value = envVar?.value ?? "";
+    expect(value).toBe("");
+    expect(value).not.toMatch(/[•*]/);
+  });
+
+  it("emits the typed value when the user edited the secret row", () => {
+    const result = transformFormToApiData(
+      buildLocalFormValues([
+        {
+          key: "API_KEY",
+          type: "secret",
+          value: "newly-typed-secret",
+          promptOnInstallation: false,
+          required: false,
+          description: "",
+        },
+      ]),
+    );
+
+    expect(result.localConfig?.environment?.[0]?.value).toBe(
+      "newly-typed-secret",
+    );
+  });
+
+  it("preserves mixed edited / unedited secret rows independently", () => {
+    const result = transformFormToApiData(
+      buildLocalFormValues([
+        {
+          key: "EDITED",
+          type: "secret",
+          value: "fresh",
+          promptOnInstallation: false,
+          required: false,
+          description: "",
+        },
+        {
+          key: "UNTOUCHED",
+          type: "secret",
+          value: "",
+          promptOnInstallation: false,
+          required: false,
+          description: "",
+        },
+      ]),
+    );
+
+    const env = result.localConfig?.environment ?? [];
+    expect(env).toHaveLength(2);
+    expect(env[0]).toMatchObject({ key: "EDITED", value: "fresh" });
+    expect(env[1]?.key).toBe("UNTOUCHED");
+    expect(env[1]?.value ?? "").toBe("");
+  });
+});

--- a/platform/frontend/src/components/environment-variables-form-field.tsx
+++ b/platform/frontend/src/components/environment-variables-form-field.tsx
@@ -79,6 +79,12 @@ interface EnvironmentVariablesFormFieldProps<TFieldValues extends FieldValues> {
   showDescription?: boolean;
   /** When true, non-prompted secret values will be sourced from external secrets manager (Vault) */
   useExternalSecretsManager?: boolean;
+  /**
+   * Set of env-var keys whose secret value is already stored on the server.
+   * Rows whose `key` is in this set render `••••••••` + an Update button
+   * instead of an empty input, so admins don't think the value has been wiped.
+   */
+  secretKeysWithStoredValue?: Set<string>;
   /** When true, the "Prompt on each installation" checkbox is disabled (e.g. multi-tenant servers) */
   disablePromptOnInstallation?: boolean;
   /** Tooltip message shown when the "Prompt on each installation" checkbox is disabled */
@@ -120,6 +126,7 @@ export function EnvironmentVariablesFormField<
   showLabel = true,
   showDescription = true,
   useExternalSecretsManager = false,
+  secretKeysWithStoredValue,
   disablePromptOnInstallation = false,
   disablePromptOnInstallationReason,
   envFrom,
@@ -214,6 +221,7 @@ export function EnvironmentVariablesFormField<
               remove={remove}
               fieldNamePrefix={fieldNamePrefix}
               useExternalSecretsManager={useExternalSecretsManager}
+              secretKeysWithStoredValue={secretKeysWithStoredValue}
               disablePromptOnInstallation={disablePromptOnInstallation}
               disablePromptOnInstallationReason={
                 disablePromptOnInstallationReason
@@ -524,6 +532,13 @@ export function EnvironmentVariablesFormField<
                           );
                         }
 
+                        const rowKey = form.watch(
+                          `${fieldNamePrefix}.${index}.key` as FieldPath<TFieldValues>,
+                        ) as string | undefined;
+                        const hasStoredSecret =
+                          !!rowKey &&
+                          secretKeysWithStoredValue?.has(rowKey) === true;
+
                         return (
                           <FormField
                             control={control}
@@ -531,7 +546,12 @@ export function EnvironmentVariablesFormField<
                               `${fieldNamePrefix}.${index}.value` as FieldPath<TFieldValues>
                             }
                             render={({ field }) => (
-                              <AutoResizeSecretTextarea field={field} />
+                              <AutoResizeSecretTextarea
+                                field={field}
+                                placeholder={
+                                  hasStoredSecret ? "••••••••" : undefined
+                                }
+                              />
                             )}
                           />
                         );
@@ -607,9 +627,11 @@ const MAX_TEXTAREA_HEIGHT = 128;
 
 function AutoResizeSecretTextarea({
   field,
+  placeholder,
 }: {
   // biome-ignore lint/suspicious/noExplicitAny: Generic field types
   field: ControllerRenderProps<any, any>;
+  placeholder?: string;
 }) {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
@@ -632,6 +654,7 @@ function AutoResizeSecretTextarea({
           className="font-mono text-xs resize-none min-h-10 max-h-32 overflow-y-auto"
           rows={1}
           autoComplete={MCP_SECRET_AUTOCOMPLETE}
+          placeholder={placeholder}
           {...field}
           ref={(el) => {
             textareaRef.current = el;

--- a/platform/frontend/src/components/install-config-fields-table.tsx
+++ b/platform/frontend/src/components/install-config-fields-table.tsx
@@ -73,6 +73,13 @@ interface InstallConfigFieldsTableProps<TFieldValues extends FieldValues> {
   descriptionFieldName?: string;
   valuePlaceholder?: string;
   useExternalSecretsManager?: boolean;
+  /**
+   * Set of env-var keys whose secret value is already stored on the server.
+   * Secret rows in this set render a disabled `••••••••` + Update button
+   * instead of an empty input. The form value stays empty so the backend's
+   * preservation logic keeps the existing secret untouched.
+   */
+  secretKeysWithStoredValue?: Set<string>;
   bearerPrefixFieldName?: string | null;
   disablePromptOnInstallation?: boolean;
   disablePromptOnInstallationReason?: string;
@@ -95,6 +102,7 @@ export function InstallConfigFieldsTable<TFieldValues extends FieldValues>({
   descriptionFieldName = "description",
   valuePlaceholder = "your-value",
   useExternalSecretsManager = false,
+  secretKeysWithStoredValue,
   bearerPrefixFieldName = null,
   disablePromptOnInstallation = false,
   disablePromptOnInstallationReason,
@@ -335,21 +343,24 @@ export function InstallConfigFieldsTable<TFieldValues extends FieldValues>({
                 />
               )}
 
-              {promptOnInstallation ? (
-                <div className="flex items-center h-10">
-                  <p className="text-xs text-muted-foreground">
-                    Prompted at installation
-                  </p>
-                </div>
-              ) : useExternalSecretsManager && valueType === "secret" ? (
-                <div className="flex items-center h-10">
-                  {(() => {
-                    const formValue = form.watch(
-                      `${fieldNamePrefix}.${index}.${valueFieldName}` as FieldPath<TFieldValues>,
-                    ) as string | undefined;
+              {(() => {
+                if (promptOnInstallation) {
+                  return (
+                    <div className="flex items-center h-10">
+                      <p className="text-xs text-muted-foreground">
+                        Prompted at installation
+                      </p>
+                    </div>
+                  );
+                }
 
-                    if (formValue) {
-                      return (
+                if (useExternalSecretsManager && valueType === "secret") {
+                  const formValue = form.watch(
+                    `${fieldNamePrefix}.${index}.${valueFieldName}` as FieldPath<TFieldValues>,
+                  ) as string | undefined;
+                  return (
+                    <div className="flex items-center h-10">
+                      {formValue ? (
                         <Button
                           type="button"
                           variant="ghost"
@@ -362,91 +373,103 @@ export function InstallConfigFieldsTable<TFieldValues extends FieldValues>({
                             {parseVaultReference(formValue).key}
                           </span>
                         </Button>
-                      );
-                    }
+                      ) : (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          className="h-8 text-xs"
+                          onClick={() => setDialogOpenForIndex(index)}
+                        >
+                          <Key className="h-3 w-3 mr-1" />
+                          Set secret
+                        </Button>
+                      )}
+                    </div>
+                  );
+                }
 
-                    return (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="h-8 text-xs"
-                        onClick={() => setDialogOpenForIndex(index)}
-                      >
-                        <Key className="h-3 w-3 mr-1" />
-                        Set secret
-                      </Button>
-                    );
-                  })()}
-                </div>
-              ) : (
-                <FormField
-                  control={control}
-                  name={
-                    `${fieldNamePrefix}.${index}.${valueFieldName}` as FieldPath<TFieldValues>
-                  }
-                  render={({ field }) => {
-                    if (valueType === "boolean") {
-                      const normalizedValue =
-                        field.value === "true" ? "true" : "false";
-                      if (field.value !== normalizedValue) {
-                        field.onChange(normalizedValue);
+                const rowKey = form.watch(
+                  `${fieldNamePrefix}.${index}.${keyFieldName}` as FieldPath<TFieldValues>,
+                ) as string | undefined;
+                const hasStoredSecret =
+                  valueType === "secret" &&
+                  !!rowKey &&
+                  secretKeysWithStoredValue?.has(rowKey) === true;
+
+                return (
+                  <FormField
+                    control={control}
+                    name={
+                      `${fieldNamePrefix}.${index}.${valueFieldName}` as FieldPath<TFieldValues>
+                    }
+                    render={({ field }) => {
+                      if (valueType === "boolean") {
+                        const normalizedValue =
+                          field.value === "true" ? "true" : "false";
+                        if (field.value !== normalizedValue) {
+                          field.onChange(normalizedValue);
+                        }
+
+                        return (
+                          <FormItem>
+                            <FormControl>
+                              <div className="flex items-center h-10">
+                                <Checkbox
+                                  checked={normalizedValue === "true"}
+                                  onCheckedChange={(checked) =>
+                                    field.onChange(checked ? "true" : "false")
+                                  }
+                                />
+                              </div>
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        );
+                      }
+
+                      if (valueType === "number") {
+                        return (
+                          <FormItem>
+                            <FormControl>
+                              <Input
+                                type="number"
+                                placeholder="0"
+                                className="font-mono"
+                                {...field}
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        );
                       }
 
                       return (
                         <FormItem>
                           <FormControl>
-                            <div className="flex items-center h-10">
-                              <Checkbox
-                                checked={normalizedValue === "true"}
-                                onCheckedChange={(checked) =>
-                                  field.onChange(checked ? "true" : "false")
-                                }
-                              />
-                            </div>
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      );
-                    }
-
-                    if (valueType === "number") {
-                      return (
-                        <FormItem>
-                          <FormControl>
                             <Input
-                              type="number"
-                              placeholder="0"
+                              type={
+                                valueType === "secret" ? "password" : "text"
+                              }
+                              placeholder={
+                                hasStoredSecret ? "••••••••" : valuePlaceholder
+                              }
                               className="font-mono"
+                              autoComplete={
+                                valueType === "secret"
+                                  ? MCP_SECRET_AUTOCOMPLETE
+                                  : MCP_CONFIG_AUTOCOMPLETE
+                              }
                               {...field}
                             />
                           </FormControl>
                           <FormMessage />
                         </FormItem>
                       );
-                    }
-
-                    return (
-                      <FormItem>
-                        <FormControl>
-                          <Input
-                            type={valueType === "secret" ? "password" : "text"}
-                            placeholder={valuePlaceholder}
-                            className="font-mono"
-                            autoComplete={
-                              valueType === "secret"
-                                ? MCP_SECRET_AUTOCOMPLETE
-                                : MCP_CONFIG_AUTOCOMPLETE
-                            }
-                            {...field}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    );
-                  }}
-                />
-              )}
+                    }}
+                  />
+                );
+              })()}
 
               <FormField
                 control={control}

--- a/platform/frontend/src/lib/secrets.query.ts
+++ b/platform/frontend/src/lib/secrets.query.ts
@@ -1,4 +1,8 @@
-import { archestraApiSdk, type archestraApiTypes } from "@shared";
+import {
+  archestraApiSdk,
+  type archestraApiTypes,
+  SecretsManagerType,
+} from "@shared";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { handleApiError } from "./utils";
 
@@ -21,7 +25,16 @@ export function useSecretsType() {
   });
 }
 
+/**
+ * Reads a secret by ID. The backend only allows this when BYOS is enabled
+ * (or the specific secret is BYOS-backed) — calling it otherwise returns 403.
+ * We gate the request on the secrets-type lookup so we don't fire pointless
+ * 403s in non-BYOS deployments.
+ */
 export function useGetSecret(secretId: string | null | undefined) {
+  const { data: secretsType } = useSecretsType();
+  const byosEnabled = secretsType?.type === SecretsManagerType.BYOS_VAULT;
+
   return useQuery({
     queryKey: secretsKeys.byId(secretId ?? ""),
     queryFn: async () => {
@@ -35,7 +48,7 @@ export function useGetSecret(secretId: string | null | undefined) {
       }
       return response.data;
     },
-    enabled: !!secretId,
+    enabled: !!secretId && byosEnabled,
   });
 }
 


### PR DESCRIPTION


---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>