### PR TITLE
ci: add random issue and PR assignee workflow

### DIFF
--- a/.github/workflows/random-issue-pr-assignee.yml
+++ b/.github/workflows/random-issue-pr-assignee.yml
@@ -3,7 +3,7 @@ name: Random Issue and PR Assignee
 on:
   issues:
     types: [opened]
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] needed to assign PRs from forks; this workflow does not check out or execute PR code.
     types: [opened, ready_for_review]
 
 permissions: {}
@@ -27,10 +27,15 @@ jobs:
           github-token: ${{ github.token }}
           script: |
             const owners = ['joeyorlando', 'iskhakov', 'Konstantinov-Innokentii'];
+            const coreTeam = [...owners, 'Matvey-Kuk'];
             const actor = context.payload.issue?.user?.login ?? context.payload.pull_request?.user?.login;
-            const availableOwners = owners.filter((owner) => owner !== actor);
-            const candidates = availableOwners.length > 0 ? availableOwners : owners;
-            const selectedOwner = candidates[Math.floor(Math.random() * candidates.length)];
+
+            if (coreTeam.includes(actor)) {
+              console.log(`Skipping assignment because ${actor} is on the core team`);
+              return;
+            }
+
+            const selectedOwner = owners[Math.floor(Math.random() * owners.length)];
 
             await github.rest.issues.addAssignees({
               owner: context.repo.owner,

--- a/.github/workflows/random-issue-pr-assignee.yml
+++ b/.github/workflows/random-issue-pr-assignee.yml
@@ -7,11 +7,13 @@ on:
   # workflows receive a read-only token for forked PRs. `pull_request_target`
   # would assign immediately, but it runs in the base repository security context
   # for untrusted PR events and has been a common source of Actions incidents.
+  #
   # A two-stage `workflow_run` flow can also assign fork PRs, but it still creates
-  # a privileged workflow triggered by PR activity and is flagged by our workflow
-  # security audit. Scheduled polling is less immediate, but it runs only from
-  # the default branch, does not execute or consume PR-controlled code, and still
-  # assigns recent fork PRs within a few minutes.
+  # a privileged workflow triggered by PR activity and is flagged by zizmor.
+  #
+  # Scheduled polling is less immediate, but it runs only from the default branch,
+  # does not execute or consume PR-controlled code, and still assigns recent fork
+  # PRs within a few minutes.
   schedule:
     - cron: "*/5 * * * *"
   workflow_dispatch:

--- a/.github/workflows/random-issue-pr-assignee.yml
+++ b/.github/workflows/random-issue-pr-assignee.yml
@@ -1,0 +1,42 @@
+name: Random Issue and PR Assignee
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened, ready_for_review]
+
+permissions: {}
+
+concurrency:
+  group: random-issue-pr-assignee-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  assign:
+    name: Assign
+    if: github.event_name == 'issues' || github.event.pull_request.draft == false
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    permissions:
+      issues: write # Required to assign issues and pull requests.
+
+    steps:
+      - name: Randomly assign owner
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const owners = ['joeyorlando', 'iskhakov', 'Konstantinov-Innokentii'];
+            const actor = context.payload.issue?.user?.login ?? context.payload.pull_request?.user?.login;
+            const availableOwners = owners.filter((owner) => owner !== actor);
+            const candidates = availableOwners.length > 0 ? availableOwners : owners;
+            const selectedOwner = candidates[Math.floor(Math.random() * candidates.length)];
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: [selectedOwner],
+            });
+
+            console.log(`Assigned #${context.issue.number} to ${selectedOwner}`);

--- a/.github/workflows/random-issue-pr-assignee.yml
+++ b/.github/workflows/random-issue-pr-assignee.yml
@@ -3,8 +3,9 @@ name: Random Issue and PR Assignee
 on:
   issues:
     types: [opened]
-  pull_request_target: # zizmor: ignore[dangerous-triggers] needed to assign PRs from forks; this workflow does not check out or execute PR code.
-    types: [opened, ready_for_review]
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
 
 permissions: {}
 
@@ -13,15 +14,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  assign:
-    name: Assign
-    if: github.event_name == 'issues' || github.event.pull_request.draft == false
+  assign-issue:
+    name: Assign Issue
+    if: github.event_name == 'issues'
     runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
-      issues: write # Required to assign issues and pull requests.
+      issues: write # Required to assign issues.
 
     steps:
-      - name: Randomly assign owner
+      - name: Randomly assign issue owner
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}
@@ -45,3 +46,62 @@ jobs:
             });
 
             console.log(`Assigned #${context.issue.number} to ${selectedOwner}`);
