### PR TITLE
perf(logging): async stdout in prod, gate pino-pretty to dev

### DIFF
--- a/platform/backend/src/logging/index.ts
+++ b/platform/backend/src/logging/index.ts
@@ -51,6 +51,9 @@ function createLogger(): pino.Logger {
       // Drop `pid` and `hostname` — they're noise in a containerized
       // environment where pod metadata already identifies the host.
       base: undefined,
+      // Use ISO 8601 timestamps instead of epoch ms — human-readable in
+      // stdout/Grafana while still parser-friendly. Pino built-in.
+      timestamp: pino.stdTimeFunctions.isoTime,
     },
     pino.multistream([
       {
@@ -153,8 +156,17 @@ function createOtelLogStream(): Writable {
           ...attributes
         } = record;
 
+        // `time` is an ISO 8601 string (pino.stdTimeFunctions.isoTime).
+        // Fall back to `Date.now()` only if parsing fails — important under
+        // async destinations where this callback can run after the log call.
+        const parsedMs =
+          typeof time === "number"
+            ? time
+            : typeof time === "string"
+              ? Date.parse(time)
+              : NaN;
         const timestamp = millisToHrTime(
-          typeof time === "number" ? time : Date.now(),
+          Number.isFinite(parsedMs) ? parsedMs : Date.now(),
         );
 
         otelLogger.emit({

--- a/platform/backend/src/logging/index.ts
+++ b/platform/backend/src/logging/index.ts
@@ -43,12 +43,25 @@ import { getActiveSessionId } from "@/observability/request-context";
 let _instance: pino.Logger | null = null;
 
 function createLogger(): pino.Logger {
-  const prettyStream = pretty({
-    colorize: true,
-    translateTime: "HH:MM:ss Z",
-    ignore: "pid,hostname",
-    singleLine: true,
-  });
+  const isProduction = process.env.NODE_ENV === "production";
+
+  // In production, write raw JSON to stdout via an async, buffered destination
+  // so log writes don't block the event loop when the container log pipe is
+  // backpressured. In development, keep pino-pretty for human-readable output.
+  const stdoutStream: pino.StreamEntry = isProduction
+    ? {
+        level: "trace",
+        stream: pino.destination({ fd: 1, sync: false, minLength: 4096 }),
+      }
+    : {
+        level: "trace",
+        stream: pretty({
+          colorize: true,
+          translateTime: "HH:MM:ss Z",
+          ignore: "pid,hostname",
+          singleLine: true,
+        }),
+      };
 
   return pino(
     {
@@ -56,7 +69,7 @@ function createLogger(): pino.Logger {
       mixin: injectTraceContext,
     },
     pino.multistream([
-      { level: "trace", stream: prettyStream },
+      stdoutStream,
       { level: "trace", stream: createOtelLogStream() },
     ]),
   );

--- a/platform/backend/src/logging/index.ts
+++ b/platform/backend/src/logging/index.ts
@@ -47,13 +47,16 @@ function createLogger(): pino.Logger {
   return pino(
     {
       level: LOG_LEVEL,
-      mixin: injectTraceContext,
+      // Keep `time` as epoch ms (pino default) so OTEL and log shippers can
+      // read it without parsing. Add a sibling `timeIso` for human readers
+      // looking at raw stdout.
+      mixin: () => ({
+        ...injectTraceContext(),
+        timeIso: new Date().toISOString(),
+      }),
       // Drop `pid` and `hostname` — they're noise in a containerized
       // environment where pod metadata already identifies the host.
       base: undefined,
-      // Use ISO 8601 timestamps instead of epoch ms — human-readable in
-      // stdout/Grafana while still parser-friendly. Pino built-in.
-      timestamp: pino.stdTimeFunctions.isoTime,
     },
     pino.multistream([
       {
@@ -156,17 +159,8 @@ function createOtelLogStream(): Writable {
           ...attributes
         } = record;
 
-        // `time` is an ISO 8601 string (pino.stdTimeFunctions.isoTime).
-        // Fall back to `Date.now()` only if parsing fails — important under
-        // async destinations where this callback can run after the log call.
-        const parsedMs =
-          typeof time === "number"
-            ? time
-            : typeof time === "string"
-              ? Date.parse(time)
-              : NaN;
         const timestamp = millisToHrTime(
-          Number.isFinite(parsedMs) ? parsedMs : Date.now(),
+          typeof time === "number" ? time : Date.now(),
         );
 
         otelLogger.emit({

--- a/platform/backend/src/logging/index.ts
+++ b/platform/backend/src/logging/index.ts
@@ -10,7 +10,6 @@ import {
   SeverityNumber,
 } from "@opentelemetry/api-logs";
 import pino from "pino";
-import pretty from "pino-pretty";
 import { LOG_LEVEL } from "@/logging/log-level";
 import { getActiveSessionId } from "@/observability/request-context";
 
@@ -43,33 +42,18 @@ import { getActiveSessionId } from "@/observability/request-context";
 let _instance: pino.Logger | null = null;
 
 function createLogger(): pino.Logger {
-  const isProduction = process.env.NODE_ENV === "production";
-
-  // In production, write raw JSON to stdout via an async, buffered destination
-  // so log writes don't block the event loop when the container log pipe is
-  // backpressured. In development, keep pino-pretty for human-readable output.
-  const stdoutStream: pino.StreamEntry = isProduction
-    ? {
-        level: "trace",
-        stream: pino.destination({ fd: 1, sync: false, minLength: 4096 }),
-      }
-    : {
-        level: "trace",
-        stream: pretty({
-          colorize: true,
-          translateTime: "HH:MM:ss Z",
-          ignore: "pid,hostname",
-          singleLine: true,
-        }),
-      };
-
+  // Write raw JSON to stdout via an async, buffered destination so log writes
+  // don't block the event loop when the container log pipe is backpressured.
   return pino(
     {
       level: LOG_LEVEL,
       mixin: injectTraceContext,
     },
     pino.multistream([
-      stdoutStream,
+      {
+        level: "trace",
+        stream: pino.destination({ fd: 1, sync: false, minLength: 4096 }),
+      },
       { level: "trace", stream: createOtelLogStream() },
     ]),
   );

--- a/platform/backend/src/logging/index.ts
+++ b/platform/backend/src/logging/index.ts
@@ -48,6 +48,9 @@ function createLogger(): pino.Logger {
     {
       level: LOG_LEVEL,
       mixin: injectTraceContext,
+      // Drop `pid` and `hostname` — they're noise in a containerized
+      // environment where pod metadata already identifies the host.
+      base: undefined,
     },
     pino.multistream([
       {

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -902,7 +902,7 @@ export async function convertToolResultsToToon(
                   },
                   "convertToolResultsToToon: compressed (string content)",
                 );
-                logger.debug(
+                logger.trace(
                   {
                     toolCallId: contentBlock.tool_use_id,
                     before: noncompressed,
@@ -984,7 +984,7 @@ export async function convertToolResultsToToon(
                       },
                       "convertToolResultsToToon: compressed (array content)",
                     );
-                    logger.debug(
+                    logger.trace(
                       {
                         toolCallId: contentBlock.tool_use_id,
                         before: noncompressed,

--- a/platform/backend/src/routes/proxy/adapters/gemini.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini.ts
@@ -886,7 +886,7 @@ async function convertToolResultsToToon(
                   },
                   "convertToolResultsToToon: compressed",
                 );
-                logger.debug(
+                logger.trace(
                   {
                     functionName:
                       "name" in functionResponse

--- a/platform/backend/src/routes/proxy/adapters/ollama.ts
+++ b/platform/backend/src/routes/proxy/adapters/ollama.ts
@@ -1030,7 +1030,7 @@ async function convertToolResultsToToon(
               },
               "convertToolResultsToToon: compressed",
             );
-            logger.debug(
+            logger.trace(
               {
                 toolCallId: message.tool_call_id,
                 before: noncompressed,

--- a/platform/backend/src/routes/proxy/adapters/openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai.ts
@@ -1037,7 +1037,7 @@ export async function convertToolResultsToToon(
               },
               "convertToolResultsToToon: compressed",
             );
-            logger.debug(
+            logger.trace(
               {
                 toolCallId: message.tool_call_id,
                 before: noncompressed,

--- a/platform/backend/src/routes/proxy/adapters/vllm.ts
+++ b/platform/backend/src/routes/proxy/adapters/vllm.ts
@@ -1030,7 +1030,7 @@ async function convertToolResultsToToon(
               },
               "convertToolResultsToToon: compressed",
             );
-            logger.debug(
+            logger.trace(
               {
                 toolCallId: message.tool_call_id,
                 before: noncompressed,

--- a/platform/backend/src/routes/proxy/adapters/zhipuai.ts
+++ b/platform/backend/src/routes/proxy/adapters/zhipuai.ts
@@ -866,7 +866,7 @@ async function convertToolResultsToToon(
               },
               "convertToolResultsToToon: compressed",
             );
-            logger.debug(
+            logger.trace(
               {
                 toolCallId: message.tool_call_id,
                 before: noncompressed,


### PR DESCRIPTION
## Summary

- Replace pino's default sync stdout with `pino.destination({ fd: 1, sync: false, minLength: 4096 })` so log writes don't block the event loop when the container log pipe is backpressured.
- Drop `pino-pretty` from the main logger path entirely. Backend logs are now raw JSON in all environments. (`pino-pretty` stays in `dependencies` because `entrypoints/_shared/log-capture.ts` still uses it.)
- Demote per-tool-result payload logs in `convertToolResultsToToon` (anthropic / gemini / ollama / openai / vllm / zhipuai adapters) from `debug` to `trace`.
- OTEL log-forwarding stream is unchanged.

## What changes at runtime

| | Before | After |
| --- | --- | --- |
| stdout format | pino-pretty (colorized, single-line) | raw JSON (one object per line) |
| stdout write mode | sync — blocks the event loop on full kernel log pipe | async, buffered (4 KB) |
| Per-line CPU on hot path | JSON parse → colorize → format → stringify → sync write | append to buffer; flush async |
| Per-tool-result payload logs | `debug` (active when `LOG_LEVEL=debug`) | `trace` (off by default) |
| OTEL log stream | enabled | enabled |

Trade-off: up to 4 KB of buffered logs may be lost on a hard crash before flush — standard pino async-destination behaviour.