### PR TITLE
chore: reduce shell noncritical startup requests

### DIFF
--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -304,11 +304,14 @@ const NavPrimary = ({
 };
 
 // Matches sidebar-10 NavSecondary: SidebarGroup with mt-auto
+// Community links are optional chrome; gate them so white-labeled shells do not
+// render the links or trigger their noncritical GitHub metadata queries.
 const NavSecondary = ({
   items,
   pathname,
   searchParams,
   permissionMap,
+  showCommunityLinks,
   starCount,
   className,
 }: {
@@ -316,6 +319,7 @@ const NavSecondary = ({
   pathname: string;
   searchParams: URLSearchParams;
   permissionMap: Record<string, boolean>;
+  showCommunityLinks: boolean;
   starCount: string;
   className?: string;
 }) => {
@@ -344,7 +348,7 @@ const NavSecondary = ({
               </SidebarMenuButton>
             </SidebarMenuItem>
           ))}
-          {!config.enterpriseFeatures.fullWhiteLabeling && (
+          {showCommunityLinks && (
             <>
               <SidebarMenuItem>
                 <SidebarMenuButton asChild tooltip="Star us on GitHub">
@@ -412,7 +416,13 @@ export function AppSidebar() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const isAuthenticated = useIsAuthenticated();
-  const { data: starCount } = useGithubStars();
+  const showCommunityLinks = !config.enterpriseFeatures.fullWhiteLabeling;
+  // GitHub stars are cosmetic and external, so defer them until after the
+  // authenticated shell data has had a chance to load.
+  const { data: starCount } = useGithubStars({
+    enabled: showCommunityLinks && isAuthenticated,
+    deferMs: 5000,
+  });
   const formattedStarCount = starCount ?? "";
   const permissionMap = usePermissionMap(requiredPagePermissionsMap);
   const appIconLogo = useAppIconLogo();
@@ -488,17 +498,19 @@ export function AppSidebar() {
               pathname={pathname}
               searchParams={searchParams}
               permissionMap={permissionMap}
+              showCommunityLinks={showCommunityLinks}
               starCount={formattedStarCount}
               className="mt-auto"
             />
           </>
         )}
-        {!isAuthenticated && !config.enterpriseFeatures.fullWhiteLabeling && (
+        {!isAuthenticated && showCommunityLinks && (
           <NavSecondary
             items={[]}
             pathname={pathname}
             searchParams={searchParams}
             permissionMap={{}}
+            showCommunityLinks={showCommunityLinks}
             starCount={formattedStarCount}
           />
         )}

--- a/platform/frontend/src/components/app-logo.test.tsx
+++ b/platform/frontend/src/components/app-logo.test.tsx
@@ -7,9 +7,15 @@ const { mockUseOrgTheme, mockUseTheme } = vi.hoisted(() => ({
 }));
 
 vi.mock("next/image", () => ({
-  default: ({ alt, src }: { alt: string; src: string }) => (
-    <img alt={alt} src={src} />
-  ),
+  default: ({
+    alt,
+    src,
+    className,
+  }: {
+    alt: string;
+    src: string;
+    className?: string;
+  }) => <img alt={alt} src={src} className={className} />,
 }));
 
 vi.mock("next-themes", () => ({
@@ -52,5 +58,18 @@ describe("AppLogo", () => {
       "data:image/png;base64,custom",
     );
     expect(screen.queryByText("Archestra.AI")).not.toBeInTheDocument();
+  });
+
+  it("uses stable dimensions for the default logo", () => {
+    mockUseTheme.mockReturnValue({ resolvedTheme: "light" });
+    mockUseOrgTheme.mockReturnValue({
+      isLoadingAppearance: false,
+      logo: null,
+      logoDark: null,
+    });
+
+    render(<AppLogo />);
+
+    expect(screen.getByAltText("Logo")).toHaveClass("size-7", "shrink-0");
   });
 });

--- a/platform/frontend/src/components/app-logo.tsx
+++ b/platform/frontend/src/components/app-logo.tsx
@@ -54,7 +54,7 @@ export function AppLogo({ centered = true }: AppLogoProps) {
         alt="Logo"
         width={28}
         height={28}
-        className="h-auto w-auto"
+        className="size-7 shrink-0"
       />
       <span className="text-base font-semibold">{DEFAULT_APP_NAME}</span>
     </div>

--- a/platform/frontend/src/components/version.test.tsx
+++ b/platform/frontend/src/components/version.test.tsx
@@ -46,7 +46,8 @@ vi.mock("@/lib/config/health.query", () => ({
 }));
 
 vi.mock("@/lib/github/github-release.query", () => ({
-  useLatestGitHubRelease: () => mockUseLatestGitHubRelease(),
+  useLatestGitHubRelease: (params?: { enabled?: boolean }) =>
+    mockUseLatestGitHubRelease(params),
 }));
 
 vi.mock("@/lib/organization.query", () => ({
@@ -101,5 +102,23 @@ describe("Version", () => {
         name: "v1.1.33",
       }),
     ).not.toBeInTheDocument();
+    expect(mockUseLatestGitHubRelease).toHaveBeenCalledWith({
+      enabled: false,
+      deferMs: 5000,
+    });
+  });
+
+  it("skips latest release lookup when custom footer text is configured", () => {
+    mockUseOrganization.mockReturnValue({
+      data: { footerText: "Custom footer" },
+    });
+
+    const { container } = render(<Version inline />);
+
+    expect(container.firstChild).toHaveTextContent("Custom footer (v1.1.32)");
+    expect(mockUseLatestGitHubRelease).toHaveBeenCalledWith({
+      enabled: false,
+      deferMs: 5000,
+    });
   });
 });

--- a/platform/frontend/src/components/version.tsx
+++ b/platform/frontend/src/components/version.tsx
@@ -17,15 +17,19 @@ interface VersionProps {
 
 export function Version({ inline = false }: VersionProps) {
   const { data } = useHealth();
-  const { data: latestRelease } = useLatestGitHubRelease();
   const { data: organization } = useOrganization();
   const { data: appearance } = useAppearanceSettings();
-  const [shouldHide, setShouldHide] = useState(false);
-
+  const hideReleaseLink = config.enterpriseFeatures.fullWhiteLabeling;
   // Prefer authenticated org data; fall back to public appearance for unauthenticated pages (e.g. sign-in)
   const footerText = organization?.footerText ?? appearance?.footerText;
   const version = data?.version;
-  const hideReleaseLink = config.enterpriseFeatures.fullWhiteLabeling;
+  // The release check only powers a footer hint, so skip it when hidden and
+  // defer it when visible to keep startup focused on app data.
+  const { data: latestRelease } = useLatestGitHubRelease({
+    enabled: !hideReleaseLink && !!version && !footerText,
+    deferMs: 5000,
+  });
+  const [shouldHide, setShouldHide] = useState(false);
 
   const hasNewVersion = useMemo(() => {
     if (!version || !latestRelease?.tag_name) return false;

--- a/platform/frontend/src/lib/github/github-release.query.ts
+++ b/platform/frontend/src/lib/github/github-release.query.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import { useDeferredEnabled } from "@/lib/hooks/use-deferred-enabled";
 
 interface GitHubRelease {
   tag_name: string;
@@ -34,12 +35,27 @@ async function fetchLatestRelease(): Promise<GitHubRelease | null> {
   }
 }
 
-export function useLatestGitHubRelease() {
+/**
+ * Fetches latest release metadata for the footer upgrade hint.
+ *
+ * Callers can disable or defer this because it is noncritical external data and
+ * should not compete with authenticated shell API calls during initial load.
+ */
+export function useLatestGitHubRelease(params?: {
+  enabled?: boolean;
+  deferMs?: number;
+}) {
+  const enabled = useDeferredEnabled(
+    params?.enabled ?? true,
+    params?.deferMs ?? 0,
+  );
+
   return useQuery({
     queryKey: ["github-latest-release"],
     queryFn: fetchLatestRelease,
     staleTime: 60 * 60 * 1000, // 1 hour
     gcTime: 60 * 60 * 1000, // 1 hour cache
     retry: false,
+    enabled,
   });
 }

--- a/platform/frontend/src/lib/github/github.query.ts
+++ b/platform/frontend/src/lib/github/github.query.ts
@@ -1,6 +1,21 @@
 import { useQuery } from "@tanstack/react-query";
+import { useDeferredEnabled } from "@/lib/hooks/use-deferred-enabled";
 
-export function useGithubStars() {
+/**
+ * Fetches GitHub stars for optional community chrome.
+ *
+ * Callers can disable or defer this because it is noncritical external data and
+ * should not compete with authenticated shell API calls during initial load.
+ */
+export function useGithubStars(params?: {
+  enabled?: boolean;
+  deferMs?: number;
+}) {
+  const enabled = useDeferredEnabled(
+    params?.enabled ?? true,
+    params?.deferMs ?? 0,
+  );
+
   return useQuery({
     queryKey: ["github", "stars"],
     queryFn: async () => {
@@ -28,6 +43,7 @@ export function useGithubStars() {
     retry: false, // Don't retry on failure
     staleTime: 60 * 60 * 1000, // 1 hour
     gcTime: 24 * 60 * 60 * 1000, // 24 hours (formerly cacheTime)
+    enabled,
   });
 }
 

--- a/platform/frontend/src/lib/hooks/use-deferred-enabled.test.ts
+++ b/platform/frontend/src/lib/hooks/use-deferred-enabled.test.ts
@@ -1,0 +1,41 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useDeferredEnabled } from "./use-deferred-enabled";
+
+describe("useDeferredEnabled", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("enables immediately when no delay is configured", () => {
+    const { result } = renderHook(() => useDeferredEnabled(true, 0));
+
+    expect(result.current).toBe(true);
+  });
+
+  it("defers enabling until the delay elapses", () => {
+    vi.useFakeTimers();
+
+    const { result } = renderHook(() => useDeferredEnabled(true, 5000));
+
+    expect(result.current).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("stays disabled when disabled", () => {
+    vi.useFakeTimers();
+
+    const { result } = renderHook(() => useDeferredEnabled(false, 5000));
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/platform/frontend/src/lib/hooks/use-deferred-enabled.ts
+++ b/platform/frontend/src/lib/hooks/use-deferred-enabled.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Delays turning an `enabled` flag on while still turning it off immediately.
+ *
+ * Useful for noncritical queries that should not compete with first-load shell
+ * data, but can still run shortly after the page settles.
+ */
+export function useDeferredEnabled(enabled: boolean, delayMs: number) {
+  const [deferredEnabled, setDeferredEnabled] = useState(
+    enabled && delayMs <= 0,
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      setDeferredEnabled(false);
+      return;
+    }
+
+    if (delayMs <= 0) {
+      setDeferredEnabled(true);
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setDeferredEnabled(true);
+    }, delayMs);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [delayMs, enabled]);
+
+  return deferredEnabled;
+}


### PR DESCRIPTION
## Summary
- Defer noncritical GitHub star and latest-release lookups by 5s so authenticated shell APIs win the cold-load network window.
- Skip latest-release checks when release links are hidden or custom footer text is configured.
- Skip GitHub stars when community links are hidden or the user is not authenticated.
- Give the default app logo stable dimensions to avoid the sidebar logo being flagged as an unsized image.

## Audit notes
Chrome DevTools performance/network pass on `/mcp/registry` showed the initial fetch/font window included two external GitHub API requests:
- `https://api.github.com/repos/archestra-ai/archestra`
- `https://api.github.com/repos/archestra-ai/archestra/releases/latest`

After this change, the same initial network window contains only local app/auth data plus the active font. The GitHub calls are delayed and no longer compete with shell startup requests.