### PR TITLE
fix: org-scoped MCP visibility

### DIFF
--- a/platform/backend/src/archestra-mcp-server/mcp-servers.test.ts
+++ b/platform/backend/src/archestra-mcp-server/mcp-servers.test.ts
@@ -11,9 +11,11 @@ import { type ArchestraContext, executeArchestraTool } from ".";
 describe("mcp server tool execution", () => {
   let testAgent: Agent;
   let mockContext: ArchestraContext;
+  let organizationId: string;
 
   beforeEach(async ({ makeAgent, makeUser, makeOrganization, makeMember }) => {
     const org = await makeOrganization();
+    organizationId = org.id;
     const user = await makeUser();
     await makeMember(user.id, org.id, { role: "admin" });
     testAgent = await makeAgent({ name: "Test Agent", organizationId: org.id });
@@ -105,6 +107,7 @@ describe("mcp server tool execution", () => {
     const catalog = await makeInternalMcpCatalog({
       name: "Test MCP Server",
       description: "A test server",
+      organizationId,
     });
 
     const result = await executeArchestraTool(
@@ -131,6 +134,7 @@ describe("mcp server tool execution", () => {
     const catalog = await makeInternalMcpCatalog({
       name: "UniqueSearchableServer",
       description: "Unique description for search",
+      organizationId,
     });
 
     const result = await executeArchestraTool(
@@ -150,6 +154,7 @@ describe("mcp server tool execution", () => {
   }) => {
     const catalog = await makeInternalMcpCatalog({
       name: "Server With Tools",
+      organizationId,
     });
     await makeTool({ catalogId: catalog.id, name: "test_tool_1" });
     await makeTool({ catalogId: catalog.id, name: "test_tool_2" });
@@ -173,6 +178,7 @@ describe("mcp server tool execution", () => {
     const catalog = await makeInternalMcpCatalog({
       name: "Original Name",
       description: "Original description",
+      organizationId,
     });
 
     const result = await executeArchestraTool(
@@ -227,6 +233,7 @@ describe("mcp server tool execution", () => {
     const catalog = await makeInternalMcpCatalog({
       name: "Configurable MCP Server",
       serverType: "local",
+      organizationId,
     });
 
     const result = await executeArchestraTool(

--- a/platform/backend/src/archestra-mcp-server/mcp-servers.ts
+++ b/platform/backend/src/archestra-mcp-server/mcp-servers.ts
@@ -479,13 +479,23 @@ async function handleSearchPrivateMcpRegistry(
   args: SearchPrivateMcpRegistryArgs,
   context: ArchestraContext,
 ): Promise<CallToolResult> {
-  const { agent: contextAgent } = context;
+  const { agent: contextAgent, organizationId } = context;
   logger.info(
     { agentId: contextAgent.id, searchArgs: args },
     "search_private_mcp_registry tool called",
   );
 
   try {
+    if (!context.userId || !organizationId) {
+      return errorResult("user/organization context not available.");
+    }
+
+    const isAdmin = await userHasPermission(
+      context.userId,
+      organizationId,
+      "mcpServerInstallation",
+      "admin",
+    );
     const query = args.query;
 
     let catalogItems: InternalMcpCatalog[];
@@ -493,10 +503,16 @@ async function handleSearchPrivateMcpRegistry(
     if (query && query.trim() !== "") {
       catalogItems = await InternalMcpCatalogModel.searchByQuery(query, {
         expandSecrets: false,
+        userId: context.userId,
+        isAdmin,
+        organizationId,
       });
     } else {
       catalogItems = await InternalMcpCatalogModel.findAll({
         expandSecrets: false,
+        userId: context.userId,
+        isAdmin,
+        organizationId,
       });
     }
 
@@ -546,13 +562,26 @@ async function handleSearchPrivateMcpRegistry(
 async function handleGetMcpServers(
   context: ArchestraContext,
 ): Promise<CallToolResult> {
-  const { agent: contextAgent } = context;
+  const { agent: contextAgent, organizationId } = context;
 
   logger.info({ agentId: contextAgent.id }, "get_mcp_servers tool called");
 
   try {
+    if (!context.userId || !organizationId) {
+      return errorResult("user/organization context not available.");
+    }
+
+    const isAdmin = await userHasPermission(
+      context.userId,
+      organizationId,
+      "mcpServerInstallation",
+      "admin",
+    );
     const catalogItems = await InternalMcpCatalogModel.findAll({
       expandSecrets: false,
+      userId: context.userId,
+      isAdmin,
+      organizationId,
     });
 
     const items = catalogItems.map((c) => ({
@@ -574,7 +603,7 @@ async function handleGetMcpServerTools(
   args: GetMcpServerToolsArgs,
   context: ArchestraContext,
 ): Promise<CallToolResult> {
-  const { agent: contextAgent } = context;
+  const { agent: contextAgent, organizationId } = context;
 
   logger.info(
     { agentId: contextAgent.id, mcpServerId: args.mcpServerId },
@@ -582,6 +611,29 @@ async function handleGetMcpServerTools(
   );
 
   try {
+    if (!context.userId || !organizationId) {
+      return errorResult("user/organization context not available.");
+    }
+
+    const isAdmin = await userHasPermission(
+      context.userId,
+      organizationId,
+      "mcpServerInstallation",
+      "admin",
+    );
+    const catalogItem = await InternalMcpCatalogModel.findById(
+      args.mcpServerId,
+      {
+        expandSecrets: false,
+        userId: context.userId,
+        isAdmin,
+        organizationId,
+      },
+    );
+    if (!catalogItem) {
+      return errorResult("MCP server not found or you don't have access.");
+    }
+
     const tools = await ToolModel.findByCatalogId(args.mcpServerId);
     return structuredSuccessResult({ tools }, JSON.stringify(tools, null, 2));
   } catch (error) {
@@ -605,17 +657,21 @@ async function handleEditMcpDescription(
       return errorResult("user/organization context not available.");
     }
 
-    const existing = await InternalMcpCatalogModel.findById(args.id);
-    if (!existing) {
-      return errorResult("MCP server not found.");
-    }
-
     const isAdmin = await userHasPermission(
       context.userId,
       organizationId,
       "mcpServerInstallation",
       "admin",
     );
+
+    const existing = await InternalMcpCatalogModel.findById(args.id, {
+      userId: context.userId,
+      isAdmin,
+      organizationId,
+    });
+    if (!existing) {
+      return errorResult("MCP server not found.");
+    }
 
     if (!isAdmin) {
       if (
@@ -702,17 +758,21 @@ async function handleEditMcpConfig(
       return errorResult("user/organization context not available.");
     }
 
-    const existing = await InternalMcpCatalogModel.findById(args.id);
-    if (!existing) {
-      return errorResult("MCP server not found.");
-    }
-
     const isAdmin = await userHasPermission(
       context.userId,
       organizationId,
       "mcpServerInstallation",
       "admin",
     );
+
+    const existing = await InternalMcpCatalogModel.findById(args.id, {
+      userId: context.userId,
+      isAdmin,
+      organizationId,
+    });
+    if (!existing) {
+      return errorResult("MCP server not found.");
+    }
 
     if (!isAdmin) {
       if (
@@ -960,7 +1020,17 @@ async function handleDeployMcpServer(
       return errorResult("user/organization context not available.");
     }
 
-    const catalogItem = await InternalMcpCatalogModel.findById(args.catalogId);
+    const isAdmin = await userHasPermission(
+      context.userId,
+      organizationId,
+      "mcpServerInstallation",
+      "admin",
+    );
+    const catalogItem = await InternalMcpCatalogModel.findById(args.catalogId, {
+      userId: context.userId,
+      isAdmin,
+      organizationId,
+    });
     if (!catalogItem) {
       return errorResult("catalog item not found.");
     }

--- a/platform/backend/src/models/agent-tool.test.ts
+++ b/platform/backend/src/models/agent-tool.test.ts
@@ -621,6 +621,57 @@ describe("AgentToolModel.findAll", () => {
       expect(includedToolNames).toContain("archestra__exclude_test_tool_1");
       expect(includedToolNames).toContain("archestra__exclude_test_tool_2");
     });
+
+    test("non-admin users can see org-agent tools bound to org-scoped MCP servers", async ({
+      makeAgent,
+      makeAgentTool,
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeMember,
+      makeOrganization,
+      makeTool,
+      makeUser,
+    }) => {
+      const organization = await makeOrganization();
+      const user = await makeUser();
+      await makeMember(user.id, organization.id);
+
+      const catalog = await makeInternalMcpCatalog({
+        organizationId: organization.id,
+        scope: "org",
+      });
+      const agent = await makeAgent({
+        organizationId: organization.id,
+        scope: "org",
+      });
+      const tool = await makeTool({
+        name: "org-installed-mcp-tool",
+        catalogId: catalog.id,
+      });
+      const mcpServer = await makeMcpServer({
+        catalogId: catalog.id,
+        scope: "org",
+      });
+
+      await makeAgentTool(agent.id, tool.id, {
+        mcpServerId: mcpServer.id,
+      });
+
+      const result = await AgentToolModel.findAll({
+        filters: {
+          agentId: agent.id,
+          excludeArchestraTools: true,
+        },
+        userId: user.id,
+        organizationId: organization.id,
+        isAgentAdmin: false,
+        skipPagination: true,
+      });
+
+      expect(result.data.map((assignment) => assignment.tool.id)).toContain(
+        tool.id,
+      );
+    });
   });
 
   describe("Combined Filters, Sorting, and Pagination", () => {

--- a/platform/backend/src/models/agent-tool.ts
+++ b/platform/backend/src/models/agent-tool.ts
@@ -273,11 +273,13 @@ class AgentToolModel {
   // ============================================================================
 
   /**
-   * Get all MCP server IDs that a user has access to (through team membership or personal access).
+   * Get all MCP server IDs that a user has access to (through team
+   * membership, personal access, or org-scoped installations).
    * Used for filtering agent_tools to only show assignments with accessible credentials.
    */
   private static async getUserAccessibleMcpServerIds(
     userId: string,
+    organizationId?: string,
   ): Promise<string[]> {
     // Get MCP servers accessible through team membership
     const teamAccessibleServers = await db
@@ -295,8 +297,30 @@ class AgentToolModel {
     const personalIds =
       await McpServerUserModel.getUserPersonalMcpServerIds(userId);
 
+    const orgScopedIds = organizationId
+      ? await db
+          .select({ mcpServerId: schema.mcpServersTable.id })
+          .from(schema.mcpServersTable)
+          .innerJoin(
+            schema.internalMcpCatalogTable,
+            eq(
+              schema.mcpServersTable.catalogId,
+              schema.internalMcpCatalogTable.id,
+            ),
+          )
+          .where(
+            and(
+              eq(schema.mcpServersTable.scope, "org"),
+              eq(schema.internalMcpCatalogTable.organizationId, organizationId),
+            ),
+          )
+          .then((rows) => rows.map((s) => s.mcpServerId))
+      : [];
+
     // Combine and deduplicate
-    return [...new Set([...teamAccessibleIds, ...personalIds])];
+    return [
+      ...new Set([...teamAccessibleIds, ...personalIds, ...orgScopedIds]),
+    ];
   }
 
   // ============================================================================
@@ -877,6 +901,7 @@ class AgentToolModel {
     };
     filters?: AgentToolFilters;
     userId?: string;
+    organizationId?: string;
     isAgentAdmin?: boolean;
     skipPagination?: boolean;
   }): Promise<PaginatedResult<AgentTool>> {
@@ -885,6 +910,7 @@ class AgentToolModel {
       sorting,
       filters,
       userId,
+      organizationId,
       isAgentAdmin,
       skipPagination = false,
     } = params;
@@ -910,7 +936,10 @@ class AgentToolModel {
       // Filter by accessible credentials (MCP servers)
       // Only show agent_tools where the user has access to the credential/execution source
       const accessibleMcpServerIds =
-        await AgentToolModel.getUserAccessibleMcpServerIds(userId);
+        await AgentToolModel.getUserAccessibleMcpServerIds(
+          userId,
+          organizationId,
+        );
 
       // Build credential access condition:
       // - No static MCP server binding, OR

--- a/platform/backend/src/models/internal-mcp-catalog.test.ts
+++ b/platform/backend/src/models/internal-mcp-catalog.test.ts
@@ -509,6 +509,7 @@ describe("InternalMcpCatalogModel", () => {
       const found = await InternalMcpCatalogModel.findById(catalog.id, {
         userId: author.id,
         isAdmin: false,
+        organizationId: org.id,
       });
       expect(found).not.toBeNull();
 
@@ -516,6 +517,7 @@ describe("InternalMcpCatalogModel", () => {
       const denied = await InternalMcpCatalogModel.findById(catalog.id, {
         userId: otherUser.id,
         isAdmin: false,
+        organizationId: org.id,
       });
       expect(denied).toBeNull();
 
@@ -523,6 +525,7 @@ describe("InternalMcpCatalogModel", () => {
       const adminAccess = await InternalMcpCatalogModel.findById(catalog.id, {
         userId: otherUser.id,
         isAdmin: true,
+        organizationId: org.id,
       });
       expect(adminAccess).not.toBeNull();
     });
@@ -571,7 +574,12 @@ describe("InternalMcpCatalogModel", () => {
       // Author finds it
       const authorResults = await InternalMcpCatalogModel.searchByQuery(
         "searchscope-personal",
-        { expandSecrets: false, userId: author.id, isAdmin: false },
+        {
+          expandSecrets: false,
+          userId: author.id,
+          isAdmin: false,
+          organizationId: org.id,
+        },
       );
       expect(
         authorResults.some((r) => r.name === "searchscope-personal-item"),
@@ -580,7 +588,12 @@ describe("InternalMcpCatalogModel", () => {
       // Other user does not
       const otherResults = await InternalMcpCatalogModel.searchByQuery(
         "searchscope-personal",
-        { expandSecrets: false, userId: otherUser.id, isAdmin: false },
+        {
+          expandSecrets: false,
+          userId: otherUser.id,
+          isAdmin: false,
+          organizationId: org.id,
+        },
       );
       expect(
         otherResults.some((r) => r.name === "searchscope-personal-item"),

--- a/platform/backend/src/models/internal-mcp-catalog.ts
+++ b/platform/backend/src/models/internal-mcp-catalog.ts
@@ -62,14 +62,28 @@ class InternalMcpCatalogModel {
     expandSecrets?: boolean;
     userId?: string;
     isAdmin?: boolean;
+    organizationId?: string;
   }): Promise<InternalMcpCatalog[]> {
-    const { expandSecrets = true, userId, isAdmin } = options ?? {};
+    const {
+      expandSecrets = true,
+      userId,
+      isAdmin,
+      organizationId,
+    } = options ?? {};
 
     let dbItems: Array<typeof schema.internalMcpCatalogTable.$inferSelect>;
 
-    if (userId && !isAdmin) {
+    if (userId && !isAdmin && !organizationId) {
+      return [];
+    }
+
+    if (userId && organizationId) {
       const accessibleIds =
-        await McpCatalogTeamModel.getUserAccessibleCatalogIds(userId, false);
+        await McpCatalogTeamModel.getUserAccessibleCatalogIds(
+          userId,
+          !!isAdmin,
+          organizationId,
+        );
       if (accessibleIds.length === 0) return [];
       dbItems = await db
         .select()
@@ -101,9 +115,15 @@ class InternalMcpCatalogModel {
       expandSecrets?: boolean;
       userId?: string;
       isAdmin?: boolean;
+      organizationId?: string;
     },
   ): Promise<InternalMcpCatalog[]> {
-    const { expandSecrets = true, userId, isAdmin } = options ?? {};
+    const {
+      expandSecrets = true,
+      userId,
+      isAdmin,
+      organizationId,
+    } = options ?? {};
 
     let dbItems: Array<typeof schema.internalMcpCatalogTable.$inferSelect>;
 
@@ -112,9 +132,17 @@ class InternalMcpCatalogModel {
       ilike(schema.internalMcpCatalogTable.description, `%${query}%`),
     );
 
-    if (userId && !isAdmin) {
+    if (userId && !isAdmin && !organizationId) {
+      return [];
+    }
+
+    if (userId && organizationId) {
       const accessibleIds =
-        await McpCatalogTeamModel.getUserAccessibleCatalogIds(userId, false);
+        await McpCatalogTeamModel.getUserAccessibleCatalogIds(
+          userId,
+          !!isAdmin,
+          organizationId,
+        );
       if (accessibleIds.length === 0) return [];
       dbItems = await db
         .select()
@@ -150,15 +178,26 @@ class InternalMcpCatalogModel {
       expandSecrets?: boolean;
       userId?: string;
       isAdmin?: boolean;
+      organizationId?: string;
     },
   ): Promise<InternalMcpCatalog | null> {
-    const { expandSecrets = true, userId, isAdmin } = options ?? {};
+    const {
+      expandSecrets = true,
+      userId,
+      isAdmin,
+      organizationId,
+    } = options ?? {};
 
-    if (userId && !isAdmin) {
+    if (userId && !isAdmin && !organizationId) {
+      return null;
+    }
+
+    if (userId && organizationId) {
       const hasAccess = await McpCatalogTeamModel.userHasCatalogAccess(
         userId,
         id,
-        false,
+        !!isAdmin,
+        organizationId,
       );
       if (!hasAccess) return null;
     }

--- a/platform/backend/src/models/internal-mcp-catalog.ts
+++ b/platform/backend/src/models/internal-mcp-catalog.ts
@@ -278,11 +278,24 @@ class InternalMcpCatalogModel {
     return result;
   }
 
-  static async findByName(name: string): Promise<InternalMcpCatalog | null> {
+  static async findByName(
+    name: string,
+    options?: { organizationId?: string },
+  ): Promise<InternalMcpCatalog | null> {
+    const whereCondition = options?.organizationId
+      ? and(
+          eq(schema.internalMcpCatalogTable.name, name),
+          eq(
+            schema.internalMcpCatalogTable.organizationId,
+            options.organizationId,
+          ),
+        )
+      : eq(schema.internalMcpCatalogTable.name, name);
+
     const [dbItem] = await db
       .select()
       .from(schema.internalMcpCatalogTable)
-      .where(eq(schema.internalMcpCatalogTable.name, name));
+      .where(whereCondition);
 
     if (!dbItem) {
       return null;

--- a/platform/backend/src/models/mcp-catalog-team.test.ts
+++ b/platform/backend/src/models/mcp-catalog-team.test.ts
@@ -19,9 +19,38 @@ test("getUserAccessibleCatalogIds returns org-scoped items for any user", async 
   const ids = await McpCatalogTeamModel.getUserAccessibleCatalogIds(
     user.id,
     false,
+    org.id,
   );
 
   expect(ids).toContain(orgCatalog.id);
+});
+
+test("getUserAccessibleCatalogIds scopes org items to the active organization", async ({
+  makeUser,
+  makeOrganization,
+  makeInternalMcpCatalog,
+}) => {
+  const user = await makeUser();
+  const org = await makeOrganization();
+  const otherOrg = await makeOrganization();
+
+  const orgCatalog = await makeInternalMcpCatalog({
+    scope: "org",
+    organizationId: org.id,
+  });
+  const otherOrgCatalog = await makeInternalMcpCatalog({
+    scope: "org",
+    organizationId: otherOrg.id,
+  });
+
+  const ids = await McpCatalogTeamModel.getUserAccessibleCatalogIds(
+    user.id,
+    false,
+    org.id,
+  );
+
+  expect(ids).toContain(orgCatalog.id);
+  expect(ids).not.toContain(otherOrgCatalog.id);
 });
 
 test("getUserAccessibleCatalogIds returns personal items only to author", async ({
@@ -42,12 +71,14 @@ test("getUserAccessibleCatalogIds returns personal items only to author", async 
   const authorIds = await McpCatalogTeamModel.getUserAccessibleCatalogIds(
     author.id,
     false,
+    org.id,
   );
   expect(authorIds).toContain(personalCatalog.id);
 
   const otherIds = await McpCatalogTeamModel.getUserAccessibleCatalogIds(
     otherUser.id,
     false,
+    org.id,
   );
   expect(otherIds).not.toContain(personalCatalog.id);
 });
@@ -74,12 +105,14 @@ test("getUserAccessibleCatalogIds returns team items to team members", async ({
   const memberIds = await McpCatalogTeamModel.getUserAccessibleCatalogIds(
     member.id,
     false,
+    org.id,
   );
   expect(memberIds).toContain(teamCatalog.id);
 
   const nonMemberIds = await McpCatalogTeamModel.getUserAccessibleCatalogIds(
     nonMember.id,
     false,
+    org.id,
   );
   expect(nonMemberIds).not.toContain(teamCatalog.id);
 });
@@ -102,6 +135,7 @@ test("getUserAccessibleCatalogIds returns all items for admin", async ({
   const adminIds = await McpCatalogTeamModel.getUserAccessibleCatalogIds(
     admin.id,
     true,
+    org.id,
   );
   expect(adminIds).toContain(personalCatalog.id);
 });
@@ -141,6 +175,7 @@ test("userHasCatalogAccess checks access correctly for all scope types", async (
       otherUser.id,
       orgCatalog.id,
       false,
+      org.id,
     ),
   ).toBe(true);
 
@@ -150,6 +185,7 @@ test("userHasCatalogAccess checks access correctly for all scope types", async (
       author.id,
       personalCatalog.id,
       false,
+      org.id,
     ),
   ).toBe(true);
   expect(
@@ -157,6 +193,7 @@ test("userHasCatalogAccess checks access correctly for all scope types", async (
       otherUser.id,
       personalCatalog.id,
       false,
+      org.id,
     ),
   ).toBe(false);
 
@@ -166,6 +203,7 @@ test("userHasCatalogAccess checks access correctly for all scope types", async (
       teamMember.id,
       teamCatalog.id,
       false,
+      org.id,
     ),
   ).toBe(true);
   expect(
@@ -173,6 +211,7 @@ test("userHasCatalogAccess checks access correctly for all scope types", async (
       otherUser.id,
       teamCatalog.id,
       false,
+      org.id,
     ),
   ).toBe(false);
 
@@ -182,8 +221,32 @@ test("userHasCatalogAccess checks access correctly for all scope types", async (
       otherUser.id,
       personalCatalog.id,
       true,
+      org.id,
     ),
   ).toBe(true);
+});
+
+test("userHasCatalogAccess denies org-scoped catalog items from other organizations", async ({
+  makeUser,
+  makeOrganization,
+  makeInternalMcpCatalog,
+}) => {
+  const user = await makeUser();
+  const org = await makeOrganization();
+  const otherOrg = await makeOrganization();
+  const otherOrgCatalog = await makeInternalMcpCatalog({
+    scope: "org",
+    organizationId: otherOrg.id,
+  });
+
+  await expect(
+    McpCatalogTeamModel.userHasCatalogAccess(
+      user.id,
+      otherOrgCatalog.id,
+      true,
+      org.id,
+    ),
+  ).resolves.toBe(false);
 });
 
 test("syncCatalogTeams replaces team assignments", async ({
@@ -255,6 +318,7 @@ test("findAll with scope filtering returns correct items", async ({
     expandSecrets: false,
     userId: author.id,
     isAdmin: false,
+    organizationId: org.id,
   });
   const authorNames = authorItems.map((i) => i.name);
   expect(authorNames).toContain(orgCatalog.name);
@@ -266,6 +330,7 @@ test("findAll with scope filtering returns correct items", async ({
     expandSecrets: false,
     userId: otherUser.id,
     isAdmin: false,
+    organizationId: org.id,
   });
   const otherNames = otherItems.map((i) => i.name);
   expect(otherNames).toContain(orgCatalog.name);

--- a/platform/backend/src/models/mcp-catalog-team.ts
+++ b/platform/backend/src/models/mcp-catalog-team.ts
@@ -13,25 +13,35 @@ class McpCatalogTeamModel {
   static async getUserAccessibleCatalogIds(
     userId: string,
     isAdmin: boolean,
+    organizationId: string,
   ): Promise<string[]> {
     if (isAdmin) {
       const allCatalogs = await db
         .select({ id: schema.internalMcpCatalogTable.id })
-        .from(schema.internalMcpCatalogTable);
+        .from(schema.internalMcpCatalogTable)
+        .where(
+          eq(schema.internalMcpCatalogTable.organizationId, organizationId),
+        );
       return allCatalogs.map((c) => c.id);
     }
 
     // Mirrors the agent (profile) access control approach: org-visible + personal + team-based
     const result = await db.execute<{ id: string }>(sql`
-      SELECT id FROM internal_mcp_catalog WHERE scope = 'org'
+      SELECT id FROM internal_mcp_catalog
+        WHERE scope = 'org' AND organization_id = ${organizationId}
       UNION
-      SELECT id FROM internal_mcp_catalog WHERE author_id = ${userId} AND scope = 'personal'
+      SELECT id FROM internal_mcp_catalog
+        WHERE author_id = ${userId}
+          AND scope = 'personal'
+          AND organization_id = ${organizationId}
       UNION
       SELECT ct.catalog_id AS id
         FROM mcp_catalog_team ct
         INNER JOIN internal_mcp_catalog c ON ct.catalog_id = c.id
         INNER JOIN team_member tm ON ct.team_id = tm.team_id
-        WHERE tm.user_id = ${userId} AND c.scope = 'team'
+        WHERE tm.user_id = ${userId}
+          AND c.scope = 'team'
+          AND c.organization_id = ${organizationId}
     `);
 
     return result.rows.map((r) => r.id);
@@ -44,19 +54,21 @@ class McpCatalogTeamModel {
     userId: string,
     catalogId: string,
     isAdmin: boolean,
+    organizationId: string,
   ): Promise<boolean> {
-    if (isAdmin) return true;
-
     const [catalog] = await db
       .select({
         scope: schema.internalMcpCatalogTable.scope,
         authorId: schema.internalMcpCatalogTable.authorId,
+        organizationId: schema.internalMcpCatalogTable.organizationId,
       })
       .from(schema.internalMcpCatalogTable)
       .where(eq(schema.internalMcpCatalogTable.id, catalogId))
       .limit(1);
 
     if (!catalog) return false;
+    if (catalog.organizationId !== organizationId) return false;
+    if (isAdmin) return true;
 
     if (catalog.scope === "org") return true;
 

--- a/platform/backend/src/routes/agent-tool.ts
+++ b/platform/backend/src/routes/agent-tool.ts
@@ -100,6 +100,7 @@ const agentToolRoutes: FastifyPluginAsyncZod = async (fastify) => {
           excludeArchestraTools,
         },
         userId: user.id,
+        organizationId,
         isAgentAdmin,
         skipPagination,
       });

--- a/platform/backend/src/routes/internal-mcp-catalog.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.test.ts
@@ -12,15 +12,34 @@ import {
   type ZodTypeProvider,
 } from "fastify-type-provider-zod";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import type { User } from "@/types";
 import internalMcpCatalogRoutes from "./internal-mcp-catalog";
 
 describe("internal MCP catalog routes", () => {
   let app: FastifyInstance;
 
-  beforeEach(async () => {
+  beforeEach(async ({ makeMember, makeOrganization, makeUser }) => {
+    const organization = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, organization.id, { role: "admin" });
+
     app = Fastify().withTypeProvider<ZodTypeProvider>();
     app.setValidatorCompiler(validatorCompiler);
     app.setSerializerCompiler(serializerCompiler);
+    app.addHook("onRequest", async (request) => {
+      (
+        request as typeof request & {
+          user: User;
+          organizationId: string;
+        }
+      ).user = user;
+      (
+        request as typeof request & {
+          user: User;
+          organizationId: string;
+        }
+      ).organizationId = organization.id;
+    });
     await app.register(internalMcpCatalogRoutes);
   });
 

--- a/platform/backend/src/routes/internal-mcp-catalog.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.test.ts
@@ -11,21 +11,45 @@ import {
   validatorCompiler,
   type ZodTypeProvider,
 } from "fastify-type-provider-zod";
+import { type Mock, vi } from "vitest";
+import { hasPermission } from "@/auth";
+import { InternalMcpCatalogModel } from "@/models";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
-import type { User } from "@/types";
+import { ApiError, type User } from "@/types";
 import internalMcpCatalogRoutes from "./internal-mcp-catalog";
+
+vi.mock("@/auth", () => ({
+  hasPermission: vi.fn(),
+}));
+
+const mockHasPermission = hasPermission as Mock;
 
 describe("internal MCP catalog routes", () => {
   let app: FastifyInstance;
+  let organizationId: string;
 
   beforeEach(async ({ makeMember, makeOrganization, makeUser }) => {
+    vi.clearAllMocks();
+    mockHasPermission.mockResolvedValue({ success: true, error: null });
+
     const organization = await makeOrganization();
+    organizationId = organization.id;
     const user = await makeUser();
     await makeMember(user.id, organization.id, { role: "admin" });
 
     app = Fastify().withTypeProvider<ZodTypeProvider>();
     app.setValidatorCompiler(validatorCompiler);
     app.setSerializerCompiler(serializerCompiler);
+    app.setErrorHandler((error, _request, reply) => {
+      if (error instanceof ApiError) {
+        return reply.status(error.statusCode).send({
+          error: { message: error.message, type: error.type },
+        });
+      }
+      const err = error as Error & { statusCode?: number };
+      const status = err.statusCode ?? 500;
+      return reply.status(status).send({ error: { message: err.message } });
+    });
     app.addHook("onRequest", async (request) => {
       (
         request as typeof request & {
@@ -67,5 +91,40 @@ describe("internal MCP catalog routes", () => {
     expect(toolNames).not.toContain(TOOL_SEARCH_TOOLS_FULL_NAME);
     expect(toolNames).not.toContain(TOOL_RUN_TOOL_FULL_NAME);
     expect(toolNames).toContain(TOOL_ARTIFACT_WRITE_FULL_NAME);
+  });
+
+  test("DELETE /api/internal_mcp_catalog/by-name/:name is scoped to the active organization", async ({
+    makeInternalMcpCatalog,
+    makeOrganization,
+  }) => {
+    const otherOrganization = await makeOrganization();
+    const catalog = await makeInternalMcpCatalog({
+      name: "other-org-catalog",
+      organizationId: otherOrganization.id,
+      scope: "org",
+    });
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/api/internal_mcp_catalog/by-name/other-org-catalog",
+    });
+
+    expect(response.statusCode).toBe(404);
+    await expect(
+      InternalMcpCatalogModel.findById(catalog.id),
+    ).resolves.not.toBeNull();
+
+    await makeInternalMcpCatalog({
+      name: "active-org-catalog",
+      organizationId,
+      scope: "org",
+    });
+
+    const activeOrgResponse = await app.inject({
+      method: "DELETE",
+      url: "/api/internal_mcp_catalog/by-name/active-org-catalog",
+    });
+
+    expect(activeOrgResponse.statusCode).toBe(200);
   });
 });

--- a/platform/backend/src/routes/internal-mcp-catalog.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.ts
@@ -799,7 +799,9 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
     },
     async (request, reply) => {
       const { name } = request.params;
-      const catalogItem = await InternalMcpCatalogModel.findByName(name);
+      const catalogItem = await InternalMcpCatalogModel.findByName(name, {
+        organizationId: request.organizationId,
+      });
 
       if (!catalogItem) {
         throw new ApiError(404, `Catalog item with name "${name}" not found`);

--- a/platform/backend/src/routes/internal-mcp-catalog.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.ts
@@ -73,6 +73,7 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
           expandSecrets: false,
           userId: request.user.id,
           isAdmin,
+          organizationId: request.organizationId,
         }),
       );
     },
@@ -292,6 +293,7 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
       const catalogItem = await InternalMcpCatalogModel.findById(id, {
         userId: request.user.id,
         isAdmin,
+        organizationId: request.organizationId,
       });
 
       if (!catalogItem) {
@@ -318,9 +320,18 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
         ),
       },
     },
-    async ({ params: { id } }, reply) => {
+    async (request, reply) => {
+      const { id } = request.params;
+      const { success: isAdmin } = await hasPermission(
+        { mcpServerInstallation: ["admin"] },
+        request.headers,
+      );
       // Verify catalog exists (including virtual Archestra catalog)
-      const catalogItem = await InternalMcpCatalogModel.findById(id);
+      const catalogItem = await InternalMcpCatalogModel.findById(id, {
+        userId: request.user.id,
+        isAdmin,
+        organizationId: request.organizationId,
+      });
 
       if (!catalogItem) {
         throw new ApiError(404, "Catalog item not found");
@@ -377,18 +388,21 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
       // before persistence, so work on a cloned object instead of the request body.
       const restBody = structuredClone(restBodyInput);
 
-      // Get the original catalog item to check if name or serverUrl changed
-      const originalCatalogItem = await InternalMcpCatalogModel.findById(id);
-
-      if (!originalCatalogItem) {
-        throw new ApiError(404, "Catalog item not found");
-      }
-
-      // Enforce scope restrictions
       const { success: isAdmin } = await hasPermission(
         { mcpServerInstallation: ["admin"] },
         request.headers,
       );
+
+      // Get the original catalog item to check if name or serverUrl changed
+      const originalCatalogItem = await InternalMcpCatalogModel.findById(id, {
+        userId: request.user.id,
+        isAdmin,
+        organizationId: request.organizationId,
+      });
+
+      if (!originalCatalogItem) {
+        throw new ApiError(404, "Catalog item not found");
+      }
 
       if (!isAdmin) {
         // Non-admins can only edit their own personal items
@@ -724,8 +738,16 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
         throw new ApiError(403, "Built-in catalog items cannot be deleted");
       }
 
+      const { success: isAdmin } = await hasPermission(
+        { mcpServerInstallation: ["admin"] },
+        request.headers,
+      );
+
       // Get the catalog item to check if it has secrets - don't expand secrets, just need IDs
       const catalogItem = await InternalMcpCatalogModel.findById(id, {
+        userId: request.user.id,
+        isAdmin,
+        organizationId: request.organizationId,
         expandSecrets: false,
       });
 
@@ -734,10 +756,6 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
       }
 
       // Enforce ownership: non-admins can only delete own personal items
-      const { success: isAdmin } = await hasPermission(
-        { mcpServerInstallation: ["admin"] },
-        request.headers,
-      );
       if (
         !isAdmin &&
         (catalogItem.scope !== "personal" ||
@@ -844,8 +862,17 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
         response: constructResponseSchema(DeploymentYamlPreviewSchema),
       },
     },
-    async ({ params: { id } }, reply) => {
-      const catalogItem = await InternalMcpCatalogModel.findById(id);
+    async (request, reply) => {
+      const { id } = request.params;
+      const { success: isAdmin } = await hasPermission(
+        { mcpServerInstallation: ["admin"] },
+        request.headers,
+      );
+      const catalogItem = await InternalMcpCatalogModel.findById(id, {
+        userId: request.user.id,
+        isAdmin,
+        organizationId: request.organizationId,
+      });
 
       if (!catalogItem) {
         throw new ApiError(404, "Catalog item not found");
@@ -925,8 +952,17 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
         response: constructResponseSchema(DeploymentYamlPreviewSchema),
       },
     },
-    async ({ params: { id } }, reply) => {
-      const catalogItem = await InternalMcpCatalogModel.findById(id);
+    async (request, reply) => {
+      const { id } = request.params;
+      const { success: isAdmin } = await hasPermission(
+        { mcpServerInstallation: ["admin"] },
+        request.headers,
+      );
+      const catalogItem = await InternalMcpCatalogModel.findById(id, {
+        userId: request.user.id,
+        isAdmin,
+        organizationId: request.organizationId,
+      });
 
       if (!catalogItem) {
         throw new ApiError(404, "Catalog item not found");

--- a/platform/backend/src/routes/internal-mcp-catalog.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.ts
@@ -326,15 +326,18 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
         { mcpServerInstallation: ["admin"] },
         request.headers,
       );
-      // Verify catalog exists (including virtual Archestra catalog)
-      const catalogItem = await InternalMcpCatalogModel.findById(id, {
-        userId: request.user.id,
-        isAdmin,
-        organizationId: request.organizationId,
-      });
+      // The built-in Archestra catalog is virtual; custom/private catalog IDs
+      // still need an access-checked backing row.
+      if (!isBuiltInCatalogId(id)) {
+        const catalogItem = await InternalMcpCatalogModel.findById(id, {
+          userId: request.user.id,
+          isAdmin,
+          organizationId: request.organizationId,
+        });
 
-      if (!catalogItem) {
-        throw new ApiError(404, "Catalog item not found");
+        if (!catalogItem) {
+          throw new ApiError(404, "Catalog item not found");
+        }
       }
 
       const tools = await ToolModel.findByCatalogId(id);


### PR DESCRIPTION
## Summary
- scope internal MCP catalog access checks to the active organization
- pass organization context through private registry routes and Archestra MCP registry tools
- include org-scoped installed MCP servers when filtering static agent-tool assignments for non-admin org members
- add regression coverage for org-scoped catalog visibility and org-agent tools bound to org-scoped MCP server installations