### PR TITLE
fix: improve MCP install UX and LLM API key defaults

### DIFF
--- a/platform/backend/src/archestra-mcp-server/mcp-servers.ts
+++ b/platform/backend/src/archestra-mcp-server/mcp-servers.ts
@@ -32,6 +32,7 @@ import {
   ResourceVisibilityScopeSchema,
   UuidIdSchema,
 } from "@/types";
+import { broadcastMcpInstallationStatus } from "@/websocket";
 import {
   catchError,
   deduplicateLabels,
@@ -1058,6 +1059,7 @@ async function handleDeployMcpServer(
         localInstallationStatus: "pending",
         localInstallationError: null,
       });
+      broadcastMcpInstallationStatus(mcpServer.id, "pending", null);
       await McpServerRuntimeManager.startServer(mcpServer);
 
       void discoverLocalMcpServerTools({
@@ -1240,6 +1242,7 @@ async function discoverLocalMcpServerTools(params: {
       localInstallationStatus: "discovering-tools",
       localInstallationError: null,
     });
+    broadcastMcpInstallationStatus(mcpServer.id, "discovering-tools", null);
 
     const discoveredTools = await McpServerModel.getToolsFromServer(mcpServer);
     const toolsToCreate = discoveredTools.map((tool) => ({
@@ -1266,16 +1269,18 @@ async function discoverLocalMcpServerTools(params: {
       localInstallationStatus: "success",
       localInstallationError: null,
     });
+    broadcastMcpInstallationStatus(mcpServer.id, "success", null);
   } catch (err) {
     logger.error(
       { err, mcpServerId: mcpServer.id },
       "Error during async tool discovery after deploy",
     );
+    const errorMessage = err instanceof Error ? err.message : "Unknown error";
     await McpServerModel.update(mcpServer.id, {
       localInstallationStatus: "error",
-      localInstallationError:
-        err instanceof Error ? err.message : "Unknown error",
+      localInstallationError: errorMessage,
     });
+    broadcastMcpInstallationStatus(mcpServer.id, "error", errorMessage);
   }
 }
 

--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
@@ -1,3 +1,4 @@
+import { PassThrough } from "node:stream";
 import type * as k8s from "@kubernetes/client-node";
 import type { Attach, Exec, Log } from "@kubernetes/client-node";
 import type { LocalConfigSchema } from "@shared";
@@ -4821,5 +4822,224 @@ describe("K8sDeployment.ensureHttpServerConfigured cluster domain", () => {
         originalLoadFromCluster;
       config.orchestrator.kubernetes.clusterDomain = originalClusterDomain;
     }
+  });
+});
+
+describe("K8sDeployment.streamLogs", () => {
+  function makeRunningPod(name = "mcp-test-pod"): k8s.V1Pod {
+    return {
+      metadata: { name },
+      status: {
+        phase: "Running",
+        containerStatuses: [
+          {
+            name: "mcp-server",
+            ready: true,
+            restartCount: 0,
+            state: { running: { startedAt: new Date() } },
+            image: "test",
+            imageID: "test",
+            started: true,
+            ready_: true,
+          } as unknown as k8s.V1ContainerStatus,
+        ],
+      },
+    } as k8s.V1Pod;
+  }
+
+  function makePendingPod(name = "mcp-test-pod"): k8s.V1Pod {
+    return {
+      metadata: { name },
+      status: {
+        phase: "Pending",
+        containerStatuses: [],
+      },
+    } as k8s.V1Pod;
+  }
+
+  function collectStream(stream: NodeJS.WritableStream): {
+    text: () => string;
+  } {
+    const chunks: string[] = [];
+    const original = stream.write.bind(stream);
+    (stream as unknown as { write: typeof stream.write }).write = ((
+      chunk: string | Buffer,
+    ) => {
+      chunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return original(chunk);
+    }) as typeof stream.write;
+    return { text: () => chunks.join("") };
+  }
+
+  test("when pod is Pending, writes events snapshot then upgrades to live logs once Ready", async () => {
+    const deployment = createK8sDeploymentInstance();
+    const ac = new AbortController();
+
+    const pendingPod = makePendingPod();
+    const runningPod = makeRunningPod();
+    vi.spyOn(
+      deployment as unknown as {
+        findAnyPodForDeployment: () => Promise<k8s.V1Pod | undefined>;
+      },
+      "findAnyPodForDeployment",
+    )
+      // initial check (in streamLogs) - Pending
+      .mockResolvedValueOnce(pendingPod)
+      // first poll - still Pending
+      .mockResolvedValueOnce(pendingPod)
+      // second poll - now Running
+      .mockResolvedValueOnce(runningPod);
+
+    vi.spyOn(
+      deployment as unknown as { getDeploymentEvents: () => Promise<string> },
+      "getDeploymentEvents",
+    ).mockResolvedValue("Normal Scheduled  test event\n");
+
+    // Capture the stream the production code passes to k8sLog.log so we can
+    // verify it gets called with a Running pod. We end the stream to model
+    // a pod going away (e.g. reinstall) and immediately abort so the
+    // "wait for replacement pod" recovery loop tears down cleanly.
+    const k8sLogMock = vi.fn(
+      async (
+        _ns: string,
+        _pod: string,
+        _container: string,
+        out: NodeJS.WritableStream,
+      ) => {
+        out.write("real container log line\n");
+        out.end();
+        ac.abort();
+        return { abort: () => {} };
+      },
+    );
+    (deployment as unknown as { k8sLog: { log: typeof k8sLogMock } }).k8sLog = {
+      log: k8sLogMock,
+    };
+
+    const out = new PassThrough();
+    const captured = collectStream(out);
+
+    vi.useFakeTimers();
+    try {
+      const done = deployment.streamLogs(out, 100, ac.signal);
+      await vi.advanceTimersByTimeAsync(2000);
+      await vi.advanceTimersByTimeAsync(2000);
+      await done;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    const text = captured.text();
+    expect(text).toContain("--- Kubernetes Events ---");
+    expect(text).toContain("test event");
+    expect(text).toContain("is now Running, switching to live logs");
+    expect(text).toContain("real container log line");
+    expect(k8sLogMock).toHaveBeenCalledTimes(1);
+    expect(k8sLogMock.mock.calls[0]?.[1]).toBe("mcp-test-pod");
+  });
+
+  test("when the running pod's log stream ends without abort, waits for a replacement pod and resumes streaming", async () => {
+    const deployment = createK8sDeploymentInstance();
+    const ac = new AbortController();
+
+    const firstPod = makeRunningPod("mcp-old-pod");
+    const replacementPod = makeRunningPod("mcp-new-pod");
+    vi.spyOn(
+      deployment as unknown as {
+        findAnyPodForDeployment: () => Promise<k8s.V1Pod | undefined>;
+      },
+      "findAnyPodForDeployment",
+    )
+      // initial check - first pod is Running
+      .mockResolvedValueOnce(firstPod)
+      // poll fires after the first log stream ends - replacement is up
+      .mockResolvedValueOnce(replacementPod);
+
+    vi.spyOn(
+      deployment as unknown as { getDeploymentEvents: () => Promise<string> },
+      "getDeploymentEvents",
+    ).mockResolvedValue("");
+
+    let invocation = 0;
+    const k8sLogMock = vi.fn(
+      async (
+        _ns: string,
+        podName: string,
+        _container: string,
+        out: NodeJS.WritableStream,
+      ) => {
+        invocation++;
+        out.write(`logs from ${podName}\n`);
+        if (invocation === 1) {
+          // simulate the pod being deleted under us (reinstall, eviction)
+          out.end();
+        } else {
+          out.end();
+          ac.abort();
+        }
+        return { abort: () => {} };
+      },
+    );
+    (deployment as unknown as { k8sLog: { log: typeof k8sLogMock } }).k8sLog = {
+      log: k8sLogMock,
+    };
+
+    const out = new PassThrough();
+    const captured = collectStream(out);
+
+    vi.useFakeTimers();
+    try {
+      const done = deployment.streamLogs(out, 100, ac.signal);
+      await vi.advanceTimersByTimeAsync(2000);
+      await done;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    const text = captured.text();
+    expect(text).toContain("logs from mcp-old-pod");
+    expect(text).toContain("waiting for replacement pod");
+    expect(text).toContain("logs from mcp-new-pod");
+    expect(k8sLogMock).toHaveBeenCalledTimes(2);
+    expect(k8sLogMock.mock.calls[0]?.[1]).toBe("mcp-old-pod");
+    expect(k8sLogMock.mock.calls[1]?.[1]).toBe("mcp-new-pod");
+  });
+
+  test("aborting while polling stops the wait and does not call k8sLog.log", async () => {
+    const deployment = createK8sDeploymentInstance();
+
+    vi.spyOn(
+      deployment as unknown as {
+        findAnyPodForDeployment: () => Promise<k8s.V1Pod | undefined>;
+      },
+      "findAnyPodForDeployment",
+    ).mockResolvedValue(makePendingPod());
+
+    vi.spyOn(
+      deployment as unknown as { getDeploymentEvents: () => Promise<string> },
+      "getDeploymentEvents",
+    ).mockResolvedValue("");
+
+    const k8sLogMock = vi.fn();
+    (deployment as unknown as { k8sLog: { log: typeof k8sLogMock } }).k8sLog = {
+      log: k8sLogMock,
+    };
+
+    const out = new PassThrough();
+    const ac = new AbortController();
+
+    vi.useFakeTimers();
+    try {
+      const done = deployment.streamLogs(out, 100, ac.signal);
+      // Let the events snapshot write, then abort before the next poll fires.
+      await vi.advanceTimersByTimeAsync(500);
+      ac.abort();
+      await vi.advanceTimersByTimeAsync(2000);
+      await done;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(k8sLogMock).not.toHaveBeenCalled();
   });
 });

--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
@@ -29,6 +29,10 @@ const {
   orchestrator: { mcpServerBaseImage },
 } = config;
 
+// How long streamLogs will keep an open WS waiting for the pod to become
+// Ready before giving up. 5 minutes covers a slow image pull on first install.
+const POD_READY_WAIT_MS = 5 * TimeInMs.Minute;
+
 /**
  * Result of processing container environment configuration.
  * Contains both environment variables and mounted secrets information.
@@ -1980,53 +1984,6 @@ export default class K8sDeployment {
   }
 
   /**
-   * Write K8s events to the stream as a fallback when pod logs aren't available
-   */
-  private async streamEventsAsFallback(
-    responseStream: NodeJS.WritableStream,
-  ): Promise<void> {
-    try {
-      // Check if any pod exists (even non-running)
-      const anyPod = await this.findAnyPodForDeployment();
-
-      let output = "=== MCP Server Status ===\n\n";
-
-      if (anyPod) {
-        // Show pod status info
-        output += "--- Pod Status ---\n";
-        output += this.getPodStatusInfo(anyPod);
-        output += "\n\n";
-      } else {
-        output += "No pod found for this deployment.\n\n";
-      }
-
-      // Get and show events
-      output += "--- Kubernetes Events ---\n";
-      const events = await this.getDeploymentEvents();
-      output += events;
-      output += "\n";
-
-      // Write to stream
-      if (!("destroyed" in responseStream) || !responseStream.destroyed) {
-        responseStream.write(output);
-        // End the stream since we're not following logs
-        responseStream.end();
-      }
-    } catch (error) {
-      logger.error(
-        { err: error },
-        `Failed to stream events fallback for ${this.deploymentName}`,
-      );
-      if (!("destroyed" in responseStream) || !responseStream.destroyed) {
-        responseStream.write(
-          `Error fetching deployment status: ${error instanceof Error ? error.message : "Unknown error"}\n`,
-        );
-        responseStream.end();
-      }
-    }
-  }
-
-  /**
    * Check if this MCP server needs an HTTP port
    */
   private async needsHttpPort(): Promise<boolean> {
@@ -2338,7 +2295,11 @@ export default class K8sDeployment {
 
   /**
    * Stream logs from the pod with follow enabled.
-   * If no running pod is found, falls back to showing K8s events.
+   * If no running pod is found, write a K8s events snapshot and then keep
+   * the stream open, polling for the pod to become Ready and switching to
+   * real container logs once it does. This way clients that opened the logs
+   * view during the brief Pending/ContainerCreating window after install
+   * don't need to refresh — the stream upgrades itself.
    * @param responseStream - The stream to write logs to
    * @param lines - Number of initial lines to fetch
    * @param abortSignal - Optional abort signal to cancel the stream
@@ -2352,8 +2313,13 @@ export default class K8sDeployment {
       // Try to find any pod (including non-running) to check container status
       const anyPod = await this.findAnyPodForDeployment();
       if (!anyPod || !anyPod.metadata?.name) {
-        // No pod at all - show events
-        await this.streamEventsAsFallback(responseStream);
+        // No pod yet — show events, then wait for one to appear and become Ready
+        await this.writeEventsSnapshot(responseStream);
+        await this.pollAndStreamLogsWhenReady(
+          responseStream,
+          lines,
+          abortSignal,
+        );
         return;
       }
 
@@ -2420,12 +2386,14 @@ export default class K8sDeployment {
                   responseStream.write("(No logs from previous container)\n\n");
                 }
               }
-              if (
-                !("destroyed" in responseStream) ||
-                !responseStream.destroyed
-              ) {
-                responseStream.end();
-              }
+              // Keep the stream open and wait for the container to become
+              // Ready again (e.g. CrashLoopBackOff recovers), then upgrade
+              // to live log streaming.
+              await this.pollAndStreamLogsWhenReady(
+                responseStream,
+                lines,
+                abortSignal,
+              );
             });
 
             await this.k8sLog.log(
@@ -2450,116 +2418,32 @@ export default class K8sDeployment {
           }
         }
 
-        // Container never started or previous logs unavailable — show events
-        await this.streamEventsAsFallback(responseStream);
+        // Container never started or previous logs unavailable — show events,
+        // then wait for it to recover and upgrade to real logs.
+        await this.writeEventsSnapshot(responseStream);
+        await this.pollAndStreamLogsWhenReady(
+          responseStream,
+          lines,
+          abortSignal,
+        );
         return;
       }
 
       // For non-waiting containers, check if pod is actually running
       const pod = anyPod.status?.phase === "Running" ? anyPod : undefined;
       if (!pod || !pod.metadata?.name) {
-        await this.streamEventsAsFallback(responseStream);
+        // Pod is e.g. Pending right after install — show what we know now,
+        // then keep the stream open and switch to real logs once it's Ready.
+        await this.writeEventsSnapshot(responseStream);
+        await this.pollAndStreamLogsWhenReady(
+          responseStream,
+          lines,
+          abortSignal,
+        );
         return;
       }
 
-      // Create a PassThrough stream to handle the log data
-      const logStream = new PassThrough();
-
-      // Handle log data by piping to the response stream
-      logStream.on("data", (chunk) => {
-        if (!("destroyed" in responseStream) || !responseStream.destroyed) {
-          responseStream.write(chunk);
-        }
-      });
-
-      // Handle stream errors
-      logStream.on("error", (error) => {
-        logger.error(
-          { err: error },
-          `Log stream error for pod ${pod.metadata?.name}:`,
-        );
-        if (!("destroyed" in responseStream) || !responseStream.destroyed) {
-          if (
-            "destroy" in responseStream &&
-            typeof responseStream.destroy === "function"
-          ) {
-            responseStream.destroy(error);
-          }
-        }
-      });
-
-      // Handle stream end
-      logStream.on("end", () => {
-        if (!("destroyed" in responseStream) || !responseStream.destroyed) {
-          responseStream.end();
-        }
-      });
-
-      // Handle response stream errors and cleanup
-      responseStream.on("error", (error) => {
-        logger.error(
-          { err: error },
-          `Response stream error for pod ${pod.metadata?.name}:`,
-        );
-        if (logStream.destroy) {
-          logStream.destroy();
-        }
-      });
-
-      // Use the Log client to stream logs with follow=true
-      const req = await this.k8sLog.log(
-        this.namespace,
-        pod.metadata.name,
-        "mcp-server", // container name
-        logStream,
-        {
-          follow: true,
-          tailLines: lines,
-          pretty: false,
-          timestamps: false,
-        },
-      );
-
-      // Track abort handler for cleanup
-      let abortHandler: (() => void) | null = null;
-
-      // Handle abort signal
-      if (abortSignal) {
-        abortHandler = () => {
-          if (req) {
-            req.abort();
-          }
-          logStream.destroy();
-          if (!("destroyed" in responseStream) || !responseStream.destroyed) {
-            responseStream.end();
-          }
-        };
-
-        if (abortSignal.aborted) {
-          abortHandler();
-          return;
-        }
-
-        abortSignal.addEventListener("abort", abortHandler, { once: true });
-      }
-
-      // Cleanup function to remove abort listener
-      const cleanupAbortListener = () => {
-        if (abortSignal && abortHandler) {
-          abortSignal.removeEventListener("abort", abortHandler);
-        }
-      };
-
-      // Handle cleanup when response stream closes
-      responseStream.on("close", () => {
-        if (req) {
-          req.abort();
-        }
-        if (logStream.destroy) {
-          logStream.destroy();
-        }
-        cleanupAbortListener();
-      });
+      await this.streamRunningPodLogs(pod, responseStream, lines, abortSignal);
     } catch (error: unknown) {
       logger.error(
         { err: error },
@@ -2576,6 +2460,225 @@ export default class K8sDeployment {
       }
 
       throw error;
+    }
+  }
+
+  /**
+   * Pipe live container logs from a Running pod into responseStream and wire
+   * up abort/cleanup. Does not end the stream on error paths it doesn't own.
+   */
+  private async streamRunningPodLogs(
+    pod: k8s.V1Pod,
+    responseStream: NodeJS.WritableStream,
+    lines: number,
+    abortSignal?: AbortSignal,
+  ): Promise<void> {
+    if (!pod.metadata?.name) return;
+    const podName = pod.metadata.name;
+
+    const logStream = new PassThrough();
+    let aborted = false;
+
+    logStream.on("data", (chunk) => {
+      if (!("destroyed" in responseStream) || !responseStream.destroyed) {
+        responseStream.write(chunk);
+      }
+    });
+
+    logStream.on("error", (error) => {
+      logger.error({ err: error }, `Log stream error for pod ${podName}:`);
+      if (!("destroyed" in responseStream) || !responseStream.destroyed) {
+        if (
+          "destroy" in responseStream &&
+          typeof responseStream.destroy === "function"
+        ) {
+          responseStream.destroy(error);
+        }
+      }
+    });
+
+    // When the log stream ends and the client did NOT abort, the pod was
+    // deleted under us (reinstall, crash, eviction). Don't close the WS —
+    // wait for a new pod to come up and switch over, the same way we do
+    // when streamLogs is first opened against a Pending pod.
+    logStream.on("end", () => {
+      if (aborted) {
+        if (!("destroyed" in responseStream) || !responseStream.destroyed) {
+          responseStream.end();
+        }
+        return;
+      }
+      if (!("destroyed" in responseStream) || !responseStream.destroyed) {
+        responseStream.write(
+          `\n--- Pod ${podName} log stream ended; waiting for replacement pod ---\n`,
+        );
+        void this.pollAndStreamLogsWhenReady(
+          responseStream,
+          lines,
+          abortSignal,
+        );
+      }
+    });
+
+    responseStream.on("error", (error) => {
+      logger.error({ err: error }, `Response stream error for pod ${podName}:`);
+      if (logStream.destroy) {
+        logStream.destroy();
+      }
+    });
+
+    const req = await this.k8sLog.log(
+      this.namespace,
+      podName,
+      "mcp-server",
+      logStream,
+      {
+        follow: true,
+        tailLines: lines,
+        pretty: false,
+        timestamps: false,
+      },
+    );
+
+    let abortHandler: (() => void) | null = null;
+    if (abortSignal) {
+      abortHandler = () => {
+        aborted = true;
+        if (req) req.abort();
+        logStream.destroy();
+        if (!("destroyed" in responseStream) || !responseStream.destroyed) {
+          responseStream.end();
+        }
+      };
+
+      if (abortSignal.aborted) {
+        abortHandler();
+        return;
+      }
+
+      abortSignal.addEventListener("abort", abortHandler, { once: true });
+    }
+
+    responseStream.on("close", () => {
+      aborted = true;
+      if (req) req.abort();
+      if (logStream.destroy) logStream.destroy();
+      if (abortSignal && abortHandler) {
+        abortSignal.removeEventListener("abort", abortHandler);
+      }
+    });
+  }
+
+  /**
+   * Write a one-shot snapshot of pod status + K8s events to the stream
+   * WITHOUT ending it. Used by streamLogs to show useful info while we
+   * wait for the pod to become Ready.
+   */
+  private async writeEventsSnapshot(
+    responseStream: NodeJS.WritableStream,
+  ): Promise<void> {
+    try {
+      const anyPod = await this.findAnyPodForDeployment();
+
+      let output = "=== MCP Server Status ===\n\n";
+      if (anyPod) {
+        output += "--- Pod Status ---\n";
+        output += this.getPodStatusInfo(anyPod);
+        output += "\n\n";
+      } else {
+        output += "No pod found for this deployment.\n\n";
+      }
+
+      output += "--- Kubernetes Events ---\n";
+      output += await this.getDeploymentEvents();
+      output += "\n";
+
+      if (!("destroyed" in responseStream) || !responseStream.destroyed) {
+        responseStream.write(output);
+      }
+    } catch (error) {
+      logger.error(
+        { err: error },
+        `Failed to write events snapshot for ${this.deploymentName}`,
+      );
+      if (!("destroyed" in responseStream) || !responseStream.destroyed) {
+        responseStream.write(
+          `Error fetching deployment status: ${error instanceof Error ? error.message : "Unknown error"}\n`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Poll for the mcp-server container to enter Ready+Running state, then
+   * upgrade the open stream to live container logs. Bounded so a stuck
+   * pod can't keep a WebSocket alive forever — the client can re-subscribe.
+   */
+  private async pollAndStreamLogsWhenReady(
+    responseStream: NodeJS.WritableStream,
+    lines: number,
+    abortSignal?: AbortSignal,
+  ): Promise<void> {
+    const pollIntervalMs = 2000;
+    const maxAttempts = Math.ceil(POD_READY_WAIT_MS / pollIntervalMs);
+
+    const isStreamClosed = () =>
+      "destroyed" in responseStream && responseStream.destroyed;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      if (abortSignal?.aborted || isStreamClosed()) return;
+
+      await new Promise<void>((resolve) => {
+        const t = setTimeout(resolve, pollIntervalMs);
+        if (abortSignal) {
+          abortSignal.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(t);
+              resolve();
+            },
+            { once: true },
+          );
+        }
+      });
+
+      if (abortSignal?.aborted || isStreamClosed()) return;
+
+      let pod: k8s.V1Pod | undefined;
+      try {
+        pod = await this.findAnyPodForDeployment();
+      } catch (error) {
+        logger.warn(
+          { err: error, deployment: this.deploymentName },
+          "Failed to poll pod while waiting for Ready",
+        );
+        continue;
+      }
+
+      const containerStatus = pod?.status?.containerStatuses?.find(
+        (cs) => cs.name === "mcp-server",
+      );
+      const isReadyAndRunning =
+        pod?.status?.phase === "Running" &&
+        !!containerStatus?.ready &&
+        !!containerStatus.state?.running;
+
+      if (!isReadyAndRunning || !pod?.metadata?.name) continue;
+
+      if (!("destroyed" in responseStream) || !responseStream.destroyed) {
+        responseStream.write(
+          `\n--- Pod ${pod.metadata.name} is now Running, switching to live logs ---\n\n`,
+        );
+      }
+      await this.streamRunningPodLogs(pod, responseStream, lines, abortSignal);
+      return;
+    }
+
+    if (!("destroyed" in responseStream) || !responseStream.destroyed) {
+      responseStream.write(
+        `\n--- Pod did not become Ready within ${Math.round(POD_READY_WAIT_MS / 1000)}s; reopen logs to retry ---\n`,
+      );
+      responseStream.end();
     }
   }
 

--- a/platform/backend/src/routes/internal-mcp-catalog.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.ts
@@ -31,6 +31,7 @@ import {
   SelectInternalMcpCatalogSchema,
   UuidIdSchema,
 } from "@/types";
+import { broadcastMcpInstallationStatus } from "@/websocket";
 
 // Match the schema from getMcpServerTools endpoint
 const ToolWithAssignedAgentCountSchema = z.object({
@@ -651,11 +652,13 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
                     localInstallationStatus: "pending",
                     localInstallationError: null,
                   });
+                  broadcastMcpInstallationStatus(server.id, "pending", null);
                   await autoReinstallServer(server, catalogItem);
                   await McpServerModel.update(server.id, {
                     localInstallationStatus: "success",
                     localInstallationError: null,
                   });
+                  broadcastMcpInstallationStatus(server.id, "success", null);
                   logger.info(
                     { serverId: server.id, serverName: server.name },
                     "Auto-reinstalled MCP server successfully",
@@ -677,6 +680,11 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
                     localInstallationStatus: "error",
                     localInstallationError: errorMessage,
                   });
+                  broadcastMcpInstallationStatus(
+                    server.id,
+                    "error",
+                    errorMessage,
+                  );
                 }
               }
             } catch (error) {

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -40,6 +40,7 @@ import {
   SelectMcpServerSchema,
   UuidIdSchema,
 } from "@/types";
+import { broadcastMcpInstallationStatus } from "@/websocket";
 
 const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
   fastify.get(
@@ -622,6 +623,7 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
               localInstallationStatus: "pending",
               localInstallationError: null,
             });
+            broadcastMcpInstallationStatus(mcpServer.id, "pending", null);
 
             await McpServerRuntimeManager.startServer(
               mcpServer,
@@ -665,6 +667,11 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   localInstallationStatus: "discovering-tools",
                   localInstallationError: null,
                 });
+                broadcastMcpInstallationStatus(
+                  mcpServer.id,
+                  "discovering-tools",
+                  null,
+                );
 
                 fastify.log.info(
                   `Attempting to fetch tools from local server: ${mcpServer.name}`,
@@ -721,6 +728,7 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   localInstallationStatus: "success",
                   localInstallationError: null,
                 });
