### PR TITLE
Add Anthropic workload identity federation auth

### DIFF
--- a/platform/.env.example
+++ b/platform/.env.example
@@ -7,6 +7,13 @@ SUBDOMAIN=n8n
 # LLM Provider Base URLs
 ARCHESTRA_OPENAI_BASE_URL=https://api.openai.com/v1
 ARCHESTRA_ANTHROPIC_BASE_URL=https://api.anthropic.com
+# Anthropic Workload Identity Federation (optional keyless auth)
+# ANTHROPIC_FEDERATION_RULE_ID=fdrl_...
+# ANTHROPIC_ORGANIZATION_ID=00000000-0000-0000-0000-000000000000
+# ANTHROPIC_SERVICE_ACCOUNT_ID=svac_...
+# ANTHROPIC_WORKSPACE_ID=wrkspc_...
+# ANTHROPIC_IDENTITY_TOKEN_FILE=/var/run/secrets/anthropic.com/token
+# ANTHROPIC_IDENTITY_TOKEN=eyJhbGciOiJSUzI1NiIs...
 ARCHESTRA_GEMINI_BASE_URL=https://generativelanguage.googleapis.com
 # Cohere Base URL (uses https://api.cohere.ai by default)
 ARCHESTRA_COHERE_BASE_URL=https://api.cohere.ai

