### PR TITLE
fix(frontend): persist list page filters across navigation  #4330

### DIFF
--- a/platform/frontend/src/app/agents/triggers/email/page.tsx
+++ b/platform/frontend/src/app/agents/triggers/email/page.tsx
@@ -2,7 +2,8 @@
 
 import { type archestraApiTypes, DocsPage } from "@shared";
 import { AlertTriangle, RefreshCw, Settings2, Trash2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useMemo, useState } from "react";
 import { CopyButton } from "@/components/copy-button";
 import Divider from "@/components/divider";
 import { ResourceVisibilityBadge } from "@/components/resource-visibility-badge";
@@ -48,6 +49,16 @@ import {
 type AgentRecord = archestraApiTypes.GetAllAgentsResponses["200"][number];
 type EmailStatusFilter = "all" | "enabled" | "disabled";
 
+const EMAIL_STATUS_FILTER_VALUES: EmailStatusFilter[] = [
+  "all",
+  "enabled",
+  "disabled",
+];
+
+function isEmailStatusFilter(value: string): value is EmailStatusFilter {
+  return (EMAIL_STATUS_FILTER_VALUES as string[]).includes(value);
+}
+
 export default function EmailPage() {
   const appName = useAppName();
   const docsUrl = getFrontendDocsUrl(DocsPage.PlatformAgentTriggersEmail);
@@ -62,10 +73,49 @@ export default function EmailPage() {
   const deleteMutation = useDeleteIncomingEmailSubscription();
   const { email: allStepsCompleted } = useTriggerStatuses();
 
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const search = searchParams.get("search") ?? "";
+  const statusParam = searchParams.get("status");
+  const statusFilter: EmailStatusFilter =
+    statusParam && isEmailStatusFilter(statusParam) ? statusParam : "all";
+
+  const updateFilters = useCallback(
+    (updates: Record<string, string | null>) => {
+      const params = new URLSearchParams(searchParams.toString());
+      for (const [key, value] of Object.entries(updates)) {
+        if (value === null || value === "") {
+          params.delete(key);
+        } else {
+          params.set(key, value);
+        }
+      }
+      params.delete("page");
+      const query = params.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname, {
+        scroll: false,
+      });
+    },
+    [pathname, router, searchParams],
+  );
+
+  const setSearch = useCallback(
+    (value: string) => {
+      updateFilters({ search: value || null });
+    },
+    [updateFilters],
+  );
+
+  const setStatusFilter = useCallback(
+    (value: EmailStatusFilter) => {
+      updateFilters({ status: value === "all" ? null : value });
+    },
+    [updateFilters],
+  );
+
   const [setupOpen, setSetupOpen] = useState(false);
   const [editingAgent, setEditingAgent] = useState<AgentRecord | null>(null);
-  const [search, setSearch] = useState("");
-  const [statusFilter, setStatusFilter] = useState<EmailStatusFilter>("all");
 
   const isLoading = featuresLoading || statusLoading || agentsLoading;
   const emailInfo = configData?.features.incomingEmail;

--- a/platform/frontend/src/app/mcp/registry/installation-requests/page.tsx
+++ b/platform/frontend/src/app/mcp/registry/installation-requests/page.tsx
@@ -2,8 +2,8 @@
 
 import type { archestraApiTypes } from "@shared";
 import { CheckCircle, Clock, XCircle } from "lucide-react";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -29,8 +29,41 @@ type RequestStatus = NonNullable<
 >;
 type RequestStatusFilter = "all" | RequestStatus;
 
+const STATUS_FILTER_VALUES: RequestStatusFilter[] = [
+  "all",
+  "pending",
+  "approved",
+  "declined",
+];
+
+function isRequestStatusFilter(value: string): value is RequestStatusFilter {
+  return (STATUS_FILTER_VALUES as string[]).includes(value);
+}
+
 export default function InstallationRequestsPage() {
-  const [statusFilter, setStatusFilter] = useState<RequestStatusFilter>("all");
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const statusParam = searchParams.get("status");
+  const statusFilter: RequestStatusFilter =
+    statusParam && isRequestStatusFilter(statusParam) ? statusParam : "all";
+
+  const setStatusFilter = useCallback(
+    (value: RequestStatusFilter) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value === "all") {
+        params.delete("status");
+      } else {
+        params.set("status", value);
+      }
+      params.delete("page");
+      const query = params.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname, {
+        scroll: false,
+      });
+    },
+    [pathname, router, searchParams],
+  );
 
   const { data: requests, isLoading } = useMcpServerInstallationRequests(
     statusFilter === "all" ? undefined : { status: statusFilter },

--- a/platform/frontend/src/app/scheduled-tasks/schedule-triggers-client.tsx
+++ b/platform/frontend/src/app/scheduled-tasks/schedule-triggers-client.tsx
@@ -57,6 +57,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useProfiles } from "@/lib/agent.query";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
+import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
 import { useOrganizationMembers } from "@/lib/organization.query";
 import {
   type ScheduleTrigger,
@@ -94,14 +95,52 @@ export function ScheduleTriggersIndexPage() {
   });
   const { data: session } = useSession();
   const currentUserId = session?.user?.id;
