### PR TITLE
fix: evaluate tool result policies when context is pre-configured as untrusted

### DIFF
--- a/platform/backend/src/guardrails/trusted-data.ts
+++ b/platform/backend/src/guardrails/trusted-data.ts
@@ -64,23 +64,20 @@ export async function evaluateIfContextIsTrusted(
   let unsafeContextBoundary: UnsafeContextBoundary | undefined;
 
   // If agent configured to consider context untrusted from the beginning,
-  // mark context as untrusted immediately and skip evaluation
+  // mark context as untrusted immediately but still evaluate tool result
+  // policies so that blocked results are properly replaced before being
+  // sent to the model.
   if (considerContextUntrusted) {
     logger.debug(
       { agentId },
-      "[trustedData] evaluateIfContextIsTrusted: context marked untrusted by agent config",
+      "[trustedData] evaluateIfContextIsTrusted: context marked untrusted by agent config, evaluating tool result policies",
     );
-    return {
-      toolResultUpdates: {},
-      contextIsTrusted: false,
-      usedDualLlm: false,
-      dualLlmAnalyses: [],
-      unsafeContextBoundary: {
-        kind: "preexisting_untrusted",
-        reason:
-          initialUntrustedReason ??
-          UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
-      },
+    hasUntrustedData = true;
+    unsafeContextBoundary = {
+      kind: "preexisting_untrusted",
+      reason:
+        initialUntrustedReason ??
+        UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
     };
   }
 


### PR DESCRIPTION
## Summary

Fixes the Blocked Tool Result Policy bypass when agent has "Treat context as sensitive from the start of chat" enabled.

/claim #4225

## Root Cause

`evaluateIfContextIsTrusted()` returned early when `considerContextUntrusted` was true, skipping Tool Result Policy evaluation.

## Fix

Set `hasUntrustedData=true` and boundary, then continue to evaluate policies. Blocked results are properly replaced.

Closes #4225