### PR TITLE
feat: add azure foundry keyless auth and model support

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -52910,8 +52910,8 @@
             },
             "in": "header",
             "name": "authorization",
-            "required": true,
-            "description": "Bearer token for OpenAI"
+            "required": false,
+            "description": "Bearer token for Azure AI Foundry"
           }
         ],
         "responses": {
@@ -53538,8 +53538,8 @@
             },
             "in": "header",
             "name": "authorization",
-            "required": true,
-            "description": "Bearer token for OpenAI"
+            "required": false,
+            "description": "Bearer token for Azure AI Foundry"
           }
         ],
         "responses": {
@@ -54133,8 +54133,8 @@
             },
             "in": "header",
             "name": "authorization",
-            "required": true,
-            "description": "Bearer token for OpenAI"
+            "required": false,
+            "description": "Bearer token for Azure AI Foundry"
           }
         ],
         "responses": {
@@ -54605,8 +54605,8 @@
             },
             "in": "header",
             "name": "authorization",
-            "required": true,
-            "description": "Bearer token for OpenAI"
+            "required": false,
+            "description": "Bearer token for Azure AI Foundry"
           }
         ],
         "responses": {

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -750,6 +750,11 @@ These environment variables set the default base URL for each LLM provider. Per-
   - Default: `https://api.anthropic.com`
   - Use this to point to your own proxy or other custom endpoints
 
+- **`ARCHESTRA_ANTHROPIC_AZURE_FOUNDRY_ENTRA_ID_ENABLED`** - Enable Microsoft Entra ID authentication for Anthropic models deployed in Microsoft Foundry.
+  - Default: `false`
+  - Set `ARCHESTRA_ANTHROPIC_BASE_URL=https://<resource-name>.services.ai.azure.com/anthropic`
+  - Uses Azure Identity `DefaultAzureCredential` with token scope `https://ai.azure.com/.default`
+
 - **`ARCHESTRA_GEMINI_BASE_URL`** - Override the Google Gemini API base URL.
   - Default: `https://generativelanguage.googleapis.com`
   - Use this to point to your own proxy or other custom endpoints
@@ -786,7 +791,8 @@ These environment variables set the default base URL for each LLM provider. Per-
   - Use this to point to your own proxy or other custom endpoints
 
 - **`ARCHESTRA_AZURE_OPENAI_BASE_URL`** - Azure AI Foundry deployment endpoint URL.
-  - Format: `https://<resource-name>.openai.azure.com/openai/deployments/<deployment-name>`
+  - Deployment URL format: `https://<resource-name>.openai.azure.com/openai/deployments/<deployment-name>`
+  - Foundry v1 format: `https://<resource-name>.services.ai.azure.com/openai/v1`
   - Required to enable the Azure AI Foundry provider.
 
 - **`ARCHESTRA_AZURE_OPENAI_API_VERSION`** - Azure OpenAI REST API version.
@@ -800,6 +806,7 @@ These environment variables set the default base URL for each LLM provider. Per-
   - Default: `false`
   - Set to `true` to use Azure Identity `DefaultAzureCredential` instead of `ARCHESTRA_CHAT_AZURE_OPENAI_API_KEY`
   - Requires `ARCHESTRA_AZURE_OPENAI_BASE_URL`
+  - Deployment URLs use token scope `https://cognitiveservices.azure.com/.default`; Foundry v1 URLs use `https://ai.azure.com/.default`
 
 - **`ARCHESTRA_LLM_PROXY_MAX_VIRTUAL_KEYS`** - Maximum number of virtual API keys per LLM API key.
   - Default: `10`

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -796,6 +796,11 @@ These environment variables set the default base URL for each LLM provider. Per-
   - Default: `2025-04-01-preview`
   - Used only for Azure `/responses` requests. Keep `ARCHESTRA_AZURE_OPENAI_API_VERSION` for Azure Chat Completions and deployment discovery.
 
+- **`ARCHESTRA_AZURE_OPENAI_ENTRA_ID_ENABLED`** - Enable Microsoft Entra ID authentication for Azure OpenAI.
+  - Default: `false`
+  - Set to `true` to use Azure Identity `DefaultAzureCredential` instead of `ARCHESTRA_CHAT_AZURE_OPENAI_API_KEY`
+  - Requires `ARCHESTRA_AZURE_OPENAI_BASE_URL`
+
 - **`ARCHESTRA_LLM_PROXY_MAX_VIRTUAL_KEYS`** - Maximum number of virtual API keys per LLM API key.
   - Default: `10`
   - See: [LLM Proxy Authentication](/docs/platform-llm-proxy-authentication)

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -238,6 +238,7 @@ Chart-managed diagnostics PVCs are validated conservatively. If more than one di
 **Deployment Settings**:
 
 - `archestra.podAnnotations` - Annotations to add to pods (useful for Prometheus, Vault agent, service mesh sidecars, etc.)
+- `archestra.podLabels` - Labels to add to pods (useful for AKS Microsoft Entra Workload ID)
 - `archestra.nodeSelector` - Node selector for scheduling pods on specific nodes (e.g., specific node pools or instance types). These values are also inherited by MCP server pods as defaults.
 - `archestra.tolerations` - Tolerations for scheduling pods on nodes with specific taints (e.g., dedicated nodes, GPU nodes, spot instances). These values are also inherited by MCP server pods as defaults. See [Kubernetes docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
 - `archestra.deploymentStrategy` - Deployment strategy configuration (default: RollingUpdate with `maxUnavailable: 25%` and `maxSurge: 25%`)

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -754,6 +754,7 @@ These environment variables set the default base URL for each LLM provider. Per-
   - Default: `false`
   - Set `ARCHESTRA_ANTHROPIC_BASE_URL=https://<resource-name>.services.ai.azure.com/anthropic`
   - Uses Azure Identity `DefaultAzureCredential` with token scope `https://ai.azure.com/.default`
+  - Claude deployments must already exist in the Azure resource. Microsoft lists additional Claude prerequisites: paid eligible subscription, supported region, Azure Marketplace access for partner models, permission to subscribe to model offerings, and Contributor or Owner role on the resource group. Azure also requires Anthropic deployment metadata: `industry`, `organizationName`, and `countryCode`.
 
 - **`ARCHESTRA_GEMINI_BASE_URL`** - Override the Google Gemini API base URL.
   - Default: `https://generativelanguage.googleapis.com`
@@ -794,6 +795,7 @@ These environment variables set the default base URL for each LLM provider. Per-
   - Deployment URL format: `https://<resource-name>.openai.azure.com/openai/deployments/<deployment-name>`
   - Foundry v1 format: `https://<resource-name>.services.ai.azure.com/openai/v1`
   - Required to enable the Azure AI Foundry provider.
+  - Use Foundry v1 for Azure-sold OpenAI-compatible models such as Grok.
 
 - **`ARCHESTRA_AZURE_OPENAI_API_VERSION`** - Azure OpenAI REST API version.
   - Default: `2024-02-01`

--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -667,11 +667,25 @@ Known region prefixes: `us`, `eu`, `ap`, `global`.
 | `ARCHESTRA_AZURE_OPENAI_BASE_URL` | Yes | Full deployment URL: `https://<resource>.openai.azure.com/openai/deployments/<deployment>` |
 | `ARCHESTRA_AZURE_OPENAI_API_VERSION` | No | Azure OpenAI API version (default: `2024-02-01`) |
 | `ARCHESTRA_AZURE_OPENAI_RESPONSES_API_VERSION` | No | Azure Responses API version (default: `2025-04-01-preview`) |
+| `ARCHESTRA_AZURE_OPENAI_ENTRA_ID_ENABLED` | No | Set to `true` to use Microsoft Entra ID instead of an Azure API key |
 | `ARCHESTRA_CHAT_AZURE_OPENAI_API_KEY` | No | Default API key for Azure AI Foundry chat (can be overridden per conversation/team/org) |
 
 ### Getting an Azure API Key
 
 You can generate an API key from the [Azure Portal](https://portal.azure.com/#view/Microsoft_Azure_ProjectOxford/CognitiveServicesHub/~/OpenAI) under your Azure OpenAI resource.
+
+### Keyless Authentication with Microsoft Entra ID
+
+To use Azure OpenAI without storing an API key, set:
+
+```bash
+ARCHESTRA_AZURE_OPENAI_ENTRA_ID_ENABLED=true
+ARCHESTRA_AZURE_OPENAI_BASE_URL=https://<resource-name>.openai.azure.com/openai/deployments/<deployment-name>
+```
+
+Archestra uses Azure Identity `DefaultAzureCredential` with the Azure OpenAI token scope. Assign the workload identity, managed identity, service principal, or local Azure CLI user a role that can invoke the Azure OpenAI resource.
+
+See the [Azure OpenAI keyless example](https://github.com/archestra-ai/examples/tree/main/azure-openai-keyless) for a minimal local script that uses the same authentication flow.
 
 ### Base URL Format
 
@@ -688,6 +702,7 @@ The same format applies when configuring a Base URL in the API key settings UI.
 ### Notes
 
 - **API Version**: Chat Completions and model discovery use `ARCHESTRA_AZURE_OPENAI_API_VERSION`. Azure `/responses` requests use `ARCHESTRA_AZURE_OPENAI_RESPONSES_API_VERSION`. You do not need to include either query parameter in the base URL.
+- **Microsoft Entra ID**: When `ARCHESTRA_AZURE_OPENAI_ENTRA_ID_ENABLED=true`, Archestra creates a system provider key at startup and sends `Authorization: Bearer <token>` to Azure OpenAI instead of `api-key`.
 - **Multiple Deployments**: To use multiple Azure deployments, create separate API key entries in Settings, each with its own deployment URL as the Base URL.
 - **Deployment URL configuration**: Keep using the deployment-specific base URL format shown above. Archestra derives the correct upstream endpoint automatically for both `/chat/completions` and `/responses` requests.
 - **Responses API model field**: For Azure `/responses` requests, send the deployment name in the `model` field. Archestra will route the request to Azure's `/openai/responses` endpoint while preserving the configured deployment URL for discovery and management.

--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -73,6 +73,14 @@ Model Router translation is text-first. Anthropic, Gemini, and Cohere routes cur
 - **Base URL**: `http://localhost:9000/v1/anthropic/{profile-id}`
 - **Authentication**: Pass your Anthropic API key in the `x-api-key` header
 
+### Anthropic on Microsoft Foundry
+
+Claude models deployed in Microsoft Foundry use the Anthropic Messages API at `https://<resource>.services.ai.azure.com/anthropic`. Set `ARCHESTRA_ANTHROPIC_BASE_URL` to that `/anthropic` base URL. For keyless Microsoft Entra ID authentication, also set `ARCHESTRA_ANTHROPIC_AZURE_FOUNDRY_ENTRA_ID_ENABLED=true`; Archestra sends a bearer token scoped to `https://ai.azure.com/.default`.
+
+Claude Foundry deployments must exist in Azure before requests will work. Use the deployed Claude model name in the Anthropic `model` field.
+
+See Microsoft's [Claude on Foundry guide](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/how-to/use-foundry-models-claude) for the Azure endpoint and authentication details.
+
 ## Google Gemini
 
 Archestra supports both the [Google AI Studio](https://ai.google.dev/) (Gemini Developer API) and [Vertex AI](https://cloud.google.com/vertex-ai) implementations of the Gemini API.
@@ -664,7 +672,7 @@ Known region prefixes: `us`, `eu`, `ap`, `global`.
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `ARCHESTRA_AZURE_OPENAI_BASE_URL` | Yes | Full deployment URL: `https://<resource>.openai.azure.com/openai/deployments/<deployment>` |
+| `ARCHESTRA_AZURE_OPENAI_BASE_URL` | Yes | Azure OpenAI deployment URL or Foundry v1 URL |
 | `ARCHESTRA_AZURE_OPENAI_API_VERSION` | No | Azure OpenAI API version (default: `2024-02-01`) |
 | `ARCHESTRA_AZURE_OPENAI_RESPONSES_API_VERSION` | No | Azure Responses API version (default: `2025-04-01-preview`) |
 | `ARCHESTRA_AZURE_OPENAI_ENTRA_ID_ENABLED` | No | Set to `true` to use Microsoft Entra ID instead of an Azure API key |
@@ -683,13 +691,21 @@ ARCHESTRA_AZURE_OPENAI_ENTRA_ID_ENABLED=true
 ARCHESTRA_AZURE_OPENAI_BASE_URL=https://<resource-name>.openai.azure.com/openai/deployments/<deployment-name>
 ```
 
-Archestra uses Azure Identity `DefaultAzureCredential` with the Azure OpenAI token scope. Assign the workload identity, managed identity, service principal, or local Azure CLI user a role that can invoke the Azure OpenAI resource.
+For Foundry v1, use:
+
+```bash
+ARCHESTRA_AZURE_OPENAI_ENTRA_ID_ENABLED=true
+ARCHESTRA_AZURE_OPENAI_BASE_URL=https://<resource-name>.services.ai.azure.com/openai/v1
+```
+
+Archestra uses Azure Identity `DefaultAzureCredential`. Deployment URLs use the `https://cognitiveservices.azure.com/.default` token scope. Foundry v1 URLs use `https://ai.azure.com/.default`. Assign the workload identity, managed identity, service principal, or local Azure CLI user a role that can invoke the Azure resource.
 
 See the [Azure OpenAI keyless example](https://github.com/archestra-ai/examples/tree/main/azure-openai-keyless) for a minimal local script that uses the same authentication flow.
+See Microsoft's [Foundry Models Entra ID guide](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/how-to/configure-entra-id) and [Foundry Models endpoint guide](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/endpoints) for the Azure endpoint formats and token scopes.
 
 ### Base URL Format
 
-The `ARCHESTRA_AZURE_OPENAI_BASE_URL` must be the full deployment URL including the deployment name:
+For Azure OpenAI deployment URLs, include the deployment name:
 
 ```
 https://<resource-name>.openai.azure.com/openai/deployments/<deployment-name>
@@ -697,13 +713,20 @@ https://<resource-name>.openai.azure.com/openai/deployments/<deployment-name>
 
 For example: `https://my-company.openai.azure.com/openai/deployments/gpt-4o`
 
+For Microsoft Foundry v1, use the OpenAI-compatible API root:
+
+```
+https://<resource-name>.services.ai.azure.com/openai/v1
+```
+
 The same format applies when configuring a Base URL in the API key settings UI.
 
 ### Notes
 
-- **API Version**: Chat Completions and model discovery use `ARCHESTRA_AZURE_OPENAI_API_VERSION`. Azure `/responses` requests use `ARCHESTRA_AZURE_OPENAI_RESPONSES_API_VERSION`. You do not need to include either query parameter in the base URL.
+- **API Version**: Deployment URLs use `ARCHESTRA_AZURE_OPENAI_API_VERSION` for Chat Completions and model discovery. Azure `/responses` requests use `ARCHESTRA_AZURE_OPENAI_RESPONSES_API_VERSION`. Foundry v1 URLs do not use either query parameter.
 - **Microsoft Entra ID**: When `ARCHESTRA_AZURE_OPENAI_ENTRA_ID_ENABLED=true`, Archestra creates a system provider key at startup and sends `Authorization: Bearer <token>` to Azure OpenAI instead of `api-key`.
-- **Multiple Deployments**: To use multiple Azure deployments, create separate API key entries in Settings, each with its own deployment URL as the Base URL.
+- **Grok on Azure**: Grok models sold directly by Azure use the Foundry v1 OpenAI-compatible Chat Completions API. The model must be deployed in the Azure resource before Archestra can route to it.
+- **Multiple Deployments**: With deployment URLs, create separate API key entries in Settings, each with its own deployment URL as the Base URL. With Foundry v1, send the deployed model name in the request `model` field.
 - **Deployment URL configuration**: Keep using the deployment-specific base URL format shown above. Archestra derives the correct upstream endpoint automatically for both `/chat/completions` and `/responses` requests.
 - **Responses API model field**: For Azure `/responses` requests, send the deployment name in the `model` field. Archestra will route the request to Azure's `/openai/responses` endpoint while preserving the configured deployment URL for discovery and management.
 - **OpenAI-compatible API**: Azure AI Foundry supports both Chat Completions and Responses-style request flows through Archestra.

--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -707,6 +707,53 @@ Archestra uses Azure Identity `DefaultAzureCredential`. Deployment URLs use the 
 See the [Azure OpenAI keyless example](https://github.com/archestra-ai/examples/tree/main/azure-openai-keyless) for a minimal local script that uses the same authentication flow.
 See Microsoft's [Foundry Models Entra ID guide](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/how-to/configure-entra-id) and [Foundry Models endpoint guide](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/endpoints) for the Azure endpoint formats and token scopes.
 
+#### AKS with Microsoft Entra Workload ID
+
+For AKS deployments, use [Microsoft Entra Workload ID](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview) with a user-assigned managed identity. Microsoft documents that Azure Identity `DefaultAzureCredential` uses the workload identity environment injected into the pod.
+
+Enable OIDC issuer and workload identity on the AKS cluster, create a federated identity credential for the Archestra Kubernetes service account, and grant the managed identity the inference role required by the resource: `Cognitive Services OpenAI User` for Azure OpenAI deployment URLs, or `Cognitive Services User` for Foundry Models. The service account subject must match the namespace and service account name used by the Helm release:
+
+```bash
+az aks update \
+  --resource-group "$AKS_RESOURCE_GROUP" \
+  --name "$AKS_CLUSTER_NAME" \
+  --enable-oidc-issuer \
+  --enable-workload-identity
+
+export AKS_OIDC_ISSUER="$(az aks show \
+  --resource-group "$AKS_RESOURCE_GROUP" \
+  --name "$AKS_CLUSTER_NAME" \
+  --query oidcIssuerProfile.issuerUrl \
+  --output tsv)"
+
+az identity federated-credential create \
+  --resource-group "$IDENTITY_RESOURCE_GROUP" \
+  --identity-name "$USER_ASSIGNED_IDENTITY_NAME" \
+  --name archestra-platform \
+  --issuer "$AKS_OIDC_ISSUER" \
+  --subject "system:serviceaccount:$NAMESPACE:$SERVICE_ACCOUNT_NAME" \
+  --audience api://AzureADTokenExchange
+```
+
+Then annotate the Helm service account and add the pod label required by the AKS workload identity webhook:
+
+```yaml
+archestra:
+  orchestrator:
+    kubernetes:
+      serviceAccount:
+        name: archestra-platform
+        annotations:
+          azure.workload.identity/client-id: "<user-assigned-managed-identity-client-id>"
+  podLabels:
+    azure.workload.identity/use: "true"
+  env:
+    ARCHESTRA_AZURE_OPENAI_ENTRA_ID_ENABLED: "true"
+    ARCHESTRA_AZURE_OPENAI_BASE_URL: "https://<resource-name>.services.ai.azure.com/openai/v1"
+```
+
+See Microsoft's [AKS Workload ID deployment guide](https://learn.microsoft.com/en-us/azure/aks/workload-identity-deploy-cluster) for the full cluster, service account, and federated credential setup.
+
 ### Base URL Format
 
 For Azure OpenAI deployment URLs, include the deployment name:

--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -72,12 +72,15 @@ Model Router translation is text-first. Anthropic, Gemini, and Cohere routes cur
 
 - **Base URL**: `http://localhost:9000/v1/anthropic/{profile-id}`
 - **Authentication**: Pass your Anthropic API key in the `x-api-key` header
+- **Messages path**: `POST /v1/anthropic/{profile-id}/v1/messages`
 
 ### Anthropic on Microsoft Foundry
 
 Claude models deployed in Microsoft Foundry use the Anthropic Messages API at `https://<resource>.services.ai.azure.com/anthropic`. Set `ARCHESTRA_ANTHROPIC_BASE_URL` to that `/anthropic` base URL. For keyless Microsoft Entra ID authentication, also set `ARCHESTRA_ANTHROPIC_AZURE_FOUNDRY_ENTRA_ID_ENABLED=true`; Archestra sends a bearer token scoped to `https://ai.azure.com/.default`.
 
-Claude Foundry deployments must exist in Azure before requests will work. Use the deployed Claude model name in the Anthropic `model` field.
+Claude Foundry deployments must exist in Azure before requests will work. Use the deployed Claude model name in the Anthropic `model` field. Microsoft lists extra Claude prerequisites: a paid eligible Azure subscription, a supported region such as East US2 or Sweden Central, Azure Marketplace access for partner models, permission to subscribe to model offerings, and Contributor or Owner role on the resource group.
+
+Azure requires Anthropic deployment metadata when creating Claude deployments: `industry`, `organizationName`, and `countryCode`. In Azure CLI this may require an ARM REST deployment call with `properties.modelProviderData`.
 
 See Microsoft's [Claude on Foundry guide](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/how-to/use-foundry-models-claude) for the Azure endpoint and authentication details.
 
@@ -666,7 +669,8 @@ Known region prefixes: `us`, `eu`, `ap`, `global`.
 ### Azure AI Foundry Connection Details
 
 - **Base URL**: `http://localhost:9000/v1/azure/{profile-id}`
-- **Authentication**: Pass your Azure API key in the `Authorization` header as `Bearer <your-api-key>`
+- **API key authentication**: Pass your Azure API key in the `Authorization` header as `Bearer <your-api-key>`
+- **Keyless authentication**: Set `ARCHESTRA_AZURE_OPENAI_ENTRA_ID_ENABLED=true` and assign the workload identity, managed identity, service principal, or local Azure CLI user an Azure role that can invoke the deployed model.
 
 ### Azure AI Foundry Environment Variables
 
@@ -726,6 +730,7 @@ The same format applies when configuring a Base URL in the API key settings UI.
 - **API Version**: Deployment URLs use `ARCHESTRA_AZURE_OPENAI_API_VERSION` for Chat Completions and model discovery. Azure `/responses` requests use `ARCHESTRA_AZURE_OPENAI_RESPONSES_API_VERSION`. Foundry v1 URLs do not use either query parameter.
 - **Microsoft Entra ID**: When `ARCHESTRA_AZURE_OPENAI_ENTRA_ID_ENABLED=true`, Archestra creates a system provider key at startup and sends `Authorization: Bearer <token>` to Azure OpenAI instead of `api-key`.
 - **Grok on Azure**: Grok models sold directly by Azure use the Foundry v1 OpenAI-compatible Chat Completions API. The model must be deployed in the Azure resource before Archestra can route to it.
+- **Claude on Azure**: Claude models on Microsoft Foundry use Anthropic's Messages API shape, not the OpenAI-compatible Azure route. Configure the Anthropic provider section above.
 - **Multiple Deployments**: With deployment URLs, create separate API key entries in Settings, each with its own deployment URL as the Base URL. With Foundry v1, send the deployed model name in the request `model` field.
 - **Deployment URL configuration**: Keep using the deployment-specific base URL format shown above. Archestra derives the correct upstream endpoint automatically for both `/chat/completions` and `/responses` requests.
 - **Responses API model field**: For Azure `/responses` requests, send the deployment name in the `model` field. Archestra will route the request to Azure's `/openai/responses` endpoint while preserving the configured deployment URL for discovery and management.

--- a/platform/backend/src/clients/azure-openai-credentials.test.ts
+++ b/platform/backend/src/clients/azure-openai-credentials.test.ts
@@ -26,7 +26,6 @@ import {
   getAzureOpenAiBearerTokenProvider,
   isAnthropicAzureFoundryEntraIdEnabled,
   isAzureOpenAiEntraIdEnabled,
-  isAzureOpenAiV1BaseUrl,
 } from "./azure-openai-credentials";
 
 describe("azure-openai-credentials", () => {
@@ -62,18 +61,5 @@ describe("azure-openai-credentials", () => {
       expect.anything(),
       "https://ai.azure.com/.default",
     );
-  });
-
-  test("detects Azure OpenAI v1 base URLs", () => {
-    expect(
-      isAzureOpenAiV1BaseUrl(
-        "https://resource.services.ai.azure.com/openai/v1",
-      ),
-    ).toBe(true);
-    expect(
-      isAzureOpenAiV1BaseUrl(
-        "https://resource.openai.azure.com/openai/deployments/gpt-4o",
-      ),
-    ).toBe(false);
   });
 });

--- a/platform/backend/src/clients/azure-openai-credentials.test.ts
+++ b/platform/backend/src/clients/azure-openai-credentials.test.ts
@@ -13,24 +13,35 @@ vi.mock("@/config", () => ({
       azure: {
         entraIdEnabled: true,
       },
+      anthropic: {
+        azureFoundryEntraIdEnabled: true,
+      },
     },
   },
 }));
 
 import { getBearerTokenProvider } from "@azure/identity";
 import {
+  getAzureAiFoundryBearerTokenProvider,
   getAzureOpenAiBearerTokenProvider,
+  isAnthropicAzureFoundryEntraIdEnabled,
   isAzureOpenAiEntraIdEnabled,
+  isAzureOpenAiV1BaseUrl,
 } from "./azure-openai-credentials";
 
 describe("azure-openai-credentials", () => {
   test("reports Entra ID auth as enabled from config", () => {
     expect(isAzureOpenAiEntraIdEnabled()).toBe(true);
+    expect(isAnthropicAzureFoundryEntraIdEnabled()).toBe(true);
   });
 
   test("creates a cached bearer token provider with the Azure OpenAI scope", () => {
-    const provider = getAzureOpenAiBearerTokenProvider();
-    const sameProvider = getAzureOpenAiBearerTokenProvider();
+    const provider = getAzureOpenAiBearerTokenProvider(
+      "https://resource.openai.azure.com/openai/deployments/gpt-4o",
+    );
+    const sameProvider = getAzureOpenAiBearerTokenProvider(
+      "https://resource.openai.azure.com/openai/deployments/gpt-4o",
+    );
 
     expect(provider).toBe(sameProvider);
     expect(getBearerTokenProvider).toHaveBeenCalledTimes(1);
@@ -38,5 +49,31 @@ describe("azure-openai-credentials", () => {
       expect.anything(),
       "https://cognitiveservices.azure.com/.default",
     );
+  });
+
+  test("uses the Azure AI Foundry scope for v1 endpoints", () => {
+    const provider = getAzureOpenAiBearerTokenProvider(
+      "https://resource.services.ai.azure.com/openai/v1",
+    );
+    const sameProvider = getAzureAiFoundryBearerTokenProvider();
+
+    expect(provider).toBe(sameProvider);
+    expect(getBearerTokenProvider).toHaveBeenCalledWith(
+      expect.anything(),
+      "https://ai.azure.com/.default",
+    );
+  });
+
+  test("detects Azure OpenAI v1 base URLs", () => {
+    expect(
+      isAzureOpenAiV1BaseUrl(
+        "https://resource.services.ai.azure.com/openai/v1",
+      ),
+    ).toBe(true);
+    expect(
+      isAzureOpenAiV1BaseUrl(
+        "https://resource.openai.azure.com/openai/deployments/gpt-4o",
+      ),
+    ).toBe(false);
   });
 });

--- a/platform/backend/src/clients/azure-openai-credentials.test.ts
+++ b/platform/backend/src/clients/azure-openai-credentials.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("@azure/identity", () => ({
+  DefaultAzureCredential: vi.fn(function DefaultAzureCredential() {
+    return { kind: "default" };
+  }),
+  getBearerTokenProvider: vi.fn(() => async () => "token"),
+}));
+
+vi.mock("@/config", () => ({
+  default: {
+    llm: {
+      azure: {
+        entraIdEnabled: true,
+      },
+    },
+  },
+}));
+
+import { getBearerTokenProvider } from "@azure/identity";
+import {
+  getAzureOpenAiBearerTokenProvider,
+  isAzureOpenAiEntraIdEnabled,
+} from "./azure-openai-credentials";
+
+describe("azure-openai-credentials", () => {
+  test("reports Entra ID auth as enabled from config", () => {
+    expect(isAzureOpenAiEntraIdEnabled()).toBe(true);
+  });
+
+  test("creates a cached bearer token provider with the Azure OpenAI scope", () => {
+    const provider = getAzureOpenAiBearerTokenProvider();
+    const sameProvider = getAzureOpenAiBearerTokenProvider();
+
+    expect(provider).toBe(sameProvider);
+    expect(getBearerTokenProvider).toHaveBeenCalledTimes(1);
+    expect(getBearerTokenProvider).toHaveBeenCalledWith(
+      expect.anything(),
+      "https://cognitiveservices.azure.com/.default",
+    );
+  });
+});

--- a/platform/backend/src/clients/azure-openai-credentials.ts
+++ b/platform/backend/src/clients/azure-openai-credentials.ts
@@ -27,7 +27,7 @@ export function getAzureAiFoundryBearerTokenProvider(): () => Promise<string> {
   return getAzureBearerTokenProvider(AZURE_AI_FOUNDRY_TOKEN_SCOPE);
 }
 
-export function isAzureOpenAiV1BaseUrl(baseUrl?: string): boolean {
+function isAzureOpenAiV1BaseUrl(baseUrl?: string): boolean {
   if (!baseUrl) {
     return false;
   }

--- a/platform/backend/src/clients/azure-openai-credentials.ts
+++ b/platform/backend/src/clients/azure-openai-credentials.ts
@@ -1,0 +1,24 @@
+import {
+  DefaultAzureCredential,
+  getBearerTokenProvider,
+} from "@azure/identity";
+import config from "@/config";
+
+const AZURE_OPENAI_TOKEN_SCOPE = "https://cognitiveservices.azure.com/.default";
+
+let azureOpenAiBearerTokenProvider: (() => Promise<string>) | null = null;
+
+export function isAzureOpenAiEntraIdEnabled(): boolean {
+  return config.llm.azure.entraIdEnabled;
+}
+
+export function getAzureOpenAiBearerTokenProvider(): () => Promise<string> {
+  if (!azureOpenAiBearerTokenProvider) {
+    azureOpenAiBearerTokenProvider = getBearerTokenProvider(
+      new DefaultAzureCredential(),
+      AZURE_OPENAI_TOKEN_SCOPE,
+    );
+  }
+
+  return azureOpenAiBearerTokenProvider;
+}

--- a/platform/backend/src/clients/azure-openai-credentials.ts
+++ b/platform/backend/src/clients/azure-openai-credentials.ts
@@ -2,6 +2,7 @@ import {
   DefaultAzureCredential,
   getBearerTokenProvider,
 } from "@azure/identity";
+import { isAzureOpenAiV1BaseUrl } from "@/clients/azure-url";
 import config from "@/config";
 
 const AZURE_OPENAI_TOKEN_SCOPE = "https://cognitiveservices.azure.com/.default";
@@ -25,19 +26,6 @@ export function getAzureOpenAiBearerTokenProvider(
 
 export function getAzureAiFoundryBearerTokenProvider(): () => Promise<string> {
   return getAzureBearerTokenProvider(AZURE_AI_FOUNDRY_TOKEN_SCOPE);
-}
-
-function isAzureOpenAiV1BaseUrl(baseUrl?: string): boolean {
-  if (!baseUrl) {
-    return false;
-  }
-
-  try {
-    const url = new URL(baseUrl);
-    return /\/openai\/v1\/?$/.test(url.pathname);
-  } catch {
-    return false;
-  }
 }
 
 function resolveAzureOpenAiTokenScope(baseUrl?: string): string {

--- a/platform/backend/src/clients/azure-openai-credentials.ts
+++ b/platform/backend/src/clients/azure-openai-credentials.ts
@@ -5,20 +5,53 @@ import {
 import config from "@/config";
 
 const AZURE_OPENAI_TOKEN_SCOPE = "https://cognitiveservices.azure.com/.default";
+const AZURE_AI_FOUNDRY_TOKEN_SCOPE = "https://ai.azure.com/.default";
 
-let azureOpenAiBearerTokenProvider: (() => Promise<string>) | null = null;
+const azureBearerTokenProviders = new Map<string, () => Promise<string>>();
 
 export function isAzureOpenAiEntraIdEnabled(): boolean {
   return config.llm.azure.entraIdEnabled;
 }
 
-export function getAzureOpenAiBearerTokenProvider(): () => Promise<string> {
-  if (!azureOpenAiBearerTokenProvider) {
-    azureOpenAiBearerTokenProvider = getBearerTokenProvider(
-      new DefaultAzureCredential(),
-      AZURE_OPENAI_TOKEN_SCOPE,
-    );
+export function isAnthropicAzureFoundryEntraIdEnabled(): boolean {
+  return config.llm.anthropic.azureFoundryEntraIdEnabled;
+}
+
+export function getAzureOpenAiBearerTokenProvider(
+  baseUrl?: string,
+): () => Promise<string> {
+  return getAzureBearerTokenProvider(resolveAzureOpenAiTokenScope(baseUrl));
+}
+
+export function getAzureAiFoundryBearerTokenProvider(): () => Promise<string> {
+  return getAzureBearerTokenProvider(AZURE_AI_FOUNDRY_TOKEN_SCOPE);
+}
+
+export function isAzureOpenAiV1BaseUrl(baseUrl?: string): boolean {
+  if (!baseUrl) {
+    return false;
   }
 
-  return azureOpenAiBearerTokenProvider;
+  try {
+    const url = new URL(baseUrl);
+    return /\/openai\/v1\/?$/.test(url.pathname);
+  } catch {
+    return false;
+  }
+}
+
+function resolveAzureOpenAiTokenScope(baseUrl?: string): string {
+  return isAzureOpenAiV1BaseUrl(baseUrl)
+    ? AZURE_AI_FOUNDRY_TOKEN_SCOPE
+    : AZURE_OPENAI_TOKEN_SCOPE;
+}
+
+function getAzureBearerTokenProvider(scope: string): () => Promise<string> {
+  let provider = azureBearerTokenProviders.get(scope);
+  if (!provider) {
+    provider = getBearerTokenProvider(new DefaultAzureCredential(), scope);
+    azureBearerTokenProviders.set(scope, provider);
+  }
+
+  return provider;
 }

--- a/platform/backend/src/clients/azure-url.test.ts
+++ b/platform/backend/src/clients/azure-url.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "@/test";
 import {
   buildAzureDeploymentsUrl,
+  buildAzureOpenAiV1ModelsUrl,
   buildAzureResponsesBaseUrl,
   createAzureFetchWithApiVersion,
   extractAzureDeploymentName,
@@ -59,6 +60,28 @@ describe("buildAzureDeploymentsUrl", () => {
     ).toBe(
       "https://my-resource.openai.azure.com/openai/deployments?api-version=2024-02-01",
     );
+  });
+});
+
+describe("buildAzureOpenAiV1ModelsUrl", () => {
+  it("builds a models URL from a Foundry v1 base URL", () => {
+    expect(
+      buildAzureOpenAiV1ModelsUrl(
+        "https://my-resource.services.ai.azure.com/openai/v1",
+      ),
+    ).toBe("https://my-resource.services.ai.azure.com/openai/v1/models");
+  });
+
+  it("returns null for deployment-scoped URLs", () => {
+    expect(
+      buildAzureOpenAiV1ModelsUrl(
+        "https://my-resource.openai.azure.com/openai/deployments/gpt-4o",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for invalid URLs", () => {
+    expect(buildAzureOpenAiV1ModelsUrl("not-a-valid-url")).toBeNull();
   });
 });
 
@@ -195,6 +218,10 @@ describe("isAzureAiFoundryBaseUrl", () => {
     expect(
       isAzureAiFoundryBaseUrl("https://my-resource.services.ai.azure.com"),
     ).toBe(true);
+  });
+
+  it("returns true for the Azure AI Foundry root hostname", () => {
+    expect(isAzureAiFoundryBaseUrl("https://ai.azure.com")).toBe(true);
   });
 
   it("returns false for the public Anthropic API hostname", () => {

--- a/platform/backend/src/clients/azure-url.test.ts
+++ b/platform/backend/src/clients/azure-url.test.ts
@@ -4,6 +4,8 @@ import {
   buildAzureResponsesBaseUrl,
   createAzureFetchWithApiVersion,
   extractAzureDeploymentName,
+  isAzureAiFoundryBaseUrl,
+  isAzureOpenAiV1BaseUrl,
   normalizeAzureApiKey,
 } from "./azure-url";
 
@@ -163,6 +165,44 @@ describe("normalizeAzureApiKey", () => {
 
   it("returns undefined when the key is undefined", () => {
     expect(normalizeAzureApiKey(undefined)).toBeUndefined();
+  });
+});
+
+describe("isAzureOpenAiV1BaseUrl", () => {
+  it("returns true for Foundry v1 OpenAI endpoints", () => {
+    expect(
+      isAzureOpenAiV1BaseUrl(
+        "https://my-resource.services.ai.azure.com/openai/v1",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for deployment-scoped Azure OpenAI endpoints", () => {
+    expect(
+      isAzureOpenAiV1BaseUrl(
+        "https://my-resource.openai.azure.com/openai/deployments/gpt-4o",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for invalid URLs", () => {
+    expect(isAzureOpenAiV1BaseUrl("not-a-valid-url")).toBe(false);
+  });
+});
+
+describe("isAzureAiFoundryBaseUrl", () => {
+  it("returns true for Azure AI Foundry resource hostnames", () => {
+    expect(
+      isAzureAiFoundryBaseUrl("https://my-resource.services.ai.azure.com"),
+    ).toBe(true);
+  });
+
+  it("returns false for the public Anthropic API hostname", () => {
+    expect(isAzureAiFoundryBaseUrl("https://api.anthropic.com")).toBe(false);
+  });
+
+  it("returns false for invalid URLs", () => {
+    expect(isAzureAiFoundryBaseUrl("not-a-valid-url")).toBe(false);
   });
 });
 

--- a/platform/backend/src/clients/azure-url.ts
+++ b/platform/backend/src/clients/azure-url.ts
@@ -70,6 +70,33 @@ export function shouldUseAzureOpenAiApiVersion(baseUrl: string | undefined) {
   }
 }
 
+export function isAzureOpenAiV1BaseUrl(baseUrl: string | undefined): boolean {
+  if (!baseUrl) {
+    return false;
+  }
+
+  try {
+    return isAzureOpenAiV1Url(new URL(baseUrl));
+  } catch {
+    return false;
+  }
+}
+
+export function isAzureAiFoundryBaseUrl(baseUrl: string | undefined): boolean {
+  if (!baseUrl) {
+    return false;
+  }
+
+  try {
+    const url = new URL(baseUrl);
+    return (
+      url.hostname === "ai.azure.com" || url.hostname.endsWith(".ai.azure.com")
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function createAzureFetchWithApiVersion(params: {
   apiVersion: string;
   fetch?: typeof globalThis.fetch;

--- a/platform/backend/src/clients/azure-url.ts
+++ b/platform/backend/src/clients/azure-url.ts
@@ -4,6 +4,10 @@ export function buildAzureDeploymentsUrl(params: {
 }): string | null {
   try {
     const url = new URL(params.baseUrl);
+    if (isAzureOpenAiV1Url(url)) {
+      return null;
+    }
+
     // Expected input is the Azure deployment base URL:
     // https://<resource>.openai.azure.com/openai/deployments/<deployment>
     const pathname = url.pathname.replace(/\/[^/]+\/?$/, "");
@@ -13,9 +17,26 @@ export function buildAzureDeploymentsUrl(params: {
   }
 }
 
+export function buildAzureOpenAiV1ModelsUrl(baseUrl: string): string | null {
+  try {
+    const url = new URL(baseUrl);
+    if (!isAzureOpenAiV1Url(url)) {
+      return null;
+    }
+
+    return `${url.origin}${url.pathname.replace(/\/+$/, "")}/models`;
+  } catch {
+    return null;
+  }
+}
+
 export function buildAzureResponsesBaseUrl(baseUrl: string): string | null {
   try {
     const url = new URL(baseUrl);
+    if (isAzureOpenAiV1Url(url)) {
+      return `${url.origin}${url.pathname.replace(/\/+$/, "")}`;
+    }
+
     if (!/\/deployments\/[^/]+\/?$/.test(url.pathname)) {
       return null;
     }
@@ -34,6 +55,18 @@ export function extractAzureDeploymentName(baseUrl: string): string | null {
     return segments.at(-1) ?? null;
   } catch {
     return null;
+  }
+}
+
+export function shouldUseAzureOpenAiApiVersion(baseUrl: string | undefined) {
+  if (!baseUrl) {
+    return true;
+  }
+
+  try {
+    return !isAzureOpenAiV1Url(new URL(baseUrl));
+  } catch {
+    return true;
   }
 }
 
@@ -70,4 +103,8 @@ function getRequestUrl(input: URL | RequestInfo): string {
   }
 
   return input.url;
+}
+
+function isAzureOpenAiV1Url(url: URL): boolean {
+  return /\/openai\/v1\/?$/.test(url.pathname);
 }

--- a/platform/backend/src/clients/azure-url.ts
+++ b/platform/backend/src/clients/azure-url.ts
@@ -5,6 +5,7 @@ export function buildAzureDeploymentsUrl(params: {
   try {
     const url = new URL(params.baseUrl);
     if (isAzureOpenAiV1Url(url)) {
+      // Foundry v1 endpoints use /openai/v1/models instead of deployment discovery.
       return null;
     }
 

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -671,6 +671,8 @@ const config = {
       responsesApiVersion:
         process.env.ARCHESTRA_AZURE_OPENAI_RESPONSES_API_VERSION ||
         "2025-04-01-preview",
+      entraIdEnabled:
+        process.env.ARCHESTRA_AZURE_OPENAI_ENTRA_ID_ENABLED === "true",
     },
   },
   chat: {

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -584,6 +584,9 @@ const config = {
     anthropic: {
       baseUrl:
         process.env.ARCHESTRA_ANTHROPIC_BASE_URL || "https://api.anthropic.com",
+      azureFoundryEntraIdEnabled:
+        process.env.ARCHESTRA_ANTHROPIC_AZURE_FOUNDRY_ENTRA_ID_ENABLED ===
+        "true",
     },
     gemini: {
       baseUrl:

--- a/platform/backend/src/routes/chat/model-fetchers/anthropic.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/anthropic.ts
@@ -1,3 +1,7 @@
+import {
+  getAzureAiFoundryBearerTokenProvider,
+  isAnthropicAzureFoundryEntraIdEnabled,
+} from "@/clients/azure-openai-credentials";
 import config from "@/config";
 import logger from "@/logging";
 import type { Anthropic } from "@/types";
@@ -14,7 +18,7 @@ export async function fetchAnthropicModels(
   const response = await fetch(url, {
     headers: {
       ...(extraHeaders ?? {}),
-      "x-api-key": apiKey,
+      ...(await getAnthropicAuthHeaders(apiKey)),
       "anthropic-version": "2023-06-01",
     },
   });
@@ -38,4 +42,19 @@ export async function fetchAnthropicModels(
     provider: "anthropic",
     createdAt: model.created_at,
   }));
+}
+
+async function getAnthropicAuthHeaders(
+  apiKey: string | undefined,
+): Promise<Record<string, string>> {
+  if (apiKey) {
+    return { "x-api-key": apiKey };
+  }
+
+  if (!isAnthropicAzureFoundryEntraIdEnabled()) {
+    return { "x-api-key": "" };
+  }
+
+  const tokenProvider = getAzureAiFoundryBearerTokenProvider();
+  return { Authorization: `Bearer ${await tokenProvider()}` };
 }

--- a/platform/backend/src/routes/chat/model-fetchers/azure.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/azure.test.ts
@@ -17,6 +17,15 @@ vi.mock("@/logging", () => ({
   default: { warn: vi.fn(), error: vi.fn() },
 }));
 
+vi.mock("@/clients/azure-openai-credentials", () => ({
+  getAzureOpenAiBearerTokenProvider: vi.fn(() => async () => "entra-token"),
+  isAzureOpenAiEntraIdEnabled: vi.fn(() => false),
+}));
+
+import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
+
+const mockIsAzureOpenAiEntraIdEnabled = vi.mocked(isAzureOpenAiEntraIdEnabled);
+
 describe("fetchAzureModels", () => {
   test("returns empty array when baseUrl is empty and no override", async () => {
     const result = await fetchAzureModels("test-key", null);
@@ -78,6 +87,29 @@ describe("fetchAzureModels", () => {
       { headers: { "api-key": "test-key" } },
     );
 
+    vi.unstubAllGlobals();
+  });
+
+  test("uses Entra ID bearer token auth when enabled and no API key is provided", async () => {
+    mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(true);
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ id: "gpt-4o" }] }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fetchAzureModels(
+      "",
+      "https://my-resource.openai.azure.com/openai/deployments/gpt-4o",
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://my-resource.openai.azure.com/openai/deployments?api-version=2024-02-01",
+      { headers: { Authorization: "Bearer entra-token" } },
+    );
+
+    mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(false);
     vi.unstubAllGlobals();
   });
 

--- a/platform/backend/src/routes/chat/model-fetchers/azure.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/azure.test.ts
@@ -22,9 +22,15 @@ vi.mock("@/clients/azure-openai-credentials", () => ({
   isAzureOpenAiEntraIdEnabled: vi.fn(() => false),
 }));
 
-import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
+import {
+  getAzureOpenAiBearerTokenProvider,
+  isAzureOpenAiEntraIdEnabled,
+} from "@/clients/azure-openai-credentials";
 
 const mockIsAzureOpenAiEntraIdEnabled = vi.mocked(isAzureOpenAiEntraIdEnabled);
+const mockGetAzureOpenAiBearerTokenProvider = vi.mocked(
+  getAzureOpenAiBearerTokenProvider,
+);
 
 describe("fetchAzureModels", () => {
   test("returns empty array when baseUrl is empty and no override", async () => {
@@ -106,6 +112,42 @@ describe("fetchAzureModels", () => {
 
     expect(mockFetch).toHaveBeenCalledWith(
       "https://my-resource.openai.azure.com/openai/deployments?api-version=2024-02-01",
+      { headers: { Authorization: "Bearer entra-token" } },
+    );
+    expect(mockGetAzureOpenAiBearerTokenProvider).toHaveBeenCalledWith(
+      "https://my-resource.openai.azure.com/openai/deployments/gpt-4o",
+    );
+
+    mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(false);
+    vi.unstubAllGlobals();
+  });
+
+  test("lists chat models from Azure OpenAI v1 model endpoint", async () => {
+    mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(true);
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { id: "gpt-4.1", capabilities: { chat_completion: true } },
+          { id: "grok-3", capabilities: { chat_completion: true } },
+          { id: "text-embedding", capabilities: { chat_completion: false } },
+        ],
+      }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await fetchAzureModels(
+      "",
+      "https://my-resource.services.ai.azure.com/openai/v1",
+    );
+
+    expect(result).toEqual([
+      { id: "gpt-4.1", displayName: "gpt-4.1", provider: "azure" },
+      { id: "grok-3", displayName: "grok-3", provider: "azure" },
+    ]);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://my-resource.services.ai.azure.com/openai/v1/models",
       { headers: { Authorization: "Bearer entra-token" } },
     );
 

--- a/platform/backend/src/routes/chat/model-fetchers/azure.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/azure.ts
@@ -1,4 +1,8 @@
 import {
+  getAzureOpenAiBearerTokenProvider,
+  isAzureOpenAiEntraIdEnabled,
+} from "@/clients/azure-openai-credentials";
+import {
   buildAzureDeploymentsUrl,
   extractAzureDeploymentName,
   normalizeAzureApiKey,
@@ -30,11 +34,11 @@ export async function fetchAzureModels(
   try {
     // Azure lists deployments at GET /openai/deployments?api-version=...
     // and returns { data: [{ id, ... }] }, which we map into ModelInfo.
-    const normalizedApiKey = normalizeAzureApiKey(apiKey);
+    const authHeaders = await getAzureAuthHeaders(apiKey);
     const response = await fetch(url, {
       headers: {
         ...(extraHeaders ?? {}),
-        "api-key": normalizedApiKey ?? "",
+        ...authHeaders,
       },
     });
 
@@ -60,6 +64,21 @@ export async function fetchAzureModels(
     logger.error({ error }, "Error fetching Azure deployments");
     return fallbackToConfiguredDeployment(deploymentName);
   }
+}
+
+async function getAzureAuthHeaders(
+  apiKey: string | undefined,
+): Promise<Record<string, string>> {
+  if (apiKey) {
+    return { "api-key": normalizeAzureApiKey(apiKey) ?? "" };
+  }
+
+  if (!isAzureOpenAiEntraIdEnabled()) {
+    return { "api-key": "" };
+  }
+
+  const tokenProvider = getAzureOpenAiBearerTokenProvider();
+  return { Authorization: `Bearer ${await tokenProvider()}` };
 }
 
 function fallbackToConfiguredDeployment(

--- a/platform/backend/src/routes/chat/model-fetchers/azure.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/azure.ts
@@ -4,6 +4,7 @@ import {
 } from "@/clients/azure-openai-credentials";
 import {
   buildAzureDeploymentsUrl,
+  buildAzureOpenAiV1ModelsUrl,
   extractAzureDeploymentName,
   normalizeAzureApiKey,
 } from "@/clients/azure-url";
@@ -26,6 +27,16 @@ export async function fetchAzureModels(
     baseUrl,
   });
   const deploymentName = extractAzureDeploymentName(baseUrl);
+  const v1ModelsUrl = buildAzureOpenAiV1ModelsUrl(baseUrl);
+  if (v1ModelsUrl) {
+    return fetchAzureOpenAiV1Models({
+      apiKey,
+      extraHeaders,
+      url: v1ModelsUrl,
+      baseUrl,
+    });
+  }
+
   if (!url) {
     logger.warn({ baseUrl }, "Could not extract Azure endpoint from baseUrl");
     return [];
@@ -34,7 +45,7 @@ export async function fetchAzureModels(
   try {
     // Azure lists deployments at GET /openai/deployments?api-version=...
     // and returns { data: [{ id, ... }] }, which we map into ModelInfo.
-    const authHeaders = await getAzureAuthHeaders(apiKey);
+    const authHeaders = await getAzureAuthHeaders(apiKey, baseUrl);
     const response = await fetch(url, {
       headers: {
         ...(extraHeaders ?? {}),
@@ -66,8 +77,56 @@ export async function fetchAzureModels(
   }
 }
 
+async function fetchAzureOpenAiV1Models(params: {
+  apiKey: string;
+  baseUrl: string;
+  extraHeaders?: Record<string, string> | null;
+  url: string;
+}): Promise<ModelInfo[]> {
+  try {
+    const authHeaders = await getAzureAuthHeaders(
+      params.apiKey,
+      params.baseUrl,
+    );
+    const response = await fetch(params.url, {
+      headers: {
+        ...(params.extraHeaders ?? {}),
+        ...authHeaders,
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      logger.error(
+        { status: response.status, error: errorText },
+        "Failed to fetch Azure OpenAI v1 models",
+      );
+      return [];
+    }
+
+    const data = (await response.json()) as {
+      data?: {
+        id: string;
+        capabilities?: { chat_completion?: boolean };
+      }[];
+    };
+
+    return (data.data ?? [])
+      .filter((model) => model.capabilities?.chat_completion !== false)
+      .map((model) => ({
+        id: model.id,
+        displayName: model.id,
+        provider: "azure" as const,
+      }));
+  } catch (error) {
+    logger.error({ error }, "Error fetching Azure OpenAI v1 models");
+    return [];
+  }
+}
+
 async function getAzureAuthHeaders(
   apiKey: string | undefined,
+  baseUrl?: string,
 ): Promise<Record<string, string>> {
   if (apiKey) {
     return { "api-key": normalizeAzureApiKey(apiKey) ?? "" };
@@ -77,7 +136,7 @@ async function getAzureAuthHeaders(
     return { "api-key": "" };
   }
 
-  const tokenProvider = getAzureOpenAiBearerTokenProvider();
+  const tokenProvider = getAzureOpenAiBearerTokenProvider(baseUrl);
   return { Authorization: `Bearer ${await tokenProvider()}` };
 }
 

--- a/platform/backend/src/routes/proxy/adapters/anthropic-azure-foundry.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic-azure-foundry.test.ts
@@ -28,7 +28,7 @@ describe("anthropicAdapterFactory Azure Foundry", () => {
     };
 
     expect(client._options?.defaultHeaders?.Authorization).toBe(
-      "Bearer azure-entra-token",
+      "Bearer <entra-id-managed>",
     );
 
     const fetch = client._options?.fetch;

--- a/platform/backend/src/routes/proxy/adapters/anthropic-azure-foundry.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic-azure-foundry.test.ts
@@ -1,0 +1,53 @@
+import type AnthropicProvider from "@anthropic-ai/sdk";
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("@/observability", () => ({
+  metrics: { llm: { getObservableFetch: vi.fn() } },
+}));
+
+vi.mock("@/clients/azure-openai-credentials", () => ({
+  getAzureAiFoundryBearerTokenProvider: vi.fn(
+    () => async () => "azure-foundry-token",
+  ),
+  isAnthropicAzureFoundryEntraIdEnabled: vi.fn(() => true),
+}));
+
+import { anthropicAdapterFactory } from "./anthropic";
+
+describe("anthropicAdapterFactory Azure Foundry", () => {
+  test("creates a keyless client that injects Entra ID bearer auth", async () => {
+    const client = anthropicAdapterFactory.createClient(undefined, {
+      baseUrl: "https://resource.services.ai.azure.com/anthropic",
+      defaultHeaders: {},
+      source: "api",
+    }) as AnthropicProvider & {
+      _options?: {
+        defaultHeaders?: Record<string, string>;
+        fetch?: typeof globalThis.fetch;
+      };
+    };
+
+    expect(client._options?.defaultHeaders?.Authorization).toBe(
+      "Bearer azure-entra-token",
+    );
+
+    const fetch = client._options?.fetch;
+    expect(fetch).toBeDefined();
+
+    const upstreamFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}"));
+
+    await fetch?.(
+      "https://resource.services.ai.azure.com/anthropic/v1/messages",
+      {
+        headers: { "anthropic-version": "2023-06-01" },
+      },
+    );
+
+    const headers = new Headers(upstreamFetch.mock.calls[0]?.[1]?.headers);
+    expect(headers.get("Authorization")).toBe("Bearer azure-foundry-token");
+
+    upstreamFetch.mockRestore();
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -1166,7 +1166,8 @@ export const anthropicAdapterFactory: LLMProvider<
         fetch: createAnthropicAzureFoundryFetch(customFetch),
         defaultHeaders: {
           ...options.defaultHeaders,
-          Authorization: "Bearer azure-entra-token",
+          // The fetch wrapper replaces this sentinel with a fresh Entra ID token on every request.
+          Authorization: "Bearer <entra-id-managed>",
         },
       });
     }

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -2,6 +2,10 @@ import AnthropicProvider from "@anthropic-ai/sdk";
 import { ArchestraInternalErrorCode } from "@shared";
 import { encode as toonEncode } from "@toon-format/toon";
 import { get } from "lodash-es";
+import {
+  getAzureAiFoundryBearerTokenProvider,
+  isAnthropicAzureFoundryEntraIdEnabled,
+} from "@/clients/azure-openai-credentials";
 import config from "@/config";
 import logger from "@/logging";
 import { ModelModel } from "@/models";
@@ -1154,6 +1158,19 @@ export const anthropicAdapterFactory: LLMProvider<
     const token = isAuthToken && apiKey ? apiKey.slice(7) : undefined;
     const regularApiKey = isAuthToken ? undefined : apiKey;
 
+    if (!apiKey && isAnthropicAzureFoundryEntraIdEnabled()) {
+      return new AnthropicProvider({
+        apiKey: null,
+        authToken: null,
+        baseURL: options.baseUrl,
+        fetch: createAnthropicAzureFoundryFetch(customFetch),
+        defaultHeaders: {
+          ...options.defaultHeaders,
+          Authorization: "Bearer azure-entra-token",
+        },
+      });
+    }
+
     return new AnthropicProvider({
       apiKey: regularApiKey,
       authToken: token,
@@ -1223,3 +1240,19 @@ export const anthropicAdapterFactory: LLMProvider<
     return "Internal server error";
   },
 };
+
+function createAnthropicAzureFoundryFetch(
+  baseFetch: typeof globalThis.fetch | undefined,
+): typeof globalThis.fetch {
+  return async (input, init) => {
+    const tokenProvider = getAzureAiFoundryBearerTokenProvider();
+    const headers = new Headers(init?.headers);
+    headers.set("Authorization", `Bearer ${await tokenProvider()}`);
+
+    const fetchFn = baseFetch ?? globalThis.fetch;
+    return fetchFn(input, {
+      ...init,
+      headers,
+    });
+  };
+}

--- a/platform/backend/src/routes/proxy/adapters/azure-responses.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure-responses.test.ts
@@ -26,6 +26,21 @@ describe("azureResponsesAdapterFactory", () => {
     expect(client._options?.apiKey).toBe("my-azure-key");
   });
 
+  test("uses Azure OpenAI v1 base URLs without api-version", () => {
+    const client = azureResponsesAdapterFactory.createClient("my-azure-key", {
+      baseUrl: "https://my-resource.services.ai.azure.com/openai/v1",
+      defaultHeaders: {},
+      source: "api",
+    }) as OpenAIProvider & {
+      _options?: { baseURL?: string; defaultQuery?: Record<string, string> };
+    };
+
+    expect(client._options?.baseURL).toBe(
+      "https://my-resource.services.ai.azure.com/openai/v1",
+    );
+    expect(client._options?.defaultQuery).toBeUndefined();
+  });
+
   test("maps response tools and tool outputs from the request", () => {
     const adapter = azureResponsesAdapterFactory.createRequestAdapter({
       model: "gpt-4.1",

--- a/platform/backend/src/routes/proxy/adapters/azure-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure-responses.ts
@@ -18,6 +18,7 @@ import {
 import {
   buildAzureResponsesBaseUrl,
   normalizeAzureApiKey,
+  shouldUseAzureOpenAiApiVersion,
 } from "@/clients/azure-url";
 import config from "@/config";
 import { metrics } from "@/observability";
@@ -115,11 +116,9 @@ export const azureResponsesAdapterFactory: LLMProvider<
 
     if (!apiKey && isAzureOpenAiEntraIdEnabled()) {
       return new OpenAIProvider({
-        apiKey: getAzureOpenAiBearerTokenProvider(),
+        apiKey: getAzureOpenAiBearerTokenProvider(options.baseUrl),
         baseURL: resolvedBaseUrl,
-        defaultQuery: {
-          "api-version": config.llm.azure.responsesApiVersion,
-        },
+        defaultQuery: getAzureResponsesDefaultQuery(options.baseUrl),
         fetch: customFetch,
         defaultHeaders: options.defaultHeaders,
       });
@@ -134,9 +133,7 @@ export const azureResponsesAdapterFactory: LLMProvider<
     return new OpenAIProvider({
       apiKey: normalizedApiKey,
       baseURL: resolvedBaseUrl,
-      defaultQuery: {
-        "api-version": config.llm.azure.responsesApiVersion,
-      },
+      defaultQuery: getAzureResponsesDefaultQuery(options.baseUrl),
       fetch: customFetch,
       defaultHeaders: {
         ...options.defaultHeaders,
@@ -183,6 +180,14 @@ export const azureResponsesAdapterFactory: LLMProvider<
     );
   },
 };
+
+function getAzureResponsesDefaultQuery(
+  baseUrl: string | undefined,
+): Record<string, string> | undefined {
+  return shouldUseAzureOpenAiApiVersion(baseUrl)
+    ? { "api-version": config.llm.azure.responsesApiVersion }
+    : undefined;
+}
 
 class AzureResponsesRequestAdapter
   implements LLMRequestAdapter<AzureResponsesRequest, AzureResponseInput>

--- a/platform/backend/src/routes/proxy/adapters/azure-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure-responses.ts
@@ -12,6 +12,10 @@ import type {
   ResponseStreamEvent,
 } from "openai/resources/responses/responses";
 import {
+  getAzureOpenAiBearerTokenProvider,
+  isAzureOpenAiEntraIdEnabled,
+} from "@/clients/azure-openai-credentials";
+import {
   buildAzureResponsesBaseUrl,
   normalizeAzureApiKey,
 } from "@/clients/azure-url";
@@ -89,10 +93,6 @@ export const azureResponsesAdapterFactory: LLMProvider<
     apiKey: string | undefined,
     options: CreateClientOptions,
   ): OpenAIProvider {
-    if (!apiKey) {
-      throw new ApiError(401, "API key required for Azure AI Foundry");
-    }
-
     const resolvedBaseUrl = options.baseUrl
       ? buildAzureResponsesBaseUrl(options.baseUrl)
       : null;
@@ -112,6 +112,23 @@ export const azureResponsesAdapterFactory: LLMProvider<
           options.externalAgentId,
         )
       : undefined;
+
+    if (!apiKey && isAzureOpenAiEntraIdEnabled()) {
+      return new OpenAIProvider({
+        apiKey: getAzureOpenAiBearerTokenProvider(),
+        baseURL: resolvedBaseUrl,
+        defaultQuery: {
+          "api-version": config.llm.azure.responsesApiVersion,
+        },
+        fetch: customFetch,
+        defaultHeaders: options.defaultHeaders,
+      });
+    }
+
+    if (!apiKey) {
+      throw new ApiError(401, "API key required for Azure AI Foundry");
+    }
+
     const normalizedApiKey = normalizeAzureApiKey(apiKey);
 
     return new OpenAIProvider({

--- a/platform/backend/src/routes/proxy/adapters/azure.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure.test.ts
@@ -6,7 +6,15 @@ vi.mock("@/observability", () => ({
   metrics: { llm: { getObservableFetch: vi.fn() } },
 }));
 
+vi.mock("@/clients/azure-openai-credentials", () => ({
+  getAzureOpenAiBearerTokenProvider: vi.fn(() => async () => "entra-token"),
+  isAzureOpenAiEntraIdEnabled: vi.fn(() => false),
+}));
+
+import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import { azureAdapterFactory } from "./azure";
+
+const mockIsAzureOpenAiEntraIdEnabled = vi.mocked(isAzureOpenAiEntraIdEnabled);
 
 describe("azureAdapterFactory", () => {
   describe("extractApiKey", () => {
@@ -35,6 +43,27 @@ describe("azureAdapterFactory", () => {
   });
 
   describe("createClient", () => {
+    test("uses an Entra ID token provider when enabled and no apiKey is provided", () => {
+      mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(true);
+
+      const client = azureAdapterFactory.createClient(undefined, {
+        baseUrl:
+          "https://my-resource.openai.azure.com/openai/deployments/gpt-4o",
+        defaultHeaders: {},
+        source: "api",
+      }) as OpenAIProvider & {
+        _options?: {
+          apiKey?: unknown;
+          defaultHeaders?: Record<string, string>;
+        };
+      };
+
+      expect(typeof client._options?.apiKey).toBe("function");
+      expect(client._options?.defaultHeaders?.["api-key"]).toBeUndefined();
+
+      mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(false);
+    });
+
     test("throws ApiError(401) when apiKey is undefined", () => {
       expect(() =>
         azureAdapterFactory.createClient(undefined, {

--- a/platform/backend/src/routes/proxy/adapters/azure.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure.test.ts
@@ -11,10 +11,16 @@ vi.mock("@/clients/azure-openai-credentials", () => ({
   isAzureOpenAiEntraIdEnabled: vi.fn(() => false),
 }));
 
-import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
+import {
+  getAzureOpenAiBearerTokenProvider,
+  isAzureOpenAiEntraIdEnabled,
+} from "@/clients/azure-openai-credentials";
 import { azureAdapterFactory } from "./azure";
 
 const mockIsAzureOpenAiEntraIdEnabled = vi.mocked(isAzureOpenAiEntraIdEnabled);
+const mockGetAzureOpenAiBearerTokenProvider = vi.mocked(
+  getAzureOpenAiBearerTokenProvider,
+);
 
 describe("azureAdapterFactory", () => {
   describe("extractApiKey", () => {
@@ -60,6 +66,30 @@ describe("azureAdapterFactory", () => {
 
       expect(typeof client._options?.apiKey).toBe("function");
       expect(client._options?.defaultHeaders?.["api-key"]).toBeUndefined();
+      expect(mockGetAzureOpenAiBearerTokenProvider).toHaveBeenCalledWith(
+        "https://my-resource.openai.azure.com/openai/deployments/gpt-4o",
+      );
+
+      mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(false);
+    });
+
+    test("omits api-version for Azure OpenAI v1 base URLs", () => {
+      mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(true);
+
+      const client = azureAdapterFactory.createClient(undefined, {
+        baseUrl: "https://my-resource.services.ai.azure.com/openai/v1",
+        defaultHeaders: {},
+        source: "api",
+      }) as OpenAIProvider & {
+        _options?: {
+          defaultQuery?: Record<string, string>;
+        };
+      };
+
+      expect(client._options?.defaultQuery).toBeUndefined();
+      expect(mockGetAzureOpenAiBearerTokenProvider).toHaveBeenCalledWith(
+        "https://my-resource.services.ai.azure.com/openai/v1",
+      );
 
       mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(false);
     });

--- a/platform/backend/src/routes/proxy/adapters/azure.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure.ts
@@ -16,6 +16,10 @@ import type {
   ChatCompletionCreateParamsNonStreaming,
   ChatCompletionCreateParamsStreaming,
 } from "openai/resources/chat/completions/completions";
+import {
+  getAzureOpenAiBearerTokenProvider,
+  isAzureOpenAiEntraIdEnabled,
+} from "@/clients/azure-openai-credentials";
 import { normalizeAzureApiKey } from "@/clients/azure-url";
 import config from "@/config";
 import { metrics } from "@/observability";
@@ -220,10 +224,6 @@ export const azureAdapterFactory: LLMProvider<
     apiKey: string | undefined,
     options: CreateClientOptions,
   ): OpenAIProvider {
-    if (!apiKey) {
-      throw new ApiError(401, "API key required for Azure AI Foundry");
-    }
-
     const customFetch = options.agent
       ? metrics.llm.getObservableFetch(
           "azure",
@@ -232,6 +232,21 @@ export const azureAdapterFactory: LLMProvider<
           options.externalAgentId,
         )
       : undefined;
+
+    if (!apiKey && isAzureOpenAiEntraIdEnabled()) {
+      return new OpenAIProvider({
+        apiKey: getAzureOpenAiBearerTokenProvider(),
+        baseURL: options.baseUrl,
+        defaultQuery: { "api-version": config.llm.azure.apiVersion },
+        fetch: customFetch,
+        defaultHeaders: options.defaultHeaders,
+      });
+    }
+
+    if (!apiKey) {
+      throw new ApiError(401, "API key required for Azure AI Foundry");
+    }
+
     const normalizedApiKey = normalizeAzureApiKey(apiKey);
 
     return new OpenAIProvider({

--- a/platform/backend/src/routes/proxy/adapters/azure.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure.ts
@@ -2,9 +2,10 @@
  * Azure AI Foundry LLM Proxy Adapter - OpenAI-compatible
  *
  * Azure AI Foundry uses an OpenAI-compatible API.
- * The baseURL must be the full deployment URL:
+ * The baseURL can be either the full deployment URL:
  *   https://<resource>.openai.azure.com/openai/deployments/<deployment>
- * An api-version query param is required (default: 2024-02-01).
+ * or the v1 Foundry endpoint:
+ *   https://<resource>.services.ai.azure.com/openai/v1
  *
  * This adapter delegates request/response/stream parsing to the OpenAI adapters
  * and only overrides provider-specific configuration.
@@ -20,7 +21,10 @@ import {
   getAzureOpenAiBearerTokenProvider,
   isAzureOpenAiEntraIdEnabled,
 } from "@/clients/azure-openai-credentials";
-import { normalizeAzureApiKey } from "@/clients/azure-url";
+import {
+  normalizeAzureApiKey,
+  shouldUseAzureOpenAiApiVersion,
+} from "@/clients/azure-url";
 import config from "@/config";
 import { metrics } from "@/observability";
 import type {
@@ -235,9 +239,9 @@ export const azureAdapterFactory: LLMProvider<
 
     if (!apiKey && isAzureOpenAiEntraIdEnabled()) {
       return new OpenAIProvider({
-        apiKey: getAzureOpenAiBearerTokenProvider(),
+        apiKey: getAzureOpenAiBearerTokenProvider(options.baseUrl),
         baseURL: options.baseUrl,
-        defaultQuery: { "api-version": config.llm.azure.apiVersion },
+        defaultQuery: getAzureDefaultQuery(options.baseUrl),
         fetch: customFetch,
         defaultHeaders: options.defaultHeaders,
       });
@@ -252,7 +256,7 @@ export const azureAdapterFactory: LLMProvider<
     return new OpenAIProvider({
       apiKey: normalizedApiKey,
       baseURL: options.baseUrl,
-      defaultQuery: { "api-version": config.llm.azure.apiVersion },
+      defaultQuery: getAzureDefaultQuery(options.baseUrl),
       fetch: customFetch,
       defaultHeaders: {
         ...options.defaultHeaders,
@@ -318,3 +322,11 @@ export const azureAdapterFactory: LLMProvider<
     return "Internal server error";
   },
 };
+
+function getAzureDefaultQuery(
+  baseUrl: string | undefined,
+): Record<string, string> | undefined {
+  return shouldUseAzureOpenAiApiVersion(baseUrl)
+    ? { "api-version": config.llm.azure.apiVersion }
+    : undefined;
+}

--- a/platform/backend/src/services/system-key-manager.ts
+++ b/platform/backend/src/services/system-key-manager.ts
@@ -1,5 +1,8 @@
 import type { SupportedProvider } from "@shared";
-import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
+import {
+  isAnthropicAzureFoundryEntraIdEnabled,
+  isAzureOpenAiEntraIdEnabled,
+} from "@/clients/azure-openai-credentials";
 import { isBedrockIamAuthEnabled } from "@/clients/bedrock-credentials";
 import { isVertexAiEnabled } from "@/clients/gemini-client";
 import { modelsDevClient } from "@/clients/models-dev-client";
@@ -10,6 +13,7 @@ import {
   LlmProviderApiKeyModelLinkModel,
   ModelModel,
 } from "@/models";
+import { fetchAnthropicModels } from "@/routes/chat/model-fetchers/anthropic";
 import { fetchAzureModels } from "@/routes/chat/model-fetchers/azure";
 import { fetchBedrockModelsViaIam } from "@/routes/chat/model-fetchers/bedrock";
 import { fetchGeminiModelsViaVertexAi } from "@/routes/chat/model-fetchers/gemini";
@@ -58,6 +62,20 @@ class SystemKeyManager {
         isAzureOpenAiEntraIdEnabled() && Boolean(config.llm.azure.baseUrl),
       customFetch: async () => {
         const models = await fetchAzureModels("", config.llm.azure.baseUrl);
+        return models.map((m) => ({ id: m.id, displayName: m.displayName }));
+      },
+    },
+    {
+      provider: "anthropic",
+      name: "Anthropic Azure Foundry Entra ID",
+      isEnabled: () =>
+        isAnthropicAzureFoundryEntraIdEnabled() &&
+        Boolean(config.llm.anthropic.baseUrl),
+      customFetch: async () => {
+        const models = await fetchAnthropicModels(
+          "",
+          config.llm.anthropic.baseUrl,
+        );
         return models.map((m) => ({ id: m.id, displayName: m.displayName }));
       },
     },

--- a/platform/backend/src/services/system-key-manager.ts
+++ b/platform/backend/src/services/system-key-manager.ts
@@ -1,13 +1,16 @@
 import type { SupportedProvider } from "@shared";
+import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import { isBedrockIamAuthEnabled } from "@/clients/bedrock-credentials";
 import { isVertexAiEnabled } from "@/clients/gemini-client";
 import { modelsDevClient } from "@/clients/models-dev-client";
+import config from "@/config";
 import logger from "@/logging";
 import {
   LlmProviderApiKeyModel,
   LlmProviderApiKeyModelLinkModel,
   ModelModel,
 } from "@/models";
+import { fetchAzureModels } from "@/routes/chat/model-fetchers/azure";
 import { fetchBedrockModelsViaIam } from "@/routes/chat/model-fetchers/bedrock";
 import { fetchGeminiModelsViaVertexAi } from "@/routes/chat/model-fetchers/gemini";
 import { buildModelsToUpsert } from "@/services/model-sync";
@@ -27,8 +30,9 @@ interface KeylessProviderConfig {
 /**
  * Manages system API keys for truly keyless providers.
  *
- * Currently Vertex AI and Bedrock (with IAM auth) qualify as keyless because
- * they use cloud provider credentials (ADC / IRSA) instead of API keys.
+ * Currently Vertex AI, Azure OpenAI (with Entra ID), and Bedrock (with IAM auth)
+ * qualify as keyless because they use cloud provider credentials instead of API
+ * keys.
  *
  * System keys are auto-created when a keyless provider is enabled via environment config,
  * and auto-deleted when the provider is disabled.
@@ -44,6 +48,16 @@ class SystemKeyManager {
       isEnabled: () => isVertexAiEnabled(),
       customFetch: async () => {
         const models = await fetchGeminiModelsViaVertexAi();
+        return models.map((m) => ({ id: m.id, displayName: m.displayName }));
+      },
+    },
+    {
+      provider: "azure",
+      name: "Azure OpenAI Entra ID",
+      isEnabled: () =>
+        isAzureOpenAiEntraIdEnabled() && Boolean(config.llm.azure.baseUrl),
+      customFetch: async () => {
+        const models = await fetchAzureModels("", config.llm.azure.baseUrl);
         return models.map((m) => ({ id: m.id, displayName: m.displayName }));
       },
     },

--- a/platform/backend/src/services/system-key-manager.ts
+++ b/platform/backend/src/services/system-key-manager.ts
@@ -3,6 +3,7 @@ import {
   isAnthropicAzureFoundryEntraIdEnabled,
   isAzureOpenAiEntraIdEnabled,
 } from "@/clients/azure-openai-credentials";
+import { isAzureAiFoundryBaseUrl } from "@/clients/azure-url";
 import { isBedrockIamAuthEnabled } from "@/clients/bedrock-credentials";
 import { isVertexAiEnabled } from "@/clients/gemini-client";
 import { modelsDevClient } from "@/clients/models-dev-client";
@@ -70,7 +71,7 @@ class SystemKeyManager {
       name: "Anthropic Azure Foundry Entra ID",
       isEnabled: () =>
         isAnthropicAzureFoundryEntraIdEnabled() &&
-        Boolean(config.llm.anthropic.baseUrl),
+        isAzureAiFoundryBaseUrl(config.llm.anthropic.baseUrl),
       customFetch: async () => {
         const models = await fetchAnthropicModels(
           "",

--- a/platform/backend/src/types/llm-providers/azure/api.ts
+++ b/platform/backend/src/types/llm-providers/azure/api.ts
@@ -7,9 +7,9 @@
  * @see https://learn.microsoft.com/en-us/azure/ai-foundry/openai/api-reference
  */
 
+import { z } from "zod";
 import {
   ChatCompletionRequestSchema,
-  ChatCompletionsHeadersSchema,
   ChatCompletionUsageSchema,
   FinishReasonSchema,
   ChatCompletionResponseSchema as OpenAIChatCompletionResponseSchema,
@@ -20,13 +20,23 @@ import {
 
 export {
   ChatCompletionRequestSchema,
-  ChatCompletionsHeadersSchema,
   ChatCompletionUsageSchema,
   FinishReasonSchema,
   ResponsesRequestSchema,
   ResponsesResponseSchema,
   ResponsesUsageSchema,
 };
+
+export const ChatCompletionsHeadersSchema = z.object({
+  "user-agent": z.string().optional().describe("The user agent of the client"),
+  authorization: z
+    .string()
+    .optional()
+    .describe("Bearer token for Azure AI Foundry")
+    .transform((authorization) =>
+      authorization ? authorization.replace("Bearer ", "") : undefined,
+    ),
+});
 
 export const ChatCompletionResponseSchema =
   OpenAIChatCompletionResponseSchema.passthrough();

--- a/platform/helm/archestra/templates/archestra-platform.yaml
+++ b/platform/helm/archestra/templates/archestra-platform.yaml
@@ -93,6 +93,9 @@ spec:
       labels:
         {{- include "archestra-platform.labels" . | nindent 8 }}
         app.kubernetes.io/component: web
+        {{- with .Values.archestra.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.archestra.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/platform/helm/archestra/templates/archestra-worker.yaml
+++ b/platform/helm/archestra/templates/archestra-worker.yaml
@@ -23,6 +23,9 @@ spec:
     metadata:
       labels:
         {{- include "archestra-platform.workerLabels" . | nindent 8 }}
+        {{- with .Values.archestra.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- if $workerPodAnnotations }}
       annotations:
         {{- toYaml $workerPodAnnotations | nindent 8 }}

--- a/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
@@ -1524,6 +1524,17 @@ tests:
           path: spec.template.metadata.annotations["config.linkerd.io/proxy-cpu-request"]
           value: "100m"
 
+  # Pod labels tests
+  - it: should apply pod labels when provided
+    documentIndex: 1
+    set:
+      archestra.podLabels:
+        azure.workload.identity/use: "true"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["azure.workload.identity/use"]
+          value: "true"
+
   # Sensitive environment variable secretKeyRef tests
   - it: should use secretKeyRef for ARCHESTRA_AUTH_ADMIN_PASSWORD when provided
     documentIndex: 1

--- a/platform/helm/archestra/tests/archestra_worker_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_worker_deployment_test.yaml
@@ -73,6 +73,15 @@ tests:
           path: spec.template.metadata.annotations["prometheus.io/path"]
           value: "/metrics"
 
+  - it: worker deployment inherits global pod labels
+    set:
+      archestra.podLabels:
+        azure.workload.identity/use: "true"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["azure.workload.identity/use"]
+          value: "true"
+
   - it: worker mounts diagnostics volume and env var when diagnostics are enabled
     set:
       archestra.diagnostics.enabled: true

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -34,6 +34,14 @@ archestra:
   #     sidecar.istio.io/inject: "true"
   podAnnotations: {}
 
+  # Labels to add to pods created by the Deployment
+  # This is useful for integrations that require pod-level labels, such as:
+  # - Azure AKS Workload Identity
+  # Example:
+  #   podLabels:
+  #     azure.workload.identity/use: "true"
+  podLabels: {}
+
   # Node selector for scheduling pods on specific nodes
   # This is useful for targeting specific node pools or nodes with particular labels
   # See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -15611,15 +15611,15 @@ export type BulkUpsertDefaultResultPolicyResponse = BulkUpsertDefaultResultPolic
 
 export type AzureChatCompletionsWithDefaultAgentData = {
     body: XaiChatCompletionRequestInput;
-    headers: {
+    headers?: {
         /**
          * The user agent of the client
          */
         'user-agent'?: string;
         /**
-         * Bearer token for OpenAI
+         * Bearer token for Azure AI Foundry
          */
-        authorization: string;
+        authorization?: string;
     };
     path?: never;
     query?: never;
@@ -15804,15 +15804,15 @@ export type AzureResponsesWithDefaultAgentData = {
         user?: string;
         [key: string]: unknown;
     };
-    headers: {
+    headers?: {
         /**
          * The user agent of the client
          */
         'user-agent'?: string;
         /**
-         * Bearer token for OpenAI
+         * Bearer token for Azure AI Foundry
          */
-        authorization: string;
+        authorization?: string;
     };
     path?: never;
     query?: never;
@@ -15973,15 +15973,15 @@ export type AzureResponsesWithAgentData = {
         user?: string;
         [key: string]: unknown;
     };
-    headers: {
+    headers?: {
         /**
          * The user agent of the client
          */
         'user-agent'?: string;
         /**
-         * Bearer token for OpenAI
+         * Bearer token for Azure AI Foundry
          */
-        authorization: string;
+        authorization?: string;
     };
     path: {
         agentId: string;
@@ -16109,15 +16109,15 @@ export type AzureResponsesWithAgentResponse = AzureResponsesWithAgentResponses[k
 
 export type AzureChatCompletionsWithAgentData = {
     body: XaiChatCompletionRequestInput;
-    headers: {
+    headers?: {
         /**
          * The user agent of the client
          */
         'user-agent'?: string;
         /**
-         * Bearer token for OpenAI
+         * Bearer token for Azure AI Foundry
          */
-        authorization: string;
+        authorization?: string;
     };
     path: {
         agentId: string;


### PR DESCRIPTION
## Summary

- Adds opt-in Azure OpenAI Microsoft Entra ID authentication using Azure Identity `DefaultAzureCredential`.
- Supports Azure OpenAI deployment URLs and Microsoft Foundry v1 OpenAI-compatible URLs (`/openai/v1`) with the correct token scopes, model discovery, and `api-version` handling.
- Supports Azure-sold OpenAI-compatible models deployed on Foundry v1, including Grok deployments.
- Adds opt-in Anthropic-on-Microsoft-Foundry keyless support for Claude deployments using the Anthropic Messages API shape.
- Adds docs for Azure OpenAI, Foundry v1, Grok-on-Azure, Claude-on-Foundry, and keyless auth with AKS Microsoft Entra Workload ID.
- Adds Helm `archestra.podLabels` support so AKS Workload ID can set the required `azure.workload.identity/use: "true"` pod label.
- Adds a companion Azure OpenAI keyless example under `archestra-ai/examples` and links it from the provider docs.

## Validation

- Direct Azure CLI Entra ID smoke test against Foundry v1 `/openai/v1/chat/completions` returned 200 and `ok` for an existing Azure OpenAI deployment.
- Built Archestra backend smoke test against `/v1/azure/{agentId}/chat/completions` returned 200 and `ok` without a provider API key.
- Deployed `grok-4-1-fast-non-reasoning` on the tested Azure resource; direct Azure and Archestra proxy calls both returned 200 and `ok`.
- Built Archestra backend Anthropic Foundry smoke test reached Azure with bearer auth. A Claude deployment attempt was accepted by Azure with the required provider metadata, but Azure later moved it to `Failed`; the failed test deployment was deleted. This leaves Claude blocked on Azure partner-model provisioning, not on Archestra request routing/auth.

## Related Microsoft docs (for future-us reference)

- https://learn.microsoft.com/en-us/azure/foundry/foundry-models/how-to/configure-entra-id
- https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/endpoints
- https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/chatgpt?view=foundry-classic
- https://learn.microsoft.com/en-us/azure/foundry/foundry-models/how-to/use-foundry-models-claude
- https://learn.microsoft.com/en-us/azure/developer/ai/keyless-connections
- https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview
- https://learn.microsoft.com/en-us/azure/aks/workload-identity-deploy-cluster
- https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/managed-identity
- https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/role-based-access-control
