### PR TITLE
feat: Anthropic Workload Identity Federation (WIF) support

### DIFF
--- a/platform/.env.example
+++ b/platform/.env.example
@@ -7,6 +7,13 @@ SUBDOMAIN=n8n
 # LLM Provider Base URLs
 ARCHESTRA_OPENAI_BASE_URL=https://api.openai.com/v1
 ARCHESTRA_ANTHROPIC_BASE_URL=https://api.anthropic.com
+# Anthropic Workload Identity Federation (optional keyless upstream auth)
+# ANTHROPIC_FEDERATION_RULE_ID=fdrl_...
+# ANTHROPIC_ORGANIZATION_ID=00000000-0000-0000-0000-000000000000
+# ANTHROPIC_SERVICE_ACCOUNT_ID=svac_...
+# ANTHROPIC_WORKSPACE_ID=wrkspc_...
+# ANTHROPIC_IDENTITY_TOKEN_FILE=/var/run/secrets/anthropic.com/token
+# ANTHROPIC_IDENTITY_TOKEN=
 ARCHESTRA_GEMINI_BASE_URL=https://generativelanguage.googleapis.com
 # Cohere Base URL (uses https://api.cohere.ai by default)
 ARCHESTRA_COHERE_BASE_URL=https://api.cohere.ai

