### PR TITLE
fix: persist messages when client disconnects during streaming

### DIFF
--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -791,6 +791,52 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   () => null,
                 );
 
+                // Fallback persistence: if the client disconnected mid-stream
+                // (e.g. page reload), toUIMessageStream's onFinish may not
+                // fire because the writable side of the pipe is closed.
+                // After the LLM finishes (usage resolved), wait briefly for
+                // onFinish, then persist the assistant response ourselves
+                // using result.text which is available once the LLM completes.
+                if (!messagesPersisted && conversationId) {
+                  // Give onFinish a moment to fire (it may still work)
+                  await new Promise((r) => setTimeout(r, 500));
+                  if (!messagesPersisted) {
+                    messagesPersisted = true;
+                    try {
+                      const fullText = await Promise.resolve(
+                        result.text,
+                      ).catch(() => "");
+                      if (fullText) {
+                        const fallbackAssistantMessage = {
+                          id: `fb-${conversationId}-${Date.now()}`,
+                          role: "assistant" as const,
+                          parts: [
+                            { type: "text" as const, text: fullText },
+                          ],
+                        };
+                        const allMessages = [
+                          ...(messages as ChatMessage[]),
+                          fallbackAssistantMessage,
+                        ];
+                        await persistNewMessages(
+                          conversationId,
+                          allMessages,
+                          "fallbackPersist",
+                        );
+                        logger.info(
+                          { conversationId, textLength: fullText.length },
+                          "Fallback: persisted assistant response after client disconnect",
+                        );
+                      }
+                    } catch (err) {
+                      logger.error(
+                        { err, conversationId },
+                        "Fallback message persistence failed",
+                      );
+                    }
+                  }
+                }
+
                 // Write token usage data to the stream as a custom data part
                 if (usage) {
                   logger.info(

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -1035,33 +1035,31 @@ export function ChatPageContent({
     status,
   ]);
 
-  // Poll for the assistant response when the page was reloaded mid-stream.
-  // After reload the DB may only contain the user message (persisted early by
-  // the backend). The assistant response arrives once the backend stream
-  // finishes. We poll until the last message is no longer a user message.
-  useEffect(() => {
+  // Detect when the backend is still streaming after a page reload.
+  // The DB may only contain the user message (persisted early by the backend).
+  // The assistant response arrives once the backend stream finishes.
+  const isWaitingForBackendStream = useMemo(() => {
     if (!conversationId || status === "streaming" || status === "submitted") {
-      return;
+      return false;
     }
-
     const lastMsg = conversation?.messages?.at(-1) as UIMessage | undefined;
-    const isWaitingForAssistant =
-      lastMsg?.role === "user" && messages.length > 0;
+    return lastMsg?.role === "user" && messages.length > 0;
+  }, [conversationId, conversation?.messages, messages.length, status]);
 
-    if (!isWaitingForAssistant) return;
+  // Poll for the assistant response when the page was reloaded mid-stream.
+  useEffect(() => {
+    if (!isWaitingForBackendStream) return;
 
     const interval = setInterval(() => {
       queryClient.invalidateQueries({
         queryKey: ["conversation", conversationId],
       });
-    }, 3000);
+    }, 2000);
 
     return () => clearInterval(interval);
   }, [
+    isWaitingForBackendStream,
     conversationId,
-    conversation?.messages,
-    messages.length,
-    status,
     queryClient,
   ]);
 
@@ -1735,6 +1733,7 @@ export function ChatPageContent({
                     status={status}
                     optimisticToolCalls={optimisticToolCalls}
                     isLoadingConversation={isLoadingConversation}
+                    isWaitingForBackendStream={isWaitingForBackendStream}
                     onMessagesUpdate={setMessages}
                     agentName={
                       (currentProfileId

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -145,6 +145,8 @@ interface ChatMessagesProps {
   selectedModel?: string;
   modelSource?: ModelSource | null;
   unsafeContextBoundary?: archestraApiTypes.GetInteractionResponses["200"]["unsafeContextBoundary"];
+  /** True when the backend is still streaming but the client reconnected after a reload */
+  isWaitingForBackendStream?: boolean;
 }
 
 type PersistedChatError =
@@ -192,6 +194,7 @@ export function ChatMessages({
   selectedModel,
   modelSource,
   unsafeContextBoundary,
+  isWaitingForBackendStream = false,
 }: ChatMessagesProps) {
   const isStreamingStalled = useStreamingStallDetection(messages, status);
   const { data: authSession } = useSession();
@@ -1230,7 +1233,8 @@ export function ChatMessages({
             />
           ))}
           {(status === "submitted" ||
-            (status === "streaming" && isStreamingStalled)) && (
+            (status === "streaming" && isStreamingStalled) ||
+            isWaitingForBackendStream) && (
             <div className="absolute bottom-[-10] left-0">
               <Message from="assistant">
                 <img


### PR DESCRIPTION
Fixes #3012

**Root cause:** When the browser reloads during LLM streaming, `toUIMessageStream`'s `onFinish` callback never fires (the writable pipe is closed). The assistant response is never persisted.

**Changes:**

- **backend/routes/chat/routes.ts** — After `result.usage` resolves, wait 500ms for `onFinish`. If it hasn't fired, persist the assistant response from `result.text` directly.
- **frontend/app/chat/page.tsx** — Derive `isWaitingForBackendStream` (last DB message is user + status ready). Reduce poll interval 3s→2s.
- **frontend/components/chat/chat-messages.tsx** — Show loading indicator while waiting for backend stream after reload.

Tested: reload during active stream → message persists and appears after reload.