### PR TITLE
fix(guardrails): apply blocked tool result policies in untrusted-start context

### DIFF
--- a/platform/backend/src/guardrails/trusted-data.test.ts
+++ b/platform/backend/src/guardrails/trusted-data.test.ts
@@ -410,6 +410,47 @@ describe("trusted-data evaluation (provider-agnostic)", () => {
       });
     });
 
+    test("still applies blocked tool result updates when context starts untrusted", async () => {
+      await TrustedDataPolicyModel.create({
+        toolId,
+        conditions: [{ key: "source", operator: "equal", value: "external" }],
+        action: "block_always",
+        description: "Block external data",
+      });
+
+      const result = await evaluateIfContextIsTrusted(
+        [
+          {
+            role: "tool",
+            toolCalls: [
+              {
+                id: "call_blocked",
+                name: "get_emails",
+                content: { source: "external", payload: "raw" },
+                isError: false,
+              },
+            ],
+          },
+        ],
+        agentId,
+        organizationId,
+        undefined,
+        true,
+        "restrictive",
+        { teamIds: [] },
+      );
+
+      expect(result.contextIsTrusted).toBe(false);
+      expect(result.toolResultUpdates).toEqual({
+        call_blocked:
+          "[Content blocked by policy: Data blocked by policy: Block external data]",
+      });
+      expect(result.unsafeContextBoundary).toEqual({
+        kind: "preexisting_untrusted",
+        reason: "agent_configured_untrusted",
+      });
+    });
+
     test("handles multiple tool calls with mixed trust", async () => {
       // Create policies
       await TrustedDataPolicyModel.create({

--- a/platform/backend/src/guardrails/trusted-data.ts
+++ b/platform/backend/src/guardrails/trusted-data.ts
@@ -59,29 +59,23 @@ export async function evaluateIfContextIsTrusted(
 
   const toolResultUpdates: ToolResultUpdates = {};
   const dualLlmAnalyses: DualLlmAnalysis[] = [];
-  let hasUntrustedData = false;
+  let hasUntrustedData = considerContextUntrusted;
   let usedDualLlm = false;
-  let unsafeContextBoundary: UnsafeContextBoundary | undefined;
+  let unsafeContextBoundary: UnsafeContextBoundary | undefined =
+    considerContextUntrusted
+      ? {
+          kind: "preexisting_untrusted",
+          reason:
+            initialUntrustedReason ??
+            UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
+        }
+      : undefined;
 
-  // If agent configured to consider context untrusted from the beginning,
-  // mark context as untrusted immediately and skip evaluation
   if (considerContextUntrusted) {
     logger.debug(
       { agentId },
-      "[trustedData] evaluateIfContextIsTrusted: context marked untrusted by agent config",
+      "[trustedData] evaluateIfContextIsTrusted: context starts as untrusted, continuing policy evaluation for tool result updates",
     );
-    return {
-      toolResultUpdates: {},
-      contextIsTrusted: false,
-      usedDualLlm: false,
-      dualLlmAnalyses: [],
-      unsafeContextBoundary: {
-        kind: "preexisting_untrusted",
-        reason:
-          initialUntrustedReason ??
-          UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
-      },
-    };
   }
 
   // First, collect all tool calls from all messages
@@ -111,14 +105,14 @@ export async function evaluateIfContextIsTrusted(
 
   if (allToolCalls.length === 0) {
     logger.debug(
-      { agentId },
-      "[trustedData] evaluateIfContextIsTrusted: no tool calls found, context is trusted",
+      { agentId, contextIsTrusted: !hasUntrustedData },
+      "[trustedData] evaluateIfContextIsTrusted: no tool calls found",
     );
     return {
       toolResultUpdates,
-      contextIsTrusted: true,
-      usedDualLlm: false,
-      dualLlmAnalyses: [],
+      contextIsTrusted: !hasUntrustedData,
+      usedDualLlm,
+      dualLlmAnalyses,
       unsafeContextBoundary,
     };
   }


### PR DESCRIPTION
## Summary\nFixes a guardrails bypass where Tool Result Policy blocking was skipped when chat starts with \considerContextUntrusted\ enabled.\n\n## Changes\n- Remove early return in trusted-data evaluation when context starts untrusted\n- Preserve preexisting-untrusted boundary while still evaluating tool result policies\n- Keep context untrusted from start and apply blocked result replacements to \	oolResultUpdates\\n- Add regression test for sensitive-from-start + blocked policy behavior\n\n## Validation\n- pnpm --dir platform/backend test -- src/guardrails/trusted-data.test.ts\n\n/claim #4225