### PR TITLE
docs: split pricing model into its own page

### DIFF
--- a/docs/pages/platform-api-reference.md
+++ b/docs/pages/platform-api-reference.md
@@ -2,7 +2,7 @@
 title: "API Reference"
 category: Archestra Platform
 description: "Interactive API documentation for Archestra"
-order: 9
+order: 6
 lastUpdated: 2025-01-10
 ---
 

--- a/docs/pages/platform-observability.md
+++ b/docs/pages/platform-observability.md
@@ -1,7 +1,7 @@
 ---
 title: Observability
 category: Archestra Platform
-order: 5
+order: 4
 ---
 
 <!--

--- a/docs/pages/platform-overview.md
+++ b/docs/pages/platform-overview.md
@@ -34,17 +34,4 @@ Archestra is built as a set of composable components. Most organizations already
 
 **[Security & Guardrails](/docs/platform-lethal-trifecta)** and **[Observability](/docs/platform-observability)** — Deterministic tool invocation policies and trusted data policies that cannot be bypassed by prompt injection. Prometheus metrics, OpenTelemetry tracing, and [per-team cost tracking](/docs/platform-costs-and-limits).
 
-## Pricing Model
-
-Archestra is Open Core software licensed under AGPL-3.0 meaning that the majority of it is open source and free to use, some features are licensed under a custom license and should be activated with an agreement with Archestra Inc.
-
-The rule of thumb is that if your company is small or mid-size, you can most likely use Open Source Archestra and never hit the limit. If you're looking to deploy an AI platform in the enterprise, we encourage you to talk to us at sales@archestra.ai.
-
-Such components are not enabled for the open source Archestra:
-
-- Role Based Access Control (granular control over what different categories of users are able to see in the platform)
-- SSO & OIDC
-- Whitelabeling
-- Advanced access control for RAG Knowledge Base
-
-If you're willing to pilot the enterprise feature set, please don't hesitate to reach out to us at sales@archestra.ai for the PoC license.
+See [Pricing Model](/docs/platform-pricing-model) for licensing details.

--- a/docs/pages/platform-performance-benchmarks.md
+++ b/docs/pages/platform-performance-benchmarks.md
@@ -1,7 +1,7 @@
 ---
 title: Performance & Latency
 category: Archestra Platform
-order: 6
+order: 5
 description: Performance metrics and benchmarks for Archestra Platform's security features
 lastUpdated: 2025-10-15
 ---

--- a/docs/pages/platform-pricing-model.md
+++ b/docs/pages/platform-pricing-model.md
@@ -1,0 +1,19 @@
+---
+title: Pricing Model
+category: Archestra Platform
+order: 2
+description: How Archestra Platform is priced and licensed
+lastUpdated: 2026-05-05
+---
+
+Archestra is Open Core software licensed under AGPL-3.0 meaning that the majority of it is open source and free to use, some features are licensed under a custom license and should be activated with an agreement with Archestra Inc.
+
+The rule of thumb is that if your company is small or mid-size, you can most likely use Open Source Archestra and never hit the limit. If you're looking to deploy an AI platform in the enterprise, we encourage you to talk to us at sales@archestra.ai.
+
+Such components are not enabled for the open source Archestra:
+
+- Role Based Access Control (granular control over what different categories of users are able to see in the platform)
+- SSO & OIDC
+- Knowledge Base and RAG with access control
+
+If you're willing to pilot the enterprise feature set, please don't hesitate to reach out to us at sales@archestra.ai for the PoC license.


### PR DESCRIPTION
Moves the Pricing Model section out of platform-overview.md into a dedicated page so it shows up as a separate entry in the docs sidebar (after Quickstart). Removes whitelabeling from the bullet list. Tightens the order field on neighboring docs.