### PR TITLE
fix(#4225): Blocked Tool Result Policy logic bug

### DIFF
--- a/platform/backend/src/guardrails/trusted-data.test.ts
+++ b/platform/backend/src/guardrails/trusted-data.test.ts
@@ -410,6 +410,73 @@ describe("trusted-data evaluation (provider-agnostic)", () => {
       });
     });
 
+    test("evaluates tool result policies even when context starts untrusted", async () => {
+      // Create a block policy
+      await TrustedDataPolicyModel.create({
+        toolId,
+        conditions: [{ key: "dangerous", operator: "equal", value: "true" }],
+        action: "block_always",
+        description: "Block dangerous data",
+      });
+
+      const commonMessages: CommonMessage[] = [
+        { role: "user", content: "Summarize this thread" },
+        {
+          role: "tool",
+          toolCalls: [
+            {
+              id: "call_blocked",
+              name: "get_emails",
+              content: { dangerous: "true", data: "sensitive info" },
+              isError: false,
+            },
+          ],
+        },
+      ];
+
+      const result = await evaluateIfContextIsTrusted(
+        commonMessages,
+        agentId,
+        organizationId,
+        undefined,
+        true, // considerContextUntrusted = true
+        "restrictive",
+        { teamIds: [] },
+      );
+
+      // Context should be untrusted AND tool result should be blocked
+      expect(result.contextIsTrusted).toBe(false);
+      expect(result.toolResultUpdates).toEqual({
+        call_blocked:
+          "[Content blocked by policy: Data blocked by policy: Block dangerous data]",
+      });
+      // Boundary should be the preexisting one (since it was untrusted from start)
+      expect(result.unsafeContextBoundary).toEqual({
+        kind: "preexisting_untrusted",
+        reason: "agent_configured_untrusted",
+      });
+    });
+
+    test("returns untrusted context when no tool calls exist but considerContextUntrusted is true", async () => {
+      const commonMessages: CommonMessage[] = [
+        { role: "user" },
+        { role: "assistant" },
+      ];
+
+      const result = await evaluateIfContextIsTrusted(
+        commonMessages,
+        agentId,
+        organizationId,
+        undefined,
+        true, // considerContextUntrusted = true
+        "restrictive",
+        { teamIds: [] },
+      );
+
+      expect(result.contextIsTrusted).toBe(false);
+      expect(result.toolResultUpdates).toEqual({});
+    });
+
     test("handles multiple tool calls with mixed trust", async () => {
       // Create policies
       await TrustedDataPolicyModel.create({

--- a/platform/backend/src/guardrails/trusted-data.ts
+++ b/platform/backend/src/guardrails/trusted-data.ts
@@ -64,23 +64,19 @@ export async function evaluateIfContextIsTrusted(
   let unsafeContextBoundary: UnsafeContextBoundary | undefined;
 
   // If agent configured to consider context untrusted from the beginning,
-  // mark context as untrusted immediately and skip evaluation
+  // mark context as untrusted immediately. We still evaluate tool calls
+  // for policies (e.g. blocking).
   if (considerContextUntrusted) {
     logger.debug(
       { agentId },
       "[trustedData] evaluateIfContextIsTrusted: context marked untrusted by agent config",
     );
-    return {
-      toolResultUpdates: {},
-      contextIsTrusted: false,
-      usedDualLlm: false,
-      dualLlmAnalyses: [],
-      unsafeContextBoundary: {
-        kind: "preexisting_untrusted",
-        reason:
-          initialUntrustedReason ??
-          UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
-      },
+    hasUntrustedData = true;
+    unsafeContextBoundary = {
+      kind: "preexisting_untrusted",
+      reason:
+        initialUntrustedReason ??
+        UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
     };
   }
 
@@ -116,7 +112,7 @@ export async function evaluateIfContextIsTrusted(
     );
     return {
       toolResultUpdates,
-      contextIsTrusted: true,
+      contextIsTrusted: !hasUntrustedData,
       usedDualLlm: false,
       dualLlmAnalyses: [],
       unsafeContextBoundary,

--- a/platform/backend/src/test/setup.ts
+++ b/platform/backend/src/test/setup.ts
@@ -29,7 +29,6 @@ process.env.ARCHESTRA_LOGGING_LEVEL = "silent";
 // Enable enterprise white-labeling in backend tests so branding-aware helpers
 // exercise the branded built-in MCP paths instead of the default prefix.
 process.env.ARCHESTRA_ENTERPRISE_LICENSE_FULL_WHITE_LABELING = "true";
-process.env.DATABASE_URL = "postgres://localhost:5432/test";
 
 // Set auth secret for tests
 process.env.ARCHESTRA_AUTH_SECRET = "auth-secret-unit-tests-32-chars!";

--- a/platform/backend/src/test/setup.ts
+++ b/platform/backend/src/test/setup.ts
@@ -29,6 +29,7 @@ process.env.ARCHESTRA_LOGGING_LEVEL = "silent";
 // Enable enterprise white-labeling in backend tests so branding-aware helpers
 // exercise the branded built-in MCP paths instead of the default prefix.
 process.env.ARCHESTRA_ENTERPRISE_LICENSE_FULL_WHITE_LABELING = "true";
+process.env.DATABASE_URL = "postgres://localhost:5432/test";
 
 // Set auth secret for tests
 process.env.ARCHESTRA_AUTH_SECRET = "auth-secret-unit-tests-32-chars!";


### PR DESCRIPTION
This PR fixes a logic bug in the `evaluateIfContextIsTrusted` function where tool result policies were skipped if the context was initially marked as untrusted. 

Key changes:
- Removed early return in `evaluateIfContextIsTrusted` when `considerContextUntrusted` is true.
- Ensured tool result policies are evaluated regardless of the initial trust state.
- Added regression tests in `trusted-data.test.ts`.
- Updated test setup to include a dummy `DATABASE_URL` to allow test execution.

Closes #4225

/claim #4225