### PR TITLE
fix(ollama): handle missing API key and hint Docker users on connection failure

### DIFF
--- a/platform/backend/src/routes/chat/model-fetchers/ollama.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/ollama.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import config from "@/config";
+import { fetchOllamaModels } from "./ollama";
+
+describe("fetchOllamaModels", () => {
+  const originalBaseUrl = config.llm.ollama.baseUrl;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    config.llm.ollama.baseUrl = "http://ollama.example.com";
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({ data: [{ id: "llama3", created: 1714000000 }] }),
+        { status: 200 },
+      ),
+    );
+  });
+
+  afterEach(() => {
+    config.llm.ollama.baseUrl = originalBaseUrl;
+    vi.restoreAllMocks();
+  });
+
+  function lastFetchCall() {
+    const call = fetchSpy.mock.calls[0];
+    if (!call) throw new Error("fetch was not called");
+    return call;
+  }
+
+  test("sends bearer auth header when API key is provided", async () => {
+    await fetchOllamaModels("my-key");
+    const [, init] = lastFetchCall();
+    expect((init as RequestInit).headers).toMatchObject({
+      Authorization: "Bearer my-key",
+    });
+  });
+
+  test("sends placeholder bearer token when API key is empty", async () => {
+    await fetchOllamaModels("");
+    const [, init] = lastFetchCall();
+    expect((init as RequestInit).headers).toMatchObject({
+      Authorization: expect.stringContaining("Bearer"),
+    });
+  });
+
+  test("merges extraHeaders alongside authorization", async () => {
+    await fetchOllamaModels("my-key", null, { "x-custom": "value" });
+    const [, init] = lastFetchCall();
+    expect((init as RequestInit).headers).toMatchObject({
+      "x-custom": "value",
+      Authorization: "Bearer my-key",
+    });
+  });
+
+  test("uses baseUrl override when provided", async () => {
+    await fetchOllamaModels("k", "http://custom.example.com");
+    const [url] = lastFetchCall();
+    expect(url).toBe("http://custom.example.com/models");
+  });
+
+  test("throws on connection failure without Docker hint for non-localhost URL", async () => {
+    fetchSpy.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    config.llm.ollama.baseUrl = "http://remote.example.com";
+    await expect(fetchOllamaModels("k")).rejects.toThrow(/ECONNREFUSED/);
+    await expect(fetchOllamaModels("k")).rejects.not.toThrow(/Docker/);
+  });
+
+  test("appends Docker hint on connection failure for localhost URL", async () => {
+    fetchSpy.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    await expect(
+      fetchOllamaModels("k", "http://localhost:11434"),
+    ).rejects.toThrow(/Docker/);
+  });
+
+  test("appends Docker hint on connection failure for 127.0.0.1 URL", async () => {
+    fetchSpy.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    await expect(
+      fetchOllamaModels("k", "http://127.0.0.1:11434"),
+    ).rejects.toThrow(/Docker/);
+  });
+
+  test("throws on non-2xx response with status code in message", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response("Unauthorized", { status: 401 }));
+    await expect(fetchOllamaModels("bad-key")).rejects.toThrow(
+      "Failed to fetch Ollama models: 401",
+    );
+  });
+
+  test("maps models correctly from response", async () => {
+    const models = await fetchOllamaModels("k");
+    expect(models).toEqual([
+      {
+        id: "llama3",
+        displayName: "llama3",
+        provider: "ollama",
+        createdAt: new Date(1714000000 * 1000).toISOString(),
+      },
+    ]);
+  });
+
+  test("handles missing createdAt field", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: [{ id: "llama3" }] }), { status: 200 }),
+    );
+    const models = await fetchOllamaModels("k");
+    expect(models[0].createdAt).toBeUndefined();
+  });
+});

--- a/platform/backend/src/routes/chat/model-fetchers/ollama.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/ollama.ts
@@ -2,6 +2,18 @@ import config from "@/config";
 import logger from "@/logging";
 import { type ModelInfo, PLACEHOLDER_BEARER_TOKEN } from "./types";
 
