### PR TITLE
fix: clean up leaked mermaid DOM elements and show styled error fallback

### DIFF
--- a/platform/frontend/src/components/mermaid-diagram.test.tsx
+++ b/platform/frontend/src/components/mermaid-diagram.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockUseTheme } = vi.hoisted(() => ({
+  mockUseTheme: vi.fn(),
+}));
+
+vi.mock("next-themes", () => ({
+  useTheme: () => mockUseTheme(),
+}));
+
+const mockRender = vi.fn();
+const mockInitialize = vi.fn();
+
+vi.mock("mermaid", () => ({
+  default: {
+    initialize: (...args: unknown[]) => mockInitialize(...args),
+    render: (...args: unknown[]) => mockRender(...args),
+  },
+}));
+
+import { MermaidDiagram } from "./mermaid-diagram";
+
+describe("MermaidDiagram", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseTheme.mockReturnValue({ theme: "light" });
+  });
+
+  it("renders a valid diagram", async () => {
+    mockRender.mockResolvedValue({
+      svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>ok</text></svg>',
+    });
+
+    render(<MermaidDiagram chart="graph TD; A-->B;" />);
+
+    await waitFor(() => {
+      expect(mockRender).toHaveBeenCalled();
+    });
+  });
+
+  it("shows an alert with source text when rendering fails", async () => {
+    mockRender.mockRejectedValue(new Error("Parse error on line 1"));
+
+    render(<MermaidDiagram chart="not valid mermaid" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Diagram could not be rendered"),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Parse error on line 1")).toBeInTheDocument();
+    expect(screen.getByText("not valid mermaid")).toBeInTheDocument();
+  });
+
+  it("cleans up orphaned mermaid DOM elements on error", async () => {
+    const orphan = document.createElement("div");
+    orphan.id = "mermaid-diagram-123";
+    document.body.appendChild(orphan);
+
+    mockRender.mockImplementation(async (uid: string) => {
+      // Simulate mermaid leaving an orphaned element
+      const leaked = document.createElement("div");
+      leaked.id = uid;
+      document.body.appendChild(leaked);
+      throw new Error("render failed");
+    });
+
+    render(<MermaidDiagram chart="bad" id="mermaid-diagram" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Diagram could not be rendered"),
+      ).toBeInTheDocument();
+    });
+
+    // The orphaned element should be removed from document.body
+    const leakedElements = document.querySelectorAll(
+      '[id^="mermaid-diagram-"]',
+    );
+    // Only the pre-existing orphan from before the render call should remain
+    // (the one created by mockRender should be cleaned up)
+    expect(leakedElements.length).toBeLessThanOrEqual(1);
+
+    // Clean up fixture
+    orphan.remove();
+  });
+
+  it("cleans up on unmount", async () => {
+    mockRender.mockResolvedValue({
+      svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>ok</text></svg>',
+    });
+
+    const { unmount } = render(<MermaidDiagram chart="graph TD; A-->B;" />);
+
+    await waitFor(() => {
+      expect(mockRender).toHaveBeenCalled();
+    });
+
+    // Should not throw on unmount
+    expect(() => unmount()).not.toThrow();
+  });
+});

--- a/platform/frontend/src/components/mermaid-diagram.tsx
+++ b/platform/frontend/src/components/mermaid-diagram.tsx
@@ -1,12 +1,25 @@
 "use client";
 
