### PR TITLE
fix: preserve MCP catalog headers when auth is OAuth or enterprise

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
@@ -669,6 +669,79 @@ describe("transformFormToApiData", () => {
     expect(values.includeBearerPrefix).toBe(false);
     expect(values.authHeaderName).toBe("");
   });
+
+  describe("preserves additionalHeaders across all auth methods", () => {
+    const additionalHeaders: McpCatalogFormValues["additionalHeaders"] = [
+      {
+        headerName: "x-api-key",
+        promptOnInstallation: true,
+        required: true,
+        value: "",
+        description: "",
+        includeBearerPrefix: false,
+      },
+    ];
+
+    const baseValues: McpCatalogFormValues = {
+      name: "Headers MCP",
+      description: "",
+      icon: null,
+      serverType: "remote",
+      serverUrl: "https://mcp.example.com",
+      authMethod: "none",
+      includeBearerPrefix: true,
+      authHeaderName: "",
+      additionalHeaders,
+      oauthConfig: {
+        client_id: "id",
+        client_secret: "secret",
+        audience: "",
+        redirect_uris: "https://app.example.com/oauth-callback",
+        scopes: "",
+        supports_resource_metadata: true,
+        grantType: "authorization_code",
+        oauthServerUrl: "",
+        authServerUrl: "",
+        authorizationEndpoint: "https://auth.example.com/authorize",
+        wellKnownUrl: "",
+        resourceMetadataUrl: "",
+        tokenEndpoint: "https://auth.example.com/token",
+      },
+      enterpriseManagedConfig: {
+        identityProviderId: "idp-1",
+        assertionMode: "exchange",
+      },
+      localConfig: undefined,
+      deploymentSpecYaml: "",
+      originalDeploymentSpecYaml: "",
+      oauthClientSecretVaultPath: "",
+      oauthClientSecretVaultKey: "",
+      localConfigVaultPath: "",
+      localConfigVaultKey: "",
+      labels: [],
+      scope: "personal",
+      teams: [],
+    };
+
+    const cases: McpCatalogFormValues["authMethod"][] = [
+      "oauth",
+      "oauth_client_credentials",
+      "enterprise_managed",
+      "idp_jwt",
+    ];
+
+    for (const authMethod of cases) {
+      it(`keeps additional headers when authMethod is ${authMethod}`, () => {
+        const result = transformFormToApiData({ ...baseValues, authMethod });
+        expect(result.userConfig).toMatchObject({
+          header_x_api_key: expect.objectContaining({
+            headerName: "x-api-key",
+            promptOnInstallation: true,
+          }),
+        });
+      });
+    }
+  });
 });
 
 describe("transformFormToApiData - secret env var preservation", () => {

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
@@ -148,6 +148,7 @@ export function transformFormToApiData(
 
     data.userConfig = isClientCredentials
       ? {
+          ...buildStaticHeaderUserConfig(values),
           client_id: {
             type: "string",
             title: "Client ID",
@@ -178,10 +179,10 @@ export function transformFormToApiData(
             sensitive: false,
           },
         }
-      : {};
+      : buildStaticHeaderUserConfig(values);
     data.enterpriseManagedConfig = null;
   } else if (values.authMethod === "enterprise_managed") {
-    data.userConfig = {};
+    data.userConfig = buildStaticHeaderUserConfig(values);
     data.oauthConfig = null;
     data.enterpriseManagedConfig = values.enterpriseManagedConfig
       ? {
@@ -190,7 +191,7 @@ export function transformFormToApiData(
         }
       : null;
   } else if (values.authMethod === "idp_jwt") {
-    data.userConfig = {};
+    data.userConfig = buildStaticHeaderUserConfig(values);
     data.oauthConfig = null;
     data.enterpriseManagedConfig = values.enterpriseManagedConfig
       ? {


### PR DESCRIPTION
## Summary

- Custom Headers added in the MCP catalog form were silently dropped on save when `authMethod` was `oauth`, `oauth_client_credentials`, `enterprise_managed`, or `idp_jwt`. 

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>