### PR TITLE
feat(mcp): accept JSON-array paste in Arguments textarea

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/custom-server-request-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/custom-server-request-dialog.tsx
@@ -20,6 +20,7 @@ import {
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -35,6 +36,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useCreateMcpServerInstallationRequest } from "@/lib/mcp/mcp-server-installation-request.query";
+import { parseArgumentsInput } from "./mcp-catalog-form.utils";
 
 const customServerRequestSchema = z
   .object({
@@ -119,10 +121,7 @@ export function CustomServerRequestDialog({
             serverType: "local" as const,
             localConfig: {
               command: values.command,
-              arguments: values.arguments
-                .split("\n")
-                .map((arg) => arg.trim())
-                .filter((arg) => arg.length > 0),
+              arguments: parseArgumentsInput(values.arguments),
               environment:
                 values.environment.length > 0 ? values.environment : undefined,
             },
@@ -276,14 +275,18 @@ export function CustomServerRequestDialog({
                     name="arguments"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>Arguments (one per line)</FormLabel>
+                        <FormLabel>Arguments</FormLabel>
                         <FormControl>
                           <Textarea
-                            placeholder={`/path/to/server.js\n--verbose`}
+                            placeholder={`/path/to/server.js\n--verbose\n\n— or paste a JSON array —\n\n["/path/to/server.js", "--verbose"]`}
                             rows={3}
                             {...field}
                           />
                         </FormControl>
+                        <FormDescription>
+                          One argument per line, or paste a JSON array of
+                          strings (e.g. <code>{`["--port", "8080"]`}</code>).
+                        </FormDescription>
                         <FormMessage />
                       </FormItem>
                     )}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -999,16 +999,21 @@ export function McpCatalogForm({
                     render={({ field }) => (
                       <FormItem>
                         <FormLabel>
-                          Arguments (one per line)
+                          Arguments
                           <ReinstallHint show={isArgumentsDirty} />
                         </FormLabel>
                         <FormControl>
                           <Textarea
-                            placeholder={`/path/to/server.js\n--verbose`}
+                            placeholder={`/path/to/server.js\n--verbose\n\n— or paste a JSON array —\n\n["/path/to/server.js", "--verbose"]`}
                             className="font-mono min-h-20"
                             {...field}
                           />
                         </FormControl>
+                        <FormDescription>
+                          One argument per line, or paste a JSON array of
+                          strings (the format most public catalogs publish),
+                          e.g. <code>{`["--port", "8080"]`}</code>.
+                        </FormDescription>
                         <FormMessage />
                       </FormItem>
                     )}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
@@ -1,9 +1,64 @@
 import type { McpCatalogFormValues } from "./mcp-catalog-form.types";
 import {
+  parseArgumentsInput,
   transformCatalogItemToFormValues,
   transformExternalCatalogToFormValues,
   transformFormToApiData,
 } from "./mcp-catalog-form.utils";
+
+describe("parseArgumentsInput", () => {
+  it("returns an empty array for empty / whitespace input", () => {
+    expect(parseArgumentsInput(undefined)).toEqual([]);
+    expect(parseArgumentsInput("")).toEqual([]);
+    expect(parseArgumentsInput("   \n  \n")).toEqual([]);
+  });
+
+  it("splits newline-separated input and trims each line", () => {
+    expect(
+      parseArgumentsInput("/path/to/server.js\n  --verbose  \n\n--port 8080"),
+    ).toEqual(["/path/to/server.js", "--verbose", "--port 8080"]);
+  });
+
+  it("accepts a JSON array of strings (the catalog-publish shape)", () => {
+    expect(
+      parseArgumentsInput('["/path/to/server.js", "--port", "8080"]'),
+    ).toEqual(["/path/to/server.js", "--port", "8080"]);
+  });
+
+  it("tolerates whitespace and inner newlines around the JSON array", () => {
+    expect(
+      parseArgumentsInput('  \n["--verbose",\n  "--port",\n  "8080"]\n  '),
+    ).toEqual(["--verbose", "--port", "8080"]);
+  });
+
+  it("falls back to newline parsing when the JSON is malformed", () => {
+    // Looks like JSON but isn't — must not silently produce one bad arg.
+    expect(parseArgumentsInput('["--verbose", \n--port')).toEqual([
+      '["--verbose",',
+      "--port",
+    ]);
+  });
+
+  it("falls back to newline parsing when JSON contains non-string entries", () => {
+    // We require an array of strings — anything else stays line-based.
+    expect(parseArgumentsInput('["--port", 8080]')).toEqual([
+      '["--port", 8080]',
+    ]);
+  });
+
+  it("treats a single-line value with bracket characters as a literal arg", () => {
+    // A path containing `[` should not be misinterpreted as JSON.
+    expect(parseArgumentsInput("[bracketed]/path/to/file")).toEqual([
+      "[bracketed]/path/to/file",
+    ]);
+  });
+
+  it("strips empty strings from a JSON array of strings", () => {
+    expect(parseArgumentsInput('["--verbose", "", "  "]')).toEqual([
+      "--verbose",
+    ]);
+  });
+});
 
 describe("transformFormToApiData", () => {
   it("maps custom auth and additional headers into userConfig", () => {
@@ -52,6 +107,49 @@ describe("transformFormToApiData", () => {
         sensitive: false,
       }),
     });
+  });
+
+  it("accepts a JSON-array Arguments paste and serialises it as an array", () => {
+    const values: McpCatalogFormValues = {
+      name: "JSON-paste MCP",
+      description: "",
+      icon: null,
+      serverType: "local",
+      serverUrl: "",
+      authMethod: "none",
+      includeBearerPrefix: true,
+      authHeaderName: "",
+      additionalHeaders: [],
+      oauthConfig: undefined,
+      enterpriseManagedConfig: null,
+      localConfig: {
+        command: "node",
+        arguments: '["/path/to/server.js", "--port", "8080"]',
+        environment: [],
+        envFrom: [],
+        dockerImage: "",
+        transportType: "stdio",
+        httpPort: "",
+        httpPath: "/mcp",
+        serviceAccount: "",
+        imagePullSecrets: [],
+      },
+      deploymentSpecYaml: "",
+      originalDeploymentSpecYaml: "",
+      oauthClientSecretVaultPath: "",
+      oauthClientSecretVaultKey: "",
+      localConfigVaultPath: "",
+      localConfigVaultKey: "",
+      labels: [],
+      scope: "personal",
+      teams: [],
+    };
+
+    expect(transformFormToApiData(values).localConfig?.arguments).toEqual([
+      "/path/to/server.js",
+      "--port",
+      "8080",
+    ]);
   });
 
   it("includes OAuth discovery overrides in the API payload", () => {

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
@@ -12,6 +12,40 @@ import type { McpCatalogFormValues } from "./mcp-catalog-form.types";
 type McpCatalogApiData =
   archestraApiTypes.CreateInternalMcpCatalogItemData["body"];
 
+/**
+ * Parses the Arguments textarea value into the wire-format array.
+ *
+ * Accepts two equivalent input shapes so users can paste from either
+ * source-of-truth catalog format:
+ *   - One argument per line (the legacy form storage shape).
+ *   - A JSON array of strings (the shape most public MCP catalogs publish),
+ *     e.g. `["--port", "8080"]`. Whitespace around the JSON is tolerated.
+ *
+ * Anything that isn't a JSON array of strings falls back to the line-based
+ * parser, so a stray `[` at the start of a path doesn't change behaviour.
+ */
+export function parseArgumentsInput(input: string | undefined): string[] {
+  if (!input) return [];
+  const trimmed = input.trim();
+  if (trimmed.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (
+        Array.isArray(parsed) &&
+        parsed.every((item) => typeof item === "string")
+      ) {
+        return parsed.map((arg) => arg.trim()).filter((arg) => arg.length > 0);
+      }
+    } catch {
+      // Not valid JSON — treat as newline-separated input below.
+    }
+  }
+  return input
+    .split("\n")
+    .map((arg) => arg.trim())
+    .filter((arg) => arg.length > 0);
+}
+
 // Transform function to convert form values to API format
 export function transformFormToApiData(
   values: McpCatalogFormValues,
@@ -34,13 +68,8 @@ export function transformFormToApiData(
 
   // Handle local configuration
   if (values.serverType === "local" && values.localConfig) {
-    // Parse arguments string into array
-    const argumentsArray = values.localConfig.arguments
-      ? values.localConfig.arguments
-          .split("\n")
-          .map((arg) => arg.trim())
-          .filter((arg) => arg.length > 0)
-      : [];
+    // Accept both newline-separated and JSON-array shapes (see parseArgumentsInput).
+    const argumentsArray = parseArgumentsInput(values.localConfig.arguments);
 
     data.localConfig = {
       command: values.localConfig.command || undefined,


### PR DESCRIPTION
Closes #3859.

## Summary

- Public MCP catalogs publish each server's `args` as a JSON array of strings; the catalog form's **Arguments** textarea (and the equivalent field in the *Custom server request* dialog) only accepted one-arg-per-line, so users had to manually re-type or strip brackets and quotes when copying from a catalog.
- A new `parseArgumentsInput` helper accepts either shape: if the trimmed input starts with `[` and parses as a JSON array of strings, those entries are used directly; otherwise the existing newline-split parser runs. Anything that looks like JSON but doesn't validate (malformed JSON, non-string entries, paths that contain `[`) falls back cleanly.
- The label / placeholder / description on both forms now show the JSON shape alongside the per-line example, so the dual format is discoverable.

## Files

- `frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts` — new `parseArgumentsInput` helper, used inside `transformFormToApiData`.
- `frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts` — unit tests for the parser (empty, newline-only, JSON array, whitespace-padded JSON, malformed JSON fallback, non-string entries fallback, single-line bracket-containing path, JSON with empty entries) and an end-to-end `transformFormToApiData` assertion.
- `frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx` — uses the helper indirectly via `transformFormToApiData`; updated label / placeholder / `FormDescription`.
- `frontend/src/app/mcp/registry/_parts/custom-server-request-dialog.tsx` — calls the helper directly; updated label / placeholder / `FormDescription`.

## Scope note

The issue mentioned considering the same JSON-paste affordance for **Command**, **Envs**, and **Type**. I deliberately kept this PR scoped to **Arguments** since:

- *Command* is a single string and already pastes verbatim.
- *Environment variables* use a structured `useFieldArray` (key/value rows), not a textarea — accepting a JSON-paste there is a different design with bigger UX trade-offs (key collisions, secret-flag inheritance) and probably warrants its own discussion.
- *Type* is a radio group, not free-form input.

Happy to follow up with a separate PR for the env-vars case if the team wants it.

## Test plan

- [x] `pnpm --filter @frontend test src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts` (32/32 pass)
- [x] `pnpm --filter @frontend test src/app/mcp/registry/_parts/` (105/105 pass — no regression in neighbour suites)
- [x] `pnpm lint` (biome clean across all 4 workspaces)
- [x] `pnpm --filter @frontend type-check`
- [ ] Manual smoke test in `tilt up`: paste `["--port", "8080"]` into Arguments → save → confirm wire payload contains the array shape (the unit test in `transformFormToApiData` covers this contract, but a UI smoke is a good extra)