### PR TITLE
fix: stale MCP pod cleanup

### DIFF
--- a/platform/backend/src/k8s/mcp-server-runtime/manager.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager.test.ts
@@ -127,6 +127,9 @@ vi.mock("./k8s-deployment", () => {
       static collectImagePullSecretNames(): string[] {
         return [];
       }
+      static constructDeploymentName(mcpServer: { name: string }): string {
+        return `mcp-${mcpServer.name.replaceAll(" ", "-")}`;
+      }
     },
     fetchPlatformPodNodeSelector: vi.fn().mockResolvedValue(undefined),
     fetchPlatformPodTolerations: vi.fn().mockResolvedValue(undefined),
@@ -1192,5 +1195,117 @@ describe("McpServerRuntimeManager.backfillRegcredTeamLabels", () => {
     const manager = new McpServerRuntimeManager();
     // k8sApi is undefined — should return without error
     await callBackfill(manager, [{ id: "srv-1", teamId: "team-x" }]);
+  });
+});
+
+describe("McpServerRuntimeManager.cleanupOrphanedDeployments", () => {
+  async function createManagerWithMockK8s(params: {
+    mockK8sApi: Record<string, unknown>;
+    mockK8sAppsApi: Record<string, unknown>;
+  }) {
+    const { McpServerRuntimeManager } = await import("./manager");
+    const manager = new McpServerRuntimeManager();
+    (manager as unknown as { k8sApi: unknown }).k8sApi = params.mockK8sApi;
+    (manager as unknown as { k8sAppsApi: unknown }).k8sAppsApi =
+      params.mockK8sAppsApi;
+    return manager;
+  }
+
+  function callCleanup(
+    manager: unknown,
+    servers: Array<{ id: string; name: string; catalogId: string }>,
+  ) {
+    const castServers = servers.map((s) => ({
+      ...s,
+      secretId: null,
+      ownerId: null,
+      teamId: null,
+      scope: "org" as const,
+      reinstallRequired: false,
+      localInstallationStatus: "idle" as const,
+      localInstallationError: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      serverType: "local" as const,
+    }));
+    return (
+      manager as { cleanupOrphanedDeployments: (s: unknown[]) => Promise<void> }
+    ).cleanupOrphanedDeployments(castServers);
+  }
+
+  test("deletes legacy name-derived deployments for existing servers", async () => {
+    const mockDeleteDeployment = vi.fn().mockResolvedValue({});
+    const mockDeleteService = vi.fn().mockResolvedValue({});
+    const manager = await createManagerWithMockK8s({
+      mockK8sApi: { deleteNamespacedService: mockDeleteService },
+      mockK8sAppsApi: {
+        listNamespacedDeployment: vi.fn().mockResolvedValue({
+          items: [
+            {
+              metadata: {
+                name: "mcp-legacy-name",
+                labels: {
+                  app: "mcp-server",
+                  "mcp-server-id": "123e4567-e89b-12d3-a456-426614174000",
+                },
+              },
+            },
+            {
+              metadata: {
+                name: "mcp-current-name",
+                labels: {
+                  app: "mcp-server",
+                  "mcp-server-id": "123e4567-e89b-12d3-a456-426614174000",
+                },
+              },
+            },
+          ],
+        }),
+        deleteNamespacedDeployment: mockDeleteDeployment,
+      },
+    });
+
+    await callCleanup(manager, [
+      {
+        id: "123e4567-e89b-12d3-a456-426614174000",
+        name: "current-name",
+        catalogId: "cat-1",
+      },
+    ]);
+
+    expect(mockDeleteDeployment).toHaveBeenCalledOnce();
+    expect(mockDeleteDeployment).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "mcp-legacy-name" }),
+    );
+    expect(mockDeleteService).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "mcp-legacy-name-service" }),
+    );
+  });
+
+  test("ignores deployments that do not belong to installed servers", async () => {
+    const mockDeleteDeployment = vi.fn().mockResolvedValue({});
+    const manager = await createManagerWithMockK8s({
+      mockK8sApi: { deleteNamespacedService: vi.fn().mockResolvedValue({}) },
+      mockK8sAppsApi: {
+        listNamespacedDeployment: vi.fn().mockResolvedValue({
+          items: [
+            {
+              metadata: {
+                name: "mcp-orphan",
+                labels: {
+                  app: "mcp-server",
+                  "mcp-server-id": "missing-server",
+                },
+              },
+            },
+          ],
+        }),
+        deleteNamespacedDeployment: mockDeleteDeployment,
+      },
+    });
+
+    await callCleanup(manager, []);
+
+    expect(mockDeleteDeployment).not.toHaveBeenCalled();
   });
 });

