### PR TITLE
chore: increase staging PostgreSQL disk

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -106,3 +106,8 @@ archestra:
           - path: /
             port: 9000
             pathType: Prefix
+
+postgresql:
+  primary:
+    persistence:
+      size: 100Gi


### PR DESCRIPTION
## Summary

Increase the staging PostgreSQL persistent volume request to `100Gi` via `.github/values-staging.yaml`.

## Why

The staging frontend outage was caused by the bundled PostgreSQL instance running out of disk. PostgreSQL could not recover, platform pods remained stuck waiting for the database, and the GKE ingress had no available frontend backends.

## Impact

Future staging Helm upgrades/installations will request a larger PostgreSQL volume. For the existing live PVC, the cluster may still need the PVC expansion applied/reconciled so the current `data-archestra-platform-postgresql-0` claim grows from its existing size.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>