### PR TITLE
fix: show error message and remove leaked DOM element for invalid mermaid diagrams

### DIFF
--- a/platform/frontend/src/components/mermaid-diagram.test.tsx
+++ b/platform/frontend/src/components/mermaid-diagram.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("mermaid", () => ({
+  default: {
+    initialize: vi.fn(),
+    render: vi.fn(),
+  },
+}));
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ theme: "light" }),
+}));
+
+import mermaid from "mermaid";
+import { MermaidDiagram } from "./mermaid-diagram";
+
+describe("MermaidDiagram", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls mermaid.render with the provided chart string", async () => {
+    vi.mocked(mermaid.render).mockResolvedValue({
+      svg: "<svg></svg>",
+      bindFunctions: undefined,
+    });
+
+    render(<MermaidDiagram chart="graph TD; A-->B;" />);
+
+    await waitFor(() => {
+      expect(mermaid.render).toHaveBeenCalledWith(
+        expect.stringContaining("mermaid-diagram"),
+        "graph TD; A-->B;",
+      );
+    });
+  });
+
+  it("shows an error message when the diagram syntax is invalid", async () => {
+    vi.mocked(mermaid.render).mockRejectedValue(
+      new Error("Parse error on line 1"),
+    );
+
+    render(<MermaidDiagram chart="not valid mermaid" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Invalid diagram")).toBeInTheDocument();
+      expect(screen.getByText(/Parse error on line 1/)).toBeInTheDocument();
+    });
+  });
+
+  it("removes the leaked mermaid container from document.body on render error", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(99999);
+    const leaked = document.createElement("div");
+    leaked.id = "mermaid-diagram-99999";
+    document.body.appendChild(leaked);
+
+    vi.mocked(mermaid.render).mockRejectedValue(new Error("syntax error"));
+
+    render(<MermaidDiagram chart="invalid" />);
+
+    await waitFor(() => {
+      expect(document.getElementById("mermaid-diagram-99999")).toBeNull();
+    });
+  });
+});

--- a/platform/frontend/src/components/mermaid-diagram.tsx
+++ b/platform/frontend/src/components/mermaid-diagram.tsx
@@ -16,9 +16,11 @@ export function MermaidDiagram({
   const ref = useRef<HTMLDivElement>(null);
   const { theme } = useTheme();
   const [isLoaded, setIsLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     setIsLoaded(false);
+    setError(null);
     const isDark = theme === "dark";
 
     mermaid.initialize({
@@ -54,9 +56,11 @@ export function MermaidDiagram({
     const renderDiagram = async () => {
       if (ref.current) {
         ref.current.replaceChildren();
+        // Declare uniqueId outside try so it's accessible in catch for cleanup.
+        // mermaid.render() creates a temporary div#uniqueId in document.body;
+        // we must remove it on error to prevent it leaking to other pages.
+        const uniqueId = `${id}-${Date.now()}`;
         try {
-          // Generate a unique ID to avoid conflicts
-          const uniqueId = `${id}-${Date.now()}`;
           const { svg } = await mermaid.render(uniqueId, chart);
           if (ref.current) {
             // Parse SVG string via DOMParser to avoid innerHTML
@@ -65,20 +69,27 @@ export function MermaidDiagram({
             ref.current.replaceChildren(svgElement);
             requestAnimationFrame(() => setIsLoaded(true));
           }
-        } catch (error) {
-          console.error("Error rendering mermaid diagram:", error);
-          if (ref.current) {
-            const pre = document.createElement("pre");
-            pre.textContent = chart;
-            ref.current.replaceChildren(pre);
-            setIsLoaded(true);
-          }
+        } catch (err) {
+          // Remove the temporary container mermaid may have left in document.body.
+          document.getElementById(uniqueId)?.remove();
+          const message = err instanceof Error ? err.message : String(err);
+          setError(message);
+          setIsLoaded(true);
         }
       }
     };
 
     renderDiagram();
   }, [chart, id, theme]);
+
+  if (error) {
+    return (
+      <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-destructive text-xs whitespace-pre-wrap break-words select-text">
+        <p className="font-medium mb-1">Invalid diagram</p>
+        {error}
+      </div>
+    );
+  }
 
   return (
     <div

--- a/platform/frontend/src/components/mermaid-diagram.tsx
+++ b/platform/frontend/src/components/mermaid-diagram.tsx
@@ -56,9 +56,6 @@ export function MermaidDiagram({
     const renderDiagram = async () => {
       if (ref.current) {
         ref.current.replaceChildren();
-        // Declare uniqueId outside try so it's accessible in catch for cleanup.
-        // mermaid.render() creates a temporary div#uniqueId in document.body;
-        // we must remove it on error to prevent it leaking to other pages.
         const uniqueId = `${id}-${Date.now()}`;
         try {
           const { svg } = await mermaid.render(uniqueId, chart);
@@ -70,7 +67,6 @@ export function MermaidDiagram({
             requestAnimationFrame(() => setIsLoaded(true));
           }
         } catch (err) {
-          // Remove the temporary container mermaid may have left in document.body.
           document.getElementById(uniqueId)?.remove();
           const message = err instanceof Error ? err.message : String(err);
           setError(message);


### PR DESCRIPTION
## What changed

**`platform/frontend/src/components/mermaid-diagram.tsx`**
- Move `uniqueId` declaration outside the `try` block so it is in scope inside `catch`
- In `catch`: call `document.getElementById(uniqueId)?.remove()` to remove the temporary element that `mermaid.render()` leaves in `document.body` on failure
- Replace the raw-chart-code fallback with an `error` state; render a styled error box (matching the `bg-destructive/10 text-destructive` pattern used elsewhere in the repo) that surfaces the parse error message to the user

**`platform/frontend/src/components/mermaid-diagram.test.tsx`** *(new file)*
- `calls mermaid.render with the provided chart string` — happy-path smoke test
- `shows an error message when the diagram syntax is invalid` — asserts the "Invalid diagram" heading and error text appear
- `removes the leaked mermaid container from document.body on render error` — directly tests the DOM-leak fix by pre-inserting the orphan element and asserting it is gone after a failed render

## Why

Fixes #3511.

`mermaid.render(id, chart)` creates a temporary `div#id` in `document.body` as a scratch area while generating the SVG. When the diagram source is invalid the library throws before removing that element, leaving it orphaned in the DOM. Because Next.js does client-side navigation without full page reloads, the orphan persists and interferes with subsequent renders on other pages — the "errors leak to other pages" symptom reported in the issue.

The previous `catch` block also discarded the `Error` object and fell back to displaying the raw chart source in a `<pre>`, giving the user no indication of what was wrong with the diagram.

## How to test

1. Start a chat and ask the model to produce an invalid mermaid block, e.g.:

   > "Show me a mermaid diagram with this exact source: `graph TD A-->`"

2. **Before fix:** a raw code block is displayed; opening DevTools shows an orphan `div#mermaid-diagram-<timestamp>` in `document.body`; navigating to another page with a valid mermaid diagram fails to render.

3. **After fix:** a red "Invalid diagram" box appears with the parse error; `document.body` has no orphan element; navigating to other pages works normally.

Automated tests: `pnpm --filter frontend test run src/components/mermaid-diagram.test.tsx` — 3 tests, all pass.