### PR TITLE
feat: add anthropic workload identity federation support

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -762,6 +762,28 @@ These environment variables set the default base URL for each LLM provider. Per-
   - Uses Azure Identity `DefaultAzureCredential` with token scope `https://ai.azure.com/.default`
   - Claude deployments must already exist in the Azure resource. Microsoft lists additional Claude prerequisites: paid eligible subscription, supported region, Azure Marketplace access for partner models, permission to subscribe to model offerings, and Contributor or Owner role on the resource group. Azure also requires Anthropic deployment metadata: `industry`, `organizationName`, and `countryCode`.
 
+- **`ARCHESTRA_ANTHROPIC_WIF_ENABLED`** - Enable Anthropic Workload Identity Federation (WIF) keyless authentication.
+  - Default: `false`
+  - When enabled, Archestra exchanges an identity JWT for a short-lived Anthropic access token via `/v1/oauth/token`.
+  - Requires the `ARCHESTRA_ANTHROPIC_WIF_*` variables below.
+  - See [Anthropic WIF documentation](https://docs.anthropic.com/en/docs/manage-claude/workload-identity-federation) for provider-side setup.
+
+- **`ARCHESTRA_ANTHROPIC_WIF_FEDERATION_RULE_ID`** - Anthropic federation rule ID (`fdrl_...`).
+  - Required when WIF is enabled.
+
+- **`ARCHESTRA_ANTHROPIC_WIF_ORGANIZATION_ID`** - Anthropic organization ID.
+  - Required when WIF is enabled.
+
+- **`ARCHESTRA_ANTHROPIC_WIF_SERVICE_ACCOUNT_ID`** - Anthropic service account ID (`svac_...`) for the federated identity.
+  - Required when WIF is enabled.
+
+- **`ARCHESTRA_ANTHROPIC_WIF_WORKSPACE_ID`** - Anthropic workspace ID (`wrkspc_...`) to scope the token.
+  - Required when WIF is enabled.
+
+- **`ARCHESTRA_ANTHROPIC_WIF_IDENTITY_TOKEN_FILE`** - Path to an identity token JWT file mounted in the runtime.
+  - Required when WIF is enabled.
+  - The file is read for each token exchange, so rotated projected tokens are picked up automatically.
+
 - **`ARCHESTRA_GEMINI_BASE_URL`** - Override the Google Gemini API base URL.
   - Default: `https://generativelanguage.googleapis.com`
   - Use this to point to your own proxy or other custom endpoints

--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -82,6 +82,25 @@ Claude Foundry deployments must exist in Azure before requests will work. Use th
 
 Azure requires Anthropic deployment metadata when creating Claude deployments: `industry`, `organizationName`, and `countryCode`. In Azure CLI this may require an ARM REST deployment call with `properties.modelProviderData`.
 
+### Anthropic Workload Identity Federation (keyless auth)
+
+Archestra supports [Anthropic Workload Identity Federation](https://docs.anthropic.com/en/docs/manage-claude/workload-identity-federation), so workloads can authenticate with short-lived tokens instead of static API keys.
+
+Set the following deployment environment variables:
+
+```bash
+ARCHESTRA_ANTHROPIC_WIF_ENABLED=true
+ARCHESTRA_ANTHROPIC_WIF_FEDERATION_RULE_ID=fdrl_...
+ARCHESTRA_ANTHROPIC_WIF_ORGANIZATION_ID=<org-id>
+ARCHESTRA_ANTHROPIC_WIF_SERVICE_ACCOUNT_ID=svac_...
+ARCHESTRA_ANTHROPIC_WIF_WORKSPACE_ID=wrkspc_...
+ARCHESTRA_ANTHROPIC_WIF_IDENTITY_TOKEN_FILE=/var/run/secrets/anthropic/identity.jwt
+```
+
+When enabled and no Anthropic API key is provided, Archestra reads the identity token file, exchanges it at Anthropic `/v1/oauth/token`, and injects the returned bearer token on each upstream Anthropic request.
+
+For full variable details, see [Platform Deployment](/docs/platform-deployment#llm-provider-configuration).
+
 See Microsoft's [Claude on Foundry guide](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/how-to/use-foundry-models-claude) for the Azure endpoint and authentication details.
 
 ## Google Gemini

--- a/platform/backend/src/clients/anthropic-wif-credentials.test.ts
+++ b/platform/backend/src/clients/anthropic-wif-credentials.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("node:fs", () => ({
+  readFileSync: vi.fn(() => "identity-jwt"),
+}));
+
+vi.mock("@/config", () => ({
+  default: {
+    llm: {
+      anthropic: {
+        baseUrl: "https://api.anthropic.com",
+        wif: {
+          enabled: true,
+          federationRuleId: "fdrl_test",
+          organizationId: "org_test",
+          serviceAccountId: "svac_test",
+          workspaceId: "wrkspc_test",
+          identityTokenFile: "/tmp/identity-token",
+        },
+      },
+    },
+  },
+}));
+
+describe("anthropic-wif-credentials", () => {
+  test("reports WIF as enabled from config", async () => {
+    const { isAnthropicWifEnabled } = await import(
+      "./anthropic-wif-credentials"
+    );
+    expect(isAnthropicWifEnabled()).toBe(true);
+  });
+
+  test("exchanges token and reuses cache before expiry", async () => {
+    vi.resetModules();
+    const fetchSpy = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          access_token: "wif-access-token",
+          token_type: "Bearer",
+          expires_in: 3600,
+        }),
+        { status: 200 },
+      );
+    });
+
+    const { getAnthropicWifAccessToken } = await import(
+      "./anthropic-wif-credentials"
+    );
+
+    const first = await getAnthropicWifAccessToken(fetchSpy);
+    const second = await getAnthropicWifAccessToken(fetchSpy);
+
+    expect(first).toBe("wif-access-token");
+    expect(second).toBe("wif-access-token");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("wraps fetch and injects bearer token", async () => {
+    vi.resetModules();
+
+    const fetchSpy = vi.fn(
+      async (input: RequestInfo | URL, _init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/v1/oauth/token")) {
+          return new Response(
+            JSON.stringify({
+              access_token: "wif-access-token",
+              token_type: "Bearer",
+              expires_in: 3600,
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      },
+    );
+
+    const { createAnthropicWifFetch } = await import(
+      "./anthropic-wif-credentials"
+    );
+    const wrappedFetch = createAnthropicWifFetch(fetchSpy);
+    await wrappedFetch("https://api.anthropic.com/v1/messages", {
+      headers: { "anthropic-version": "2023-06-01" },
+    });
+
+    const requestCall = fetchSpy.mock.calls[1];
+    const headers = new Headers(requestCall?.[1]?.headers);
+    expect(headers.get("Authorization")).toBe("Bearer wif-access-token");
+  });
+});

--- a/platform/backend/src/clients/anthropic-wif-credentials.ts
+++ b/platform/backend/src/clients/anthropic-wif-credentials.ts
@@ -1,0 +1,148 @@
+import { readFileSync } from "node:fs";
+import config from "@/config";
+import logger from "@/logging";
+
+const ANTHROPIC_OAUTH_TOKEN_PATH = "/v1/oauth/token";
+const REFRESH_EARLY_MS = 120_000;
+const MIN_FALLBACK_TOKEN_TTL_MS = 30_000;
+
+interface AnthropicWifTokenResponse {
+  access_token: string;
+  expires_in: number;
+  token_type: string;
+}
+
+let cachedToken: {
+  accessToken: string;
+  expiresAtMs: number;
+} | null = null;
+
+export function isAnthropicWifEnabled(): boolean {
+  return config.llm.anthropic.wif.enabled;
+}
+
+function assertWifConfig(): void {
+  const {
+    federationRuleId,
+    identityTokenFile,
+    organizationId,
+    serviceAccountId,
+    workspaceId,
+  } = config.llm.anthropic.wif;
+
+  if (!federationRuleId) {
+    throw new Error(
+      "ARCHESTRA_ANTHROPIC_WIF_FEDERATION_RULE_ID is not configured",
+    );
+  }
+  if (!organizationId) {
+    throw new Error(
+      "ARCHESTRA_ANTHROPIC_WIF_ORGANIZATION_ID is not configured",
+    );
+  }
+  if (!serviceAccountId) {
+    throw new Error(
+      "ARCHESTRA_ANTHROPIC_WIF_SERVICE_ACCOUNT_ID is not configured",
+    );
+  }
+  if (!workspaceId) {
+    throw new Error("ARCHESTRA_ANTHROPIC_WIF_WORKSPACE_ID is not configured");
+  }
+  if (!identityTokenFile) {
+    throw new Error(
+      "ARCHESTRA_ANTHROPIC_WIF_IDENTITY_TOKEN_FILE is not configured",
+    );
+  }
+}
+
+function readIdentityTokenFromFile(): string {
+  const filePath = config.llm.anthropic.wif.identityTokenFile;
+  return readFileSync(filePath, "utf-8").trim();
+}
+
+async function exchangeAnthropicWifToken(
+  fetchFn: typeof globalThis.fetch,
+): Promise<AnthropicWifTokenResponse> {
+  assertWifConfig();
+
+  const { federationRuleId, organizationId, serviceAccountId, workspaceId } =
+    config.llm.anthropic.wif;
+
+  const response = await fetchFn(
+    `${config.llm.anthropic.baseUrl}${ANTHROPIC_OAUTH_TOKEN_PATH}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion: readIdentityTokenFromFile(),
+        federation_rule_id: federationRuleId,
+        organization_id: organizationId,
+        service_account_id: serviceAccountId,
+        workspace_id: workspaceId,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    const responseText = await response.text();
+    throw new Error(
+      `Anthropic WIF token exchange failed (${response.status}): ${responseText}`,
+    );
+  }
+
+  return (await response.json()) as AnthropicWifTokenResponse;
+}
+
+export async function getAnthropicWifAccessToken(
+  baseFetch?: typeof globalThis.fetch,
+): Promise<string> {
+  const now = Date.now();
+  if (cachedToken && cachedToken.expiresAtMs - now > REFRESH_EARLY_MS) {
+    return cachedToken.accessToken;
+  }
+
+  const fetchFn = baseFetch ?? globalThis.fetch;
+
+  try {
+    const tokenResponse = await exchangeAnthropicWifToken(fetchFn);
+    cachedToken = {
+      accessToken: tokenResponse.access_token,
+      expiresAtMs: now + tokenResponse.expires_in * 1000,
+    };
+    return cachedToken.accessToken;
+  } catch (error) {
+    if (
+      cachedToken &&
+      cachedToken.expiresAtMs - now > MIN_FALLBACK_TOKEN_TTL_MS
+    ) {
+      logger.warn(
+        {
+          errorMessage: error instanceof Error ? error.message : String(error),
+        },
+        "Anthropic WIF token refresh failed, falling back to cached token",
+      );
+      return cachedToken.accessToken;
+    }
+    throw error;
+  }
+}
+
+export function createAnthropicWifFetch(
+  baseFetch?: typeof globalThis.fetch,
+): typeof globalThis.fetch {
+  return async (input, init) => {
+    const fetchFn = baseFetch ?? globalThis.fetch;
+    const headers = new Headers(init?.headers);
+    headers.set(
+      "Authorization",
+      `Bearer ${await getAnthropicWifAccessToken(fetchFn)}`,
+    );
+    return fetchFn(input, {
+      ...init,
+      headers,
+    });
+  };
+}

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -609,6 +609,18 @@ const config = {
       azureFoundryEntraIdEnabled:
         process.env.ARCHESTRA_ANTHROPIC_AZURE_FOUNDRY_ENTRA_ID_ENABLED ===
         "true",
+      wif: {
+        enabled: process.env.ARCHESTRA_ANTHROPIC_WIF_ENABLED === "true",
+        federationRuleId:
+          process.env.ARCHESTRA_ANTHROPIC_WIF_FEDERATION_RULE_ID || "",
+        organizationId:
+          process.env.ARCHESTRA_ANTHROPIC_WIF_ORGANIZATION_ID || "",
+        serviceAccountId:
+          process.env.ARCHESTRA_ANTHROPIC_WIF_SERVICE_ACCOUNT_ID || "",
+        workspaceId: process.env.ARCHESTRA_ANTHROPIC_WIF_WORKSPACE_ID || "",
+        identityTokenFile:
+          process.env.ARCHESTRA_ANTHROPIC_WIF_IDENTITY_TOKEN_FILE || "",
+      },
     },
     gemini: {
       baseUrl:

--- a/platform/backend/src/routes/chat/model-fetchers/anthropic.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/anthropic.ts
@@ -1,4 +1,8 @@
 import {
+  getAnthropicWifAccessToken,
+  isAnthropicWifEnabled,
+} from "@/clients/anthropic-wif-credentials";
+import {
   getAzureAiFoundryBearerTokenProvider,
   isAnthropicAzureFoundryEntraIdEnabled,
 } from "@/clients/azure-openai-credentials";
@@ -52,7 +56,10 @@ async function getAnthropicAuthHeaders(
   }
 
   if (!isAnthropicAzureFoundryEntraIdEnabled()) {
-    return { "x-api-key": "" };
+    if (!isAnthropicWifEnabled()) {
+      return { "x-api-key": "" };
+    }
+    return { Authorization: `Bearer ${await getAnthropicWifAccessToken()}` };
   }
 
   const tokenProvider = getAzureAiFoundryBearerTokenProvider();

--- a/platform/backend/src/routes/proxy/adapters/anthropic-wif.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic-wif.test.ts
@@ -1,0 +1,72 @@
+import type AnthropicProvider from "@anthropic-ai/sdk";
+import { describe, expect, test, vi } from "vitest";
+
+process.env.ARCHESTRA_DATABASE_URL = "postgres://test:test@localhost:5432/test";
+process.env.ARCHESTRA_ANTHROPIC_WIF_ENABLED = "true";
+process.env.ARCHESTRA_ANTHROPIC_WIF_FEDERATION_RULE_ID = "fdrl_test";
+process.env.ARCHESTRA_ANTHROPIC_WIF_ORGANIZATION_ID = "org_test";
+process.env.ARCHESTRA_ANTHROPIC_WIF_SERVICE_ACCOUNT_ID = "svac_test";
+process.env.ARCHESTRA_ANTHROPIC_WIF_WORKSPACE_ID = "wrkspc_test";
+process.env.ARCHESTRA_ANTHROPIC_WIF_IDENTITY_TOKEN_FILE = "/tmp/identity-token";
+
+const metricFetch = vi.fn();
+
+vi.mock("@/observability", () => ({
+  metrics: { llm: { getObservableFetch: vi.fn(() => metricFetch) } },
+}));
+
+vi.mock("@/clients/azure-openai-credentials", () => ({
+  getAzureAiFoundryBearerTokenProvider: vi.fn(),
+  isAnthropicAzureFoundryEntraIdEnabled: vi.fn(() => false),
+}));
+
+vi.mock("@/clients/anthropic-wif-credentials", () => ({
+  isAnthropicWifEnabled: vi.fn(() => true),
+  createAnthropicWifFetch: vi.fn((baseFetch?: typeof globalThis.fetch) => {
+    const fetchFn = baseFetch ?? globalThis.fetch;
+    return async (input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      headers.set("Authorization", "Bearer wif-token");
+      return fetchFn(input, { ...init, headers });
+    };
+  }),
+}));
+
+vi.mock("node:fs", () => ({
+  readFileSync: vi.fn(() => "identity-jwt"),
+}));
+
+import { anthropicAdapterFactory } from "./anthropic";
+
+describe("anthropicAdapterFactory WIF", () => {
+  test("creates a keyless client that injects Anthropic WIF bearer auth", async () => {
+    metricFetch.mockResolvedValue(new Response("{}"));
+
+    const client = anthropicAdapterFactory.createClient(undefined, {
+      baseUrl: "https://api.anthropic.com",
+      defaultHeaders: {},
+      agent: { id: "agent-id" } as never,
+      source: "api",
+    }) as AnthropicProvider & {
+      _options?: {
+        defaultHeaders?: Record<string, string>;
+        fetch?: typeof globalThis.fetch;
+      };
+    };
+
+    expect(client._options?.defaultHeaders?.Authorization).toBe(
+      "Bearer <anthropic-wif-managed>",
+    );
+
+    const fetch = client._options?.fetch;
+    expect(fetch).toBeDefined();
+
+    await fetch?.("https://api.anthropic.com/v1/messages", {
+      headers: { "anthropic-version": "2023-06-01" },
+    });
+
+    const requestCall = metricFetch.mock.calls[0];
+    const headers = new Headers(requestCall?.[1]?.headers);
+    expect(headers.get("Authorization")).toBe("Bearer wif-token");
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -3,6 +3,10 @@ import { ArchestraInternalErrorCode } from "@shared";
 import { encode as toonEncode } from "@toon-format/toon";
 import { get } from "lodash-es";
 import {
+  createAnthropicWifFetch,
+  isAnthropicWifEnabled,
+} from "@/clients/anthropic-wif-credentials";
+import {
   getAzureAiFoundryBearerTokenProvider,
   isAnthropicAzureFoundryEntraIdEnabled,
 } from "@/clients/azure-openai-credentials";
@@ -1168,6 +1172,20 @@ export const anthropicAdapterFactory: LLMProvider<
           ...options.defaultHeaders,
           // The fetch wrapper replaces this sentinel with a fresh Entra ID token on every request.
           Authorization: "Bearer <entra-id-managed>",
+        },
+      });
+    }
+
+    if (!apiKey && isAnthropicWifEnabled()) {
+      return new AnthropicProvider({
+        apiKey: null,
+        authToken: null,
+        baseURL: options.baseUrl,
+        fetch: createAnthropicWifFetch(customFetch),
+        defaultHeaders: {
+          ...options.defaultHeaders,
+          // The fetch wrapper replaces this sentinel with a short-lived WIF token per request.
+          Authorization: "Bearer <anthropic-wif-managed>",
         },
       });
     }

--- a/platform/backend/src/services/system-key-manager.ts
+++ b/platform/backend/src/services/system-key-manager.ts
@@ -1,4 +1,5 @@
 import type { SupportedProvider } from "@shared";
+import { isAnthropicWifEnabled } from "@/clients/anthropic-wif-credentials";
 import {
   isAnthropicAzureFoundryEntraIdEnabled,
   isAzureOpenAiEntraIdEnabled,
@@ -68,10 +69,11 @@ class SystemKeyManager {
     },
     {
       provider: "anthropic",
-      name: "Anthropic Azure Foundry Entra ID",
+      name: "Anthropic keyless auth",
       isEnabled: () =>
-        isAnthropicAzureFoundryEntraIdEnabled() &&
-        isAzureAiFoundryBaseUrl(config.llm.anthropic.baseUrl),
+        (isAnthropicAzureFoundryEntraIdEnabled() &&
+          isAzureAiFoundryBaseUrl(config.llm.anthropic.baseUrl)) ||
+        isAnthropicWifEnabled(),
       customFetch: async () => {
         const models = await fetchAnthropicModels(
           "",


### PR DESCRIPTION
## Summary
- add Anthropic WIF credential exchange client with token caching and refresh fallback
- support `ARCHESTRA_ANTHROPIC_WIF_*` env vars in backend config
- wire keyless WIF auth into Anthropic proxy adapter when no API key is present
- enable Anthropic model discovery + system key sync flows to use WIF auth
- document Anthropic WIF setup in deployment and supported providers docs
- add focused backend tests for WIF credentials + adapter behavior

## Validation
- `cd platform/backend && ARCHESTRA_DATABASE_URL='postgres://test:test@localhost:5432/test' corepack pnpm vitest run src/clients/anthropic-wif-credentials.test.ts src/routes/proxy/adapters/anthropic-wif.test.ts src/routes/proxy/adapters/anthropic-azure-foundry.test.ts`
- `cd platform/backend && corepack pnpm biome check src/clients/anthropic-wif-credentials.ts src/clients/anthropic-wif-credentials.test.ts src/routes/chat/model-fetchers/anthropic.ts src/routes/proxy/adapters/anthropic.ts src/routes/proxy/adapters/anthropic-wif.test.ts src/services/system-key-manager.ts`

/claim #4468
