### PR TITLE
feat: support JSON array in arguments textarea (#3859)

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/custom-server-request-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/custom-server-request-dialog.tsx
@@ -64,6 +64,27 @@ const customServerRequestSchema = z
 
 type CustomServerRequestFormValues = z.infer<typeof customServerRequestSchema>;
 
+function parseArguments(value: string): string[] {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return [];
+
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed.map((arg: unknown) => String(arg));
+      }
+    } catch {
+      // Fallback to line-split if JSON parse fails
+    }
+  }
+
+  return trimmed
+    .split("\n")
+    .map((arg) => arg.trim())
+    .filter((arg) => arg.length > 0);
+}
+
 export function CustomServerRequestDialog({
   isOpen,
   onClose,
@@ -119,10 +140,7 @@ export function CustomServerRequestDialog({
             serverType: "local" as const,
             localConfig: {
               command: values.command,
-              arguments: values.arguments
-                .split("\n")
-                .map((arg) => arg.trim())
-                .filter((arg) => arg.length > 0),
+              arguments: parseArguments(values.arguments),
               environment:
                 values.environment.length > 0 ? values.environment : undefined,
             },
@@ -276,12 +294,38 @@ export function CustomServerRequestDialog({
                     name="arguments"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>Arguments (one per line)</FormLabel>
+                        <FormLabel>
+                          Arguments (one per line or JSON array)
+                        </FormLabel>
                         <FormControl>
                           <Textarea
-                            placeholder={`/path/to/server.js\n--verbose`}
+                            placeholder={`/path/to/server.js\n--verbose\nor ["--arg1", "--arg2"]`}
                             rows={3}
                             {...field}
+                            onPaste={(e) => {
+                              const pastedText =
+                                e.clipboardData.getData("text");
+                              const trimmed = pastedText.trim();
+                              if (
+                                trimmed.startsWith("[") &&
+                                trimmed.endsWith("]")
+                              ) {
+                                try {
+                                  const parsed = JSON.parse(trimmed);
+                                  if (Array.isArray(parsed)) {
+                                    e.preventDefault();
+                                    const formatted = parsed
+                                      .map((arg: unknown) => String(arg))
+                                      .join("\n");
+                                    form.setValue("arguments", formatted, {
+                                      shouldDirty: true,
+                                    });
+                                  }
+                                } catch {
+                                  // Not a valid JSON array, let default paste happen
+                                }
+                              }
+                            }}
                           />
                         </FormControl>
                         <FormMessage />

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -999,14 +999,39 @@ export function McpCatalogForm({
                     render={({ field }) => (
                       <FormItem>
                         <FormLabel>
-                          Arguments (one per line)
+                          Arguments (one per line or JSON array)
                           <ReinstallHint show={isArgumentsDirty} />
                         </FormLabel>
                         <FormControl>
                           <Textarea
-                            placeholder={`/path/to/server.js\n--verbose`}
+                            placeholder={`/path/to/server.js\n--verbose\nor ["--arg1", "--arg2"]`}
                             className="font-mono min-h-20"
                             {...field}
+                            onPaste={(e) => {
+                              const pastedText = e.clipboardData.getData("text");
+                              const trimmed = pastedText.trim();
+                              if (
+                                trimmed.startsWith("[") &&
+                                trimmed.endsWith("]")
+                              ) {
+                                try {
+                                  const parsed = JSON.parse(trimmed);
+                                  if (Array.isArray(parsed)) {
+                                    e.preventDefault();
+                                    const formatted = parsed
+                                      .map((arg) => String(arg))
+                                      .join("\n");
+                                    form.setValue(
+                                      "localConfig.arguments",
+                                      formatted,
+                                      { shouldDirty: true },
+                                    );
+                                  }
+                                } catch (err) {
+                                  // Not a valid JSON array, let default paste happen
+                                }
+                              }
+                            }}
                           />
                         </FormControl>
                         <FormMessage />

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
@@ -860,3 +860,72 @@ describe("transformFormToApiData - secret env var preservation", () => {
     expect(env[1]?.value ?? "").toBe("");
   });
 });
+
+describe("transformFormToApiData - arguments parsing", () => {
+  function buildArgsFormValues(args: string): McpCatalogFormValues {
+    return {
+      name: "args-test",
+      description: "",
+      icon: null,
+      serverType: "local",
+      serverUrl: "",
+      authMethod: "none",
+      includeBearerPrefix: true,
+      authHeaderName: "",
+      additionalHeaders: [],
+      oauthConfig: undefined,
+      enterpriseManagedConfig: null,
+      localConfig: {
+        command: "node",
+        arguments: args,
+        environment: [],
+        envFrom: [],
+        dockerImage: "",
+        transportType: "stdio",
+        httpPort: "",
+        httpPath: "",
+        serviceAccount: "",
+        imagePullSecrets: [],
+      },
+      deploymentSpecYaml: "",
+      originalDeploymentSpecYaml: "",
+      oauthClientSecretVaultPath: "",
+      oauthClientSecretVaultKey: "",
+      localConfigVaultPath: "",
+      localConfigVaultKey: "",
+      labels: [],
+      scope: "personal",
+      teams: [],
+    };
+  }
+
+  it("parses newline-separated arguments", () => {
+    const result = transformFormToApiData(buildArgsFormValues("--verbose\n--port\n8080"));
+    expect(result.localConfig?.arguments).toEqual(["--verbose", "--port", "8080"]);
+  });
+
+  it("parses minified JSON array arguments", () => {
+    const result = transformFormToApiData(buildArgsFormValues('["--verbose","--port","8080"]'));
+    expect(result.localConfig?.arguments).toEqual(["--verbose", "--port", "8080"]);
+  });
+
+  it("parses pretty-printed JSON array arguments", () => {
+    const result = transformFormToApiData(buildArgsFormValues('[\n  "--verbose",\n  "--port",\n  "8080"\n]'));
+    expect(result.localConfig?.arguments).toEqual(["--verbose", "--port", "8080"]);
+  });
+
+  it("handles non-array JSON by falling back to line splitting", () => {
+    const result = transformFormToApiData(buildArgsFormValues('{"not": "an array"}'));
+    expect(result.localConfig?.arguments).toEqual(['{"not": "an array"}']);
+  });
+
+  it("handles empty JSON array correctly", () => {
+    const result = transformFormToApiData(buildArgsFormValues("[]"));
+    expect(result.localConfig?.arguments).toBeUndefined();
+  });
+
+  it("handles invalid JSON by falling back to line splitting", () => {
+    const result = transformFormToApiData(buildArgsFormValues('[invalid, json]'));
+    expect(result.localConfig?.arguments).toEqual(['[invalid, json]']);
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
@@ -34,13 +34,29 @@ export function transformFormToApiData(
 
   // Handle local configuration
   if (values.serverType === "local" && values.localConfig) {
-    // Parse arguments string into array
-    const argumentsArray = values.localConfig.arguments
-      ? values.localConfig.arguments
-          .split("\n")
-          .map((arg) => arg.trim())
-          .filter((arg) => arg.length > 0)
-      : [];
+    // Parse arguments string into array (supports both JSON array and one-per-line format)
+    const argumentsValue = values.localConfig.arguments?.trim() || "";
+    let argumentsArray: string[] = [];
+    let jsonParsed = false;
+
+    if (argumentsValue.startsWith("[") && argumentsValue.endsWith("]")) {
+      try {
+        const parsed = JSON.parse(argumentsValue);
+        if (Array.isArray(parsed)) {
+          argumentsArray = parsed.map((arg) => String(arg));
+          jsonParsed = true;
+        }
+      } catch (e) {
+        // Fallback to line-split if JSON parse fails
+      }
+    }
+
+    if (!jsonParsed && argumentsValue.length > 0) {
+      argumentsArray = argumentsValue
+        .split("\n")
+        .map((arg) => arg.trim())
+        .filter((arg) => arg.length > 0);
+    }
 
     data.localConfig = {
       command: values.localConfig.command || undefined,

--- a/platform/frontend/tsconfig.json
+++ b/platform/frontend/tsconfig.json
@@ -29,6 +29,9 @@
     "paths": {
       "@/*": [
         "./src/*"
+      ],
+      "@shared": [
+        "../shared/index.ts"
       ]
     }
   },


### PR DESCRIPTION
This PR adds support for JSON array format in the MCP server arguments textarea. It also adds an onPaste handler to automatically format pasted JSON arrays into a newline-separated list.

Closes #3859