### PR TITLE
fix(mcp-inspector): use textarea for args to support JSON input

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-inspector.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-inspector.tsx
@@ -12,6 +12,7 @@ import {
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
@@ -396,8 +397,8 @@ export function McpInspector({ serverId, isActive }: McpInspectorProps) {
                                 </span>
                               )}
                             </Label>
-                            <Input
-                              placeholder={prop.description || `Enter ${name}`}
+                            <Textarea
+                              placeholder={prop.description || `Enter ${name} (supports JSON)`}
                               value={paramValues[name] ?? ""}
                               onChange={(e) =>
                                 setParamValues((prev) => ({
@@ -405,7 +406,8 @@ export function McpInspector({ serverId, isActive }: McpInspectorProps) {
                                   [name]: e.target.value,
                                 }))
                               }
-                              className="font-mono text-xs"
+                              className="font-mono text-xs min-h-[60px] resize-y"
+                              rows={2}
                             />
                           </div>
                         );


### PR DESCRIPTION
Fixes #3859

## Problem
The MCP inspector currently uses `Input` fields for tool arguments, which only supports single-line text. This makes it difficult to paste multi-line JSON arguments as most catalogs display them.

## Solution
Replaced `Input` with `Textarea` for parameter values in the MCP inspector.

## Changes
- Added `Textarea` import from `@/components/ui/textarea`
- Changed parameter input from `Input` to `Textarea`
- Added `min-h-[60px]` and `resize-y` for multi-line support
- Set `rows={2}` for better default height
- Updated placeholder to indicate JSON support

## Testing
- Verified Textarea component renders correctly
- Confirmed JSON with newlines can be pasted
- Existing JSON parsing logic (already present in handleCallTool) continues to work

This allows users to paste properly formatted JSON with newlines and indentation directly into the arguments field.