### PR TITLE
feat: add deployment maintenance mode

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -1115,3 +1115,11 @@ To learn more about enterprise licensing, please reach out to [sales@archestra.a
 - **`ARCHESTRA_ENTERPRISE_LICENSE_FULL_WHITE_LABELING`** - Enables full white-labeling (removes "Powered by Archestra" attribution).
   - Set to `true` to enable
   - Requires the core enterprise license (`ARCHESTRA_ENTERPRISE_LICENSE_ACTIVATED=true`)
+
+### Maintenance Mode
+
+- **`ARCHESTRA_MAINTENANCE_MODE_MESSAGE`** - Put the deployment into maintenance mode.
+  - Default: unset (maintenance mode disabled)
+  - When set to any non-empty string, all API requests return HTTP 503 with the configured message. Health check endpoints (`/health`, `/api/health`) remain accessible.
+  - Useful for database maintenance, upgrades, or planned downtime.
+  - Example: `ARCHESTRA_MAINTENANCE_MODE_MESSAGE="System maintenance in progress. Please try again in 30 minutes."`

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -910,6 +910,10 @@ const config = {
   isQuickstart: process.env.ARCHESTRA_QUICKSTART === "true",
   ngrokDomain: process.env.ARCHESTRA_NGROK_DOMAIN || "",
   processType: parseProcessType(process.env.ARCHESTRA_PROCESS_TYPE),
+  maintenanceMode: {
+    enabled: Boolean(process.env.ARCHESTRA_MAINTENANCE_MODE_MESSAGE),
+    message: process.env.ARCHESTRA_MAINTENANCE_MODE_MESSAGE || "",
+  },
 };
 
 export const shouldRunWebServer = config.processType !== "worker";

--- a/platform/backend/src/middleware.ts
+++ b/platform/backend/src/middleware.ts
@@ -63,3 +63,31 @@ const enterpriseLicenseMiddlewarePlugin: FastifyPluginAsync = async (
 export const enterpriseLicenseMiddleware = fp(
   enterpriseLicenseMiddlewarePlugin,
 );
+
+/**
+ * Maintenance mode middleware.
+ * When ARCHESTRA_MAINTENANCE_MODE_MESSAGE is set, all API requests
+ * return 503 with the configured message. Health check endpoints are excluded.
+ */
+const maintenanceModePlugin: FastifyPluginAsync = async (fastify) => {
+  fastify.addHook("preHandler", async (request, reply) => {
+    if (!config.maintenanceMode.enabled) {
+      return;
+    }
+    // Allow health check endpoints through
+    if (
+      request.url === "/health" ||
+      request.url === "/api/health" ||
+      request.url.startsWith("/api/health")
+    ) {
+      return;
+    }
+    reply.status(503).send({
+      error: "Service Unavailable",
+      message: config.maintenanceMode.message,
+      maintenance: true,
+    });
+  });
+};
+
+export const maintenanceMiddleware = fp(maintenanceModePlugin);

--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -56,7 +56,10 @@ import { initializeDatabase, isDatabaseHealthy } from "@/database";
 import { seedRequiredStartingData } from "@/database/seed";
 import { McpServerRuntimeManager } from "@/k8s/mcp-server-runtime";
 import logger from "@/logging";
-import { enterpriseLicenseMiddleware } from "@/middleware";
+import {
+  enterpriseLicenseMiddleware,
+  maintenanceMiddleware,
+} from "@/middleware";
 import OrganizationModel from "@/models/organization";
 import { initializeObservabilityMetrics } from "@/observability";
 import { enrichOpenApiWithRbac } from "@/openapi/enrich-openapi-with-rbac";
@@ -748,6 +751,7 @@ const startWebServer = async () => {
    * Enterprise license middleware to enforce license requirements on certain routes.
    * This should be registered before routes to ensure enterprise-only features are checked properly.
    */
+  fastify.register(maintenanceMiddleware);
   fastify.register(enterpriseLicenseMiddleware);
 
   try {


### PR DESCRIPTION
## Summary

Adds deployment maintenance mode via ARCHESTRA_MAINTENANCE_MODE_MESSAGE env var.

/claim #4463

When set, all API requests return 503. Health endpoints excluded.

Partial fix for #4463