### PR TITLE
feat: per-limit cleanup interval + org-wide default

### DIFF
--- a/platform/backend/src/database/migrations/0235_add_limit_cleanup_interval.sql
+++ b/platform/backend/src/database/migrations/0235_add_limit_cleanup_interval.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "limits" ADD COLUMN "cleanup_interval" varchar(10);

--- a/platform/backend/src/database/schemas/limit.ts
+++ b/platform/backend/src/database/schemas/limit.ts
@@ -27,6 +27,7 @@ const limitsTable = pgTable(
     // 3. Validation: Check if incoming interaction's model is within limit scope
     model: jsonb("model").$type<string[] | null>(),
     lastCleanup: timestamp("last_cleanup", { mode: "date" }),
+    cleanupInterval: varchar("cleanup_interval", { length: 10 }),
     createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()

--- a/platform/backend/src/models/limit.ts
+++ b/platform/backend/src/models/limit.ts
@@ -390,9 +390,31 @@ class LimitModel {
 
   static async resolveLimitsCleanupIntervalSqlLiteral(
     organizationId?: string,
+    limitId?: string,
   ): Promise<LimitsCleanupIntervalSqlLiteral> {
     // Use default cleanup interval if not set
     let cleanupInterval: LimitsCleanupIntervalSqlLiteral = "1 hour";
+
+    // Check per-limit cleanup interval first
+    if (limitId) {
+      const [limit] = await db
+        .select()
+        .from(schema.limitsTable)
+        .where(eq(schema.limitsTable.id, limitId));
+
+      if (limit?.cleanupInterval) {
+        const perLimitInterval =
+          LimitModel.limitsCleanupIntervalSqlLiterals[
+            limit.cleanupInterval as Exclude<OrganizationLimitCleanupInterval, null>
+          ];
+        if (perLimitInterval) {
+          logger.info(
+            `[LimitsCleanup] Using per-limit cleanup interval: ${perLimitInterval} for limit: ${limitId}`,
+          );
+          return perLimitInterval;
+        }
+      }
+    }
 
     if (!organizationId) {
       logger.warn(
@@ -497,7 +519,18 @@ class LimitModel {
       return [];
     }
 
-    const cutoffIntervalSqlExpr = sql`now() - interval ${sql.raw(`'${limitsResetInterval}'`)}`;
+    // For limits with their own cleanup_interval, use that; otherwise use the org-wide interval
+    const orgCutoff = sql`now() - interval ${sql.raw(`'${limitsResetInterval}'`)}`;
+    const perLimitCutoff = sql`now() - CASE ${schema.limitsTable.cleanupInterval}
+      WHEN '1h' THEN interval '1 hour'
+      WHEN '12h' THEN interval '12 hours'
+      WHEN '24h' THEN interval '24 hours'
+      WHEN '1w' THEN interval '1 week'
+      WHEN '1m' THEN interval '1 month'
+      ELSE interval ${sql.raw(`'${limitsResetInterval}'`)}
+    END`;
+
+    const cutoffExpr = sql`CASE WHEN ${schema.limitsTable.cleanupInterval} IS NOT NULL THEN ${perLimitCutoff} ELSE ${orgCutoff} END`;
 
     const limitsToReset = await db
       .select({ id: schema.limitsTable.id })
@@ -507,7 +540,7 @@ class LimitModel {
           ...scopeConditions,
           or(
             isNull(schema.limitsTable.lastCleanup),
-            lt(schema.limitsTable.lastCleanup, cutoffIntervalSqlExpr),
+            lt(schema.limitsTable.lastCleanup, cutoffExpr),
           ),
         ),
       );


### PR DESCRIPTION
## Summary

Adds per-limit cleanup interval support.

/claim #4461

Each limit can now have its own cleanup_interval that overrides the org-wide default.

Partial fix for #4461