### PR TITLE
fix: handle custom logos with non-standard aspect ratios

### DIFF
--- a/platform/frontend/src/components/app-logo.test.tsx
+++ b/platform/frontend/src/components/app-logo.test.tsx
@@ -54,3 +54,19 @@ describe("AppLogo", () => {
     expect(screen.queryByText("Archestra.AI")).not.toBeInTheDocument();
   });
 });
+
+  it("renders custom logo left-aligned when centered is false", () => {
+    mockUseTheme.mockReturnValue({ resolvedTheme: "light" });
+    mockUseOrgTheme.mockReturnValue({
+      isLoadingAppearance: false,
+      logo: "data:image/png;base64,square-logo",
+      logoDark: null,
+    });
+
+    const { container } = render(<AppLogo centered={false} />);
+
+    expect(screen.getByAltText("Organization logo")).toBeInTheDocument();
+    // Wrapper should not have justify-center when centered is false
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).not.toContain("justify-center");
+  });

--- a/platform/frontend/src/components/app-logo.tsx
+++ b/platform/frontend/src/components/app-logo.tsx
@@ -26,14 +26,21 @@ export function AppLogo({ centered = true }: AppLogoProps) {
 
   if (effectiveLogo) {
     return (
-      <div className="flex justify-center">
-        <div className="flex flex-col items-center gap-1">
+      <div className={`flex ${centered ? "justify-center" : ""}`}>
+        <div
+          className={`flex flex-col ${centered ? "items-center" : "items-start"} gap-1`}
+        >
           <Image
             src={effectiveLogo}
             alt="Organization logo"
             width={200}
-            height={60}
-            className="object-contain max-w-full max-h-12 w-auto h-auto"
+            height={200}
+            unoptimized
+            className={`object-contain w-auto h-auto ${
+              centered
+                ? "max-w-[200px] max-h-12"
+                : "max-w-[140px] max-h-9"
+            }`}
           />
           {!config.enterpriseFeatures.fullWhiteLabeling && (
             <p className="text-[10px] text-muted-foreground">


### PR DESCRIPTION
## Summary

Fixes custom logos with non-standard aspect ratios (square, portrait, or very wide) breaking the layout in auth pages, chat, and sidebar.

## Root Cause

The `AppLogo` component had two issues:

1. **Hardcoded landscape aspect ratio** — `width={200} height={60}` told Next.js Image to assume a ~3.3:1 ratio, causing layout shifts for square or portrait logos.
2. **`centered` prop ignored for custom logos** — The wrapper div always used `justify-center` regardless of the `centered` prop, so custom logos were always centered even in the sidebar where left-alignment is expected.

## Changes

**`app-logo.tsx`:**
- Changed `height={60}` → `height={200}` (square hint so Next.js doesn't assume landscape)
- Added `unoptimized` since custom logos are user-uploaded and may be data URIs or external URLs
- Fixed wrapper to respect `centered` prop: `justify-center` only when `centered={true}`
- Fixed inner flex alignment: `items-center` vs `items-start` based on `centered`
- Applied context-aware max constraints: `max-w-[200px] max-h-12` centered, `max-w-[140px] max-h-9` sidebar

**`app-logo.test.tsx`:**
- Added test verifying `centered={false}` removes `justify-center` from wrapper

## Testing

- Square logos: constrained to max-h (48px centered / 36px sidebar), width scales proportionally
- Wide banner logos: constrained to max-w (200px / 140px), height scales proportionally
- Tall portrait logos: constrained to max-h, width scales down
- Default logos: unchanged behavior

## Disclosure

This PR was generated with AI assistance (Claude), operated by a human contributor. All changes reviewed for correctness before submission.

Fixes #4432
