### PR TITLE
feat: add Anthropic workload identity federation support

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -757,6 +757,19 @@ These environment variables set the default base URL for each LLM provider. Per-
   - Uses Azure Identity `DefaultAzureCredential` with token scope `https://ai.azure.com/.default`
   - Claude deployments must already exist in the Azure resource. Microsoft lists additional Claude prerequisites: paid eligible subscription, supported region, Azure Marketplace access for partner models, permission to subscribe to model offerings, and Contributor or Owner role on the resource group. Azure also requires Anthropic deployment metadata: `industry`, `organizationName`, and `countryCode`.
 
+  #### Anthropic Workload Identity Federation
+
+These environment variables configure Anthropic Workload Identity Federation for keyless authentication. When configured, Archestra creates the Anthropic SDK client without an API key and allows the SDK to perform federation token exchange and refresh.
+
+- **`ARCHESTRA_CHAT_ANTHROPIC_FEDERATION_RULE_ID`** - Anthropic federation rule ID.
+- **`ARCHESTRA_CHAT_ANTHROPIC_ORGANIZATION_ID`** - Anthropic organization ID.
+- **`ARCHESTRA_CHAT_ANTHROPIC_SERVICE_ACCOUNT_ID`** - Anthropic service account ID.
+- **`ARCHESTRA_CHAT_ANTHROPIC_WORKSPACE_ID`** - Optional Anthropic workspace ID.
+- **`ARCHESTRA_CHAT_ANTHROPIC_IDENTITY_TOKEN_FILE`** - Path to the OIDC identity token file. Required when `ARCHESTRA_CHAT_ANTHROPIC_IDENTITY_TOKEN` is not set.
+- **`ARCHESTRA_CHAT_ANTHROPIC_IDENTITY_TOKEN`** - Raw OIDC identity token. Required when `ARCHESTRA_CHAT_ANTHROPIC_IDENTITY_TOKEN_FILE` is not set.
+
+Do not configure `ARCHESTRA_CHAT_ANTHROPIC_API_KEY` for the same system provider when using Workload Identity Federation.
+
 - **`ARCHESTRA_GEMINI_BASE_URL`** - Override the Google Gemini API base URL.
   - Default: `https://generativelanguage.googleapis.com`
   - Use this to point to your own proxy or other custom endpoints

--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -74,6 +74,26 @@ Model Router translation is text-first. Anthropic, Gemini, and Cohere routes cur
 - **Authentication**: Pass your Anthropic API key in the `x-api-key` header
 - **Messages path**: `POST /v1/anthropic/{profile-id}/v1/messages`
 
+### Anthropic Workload Identity Federation
+
+Archestra supports Anthropic Workload Identity Federation for keyless authentication. This allows deployments to authenticate with Anthropic using a workload identity token instead of a long-lived Anthropic API key.
+
+Configure the following deployment environment variables:
+
+```bash
+ARCHESTRA_CHAT_ANTHROPIC_FEDERATION_RULE_ID=fdrl_...
+ARCHESTRA_CHAT_ANTHROPIC_ORGANIZATION_ID=...
+ARCHESTRA_CHAT_ANTHROPIC_SERVICE_ACCOUNT_ID=svac_...
+ARCHESTRA_CHAT_ANTHROPIC_WORKSPACE_ID=...
+ARCHESTRA_CHAT_ANTHROPIC_IDENTITY_TOKEN_FILE=/var/run/secrets/anthropic/token
+# or
+ARCHESTRA_CHAT_ANTHROPIC_IDENTITY_TOKEN=...
+```
+
+`ARCHESTRA_CHAT_ANTHROPIC_IDENTITY_TOKEN_FILE` or `ARCHESTRA_CHAT_ANTHROPIC_IDENTITY_TOKEN` must be provided. When these variables are configured and no API key is supplied, Archestra lets the Anthropic SDK perform the federation token exchange and refresh flow.
+
+For Kubernetes deployments, these values can be supplied through `archestra.env`, `archestra.envFromSecrets`, or `archestra.envWithValueFrom`. See [Deployment - Environment Variables](/docs/platform-deployment#environment-variables).
+
 ### Anthropic on Microsoft Foundry
 
 Claude models deployed in Microsoft Foundry use the Anthropic Messages API at `https://<resource>.services.ai.azure.com/anthropic`. Set `ARCHESTRA_ANTHROPIC_BASE_URL` to that `/anthropic` base URL. For keyless Microsoft Entra ID authentication, also set `ARCHESTRA_ANTHROPIC_AZURE_FOUNDRY_ENTRA_ID_ENABLED=true`; Archestra sends a bearer token scoped to `https://ai.azure.com/.default`.

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -687,6 +687,19 @@ const config = {
     },
     anthropic: {
       apiKey: process.env.ARCHESTRA_CHAT_ANTHROPIC_API_KEY || "",
+      wif: {
+        federationRuleId:
+          process.env.ARCHESTRA_CHAT_ANTHROPIC_FEDERATION_RULE_ID || "",
+        organizationId:
+          process.env.ARCHESTRA_CHAT_ANTHROPIC_ORGANIZATION_ID || "",
+        serviceAccountId:
+          process.env.ARCHESTRA_CHAT_ANTHROPIC_SERVICE_ACCOUNT_ID || "",
+        workspaceId: process.env.ARCHESTRA_CHAT_ANTHROPIC_WORKSPACE_ID || "",
+        identityTokenFile:
+          process.env.ARCHESTRA_CHAT_ANTHROPIC_IDENTITY_TOKEN_FILE || "",
+        identityToken:
+          process.env.ARCHESTRA_CHAT_ANTHROPIC_IDENTITY_TOKEN || "",
+      },
     },
     gemini: {
       apiKey: process.env.ARCHESTRA_CHAT_GEMINI_API_KEY || "",

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -1172,6 +1172,20 @@ export const anthropicAdapterFactory: LLMProvider<
       });
     }
 