--- a/platform/backend/src/clients/anthropic-workload-identity.test.ts
+++ b/platform/backend/src/clients/anthropic-workload-identity.test.ts
@@ -1,0 +1,190 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  createAnthropicWorkloadIdentityFetch,
+  getAnthropicWorkloadIdentityAccessToken,
+  hasAnthropicSdkStaticCredentialsConfigured,
+  isAnthropicWorkloadIdentityConfigured,
+  resetAnthropicWorkloadIdentityTokenCacheForTests,
+} from "./anthropic-workload-identity";
+
+const WIF_ENV_KEYS = [
+  "ANTHROPIC_FEDERATION_RULE_ID",
+  "ANTHROPIC_ORGANIZATION_ID",
+  "ANTHROPIC_SERVICE_ACCOUNT_ID",
+  "ANTHROPIC_WORKSPACE_ID",
+  "ANTHROPIC_IDENTITY_TOKEN",
+  "ANTHROPIC_IDENTITY_TOKEN_FILE",
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+] as const;
+
+const originalEnv = Object.fromEntries(
+  WIF_ENV_KEYS.map((key) => [key, process.env[key]]),
+);
+
+function restoreEnv() {
+  for (const key of WIF_ENV_KEYS) {
+    const value = originalEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function configureWifEnv(
+  overrides: Partial<Record<(typeof WIF_ENV_KEYS)[number], string>> = {},
+) {
+  process.env.ANTHROPIC_FEDERATION_RULE_ID = "fdrl_test";
+  process.env.ANTHROPIC_ORGANIZATION_ID =
+    "00000000-0000-0000-0000-000000000000";
+  process.env.ANTHROPIC_SERVICE_ACCOUNT_ID = "svac_test";
+  process.env.ANTHROPIC_WORKSPACE_ID = "wrkspc_test";
+  process.env.ANTHROPIC_IDENTITY_TOKEN = "jwt-from-env";
+  delete process.env.ANTHROPIC_IDENTITY_TOKEN_FILE;
+
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete process.env[key as (typeof WIF_ENV_KEYS)[number]];
+    } else {
+      process.env[key as (typeof WIF_ENV_KEYS)[number]] = value;
+    }
+  }
+}
+
+describe("Anthropic Workload Identity Federation", () => {
+  beforeEach(() => {
+    resetAnthropicWorkloadIdentityTokenCacheForTests();
+    vi.restoreAllMocks();
+    restoreEnv();
+  });
+
+  afterEach(() => {
+    resetAnthropicWorkloadIdentityTokenCacheForTests();
+    vi.restoreAllMocks();
+    restoreEnv();
+  });
+
+  test("detects a complete direct environment configuration", () => {
+    configureWifEnv();
+
+    expect(isAnthropicWorkloadIdentityConfigured()).toBe(true);
+  });
+
+  test("does not activate without an identity token source", () => {
+    configureWifEnv({ ANTHROPIC_IDENTITY_TOKEN: undefined });
+
+    expect(isAnthropicWorkloadIdentityConfigured()).toBe(false);
+  });
+
+  test("detects SDK static credentials as higher precedence", () => {
+    configureWifEnv();
+    process.env.ANTHROPIC_API_KEY = "";
+
+    expect(hasAnthropicSdkStaticCredentialsConfigured()).toBe(true);
+  });
+
+  test("exchanges an identity token file for an access token", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "anthropic-wif-"));
+    const tokenFile = join(dir, "token.jwt");
+    await writeFile(tokenFile, "jwt-from-file\n", "utf8");
+    configureWifEnv({
+      ANTHROPIC_IDENTITY_TOKEN: undefined,
+      ANTHROPIC_IDENTITY_TOKEN_FILE: tokenFile,
+    });
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: "sk-ant-oat01-test",
+          token_type: "Bearer",
+          expires_in: 3600,
+          scope: "workspace:developer",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await expect(
+      getAnthropicWorkloadIdentityAccessToken("https://api.anthropic.com"),
+    ).resolves.toBe("sk-ant-oat01-test");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.anthropic.com/v1/oauth/token",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+          assertion: "jwt-from-file",
+          federation_rule_id: "fdrl_test",
+          organization_id: "00000000-0000-0000-0000-000000000000",
+          service_account_id: "svac_test",
+          workspace_id: "wrkspc_test",
+        }),
+      }),
+    );
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("caches exchanged access tokens", async () => {
+    configureWifEnv();
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: "sk-ant-oat01-cached",
+          token_type: "Bearer",
+          expires_in: 3600,
+          scope: "workspace:developer",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await getAnthropicWorkloadIdentityAccessToken(undefined);
+    await getAnthropicWorkloadIdentityAccessToken(undefined);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("injects a federated bearer token into Anthropic requests", async () => {
+    configureWifEnv();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: "sk-ant-oat01-wrapper",
+          token_type: "Bearer",
+          expires_in: 3600,
+          scope: "workspace:developer",
+        }),
+        { status: 200 },
+      ),
+    );
+    const providerFetch = vi.fn().mockResolvedValue(new Response("{}"));
+    const wrappedFetch = createAnthropicWorkloadIdentityFetch(
+      providerFetch as typeof fetch,
+      "https://api.anthropic.com/",
+    );
+
+    await wrappedFetch("https://api.anthropic.com/v1/messages", {
+      headers: {
+        "x-api-key": "placeholder",
+        "anthropic-version": "2023-06-01",
+      },
+    });
+
+    expect(providerFetch).toHaveBeenCalledWith(
+      "https://api.anthropic.com/v1/messages",
+      expect.objectContaining({
+        headers: expect.any(Headers),
+      }),
+    );
+    const headers = providerFetch.mock.calls[0][1].headers as Headers;
+    expect(headers.get("authorization")).toBe("Bearer sk-ant-oat01-wrapper");
+    expect(headers.has("x-api-key")).toBe(false);
+  });
+});