+                broadcastMcpInstallationStatus(mcpServer.id, "success", null);
 
                 fastify.log.info(
                   `Successfully fetched and persisted ${tools.length} tools from local server: ${mcpServer.name}`,
@@ -739,6 +747,11 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   localInstallationStatus: "error",
                   localInstallationError: errorMessage,
                 });
+                broadcastMcpInstallationStatus(
+                  mcpServer.id,
+                  "error",
+                  errorMessage,
+                );
               }
             })();
 
@@ -760,6 +773,11 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
               localInstallationStatus: "error",
               localInstallationError: `Failed to start deployment: ${errorMessage}`,
             });
+            broadcastMcpInstallationStatus(
+              mcpServer.id,
+              "error",
+              `Failed to start deployment: ${errorMessage}`,
+            );
 
             // Return the server with error status instead of throwing 500
             return reply.send({
@@ -835,6 +853,7 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           localInstallationStatus: "success",
           localInstallationError: null,
         });
+        broadcastMcpInstallationStatus(mcpServer.id, "success", null);
 
         return reply.send({
           ...mcpServer,
@@ -1594,6 +1613,7 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
         localInstallationStatus: "pending",
         localInstallationError: null,
       });
+      broadcastMcpInstallationStatus(id, "pending", null);
 
       // Refetch the server with updated status
       const updatedServer = await McpServerModel.findById(id);
