### PR TITLE
feat: add Anthropic Workload Identity Federation (WIF) support

### DIFF
--- a/platform/.env.example
+++ b/platform/.env.example
@@ -7,6 +7,14 @@ SUBDOMAIN=n8n
 # LLM Provider Base URLs
 ARCHESTRA_OPENAI_BASE_URL=https://api.openai.com/v1
 ARCHESTRA_ANTHROPIC_BASE_URL=https://api.anthropic.com
+# Anthropic Workload Identity Federation (keyless auth via OIDC tokens)
+# See: https://platform.claude.com/docs/en/manage-claude/workload-identity-federation
+# ARCHESTRA_ANTHROPIC_WIF_ENABLED=true
+# ARCHESTRA_ANTHROPIC_FEDERATION_RULE_ID=fdrl_...
+# ARCHESTRA_ANTHROPIC_ORGANIZATION_ID=00000000-0000-0000-0000-000000000000
+# ARCHESTRA_ANTHROPIC_SERVICE_ACCOUNT_ID=svac_...
+# ARCHESTRA_ANTHROPIC_WORKSPACE_ID=wrkspc_...
+# ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN_FILE=/var/run/secrets/anthropic.com/token
 ARCHESTRA_GEMINI_BASE_URL=https://generativelanguage.googleapis.com
 # Cohere Base URL (uses https://api.cohere.ai by default)
 ARCHESTRA_COHERE_BASE_URL=https://api.cohere.ai