+import { AlertTriangle } from "lucide-react";
 import mermaid from "mermaid";
 import { useTheme } from "next-themes";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
 interface MermaidDiagramProps {
   chart: string;
   id?: string;
+}
+
+/**
+ * Remove orphaned elements that mermaid.render() leaves in document.body
+ * when parsing or rendering fails. Mermaid attaches temporary containers
+ * using both the supplied id and a `d`-prefixed variant.
+ */
+function cleanupMermaidArtifacts(uniqueId: string) {
+  document.getElementById(uniqueId)?.remove();
+  document.getElementById(`d${uniqueId}`)?.remove();
 }
 
 export function MermaidDiagram({
@@ -16,9 +29,24 @@ export function MermaidDiagram({
   const ref = useRef<HTMLDivElement>(null);
   const { theme } = useTheme();
   const [isLoaded, setIsLoaded] = useState(false);
+  const [renderError, setRenderError] = useState<string | null>(null);
+
+  // Track generated ids so we can clean them up on unmount
+  const generatedIdsRef = useRef<string[]>([]);
+
+  const cleanup = useCallback(() => {
+    for (const gid of generatedIdsRef.current) {
+      cleanupMermaidArtifacts(gid);
+    }
+    generatedIdsRef.current = [];
+  }, []);
 
   useEffect(() => {
+    let cancelled = false;
+
     setIsLoaded(false);
+    setRenderError(null);
+
     const isDark = theme === "dark";
 
     mermaid.initialize({
@@ -52,33 +80,64 @@ export function MermaidDiagram({
     });
 
     const renderDiagram = async () => {
-      if (ref.current) {
-        ref.current.replaceChildren();
-        try {
-          // Generate a unique ID to avoid conflicts
-          const uniqueId = `${id}-${Date.now()}`;
-          const { svg } = await mermaid.render(uniqueId, chart);
-          if (ref.current) {
-            // Parse SVG string via DOMParser to avoid innerHTML
-            const doc = new DOMParser().parseFromString(svg, "image/svg+xml");
-            const svgElement = doc.documentElement;
-            ref.current.replaceChildren(svgElement);
-            requestAnimationFrame(() => setIsLoaded(true));
-          }
-        } catch (error) {
-          console.error("Error rendering mermaid diagram:", error);
-          if (ref.current) {
-            const pre = document.createElement("pre");
-            pre.textContent = chart;
-            ref.current.replaceChildren(pre);
-            setIsLoaded(true);
-          }
-        }
+      // Clean up any previous render artifacts before starting a new one
+      cleanup();
+
+      if (!ref.current) return;
+
+      ref.current.replaceChildren();
+
+      const uniqueId = `${id}-${Date.now()}`;
+      generatedIdsRef.current.push(uniqueId);
+
+      try {
+        const { svg } = await mermaid.render(uniqueId, chart);
+
+        if (cancelled || !ref.current) return;
+
+        // Parse SVG string via DOMParser to avoid innerHTML
+        const doc = new DOMParser().parseFromString(svg, "image/svg+xml");
+        const svgElement = doc.documentElement;
+        ref.current.replaceChildren(svgElement);
+        requestAnimationFrame(() => {
+          if (!cancelled) setIsLoaded(true);
+        });
+      } catch (error) {
+        // Clean up the orphaned temp element mermaid leaves in document.body
+        cleanupMermaidArtifacts(uniqueId);
+
+        if (cancelled || !ref.current) return;
+
+        console.error("Error rendering mermaid diagram:", error);
+        setRenderError(
+          error instanceof Error ? error.message : "Invalid diagram syntax",
+        );
+        setIsLoaded(true);
       }
     };
 
     renderDiagram();
-  }, [chart, id, theme]);
+
+    return () => {
+      cancelled = true;
+      cleanup();
+    };
+  }, [chart, cleanup, id, theme]);
+
+  if (renderError) {
+    return (
+      <Alert variant="warning">
+        <AlertTriangle className="h-4 w-4" />
+        <AlertTitle>Diagram could not be rendered</AlertTitle>
+        <AlertDescription>
+          <p>{renderError}</p>
+          <pre className="mt-2 max-h-48 overflow-auto rounded-md bg-muted p-3 text-xs">
+            <code>{chart}</code>
+          </pre>
+        </AlertDescription>
+      </Alert>
+    );
+  }
 
   return (
     <div


### PR DESCRIPTION
## What changed

Fixes #3511 — invalid mermaid diagrams leak error SVGs to other pages and show raw unstyled text.

### Problem

1. **Error SVGs leak to other pages** — `mermaid.render()` attaches a temporary element to `document.body` for rendering. When parsing fails, this orphaned element is never removed, causing error artifacts to appear on unrelated pages.
2. **Raw unstyled fallback** — the catch block injects a bare `<pre>` via direct DOM manipulation, bypassing React state and producing an inconsistent UI.
3. **No cleanup on unmount** — navigating away from a page mid-render leaves mermaid artifacts in the DOM.
4. **Race condition** — rapid `chart` or `theme` changes can cause stale renders to overwrite current state.

### Solution

**`mermaid-diagram.tsx`:**
- Extract `cleanupMermaidArtifacts()` helper that removes orphaned elements by both the supplied id and mermaid's `d`-prefixed variant
- Track all generated render ids via `useRef` and clean them up on every new render and on unmount
- Use `renderError` state instead of DOM injection — when set, the component renders a styled `Alert` (warning variant) with the error message and the raw diagram source in a scrollable code block
- Add `cancelled` flag to prevent state updates from stale async renders
- Return a cleanup function from `useEffect` that cancels in-flight renders and removes artifacts

**`mermaid-diagram.test.tsx`** (new):
- Tests successful render
- Tests error state shows Alert with source text
- Tests orphaned DOM element cleanup on error
- Tests clean unmount

### How to test

1. Create a chat with an AI that produces a mermaid diagram
2. Trigger an invalid diagram (e.g., malformed syntax)
3. Verify: styled warning alert appears with source text, no error SVG leaks to other pages
4. Navigate away and back — no stale error artifacts