@@ -1632,17 +1652,20 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           await McpServerModel.update(id, {
             localInstallationStatus: "success",
           });
+          broadcastMcpInstallationStatus(id, "success", null);
           logger.info(
             { serverId: id, serverName: mcpServer.name },
             "MCP server reinstalled successfully",
           );
         } catch (error) {
           // Set status to error if reinstall fails
+          const errorMessage =
+            error instanceof Error ? error.message : "Unknown error";
           await McpServerModel.update(id, {
             localInstallationStatus: "error",
-            localInstallationError:
-              error instanceof Error ? error.message : "Unknown error",
+            localInstallationError: errorMessage,
           });
+          broadcastMcpInstallationStatus(id, "error", errorMessage);
           logger.error(
             { err: error, serverId: id },
             "Failed to reinstall MCP server",

--- a/platform/backend/src/services/mcp-reinstall.test.ts
+++ b/platform/backend/src/services/mcp-reinstall.test.ts
@@ -44,6 +44,10 @@ describe("mcp-reinstall", () => {
         promptOnInstallation: boolean;
         required?: boolean;
       }> = [],
+      userConfig: Record<
+        string,
+        { type: string; required?: boolean; headerName?: string }
+      > = {},
     ): InternalMcpCatalog =>
       ({
         id: "test-id",
@@ -54,6 +58,7 @@ describe("mcp-reinstall", () => {
           arguments: ["start"],
           environment,
         },
+        userConfig,
       }) as InternalMcpCatalog;
 
     // Helper to create a minimal remote catalog item
@@ -398,6 +403,42 @@ describe("mcp-reinstall", () => {
           serverType: "local",
           localConfig: null,
         } as InternalMcpCatalog;
+
+        const result = requiresNewUserInputForReinstall(oldConfig, newConfig);
+
+        expect(result).toBe(false);
+      });
+
+      test("returns true when a required header userConfig field is ADDED", () => {
+        const oldConfig = createLocalCatalog([], {});
+        const newConfig = createLocalCatalog(
+          [],
+          {
+            db_url: {
+              type: "string",
+              required: true,
+              headerName: "x-db-url",
+            },
+          },
+        );
+
+        const result = requiresNewUserInputForReinstall(oldConfig, newConfig);
+
+        expect(result).toBe(true);
+      });
+
+      test("returns false when an OPTIONAL userConfig field is added", () => {
+        const oldConfig = createLocalCatalog([], {});
+        const newConfig = createLocalCatalog(
+          [],
+          {
+            tenant_id: {
+              type: "string",
+              required: false,
+              headerName: "x-tenant-id",
+            },
+          },
+        );
 
         const result = requiresNewUserInputForReinstall(oldConfig, newConfig);
 

--- a/platform/backend/src/services/mcp-reinstall.test.ts
+++ b/platform/backend/src/services/mcp-reinstall.test.ts
@@ -411,16 +411,13 @@ describe("mcp-reinstall", () => {
 
       test("returns true when a required header userConfig field is ADDED", () => {
         const oldConfig = createLocalCatalog([], {});
-        const newConfig = createLocalCatalog(
-          [],
-          {
-            db_url: {
-              type: "string",
-              required: true,
-              headerName: "x-db-url",
-            },
+        const newConfig = createLocalCatalog([], {
+          db_url: {
+            type: "string",
+            required: true,
+            headerName: "x-db-url",
           },
-        );
+        });
 
         const result = requiresNewUserInputForReinstall(oldConfig, newConfig);
 
@@ -429,16 +426,13 @@ describe("mcp-reinstall", () => {
 
       test("returns false when an OPTIONAL userConfig field is added", () => {
         const oldConfig = createLocalCatalog([], {});
-        const newConfig = createLocalCatalog(
-          [],
-          {
-            tenant_id: {
-              type: "string",
-              required: false,
-              headerName: "x-tenant-id",
-            },
+        const newConfig = createLocalCatalog([], {
+          tenant_id: {
+            type: "string",
+            required: false,
+            headerName: "x-tenant-id",
           },
-        );
+        });
 
         const result = requiresNewUserInputForReinstall(oldConfig, newConfig);
 

--- a/platform/backend/src/services/mcp-reinstall.ts
+++ b/platform/backend/src/services/mcp-reinstall.ts
@@ -11,7 +11,7 @@ import type { InternalMcpCatalog, LocalConfig, McpServer } from "@/types";
  * - Local execution config changed (command/args/docker/transport) - restart should be explicit
  * - Prompted env vars changed: added, removed, or key/required/type changed (local servers)
  * - OAuth config changed: added or removed (remote servers)
- * - Required userConfig fields changed: added, removed, or type changed (remote servers)
+ * - Required userConfig fields changed: added, removed, or type changed (local + remote servers)
  *
  * Returns false (auto-reinstall possible) when:
  * - Only non-prompted config changed (local servers) - existing secrets can be reused
@@ -55,6 +55,23 @@ export function requiresNewUserInputForReinstall(
       logger.info(
         { catalogId: newCatalogItem.id },
         "Local execution config changed - manual reinstall required",
+      );
+      return true;
+    }
+
+    // 4. Check if required userConfig fields changed (e.g. header-backed fields
+    // added by editing the Headers section). Without this, installs end up with
+    // a credential record that has no value for the new field and the header is
+    // silently omitted on the wire.
+    if (
+      requiredUserConfigChanged(
+        getRequiredUserConfigFields(oldCatalogItem),
+        getRequiredUserConfigFields(newCatalogItem),
+      )
+    ) {
+      logger.info(
+        { catalogId: newCatalogItem.id },
+        "Required userConfig fields changed - manual reinstall required",
       );
       return true;
     }

--- a/platform/backend/src/types/mcp-server.ts
+++ b/platform/backend/src/types/mcp-server.ts
@@ -1,3 +1,4 @@
+import { LOCAL_MCP_INSTALLATION_STATES } from "@shared";
 import {
   createInsertSchema,
   createSelectSchema,
@@ -8,13 +9,9 @@ import { schema } from "@/database";
 import { InternalMcpCatalogServerTypeSchema } from "./mcp-catalog";
 import { ResourceVisibilityScopeSchema } from "./visibility";
 
-export const LocalMcpServerInstallationStatusSchema = z.enum([
-  "idle",
-  "pending",
-  "discovering-tools",
-  "success",
-  "error",
-]);
+export const LocalMcpServerInstallationStatusSchema = z.enum(
+  LOCAL_MCP_INSTALLATION_STATES,
+);
 
 export const SecretStorageTypeSchema = z.enum([
   "vault",

--- a/platform/backend/src/websocket.ts
+++ b/platform/backend/src/websocket.ts
@@ -4,6 +4,7 @@ import {
   type ClientWebSocketMessage,
   ClientWebSocketMessageSchema,
   type ClientWebSocketMessageType,
+  type LocalMcpInstallationState,
   MCP_DEFAULT_LOG_LINES,
   type McpDeploymentStatusEntry,
   type ServerWebSocketMessage,
@@ -879,6 +880,33 @@ class WebSocketService {
     });
     ws.close(4401, "Unauthorized");
   }
+
+  broadcastMcpInstallationStatus(
+    serverId: string,
+    status: LocalMcpInstallationState,
+    error: string | null,
+  ): void {
+    if (!this.wss) return;
+    this.broadcast({
+      type: "mcp_installation_status",
+      payload: { serverId, status, error },
+    });
+  }
 }
 
-export default new WebSocketService();
+const websocketService = new WebSocketService();
+
+/**
+ * Push an install-status update to all connected clients. Call this from
+ * any code path that writes mcp_server.local_installation_status so the UI
+ * doesn't depend on the 2s React Query poll catching the change.
+ */
+export function broadcastMcpInstallationStatus(
+  serverId: string,
+  status: LocalMcpInstallationState,
+  error: string | null = null,
+): void {
+  websocketService.broadcastMcpInstallationStatus(serverId, status, error);
+}
+
+export default websocketService;

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -2174,16 +2174,7 @@ function getObjectMetadata(message: UIMessage): Record<string, unknown> {
 // No API Key Setup — shown when user has no API keys configured
 // =========================================================================
 
-const DEFAULT_FORM_VALUES: LlmProviderApiKeyFormValues = {
-  name: "",
-  provider: "anthropic",
-  apiKey: null,
-  baseUrl: null,
-  extraHeaders: [],
-  scope: "personal",
-  teamId: null,
-  vaultSecretPath: null,
-  vaultSecretKey: null,
+const DEFAULT_FORM_VALUES: Partial<LlmProviderApiKeyFormValues> = {
   isPrimary: true,
 };
 

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -599,9 +599,10 @@ export function McpCatalogForm({
             <Alert variant="info">
               <Info className="h-4 w-4" />
               <AlertDescription>
-                Changes to {nameDisabled ? "" : "Name, "}Server URL or
-                Authentication will require reinstalling the server for the
-                changes to take effect.
+                Changes to {nameDisabled ? "" : "Name, "}Server URL,
+                Authentication, prompted Environment Variables, or Headers will
+                require existing installations to be reinstalled (and their
+                credentials updated) before the new values take effect.
               </AlertDescription>
             </Alert>
           )}

--- a/platform/frontend/src/components/create-llm-provider-api-key-dialog.test.tsx
+++ b/platform/frontend/src/components/create-llm-provider-api-key-dialog.test.tsx
@@ -4,10 +4,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CreateLlmProviderApiKeyDialog } from "./create-llm-provider-api-key-dialog";
 
 const mutateAsync = vi.fn();
+const hasPermissions = vi.fn(() => ({ data: true }));
 
 vi.mock("@/components/llm-provider-api-key-form", () => ({
   LLM_PROVIDER_API_KEY_PLACEHOLDER: "••••••••••••••••",
   serializeExtraHeaders: () => null,
+  PROVIDER_CONFIG: { anthropic: { name: "Anthropic" } },
   LlmProviderApiKeyForm: ({
     form,
   }: {
@@ -34,10 +36,16 @@ vi.mock("@/lib/config/config.query", () => ({
   useFeature: () => false,
 }));
 
+vi.mock("@/lib/auth/auth.query", () => ({
+  useHasPermissions: () => hasPermissions(),
+}));
+
 describe("CreateLlmProviderApiKeyDialog", () => {
   beforeEach(() => {
     mutateAsync.mockReset();
     mutateAsync.mockResolvedValue({});
+    hasPermissions.mockReset();
+    hasPermissions.mockReturnValue({ data: false });
   });
 
   it("submits the shared create API key flow and closes on success", async () => {
@@ -73,5 +81,47 @@ describe("CreateLlmProviderApiKeyDialog", () => {
     });
     expect(onOpenChange).toHaveBeenCalledWith(false);
     expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to the provider name when the name field is empty", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <CreateLlmProviderApiKeyDialog
+        open
+        onOpenChange={vi.fn()}
+        title="Add API Key"
+        description="Shared dialog"
+      />,
+    );
+
+    await user.type(screen.getByLabelText("API Key"), "sk-test");
+    await user.click(screen.getByRole("button", { name: /test & create/i }));
+
+    expect(mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Anthropic" }),
+    );
+  });
+
+  it("defaults the scope to org when the user has llmProviderApiKey:admin", async () => {
+    hasPermissions.mockReturnValue({ data: true });
+    const user = userEvent.setup();
+
+    render(
+      <CreateLlmProviderApiKeyDialog
+        open
+        onOpenChange={vi.fn()}
+        title="Add API Key"
+        description="Shared dialog"
+      />,
+    );
+
+    await user.type(screen.getByLabelText("Name"), "Org Wide Key");
+    await user.type(screen.getByLabelText("API Key"), "sk-test");
+    await user.click(screen.getByRole("button", { name: /test & create/i }));
+
+    expect(mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: "org" }),
+    );
   });
 });

--- a/platform/frontend/src/components/create-llm-provider-api-key-dialog.tsx
+++ b/platform/frontend/src/components/create-llm-provider-api-key-dialog.tsx
@@ -9,6 +9,7 @@ import {
   LLM_PROVIDER_API_KEY_PLACEHOLDER,
   LlmProviderApiKeyForm,
   type LlmProviderApiKeyFormValues,
+  PROVIDER_CONFIG,
   serializeExtraHeaders,
 } from "@/components/llm-provider-api-key-form";
 import { Button } from "@/components/ui/button";
@@ -17,6 +18,7 @@ import {
   DialogForm,
   DialogStickyFooter,
 } from "@/components/ui/dialog";
+import { useHasPermissions } from "@/lib/auth/auth.query";
 import { useFeature } from "@/lib/config/config.query";
 import {
   useCreateLlmProviderApiKey,
@@ -47,15 +49,26 @@ export function CreateLlmProviderApiKeyDialog({
   const byosEnabled = useFeature("byosEnabled");
   const bedrockIamAuthEnabled = useFeature("bedrockIamAuthEnabled");
   const geminiVertexAiEnabled = useFeature("geminiVertexAiEnabled");
+  const { data: canCreateOrgScopedKey } = useHasPermissions({
+    llmProviderApiKey: ["admin"],
+  });
 
   const form = useForm<LlmProviderApiKeyFormValues>({
-    defaultValues: getDefaultFormValues(defaultValues),
+    defaultValues: getDefaultFormValues({
+      defaultValues,
+      canCreateOrgScopedKey: canCreateOrgScopedKey === true,
+    }),
   });
 
   useEffect(() => {
     if (!open) return;
-    form.reset(getDefaultFormValues(defaultValues));
-  }, [defaultValues, form, open]);
+    form.reset(
+      getDefaultFormValues({
+        defaultValues,
+        canCreateOrgScopedKey: canCreateOrgScopedKey === true,
+      }),
+    );
+  }, [canCreateOrgScopedKey, defaultValues, form, open]);
 
   const formValues = form.watch();
   const isValid = getIsCreateFormValid({
@@ -66,7 +79,7 @@ export function CreateLlmProviderApiKeyDialog({
   const handleCreate = form.handleSubmit(async (values) => {
     try {
       await createMutation.mutateAsync({
-        name: values.name,
+        name: values.name?.trim() || PROVIDER_CONFIG[values.provider].name,
         provider: values.provider,
         apiKey: values.apiKey || undefined,
         baseUrl: values.baseUrl || undefined,
@@ -134,16 +147,18 @@ export function CreateLlmProviderApiKeyDialog({
   );
 }
 
-function getDefaultFormValues(
-  defaultValues?: Partial<LlmProviderApiKeyFormValues>,
-): LlmProviderApiKeyFormValues {
+function getDefaultFormValues(params: {
+  defaultValues?: Partial<LlmProviderApiKeyFormValues>;
+  canCreateOrgScopedKey: boolean;
+}): LlmProviderApiKeyFormValues {
+  const { defaultValues, canCreateOrgScopedKey } = params;
   return {
     name: "",
     provider: "anthropic",
     apiKey: null,
     baseUrl: null,
     extraHeaders: [],
-    scope: "personal",
+    scope: canCreateOrgScopedKey ? "org" : "personal",
     teamId: null,
     vaultSecretPath: null,
     vaultSecretKey: null,
@@ -160,7 +175,6 @@ function getIsCreateFormValid(params: {
 
   return Boolean(
     values.apiKey !== LLM_PROVIDER_API_KEY_PLACEHOLDER &&
-      values.name &&
       (values.scope !== "team" || values.teamId) &&
       (byosEnabled
         ? values.vaultSecretPath && values.vaultSecretKey

--- a/platform/frontend/src/components/llm-provider-api-key-form.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.tsx
@@ -495,10 +495,15 @@ export function LlmProviderApiKeyForm({
 
           {mode === "full" && (
             <div className="space-y-2">
-              <Label htmlFor="llm-provider-api-key-name">Name</Label>
+              <Label htmlFor="llm-provider-api-key-name">
+                Name{" "}
+                <span className="text-muted-foreground font-normal">
+                  (optional)
+                </span>
+              </Label>
               <Input
                 id="llm-provider-api-key-name"
-                placeholder={`My ${providerConfig.name} Key`}
+                placeholder={providerConfig.name}
                 disabled={isPending}
                 {...form.register("name")}
               />

--- a/platform/frontend/src/lib/mcp/mcp-server.query.ts
+++ b/platform/frontend/src/lib/mcp/mcp-server.query.ts
@@ -3,6 +3,7 @@ import {
   type archestraApiTypes,
   type McpDeploymentStatusEntry,
   type McpDeploymentStatusesMessage,
+  type McpInstallationStatusMessage,
 } from "@shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
@@ -203,8 +204,9 @@ export function useMcpServerInstallationStatus(
   installingMcpServerId: string | null,
 ) {
   const queryClient = useQueryClient();
-  return useQuery({
-    queryKey: ["mcp-servers-installation-polling", installingMcpServerId],
+  const queryKey = ["mcp-servers-installation-polling", installingMcpServerId];
+  const query = useQuery({
+    queryKey,
     queryFn: async () => {
       if (!installingMcpServerId) {
         await queryClient.refetchQueries({ queryKey: ["mcp-servers"] });
@@ -227,10 +229,12 @@ export function useMcpServerInstallationStatus(
       return result;
     },
     throwOnError: false,
-    refetchInterval: (query) => {
-      const status = query.state.data;
+    // 2s poll is a safety net; the WebSocket subscription below pushes
+    // updates the moment the backend writes to the DB.
+    refetchInterval: (q) => {
+      const status = q.state.data;
       return (
-        !query.state.error &&
+        !q.state.error &&
         (status === "pending" ||
         status === "discovering-tools" ||
         status === null
@@ -240,6 +244,41 @@ export function useMcpServerInstallationStatus(
     },
     enabled: !!installingMcpServerId,
   });
+
+  // Eagerly seed the cache from WS pushes so the UI updates without waiting
+  // for the next 2s poll tick — and so it still updates after the poll has
+  // been disabled (status went success/error and React Query stops polling).
+  useEffect(() => {
+    if (!installingMcpServerId) return;
+    const cacheKey = [
+      "mcp-servers-installation-polling",
+      installingMcpServerId,
+    ];
+    websocketService.connect();
+    const unsubscribe = websocketService.subscribe(
+      "mcp_installation_status",
+      (message: McpInstallationStatusMessage) => {
+        if (message.payload.serverId !== installingMcpServerId) return;
+        const status = message.payload.status;
+        const previous = queryClient.getQueryData<typeof status>(cacheKey);
+        queryClient.setQueryData(cacheKey, status);
+        // Only toast on a genuine transition into a terminal state, so we
+        // don't double-toast when the 2s poll happens to land first.
+        if (status === "success" && previous !== "success") {
+          void queryClient.refetchQueries({
+            queryKey: ["mcp-servers", installingMcpServerId],
+          });
+          toast.success("Successfully installed server");
+        } else if (status === "error" && previous !== "error") {
+          void queryClient.refetchQueries({ queryKey: ["mcp-servers"] });
+          toast.error("Failed to install server");
+        }
+      },
+    );
+    return unsubscribe;
+  }, [installingMcpServerId, queryClient]);
+
+  return query;
 }
 
 export function useReauthenticateMcpServer() {

--- a/platform/shared/websocket.ts
+++ b/platform/shared/websocket.ts
@@ -350,6 +350,28 @@ export type McpDeploymentStatusesMessage = {
   };
 };
 
+// MCP installation-status push (sent on every change in the DB row, no
+// subscription needed — clients filter by serverId in their query cache).
+export const LOCAL_MCP_INSTALLATION_STATES = [
+  "idle",
+  "pending",
+  "discovering-tools",
+  "success",
+  "error",
+] as const;
+
+export type LocalMcpInstallationState =
+  (typeof LOCAL_MCP_INSTALLATION_STATES)[number];
+
+export type McpInstallationStatusMessage = {
+  type: "mcp_installation_status";
+  payload: {
+    serverId: string;
+    status: LocalMcpInstallationState;
+    error: string | null;
+  };
+};
+
 export type ErrorMessage = {
   type: "error";
   payload: {
@@ -375,6 +397,7 @@ export type ServerWebSocketMessage =
   | McpExecErrorMessage
   | McpExecClosedMessage
   | McpDeploymentStatusesMessage
+  | McpInstallationStatusMessage
   | ErrorMessage;
 
 /**


### PR DESCRIPTION
- MCP server logs WS auto-upgrades from K8s events to live container logs once the pod is Ready, and recovers when the pod is replaced.
- Add mcp_installation_status WS push so install/reinstall progress clears immediately on backend DB update instead of waiting for the next 2s poll.
- LLM provider API key dialog: default scope is now org for users with llmProviderApiKey:admin, falling back to personal otherwise. Org option is gated on the same permission. Name field is optional and defaults to the provider name when empty.
- Catalog edits that add or rename required header fields on local servers now correctly mark installs as reinstallRequired (with test). Catalog edit-mode alert calls out env vars and headers so admins know credentials need updating.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>