### PR TITLE
fix: global MCP catalog access

### DIFF
--- a/platform/backend/src/models/mcp-catalog-team.test.ts
+++ b/platform/backend/src/models/mcp-catalog-team.test.ts
@@ -25,6 +25,28 @@ test("getUserAccessibleCatalogIds returns org-scoped items for any user", async 
   expect(ids).toContain(orgCatalog.id);
 });
 
+test("getUserAccessibleCatalogIds returns global org-scoped items for any user", async ({
+  makeUser,
+  makeOrganization,
+}) => {
+  const user = await makeUser();
+  const org = await makeOrganization();
+
+  const globalCatalog = await InternalMcpCatalogModel.create({
+    name: "global-catalog",
+    serverType: "builtin",
+    scope: "org",
+  });
+
+  const ids = await McpCatalogTeamModel.getUserAccessibleCatalogIds(
+    user.id,
+    false,
+    org.id,
+  );
+
+  expect(ids).toContain(globalCatalog.id);
+});
+
 test("getUserAccessibleCatalogIds scopes org items to the active organization", async ({
   makeUser,
   makeOrganization,
@@ -140,6 +162,28 @@ test("getUserAccessibleCatalogIds returns all items for admin", async ({
   expect(adminIds).toContain(personalCatalog.id);
 });
 
+test("getUserAccessibleCatalogIds returns global items for admin", async ({
+  makeUser,
+  makeOrganization,
+}) => {
+  const admin = await makeUser();
+  const org = await makeOrganization();
+
+  const globalCatalog = await InternalMcpCatalogModel.create({
+    name: "global-admin-catalog",
+    serverType: "builtin",
+    scope: "org",
+  });
+
+  const adminIds = await McpCatalogTeamModel.getUserAccessibleCatalogIds(
+    admin.id,
+    true,
+    org.id,
+  );
+
+  expect(adminIds).toContain(globalCatalog.id);
+});
+
 test("userHasCatalogAccess checks access correctly for all scope types", async ({
   makeUser,
   makeOrganization,
@@ -249,6 +293,28 @@ test("userHasCatalogAccess denies org-scoped catalog items from other organizati
   ).resolves.toBe(false);
 });
 
+test("userHasCatalogAccess allows global org-scoped catalog items", async ({
+  makeUser,
+  makeOrganization,
+}) => {
+  const user = await makeUser();
+  const org = await makeOrganization();
+  const globalCatalog = await InternalMcpCatalogModel.create({
+    name: "global-access-catalog",
+    serverType: "builtin",
+    scope: "org",
+  });
+
+  await expect(
+    McpCatalogTeamModel.userHasCatalogAccess(
+      user.id,
+      globalCatalog.id,
+      false,
+      org.id,
+    ),
+  ).resolves.toBe(true);
+});
+
 test("syncCatalogTeams replaces team assignments", async ({
   makeOrganization,
   makeUser,
@@ -336,4 +402,26 @@ test("findAll with scope filtering returns correct items", async ({
   expect(otherNames).toContain(orgCatalog.name);
   expect(otherNames).not.toContain(personalCatalog.name);
   expect(otherNames).not.toContain(teamCatalog.name);
+});
+
+test("findAll with scope filtering includes global org-scoped items", async ({
+  makeUser,
+  makeOrganization,
+}) => {
+  const user = await makeUser();
+  const org = await makeOrganization();
+  const globalCatalog = await InternalMcpCatalogModel.create({
+    name: "scope-test-global",
+    serverType: "builtin",
+    scope: "org",
+  });
+
+  const items = await InternalMcpCatalogModel.findAll({
+    expandSecrets: false,
+    userId: user.id,
+    isAdmin: false,
+    organizationId: org.id,
+  });
+
+  expect(items.map((i) => i.id)).toContain(globalCatalog.id);
 });

--- a/platform/backend/src/models/mcp-catalog-team.ts
+++ b/platform/backend/src/models/mcp-catalog-team.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, or, sql } from "drizzle-orm";
 import db, { schema } from "@/database";
 import logger from "@/logging";
 
@@ -20,7 +20,10 @@ class McpCatalogTeamModel {
         .select({ id: schema.internalMcpCatalogTable.id })
         .from(schema.internalMcpCatalogTable)
         .where(
-          eq(schema.internalMcpCatalogTable.organizationId, organizationId),
+          or(
+            eq(schema.internalMcpCatalogTable.organizationId, organizationId),
+            isNull(schema.internalMcpCatalogTable.organizationId),
+          ),
         );
       return allCatalogs.map((c) => c.id);
     }
@@ -28,7 +31,8 @@ class McpCatalogTeamModel {
     // Mirrors the agent (profile) access control approach: org-visible + personal + team-based
     const result = await db.execute<{ id: string }>(sql`
       SELECT id FROM internal_mcp_catalog
-        WHERE scope = 'org' AND organization_id = ${organizationId}
+        WHERE scope = 'org'
+          AND (organization_id = ${organizationId} OR organization_id IS NULL)
       UNION
       SELECT id FROM internal_mcp_catalog
         WHERE author_id = ${userId}
@@ -67,7 +71,9 @@ class McpCatalogTeamModel {
       .limit(1);
 
     if (!catalog) return false;
-    if (catalog.organizationId !== organizationId) return false;
+    if (catalog.organizationId && catalog.organizationId !== organizationId) {
+      return false;
+    }
     if (isAdmin) return true;
 
     if (catalog.scope === "org") return true;


### PR DESCRIPTION
## Summary

Fixes MCP catalog access filtering so global out-of-the-box catalog entries with `organization_id = NULL` remain visible after a fresh database reset.

The seeded Archestra and Playwright MCP catalog rows are global rows. The scoped catalog access code only returned rows whose `organization_id` matched the active organization, so both the MCP Registry page and agent tool assignment UI could show empty states even though the seeded rows existed.

## Changes

- Include global org-scoped catalog rows in `getUserAccessibleCatalogIds` for admins and non-admin users.
- Allow direct catalog access checks for global rows while still rejecting rows from other organizations.
- Add regression tests for global catalog visibility through access IDs, direct access checks, and `InternalMcpCatalogModel.findAll`.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>