### PR TITLE
docs: clarify IdP group claims setup

### DIFF
--- a/docs/pages/platform-entra-obo-setup.md
+++ b/docs/pages/platform-entra-obo-setup.md
@@ -4,7 +4,7 @@ category: Administration
 subcategory: Identity Providers
 description: "End-to-end setup for Microsoft Entra ID — SSO sign-in plus On-Behalf-Of token exchange for downstream MCP tool calls"
 order: 7
-lastUpdated: 2026-04-30
+lastUpdated: 2026-05-05
 ---
 
 <!--
@@ -83,12 +83,14 @@ Role mapping and team sync are provider-agnostic and fully documented on dedicat
 - [Role Mapping](/docs/platform-sso-role-mapping)
 - [Team Sync](/docs/platform-sso-team-sync)
 
-For Entra, the most common pattern is mapping the `groups` claim to Archestra teams. Make sure the **Groups claim** is enabled in the Entra app's **Token configuration** (set it to `Group ID` for object IDs, or `sAMAccountName` for on-prem-synced names). Then in Archestra:
+For Entra, the most common pattern is mapping the `groups` claim to Archestra teams. Make sure the **Groups claim** is enabled in the Entra app's **Token configuration** (set it to `Group ID` for object IDs, or `sAMAccountName` for on-prem-synced names). Entra does not require an additional OAuth scope for group claims; the Token configuration blade controls what appears in the ID token. Microsoft's guide covers the IdP-side configuration: [Configure group claims for applications by using Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/how-to-connect-fed-group-claims).
+
+Then in Archestra:
 
 - **Groups Handlebars Template** _(default extraction works for `groups`)_: leave empty, or use `{{#each groups}}{{this}},{{/each}}`
 - Link your Archestra teams to the Entra group object IDs (or names) under **Settings > Teams** > link icon
 
-🎉 **SSO is done.** Your users can now sign in with Microsoft and land in the right teams. If you don't need per-user downstream API calls, you can stop here.
+**SSO is done.** Your users can now sign in with Microsoft and land in the right teams. If you don't need per-user downstream API calls, you can stop here.
 
 # Configuring OBO for Enterprise MCP Auth
 

--- a/docs/pages/platform-identity-providers.md
+++ b/docs/pages/platform-identity-providers.md
@@ -3,7 +3,7 @@ title: "Identity Providers"
 category: Administration
 description: "Index of identity-related configuration in Archestra — SSO sign-in, downstream token exchange, role mapping, team sync, and per-provider walkthroughs"
 order: 2
-lastUpdated: 2026-04-30
+lastUpdated: 2026-05-05
 ---
 
 <!--
@@ -114,7 +114,7 @@ Optional:
 
 - **Discovery Endpoint:** the `.well-known/openid-configuration` URL (defaults to issuer + `/.well-known/openid-configuration`)
 - **Authorization / Token / User Info / JWKS endpoints:** override the discovery defaults
-- **Scopes:** additional OAuth scopes (default: `openid`, `email`, `profile`)
+- **Scopes:** additional OAuth scopes (default: `openid`, `email`, `profile`). Add the provider's groups scope, often `groups`, when role mapping or team sync reads group claims.
 - **PKCE:** enable if your provider requires it
 - **Enable RP-Initiated Logout:** sends `post_logout_redirect_uri` during sign-out (on by default; disable for providers that reject it)
 
@@ -149,4 +149,3 @@ Optional:
 - [Enterprise-Managed Auth](/docs/platform-enterprise-managed-auth) — downstream token exchange (OBO, ID-JAG, RFC 8693)
 - [Role Mapping](/docs/platform-sso-role-mapping) — map IdP claims to Archestra roles
 - [Team Sync](/docs/platform-sso-team-sync) — sync IdP groups to Archestra teams
-

--- a/docs/pages/platform-okta-setup.md
+++ b/docs/pages/platform-okta-setup.md
@@ -4,7 +4,7 @@ category: Administration
 subcategory: Identity Providers
 description: "End-to-end setup for Okta — SSO sign-in plus Okta-managed token exchange for downstream MCP tool calls"
 order: 8
-lastUpdated: 2026-04-30
+lastUpdated: 2026-05-05
 ---
 
 <!--
@@ -131,6 +131,15 @@ Click **Create Provider**. Users can now sign in:
 
 Test in a private browser window with a user who is assigned to the Okta app.
 
+### Supported SSO features
+
+| Feature | Supported | Notes |
+| --- | --- | --- |
+| **IdP-initiated SSO** | Yes | Users can start from the Archestra tile in the Okta End-User Dashboard when using the OIN app. |
+| **SP-initiated SSO** | Yes | Users start from the Archestra sign-in page, select **Sign in with Okta**, authenticate in Okta, and return to Archestra through the OIDC callback URL. |
+| **SP-initiated SLO** | Yes | When users sign out of Archestra, Archestra can redirect them to Okta's OIDC logout endpoint. Keep **Enable RP-Initiated Logout** on unless your Okta app rejects the `post_logout_redirect_uri` parameter. |
+| **JIT provisioning** | Yes | First-time SSO users are created during login, then role mapping and team sync are applied from Okta claims. |
+
 At this point SSO is working. If you also want token exchange for downstream MCP tool calls, continue with Section 4.
 
 ## 3. Roles & Teams Sync
