### PR TITLE
chore: reduce MCP registry request churn

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -101015,7 +101015,9 @@
                       },
                       "toolCount": {
                         "default": 0,
-                        "type": "number"
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
                       }
                     },
                     "required": [
@@ -102389,7 +102391,9 @@
                     },
                     "toolCount": {
                       "default": 0,
-                      "type": "number"
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
                     }
                   },
                   "required": [
@@ -103245,7 +103249,9 @@
                     },
                     "toolCount": {
                       "default": 0,
-                      "type": "number"
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
                     }
                   },
                   "required": [
@@ -104618,7 +104624,9 @@
                     },
                     "toolCount": {
                       "default": 0,
-                      "type": "number"
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
                     }
                   },
                   "required": [

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Archestra",
-    "version": "1.2.38"
+    "version": "1.2.39"
   },
   "components": {
     "schemas": {
@@ -101012,6 +101012,10 @@
                       "authorName": {
                         "nullable": true,
                         "type": "string"
+                      },
+                      "toolCount": {
+                        "default": 0,
+                        "type": "number"
                       }
                     },
                     "required": [
@@ -101043,7 +101047,8 @@
                       "createdAt",
                       "updatedAt",
                       "labels",
-                      "teams"
+                      "teams",
+                      "toolCount"
                     ],
                     "additionalProperties": false
                   }
@@ -102381,6 +102386,10 @@
                     "authorName": {
                       "nullable": true,
                       "type": "string"
+                    },
+                    "toolCount": {
+                      "default": 0,
+                      "type": "number"
                     }
                   },
                   "required": [
@@ -102412,7 +102421,8 @@
                     "createdAt",
                     "updatedAt",
                     "labels",
-                    "teams"
+                    "teams",
+                    "toolCount"
                   ],
                   "additionalProperties": false
                 }
@@ -103232,6 +103242,10 @@
                     "authorName": {
                       "nullable": true,
                       "type": "string"
+                    },
+                    "toolCount": {
+                      "default": 0,
+                      "type": "number"
                     }
                   },
                   "required": [
@@ -103263,7 +103277,8 @@
                     "createdAt",
                     "updatedAt",
                     "labels",
-                    "teams"
+                    "teams",
+                    "toolCount"
                   ],
                   "additionalProperties": false
                 }
@@ -104600,6 +104615,10 @@
                     "authorName": {
                       "nullable": true,
                       "type": "string"
+                    },
+                    "toolCount": {
+                      "default": 0,
+                      "type": "number"
                     }
                   },
                   "required": [
@@ -104631,7 +104650,8 @@
                     "createdAt",
                     "updatedAt",
                     "labels",
-                    "teams"
+                    "teams",
+                    "toolCount"
                   ],
                   "additionalProperties": false
                 }

--- a/platform/backend/src/models/internal-mcp-catalog.test.ts
+++ b/platform/backend/src/models/internal-mcp-catalog.test.ts
@@ -359,7 +359,9 @@ describe("InternalMcpCatalogModel", () => {
       expect(found?.labels[0].value).toBe("ai");
     });
 
