### PR TITLE
fix(guardrails): apply blocked Tool Result Policy when context starts untrusted (#4225)

### DIFF
--- a/platform/backend/src/guardrails/trusted-data.test.ts
+++ b/platform/backend/src/guardrails/trusted-data.test.ts
@@ -410,6 +410,187 @@ describe("trusted-data evaluation (provider-agnostic)", () => {
       });
     });
 
+    test(
+      "still applies blocked Tool Result Policy when context starts untrusted (regression: #4225)",
+      async () => {
+        // Same block policy used in the "block policy" test above.
+        await TrustedDataPolicyModel.create({
+          toolId,
+          conditions: [
+            { key: "emails[*].from", operator: "contains", value: "hacker" },
+          ],
+          action: "block_always",
+          description: "Block hacker emails",
+        });
+
+        const commonMessages: CommonMessage[] = [
+          { role: "user", content: "Get my emails" },
+          {
+            role: "tool",
+            toolCalls: [
+              {
+                id: "call_789",
+                name: "get_emails",
+                content: {
+                  emails: [
+                    { from: "hacker@evil.com", subject: "Malicious" },
+                  ],
+                },
+                isError: false,
+              },
+            ],
+          },
+          { role: "assistant" },
+        ];
+
+        const result = await evaluateIfContextIsTrusted(
+          commonMessages,
+          agentId,
+          organizationId,
+          undefined,
+          true, // considerContextUntrusted = true
+          "restrictive",
+          { teamIds: [] },
+        );
+
+        // Context starts untrusted, so it stays untrusted...
+        expect(result.contextIsTrusted).toBe(false);
+
+        // ...but the blocked tool result MUST still be replaced before reaching the model.
+        expect(result.toolResultUpdates).toEqual({
+          call_789:
+            "[Content blocked by policy: Data blocked by policy: Block hacker emails]",
+        });
+
+        // The first untrust point wins, which is the preexisting boundary set
+        // at the top of the function — not the tool_result boundary.
+        expect(result.unsafeContextBoundary).toEqual({
+          kind: "preexisting_untrusted",
+          reason: "agent_configured_untrusted",
+        });
+      },
+    );
+
+    test(
+      "mixed tool calls with considerContextUntrusted=true: blocked result is still replaced, preexisting boundary is preserved",
+      async () => {
+        await TrustedDataPolicyModel.create({
+          toolId,
+          conditions: [
+            { key: "source", operator: "equal", value: "malicious" },
+          ],
+          action: "block_always",
+          description: "Block malicious source",
+        });
+        await TrustedDataPolicyModel.create({
+          toolId,
+          conditions: [
+            { key: "source", operator: "equal", value: "trusted" },
+          ],
+          action: "mark_as_trusted",
+          description: "Allow trusted source",
+        });
+
+        const commonMessages: CommonMessage[] = [
+          { role: "user", content: "Summarize" },
+          {
+            role: "tool",
+            toolCalls: [
+              {
+                id: "call_trusted",
+                name: "get_emails",
+                content: { source: "trusted", data: "good" },
+                isError: false,
+              },
+              {
+                id: "call_blocked",
+                name: "get_emails",
+                content: { source: "malicious", data: "bad" },
+                isError: false,
+              },
+              {
+                id: "call_unknown",
+                name: "get_emails",
+                content: { source: "unknown", data: "?" },
+                isError: false,
+              },
+            ],
+          },
+        ];
+
+        const result = await evaluateIfContextIsTrusted(
+          commonMessages,
+          agentId,
+          organizationId,
+          undefined,
+          true, // considerContextUntrusted = true
+          "restrictive",
+          { teamIds: [] },
+        );
+
+        expect(result.contextIsTrusted).toBe(false);
+        // Only the blocked call gets replaced; trusted and unknown pass through unchanged.
+        expect(result.toolResultUpdates).toEqual({
+          call_blocked:
+            "[Content blocked by policy: Data blocked by policy: Block malicious source]",
+        });
+        // Boundary must remain preexisting — it was set before any tool was evaluated,
+        // so later tool-result boundaries (blocked/marked-untrusted) must NOT overwrite it.
+        expect(result.unsafeContextBoundary).toEqual({
+          kind: "preexisting_untrusted",
+          reason: "agent_configured_untrusted",
+        });
+      },
+    );
+
+    test(
+      "considerContextUntrusted=true with permissive global policy: block policies are skipped, no result is replaced",
+      async () => {
+        await TrustedDataPolicyModel.create({
+          toolId,
+          conditions: [
+            { key: "emails[*].from", operator: "contains", value: "hacker" },
+          ],
+          action: "block_always",
+          description: "Block hacker emails",
+        });
+
+        const result = await evaluateIfContextIsTrusted(
+          [
+            { role: "user", content: "Get my emails" },
+            {
+              role: "tool",
+              toolCalls: [
+                {
+                  id: "call_permissive",
+                  name: "get_emails",
+                  content: {
+                    emails: [{ from: "hacker@evil.com", subject: "hi" }],
+                  },
+                  isError: false,
+                },
+              ],
+            },
+          ],
+          agentId,
+          organizationId,
+          undefined,
+          true, // considerContextUntrusted = true
+          "permissive", // Permissive mode: block policies are not enforced.
+          { teamIds: [] },
+        );
+
+        // Context still marked untrusted (preexisting), but no result is replaced
+        // because permissive mode skips block enforcement.
+        expect(result.contextIsTrusted).toBe(false);
+        expect(result.toolResultUpdates).toEqual({});
+        expect(result.unsafeContextBoundary).toEqual({
+          kind: "preexisting_untrusted",
+          reason: "agent_configured_untrusted",
+        });
+      },
+    );
+
     test("handles multiple tool calls with mixed trust", async () => {
       // Create policies
       await TrustedDataPolicyModel.create({

--- a/platform/backend/src/guardrails/trusted-data.ts
+++ b/platform/backend/src/guardrails/trusted-data.ts
@@ -63,24 +63,21 @@ export async function evaluateIfContextIsTrusted(
   let usedDualLlm = false;
   let unsafeContextBoundary: UnsafeContextBoundary | undefined;
 
-  // If agent configured to consider context untrusted from the beginning,
-  // mark context as untrusted immediately and skip evaluation
+  // If the agent is configured to treat context as untrusted from the start,
+  // record that as the preexisting boundary up front — but DO NOT skip Tool
+  // Result Policy evaluation. Blocked policies must still replace raw results
+  // before they reach the model (see issue #4225).
   if (considerContextUntrusted) {
     logger.debug(
       { agentId },
-      "[trustedData] evaluateIfContextIsTrusted: context marked untrusted by agent config",
+      "[trustedData] evaluateIfContextIsTrusted: context marked untrusted by agent config; still evaluating tool result policies",
     );
-    return {
-      toolResultUpdates: {},
-      contextIsTrusted: false,
-      usedDualLlm: false,
-      dualLlmAnalyses: [],
-      unsafeContextBoundary: {
-        kind: "preexisting_untrusted",
-        reason:
-          initialUntrustedReason ??
-          UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
-      },
+    hasUntrustedData = true;
+    unsafeContextBoundary = {
+      kind: "preexisting_untrusted",
+      reason:
+        initialUntrustedReason ??
+        UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
     };
   }
 
@@ -111,12 +108,12 @@ export async function evaluateIfContextIsTrusted(
 
   if (allToolCalls.length === 0) {
     logger.debug(
-      { agentId },
-      "[trustedData] evaluateIfContextIsTrusted: no tool calls found, context is trusted",
+      { agentId, contextIsTrusted: !hasUntrustedData },
+      "[trustedData] evaluateIfContextIsTrusted: no tool calls found",
     );
     return {
       toolResultUpdates,
-      contextIsTrusted: true,
+      contextIsTrusted: !hasUntrustedData,
       usedDualLlm: false,
       dualLlmAnalyses: [],
       unsafeContextBoundary,


### PR DESCRIPTION
# PR: Fix blocked Tool Result Policy bypass when context starts untrusted

Closes #4225

## Problem

`evaluateIfContextIsTrusted` returned early when `considerContextUntrusted` was `true`, producing an empty `toolResultUpdates`. As a result, agents configured with **"Treat context as sensitive from the start of chat"** sent raw tool results to the model even when Tool Result Policies were set to `Blocked`.

The early-return short-circuited the policy evaluation loop, so:
- Blocked tool results were NOT replaced with the policy block message.
- `shouldSanitizeWithDualLlm` policies were skipped.
- Raw potentially-sensitive content reached the model.

## Fix

Replaced the early-return with an up-front bookkeeping step: set `hasUntrustedData = true` and record the `preexisting_untrusted` boundary, **then continue into the existing evaluation loop**. The loop now still processes blocked / sanitize policies and produces `toolResultUpdates` correctly.

The `allToolCalls.length === 0` short-circuit was also updated to use `!hasUntrustedData` instead of hard-coded `true`, so an agent that starts untrusted with no tool calls is still reported as untrusted.

## Files changed

- `platform/backend/src/guardrails/trusted-data.ts` — fix
- `platform/backend/src/guardrails/trusted-data.test.ts` — regression test

## New test

Added `"still applies blocked Tool Result Policy when context starts untrusted (regression: #4225)"` that:

1. Sets up a `block_always` policy on `get_emails`.
2. Calls `evaluateIfContextIsTrusted` with `considerContextUntrusted = true` AND a tool call with content that matches the block policy.
3. Asserts:
   - `contextIsTrusted === false` (preexisting boundary still wins)
   - `toolResultUpdates[call_789]` equals the policy block string (the bug case)
   - `unsafeContextBoundary` is `preexisting_untrusted` (first-untrust-wins ordering preserved)

## Verification

```bash
cd platform/backend
pnpm test -- trusted-data
pnpm type-check
pnpm lint
```

Manual repro from the issue:

1. Configure a tool like `read_issue`.
2. Set Tool Call Policy → allowed.
3. Set Tool Result Policy → `Blocked`.
4. Enable `Treat context as sensitive from the start of chat`.
5. Ask the agent to read an issue.

**Before:** raw result reaches model. **After:** `[Content blocked by policy: ...]` reaches model.

## Notes

- The behavior of `unsafeContextBoundary` deliberately keeps the `preexisting_untrusted` boundary as the first-untrust-point even when a blocked tool result is found later. This preserves the contract that the UI shows the *original* unsafe boundary.
- No public API surface changed; only the body of `evaluateIfContextIsTrusted` and one short-circuit return value.
- Algora bounty: `$80`

/claim #4225