--- a/platform/backend/src/k8s/mcp-server-runtime/manager.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager.ts
@@ -149,6 +149,10 @@ export class McpServerRuntimeManager {
           "Failed to backfill team-id labels on regcred secrets",
         );
       });
+
+      this.cleanupOrphanedDeployments(installedServers).catch((err) => {
+        logger.warn({ err }, "Failed to cleanup orphaned MCP deployments");
+      });
     } catch (error: unknown) {
       const errorMsg = error instanceof Error ? error.message : "Unknown error";
       logger.error(`Failed to initialize MCP Server Runtime: ${errorMsg}`);
@@ -909,6 +913,93 @@ export class McpServerRuntimeManager {
         { err: error },
         "Failed to list secrets for team-id backfill",
       );
+    }
+  }
+
+  /**
+   * Sweep deployments whose names no longer match the current name produced by
+   * K8sDeployment.constructDeploymentName for their owning server.
+   */
+  private async cleanupOrphanedDeployments(
+    installedServers: McpServer[],
+  ): Promise<void> {
+    if (!this.k8sApi || !this.k8sAppsApi) return;
+
+    const serverById = new Map<string, McpServer>();
+    for (const server of installedServers) {
+      serverById.set(server.id, server);
+    }
+
+    const catalogCache = new Map<
+      string,
+      Awaited<ReturnType<typeof InternalMcpCatalogModel.findById>>
+    >();
+    const getCatalog = async (catalogId: string | null | undefined) => {
+      if (!catalogId) return null;
+      if (catalogCache.has(catalogId)) {
+        return catalogCache.get(catalogId) ?? null;
+      }
+      const catalog = await InternalMcpCatalogModel.findById(catalogId);
+      catalogCache.set(catalogId, catalog);
+      return catalog;
+    };
+
+    try {
+      const deployments = await this.k8sAppsApi.listNamespacedDeployment({
+        namespace: this.namespace,
+        labelSelector: "app=mcp-server",
+      });
+
+      for (const deployment of deployments.items) {
+        const labels = deployment.metadata?.labels;
+        const deploymentName = deployment.metadata?.name;
+        if (!labels || !deploymentName) continue;
+
+        const serverId = labels["mcp-server-id"];
+        if (!serverId) continue;
+
+        const server = serverById.get(serverId);
+        if (!server) continue;
+
+        const catalog = await getCatalog(server.catalogId);
+        const expectedName = K8sDeployment.constructDeploymentName(
+          server,
+          catalog,
+        );
+
+        if (deploymentName === expectedName) continue;
+
+        logger.info(
+          { deploymentName, expectedName, serverId },
+          "Deleting orphaned MCP deployment with stale name",
+        );
+
+        try {
+          await this.k8sAppsApi.deleteNamespacedDeployment({
+            name: deploymentName,
+            namespace: this.namespace,
+          });
+        } catch (err) {
+          logger.warn(
+            { err, deploymentName },
+            "Failed to delete orphaned MCP deployment",
+          );
+        }
+
+        try {
+          await this.k8sApi.deleteNamespacedService({
+            name: `${deploymentName}-service`,
+            namespace: this.namespace,
+          });
+        } catch (err) {
+          logger.debug(
+            { err, deploymentName },
+            "No orphaned service to delete (or already gone)",
+          );
+        }
+      }
+    } catch (error) {
+      logger.warn({ err: error }, "Failed to sweep orphaned MCP deployments");
     }
   }
 


### PR DESCRIPTION
Adds a startup sweep that deletes Archestra-managed stale deployments and matching services when their `mcp-server-id` label points to an existing server but the deployment name no longer matches the current expected name.