--- a/platform/backend/src/clients/anthropic-workload-identity.ts
+++ b/platform/backend/src/clients/anthropic-workload-identity.ts
@@ -1,0 +1,211 @@
+import { readFile } from "node:fs/promises";
+
+const JWT_BEARER_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+const ADVISORY_REFRESH_MS = 120_000;
+const MANDATORY_REFRESH_MS = 30_000;
+
+type FetchLike = typeof fetch;
+
+interface AnthropicWorkloadIdentityConfig {
+  federationRuleId: string;
+  organizationId: string;
+  serviceAccountId: string;
+  workspaceId?: string;
+  identityToken?: string;
+  identityTokenFile?: string;
+}
+
+interface TokenCacheEntry {
+  accessToken: string;
+  expiresAtMs: number;
+}
+
+interface TokenExchangeResponse {
+  access_token?: unknown;
+  token_type?: unknown;
+  expires_in?: unknown;
+  scope?: unknown;
+}
+
+let cachedToken: TokenCacheEntry | null = null;
+
+export function isAnthropicWorkloadIdentityConfigured(): boolean {
+  return getAnthropicWorkloadIdentityConfig() !== null;
+}
+
+export function hasAnthropicSdkStaticCredentialsConfigured(): boolean {
+  return (
+    process.env.ANTHROPIC_API_KEY !== undefined ||
+    process.env.ANTHROPIC_AUTH_TOKEN !== undefined
+  );
+}
+
+export function resetAnthropicWorkloadIdentityTokenCacheForTests(): void {
+  cachedToken = null;
+}
+
+export function createAnthropicWorkloadIdentityFetch(
+  baseFetch: FetchLike | undefined,
+  baseUrl: string | undefined,
+): FetchLike {
+  const fetchFn = baseFetch ?? fetch;
+
+  return (async (input, init) => {
+    const token = await getAnthropicWorkloadIdentityAccessToken(baseUrl);
+    const headers = buildHeaders(input, init);
+    headers.delete("x-api-key");
+    headers.set("authorization", `Bearer ${token}`);
+
+    return fetchFn(input, {
+      ...init,
+      headers,
+    });
+  }) as FetchLike;
+}
+
+export async function getAnthropicWorkloadIdentityAccessToken(
+  baseUrl: string | undefined,
+): Promise<string> {
+  const now = Date.now();
+  if (cachedToken && now < cachedToken.expiresAtMs - ADVISORY_REFRESH_MS) {
+    return cachedToken.accessToken;
+  }
+
+  try {
+    cachedToken = await exchangeAnthropicWorkloadIdentityToken(baseUrl);
+    return cachedToken.accessToken;
+  } catch (error) {
+    if (cachedToken && now < cachedToken.expiresAtMs - MANDATORY_REFRESH_MS) {
+      return cachedToken.accessToken;
+    }
+    throw error;
+  }
+}
+
+async function exchangeAnthropicWorkloadIdentityToken(
+  baseUrl: string | undefined,
+): Promise<TokenCacheEntry> {
+  const config = getAnthropicWorkloadIdentityConfig();
+  if (!config) {
+    throw new Error(
+      "Anthropic Workload Identity Federation is not configured. Set ANTHROPIC_FEDERATION_RULE_ID, ANTHROPIC_ORGANIZATION_ID, ANTHROPIC_SERVICE_ACCOUNT_ID, and ANTHROPIC_IDENTITY_TOKEN_FILE or ANTHROPIC_IDENTITY_TOKEN.",
+    );
+  }
+
+  const assertion = await readIdentityToken(config);
+  const body: Record<string, string> = {
+    grant_type: JWT_BEARER_GRANT_TYPE,
+    assertion,
+    federation_rule_id: config.federationRuleId,
+    organization_id: config.organizationId,
+    service_account_id: config.serviceAccountId,
+  };
+
+  if (config.workspaceId) {
+    body.workspace_id = config.workspaceId;
+  }
+
+  const response = await fetch(`${normalizeBaseUrl(baseUrl)}/v1/oauth/token`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const requestId = response.headers.get("request-id");
+    throw new Error(
+      `Anthropic Workload Identity Federation token exchange failed with status ${response.status}${requestId ? ` (request-id: ${requestId})` : ""}`,
+    );
+  }
+
+  const data = (await response.json()) as TokenExchangeResponse;
+  if (
+    typeof data.access_token !== "string" ||
+    data.access_token.length === 0 ||
+    data.token_type !== "Bearer" ||
+    typeof data.expires_in !== "number" ||
+    !Number.isFinite(data.expires_in) ||
+    data.expires_in <= 0
+  ) {
+    throw new Error(
+      "Anthropic Workload Identity Federation token exchange returned an invalid token response.",
+    );
+  }
+
+  return {
+    accessToken: data.access_token,
+    expiresAtMs: Date.now() + data.expires_in * 1000,
+  };
+}
+
+function getAnthropicWorkloadIdentityConfig(): AnthropicWorkloadIdentityConfig | null {
+  const federationRuleId = readRequiredEnv("ANTHROPIC_FEDERATION_RULE_ID");
+  const organizationId = readRequiredEnv("ANTHROPIC_ORGANIZATION_ID");
+  const serviceAccountId = readRequiredEnv("ANTHROPIC_SERVICE_ACCOUNT_ID");
+  const identityTokenFile = readOptionalEnv("ANTHROPIC_IDENTITY_TOKEN_FILE");
+  const identityToken = readOptionalEnv("ANTHROPIC_IDENTITY_TOKEN");
+
+  if (
+    !federationRuleId ||
+    !organizationId ||
+    !serviceAccountId ||
+    (!identityTokenFile && !identityToken)
+  ) {
+    return null;
+  }
+
+  return {
+    federationRuleId,
+    organizationId,
+    serviceAccountId,
+    workspaceId: readOptionalEnv("ANTHROPIC_WORKSPACE_ID"),
+    identityToken,
+    identityTokenFile,
+  };
+}
+
+async function readIdentityToken(
+  config: AnthropicWorkloadIdentityConfig,
+): Promise<string> {
+  if (config.identityToken) {
+    return config.identityToken;
+  }
+
+  if (!config.identityTokenFile) {
+    throw new Error(
+      "Anthropic Workload Identity Federation requires ANTHROPIC_IDENTITY_TOKEN_FILE or ANTHROPIC_IDENTITY_TOKEN.",
+    );
+  }
+
+  return (await readFile(config.identityTokenFile, "utf8")).trim();
+}
+
+function readRequiredEnv(name: string): string | null {
+  const value = process.env[name];
+  return value && value.length > 0 ? value : null;
+}
+
+function readOptionalEnv(name: string): string | undefined {
+  const value = process.env[name];
+  return value && value.length > 0 ? value : undefined;
+}
+
+function normalizeBaseUrl(baseUrl: string | undefined): string {
+  return (baseUrl || "https://api.anthropic.com").replace(/\/+$/, "");
+}
+
+function buildHeaders(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+): Headers {
+  const headers = new Headers(
+    input instanceof Request ? input.headers : undefined,
+  );
+  const initHeaders = new Headers(init?.headers);
+  for (const [key, value] of initHeaders.entries()) {
+    headers.set(key, value);
+  }
+  return headers;
+}

