### PR TITLE
fix(guardrails): prevent bypass of blocked tool result policies in untrusted-start context

### DIFF
--- a/platform/backend/src/guardrails/trusted-data.ts
+++ b/platform/backend/src/guardrails/trusted-data.ts
@@ -70,17 +70,12 @@ export async function evaluateIfContextIsTrusted(
       { agentId },
       "[trustedData] evaluateIfContextIsTrusted: context marked untrusted by agent config",
     );
-    return {
-      toolResultUpdates: {},
-      contextIsTrusted: false,
-      usedDualLlm: false,
-      dualLlmAnalyses: [],
-      unsafeContextBoundary: {
-        kind: "preexisting_untrusted",
-        reason:
-          initialUntrustedReason ??
-          UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
-      },
+    hasUntrustedData = true;
+    unsafeContextBoundary = {
+      kind: "preexisting_untrusted",
+      reason:
+        initialUntrustedReason ??
+        UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
     };
   }
 
@@ -116,7 +111,7 @@ export async function evaluateIfContextIsTrusted(
     );
     return {
       toolResultUpdates,
-      contextIsTrusted: true,
+      contextIsTrusted: !hasUntrustedData,
       usedDualLlm: false,
       dualLlmAnalyses: [],
       unsafeContextBoundary,


### PR DESCRIPTION
Resolves https://github.com/archestra-ai/archestra/issues/4225
/claim #4225

## What
Ensures that tool result policies are evaluated even when the agent starts in a context marked as untrusted (via `considerContextUntrusted`). Previously, an early return would skip policy evaluation, allowing blocked tool results to be leaked to the LLM.

## Why
The `evaluateIfContextIsTrusted` function returned immediately if the initial context was untrusted, but security policies for tool results must be enforced regardless of the initial trust state.