### PR TITLE
fix: bind quickstart Docker ports to localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ _For Management:_
 
 ```
 docker pull archestra/platform:latest;
-docker run -p 9000:9000 -p 3000:3000 \
+docker run -p 127.0.0.1:9000:9000 -p 127.0.0.1:3000:3000 \
   -e ARCHESTRA_QUICKSTART=true \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v archestra-postgres-data:/var/lib/postgresql/data \

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -28,7 +28,7 @@ Run the platform with a single command:
 
 ```bash
 docker pull archestra/platform:latest;
-docker run -p 9000:9000 -p 3000:3000\
+docker run -p 127.0.0.1:9000:9000 -p 127.0.0.1:3000:3000\
    -e ARCHESTRA_QUICKSTART=true \
    -v /var/run/docker.sock:/var/run/docker.sock \
    -v archestra-postgres-data:/var/lib/postgresql/data \
@@ -40,7 +40,7 @@ docker run -p 9000:9000 -p 3000:3000\
 
 ```powershell
 docker pull archestra/platform:latest;
-docker run -p 9000:9000 -p 3000:3000`
+docker run -p 127.0.0.1:9000:9000 -p 127.0.0.1:3000:3000`
    -e ARCHESTRA_QUICKSTART=true `
    -v /var/run/docker.sock:/var/run/docker.sock `
    -v archestra-postgres-data:/var/lib/postgresql/data `
@@ -62,7 +62,7 @@ This will start the platform with:
 If you have Kubernetes installed locally, you can use it for the MCP orchestrator. Make sure `kubectl` points to the right cluster and run the container without the socket and without `ARCHESTRA_QUICKSTART`. The orchestrator will create a cluster in the current context. See [Development with Standalone Kubernetes](./platform-orchestrator#local-development-with-docker-and-standalone-kubernetes)
 
 ```diff
-docker run -p 9000:9000 -p 3000:3000\
+docker run -p 127.0.0.1:9000:9000 -p 127.0.0.1:3000:3000\
 -  -e ARCHESTRA_QUICKSTART=true \
 -  -v /var/run/docker.sock:/var/run/docker.sock \
    -v archestra-postgres-data:/var/lib/postgresql/data \
@@ -78,7 +78,7 @@ To use an external PostgreSQL database, pass the `DATABASE_URL` environment vari
 
 ```bash
 docker pull archestra/platform:latest;
-docker run -p 9000:9000 -p 3000:3000 \
+docker run -p 127.0.0.1:9000:9000 -p 127.0.0.1:3000:3000 \
   -e DATABASE_URL=postgresql://user:password@host:5432/database \
   archestra/platform
 ```

--- a/docs/pages/platform-pydantic-example.md
+++ b/docs/pages/platform-pydantic-example.md
@@ -76,7 +76,7 @@ This demonstrates the vulnerability: an agent with access to external data and c
 Now let's add the security layer:
 
 ```shell
-docker run -p 9000:9000 -p 3000:3000 archestra/platform
+docker run -p 127.0.0.1:9000:9000 -p 127.0.0.1:3000:3000 archestra/platform
 ```
 
 This starts Archestra Platform with:

--- a/docs/pages/platform-quickstart.md
+++ b/docs/pages/platform-quickstart.md
@@ -21,7 +21,7 @@ The fact that you're reading this means that you're willing to give it a try. Fi
 
 ```bash
 docker pull archestra/platform:latest;
-docker run -p 9000:9000 -p 3000:3000 \
+docker run -p 127.0.0.1:9000:9000 -p 127.0.0.1:3000:3000 \
    -e ARCHESTRA_QUICKSTART=true \
    -v /var/run/docker.sock:/var/run/docker.sock \
    -v archestra-postgres-data:/var/lib/postgresql/data \
@@ -33,7 +33,7 @@ docker run -p 9000:9000 -p 3000:3000 \
 
 ```powershell
 docker pull archestra/platform:latest;
-docker run -p 9000:9000 -p 3000:3000 `
+docker run -p 127.0.0.1:9000:9000 -p 127.0.0.1:3000:3000 `
    -e ARCHESTRA_QUICKSTART=true `
    -v /var/run/docker.sock:/var/run/docker.sock `
    -v archestra-postgres-data:/var/lib/postgresql/data `

--- a/docs/pages/platform-vercel-ai-example.md
+++ b/docs/pages/platform-vercel-ai-example.md
@@ -78,7 +78,7 @@ For OpenAI, you can get an API key from:
 
 ```shell
 docker pull archestra/platform:latest;
-docker run -p 9000:9000 -p 3000:3000 \
+docker run -p 127.0.0.1:9000:9000 -p 127.0.0.1:3000:3000 \
    -v archestra-postgres-data:/var/lib/postgresql/data \
    -v archestra-app-data:/app/data \
    archestra/platform;


### PR DESCRIPTION
## Summary

Binds quickstart Docker port mappings to `127.0.0.1` (localhost) instead of the default `0.0.0.0` (all interfaces).

**Before:** `-p 9000:9000 -p 3000:3000`
**After:** `-p 127.0.0.1:9000:9000 -p 127.0.0.1:3000:3000`

## Why

When users run the quickstart `docker run` commands, the services are currently exposed to the entire network. Binding to localhost ensures the services are only accessible from the local machine, which is the expected behavior for a development/evaluation setup.

## Changes

Updated port bindings in all quickstart and deployment documentation:
- `README.md`
- `docs/pages/platform-quickstart.md`
- `docs/pages/platform-deployment.md`
- `docs/pages/platform-vercel-ai-example.md`
- `docs/pages/platform-pydantic-example.md`

**Not changed** (intentionally):
- `.github/workflows/platform-e2e-tests.yml` — CI containers may need non-localhost binding for inter-container communication
- `platform/benchmarks/setup-gcp-benchmark.sh` — GCP benchmark needs external access

## Disclosure

This PR was generated with AI assistance (Claude), operated by a human contributor. All changes reviewed for correctness before submission.

Fixes #4388