--- a/platform/backend/src/routes/chat/model-fetchers/anthropic.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/anthropic.ts
@@ -1,4 +1,9 @@
 import {
+  getAnthropicWorkloadIdentityAccessToken,
+  hasAnthropicSdkStaticCredentialsConfigured,
+  isAnthropicWorkloadIdentityConfigured,
+} from "@/clients/anthropic-workload-identity";
+import {
   getAzureAiFoundryBearerTokenProvider,
   isAnthropicAzureFoundryEntraIdEnabled,
 } from "@/clients/azure-openai-credentials";
@@ -18,7 +23,7 @@ export async function fetchAnthropicModels(
   const response = await fetch(url, {
     headers: {
       ...(extraHeaders ?? {}),
-      ...(await getAnthropicAuthHeaders(apiKey)),
+      ...(await getAnthropicAuthHeaders(apiKey, baseUrl)),
       "anthropic-version": "2023-06-01",
     },
   });
@@ -46,15 +51,25 @@ export async function fetchAnthropicModels(
 
 async function getAnthropicAuthHeaders(
   apiKey: string | undefined,
+  baseUrl: string,
 ): Promise<Record<string, string>> {
   if (apiKey) {
     return { "x-api-key": apiKey };
   }
 
-  if (!isAnthropicAzureFoundryEntraIdEnabled()) {
-    return { "x-api-key": "" };
+  if (isAnthropicAzureFoundryEntraIdEnabled()) {
+    const tokenProvider = getAzureAiFoundryBearerTokenProvider();
+    return { Authorization: `Bearer ${await tokenProvider()}` };
   }
 
-  const tokenProvider = getAzureAiFoundryBearerTokenProvider();
-  return { Authorization: `Bearer ${await tokenProvider()}` };
+  if (
+    !hasAnthropicSdkStaticCredentialsConfigured() &&
+    isAnthropicWorkloadIdentityConfigured()
+  ) {
+    return {
+      Authorization: `Bearer ${await getAnthropicWorkloadIdentityAccessToken(baseUrl)}`,
+    };
+  }
+
+  return { "x-api-key": "" };
 }

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -3,6 +3,11 @@ import { ArchestraInternalErrorCode } from "@shared";
 import { encode as toonEncode } from "@toon-format/toon";
 import { get } from "lodash-es";
 import {
+  createAnthropicWorkloadIdentityFetch,
+  hasAnthropicSdkStaticCredentialsConfigured,
+  isAnthropicWorkloadIdentityConfigured,
+} from "@/clients/anthropic-workload-identity";
+import {
   getAzureAiFoundryBearerTokenProvider,
   isAnthropicAzureFoundryEntraIdEnabled,
 } from "@/clients/azure-openai-credentials";
@@ -1168,6 +1173,27 @@ export const anthropicAdapterFactory: LLMProvider<
           ...options.defaultHeaders,
           // The fetch wrapper replaces this sentinel with a fresh Entra ID token on every request.
           Authorization: "Bearer <entra-id-managed>",
+        },
+      });
+    }
+
+    if (
+      !apiKey &&
+      !hasAnthropicSdkStaticCredentialsConfigured() &&
+      isAnthropicWorkloadIdentityConfigured()
+    ) {
+      return new AnthropicProvider({
+        apiKey: null,
+        authToken: null,
+        baseURL: options.baseUrl,
+        fetch: createAnthropicWorkloadIdentityFetch(
+          customFetch,
+          options.baseUrl,
+        ),
+        defaultHeaders: {
+          ...options.defaultHeaders,
+          // The fetch wrapper replaces this sentinel with a fresh WIF access token on every request.
+          Authorization: "Bearer <workload-identity-managed>",
         },
       });
     }


