### PR TITLE
fix(mcp): preserve tool guardrails when credentials are recreated

### DIFF
--- a/platform/backend/src/models/agent-tool.ts
+++ b/platform/backend/src/models/agent-tool.ts
@@ -1138,27 +1138,6 @@ class AgentToolModel {
   }
 
   /**
-   * Delete all static agent-tool assignments that use a specific MCP server.
-   */
-  static async deleteByExecutionSourceMcpServerId(
-    mcpServerId: string,
-  ): Promise<number> {
-    const result = await db
-      .delete(schema.agentToolsTable)
-      .where(eq(schema.agentToolsTable.mcpServerId, mcpServerId));
-    return result.rowCount ?? 0;
-  }
-
-  /**
-   * Delete all static agent-tool assignments that use a specific MCP server.
-   */
-  static async deleteByCredentialSourceMcpServerId(
-    mcpServerId: string,
-  ): Promise<number> {
-    return AgentToolModel.deleteByExecutionSourceMcpServerId(mcpServerId);
-  }
-
-  /**
    * Clean up invalid static MCP server assignments when a user is removed from a team.
    * Sets mcpServerId to null for agent-tools where:
    * - The assigned MCP server is owned by the removed user

--- a/platform/backend/src/models/mcp-server.test.ts
+++ b/platform/backend/src/models/mcp-server.test.ts
@@ -173,7 +173,7 @@ describe("McpServerModel", () => {
       expect(trustedDataPolicyAfterDelete?.toolId).toBe(tool.id);
     });
 
-    test("recreated credentials reuse the existing tool row and can repin preserved assignments", async ({
+    test("recreated credentials reuse the existing tool row, refresh schema, and repin assignments", async ({
       makeAgent,
       makeAgentTool,
       makeInternalMcpCatalog,
@@ -193,6 +193,13 @@ describe("McpServerModel", () => {
       });
       const tool = await makeTool({
         name: "delete_recreate__search",
+        description: "Old search description",
+        parameters: {
+          type: "object",
+          properties: {
+            query: { type: "string" },
+          },
+        },
         catalogId: catalog.id,
       });
       const agent = await makeAgent();
@@ -215,12 +222,26 @@ describe("McpServerModel", () => {
       const [reusedTool] = await ToolModel.bulkCreateToolsIfNotExists([
         {
           name: tool.name,
-          description: tool.description,
-          parameters: tool.parameters ?? {},
+          description: "Updated search description",
+          parameters: {
+            type: "object",
+            properties: {
+              query: { type: "string" },
+              limit: { type: "number" },
+            },
+          },
           catalogId: catalog.id,
         },
       ]);
       expect(reusedTool.id).toBe(tool.id);
+      expect(reusedTool.description).toBe("Updated search description");
+      expect(reusedTool.parameters).toEqual({
+        type: "object",
+        properties: {
+          query: { type: "string" },
+          limit: { type: "number" },
+        },
+      });
 
       await AgentToolModel.bulkCreateForAgentsAndTools([agent.id], [tool.id], {
         mcpServerId: secondServer.id,

--- a/platform/backend/src/models/mcp-server.test.ts
+++ b/platform/backend/src/models/mcp-server.test.ts
@@ -173,6 +173,92 @@ describe("McpServerModel", () => {
       expect(trustedDataPolicyAfterDelete?.toolId).toBe(tool.id);
     });
 
+    test("preserves other installations and guardrail policies when one installation is removed", async ({
+      makeAgent,
+      makeAgentTool,
+      makeInternalMcpCatalog,
+      makeTool,
+      makeToolPolicy,
+      makeTrustedDataPolicy,
+    }) => {
+      const catalog = await makeInternalMcpCatalog({
+        name: "Delete One Of Many",
+        serverType: "remote",
+        serverUrl: "https://example.com/mcp",
+      });
+      const firstServer = await McpServerModel.create({
+        name: `${catalog.name} first`,
+        serverType: "remote",
+        catalogId: catalog.id,
+        scope: "personal",
+      });
+      const secondServer = await McpServerModel.create({
+        name: `${catalog.name} second`,
+        serverType: "remote",
+        catalogId: catalog.id,
+        scope: "personal",
+      });
+      const tool = await makeTool({
+        name: "delete_one_of_many__read",
+        catalogId: catalog.id,
+      });
+      const firstAgent = await makeAgent();
+      const secondAgent = await makeAgent();
+      const firstAgentTool = await makeAgentTool(firstAgent.id, tool.id, {
+        mcpServerId: firstServer.id,
+        credentialResolutionMode: "static",
+      });
+      const secondAgentTool = await makeAgentTool(secondAgent.id, tool.id, {
+        mcpServerId: secondServer.id,
+        credentialResolutionMode: "static",
+      });
+      const invocationPolicy = await makeToolPolicy(tool.id, {
+        reason: "Policy survives deleting one installation",
+      });
+      const trustedDataPolicy = await makeTrustedDataPolicy(tool.id, {
+        description: "Trusted data policy survives deleting one installation",
+      });
+
+      await expect(McpServerModel.delete(firstServer.id)).resolves.toBe(true);
+
+      const remainingServer = await McpServerModel.findById(secondServer.id);
+      expect(remainingServer?.id).toBe(secondServer.id);
+
+      const [firstAssignmentAfterDelete] = await db
+        .select()
+        .from(schema.agentToolsTable)
+        .where(eq(schema.agentToolsTable.id, firstAgentTool.id));
+      expect(firstAssignmentAfterDelete).toMatchObject({
+        agentId: firstAgent.id,
+        toolId: tool.id,
+        mcpServerId: null,
+        credentialResolutionMode: "static",
+      });
+
+      const [secondAssignmentAfterDelete] = await db
+        .select()
+        .from(schema.agentToolsTable)
+        .where(eq(schema.agentToolsTable.id, secondAgentTool.id));
+      expect(secondAssignmentAfterDelete).toMatchObject({
+        agentId: secondAgent.id,
+        toolId: tool.id,
+        mcpServerId: secondServer.id,
+        credentialResolutionMode: "static",
+      });
+
+      const [invocationPolicyAfterDelete] = await db
+        .select()
+        .from(schema.toolInvocationPoliciesTable)
+        .where(eq(schema.toolInvocationPoliciesTable.id, invocationPolicy.id));
+      expect(invocationPolicyAfterDelete?.toolId).toBe(tool.id);
+
+      const [trustedDataPolicyAfterDelete] = await db
+        .select()
+        .from(schema.trustedDataPoliciesTable)
+        .where(eq(schema.trustedDataPoliciesTable.id, trustedDataPolicy.id));
+      expect(trustedDataPolicyAfterDelete?.toolId).toBe(tool.id);
+    });
+
     test("recreated credentials reuse the existing tool row, refresh schema, and repin assignments", async ({
       makeAgent,
       makeAgentTool,
@@ -219,6 +305,9 @@ describe("McpServerModel", () => {
         catalogId: catalog.id,
         scope: "personal",
       });
+
+      // Mirrors the credential install path in routes/mcp-server.ts, which
+      // fetches tools before assigning them back to agents.
       const [reusedTool] = await ToolModel.bulkCreateToolsIfNotExists([
         {
           name: tool.name,

--- a/platform/backend/src/models/mcp-server.test.ts
+++ b/platform/backend/src/models/mcp-server.test.ts
@@ -1,7 +1,10 @@
+import { and, eq } from "drizzle-orm";
 import db, { schema } from "@/database";
 import { describe, expect, test } from "@/test";
+import AgentToolModel from "./agent-tool";
 import McpServerModel from "./mcp-server";
 import McpServerUserModel from "./mcp-server-user";
+import ToolModel from "./tool";
 
 describe("McpServerModel", () => {
   describe("serverType field", () => {
@@ -99,6 +102,147 @@ describe("McpServerModel", () => {
         crypto.randomUUID(),
       ]);
       expect(results).toEqual([]);
+    });
+  });
+
+  describe("delete", () => {
+    test("preserves catalog tools, assignments, and guardrail policies after the last installation is removed", async ({
+      makeAgent,
+      makeAgentTool,
+      makeInternalMcpCatalog,
+      makeTool,
+      makeToolPolicy,
+      makeTrustedDataPolicy,
+    }) => {
+      const catalog = await makeInternalMcpCatalog({
+        name: "Delete Preserve",
+        serverType: "remote",
+        serverUrl: "https://example.com/mcp",
+      });
+      const mcpServer = await McpServerModel.create({
+        name: catalog.name,
+        serverType: "remote",
+        catalogId: catalog.id,
+        scope: "personal",
+      });
+      const tool = await makeTool({
+        name: "delete_preserve__read",
+        catalogId: catalog.id,
+      });
+      const agent = await makeAgent();
+      const agentTool = await makeAgentTool(agent.id, tool.id, {
+        mcpServerId: mcpServer.id,
+        credentialResolutionMode: "static",
+      });
+      const invocationPolicy = await makeToolPolicy(tool.id, {
+        reason: "Keep this invocation policy",
+      });
+      const trustedDataPolicy = await makeTrustedDataPolicy(tool.id, {
+        description: "Keep this result policy",
+      });
+
+      await expect(McpServerModel.delete(mcpServer.id)).resolves.toBe(true);
+
+      const [toolAfterDelete] = await db
+        .select()
+        .from(schema.toolsTable)
+        .where(eq(schema.toolsTable.id, tool.id));
+      expect(toolAfterDelete?.catalogId).toBe(catalog.id);
+
+      const [agentToolAfterDelete] = await db
+        .select()
+        .from(schema.agentToolsTable)
+        .where(eq(schema.agentToolsTable.id, agentTool.id));
+      expect(agentToolAfterDelete).toMatchObject({
+        agentId: agent.id,
+        toolId: tool.id,
+        mcpServerId: null,
+        credentialResolutionMode: "static",
+      });
+
+      const [invocationPolicyAfterDelete] = await db
+        .select()
+        .from(schema.toolInvocationPoliciesTable)
+        .where(eq(schema.toolInvocationPoliciesTable.id, invocationPolicy.id));
+      expect(invocationPolicyAfterDelete?.toolId).toBe(tool.id);
+
+      const [trustedDataPolicyAfterDelete] = await db
+        .select()
+        .from(schema.trustedDataPoliciesTable)
+        .where(eq(schema.trustedDataPoliciesTable.id, trustedDataPolicy.id));
+      expect(trustedDataPolicyAfterDelete?.toolId).toBe(tool.id);
+    });
+
+    test("recreated credentials reuse the existing tool row and can repin preserved assignments", async ({
+      makeAgent,
+      makeAgentTool,
+      makeInternalMcpCatalog,
+      makeTool,
+      makeToolPolicy,
+    }) => {
+      const catalog = await makeInternalMcpCatalog({
+        name: "Delete Recreate",
+        serverType: "remote",
+        serverUrl: "https://example.com/mcp",
+      });
+      const firstServer = await McpServerModel.create({
+        name: catalog.name,
+        serverType: "remote",
+        catalogId: catalog.id,
+        scope: "personal",
+      });
+      const tool = await makeTool({
+        name: "delete_recreate__search",
+        catalogId: catalog.id,
+      });
+      const agent = await makeAgent();
+      await makeAgentTool(agent.id, tool.id, {
+        mcpServerId: firstServer.id,
+        credentialResolutionMode: "static",
+      });
+      const invocationPolicy = await makeToolPolicy(tool.id, {
+        reason: "Policy survives credential recreation",
+      });
+
+      await expect(McpServerModel.delete(firstServer.id)).resolves.toBe(true);
+
+      const secondServer = await McpServerModel.create({
+        name: catalog.name,
+        serverType: "remote",
+        catalogId: catalog.id,
+        scope: "personal",
+      });
+      const [reusedTool] = await ToolModel.bulkCreateToolsIfNotExists([
+        {
+          name: tool.name,
+          description: tool.description,
+          parameters: tool.parameters ?? {},
+          catalogId: catalog.id,
+        },
+      ]);
+      expect(reusedTool.id).toBe(tool.id);
+
+      await AgentToolModel.bulkCreateForAgentsAndTools([agent.id], [tool.id], {
+        mcpServerId: secondServer.id,
+        credentialResolutionMode: "static",
+      });
+
+      const [agentToolAfterRecreate] = await db
+        .select()
+        .from(schema.agentToolsTable)
+        .where(
+          and(
+            eq(schema.agentToolsTable.agentId, agent.id),
+            eq(schema.agentToolsTable.toolId, tool.id),
+          ),
+        );
+      expect(agentToolAfterRecreate?.mcpServerId).toBe(secondServer.id);
+
+      const [policyAfterRecreate] = await db
+        .select()
+        .from(schema.toolInvocationPoliciesTable)
+        .where(eq(schema.toolInvocationPoliciesTable.id, invocationPolicy.id));
+      expect(policyAfterRecreate?.toolId).toBe(tool.id);
     });
   });
 

--- a/platform/backend/src/models/mcp-server.ts
+++ b/platform/backend/src/models/mcp-server.ts
@@ -12,11 +12,9 @@ import type {
   ResourceVisibilityScope,
   UpdateMcpServer,
 } from "@/types";
-import AgentToolModel from "./agent-tool";
 import InternalMcpCatalogModel from "./internal-mcp-catalog";
 import McpHttpSessionModel from "./mcp-http-session";
 import McpServerUserModel from "./mcp-server-user";
-import ToolModel from "./tool";
 
 // Alias for users table to avoid conflict with the owner LEFT JOIN
 const assignedUsersTable = alias(schema.usersTable, "assigned_users");
@@ -468,31 +466,6 @@ class McpServerModel {
       // Continue with deletion even if session cleanup fails
     }
 
-    // Clean up agent_tools that reference this server
-    // Must be done before deletion to ensure agents do not retain unusable tool assignments
-    // FK constraint would only null out the reference, not remove the assignment
-    try {
-      let deletedAgentTools = 0;
-      if (mcpServer.serverType === "local") {
-        deletedAgentTools =
-          await AgentToolModel.deleteByExecutionSourceMcpServerId(id);
-      } else {
-        deletedAgentTools =
-          await AgentToolModel.deleteByCredentialSourceMcpServerId(id);
-      }
-      if (deletedAgentTools > 0) {
-        logger.info(
-          `Deleted ${deletedAgentTools} agent tool assignments for MCP server: ${mcpServer.name}`,
-        );
-      }
-    } catch (error) {
-      logger.error(
-        { err: error },
-        `Failed to clean up agent tools for MCP server ${mcpServer.name}:`,
-      );
-      // Continue with deletion even if agent tool cleanup fails
-    }
-
     // For local servers, stop and remove the K8s deployment
     if (mcpServer.serverType === "local") {
       try {
@@ -511,42 +484,16 @@ class McpServerModel {
 
     // Delete the MCP server from database
     logger.info(`Deleting MCP server: ${mcpServer.name} with id: ${id}`);
-    const result = await db
+    const deletedRows = await db
       .delete(schema.mcpServersTable)
-      .where(eq(schema.mcpServersTable.id, id));
+      .where(eq(schema.mcpServersTable.id, id))
+      .returning({ id: schema.mcpServersTable.id });
 
-    const deleted = result.rowCount !== null && result.rowCount > 0;
+    const deleted = deletedRows.length > 0;
 
     // If the MCP server was deleted and it had an associated secret, delete the secret
     if (deleted && mcpServer.secretId) {
       await secretManager().deleteSecret(mcpServer.secretId);
-    }
-
-    // If the MCP server was deleted and had a catalogId, check if this was the last installation
-    // If so, clean up all tools for this catalog
-    if (deleted && mcpServer.catalogId) {
-      try {
-        // Check if any other servers exist for this catalog
-        const remainingServers = await McpServerModel.findByCatalogId(
-          mcpServer.catalogId,
-        );
-
-        if (remainingServers.length === 0) {
-          // No more servers for this catalog, delete all tools
-          const deletedToolsCount = await ToolModel.deleteByCatalogId(
-            mcpServer.catalogId,
-          );
-          logger.info(
-            `Deleted ${deletedToolsCount} tools for catalog ${mcpServer.catalogId} (last installation removed)`,
-          );
-        }
-      } catch (error) {
-        logger.error(
-          { err: error },
-          `Failed to clean up tools for catalog ${mcpServer.catalogId}:`,
-        );
-        // Don't fail the deletion if tool cleanup fails
-      }
     }
 
     return deleted;

--- a/platform/backend/src/models/tool.test.ts
+++ b/platform/backend/src/models/tool.test.ts
@@ -966,6 +966,53 @@ describe("ToolModel", () => {
       expect(createdTools.map((t) => t.name)).toContain("tool-3");
     });
 
+    test("does not refresh shared schema from later installs when multiple installs exist", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+    }) => {
+      const catalog = await makeInternalMcpCatalog();
+      await makeMcpServer({ catalogId: catalog.id });
+      await makeMcpServer({ catalogId: catalog.id });
+
+      const [created] = await ToolModel.bulkCreateToolsIfNotExists([
+        {
+          name: "multi-install-shared-tool",
+          description: "First install schema",
+          parameters: {
+            type: "object",
+            properties: {
+              query: { type: "string" },
+            },
+          },
+          catalogId: catalog.id,
+        },
+      ]);
+
+      const [result] = await ToolModel.bulkCreateToolsIfNotExists([
+        {
+          name: "multi-install-shared-tool",
+          description: "Second install schema",
+          parameters: {
+            type: "object",
+            properties: {
+              query: { type: "string" },
+              limit: { type: "number" },
+            },
+          },
+          catalogId: catalog.id,
+        },
+      ]);
+
+      expect(result.id).toBe(created.id);
+      expect(result.description).toBe("First install schema");
+      expect(result.parameters).toEqual({
+        type: "object",
+        properties: {
+          query: { type: "string" },
+        },
+      });
+    });
+
     test("maintains input order in returned tools", async ({
       makeInternalMcpCatalog,
       makeMcpServer,

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -565,19 +565,30 @@ class ToolModel {
     const toolsToInsert: InsertTool[] = [];
     const resultTools: Tool[] = [];
 
-    // Collect meta-update promises so they run in parallel instead of N+1 sequential UPDATEs.
-    const metaUpdatePromises: Promise<Tool>[] = [];
+    // Refresh existing tool definitions while preserving IDs, assignments, and policies.
+    const existingToolUpdatePromises: Promise<Tool>[] = [];
 
     for (const tool of tools) {
       const existingTool = existingToolsByName.get(tool.name);
       if (existingTool) {
+        const descriptionChanged =
+          existingTool.description !== tool.description;
+        const parametersChanged =
+          JSON.stringify(existingTool.parameters) !==
+          JSON.stringify(tool.parameters);
         const metaChanged =
-          JSON.stringify(existingTool.meta) !== JSON.stringify(tool.meta);
-        if (metaChanged) {
-          metaUpdatePromises.push(
+          JSON.stringify(existingTool.meta ?? null) !==
+          JSON.stringify(tool.meta ?? null);
+        if (descriptionChanged || parametersChanged || metaChanged) {
+          existingToolUpdatePromises.push(
             db
               .update(schema.toolsTable)
-              .set({ meta: tool.meta ?? null, updatedAt: new Date() })
+              .set({
+                description: tool.description,
+                parameters: tool.parameters,
+                meta: tool.meta ?? null,
+                updatedAt: new Date(),
+              })
               .where(eq(schema.toolsTable.id, existingTool.id))
               .returning()
               .then(([updated]) => updated ?? existingTool),
@@ -597,8 +608,8 @@ class ToolModel {
       }
     }
 
-    if (metaUpdatePromises.length > 0) {
-      resultTools.push(...(await Promise.all(metaUpdatePromises)));
+    if (existingToolUpdatePromises.length > 0) {
+      resultTools.push(...(await Promise.all(existingToolUpdatePromises)));
     }
 
     // Bulk insert new tools if any

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -561,6 +561,13 @@ class ToolModel {
 
     const existingToolsByName = new Map(existingTools.map((t) => [t.name, t]));
 
+    const [{ activeInstallCount = 0 } = { activeInstallCount: 0 }] = await db
+      .select({ activeInstallCount: count() })
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.catalogId, catalogId));
+    // Tool schemas are catalog-scoped; avoid letting later installs thrash them.
+    const shouldRefreshSharedSchema = Number(activeInstallCount) <= 1;
+
     // Prepare tools to insert (only those that don't exist)
     const toolsToInsert: InsertTool[] = [];
     const resultTools: Tool[] = [];
@@ -572,10 +579,12 @@ class ToolModel {
       const existingTool = existingToolsByName.get(tool.name);
       if (existingTool) {
         const descriptionChanged =
+          shouldRefreshSharedSchema &&
           existingTool.description !== tool.description;
         const parametersChanged =
+          shouldRefreshSharedSchema &&
           JSON.stringify(existingTool.parameters) !==
-          JSON.stringify(tool.parameters);
+            JSON.stringify(tool.parameters);
         const metaChanged =
           JSON.stringify(existingTool.meta ?? null) !==
           JSON.stringify(tool.meta ?? null);
@@ -1151,19 +1160,6 @@ class ToolModel {
       .where(inArray(schema.toolsTable.catalogId, catalogIds));
 
     return tools.map((t) => t.id);
-  }
-
-  /**
-   * Delete all tools for a specific catalog item
-   * Used when the last MCP server installation for a catalog is removed
-   * Returns the number of tools deleted
-   */
-  static async deleteByCatalogId(catalogId: string): Promise<number> {
-    const result = await db
-      .delete(schema.toolsTable)
-      .where(eq(schema.toolsTable.catalogId, catalogId));
-
-    return result.rowCount || 0;
   }
 
   /**


### PR DESCRIPTION
Fixes #4433.

Deleting the last MCP server installation used to delete the catalog tools. Guardrail policies are attached to those tool rows, so recreating credentials started from fresh default policies.

This keeps catalog tools and existing agent-tool assignments when an installation is removed. The deleted installation reference falls back to null until credentials are recreated.

Tested:
- `env ARCHESTRA_DATABASE_URL=postgresql://test:test@localhost:5432/test corepack pnpm --config.engine-strict=false --dir backend exec vitest run src/models/mcp-server.test.ts`
- `corepack pnpm --config.engine-strict=false --dir backend exec tsgo --noEmit`
- `corepack pnpm --config.engine-strict=false exec biome check backend/src/models/mcp-server.ts backend/src/models/mcp-server.test.ts`