### PR TITLE
chore: reduce frontend request churn

### DIFF
--- a/platform/frontend/src/app/_parts/posthog-provider.test.tsx
+++ b/platform/frontend/src/app/_parts/posthog-provider.test.tsx
@@ -1,6 +1,6 @@
 import { render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { authClient } from "@/lib/clients/auth/auth-client";
+import { useSession } from "@/lib/auth/auth.query";
 import { usePublicConfig } from "@/lib/config/config.query";
 import { PostHogProviderWrapper } from "./posthog-provider";
 
@@ -27,10 +27,8 @@ vi.mock("posthog-js/react", () => ({
   }) => <>{children}</>,
 }));
 
-vi.mock("@/lib/clients/auth/auth-client", () => ({
-  authClient: {
-    useSession: vi.fn(),
-  },
+vi.mock("@/lib/auth/auth.query", () => ({
+  useSession: vi.fn(),
 }));
 
 vi.mock("@/lib/config/config.query", () => ({
@@ -62,7 +60,7 @@ describe("PostHogProviderWrapper", () => {
       isRefetching: false,
       error: null,
       refetch: vi.fn(),
-    }) as unknown as ReturnType<typeof authClient.useSession>;
+    }) as unknown as ReturnType<typeof useSession>;
 
   const makePublicConfigResult = ({
     enabled,
@@ -93,7 +91,7 @@ describe("PostHogProviderWrapper", () => {
     }) as unknown as ReturnType<typeof usePublicConfig>;
 
   it("initializes PostHog and identifies the authenticated user", async () => {
-    vi.mocked(authClient.useSession).mockReturnValue(
+    vi.mocked(useSession).mockReturnValue(
       makeSessionResult({
         data: {
           user: {
@@ -138,7 +136,7 @@ describe("PostHogProviderWrapper", () => {
       session: { id: "session-123" },
     };
 
-    vi.mocked(authClient.useSession).mockImplementation(() =>
+    vi.mocked(useSession).mockImplementation(() =>
       makeSessionResult({ data: sessionData }),
     );
 
@@ -182,7 +180,7 @@ describe("PostHogProviderWrapper", () => {
       session: { id: "session-123" },
     };
 
-    vi.mocked(authClient.useSession).mockImplementation(() =>
+    vi.mocked(useSession).mockImplementation(() =>
       makeSessionResult({ data: sessionData }),
     );
 
@@ -224,7 +222,7 @@ describe("PostHogProviderWrapper", () => {
   });
 
   it("uses the email as the fallback name when the user has no display name", async () => {
-    vi.mocked(authClient.useSession).mockReturnValue(
+    vi.mocked(useSession).mockReturnValue(
       makeSessionResult({
         data: {
           user: {
@@ -261,7 +259,7 @@ describe("PostHogProviderWrapper", () => {
       session: { id: "session-123" },
     };
 
-    vi.mocked(authClient.useSession).mockImplementation(() =>
+    vi.mocked(useSession).mockImplementation(() =>
       makeSessionResult({ data: sessionData }),
     );
 
@@ -297,7 +295,7 @@ describe("PostHogProviderWrapper", () => {
       }),
     );
 
-    vi.mocked(authClient.useSession).mockReturnValue(
+    vi.mocked(useSession).mockReturnValue(
       makeSessionResult({
         data: {
           user: {
@@ -332,7 +330,7 @@ describe("PostHogProviderWrapper", () => {
       }),
     );
 
-    vi.mocked(authClient.useSession).mockReturnValue(
+    vi.mocked(useSession).mockReturnValue(
       makeSessionResult({
         data: {
           user: {
@@ -359,7 +357,7 @@ describe("PostHogProviderWrapper", () => {
   });
 
   it("does not reset PostHog while the auth session is still loading", async () => {
-    vi.mocked(authClient.useSession).mockReturnValue(
+    vi.mocked(useSession).mockReturnValue(
       makeSessionResult({
         data: null,
         isPending: true,

--- a/platform/frontend/src/app/_parts/posthog-provider.tsx
+++ b/platform/frontend/src/app/_parts/posthog-provider.tsx
@@ -3,7 +3,7 @@
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
 import { useEffect, useRef } from "react";
-import { authClient } from "@/lib/clients/auth/auth-client";
+import { useSession } from "@/lib/auth/auth.query";
 import config from "@/lib/config/config";
 import { usePublicConfig } from "@/lib/config/config.query";
 
@@ -12,8 +12,7 @@ export function PostHogProviderWrapper({
 }: {
   children: React.ReactNode;
 }) {
-  const { data: session, isPending: isSessionPending } =
-    authClient.useSession();
+  const { data: session, isPending: isSessionPending } = useSession();
   const { data: publicConfig, isLoading: isPublicConfigLoading } =
     usePublicConfig();
   const hasIdentifiedUserRef = useRef(false);

--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -226,7 +226,6 @@ const NavPrimary = ({
   chatSection?: React.ReactNode;
 }) => {
   const { isMobile, setOpenMobile } = useSidebar();
-  const router = useRouter();
 
   const renderItem = (item: NavItem) => (
     <SidebarMenuItem key={item.title}>
@@ -238,17 +237,16 @@ const NavPrimary = ({
           pathname.startsWith(item.url)
         }
       >
-        <Link
+        <SidebarPrefetchLink
           href={item.url}
           data-testid={item.testId}
-          {...getManualPrefetchProps(router, item.url)}
           onClick={() => {
             if (isMobile) setOpenMobile(false);
           }}
         >
           <item.icon className={item.iconClassName} />
           <span>{item.title}</span>
-        </Link>
+        </SidebarPrefetchLink>
       </SidebarMenuButton>
       {item.title === "New Chat" && chatSection}
       {item.subItems && item.subItems.length > 0 && (
@@ -264,16 +262,15 @@ const NavPrimary = ({
                     pathname.startsWith(sub.url)
                   }
                 >
-                  <Link
+                  <SidebarPrefetchLink
                     href={sub.url}
                     data-testid={sub.testId}
-                    {...getManualPrefetchProps(router, sub.url)}
                     onClick={() => {
                       if (isMobile) setOpenMobile(false);
                     }}
                   >
                     <span>{sub.title}</span>
-                  </Link>
+                  </SidebarPrefetchLink>
                 </SidebarMenuSubButton>
               </SidebarMenuSubItem>
             ))}
@@ -322,7 +319,6 @@ const NavSecondary = ({
   starCount: string;
   className?: string;
 }) => {
-  const router = useRouter();
   const permittedItems = items.filter(
     (item) => permissionMap[item.url] ?? true,
   );
@@ -341,13 +337,10 @@ const NavSecondary = ({
                   pathname.startsWith(item.url)
                 }
               >
-                <Link
-                  href={item.url}
-                  {...getManualPrefetchProps(router, item.url)}
-                >
+                <SidebarPrefetchLink href={item.url}>
                   <item.icon className={item.iconClassName} />
                   <span>{item.title}</span>
-                </Link>
+                </SidebarPrefetchLink>
               </SidebarMenuButton>
             </SidebarMenuItem>
           ))}
@@ -416,7 +409,6 @@ const NavSecondary = ({
 };
 
 export function AppSidebar() {
-  const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const isAuthenticated = useIsAuthenticated();
@@ -467,22 +459,17 @@ export function AppSidebar() {
     <Sidebar collapsible="icon">
       <SidebarHeader className="pt-4 group-data-[collapsible=icon]:pt-2 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:gap-1">
         <div className="flex items-center justify-between group-data-[collapsible=icon]:hidden">
-          <Link
-            href="/chat"
-            className="flex-1 min-w-0"
-            {...getManualPrefetchProps(router, "/chat")}
-          >
+          <SidebarPrefetchLink href="/chat" className="flex-1 min-w-0">
             <AppLogo centered={false} />
-          </Link>
+          </SidebarPrefetchLink>
           <SidebarTrigger className="size-7 cursor-pointer" />
         </div>
-        <Link
+        <SidebarPrefetchLink
           href="/chat"
           className="hidden group-data-[collapsible=icon]:flex"
-          {...getManualPrefetchProps(router, "/chat")}
         >
           <img src={appIconLogo} alt="Logo" className="size-7" />
-        </Link>
+        </SidebarPrefetchLink>
         <SidebarTrigger className="hidden group-data-[collapsible=icon]:flex size-8 cursor-pointer" />
       </SidebarHeader>
       <SidebarContent>
@@ -552,13 +539,27 @@ export function AppSidebar() {
   );
 }
 
-function getManualPrefetchProps(
-  router: ReturnType<typeof useRouter>,
-  href: string,
-) {
-  return {
-    prefetch: false,
-    onFocus: () => router.prefetch(href),
-    onMouseEnter: () => router.prefetch(href),
-  } as const;
+function SidebarPrefetchLink({
+  href,
+  onFocus,
+  onMouseEnter,
+  ...props
+}: React.ComponentProps<typeof Link>) {
+  const router = useRouter();
+
+  return (
+    <Link
+      href={href}
+      prefetch={false}
+      onFocus={(event) => {
+        router.prefetch(String(href));
+        onFocus?.(event);
+      }}
+      onMouseEnter={(event) => {
+        router.prefetch(String(href));
+        onMouseEnter?.(event);
+      }}
+      {...props}
+    />
+  );
 }

--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -539,6 +539,12 @@ export function AppSidebar() {
   );
 }
 
+/**
+ * Sidebar links opt out of Next.js viewport prefetch to avoid fetching every
+ * visible sidebar route's RSC payload when the app shell mounts. Hover/focus
+ * prefetch keeps intentional navigation fast without competing with initial
+ * page API requests.
+ */
 function SidebarPrefetchLink({
   href,
   onFocus,

--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -25,7 +25,7 @@ import {
   Star,
 } from "lucide-react";
 import Link from "next/link";
-import { usePathname, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import React from "react";
 import { ChatSidebarSection } from "@/app/_parts/chat-sidebar-section";
 import { AppLogo } from "@/components/app-logo";
@@ -226,6 +226,7 @@ const NavPrimary = ({
   chatSection?: React.ReactNode;
 }) => {
   const { isMobile, setOpenMobile } = useSidebar();
+  const router = useRouter();
 
   const renderItem = (item: NavItem) => (
     <SidebarMenuItem key={item.title}>
@@ -240,6 +241,7 @@ const NavPrimary = ({
         <Link
           href={item.url}
           data-testid={item.testId}
+          {...getManualPrefetchProps(router, item.url)}
           onClick={() => {
             if (isMobile) setOpenMobile(false);
           }}
@@ -265,6 +267,7 @@ const NavPrimary = ({
                   <Link
                     href={sub.url}
                     data-testid={sub.testId}
+                    {...getManualPrefetchProps(router, sub.url)}
                     onClick={() => {
                       if (isMobile) setOpenMobile(false);
                     }}
@@ -319,6 +322,7 @@ const NavSecondary = ({
   starCount: string;
   className?: string;
 }) => {
+  const router = useRouter();
   const permittedItems = items.filter(
     (item) => permissionMap[item.url] ?? true,
   );
@@ -337,7 +341,10 @@ const NavSecondary = ({
                   pathname.startsWith(item.url)
                 }
               >
-                <Link href={item.url}>
+                <Link
+                  href={item.url}
+                  {...getManualPrefetchProps(router, item.url)}
+                >
                   <item.icon className={item.iconClassName} />
                   <span>{item.title}</span>
                 </Link>
@@ -409,6 +416,7 @@ const NavSecondary = ({
 };
 
 export function AppSidebar() {
+  const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const isAuthenticated = useIsAuthenticated();
@@ -459,7 +467,11 @@ export function AppSidebar() {
     <Sidebar collapsible="icon">
       <SidebarHeader className="pt-4 group-data-[collapsible=icon]:pt-2 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:gap-1">
         <div className="flex items-center justify-between group-data-[collapsible=icon]:hidden">
-          <Link href="/chat" className="flex-1 min-w-0">
+          <Link
+            href="/chat"
+            className="flex-1 min-w-0"
+            {...getManualPrefetchProps(router, "/chat")}
+          >
             <AppLogo centered={false} />
           </Link>
           <SidebarTrigger className="size-7 cursor-pointer" />
@@ -467,6 +479,7 @@ export function AppSidebar() {
         <Link
           href="/chat"
           className="hidden group-data-[collapsible=icon]:flex"
+          {...getManualPrefetchProps(router, "/chat")}
         >
           <img src={appIconLogo} alt="Logo" className="size-7" />
         </Link>
@@ -537,4 +550,15 @@ export function AppSidebar() {
       </SidebarFooter>
     </Sidebar>
   );
+}
+
+function getManualPrefetchProps(
+  router: ReturnType<typeof useRouter>,
+  href: string,
+) {
+  return {
+    prefetch: false,
+    onFocus: () => router.prefetch(href),
+    onMouseEnter: () => router.prefetch(href),
+  } as const;
 }

--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -558,14 +558,35 @@ function SidebarPrefetchLink({
       href={href}
       prefetch={false}
       onFocus={(event) => {
-        router.prefetch(String(href));
+        const prefetchHref = getPrefetchHref(href);
+        if (prefetchHref) router.prefetch(prefetchHref);
         onFocus?.(event);
       }}
       onMouseEnter={(event) => {
-        router.prefetch(String(href));
+        const prefetchHref = getPrefetchHref(href);
+        if (prefetchHref) router.prefetch(prefetchHref);
         onMouseEnter?.(event);
       }}
       {...props}
     />
   );
+}
+
+function getPrefetchHref(href: React.ComponentProps<typeof Link>["href"]) {
+  if (typeof href === "string") return href;
+  if (!href.pathname) return null;
+
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(href.query ?? {})) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item != null) searchParams.append(key, String(item));
+      }
+      continue;
+    }
+    if (value != null) searchParams.set(key, String(value));
+  }
+
+  const query = searchParams.toString();
+  return `${href.pathname}${query ? `?${query}` : ""}${href.hash ?? ""}`;
 }

--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -572,6 +572,11 @@ function SidebarPrefetchLink({
   );
 }
 
+/**
+ * Converts a Next.js Link href into the string URL required by router.prefetch.
+ * Sidebar links currently pass strings, but this keeps manual prefetch safe if
+ * a future item uses a UrlObject with query or hash fields.
+ */
 function getPrefetchHref(href: React.ComponentProps<typeof Link>["href"]) {
   if (typeof href === "string") return href;
   if (!href.pathname) return null;

--- a/platform/frontend/src/app/_parts/with-auth-check.test.tsx
+++ b/platform/frontend/src/app/_parts/with-auth-check.test.tsx
@@ -2,8 +2,7 @@ import * as Sentry from "@sentry/nextjs";
 import { render, screen } from "@testing-library/react";
 import { usePathname, useRouter } from "next/navigation";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useHasPermissions } from "@/lib/auth/auth.query";
-import { authClient } from "@/lib/clients/auth/auth-client";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { WithAuthCheck } from "./with-auth-check";
 
 // Mock Sentry
@@ -17,16 +16,10 @@ vi.mock("next/navigation", () => ({
   usePathname: vi.fn(),
 }));
 
-// Mock auth client
-vi.mock("@/lib/clients/auth/auth-client", () => ({
-  authClient: {
-    useSession: vi.fn(),
-  },
-}));
-
 // Mock auth query
 vi.mock("@/lib/auth/auth.query", () => ({
   useHasPermissions: vi.fn(),
+  useSession: vi.fn(),
 }));
 
 // Mock shared module
@@ -71,10 +64,10 @@ describe("WithAuthCheck", () => {
 
   describe("when user is not authenticated", () => {
     beforeEach(() => {
-      vi.mocked(authClient.useSession).mockReturnValue({
+      vi.mocked(useSession).mockReturnValue({
         data: null,
         isPending: false,
-      } as ReturnType<typeof authClient.useSession>);
+      } as unknown as ReturnType<typeof useSession>);
     });
 
     it("should redirect to sign-in with redirectTo param when accessing protected page", () => {
@@ -178,13 +171,13 @@ describe("WithAuthCheck", () => {
 
   describe("when user is authenticated", () => {
     beforeEach(() => {
-      vi.mocked(authClient.useSession).mockReturnValue({
+      vi.mocked(useSession).mockReturnValue({
         data: {
           user: { id: "user123", email: "test@example.com" },
           session: { id: "session123" },
         },
         isPending: false,
-      } as ReturnType<typeof authClient.useSession>);
+      } as unknown as ReturnType<typeof useSession>);
     });
 
     it("should redirect to home when accessing auth pages without redirectTo", () => {
@@ -288,10 +281,10 @@ describe("WithAuthCheck", () => {
 
   describe("when auth check is pending", () => {
     beforeEach(() => {
-      vi.mocked(authClient.useSession).mockReturnValue({
+      vi.mocked(useSession).mockReturnValue({
         data: null,
         isPending: true,
-      } as ReturnType<typeof authClient.useSession>);
+      } as unknown as ReturnType<typeof useSession>);
     });
 
     it("should render nothing while checking auth", () => {
@@ -310,10 +303,10 @@ describe("WithAuthCheck", () => {
 
   describe("special auth pages (/auth/two-factor)", () => {
     it("should allow access to /auth/two-factor when not authenticated (2FA verification during login)", () => {
-      vi.mocked(authClient.useSession).mockReturnValue({
+      vi.mocked(useSession).mockReturnValue({
         data: null,
         isPending: false,
-      } as ReturnType<typeof authClient.useSession>);
+      } as unknown as ReturnType<typeof useSession>);
       vi.mocked(usePathname).mockReturnValue("/auth/two-factor");
 
       render(
@@ -327,13 +320,13 @@ describe("WithAuthCheck", () => {
     });
 
     it("should allow access to /auth/two-factor when authenticated (2FA setup)", () => {
-      vi.mocked(authClient.useSession).mockReturnValue({
+      vi.mocked(useSession).mockReturnValue({
         data: {
           user: { id: "user123", email: "test@example.com" },
           session: { id: "session123" },
         },
         isPending: false,
-      } as ReturnType<typeof authClient.useSession>);
+      } as unknown as ReturnType<typeof useSession>);
       vi.mocked(usePathname).mockReturnValue("/auth/two-factor");
 
       render(
@@ -347,10 +340,10 @@ describe("WithAuthCheck", () => {
     });
 
     it("should allow access to /auth/two-factor sub-paths", () => {
-      vi.mocked(authClient.useSession).mockReturnValue({
+      vi.mocked(useSession).mockReturnValue({
         data: null,
         isPending: false,
-      } as ReturnType<typeof authClient.useSession>);
+      } as unknown as ReturnType<typeof useSession>);
       vi.mocked(usePathname).mockReturnValue("/auth/two-factor/setup");
 
       render(
@@ -372,13 +365,13 @@ describe("WithAuthCheck", () => {
         name: "Test User",
       };
 
-      vi.mocked(authClient.useSession).mockReturnValue({
+      vi.mocked(useSession).mockReturnValue({
         data: {
           user: mockUser,
           session: { id: "session123" },
         },
         isPending: false,
-      } as ReturnType<typeof authClient.useSession>);
+      } as unknown as ReturnType<typeof useSession>);
 
       vi.mocked(usePathname).mockReturnValue("/dashboard");
 
@@ -401,13 +394,13 @@ describe("WithAuthCheck", () => {
         email: "another@example.com",
       };
 
-      vi.mocked(authClient.useSession).mockReturnValue({
+      vi.mocked(useSession).mockReturnValue({
         data: {
           user: mockUser,
           session: { id: "session456" },
         },
         isPending: false,
-      } as ReturnType<typeof authClient.useSession>);
+      } as unknown as ReturnType<typeof useSession>);
 
       vi.mocked(usePathname).mockReturnValue("/dashboard");
 
@@ -425,10 +418,10 @@ describe("WithAuthCheck", () => {
     });
 
     it("should clear Sentry user context when user is not authenticated", () => {
-      vi.mocked(authClient.useSession).mockReturnValue({
+      vi.mocked(useSession).mockReturnValue({
         data: null,
         isPending: false,
-      } as ReturnType<typeof authClient.useSession>);
+      } as unknown as ReturnType<typeof useSession>);
 
       vi.mocked(usePathname).mockReturnValue("/auth/sign-in");
 
@@ -446,13 +439,13 @@ describe("WithAuthCheck", () => {
         throw new Error("Sentry error");
       });
 
-      vi.mocked(authClient.useSession).mockReturnValue({
+      vi.mocked(useSession).mockReturnValue({
         data: {
           user: { id: "user789", email: "error@example.com" },
           session: { id: "session789" },
         },
         isPending: false,
-      } as ReturnType<typeof authClient.useSession>);
+      } as unknown as ReturnType<typeof useSession>);
 
       vi.mocked(usePathname).mockReturnValue("/dashboard");
 

--- a/platform/frontend/src/app/_parts/with-auth-check.tsx
+++ b/platform/frontend/src/app/_parts/with-auth-check.tsx
@@ -5,7 +5,7 @@ import { usePathname, useRouter } from "next/navigation";
 import type React from "react";
 import { useEffect, useState } from "react";
 import { isDefaultPasswordChangePending } from "@/lib/auth/default-password-change";
-import { authClient } from "@/lib/clients/auth/auth-client";
+import { useSession } from "@/lib/auth/auth.query";
 import { getValidatedRedirectPath } from "@/lib/utils/redirect-validation";
 
 type SentryUser = Parameters<typeof Sentry.setUser>[0];
@@ -59,7 +59,7 @@ export const WithAuthCheck: React.FC<React.PropsWithChildren> = ({
     data: session,
     isPending: isAuthPending,
     isRefetching: isAuthRefetching,
-  } = authClient.useSession();
+  } = useSession();
 
   const isLoggedIn = session?.user;
   const isAuthPage = pathCorrespondsToAnAuthPage(pathname);

--- a/platform/frontend/src/app/_parts/with-auth-check.tsx
+++ b/platform/frontend/src/app/_parts/with-auth-check.tsx
@@ -4,8 +4,8 @@ import * as Sentry from "@sentry/nextjs";
 import { usePathname, useRouter } from "next/navigation";
 import type React from "react";
 import { useEffect, useState } from "react";
-import { isDefaultPasswordChangePending } from "@/lib/auth/default-password-change";
 import { useSession } from "@/lib/auth/auth.query";
+import { isDefaultPasswordChangePending } from "@/lib/auth/default-password-change";
 import { getValidatedRedirectPath } from "@/lib/utils/redirect-validation";
 
 type SentryUser = Parameters<typeof Sentry.setUser>[0];

--- a/platform/frontend/src/app/agents/page.client.tsx
+++ b/platform/frontend/src/app/agents/page.client.tsx
@@ -44,8 +44,7 @@ import {
   useProfiles,
   useProfilesPaginated,
 } from "@/lib/agent.query";
-import { useHasPermissions } from "@/lib/auth/auth.query";
-import { authClient } from "@/lib/clients/auth/auth-client";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useAppName } from "@/lib/hooks/use-app-name";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
 import { AgentActions } from "./agent-actions";
@@ -173,7 +172,7 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
   const { data: isAgentTeamAdmin } = useHasPermissions({
     agent: ["team-admin"],
   });
-  const { data: session } = authClient.useSession();
+  const { data: session } = useSession();
   const currentUserId = session?.user?.id;
   const userTeamIdSet = new Set((userTeams ?? []).map((t) => t.id));
 

--- a/platform/frontend/src/app/auth/auth-provider.test.tsx
+++ b/platform/frontend/src/app/auth/auth-provider.test.tsx
@@ -9,7 +9,6 @@ import { useArchestraHasPermission } from "./auth-provider";
 vi.mock("@/lib/clients/auth/auth-client", () => ({
   authClient: {
     getSession: vi.fn(),
-    useSession: vi.fn(),
     organization: {
       listMembers: vi.fn(),
     },
@@ -43,13 +42,12 @@ const createWrapper = () => {
 beforeEach(() => {
   vi.clearAllMocks();
 
-  // Default mock for authClient.useSession - returns authenticated state
-  vi.mocked(authClient.useSession).mockReturnValue({
+  vi.mocked(authClient.getSession).mockResolvedValue({
     data: {
       user: { id: "test-user", email: "test@example.com" },
       session: { id: "test-session" },
     },
-  } as ReturnType<typeof authClient.useSession>);
+  } as Awaited<ReturnType<typeof authClient.getSession>>);
 });
 
 describe("useArchestraHasPermission", () => {

--- a/platform/frontend/src/app/layout.tsx
+++ b/platform/frontend/src/app/layout.tsx
@@ -15,8 +15,9 @@ import { WithAuthCheck } from "./_parts/with-auth-check";
 import { WithPagePermissions } from "./_parts/with-page-permissions";
 import { AuthProvider } from "./auth/auth-provider";
 
-// Load fonts for white-labeling (self-hosted to avoid Google Fonts network
-// dependency during Docker builds — Turbopack cannot fetch them reliably)
+// Register theme fonts for white-labeling without preloading every file.
+// The active theme decides which CSS variable is used after appearance settings
+// load, so eager preload would fetch every optional font on every page.
 const latoFont = localFont({
   src: [
     { path: "../fonts/Lato-Light.woff2", weight: "300" },
@@ -26,6 +27,7 @@ const latoFont = localFont({
   ],
   variable: "--font-lato",
   display: "swap",
+  preload: false,
 });
 
 const interFont = localFont({
@@ -33,6 +35,7 @@ const interFont = localFont({
   variable: "--font-inter",
   weight: "100 900",
   display: "swap",
+  preload: false,
 });
 
 const openSansFont = localFont({
@@ -40,6 +43,7 @@ const openSansFont = localFont({
   variable: "--font-open-sans",
   weight: "300 800",
   display: "swap",
+  preload: false,
 });
 
 const robotoFont = localFont({
@@ -47,6 +51,7 @@ const robotoFont = localFont({
   variable: "--font-roboto",
   weight: "100 900",
   display: "swap",
+  preload: false,
 });
 
 const sourceSansFont = localFont({
@@ -54,6 +59,7 @@ const sourceSansFont = localFont({
   variable: "--font-source-sans",
   weight: "200 900",
   display: "swap",
+  preload: false,
 });
 
 const jetbrainsMonoFont = localFont({
@@ -61,6 +67,7 @@ const jetbrainsMonoFont = localFont({
   variable: "--font-jetbrains-mono",
   weight: "100 800",
   display: "swap",
+  preload: false,
 });
 
 const dmSansFont = localFont({
@@ -68,6 +75,7 @@ const dmSansFont = localFont({
   variable: "--font-dm-sans",
   weight: "100 1000",
   display: "swap",
+  preload: false,
 });
 
 const poppinsFont = localFont({
@@ -80,6 +88,7 @@ const poppinsFont = localFont({
   ],
   variable: "--font-poppins",
   display: "swap",
+  preload: false,
 });
 
 const oxaniumFont = localFont({
@@ -87,6 +96,7 @@ const oxaniumFont = localFont({
   variable: "--font-oxanium",
   weight: "200 800",
   display: "swap",
+  preload: false,
 });
 
 const montserratFont = localFont({
@@ -94,6 +104,7 @@ const montserratFont = localFont({
   variable: "--font-montserrat",
   weight: "100 900",
   display: "swap",
+  preload: false,
 });
 
 const sourceCodeProFont = localFont({
@@ -101,6 +112,7 @@ const sourceCodeProFont = localFont({
   variable: "--font-source-code-pro",
   weight: "200 900",
   display: "swap",
+  preload: false,
 });
 
 const merriweatherFont = localFont({
@@ -108,6 +120,7 @@ const merriweatherFont = localFont({
   variable: "--font-merriweather",
   weight: "300 900",
   display: "swap",
+  preload: false,
 });
 
 const quicksandFont = localFont({
@@ -115,6 +128,7 @@ const quicksandFont = localFont({
   variable: "--font-quicksand",
   weight: "300 700",
   display: "swap",
+  preload: false,
 });
 
 const outfitFont = localFont({
@@ -122,6 +136,7 @@ const outfitFont = localFont({
   variable: "--font-outfit",
   weight: "100 900",
   display: "swap",
+  preload: false,
 });
 
 const plusJakartaSansFont = localFont({
@@ -129,6 +144,7 @@ const plusJakartaSansFont = localFont({
   variable: "--font-plus-jakarta-sans",
   weight: "200 800",
   display: "swap",
+  preload: false,
 });
 
 const libreBaskervilleFont = localFont({
@@ -136,6 +152,7 @@ const libreBaskervilleFont = localFont({
   variable: "--font-libre-baskerville",
   weight: "400 700",
   display: "swap",
+  preload: false,
 });
 
 export const metadata: Metadata = {

--- a/platform/frontend/src/app/llm/credentials/virtual-keys/page.tsx
+++ b/platform/frontend/src/app/llm/credentials/virtual-keys/page.tsx
@@ -50,8 +50,7 @@ import {
   type VisibilityOption,
   VisibilitySelector,
 } from "@/components/visibility-selector";
-import { useHasPermissions } from "@/lib/auth/auth.query";
-import { authClient } from "@/lib/clients/auth/auth-client";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useFeature } from "@/lib/config/config.query";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
 import { useLlmProviderApiKeys } from "@/lib/llm-provider-api-keys.query";
@@ -94,7 +93,7 @@ export default function VirtualKeysPage() {
   const paginationMeta = response?.pagination;
 
   const { data: apiKeys = [] } = useLlmProviderApiKeys();
-  const { data: session } = authClient.useSession();
+  const { data: session } = useSession();
   const { data: canReadTeams } = useHasPermissions({ team: ["read"] });
   const { data: isVirtualKeyAdmin } = useHasPermissions({
     llmVirtualKey: ["admin"],

--- a/platform/frontend/src/app/llm/proxies/page.client.tsx
+++ b/platform/frontend/src/app/llm/proxies/page.client.tsx
@@ -34,8 +34,7 @@ import {
 } from "@/components/ui/tooltip";
 import { DEFAULT_SORT_BY, DEFAULT_SORT_DIRECTION } from "@/consts";
 import { useDeleteProfile, useProfilesPaginated } from "@/lib/agent.query";
-import { useHasPermissions } from "@/lib/auth/auth.query";
-import { authClient } from "@/lib/clients/auth/auth-client";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { getFrontendDocsUrl } from "@/lib/docs/docs";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
 import { LlmProxyActions } from "./llm-proxy-actions";
@@ -158,7 +157,7 @@ function LlmProxies({ initialData }: { initialData?: LlmProxiesInitialData }) {
   const { data: isTeamAdmin } = useHasPermissions({
     llmProxy: ["team-admin"],
   });
-  const { data: session } = authClient.useSession();
+  const { data: session } = useSession();
   const currentUserId = session?.user?.id;
   const userTeamIdSet = new Set((userTeams ?? []).map((t) => t.id));
 

--- a/platform/frontend/src/app/mcp/gateways/page.client.tsx
+++ b/platform/frontend/src/app/mcp/gateways/page.client.tsx
@@ -38,8 +38,7 @@ import {
   useProfile,
   useProfilesPaginated,
 } from "@/lib/agent.query";
-import { useHasPermissions } from "@/lib/auth/auth.query";
-import { authClient } from "@/lib/clients/auth/auth-client";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { getFrontendDocsUrl } from "@/lib/docs/docs";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
 import { McpGatewayActions } from "./mcp-gateway-actions";
@@ -171,7 +170,7 @@ function McpGateways({
   const { data: isTeamAdmin } = useHasPermissions({
     mcpGateway: ["team-admin"],
   });
-  const { data: session } = authClient.useSession();
+  const { data: session } = useSession();
   const currentUserId = session?.user?.id;
   const userTeamIdSet = new Set((userTeams ?? []).map((t) => t.id));
 

--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/components/oauth-confirmation-dialog";
 import { SearchInput } from "@/components/search-input";
 import { Button } from "@/components/ui/button";
-import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useInitiateOAuth } from "@/lib/auth/oauth.query";
 import {
   clearInstallationCompleteCatalogId,
@@ -44,7 +44,6 @@ import {
   setOAuthTeamId,
   setOAuthUserConfigValues,
 } from "@/lib/auth/oauth-session";
-import { authClient } from "@/lib/clients/auth/auth-client";
 import { useDialogs } from "@/lib/hooks/use-dialog";
 import { useMcpRegistryServer } from "@/lib/mcp/external-mcp-catalog.query";
 import {
@@ -118,8 +117,8 @@ export function InternalMCPCatalog({
   const reauthMutation = useReauthenticateMcpServer();
   const initiateOAuthMutation = useInitiateOAuth();
   const deploymentStatuses = useMcpDeploymentStatuses();
-  const session = authClient.useSession();
-  const currentUserId = session.data?.user?.id;
+  const { data: session } = useSession();
+  const currentUserId = session?.user?.id;
 
   const { isDialogOpened, openDialog, closeDialog } = useDialogs<
     | "create"

--- a/platform/frontend/src/app/mcp/registry/_parts/manage-users-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/manage-users-dialog.tsx
@@ -55,14 +55,13 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useInitiateOAuth } from "@/lib/auth/oauth.query";
 import {
   setOAuthCatalogId,
   setOAuthMcpServerId,
   setOAuthState,
 } from "@/lib/auth/oauth-session";
-import { authClient } from "@/lib/clients/auth/auth-client";
 import { useInternalMcpCatalog } from "@/lib/mcp/internal-mcp-catalog.query";
 import { useDeleteMcpServer, useMcpServers } from "@/lib/mcp/mcp-server.query";
 import { useTeams } from "@/lib/teams/team.query";
@@ -148,7 +147,7 @@ export function ManageUsersContent({
     catalogId,
   });
   const { data: catalogItems } = useInternalMcpCatalog({});
-  const { data: session } = authClient.useSession();
+  const { data: session } = useSession();
   const currentUserId = session?.user?.id;
 
   // Get user's teams and permissions for re-authentication checks

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -42,8 +42,7 @@ import { TruncatedTooltip } from "@/components/ui/truncated-tooltip";
 import { LOCAL_MCP_DISABLED_MESSAGE } from "@/consts";
 import { useCreateProfile } from "@/lib/agent.query";
 import { useBulkAssignTools } from "@/lib/agent-tools.query";
-import { useHasPermissions } from "@/lib/auth/auth.query";
-import { authClient } from "@/lib/clients/auth/auth-client";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useFeature } from "@/lib/config/config.query";
 import { useCatalogTools } from "@/lib/mcp/internal-mcp-catalog.query";
 import { useMcpServers, useMcpServerTools } from "@/lib/mcp/mcp-server.query";
@@ -140,8 +139,8 @@ export function McpServerCard({
   const [isChatCreating, setIsChatCreating] = useState(false);
 
   const isByosEnabled = useFeature("byosEnabled");
-  const session = authClient.useSession();
-  const currentUserId = session.data?.user?.id;
+  const { data: session } = useSession();
+  const currentUserId = session?.user?.id;
   const { data: userIsMcpServerAdmin } = useHasPermissions({
     mcpServerInstallation: ["admin"],
   });

--- a/platform/frontend/src/app/mcp/registry/_parts/select-mcp-server-credential-type-and-teams.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/select-mcp-server-credential-type-and-teams.tsx
@@ -16,8 +16,7 @@ import {
   type VisibilityOption,
   VisibilitySelector,
 } from "@/components/visibility-selector";
-import { useHasPermissions } from "@/lib/auth/auth.query";
-import { authClient } from "@/lib/clients/auth/auth-client";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useMcpServers } from "@/lib/mcp/mcp-server.query";
 import { useTeams } from "@/lib/teams/team.query";
 
@@ -62,7 +61,7 @@ export function SelectMcpServerCredentialTypeAndTeams({
 }: SelectMcpServerCredentialTypeAndTeamsProps) {
   const { data: teams, isLoading: isLoadingTeams } = useTeams();
   const { data: installedServers } = useMcpServers();
-  const { data: session } = authClient.useSession();
+  const { data: session } = useSession();
   const currentUserId = session?.user?.id;
 
   // WHY: Check mcpServer:update permission to determine if user can create team installations

--- a/platform/frontend/src/app/settings/settings-tabs.test.tsx
+++ b/platform/frontend/src/app/settings/settings-tabs.test.tsx
@@ -7,7 +7,7 @@ import { useSettingsTabs } from "./settings-tabs";
 
 vi.mock("@/lib/clients/auth/auth-client", () => ({
   authClient: {
-    useSession: vi.fn(),
+    getSession: vi.fn(),
   },
 }));
 
@@ -59,12 +59,12 @@ beforeEach(() => {
   mockSecretsType = "DB";
   mockEnterpriseFeatures = false;
 
-  vi.mocked(authClient.useSession).mockReturnValue({
+  vi.mocked(authClient.getSession).mockResolvedValue({
     data: {
       user: { id: "test-user", email: "test@example.com" },
       session: { id: "test-session" },
     },
-  } as ReturnType<typeof authClient.useSession>);
+  } as Awaited<ReturnType<typeof authClient.getSession>>);
 });
 
 function getTabLabels(tabs: Array<{ label: string }>) {

--- a/platform/frontend/src/components/chat/initial-agent-selector.tsx
+++ b/platform/frontend/src/components/chat/initial-agent-selector.tsx
@@ -71,8 +71,7 @@ import {
   useSyncAgentDelegations,
   useUnassignTool,
 } from "@/lib/agent-tools.query";
-import { useHasPermissions } from "@/lib/auth/auth.query";
-import { authClient } from "@/lib/clients/auth/auth-client";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useAppName } from "@/lib/hooks/use-app-name";
 import { useConnectors } from "@/lib/knowledge/connector.query";
 import { useKnowledgeBases } from "@/lib/knowledge/knowledge-base.query";
@@ -111,7 +110,7 @@ export function InitialAgentSelector({
   onAgentChange,
 }: InitialAgentSelectorProps) {
   const { data: allAgents = [] } = useInternalAgents();
-  const { data: session } = authClient.useSession();
+  const { data: session } = useSession();
   const userId = session?.user?.id;
   const { data: isAgentAdmin } = useHasPermissions({ agent: ["admin"] });
   const createProfile = useCreateProfile();

--- a/platform/frontend/src/components/chat/initial-agent-selector.tsx
+++ b/platform/frontend/src/components/chat/initial-agent-selector.tsx
@@ -130,8 +130,6 @@ export function InitialAgentSelector({
   const [configureToolFrom, setConfigureToolFrom] = useState<
     "settings" | "add-tool"
   >("settings");
-  const installer = useMcpInstallOrchestrator();
-
   const filteredAgents = useMemo(() => {
     return filterAndSortInitialAgents({
       allAgents,
@@ -148,6 +146,11 @@ export function InitialAgentSelector({
   );
   const displayAgentName =
     currentAgent?.name ?? currentAgentName ?? "Select agent";
+  const effectiveAgentId = currentAgent?.id ?? currentAgentId;
+  const shouldLoadAgentManagementDetails = open || !!editingAgentId;
+  const installer = useMcpInstallOrchestrator({
+    enabled: shouldLoadAgentManagementDetails,
+  });
 
   const canEditCurrentAgent = useMemo(() => {
     if (!currentAgent) return false;
@@ -156,7 +159,6 @@ export function InitialAgentSelector({
     return authorId === userId;
   }, [currentAgent, isAgentAdmin, userId]);
 
-  const effectiveAgentId = currentAgent?.id ?? currentAgentId;
   const { data: canReadMcpRegistry } = useHasPermissions({
     mcpRegistry: ["read"],
   });
@@ -1034,7 +1036,7 @@ function AssignedToolsGrid({
             <span className="text-xs font-medium truncate w-full">
               {agent.name}
             </span>
-            <AgentToolAvatars agentId={agent.id} />
+            <AgentToolAvatars agentId={agent.id} enabled />
           </div>
         </div>
       ))}
@@ -1709,7 +1711,7 @@ function AddDelegationView({
                     className="text-[10px] px-1.5 py-0"
                   />
                   <div className="flex-1" />
-                  <AgentToolAvatars agentId={agent.id} />
+                  <AgentToolAvatars agentId={agent.id} enabled />
                 </div>
               </button>
             ))}
@@ -1983,15 +1985,21 @@ function EditKnowledgeSourcesView({
   );
 }
 
-function AgentToolAvatars({ agentId }: { agentId: string }) {
-  const { data: catalogItems = [] } = useInternalMcpCatalog();
+function AgentToolAvatars({
+  agentId,
+  enabled = true,
+}: {
+  agentId: string;
+  enabled?: boolean;
+}) {
+  const { data: catalogItems = [] } = useInternalMcpCatalog({ enabled });
   const { data: allAgents = [] } = useInternalAgents();
   const { data: assignedToolsData } = useAllProfileTools({
     filters: { agentId },
     skipPagination: true,
-    enabled: !!agentId,
+    enabled: enabled && !!agentId,
   });
-  const { data: delegations = [] } = useAgentDelegations(agentId);
+  const { data: delegations = [] } = useAgentDelegations(agentId, { enabled });
 
   const catalogs = useMemo(() => {
     const catalogIds = new Set<string>();

--- a/platform/frontend/src/components/chat/playwright-install-dialog.tsx
+++ b/platform/frontend/src/components/chat/playwright-install-dialog.tsx
@@ -13,6 +13,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { useAgentDelegations } from "@/lib/agent-tools.query";
+import { useSession } from "@/lib/auth/auth.query";
 import {
   fetchAgentMcpTools,
   useConversationEnabledTools,
@@ -26,7 +27,6 @@ import {
   getPendingActions,
   PENDING_TOOL_STATE_CHANGE_EVENT,
 } from "@/lib/chat/pending-tool-state";
-import { useSession } from "@/lib/auth/auth.query";
 import { useMcpServers } from "@/lib/mcp/mcp-server.query";
 import { cn } from "@/lib/utils";
 

--- a/platform/frontend/src/components/chat/playwright-install-dialog.tsx
+++ b/platform/frontend/src/components/chat/playwright-install-dialog.tsx
@@ -26,7 +26,7 @@ import {
   getPendingActions,
   PENDING_TOOL_STATE_CHANGE_EVENT,
 } from "@/lib/chat/pending-tool-state";
-import { authClient } from "@/lib/clients/auth/auth-client";
+import { useSession } from "@/lib/auth/auth.query";
 import { useMcpServers } from "@/lib/mcp/mcp-server.query";
 import { cn } from "@/lib/utils";
 
@@ -62,7 +62,7 @@ export function usePlaywrightSetupRequired(
     catalogId: PLAYWRIGHT_MCP_CATALOG_ID,
     enabled: options?.enabled,
   });
-  const { data: session } = authClient.useSession();
+  const { data: session } = useSession();
   const isPlaywrightInstalledByCurrentUser = playwrightServers.some(
     (s) => s.ownerId === session?.user?.id,
   );

--- a/platform/frontend/src/components/conversation-search-palette.test.tsx
+++ b/platform/frontend/src/components/conversation-search-palette.test.tsx
@@ -8,9 +8,17 @@ global.ResizeObserver = vi.fn().mockImplementation(() => ({
   disconnect: vi.fn(),
 }));
 
-const mockRouterPush = vi.fn();
-const mockUsePathname = vi.fn();
-const mockDeleteMutate = vi.fn();
+const {
+  mockRouterPush,
+  mockUsePathname,
+  mockDeleteMutate,
+  mockUseConversations,
+} = vi.hoisted(() => ({
+  mockRouterPush: vi.fn(),
+  mockUsePathname: vi.fn(),
+  mockDeleteMutate: vi.fn(),
+  mockUseConversations: vi.fn(),
+}));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockRouterPush }),
@@ -43,24 +51,7 @@ vi.mock("@/lib/chat/chat-utils", () => ({
 }));
 
 vi.mock("@/lib/chat/chat.query", () => ({
-  useConversations: () => ({
-    data: [
-      {
-        id: "conv-1",
-        title: "First conversation",
-        updatedAt: new Date().toISOString(),
-        messages: [],
-      },
-      {
-        id: "conv-2",
-        title: "Second conversation",
-        updatedAt: new Date().toISOString(),
-        messages: [],
-      },
-    ],
-    isLoading: false,
-    isFetching: false,
-  }),
+  useConversations: mockUseConversations,
   useDeleteConversation: () => ({
     mutate: mockDeleteMutate,
   }),
@@ -155,7 +146,41 @@ describe("ConversationSearchPalette", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUsePathname.mockReturnValue("/chat");
+    mockUseConversations.mockReturnValue({
+      data: [
+        {
+          id: "conv-1",
+          title: "First conversation",
+          updatedAt: new Date().toISOString(),
+          messages: [],
+        },
+        {
+          id: "conv-2",
+          title: "Second conversation",
+          updatedAt: new Date().toISOString(),
+          messages: [],
+        },
+      ],
+      isLoading: false,
+      isFetching: false,
+    });
     capturedOnValueChange = null;
+  });
+
+  it("only enables conversation fetching while open", () => {
+    const { rerender } = render(
+      <ConversationSearchPalette {...defaultProps} open={false} />,
+    );
+
+    expect(mockUseConversations).toHaveBeenLastCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+
+    rerender(<ConversationSearchPalette {...defaultProps} open={true} />);
+
+    expect(mockUseConversations).toHaveBeenLastCalledWith(
+      expect.objectContaining({ enabled: true }),
+    );
   });
 
   it("renders conversations when open", () => {

--- a/platform/frontend/src/components/conversation-search-palette.tsx
+++ b/platform/frontend/src/components/conversation-search-palette.tsx
@@ -240,7 +240,7 @@ export function ConversationSearchPalette({
     isLoading,
     isFetching,
   } = useConversations({
-    enabled: isAuthenticated && canReadConversation === true,
+    enabled: open && isAuthenticated && canReadConversation === true,
     search: debouncedSearch,
   });
 

--- a/platform/frontend/src/components/default-credentials-warning.tsx
+++ b/platform/frontend/src/components/default-credentials-warning.tsx
@@ -10,8 +10,10 @@ import { AlertTriangle } from "lucide-react";
 import { CopyButton } from "@/components/copy-button";
 import { ExternalDocsLink } from "@/components/external-docs-link";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { useDefaultCredentialsEnabled } from "@/lib/auth/auth.query";
-import { authClient } from "@/lib/clients/auth/auth-client";
+import {
+  useDefaultCredentialsEnabled,
+  useSession,
+} from "@/lib/auth/auth.query";
 
 export function DefaultCredentialsWarning({
   alwaysShow = false,
@@ -20,7 +22,7 @@ export function DefaultCredentialsWarning({
   alwaysShow?: boolean;
   slim?: boolean;
 }) {
-  const { data: session } = authClient.useSession();
+  const { data: session } = useSession();
   const userEmail = session?.user?.email;
   const { data: defaultCredentialsEnabled, isLoading } =
     useDefaultCredentialsEnabled();

--- a/platform/frontend/src/components/settings/role-permissions-card.test.tsx
+++ b/platform/frontend/src/components/settings/role-permissions-card.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RolePermissionsCard } from "@/components/settings/role-permissions-card";
-import { authClient } from "@/lib/clients/auth/auth-client";
+import { useSession } from "@/lib/auth/auth.query";
 
 const mockUpdateNameMutateAsync = vi.fn();
 
@@ -17,12 +17,7 @@ vi.mock("@/lib/auth/auth.query", () => ({
     data: null,
     isLoading: false,
   }),
-}));
-
-vi.mock("@/lib/clients/auth/auth-client", () => ({
-  authClient: {
-    useSession: vi.fn(),
-  },
+  useSession: vi.fn(),
 }));
 
 vi.mock("@/lib/organization.query", () => ({
@@ -39,7 +34,7 @@ describe("RolePermissionsCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUpdateNameMutateAsync.mockResolvedValue(true);
-    vi.mocked(authClient.useSession).mockReturnValue({
+    vi.mocked(useSession).mockReturnValue({
       data: {
         user: {
           id: "user-1",
@@ -47,7 +42,7 @@ describe("RolePermissionsCard", () => {
           email: "admin@example.com",
         },
       },
-    } as ReturnType<typeof authClient.useSession>);
+    } as unknown as ReturnType<typeof useSession>);
   });
 
   it("updates the account name from the top account section", async () => {

--- a/platform/frontend/src/components/settings/role-permissions-card.tsx
+++ b/platform/frontend/src/components/settings/role-permissions-card.tsx
@@ -39,8 +39,7 @@ import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useUpdateAccountNameMutation } from "@/lib/auth/account.query";
-import { useAllPermissions } from "@/lib/auth/auth.query";
-import { authClient } from "@/lib/clients/auth/auth-client";
+import { useAllPermissions, useSession } from "@/lib/auth/auth.query";
 import {
   useActiveMemberRole,
   useActiveOrganization,
@@ -65,7 +64,7 @@ const actionLabels: Record<Action, string> = {
 };
 
 export function RolePermissionsCard() {
-  const { data: session } = authClient.useSession();
+  const { data: session } = useSession();
   const { data: activeOrg } = useActiveOrganization();
   const { data: role, isLoading: isRoleLoading } = useActiveMemberRole(
     activeOrg?.id,

--- a/platform/frontend/src/components/sidebar-warnings-accordion.tsx
+++ b/platform/frontend/src/components/sidebar-warnings-accordion.tsx
@@ -20,13 +20,13 @@ import {
 import {
   useDefaultCredentialsEnabled,
   useHasPermissions,
+  useSession,
 } from "@/lib/auth/auth.query";
-import { authClient } from "@/lib/clients/auth/auth-client";
 import { useDisableBasicAuth, useFeature } from "@/lib/config/config.query";
 import { cn } from "@/lib/utils";
 
 export function SidebarWarningsAccordion() {
-  const { data: session } = authClient.useSession();
+  const { data: session } = useSession();
   const userEmail = session?.user?.email;
   const { data: defaultCredentialsEnabled, isLoading: isLoadingCreds } =
     useDefaultCredentialsEnabled();

--- a/platform/frontend/src/components/sidebar-warnings.test.tsx
+++ b/platform/frontend/src/components/sidebar-warnings.test.tsx
@@ -8,16 +8,11 @@ const mockUseHasPermissions = vi.fn();
 const mockUseFeature = vi.fn();
 const mockUseDisableBasicAuth = vi.fn();
 
-vi.mock("@/lib/clients/auth/auth-client", () => ({
-  authClient: {
-    useSession: (...args: unknown[]) => mockUseSession(...args),
-  },
-}));
-
 vi.mock("@/lib/auth/auth.query", () => ({
   useDefaultCredentialsEnabled: (...args: unknown[]) =>
     mockUseDefaultCredentialsEnabled(...args),
   useHasPermissions: (...args: unknown[]) => mockUseHasPermissions(...args),
+  useSession: (...args: unknown[]) => mockUseSession(...args),
 }));
 
 vi.mock("@/lib/config/config.query", () => ({

--- a/platform/frontend/src/components/sidebar-warnings.tsx
+++ b/platform/frontend/src/components/sidebar-warnings.tsx
@@ -7,12 +7,12 @@ import { DefaultCredentialsWarning } from "@/components/default-credentials-warn
 import {
   useDefaultCredentialsEnabled,
   useHasPermissions,
+  useSession,
 } from "@/lib/auth/auth.query";
-import { authClient } from "@/lib/clients/auth/auth-client";
 import { useDisableBasicAuth, useFeature } from "@/lib/config/config.query";
 
 export function SidebarWarnings() {
-  const { data: session } = authClient.useSession();
+  const { data: session } = useSession();
   const userEmail = session?.user?.email;
   const { data: defaultCredentialsEnabled, isLoading: isLoadingCreds } =
     useDefaultCredentialsEnabled();

--- a/platform/frontend/src/lib/agent-tools.query.ts
+++ b/platform/frontend/src/lib/agent-tools.query.ts
@@ -368,7 +368,10 @@ export const agentDelegationsQueryKeys = {
 /**
  * Get all delegation targets for an internal agent.
  */
-export function useAgentDelegations(agentId: string | undefined) {
+export function useAgentDelegations(
+  agentId: string | undefined,
+  params?: { enabled?: boolean },
+) {
   return useQuery({
     queryKey: agentDelegationsQueryKeys.byAgent(agentId ?? ""),
     queryFn: async () => {
@@ -379,8 +382,8 @@ export function useAgentDelegations(agentId: string | undefined) {
       }
       return response.data ?? [];
     },
-    enabled: !!agentId,
-    staleTime: 0, // Always refetch to ensure fresh data
+    enabled: !!agentId && (params?.enabled ?? true),
+    staleTime: 30 * 1000,
     placeholderData: keepPreviousData,
   });
 }

--- a/platform/frontend/src/lib/auth/account.query.ts
+++ b/platform/frontend/src/lib/auth/account.query.ts
@@ -1,6 +1,7 @@
 import { archestraApiSdk, DEFAULT_ADMIN_EMAIL } from "@shared";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { authQueryKeys } from "@/lib/auth/auth.query";
 import { authClient } from "@/lib/clients/auth/auth-client";
 import {
   clearDefaultPasswordChangePending,
@@ -27,7 +28,7 @@ export function useUpdateAccountNameMutation() {
     onSuccess: async (updated) => {
       if (!updated) return;
       toast.success("Name updated");
-      await queryClient.invalidateQueries({ queryKey: ["auth", "session"] });
+      await queryClient.invalidateQueries({ queryKey: authQueryKeys.session() });
     },
   });
 }
@@ -54,13 +55,15 @@ export function useChangeAccountPasswordMutation() {
       if (!changed) return;
       toast.success("Password changed");
       await queryClient.invalidateQueries({
-        queryKey: ["auth", "defaultCredentialsEnabled"],
+        queryKey: authQueryKeys.defaultCredentialsEnabled(),
       });
     },
   });
 }
 
 export function useSignInWithEmailMutation() {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: async (params: {
       email: string;
@@ -93,6 +96,8 @@ export function useSignInWithEmailMutation() {
         toast.error(getAuthErrorMessage(error, "Failed to sign in"));
         return null;
       }
+
+      await queryClient.invalidateQueries({ queryKey: authQueryKeys.all });
 
       if (!isDefaultAdminEmail) {
         return {

--- a/platform/frontend/src/lib/auth/account.query.ts
+++ b/platform/frontend/src/lib/auth/account.query.ts
@@ -28,7 +28,9 @@ export function useUpdateAccountNameMutation() {
     onSuccess: async (updated) => {
       if (!updated) return;
       toast.success("Name updated");
-      await queryClient.invalidateQueries({ queryKey: authQueryKeys.session() });
+      await queryClient.invalidateQueries({
+        queryKey: authQueryKeys.session(),
+      });
     },
   });
 }

--- a/platform/frontend/src/lib/auth/auth.hook.test.ts
+++ b/platform/frontend/src/lib/auth/auth.hook.test.ts
@@ -1,21 +1,18 @@
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { useIsAuthenticated } from "@/lib/auth/auth.hook";
-import { authClient } from "@/lib/clients/auth/auth-client";
+import { useSession } from "@/lib/auth/auth.query";
 
-// Mock the auth client
-vi.mock("@/lib/clients/auth/auth-client", () => ({
-  authClient: {
-    useSession: vi.fn(),
-  },
+vi.mock("@/lib/auth/auth.query", () => ({
+  useSession: vi.fn(),
 }));
 
-type Session = Awaited<ReturnType<typeof authClient.useSession>>;
+type Session = ReturnType<typeof useSession>;
 
 describe("useIsAuthenticated", () => {
   it("should return true when user is authenticated", () => {
     // Mock session with user
-    vi.mocked(authClient.useSession).mockReturnValue({
+    vi.mocked(useSession).mockReturnValue({
       data: {
         user: { id: "user123", email: "test@example.com" },
         session: { id: "session123" },
@@ -29,7 +26,7 @@ describe("useIsAuthenticated", () => {
 
   it("should return false when user is not authenticated", () => {
     // Mock session without user
-    vi.mocked(authClient.useSession).mockReturnValue({
+    vi.mocked(useSession).mockReturnValue({
       data: null,
     } as Session);
 
@@ -40,7 +37,7 @@ describe("useIsAuthenticated", () => {
 
   it("should return false when session data has no user", () => {
     // Mock session with null user
-    vi.mocked(authClient.useSession).mockReturnValue({
+    vi.mocked(useSession).mockReturnValue({
       data: {
         user: null,
         session: { id: "session123" },
@@ -54,7 +51,7 @@ describe("useIsAuthenticated", () => {
 
   it("should return false when session data is undefined", () => {
     // Mock undefined session
-    vi.mocked(authClient.useSession).mockReturnValue({
+    vi.mocked(useSession).mockReturnValue({
       data: undefined,
     } as unknown as Session);
 

--- a/platform/frontend/src/lib/auth/auth.hook.ts
+++ b/platform/frontend/src/lib/auth/auth.hook.ts
@@ -1,6 +1,6 @@
-import { authClient } from "@/lib/clients/auth/auth-client";
+import { useSession } from "@/lib/auth/auth.query";
 
 export function useIsAuthenticated() {
-  const session = authClient.useSession();
+  const session = useSession();
   return session.data?.user != null;
 }

--- a/platform/frontend/src/lib/auth/auth.query.test.tsx
+++ b/platform/frontend/src/lib/auth/auth.query.test.tsx
@@ -16,7 +16,6 @@ import { authClient } from "@/lib/clients/auth/auth-client";
 vi.mock("@/lib/clients/auth/auth-client", () => ({
   authClient: {
     getSession: vi.fn(),
-    useSession: vi.fn(),
     organization: {
       listMembers: vi.fn(),
     },
@@ -50,13 +49,12 @@ const createWrapper = () => {
 beforeEach(() => {
   vi.clearAllMocks();
 
-  // Default mock for authClient.useSession - returns authenticated state
-  vi.mocked(authClient.useSession).mockReturnValue({
+  vi.mocked(authClient.getSession).mockResolvedValue({
     data: {
       user: { id: "test-user", email: "test@example.com" },
       session: { id: "test-session" },
     },
-  } as ReturnType<typeof authClient.useSession>);
+  } as Awaited<ReturnType<typeof authClient.getSession>>);
 });
 
 describe("useSession", () => {
@@ -303,6 +301,7 @@ describe("useHasPermissions", () => {
     expect(result2.current.data).toBe(true);
 
     // But getUserPermissions should only have been called once
+    expect(authClient.getSession).toHaveBeenCalledTimes(1);
     expect(archestraApiSdk.getUserPermissions).toHaveBeenCalledTimes(1);
   });
 });

--- a/platform/frontend/src/lib/auth/auth.query.ts
+++ b/platform/frontend/src/lib/auth/auth.query.ts
@@ -29,7 +29,7 @@ export function useSession() {
     },
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
-    refetchOnWindowFocus: false,
+    refetchOnWindowFocus: true,
   });
 }
 

--- a/platform/frontend/src/lib/auth/auth.query.ts
+++ b/platform/frontend/src/lib/auth/auth.query.ts
@@ -1,27 +1,39 @@
 import { archestraApiSdk, type Permissions } from "@shared";
 import { useQuery } from "@tanstack/react-query";
-import { useIsAuthenticated } from "@/lib/auth/auth.hook";
 import { hasPermissions } from "@/lib/auth/auth.utils";
 import { authClient } from "@/lib/clients/auth/auth-client";
+
+export const authQueryKeys = {
+  all: ["auth"] as const,
+  session: () => [...authQueryKeys.all, "session"] as const,
+  orgMembers: () => [...authQueryKeys.all, "orgMembers"] as const,
+  userPermissions: () => [...authQueryKeys.all, "userPermissions"] as const,
+  defaultCredentialsEnabled: () =>
+    [...authQueryKeys.all, "defaultCredentialsEnabled"] as const,
+};
 
 /**
  * Fetch current session
  */
 export function useSession() {
   return useQuery({
-    queryKey: ["auth", "session"],
+    queryKey: authQueryKeys.session(),
     queryFn: async () => {
       const { data } = await authClient.getSession();
       return data;
     },
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    refetchOnWindowFocus: false,
   });
 }
 
 export function useCurrentOrgMembers() {
-  const isAuthenticated = useIsAuthenticated();
+  const { data: session } = useSession();
+  const isAuthenticated = !!session?.user;
 
   return useQuery({
-    queryKey: ["auth", "orgMembers"],
+    queryKey: authQueryKeys.orgMembers(),
     queryFn: async () => {
       const { data } = await authClient.organization.listMembers();
       return data?.members ?? [];
@@ -98,17 +110,20 @@ export function useMissingPermissions(
  * Avoid using directly in components and use useHasPermissions instead.
  */
 export function useAllPermissions() {
-  const isAuthenticated = useIsAuthenticated();
+  const { data: session, isPending: isSessionPending } = useSession();
+  const isAuthenticated = !!session?.user;
 
   return useQuery({
-    queryKey: ["auth", "userPermissions"],
+    queryKey: authQueryKeys.userPermissions(),
     queryFn: async () => {
       const { data } = await archestraApiSdk.getUserPermissions();
       return data;
     },
     retry: false,
     throwOnError: false,
-    enabled: isAuthenticated,
+    enabled: !isSessionPending && isAuthenticated,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
   });
 }
 
@@ -140,7 +155,7 @@ export function usePermissionMap<Key extends string>(
 
 export function useDefaultCredentialsEnabled() {
   return useQuery({
-    queryKey: ["auth", "defaultCredentialsEnabled"],
+    queryKey: authQueryKeys.defaultCredentialsEnabled(),
     queryFn: async () => {
       const { data } = await archestraApiSdk.getDefaultCredentialsStatus();
       return data?.enabled ?? false;

--- a/platform/frontend/src/lib/auth/auth.query.ts
+++ b/platform/frontend/src/lib/auth/auth.query.ts
@@ -29,6 +29,7 @@ export function useSession() {
     },
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
+    // Keep focus refetching on so backgrounded tabs discover revoked or changed sessions promptly.
     refetchOnWindowFocus: true,
   });
 }

--- a/platform/frontend/src/lib/auth/auth.query.ts
+++ b/platform/frontend/src/lib/auth/auth.query.ts
@@ -13,7 +13,12 @@ export const authQueryKeys = {
 };
 
 /**
- * Fetch current session
+ * Fetch the current session through the shared TanStack Query cache.
+ *
+ * Always use this hook instead of calling `authClient.getSession()` directly in
+ * components/hooks. This keeps every session consumer on one query key with the
+ * same stale-time and invalidation path, and prevents repeated session requests
+ * when many auth-aware components mount together.
  */
 export function useSession() {
   return useQuery({

--- a/platform/frontend/src/lib/auth/use-can-manage-gateway.ts
+++ b/platform/frontend/src/lib/auth/use-can-manage-gateway.ts
@@ -1,7 +1,6 @@
 import { archestraApiSdk, type archestraApiTypes } from "@shared";
 import { useQuery } from "@tanstack/react-query";
-import { useHasPermissions } from "@/lib/auth/auth.query";
-import { authClient } from "@/lib/clients/auth/auth-client";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 
 type Gateway = archestraApiTypes.GetAgentResponses["200"] | null | undefined;
 
@@ -23,8 +22,7 @@ export function useCanManageGateway(gateway: Gateway): {
     useHasPermissions({ mcpGateway: ["team-admin"] });
   const { data: canReadTeams } = useHasPermissions({ team: ["read"] });
 
-  const { data: session, isPending: isSessionLoading } =
-    authClient.useSession();
+  const { data: session, isPending: isSessionLoading } = useSession();
   const currentUserId = session?.user?.id;
 
   const { data: userTeams, isLoading: isTeamsLoading } = useQuery({

--- a/platform/frontend/src/lib/chat/chat.query.ts
+++ b/platform/frontend/src/lib/chat/chat.query.ts
@@ -14,7 +14,7 @@ import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { invalidateToolAssignmentQueries } from "@/lib/agent-tools.hook";
 import { conversationStorageKeys } from "@/lib/chat/chat-utils";
-import { authClient } from "@/lib/clients/auth/auth-client";
+import { useSession } from "@/lib/auth/auth.query";
 import { useMcpServers } from "@/lib/mcp/mcp-server.query";
 import { handleApiError } from "@/lib/utils";
 
@@ -726,7 +726,7 @@ export function useHasPlaywrightMcpTools(
   const playwrightServersQuery = useMcpServers({
     catalogId: PLAYWRIGHT_MCP_CATALOG_ID,
   });
-  const { data: session } = authClient.useSession();
+  const { data: session } = useSession();
   const currentUserId = session?.user?.id;
   // Find the server owned by the current user (admins see all servers)
   const playwrightServer = playwrightServersQuery.data?.find(

--- a/platform/frontend/src/lib/chat/chat.query.ts
+++ b/platform/frontend/src/lib/chat/chat.query.ts
@@ -13,8 +13,8 @@ import {
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { invalidateToolAssignmentQueries } from "@/lib/agent-tools.hook";
-import { conversationStorageKeys } from "@/lib/chat/chat-utils";
 import { useSession } from "@/lib/auth/auth.query";
+import { conversationStorageKeys } from "@/lib/chat/chat-utils";
 import { useMcpServers } from "@/lib/mcp/mcp-server.query";
 import { handleApiError } from "@/lib/utils";
 

--- a/platform/frontend/src/lib/clients/auth/auth-client.ts
+++ b/platform/frontend/src/lib/clients/auth/auth-client.ts
@@ -21,6 +21,15 @@ const adminRole = ac.newRole(allAvailableActions);
 const editorRole = ac.newRole(editorPermissions);
 const memberRole = ac.newRole(memberPermissions);
 
+/**
+ * Low-level Better Auth client.
+ *
+ * Do not call `authClient.useSession()` directly. It maintains session state
+ * outside the app's TanStack Query cache, which can create duplicate session
+ * fetches on pages with many auth-aware components. Use `useSession()` from
+ * `@/lib/auth/auth.query` instead so session reads share one query key,
+ * stale-time, and invalidation path.
+ */
 export const authClient = createAuthClient({
   baseURL: "", // Always use relative URLs (proxied through Next.js)
   plugins: [

--- a/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.ts
+++ b/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.ts
@@ -39,9 +39,13 @@ type DialogKey =
   | "no-auth"
   | "manage";
 
-export function useMcpInstallOrchestrator() {
-  const { data: catalogItems } = useInternalMcpCatalog({});
-  const { data: installedServers } = useMcpServers({});
+export function useMcpInstallOrchestrator(options?: { enabled?: boolean }) {
+  const { data: catalogItems } = useInternalMcpCatalog({
+    enabled: options?.enabled,
+  });
+  const { data: installedServers } = useMcpServers({
+    enabled: options?.enabled,
+  });
   const installMutation = useInstallMcpServer();
   const reauthMutation = useReauthenticateMcpServer();
   const initiateOAuthMutation = useInitiateOAuth();

--- a/platform/frontend/src/lib/mcp/mcp-server.query.ts
+++ b/platform/frontend/src/lib/mcp/mcp-server.query.ts
@@ -9,7 +9,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { invalidateToolAssignmentQueries } from "@/lib/agent-tools.hook";
-import { authClient } from "@/lib/clients/auth/auth-client";
+import { useSession } from "@/lib/auth/auth.query";
 import { useFeature } from "@/lib/config/config.query";
 import { handleApiError } from "@/lib/utils";
 import websocketService from "@/lib/websocket/websocket";
@@ -81,7 +81,7 @@ export function useMcpServersGroupedByCatalog(params?: McpServersQuery) {
     assignmentScope: params?.assignmentScope,
     assignmentTeamIds: params?.assignmentTeamIds,
   });
-  const { data: session } = authClient.useSession();
+  const { data: session } = useSession();
   const currentUserId = session?.user?.id;
 
   return useMemo(() => {

--- a/platform/frontend/src/lib/organization.query.ts
+++ b/platform/frontend/src/lib/organization.query.ts
@@ -66,9 +66,6 @@ export function useInvitation(invitationId: string) {
   return useQuery({
     queryKey: organizationKeys.invitation(invitationId),
     queryFn: async () => {
-      if (!session.data?.user) {
-        return undefined;
-      }
       const response = await authClient.organization.getInvitation({
         query: { id: invitationId },
       });

--- a/platform/frontend/src/lib/organization.query.ts
+++ b/platform/frontend/src/lib/organization.query.ts
@@ -7,6 +7,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { Invitation } from "better-auth/plugins/organization";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
+import { useSession } from "@/lib/auth/auth.query";
 import { authClient } from "@/lib/clients/auth/auth-client";
 import { handleApiError } from "./utils";
 
@@ -61,7 +62,7 @@ export const organizationKeys = {
  * Fetch invitation details by ID
  */
 export function useInvitation(invitationId: string) {
-  const session = authClient.useSession();
+  const session = useSession();
   return useQuery({
     queryKey: organizationKeys.invitation(invitationId),
     queryFn: async () => {
@@ -254,7 +255,7 @@ export function useCreateInvitation(organizationId: string | undefined) {
  * Get organization
  */
 export function useOrganization(enabled = true) {
-  const session = authClient.useSession();
+  const session = useSession();
 
   return useQuery({
     queryKey: organizationKeys.details(),

--- a/platform/frontend/src/lib/organization.query.ts
+++ b/platform/frontend/src/lib/organization.query.ts
@@ -66,7 +66,7 @@ export function useInvitation(invitationId: string) {
   return useQuery({
     queryKey: organizationKeys.invitation(invitationId),
     queryFn: async () => {
-      if (!session) {
+      if (!session.data?.user) {
         return undefined;
       }
       const response = await authClient.organization.getInvitation({
@@ -74,6 +74,7 @@ export function useInvitation(invitationId: string) {
       });
       return response.data;
     },
+    enabled: !!session.data?.user,
   });
 }
 


### PR DESCRIPTION
## Summary
- Route frontend session reads through the shared TanStack Query `useSession()` wrapper instead of calling Better Auth session APIs directly.
- Add shared auth query keys, longer session/permission stale times, auth cache invalidation after sign-in/account changes, and focus refetching for session freshness.
- Document `authClient` as the low-level client and warn against direct session fetching.
- Prevent invitation detail queries from firing before an authenticated user is available.
- Disable eager `next/font` preloads for optional white-label theme fonts so pages do not fetch every registered font before appearance settings choose the active theme.
- Disable viewport prefetch on shell sidebar links and replace it with manual `router.prefetch()` on hover/focus, including safer handling for future object hrefs.
- Reduce chat shell query churn by keeping the closed global conversation search palette from fetching conversations, caching agent delegations briefly, and deferring MCP install-orchestrator reads until the agent selector/edit flow is active.

## Why
Pages with many auth-aware components could mount independent session observers outside the app query cache. Centralizing session reads lets session, permissions, and dependent UI queries share a single cache and invalidation path. Session focus refetching stays enabled so a backgrounded tab can still discover revoked or changed auth state promptly.

The invitation detail hook also had a dead session guard because `useSession()` always returns a query object. It now checks for `session.data?.user` and disables the query until the user exists.

The root layout registered all theme font variables with preload enabled, which caused every local font file to be fetched up front. The fonts remain registered for theme switching, but the browser now lazy-loads only the font referenced by the active theme.

The sidebar rendered many visible internal links, so Next.js prefetched their RSC payloads as soon as the shell mounted. Manual hover/focus prefetch preserves fast intentional navigation without competing with initial page API calls.

The chat shell also had avoidable duplicate/eager data reads. The conversation search palette now waits until it is opened, delegation queries reuse a short-lived cache, and the agent selector still shows current-agent avatars while avoiding install-management registry/server reads until the user opens selector management UI.