### PR TITLE
fix: targeted personal MCP installs

### DIFF
--- a/docs/pages/platform-private-registry.md
+++ b/docs/pages/platform-private-registry.md
@@ -3,7 +3,7 @@ title: Private MCP Registry
 category: MCP
 order: 2
 description: Managing your organization's MCP servers in a private registry
-lastUpdated: 2026-04-27
+lastUpdated: 2026-05-08
 ---
 
 <!--
@@ -63,12 +63,15 @@ See [MCP Authentication](/docs/mcp-authentication) for the full gateway and upst
 
 ## Installation Scope
 
-Installations can be personal or team-scoped.
+Installations can be personal, team-scoped, or organization-scoped.
 
 - **Personal installations** are owned by one user and are useful when each person needs their own upstream account.
 - **Team installations** are shared with a team and are useful for shared service accounts or team-owned integrations.
+- **Organization installations** are shared across the organization and require MCP server installation admin permission.
 
-When assigning tools to an Agent or MCP Gateway, you can pin a specific installation or use **Resolve at call time**. Resolve-at-call-time resolves deterministically from the caller identity and the available personal or team-scoped credentials. If no credential can be resolved, Archestra returns an error with an install link.
+When using the API, `userId` can only be provided for personal installations. It defaults to the caller. Setting it to another organization member installs the personal connection on that member's behalf and requires `mcpServerInstallation:admin`.
+
+When assigning tools to an Agent or MCP Gateway, you can pin a specific installation or use **Resolve at call time**. Resolve-at-call-time resolves deterministically from the caller identity and the available personal, team-scoped, or organization-scoped credentials. If no credential can be resolved, Archestra returns an error with an install link.
 
 See [Credential Resolution](/docs/mcp-authentication#credential-resolution) for the resolution order and missing credential behavior.
 

--- a/platform/backend/src/archestra-mcp-server/mcp-servers.test.ts
+++ b/platform/backend/src/archestra-mcp-server/mcp-servers.test.ts
@@ -3,7 +3,7 @@ import {
   ARCHESTRA_MCP_SERVER_NAME,
   MCP_SERVER_TOOL_NAME_SEPARATOR,
 } from "@shared";
-import { InternalMcpCatalogModel } from "@/models";
+import { InternalMcpCatalogModel, McpServerModel } from "@/models";
 import { beforeEach, describe, expect, test } from "@/test";
 import type { Agent } from "@/types";
 import { type ArchestraContext, executeArchestraTool } from ".";
@@ -360,6 +360,19 @@ describe("deploy_mcp_server", () => {
     );
 
     expect(result.isError).toBe(false);
+
+    const [createdServer] = await McpServerModel.findByCatalogId(catalog.id);
+    expect(createdServer).toMatchObject({
+      ownerId: notTeamMember.id,
+      scope: "team",
+      teamId: team.id,
+    });
+    const hydratedServer = await McpServerModel.findById(
+      createdServer.id,
+      notTeamMember.id,
+      true,
+    );
+    expect(hydratedServer?.users).toEqual([]);
   });
 
   test("team install: member of team and editor succeeds", async ({
@@ -519,6 +532,19 @@ describe("deploy_mcp_server", () => {
     );
 
     expect(result.isError).toBe(false);
+
+    const [createdServer] = await McpServerModel.findByCatalogId(catalog.id);
+    expect(createdServer).toMatchObject({
+      ownerId: user.id,
+      scope: "org",
+      teamId: null,
+    });
+    const hydratedServer = await McpServerModel.findById(
+      createdServer.id,
+      user.id,
+      true,
+    );
+    expect(hydratedServer?.users).toEqual([]);
   });
 
   test("org install: non-admin (no mcpServerInstallation:admin) is rejected", async ({

--- a/platform/backend/src/archestra-mcp-server/mcp-servers.ts
+++ b/platform/backend/src/archestra-mcp-server/mcp-servers.ts
@@ -1108,8 +1108,8 @@ async function handleDeployMcpServer(
       catalogId: args.catalogId,
       serverType: catalogItem.serverType,
       ownerId: context.userId,
-      userId: context.userId,
       scope,
+      ...(scope === "personal" && { userId: context.userId }),
       ...(teamId && { teamId }),
     });
 

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -2054,6 +2054,358 @@ describe("mcp server inspect route", () => {
       expect(assignments.length).toBe(2);
     });
 
+    test("admin can install a personal connection for another organization member", async ({
+      makeInternalMcpCatalog,
+      makeMember,
+      makeUser,
+    }) => {
+      const { default: AgentModel } = await import("@/models/agent");
+      const { default: AgentToolModel } = await import("@/models/agent-tool");
+
+      const targetUser = await makeUser({
+        email: "target-install@example.com",
+      });
+      await makeMember(targetUser.id, organizationId);
+
+      const catalog = await makeInternalMcpCatalog({
+        name: "Targeted Personal Remote",
+        serverType: "remote",
+        serverUrl: "http://localhost:30082/mcp",
+      });
+
+      connectAndGetToolsMock.mockResolvedValueOnce([
+        {
+          name: "target-tool",
+          description: "target tool",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ]);
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/mcp_server",
+        payload: {
+          name: "Targeted Personal Remote",
+          catalogId: catalog.id,
+          scope: "personal",
+          userId: targetUser.id,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        ownerId: targetUser.id,
+        users: [targetUser.id],
+        userDetails: [
+          expect.objectContaining({
+            userId: targetUser.id,
+            email: "target-install@example.com",
+          }),
+        ],
+      });
+
+      const targetPersonalGateway = await AgentModel.getPersonalMcpGateway(
+        targetUser.id,
+        organizationId,
+      );
+      if (!targetPersonalGateway) {
+        throw new Error("expected target user's personal gateway");
+      }
+      const targetAssignments = await AgentToolModel.findToolIdsByAgent(
+        targetPersonalGateway.id,
+      );
+      expect(targetAssignments.length).toBe(1);
+
+      const currentUserPersonalGateway = await AgentModel.getPersonalMcpGateway(
+        user.id,
+        organizationId,
+      );
+      const currentUserAssignments = currentUserPersonalGateway
+        ? await AgentToolModel.findToolIdsByAgent(currentUserPersonalGateway.id)
+        : [];
+      expect(currentUserAssignments.length).toBe(0);
+    });
+
+    test("same catalog can be installed as separate personal connections for different users", async ({
+      makeInternalMcpCatalog,
+      makeMember,
+      makeUser,
+    }) => {
+      const { default: AgentModel } = await import("@/models/agent");
+
+      const targetUser = await makeUser({
+        email: "target-second-personal-install@example.com",
+      });
+      await makeMember(targetUser.id, organizationId);
+
+      const catalog = await makeInternalMcpCatalog({
+        name: "Per User Personal Remote",
+        serverType: "remote",
+        serverUrl: "http://localhost:30082/mcp",
+      });
+
+      connectAndGetToolsMock.mockResolvedValue([
+        {
+          name: "shared-tool",
+          description: "shared tool",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ]);
+
+      const currentUserResponse = await app.inject({
+        method: "POST",
+        url: "/api/mcp_server",
+        payload: {
+          name: "Per User Personal Remote",
+          catalogId: catalog.id,
+          scope: "personal",
+        },
+      });
+      expect(currentUserResponse.statusCode).toBe(200);
+
+      const targetUserResponse = await app.inject({
+        method: "POST",
+        url: "/api/mcp_server",
+        payload: {
+          name: "Per User Personal Remote",
+          catalogId: catalog.id,
+          scope: "personal",
+          userId: targetUser.id,
+        },
+      });
+      expect(targetUserResponse.statusCode).toBe(200);
+
+      const currentUserServer = currentUserResponse.json();
+      const targetUserServer = targetUserResponse.json();
+      expect(currentUserServer).toMatchObject({
+        ownerId: user.id,
+        users: [user.id],
+      });
+      expect(targetUserServer).toMatchObject({
+        ownerId: targetUser.id,
+        users: [targetUser.id],
+      });
+
+      const serversForCatalog = await db
+        .select()
+        .from(schema.mcpServersTable)
+        .where(eq(schema.mcpServersTable.catalogId, catalog.id));
+      expect(serversForCatalog.map((server) => server.id).sort()).toEqual(
+        [currentUserServer.id, targetUserServer.id].sort(),
+      );
+
+      const currentPersonalGateway = await AgentModel.getPersonalMcpGateway(
+        user.id,
+        organizationId,
+      );
+      const targetPersonalGateway = await AgentModel.getPersonalMcpGateway(
+        targetUser.id,
+        organizationId,
+      );
+      if (!currentPersonalGateway || !targetPersonalGateway) {
+        throw new Error("expected personal gateways for both users");
+      }
+
+      const currentAssignments = await db
+        .select({ mcpServerId: schema.agentToolsTable.mcpServerId })
+        .from(schema.agentToolsTable)
+        .where(eq(schema.agentToolsTable.agentId, currentPersonalGateway.id));
+      const targetAssignments = await db
+        .select({ mcpServerId: schema.agentToolsTable.mcpServerId })
+        .from(schema.agentToolsTable)
+        .where(eq(schema.agentToolsTable.agentId, targetPersonalGateway.id));
+
+      expect(currentAssignments.map((row) => row.mcpServerId)).toEqual([
+        currentUserServer.id,
+      ]);
+      expect(targetAssignments.map((row) => row.mcpServerId)).toEqual([
+        targetUserServer.id,
+      ]);
+    });
+
+    test("targeted personal install uses the target user's identity-provider fallback token", async ({
+      makeAccount,
+      makeInternalMcpCatalog,
+      makeMember,
+      makeUser,
+    }) => {
+      const targetUser = await makeUser({
+        email: "target-install-token@example.com",
+      });
+      await makeMember(targetUser.id, organizationId);
+      await makeAccount(user.id, {
+        providerId: "keycloak",
+        accessToken: "installer-session-token",
+      });
+      await makeAccount(targetUser.id, {
+        providerId: "keycloak",
+        accessToken: "target-session-token",
+      });
+
+      const catalog = await makeInternalMcpCatalog({
+        name: "Targeted Protected Remote",
+        serverType: "remote",
+        serverUrl: "http://localhost:30082/mcp",
+      });
+
+      connectAndGetToolsMock
+        .mockRejectedValueOnce(
+          new Error(
+            "Failed to connect to MCP server Targeted Protected Remote: unauthorized",
+          ),
+        )
+        .mockResolvedValueOnce([
+          {
+            name: "target-protected-tool",
+            description: "target protected tool",
+            inputSchema: { type: "object", properties: {} },
+          },
+        ]);
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/mcp_server",
+        payload: {
+          name: "Targeted Protected Remote",
+          catalogId: catalog.id,
+          scope: "personal",
+          userId: targetUser.id,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(connectAndGetToolsMock).toHaveBeenCalledTimes(2);
+      expect(connectAndGetToolsMock.mock.calls[1][0]).toMatchObject({
+        secrets: { access_token: "target-session-token" },
+      });
+      expect(connectAndGetToolsMock.mock.calls[1][0].secrets).not.toMatchObject(
+        {
+          access_token: "installer-session-token",
+        },
+      );
+    });
+
+    test("rejects explicit agentIds when installing a personal connection for another organization member", async ({
+      makeAgent,
+      makeInternalMcpCatalog,
+      makeMember,
+      makeUser,
+    }) => {
+      const targetUser = await makeUser({
+        email: "target-agentids-denied@example.com",
+      });
+      await makeMember(targetUser.id, organizationId);
+      const explicitAgent = await makeAgent({
+        name: "Rejected Explicit Agent",
+        agentType: "mcp_gateway",
+        scope: "personal",
+        organizationId,
+        authorId: user.id,
+      });
+      const catalog = await makeInternalMcpCatalog({
+        name: "Rejected Targeted AgentIds Remote",
+        serverType: "remote",
+        serverUrl: "http://localhost:30082/mcp",
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/mcp_server",
+        payload: {
+          name: "Rejected Targeted AgentIds Remote",
+          catalogId: catalog.id,
+          scope: "personal",
+          userId: targetUser.id,
+          agentIds: [explicitAgent.id],
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error.message).toContain(
+        "agentIds cannot be provided when installing a personal MCP server for another user",
+      );
+      expect(connectAndGetToolsMock).not.toHaveBeenCalled();
+
+      const serversForCatalog = await db
+        .select()
+        .from(schema.mcpServersTable)
+        .where(eq(schema.mcpServersTable.catalogId, catalog.id));
+      expect(serversForCatalog).toHaveLength(0);
+    });
+
+    test("non-admin cannot install a personal connection for another user", async ({
+      makeInternalMcpCatalog,
+      makeMember,
+      makeUser,
+    }) => {
+      hasPermissionMock.mockImplementation(
+        async (permission: Record<string, string[]>) => {
+          if (permission.mcpServerInstallation?.includes("admin")) {
+            return { success: false };
+          }
+          return { success: true };
+        },
+      );
+
+      const targetUser = await makeUser({
+        email: "target-denied@example.com",
+      });
+      await makeMember(targetUser.id, organizationId);
+      const catalog = await makeInternalMcpCatalog({
+        name: "Denied Targeted Personal Remote",
+        serverType: "remote",
+        serverUrl: "http://localhost:30082/mcp",
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/mcp_server",
+        payload: {
+          name: "Denied Targeted Personal Remote",
+          catalogId: catalog.id,
+          scope: "personal",
+          userId: targetUser.id,
+        },
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.json().error.message).toContain(
+        "Only mcpServerInstallation admins can install personal MCP servers for another user",
+      );
+      expect(connectAndGetToolsMock).not.toHaveBeenCalled();
+    });
+
+    test("admin cannot install a personal connection for a user outside the organization", async ({
+      makeInternalMcpCatalog,
+      makeUser,
+    }) => {
+      const targetUser = await makeUser({
+        email: "target-outside-org@example.com",
+      });
+      const catalog = await makeInternalMcpCatalog({
+        name: "Outside Org Targeted Personal Remote",
+        serverType: "remote",
+        serverUrl: "http://localhost:30082/mcp",
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/mcp_server",
+        payload: {
+          name: "Outside Org Targeted Personal Remote",
+          catalogId: catalog.id,
+          scope: "personal",
+          userId: targetUser.id,
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error.message).toContain(
+        "Target user must be a member of the active organization",
+      );
+      expect(connectAndGetToolsMock).not.toHaveBeenCalled();
+    });
+
     test("remote install with explicit agentIds still assigns tools to the personal gateway with no duplicate-key errors", async ({
       makeInternalMcpCatalog,
       makeAgent,
@@ -2152,6 +2504,156 @@ describe("mcp server inspect route", () => {
         otherPersonalGateway.id,
       );
       expect(otherAssignments.length).toBe(0);
+    });
+
+    test("targeted personal install returns the target user's existing installation", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeMember,
+      makeUser,
+    }) => {
+      const targetUser = await makeUser({
+        email: "target-existing@example.com",
+      });
+      await makeMember(targetUser.id, organizationId);
+      const catalog = await makeInternalMcpCatalog({
+        name: "Existing Targeted Personal Remote",
+        serverType: "remote",
+        serverUrl: "http://localhost:30082/mcp",
+      });
+      const existingServer = await makeMcpServer({
+        catalogId: catalog.id,
+        ownerId: targetUser.id,
+        scope: "personal",
+      });
+      await McpServerUserModel.assignUserToMcpServer(
+        existingServer.id,
+        targetUser.id,
+      );
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/mcp_server",
+        payload: {
+          name: "Existing Targeted Personal Remote",
+          catalogId: catalog.id,
+          scope: "personal",
+          userId: targetUser.id,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        id: existingServer.id,
+        ownerId: targetUser.id,
+        users: [targetUser.id],
+      });
+
+      const serversForCatalog = await db
+        .select()
+        .from(schema.mcpServersTable)
+        .where(eq(schema.mcpServersTable.catalogId, catalog.id));
+      expect(serversForCatalog).toHaveLength(1);
+      expect(connectAndGetToolsMock).not.toHaveBeenCalled();
+    });
+
+    test("rejects explicit agentIds when targeted personal install already exists", async ({
+      makeAgent,
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeMember,
+      makeTool,
+      makeUser,
+    }) => {
+      const { default: AgentToolModel } = await import("@/models/agent-tool");
+
+      const targetUser = await makeUser({
+        email: "target-existing-agentids-denied@example.com",
+      });
+      await makeMember(targetUser.id, organizationId);
+      const explicitAgent = await makeAgent({
+        name: "Rejected Existing Explicit Agent",
+        agentType: "mcp_gateway",
+        scope: "personal",
+        organizationId,
+        authorId: user.id,
+      });
+      const catalog = await makeInternalMcpCatalog({
+        name: "Existing Rejected Targeted AgentIds Remote",
+        serverType: "remote",
+        serverUrl: "http://localhost:30082/mcp",
+      });
+      const existingServer = await makeMcpServer({
+        catalogId: catalog.id,
+        ownerId: targetUser.id,
+        scope: "personal",
+      });
+      await McpServerUserModel.assignUserToMcpServer(
+        existingServer.id,
+        targetUser.id,
+      );
+      await makeTool({
+        name: "existing-targeted-agentids-tool",
+        catalogId: catalog.id,
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/mcp_server",
+        payload: {
+          name: "Existing Rejected Targeted AgentIds Remote",
+          catalogId: catalog.id,
+          scope: "personal",
+          userId: targetUser.id,
+          agentIds: [explicitAgent.id],
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error.message).toContain(
+        "agentIds cannot be provided when installing a personal MCP server for another user",
+      );
+
+      const explicitAssignments = await AgentToolModel.findToolIdsByAgent(
+        explicitAgent.id,
+      );
+      expect(explicitAssignments).toHaveLength(0);
+      const serversForCatalog = await db
+        .select()
+        .from(schema.mcpServersTable)
+        .where(eq(schema.mcpServersTable.catalogId, catalog.id));
+      expect(serversForCatalog).toHaveLength(1);
+    });
+
+    test("rejects userId on team-scoped installs", async ({
+      makeInternalMcpCatalog,
+      makeTeam,
+    }) => {
+      const team = await makeTeam(organizationId, user.id, {
+        name: "Reject UserId Team",
+      });
+      const catalog = await makeInternalMcpCatalog({
+        name: "Reject UserId Team Remote",
+        serverType: "remote",
+        serverUrl: "http://localhost:30082/mcp",
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/mcp_server",
+        payload: {
+          name: "Reject UserId Team Remote",
+          catalogId: catalog.id,
+          scope: "team",
+          teamId: team.id,
+          userId: user.id,
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error.message).toContain(
+        "userId can only be provided for personal-scoped MCP server installations",
+      );
     });
 
     test("re-install pins mcp_server_id on newly inserted agent_tools rows", async ({

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -15,6 +15,7 @@ import {
   AgentToolModel,
   InternalMcpCatalogModel,
   McpServerModel,
+  MemberModel,
   TeamModel,
   ToolModel,
 } from "@/models";
@@ -169,9 +170,37 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
         serverType: "local",
       };
 
-      // Set owner_id and userId to current user
-      serverData.ownerId = user.id;
-      serverData.userId = user.id;
+      if (serverData.scope !== "personal" && serverData.userId) {
+        throw new ApiError(
+          400,
+          "userId can only be provided for personal-scoped MCP server installations",
+        );
+      }
+
+      const effectivePersonalUserId =
+        serverData.scope === "personal"
+          ? await resolvePersonalInstallUserId({
+              requestedUserId: serverData.userId,
+              currentUserId: user.id,
+              organizationId,
+              headers,
+            })
+          : undefined;
+
+      if (
+        serverData.scope === "personal" &&
+        effectivePersonalUserId !== undefined &&
+        effectivePersonalUserId !== user.id &&
+        agentIds?.length
+      ) {
+        throw new ApiError(
+          400,
+          "agentIds cannot be provided when installing a personal MCP server for another user",
+        );
+      }
+
+      serverData.ownerId = effectivePersonalUserId ?? user.id;
+      serverData.userId = effectivePersonalUserId;
 
       // Track if we created a new secret (for cleanup on failure)
       let createdSecretId: string | undefined;
@@ -219,7 +248,8 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
         // Return existing server instead of erroring (idempotent behavior)
         if (serverData.scope === "personal") {
           const existingPersonal = existingServers.find(
-            (s) => s.scope === "personal" && s.ownerId === user.id,
+            (s) =>
+              s.scope === "personal" && s.ownerId === effectivePersonalUserId,
           );
           if (existingPersonal) {
             const catalogTools = await ToolModel.findByCatalogId(
@@ -229,7 +259,7 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
             if (toolIds.length > 0) {
               const personalGateway = await AgentModel.ensurePersonalMcpGateway(
                 {
-                  userId: user.id,
+                  userId: effectivePersonalUserId ?? user.id,
                   organizationId,
                 },
               );
@@ -247,7 +277,12 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 },
               );
             }
-            return reply.send(existingPersonal);
+            const hydratedExisting = await McpServerModel.findById(
+              existingPersonal.id,
+              user.id,
+              true,
+            );
+            return reply.send(hydratedExisting ?? existingPersonal);
           }
         }
 
@@ -611,10 +646,13 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
       }
 
       // Create the MCP server with optional secret reference
-      const mcpServer = await McpServerModel.create({
+      let mcpServer = await McpServerModel.create({
         ...serverData,
         ...(secretId && { secretId }),
       });
+      mcpServer =
+        (await McpServerModel.findById(mcpServer.id, user.id, true)) ??
+        mcpServer;
 
       try {
         // For local servers, start the K8s deployment first
@@ -703,16 +741,19 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   await ToolModel.bulkCreateToolsIfNotExists(toolsToCreate);
 
                 // For personal installs, auto-assign every discovered tool to the
-                // installer's personal gateway alongside any explicit agentIds.
-                // Team-scoped installs only honor explicit agentIds.
+                // effective owner's personal gateway alongside any explicit agentIds.
+                // Shared-scope installs only honor explicit agentIds.
                 {
                   const toolIds = createdTools.map((t) => t.id);
                   if (toolIds.length > 0) {
                     const targetAgentIds: string[] = [];
-                    if (!mcpServer.teamId) {
+                    if (
+                      mcpServer.scope === "personal" &&
+                      effectivePersonalUserId
+                    ) {
                       const personalGateway =
                         await AgentModel.ensurePersonalMcpGateway({
-                          userId: user.id,
+                          userId: effectivePersonalUserId,
                           organizationId,
                         });
                       targetAgentIds.push(personalGateway.id);
@@ -809,12 +850,12 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
 
         // For non-local servers, fetch tools synchronously during installation.
         // If discovery fails with auth and this is a personal install, retry once
-        // with the current user's linked IdP access token.
+        // with the effective owner's linked IdP access token.
         const tools = await connectAndGetToolsForInstallation({
           catalogItem,
           mcpServerId: mcpServer.id,
           secretId: mcpServer.secretId ?? undefined,
-          userId: user.id,
+          userId: effectivePersonalUserId ?? user.id,
           allowCurrentUserTokenFallback: mcpServer.scope === "personal",
         });
 
@@ -833,16 +874,16 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           await ToolModel.bulkCreateToolsIfNotExists(toolsToCreate);
 
         // For personal installs, auto-assign every discovered tool to the
-        // installer's personal gateway alongside any explicit agentIds.
-        // Team-scoped installs only honor explicit agentIds.
+        // effective owner's personal gateway alongside any explicit agentIds.
+        // Shared-scope installs only honor explicit agentIds.
         {
           const toolIds = createdTools.map((t) => t.id);
           if (toolIds.length > 0) {
             const targetAgentIds: string[] = [];
-            if (!mcpServer.teamId) {
+            if (mcpServer.scope === "personal" && effectivePersonalUserId) {
               const personalGateway = await AgentModel.ensurePersonalMcpGateway(
                 {
-                  userId: user.id,
+                  userId: effectivePersonalUserId,
                   organizationId,
                 },
               );
@@ -1850,7 +1891,7 @@ async function connectAndGetToolsForInstallation(params: {
         mcpServerId: params.mcpServerId,
         userId: params.userId,
       },
-      "Retrying MCP install-time tool discovery with the current user's identity-provider access token",
+      "Retrying MCP install-time tool discovery with the effective user's identity-provider access token",
     );
 
     return await mcpClient.connectAndGetTools({
@@ -2190,6 +2231,43 @@ function filterInstallUserConfigValues(params: {
   }
 
   return Object.fromEntries(filteredEntries);
+}
+
+async function resolvePersonalInstallUserId(params: {
+  requestedUserId: string | undefined;
+  currentUserId: string;
+  organizationId: string;
+  headers: IncomingHttpHeaders;
+}): Promise<string> {
+  const targetUserId = params.requestedUserId ?? params.currentUserId;
+
+  if (targetUserId === params.currentUserId) {
+    return targetUserId;
+  }
+
+  const { success: isMcpServerInstallationAdmin } = await hasPermission(
+    { mcpServerInstallation: ["admin"] },
+    params.headers,
+  );
+  if (!isMcpServerInstallationAdmin) {
+    throw new ApiError(
+      403,
+      "Only mcpServerInstallation admins can install personal MCP servers for another user",
+    );
+  }
+
+  const targetMember = await MemberModel.getByUserId(
+    targetUserId,
+    params.organizationId,
+  );
+  if (!targetMember) {
+    throw new ApiError(
+      400,
+      "Target user must be a member of the active organization",
+    );
+  }
+
+  return targetUserId;
 }
 
 async function validateScopeAndAuthorization(params: {


### PR DESCRIPTION
## Summary
- Allow `POST /api/mcp_server` personal installs to target another organization member via `userId` when the caller has `mcpServerInstallation:admin`.
- Keep same-user personal installs as the default when `userId` is omitted.
- Use the effective personal owner for duplicate detection, MCP server ownership, user assignment, personal gateway tool assignment, and linked IdP token fallback.
- Reject `userId` on non-personal installs and document the API behavior.

## Root Cause
The install route accepted `userId` in the schema but overwrote both `ownerId` and `userId` with the authenticated request user. That made admin pre-provisioning for another user impossible and caused duplicate detection and tool assignment to resolve against the API key owner instead of the intended personal installation owner.

Fixes #4452