### PR TITLE
fix: make LLM provider name optional in backend schema

### DIFF
--- a/platform/backend/src/routes/llm-provider-api-keys.ts
+++ b/platform/backend/src/routes/llm-provider-api-keys.ts
@@ -170,7 +170,7 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
         tags: ["LLM Provider API Keys"],
         body: z
           .object({
-            name: z.string().min(1, "Name is required"),
+            name: z.string().optional(),
             provider: SupportedProvidersSchema,
             apiKey: z.string().min(1).optional(),
             baseUrl: z.string().url().nullable().optional(),


### PR DESCRIPTION
There was a logic mismatch between the Frontend and Backend. The UI labels the Name field as (optional), but the backend was strictly requiring at least one character.
I updated the Zod schema in llm-provider-api-keys.ts to .optional(). This aligns the backend with the frontend's fallback logic, which automatically uses the provider name if the user leaves the field blank.

Evidence: Verified via the project's full test suite. 236/236 tests passed successfully.

https://github.com/user-attachments/assets/5c5f2dcd-6fac-453c-8959-07325d821465

