### PR TITLE
fix(chat): recover assistant turns missed by a mid-stream reload

### DIFF
--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -107,6 +107,7 @@ import {
   getConversationDisplayTitle,
 } from "@/lib/chat/chat-utils";
 import { useChatSession } from "@/lib/chat/global-chat.context";
+import { mergePersistedMessageMetadata } from "@/lib/chat/merge-persisted-messages";
 import {
   applyPendingActions,
   clearPendingActions,
@@ -2101,73 +2102,6 @@ export function ChatPageContent({
 
 export default function ChatPage() {
   return <ChatPageContent key="new-chat" />;
-}
-
-function mergePersistedMessageMetadata(params: {
-  liveMessages: UIMessage[];
-  persistedMessages: UIMessage[];
-}): UIMessage[] {
-  const remainingPersistedMessages = [...params.persistedMessages];
-
-  return params.liveMessages.map((liveMessage) => {
-    if (hasCreatedAtMetadata(liveMessage)) {
-      return liveMessage;
-    }
-
-    const persistedIndex = remainingPersistedMessages.findIndex(
-      (persistedMessage) =>
-        messagesHaveSameRenderableContent({
-          liveMessage,
-          persistedMessage,
-        }),
-    );
-
-    if (persistedIndex === -1) {
-      return liveMessage;
-    }
-
-    const [persistedMessage] = remainingPersistedMessages.splice(
-      persistedIndex,
-      1,
-    );
-
-    return {
-      ...liveMessage,
-      metadata: {
-        ...getObjectMetadata(persistedMessage),
-        ...getObjectMetadata(liveMessage),
-      },
-    };
-  });
-}
-
-function messagesHaveSameRenderableContent(params: {
-  liveMessage: UIMessage;
-  persistedMessage: UIMessage;
-}) {
-  return (
-    params.liveMessage.role === params.persistedMessage.role &&
-    getMessageText(params.liveMessage) ===
-      getMessageText(params.persistedMessage)
-  );
-}
-
-function getMessageText(message: UIMessage) {
-  return message.parts
-    .filter((part) => part.type === "text")
-    .map((part) => part.text)
-    .join("\n");
-}
-
-function hasCreatedAtMetadata(message: UIMessage) {
-  const metadata = getObjectMetadata(message);
-  return typeof metadata.createdAt === "string";
-}
-
-function getObjectMetadata(message: UIMessage): Record<string, unknown> {
-  return typeof message.metadata === "object" && message.metadata !== null
-    ? { ...message.metadata }
-    : {};
 }
 
 // =========================================================================

--- a/platform/frontend/src/lib/chat/merge-persisted-messages.test.ts
+++ b/platform/frontend/src/lib/chat/merge-persisted-messages.test.ts
@@ -1,0 +1,194 @@
+import type { UIMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import { mergePersistedMessageMetadata } from "./merge-persisted-messages";
+
+function userMessage(
+  id: string,
+  text: string,
+  metadata?: Record<string, unknown>,
+): UIMessage {
+  return {
+    id,
+    role: "user",
+    parts: [{ type: "text", text }],
+    metadata,
+  } as UIMessage;
+}
+
+function assistantMessage(
+  id: string,
+  text: string,
+  metadata?: Record<string, unknown>,
+): UIMessage {
+  return {
+    id,
+    role: "assistant",
+    parts: [{ type: "text", text }],
+    metadata,
+  } as UIMessage;
+}
+
+describe("mergePersistedMessageMetadata", () => {
+  it("returns persisted messages unchanged when the live thread is empty", () => {
+    const persisted = [
+      userMessage("u1", "hi", { createdAt: "2026-05-05T08:00:00.000Z" }),
+      assistantMessage("a1", "hello", {
+        createdAt: "2026-05-05T08:00:01.000Z",
+      }),
+    ];
+
+    expect(
+      mergePersistedMessageMetadata({
+        liveMessages: [],
+        persistedMessages: persisted,
+      }),
+    ).toEqual(persisted);
+  });
+
+  it("decorates live messages with persisted metadata when both threads agree", () => {
+    const live = [userMessage("u1", "hi"), assistantMessage("a1", "hello")];
+    const persisted = [
+      userMessage("u1", "hi", { createdAt: "2026-05-05T08:00:00.000Z" }),
+      assistantMessage("a1", "hello", {
+        createdAt: "2026-05-05T08:00:01.000Z",
+      }),
+    ];
+
+    const merged = mergePersistedMessageMetadata({
+      liveMessages: live,
+      persistedMessages: persisted,
+    });
+
+    expect(merged).toHaveLength(2);
+    expect(merged[0].metadata).toMatchObject({
+      createdAt: "2026-05-05T08:00:00.000Z",
+    });
+    expect(merged[1].metadata).toMatchObject({
+      createdAt: "2026-05-05T08:00:01.000Z",
+    });
+    // Original parts preserved
+    expect(merged[1].parts).toEqual([{ type: "text", text: "hello" }]);
+  });
+
+  it("preserves live metadata over persisted when both define the same key", () => {
+    const live = [
+      assistantMessage("a1", "live text", { createdAt: "live-time" }),
+    ];
+    const persisted = [
+      assistantMessage("a1", "persisted text", { createdAt: "persisted-time" }),
+    ];
+
+    const merged = mergePersistedMessageMetadata({
+      liveMessages: live,
+      persistedMessages: persisted,
+    });
+
+    // hasCreatedAtMetadata short-circuits — live message returned untouched.
+    expect(merged[0]).toBe(live[0]);
+  });
+
+  it("recovers an assistant turn the live thread missed (the page-reload bug)", () => {
+    // The user reloaded while the LLM was still thinking. The new useChat
+    // hook started from whatever the DB had at reload time (just the user
+    // message). The backend's onFinish later wrote the assistant turn to
+    // the DB, but the live thread never received it.
+    const live = [userMessage("u1", "what time is it?")];
+    const persisted = [
+      userMessage("u1", "what time is it?", {
+        createdAt: "2026-05-05T08:00:00.000Z",
+      }),
+      assistantMessage("a1", "It's 8 AM UTC.", {
+        createdAt: "2026-05-05T08:00:05.000Z",
+      }),
+    ];
+
+    const merged = mergePersistedMessageMetadata({
+      liveMessages: live,
+      persistedMessages: persisted,
+    });
+
+    expect(merged).toHaveLength(2);
+    expect(merged[0].id).toBe("u1");
+    expect(merged[0].role).toBe("user");
+    // The recovered assistant message keeps its persisted id + parts.
+    expect(merged[1].id).toBe("a1");
+    expect(merged[1].role).toBe("assistant");
+    expect(merged[1].parts).toEqual([{ type: "text", text: "It's 8 AM UTC." }]);
+  });
+
+  it("does not resurrect deleted history when the live thread already ends with an assistant turn", () => {
+    // The user deleted the last two messages (e.g. via the message editor's
+    // "delete subsequent messages"). Persisted has a window where it still
+    // shows the deleted messages until the backend invalidate completes.
+    // The live tail is an assistant message — the conversation is in a
+    // settled state — so we should NOT re-introduce the persisted-only
+    // tail.
+    const live = [userMessage("u1", "hi"), assistantMessage("a1", "hello")];
+    const persisted = [
+      userMessage("u1", "hi", { createdAt: "0" }),
+      assistantMessage("a1", "hello", { createdAt: "1" }),
+      userMessage("u2", "stale, soon-to-be-deleted", { createdAt: "2" }),
+      assistantMessage("a2", "stale assistant reply", { createdAt: "3" }),
+    ];
+
+    const merged = mergePersistedMessageMetadata({
+      liveMessages: live,
+      persistedMessages: persisted,
+    });
+
+    expect(merged).toHaveLength(2);
+    expect(merged.map((m) => m.id)).toEqual(["u1", "a1"]);
+  });
+
+  it("does not duplicate when an in-flight assistant message has matching content in persisted", () => {
+    // Edge case: the assistant message has been persisted (post-onFinish)
+    // and the live thread still has its in-flight copy. They share text
+    // content, so content matching collapses them; we must not also append
+    // the persisted copy as a trailing item.
+    const live = [
+      userMessage("u1", "hi"),
+      assistantMessage("a1-live", "hello there"),
+    ];
+    const persisted = [
+      userMessage("u1", "hi", { createdAt: "0" }),
+      assistantMessage("a1-db", "hello there", { createdAt: "1" }),
+    ];
+
+    const merged = mergePersistedMessageMetadata({
+      liveMessages: live,
+      persistedMessages: persisted,
+    });
+
+    expect(merged).toHaveLength(2);
+    // Live id wins (live thread is authoritative for messages it knows).
+    expect(merged[1].id).toBe("a1-live");
+    // Metadata still flows in from persisted.
+    expect(merged[1].metadata).toMatchObject({ createdAt: "1" });
+  });
+
+  it("leaves an unmatched live message in place and still recovers a tail assistant", () => {
+    // The live thread has a message the persisted thread lacks (e.g. a
+    // tool-call placeholder mid-stream that the backend hasn't written
+    // yet). We still want the recovered assistant turn to land at the end.
+    const live = [
+      userMessage("u1", "hi"),
+      // Some live-only artefact (no persisted twin yet).
+      {
+        id: "tool-1",
+        role: "user",
+        parts: [{ type: "text", text: "tool placeholder" }],
+      } as UIMessage,
+    ];
+    const persisted = [
+      userMessage("u1", "hi", { createdAt: "0" }),
+      assistantMessage("a1", "answer"),
+    ];
+
+    const merged = mergePersistedMessageMetadata({
+      liveMessages: live,
+      persistedMessages: persisted,
+    });
+
+    expect(merged.map((m) => m.id)).toEqual(["u1", "tool-1", "a1"]);
+  });
+});

--- a/platform/frontend/src/lib/chat/merge-persisted-messages.ts
+++ b/platform/frontend/src/lib/chat/merge-persisted-messages.ts
@@ -1,0 +1,144 @@
+import type { UIMessage } from "ai";
+
+/**
+ * Merge a live `useChat` thread with the persisted-from-DB thread.
+ *
+ * The two threads describe the same conversation but each carries facts the
+ * other lacks:
+ *   - The live thread is the source of truth for in-flight tokens, tool
+ *     calls, and any optimistic state the user is currently looking at.
+ *   - The persisted thread is the source of truth for `createdAt` timestamps
+ *     and for any messages the backend wrote *while the live thread was not
+ *     listening*. The classic case is a page reload while the LLM is still
+ *     thinking: the new `useChat` instance starts from whatever was in the
+ *     DB at that moment (just the user turn), and the assistant's reply
+ *     lands in the DB later via `onFinish` — but the live thread never sees
+ *     it.
+ *
+ * The merge therefore:
+ *   1. Walks the live thread, decorating each message with the matching
+ *      persisted message's metadata (so timestamps stay stable across
+ *      remounts).
+ *   2. If the live thread is awaiting an assistant turn (it ends with a
+ *      user message, or it is empty), appends any persisted messages that
+ *      come after the last matched live message. That recovers the missing
+ *      assistant turn without resurrecting earlier history that the user
+ *      may have intentionally edited away.
+ */
+export function mergePersistedMessageMetadata(params: {
+  liveMessages: UIMessage[];
+  persistedMessages: UIMessage[];
+}): UIMessage[] {
+  const matchedPersistedIds = new Set<string>();
+  let lastMatchedPersistedIndex = -1;
+
+  const merged = params.liveMessages.map((liveMessage) => {
+    const persistedIndex = findMatchingPersistedIndex({
+      liveMessage,
+      persistedMessages: params.persistedMessages,
+      matchedPersistedIds,
+    });
+
+    if (persistedIndex === -1) {
+      return liveMessage;
+    }
+
+    const persistedMessage = params.persistedMessages[persistedIndex];
+    matchedPersistedIds.add(persistedMessage.id);
+    if (persistedIndex > lastMatchedPersistedIndex) {
+      lastMatchedPersistedIndex = persistedIndex;
+    }
+
+    if (hasCreatedAtMetadata(liveMessage)) {
+      return liveMessage;
+    }
+
+    return {
+      ...liveMessage,
+      metadata: {
+        ...getObjectMetadata(persistedMessage),
+        ...getObjectMetadata(liveMessage),
+      },
+    };
+  });
+
+  // Only resurrect persisted-only tail messages when the live thread
+  // suggests it's waiting on an assistant turn. If the tail is already an
+  // assistant message, the live thread is up-to-date and we should not
+  // re-introduce older persisted history that may have been edited away.
+  const lastLive = params.liveMessages[params.liveMessages.length - 1];
+  const liveIsAwaitingAssistant = !lastLive || lastLive.role === "user";
+  if (!liveIsAwaitingAssistant) {
+    return merged;
+  }
+
+  const trailingPersisted = params.persistedMessages
+    .slice(lastMatchedPersistedIndex + 1)
+    .filter((message) => !matchedPersistedIds.has(message.id));
+
+  if (trailingPersisted.length === 0) {
+    return merged;
+  }
+
+  return [...merged, ...trailingPersisted];
+}
+
+function findMatchingPersistedIndex(params: {
+  liveMessage: UIMessage;
+  persistedMessages: UIMessage[];
+  matchedPersistedIds: Set<string>;
+}): number {
+  // Prefer id-equality when both threads agree on a stable id (the common
+  // case once the conversation has been hydrated from the DB at least once).
+  if (typeof params.liveMessage.id === "string" && params.liveMessage.id) {
+    const idMatch = params.persistedMessages.findIndex(
+      (persistedMessage) =>
+        persistedMessage.id === params.liveMessage.id &&
+        !params.matchedPersistedIds.has(persistedMessage.id),
+    );
+    if (idMatch !== -1) {
+      return idMatch;
+    }
+  }
+
+  // Fall back to renderable-text matching for messages whose ids haven't
+  // synced yet (e.g. an in-flight assistant message whose AI SDK temp id
+  // doesn't match the eventual DB UUID).
+  return params.persistedMessages.findIndex(
+    (persistedMessage) =>
+      !params.matchedPersistedIds.has(persistedMessage.id) &&
+      messagesHaveSameRenderableContent({
+        liveMessage: params.liveMessage,
+        persistedMessage,
+      }),
+  );
+}
+
+function messagesHaveSameRenderableContent(params: {
+  liveMessage: UIMessage;
+  persistedMessage: UIMessage;
+}) {
+  return (
+    params.liveMessage.role === params.persistedMessage.role &&
+    getMessageText(params.liveMessage) ===
+      getMessageText(params.persistedMessage)
+  );
+}
+
+function getMessageText(message: UIMessage): string {
+  return message.parts
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("\n");
+}
+
+function hasCreatedAtMetadata(message: UIMessage): boolean {
+  const metadata = getObjectMetadata(message);
+  return typeof metadata.createdAt === "string";
+}
+
+function getObjectMetadata(message: UIMessage): Record<string, unknown> {
+  return typeof message.metadata === "object" && message.metadata !== null
+    ? { ...message.metadata }
+    : {};
+}


### PR DESCRIPTION
Closes #3012.

/claim #3012

## Repro

Reload the chat tab while the LLM is still thinking. The new \`useChat\` hook initialises from whatever the DB contained at reload time — typically just the user turn (the backend persists the user message immediately so it survives reloads). The LLM eventually finishes; \`onFinish\` writes the assistant turn to the DB; but the live \`useChat\` thread never receives it.

Before this PR, \`mergePersistedMessageMetadata\` returned \`liveMessages.map(...)\`, so the assistant message — sitting right there in \`persistedConversationMessages\` after the next \`useConversation\` refetch — was silently dropped.

That matches all three symptoms in the issue:

- *\"messages just disappear and never show up, even once the agent executed the task\"* — the persisted assistant turn never makes it through the merge.
- *\"sometimes they do after some time\"* — only when something else (a follow-up edit, a new turn) replaces the live thread or invalidates it in a way that bypasses the merge.
- *\"sometimes they get duplicated\"* — adjacent fix below.

## Fix

\`frontend/src/lib/chat/merge-persisted-messages.ts\` (new module — extracted from \`app/chat/page.tsx\` so it's testable in isolation):

1. Match each live message to a persisted one — id first, then a content fallback for the in-flight assistant whose AI-SDK temp id hasn't yet been re-keyed to the DB UUID.
2. **New:** if the live thread is empty *or* its last message has role \`user\` (i.e. it's awaiting an assistant turn), append any persisted messages that come after the last matched index. That recovers the missing assistant turn.
3. The \"awaiting assistant\" guard is deliberately strict: when the live thread already ends with an assistant message we leave it alone, so we don't resurrect messages the user just edited away during the window between \`setMessages()\` and the persisted refetch.

The duplication case is also covered: when an in-flight assistant message has the same renderable text as a persisted twin, the content matcher collapses them, so the persisted copy is not also appended (see test).

## Files

- \`frontend/src/lib/chat/merge-persisted-messages.ts\` — new home for the merge function (was an internal helper inside \`page.tsx\`). Same id+content matching logic, plus the new tail-recovery step. \`messagesHaveSameRenderableContent\`, \`getMessageText\`, \`hasCreatedAtMetadata\`, \`getObjectMetadata\` moved alongside it.
- \`frontend/src/lib/chat/merge-persisted-messages.test.ts\` — 7 tests covering: empty live, agreed threads, metadata collision (live wins), the reload-recovery bug, edited-shorter (must not resurrect), in-flight assistant with matching content (must not duplicate), unmatched live message (still recovers tail).
- \`frontend/src/app/chat/page.tsx\` — imports from the new module; the inlined helpers are removed.

## Test plan

- [x] \`pnpm --filter @frontend test src/lib/chat/merge-persisted-messages.test.ts\` (7/7 pass).
- [x] \`pnpm --filter @frontend test src/lib/chat/ src/app/chat/\` (211/211 pass — no regression in neighbour suites).
- [x] \`pnpm --filter @frontend type-check\`.
- [x] \`pnpm lint\` (biome clean across all 4 workspaces).
- [x] Verification on the pre-fix code: I temporarily reverted the merge function to its previous body and re-ran the new test file — 3 of 7 tests fail (the reload-recovery test, the unmatched-live-message test, and the empty-live test), confirming the bug is real and the new behaviour fixes it.
- [ ] Manual smoke test: \`tilt up\`, send a long-running prompt (e.g. \"write a 500-word story\"), reload mid-stream, wait for backend's \`onFinish\` to write the assistant message to the DB, observe that it appears in the UI on next \`useConversation\` refetch instead of disappearing.