--- a/platform/backend/src/clients/anthropic-wif-credentials.test.ts
+++ b/platform/backend/src/clients/anthropic-wif-credentials.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test, vi, beforeEach } from "vitest";
+
+// Mock config before importing the module
+vi.mock("@/config", () => ({
+  default: {
+    llm: {
+      anthropic: {
+        baseUrl: "https://api.anthropic.com",
+        workloadIdentityFederation: {
+          enabled: true,
+          federationRuleId: "fdrl_test123",
+          organizationId: "org-123",
+          serviceAccountId: "svac_test",
+          workspaceId: "wrkspc_test",
+          identityTokenFile: "/tmp/test-token",
+        },
+      },
+    },
+  },
+}));
+
+// Mock fs/promises
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(async () => "mock-oidc-jwt-token"),
+}));
+
+import { isAnthropicWifEnabled, getAnthropicWifAccessToken } from "./anthropic-wif-credentials";
+
+describe("Anthropic WIF Credentials", () => {
+  test("isAnthropicWifEnabled returns true when fully configured", () => {
+    expect(isAnthropicWifEnabled()).toBe(true);
+  });
+
+  test("getAnthropicWifAccessToken exchanges JWT for access token", async () => {
+    const mockResponse = {
+      access_token: "test-access-token",
+      expires_in: 3600,
+      token_type: "Bearer",
+      scope: "workspace:developer",
+    };
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify(mockResponse)));
+
+    const token = await getAnthropicWifAccessToken();
+
+    expect(token).toBe("test-access-token");
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.anthropic.com/v1/oauth/token",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: expect.stringContaining("fdrl_test123"),
+      }),
+    );
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/platform/backend/src/clients/anthropic-wif-credentials.ts
+++ b/platform/backend/src/clients/anthropic-wif-credentials.ts
@@ -1,0 +1,100 @@
+import { readFile } from "node:fs/promises";
+import config from "@/config";
+
+/**
+ * Anthropic Workload Identity Federation (WIF) support.
+ *
+ * Exchanges a short-lived OIDC token from an external identity provider
+ * (AWS, GCP, Azure, GitHub Actions, Kubernetes, etc.) for an Anthropic
+ * access token, eliminating the need for long-lived API keys.
+ *
+ * @see https://platform.claude.com/docs/en/manage-claude/workload-identity-federation
+ */
+
+let cachedAccessToken: string | null = null;
+let tokenExpiresAt = 0;
+
+/**
+ * Check if Anthropic WIF is enabled and fully configured.
+ */
+export function isAnthropicWifEnabled(): boolean {
+  const wif = config.llm.anthropic.workloadIdentityFederation;
+  return (
+    wif.enabled &&
+    wif.federationRuleId !== "" &&
+    wif.organizationId !== "" &&
+    wif.serviceAccountId !== "" &&
+    wif.workspaceId !== "" &&
+    wif.identityTokenFile !== ""
+  );
+}
+
+/**
+ * Read the OIDC identity token from the configured file path.
+ */
+async function readIdentityToken(): Promise<string> {
+  const tokenFile =
+    config.llm.anthropic.workloadIdentityFederation.identityTokenFile;
+  const token = await readFile(tokenFile, "utf-8");
+  return token.trim();
+}
+
+/**
+ * Exchange the OIDC identity token for a short-lived Anthropic access token.
+ * Caches the token until it expires (with a 60s safety margin).
+ */
+async function exchangeToken(): Promise<string> {
+  if (cachedAccessToken && Date.now() < tokenExpiresAt) {
+    return cachedAccessToken;
+  }
+
+  const wif = config.llm.anthropic.workloadIdentityFederation;
+  const identityToken = await readIdentityToken();
+
+  const baseUrl = config.llm.anthropic.baseUrl;
+  const response = await fetch(`${baseUrl}/v1/oauth/token`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion: identityToken,
+      federation_rule_id: wif.federationRuleId,
+      organization_id: wif.organizationId,
+      service_account_id: wif.serviceAccountId,
+      workspace_id: wif.workspaceId,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    // Clear cached token on failure
+    cachedAccessToken = null;
+    tokenExpiresAt = 0;
+    throw new Error(
+      `Anthropic WIF token exchange failed: ${response.status} ${errorText}`,
+    );
+  }
+
+  const data = (await response.json()) as {
+    access_token: string;
+    expires_in: number;
+    token_type: string;
+    scope: string;
+  };
+
+  cachedAccessToken = data.access_token;
+  // Refresh 60 seconds before expiry
+  tokenExpiresAt = Date.now() + (data.expires_in - 60) * 1000;
+
+  return cachedAccessToken;
+}
+
+/**
+ * Get the Anthropic WIF access token for use in API requests.
+ * Returns a Bearer token suitable for the Authorization header.
+ */
+export async function getAnthropicWifAccessToken(): Promise<string> {
+  return await exchangeToken();
+}

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -609,6 +609,20 @@ const config = {
       azureFoundryEntraIdEnabled:
         process.env.ARCHESTRA_ANTHROPIC_AZURE_FOUNDRY_ENTRA_ID_ENABLED ===
         "true",
+      workloadIdentityFederation: {
+        enabled:
+          process.env.ARCHESTRA_ANTHROPIC_WIF_ENABLED === "true",
+        federationRuleId:
+          process.env.ARCHESTRA_ANTHROPIC_FEDERATION_RULE_ID || "",
+        organizationId:
+          process.env.ARCHESTRA_ANTHROPIC_ORGANIZATION_ID || "",
+        serviceAccountId:
+          process.env.ARCHESTRA_ANTHROPIC_SERVICE_ACCOUNT_ID || "",
+        workspaceId:
+          process.env.ARCHESTRA_ANTHROPIC_WORKSPACE_ID || "",
+        identityTokenFile:
+          process.env.ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN_FILE || "",
+      },
     },
     gemini: {
       baseUrl:

--- a/platform/backend/src/routes/chat/model-fetchers/anthropic.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/anthropic.ts
@@ -2,6 +2,10 @@ import {
   getAzureAiFoundryBearerTokenProvider,
   isAnthropicAzureFoundryEntraIdEnabled,
 } from "@/clients/azure-openai-credentials";
+import {
+  getAnthropicWifAccessToken,
+  isAnthropicWifEnabled,
+} from "@/clients/anthropic-wif-credentials";
 import config from "@/config";
 import logger from "@/logging";
 import type { Anthropic } from "@/types";
@@ -47,14 +51,23 @@ export async function fetchAnthropicModels(
 async function getAnthropicAuthHeaders(
   apiKey: string | undefined,
 ): Promise<Record<string, string>> {
+  // 1. Explicit API key takes precedence
   if (apiKey) {
     return { "x-api-key": apiKey };
   }
 
-  if (!isAnthropicAzureFoundryEntraIdEnabled()) {
-    return { "x-api-key": "" };
+  // 2. Workload Identity Federation (keyless auth)
+  if (isAnthropicWifEnabled()) {
+    const accessToken = await getAnthropicWifAccessToken();
+    return { Authorization: `Bearer ${accessToken}` };
   }
 
-  const tokenProvider = getAzureAiFoundryBearerTokenProvider();
-  return { Authorization: `Bearer ${await tokenProvider()}` };
+  // 3. Azure AI Foundry Entra ID
+  if (isAnthropicAzureFoundryEntraIdEnabled()) {
+    const tokenProvider = getAzureAiFoundryBearerTokenProvider();
+    return { Authorization: `Bearer ${await tokenProvider()}` };
+  }
+
+  // 4. Fallback: no auth
+  return { "x-api-key": "" };
 }

--- a/platform/backend/src/routes/proxy/adapters/anthropic-wif.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic-wif.test.ts
@@ -1,0 +1,71 @@
+import type AnthropicProvider from "@anthropic-ai/sdk";
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("@/observability", () => ({
+  metrics: { llm: { getObservableFetch: vi.fn() } },
+}));
+
+vi.mock("@/clients/anthropic-wif-credentials", () => ({
+  getAnthropicWifAccessToken: vi.fn(async () => "wif-access-token"),
+  isAnthropicWifEnabled: vi.fn(() => true),
+}));
+
+vi.mock("@/clients/azure-openai-credentials", () => ({
+  getAzureAiFoundryBearerTokenProvider: vi.fn(),
+  isAnthropicAzureFoundryEntraIdEnabled: vi.fn(() => false),
+}));
+
+import { anthropicAdapterFactory } from "./anthropic";
+
+describe("anthropicAdapterFactory WIF", () => {
+  test("creates a keyless client that injects WIF bearer auth", async () => {
+    const client = anthropicAdapterFactory.createClient(undefined, {
+      baseUrl: "https://api.anthropic.com",
+      defaultHeaders: {},
+      source: "api",
+    }) as AnthropicProvider & {
+      _options?: {
+        defaultHeaders?: Record<string, string>;
+        fetch?: typeof globalThis.fetch;
+      };
+    };
+
+    expect(client._options?.defaultHeaders?.Authorization).toBe(
+      "Bearer <wif-managed>",
+    );
+
+    const fetch = client._options?.fetch;
+    expect(fetch).toBeDefined();
+
+    const upstreamFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}"));
+
+    await fetch?.("https://api.anthropic.com/v1/messages", {
+      headers: { "anthropic-version": "2023-06-01" },
+    });
+
+    const headers = new Headers(upstreamFetch.mock.calls[0]?.[1]?.headers);
+    expect(headers.get("Authorization")).toBe("Bearer wif-access-token");
+
+    upstreamFetch.mockRestore();
+  });
+
+  test("WIF takes precedence over Azure Foundry when both are enabled", async () => {
+    // WIF is mocked as enabled, Azure is mocked as disabled
+    // So WIF should win
+    const client = anthropicAdapterFactory.createClient(undefined, {
+      baseUrl: "https://api.anthropic.com",
+      defaultHeaders: {},
+      source: "api",
+    }) as AnthropicProvider & {
+      _options?: {
+        defaultHeaders?: Record<string, string>;
+      };
+    };
+
+    expect(client._options?.defaultHeaders?.Authorization).toBe(
+      "Bearer <wif-managed>",
+    );
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -6,6 +6,10 @@ import {
   getAzureAiFoundryBearerTokenProvider,
   isAnthropicAzureFoundryEntraIdEnabled,
 } from "@/clients/azure-openai-credentials";
+import {
+  getAnthropicWifAccessToken,
+  isAnthropicWifEnabled,
+} from "@/clients/anthropic-wif-credentials";
 import config from "@/config";
 import logger from "@/logging";
 import { ModelModel } from "@/models";
@@ -1158,6 +1162,22 @@ export const anthropicAdapterFactory: LLMProvider<
     const token = isAuthToken && apiKey ? apiKey.slice(7) : undefined;
     const regularApiKey = isAuthToken ? undefined : apiKey;
 
+    // Workload Identity Federation (keyless auth via OIDC tokens)
+    if (!apiKey && isAnthropicWifEnabled()) {
+      return new AnthropicProvider({
+        apiKey: null,
+        authToken: null,
+        baseURL: options.baseUrl,
+        fetch: createAnthropicWifFetch(customFetch),
+        defaultHeaders: {
+          ...options.defaultHeaders,
+          // The fetch wrapper replaces this sentinel with a fresh WIF token on every request.
+          Authorization: "Bearer <wif-managed>",
+        },
+      });
+    }
+
+    // Azure AI Foundry Entra ID
     if (!apiKey && isAnthropicAzureFoundryEntraIdEnabled()) {
       return new AnthropicProvider({
         apiKey: null,
@@ -1249,6 +1269,22 @@ function createAnthropicAzureFoundryFetch(
     const tokenProvider = getAzureAiFoundryBearerTokenProvider();
     const headers = new Headers(init?.headers);
     headers.set("Authorization", `Bearer ${await tokenProvider()}`);
+
+    const fetchFn = baseFetch ?? globalThis.fetch;
+    return fetchFn(input, {
+      ...init,
+      headers,
+    });
+  };
+}
+
+function createAnthropicWifFetch(
+  baseFetch: typeof globalThis.fetch | undefined,
+): typeof globalThis.fetch {
+  return async (input, init) => {
+    const accessToken = await getAnthropicWifAccessToken();
+    const headers = new Headers(init?.headers);
+    headers.set("Authorization", `Bearer ${accessToken}`);
 
     const fetchFn = baseFetch ?? globalThis.fetch;
     return fetchFn(input, {


### PR DESCRIPTION
## Summary

Adds keyless authentication for Anthropic via OIDC tokens from external identity providers (AWS, GCP, Azure, GitHub Actions, Kubernetes, etc.), using the new [Workload Identity Federation](https://platform.claude.com/docs/en/manage-claude/workload-identity-federation) feature.

This eliminates the need for long-lived `sk-ant-...` API keys in production environments.

## Changes

- **`config.ts`** — Add WIF configuration options (federation rule ID, org ID, service account, workspace, token file)
- **`anthropic-wif-credentials.ts`** — New module for OIDC token exchange and caching
- **`model-fetchers/anthropic.ts`** — Use WIF auth headers when enabled (priority: API key > WIF > Azure Foundry)
- **`proxy/adapters/anthropic.ts`** — Add WIF fetch wrapper for proxy requests
- **`.env.example`** — Document new environment variables
- **Tests** — Unit tests for WIF credentials and proxy adapter

## Environment Variables

```env
ARCHESTRA_ANTHROPIC_WIF_ENABLED=true
ARCHESTRA_ANTHROPIC_FEDERATION_RULE_ID=fdrl_...
ARCHESTRA_ANTHROPIC_ORGANIZATION_ID=00000000-0000-0000-0000-000000000000
ARCHESTRA_ANTHROPIC_SERVICE_ACCOUNT_ID=svac_...
ARCHESTRA_ANTHROPIC_WORKSPACE_ID=wrkspc_...
ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN_FILE=/var/run/secrets/anthropic.com/token
```

## Authentication Priority

1. **Explicit API key** (if provided) — takes precedence
2. **Workload Identity Federation** (if enabled) — keyless OIDC auth
3. **Azure AI Foundry Entra ID** (if enabled) — existing Azure auth
4. **Fallback** — no auth

## Testing

- Added unit tests for `anthropic-wif-credentials.ts`
- Added unit tests for proxy adapter WIF integration
- Follows existing patterns from `anthropic-azure-foundry.test.ts`