### PR TITLE
fix: support protected resource enterprise credentials

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -98104,6 +98104,9 @@
                           "clientIdOverride": {
                             "type": "string"
                           },
+                          "clientSecretOverride": {
+                            "type": "string"
+                          },
                           "tokenInjectionMode": {
                             "type": "string",
                             "enum": [
@@ -98934,6 +98937,9 @@
                       "clientIdOverride": {
                         "type": "string"
                       },
+                      "clientSecretOverride": {
+                        "type": "string"
+                      },
                       "tokenInjectionMode": {
                         "type": "string",
                         "enum": [
@@ -99477,6 +99483,9 @@
                           "type": "string"
                         },
                         "clientIdOverride": {
+                          "type": "string"
+                        },
+                        "clientSecretOverride": {
                           "type": "string"
                         },
                         "tokenInjectionMode": {
@@ -100333,6 +100342,9 @@
                         "clientIdOverride": {
                           "type": "string"
                         },
+                        "clientSecretOverride": {
+                          "type": "string"
+                        },
                         "tokenInjectionMode": {
                           "type": "string",
                           "enum": [
@@ -101154,6 +101166,9 @@
                       "clientIdOverride": {
                         "type": "string"
                       },
+                      "clientSecretOverride": {
+                        "type": "string"
+                      },
                       "tokenInjectionMode": {
                         "type": "string",
                         "enum": [
@@ -101705,6 +101720,9 @@
                           "type": "string"
                         },
                         "clientIdOverride": {
+                          "type": "string"
+                        },
+                        "clientSecretOverride": {
                           "type": "string"
                         },
                         "tokenInjectionMode": {

--- a/docs/pages/platform-enterprise-managed-auth.md
+++ b/docs/pages/platform-enterprise-managed-auth.md
@@ -4,7 +4,7 @@ category: Administration
 subcategory: Identity Providers
 description: "Per-user identity for downstream MCP tool calls — OBO, ID-JAG, Cross-App Access, and RFC 8693 token exchange"
 order: 4
-lastUpdated: 2026-04-30
+lastUpdated: 2026-05-05
 ---
 
 <!--
@@ -81,8 +81,9 @@ A live demo of this is [motd.xaa.rocks](https://motd.xaa.rocks) — a "Resource"
 To use ID-JAG with Archestra:
 
 1. Configure your IdP to issue ID-JAGs with the audience equal to the third-party app
-2. In the MCP catalog item, set **Requested Credential** to **ID-JAG** and **Managed Resource Identifier** to the audience
-3. Archestra includes the assertion in tool calls; the third-party verifies it and exchanges for its own token
+2. In the MCP catalog item, set **Requested Credential** to **ID-JAG** and **Managed Resource Identifier** to the resource server URL or audience
+3. If the MCP server is an OAuth protected resource, set the protected-resource token endpoint audience and resource client credentials
+4. Archestra exchanges the user's IdP token for an ID-JAG, swaps that ID-JAG at the protected resource's authorization server, and sends the resulting access token to the MCP server
 
 ## Field reference
 
@@ -97,6 +98,8 @@ The Enterprise-Managed Credentials form on each OIDC provider has these fields:
 | **Signing Key ID** | The `kid` of the public key registered with the IdP. Only used with `private_key_jwt`. |
 | **Client Assertion Audience** | Optional override for the `aud` claim of the client assertion. Defaults to the exchange token endpoint. |
 | **User Token To Exchange** | Which token Archestra should hand back to the IdP for exchange. `Access token` (Entra default), `ID token` (Okta default), or generic `JWT`. |
+
+For OAuth protected resources that accept ID-JAG, the MCP catalog item can also override the resource app's client ID and secret. Use these overrides when the requesting app registered with the IdP is different from the client that authenticates to the resource authorization server.
 
 ### Strategy defaults
 

--- a/docs/pages/platform-mcp.md
+++ b/docs/pages/platform-mcp.md
@@ -3,7 +3,7 @@ title: Overview
 category: MCP
 order: -1
 description: How MCP servers, gateways, authentication, and orchestration fit together
-lastUpdated: 2026-04-20
+lastUpdated: 2026-05-05
 ---
 
 <!--
@@ -46,6 +46,8 @@ Remote MCP servers run outside Archestra and are reached over HTTP. Use them whe
 Self-hosted MCP servers run inside your Kubernetes cluster through the MCP Orchestrator. Use them when you want isolation, lifecycle management, local network access, or a custom server image.
 
 Both types can be assigned to Agents and MCP Gateways. The client does not need to know which runtime backs each tool.
+
+Some MCP servers expose resources through `resources/list` instead of callable tools through `tools/list`. When a remote server has resources but no tools, Archestra creates read-resource tools during installation so agents can access those resources through the normal tool assignment flow.
 
 ## Authentication Model
 

--- a/docs/pages/platform-okta-setup.md
+++ b/docs/pages/platform-okta-setup.md
@@ -126,7 +126,7 @@ Fill in:
 
 Click **Create Provider**. Users can now sign in:
 
-- **From the Archestra sign-in page** by clicking **Sign in with Okta**
+- **From the Archestra sign-in page** by entering their email address and clicking **Log in**. Archestra matches the email domain to the Okta provider, redirects the user to Okta, then completes the OIDC callback after Okta authentication.
 - **From the Archestra tile on their Okta End-User Dashboard** (OIN install only) — Okta redirects to Archestra and Archestra completes the SSO flow
 
 Test in a private browser window with a user who is assigned to the Okta app.
@@ -136,7 +136,7 @@ Test in a private browser window with a user who is assigned to the Okta app.
 | Feature | Supported | Notes |
 | --- | --- | --- |
 | **IdP-initiated SSO** | Yes | Users can start from the Archestra tile in the Okta End-User Dashboard when using the OIN app. |
-| **SP-initiated SSO** | Yes | Users start from the Archestra sign-in page, select **Sign in with Okta**, authenticate in Okta, and return to Archestra through the OIDC callback URL. |
+| **SP-initiated SSO** | Yes | Users open the Archestra login page, enter their email address, and click **Log in**. Archestra redirects them to Okta, then Okta returns them to Archestra through the OIDC callback URL after authentication. |
 | **SP-initiated SLO** | Yes | When users sign out of Archestra, Archestra can redirect them to Okta's OIDC logout endpoint. Keep **Enable RP-Initiated Logout** on unless your Okta app rejects the `post_logout_redirect_uri` parameter. |
 | **JIT provisioning** | Yes | First-time SSO users are created during login, then role mapping and team sync are applied from Okta claims. |
 

--- a/platform/backend/src/clients/chat-mcp-client.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.test.ts
@@ -59,6 +59,7 @@ vi.mock("@/services/identity-providers/session-token", () => ({
 beforeEach(() => {
   vi.mocked(mcpClient.executeToolCall).mockReset();
   vi.mocked(resolveSessionExternalIdpToken).mockResolvedValue(null);
+  vi.mocked(StreamableHTTPClientTransport).mockClear();
 });
 
 describe("isBrowserMcpTool", () => {
@@ -1267,6 +1268,44 @@ describe("getChatMcpClient", () => {
       .calls[0] as [URL, { requestInit?: RequestInit }];
     const headers = new Headers(options.requestInit?.headers);
     expect(headers.get("Authorization")).toBe("Bearer external-idp-jwt");
+  });
+
+  test("falls back to the internal gateway token when session-derived external IdP auth fails", async () => {
+    mockConnect.mockReset();
+    mockConnect
+      .mockRejectedValueOnce(new Error("Unauthorized"))
+      .mockResolvedValueOnce(undefined);
+    mockClose.mockReset();
+    vi.mocked(resolveSessionExternalIdpToken).mockResolvedValue({
+      identityProviderId: crypto.randomUUID(),
+      providerId: "okta-chat",
+      rawToken: "external-idp-jwt",
+    });
+
+    const agentId = crypto.randomUUID();
+    const userId = crypto.randomUUID();
+    const organizationId = crypto.randomUUID();
+
+    const client = await chatClient.getChatMcpClient(
+      agentId,
+      userId,
+      organizationId,
+      undefined,
+      "internal-fallback-token",
+    );
+
+    expect(client).not.toBeNull();
+    expect(mockConnect).toHaveBeenCalledTimes(2);
+
+    const authorizationHeaders = vi
+      .mocked(StreamableHTTPClientTransport)
+      .mock.calls.map(([, options]) =>
+        new Headers(
+          (options as { requestInit?: RequestInit }).requestInit?.headers,
+        ).get("Authorization"),
+      );
+    expect(authorizationHeaders).toContain("Bearer external-idp-jwt");
+    expect(authorizationHeaders).toContain("Bearer internal-fallback-token");
   });
 });
 

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -468,7 +468,7 @@ export async function getChatMcpClient(
       await pingClientWithTimeout(cachedClient);
       logger.info(
         { agentId, userId },
-        "✅ Returning cached MCP client for agent/user (ping succeeded, session will be reused)",
+        "Returning cached MCP client for agent/user (ping succeeded, session will be reused)",
       );
       clientCache.set(cacheKey, cachedClient);
       return cachedClient;
@@ -502,7 +502,7 @@ export async function getChatMcpClient(
       userId,
       totalCachedClients: clientCache.size,
     },
-    "🔄 No cached client found - creating new MCP client for agent/user via gateway",
+    "No cached client found - creating new MCP client for agent/user via gateway",
   );
 
   const externalIdpToken = await resolveSessionExternalIdpToken({
@@ -597,7 +597,7 @@ export async function getChatMcpClient(
         userId,
         totalCachedClients: clientCache.size,
       },
-      "✅ MCP client cached - subsequent requests will reuse this session",
+      "MCP client cached - subsequent requests will reuse this session",
     );
 
     return client;
@@ -629,7 +629,7 @@ export async function getChatMcpClient(
             userId,
             totalCachedClients: clientCache.size,
           },
-          "✅ MCP client cached - subsequent requests will reuse this session",
+          "MCP client cached - subsequent requests will reuse this session",
         );
 
         return client;

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -513,8 +513,10 @@ export async function getChatMcpClient(
   // Reuse pre-resolved token when available to avoid a redundant DB round-trip
   // (getChatMcpTools already calls selectMCPGatewayToken before this).
   let tokenValue: string;
+  let fallbackTokenValue: string | null = null;
   if (externalIdpToken) {
     tokenValue = externalIdpToken.rawToken;
+    fallbackTokenValue = preResolvedTokenValue ?? null;
     logger.info(
       {
         agentId,
@@ -545,14 +547,14 @@ export async function getChatMcpClient(
   // Use new URL format with profileId in path
   const mcpGatewayUrl = `${MCP_GATEWAY_BASE_URL}/${agentId}`;
 
-  try {
+  const connectWithToken = async (authToken: string) => {
     // Create StreamableHTTP transport with profile token authentication
     const transport = new StreamableHTTPClientTransport(
       new URL(mcpGatewayUrl),
       {
         requestInit: {
           headers: new Headers({
-            Authorization: `Bearer ${tokenValue}`,
+            Authorization: `Bearer ${authToken}`,
             Accept: "application/json, text/event-stream",
           }),
         },
@@ -574,6 +576,11 @@ export async function getChatMcpClient(
       "Connecting to MCP Gateway...",
     );
     await client.connect(transport);
+    return client;
+  };
+
+  try {
+    const client = await connectWithToken(tokenValue);
 
     logger.info(
       { agentId, userId },
@@ -595,6 +602,46 @@ export async function getChatMcpClient(
 
     return client;
   } catch (error) {
+    if (fallbackTokenValue) {
+      logger.warn(
+        {
+          error,
+          agentId,
+          userId,
+          url: mcpGatewayUrl,
+        },
+        "Failed to connect to MCP Gateway with session-derived external IdP token; retrying with internal gateway token",
+      );
+
+      try {
+        const client = await connectWithToken(fallbackTokenValue);
+
+        logger.info(
+          { agentId, userId },
+          "Successfully connected to MCP Gateway with internal gateway token fallback",
+        );
+
+        clientCache.set(cacheKey, client);
+
+        logger.info(
+          {
+            agentId,
+            userId,
+            totalCachedClients: clientCache.size,
+          },
+          "✅ MCP client cached - subsequent requests will reuse this session",
+        );
+
+        return client;
+      } catch (fallbackError) {
+        logger.error(
+          { error: fallbackError, agentId, userId, url: mcpGatewayUrl },
+          "Failed to connect to MCP Gateway for agent/user with fallback token",
+        );
+        return null;
+      }
+    }
+
     logger.error(
       { error, agentId, userId, url: mcpGatewayUrl },
       "Failed to connect to MCP Gateway for agent/user",

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -5,6 +5,7 @@ import {
   MCP_CATALOG_REAUTH_QUERY_PARAM,
   MCP_CATALOG_SERVER_QUERY_PARAM,
   MCP_ENTERPRISE_AUTH_EXTENSION_ID,
+  OAUTH_TOKEN_TYPE,
 } from "@shared";
 import { vi } from "vitest";
 import config from "@/config";
@@ -1509,7 +1510,7 @@ describe("McpClient", () => {
               tokenEndpoint:
                 "http://localhost:30081/realms/archestra/protocol/openid-connect/token",
               tokenEndpointAuthentication: "client_secret_post",
-              subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+              subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
             },
           },
         });
@@ -1852,7 +1853,7 @@ describe("McpClient", () => {
               tokenEndpoint:
                 "http://localhost:30081/realms/archestra/protocol/openid-connect/token",
               tokenEndpointAuthentication: "client_secret_post",
-              subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+              subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
             },
           },
         });

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -27,6 +27,7 @@ const mockCallTool = vi.fn();
 const mockConnect = vi.fn();
 const mockClose = vi.fn();
 const mockListTools = vi.fn();
+const mockListResources = vi.fn();
 const mockPing = vi.fn();
 
 vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
@@ -36,6 +37,7 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
     this.callTool = mockCallTool;
     this.close = mockClose;
     this.listTools = mockListTools;
+    this.listResources = mockListResources;
     this.ping = mockPing;
   }),
 }));
@@ -121,6 +123,7 @@ describe("McpClient", () => {
     mockConnect.mockReset();
     mockClose.mockReset();
     mockListTools.mockReset();
+    mockListResources.mockReset();
     mockPing.mockReset();
     mockUsesStreamableHttp.mockReset();
     mockGetHttpEndpointUrl.mockReset();
@@ -144,6 +147,7 @@ describe("McpClient", () => {
 
     // Default: listTools returns empty list (fallback to stripped name)
     mockListTools.mockResolvedValue({ tools: [] });
+    mockListResources.mockResolvedValue({ resources: [] });
   });
 
   test("invalidateConnectionsForServer closes cached active connections for the server", async () => {
@@ -191,6 +195,45 @@ describe("McpClient", () => {
     );
 
     expect(mockConnect).toHaveBeenCalledTimes(1);
+  });
+
+  test("connectAndGetTools synthesizes read-resource tools when upstream has no tools/list", async () => {
+    mockListTools.mockRejectedValueOnce(new Error("Method not found"));
+    mockListResources.mockResolvedValueOnce({
+      resources: [
+        {
+          uri: "todo://todos",
+          name: "Todos",
+          description: "Read todos",
+        },
+      ],
+    });
+
+    const catalogItem = await InternalMcpCatalogModel.findById(catalogId);
+    if (!catalogItem) throw new Error("expected catalog item");
+
+    const tools = await mcpClient.connectAndGetTools({
+      catalogItem,
+      mcpServerId,
+      secrets: { access_token: "resource-token" },
+    });
+
+    expect(tools).toEqual([
+      {
+        name: "read_resource_todos",
+        description: "Read todos",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+        },
+        _meta: {
+          archestraResourceUri: "todo://todos",
+        },
+        annotations: undefined,
+      },
+    ]);
+    expect(mockListResources).toHaveBeenCalledTimes(1);
   });
 
   describe("executeToolCall", () => {

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -237,6 +237,31 @@ describe("McpClient", () => {
     expect(mockListResources).toHaveBeenCalledTimes(1);
   });
 
+  test("connectAndGetTools treats JSON-RPC method-not-found code as resource-only discovery", async () => {
+    mockListTools.mockRejectedValueOnce({ code: -32601 });
+    mockListResources.mockResolvedValueOnce({
+      resources: [
+        {
+          uri: "todo://todos",
+          name: "Todos",
+        },
+      ],
+    });
+
+    const catalogItem = await InternalMcpCatalogModel.findById(catalogId);
+    if (!catalogItem) throw new Error("expected catalog item");
+
+    const tools = await mcpClient.connectAndGetTools({
+      catalogItem,
+      mcpServerId,
+      secrets: { access_token: "resource-token" },
+    });
+
+    expect(tools).toHaveLength(1);
+    expect(tools[0].name).toBe("read_resource_todos");
+    expect(mockListResources).toHaveBeenCalledTimes(1);
+  });
+
   describe("executeToolCall", () => {
     test("returns error when tool not found for agent", async () => {
       const toolCall = {

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -493,6 +493,28 @@ class McpClient {
           targetToolName = parseFullToolName(toolCall.name).toolName;
         }
 
+        const resourceUri = getSyntheticResourceToolUri(tool.meta);
+        if (resourceUri) {
+          const result = await client.readResource({ uri: resourceUri });
+          return await this.createSuccessResult({
+            toolCall,
+            agentId,
+            mcpServerName,
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(result.contents),
+              },
+            ],
+            isError: false,
+            _meta: { resourceUri },
+            authInfo,
+            structuredContent: {
+              contents: result.contents as unknown,
+            },
+          });
+        }
+
         // Resolve the actual tool name from the server (preserving original casing).
         // Tool names in the DB are lowercased by slugifyName(), but remote MCP servers
         // may use camelCase or mixed-case names (e.g., "atlassianUserInfo" vs "atlassianuserinfo").
@@ -2374,18 +2396,16 @@ class McpClient {
           "Connection timeout after 30 seconds",
         );
 
-        // List tools with timeout
-        const toolsResult = await this.raceWithTimeout(
-          client.listTools(),
-          30000,
-          "List tools timeout after 30 seconds",
-        );
+        // List tools with timeout. Some MCP servers expose only resources; for
+        // those, synthesize read-resource tools so agents can still exercise the
+        // server through the normal tool-assignment path.
+        const tools = await this.discoverToolsOrResourceTools(client);
 
         // Close connection (we just needed the tools)
         await client.close();
 
         // Transform tools to our format
-        return toolsResult.tools.map((tool: Tool) => ({
+        return tools.map((tool: Tool) => ({
           name: tool.name,
           description: tool.description || `Tool: ${tool.name}`,
           inputSchema: tool.inputSchema as Record<string, unknown>,
@@ -2418,6 +2438,47 @@ class McpClient {
         lastError?.message || "Unknown error"
       }`,
     );
+  }
+
+  private async discoverToolsOrResourceTools(
+    client: Client,
+  ): Promise<Tool[]> {
+    try {
+      const toolsResult = await this.raceWithTimeout(
+        client.listTools(),
+        30000,
+        "List tools timeout after 30 seconds",
+      );
+      return toolsResult.tools;
+    } catch (error) {
+      if (!isMethodNotFoundError(error)) {
+        throw error;
+      }
+
+      const resourcesResult = await this.raceWithTimeout(
+        client.listResources(),
+        30000,
+        "List resources timeout after 30 seconds",
+      );
+
+      return resourcesResult.resources.map((resource) => {
+        const uri = resource.uri;
+        const displayName = resource.name ?? resource.uri;
+        return {
+          name: makeSyntheticResourceToolName(uri),
+          description:
+            resource.description ?? `Read MCP resource ${displayName}`,
+          inputSchema: {
+            type: "object",
+            properties: {},
+            additionalProperties: false,
+          },
+          _meta: {
+            archestraResourceUri: uri,
+          },
+        };
+      }) as Tool[];
+    }
   }
 
   /**
@@ -3083,6 +3144,34 @@ function isHighFrequencyBrowserTool(toolName: string): boolean {
     name.includes("browser_tabs") ||
     name.includes("browser_resize")
   );
+}
+
+function getSyntheticResourceToolUri(
+  meta: Record<string, unknown> | null | undefined,
+): string | null {
+  const nestedMeta = meta?._meta;
+  if (!nestedMeta || typeof nestedMeta !== "object") {
+    return null;
+  }
+
+  const resourceUri = (nestedMeta as Record<string, unknown>)
+    .archestraResourceUri;
+  return typeof resourceUri === "string" && resourceUri.length > 0
+    ? resourceUri
+    : null;
+}
+
+function makeSyntheticResourceToolName(uri: string): string {
+  const slug = uri
+    .replace(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//, "")
+    .replace(/[^a-zA-Z0-9_-]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toLowerCase();
+  return `read_resource_${slug || "resource"}`.slice(0, 128);
+}
+
+function isMethodNotFoundError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes("Method not found");
 }
 
 // Singleton instance

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -3169,7 +3169,16 @@ function makeSyntheticResourceToolName(uri: string): string {
 }
 
 function isMethodNotFoundError(error: unknown): boolean {
-  return error instanceof Error && error.message.includes("Method not found");
+  if (error instanceof Error && error.message.includes("Method not found")) {
+    return true;
+  }
+
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === -32601
+  );
 }
 
 // Singleton instance

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -2440,9 +2440,7 @@ class McpClient {
     );
   }
 
-  private async discoverToolsOrResourceTools(
-    client: Client,
-  ): Promise<Tool[]> {
+  private async discoverToolsOrResourceTools(client: Client): Promise<Tool[]> {
     try {
       const toolsResult = await this.raceWithTimeout(
         client.listTools(),

--- a/platform/backend/src/models/agent-tool.ts
+++ b/platform/backend/src/models/agent-tool.ts
@@ -524,7 +524,9 @@ class AgentToolModel {
   static async bulkCreateForAgentsAndTools(
     agentIds: string[],
     toolIds: string[],
-    options?: Partial<Pick<InsertAgentTool, "mcpServerId">>,
+    options?: Partial<
+      Pick<InsertAgentTool, "mcpServerId" | "credentialResolutionMode">
+    >,
   ): Promise<void> {
     if (agentIds.length === 0 || toolIds.length === 0) return;
 
@@ -533,6 +535,7 @@ class AgentToolModel {
       agentId: string;
       toolId: string;
       mcpServerId?: string | null;
+      credentialResolutionMode?: CredentialResolutionMode;
     }> = [];
 
     for (const agentId of agentIds) {
@@ -541,6 +544,9 @@ class AgentToolModel {
           agentId,
           toolId,
           ...(options?.mcpServerId ? { mcpServerId: options.mcpServerId } : {}),
+          ...(options?.credentialResolutionMode
+            ? { credentialResolutionMode: options.credentialResolutionMode }
+            : {}),
         });
       }
     }
@@ -573,6 +579,24 @@ class AgentToolModel {
         .insert(schema.agentToolsTable)
         .values(newAssignments)
         .onConflictDoNothing();
+    }
+
+    if (options?.mcpServerId || options?.credentialResolutionMode) {
+      await db
+        .update(schema.agentToolsTable)
+        .set({
+          ...(options.mcpServerId ? { mcpServerId: options.mcpServerId } : {}),
+          ...(options.credentialResolutionMode
+            ? { credentialResolutionMode: options.credentialResolutionMode }
+            : {}),
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            inArray(schema.agentToolsTable.agentId, agentIds),
+            inArray(schema.agentToolsTable.toolId, toolIds),
+          ),
+        );
     }
   }
 

--- a/platform/backend/src/models/agent-tool.ts
+++ b/platform/backend/src/models/agent-tool.ts
@@ -581,7 +581,10 @@ class AgentToolModel {
         .onConflictDoNothing();
     }
 
-    if (options?.mcpServerId || options?.credentialResolutionMode) {
+    if (
+      (options?.mcpServerId || options?.credentialResolutionMode) &&
+      existingAssignments.length > 0
+    ) {
       await db
         .update(schema.agentToolsTable)
         .set({

--- a/platform/backend/src/models/identity-provider.ee.test.ts
+++ b/platform/backend/src/models/identity-provider.ee.test.ts
@@ -1,5 +1,9 @@
 import type { IdpRoleMappingConfig } from "@shared";
-import { IDENTITY_TRUSTED_PROVIDER_IDS, MEMBER_ROLE_NAME } from "@shared";
+import {
+  IDENTITY_TRUSTED_PROVIDER_IDS,
+  MEMBER_ROLE_NAME,
+  OAUTH_TOKEN_TYPE,
+} from "@shared";
 import { APIError } from "better-auth";
 import { vi } from "vitest";
 import { retrieveIdpGroups } from "@/auth/idp-team-sync-cache.ee";
@@ -202,7 +206,7 @@ describe("IdentityProviderModel", () => {
               tokenEndpoint:
                 "https://keycloak.example.com/realms/archestra/protocol/openid-connect/token",
               tokenEndpointAuthentication: "client_secret_post",
-              subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+              subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
             },
           },
         },
@@ -226,7 +230,7 @@ describe("IdentityProviderModel", () => {
       );
       expect(
         created.oidcConfig?.enterpriseManagedCredentials?.subjectTokenType,
-      ).toBe("urn:ietf:params:oauth:token-type:access_token");
+      ).toBe(OAUTH_TOKEN_TYPE.AccessToken);
     });
 
     test("clears persisted allowed email domains for non-Google API submissions", async ({
@@ -1227,7 +1231,7 @@ describe("IdentityProviderModel", () => {
               tokenEndpoint:
                 "http://localhost:30081/realms/archestra/protocol/openid-connect/token",
               tokenEndpointAuthentication: "client_secret_post",
-              subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+              subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
             },
           } as never,
         },

--- a/platform/backend/src/models/internal-mcp-catalog.test.ts
+++ b/platform/backend/src/models/internal-mcp-catalog.test.ts
@@ -104,9 +104,9 @@ describe("InternalMcpCatalogModel", () => {
       const catalogItems = await InternalMcpCatalogModel.findAll();
       const foundCatalog = catalogItems.find((item) => item.id === catalog.id);
 
-      expect(
-        foundCatalog?.enterpriseManagedConfig?.clientSecretOverride,
-      ).toBe("resource-client-secret");
+      expect(foundCatalog?.enterpriseManagedConfig?.clientSecretOverride).toBe(
+        "resource-client-secret",
+      );
     });
 
     test("does not expand secrets when expandSecrets: false", async ({

--- a/platform/backend/src/models/internal-mcp-catalog.test.ts
+++ b/platform/backend/src/models/internal-mcp-catalog.test.ts
@@ -1,6 +1,9 @@
 import { ARCHESTRA_MCP_CATALOG_ID, DEFAULT_APP_NAME } from "@shared";
 import { describe, expect, test } from "@/test";
-import { SelectInternalMcpCatalogSchema } from "@/types";
+import {
+  ENTERPRISE_MANAGED_CLIENT_SECRET_OVERRIDE_SECRET_KEY,
+  SelectInternalMcpCatalogSchema,
+} from "@/types";
 import InternalMcpCatalogModel from "./internal-mcp-catalog";
 import McpCatalogLabelModel from "./mcp-catalog-label";
 
@@ -73,6 +76,37 @@ describe("InternalMcpCatalogModel", () => {
       expect(foundCatalog?.localConfig?.environment?.[1].value).toBe(
         "test-db-pass-789",
       );
+    });
+
+    test("expands enterprise-managed client secret override from catalog secret", async ({
+      makeSecret,
+    }) => {
+      const clientSecret = await makeSecret({
+        name: "enterprise-managed-resource-secret",
+        secret: {
+          [ENTERPRISE_MANAGED_CLIENT_SECRET_OVERRIDE_SECRET_KEY]:
+            "resource-client-secret",
+        },
+      });
+
+      const catalog = await InternalMcpCatalogModel.create({
+        name: "test-catalog-with-enterprise-secret",
+        serverType: "remote",
+        serverUrl: "https://example.com/mcp",
+        clientSecretId: clientSecret.id,
+        enterpriseManagedConfig: {
+          resourceType: "oauth_protected_resource",
+          resourceIdentifier: "https://example.com/mcp",
+          requestedCredentialType: "id_jag",
+        },
+      });
+
+      const catalogItems = await InternalMcpCatalogModel.findAll();
+      const foundCatalog = catalogItems.find((item) => item.id === catalog.id);
+
+      expect(
+        foundCatalog?.enterpriseManagedConfig?.clientSecretOverride,
+      ).toBe("resource-client-secret");
     });
 
     test("does not expand secrets when expandSecrets: false", async ({

--- a/platform/backend/src/models/internal-mcp-catalog.ts
+++ b/platform/backend/src/models/internal-mcp-catalog.ts
@@ -1,10 +1,11 @@
 import { and, desc, eq, ilike, inArray, or } from "drizzle-orm";
 import db, { schema } from "@/database";
 import { secretManager } from "@/secrets-manager";
-import type {
-  InsertInternalMcpCatalog,
-  InternalMcpCatalog,
-  UpdateInternalMcpCatalog,
+import {
+  ENTERPRISE_MANAGED_CLIENT_SECRET_OVERRIDE_SECRET_KEY,
+  type InsertInternalMcpCatalog,
+  type InternalMcpCatalog,
+  type UpdateInternalMcpCatalog,
 } from "@/types";
 import McpCatalogLabelModel from "./mcp-catalog-label";
 import McpCatalogTeamModel from "./mcp-catalog-team";
@@ -386,6 +387,21 @@ class InternalMcpCatalogModel {
         }
       }
 
+      if (catalogItem.clientSecretId && catalogItem.enterpriseManagedConfig) {
+        const unresolvedSecret = unresolvedSecretMap.get(
+          catalogItem.clientSecretId,
+        );
+        const secret = unresolvedSecret?.isByosVault
+          ? unresolvedSecret
+          : resolvedSecretMap.get(catalogItem.clientSecretId);
+        const value =
+          secret?.secret[ENTERPRISE_MANAGED_CLIENT_SECRET_OVERRIDE_SECRET_KEY];
+        if (value) {
+          catalogItem.enterpriseManagedConfig.clientSecretOverride =
+            String(value);
+        }
+      }
+
       // Enrich local config secret env vars
       if (
         catalogItem.localConfigSecretId &&
@@ -445,6 +461,16 @@ class InternalMcpCatalogModel {
         const value = secret?.secret.client_secret;
         if (value) {
           catalogItem.oauthConfig.client_secret = String(value);
+        }
+      }
+
+      if (catalogItem.clientSecretId && catalogItem.enterpriseManagedConfig) {
+        const secret = secretMap.get(catalogItem.clientSecretId);
+        const value =
+          secret?.secret[ENTERPRISE_MANAGED_CLIENT_SECRET_OVERRIDE_SECRET_KEY];
+        if (value) {
+          catalogItem.enterpriseManagedConfig.clientSecretOverride =
+            String(value);
         }
       }
 

--- a/platform/backend/src/models/team-token.test.ts
+++ b/platform/backend/src/models/team-token.test.ts
@@ -195,7 +195,7 @@ describe("TeamTokenModel", () => {
       expect(validated).toBeNull();
     });
 
-    test("validates correct token among multiple tokens (batch fetch)", async ({
+    test("validates correct token among multiple token candidates", async ({
       makeOrganization,
       makeUser,
       makeTeam,
@@ -205,7 +205,7 @@ describe("TeamTokenModel", () => {
       const team1 = await makeTeam(org.id, user.id, { name: "Team A" });
       const team2 = await makeTeam(org.id, user.id, { name: "Team B" });
 
-      // Create multiple tokens to verify batch secret fetching
+      // Create multiple tokens to verify candidate matching.
       await TeamTokenModel.create({
         organizationId: org.id,
         name: "Org Token",
@@ -224,7 +224,7 @@ describe("TeamTokenModel", () => {
         teamId: team2.id,
       });
 
-      // Validate the middle token - should find it via batch secret lookup
+      // Validate the middle token - should match the correct secret.
       const validated = await TeamTokenModel.validateToken(value2);
       expect(validated).not.toBeNull();
       expect(validated?.name).toBe("Team A Token");

--- a/platform/backend/src/models/team-token.ts
+++ b/platform/backend/src/models/team-token.ts
@@ -278,9 +278,18 @@ class TeamTokenModel {
       .where(eq(schema.teamTokensTable.tokenStart, tokenStart));
     if (candidates.length === 0) return null;
 
+    const secretsById = new Map(
+      await Promise.all(
+        candidates.map(async (token) => [
+          token.secretId,
+          await secretManager().getSecret(token.secretId),
+        ] as const),
+      ),
+    );
+
     // Match the provided token value against stored secrets
     for (const token of candidates) {
-      const secret = await secretManager().getSecret(token.secretId);
+      const secret = secretsById.get(token.secretId);
       if (
         secret?.secret &&
         (secret.secret as { token?: string }).token === tokenValue

--- a/platform/backend/src/models/team-token.ts
+++ b/platform/backend/src/models/team-token.ts
@@ -2,7 +2,6 @@ import { randomBytes } from "node:crypto";
 import { ARCHESTRA_TOKEN_PREFIX } from "@shared";
 import { desc, eq } from "drizzle-orm";
 import db, { schema } from "@/database";
-import SecretModel from "@/models/secret";
 import { secretManager } from "@/secrets-manager";
 import type {
   InsertTeamToken,
@@ -279,14 +278,9 @@ class TeamTokenModel {
       .where(eq(schema.teamTokensTable.tokenStart, tokenStart));
     if (candidates.length === 0) return null;
 
-    // Batch-fetch secrets for candidates (team tokens always use DB storage)
-    const secretIds = candidates.map((t) => t.secretId);
-    const secrets = await SecretModel.findByIds(secretIds);
-    const secretMap = new Map(secrets.map((s) => [s.id, s]));
-
     // Match the provided token value against stored secrets
     for (const token of candidates) {
-      const secret = secretMap.get(token.secretId);
+      const secret = await secretManager().getSecret(token.secretId);
       if (
         secret?.secret &&
         (secret.secret as { token?: string }).token === tokenValue

--- a/platform/backend/src/models/team-token.ts
+++ b/platform/backend/src/models/team-token.ts
@@ -280,10 +280,13 @@ class TeamTokenModel {
 
     const secretsById = new Map(
       await Promise.all(
-        candidates.map(async (token) => [
-          token.secretId,
-          await secretManager().getSecret(token.secretId),
-        ] as const),
+        candidates.map(
+          async (token) =>
+            [
+              token.secretId,
+              await secretManager().getSecret(token.secretId),
+            ] as const,
+        ),
       ),
     );
 

--- a/platform/backend/src/models/tool.test.ts
+++ b/platform/backend/src/models/tool.test.ts
@@ -435,6 +435,7 @@ describe("ToolModel", () => {
         catalogId: catalogItem.id,
         catalogName: "github-mcp-server",
         credentialResolutionMode: "static",
+        meta: null,
       });
     });
 

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -932,6 +932,7 @@ class ToolModel {
           schema.agentToolsTable.credentialResolutionMode,
         catalogId: schema.toolsTable.catalogId,
         catalogName: schema.internalMcpCatalogTable.name,
+        meta: schema.toolsTable.meta,
       })
       .from(schema.toolsTable)
       .innerJoin(
@@ -975,6 +976,7 @@ class ToolModel {
           schema.agentToolsTable.credentialResolutionMode,
         catalogId: schema.toolsTable.catalogId,
         catalogName: schema.internalMcpCatalogTable.name,
+        meta: schema.toolsTable.meta,
       })
       .from(schema.toolsTable)
       .innerJoin(

--- a/platform/backend/src/models/user-token.test.ts
+++ b/platform/backend/src/models/user-token.test.ts
@@ -196,12 +196,12 @@ describe("UserTokenModel", () => {
       expect(updated?.lastUsedAt).not.toBeNull();
     });
 
-    test("validates correct token among multiple tokens (batch fetch)", async ({
+    test("validates correct token among multiple token candidates", async ({
       makeUser,
       makeOrganization,
       makeMember,
     }) => {
-      // Create multiple users with tokens to exercise batch secret fetching
+      // Create multiple users with tokens to exercise candidate matching.
       const org = await makeOrganization();
       const user1 = await makeUser();
       const user2 = await makeUser();
@@ -218,7 +218,7 @@ describe("UserTokenModel", () => {
       );
       await UserTokenModel.create(user3.id, org.id, "Token 3");
 
-      // Validate the middle token to ensure batch lookup works correctly
+      // Validate the middle token to ensure lookup matches the correct secret.
       const validated = await UserTokenModel.validateToken(value2);
       expect(validated?.id).toBe(token2.id);
       expect(validated?.userId).toBe(user2.id);

--- a/platform/backend/src/models/user-token.ts
+++ b/platform/backend/src/models/user-token.ts
@@ -207,9 +207,18 @@ class UserTokenModel {
       .where(eq(schema.userTokensTable.tokenStart, tokenStart));
     if (candidates.length === 0) return null;
 
+    const secretsById = new Map(
+      await Promise.all(
+        candidates.map(async (token) => [
+          token.secretId,
+          await secretManager().getSecret(token.secretId),
+        ] as const),
+      ),
+    );
+
     // Match the provided token value against stored secrets
     for (const token of candidates) {
-      const secret = await secretManager().getSecret(token.secretId);
+      const secret = secretsById.get(token.secretId);
       if (
         secret?.secret &&
         (secret.secret as { token?: string }).token === tokenValue

--- a/platform/backend/src/models/user-token.ts
+++ b/platform/backend/src/models/user-token.ts
@@ -3,7 +3,6 @@ import { ARCHESTRA_TOKEN_PREFIX } from "@shared";
 import { and, eq } from "drizzle-orm";
 import db, { schema } from "@/database";
 import logger from "@/logging";
-import SecretModel from "@/models/secret";
 import { secretManager } from "@/secrets-manager";
 import type { SelectUserToken } from "@/types";
 
@@ -208,14 +207,9 @@ class UserTokenModel {
       .where(eq(schema.userTokensTable.tokenStart, tokenStart));
     if (candidates.length === 0) return null;
 
-    // Batch-fetch secrets for candidates (user tokens always use DB storage)
-    const secretIds = candidates.map((t) => t.secretId);
-    const secrets = await SecretModel.findByIds(secretIds);
-    const secretMap = new Map(secrets.map((s) => [s.id, s]));
-
     // Match the provided token value against stored secrets
     for (const token of candidates) {
-      const secret = secretMap.get(token.secretId);
+      const secret = await secretManager().getSecret(token.secretId);
       if (
         secret?.secret &&
         (secret.secret as { token?: string }).token === tokenValue

--- a/platform/backend/src/models/user-token.ts
+++ b/platform/backend/src/models/user-token.ts
@@ -209,10 +209,13 @@ class UserTokenModel {
 
     const secretsById = new Map(
       await Promise.all(
-        candidates.map(async (token) => [
-          token.secretId,
-          await secretManager().getSecret(token.secretId),
-        ] as const),
+        candidates.map(
+          async (token) =>
+            [
+              token.secretId,
+              await secretManager().getSecret(token.secretId),
+            ] as const,
+        ),
       ),
     );
 

--- a/platform/backend/src/routes/auth.ts
+++ b/platform/backend/src/routes/auth.ts
@@ -5,6 +5,7 @@ import {
   IDENTITY_PROVIDER_ID,
   LLM_OAUTH_CLIENT_CREDENTIALS_ACCESS_TOKEN_LIFETIME_SECONDS,
   LLM_PROXY_OAUTH_SCOPE,
+  OAUTH_GRANT_TYPE,
   RouteId,
 } from "@shared";
 import { verifyPassword } from "better-auth/crypto";
@@ -28,7 +29,6 @@ import {
 import {
   buildOAuthIssuer,
   exchangeIdentityAssertionForAccessToken,
-  JWT_BEARER_GRANT_TYPE,
   MCP_RESOURCE_REFERENCE_PREFIX,
 } from "@/services/identity-providers/enterprise-managed/authorization";
 import { ApiError, constructResponseSchema } from "@/types";
@@ -388,7 +388,7 @@ const authRoutes: FastifyPluginAsyncZod = async (fastify) => {
         }
       }
 
-      if (body?.grant_type === JWT_BEARER_GRANT_TYPE) {
+      if (body?.grant_type === OAUTH_GRANT_TYPE.JwtBearer) {
         const { clientId: authenticatedClientId, clientSecret } =
           extractOAuthClientCredentials({
             authorizationHeader: request.headers.authorization,

--- a/platform/backend/src/routes/internal-mcp-catalog.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.ts
@@ -26,6 +26,7 @@ import {
   ApiError,
   constructResponseSchema,
   DeleteObjectResponseSchema,
+  ENTERPRISE_MANAGED_CLIENT_SECRET_OVERRIDE_SECRET_KEY,
   InsertInternalMcpCatalogSchema,
   PartialUpdateInternalMcpCatalogSchema,
   SelectInternalMcpCatalogSchema,
@@ -165,14 +166,31 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
       ) {
         // Direct client_secret value
         const clientSecret = restBody.oauthConfig.client_secret;
-        const secret = await secretManager().createSecret(
-          { client_secret: clientSecret },
-          `${restBody.name}-oauth-client-secret`,
-        );
-        clientSecretId = secret.id;
+        if (clientSecret) {
+          clientSecretId = await upsertCatalogClientSecretValue({
+            clientSecretId,
+            catalogName: restBody.name,
+            key: "client_secret",
+            value: clientSecret,
+          });
+
+          restBody.clientSecretId = clientSecretId;
+        }
+        delete restBody.oauthConfig.client_secret;
+      }
+
+      const enterpriseManagedClientSecretOverride =
+        restBody.enterpriseManagedConfig?.clientSecretOverride;
+      if (enterpriseManagedClientSecretOverride) {
+        clientSecretId = await upsertCatalogClientSecretValue({
+          clientSecretId,
+          catalogName: restBody.name,
+          key: ENTERPRISE_MANAGED_CLIENT_SECRET_OVERRIDE_SECRET_KEY,
+          value: enterpriseManagedClientSecretOverride,
+        });
 
         restBody.clientSecretId = clientSecretId;
-        delete restBody.oauthConfig.client_secret;
+        delete restBody.enterpriseManagedConfig?.clientSecretOverride;
       }
 
       // Handle local config secrets - either via Readonly Vault or direct values
@@ -428,6 +446,9 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
           );
         }
 
+        const existingSecretValues =
+          await getCatalogClientSecretValues(clientSecretId);
+
         // Delete existing secret if any
         if (clientSecretId) {
           await secretManager().deleteSecret(clientSecretId);
@@ -436,7 +457,7 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
         // Store as { client_secret: "path#key" } format
         const vaultReference = `${oauthClientSecretVaultPath}#${oauthClientSecretVaultKey}`;
         const secret = await secretManager().createSecret(
-          { client_secret: vaultReference },
+          { ...existingSecretValues, client_secret: vaultReference },
           `${originalCatalogItem.name}-oauth-client-secret-vault`,
         );
         clientSecretId = secret.id;
@@ -456,22 +477,31 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
       ) {
         // Direct client_secret value
         const clientSecret = restBody.oauthConfig.client_secret;
-        if (clientSecretId) {
-          // Update existing secret
-          await secretManager().updateSecret(clientSecretId, {
-            client_secret: clientSecret,
+        if (clientSecret) {
+          clientSecretId = await upsertCatalogClientSecretValue({
+            clientSecretId,
+            catalogName: originalCatalogItem.name,
+            key: "client_secret",
+            value: clientSecret,
           });
-        } else {
-          // Create new secret
-          const secret = await secretManager().createSecret(
-            { client_secret: clientSecret },
-            `${originalCatalogItem.name}-oauth-client-secret`,
-          );
-          clientSecretId = secret.id;
+
+          restBody.clientSecretId = clientSecretId;
         }
+        delete restBody.oauthConfig.client_secret;
+      }
+
+      const enterpriseManagedClientSecretOverride =
+        restBody.enterpriseManagedConfig?.clientSecretOverride;
+      if (enterpriseManagedClientSecretOverride) {
+        clientSecretId = await upsertCatalogClientSecretValue({
+          clientSecretId,
+          catalogName: originalCatalogItem.name,
+          key: ENTERPRISE_MANAGED_CLIENT_SECRET_OVERRIDE_SECRET_KEY,
+          value: enterpriseManagedClientSecretOverride,
+        });
 
         restBody.clientSecretId = clientSecretId;
-        delete restBody.oauthConfig.client_secret;
+        delete restBody.enterpriseManagedConfig?.clientSecretOverride;
       }
 
       // Handle local config secrets - either via Readonly Vault or direct values
@@ -1036,5 +1066,51 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
     },
   );
 };
+
+async function upsertCatalogClientSecretValue(params: {
+  clientSecretId: string | null | undefined;
+  catalogName: string;
+  key: string;
+  value: string;
+}): Promise<string> {
+  const existingSecretValues = await getCatalogClientSecretValues(
+    params.clientSecretId,
+  );
+  const secretValue = {
+    ...existingSecretValues,
+    [params.key]: params.value,
+  };
+
+  if (params.clientSecretId) {
+    await secretManager().updateSecret(params.clientSecretId, secretValue);
+    return params.clientSecretId;
+  }
+
+  const secret = await secretManager().createSecret(
+    secretValue,
+    `${params.catalogName}-client-secrets`,
+  );
+  return secret.id;
+}
+
+async function getCatalogClientSecretValues(
+  clientSecretId: string | null | undefined,
+): Promise<Record<string, string>> {
+  if (!clientSecretId) {
+    return {};
+  }
+
+  const existingSecret = await secretManager().getSecret(clientSecretId);
+  if (!existingSecret?.secret) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(existingSecret.secret).map(([key, value]) => [
+      key,
+      String(value),
+    ]),
+  );
+}
 
 export default internalMcpCatalogRoutes;

--- a/platform/backend/src/routes/mcp-gateway.utils.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.test.ts
@@ -684,6 +684,39 @@ describe("validateExternalIdpToken", () => {
     expect(result).toBeNull();
   });
 
+  test("uses email-shaped subject when JWT has no email claim", async ({
+    makeOrganization,
+    makeIdentityProvider,
+    makeAgent,
+    makeUser,
+    makeMember,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser({ email: "user@example.com" });
+    await makeMember(user.id, org.id, { role: "admin" });
+    const idp = await makeIdentityProvider(org.id, {
+      oidcConfig: {
+        clientId: "test-client",
+        jwksEndpoint: "https://example.com/.well-known/jwks.json",
+      },
+    });
+    const agent = await makeAgent({
+      organizationId: org.id,
+      identityProviderId: idp.id,
+    });
+
+    mockValidateJwt.mockResolvedValueOnce({
+      sub: "user@example.com",
+      email: null,
+      name: "Test User",
+      rawClaims: { sub: "user@example.com" },
+    });
+
+    const result = await validateExternalIdpToken(agent.id, FAKE_JWT);
+    expect(result?.userId).toBe(user.id);
+    expect(result?.isExternalIdp).toBe(true);
+  });
+
   test("returns null when the identity provider OIDC config has no clientId for audience validation", async ({
     makeOrganization,
     makeIdentityProvider,

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -1094,8 +1094,10 @@ export async function validateExternalIdpToken(
       "validateExternalIdpToken: JWT validated via external IdP JWKS",
     );
 
-    // Match JWT email claim to an Archestra user for access control
-    if (!result.email) {
+    // Match JWT email claim to an Archestra user for access control. Some IdPs
+    // use the subject as the user email and omit the email claim.
+    const userEmail = result.email ?? getEmailFromSubject(result.sub);
+    if (!userEmail) {
       logger.warn(
         { profileId, sub: result.sub },
         "validateExternalIdpToken: JWT has no email claim, cannot match to Archestra user",
@@ -1103,10 +1105,10 @@ export async function validateExternalIdpToken(
       return null;
     }
 
-    const user = await UserModel.findByEmail(result.email);
+    const user = await UserModel.findByEmail(userEmail);
     if (!user) {
       logger.warn(
-        { profileId, email: result.email },
+        { profileId, email: userEmail },
         "validateExternalIdpToken: JWT email does not match any Archestra user",
       );
       return null;
@@ -1115,7 +1117,7 @@ export async function validateExternalIdpToken(
     const member = await MemberModel.getByUserId(user.id, agent.organizationId);
     if (!member) {
       logger.warn(
-        { profileId, userId: user.id, email: result.email },
+        { profileId, userId: user.id, email: userEmail },
         "validateExternalIdpToken: user is not a member of the gateway's organization",
       );
       return null;
@@ -1171,6 +1173,13 @@ export async function validateExternalIdpToken(
     );
     return null;
   }
+}
+
+function getEmailFromSubject(subject: string | undefined): string | null {
+  if (!subject || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(subject)) {
+    return null;
+  }
+  return subject;
 }
 
 /**

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -1176,6 +1176,8 @@ export async function validateExternalIdpToken(
 }
 
 function getEmailFromSubject(subject: string | undefined): string | null {
+  // This fallback is intentionally loose: after token validation succeeds,
+  // it only decides whether an email-shaped subject can be used for lookup.
   if (!subject || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(subject)) {
     return null;
   }

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -1141,6 +1141,165 @@ describe("mcp server inspect route", () => {
     });
   });
 
+  test("exchanges an install-time session ID token for an ID-JAG before protected resource discovery", async ({
+    makeAccount,
+    makeAgent,
+    makeIdentityProvider,
+    makeInternalMcpCatalog,
+  }) => {
+    const { default: AgentToolModel } = await import("@/models/agent-tool");
+    const { ToolModel } = await import("@/models");
+
+    const agent = await makeAgent({
+      name: "Protected Resource Demo Agent",
+      agentType: "mcp_gateway",
+      scope: "personal",
+      organizationId,
+      authorId: user.id,
+    });
+
+    const identityProvider = await makeIdentityProvider(user.id, {
+      providerId: "GenericOIDC",
+      issuer: "https://idp.example.com",
+      oidcConfig: {
+        clientId: "archestra-client-id",
+        clientSecret: "archestra-client-secret",
+        tokenEndpoint: "https://idp.example.com/token",
+        tokenEndpointAuthentication: "client_secret_basic",
+        enterpriseManagedCredentials: {
+          exchangeStrategy: "rfc8693",
+          subjectTokenType: "urn:ietf:params:oauth:token-type:id_token",
+        },
+      },
+    });
+
+    const catalog = await makeInternalMcpCatalog({
+      name: "Protected Resource Remote",
+      serverType: "remote",
+      serverUrl: "https://mcp.example.com/mcp",
+      enterpriseManagedConfig: {
+        identityProviderId: identityProvider.id,
+        requestedCredentialType: "id_jag",
+        resourceType: "oauth_protected_resource",
+        resourceIdentifier: "https://mcp.example.com/mcp",
+        tokenInjectionMode: "authorization_bearer",
+      },
+    });
+
+    await makeAccount(user.id, {
+      providerId: "GenericOIDC",
+      accessToken: "session-access-token",
+      idToken: "session-id-token",
+    });
+
+    exchangeEnterpriseManagedCredentialMock.mockResolvedValueOnce({
+      credentialType: "id_jag",
+      expiresInSeconds: 300,
+      issuedTokenType: "urn:ietf:params:oauth:token-type:id_jag",
+      value: "session-id-jag",
+    });
+
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const href = String(url);
+      if (
+        href ===
+        "https://mcp.example.com/.well-known/oauth-protected-resource/mcp"
+      ) {
+        return Response.json({
+          resource: "https://mcp.example.com/mcp",
+          authorization_servers: ["https://auth.example.com"],
+        });
+      }
+
+      if (
+        href === "https://auth.example.com/.well-known/oauth-authorization-server"
+      ) {
+        return Response.json({
+          token_endpoint: "https://auth.example.com/oauth/token",
+        });
+      }
+
+      if (href === "https://auth.example.com/oauth/token") {
+        expect(init?.method).toBe("POST");
+        expect(init?.body?.toString()).toContain("assertion=session-id-jag");
+        return Response.json({
+          access_token: "mcp-server-access-token",
+          expires_in: 300,
+        });
+      }
+
+      return new Response(null, { status: 404 });
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    connectAndGetToolsMock
+      .mockRejectedValueOnce(
+        new Error(
+          "Failed to connect to MCP server Protected Resource: Streamable HTTP error: unauthorized",
+        ),
+      )
+      .mockResolvedValueOnce([
+        {
+          name: "read_resource_todos",
+          description: "Read todos",
+          inputSchema: { type: "object", properties: {} },
+          _meta: {
+            archestraResourceUri: "todo://todos",
+          },
+        },
+      ]);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/mcp_server",
+      payload: {
+        name: "Protected Resource",
+        catalogId: catalog.id,
+        agentIds: [agent.id],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(exchangeEnterpriseManagedCredentialMock).toHaveBeenCalledWith({
+      identityProviderId: identityProvider.id,
+      assertion: "session-id-token",
+      enterpriseManagedConfig: expect.objectContaining({
+        requestedCredentialType: "id_jag",
+      }),
+    });
+    expect(connectAndGetToolsMock.mock.calls[1][0]).toMatchObject({
+      secrets: { access_token: "mcp-server-access-token" },
+    });
+
+    const persistedTool = await ToolModel.findByName(
+      "protected_resource__read_resource_todos",
+    );
+    expect(persistedTool).toMatchObject({
+      catalogId: catalog.id,
+      meta: {
+        _meta: {
+          archestraResourceUri: "todo://todos",
+        },
+      },
+    });
+    const assignedToolIds = await AgentToolModel.findToolIdsByAgent(agent.id);
+    expect(assignedToolIds).toContain(persistedTool?.id);
+    if (!persistedTool) throw new Error("expected persisted tool");
+    const [assignment] = await db
+      .select({
+        credentialResolutionMode:
+          schema.agentToolsTable.credentialResolutionMode,
+      })
+      .from(schema.agentToolsTable)
+      .where(
+        and(
+          eq(schema.agentToolsTable.agentId, agent.id),
+          eq(schema.agentToolsTable.toolId, persistedTool.id),
+        ),
+      );
+    expect(assignment?.credentialResolutionMode).toBe("enterprise_managed");
+  });
+
   test("persists enterprise-managed config on installed MCP servers", async ({
     makeInternalMcpCatalog,
   }) => {

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -1,5 +1,5 @@
-import { and, eq } from "drizzle-orm";
 import { OAUTH_TOKEN_TYPE } from "@shared";
+import { and, eq } from "drizzle-orm";
 import { vi } from "vitest";
 import db, { schema } from "@/database";
 import McpServerUserModel from "@/models/mcp-server-user";

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -1,4 +1,5 @@
 import { and, eq } from "drizzle-orm";
+import { OAUTH_TOKEN_TYPE } from "@shared";
 import { vi } from "vitest";
 import db, { schema } from "@/database";
 import McpServerUserModel from "@/models/mcp-server-user";
@@ -1076,7 +1077,7 @@ describe("mcp server inspect route", () => {
         tokenEndpointAuthentication: "client_secret_post",
         enterpriseManagedCredentials: {
           exchangeStrategy: "rfc8693",
-          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
         },
       },
     });
@@ -1101,7 +1102,7 @@ describe("mcp server inspect route", () => {
     exchangeEnterpriseManagedCredentialMock.mockResolvedValueOnce({
       credentialType: "bearer_token",
       expiresInSeconds: null,
-      issuedTokenType: "urn:ietf:params:oauth:token-type:access_token",
+      issuedTokenType: OAUTH_TOKEN_TYPE.AccessToken,
       value: "exchanged-github-token",
     });
 
@@ -1168,7 +1169,7 @@ describe("mcp server inspect route", () => {
         tokenEndpointAuthentication: "client_secret_basic",
         enterpriseManagedCredentials: {
           exchangeStrategy: "rfc8693",
-          subjectTokenType: "urn:ietf:params:oauth:token-type:id_token",
+          subjectTokenType: OAUTH_TOKEN_TYPE.IdToken,
         },
       },
     });
@@ -1195,7 +1196,7 @@ describe("mcp server inspect route", () => {
     exchangeEnterpriseManagedCredentialMock.mockResolvedValueOnce({
       credentialType: "id_jag",
       expiresInSeconds: 300,
-      issuedTokenType: "urn:ietf:params:oauth:token-type:id_jag",
+      issuedTokenType: OAUTH_TOKEN_TYPE.IdJag,
       value: "session-id-jag",
     });
 
@@ -1212,7 +1213,8 @@ describe("mcp server inspect route", () => {
       }
 
       if (
-        href === "https://auth.example.com/.well-known/oauth-authorization-server"
+        href ===
+        "https://auth.example.com/.well-known/oauth-authorization-server"
       ) {
         return Response.json({
           token_endpoint: "https://auth.example.com/oauth/token",

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -1,5 +1,5 @@
 import type { IncomingHttpHeaders } from "node:http";
-import { isPlaywrightCatalogItem, RouteId } from "@shared";
+import { isPlaywrightCatalogItem, OAUTH_TOKEN_TYPE, RouteId } from "@shared";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
 import { hasPermission, userHasPermission } from "@/auth";
@@ -1917,16 +1917,17 @@ async function getInstallDiscoveryAccessToken(params: {
     ? await findExternalIdentityProviderById(
         enterpriseManagedConfig.identityProviderId,
       )
-    : await findExternalIdentityProviderByProviderId(fallbackAccount.providerId);
+    : await findExternalIdentityProviderByProviderId(
+        fallbackAccount.providerId,
+      );
   if (!identityProvider) {
     return getCurrentInstallDiscoveryAccessToken(fallbackAccount);
   }
 
-  const account =
-    await AccountModel.getLatestSsoAccountByUserIdAndProviderId(
-      params.userId,
-      identityProvider.providerId,
-    );
+  const account = await AccountModel.getLatestSsoAccountByUserIdAndProviderId(
+    params.userId,
+    identityProvider.providerId,
+  );
   if (!account) {
     return undefined;
   }
@@ -1970,7 +1971,9 @@ async function getInstallDiscoveryAccessToken(params: {
 
 async function getInstallDiscoverySubjectToken(params: {
   account: NonNullable<
-    Awaited<ReturnType<typeof AccountModel.getLatestSsoAccountByUserIdAndProviderId>>
+    Awaited<
+      ReturnType<typeof AccountModel.getLatestSsoAccountByUserIdAndProviderId>
+    >
   >;
   identityProvider: NonNullable<
     Awaited<ReturnType<typeof findExternalIdentityProviderById>>
@@ -1985,7 +1988,9 @@ async function getInstallDiscoverySubjectToken(params: {
 
 async function getCurrentInstallDiscoveryAccessToken(
   account: NonNullable<
-    Awaited<ReturnType<typeof AccountModel.getLatestSsoAccountWithAccessTokenByUserId>>
+    Awaited<
+      ReturnType<typeof AccountModel.getLatestSsoAccountWithAccessTokenByUserId>
+    >
   >,
 ): Promise<string | undefined> {
   if (!account.accessToken) {
@@ -2018,7 +2023,7 @@ function shouldUseInstallDiscoveryIdToken(
     identityProvider.oidcConfig?.enterpriseManagedCredentials;
   return (
     enterpriseManagedCredentials?.subjectTokenType ===
-      "urn:ietf:params:oauth:token-type:id_token" ||
+      OAUTH_TOKEN_TYPE.IdToken ||
     enterpriseManagedCredentials?.exchangeStrategy === "okta_managed"
   );
 }

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -21,6 +21,7 @@ import {
 import { isByosEnabled, secretManager } from "@/secrets-manager";
 import { filterMcpServersAssignableToTarget } from "@/services/agent-tool-assignment";
 import { refreshLinkedIdentityProviderAccessToken } from "@/services/identity-providers/access-token-refresh";
+import { exchangeIdJagAtProtectedResource } from "@/services/identity-providers/enterprise-managed/broker";
 import { exchangeEnterpriseManagedCredential } from "@/services/identity-providers/enterprise-managed/exchange";
 import {
   findExternalIdentityProviderById,
@@ -238,7 +239,12 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
               await AgentToolModel.bulkCreateForAgentsAndTools(
                 targetAgentIds,
                 toolIds,
-                { mcpServerId: existingPersonal.id },
+                {
+                  mcpServerId: existingPersonal.id,
+                  credentialResolutionMode: catalogItem.enterpriseManagedConfig
+                    ? "enterprise_managed"
+                    : "static",
+                },
               );
             }
             return reply.send(existingPersonal);
@@ -617,6 +623,8 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
             // Capture catalogId before async callback to ensure it's available
             const capturedCatalogId = catalogItem.id;
             const capturedCatalogName = catalogItem.name;
+            const capturedEnterpriseManagedConfig =
+              catalogItem.enterpriseManagedConfig;
 
             // Set status to pending before starting the deployment
             await McpServerModel.update(mcpServer.id, {
@@ -717,7 +725,13 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
                       await AgentToolModel.bulkCreateForAgentsAndTools(
                         dedupedAgentIds,
                         toolIds,
-                        { mcpServerId: mcpServer.id },
+                        {
+                          mcpServerId: mcpServer.id,
+                          credentialResolutionMode:
+                            capturedEnterpriseManagedConfig
+                              ? "enterprise_managed"
+                              : "static",
+                        },
                       );
                     }
                   }
@@ -842,7 +856,12 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
               await AgentToolModel.bulkCreateForAgentsAndTools(
                 dedupedAgentIds,
                 toolIds,
-                { mcpServerId: mcpServer.id },
+                {
+                  mcpServerId: mcpServer.id,
+                  credentialResolutionMode: catalogItem.enterpriseManagedConfig
+                    ? "enterprise_managed"
+                    : "static",
+                },
               );
             }
           }
@@ -1878,44 +1897,143 @@ async function getInstallDiscoveryAccessToken(params: {
   >;
   userId: string;
 }): Promise<string | undefined> {
-  const account = await AccountModel.getLatestSsoAccountWithAccessTokenByUserId(
-    params.userId,
-  );
-  if (!account?.accessToken) {
-    return undefined;
-  }
-
-  const accessToken = await getCurrentIdentityProviderAccessToken(
-    params.userId,
-  );
-  if (!accessToken) {
-    return undefined;
-  }
-
   const enterpriseManagedConfig = params.catalogItem.enterpriseManagedConfig;
   if (!enterpriseManagedConfig) {
+    const accessToken = await getCurrentIdentityProviderAccessToken(
+      params.userId,
+    );
     return accessToken;
+  }
+
+  const fallbackAccount =
+    await AccountModel.getLatestSsoAccountWithAccessTokenByUserId(
+      params.userId,
+    );
+  if (!fallbackAccount) {
+    return undefined;
   }
 
   const identityProvider = enterpriseManagedConfig.identityProviderId
     ? await findExternalIdentityProviderById(
         enterpriseManagedConfig.identityProviderId,
       )
-    : await findExternalIdentityProviderByProviderId(account.providerId);
+    : await findExternalIdentityProviderByProviderId(fallbackAccount.providerId);
   if (!identityProvider) {
-    return accessToken;
+    return getCurrentInstallDiscoveryAccessToken(fallbackAccount);
+  }
+
+  const account =
+    await AccountModel.getLatestSsoAccountByUserIdAndProviderId(
+      params.userId,
+      identityProvider.providerId,
+    );
+  if (!account) {
+    return undefined;
+  }
+
+  const assertion = await getInstallDiscoverySubjectToken({
+    account,
+    identityProvider,
+  });
+  if (!assertion) {
+    return undefined;
   }
 
   const credential = await exchangeEnterpriseManagedCredential({
     identityProviderId: identityProvider.id,
-    assertion: accessToken,
+    assertion,
     enterpriseManagedConfig,
   });
+
+  if (shouldExchangeInstallIdJagAtProtectedResource(enterpriseManagedConfig)) {
+    const idJagAssertion = extractInstallDiscoveryCredentialValue({
+      credentialValue: credential.value,
+      responseFieldPath: enterpriseManagedConfig.responseFieldPath,
+    });
+    const protectedResourceCredential = await exchangeIdJagAtProtectedResource({
+      assertion: idJagAssertion,
+      identityProviderId: identityProvider.id,
+      enterpriseManagedConfig,
+    });
+
+    return extractInstallDiscoveryCredentialValue({
+      credentialValue: protectedResourceCredential.value,
+      responseFieldPath: enterpriseManagedConfig.responseFieldPath,
+    });
+  }
 
   return extractInstallDiscoveryCredentialValue({
     credentialValue: credential.value,
     responseFieldPath: enterpriseManagedConfig.responseFieldPath,
   });
+}
+
+async function getInstallDiscoverySubjectToken(params: {
+  account: NonNullable<
+    Awaited<ReturnType<typeof AccountModel.getLatestSsoAccountByUserIdAndProviderId>>
+  >;
+  identityProvider: NonNullable<
+    Awaited<ReturnType<typeof findExternalIdentityProviderById>>
+  >;
+}): Promise<string | undefined> {
+  if (shouldUseInstallDiscoveryIdToken(params.identityProvider)) {
+    return params.account.idToken ?? undefined;
+  }
+
+  return getCurrentInstallDiscoveryAccessToken(params.account);
+}
+
+async function getCurrentInstallDiscoveryAccessToken(
+  account: NonNullable<
+    Awaited<ReturnType<typeof AccountModel.getLatestSsoAccountWithAccessTokenByUserId>>
+  >,
+): Promise<string | undefined> {
+  if (!account.accessToken) {
+    return undefined;
+  }
+
+  const isAccessTokenExpired =
+    !!account.accessTokenExpiresAt &&
+    account.accessTokenExpiresAt <= new Date();
+  if (!isAccessTokenExpired) {
+    return account.accessToken;
+  }
+
+  return await refreshLinkedIdentityProviderAccessToken({
+    account: {
+      id: account.id,
+      providerId: account.providerId,
+      refreshToken: account.refreshToken,
+      refreshTokenExpiresAt: account.refreshTokenExpiresAt,
+    },
+  });
+}
+
+function shouldUseInstallDiscoveryIdToken(
+  identityProvider: NonNullable<
+    Awaited<ReturnType<typeof findExternalIdentityProviderById>>
+  >,
+): boolean {
+  const enterpriseManagedCredentials =
+    identityProvider.oidcConfig?.enterpriseManagedCredentials;
+  return (
+    enterpriseManagedCredentials?.subjectTokenType ===
+      "urn:ietf:params:oauth:token-type:id_token" ||
+    enterpriseManagedCredentials?.exchangeStrategy === "okta_managed"
+  );
+}
+
+function shouldExchangeInstallIdJagAtProtectedResource(
+  config: NonNullable<
+    NonNullable<
+      Awaited<ReturnType<typeof InternalMcpCatalogModel.findById>>
+    >["enterpriseManagedConfig"]
+  >,
+): boolean {
+  return (
+    config.requestedCredentialType === "id_jag" &&
+    config.resourceType === "oauth_protected_resource"
+  );
 }
 
 async function getSecretValues(

--- a/platform/backend/src/routes/oauth-server.test.ts
+++ b/platform/backend/src/routes/oauth-server.test.ts
@@ -1,10 +1,10 @@
+import { OAUTH_GRANT_TYPE } from "@shared";
 import Fastify, { type FastifyInstance } from "fastify";
 import {
   serializerCompiler,
   validatorCompiler,
   type ZodTypeProvider,
 } from "fastify-type-provider-zod";
-import { OAUTH_GRANT_TYPE } from "@shared";
 import { parseTrustProxy } from "@/config";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import oauthServerRoutes from "./oauth-server";

--- a/platform/backend/src/routes/oauth-server.test.ts
+++ b/platform/backend/src/routes/oauth-server.test.ts
@@ -4,8 +4,8 @@ import {
   validatorCompiler,
   type ZodTypeProvider,
 } from "fastify-type-provider-zod";
+import { OAUTH_GRANT_TYPE } from "@shared";
 import { parseTrustProxy } from "@/config";
-import { JWT_BEARER_GRANT_TYPE } from "@/services/identity-providers/enterprise-managed/authorization";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import oauthServerRoutes from "./oauth-server";
 
@@ -90,7 +90,7 @@ describe("OAuth Server - Well-Known Endpoints", () => {
         "authorization_code",
         "refresh_token",
         "client_credentials",
-        JWT_BEARER_GRANT_TYPE,
+        OAUTH_GRANT_TYPE.JwtBearer,
       ]);
       expect(body.code_challenge_methods_supported).toEqual(["S256"]);
       expect(body.token_endpoint_auth_methods_supported).toContain("none");

--- a/platform/backend/src/routes/oauth-server.ts
+++ b/platform/backend/src/routes/oauth-server.ts
@@ -1,11 +1,10 @@
-import { OAUTH_ENDPOINTS, OAUTH_SCOPES } from "@shared";
+import { OAUTH_ENDPOINTS, OAUTH_GRANT_TYPE, OAUTH_SCOPES } from "@shared";
 import { eq } from "drizzle-orm";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
 import config from "@/config";
 import db, { schema as dbSchema } from "@/database";
 import { AgentModel } from "@/models";
-import { JWT_BEARER_GRANT_TYPE } from "@/services/identity-providers/enterprise-managed/authorization";
 
 /**
  * OAuth 2.1 well-known discovery endpoints.
@@ -130,7 +129,7 @@ const oauthServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           "authorization_code",
           "refresh_token",
           "client_credentials",
-          JWT_BEARER_GRANT_TYPE,
+          OAUTH_GRANT_TYPE.JwtBearer,
         ],
         token_endpoint_auth_methods_supported: [
           "client_secret_basic",

--- a/platform/backend/src/services/identity-providers/enterprise-managed/authorization.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/authorization.ts
@@ -1,6 +1,7 @@
 import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
 import {
   DEFAULT_OAUTH_ACCESS_TOKEN_LIFETIME_SECONDS,
+  OAUTH_GRANT_TYPE,
   OAUTH_SCOPES,
 } from "@shared";
 import { decodeProtectedHeader } from "jose";
@@ -18,8 +19,7 @@ import {
 } from "@/services/identity-providers/oidc";
 import { jwksValidator } from "@/services/jwks-validator";
 
-export const JWT_BEARER_GRANT_TYPE =
-  "urn:ietf:params:oauth:grant-type:jwt-bearer";
+export const JWT_BEARER_GRANT_TYPE = OAUTH_GRANT_TYPE.JwtBearer;
 /** @public — exported for testability */
 export const OAUTH_ID_JAG_TYP = "oauth-id-jag+jwt";
 export const MCP_RESOURCE_REFERENCE_PREFIX = "mcp-resource:";

--- a/platform/backend/src/services/identity-providers/enterprise-managed/authorization.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/authorization.ts
@@ -1,7 +1,6 @@
 import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
 import {
   DEFAULT_OAUTH_ACCESS_TOKEN_LIFETIME_SECONDS,
-  OAUTH_GRANT_TYPE,
   OAUTH_SCOPES,
 } from "@shared";
 import { decodeProtectedHeader } from "jose";

--- a/platform/backend/src/services/identity-providers/enterprise-managed/authorization.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/authorization.ts
@@ -19,7 +19,6 @@ import {
 } from "@/services/identity-providers/oidc";
 import { jwksValidator } from "@/services/jwks-validator";
 
-export const JWT_BEARER_GRANT_TYPE = OAUTH_GRANT_TYPE.JwtBearer;
 /** @public — exported for testability */
 export const OAUTH_ID_JAG_TYP = "oauth-id-jag+jwt";
 export const MCP_RESOURCE_REFERENCE_PREFIX = "mcp-resource:";

--- a/platform/backend/src/services/identity-providers/enterprise-managed/broker.test.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/broker.test.ts
@@ -288,6 +288,7 @@ describe("resolveEnterpriseTransportCredential", () => {
         requestedCredentialType: "id_jag",
         resourceType: "oauth_protected_resource",
         resourceIdentifier: "https://resource.example.com/mcp",
+        scopes: ["todos.read", "mcp.access"],
         tokenInjectionMode: "authorization_bearer",
       },
     });
@@ -307,12 +308,230 @@ describe("resolveEnterpriseTransportCredential", () => {
     expect(String(tokenRequest?.[1]?.body)).toContain(
       "assertion=caller-id-jag",
     );
+    expect(String(tokenRequest?.[1]?.body)).toContain(
+      "scope=todos.read+mcp.access",
+    );
     const tokenRequestHeaders = tokenRequest?.[1]?.headers as
       | Headers
       | undefined;
     expect(tokenRequestHeaders?.get("authorization")).toBe(
       `Basic ${Buffer.from("resource-client:resource-secret").toString("base64")}`,
     );
+
+    fetchMock.mockRestore();
+  });
+
+  test("uses protected resource client credential overrides for ID-JAG exchange", async ({
+    makeAgent,
+    makeIdentityProvider,
+    makeOrganization,
+  }) => {
+    const organization = await makeOrganization();
+    const identityProvider = await makeIdentityProvider(organization.id, {
+      providerId: "id-jag-demo-idp",
+      issuer: "https://idp.example.com",
+      oidcConfig: {
+        clientId: "idp-client",
+        clientSecret: "idp-secret",
+        tokenEndpoint: "https://idp.example.com/token",
+        enterpriseManagedCredentials: {
+          clientId: "idp-exchange-client",
+          tokenEndpointAuthentication: "client_secret_basic",
+          clientSecret: "idp-exchange-secret",
+        },
+      },
+    });
+    const agent = await makeAgent({
+      organizationId: organization.id,
+      identityProviderId: identityProvider.id,
+    });
+
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (
+          url ===
+          "https://resource.example.com/.well-known/oauth-protected-resource/mcp"
+        ) {
+          return Response.json({
+            resource: "https://resource.example.com/mcp",
+            authorization_servers: ["https://resource.example.com"],
+          });
+        }
+
+        if (
+          url ===
+          "https://resource.example.com/.well-known/oauth-authorization-server"
+        ) {
+          return Response.json({
+            token_endpoint: "https://resource.example.com/token",
+          });
+        }
+
+        if (url === "https://resource.example.com/token") {
+          const headers = init?.headers as Headers;
+          expect(headers.get("authorization")).toBe(
+            `Basic ${Buffer.from("resource-client:resource-secret").toString("base64")}`,
+          );
+          return Response.json({
+            access_token: "resource-access-token",
+            expires_in: 300,
+          });
+        }
+
+        throw new Error(`Unexpected fetch URL: ${url}`);
+      });
+
+    const result = await resolveEnterpriseTransportCredential({
+      agentId: agent.id,
+      tokenAuth: {
+        tokenId: "external-id-jag",
+        teamId: null,
+        isOrganizationToken: false,
+        userId: "user-1",
+        isExternalIdp: true,
+        rawToken: "caller-id-jag",
+      },
+      enterpriseManagedConfig: {
+        requestedCredentialType: "id_jag",
+        resourceType: "oauth_protected_resource",
+        resourceIdentifier: "https://resource.example.com/mcp",
+        clientIdOverride: "resource-client",
+        clientSecretOverride: "resource-secret",
+        tokenInjectionMode: "authorization_bearer",
+      },
+    });
+
+    expect(result).toMatchObject({
+      headerName: "Authorization",
+      headerValue: "Bearer resource-access-token",
+    });
+
+    fetchMock.mockRestore();
+  });
+
+  test("mints an ID-JAG from the session IdP token before exchanging at an OAuth protected resource", async ({
+    makeAgent,
+    makeIdentityProvider,
+    makeOrganization,
+    makeUser,
+  }) => {
+    const organization = await makeOrganization();
+    const user = await makeUser({ email: "id-jag-session@example.com" });
+    const identityProvider = await makeIdentityProvider(organization.id, {
+      providerId: "generic-id-jag",
+      issuer: "https://idp.example.com",
+      oidcConfig: {
+        clientId: "gateway-client",
+        tokenEndpoint: "https://idp.example.com/token",
+        enterpriseManagedCredentials: {
+          exchangeStrategy: "rfc8693",
+          clientId: "resource-client",
+          tokenEndpoint: "https://idp.example.com/token",
+          tokenEndpointAuthentication: "client_secret_basic",
+          clientSecret: "resource-secret",
+          subjectTokenType: "urn:ietf:params:oauth:token-type:id_token",
+        },
+      },
+    });
+    const agent = await makeAgent({
+      organizationId: organization.id,
+      identityProviderId: identityProvider.id,
+    });
+
+    await db.insert(schema.accountsTable).values({
+      id: randomUUID(),
+      accountId: "acct-generic-id-jag",
+      providerId: identityProvider.providerId,
+      userId: user.id,
+      idToken: createJwt({ exp: futureExpSeconds(300) }),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === "https://idp.example.com/token") {
+          expect(String(init?.body)).toContain(
+            "requested_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aid-jag",
+          );
+          return new Response(
+            JSON.stringify({
+              access_token: "session-id-jag",
+              issued_token_type: "urn:ietf:params:oauth:token-type:id-jag",
+              expires_in: 300,
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+
+        if (
+          url ===
+          "https://resource.example.com/.well-known/oauth-protected-resource/mcp"
+        ) {
+          return new Response(
+            JSON.stringify({
+              resource: "https://resource.example.com/mcp",
+              authorization_servers: ["https://resource.example.com"],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+
+        if (
+          url ===
+          "https://resource.example.com/.well-known/oauth-authorization-server"
+        ) {
+          return new Response(
+            JSON.stringify({
+              issuer: "https://resource.example.com",
+              token_endpoint: "https://resource.example.com/token",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+
+        if (url === "https://resource.example.com/token") {
+          expect(String(init?.body)).toContain("assertion=session-id-jag");
+          return new Response(
+            JSON.stringify({
+              access_token: "mcp-server-access-token",
+              issued_token_type:
+                "urn:ietf:params:oauth:token-type:access_token",
+              expires_in: 300,
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+
+        throw new Error(`Unexpected fetch URL: ${url}`);
+      });
+
+    const result = await resolveEnterpriseTransportCredential({
+      agentId: agent.id,
+      tokenAuth: {
+        tokenId: "session-token",
+        teamId: null,
+        isOrganizationToken: false,
+        userId: user.id,
+        isSessionAuth: true,
+      },
+      enterpriseManagedConfig: {
+        requestedCredentialType: "id_jag",
+        resourceType: "oauth_protected_resource",
+        resourceIdentifier: "https://resource.example.com/mcp",
+        tokenInjectionMode: "authorization_bearer",
+      },
+    });
+
+    expect(result).toEqual({
+      headerName: "Authorization",
+      headerValue: "Bearer mcp-server-access-token",
+      expiresInSeconds: 300,
+    });
 
     fetchMock.mockRestore();
   });

--- a/platform/backend/src/services/identity-providers/enterprise-managed/broker.test.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/broker.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { OAUTH_TOKEN_TYPE } from "@shared";
 import { vi } from "vitest";
 import db, { schema } from "@/database";
 import { describe, expect, test } from "@/test";
@@ -119,7 +120,7 @@ describe("resolveEnterpriseTransportCredential", () => {
       new Response(
         JSON.stringify({
           access_token: "id-jag-value",
-          issued_token_type: "urn:ietf:params:oauth:token-type:id-jag",
+          issued_token_type: OAUTH_TOKEN_TYPE.IdJag,
           expires_in: 300,
         }),
         { status: 200, headers: { "Content-Type": "application/json" } },
@@ -264,7 +265,7 @@ describe("resolveEnterpriseTransportCredential", () => {
             JSON.stringify({
               access_token: "mcp-server-access-token",
               issued_token_type:
-                "urn:ietf:params:oauth:token-type:access_token",
+                OAUTH_TOKEN_TYPE.AccessToken,
               expires_in: 300,
             }),
             { status: 200, headers: { "Content-Type": "application/json" } },
@@ -431,7 +432,7 @@ describe("resolveEnterpriseTransportCredential", () => {
           tokenEndpoint: "https://idp.example.com/token",
           tokenEndpointAuthentication: "client_secret_basic",
           clientSecret: "resource-secret",
-          subjectTokenType: "urn:ietf:params:oauth:token-type:id_token",
+          subjectTokenType: OAUTH_TOKEN_TYPE.IdToken,
         },
       },
     });
@@ -461,7 +462,7 @@ describe("resolveEnterpriseTransportCredential", () => {
           return new Response(
             JSON.stringify({
               access_token: "session-id-jag",
-              issued_token_type: "urn:ietf:params:oauth:token-type:id-jag",
+              issued_token_type: OAUTH_TOKEN_TYPE.IdJag,
               expires_in: 300,
             }),
             { status: 200, headers: { "Content-Type": "application/json" } },
@@ -500,7 +501,7 @@ describe("resolveEnterpriseTransportCredential", () => {
             JSON.stringify({
               access_token: "mcp-server-access-token",
               issued_token_type:
-                "urn:ietf:params:oauth:token-type:access_token",
+                OAUTH_TOKEN_TYPE.AccessToken,
               expires_in: 300,
             }),
             { status: 200, headers: { "Content-Type": "application/json" } },
@@ -559,7 +560,7 @@ describe("resolveEnterpriseTransportCredential", () => {
           tokenEndpoint:
             "http://localhost:30081/realms/archestra/protocol/openid-connect/token",
           tokenEndpointAuthentication: "client_secret_post",
-          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
         },
       },
     });
@@ -584,7 +585,7 @@ describe("resolveEnterpriseTransportCredential", () => {
       new Response(
         JSON.stringify({
           access_token: "github-mock-access-token",
-          issued_token_type: "urn:ietf:params:oauth:token-type:access_token",
+          issued_token_type: OAUTH_TOKEN_TYPE.AccessToken,
           expires_in: 300,
         }),
         { status: 200, headers: { "Content-Type": "application/json" } },
@@ -641,7 +642,7 @@ describe("resolveEnterpriseTransportCredential", () => {
           clientSecret: "archestra-oidc-secret",
           tokenEndpoint: "https://idp.example.com/oauth2/v1/token",
           tokenEndpointAuthentication: "client_secret_post",
-          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
         },
       },
     });
@@ -666,7 +667,7 @@ describe("resolveEnterpriseTransportCredential", () => {
       new Response(
         JSON.stringify({
           access_token: "generic-downstream-access-token",
-          issued_token_type: "urn:ietf:params:oauth:token-type:access_token",
+          issued_token_type: OAUTH_TOKEN_TYPE.AccessToken,
           expires_in: 300,
         }),
         { status: 200, headers: { "Content-Type": "application/json" } },
@@ -728,7 +729,7 @@ describe("resolveEnterpriseTransportCredential", () => {
           tokenEndpoint:
             "https://login.microsoftonline.com/test-tenant/oauth2/v2.0/token",
           tokenEndpointAuthentication: "client_secret_post",
-          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
         },
       },
     });
@@ -818,7 +819,7 @@ describe("resolveEnterpriseTransportCredential", () => {
           tokenEndpoint:
             "https://login.microsoftonline.com/test-tenant/oauth2/v2.0/token",
           tokenEndpointAuthentication: "client_secret_post",
-          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
         },
       },
     });
@@ -843,7 +844,7 @@ describe("resolveEnterpriseTransportCredential", () => {
       new Response(
         JSON.stringify({
           access_token: "downstream-access-token",
-          issued_token_type: "urn:ietf:params:oauth:token-type:access_token",
+          issued_token_type: OAUTH_TOKEN_TYPE.AccessToken,
           expires_in: 300,
         }),
         { status: 200, headers: { "Content-Type": "application/json" } },

--- a/platform/backend/src/services/identity-providers/enterprise-managed/broker.test.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/broker.test.ts
@@ -264,8 +264,7 @@ describe("resolveEnterpriseTransportCredential", () => {
           return new Response(
             JSON.stringify({
               access_token: "mcp-server-access-token",
-              issued_token_type:
-                OAUTH_TOKEN_TYPE.AccessToken,
+              issued_token_type: OAUTH_TOKEN_TYPE.AccessToken,
               expires_in: 300,
             }),
             { status: 200, headers: { "Content-Type": "application/json" } },
@@ -500,8 +499,7 @@ describe("resolveEnterpriseTransportCredential", () => {
           return new Response(
             JSON.stringify({
               access_token: "mcp-server-access-token",
-              issued_token_type:
-                OAUTH_TOKEN_TYPE.AccessToken,
+              issued_token_type: OAUTH_TOKEN_TYPE.AccessToken,
               expires_in: 300,
             }),
             { status: 200, headers: { "Content-Type": "application/json" } },

--- a/platform/backend/src/services/identity-providers/enterprise-managed/broker.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/broker.ts
@@ -1,4 +1,4 @@
-import { OAUTH_TOKEN_TYPE } from "@shared";
+import { OAUTH_GRANT_TYPE, OAUTH_TOKEN_TYPE } from "@shared";
 import type { TokenAuthContext } from "@/clients/mcp-client";
 import logger from "@/logging";
 import { resolveEnterpriseAssertion } from "@/services/identity-providers/enterprise-managed/assertion-resolver";
@@ -15,8 +15,6 @@ export type ResolvedEnterpriseTransportCredential = {
   headerValue: string;
   expiresInSeconds: number | null;
 };
-
-const JWT_BEARER_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
 
 export async function resolveEnterpriseTransportCredential(params: {
   agentId: string;
@@ -128,8 +126,8 @@ export async function exchangeIdJagAtProtectedResource(params: {
 
   const tokenEndpoint =
     await discoverProtectedResourceTokenEndpoint(resourceIdentifier);
-  const requestBody = new URLSearchParams({
-    grant_type: JWT_BEARER_GRANT_TYPE,
+    const requestBody = new URLSearchParams({
+      grant_type: OAUTH_GRANT_TYPE.JwtBearer,
     assertion: params.assertion,
   });
   if (params.enterpriseManagedConfig.scopes?.length) {

--- a/platform/backend/src/services/identity-providers/enterprise-managed/broker.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/broker.ts
@@ -183,10 +183,10 @@ export async function exchangeIdJagAtProtectedResource(params: {
         ? responseBody.expires_in
         : null,
     value: accessToken,
-      issuedTokenType:
-        typeof responseBody.issued_token_type === "string"
-          ? responseBody.issued_token_type
-          : OAUTH_TOKEN_TYPE.AccessToken,
+    issuedTokenType:
+      typeof responseBody.issued_token_type === "string"
+        ? responseBody.issued_token_type
+        : OAUTH_TOKEN_TYPE.AccessToken,
   };
 }
 

--- a/platform/backend/src/services/identity-providers/enterprise-managed/broker.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/broker.ts
@@ -53,8 +53,15 @@ export async function resolveEnterpriseTransportCredential(params: {
   }
 
   if (shouldExchangeIdJagAtProtectedResource(config)) {
+    const idJagAssertion = params.tokenAuth?.isExternalIdp
+      ? assertion.assertion
+      : await exchangeSessionAssertionForIdJag({
+          assertion: assertion.assertion,
+          identityProviderId: assertion.identityProviderId,
+          enterpriseManagedConfig: config,
+        });
     const credential = await exchangeIdJagAtProtectedResource({
-      assertion: assertion.assertion,
+      assertion: idJagAssertion,
       identityProviderId: assertion.identityProviderId,
       enterpriseManagedConfig: config,
     });
@@ -77,7 +84,24 @@ export async function resolveEnterpriseTransportCredential(params: {
   });
 }
 
-async function exchangeIdJagAtProtectedResource(params: {
+async function exchangeSessionAssertionForIdJag(params: {
+  assertion: string;
+  identityProviderId: string;
+  enterpriseManagedConfig: EnterpriseManagedCredentialConfig;
+}): Promise<string> {
+  const credential = await exchangeEnterpriseManagedCredential({
+    identityProviderId: params.identityProviderId,
+    assertion: params.assertion,
+    enterpriseManagedConfig: params.enterpriseManagedConfig,
+  });
+
+  return extractInjectionValue({
+    value: credential.value,
+    responseFieldPath: params.enterpriseManagedConfig.responseFieldPath,
+  });
+}
+
+export async function exchangeIdJagAtProtectedResource(params: {
   assertion: string;
   identityProviderId: string;
   enterpriseManagedConfig: EnterpriseManagedCredentialConfig;
@@ -108,9 +132,13 @@ async function exchangeIdJagAtProtectedResource(params: {
     grant_type: JWT_BEARER_GRANT_TYPE,
     assertion: params.assertion,
   });
+  if (params.enterpriseManagedConfig.scopes?.length) {
+    requestBody.set("scope", params.enterpriseManagedConfig.scopes.join(" "));
+  }
   const headers = buildProtectedResourceTokenHeaders({
     clientId,
     clientSecret:
+      params.enterpriseManagedConfig.clientSecretOverride ??
       enterpriseConfig?.clientSecret ??
       identityProvider?.oidcConfig?.clientSecret,
     tokenEndpointAuthentication:

--- a/platform/backend/src/services/identity-providers/enterprise-managed/broker.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/broker.ts
@@ -126,8 +126,8 @@ export async function exchangeIdJagAtProtectedResource(params: {
 
   const tokenEndpoint =
     await discoverProtectedResourceTokenEndpoint(resourceIdentifier);
-    const requestBody = new URLSearchParams({
-      grant_type: OAUTH_GRANT_TYPE.JwtBearer,
+  const requestBody = new URLSearchParams({
+    grant_type: OAUTH_GRANT_TYPE.JwtBearer,
     assertion: params.assertion,
   });
   if (params.enterpriseManagedConfig.scopes?.length) {

--- a/platform/backend/src/services/identity-providers/enterprise-managed/broker.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/broker.ts
@@ -1,3 +1,4 @@
+import { OAUTH_TOKEN_TYPE } from "@shared";
 import type { TokenAuthContext } from "@/clients/mcp-client";
 import logger from "@/logging";
 import { resolveEnterpriseAssertion } from "@/services/identity-providers/enterprise-managed/assertion-resolver";
@@ -16,7 +17,6 @@ export type ResolvedEnterpriseTransportCredential = {
 };
 
 const JWT_BEARER_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
-const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
 
 export async function resolveEnterpriseTransportCredential(params: {
   agentId: string;
@@ -183,10 +183,10 @@ export async function exchangeIdJagAtProtectedResource(params: {
         ? responseBody.expires_in
         : null,
     value: accessToken,
-    issuedTokenType:
-      typeof responseBody.issued_token_type === "string"
-        ? responseBody.issued_token_type
-        : ACCESS_TOKEN_TYPE,
+      issuedTokenType:
+        typeof responseBody.issued_token_type === "string"
+          ? responseBody.issued_token_type
+          : OAUTH_TOKEN_TYPE.AccessToken,
   };
 }
 

--- a/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/entra-obo-strategy.test.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/entra-obo-strategy.test.ts
@@ -1,5 +1,5 @@
 import { generateKeyPairSync } from "node:crypto";
-import { OAUTH_TOKEN_TYPE } from "@shared";
+import { OAUTH_CLIENT_ASSERTION_TYPE, OAUTH_TOKEN_TYPE } from "@shared";
 import { vi } from "vitest";
 import type { ExternalIdentityProviderConfig } from "@/services/identity-providers/oidc";
 import { describe, expect, test } from "@/test";
@@ -167,7 +167,7 @@ describe("entraOboStrategy", () => {
     const requestBody = new URLSearchParams(String(requestInit?.body));
     expect(requestBody.get("client_secret")).toBeNull();
     expect(requestBody.get("client_assertion_type")).toBe(
-      "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      OAUTH_CLIENT_ASSERTION_TYPE.JwtBearer,
     );
 
     const clientAssertion = requestBody.get("client_assertion");

--- a/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/entra-obo-strategy.test.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/entra-obo-strategy.test.ts
@@ -1,4 +1,5 @@
 import { generateKeyPairSync } from "node:crypto";
+import { OAUTH_TOKEN_TYPE } from "@shared";
 import { vi } from "vitest";
 import type { ExternalIdentityProviderConfig } from "@/services/identity-providers/oidc";
 import { describe, expect, test } from "@/test";
@@ -19,7 +20,7 @@ describe("entraOboStrategy", () => {
           tokenEndpoint:
             "https://login.microsoftonline.com/test-tenant/oauth2/v2.0/token",
           tokenEndpointAuthentication: "client_secret_post",
-          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
         },
       },
     });
@@ -49,7 +50,7 @@ describe("entraOboStrategy", () => {
       credentialType: "bearer_token",
       expiresInSeconds: 3599,
       value: "downstream-graph-access-token",
-      issuedTokenType: "urn:ietf:params:oauth:token-type:access_token",
+      issuedTokenType: OAUTH_TOKEN_TYPE.AccessToken,
     });
 
     const [, requestInit] = fetchMock.mock.calls[0] ?? [];
@@ -84,7 +85,7 @@ describe("entraOboStrategy", () => {
           tokenEndpoint:
             "https://login.microsoftonline.com/test-tenant/oauth2/v2.0/token",
           tokenEndpointAuthentication: "client_secret_post",
-          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
         },
       },
     });
@@ -136,7 +137,7 @@ describe("entraOboStrategy", () => {
           tokenEndpoint:
             "https://login.microsoftonline.com/test-tenant/oauth2/v2.0/token",
           tokenEndpointAuthentication: "private_key_jwt",
-          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
         },
       },
     });

--- a/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/entra-obo-strategy.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/entra-obo-strategy.ts
@@ -1,5 +1,9 @@
 import { createPrivateKey, randomUUID } from "node:crypto";
-import { OAUTH_TOKEN_TYPE } from "@shared";
+import {
+  OAUTH_CLIENT_ASSERTION_TYPE,
+  OAUTH_GRANT_TYPE,
+  OAUTH_TOKEN_TYPE,
+} from "@shared";
 import { importPKCS8, SignJWT } from "jose";
 import logger from "@/logging";
 import { discoverOidcTokenEndpoint } from "@/services/identity-providers/oidc";
@@ -9,10 +13,6 @@ import {
   type EnterpriseManagedCredentialResult,
   extractProviderErrorMessage,
 } from "../exchange";
-
-const JWT_BEARER_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
-const CLIENT_ASSERTION_TYPE =
-  "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
 
 class EntraOboStrategy implements EnterpriseCredentialExchangeStrategy {
   async exchangeCredential(
@@ -44,7 +44,7 @@ class EntraOboStrategy implements EnterpriseCredentialExchangeStrategy {
 
     const requestBody = new URLSearchParams({
       client_id: clientId,
-      grant_type: JWT_BEARER_GRANT_TYPE,
+      grant_type: OAUTH_GRANT_TYPE.JwtBearer,
       requested_token_use: "on_behalf_of",
       assertion: params.assertion,
     });
@@ -167,7 +167,10 @@ async function buildAuthenticatedHeaders(params: {
 
   const algorithm = inferPrivateKeyAlgorithm(params.privateKeyPem);
 
-  params.requestBody.set("client_assertion_type", CLIENT_ASSERTION_TYPE);
+    params.requestBody.set(
+      "client_assertion_type",
+      OAUTH_CLIENT_ASSERTION_TYPE.JwtBearer,
+    );
   params.requestBody.set(
     "client_assertion",
     await new SignJWT({})

--- a/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/entra-obo-strategy.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/entra-obo-strategy.ts
@@ -167,10 +167,10 @@ async function buildAuthenticatedHeaders(params: {
 
   const algorithm = inferPrivateKeyAlgorithm(params.privateKeyPem);
 
-    params.requestBody.set(
-      "client_assertion_type",
-      OAUTH_CLIENT_ASSERTION_TYPE.JwtBearer,
-    );
+  params.requestBody.set(
+    "client_assertion_type",
+    OAUTH_CLIENT_ASSERTION_TYPE.JwtBearer,
+  );
   params.requestBody.set(
     "client_assertion",
     await new SignJWT({})

--- a/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/entra-obo-strategy.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/entra-obo-strategy.ts
@@ -1,4 +1,5 @@
 import { createPrivateKey, randomUUID } from "node:crypto";
+import { OAUTH_TOKEN_TYPE } from "@shared";
 import { importPKCS8, SignJWT } from "jose";
 import logger from "@/logging";
 import { discoverOidcTokenEndpoint } from "@/services/identity-providers/oidc";
@@ -12,7 +13,6 @@ import {
 const JWT_BEARER_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
 const CLIENT_ASSERTION_TYPE =
   "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
-const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
 
 class EntraOboStrategy implements EnterpriseCredentialExchangeStrategy {
   async exchangeCredential(
@@ -106,7 +106,7 @@ class EntraOboStrategy implements EnterpriseCredentialExchangeStrategy {
       issuedTokenType:
         typeof responseBody.issued_token_type === "string"
           ? responseBody.issued_token_type
-          : ACCESS_TOKEN_TYPE,
+          : OAUTH_TOKEN_TYPE.AccessToken,
     };
   }
 }

--- a/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/okta-managed-credential-exchange.test.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/okta-managed-credential-exchange.test.ts
@@ -1,3 +1,4 @@
+import { OAUTH_TOKEN_TYPE } from "@shared";
 import { vi } from "vitest";
 import type { ExternalIdentityProviderConfig } from "@/services/identity-providers/oidc";
 import { describe, expect, test } from "@/test";
@@ -15,7 +16,7 @@ describe("oktaManagedCredentialExchangeStrategy", () => {
           tokenEndpoint: "https://example.okta.com/oauth2/v1/token",
           tokenEndpointAuthentication: "client_secret_post",
           clientSecret: "ai-agent-client-secret",
-          subjectTokenType: "urn:ietf:params:oauth:token-type:id_token",
+          subjectTokenType: OAUTH_TOKEN_TYPE.IdToken,
         },
       },
     });

--- a/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/okta-managed-credential-exchange.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/okta-managed-credential-exchange.ts
@@ -1,4 +1,5 @@
 import { createPrivateKey, randomUUID } from "node:crypto";
+import { OAUTH_TOKEN_TYPE } from "@shared";
 import { importPKCS8, SignJWT } from "jose";
 import logger from "@/logging";
 import { discoverOidcTokenEndpoint } from "@/services/identity-providers/oidc";
@@ -14,9 +15,6 @@ const TOKEN_EXCHANGE_GRANT_TYPE =
   "urn:ietf:params:oauth:grant-type:token-exchange";
 const CLIENT_ASSERTION_TYPE =
   "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
-const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
-const ID_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:id_token";
-const ID_JAG_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:id-jag";
 const OKTA_SECRET_TOKEN_TYPE = "urn:okta:params:oauth:token-type:secret";
 const OKTA_SERVICE_ACCOUNT_TOKEN_TYPE =
   "urn:okta:params:oauth:token-type:service-account";
@@ -60,7 +58,8 @@ class OktaManagedCredentialExchangeStrategy
         params.enterpriseManagedConfig.requestedCredentialType,
       ),
       subject_token: params.assertion,
-      subject_token_type: enterpriseConfig.subjectTokenType ?? ID_TOKEN_TYPE,
+      subject_token_type:
+        enterpriseConfig.subjectTokenType ?? OAUTH_TOKEN_TYPE.IdToken,
     });
 
     if (params.enterpriseManagedConfig.resourceIdentifier) {
@@ -244,13 +243,13 @@ function mapRequestedTokenType(
 ): string {
   switch (credentialType) {
     case "id_jag":
-      return ID_JAG_TOKEN_TYPE;
+      return OAUTH_TOKEN_TYPE.IdJag;
     case "secret":
       return OKTA_SECRET_TOKEN_TYPE;
     case "service_account":
       return OKTA_SERVICE_ACCOUNT_TOKEN_TYPE;
     default:
-      return ACCESS_TOKEN_TYPE;
+      return OAUTH_TOKEN_TYPE.AccessToken;
   }
 }
 

--- a/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/okta-managed-credential-exchange.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/okta-managed-credential-exchange.ts
@@ -1,5 +1,9 @@
 import { createPrivateKey, randomUUID } from "node:crypto";
-import { OAUTH_TOKEN_TYPE } from "@shared";
+import {
+  OAUTH_CLIENT_ASSERTION_TYPE,
+  OAUTH_GRANT_TYPE,
+  OAUTH_TOKEN_TYPE,
+} from "@shared";
 import { importPKCS8, SignJWT } from "jose";
 import logger from "@/logging";
 import { discoverOidcTokenEndpoint } from "@/services/identity-providers/oidc";
@@ -11,10 +15,6 @@ import {
   extractProviderErrorMessage,
 } from "../exchange";
 
-const TOKEN_EXCHANGE_GRANT_TYPE =
-  "urn:ietf:params:oauth:grant-type:token-exchange";
-const CLIENT_ASSERTION_TYPE =
-  "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
 const OKTA_SECRET_TOKEN_TYPE = "urn:okta:params:oauth:token-type:secret";
 const OKTA_SERVICE_ACCOUNT_TOKEN_TYPE =
   "urn:okta:params:oauth:token-type:service-account";
@@ -53,7 +53,7 @@ class OktaManagedCredentialExchangeStrategy
     }
 
     const requestBody = new URLSearchParams({
-      grant_type: TOKEN_EXCHANGE_GRANT_TYPE,
+      grant_type: OAUTH_GRANT_TYPE.TokenExchange,
       requested_token_type: mapRequestedTokenType(
         params.enterpriseManagedConfig.requestedCredentialType,
       ),
@@ -175,7 +175,10 @@ class OktaManagedCredentialExchangeStrategy
     }
 
     params.requestBody.set("client_id", params.clientId);
-    params.requestBody.set("client_assertion_type", CLIENT_ASSERTION_TYPE);
+    params.requestBody.set(
+      "client_assertion_type",
+      OAUTH_CLIENT_ASSERTION_TYPE.JwtBearer,
+    );
     params.requestBody.set(
       "client_assertion",
       await buildClientAssertion({

--- a/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/rfc8693-token-exchange.test.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/rfc8693-token-exchange.test.ts
@@ -126,6 +126,71 @@ describe("rfc8693TokenExchangeStrategy", () => {
 
     fetchMock.mockRestore();
   });
+
+  test("requests an ID-JAG with audience and resource for protected-resource token exchange", async () => {
+    const identityProvider = makeIdentityProvider({
+      issuer: "https://idp.example.com",
+      oidcConfig: {
+        clientId: "requesting-client",
+        clientSecret: "requesting-secret",
+        tokenEndpoint: "https://idp.example.com/token",
+        enterpriseManagedCredentials: {
+          clientId: "requesting-client",
+          clientSecret: "requesting-secret",
+          tokenEndpoint: "https://idp.example.com/token",
+          tokenEndpointAuthentication: "client_secret_post",
+          subjectTokenType: "urn:ietf:params:oauth:token-type:id_token",
+        },
+      },
+    });
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: "id-jag-token",
+          issued_token_type: "urn:ietf:params:oauth:token-type:id-jag",
+          expires_in: 300,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const result = await rfc8693TokenExchangeStrategy.exchangeCredential({
+      identityProvider,
+      assertion: "user-id-token",
+      enterpriseManagedConfig: {
+        requestedCredentialType: "id_jag",
+        audience: "https://auth.resource.example.com",
+        resourceIdentifier: "https://mcp.example.com/mcp",
+        scopes: ["todos.read", "mcp.access"],
+        tokenInjectionMode: "authorization_bearer",
+      },
+    });
+
+    expect(result).toEqual({
+      credentialType: "id_jag",
+      expiresInSeconds: 300,
+      value: "id-jag-token",
+      issuedTokenType: "urn:ietf:params:oauth:token-type:id-jag",
+    });
+
+    const [, requestInit] = fetchMock.mock.calls[0] ?? [];
+    expect(String(requestInit?.body)).toContain(
+      "requested_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aid-jag",
+    );
+    expect(String(requestInit?.body)).toContain(
+      "subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aid_token",
+    );
+    expect(String(requestInit?.body)).toContain(
+      "audience=https%3A%2F%2Fauth.resource.example.com",
+    );
+    expect(String(requestInit?.body)).toContain(
+      "resource=https%3A%2F%2Fmcp.example.com%2Fmcp",
+    );
+    expect(String(requestInit?.body)).toContain("scope=todos.read+mcp.access");
+
+    fetchMock.mockRestore();
+  });
 });
 
 function makeIdentityProvider(

--- a/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/rfc8693-token-exchange.test.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/rfc8693-token-exchange.test.ts
@@ -1,3 +1,4 @@
+import { OAUTH_TOKEN_TYPE } from "@shared";
 import { vi } from "vitest";
 import type { ExternalIdentityProviderConfig } from "@/services/identity-providers/oidc";
 import { describe, expect, test } from "@/test";
@@ -18,7 +19,7 @@ describe("rfc8693TokenExchangeStrategy", () => {
           tokenEndpoint:
             "http://localhost:30081/realms/archestra/protocol/openid-connect/token",
           tokenEndpointAuthentication: "client_secret_post",
-          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
         },
       },
     });
@@ -27,7 +28,7 @@ describe("rfc8693TokenExchangeStrategy", () => {
       new Response(
         JSON.stringify({
           access_token: "exchanged-access-token",
-          issued_token_type: "urn:ietf:params:oauth:token-type:access_token",
+          issued_token_type: OAUTH_TOKEN_TYPE.AccessToken,
           expires_in: 300,
         }),
         { status: 200, headers: { "Content-Type": "application/json" } },
@@ -49,7 +50,7 @@ describe("rfc8693TokenExchangeStrategy", () => {
       credentialType: "bearer_token",
       expiresInSeconds: 300,
       value: "exchanged-access-token",
-      issuedTokenType: "urn:ietf:params:oauth:token-type:access_token",
+      issuedTokenType: OAUTH_TOKEN_TYPE.AccessToken,
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
@@ -93,7 +94,7 @@ describe("rfc8693TokenExchangeStrategy", () => {
           tokenEndpoint:
             "http://localhost:30081/realms/archestra/protocol/openid-connect/token",
           tokenEndpointAuthentication: "client_secret_post",
-          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
         },
       },
     });
@@ -102,7 +103,7 @@ describe("rfc8693TokenExchangeStrategy", () => {
       new Response(
         JSON.stringify({
           access_token: "github-access-token",
-          issued_token_type: "urn:ietf:params:oauth:token-type:access_token",
+          issued_token_type: OAUTH_TOKEN_TYPE.AccessToken,
           expires_in: 300,
         }),
         { status: 200, headers: { "Content-Type": "application/json" } },
@@ -139,7 +140,7 @@ describe("rfc8693TokenExchangeStrategy", () => {
           clientSecret: "requesting-secret",
           tokenEndpoint: "https://idp.example.com/token",
           tokenEndpointAuthentication: "client_secret_post",
-          subjectTokenType: "urn:ietf:params:oauth:token-type:id_token",
+          subjectTokenType: OAUTH_TOKEN_TYPE.IdToken,
         },
       },
     });
@@ -148,7 +149,7 @@ describe("rfc8693TokenExchangeStrategy", () => {
       new Response(
         JSON.stringify({
           access_token: "id-jag-token",
-          issued_token_type: "urn:ietf:params:oauth:token-type:id-jag",
+          issued_token_type: OAUTH_TOKEN_TYPE.IdJag,
           expires_in: 300,
         }),
         { status: 200, headers: { "Content-Type": "application/json" } },
@@ -171,7 +172,7 @@ describe("rfc8693TokenExchangeStrategy", () => {
       credentialType: "id_jag",
       expiresInSeconds: 300,
       value: "id-jag-token",
-      issuedTokenType: "urn:ietf:params:oauth:token-type:id-jag",
+      issuedTokenType: OAUTH_TOKEN_TYPE.IdJag,
     });
 
     const [, requestInit] = fetchMock.mock.calls[0] ?? [];

--- a/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/rfc8693-token-exchange.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/rfc8693-token-exchange.ts
@@ -1,4 +1,4 @@
-import { OAUTH_TOKEN_TYPE } from "@shared";
+import { OAUTH_GRANT_TYPE, OAUTH_TOKEN_TYPE } from "@shared";
 import logger from "@/logging";
 import { discoverOidcTokenEndpoint } from "@/services/identity-providers/oidc";
 import {
@@ -7,9 +7,6 @@ import {
   type EnterpriseManagedCredentialResult,
   extractProviderErrorMessage,
 } from "../exchange";
-
-const TOKEN_EXCHANGE_GRANT_TYPE =
-  "urn:ietf:params:oauth:grant-type:token-exchange";
 
 class Rfc8693TokenExchangeStrategy
   implements EnterpriseCredentialExchangeStrategy
@@ -43,7 +40,7 @@ class Rfc8693TokenExchangeStrategy
 
     const requestBody = new URLSearchParams({
       client_id: clientId,
-      grant_type: TOKEN_EXCHANGE_GRANT_TYPE,
+      grant_type: OAUTH_GRANT_TYPE.TokenExchange,
       requested_token_type: mapRequestedTokenType(
         params.enterpriseManagedConfig.requestedCredentialType,
       ),

--- a/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/rfc8693-token-exchange.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/rfc8693-token-exchange.ts
@@ -10,6 +10,7 @@ import {
 const TOKEN_EXCHANGE_GRANT_TYPE =
   "urn:ietf:params:oauth:grant-type:token-exchange";
 const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
+const ID_JAG_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:id-jag";
 
 class Rfc8693TokenExchangeStrategy
   implements EnterpriseCredentialExchangeStrategy
@@ -44,7 +45,9 @@ class Rfc8693TokenExchangeStrategy
     const requestBody = new URLSearchParams({
       client_id: clientId,
       grant_type: TOKEN_EXCHANGE_GRANT_TYPE,
-      requested_token_type: ACCESS_TOKEN_TYPE,
+      requested_token_type: mapRequestedTokenType(
+        params.enterpriseManagedConfig.requestedCredentialType,
+      ),
       subject_token: params.assertion,
       subject_token_type:
         enterpriseConfig.subjectTokenType ?? ACCESS_TOKEN_TYPE,
@@ -55,6 +58,13 @@ class Rfc8693TokenExchangeStrategy
       params.enterpriseManagedConfig.resourceIdentifier;
     if (targetAudience) {
       requestBody.set("audience", targetAudience);
+    }
+
+    if (params.enterpriseManagedConfig.resourceIdentifier) {
+      requestBody.set(
+        "resource",
+        params.enterpriseManagedConfig.resourceIdentifier,
+      );
     }
 
     if (params.enterpriseManagedConfig.requestedIssuer) {
@@ -110,7 +120,9 @@ class Rfc8693TokenExchangeStrategy
     }
 
     return {
-      credentialType: "bearer_token",
+      credentialType:
+        params.enterpriseManagedConfig.requestedCredentialType ??
+        "bearer_token",
       expiresInSeconds:
         typeof responseBody.expires_in === "number"
           ? responseBody.expires_in
@@ -165,4 +177,14 @@ function buildAuthenticatedHeaders(params: {
   throw new Error(
     "RFC 8693 token exchange does not support private_key_jwt in this implementation",
   );
+}
+
+function mapRequestedTokenType(
+  credentialType: EnterpriseCredentialExchangeParams["enterpriseManagedConfig"]["requestedCredentialType"],
+): string {
+  if (credentialType === "id_jag") {
+    return ID_JAG_TOKEN_TYPE;
+  }
+
+  return ACCESS_TOKEN_TYPE;
 }

--- a/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/rfc8693-token-exchange.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/exchange-strategies/rfc8693-token-exchange.ts
@@ -1,3 +1,4 @@
+import { OAUTH_TOKEN_TYPE } from "@shared";
 import logger from "@/logging";
 import { discoverOidcTokenEndpoint } from "@/services/identity-providers/oidc";
 import {
@@ -9,8 +10,6 @@ import {
 
 const TOKEN_EXCHANGE_GRANT_TYPE =
   "urn:ietf:params:oauth:grant-type:token-exchange";
-const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
-const ID_JAG_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:id-jag";
 
 class Rfc8693TokenExchangeStrategy
   implements EnterpriseCredentialExchangeStrategy
@@ -50,7 +49,7 @@ class Rfc8693TokenExchangeStrategy
       ),
       subject_token: params.assertion,
       subject_token_type:
-        enterpriseConfig.subjectTokenType ?? ACCESS_TOKEN_TYPE,
+        enterpriseConfig.subjectTokenType ?? OAUTH_TOKEN_TYPE.AccessToken,
     });
 
     const targetAudience =
@@ -131,7 +130,7 @@ class Rfc8693TokenExchangeStrategy
       issuedTokenType:
         typeof responseBody.issued_token_type === "string"
           ? responseBody.issued_token_type
-          : ACCESS_TOKEN_TYPE,
+          : OAUTH_TOKEN_TYPE.AccessToken,
     };
   }
 }
@@ -183,8 +182,8 @@ function mapRequestedTokenType(
   credentialType: EnterpriseCredentialExchangeParams["enterpriseManagedConfig"]["requestedCredentialType"],
 ): string {
   if (credentialType === "id_jag") {
-    return ID_JAG_TOKEN_TYPE;
+    return OAUTH_TOKEN_TYPE.IdJag;
   }
 
-  return ACCESS_TOKEN_TYPE;
+  return OAUTH_TOKEN_TYPE.AccessToken;
 }

--- a/platform/backend/src/services/identity-providers/session-token.test.ts
+++ b/platform/backend/src/services/identity-providers/session-token.test.ts
@@ -2,7 +2,10 @@ import { randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
 import db, { schema } from "@/database";
 import { afterEach, describe, expect, test, vi } from "@/test";
-import { resolveSessionExternalIdpToken } from "./session-token";
+import {
+  EnterpriseSubjectTokenType,
+  resolveSessionExternalIdpToken,
+} from "./session-token";
 
 describe("resolveSessionExternalIdpToken", () => {
   const originalFetch = global.fetch;
@@ -139,7 +142,7 @@ describe("resolveSessionExternalIdpToken", () => {
         clientId: "archestra-oidc",
         enterpriseManagedCredentials: {
           exchangeStrategy: "rfc8693",
-          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          subjectTokenType: EnterpriseSubjectTokenType.AccessToken,
         },
       },
     });
@@ -190,7 +193,7 @@ describe("resolveSessionExternalIdpToken", () => {
         clientId: "archestra-oidc",
         enterpriseManagedCredentials: {
           exchangeStrategy: "rfc8693",
-          subjectTokenType: "urn:ietf:params:oauth:token-type:id_token",
+          subjectTokenType: EnterpriseSubjectTokenType.IdToken,
         },
       },
     });
@@ -296,7 +299,7 @@ describe("resolveSessionExternalIdpToken", () => {
         tokenEndpointAuthentication: "client_secret_post",
         enterpriseManagedCredentials: {
           exchangeStrategy: "rfc8693",
-          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          subjectTokenType: EnterpriseSubjectTokenType.AccessToken,
         },
       },
     });
@@ -366,7 +369,7 @@ describe("resolveSessionExternalIdpToken", () => {
         clientId: "archestra-oidc",
         enterpriseManagedCredentials: {
           exchangeStrategy: "rfc8693",
-          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          subjectTokenType: EnterpriseSubjectTokenType.AccessToken,
         },
       },
     });

--- a/platform/backend/src/services/identity-providers/session-token.test.ts
+++ b/platform/backend/src/services/identity-providers/session-token.test.ts
@@ -172,6 +172,58 @@ describe("resolveSessionExternalIdpToken", () => {
     });
   });
 
+  test("uses the stored ID token when RFC 8693 exchange explicitly requests an ID token subject", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeIdentityProvider,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: "member" });
+
+    const identityProvider = await makeIdentityProvider(org.id, {
+      providerId: "generic-id-token-enterprise",
+      issuer: "https://idp.example.com",
+      oidcConfig: {
+        clientId: "archestra-oidc",
+        enterpriseManagedCredentials: {
+          exchangeStrategy: "rfc8693",
+          subjectTokenType: "urn:ietf:params:oauth:token-type:id_token",
+        },
+      },
+    });
+    const agent = await makeAgent({
+      organizationId: org.id,
+      identityProviderId: identityProvider.id,
+    });
+    const idToken = createJwt({ exp: futureExpSeconds() });
+
+    await db.insert(schema.accountsTable).values({
+      id: randomUUID(),
+      accountId: "acct-generic-id-token-enterprise",
+      providerId: "generic-id-token-enterprise",
+      userId: user.id,
+      accessToken: "wrong-access-token",
+      accessTokenExpiresAt: new Date(Date.now() + 3600_000),
+      idToken,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const result = await resolveSessionExternalIdpToken({
+      agentId: agent.id,
+      userId: user.id,
+    });
+
+    expect(result).toEqual({
+      identityProviderId: identityProvider.id,
+      providerId: "generic-id-token-enterprise",
+      rawToken: idToken,
+    });
+  });
+
   test("uses the stored access token for Entra enterprise-managed exchange", async ({
     makeOrganization,
     makeUser,

--- a/platform/backend/src/services/identity-providers/session-token.test.ts
+++ b/platform/backend/src/services/identity-providers/session-token.test.ts
@@ -1,11 +1,9 @@
 import { randomUUID } from "node:crypto";
+import { OAUTH_TOKEN_TYPE } from "@shared";
 import { eq } from "drizzle-orm";
 import db, { schema } from "@/database";
 import { afterEach, describe, expect, test, vi } from "@/test";
-import {
-  EnterpriseSubjectTokenType,
-  resolveSessionExternalIdpToken,
-} from "./session-token";
+import { resolveSessionExternalIdpToken } from "./session-token";
 
 describe("resolveSessionExternalIdpToken", () => {
   const originalFetch = global.fetch;
@@ -142,7 +140,7 @@ describe("resolveSessionExternalIdpToken", () => {
         clientId: "archestra-oidc",
         enterpriseManagedCredentials: {
           exchangeStrategy: "rfc8693",
-          subjectTokenType: EnterpriseSubjectTokenType.AccessToken,
+          subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
         },
       },
     });
@@ -193,7 +191,7 @@ describe("resolveSessionExternalIdpToken", () => {
         clientId: "archestra-oidc",
         enterpriseManagedCredentials: {
           exchangeStrategy: "rfc8693",
-          subjectTokenType: EnterpriseSubjectTokenType.IdToken,
+          subjectTokenType: OAUTH_TOKEN_TYPE.IdToken,
         },
       },
     });
@@ -299,7 +297,7 @@ describe("resolveSessionExternalIdpToken", () => {
         tokenEndpointAuthentication: "client_secret_post",
         enterpriseManagedCredentials: {
           exchangeStrategy: "rfc8693",
-          subjectTokenType: EnterpriseSubjectTokenType.AccessToken,
+          subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
         },
       },
     });
@@ -369,7 +367,7 @@ describe("resolveSessionExternalIdpToken", () => {
         clientId: "archestra-oidc",
         enterpriseManagedCredentials: {
           exchangeStrategy: "rfc8693",
-          subjectTokenType: EnterpriseSubjectTokenType.AccessToken,
+          subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
         },
       },
     });

--- a/platform/backend/src/services/identity-providers/session-token.ts
+++ b/platform/backend/src/services/identity-providers/session-token.ts
@@ -10,6 +10,13 @@ interface SessionExternalIdpToken {
   rawToken: string;
 }
 
+export enum EnterpriseSubjectTokenType {
+  AccessToken = "urn:ietf:params:oauth:token-type:access_token",
+  IdToken = "urn:ietf:params:oauth:token-type:id_token",
+}
+
+type SubjectTokenPreference = "access_token" | "id_token";
+
 export async function resolveSessionExternalIdpToken(params: {
   agentId: string;
   userId: string;
@@ -105,13 +112,14 @@ function resolveSubjectTokenPreference(identityProvider: {
       exchangeStrategy?: string;
     };
   } | null;
-}): "access_token" | "id_token" {
-  const subjectTokenType =
-    identityProvider.oidcConfig?.enterpriseManagedCredentials?.subjectTokenType;
-  if (subjectTokenType === "urn:ietf:params:oauth:token-type:access_token") {
+}): SubjectTokenPreference {
+  const subjectTokenType = parseEnterpriseSubjectTokenType(
+    identityProvider.oidcConfig?.enterpriseManagedCredentials?.subjectTokenType,
+  );
+  if (subjectTokenType === EnterpriseSubjectTokenType.AccessToken) {
     return "access_token";
   }
-  if (subjectTokenType === "urn:ietf:params:oauth:token-type:id_token") {
+  if (subjectTokenType === EnterpriseSubjectTokenType.IdToken) {
     return "id_token";
   }
 
@@ -127,11 +135,23 @@ function resolveSubjectTokenPreference(identityProvider: {
   return "id_token";
 }
 
+function parseEnterpriseSubjectTokenType(
+  value: string | undefined,
+): EnterpriseSubjectTokenType | null {
+  if (value === EnterpriseSubjectTokenType.AccessToken) {
+    return EnterpriseSubjectTokenType.AccessToken;
+  }
+  if (value === EnterpriseSubjectTokenType.IdToken) {
+    return EnterpriseSubjectTokenType.IdToken;
+  }
+  return null;
+}
+
 function isStoredSubjectTokenExpired(params: {
   account: {
     accessTokenExpiresAt: Date | null;
   };
-  tokenPreference: "access_token" | "id_token";
+  tokenPreference: SubjectTokenPreference;
   rawToken: string;
 }): boolean {
   if (params.tokenPreference === "access_token") {

--- a/platform/backend/src/services/identity-providers/session-token.ts
+++ b/platform/backend/src/services/identity-providers/session-token.ts
@@ -1,4 +1,5 @@
 import { jwtDecode } from "jwt-decode";
+import { OAUTH_TOKEN_TYPE, type OAuthTokenType } from "@shared";
 import logger from "@/logging";
 import { AccountModel, AgentModel } from "@/models";
 import { refreshLinkedIdentityProviderAccessToken } from "@/services/identity-providers/access-token-refresh";
@@ -8,11 +9,6 @@ interface SessionExternalIdpToken {
   identityProviderId: string;
   providerId: string;
   rawToken: string;
-}
-
-export enum EnterpriseSubjectTokenType {
-  AccessToken = "urn:ietf:params:oauth:token-type:access_token",
-  IdToken = "urn:ietf:params:oauth:token-type:id_token",
 }
 
 type SubjectTokenPreference = "access_token" | "id_token";
@@ -116,10 +112,10 @@ function resolveSubjectTokenPreference(identityProvider: {
   const subjectTokenType = parseEnterpriseSubjectTokenType(
     identityProvider.oidcConfig?.enterpriseManagedCredentials?.subjectTokenType,
   );
-  if (subjectTokenType === EnterpriseSubjectTokenType.AccessToken) {
+  if (subjectTokenType === OAUTH_TOKEN_TYPE.AccessToken) {
     return "access_token";
   }
-  if (subjectTokenType === EnterpriseSubjectTokenType.IdToken) {
+  if (subjectTokenType === OAUTH_TOKEN_TYPE.IdToken) {
     return "id_token";
   }
 
@@ -137,12 +133,12 @@ function resolveSubjectTokenPreference(identityProvider: {
 
 function parseEnterpriseSubjectTokenType(
   value: string | undefined,
-): EnterpriseSubjectTokenType | null {
-  if (value === EnterpriseSubjectTokenType.AccessToken) {
-    return EnterpriseSubjectTokenType.AccessToken;
+): OAuthTokenType | null {
+  if (value === OAUTH_TOKEN_TYPE.AccessToken) {
+    return OAUTH_TOKEN_TYPE.AccessToken;
   }
-  if (value === EnterpriseSubjectTokenType.IdToken) {
-    return EnterpriseSubjectTokenType.IdToken;
+  if (value === OAUTH_TOKEN_TYPE.IdToken) {
+    return OAUTH_TOKEN_TYPE.IdToken;
   }
   return null;
 }

--- a/platform/backend/src/services/identity-providers/session-token.ts
+++ b/platform/backend/src/services/identity-providers/session-token.ts
@@ -1,5 +1,5 @@
-import { jwtDecode } from "jwt-decode";
 import { OAUTH_TOKEN_TYPE, type OAuthTokenType } from "@shared";
+import { jwtDecode } from "jwt-decode";
 import logger from "@/logging";
 import { AccountModel, AgentModel } from "@/models";
 import { refreshLinkedIdentityProviderAccessToken } from "@/services/identity-providers/access-token-refresh";

--- a/platform/backend/src/services/identity-providers/session-token.ts
+++ b/platform/backend/src/services/identity-providers/session-token.ts
@@ -111,6 +111,9 @@ function resolveSubjectTokenPreference(identityProvider: {
   if (subjectTokenType === "urn:ietf:params:oauth:token-type:access_token") {
     return "access_token";
   }
+  if (subjectTokenType === "urn:ietf:params:oauth:token-type:id_token") {
+    return "id_token";
+  }
 
   if (
     identityProvider.oidcConfig?.enterpriseManagedCredentials

--- a/platform/backend/src/types/agent-tool.ts
+++ b/platform/backend/src/types/agent-tool.ts
@@ -98,4 +98,5 @@ export type McpToolAssignment = {
   credentialResolutionMode: z.infer<typeof CredentialResolutionModeSchema>;
   catalogId: string | null;
   catalogName: string | null;
+  meta: Record<string, unknown> | null;
 };

--- a/platform/backend/src/types/enterprise-managed-credentials.ts
+++ b/platform/backend/src/types/enterprise-managed-credentials.ts
@@ -51,6 +51,7 @@ export const EnterpriseManagedCredentialConfigSchema = z.object({
   scopes: z.array(z.string()).optional(),
   audience: z.string().optional(),
   clientIdOverride: z.string().optional(),
+  clientSecretOverride: z.string().optional(),
   tokenInjectionMode: EnterpriseManagedTokenInjectionModeSchema.optional(),
   headerName: z.string().optional(),
   envVarName: z.string().optional(),

--- a/platform/backend/src/types/enterprise-managed-credentials.ts
+++ b/platform/backend/src/types/enterprise-managed-credentials.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+export const ENTERPRISE_MANAGED_CLIENT_SECRET_OVERRIDE_SECRET_KEY =
+  "enterprise_managed_client_secret_override";
+
 export const CredentialResolutionModeSchema = z.enum([
   "static",
   "dynamic",

--- a/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.test.ts
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.test.ts
@@ -1,4 +1,4 @@
-import type { IdentityProviderFormValues } from "@shared";
+import { type IdentityProviderFormValues, OAUTH_TOKEN_TYPE } from "@shared";
 import { describe, expect, it } from "vitest";
 import { normalizeIdentityProviderFormValues } from "./identity-provider-form.utils";
 
@@ -119,7 +119,7 @@ describe("normalizeIdentityProviderFormValues", () => {
       expect.objectContaining({
         exchangeStrategy: "rfc8693",
         tokenEndpointAuthentication: "client_secret_post",
-        subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+        subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
       }),
     );
   });
@@ -167,7 +167,7 @@ describe("normalizeIdentityProviderFormValues", () => {
       expect.objectContaining({
         exchangeStrategy: "rfc8693",
         tokenEndpointAuthentication: "client_secret_post",
-        subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+        subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
       }),
     );
   });
@@ -199,7 +199,7 @@ describe("normalizeIdentityProviderFormValues", () => {
       expect.objectContaining({
         exchangeStrategy: "entra_obo",
         tokenEndpointAuthentication: "client_secret_post",
-        subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+        subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
       }),
     );
   });

--- a/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.ts
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.ts
@@ -156,9 +156,7 @@ export function getDefaultTokenEndpointAuthentication(
 
 export function getDefaultSubjectTokenType(
   exchangeStrategy: "okta_managed" | "rfc8693" | "entra_obo",
-):
-  | typeof OAUTH_TOKEN_TYPE.AccessToken
-  | typeof OAUTH_TOKEN_TYPE.IdToken {
+): typeof OAUTH_TOKEN_TYPE.AccessToken | typeof OAUTH_TOKEN_TYPE.IdToken {
   return exchangeStrategy === "rfc8693" || exchangeStrategy === "entra_obo"
     ? OAUTH_TOKEN_TYPE.AccessToken
     : OAUTH_TOKEN_TYPE.IdToken;

--- a/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.ts
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.ts
@@ -7,7 +7,7 @@ import {
   OAUTH_TOKEN_TYPE,
 } from "@shared";
 
-type EnterpriseSubjectTokenType = NonNullable<
+export type EnterpriseSubjectTokenType = NonNullable<
   NonNullable<
     NonNullable<
       archestraApiTypes.CreateIdentityProviderData["body"]["oidcConfig"]

--- a/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.ts
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.ts
@@ -1,10 +1,19 @@
 import {
+  type archestraApiTypes,
   IDENTITY_PROVIDER_ID,
   type IdentityProviderFormValues,
   isEntraHostname,
   isOktaHostname,
   OAUTH_TOKEN_TYPE,
 } from "@shared";
+
+type EnterpriseSubjectTokenType = NonNullable<
+  NonNullable<
+    NonNullable<
+      archestraApiTypes.CreateIdentityProviderData["body"]["oidcConfig"]
+    >["enterpriseManagedCredentials"]
+  >["subjectTokenType"]
+>;
 
 export function normalizeIdentityProviderFormValues(
   data: IdentityProviderFormValues,
@@ -156,7 +165,7 @@ export function getDefaultTokenEndpointAuthentication(
 
 export function getDefaultSubjectTokenType(
   exchangeStrategy: "okta_managed" | "rfc8693" | "entra_obo",
-): typeof OAUTH_TOKEN_TYPE.AccessToken | typeof OAUTH_TOKEN_TYPE.IdToken {
+): EnterpriseSubjectTokenType {
   return exchangeStrategy === "rfc8693" || exchangeStrategy === "entra_obo"
     ? OAUTH_TOKEN_TYPE.AccessToken
     : OAUTH_TOKEN_TYPE.IdToken;

--- a/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.ts
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.ts
@@ -3,6 +3,7 @@ import {
   type IdentityProviderFormValues,
   isEntraHostname,
   isOktaHostname,
+  OAUTH_TOKEN_TYPE,
 } from "@shared";
 
 export function normalizeIdentityProviderFormValues(
@@ -156,9 +157,9 @@ export function getDefaultTokenEndpointAuthentication(
 export function getDefaultSubjectTokenType(
   exchangeStrategy: "okta_managed" | "rfc8693" | "entra_obo",
 ):
-  | "urn:ietf:params:oauth:token-type:access_token"
-  | "urn:ietf:params:oauth:token-type:id_token" {
+  | typeof OAUTH_TOKEN_TYPE.AccessToken
+  | typeof OAUTH_TOKEN_TYPE.IdToken {
   return exchangeStrategy === "rfc8693" || exchangeStrategy === "entra_obo"
-    ? "urn:ietf:params:oauth:token-type:access_token"
-    : "urn:ietf:params:oauth:token-type:id_token";
+    ? OAUTH_TOKEN_TYPE.AccessToken
+    : OAUTH_TOKEN_TYPE.IdToken;
 }

--- a/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  type archestraApiTypes,
   DocsPage,
   type IdentityProviderFormValues,
   OAUTH_TOKEN_TYPE,
@@ -46,20 +45,13 @@ import {
 import { getFrontendDocsUrl } from "@/lib/docs/docs";
 import { useAppName } from "@/lib/hooks/use-app-name";
 import {
+  type EnterpriseSubjectTokenType,
   getDefaultSubjectTokenType,
   getDefaultTokenEndpointAuthentication,
   inferEnterpriseExchangeType,
 } from "./identity-provider-form.utils";
 import { RoleMappingForm } from "./role-mapping-form.ee";
 import { TeamSyncConfigForm } from "./team-sync-config-form.ee";
-
-type EnterpriseSubjectTokenType = NonNullable<
-  NonNullable<
-    NonNullable<
-      archestraApiTypes.CreateIdentityProviderData["body"]["oidcConfig"]
-    >["enterpriseManagedCredentials"]
-  >["subjectTokenType"]
->;
 
 const SUBJECT_TOKEN_LABEL_BY_TYPE = {
   [OAUTH_TOKEN_TYPE.AccessToken]: "Access token",

--- a/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import {
+  type archestraApiTypes,
   DocsPage,
-  type EnterpriseSubjectTokenType,
   type IdentityProviderFormValues,
   OAUTH_TOKEN_TYPE,
 } from "@shared";
@@ -52,6 +52,20 @@ import {
 } from "./identity-provider-form.utils";
 import { RoleMappingForm } from "./role-mapping-form.ee";
 import { TeamSyncConfigForm } from "./team-sync-config-form.ee";
+
+type EnterpriseSubjectTokenType = NonNullable<
+  NonNullable<
+    NonNullable<
+      archestraApiTypes.CreateIdentityProviderData["body"]["oidcConfig"]
+    >["enterpriseManagedCredentials"]
+  >["subjectTokenType"]
+>;
+
+const SUBJECT_TOKEN_LABEL_BY_TYPE = {
+  [OAUTH_TOKEN_TYPE.AccessToken]: "Access token",
+  [OAUTH_TOKEN_TYPE.IdToken]: "ID token",
+  [OAUTH_TOKEN_TYPE.Jwt]: "Generic JWT",
+} as const satisfies Record<EnterpriseSubjectTokenType, string>;
 
 interface OidcConfigFormProps {
   form: UseFormReturn<IdentityProviderFormValues>;
@@ -793,15 +807,13 @@ function EnterpriseManagedCredentialsForm(props: {
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      <SelectItem value={OAUTH_TOKEN_TYPE.AccessToken}>
-                        Access token
-                      </SelectItem>
-                      <SelectItem value={OAUTH_TOKEN_TYPE.IdToken}>
-                        ID token
-                      </SelectItem>
-                      <SelectItem value={OAUTH_TOKEN_TYPE.Jwt}>
-                        Generic JWT
-                      </SelectItem>
+                      {Object.entries(SUBJECT_TOKEN_LABEL_BY_TYPE).map(
+                        ([tokenType, label]) => (
+                          <SelectItem key={tokenType} value={tokenType}>
+                            {label}
+                          </SelectItem>
+                        ),
+                      )}
                     </SelectContent>
                   </Select>
                   <FormDescription>

--- a/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { DocsPage, type IdentityProviderFormValues } from "@shared";
+import {
+  DocsPage,
+  type EnterpriseSubjectTokenType,
+  type IdentityProviderFormValues,
+  OAUTH_TOKEN_TYPE,
+} from "@shared";
 import { Info, Plus, X } from "lucide-react";
 import { useCallback, useState } from "react";
 import type { UseFormReturn } from "react-hook-form";
@@ -568,10 +573,7 @@ function EnterpriseManagedCredentialsForm(props: {
     | "client_secret_basic";
   form: UseFormReturn<IdentityProviderFormValues>;
   inferredEnterpriseExchangeType: "okta_managed" | "rfc8693" | "entra_obo";
-  subjectTokenTypeDefault:
-    | "urn:ietf:params:oauth:token-type:access_token"
-    | "urn:ietf:params:oauth:token-type:id_token"
-    | "urn:ietf:params:oauth:token-type:jwt";
+  subjectTokenTypeDefault: EnterpriseSubjectTokenType;
 }) {
   const {
     authenticationDefault,
@@ -791,13 +793,13 @@ function EnterpriseManagedCredentialsForm(props: {
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      <SelectItem value="urn:ietf:params:oauth:token-type:access_token">
+                      <SelectItem value={OAUTH_TOKEN_TYPE.AccessToken}>
                         Access token
                       </SelectItem>
-                      <SelectItem value="urn:ietf:params:oauth:token-type:id_token">
+                      <SelectItem value={OAUTH_TOKEN_TYPE.IdToken}>
                         ID token
                       </SelectItem>
-                      <SelectItem value="urn:ietf:params:oauth:token-type:jwt">
+                      <SelectItem value={OAUTH_TOKEN_TYPE.Jwt}>
                         Generic JWT
                       </SelectItem>
                     </SelectContent>

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -26621,6 +26621,7 @@ export type GetInternalMcpCatalogResponses = {
             scopes?: Array<string>;
             audience?: string;
             clientIdOverride?: string;
+            clientSecretOverride?: string;
             tokenInjectionMode?: 'authorization_bearer' | 'raw_authorization' | 'header' | 'env' | 'body_field';
             headerName?: string;
             envVarName?: string;
@@ -26747,6 +26748,7 @@ export type CreateInternalMcpCatalogItemData = {
             scopes?: Array<string>;
             audience?: string;
             clientIdOverride?: string;
+            clientSecretOverride?: string;
             tokenInjectionMode?: 'authorization_bearer' | 'raw_authorization' | 'header' | 'env' | 'body_field';
             headerName?: string;
             envVarName?: string;
@@ -26938,6 +26940,7 @@ export type CreateInternalMcpCatalogItemResponses = {
             scopes?: Array<string>;
             audience?: string;
             clientIdOverride?: string;
+            clientSecretOverride?: string;
             tokenInjectionMode?: 'authorization_bearer' | 'raw_authorization' | 'header' | 'env' | 'body_field';
             headerName?: string;
             envVarName?: string;
@@ -27226,6 +27229,7 @@ export type GetInternalMcpCatalogItemResponses = {
             scopes?: Array<string>;
             audience?: string;
             clientIdOverride?: string;
+            clientSecretOverride?: string;
             tokenInjectionMode?: 'authorization_bearer' | 'raw_authorization' | 'header' | 'env' | 'body_field';
             headerName?: string;
             envVarName?: string;
@@ -27350,6 +27354,7 @@ export type UpdateInternalMcpCatalogItemData = {
             scopes?: Array<string>;
             audience?: string;
             clientIdOverride?: string;
+            clientSecretOverride?: string;
             tokenInjectionMode?: 'authorization_bearer' | 'raw_authorization' | 'header' | 'env' | 'body_field';
             headerName?: string;
             envVarName?: string;
@@ -27543,6 +27548,7 @@ export type UpdateInternalMcpCatalogItemResponses = {
             scopes?: Array<string>;
             audience?: string;
             clientIdOverride?: string;
+            clientSecretOverride?: string;
             tokenInjectionMode?: 'authorization_bearer' | 'raw_authorization' | 'header' | 'env' | 'body_field';
             headerName?: string;
             envVarName?: string;

--- a/platform/shared/identity-provider.ts
+++ b/platform/shared/identity-provider.ts
@@ -32,6 +32,21 @@ export const OAUTH_TOKEN_TYPE = {
 export type OAuthTokenType =
   (typeof OAUTH_TOKEN_TYPE)[keyof typeof OAUTH_TOKEN_TYPE];
 
+export const OAUTH_GRANT_TYPE = {
+  TokenExchange: "urn:ietf:params:oauth:grant-type:token-exchange",
+  JwtBearer: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+} as const;
+
+export type OAuthGrantType =
+  (typeof OAUTH_GRANT_TYPE)[keyof typeof OAUTH_GRANT_TYPE];
+
+export const OAUTH_CLIENT_ASSERTION_TYPE = {
+  JwtBearer: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+} as const;
+
+export type OAuthClientAssertionType =
+  (typeof OAUTH_CLIENT_ASSERTION_TYPE)[keyof typeof OAUTH_CLIENT_ASSERTION_TYPE];
+
 export const ENTERPRISE_SUBJECT_TOKEN_TYPES = [
   OAUTH_TOKEN_TYPE.AccessToken,
   OAUTH_TOKEN_TYPE.IdToken,

--- a/platform/shared/identity-provider.ts
+++ b/platform/shared/identity-provider.ts
@@ -22,6 +22,25 @@ export type IdentityProviderId =
 export const IDENTITY_TRUSTED_PROVIDER_IDS =
   Object.values(IDENTITY_PROVIDER_ID);
 
+export const OAUTH_TOKEN_TYPE = {
+  AccessToken: "urn:ietf:params:oauth:token-type:access_token",
+  IdToken: "urn:ietf:params:oauth:token-type:id_token",
+  Jwt: "urn:ietf:params:oauth:token-type:jwt",
+  IdJag: "urn:ietf:params:oauth:token-type:id-jag",
+} as const;
+
+export type OAuthTokenType =
+  (typeof OAUTH_TOKEN_TYPE)[keyof typeof OAUTH_TOKEN_TYPE];
+
+export const ENTERPRISE_SUBJECT_TOKEN_TYPES = [
+  OAUTH_TOKEN_TYPE.AccessToken,
+  OAUTH_TOKEN_TYPE.IdToken,
+  OAUTH_TOKEN_TYPE.Jwt,
+] as const;
+
+export type EnterpriseSubjectTokenType =
+  (typeof ENTERPRISE_SUBJECT_TOKEN_TYPES)[number];
+
 export function emailMatchesAllowedIdentityProviderDomains(
   email: string,
   allowedDomains: string,
@@ -92,11 +111,7 @@ export const IdentityProviderOidcConfigSchema = z
         privateKeyId: z.string().optional(),
         clientAssertionAudience: z.string().optional(),
         subjectTokenType: z
-          .enum([
-            "urn:ietf:params:oauth:token-type:access_token",
-            "urn:ietf:params:oauth:token-type:id_token",
-            "urn:ietf:params:oauth:token-type:jwt",
-          ])
+          .enum(ENTERPRISE_SUBJECT_TOKEN_TYPES)
           .optional(),
       })
       .optional(),


### PR DESCRIPTION
## Summary
- support protected-resource credential exchange for enterprise-managed MCP transports
- synthesize read-resource tools for resource-only MCP servers during discovery
- preserve enterprise-managed credential mode when assigning installed catalog tools
- keep chat tool discovery available when session-derived external gateway auth fails
- validate gateway tokens through the configured secret manager and allow email-shaped JWT subjects when the email claim is omitted
- centralize OAuth token, grant, and client assertion constants shared by backend and frontend identity-provider flows
- type enterprise subject-token form options against generated API types while using shared runtime constants
- clarify Okta SP-initiated SSO in the supported features docs table

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>