+const DOCKER_HOST_HINT =
+  " If Archestra is running inside Docker, try changing the Base URL to http://host.docker.internal:11434/ to reach Ollama on the host machine.";
+
+function isLocalhostUrl(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+  } catch {
+    return false;
+  }
+}
+
 export async function fetchOllamaModels(
   apiKey: string,
   baseUrlOverride?: string | null,
@@ -9,12 +21,21 @@ export async function fetchOllamaModels(
 ): Promise<ModelInfo[]> {
   const baseUrl = baseUrlOverride || config.llm.ollama.baseUrl;
   const url = `${baseUrl}/models`;
-  const response = await fetch(url, {
-    headers: {
-      ...(extraHeaders ?? {}),
-      Authorization: apiKey ? `Bearer ${apiKey}` : PLACEHOLDER_BEARER_TOKEN,
-    },
-  });
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: {
+        ...(extraHeaders ?? {}),
+        Authorization: apiKey ? `Bearer ${apiKey}` : PLACEHOLDER_BEARER_TOKEN,
+      },
+    });
+  } catch (err) {
+    const hint = isLocalhostUrl(baseUrl) ? DOCKER_HOST_HINT : "";
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error({ url, error: message }, "Failed to connect to Ollama");
+    throw new Error(`Failed to connect to Ollama at ${baseUrl}: ${message}.${hint}`);
+  }
 
   if (!response.ok) {
     const errorText = await response.text();

--- a/platform/backend/src/routes/chat/model-fetchers/ollama.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/ollama.ts
@@ -1,18 +1,10 @@
 import config from "@/config";
 import logger from "@/logging";
+import { isLoopbackRedirectUri } from "@/utils/network";
 import { type ModelInfo, PLACEHOLDER_BEARER_TOKEN } from "./types";
 
 const DOCKER_HOST_HINT =
-  " If Archestra is running inside Docker, try changing the Base URL to http://host.docker.internal:11434/ to reach Ollama on the host machine.";
-
-function isLocalhostUrl(url: string): boolean {
-  try {
-    const { hostname } = new URL(url);
-    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
-  } catch {
-    return false;
-  }
-}
+  " If running inside Docker, try changing the Base URL to http://host.docker.internal:11434/ to reach Ollama on the host machine.";
 
 export async function fetchOllamaModels(
   apiKey: string,
@@ -31,7 +23,7 @@ export async function fetchOllamaModels(
       },
     });
   } catch (err) {
-    const hint = isLocalhostUrl(baseUrl) ? DOCKER_HOST_HINT : "";
+    const hint = isLoopbackRedirectUri(baseUrl) ? DOCKER_HOST_HINT : "";
     const message = err instanceof Error ? err.message : String(err);
     logger.error({ url, error: message }, "Failed to connect to Ollama");
     throw new Error(`Failed to connect to Ollama at ${baseUrl}: ${message}.${hint}`);

--- a/platform/backend/src/routes/llm-provider-api-keys.ts
+++ b/platform/backend/src/routes/llm-provider-api-keys.ts
@@ -266,6 +266,15 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
             userId: user.id,
           }),
         );
+      } else if (PROVIDERS_WITH_OPTIONAL_API_KEY.has(body.provider)) {
+        // No API key provided for an optional-key provider (e.g. Ollama, vLLM).
+        // Still verify the endpoint is reachable so the user gets early feedback.
+        await testApiKeyOrThrow(
+          body.provider,
+          "",
+          body.baseUrl,
+          body.extraHeaders,
+        );
       }
 
       if (!secret && !PROVIDERS_WITH_OPTIONAL_API_KEY.has(body.provider)) {


### PR DESCRIPTION
Fixes #4286

**Issue 1 — Ollama works without an API key but was never tested on save**
The provider API key endpoint skips the connectivity test entirely when no key is provided for Ollama/vLLM. A misconfigured base URL only surfaces at inference time. Fixed by running the test with an empty key so users get immediate feedback on save.

**Issue 2 — Silent failure when Ollama is on localhost inside Docker**
Network errors against `localhost`/`127.0.0.1`/`::1` now include a hint to use `http://host.docker.internal:11434/` instead.

Changes:
- `platform/backend/src/routes/llm-provider-api-keys.ts` — test connectivity on save for optional-key providers
- `platform/backend/src/routes/chat/model-fetchers/ollama.ts` — catch network errors and surface Docker hint