### PR TITLE
fix(frontend): support JSON and multiline MCP server arguments (#3859)

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/custom-server-request-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/custom-server-request-dialog.tsx
@@ -6,6 +6,7 @@ import { EnvironmentVariableSchema } from "@shared";
 import { Loader2 } from "lucide-react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { z } from "zod";
+import { parseMcpArguments } from "@/lib/mcp/mcp-arguments-parser";
 import { EnvironmentVariablesFormField } from "@/components/environment-variables-form-field";
 import { Button } from "@/components/ui/button";
 import {
@@ -20,6 +21,7 @@ import {
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -119,10 +121,7 @@ export function CustomServerRequestDialog({
             serverType: "local" as const,
             localConfig: {
               command: values.command,
-              arguments: values.arguments
-                .split("\n")
-                .map((arg) => arg.trim())
-                .filter((arg) => arg.length > 0),
+              arguments: parseMcpArguments(values.arguments),
               environment:
                 values.environment.length > 0 ? values.environment : undefined,
             },
@@ -276,14 +275,17 @@ export function CustomServerRequestDialog({
                     name="arguments"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>Arguments (one per line)</FormLabel>
+                        <FormLabel>Arguments</FormLabel>
                         <FormControl>
                           <Textarea
-                            placeholder={`/path/to/server.js\n--verbose`}
+                            placeholder={`--verbose\n/path/to/server.js\n\nOR JSON format:\n["--verbose", "/path/to/server.js"]`}
                             rows={3}
                             {...field}
                           />
                         </FormControl>
+                        <FormDescription>
+                          One argument per line, or a JSON array of strings.
+                        </FormDescription>
                         <FormMessage />
                       </FormItem>
                     )}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -999,16 +999,19 @@ export function McpCatalogForm({
                     render={({ field }) => (
                       <FormItem>
                         <FormLabel>
-                          Arguments (one per line)
+                          Arguments
                           <ReinstallHint show={isArgumentsDirty} />
                         </FormLabel>
                         <FormControl>
                           <Textarea
-                            placeholder={`/path/to/server.js\n--verbose`}
+                            placeholder={`--verbose\n/path/to/server.js\n\nOR JSON format:\n["--verbose", "/path/to/server.js"]`}
                             className="font-mono min-h-20"
                             {...field}
                           />
                         </FormControl>
+                        <FormDescription>
+                          One argument per line, or a JSON array of strings.
+                        </FormDescription>
                         <FormMessage />
                       </FormItem>
                     )}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
@@ -859,4 +859,30 @@ describe("transformFormToApiData - secret env var preservation", () => {
     expect(env[1]?.key).toBe("UNTOUCHED");
     expect(env[1]?.value ?? "").toBe("");
   });
+
+  it("parses arguments as JSON if they are in JSON format", () => {
+    const values = buildLocalFormValues([]);
+    if (values.localConfig) {
+      values.localConfig.arguments = '["--verbose", "/path/to/server.js"]';
+    }
+
+    const result = transformFormToApiData(values);
+    expect(result.localConfig?.arguments).toEqual([
+      "--verbose",
+      "/path/to/server.js",
+    ]);
+  });
+
+  it("parses arguments as newline-separated by default", () => {
+    const values = buildLocalFormValues([]);
+    if (values.localConfig) {
+      values.localConfig.arguments = "--verbose\n/path/to/server.js";
+    }
+
+    const result = transformFormToApiData(values);
+    expect(result.localConfig?.arguments).toEqual([
+      "--verbose",
+      "/path/to/server.js",
+    ]);
+  });
 });

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
@@ -7,6 +7,7 @@ import {
   parseVaultReference,
 } from "@shared";
 import { parseDockerArgsToLocalConfig } from "./docker-args-parser";
+import { parseMcpArguments } from "@/lib/mcp/mcp-arguments-parser";
 import type { McpCatalogFormValues } from "./mcp-catalog-form.types";
 
 type McpCatalogApiData =
@@ -34,12 +35,9 @@ export function transformFormToApiData(
 
   // Handle local configuration
   if (values.serverType === "local" && values.localConfig) {
-    // Parse arguments string into array
+    // Parse arguments using the dedicated parser (supports JSON and newline formats)
     const argumentsArray = values.localConfig.arguments
-      ? values.localConfig.arguments
-          .split("\n")
-          .map((arg) => arg.trim())
-          .filter((arg) => arg.length > 0)
+      ? parseMcpArguments(values.localConfig.arguments)
       : [];
 
     data.localConfig = {

--- a/platform/frontend/src/lib/mcp/mcp-arguments-parser.test.ts
+++ b/platform/frontend/src/lib/mcp/mcp-arguments-parser.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { parseMcpArguments } from "./mcp-arguments-parser";
+
+describe("parseMcpArguments", () => {
+  it("should parse newline-separated arguments", () => {
+    const input = "arg1\narg2\n  arg3  \n\narg4";
+    const result = parseMcpArguments(input);
+    expect(result).toEqual(["arg1", "arg2", "arg3", "arg4"]);
+  });
+
+  it("should parse JSON array of strings", () => {
+    const input = '["arg1", "arg2", "arg3"]';
+    const result = parseMcpArguments(input);
+    expect(result).toEqual(["arg1", "arg2", "arg3"]);
+  });
+
+  it("should parse multi-line JSON array of strings", () => {
+    const input = `[
+      "arg1",
+      "arg2",
+      "arg3"
+    ]`;
+    const result = parseMcpArguments(input);
+    expect(result).toEqual(["arg1", "arg2", "arg3"]);
+  });
+
+  it("should fallback to newline-splitting if JSON is invalid", () => {
+    const input = '["arg1", "arg2"'; // Missing closing bracket
+    const result = parseMcpArguments(input);
+    expect(result).toEqual(['["arg1", "arg2"']);
+  });
+
+  it("should handle empty input", () => {
+    expect(parseMcpArguments("")).toEqual([]);
+    expect(parseMcpArguments("   ")).toEqual([]);
+    expect(parseMcpArguments("\n\n")).toEqual([]);
+  });
+
+  it("should handle JSON with non-string elements by converting to string", () => {
+    const input = '["arg1", 123, true]';
+    const result = parseMcpArguments(input);
+    expect(result).toEqual(["arg1", "123", "true"]);
+  });
+
+  it("should filter out empty arguments in both modes", () => {
+    const input1 = "arg1\n\narg2";
+    const input2 = '["arg1", "", "arg2"]';
+    expect(parseMcpArguments(input1)).toEqual(["arg1", "arg2"]);
+    expect(parseMcpArguments(input2)).toEqual(["arg1", "arg2"]);
+  });
+});

--- a/platform/frontend/src/lib/mcp/mcp-arguments-parser.ts
+++ b/platform/frontend/src/lib/mcp/mcp-arguments-parser.ts
@@ -1,0 +1,31 @@
+/**
+ * Parses MCP server arguments from a string input.
+ * Supports both newline-separated strings and JSON arrays of strings.
+ * 
+ * If the input is valid JSON and represents an array, it returns the array of strings.
+ * Otherwise, it falls back to splitting by newline and trimming each line.
+ */
+export function parseMcpArguments(input: string): string[] {
+  const trimmedInput = input.trim();
+  if (!trimmedInput) {
+    return [];
+  }
+
+  // Attempt JSON parsing if it looks like an array
+  if (trimmedInput.startsWith("[") && trimmedInput.endsWith("]")) {
+    try {
+      const parsed = JSON.parse(trimmedInput);
+      if (Array.isArray(parsed)) {
+        return parsed.map((arg) => String(arg).trim()).filter((arg) => arg.length > 0);
+      }
+    } catch (e) {
+      // Fallback to newline splitting if JSON parsing fails
+    }
+  }
+
+  // Default behavior: newline-separated strings
+  return trimmedInput
+    .split("\n")
+    .map((arg) => arg.trim())
+    .filter((arg) => arg.length > 0);
+}


### PR DESCRIPTION
## Fix for Issue #3859: MCP Server Arguments UI/UX

This PR improves the way MCP server arguments are handled in the frontend registry.

### Changes:
- **Dual Format Support**: Arguments can now be entered as one per line (newline-separated) OR as a JSON array of strings (e.g., ["--verbose", "server.js"]).
- - **New Utility**: Created parseMcpArguments to handle robust parsing, trimming, and JSON fallback.
- - **Improved UI**:
-     - Updated labels to just "Arguments".
-     - Added FormDescription explaining the supported formats.
-     - Updated placeholders with JSON examples.
- - **Validation**: Refactored the form transformation layer to use the new parser.
- - **Testing**: Added comprehensive unit tests for the parser and updated regression tests for the form utils.
Fixes #3859.