--- a/platform/backend/src/clients/anthropic-workload-identity.ts
+++ b/platform/backend/src/clients/anthropic-workload-identity.ts
@@ -1,0 +1,268 @@
+import fs from "node:fs/promises";
+
+const GRANT_TYPE_JWT_BEARER = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+const TOKEN_ENDPOINT = "/v1/oauth/token";
+const OAUTH_API_BETA_HEADER = "oauth-2025-04-20";
+const FEDERATION_BETA_HEADER = "oidc-federation-2026-04-01";
+const ADVISORY_REFRESH_THRESHOLD_SECONDS = 120;
+const MAX_IDENTITY_TOKEN_BYTES = 16 * 1024;
+
+type Fetch = typeof globalThis.fetch;
+
+type AnthropicWorkloadIdentityConfig = {
+  federationRuleId: string;
+  organizationId: string;
+  serviceAccountId: string;
+  workspaceId?: string;
+  identityToken?: string;
+  identityTokenFile?: string;
+};
+
+type CachedToken = {
+  token: string;
+  expiresAtMs: number;
+};
+
+const tokenCaches = new Map<string, Promise<CachedToken> | CachedToken>();
+
+export function isAnthropicWorkloadIdentityEnabled(): boolean {
+  const config = getAnthropicWorkloadIdentityConfig();
+  return Boolean(
+    config.federationRuleId &&
+      config.organizationId &&
+      config.serviceAccountId &&
+      (config.identityToken || config.identityTokenFile),
+  );
+}
+
+export function createAnthropicWorkloadIdentityFetch(
+  baseUrl: string | undefined,
+  upstreamFetch?: Fetch,
+): Fetch {
+  const resolvedBaseUrl = baseUrl || "https://api.anthropic.com";
+  const fetchForUpstream = upstreamFetch ?? globalThis.fetch.bind(globalThis);
+
+  return async (input, init = {}) => {
+    const token = await getAnthropicWorkloadIdentityToken(resolvedBaseUrl);
+    const headers = new Headers(init.headers);
+    headers.set("Authorization", `Bearer ${token}`);
+    appendAnthropicBeta(headers, OAUTH_API_BETA_HEADER);
+
+    return fetchForUpstream(input, {
+      ...init,
+      headers,
+    });
+  };
+}
+
+function getAnthropicWorkloadIdentityConfig(): AnthropicWorkloadIdentityConfig {
+  const identityToken = process.env.ANTHROPIC_IDENTITY_TOKEN?.trim();
+  const identityTokenFile = process.env.ANTHROPIC_IDENTITY_TOKEN_FILE?.trim();
+  return {
+    federationRuleId: process.env.ANTHROPIC_FEDERATION_RULE_ID?.trim() ?? "",
+    organizationId: process.env.ANTHROPIC_ORGANIZATION_ID?.trim() ?? "",
+    serviceAccountId: process.env.ANTHROPIC_SERVICE_ACCOUNT_ID?.trim() ?? "",
+    workspaceId: process.env.ANTHROPIC_WORKSPACE_ID?.trim() || undefined,
+    identityToken: identityToken || undefined,
+    identityTokenFile: identityTokenFile || undefined,
+  };
+}
+
+async function getAnthropicWorkloadIdentityToken(
+  baseUrl: string,
+): Promise<string> {
+  const config = getAnthropicWorkloadIdentityConfig();
+  const cacheKey = JSON.stringify({
+    baseUrl,
+    federationRuleId: config.federationRuleId,
+    organizationId: config.organizationId,
+    serviceAccountId: config.serviceAccountId,
+    workspaceId: config.workspaceId,
+    identityTokenFile: config.identityTokenFile,
+    hasInlineToken: Boolean(config.identityToken),
+  });
+
+  const cached = tokenCaches.get(cacheKey);
+  if (cached) {
+    const token = cached instanceof Promise ? await cached : cached;
+    if (
+      token.expiresAtMs - Date.now() >
+      ADVISORY_REFRESH_THRESHOLD_SECONDS * 1000
+    ) {
+      return token.token;
+    }
+  }
+
+  const pending = exchangeAnthropicWorkloadIdentityToken(baseUrl, config);
+  tokenCaches.set(cacheKey, pending);
+
+  try {
+    const token = await pending;
+    tokenCaches.set(cacheKey, token);
+    return token.token;
+  } catch (error) {
+    tokenCaches.delete(cacheKey);
+    throw error;
+  }
+}
+
+async function exchangeAnthropicWorkloadIdentityToken(
+  baseUrl: string,
+  config: AnthropicWorkloadIdentityConfig,
+): Promise<CachedToken> {
+  assertWorkloadIdentityConfig(config);
+  requireSecureTokenEndpoint(baseUrl);
+
+  const assertion = await readIdentityToken(config);
+  if (Buffer.byteLength(assertion, "utf8") > MAX_IDENTITY_TOKEN_BYTES) {
+    throw new Error(
+      "Anthropic identity token exceeds the 16 KiB Workload Identity Federation assertion limit",
+    );
+  }
+
+  const body: Record<string, string> = {
+    grant_type: GRANT_TYPE_JWT_BEARER,
+    assertion,
+    federation_rule_id: config.federationRuleId,
+    organization_id: config.organizationId,
+    service_account_id: config.serviceAccountId,
+  };
+
+  if (config.workspaceId) {
+    body.workspace_id = config.workspaceId;
+  }
+
+  const response = await globalThis.fetch(`${baseUrl}${TOKEN_ENDPOINT}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "anthropic-beta": `${OAUTH_API_BETA_HEADER},${FEDERATION_BETA_HEADER}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const requestId = response.headers.get("request-id");
+
+  if (!response.ok) {
+    const errorBody = await response.text().catch(() => "");
+    throw new Error(
+      `Anthropic Workload Identity Federation token exchange failed with status ${
+        response.status
+      }${requestId ? ` (request-id ${requestId})` : ""}: ${redactTokenError(
+        errorBody,
+      )}`,
+    );
+  }
+
+  const payload = (await response.json()) as {
+    access_token?: unknown;
+    expires_in?: unknown;
+    token_type?: unknown;
+  };
+
+  if (
+    typeof payload.access_token !== "string" ||
+    !payload.access_token ||
+    typeof payload.expires_in !== "number" ||
+    !Number.isFinite(payload.expires_in)
+  ) {
+    throw new Error("Anthropic WIF token exchange response is missing fields");
+  }
+
+  if (
+    typeof payload.token_type === "string" &&
+    payload.token_type.toLowerCase() !== "bearer"
+  ) {
+    throw new Error(
+      `Anthropic WIF token exchange returned unsupported token_type "${payload.token_type}"`,
+    );
+  }
+
+  return {
+    token: payload.access_token,
+    expiresAtMs: Date.now() + payload.expires_in * 1000,
+  };
+}
+
+function assertWorkloadIdentityConfig(
+  config: AnthropicWorkloadIdentityConfig,
+): void {
+  const missing: string[] = [];
+  if (!config.federationRuleId) missing.push("ANTHROPIC_FEDERATION_RULE_ID");
+  if (!config.organizationId) missing.push("ANTHROPIC_ORGANIZATION_ID");
+  if (!config.serviceAccountId) missing.push("ANTHROPIC_SERVICE_ACCOUNT_ID");
+  if (!config.identityToken && !config.identityTokenFile) {
+    missing.push("ANTHROPIC_IDENTITY_TOKEN or ANTHROPIC_IDENTITY_TOKEN_FILE");
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Anthropic Workload Identity Federation is missing required environment variables: ${missing.join(
+        ", ",
+      )}`,
+    );
+  }
+}
+
+async function readIdentityToken(
+  config: AnthropicWorkloadIdentityConfig,
+): Promise<string> {
+  if (config.identityToken) {
+    return config.identityToken;
+  }
+
+  if (!config.identityTokenFile) {
+    throw new Error("Anthropic Workload Identity Federation token is missing");
+  }
+
+  const token = (await fs.readFile(config.identityTokenFile, "utf8")).trim();
+  if (!token) {
+    throw new Error(
+      `Anthropic identity token file is empty: ${config.identityTokenFile}`,
+    );
+  }
+  return token;
+}
+
+function requireSecureTokenEndpoint(baseUrl: string): void {
+  const url = new URL(baseUrl);
+  if (url.protocol === "https:") return;
+
+  const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (
+    url.protocol === "http:" &&
+    (host === "localhost" || host === "127.0.0.1" || host === "::1")
+  ) {
+    return;
+  }
+
+  throw new Error(
+    `Refusing to send Anthropic Workload Identity Federation assertion to non-HTTPS endpoint: ${baseUrl}`,
+  );
+}
+
+function appendAnthropicBeta(headers: Headers, beta: string): void {
+  const current = headers.get("anthropic-beta");
+  if (!current) {
+    headers.set("anthropic-beta", beta);
+    return;
+  }
+
+  const values = current.split(",").map((value) => value.trim());
+  if (!values.includes(beta)) {
+    headers.set("anthropic-beta", `${current},${beta}`);
+  }
+}
+
+function redactTokenError(body: string): string {
+  try {
+    const parsed = JSON.parse(body) as Record<string, unknown>;
+    return JSON.stringify({
+      error: parsed.error,
+      error_description: parsed.error_description,
+      error_uri: parsed.error_uri,
+    });
+  } catch {
+    return body.slice(0, 2000);
+  }
+}

--- a/platform/backend/src/routes/proxy/adapters/anthropic-workload-identity.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic-workload-identity.test.ts
@@ -1,0 +1,125 @@
+import type AnthropicProvider from "@anthropic-ai/sdk";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/observability", () => ({
+  metrics: { llm: { getObservableFetch: vi.fn() } },
+}));
+
+vi.mock("@/clients/azure-openai-credentials", () => ({
+  getAzureAiFoundryBearerTokenProvider: vi.fn(),
+  isAnthropicAzureFoundryEntraIdEnabled: vi.fn(() => false),
+}));
+
+vi.stubEnv(
+  "ARCHESTRA_DATABASE_URL",
+  "postgresql://archestra:archestra@localhost:5432/archestra_test",
+);
+
+const { anthropicAdapterFactory } = await import("./anthropic");
+
+describe("anthropicAdapterFactory Workload Identity Federation", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  test("creates a keyless client that exchanges OIDC identity for Anthropic bearer auth", async () => {
+    vi.stubEnv("ANTHROPIC_FEDERATION_RULE_ID", "fdrl_test");
+    vi.stubEnv(
+      "ANTHROPIC_ORGANIZATION_ID",
+      "00000000-0000-0000-0000-000000000000",
+    );
+    vi.stubEnv("ANTHROPIC_SERVICE_ACCOUNT_ID", "svac_test");
+    vi.stubEnv("ANTHROPIC_WORKSPACE_ID", "wrkspc_test");
+    vi.stubEnv("ANTHROPIC_IDENTITY_TOKEN", "jwt-from-idp");
+
+    const upstreamFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        const url = String(input);
+        if (url.endsWith("/v1/oauth/token")) {
+          return new Response(
+            JSON.stringify({
+              access_token: "sk-ant-oat01-token",
+              token_type: "Bearer",
+              expires_in: 3600,
+              scope: "workspace:developer",
+            }),
+            { headers: { "request-id": "req-token" } },
+          );
+        }
+
+        return new Response("{}");
+      });
+
+    const client = anthropicAdapterFactory.createClient(undefined, {
+      baseUrl: "https://api.anthropic.com",
+      defaultHeaders: {},
+      source: "api",
+    }) as AnthropicProvider & {
+      _options?: {
+        defaultHeaders?: Record<string, string>;
+        fetch?: typeof globalThis.fetch;
+      };
+    };
+
+    expect(client._options?.defaultHeaders?.Authorization).toBe(
+      "Bearer <anthropic-wif-managed>",
+    );
+
+    const fetch = client._options?.fetch;
+    expect(fetch).toBeDefined();
+
+    await fetch?.("https://api.anthropic.com/v1/messages", {
+      headers: { "anthropic-version": "2023-06-01" },
+    });
+
+    expect(upstreamFetch).toHaveBeenCalledTimes(2);
+
+    const tokenRequest = upstreamFetch.mock.calls[0];
+    expect(tokenRequest?.[0]).toBe("https://api.anthropic.com/v1/oauth/token");
+    const tokenHeaders = new Headers(tokenRequest?.[1]?.headers);
+    expect(tokenHeaders.get("anthropic-beta")).toContain(
+      "oidc-federation-2026-04-01",
+    );
+    expect(JSON.parse(String(tokenRequest?.[1]?.body))).toMatchObject({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion: "jwt-from-idp",
+      federation_rule_id: "fdrl_test",
+      organization_id: "00000000-0000-0000-0000-000000000000",
+      service_account_id: "svac_test",
+      workspace_id: "wrkspc_test",
+    });
+
+    const messageRequest = upstreamFetch.mock.calls[1];
+    const messageHeaders = new Headers(messageRequest?.[1]?.headers);
+    expect(messageHeaders.get("Authorization")).toBe(
+      "Bearer sk-ant-oat01-token",
+    );
+    expect(messageHeaders.get("anthropic-beta")).toContain("oauth-2025-04-20");
+  });
+
+  test("does not use workload identity when a request supplies an API key", () => {
+    vi.stubEnv("ANTHROPIC_FEDERATION_RULE_ID", "fdrl_test");
+    vi.stubEnv(
+      "ANTHROPIC_ORGANIZATION_ID",
+      "00000000-0000-0000-0000-000000000000",
+    );
+    vi.stubEnv("ANTHROPIC_SERVICE_ACCOUNT_ID", "svac_test");
+    vi.stubEnv("ANTHROPIC_IDENTITY_TOKEN", "jwt-from-idp");
+
+    const client = anthropicAdapterFactory.createClient("sk-ant-api-key", {
+      baseUrl: "https://api.anthropic.com",
+      defaultHeaders: {},
+      source: "api",
+    }) as AnthropicProvider & {
+      _options?: {
+        apiKey?: unknown;
+        defaultHeaders?: Record<string, string>;
+      };
+    };
+
+    expect(client._options?.apiKey).toBe("sk-ant-api-key");
+    expect(client._options?.defaultHeaders?.Authorization).toBeUndefined();
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -3,6 +3,10 @@ import { ArchestraInternalErrorCode } from "@shared";
 import { encode as toonEncode } from "@toon-format/toon";
 import { get } from "lodash-es";
 import {
+  createAnthropicWorkloadIdentityFetch,
+  isAnthropicWorkloadIdentityEnabled,
+} from "@/clients/anthropic-workload-identity";
+import {
   getAzureAiFoundryBearerTokenProvider,
   isAnthropicAzureFoundryEntraIdEnabled,
 } from "@/clients/azure-openai-credentials";
@@ -1168,6 +1172,23 @@ export const anthropicAdapterFactory: LLMProvider<
           ...options.defaultHeaders,
           // The fetch wrapper replaces this sentinel with a fresh Entra ID token on every request.
           Authorization: "Bearer <entra-id-managed>",
+        },
+      });
+    }
+
+    if (!apiKey && isAnthropicWorkloadIdentityEnabled()) {
+      return new AnthropicProvider({
+        apiKey: null,
+        authToken: null,
+        baseURL: options.baseUrl,
+        fetch: createAnthropicWorkloadIdentityFetch(
+          options.baseUrl,
+          customFetch,
+        ),
+        defaultHeaders: {
+          ...options.defaultHeaders,
+          // The fetch wrapper replaces this sentinel with a short-lived Anthropic WIF token.
+          Authorization: "Bearer <anthropic-wif-managed>",
         },
       });
     }


### PR DESCRIPTION
Fixes #4468
/claim #4468

## Summary
- Add Anthropic Workload Identity Federation credentials exchange for keyless auth.
- Wire Anthropic adapter support for WIF-sourced API keys.
- Document the required environment variables and add focused tests.

## Verification
- cd platform && pnpm --filter @backend exec biome check src/clients/anthropic-workload-identity.ts src/routes/proxy/adapters/anthropic.ts src/routes/proxy/adapters/anthropic-workload-identity.test.ts
- cd platform && pnpm --filter @backend exec vitest run src/routes/proxy/adapters/anthropic-workload-identity.test.ts
- cd platform && pnpm --filter @backend type-check