### PR TITLE
fix(model-router): hide models not linked to mapped API keys

### DIFF
--- a/platform/backend/src/routes/proxy/model-router-resolver.ts
+++ b/platform/backend/src/routes/proxy/model-router-resolver.ts
@@ -3,7 +3,7 @@ import {
   type SupportedProvider,
   SupportedProviders,
 } from "@shared";
-import { ModelModel } from "@/models";
+import { LlmProviderApiKeyModelLinkModel, ModelModel } from "@/models";
 import { ApiError, type Model } from "@/types";
 
 export type ModelRouterResolution = {
@@ -15,6 +15,7 @@ export type ModelRouterResolution = {
 export async function resolveModelRoute(params: {
   requestedModel: string;
   allowedProviders?: Set<SupportedProvider>;
+  allowedApiKeyIds?: string[];
 }): Promise<ModelRouterResolution> {
   const requestedModel = params.requestedModel.trim();
   if (!requestedModel) {
@@ -38,13 +39,20 @@ export async function resolveModelRoute(params: {
       provider: explicit.provider,
     });
 
-    if (providerMatches.length === 1) {
-      return toResolution(providerMatches[0], requestedModel);
+    const accessibleMatches = params.allowedApiKeyIds
+      ? await filterModelsByLinkedApiKeys(
+          providerMatches,
+          params.allowedApiKeyIds,
+        )
+      : providerMatches;
+
+    if (accessibleMatches.length === 1) {
+      return toResolution(accessibleMatches[0], requestedModel);
     }
-    if (providerMatches.length > 1) {
+    if (accessibleMatches.length > 1) {
       throw new ApiError(
         500,
-        `Ambiguous model resolution: "${requestedModel}" matched ${providerMatches.length} models.`,
+        `Ambiguous model resolution: "${requestedModel}" matched ${accessibleMatches.length} models.`,
       );
     }
   }
@@ -92,6 +100,19 @@ function toResolution(
 function providerSortIndex(provider: SupportedProvider): number {
   const index = SupportedProviders.indexOf(provider);
   return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+}
+
+async function filterModelsByLinkedApiKeys(
+  models: Model[],
+  apiKeyIds: string[],
+): Promise<Model[]> {
+  if (models.length === 0 || apiKeyIds.length === 0) {
+    return [];
+  }
+  const linked =
+    await LlmProviderApiKeyModelLinkModel.getModelsForApiKeyIds(apiKeyIds);
+  const linkedIds = new Set(linked.map(({ model }) => model.id));
+  return models.filter((model) => linkedIds.has(model.id));
 }
 
 export function sortRoutableModels(models: Model[]): Model[] {

--- a/platform/backend/src/routes/proxy/routes/model-router.test.ts
+++ b/platform/backend/src/routes/proxy/routes/model-router.test.ts
@@ -17,6 +17,7 @@ import {
   InteractionModel,
   LlmOauthClientModel,
   LlmProviderApiKeyModel,
+  LlmProviderApiKeyModelLinkModel,
   ModelModel,
   OAuthAccessTokenModel,
   OAuthClientModel,
@@ -126,6 +127,7 @@ async function createModelRouterVirtualKey(params: {
       provider: params.provider,
     },
   );
+  await linkAllProviderModelsToApiKey(params.provider, chatApiKey.id);
   return VirtualApiKeyModel.create({
     name: `${params.provider} model router virtual key`,
     expiresAt: params.expiresAt,
@@ -136,6 +138,17 @@ async function createModelRouterVirtualKey(params: {
       },
     ],
   });
+}
+
+async function linkAllProviderModelsToApiKey(
+  provider: SupportedProvider,
+  apiKeyId: string,
+) {
+  const models = await ModelModel.findAll({ provider });
+  await LlmProviderApiKeyModelLinkModel.linkModelsToApiKey(
+    apiKeyId,
+    models.map((m) => m.id),
+  );
 }
 
 const ROUTABLE_PROVIDER_CASES: Array<{
@@ -628,6 +641,7 @@ describe("model router proxy routes", () => {
     const chatApiKey = await makeLlmProviderApiKey(organization.id, secret.id, {
       provider,
     });
+    await linkAllProviderModelsToApiKey(provider, chatApiKey.id);
     const agent = await makeAgent({
       organizationId: organization.id,
       name: "OAuth Client Model Router Agent",
@@ -836,7 +850,7 @@ describe("model router proxy routes", () => {
     const olderSecret = await makeSecret({
       secret: { apiKey: "sk-older-openai" },
     });
-    await LlmProviderApiKeyModel.create({
+    const olderKey = await LlmProviderApiKeyModel.create({
       organizationId: organization.id,
       secretId: olderSecret.id,
       name: "Older User OpenAI Key",
@@ -846,10 +860,11 @@ describe("model router proxy routes", () => {
       teamId: null,
       isPrimary: false,
     });
+    await linkAllProviderModelsToApiKey(provider, olderKey.id);
     const primarySecret = await makeSecret({
       secret: { apiKey: "sk-primary-openai" },
     });
-    await LlmProviderApiKeyModel.create({
+    const primaryKey = await LlmProviderApiKeyModel.create({
       organizationId: organization.id,
       secretId: primarySecret.id,
       name: "Primary User OpenAI Key",
@@ -859,6 +874,7 @@ describe("model router proxy routes", () => {
       teamId: null,
       isPrimary: true,
     });
+    await linkAllProviderModelsToApiKey(provider, primaryKey.id);
     const agent = await makeAgent({
       organizationId: organization.id,
       name: "User OAuth Model Router Agent",
@@ -1010,6 +1026,7 @@ describe("model router proxy routes", () => {
     const chatApiKey = await makeLlmProviderApiKey(organization.id, secret.id, {
       provider: "openai",
     });
+    await linkAllProviderModelsToApiKey("openai", chatApiKey.id);
     const { value } = await VirtualApiKeyModel.create({
       providerApiKeys: [
         { provider: chatApiKey.provider, providerApiKeyId: chatApiKey.id },
@@ -1120,6 +1137,7 @@ describe("model router proxy routes", () => {
     const chatApiKey = await makeLlmProviderApiKey(organization.id, secret.id, {
       provider: "openai",
     });
+    await linkAllProviderModelsToApiKey("openai", chatApiKey.id);
     const {
       virtualKey: { id: virtualKeyId },
       value,
@@ -1190,6 +1208,7 @@ describe("model router proxy routes", () => {
       name: "Vertex AI",
       provider: "gemini",
     });
+    await linkAllProviderModelsToApiKey("gemini", systemKey.id);
     const { value } = await VirtualApiKeyModel.create({
       name: "model-router-gemini-system-vk",
       providerApiKeys: [{ provider: "gemini", providerApiKeyId: systemKey.id }],
@@ -1336,6 +1355,8 @@ describe("model router proxy routes", () => {
       groqSecret.id,
       { provider: "groq" },
     );
+    await linkAllProviderModelsToApiKey("openai", openaiKey.id);
+    await linkAllProviderModelsToApiKey("groq", groqKey.id);
     const { value } = await VirtualApiKeyModel.create({
       name: "model-router-openai-groq-vk",
       providerApiKeys: [
@@ -1509,6 +1530,8 @@ describe("model router proxy routes", () => {
       groqSecret.id,
       { provider: "groq" },
     );
+    await linkAllProviderModelsToApiKey("openai", openaiKey.id);
+    await linkAllProviderModelsToApiKey("groq", groqKey.id);
     const { value } = await VirtualApiKeyModel.create({
       name: "model-router-multi-vk",
       providerApiKeys: [
@@ -1676,5 +1699,62 @@ describe("model router proxy routes", () => {
 
     expect(response.statusCode).toBe(400);
     expect(response.json().error.message).toContain("not mapped");
+  });
+
+  test("excludes models that exist for the mapped provider but are not linked to the virtual key's chat api key", async ({
+    makeAgent,
+    makeOrganization,
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    const app = createFastifyApp();
+    await app.register(modelRouterProxyRoutes);
+    await upsertModel({ provider: "groq", modelId: "llama-3.1-8b-instant" });
+    await upsertModel({ provider: "groq", modelId: "unlinked-model" });
+    const organization = await makeOrganization();
+    const { value } = await createModelRouterVirtualKey({
+      organizationId: organization.id,
+      provider: "groq",
+      makeSecret,
+      makeLlmProviderApiKey,
+    });
+    // Add a second model AFTER the virtual key so it's not linked
+    await upsertModel({ provider: "groq", modelId: "added-after-link" });
+    const agent = await makeAgent({
+      organizationId: organization.id,
+      name: "Unlinked Model Test Agent",
+      agentType: "llm_proxy",
+    });
+
+    const listResponse = await app.inject({
+      method: "GET",
+      url: `/v1/model-router/${agent.id}/models`,
+      headers: {
+        authorization: `Bearer ${value}`,
+      },
+    });
+
+    expect(listResponse.statusCode).toBe(200);
+    const listedIds = listResponse.json().data.map((m: { id: string }) => m.id);
+    expect(listedIds).toContain("groq:llama-3.1-8b-instant");
+    expect(listedIds).toContain("groq:unlinked-model");
+    expect(listedIds).not.toContain("groq:added-after-link");
+
+    const routeResponse = await app.inject({
+      method: "POST",
+      url: `/v1/model-router/${agent.id}/chat/completions`,
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${value}`,
+        "user-agent": "test-client",
+      },
+      payload: {
+        model: "groq:added-after-link",
+        messages: [{ role: "user", content: "Hello" }],
+      },
+    });
+
+    expect(routeResponse.statusCode).toBe(404);
+    expect(routeResponse.json().error.message).toContain("not available");
   });
 });

--- a/platform/backend/src/routes/proxy/routes/model-router.ts
+++ b/platform/backend/src/routes/proxy/routes/model-router.ts
@@ -13,6 +13,7 @@ import {
   AgentTeamModel,
   LlmOauthClientModel,
   LlmProviderApiKeyModel,
+  LlmProviderApiKeyModelLinkModel,
   MemberModel,
   ModelModel,
   OAuthAccessTokenModel,
@@ -242,11 +243,7 @@ const modelRouterProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
       const auth = await getModelRouterAuth(request);
       const agent = await getDefaultModelRouterAgent();
       await ensureModelRouterAgentAccess({ agent, auth });
-      return reply.send(
-        await listModels({
-          providers: getMappedProviders(auth),
-        }),
-      );
+      return reply.send(await listModels({ auth }));
     },
   );
 
@@ -268,11 +265,7 @@ const modelRouterProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
       const auth = await getModelRouterAuth(request);
       const agent = await getModelRouterAgent(request.params.agentId);
       await ensureModelRouterAgentAccess({ agent, auth });
-      return reply.send(
-        await listModels({
-          providers: getMappedProviders(auth),
-        }),
-      );
+      return reply.send(await listModels({ auth }));
     },
   );
 
@@ -379,6 +372,7 @@ async function routeChatCompletion(
   const resolution = await resolveModelRoute({
     requestedModel: body.model,
     allowedProviders: getMappedProviders(auth),
+    allowedApiKeyIds: getMappedApiKeyIds(auth),
   });
   const routedBody = {
     ...body,
@@ -419,6 +413,7 @@ async function routeResponse(request: FastifyRequest, reply: FastifyReply) {
   const resolution = await resolveModelRoute({
     requestedModel: chatBody.model,
     allowedProviders: getMappedProviders(auth),
+    allowedApiKeyIds: getMappedApiKeyIds(auth),
   });
   const routedChatBody = {
     ...chatBody,
@@ -571,21 +566,24 @@ function handleModelRouterResponsesProvider(
   }
 }
 
-async function listModels(params: { providers: Set<SupportedProvider> }) {
-  const providers = [...params.providers].filter((provider) =>
-    modelRouterSupportedProviders.has(provider),
-  );
-  const allModels = await ModelModel.findAll({ providers });
+async function listModels(params: { auth: ModelRouterAuth }) {
+  const apiKeyIds = [...params.auth.providerApiKeysByProvider.values()]
+    .filter((mapping) => modelRouterSupportedProviders.has(mapping.provider))
+    .map((mapping) => mapping.providerApiKeyId);
+  const linkedModels =
+    await LlmProviderApiKeyModelLinkModel.getModelsForApiKeyIds(apiKeyIds);
   const chatModels = sortRoutableModels(
-    allModels.filter((model) => {
-      if (!ModelModel.supportsTextChat(model)) {
-        return false;
-      }
-      if (!modelRouterSupportedProviders.has(model.provider)) {
-        return false;
-      }
-      return true;
-    }),
+    linkedModels
+      .map(({ model }) => model)
+      .filter((model) => {
+        if (!ModelModel.supportsTextChat(model)) {
+          return false;
+        }
+        if (!modelRouterSupportedProviders.has(model.provider)) {
+          return false;
+        }
+        return true;
+      }),
   );
 
   return {
@@ -704,6 +702,12 @@ async function getModelRouterAuth(
 
 function getMappedProviders(auth: ModelRouterAuth): Set<SupportedProvider> {
   return new Set(auth.providerApiKeysByProvider.keys());
+}
+
+function getMappedApiKeyIds(auth: ModelRouterAuth): string[] {
+  return [...auth.providerApiKeysByProvider.values()].map(
+    (mapping) => mapping.providerApiKeyId,
+  );
 }
 
 function isTranslatedModelRouterProvider(


### PR DESCRIPTION
The model router exposed every DB model for the mapped providers, including ones operators hid via Settings -> Models. Mirror the UI's /api/llm-models/available scoping by restricting both the /models listing and route resolution to models linked to the virtual key's chat API keys.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>