+    if (!apiKey && isAnthropicWifConfigured()) {
+      configureAnthropicWifEnv();
+
+      logger.info(
+        "[AnthropicAdapter] Using Anthropic Workload Identity Federation",
+      );
+
+      return new AnthropicProvider({
+        baseURL: options.baseUrl,
+        fetch: customFetch,
+        defaultHeaders: options.defaultHeaders,
+      });
+    }
+
     return new AnthropicProvider({
       apiKey: regularApiKey,
       authToken: token,
@@ -1241,6 +1255,37 @@ export const anthropicAdapterFactory: LLMProvider<
     return "Internal server error";
   },
 };
+
+function isAnthropicWifConfigured(): boolean {
+  const wif = config.chat.anthropic.wif;
+
+  return Boolean(
+    wif.federationRuleId &&
+      wif.organizationId &&
+      wif.serviceAccountId &&
+      (wif.identityTokenFile || wif.identityToken),
+  );
+}
+
+function configureAnthropicWifEnv(): void {
+  const wif = config.chat.anthropic.wif;
+
+  process.env.ANTHROPIC_FEDERATION_RULE_ID = wif.federationRuleId;
+  process.env.ANTHROPIC_ORGANIZATION_ID = wif.organizationId;
+  process.env.ANTHROPIC_SERVICE_ACCOUNT_ID = wif.serviceAccountId;
+
+  if (wif.workspaceId) {
+    process.env.ANTHROPIC_WORKSPACE_ID = wif.workspaceId;
+  }
+
+  if (wif.identityTokenFile) {
+    process.env.ANTHROPIC_IDENTITY_TOKEN_FILE = wif.identityTokenFile;
+  }
+
+  if (wif.identityToken) {
+    process.env.ANTHROPIC_IDENTITY_TOKEN = wif.identityToken;
+  }
+}
 
 function createAnthropicAzureFoundryFetch(
   baseFetch: typeof globalThis.fetch | undefined,


### PR DESCRIPTION
## Summary

Adds support for Anthropic Workload Identity Federation/keyless authentication.

## Changes

- Added `ARCHESTRA_CHAT_ANTHROPIC_*` Workload Identity Federation configuration to backend config.
- Added Anthropic WIF detection in the Anthropic adapter.
- When no API key or bearer token is provided and WIF is configured, Archestra now creates the Anthropic SDK client without an API key so the SDK can resolve federation credentials.
- Preserved existing Anthropic API key authentication behavior.
- Preserved existing Anthropic OAuth bearer token behavior.
- Preserved existing Anthropic on Microsoft Foundry Entra ID behavior.
- Documented Anthropic WIF environment variables in deployment docs.
- Added Anthropic WIF setup notes under Supported LLM Providers.

## Testing

- `pnpm lint` ✅
- `pnpm exec vitest run src/routes/proxy/routes/anthropic.test.ts` ✅
  - 12 tests passed

## Notes

- Helm template changes were not required because the chart already supports generic environment variable injection through `archestra.env`, `archestra.envFromSecrets`, `archestra.envWithValueFrom`, and `archestra.envFrom`.

 /claim #4468