-    test("findAll returns labels for all items", async () => {
+    test("findAll returns labels and tool counts for all items", async ({
+      makeTool,
+    }) => {
       const catalog = await InternalMcpCatalogModel.create({
         name: "catalog-find-all-labels",
         serverType: "remote",
@@ -368,6 +370,8 @@ describe("InternalMcpCatalogModel", () => {
           { key: "team", value: "platform" },
         ],
       });
+      await makeTool({ catalogId: catalog.id, name: "catalog-label-tool-1" });
+      await makeTool({ catalogId: catalog.id, name: "catalog-label-tool-2" });
 
       const all = await InternalMcpCatalogModel.findAll({
         expandSecrets: false,
@@ -378,6 +382,7 @@ describe("InternalMcpCatalogModel", () => {
       expect(found?.labels).toHaveLength(2);
       expect(found?.labels[0].key).toBe("region");
       expect(found?.labels[1].key).toBe("team");
+      expect(found?.toolCount).toBe(2);
     });
 
     test("searchByQuery returns labels", async () => {

--- a/platform/backend/src/models/internal-mcp-catalog.ts
+++ b/platform/backend/src/models/internal-mcp-catalog.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, ilike, inArray, or } from "drizzle-orm";
+import { and, count, desc, eq, ilike, inArray, or } from "drizzle-orm";
 import db, { schema } from "@/database";
 import { secretManager } from "@/secrets-manager";
 import {
@@ -54,6 +54,7 @@ class InternalMcpCatalogModel {
       ...createdItem,
       labels: itemLabels,
       teams: itemTeams,
+      toolCount: 0,
     };
     await InternalMcpCatalogModel.populateAuthorNames([result]);
     return result;
@@ -99,7 +100,7 @@ class InternalMcpCatalogModel {
     }
 
     const catalogItems =
-      await InternalMcpCatalogModel.attachLabelsAndTeams(dbItems);
+      await InternalMcpCatalogModel.attachListMetadata(dbItems);
 
     if (expandSecrets) {
       await InternalMcpCatalogModel.expandSecrets(catalogItems);
@@ -162,7 +163,7 @@ class InternalMcpCatalogModel {
     }
 
     const catalogItems =
-      await InternalMcpCatalogModel.attachLabelsAndTeams(dbItems);
+      await InternalMcpCatalogModel.attachListMetadata(dbItems);
 
     if (expandSecrets) {
       await InternalMcpCatalogModel.expandSecrets(catalogItems);
@@ -214,7 +215,13 @@ class InternalMcpCatalogModel {
 
     const labels = await McpCatalogLabelModel.getLabelsForCatalogItem(id);
     const teams = await McpCatalogTeamModel.getTeamDetailsForCatalog(id);
-    const catalogItem: InternalMcpCatalog = { ...dbItem, labels, teams };
+    const toolCount = await InternalMcpCatalogModel.getToolCount(id);
+    const catalogItem: InternalMcpCatalog = {
+      ...dbItem,
+      labels,
+      teams,
+      toolCount,
+    };
 
     if (expandSecrets) {
       await InternalMcpCatalogModel.expandSecrets([catalogItem]);
@@ -243,7 +250,13 @@ class InternalMcpCatalogModel {
 
     const labels = await McpCatalogLabelModel.getLabelsForCatalogItem(id);
     const teams = await McpCatalogTeamModel.getTeamDetailsForCatalog(id);
-    const catalogItem: InternalMcpCatalog = { ...dbItem, labels, teams };
+    const toolCount = await InternalMcpCatalogModel.getToolCount(id);
+    const catalogItem: InternalMcpCatalog = {
+      ...dbItem,
+      labels,
+      teams,
+      toolCount,
+    };
 
     await InternalMcpCatalogModel.expandSecretsAndAlwaysResolveValues([
       catalogItem,
@@ -269,7 +282,7 @@ class InternalMcpCatalogModel {
       .where(inArray(schema.internalMcpCatalogTable.id, ids));
 
     const catalogItems =
-      await InternalMcpCatalogModel.attachLabelsAndTeams(dbItems);
+      await InternalMcpCatalogModel.attachListMetadata(dbItems);
 
     const result = new Map<string, InternalMcpCatalog>();
     for (const item of catalogItems) {
@@ -306,7 +319,8 @@ class InternalMcpCatalogModel {
       dbItem.id,
     );
     const teams = await McpCatalogTeamModel.getTeamDetailsForCatalog(dbItem.id);
-    return { ...dbItem, labels, teams };
+    const toolCount = await InternalMcpCatalogModel.getToolCount(dbItem.id);
+    return { ...dbItem, labels, teams, toolCount };
   }
 
   static async update(
@@ -347,10 +361,12 @@ class InternalMcpCatalogModel {
 
     const itemLabels = await McpCatalogLabelModel.getLabelsForCatalogItem(id);
     const itemTeams = await McpCatalogTeamModel.getTeamDetailsForCatalog(id);
+    const toolCount = await InternalMcpCatalogModel.getToolCount(id);
     const result: InternalMcpCatalog = {
       ...dbItem,
       labels: itemLabels,
       teams: itemTeams,
+      toolCount,
     };
     await InternalMcpCatalogModel.populateAuthorNames([result]);
     return result;
@@ -544,9 +560,9 @@ class InternalMcpCatalogModel {
   }
 
   /**
-   * Bulk-load labels and teams for an array of DB rows and attach them.
+   * Bulk-load list metadata for an array of DB rows and attach it.
    */
-  private static async attachLabelsAndTeams(
+  private static async attachListMetadata(
     dbItems: Array<typeof schema.internalMcpCatalogTable.$inferSelect>,
   ): Promise<InternalMcpCatalog[]> {
     if (dbItems.length === 0) {
@@ -554,16 +570,52 @@ class InternalMcpCatalogModel {
     }
 
     const ids = dbItems.map((item) => item.id);
-    const [labelsMap, teamsMap] = await Promise.all([
+    const [labelsMap, teamsMap, toolCountMap] = await Promise.all([
       McpCatalogLabelModel.getLabelsForCatalogItems(ids),
       McpCatalogTeamModel.getTeamDetailsForCatalogs(ids),
+      InternalMcpCatalogModel.getToolCounts(ids),
     ]);
 
     return dbItems.map((item) => ({
       ...item,
       labels: labelsMap.get(item.id) || [],
       teams: teamsMap.get(item.id) || [],
+      toolCount: toolCountMap.get(item.id) ?? 0,
     }));
+  }
+
+  private static async getToolCounts(
+    catalogIds: string[],
+  ): Promise<Map<string, number>> {
+    if (catalogIds.length === 0) {
+      return new Map();
+    }
+
+    const rows = await db
+      .select({
+        catalogId: schema.toolsTable.catalogId,
+        toolCount: count(schema.toolsTable.id),
+      })
+      .from(schema.toolsTable)
+      .where(inArray(schema.toolsTable.catalogId, catalogIds))
+      .groupBy(schema.toolsTable.catalogId);
+
+    return new Map(
+      rows
+        .filter(
+          (row): row is { catalogId: string; toolCount: number } =>
+            row.catalogId !== null,
+        )
+        .map((row) => [row.catalogId, row.toolCount]),
+    );
+  }
+
+  private static async getToolCount(catalogId: string): Promise<number> {
+    return (
+      (await InternalMcpCatalogModel.getToolCounts([catalogId])).get(
+        catalogId,
+      ) ?? 0
+    );
   }
 
   /**

--- a/platform/backend/src/types/mcp-catalog.ts
+++ b/platform/backend/src/types/mcp-catalog.ts
@@ -113,7 +113,7 @@ export const SelectInternalMcpCatalogSchema = createSelectSchema(
   // Teams are loaded from the junction table, not from the DB row
   teams: z.array(z.object({ id: z.string(), name: z.string() })).default([]),
   authorName: z.string().nullable().optional(),
-  toolCount: z.number().default(0),
+  toolCount: z.number().int().default(0),
 });
 
 const InsertInternalMcpCatalogSchemaBase = createInsertSchema(

--- a/platform/backend/src/types/mcp-catalog.ts
+++ b/platform/backend/src/types/mcp-catalog.ts
@@ -113,6 +113,7 @@ export const SelectInternalMcpCatalogSchema = createSelectSchema(
   // Teams are loaded from the junction table, not from the DB row
   teams: z.array(z.object({ id: z.string(), name: z.string() })).default([]),
   authorName: z.string().nullable().optional(),
+  toolCount: z.number().default(0),
 });
 
 const InsertInternalMcpCatalogSchemaBase = createInsertSchema(

--- a/platform/frontend/src/app/agents/page.client.tsx
+++ b/platform/frontend/src/app/agents/page.client.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  type AgentType,
-  archestraApiSdk,
-  type archestraApiTypes,
-  E2eTestId,
-} from "@shared";
-import { useQuery } from "@tanstack/react-query";
+import { type AgentType, type archestraApiTypes, E2eTestId } from "@shared";
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
 import { ChevronDown, ChevronUp, Plus, Upload } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -47,6 +41,7 @@ import {
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useAppName } from "@/lib/hooks/use-app-name";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
+import { useTeams } from "@/lib/teams/team.query";
 import { AgentActions } from "./agent-actions";
 
 type AgentsInitialData = {
@@ -155,15 +150,7 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
   });
   const { data: canReadTeams } = useHasPermissions({ team: ["read"] });
 
-  // Keep teams cache warm for AgentDialog
-  const { data: userTeams } = useQuery({
-    queryKey: ["teams"],
-    queryFn: async () => {
-      const { data } = await archestraApiSdk.getTeams({
-        query: { limit: 100, offset: 0 },
-      });
-      return data?.data || [];
-    },
+  const { data: userTeams } = useTeams({
     initialData: initialData?.teams,
     enabled: !!canReadTeams,
   });

--- a/platform/frontend/src/app/llm/proxies/page.client.tsx
+++ b/platform/frontend/src/app/llm/proxies/page.client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { archestraApiSdk, type archestraApiTypes, E2eTestId } from "@shared";
-import { useQuery } from "@tanstack/react-query";
+import { type archestraApiTypes, E2eTestId } from "@shared";
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
 import { ChevronDown, ChevronUp, Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -37,6 +36,7 @@ import { useDeleteProfile, useProfilesPaginated } from "@/lib/agent.query";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { getFrontendDocsUrl } from "@/lib/docs/docs";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
+import { useTeams } from "@/lib/teams/team.query";
 import { LlmProxyActions } from "./llm-proxy-actions";
 
 type LlmProxiesInitialData = {
@@ -141,14 +141,7 @@ function LlmProxies({ initialData }: { initialData?: LlmProxiesInitialData }) {
   });
   const { data: canReadTeams } = useHasPermissions({ team: ["read"] });
 
-  const { data: userTeams } = useQuery({
-    queryKey: ["teams"],
-    queryFn: async () => {
-      const { data } = await archestraApiSdk.getTeams({
-        query: { limit: 100, offset: 0 },
-      });
-      return data?.data || [];
-    },
+  const { data: userTeams } = useTeams({
     initialData: initialData?.teams,
     enabled: !!canReadTeams,
   });

--- a/platform/frontend/src/app/mcp/gateways/page.client.tsx
+++ b/platform/frontend/src/app/mcp/gateways/page.client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { archestraApiSdk, type archestraApiTypes, E2eTestId } from "@shared";
-import { useQuery } from "@tanstack/react-query";
+import { type archestraApiTypes, E2eTestId } from "@shared";
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
 import { ChevronDown, ChevronUp, Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -41,6 +40,7 @@ import {
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { getFrontendDocsUrl } from "@/lib/docs/docs";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
+import { useTeams } from "@/lib/teams/team.query";
 import { McpGatewayActions } from "./mcp-gateway-actions";
 
 type McpGatewaysInitialData = {
@@ -154,14 +154,7 @@ function McpGateways({
   });
   const { data: canReadTeams } = useHasPermissions({ team: ["read"] });
 
-  const { data: userTeams } = useQuery({
-    queryKey: ["teams"],
-    queryFn: async () => {
-      const { data } = await archestraApiSdk.getTeams({
-        query: { limit: 100, offset: 0 },
-      });
-      return data?.data || [];
-    },
+  const { data: userTeams } = useTeams({
     initialData: initialData?.teams,
     enabled: !!canReadTeams,
   });

--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -54,6 +54,7 @@ import {
 import {
   useInstallMcpServer,
   useMcpDeploymentStatuses,
+  useMcpInstallationStatusCacheSync,
   useMcpServers,
   useReauthenticateMcpServer,
   useReinstallMcpServer,
@@ -110,8 +111,8 @@ export function InternalMCPCatalog({
   >(new Set());
   const { data: installedServers } = useMcpServers({
     initialData: initialInstalledServers,
-    hasInstallingServers: installingServerIds.size > 0,
   });
+  useMcpInstallationStatusCacheSync();
   const installMutation = useInstallMcpServer();
   const reinstallMutation = useReinstallMcpServer();
   const reauthMutation = useReauthenticateMcpServer();

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  archestraApiSdk,
   type archestraApiTypes,
   E2eTestId,
   getManageCredentialsButtonTestId,
@@ -40,10 +39,11 @@ import {
 } from "@/components/ui/tooltip";
 import { TruncatedTooltip } from "@/components/ui/truncated-tooltip";
 import { LOCAL_MCP_DISABLED_MESSAGE } from "@/consts";
-import { useCreateProfile } from "@/lib/agent.query";
+import { fetchInternalAgents, useCreateProfile } from "@/lib/agent.query";
 import { useBulkAssignTools } from "@/lib/agent-tools.query";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useFeature } from "@/lib/config/config.query";
+import { fetchCatalogTools } from "@/lib/mcp/internal-mcp-catalog.query";
 import { useMcpServers } from "@/lib/mcp/mcp-server.query";
 import { useTeams } from "@/lib/teams/team.query";
 import {
@@ -189,9 +189,7 @@ export function McpServerCard({
     const agentName = item.name;
     try {
       // Get or create: check if a personal agent with this name already exists for the current user
-      const { data: existingAgents } = await archestraApiSdk.getAllAgents({
-        query: { agentType: "agent" },
-      });
+      const existingAgents = await fetchInternalAgents();
       const existing = existingAgents?.find(
         (a) => a.name === agentName && a.authorId === currentUserId,
       );
@@ -206,14 +204,7 @@ export function McpServerCard({
           icon: item.icon ?? undefined,
         }));
 
-      const { data: tools, error } =
-        await archestraApiSdk.getInternalMcpCatalogTools({
-          path: { id: item.id },
-        });
-      if (error) {
-        toast.error("Failed to load MCP server tools");
-        return;
-      }
+      const tools = await fetchCatalogTools(item.id);
 
       if (agent && tools && tools.length > 0) {
         const assignments = tools.map((tool) => ({

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -44,8 +44,7 @@ import { useCreateProfile } from "@/lib/agent.query";
 import { useBulkAssignTools } from "@/lib/agent-tools.query";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useFeature } from "@/lib/config/config.query";
-import { useCatalogTools } from "@/lib/mcp/internal-mcp-catalog.query";
-import { useMcpServers, useMcpServerTools } from "@/lib/mcp/mcp-server.query";
+import { useMcpServers } from "@/lib/mcp/mcp-server.query";
 import { useTeams } from "@/lib/teams/team.query";
 import {
   computeDeploymentStatusSummary,
@@ -61,15 +60,11 @@ import { UninstallServerDialog } from "./uninstall-server-dialog";
 export type CatalogItem =
   archestraApiTypes.GetInternalMcpCatalogResponses["200"][number];
 
-export type CatalogItemWithOptionalLabel = CatalogItem & {
-  label?: string | null;
-};
-
 export type InstalledServer =
   archestraApiTypes.GetMcpServersResponses["200"][number];
 
 export type McpServerCardProps = {
-  item: CatalogItemWithOptionalLabel;
+  item: CatalogItem;
   installedServer?: InstalledServer | null;
   installingItemId: string | null;
   installationStatus?:
@@ -122,17 +117,7 @@ export function McpServerCard({
   onAddOrgConnection,
   isBuiltInPlaywright = false,
 }: McpServerCardBaseProps) {
-  const isBuiltin = variant === "builtin";
   const isPlaywrightVariant = isBuiltInPlaywright;
-
-  // For builtin servers, fetch tools by catalog ID
-  // For regular MCP servers, fetch by server ID
-  const { data: mcpServerTools } = useMcpServerTools(
-    !isBuiltin ? (installedServer?.id ?? null) : null,
-  );
-  const { data: catalogTools } = useCatalogTools(isBuiltin ? item.id : null);
-
-  const tools = isBuiltin ? catalogTools : mcpServerTools;
 
   const createAgent = useCreateProfile();
   const bulkAssignTools = useBulkAssignTools();
@@ -201,7 +186,7 @@ export function McpServerCard({
 
   const handleChatWithMcpServer = async () => {
     setIsChatCreating(true);
-    const agentName = item.label || item.name;
+    const agentName = item.name;
     try {
       // Get or create: check if a personal agent with this name already exists for the current user
       const { data: existingAgents } = await archestraApiSdk.getAllAgents({
@@ -220,6 +205,15 @@ export function McpServerCard({
           teams: [],
           icon: item.icon ?? undefined,
         }));
+
+      const { data: tools, error } =
+        await archestraApiSdk.getInternalMcpCatalogTools({
+          path: { id: item.id },
+        });
+      if (error) {
+        toast.error("Failed to load MCP server tools");
+        return;
+      }
 
       if (agent && tools && tools.length > 0) {
         const assignments = tools.map((tool) => ({
@@ -368,9 +362,10 @@ export function McpServerCard({
     deploymentServerIds,
     effectiveDeploymentStatuses,
   );
+  const toolsCount = item.toolCount ?? 0;
 
   const chatButton =
-    tools && tools.length > 0 ? (
+    toolsCount > 0 ? (
       <Button
         variant="outline"
         size="sm"
@@ -440,8 +435,6 @@ export function McpServerCard({
     }
   }
   const extraCount = connectionAvatars.length - MAX_AVATARS;
-
-  const toolsCount = tools?.length ?? 0;
 
   const showAuthorAvatar =
     item.scope === "personal" && Boolean(item.authorName);

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-settings-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-settings-dialog.tsx
@@ -31,7 +31,7 @@ import {
 import { EditCatalogContent } from "./edit-catalog-dialog";
 import { ManageUsersContent } from "./manage-users-dialog";
 import { McpLogsContent, type McpLogsTab } from "./mcp-logs-dialog";
-import type { CatalogItemWithOptionalLabel } from "./mcp-server-card";
+import type { CatalogItem } from "./mcp-server-card";
 import { YamlConfigContent } from "./yaml-config-dialog";
 
 type SettingsPage =
@@ -52,7 +52,7 @@ interface McpServerSettingsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   initialPage?: SettingsPage;
-  item: CatalogItemWithOptionalLabel;
+  item: CatalogItem;
   variant: "remote" | "local" | "builtin";
   showConnections: boolean;
   connectionCount?: number;
@@ -216,9 +216,7 @@ export function McpServerSettingsDialog({
           className="max-w-6xl h-[85vh] flex flex-row p-0 gap-0 overflow-hidden"
           showCloseButton={false}
         >
-          <DialogTitle className="sr-only">
-            {item.label || item.name} Settings
-          </DialogTitle>
+          <DialogTitle className="sr-only">{item.name} Settings</DialogTitle>
           <DialogDescription className="sr-only">
             Server settings and configuration
           </DialogDescription>
@@ -229,9 +227,9 @@ export function McpServerSettingsDialog({
               <div className="flex min-w-0 items-center gap-2.5">
                 <SidebarIcon icon={item.icon} catalogId={item.id} />
                 <div className="min-w-0 flex-1">
-                  <TruncatedTooltip content={item.label || item.name}>
+                  <TruncatedTooltip content={item.name}>
                     <div className="font-semibold text-sm truncate">
-                      {item.label || item.name}
+                      {item.name}
                     </div>
                   </TruncatedTooltip>
                   {summary && (
@@ -359,7 +357,7 @@ export function McpServerSettingsDialog({
                 <ManageUsersContent
                   isActive={open && validPage === "connections"}
                   onClose={handleClose}
-                  label={item.label || item.name}
+                  label={item.name}
                   catalogId={item.id}
                   onAddPersonalConnection={onAddPersonalConnection}
                   onAddSharedConnection={onAddSharedConnection}
@@ -383,7 +381,7 @@ export function McpServerSettingsDialog({
                   <div className="flex flex-col flex-1 min-h-0">
                     <McpLogsContent
                       isActive={open && isDebugPage}
-                      serverName={item.label || item.name}
+                      serverName={item.name}
                       installs={
                         item.multitenant
                           ? // Multi-tenant catalogs alias one pod; pick the
@@ -397,7 +395,7 @@ export function McpServerSettingsDialog({
                               return [
                                 {
                                   ...reporting,
-                                  name: item.label || item.name,
+                                  name: item.name,
                                   ownerEmail: null,
                                   teamDetails: null,
                                   scope: null,

--- a/platform/frontend/src/app/scheduled-tasks/schedule-triggers-client.tsx
+++ b/platform/frontend/src/app/scheduled-tasks/schedule-triggers-client.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { archestraApiSdk } from "@shared";
-import { useQuery } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
 import { Cron } from "croner";
 import {
@@ -73,6 +71,7 @@ import {
   useScheduleTriggers,
   useUpdateScheduleTrigger,
 } from "@/lib/schedule-trigger.query";
+import { useTeams } from "@/lib/teams/team.query";
 import { cn } from "@/lib/utils";
 import { formatRelativeTimeFromNow } from "@/lib/utils/date-time";
 import { formatCronSchedule } from "@/lib/utils/format-cron";
@@ -578,15 +577,7 @@ export function ScheduleTriggerDetailPage({
   const { data: isAgentTeamAdmin = false } = useHasPermissions({
     agent: ["team-admin"],
   });
-  const { data: userTeams = [] } = useQuery({
-    queryKey: ["teams"],
-    queryFn: async () => {
-      const response = await archestraApiSdk.getTeams({
-        query: { limit: 100, offset: 0 },
-      });
-      return response.data?.data ?? [];
-    },
-  });
+  const { data: userTeams = [] } = useTeams();
   const userTeamIdSet = useMemo(
     () => new Set(userTeams.map((t) => t.id)),
     [userTeams],

--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -4,7 +4,6 @@ import {
   type AgentScope,
   type AgentToolAssignmentMode,
   type AgentType,
-  archestraApiSdk,
   type archestraApiTypes,
   BLOCKED_PASSTHROUGH_HEADERS,
   BUILT_IN_AGENT_DEFAULT_SYSTEM_PROMPTS,
@@ -23,7 +22,6 @@ import {
   TOOL_RUN_TOOL_SHORT_NAME,
   TOOL_SEARCH_TOOLS_SHORT_NAME,
 } from "@shared";
-import { useQuery } from "@tanstack/react-query";
 import {
   AlertTriangle,
   Bot,
@@ -141,6 +139,7 @@ import { useConnectors } from "@/lib/knowledge/connector.query";
 import { useKnowledgeBases } from "@/lib/knowledge/knowledge-base.query";
 import { useLlmModelsByProvider } from "@/lib/llm-models.query";
 import { useAvailableLlmProviderApiKeys } from "@/lib/llm-provider-api-keys.query";
+import { useTeams } from "@/lib/teams/team.query";
 import { cn } from "@/lib/utils";
 import {
   getDescriptionPlaceholder,
@@ -582,14 +581,7 @@ export function AgentDialog({
 
   // Fetch fresh agent data when dialog opens
   const { data: freshAgent, refetch: refetchAgent } = useProfile(agent?.id);
-  const { data: teams } = useQuery({
-    queryKey: ["teams"],
-    queryFn: async () => {
-      const response = await archestraApiSdk.getTeams({
-        query: { limit: 100, offset: 0 },
-      });
-      return response.data?.data ?? [];
-    },
+  const { data: teams } = useTeams({
     enabled: open && !!canReadTeams,
   });
   const resource = getResourceForAgentType(agentType);

--- a/platform/frontend/src/components/teams/teams-list.tsx
+++ b/platform/frontend/src/components/teams/teams-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { archestraApiSdk, type archestraApiTypes, E2eTestId } from "@shared";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
 import { Key, Link2, Plus, Trash2, Users, Vault } from "lucide-react";
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
@@ -23,6 +23,7 @@ import { Textarea } from "@/components/ui/textarea";
 import config from "@/lib/config/config";
 import { useFeature } from "@/lib/config/config.query";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
+import { useTeams } from "@/lib/teams/team.query";
 import { type TeamToken, useTokens } from "@/lib/teams/team-token.query";
 import { formatRelativeTimeFromNow } from "@/lib/utils/date-time";
 import { TeamMembersDialog } from "./team-members-dialog";
@@ -71,15 +72,7 @@ export function TeamsList() {
   const { data: tokensData, isLoading: tokensLoading } = useTokens();
   const tokens = tokensData?.tokens;
 
-  const { data: teams, isLoading } = useQuery({
-    queryKey: ["teams"],
-    queryFn: async () => {
-      const { data } = await archestraApiSdk.getTeams({
-        query: { limit: 100, offset: 0 },
-      });
-      return data?.data ?? [];
-    },
-  });
+  const { data: teams, isLoading } = useTeams();
 
   const createMutation = useMutation({
     mutationFn: async (data: { name: string; description?: string }) => {

--- a/platform/frontend/src/lib/agent.query.ts
+++ b/platform/frontend/src/lib/agent.query.ts
@@ -26,6 +26,19 @@ const {
   getMemberDefaultAgent,
 } = archestraApiSdk;
 
+export const internalAgentsQueryKey = [
+  "agents",
+  "all",
+  { agentType: "agent", excludeBuiltIn: true },
+] as const;
+
+export async function fetchInternalAgents() {
+  const response = await getAllAgents({
+    query: { agentType: "agent", excludeBuiltIn: true },
+  });
+  return response.data ?? [];
+}
+
 // Returns all agents as an array
 export function useProfiles(
   params: {
@@ -303,13 +316,8 @@ export function useDefaultAgentId() {
 
 export function useInternalAgents(params?: { enabled?: boolean }) {
   return useQuery({
-    queryKey: ["agents", "all", { agentType: "agent", excludeBuiltIn: true }],
-    queryFn: async () => {
-      const response = await getAllAgents({
-        query: { agentType: "agent", excludeBuiltIn: true },
-      });
-      return response.data ?? [];
-    },
+    queryKey: internalAgentsQueryKey,
+    queryFn: fetchInternalAgents,
     enabled: params?.enabled,
   });
 }

--- a/platform/frontend/src/lib/auth/use-can-manage-gateway.ts
+++ b/platform/frontend/src/lib/auth/use-can-manage-gateway.ts
@@ -1,6 +1,6 @@
-import { archestraApiSdk, type archestraApiTypes } from "@shared";
-import { useQuery } from "@tanstack/react-query";
+import type { archestraApiTypes } from "@shared";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
+import { useTeams } from "@/lib/teams/team.query";
 
 type Gateway = archestraApiTypes.GetAgentResponses["200"] | null | undefined;
 
@@ -25,14 +25,7 @@ export function useCanManageGateway(gateway: Gateway): {
   const { data: session, isPending: isSessionLoading } = useSession();
   const currentUserId = session?.user?.id;
 
-  const { data: userTeams, isLoading: isTeamsLoading } = useQuery({
-    queryKey: ["teams"],
-    queryFn: async () => {
-      const { data } = await archestraApiSdk.getTeams({
-        query: { limit: 100, offset: 0 },
-      });
-      return data?.data ?? [];
-    },
+  const { data: userTeams, isLoading: isTeamsLoading } = useTeams({
     enabled: !!canReadTeams && gateway?.scope === "team",
   });
 

--- a/platform/frontend/src/lib/mcp/mcp-server.query.test.tsx
+++ b/platform/frontend/src/lib/mcp/mcp-server.query.test.tsx
@@ -1,0 +1,81 @@
+import type { McpInstallationStatusMessage } from "@shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useMcpInstallationStatusCacheSync } from "./mcp-server.query";
+
+const { connectMock, subscribeMock } = vi.hoisted(() => ({
+  connectMock: vi.fn(),
+  subscribeMock: vi.fn(),
+}));
+
+vi.mock("@/lib/websocket/websocket", () => ({
+  default: {
+    connect: connectMock,
+    subscribe: subscribeMock,
+  },
+}));
+
+describe("useMcpInstallationStatusCacheSync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updates cached MCP server installation status from websocket messages", () => {
+    let statusHandler:
+      | ((message: McpInstallationStatusMessage) => void)
+      | null = null;
+    subscribeMock.mockImplementation((type, handler) => {
+      if (type === "mcp_installation_status") {
+        statusHandler = handler;
+      }
+      return vi.fn();
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    queryClient.setQueryData(
+      ["mcp-servers", {}],
+      [
+        {
+          id: "server-1",
+          localInstallationStatus: "pending",
+          localInstallationError: null,
+        },
+      ],
+    );
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    renderHook(() => useMcpInstallationStatusCacheSync(), { wrapper });
+
+    expect(connectMock).toHaveBeenCalledTimes(1);
+    expect(subscribeMock).toHaveBeenCalledWith(
+      "mcp_installation_status",
+      expect.any(Function),
+    );
+
+    act(() => {
+      statusHandler?.({
+        type: "mcp_installation_status",
+        payload: {
+          serverId: "server-1",
+          status: "error",
+          error: "Install failed",
+        },
+      });
+    });
+
+    expect(queryClient.getQueryData(["mcp-servers", {}])).toMatchObject([
+      {
+        id: "server-1",
+        localInstallationStatus: "error",
+        localInstallationError: "Install failed",
+      },
+    ]);
+  });
+});

--- a/platform/frontend/src/lib/mcp/mcp-server.query.ts
+++ b/platform/frontend/src/lib/mcp/mcp-server.query.ts
@@ -69,6 +69,48 @@ export function useMcpServers(params?: McpServersParams) {
   });
 }
 
+export function useMcpInstallationStatusCacheSync(enabled = true) {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    websocketService.connect();
+    const unsubscribe = websocketService.subscribe(
+      "mcp_installation_status",
+      (message: McpInstallationStatusMessage) => {
+        const { serverId, status, error } = message.payload;
+
+        queryClient.setQueriesData<
+          archestraApiTypes.GetMcpServersResponses["200"]
+        >({ queryKey: ["mcp-servers"] }, (servers) => {
+          if (!servers) return servers;
+          let didUpdate = false;
+          const nextServers = servers.map((server) => {
+            if (server.id !== serverId) return server;
+            didUpdate = true;
+            return {
+              ...server,
+              localInstallationStatus: status,
+              localInstallationError: error,
+            };
+          });
+          return didUpdate ? nextServers : servers;
+        });
+
+        if (status === "success" || status === "error") {
+          void queryClient.invalidateQueries({ queryKey: ["mcp-catalog"] });
+          void queryClient.invalidateQueries({
+            queryKey: ["mcp-servers", serverId, "tools"],
+          });
+        }
+      },
+    );
+
+    return unsubscribe;
+  }, [enabled, queryClient]);
+}
+
 /**
  * Get MCP servers grouped by catalogId with current user's credentials first.
  * Used for credential/installation selection in tool configuration.

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -27287,6 +27287,7 @@ export type GetInternalMcpCatalogResponses = {
             name: string;
         }>;
         authorName?: string | null;
+        toolCount: number;
     }>;
 };
 
@@ -27606,6 +27607,7 @@ export type CreateInternalMcpCatalogItemResponses = {
             name: string;
         }>;
         authorName?: string | null;
+        toolCount: number;
     };
 };
 
@@ -27895,6 +27897,7 @@ export type GetInternalMcpCatalogItemResponses = {
             name: string;
         }>;
         authorName?: string | null;
+        toolCount: number;
     };
 };
 
@@ -28214,6 +28217,7 @@ export type UpdateInternalMcpCatalogItemResponses = {
             name: string;
         }>;
         authorName?: string | null;
+        toolCount: number;
     };
 };
 


### PR DESCRIPTION
## Summary
- Remove the `/mcp/registry` 2s `/api/mcp_server` polling path while local installs are pending.
- Subscribe to existing `mcp_installation_status` websocket messages and patch the `mcp-servers` TanStack Query cache in place.
- Add integer `toolCount` to internal MCP catalog list responses so registry cards can render tool counts without fetching every installed server's `/tools` endpoint.
- Stop registry cards from eagerly fetching `/api/mcp_server/:id/tools`; full tool data is fetched only when the user starts a chat.
- Route registry card click-time agent/tool lookups through shared `frontend/src/lib` helpers instead of direct component SDK calls.
- Replace repeated client-side `getTeams` query definitions with the shared `useTeams` hook.

## Why
The registry page mounted one card per catalog item. Each installed card fetched `/api/mcp_server/:id/tools` even though the card only needed a count for the compact metadata row and chat button visibility. With many installed servers, this created a large request fanout on page load.

Pending local installs also enabled a 2s refetch interval for `/api/mcp_server`. The backend already emits installation status changes over websocket, so the registry can update from push messages instead of polling the full server list.

Several client components also duplicated the same teams query inline. They now use the shared `useTeams` hook so cache key, pagination defaults, initial data, and enabled behavior stay centralized.

Click-time chat setup still fetches the full agent/tool data it needs, but that work now happens only after explicit user intent and the SDK calls live behind shared lib helpers rather than inside the card component.