-  const [showOtherUsers, setShowOtherUsers] = useState(false);
-  const [selectedAuthorIds, setSelectedAuthorIds] = useState<string[]>([]);
-  const [searchName, setSearchName] = useState("");
-  const [filterAgentId, setFilterAgentId] = useState<string | null>(
-    agentIdParam,
+  const {
+    pageIndex,
+    pageSize,
+    offset,
+    updateQueryParams,
+    setPagination,
+  } = useDataTableQueryParams({ defaultPageSize: 10 });
+  const showOtherUsers = searchParams.get("view") === "others";
+  const selectedAuthorIds = useMemo(() => {
+    const raw = searchParams.get("authorIds");
+    if (!raw) return [];
+    return raw.split(",").filter(Boolean);
+  }, [searchParams]);
+  const searchName = searchParams.get("search") ?? "";
+  const filterAgentId = agentIdParam;
+  const setSearchName = useCallback(
+    (value: string) => {
+      updateQueryParams({ search: value || null, page: "1" });
+    },
+    [updateQueryParams],
   );
-  const [pageSize, setPageSize] = useState(10);
-  const [pageIndex, setPageIndex] = useState(0);
+  const setFilterAgentId = useCallback(
+    (value: string | null) => {
+      updateQueryParams({ agentId: value, page: "1" });
+    },
+    [updateQueryParams],
+  );
+  const setShowOtherUsers = useCallback(
+    (value: boolean) => {
+      updateQueryParams({
+        view: value ? "others" : null,
+        authorIds: null,
+        page: "1",
+      });
+    },
+    [updateQueryParams],
+  );
+  const setSelectedAuthorIds = useCallback(
+    (ids: string[]) => {
+      updateQueryParams({
+        authorIds: ids.length > 0 ? ids.join(",") : null,
+        page: "1",
+      });
+    },
+    [updateQueryParams],
+  );
   const { data: members } = useOrganizationMembers(
     isScheduledTaskAdmin && showOtherUsers,
   );
@@ -117,7 +156,7 @@ export function ScheduleTriggersIndexPage() {
   );
   const { data: triggersResponse, isLoading } = useScheduleTriggers({
     limit: pageSize,
-    offset: pageIndex * pageSize,
+    offset,
     name: searchName || undefined,
     showAll: showOtherUsers,
     agentIds: filterAgentId ? [filterAgentId] : undefined,
@@ -275,9 +314,6 @@ export function ScheduleTriggersIndexPage() {
     setCreateFormOpen(false);
     nameTouchedRef.current = false;
     setFormState(DEFAULT_FORM_STATE());
-    if (agentIdParam) {
-      router.replace("/scheduled-tasks");
-    }
   };
 
   const submitForm = async () => {
@@ -403,16 +439,15 @@ export function ScheduleTriggersIndexPage() {
           objectNamePlural="tasks"
           searchFields={["name"]}
           syncQueryParams={false}
+          value={searchName}
           onSearchChange={(value) => {
             setSearchName(value);
-            setPageIndex(0);
           }}
         />
         <Select
           value={filterAgentId ?? "all"}
           onValueChange={(value) => {
             setFilterAgentId(value === "all" ? null : value);
-            setPageIndex(0);
           }}
         >
           <SelectTrigger className="w-[200px]">
@@ -432,8 +467,6 @@ export function ScheduleTriggersIndexPage() {
             value={showOtherUsers ? "others" : "mine"}
             onValueChange={(value) => {
               setShowOtherUsers(value === "others");
-              setSelectedAuthorIds([]);
-              setPageIndex(0);
             }}
           >
             <SelectTrigger className="w-[160px]">
@@ -450,7 +483,6 @@ export function ScheduleTriggersIndexPage() {
             value={selectedAuthorIds}
             onValueChange={(ids) => {
               setSelectedAuthorIds(ids);
-              setPageIndex(0);
             }}
             items={memberItems}
             placeholder="All users"
@@ -529,8 +561,7 @@ export function ScheduleTriggersIndexPage() {
           total: triggersResponse?.pagination.total ?? 0,
         }}
         onPaginationChange={(p) => {
-          setPageIndex(p.pageIndex);
-          setPageSize(p.pageSize);
+          setPagination(p);
         }}
         onRowClick={(trigger) => router.push(`/scheduled-tasks/${trigger.id}`)}
         hideSelectedCount


### PR DESCRIPTION
Fixes #4330

Filters and label selections on the scheduled tasks index, the email triggers admin section, and the MCP installation requests view were stored in component-local [useState](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), so they were lost the moment the user navigated away and came back. This PR moves those filter values into URL search parameters, which is already the established pattern in this codebase (the agents page and the MCP registry catalog already read filters from [useSearchParams](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and write them via [useDataTableQueryParams](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) / [router.replace](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)). URL params were chosen over a new global store or sessionStorage because the project already uses them everywhere else, they are bookmarkable and refresh-safe, and they require no new dependencies. Filter writes use [router.replace](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) with [scroll: false](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to avoid polluting the browser history, and any filter mutation also clears the [page](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) query param so the table jumps back to page 1.

To verify: open /scheduled-tasks, type a name in the search box and pick a specific agent in the agent dropdown; navigate to [/agents](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and back — the same filters should still be applied. Repeat on [/agents/triggers/email](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (search box plus the All / Enabled / Disabled toggle) and on [/mcp/registry/installation-requests](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (the status tabs). A full browser refresh should also keep the filters in place. Changing any filter while on page 2+ should snap the table back to page 1.