@@ -140,7 +149,9 @@ Role mapping and team sync are provider-agnostic and fully documented on dedicat
 - [Role Mapping](/docs/platform-sso-role-mapping)
 - [Team Sync](/docs/platform-sso-team-sync)
 
-For Okta, the most common pattern is mapping the `groups` claim to Archestra teams. Make sure the **Groups claim** is enabled in your Okta authorization server (or for the app integration). Then in Archestra, leave the default group extraction or use:
+For Okta, the most common pattern is mapping the `groups` claim to Archestra teams. Make sure the **Groups claim** is enabled in your Okta authorization server or app integration, and that the SSO provider scopes include `groups`. Okta's guide covers both pieces: [Customize tokens returned from Okta with a groups claim](https://developer.okta.com/docs/guides/customize-tokens-groups-claim/main/).
+
+Then in Archestra, leave the default group extraction or use:
 
 ```handlebars
 {{#each groups}}{{this}},{{/each}}

--- a/docs/pages/platform-sso-role-mapping.md
+++ b/docs/pages/platform-sso-role-mapping.md
@@ -4,7 +4,7 @@ category: Administration
 subcategory: Identity Providers
 description: "Map SSO claims to Archestra roles using Handlebars templates"
 order: 5
-lastUpdated: 2026-04-30
+lastUpdated: 2026-05-05
 ---
 
 <!--
@@ -64,6 +64,10 @@ Templates should render to any non-empty string (like `"true"`) when the rule ma
 
 > **Tip:** templates should output any non-empty string when matching. The text `"true"` is commonly used but any output works.
 
+### OIDC group claims
+
+For OIDC providers, group-based rules only work if the ID token contains the group claim. Many IdPs do not include groups with the default `openid`, `email`, and `profile` scopes. If your template reads `groups`, add the provider's group scope (commonly named `groups`) and configure the IdP to emit that claim in the ID token.
+
 ### Handling JSON string claims
 
 Some identity providers (like Okta) may send complex claims as JSON strings rather than native arrays. For example:
@@ -100,7 +104,7 @@ This template:
 
 **Missing groups claim:**
 
-- For OIDC: verify your IdP is configured to include groups in the token/userinfo
+- For OIDC: verify your IdP is configured to include groups in the ID token, and that the SSO provider requests the groups scope required by your IdP
 - For SAML: check that group attributes are included in the assertion and properly mapped
 
 **Template always returns empty:**

--- a/docs/pages/platform-sso-team-sync.md
+++ b/docs/pages/platform-sso-team-sync.md
@@ -4,7 +4,7 @@ category: Administration
 subcategory: Identity Providers
 description: "Automatically add and remove users from Archestra teams based on IdP group membership"
 order: 6
-lastUpdated: 2026-04-30
+lastUpdated: 2026-05-05
 ---
 
 <!--
@@ -40,6 +40,8 @@ If no custom Handlebars template is configured, Archestra automatically checks t
 `groups`, `group`, `memberOf`, `member_of`, `roles`, `role`, `teams`, `team`
 
 The first claim that contains non-empty group data is used.
+
+For OIDC providers, make sure the ID token actually includes group data before configuring extraction. Many IdPs do not include groups with the default `openid`, `email`, and `profile` scopes. If you sync from `groups`, add the provider's groups scope (often `groups`) and configure the IdP to emit that claim in the ID token.
 
 ### Custom Handlebars templates
 
@@ -152,7 +154,7 @@ If your IdP sends roles as objects (for example `roles: [{name: "admin"}, {name:
 2. Verify your Handlebars template extracts the expected groups from the ID token
 3. Use a JWT decoder (like [jwt.io](https://jwt.io)) to inspect your ID token claims
 4. Check that the group identifier in Archestra exactly matches the extracted group name
-5. Ensure your IdP is configured to include group claims in the ID token (not just userinfo)
+5. Ensure your IdP is configured to include group claims in the ID token, and that Archestra requests the groups scope required by your IdP
 6. Check backend logs for sync errors
 
 You can test Handlebars templates at [tryhandlebarsjs.com](http://tryhandlebarsjs.com/) using your actual ID token claims as input.


### PR DESCRIPTION
## Summary

- Document that OIDC group-based role mapping and team sync require group claims in the ID token.
- Clarify that providers may need an additional groups scope, often `groups`, beyond `openid`, `email`, and `profile`.
- Add provider-specific guidance and official links for Okta group claims and Microsoft Entra group claims.
- Add Okta supported SSO features: IdP-initiated SSO, SP-initiated SSO, SP-initiated SLO, and JIT provisioning.

## Why

Some IdPs do not include group claims with only the default `openid`, `email`, and `profile` scopes. That can make role mapping and team sync look misconfigured even when the Archestra mapping templates are correct.