### PR TITLE
fix: Bedrock empty chat content

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Archestra",
-    "version": "1.2.43"
+    "version": "1.2.44"
   },
   "components": {
     "schemas": {

--- a/platform/backend/src/routes/chat/routes.test.ts
+++ b/platform/backend/src/routes/chat/routes.test.ts
@@ -313,6 +313,26 @@ describe("prepareMessagesForProvider", () => {
 
     expect(messages[0]).toBe(message);
   });
+
+  it("leaves bedrock messages with reasoning that carries provider metadata", () => {
+    const message = {
+      role: "assistant" as const,
+      parts: [
+        {
+          type: "reasoning",
+          text: "thinking...",
+          providerMetadata: { bedrock: { signature: "sig-abc" } },
+        },
+      ],
+    };
+
+    const messages = __test.prepareMessagesForProvider({
+      provider: "bedrock",
+      messages: [message],
+    });
+
+    expect(messages[0]).toBe(message);
+  });
 });
 
 describe("getMessagesNotYetPersisted", () => {

--- a/platform/backend/src/routes/chat/routes.test.ts
+++ b/platform/backend/src/routes/chat/routes.test.ts
@@ -193,6 +193,86 @@ describe("prepareMessagesForProvider", () => {
     );
   });
 
+  it("pads bedrock messages that only contain ignored UI data parts", () => {
+    const messages = __test.prepareMessagesForProvider({
+      provider: "bedrock",
+      messages: [
+        {
+          role: "assistant",
+          parts: [
+            {
+              type: "data-token-usage",
+              data: {
+                inputTokens: 10,
+                outputTokens: 5,
+                totalTokens: 15,
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(messages[0].parts).toContainEqual(
+      expect.objectContaining({
+        type: "text",
+        text: expect.stringMatching(/\S/),
+      }),
+    );
+  });
+
+  it("pads bedrock messages that only contain step markers and ignored data parts", () => {
+    const messages = __test.prepareMessagesForProvider({
+      provider: "bedrock",
+      messages: [
+        {
+          role: "assistant",
+          parts: [
+            { type: "step-start" },
+            {
+              type: "data-heartbeat",
+              data: { timestamp: 1778603432000 },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(messages[0].parts).toContainEqual(
+      expect.objectContaining({
+        type: "text",
+        text: expect.stringMatching(/\S/),
+      }),
+    );
+  });
+
+  it("pads bedrock messages that only contain streaming tool input", () => {
+    const messages = __test.prepareMessagesForProvider({
+      provider: "bedrock",
+      messages: [
+        {
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-search",
+              toolCallId: "call_123",
+              toolName: "search",
+              state: "input-streaming",
+              input: { q: "partial" },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(messages[0].parts).toContainEqual(
+      expect.objectContaining({
+        type: "text",
+        text: expect.stringMatching(/\S/),
+      }),
+    );
+  });
+
   it("leaves bedrock assistant messages with a tool-call part untouched", () => {
     const message = {
       role: "assistant" as const,

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -2207,19 +2207,29 @@ function ensureBedrockMessageHasContent(message: ChatMessage): ChatMessage {
   };
 }
 
-// Mirrors the AI SDK's bedrock converter: text/reasoning blocks without usable
-// payload are silently dropped; everything else (tool-call, tool-result, file,
-// image) always produces a content block.
+// Mirrors the AI SDK's UI-to-model conversion plus Bedrock's converter:
+// data/control parts are ignored without a converter, streaming tool inputs are
+// dropped, and empty text/reasoning blocks are not provider-visible content.
 function producesBedrockContentBlock(part: ChatMessagePart): boolean {
   if (part.type === "text") {
     return typeof part.text === "string" && part.text.trim().length > 0;
   }
+  if (part.type === "file") {
+    return true;
+  }
   if (part.type === "reasoning") {
-    const bedrock = (part.providerOptions as { bedrock?: unknown } | undefined)
-      ?.bedrock as { signature?: unknown; redactedData?: unknown } | undefined;
+    const providerMetadata =
+      (part.providerMetadata as { bedrock?: unknown } | undefined) ??
+      (part.providerOptions as { bedrock?: unknown } | undefined);
+    const bedrock = providerMetadata?.bedrock as
+      | { signature?: unknown; redactedData?: unknown }
+      | undefined;
     return Boolean(bedrock?.signature || bedrock?.redactedData);
   }
-  return true;
+  if (part.type.startsWith("tool-")) {
+    return part.state !== "input-streaming";
+  }
+  return false;
 }
 
 const BEDROCK_DOCUMENT_PLACEHOLDER_TEXT =

--- a/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
@@ -1387,7 +1387,7 @@ tests:
           value: 10
       - equal:
           path: spec.template.spec.containers[0].startupProbe.timeoutSeconds
-          value: 5
+          value: 45
       - equal:
           path: spec.template.spec.containers[0].startupProbe.failureThreshold
           value: 30
@@ -1408,10 +1408,10 @@ tests:
           value: 10
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
-          value: 5
+          value: 45
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.failureThreshold
-          value: 3
+          value: 5
 
   - it: should have readiness probe configured
     documentIndex: 1
@@ -1429,7 +1429,7 @@ tests:
           value: 10
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
-          value: 5
+          value: 45
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.failureThreshold
           value: 3


### PR DESCRIPTION
## Summary
- Tighten Bedrock chat message content detection to match provider-visible UI message parts
- Pad messages made only of ignored data/control parts or streaming tool input before sending to Bedrock
- Add regression coverage for ignored data parts, step markers, and streaming tool input

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>