### PR DESCRIPTION
### Motivation
- Enable keyless, secure Anthropic (Claude) authentication via Workload Identity Federation so the proxy and model-listing can use short-lived bearer tokens instead of static API keys in certain deployments.
- Preserve existing Anthropic Azure Foundry behavior and explicit SDK static credentials while adding an optional WIF path for K8s/service-account-style setups.

### Description
- Add a new helper client `backend/src/clients/anthropic-workload-identity.ts` that implements RFC-7523 JWT-bearer token exchange, caching/refresh behavior, an accessor `getAnthropicWorkloadIdentityAccessToken`, and a fetch wrapper `createAnthropicWorkloadIdentityFetch` for injecting bearer tokens into requests.
- Wire WIF into the Anthropic adapter so `backend/src/routes/proxy/adapters/anthropic.ts` will instantiate the Anthropic SDK with the WIF `fetch` wrapper when no per-request API key and no higher-precedence Anthropic SDK static credentials are present, while keeping Azure Foundry support intact.
- Use WIF for Anthropic model listing in `backend/src/routes/chat/model-fetchers/anthropic.ts` when applicable, passing `Authorization: Bearer <wif-token>` instead of `x-api-key`.
- Add environment docs to `.env.example` describing the Anthropic WIF variables (`ANTHROPIC_FEDERATION_RULE_ID`, `ANTHROPIC_ORGANIZATION_ID`, `ANTHROPIC_SERVICE_ACCOUNT_ID`, `ANTHROPIC_WORKSPACE_ID`, `ANTHROPIC_IDENTITY_TOKEN_FILE`, `ANTHROPIC_IDENTITY_TOKEN`).
- Add unit tests `backend/src/clients/anthropic-workload-identity.test.ts` covering activation, precedence over SDK static credentials, token exchange, caching, and header injection via the fetch wrapper.

### Testing
- Ran the new unit tests with `ARCHESTRA_DATABASE_URL=postgresql://test:test@localhost:5432/test pnpm --filter @backend test src/clients/anthropic-workload-identity.test.ts`, which passed (`6 passed` for the test file).
- Ran linting with `pnpm --filter @backend lint` which passed (no issues reported after formatting changes).
- Ran type checking with `pnpm --filter @backend type-check` which completed with no errors.

closes #4468
/claim #4468 

Side note: I was unable to test the actual functionality because I don't have a paid Anthropic plan 