+
+  assign-recent-prs:
+    name: Assign Recent PRs
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    permissions:
+      issues: write # Required to assign pull requests.
+      pull-requests: read # Required to read PR metadata.
+
+    steps:
+      - name: Randomly assign recent PR owners
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const owners = ['joeyorlando', 'iskhakov', 'Konstantinov-Innokentii'];
+            const coreTeam = [...owners, 'Matvey-Kuk'];
+            const updatedSince = new Date(Date.now() - 30 * 60 * 1000);
+
+            const { data: pullRequests } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 50,
+            });
+
+            for (const pr of pullRequests) {
+              if (new Date(pr.updated_at) < updatedSince) {
+                break;
+              }
+
+              if (pr.draft) {
+                console.log(`Skipping assignment because PR #${pr.number} is still a draft`);
+                continue;
+              }
+
+              if (pr.assignees.length > 0) {
+                console.log(`Skipping assignment because PR #${pr.number} already has an assignee`);
+                continue;
+              }
+
+              if (coreTeam.includes(pr.user.login)) {
+                console.log(`Skipping assignment because ${pr.user.login} is on the core team`);
+                continue;
+              }
+
+              const selectedOwner = owners[Math.floor(Math.random() * owners.length)];
+
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                assignees: [selectedOwner],
+              });
+
+              console.log(`Assigned PR #${pr.number} to ${selectedOwner}`);
+            }

--- a/.github/workflows/random-issue-pr-assignee.yml
+++ b/.github/workflows/random-issue-pr-assignee.yml
@@ -45,9 +45,17 @@ jobs:
             const owners = JSON.parse(process.env.ASSIGNEE_LOGINS);
             const coreTeam = JSON.parse(process.env.CORE_TEAM_LOGINS);
             const actor = context.payload.issue.user.login;
+            const existingOwner = context.payload.issue.assignees.find((assignee) =>
+              owners.includes(assignee.login)
+            );
 
             if (coreTeam.includes(actor)) {
               console.log(`Skipping assignment because ${actor} is on the core team`);
+              return;
+            }
+
+            if (existingOwner) {
+              console.log(`Skipping assignment because #${context.issue.number} is already assigned to ${existingOwner.login}`);
               return;
             }
 
@@ -102,8 +110,12 @@ jobs:
                     continue;
                   }
 
