### PR TITLE
fix: enforce blocked Tool Result Policies when context starts untrusted (#4225)

### DIFF
--- a/platform/backend/src/guardrails/trusted-data.test.ts
+++ b/platform/backend/src/guardrails/trusted-data.test.ts
@@ -3,6 +3,7 @@ import { DualLlmSubagent } from "@/agents/subagents/dual-llm";
 import { AgentToolModel, ToolModel, TrustedDataPolicyModel } from "@/models";
 import { beforeEach, describe, expect, test } from "@/test";
 import type { CommonMessage, Tool } from "@/types";
+import { UNSAFE_CONTEXT_BOUNDARY_REASON } from "@/types";
 import { evaluateIfContextIsTrusted } from "./trusted-data";
 
 describe("trusted-data evaluation (provider-agnostic)", () => {
@@ -386,6 +387,173 @@ describe("trusted-data evaluation (provider-agnostic)", () => {
         toolCallId: "call_789",
         toolName: "get_emails",
       });
+    });
+
+
+    test("applies blocked tool result policies even when context starts untrusted (regression #4225)", async () => {
+      await TrustedDataPolicyModel.create({
+        toolId,
+        conditions: [
+          { key: "emails[*].from", operator: "contains", value: "hacker" },
+        ],
+        action: "block_always",
+        description: "Block hacker emails",
+      });
+
+      const result = await evaluateIfContextIsTrusted(
+        [
+          { role: "user", content: "Read my emails" },
+          {
+            role: "tool",
+            toolCalls: [
+              {
+                id: "call_blocked",
+                name: "get_emails",
+                content: {
+                  emails: [{ from: "hacker@evil.com", subject: "Malicious" }],
+                },
+                isError: false,
+              },
+            ],
+          },
+        ],
+        agentId,
+        organizationId,
+        undefined,
+        true,
+        "restrictive",
+        { teamIds: [] },
+      );
+
+      expect(result.contextIsTrusted).toBe(false);
+      expect(result.toolResultUpdates).toEqual({
+        call_blocked:
+          "[Content blocked by policy: Data blocked by policy: Block hacker emails]",
+      });
+      // Boundary must be preexisting, not tool_result — context was untrusted before the tool ran
+      expect(result.unsafeContextBoundary).toEqual({
+        kind: "preexisting_untrusted",
+        reason: UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
+      });
+    });
+
+    test("mixed tool calls with considerContextUntrusted=true: only blocked result is replaced, boundary stays preexisting", async () => {
+      await TrustedDataPolicyModel.create({
+        toolId,
+        conditions: [{ key: "source", operator: "equal", value: "malicious" }],
+        action: "block_always",
+        description: "Block malicious source",
+      });
+
+      await TrustedDataPolicyModel.create({
+        toolId,
+        conditions: [{ key: "source", operator: "equal", value: "trusted" }],
+        action: "mark_as_trusted",
+        description: "Allow trusted source",
+      });
+
+      const result = await evaluateIfContextIsTrusted(
+        [
+          { role: "user", content: "Summarize" },
+          {
+            role: "tool",
+            toolCalls: [
+              {
+                id: "call_trusted",
+                name: "get_emails",
+                content: { source: "trusted", data: "good" },
+                isError: false,
+              },
+              {
+                id: "call_blocked",
+                name: "get_emails",
+                content: { source: "malicious", data: "bad" },
+                isError: false,
+              },
+              {
+                id: "call_unknown",
+                name: "get_emails",
+                content: { source: "unknown", data: "?" },
+                isError: false,
+              },
+            ],
+          },
+        ],
+        agentId,
+        organizationId,
+        undefined,
+        true,
+        "restrictive",
+        { teamIds: [] },
+      );
+
+      expect(result.contextIsTrusted).toBe(false);
+      expect(result.toolResultUpdates).toEqual({
+        call_blocked:
+          "[Content blocked by policy: Data blocked by policy: Block malicious source]",
+      });
+      // Boundary must be preexisting — set before any tool ran
+      expect(result.unsafeContextBoundary).toEqual({
+        kind: "preexisting_untrusted",
+        reason: UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
+      });
+    });
+
+    test("explicit initialUntrustedReason is preserved in boundary when considerContextUntrusted=true", async () => {
+      const result = await evaluateIfContextIsTrusted(
+        [{ role: "user", content: "hi" }],
+        agentId,
+        organizationId,
+        undefined,
+        true,
+        "restrictive",
+        { teamIds: [] },
+        undefined,
+        undefined,
+        "inherited_from_parent",
+      );
+
+      expect(result.contextIsTrusted).toBe(false);
+      expect(result.toolResultUpdates).toEqual({});
+      expect(result.unsafeContextBoundary).toEqual({
+        kind: "preexisting_untrusted",
+        reason: "inherited_from_parent",
+      });
+    });
+
+    test("considerContextUntrusted=true with permissive mode: block policies are ignored", async () => {
+      await TrustedDataPolicyModel.create({
+        toolId,
+        conditions: [{ key: "from", operator: "contains", value: "hacker" }],
+        action: "block_always",
+        description: "Block hackers",
+      });
+
+      const result = await evaluateIfContextIsTrusted(
+        [
+          {
+            role: "tool",
+            toolCalls: [
+              {
+                id: "call_yolo",
+                name: "get_emails",
+                content: { from: "hacker@evil.com" },
+                isError: false,
+              },
+            ],
+          },
+        ],
+        agentId,
+        organizationId,
+        undefined,
+        true,
+        "permissive",
+        { teamIds: [] },
+      );
+
+      // Permissive mode ignores block policies even in sensitive context
+      expect(result.contextIsTrusted).toBe(false); // still untrusted due to considerContextUntrusted
+      expect(result.toolResultUpdates).toEqual({});
     });
 
     test("records a preexisting unsafe boundary when context starts untrusted", async () => {

--- a/platform/backend/src/guardrails/trusted-data.ts
+++ b/platform/backend/src/guardrails/trusted-data.ts
@@ -64,24 +64,23 @@ export async function evaluateIfContextIsTrusted(
   let unsafeContextBoundary: UnsafeContextBoundary | undefined;
 
   // If agent configured to consider context untrusted from the beginning,
-  // mark context as untrusted immediately and skip evaluation
+  // mark context as untrusted immediately but still fall through to policy
+  // evaluation so that blocked tool results are properly replaced before
+  // being sent to the model. Skipping evaluation here was the root cause
+  // of the bypass described in issue #4225.
   if (considerContextUntrusted) {
     logger.debug(
       { agentId },
-      "[trustedData] evaluateIfContextIsTrusted: context marked untrusted by agent config",
+      "[trustedData] evaluateIfContextIsTrusted: context marked untrusted by agent config, continuing to evaluate tool result policies",
     );
-    return {
-      toolResultUpdates: {},
-      contextIsTrusted: false,
-      usedDualLlm: false,
-      dualLlmAnalyses: [],
-      unsafeContextBoundary: {
-        kind: "preexisting_untrusted",
-        reason:
-          initialUntrustedReason ??
-          UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
-      },
+    hasUntrustedData = true;
+    unsafeContextBoundary = {
+      kind: "preexisting_untrusted",
+      reason:
+        initialUntrustedReason ??
+        UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
     };
+    // Do NOT return early — fall through so blocked results get replaced.
   }
 
   // First, collect all tool calls from all messages
@@ -112,11 +111,11 @@ export async function evaluateIfContextIsTrusted(
   if (allToolCalls.length === 0) {
     logger.debug(
       { agentId },
-      "[trustedData] evaluateIfContextIsTrusted: no tool calls found, context is trusted",
+      "[trustedData] evaluateIfContextIsTrusted: no tool calls found",
     );
     return {
       toolResultUpdates,
-      contextIsTrusted: true,
+      contextIsTrusted: !hasUntrustedData,
       usedDualLlm: false,
       dualLlmAnalyses: [],
       unsafeContextBoundary,


### PR DESCRIPTION
## Root cause

`evaluateIfContextIsTrusted` returned early with empty `toolResultUpdates` when `considerContextUntrusted=true`, bypassing all Tool Result Policy evaluation. Raw tool output was sent to the LLM regardless of block policies.

## Fix

Remove the early return inside the `considerContextUntrusted` block. Instead, set `hasUntrustedData=true` and `unsafeContextBoundary`, then fall through to normal policy evaluation.

Also fix the no-tool-calls early return which hardcoded `contextIsTrusted: true` — now correctly uses `!hasUntrustedData`.

## Tests added

- Blocked policy enforced when context starts untrusted (regression #4225)
- Mixed tool calls with `considerContextUntrusted=true`: only blocked result replaced, boundary stays `preexisting_untrusted`
- Explicit `initialUntrustedReason` preserved in boundary
- Permissive mode ignores block policies even in sensitive context

/claim #4225
