### PR TITLE
feat: support JSON arrays in MCP server arguments field

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
@@ -1,9 +1,83 @@
 import type { McpCatalogFormValues } from "./mcp-catalog-form.types";
 import {
+  parseArgumentsString,
   transformCatalogItemToFormValues,
   transformExternalCatalogToFormValues,
   transformFormToApiData,
 } from "./mcp-catalog-form.utils";
+
+describe("parseArgumentsString", () => {
+  describe("JSON array format", () => {
+    it("parses a valid JSON array of strings", () => {
+      expect(parseArgumentsString('["--port", "8080", "--verbose"]')).toEqual([
+        "--port",
+        "8080",
+        "--verbose",
+      ]);
+    });
+
+    it("filters out empty strings inside a JSON array", () => {
+      expect(parseArgumentsString('["--flag", "", "value"]')).toEqual([
+        "--flag",
+        "value",
+      ]);
+    });
+
+    it("returns [] for an empty JSON array", () => {
+      expect(parseArgumentsString("[]")).toEqual([]);
+    });
+
+    it("throws a descriptive error for malformed JSON", () => {
+      expect(() =>
+        parseArgumentsString('["--flag", "value"'),
+      ).toThrow(/could not be parsed/);
+    });
+
+    it("throws when the parsed JSON value is not an array", () => {
+      expect(() =>
+        parseArgumentsString('{"key": "value"}'),
+      ).toThrow(/not an array/);
+    });
+
+    it("throws when the JSON array contains non-string elements", () => {
+      expect(() =>
+        parseArgumentsString('["--port", 8080, true]'),
+      ).toThrow(/only strings/);
+    });
+  });
+
+  describe("newline-separated format (fallback)", () => {
+    it("parses one-arg-per-line input", () => {
+      expect(parseArgumentsString("--port\n8080\n--verbose")).toEqual([
+        "--port",
+        "8080",
+        "--verbose",
+      ]);
+    });
+
+    it("trims whitespace from each line", () => {
+      expect(parseArgumentsString("  --flag  \n  value  ")).toEqual([
+        "--flag",
+        "value",
+      ]);
+    });
+
+    it("ignores blank lines", () => {
+      expect(parseArgumentsString("--a\n\n--b\n\n")).toEqual(["--a", "--b"]);
+    });
+
+    it("returns [] for an empty / whitespace-only string", () => {
+      expect(parseArgumentsString("")).toEqual([]);
+      expect(parseArgumentsString("   ")).toEqual([]);
+    });
+
+    it("returns a single-element array for a single argument", () => {
+      expect(parseArgumentsString("server.js")).toEqual(["server.js"]);
+    });
+  });
+});
+
+
 
 describe("transformFormToApiData", () => {
   it("maps custom auth and additional headers into userConfig", () => {

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
@@ -12,6 +12,58 @@ import type { McpCatalogFormValues } from "./mcp-catalog-form.types";
 type McpCatalogApiData =
   archestraApiTypes.CreateInternalMcpCatalogItemData["body"];
 
+/**
+ * Parses the free-form "arguments" textarea into a string array.
+ *
+ * Accepted formats (checked in order):
+ * 1. **JSON array** – if the trimmed input starts with `[`, it is parsed as
+ *    JSON. The result must be an array whose every element is a string;
+ *    otherwise an error is thrown so callers can surface it to the user.
+ * 2. **Newline-separated list** – one argument per line; blank lines are
+ *    ignored, each entry is trimmed.
+ *
+ * @throws {Error} When the input looks like a JSON array but is malformed or
+ *   contains non-string elements.
+ */
+export function parseArgumentsString(raw: string): string[] {
+  const trimmed = raw.trim();
+  if (!trimmed) return [];
+
+  if (trimmed.startsWith("[")) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (err) {
+      throw new Error(
+        `Arguments field looks like a JSON array but could not be parsed: ${err instanceof Error ? err.message : "invalid JSON"}`,
+      );
+    }
+
+    if (!Array.isArray(parsed)) {
+      throw new Error(
+        "Arguments field was parsed as JSON but is not an array. " +
+          "Use a JSON array of strings, e.g. [\"--flag\", \"value\"].",
+      );
+    }
+
+    const nonStrings = parsed.filter((el) => typeof el !== "string");
+    if (nonStrings.length > 0) {
+      throw new Error(
+        `Arguments JSON array must contain only strings, ` +
+          `but found: ${nonStrings.map((el) => JSON.stringify(el)).join(", ")}.`,
+      );
+    }
+
+    return (parsed as string[]).filter((arg) => arg.length > 0);
+  }
+
+  // Fallback: newline-separated format
+  return trimmed
+    .split("\n")
+    .map((arg) => arg.trim())
+    .filter((arg) => arg.length > 0);
+}
+
 // Transform function to convert form values to API format
 export function transformFormToApiData(
   values: McpCatalogFormValues,
@@ -34,12 +86,9 @@ export function transformFormToApiData(
 
   // Handle local configuration
   if (values.serverType === "local" && values.localConfig) {
-    // Parse arguments string into array
+    // Parse arguments string into array (supports JSON array or newline-separated)
     const argumentsArray = values.localConfig.arguments
-      ? values.localConfig.arguments
-          .split("\n")
-          .map((arg) => arg.trim())
-          .filter((arg) => arg.length > 0)
+      ? parseArgumentsString(values.localConfig.arguments)
       : [];
 
     data.localConfig = {


### PR DESCRIPTION
The arguments textarea in the local MCP server configuration form previously only accepted a newline-separated list of arguments.

This change introduces a new exported helper, parseArgumentsString(), that detects a JSON array (by a leading '[') and parses it first, falling back to the existing newline-separated format if the input is not a JSON array.

Error handling surfaces three distinct, user-actionable messages:
- Malformed JSON that cannot be parsed
- Valid JSON that is not an array (e.g. an object)
- JSON array containing non-string elements (e.g. numbers, booleans)

The inline split logic in transformFormToApiData is replaced by a call to parseArgumentsString. The reverse path (join by newline when loading from the API) is intentionally unchanged.

Tests: 11 new unit test cases covering both parsing paths and all three error branches are added to mcp-catalog-form.utils.test.ts.