### PR TITLE
fix: enforce api key owner permissions

### DIFF
--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -159,10 +159,9 @@ export const auth = betterAuth({
       },
       permissions: {
         /**
-         * NOTE: for now we will just grant all permissions to all API keys
-         *
-         * If we'd like to allow granting "scopes" to API keys, we will need to implement a more complex API-key
-         * permissions system/UI
+         * Better Auth stores broad key permissions so API key sessions can be
+         * established. Route authorization still checks the API key owner's
+         * current RBAC permissions in hasPermission.
          */
         defaultPermissions: allAvailableActions,
       },

--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -159,9 +159,15 @@ export const auth = betterAuth({
       },
       permissions: {
         /**
-         * Better Auth stores broad key permissions so API key sessions can be
-         * established. Route authorization still checks the API key owner's
-         * current RBAC permissions in hasPermission.
+         * Better Auth applies these defaults to new API keys and uses them
+         * when `verifyApiKey` is called with a `permissions` body. Archestra
+         * route authorization does not rely on the stored key permissions;
+         * API-key requests are checked against the key owner's current RBAC
+         * permissions in hasPermission.
+         *
+         * Docs:
+         * - https://better-auth.com/docs/plugins/api-key/reference#permissions
+         * - https://better-auth.com/docs/plugins/api-key/advanced#sessions-from-api-keys
          */
         defaultPermissions: allAvailableActions,
       },

--- a/platform/backend/src/auth/utils.test.ts
+++ b/platform/backend/src/auth/utils.test.ts
@@ -13,6 +13,7 @@ import { hasPermission } from "./utils";
 
 vi.mock("@/models", () => ({
   UserModel: {
+    getById: vi.fn(),
     getUserPermissions: vi.fn(),
   },
 }));
@@ -30,6 +31,7 @@ import { auth as betterAuth } from "./better-auth";
 
 // Type the mocked functions
 const mockUserModel = UserModel as unknown as {
+  getById: MockedFunction<typeof UserModel.getById>;
   getUserPermissions: MockedFunction<typeof UserModel.getUserPermissions>;
 };
 
@@ -45,6 +47,21 @@ type ApiKey = Awaited<ReturnType<typeof betterAuth.api.verifyApiKey>>["key"];
 describe("hasPermission", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUserModel.getById.mockResolvedValue({
+      id: "user1",
+      name: "Test User",
+      email: "user1@test.com",
+      emailVerified: true,
+      image: null,
+      role: null,
+      banned: null,
+      banReason: null,
+      banExpires: null,
+      twoFactorEnabled: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      organizationId: "org-1",
+    });
     mockUserModel.getUserPermissions.mockResolvedValue({
       agent: ["read", "create", "update", "delete", "admin"],
       mcpServerInstallation: ["admin"],
@@ -115,13 +132,18 @@ describe("hasPermission", () => {
         error: null,
         key: makeApiKey({
           referenceId: "user1",
-          metadata: { organizationId: "org-1" },
+          metadata: null,
         }),
       });
 
       const result = await hasPermission(permissions, headers);
 
       expect(result).toEqual({ success: true, error: null });
+      expect(mockUserModel.getById).toHaveBeenCalledWith("user1");
+      expect(mockUserModel.getUserPermissions).toHaveBeenCalledWith(
+        "user1",
+        "org-1",
+      );
       expect(mockBetterAuth.api.verifyApiKey).toHaveBeenCalledWith({
         body: { key: "Bearer api-key-123" },
       });
@@ -141,7 +163,7 @@ describe("hasPermission", () => {
         error: null,
         key: makeApiKey({
           referenceId: "user-limited",
-          metadata: { organizationId: "org-1" },
+          metadata: null,
         }),
       });
       mockUserModel.getUserPermissions.mockResolvedValue({
@@ -272,13 +294,14 @@ describe("hasPermission", () => {
         error: null,
         key: makeApiKey({
           referenceId: "user1",
-          metadata: { organizationId: "org-1" },
+          metadata: null,
         }),
       });
 
       const result = await hasPermission(permissions, headers);
 
       expect(result).toEqual({ success: true, error: null });
+      expect(mockUserModel.getUserPermissions).toHaveBeenCalledTimes(1);
       expect(mockBetterAuth.api.verifyApiKey).toHaveBeenCalledWith({
         body: { key: "Bearer api-key-complex" },
       });
@@ -308,7 +331,7 @@ describe("hasPermission", () => {
           error: null,
           key: makeApiKey({
             referenceId: "user1",
-            metadata: { organizationId: "org-1" },
+            metadata: null,
           }),
         });
 

--- a/platform/backend/src/auth/utils.test.ts
+++ b/platform/backend/src/auth/utils.test.ts
@@ -17,6 +17,7 @@ vi.mock("@/models", () => ({
     getUserPermissions: vi.fn(),
   },
 }));
+
 // Mock the better-auth module
 vi.mock("./better-auth", () => ({
   auth: {
@@ -47,21 +48,7 @@ type ApiKey = Awaited<ReturnType<typeof betterAuth.api.verifyApiKey>>["key"];
 describe("hasPermission", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUserModel.getById.mockResolvedValue({
-      id: "user1",
-      name: "Test User",
-      email: "user1@test.com",
-      emailVerified: true,
-      image: null,
-      role: null,
-      banned: null,
-      banReason: null,
-      banExpires: null,
-      twoFactorEnabled: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      organizationId: "org-1",
-    });
+    mockUserModel.getById.mockResolvedValue(makeUserWithOrganization());
     mockUserModel.getUserPermissions.mockResolvedValue({
       agent: ["read", "create", "update", "delete", "admin"],
       mcpServerInstallation: ["admin"],
@@ -166,6 +153,12 @@ describe("hasPermission", () => {
           metadata: null,
         }),
       });
+      mockUserModel.getById.mockResolvedValue(
+        makeUserWithOrganization({
+          id: "user-limited",
+          email: "user-limited@test.com",
+        }),
+      );
       mockUserModel.getUserPermissions.mockResolvedValue({
         agent: ["read"],
       });
@@ -204,6 +197,35 @@ describe("hasPermission", () => {
           message: "No API key provided",
         }),
       });
+    });
+
+    test("should reject API key without an owner reference", async () => {
+      const permissions: Permissions = { agent: ["read"] };
+      const headers: IncomingHttpHeaders = {
+        authorization: "Bearer ownerless-key",
+      };
+
+      mockBetterAuth.api.hasPermission.mockRejectedValue(
+        new Error("No active organization"),
+      );
+      mockBetterAuth.api.verifyApiKey.mockResolvedValue({
+        valid: true,
+        error: null,
+        key: makeApiKey({
+          referenceId: undefined as unknown as string,
+        }),
+      });
+
+      const result = await hasPermission(permissions, headers);
+
+      expect(result).toEqual({
+        success: false,
+        error: expect.objectContaining({
+          message: "No API key provided",
+        }),
+      });
+      expect(mockUserModel.getById).not.toHaveBeenCalled();
+      expect(mockUserModel.getUserPermissions).not.toHaveBeenCalled();
     });
 
     test("should handle API key verification errors", async () => {
@@ -373,6 +395,27 @@ function makeApiKey(
     updatedAt: new Date(),
     metadata: null,
     permissions: null,
+    ...overrides,
+  };
+}
+
+function makeUserWithOrganization(
+  overrides: Partial<Awaited<ReturnType<typeof UserModel.getById>>> = {},
+): Awaited<ReturnType<typeof UserModel.getById>> {
+  return {
+    id: "user1",
+    name: "Test User",
+    email: "user1@test.com",
+    emailVerified: true,
+    image: null,
+    role: null,
+    banned: null,
+    banReason: null,
+    banExpires: null,
+    twoFactorEnabled: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    organizationId: "org-1",
     ...overrides,
   };
 }

--- a/platform/backend/src/auth/utils.test.ts
+++ b/platform/backend/src/auth/utils.test.ts
@@ -1,6 +1,7 @@
 import type { IncomingHttpHeaders } from "node:http";
 import type { Permissions } from "@shared";
 import { vi } from "vitest";
+import { UserModel } from "@/models";
 import {
   beforeEach,
   describe,
@@ -10,6 +11,11 @@ import {
 } from "@/test";
 import { hasPermission } from "./utils";
 
+vi.mock("@/models", () => ({
+  UserModel: {
+    getUserPermissions: vi.fn(),
+  },
+}));
 // Mock the better-auth module
 vi.mock("./better-auth", () => ({
   auth: {
@@ -23,6 +29,10 @@ vi.mock("./better-auth", () => ({
 import { auth as betterAuth } from "./better-auth";
 
 // Type the mocked functions
+const mockUserModel = UserModel as unknown as {
+  getUserPermissions: MockedFunction<typeof UserModel.getUserPermissions>;
+};
+
 const mockBetterAuth = betterAuth as unknown as {
   api: {
     hasPermission: MockedFunction<typeof betterAuth.api.hasPermission>;
@@ -35,6 +45,11 @@ type ApiKey = Awaited<ReturnType<typeof betterAuth.api.verifyApiKey>>["key"];
 describe("hasPermission", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUserModel.getUserPermissions.mockResolvedValue({
+      agent: ["read", "create", "update", "delete", "admin"],
+      mcpServerInstallation: ["admin"],
+      team: ["read"],
+    });
   });
 
   describe("session-based authentication", () => {
@@ -98,7 +113,10 @@ describe("hasPermission", () => {
       mockBetterAuth.api.verifyApiKey.mockResolvedValue({
         valid: true,
         error: null,
-        key: makeApiKey({ referenceId: "user1" }),
+        key: makeApiKey({
+          referenceId: "user1",
+          metadata: { organizationId: "org-1" },
+        }),
       });
 
       const result = await hasPermission(permissions, headers);
@@ -106,6 +124,35 @@ describe("hasPermission", () => {
       expect(result).toEqual({ success: true, error: null });
       expect(mockBetterAuth.api.verifyApiKey).toHaveBeenCalledWith({
         body: { key: "Bearer api-key-123" },
+      });
+    });
+
+    test("should reject when API key owner lacks required permissions", async () => {
+      const permissions: Permissions = { agent: ["admin"] };
+      const headers: IncomingHttpHeaders = {
+        authorization: "Bearer limited-user-key",
+      };
+
+      mockBetterAuth.api.hasPermission.mockRejectedValue(
+        new Error("No session"),
+      );
+      mockBetterAuth.api.verifyApiKey.mockResolvedValue({
+        valid: true,
+        error: null,
+        key: makeApiKey({
+          referenceId: "user-limited",
+          metadata: { organizationId: "org-1" },
+        }),
+      });
+      mockUserModel.getUserPermissions.mockResolvedValue({
+        agent: ["read"],
+      });
+
+      const result = await hasPermission(permissions, headers);
+
+      expect(result).toEqual({
+        success: false,
+        error: expect.objectContaining({ message: "Forbidden" }),
       });
     });
 
@@ -223,7 +270,10 @@ describe("hasPermission", () => {
       mockBetterAuth.api.verifyApiKey.mockResolvedValue({
         valid: true,
         error: null,
-        key: makeApiKey({ referenceId: "user1" }),
+        key: makeApiKey({
+          referenceId: "user1",
+          metadata: { organizationId: "org-1" },
+        }),
       });
 
       const result = await hasPermission(permissions, headers);
@@ -256,7 +306,10 @@ describe("hasPermission", () => {
         mockBetterAuth.api.verifyApiKey.mockResolvedValue({
           valid: true,
           error: null,
-          key: makeApiKey({ referenceId: "user1" }),
+          key: makeApiKey({
+            referenceId: "user1",
+            metadata: { organizationId: "org-1" },
+          }),
         });
 
         const result = await hasPermission(permissions, headers);

--- a/platform/backend/src/auth/utils.ts
+++ b/platform/backend/src/auth/utils.ts
@@ -45,16 +45,29 @@ export const hasPermission = async (
           body: { key: authHeader },
         });
         if (apiKeyResult?.valid && apiKeyResult.key?.referenceId) {
+          const apiKeyUserId = apiKeyResult.key.referenceId;
           logger.trace(
-            { apiKeyUserId: apiKeyResult.key.referenceId },
+            { apiKeyUserId },
             "[hasPermission] Valid API key found, checking owner permissions",
           );
 
-          const hasAllPermissions = await checkUserPermissions({
-            userId: apiKeyResult.key.referenceId,
-            organizationId: apiKeyResult.key.metadata?.organizationId ?? "",
+          const apiKeyOwner = await UserModel.getById(apiKeyUserId);
+          const organizationId = apiKeyOwner?.organizationId;
+          if (!organizationId) {
+            logger.trace(
+              "[hasPermission] API key missing organization context",
+            );
+            return { success: false, error: new Error("Forbidden") };
+          }
+
+          const userPermissions = await UserModel.getUserPermissions(
+            apiKeyUserId,
+            organizationId,
+          );
+          const hasAllPermissions = hasRequiredPermissions(
+            userPermissions,
             permissions,
-          });
+          );
 
           return {
             success: hasAllPermissions,
@@ -93,34 +106,17 @@ export const userHasPermission = async (
   return permissions[resource]?.includes(action) ?? false;
 };
 
-const checkUserPermissions = async (params: {
-  userId: string;
-  organizationId: string;
-  permissions: Permissions;
-}): Promise<boolean> => {
-  const { userId, organizationId, permissions } = params;
-
-  if (!organizationId) {
-    logger.trace("[hasPermission] API key missing organization context");
-    return false;
-  }
-
-  const permissionEntries = Object.entries(permissions);
-
-  for (const [resource, actions] of permissionEntries) {
+function hasRequiredPermissions(
+  userPermissions: Permissions,
+  requiredPermissions: Permissions,
+): boolean {
+  for (const [resource, actions] of Object.entries(requiredPermissions)) {
     for (const action of actions) {
-      const hasAccess = await userHasPermission(
-        userId,
-        organizationId,
-        resource as Resource,
-        action as Action,
-      );
-
-      if (!hasAccess) {
+      if (!userPermissions[resource as Resource]?.includes(action as Action)) {
         return false;
       }
     }
   }
 
   return true;
-};
+}

--- a/platform/backend/src/auth/utils.ts
+++ b/platform/backend/src/auth/utils.ts
@@ -44,12 +44,22 @@ export const hasPermission = async (
         const apiKeyResult = await betterAuth.api.verifyApiKey({
           body: { key: authHeader },
         });
-        if (apiKeyResult?.valid) {
-          // API keys have all permissions, so allow the request
+        if (apiKeyResult?.valid && apiKeyResult.key?.referenceId) {
           logger.trace(
-            "[hasPermission] Valid API key found, granting all permissions",
+            { apiKeyUserId: apiKeyResult.key.referenceId },
+            "[hasPermission] Valid API key found, checking owner permissions",
           );
-          return { success: true, error: null };
+
+          const hasAllPermissions = await checkUserPermissions({
+            userId: apiKeyResult.key.referenceId,
+            organizationId: apiKeyResult.key.metadata?.organizationId ?? "",
+            permissions,
+          });
+
+          return {
+            success: hasAllPermissions,
+            error: hasAllPermissions ? null : new Error("Forbidden"),
+          };
         }
         logger.trace("[hasPermission] API key verification returned invalid");
       } catch (_apiKeyError) {
@@ -81,4 +91,36 @@ export const userHasPermission = async (
     organizationId,
   );
   return permissions[resource]?.includes(action) ?? false;
+};
+
+const checkUserPermissions = async (params: {
+  userId: string;
+  organizationId: string;
+  permissions: Permissions;
+}): Promise<boolean> => {
+  const { userId, organizationId, permissions } = params;
+
+  if (!organizationId) {
+    logger.trace("[hasPermission] API key missing organization context");
+    return false;
+  }
+
+  const permissionEntries = Object.entries(permissions);
+
+  for (const [resource, actions] of permissionEntries) {
+    for (const action of actions) {
+      const hasAccess = await userHasPermission(
+        userId,
+        organizationId,
+        resource as Resource,
+        action as Action,
+      );
+
+      if (!hasAccess) {
+        return false;
+      }
+    }
+  }
+
+  return true;
 };

--- a/platform/backend/src/auth/utils.ts
+++ b/platform/backend/src/auth/utils.ts
@@ -28,8 +28,8 @@ export const hasPermission = async (
     return result;
   } catch (error) {
     /**
-     * Handle API key sessions that don't have organization context
-     * API keys have all permissions by default (see auth config)
+     * Fall back to API key verification and check the key owner's current
+     * RBAC permissions.
      */
     logger.trace(
       { error: error instanceof Error ? error.message : "unknown" },

--- a/platform/backend/src/routes/api-key-auth.test.ts
+++ b/platform/backend/src/routes/api-key-auth.test.ts
@@ -1,0 +1,138 @@
+import { ADMIN_ROLE_NAME } from "@shared";
+import { vi } from "vitest";
+import db, { schema } from "@/database";
+import type { FastifyInstanceWithZod } from "@/server";
+import { createFastifyInstance } from "@/server";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+
+const { getSessionMock, hasPermissionMock, verifyApiKeyMock } = vi.hoisted(
+  () => ({
+    getSessionMock: vi.fn(),
+    hasPermissionMock: vi.fn(),
+    verifyApiKeyMock: vi.fn(),
+  }),
+);
+
+vi.mock("@/auth/better-auth", () => ({
+  auth: {
+    api: {
+      getSession: getSessionMock,
+      hasPermission: hasPermissionMock,
+      verifyApiKey: verifyApiKeyMock,
+    },
+  },
+}));
+
+describe("API key route authorization", () => {
+  let app: FastifyInstanceWithZod;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    app = createFastifyInstance();
+    const { fastifyAuthPlugin } = await import("@/auth");
+    const { default: apiKeyRoutes } = await import("./api-key");
+    await app.register(fastifyAuthPlugin);
+    await app.register(apiKeyRoutes);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  test("allows a protected route when API key owner has required permissions and key metadata is null", async ({
+    makeUser,
+    makeOrganization,
+    makeMember,
+  }) => {
+    const user = await makeUser();
+    const organization = await makeOrganization();
+    await makeMember(user.id, organization.id, { role: ADMIN_ROLE_NAME });
+    await db.insert(schema.apikeysTable).values({
+      id: "route-key-1",
+      configId: "default",
+      name: "CLI Key",
+      key: "hashed-key-1",
+      referenceId: user.id,
+      enabled: true,
+      metadata: null,
+      createdAt: new Date("2026-03-15T00:00:00.000Z"),
+      updatedAt: new Date("2026-03-15T00:00:00.000Z"),
+    });
+
+    getSessionMock.mockRejectedValue(new Error("No session"));
+    hasPermissionMock.mockRejectedValue(new Error("No active organization"));
+    verifyApiKeyMock.mockResolvedValue({
+      valid: true,
+      error: null,
+      key: {
+        id: "route-key-1",
+        referenceId: user.id,
+        metadata: null,
+      },
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/api-keys",
+      headers: {
+        authorization: "archestra_test_key",
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject([
+      {
+        id: "route-key-1",
+        name: "CLI Key",
+        userId: user.id,
+        metadata: null,
+      },
+    ]);
+    expect(verifyApiKeyMock).toHaveBeenCalledWith({
+      body: { key: "archestra_test_key" },
+    });
+  });
+
+  test("rejects a protected route when API key owner lacks required permissions", async ({
+    makeUser,
+    makeOrganization,
+    makeCustomRole,
+    makeMember,
+  }) => {
+    const user = await makeUser();
+    const organization = await makeOrganization();
+    const role = await makeCustomRole(organization.id, {
+      permission: { agent: ["read"] },
+    });
+    await makeMember(user.id, organization.id, { role: role.role });
+
+    getSessionMock.mockRejectedValue(new Error("No session"));
+    hasPermissionMock.mockRejectedValue(new Error("No active organization"));
+    verifyApiKeyMock.mockResolvedValue({
+      valid: true,
+      error: null,
+      key: {
+        id: "route-key-2",
+        referenceId: user.id,
+        metadata: null,
+      },
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/api-keys",
+      headers: {
+        authorization: "archestra_limited_key",
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({
+      error: {
+        message: "Forbidden",
+        type: "api_authorization_error",
+      },
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Fix a security bug where API keys implicitly granted all permissions regardless of the creator’s role by enforcing authorization based on the API key owner’s effective permissions at request time.

### Description
- Change `hasPermission` fallback to verify the API key owner (`referenceId`) and evaluate their permissions instead of granting blanket access, in `backend/src/auth/utils.ts`.
- Add `checkUserPermissions` helper which uses `UserModel.getUserPermissions` to validate every requested resource/action against the API key owner’s permissions.
- Update unit tests in `backend/src/auth/utils.test.ts` to mock `UserModel.getUserPermissions`, cover successful API key-owner authorization, and add a test for the forbidden case when the owner lacks required permissions.
- Minor formatting/import adjustments to satisfy linter and keep tests deterministic.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>