-                  if (pr.assignees.length > 0) {
-                    console.log(`Skipping assignment because PR #${pr.number} already has an assignee`);
+                  const existingOwner = pr.assignees.find((assignee) =>
+                    owners.includes(assignee.login)
+                  );
+
+                  if (existingOwner) {
+                    console.log(`Skipping assignment because PR #${pr.number} is already assigned to ${existingOwner.login}`);
                     continue;
                   }
 

--- a/.github/workflows/random-issue-pr-assignee.yml
+++ b/.github/workflows/random-issue-pr-assignee.yml
@@ -1,19 +1,19 @@
-name: Random Issue and PR Assignee
+name: Random Issue Assignee and PR Reviewer
 
 on:
   issues:
     types: [opened]
-  # PRs from forks need a write-capable token for assignment, but `pull_request`
+  # PRs from forks need a write-capable token for reviewer requests, but `pull_request`
   # workflows receive a read-only token for forked PRs. `pull_request_target`
-  # would assign immediately, but it runs in the base repository security context
+  # would request reviewers immediately, but it runs in the base repository security context
   # for untrusted PR events and has been a common source of Actions incidents.
   #
-  # A two-stage `workflow_run` flow can also assign fork PRs, but it still creates
+  # A two-stage `workflow_run` flow can also request reviewers on fork PRs, but it still creates
   # a privileged workflow triggered by PR activity and is flagged by zizmor.
   #
   # Scheduled polling is less immediate, but it runs only from the default branch,
-  # does not execute or consume PR-controlled code, and still assigns recent fork
-  # PRs within a few minutes.
+  # does not execute or consume PR-controlled code, and still requests reviewers
+  # on recent fork PRs within a few minutes.
   schedule:
     - cron: "*/5 * * * *"
   workflow_dispatch:
@@ -25,7 +25,7 @@ env:
   CORE_TEAM_LOGINS: '["joeyorlando","iskhakov","Konstantinov-Innokentii","Matvey-Kuk"]'
 
 concurrency:
-  group: random-issue-pr-assignee-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
+  group: random-issue-pr-assignee-${{ github.event.issue.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -70,16 +70,15 @@ jobs:
 
             console.log(`Assigned #${context.issue.number} to ${selectedOwner}`);
 
-  assign-recent-prs:
-    name: Assign Recent PRs
+  request-recent-pr-reviewers:
+    name: Request Recent PR Reviewers
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
-      issues: write # Required to assign pull requests.
-      pull-requests: read # Required to read PR metadata.
+      pull-requests: write # Required to read PR metadata and request reviewers.
 
     steps:
-      - name: Randomly assign recent PR owners
+      - name: Randomly request recent PR reviewers
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}
@@ -106,37 +105,52 @@ jobs:
 
                 try {
                   if (pr.draft) {
-                    console.log(`Skipping assignment because PR #${pr.number} is still a draft`);
+                    console.log(`Skipping reviewer request because PR #${pr.number} is still a draft`);
                     continue;
                   }
 
-                  const existingOwner = pr.assignees.find((assignee) =>
-                    owners.includes(assignee.login)
+                  const reviewerLogins = new Set(
+                    pr.requested_reviewers.map((reviewer) => reviewer.login)
                   );
 
-                  if (existingOwner) {
-                    console.log(`Skipping assignment because PR #${pr.number} is already assigned to ${existingOwner.login}`);
+                  for await (const reviewsResponse of github.paginate.iterator(github.rest.pulls.listReviews, {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: pr.number,
+                    per_page: 100,
+                  })) {
+                    for (const review of reviewsResponse.data) {
+                      if (review.user?.login) {
+                        reviewerLogins.add(review.user.login);
+                      }
+                    }
+                  }
+
+                  const existingReviewer = owners.find((owner) => reviewerLogins.has(owner));
+
+                  if (existingReviewer) {
+                    console.log(`Skipping reviewer request because PR #${pr.number} already has ${existingReviewer} as a reviewer`);
                     continue;
                   }
 
                   if (coreTeam.includes(pr.user.login)) {
-                    console.log(`Skipping assignment because ${pr.user.login} is on the core team`);
+                    console.log(`Skipping reviewer request because ${pr.user.login} is on the core team`);
                     continue;
                   }
 
                   const selectedOwner = owners[Math.floor(Math.random() * owners.length)];
 
-                  await github.rest.issues.addAssignees({
+                  await github.rest.pulls.requestReviewers({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    issue_number: pr.number,
-                    assignees: [selectedOwner],
+                    pull_number: pr.number,
+                    reviewers: [selectedOwner],
                   });
 
-                  console.log(`Assigned PR #${pr.number} to ${selectedOwner}`);
+                  console.log(`Requested ${selectedOwner} to review PR #${pr.number}`);
                 } catch (error) {
                   const message = error instanceof Error ? error.message : String(error);
-                  console.error(`Failed to assign PR #${pr.number}: ${message}`);
+                  console.error(`Failed to request a reviewer for PR #${pr.number}: ${message}`);
                 }
               }
 

--- a/.github/workflows/random-issue-pr-assignee.yml
+++ b/.github/workflows/random-issue-pr-assignee.yml
@@ -3,6 +3,15 @@ name: Random Issue and PR Assignee
 on:
   issues:
     types: [opened]
+  # PRs from forks need a write-capable token for assignment, but `pull_request`
+  # workflows receive a read-only token for forked PRs. `pull_request_target`
+  # would assign immediately, but it runs in the base repository security context
+  # for untrusted PR events and has been a common source of Actions incidents.
+  # A two-stage `workflow_run` flow can also assign fork PRs, but it still creates
+  # a privileged workflow triggered by PR activity and is flagged by our workflow
+  # security audit. Scheduled polling is less immediate, but it runs only from
+  # the default branch, does not execute or consume PR-controlled code, and still
+  # assigns recent fork PRs within a few minutes.
   schedule:
     - cron: "*/5 * * * *"
   workflow_dispatch:

--- a/.github/workflows/random-issue-pr-assignee.yml
+++ b/.github/workflows/random-issue-pr-assignee.yml
@@ -20,6 +20,10 @@ on:
 
 permissions: {}
 
+env:
+  ASSIGNEE_LOGINS: '["joeyorlando","iskhakov","Konstantinov-Innokentii"]'
+  CORE_TEAM_LOGINS: '["joeyorlando","iskhakov","Konstantinov-Innokentii","Matvey-Kuk"]'
+
 concurrency:
   group: random-issue-pr-assignee-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -38,9 +42,9 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
-            const owners = ['joeyorlando', 'iskhakov', 'Konstantinov-Innokentii'];
-            const coreTeam = [...owners, 'Matvey-Kuk'];
-            const actor = context.payload.issue?.user?.login ?? context.payload.pull_request?.user?.login;
+            const owners = JSON.parse(process.env.ASSIGNEE_LOGINS);
+            const coreTeam = JSON.parse(process.env.CORE_TEAM_LOGINS);
+            const actor = context.payload.issue.user.login;
 
             if (coreTeam.includes(actor)) {
               console.log(`Skipping assignment because ${actor} is on the core team`);
@@ -72,47 +76,59 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
-            const owners = ['joeyorlando', 'iskhakov', 'Konstantinov-Innokentii'];
-            const coreTeam = [...owners, 'Matvey-Kuk'];
+            const owners = JSON.parse(process.env.ASSIGNEE_LOGINS);
+            const coreTeam = JSON.parse(process.env.CORE_TEAM_LOGINS);
             const updatedSince = new Date(Date.now() - 30 * 60 * 1000);
 
-            const { data: pullRequests } = await github.rest.pulls.list({
+            for await (const response of github.paginate.iterator(github.rest.pulls.list, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
               sort: 'updated',
               direction: 'desc',
-              per_page: 50,
-            });
+              per_page: 100,
+            })) {
+              let reachedOlderPrs = false;
 
-            for (const pr of pullRequests) {
-              if (new Date(pr.updated_at) < updatedSince) {
+              for (const pr of response.data) {
+                if (new Date(pr.updated_at) < updatedSince) {
+                  reachedOlderPrs = true;
+                  break;
+                }
+
+                try {
+                  if (pr.draft) {
+                    console.log(`Skipping assignment because PR #${pr.number} is still a draft`);
+                    continue;
+                  }
+
+                  if (pr.assignees.length > 0) {
+                    console.log(`Skipping assignment because PR #${pr.number} already has an assignee`);
+                    continue;
+                  }
+
+                  if (coreTeam.includes(pr.user.login)) {
+                    console.log(`Skipping assignment because ${pr.user.login} is on the core team`);
+                    continue;
+                  }
+
+                  const selectedOwner = owners[Math.floor(Math.random() * owners.length)];
+
+                  await github.rest.issues.addAssignees({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    assignees: [selectedOwner],
+                  });
+
+                  console.log(`Assigned PR #${pr.number} to ${selectedOwner}`);
+                } catch (error) {
+                  const message = error instanceof Error ? error.message : String(error);
+                  console.error(`Failed to assign PR #${pr.number}: ${message}`);
+                }
+              }
+
+              if (reachedOlderPrs) {
                 break;
               }
-
-              if (pr.draft) {
-                console.log(`Skipping assignment because PR #${pr.number} is still a draft`);
-                continue;
-              }
-
-              if (pr.assignees.length > 0) {
-                console.log(`Skipping assignment because PR #${pr.number} already has an assignee`);
-                continue;
-              }
-
-              if (coreTeam.includes(pr.user.login)) {
-                console.log(`Skipping assignment because ${pr.user.login} is on the core team`);
-                continue;
-              }
-
-              const selectedOwner = owners[Math.floor(Math.random() * owners.length)];
-
-              await github.rest.issues.addAssignees({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                assignees: [selectedOwner],
-              });
-
-              console.log(`Assigned PR #${pr.number} to ${selectedOwner}`);
             }


### PR DESCRIPTION
## What changed

Adds a GitHub Actions workflow that assigns new issues and requests PR reviewers from one randomly selected owner:

- joeyorlando
- iskhakov
- Konstantinov-Innokentii

Issues are assigned immediately when opened. Pull request reviewers are requested by a scheduled default-branch workflow that polls recently updated open PRs every five minutes, which supports fork PRs without using `pull_request_target` or `workflow_run`.

Issue assignment and PR reviewer requests are skipped when the issue or PR opener is already on the current core team:

- joeyorlando
- iskhakov
- Konstantinov-Innokentii
- Matvey-Kuk

Draft PRs are skipped. Issues already assigned to one of the three owners are skipped. PRs that already have one of the three owners requested as a reviewer, or have already been reviewed by one of them, are also skipped.

## Why

This restores lightweight automatic ownership for incoming community issues and PRs while avoiding privileged PR-triggered workflows.

## Validation

- Parsed `.github/workflows/random-issue-pr-assignee.yml` with Ruby's YAML parser.
- Ran `zizmor ../.github/workflows/random-issue-pr-assignee.yml`; no findings reported.
