### PR TITLE
chore: revert staging PostgreSQL PVC template size

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -106,8 +106,3 @@ archestra:
           - path: /
             port: 9000
             pathType: Prefix
-
-postgresql:
-  primary:
-    persistence:
-      size: 100Gi


### PR DESCRIPTION
## Summary

Revert the staging `postgresql.primary.persistence.size: 100Gi` override from `.github/values-staging.yaml`.

## Why

That value changes the Bitnami PostgreSQL StatefulSet `volumeClaimTemplates`. Kubernetes rejects that during Helm upgrade because StatefulSet claim templates are immutable after creation.

The live staging PVC was expanded directly with `kubectl` instead, which is the correct operation for an existing claim.

## Impact

Staging Helm upgrades should no longer fail while trying to patch the PostgreSQL StatefulSet spec. The existing live PVC remains expanded independently of this values file.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>