### PR TITLE
fix(guardrails): evaluate blocked tool result policies in untrusted contexts

### DIFF
--- a/platform/backend/src/guardrails/trusted-data.test.ts
+++ b/platform/backend/src/guardrails/trusted-data.test.ts
@@ -410,6 +410,105 @@ describe("trusted-data evaluation (provider-agnostic)", () => {
       });
     });
 
+    test("evaluates blocked tool result policies even when context starts untrusted", async () => {
+      // Create a block policy
+      await TrustedDataPolicyModel.create({
+        toolId,
+        conditions: [{ key: "dangerous", operator: "equal", value: "true" }],
+        action: "block_always",
+        description: "Block dangerous data",
+      });
+
+      const commonMessages: CommonMessage[] = [
+        { role: "user", content: "Summarize this thread" },
+        {
+          role: "tool",
+          toolCalls: [
+            {
+              id: "call_blocked",
+              name: "get_emails",
+              content: { dangerous: "true", other: "sensitive" },
+              isError: false,
+            },
+          ],
+        },
+      ];
+
+      const result = await evaluateIfContextIsTrusted(
+        commonMessages,
+        agentId,
+        organizationId,
+        undefined,
+        true, // considerContextUntrusted
+        "restrictive",
+        { teamIds: [] },
+      );
+
+      // Context should be untrusted (preexisting) and the blocked tool result
+      // should be replaced — this is the bug fix: previously the early return
+      // when considerContextUntrusted=true skipped policy evaluation entirely.
+      expect(result.contextIsTrusted).toBe(false);
+      expect(result.toolResultUpdates).toEqual({
+        call_blocked:
+          "[Content blocked by policy: Data blocked by policy: Block dangerous data]",
+      });
+      // The preexisting boundary should be preserved (not overwritten by the
+      // blocked tool result boundary)
+      expect(result.unsafeContextBoundary).toEqual({
+        kind: "preexisting_untrusted",
+        reason: "agentConfiguredUntrusted",
+      });
+    });
+
+    test("preserves preexisting unsafe boundary reason when evaluating policies in untrusted context", async () => {
+      // Create a block policy
+      await TrustedDataPolicyModel.create({
+        toolId,
+        conditions: [{ key: "dangerous", operator: "equal", value: "true" }],
+        action: "block_always",
+        description: "Block dangerous data",
+      });
+
+      const commonMessages: CommonMessage[] = [
+        { role: "user", content: "Summarize this thread" },
+        {
+          role: "tool",
+          toolCalls: [
+            {
+              id: "call_blocked",
+              name: "get_emails",
+              content: { dangerous: "true", other: "sensitive" },
+              isError: false,
+            },
+          ],
+        },
+      ];
+
+      const result = await evaluateIfContextIsTrusted(
+        commonMessages,
+        agentId,
+        organizationId,
+        undefined,
+        true, // considerContextUntrusted
+        "restrictive",
+        { teamIds: [] },
+        undefined,
+        undefined,
+        "inherited_from_parent",
+      );
+
+      // The custom initialUntrustedReason should be preserved
+      expect(result.contextIsTrusted).toBe(false);
+      expect(result.toolResultUpdates).toEqual({
+        call_blocked:
+          "[Content blocked by policy: Data blocked by policy: Block dangerous data]",
+      });
+      expect(result.unsafeContextBoundary).toEqual({
+        kind: "preexisting_untrusted",
+        reason: "inherited_from_parent",
+      });
+    });
+
     test("handles multiple tool calls with mixed trust", async () => {
       // Create policies
       await TrustedDataPolicyModel.create({

--- a/platform/backend/src/guardrails/trusted-data.ts
+++ b/platform/backend/src/guardrails/trusted-data.ts
@@ -64,23 +64,19 @@ export async function evaluateIfContextIsTrusted(
   let unsafeContextBoundary: UnsafeContextBoundary | undefined;
 
   // If agent configured to consider context untrusted from the beginning,
-  // mark context as untrusted immediately and skip evaluation
+  // mark context as untrusted immediately but still evaluate tool result
+  // policies so that blocked results are properly replaced.
   if (considerContextUntrusted) {
     logger.debug(
       { agentId },
-      "[trustedData] evaluateIfContextIsTrusted: context marked untrusted by agent config",
+      "[trustedData] evaluateIfContextIsTrusted: context marked untrusted by agent config, continuing policy evaluation",
     );
-    return {
-      toolResultUpdates: {},
-      contextIsTrusted: false,
-      usedDualLlm: false,
-      dualLlmAnalyses: [],
-      unsafeContextBoundary: {
-        kind: "preexisting_untrusted",
-        reason:
-          initialUntrustedReason ??
-          UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
-      },
+    hasUntrustedData = true;
+    unsafeContextBoundary = {
+      kind: "preexisting_untrusted",
+      reason:
+        initialUntrustedReason ??
+        UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
     };
   }
 
@@ -112,11 +108,11 @@ export async function evaluateIfContextIsTrusted(
   if (allToolCalls.length === 0) {
     logger.debug(
       { agentId },
-      "[trustedData] evaluateIfContextIsTrusted: no tool calls found, context is trusted",
+      "[trustedData] evaluateIfContextIsTrusted: no tool calls found",
     );
     return {
       toolResultUpdates,
-      contextIsTrusted: true,
+      contextIsTrusted: !hasUntrustedData,
       usedDualLlm: false,
       dualLlmAnalyses: [],
       unsafeContextBoundary,


### PR DESCRIPTION
## Summary

Fixes #4225

When `considerContextUntrusted` is `true`, `evaluateIfContextIsTrusted` returned early on line 68, skipping all policy evaluation. This meant blocked tool results passed through unfiltered when the agent started in a sensitive context.

**Root cause:** The early return at the top of the function bypassed `TrustedDataPolicyModel.evaluateBulk()`, so `block_always` policies were never checked.

**Fix:** Instead of returning early, set `hasUntrustedData = true` and `unsafeContextBoundary`, then fall through to the normal policy evaluation loop. Also fixed the no-tool-calls early return to use `!hasUntrustedData` instead of hardcoded `true`.

**Key behavior preserved:**
- The `preexisting_untrusted` boundary is set first and not overwritten by later tool result boundaries (uses `??=`)
- `contextIsTrusted` correctly returns `false` when context starts untrusted
- `toolResultUpdates` now properly contains blocked results instead of being empty

## Changes

- `platform/backend/src/guardrails/trusted-data.ts`: Remove early return when `considerContextUntrusted=true`, continue to policy evaluation
- `platform/backend/src/guardrails/trusted-data.test.ts`: Add regression tests for blocked policies in untrusted contexts

## Verification

```bash
cd platform/backend && pnpm test -- src/guardrails/trusted-data.test.ts
```