### PR TITLE
feat: add Anthropic Workload Identity Federation (keyless auth)

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -762,6 +762,29 @@ These environment variables set the default base URL for each LLM provider. Per-
   - Uses Azure Identity `DefaultAzureCredential` with token scope `https://ai.azure.com/.default`
   - Claude deployments must already exist in the Azure resource. Microsoft lists additional Claude prerequisites: paid eligible subscription, supported region, Azure Marketplace access for partner models, permission to subscribe to model offerings, and Contributor or Owner role on the resource group. Azure also requires Anthropic deployment metadata: `industry`, `organizationName`, and `countryCode`.
 
+- **`ARCHESTRA_ANTHROPIC_WIF_ENABLED`** - Enable Anthropic Workload Identity Federation (keyless auth).
+  - Default: `false`
+  - When enabled, Archestra exchanges a JWT from your identity provider for a short-lived Anthropic access token via the `/v1/oauth/token` endpoint. No static API key is needed.
+  - Requires all `ARCHESTRA_ANTHROPIC_WIF_*` variables below to be configured.
+  - See [Anthropic WIF documentation](https://docs.anthropic.com/en/docs/manage-claude/workload-identity-federation) for setup instructions.
+
+- **`ARCHESTRA_ANTHROPIC_WIF_FEDERATION_RULE_ID`** - The federation rule ID (`fdrl_...`) from the Anthropic Console.
+  - Required when WIF is enabled.
+
+- **`ARCHESTRA_ANTHROPIC_WIF_ORGANIZATION_ID`** - Your Anthropic organization ID.
+  - Required when WIF is enabled.
+
+- **`ARCHESTRA_ANTHROPIC_WIF_SERVICE_ACCOUNT_ID`** - The service account ID (`svac_...`) the federated token acts as.
+  - Required when WIF is enabled.
+
+- **`ARCHESTRA_ANTHROPIC_WIF_WORKSPACE_ID`** - The workspace ID (`wrkspc_...`) to scope the token to.
+  - Required when WIF is enabled.
+
+- **`ARCHESTRA_ANTHROPIC_WIF_IDENTITY_TOKEN_FILE`** - Path to a file containing the OIDC identity token (JWT) from your identity provider.
+  - Required when WIF is enabled.
+  - The file is re-read on each token exchange, so rotated tokens (e.g., Kubernetes projected service-account tokens) are picked up automatically.
+  - Supported identity providers: AWS IAM, Google Cloud, Azure, GitHub Actions, Kubernetes, SPIFFE, Okta.
+
 - **`ARCHESTRA_GEMINI_BASE_URL`** - Override the Google Gemini API base URL.
   - Default: `https://generativelanguage.googleapis.com`
   - Use this to point to your own proxy or other custom endpoints

--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -82,6 +82,25 @@ Claude Foundry deployments must exist in Azure before requests will work. Use th
 
 Azure requires Anthropic deployment metadata when creating Claude deployments: `industry`, `organizationName`, and `countryCode`. In Azure CLI this may require an ARM REST deployment call with `properties.modelProviderData`.
 
+### Anthropic Workload Identity Federation (Keyless Auth)
+
+Archestra supports [Anthropic Workload Identity Federation](https://docs.anthropic.com/en/docs/manage-claude/workload-identity-federation) for keyless authentication. Instead of static API keys, your workload authenticates using short-lived OIDC tokens from your identity provider (AWS IAM, Google Cloud, GitHub Actions, Kubernetes, etc.).
+
+To enable, set the following environment variables:
+
+```bash
+ARCHESTRA_ANTHROPIC_WIF_ENABLED=true
+ARCHESTRA_ANTHROPIC_WIF_FEDERATION_RULE_ID=fdrl_...
+ARCHESTRA_ANTHROPIC_WIF_ORGANIZATION_ID=00000000-0000-0000-0000-000000000000
+ARCHESTRA_ANTHROPIC_WIF_SERVICE_ACCOUNT_ID=svac_...
+ARCHESTRA_ANTHROPIC_WIF_WORKSPACE_ID=wrkspc_...
+ARCHESTRA_ANTHROPIC_WIF_IDENTITY_TOKEN_FILE=/var/run/secrets/anthropic.com/token
+```
+
+Archestra reads the JWT from the configured file, exchanges it for a short-lived Anthropic access token via `/v1/oauth/token`, and automatically refreshes it before expiry. The identity token file is re-read on each exchange, so rotated tokens (e.g., Kubernetes projected service-account tokens) are picked up automatically.
+
+See the [platform-deployment](./platform-deployment.md) page for full environment variable reference.
+
 See Microsoft's [Claude on Foundry guide](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/how-to/use-foundry-models-claude) for the Azure endpoint and authentication details.
 
 ## Google Gemini

--- a/platform/backend/src/clients/anthropic-wif-credentials.ts
+++ b/platform/backend/src/clients/anthropic-wif-credentials.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from "node:fs";
+import config from "@/config";
+import logger from "@/logging";
+
+const ANTHROPIC_TOKEN_ENDPOINT = "/v1/oauth/token";
+
+interface WifTokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+}
+
+let cachedToken: { token: string; expiresAt: number } | null = null;
+
+export function isAnthropicWifEnabled(): boolean {
+  return config.llm.anthropic.wif.enabled;
+}
+
+function readIdentityToken(): string {
+  const filePath = config.llm.anthropic.wif.identityTokenFile;
+  if (!filePath) {
+    throw new Error(
+      "ARCHESTRA_ANTHROPIC_WIF_IDENTITY_TOKEN_FILE is not configured",
+    );
+  }
+  return readFileSync(filePath, "utf-8").trim();
+}
+
+async function exchangeToken(
+  baseFetch: typeof globalThis.fetch,
+): Promise<WifTokenResponse> {
+  const { federationRuleId, organizationId, serviceAccountId, workspaceId } =
+    config.llm.anthropic.wif;
+  const baseUrl = config.llm.anthropic.baseUrl;
+  const identityToken = readIdentityToken();
+
+  const response = await baseFetch(`${baseUrl}${ANTHROPIC_TOKEN_ENDPOINT}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion: identityToken,
+      federation_rule_id: federationRuleId,
+      organization_id: organizationId,
+      service_account_id: serviceAccountId,
+      workspace_id: workspaceId,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Anthropic WIF token exchange failed (${response.status}): ${body}`,
+    );
+  }
+
+  return (await response.json()) as WifTokenResponse;
+}
+
+async function getAccessToken(
+  baseFetch: typeof globalThis.fetch,
+): Promise<string> {
+  const now = Date.now();
+  // Refresh 120s before expiry (advisory refresh)
+  if (cachedToken && cachedToken.expiresAt - now > 120_000) {
+    return cachedToken.token;
+  }
+
+  try {
+    const tokenResponse = await exchangeToken(baseFetch);
+    cachedToken = {
+      token: tokenResponse.access_token,
+      expiresAt: now + tokenResponse.expires_in * 1000,
+    };
+    logger.info("Anthropic WIF token exchanged successfully");
+    return cachedToken.token;
+  } catch (error) {
+    // If we still have a valid (but soon-expiring) token, use it
+    if (cachedToken && cachedToken.expiresAt - now > 30_000) {
+      logger.warn("Anthropic WIF token refresh failed, using cached token", {
+        error,
+      });
+      return cachedToken.token;
+    }
+    throw error;
+  }
+}
+
+export function createAnthropicWifFetch(
+  baseFetch: typeof globalThis.fetch | undefined,
+): typeof globalThis.fetch {
+  return async (input, init) => {
+    const fetchFn = baseFetch ?? globalThis.fetch;
+    const token = await getAccessToken(fetchFn);
+    const headers = new Headers(init?.headers);
+    headers.set("Authorization", `Bearer ${token}`);
+    return fetchFn(input, { ...init, headers });
+  };
+}

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -609,6 +609,20 @@ const config = {
       azureFoundryEntraIdEnabled:
         process.env.ARCHESTRA_ANTHROPIC_AZURE_FOUNDRY_ENTRA_ID_ENABLED ===
         "true",
+      wif: {
+        enabled:
+          process.env.ARCHESTRA_ANTHROPIC_WIF_ENABLED === "true",
+        federationRuleId:
+          process.env.ARCHESTRA_ANTHROPIC_WIF_FEDERATION_RULE_ID || "",
+        organizationId:
+          process.env.ARCHESTRA_ANTHROPIC_WIF_ORGANIZATION_ID || "",
+        serviceAccountId:
+          process.env.ARCHESTRA_ANTHROPIC_WIF_SERVICE_ACCOUNT_ID || "",
+        workspaceId:
+          process.env.ARCHESTRA_ANTHROPIC_WIF_WORKSPACE_ID || "",
+        identityTokenFile:
+          process.env.ARCHESTRA_ANTHROPIC_WIF_IDENTITY_TOKEN_FILE || "",
+      },
     },
     gemini: {
       baseUrl:

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -3,6 +3,10 @@ import { ArchestraInternalErrorCode } from "@shared";
 import { encode as toonEncode } from "@toon-format/toon";
 import { get } from "lodash-es";
 import {
+  createAnthropicWifFetch,
+  isAnthropicWifEnabled,
+} from "@/clients/anthropic-wif-credentials";
+import {
   getAzureAiFoundryBearerTokenProvider,
   isAnthropicAzureFoundryEntraIdEnabled,
 } from "@/clients/azure-openai-credentials";
@@ -1169,6 +1173,16 @@ export const anthropicAdapterFactory: LLMProvider<
           // The fetch wrapper replaces this sentinel with a fresh Entra ID token on every request.
           Authorization: "Bearer <entra-id-managed>",
         },
+      });
+    }
+
+    if (!apiKey && isAnthropicWifEnabled()) {
+      return new AnthropicProvider({
+        apiKey: null,
+        authToken: null,
+        baseURL: options.baseUrl,
+        fetch: createAnthropicWifFetch(customFetch),
+        defaultHeaders: options.defaultHeaders,
       });
     }
 


### PR DESCRIPTION
## Summary

Adds Anthropic Workload Identity Federation (keyless auth) support.

/claim #4468

## Changes
- anthropic-wif-credentials.ts: JWT token exchange with caching and auto-refresh
- config.ts: ARCHESTRA_ANTHROPIC_WIF_* env vars
- anthropic.ts adapter: WIF fetch wrapper when enabled
- Documentation updated

Closes #4468