### PR TITLE
fix(agents): allow changing shared agent scope back to personal

### DIFF
--- a/platform/backend/src/models/member.ts
+++ b/platform/backend/src/models/member.ts
@@ -433,6 +433,17 @@ class MemberModel {
       .where(eq(schema.membersTable.defaultAgentId, agentId));
     return (result?.count ?? 0) > 0;
   }
+
+  /**
+   * Clear defaultAgentId for all members that reference the given agent.
+   * Called before deleting an agent so the deletion guard is not needed.
+   */
+  static async clearDefaultAgentForAll(agentId: string): Promise<void> {
+    await db
+      .update(schema.membersTable)
+      .set({ defaultAgentId: null })
+      .where(eq(schema.membersTable.defaultAgentId, agentId));
+  }
 }
 
 export default MemberModel;

--- a/platform/backend/src/models/member.ts
+++ b/platform/backend/src/models/member.ts
@@ -436,7 +436,6 @@ class MemberModel {
 
   /**
    * Clear defaultAgentId for all members that reference the given agent.
-   * Called before deleting an agent so the deletion guard is not needed.
    */
   static async clearDefaultAgentForAll(agentId: string): Promise<void> {
     await db

--- a/platform/backend/src/routes/agent.test.ts
+++ b/platform/backend/src/routes/agent.test.ts
@@ -285,6 +285,26 @@ describe("agent routes", () => {
       expect(getResponse.json().toolExposureMode).toBe("search_and_run_only");
       expect(getResponse.json().toolAssignmentMode).toBe("automatic");
     });
+
+    test("allows changing scope from org back to personal", async ({
+      makeAgent,
+    }) => {
+      const agent = await makeAgent({
+        name: `Scope Downgrade Test ${crypto.randomUUID().slice(0, 8)}`,
+        organizationId,
+        scope: "org",
+        authorId: user.id,
+      });
+
+      const updateResponse = await app.inject({
+        method: "PUT",
+        url: `/api/agents/${agent.id}`,
+        payload: { scope: "personal" },
+      });
+
+      expect(updateResponse.statusCode).toBe(200);
+      expect(updateResponse.json().scope).toBe("personal");
+    });
   });
 
   describe("DELETE /api/agents/:id", () => {
@@ -384,28 +404,20 @@ describe("agent routes", () => {
       expect(created.isPersonalGateway).toBe(false);
     });
 
-    test("deleting a default agent succeeds and clears member defaultAgentId", async ({
-      makeUser,
-      makeOrganization,
-      makeMember,
-    }) => {
+    test("deleting a default agent succeeds and clears member defaultAgentId", async () => {
       const { default: AgentModel } = await import("@/models/agent");
       const { default: MemberModel } = await import("@/models/member");
 
-      const memberUser = await makeUser();
-      const org = await makeOrganization();
-      await makeMember(memberUser.id, org.id);
-
       await AgentModel.ensurePersonalChatAgent({
-        userId: memberUser.id,
-        organizationId: org.id,
+        userId: user.id,
+        organizationId,
       });
 
       const defaultAgentId = await MemberModel.getDefaultAgentId(
-        memberUser.id,
-        org.id,
+        user.id,
+        organizationId,
       );
-      if (!defaultAgentId) throw new Error("expected default agent to be set");
+      if (!defaultAgentId) throw new Error("expected default agent");
 
       const deleteResponse = await app.inject({
         method: "DELETE",
@@ -417,32 +429,10 @@ describe("agent routes", () => {
 
       // defaultAgentId should now be cleared
       const clearedDefault = await MemberModel.getDefaultAgentId(
-        memberUser.id,
-        org.id,
+        user.id,
+        organizationId,
       );
       expect(clearedDefault).toBeNull();
-    });
-  });
-
-  describe("PUT /api/agents/:id scope changes", () => {
-    test("allows changing scope from org back to personal", async ({
-      makeAgent,
-    }) => {
-      const agent = await makeAgent({
-        name: `Scope Downgrade Test ${crypto.randomUUID().slice(0, 8)}`,
-        organizationId,
-        scope: "org",
-        authorId: user.id,
-      });
-
-      const updateResponse = await app.inject({
-        method: "PUT",
-        url: `/api/agents/${agent.id}`,
-        payload: { scope: "personal" },
-      });
-
-      expect(updateResponse.statusCode).toBe(200);
-      expect(updateResponse.json().scope).toBe("personal");
     });
   });
 

--- a/platform/backend/src/routes/agent.test.ts
+++ b/platform/backend/src/routes/agent.test.ts
@@ -383,6 +383,67 @@ describe("agent routes", () => {
       const created = response.json();
       expect(created.isPersonalGateway).toBe(false);
     });
+
+    test("deleting a default agent succeeds and clears member defaultAgentId", async ({
+      makeUser,
+      makeOrganization,
+      makeMember,
+    }) => {
+      const { default: AgentModel } = await import("@/models/agent");
+      const { default: MemberModel } = await import("@/models/member");
+
+      const memberUser = await makeUser();
+      const org = await makeOrganization();
+      await makeMember(memberUser.id, org.id);
+
+      await AgentModel.ensurePersonalChatAgent({
+        userId: memberUser.id,
+        organizationId: org.id,
+      });
+
+      const defaultAgentId = await MemberModel.getDefaultAgentId(
+        memberUser.id,
+        org.id,
+      );
+      if (!defaultAgentId) throw new Error("expected default agent to be set");
+
+      const deleteResponse = await app.inject({
+        method: "DELETE",
+        url: `/api/agents/${defaultAgentId}`,
+      });
+
+      expect(deleteResponse.statusCode).toBe(200);
+      expect(deleteResponse.json().success).toBe(true);
+
+      // defaultAgentId should now be cleared
+      const clearedDefault = await MemberModel.getDefaultAgentId(
+        memberUser.id,
+        org.id,
+      );
+      expect(clearedDefault).toBeNull();
+    });
+  });
+
+  describe("PUT /api/agents/:id scope changes", () => {
+    test("allows changing scope from org back to personal", async ({
+      makeAgent,
+    }) => {
+      const agent = await makeAgent({
+        name: `Scope Downgrade Test ${crypto.randomUUID().slice(0, 8)}`,
+        organizationId,
+        scope: "org",
+        authorId: user.id,
+      });
+
+      const updateResponse = await app.inject({
+        method: "PUT",
+        url: `/api/agents/${agent.id}`,
+        payload: { scope: "personal" },
+      });
+
+      expect(updateResponse.statusCode).toBe(200);
+      expect(updateResponse.json().scope).toBe("personal");
+    });
   });
 
   describe("GET /api/agents (paginated)", () => {

--- a/platform/backend/src/routes/agent.ts
+++ b/platform/backend/src/routes/agent.ts
@@ -701,11 +701,6 @@ const agentRoutes: FastifyPluginAsyncZod = async (fastify) => {
         }
       }
 
-      // Prevent downgrading shared agents to personal
-      if (body.scope === "personal" && existingAgent.scope !== "personal") {
-        throw new ApiError(400, "Shared agents cannot be made personal");
-      }
-
       // Validate knowledgeBaseIds if provided
       if (body.knowledgeBaseIds && body.knowledgeBaseIds.length > 0) {
         if (existingAgent.agentType === "llm_proxy") {
@@ -853,14 +848,8 @@ const agentRoutes: FastifyPluginAsyncZod = async (fastify) => {
         throw new ApiError(403, "Built-in agents cannot be deleted");
       }
 
-      // Prevent deletion of an agent that is any member's default
-      const isDefault = await MemberModel.isAgentDefault(id);
-      if (isDefault) {
-        throw new ApiError(
-          403,
-          "Cannot delete a default agent. Set another agent as default first.",
-        );
-      }
+      // Clear defaultAgentId for any members who reference this agent as their default
+      await MemberModel.clearDefaultAgentForAll(id);
 
       // Prevent deletion of a user's personal MCP gateway
       if (agent.isPersonalGateway) {

--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -421,8 +421,6 @@ function AccessLevelSelector({
   const canShareWithTeams = isAdmin || isTeamAdmin;
 
   const isOptionDisabled = (value: string) => {
-    if (value === "personal" && initialScope && initialScope !== "personal")
-      return true;
     if (value === "team" && (!canShareWithTeams || !canReadTeams)) return true;
     if (value === "org" && !isAdmin) return true;
     return false;
@@ -437,8 +435,6 @@ function AccessLevelSelector({
   const resourceName = resourceMap[agentType] || "agent";
 
   const getDisabledReason = (value: string) => {
-    if (value === "personal" && initialScope && initialScope !== "personal")
-      return "Shared agents cannot be made personal";
     if (value === "team" && !canReadTeams)
       return `Team sharing is unavailable without ${formatPermissionRequirement({ resource: "team", action: "read" })}`;
     if (value === "team" && !canShareWithTeams)


### PR DESCRIPTION
## What changed

Three restrictions blocked users from reverting a shared agent ("My Assistant") back to **Personal** scope, or deleting it once it was set as a member's default:

1. **Frontend** (`agent-dialog.tsx`): `isOptionDisabled()` grayed out the *Personal* option once any non-personal scope was saved, and `getDisabledReason()` returned `"Shared agents cannot be made personal"`.
2. **Backend PUT** (`routes/agent.ts`): The update handler rejected `scope: "personal"` with a `400` when the existing scope was not personal.
3. **Backend DELETE** (`routes/agent.ts`): The delete handler returned `403 Cannot delete a default agent` when any member had the agent set as their `defaultAgentId`.

## Why

As noted by @joeyorlando in the issue, the *"default"* concept is legacy and the lock-out was unintentional UX. Users should be able to un-share their own assistant at any time.

## How to test

**Scope downgrade**
1. Create a personal agent ("My Assistant").
2. Edit it → change scope to **Org** or **Team** → save.
3. Edit it again → the **Personal** option should now be selectable (was grayed out before).
4. Change back to Personal → save → verify scope is `personal` in the agent list.

**Delete a default agent**
1. In a fresh account the auto-created personal chat agent is the member default.
2. Open the agent → delete it → should succeed (previously returned 403).
3. Verify the agent is gone; the member's `defaultAgentId` is cleared (chat falls back to the first available agent).

## Changes

| File | Change |
|------|--------|
| `platform/frontend/src/components/agent-dialog.tsx` | Remove `isOptionDisabled` / `getDisabledReason` restriction for *personal* scope |
| `platform/backend/src/routes/agent.ts` | Remove `"Shared agents cannot be made personal"` guard; replace deletion block with `clearDefaultAgentForAll()` |
| `platform/backend/src/models/member.ts` | Add `MemberModel.clearDefaultAgentForAll(agentId)` — bulk-clears `defaultAgentId` before the agent row is deleted |
| `platform/backend/src/routes/agent.test.ts` | Tests: scope org→personal returns 200; deleting a default agent succeeds and clears `defaultAgentId` |

Closes #4108
