### PR TITLE
perf: reduce MCP client ping hot path

### DIFF
--- a/platform/backend/src/clients/chat-mcp-client.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.test.ts
@@ -372,6 +372,52 @@ describe("chat-mcp-client health check", () => {
     await chatClient.__test.clearToolCache(cacheKey);
   });
 
+  test("skips ping for recently validated cached clients", async ({
+    makeAgent,
+    makeUser,
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const team = await makeTeam(org.id, user.id);
+    const agent = await makeAgent({ teams: [team.id] });
+    await makeTeamMember(team.id, user.id);
+    await TeamTokenModel.createTeamToken(team.id, team.name);
+
+    const cacheKey = chatClient.__test.getCacheKey(agent.id, user.id);
+    chatClient.clearChatMcpClient(agent.id);
+    await chatClient.__test.clearToolCache(cacheKey);
+
+    const cachedClient = {
+      ping: vi.fn().mockResolvedValue(undefined),
+      listTools: vi.fn().mockResolvedValue({ tools: [] }),
+      callTool: vi.fn(),
+      close: vi.fn(),
+    };
+
+    chatClient.__test.setCachedClient(
+      cacheKey,
+      cachedClient as unknown as Client,
+    );
+    chatClient.__test.setCachedClientLastValidatedAt(cacheKey, Date.now());
+
+    const tools = await chatClient.getChatMcpTools({
+      agentName: agent.name,
+      agentId: agent.id,
+      userId: user.id,
+      organizationId: org.id,
+    });
+
+    expect(cachedClient.ping).not.toHaveBeenCalled();
+    expect(cachedClient.listTools).toHaveBeenCalledTimes(1);
+    expect(tools).toEqual({});
+
+    chatClient.clearChatMcpClient(agent.id);
+    await chatClient.__test.clearToolCache(cacheKey);
+  });
+
   test("discards cached client when ping hangs past timeout", async ({
     makeAgent,
     makeUser,

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -103,6 +103,7 @@ const clientCache = new LRUCacheManager<Client>({
         "Error closing evicted MCP client (non-fatal)",
       );
     }
+    clientLastValidatedAt.delete(key);
   },
 });
 
@@ -111,6 +112,7 @@ const clientCache = new LRUCacheManager<Client>({
  */
 const TOOL_CACHE_TTL_MS = 30 * TimeInMs.Second;
 const CLIENT_PING_TIMEOUT_MS = 5 * TimeInMs.Second;
+const CLIENT_PING_VALIDATION_INTERVAL_MS = 30 * TimeInMs.Second;
 
 function getChatExternalAgentId(): string {
   return `${archestraMcpBranding.catalogName} Chat`;
@@ -139,6 +141,8 @@ const toolCache = new LRUCacheManager<Record<string, Tool>>({
   maxSize: MAX_TOOL_CACHE_SIZE,
   defaultTtl: TOOL_CACHE_TTL_MS,
 });
+
+const clientLastValidatedAt = new Map<string, number>();
 
 /**
  * UI resource cache TTL — 60 seconds.
@@ -192,6 +196,10 @@ function getToolCacheKey(
 export const __test = {
   setCachedClient(cacheKey: string, client: Client, ttl?: number) {
     clientCache.set(cacheKey, client, ttl);
+    clientLastValidatedAt.set(cacheKey, 0);
+  },
+  setCachedClientLastValidatedAt(cacheKey: string, timestamp: number) {
+    clientLastValidatedAt.set(cacheKey, timestamp);
   },
   async clearToolCache(cacheKey?: string) {
     if (cacheKey) {
@@ -372,6 +380,7 @@ export function clearChatMcpClient(agentId: string): void {
         );
       }
       clientCache.delete(key);
+      clientLastValidatedAt.delete(key);
       clientClearedCount++;
     }
   }
@@ -431,6 +440,7 @@ export function closeChatMcpClient(
       );
     }
     clientCache.delete(cacheKey);
+    clientLastValidatedAt.delete(cacheKey);
   }
 
   // Also clear tool cache for this conversation
@@ -463,12 +473,16 @@ export async function getChatMcpClient(
   // Check cache first
   const cachedClient = clientCache.get(cacheKey);
   if (cachedClient) {
-    // Health check: ping the client to verify connection is still alive
+    // Health check idle clients to verify the connection is still alive.
+    // Recently-used clients skip the ping and recover on actual call failure.
     try {
-      await pingClientWithTimeout(cachedClient);
+      if (shouldValidateCachedClient(cacheKey)) {
+        await pingClientWithTimeout(cachedClient);
+        clientLastValidatedAt.set(cacheKey, Date.now());
+      }
       logger.info(
         { agentId, userId },
-        "Returning cached MCP client for agent/user (ping succeeded, session will be reused)",
+        "Returning cached MCP client for agent/user",
       );
       clientCache.set(cacheKey, cachedClient);
       return cachedClient;
@@ -492,6 +506,7 @@ export async function getChatMcpClient(
         );
       }
       clientCache.delete(cacheKey);
+      clientLastValidatedAt.delete(cacheKey);
       // Fall through to create new client
     }
   }
@@ -590,6 +605,7 @@ export async function getChatMcpClient(
     // Cache the client with idle expiration to prevent abandoned
     // conversation-scoped sessions from accumulating indefinitely.
     clientCache.set(cacheKey, client);
+    clientLastValidatedAt.set(cacheKey, Date.now());
 
     logger.info(
       {
@@ -622,6 +638,7 @@ export async function getChatMcpClient(
         );
 
         clientCache.set(cacheKey, client);
+        clientLastValidatedAt.set(cacheKey, Date.now());
 
         logger.info(
           {
@@ -663,6 +680,11 @@ async function pingClientWithTimeout(
       timeout.unref?.();
     }),
   ]);
+}
+
+function shouldValidateCachedClient(cacheKey: string): boolean {
+  const lastValidatedAt = clientLastValidatedAt.get(cacheKey) ?? 0;
+  return Date.now() - lastValidatedAt >= CLIENT_PING_VALIDATION_INTERVAL_MS;
 }
 
 /**

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -549,6 +549,41 @@ describe("McpClient", () => {
       expect(mockConnect).toHaveBeenCalledTimes(1);
     });
 
+    test("skips ping for recently validated active connections", async () => {
+      const tool = await ToolModel.createToolIfNotExists({
+        name: "github-mcp-server__recent_reuse",
+        description: "Recent active connection reuse",
+        parameters: {},
+        catalogId,
+      });
+
+      await AgentToolModel.create(agentId, tool.id, {
+        mcpServerId,
+        credentialResolutionMode: "static",
+      });
+
+      mockConnect.mockResolvedValue(undefined);
+      mockPing.mockResolvedValue(undefined);
+      mockCallTool.mockResolvedValue({
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      });
+
+      const toolCall = {
+        id: "call_recent_reuse",
+        name: tool.name,
+        arguments: {},
+      };
+
+      const firstResult = await mcpClient.executeToolCall(toolCall, agentId);
+      const secondResult = await mcpClient.executeToolCall(toolCall, agentId);
+
+      expect(firstResult.isError).toBe(false);
+      expect(secondResult.isError).toBe(false);
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+      expect(mockPing).not.toHaveBeenCalled();
+    });
+
     describe("Concurrency limiter", () => {
       test("limits HTTP concurrency to 4", async () => {
         const clientWithInternals = mcpClient as unknown as {

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -576,9 +576,13 @@ describe("McpClient", () => {
       };
 
       const firstResult = await mcpClient.executeToolCall(toolCall, agentId);
-      const secondResult = await mcpClient.executeToolCall(toolCall, agentId);
-
       expect(firstResult.isError).toBe(false);
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+      expect(mockPing).not.toHaveBeenCalled();
+
+      mockPing.mockClear();
+
+      const secondResult = await mcpClient.executeToolCall(toolCall, agentId);
       expect(secondResult.isError).toBe(false);
       expect(mockConnect).toHaveBeenCalledTimes(1);
       expect(mockPing).not.toHaveBeenCalled();

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -187,6 +187,7 @@ const CLIENT_CREDENTIALS_FALLBACK_TTL_MS = 5 * TimeInMs.Minute;
 // reclaiming abandoned connections on a reasonable operational timescale.
 const ACTIVE_CONNECTION_CACHE_TTL_MS = 15 * TimeInMs.Minute;
 const ACTIVE_CONNECTION_CACHE_MAX_SIZE = 500;
+const ACTIVE_CONNECTION_PING_VALIDATION_INTERVAL_MS = 30 * TimeInMs.Second;
 
 const RESOURCE_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 1 day
 const RESOURCE_CACHE_MAX_SIZE = 1000;
@@ -224,9 +225,11 @@ class McpClient {
       this.activeConnectionServerState.delete(key);
       this.toolNameCache.delete(key);
       this.pendingHttpSessionMetadata.delete(key);
+      this.activeConnectionLastValidatedAt.delete(key);
     },
   });
   private activeConnectionServerState = new Map<string, CachedServerState>();
+  private activeConnectionLastValidatedAt = new Map<string, number>();
   private connectionLimiter = new ConnectionLimiter();
   // Cache of actual tool names per connection key: lowercased name -> original cased name
   private toolNameCache = new LRUCacheManager<Map<string, string>>({
@@ -302,6 +305,7 @@ class McpClient {
       this.activeConnectionServerState.delete(connectionKey);
       this.toolNameCache.delete(connectionKey);
       this.pendingHttpSessionMetadata.delete(connectionKey);
+      this.activeConnectionLastValidatedAt.delete(connectionKey);
       logger.info({ connectionKey }, "Closed cached MCP session");
     }
 
@@ -660,6 +664,7 @@ class McpClient {
             this.activeConnectionServerState.delete(connectionKey);
             this.toolNameCache.delete(connectionKey);
             this.pendingHttpSessionMetadata.delete(connectionKey);
+            this.activeConnectionLastValidatedAt.delete(connectionKey);
             return await executeToolCall(getTransport, currentSecrets, true);
           } finally {
             resolveRecovery();
@@ -749,6 +754,7 @@ class McpClient {
           this.activeConnectionServerState.delete(connectionKey);
           this.toolNameCache.delete(connectionKey);
           this.pendingHttpSessionMetadata.delete(connectionKey);
+          this.activeConnectionLastValidatedAt.delete(connectionKey);
 
           return await executeToolCall(
             () =>
@@ -924,18 +930,20 @@ class McpClient {
         this.activeConnectionServerState.delete(connectionKey);
         this.toolNameCache.delete(connectionKey);
         this.pendingHttpSessionMetadata.delete(connectionKey);
+        this.activeConnectionLastValidatedAt.delete(connectionKey);
       }
     }
 
     const reusableClient = this.activeConnections.get(connectionKey);
     if (reusableClient) {
-      // Health check: ping the client to verify connection is still alive
+      // Health check idle clients to verify the connection is still alive.
+      // Recently-used clients skip the ping and recover on actual call failure.
       try {
-        await reusableClient.ping();
-        logger.debug(
-          { connectionKey },
-          "Client ping successful, reusing cached client",
-        );
+        if (this.shouldValidateActiveConnection(connectionKey)) {
+          await reusableClient.ping();
+          this.activeConnectionLastValidatedAt.set(connectionKey, Date.now());
+        }
+        logger.debug({ connectionKey }, "Reusing cached MCP client");
         this.activeConnections.set(connectionKey, reusableClient);
         this.activeConnectionServerState.set(connectionKey, currentServerState);
         return reusableClient;
@@ -952,6 +960,7 @@ class McpClient {
         this.activeConnectionServerState.delete(connectionKey);
         this.toolNameCache.delete(connectionKey);
         this.pendingHttpSessionMetadata.delete(connectionKey);
+        this.activeConnectionLastValidatedAt.delete(connectionKey);
         // If the transport carries a stored session ID the session is likely
         // stale (e.g. Playwright pod restarted).  Delete it from the DB so
         // the retry path creates a truly fresh connection instead of reading
@@ -1030,6 +1039,7 @@ class McpClient {
     // while the upsert is in flight.
     this.activeConnections.set(connectionKey, client);
     this.activeConnectionServerState.set(connectionKey, currentServerState);
+    this.activeConnectionLastValidatedAt.set(connectionKey, Date.now());
 
     // Persist the MCP session ID so other backend pods can reuse it.
     // With --isolated, each Mcp-Session-Id maps to a separate browser context;
@@ -1059,6 +1069,15 @@ class McpClient {
     }
 
     return client;
+  }
+
+  private shouldValidateActiveConnection(connectionKey: string): boolean {
+    const lastValidatedAt =
+      this.activeConnectionLastValidatedAt.get(connectionKey) ?? 0;
+    return (
+      Date.now() - lastValidatedAt >=
+      ACTIVE_CONNECTION_PING_VALIDATION_INTERVAL_MS
+    );
   }
 
   /**
@@ -2155,6 +2174,7 @@ class McpClient {
         this.activeConnections.delete(connectionKey);
         this.activeConnectionServerState.delete(connectionKey);
         this.pendingHttpSessionMetadata.delete(connectionKey);
+        this.activeConnectionLastValidatedAt.delete(connectionKey);
       }
 
       const refreshed = await refreshOAuthToken(secretId, catalogId);
@@ -2660,6 +2680,7 @@ class McpClient {
     this.activeConnections.clear();
     this.activeConnectionServerState.clear();
     this.pendingHttpSessionMetadata.clear();
+    this.activeConnectionLastValidatedAt.clear();
   }
 
   async invalidateConnectionsForServer(
@@ -2690,6 +2711,7 @@ class McpClient {
         this.activeConnectionServerState.delete(connectionKey);
         this.toolNameCache.delete(connectionKey);
         this.pendingHttpSessionMetadata.delete(connectionKey);
+        this.activeConnectionLastValidatedAt.delete(connectionKey);
         await McpHttpSessionModel.deleteStaleSession(connectionKey).catch(
           (error) => {
             logger.warn(

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -301,11 +301,7 @@ class McpClient {
           "Error closing MCP session (non-fatal)",
         );
       }
-      this.activeConnections.delete(connectionKey);
-      this.activeConnectionServerState.delete(connectionKey);
-      this.toolNameCache.delete(connectionKey);
-      this.pendingHttpSessionMetadata.delete(connectionKey);
-      this.activeConnectionLastValidatedAt.delete(connectionKey);
+      this.clearConnectionState(connectionKey);
       logger.info({ connectionKey }, "Closed cached MCP session");
     }
 
@@ -660,11 +656,7 @@ class McpClient {
                 );
               }
             }
-            this.activeConnections.delete(connectionKey);
-            this.activeConnectionServerState.delete(connectionKey);
-            this.toolNameCache.delete(connectionKey);
-            this.pendingHttpSessionMetadata.delete(connectionKey);
-            this.activeConnectionLastValidatedAt.delete(connectionKey);
+            this.clearConnectionState(connectionKey);
             return await executeToolCall(getTransport, currentSecrets, true);
           } finally {
             resolveRecovery();
@@ -750,11 +742,7 @@ class McpClient {
             secrets: resetSecrets,
             secretId,
           });
-          this.activeConnections.delete(connectionKey);
-          this.activeConnectionServerState.delete(connectionKey);
-          this.toolNameCache.delete(connectionKey);
-          this.pendingHttpSessionMetadata.delete(connectionKey);
-          this.activeConnectionLastValidatedAt.delete(connectionKey);
+          this.clearConnectionState(connectionKey);
 
           return await executeToolCall(
             () =>
@@ -926,11 +914,7 @@ class McpClient {
             "Error closing stale cached MCP client after credential change",
           );
         }
-        this.activeConnections.delete(connectionKey);
-        this.activeConnectionServerState.delete(connectionKey);
-        this.toolNameCache.delete(connectionKey);
-        this.pendingHttpSessionMetadata.delete(connectionKey);
-        this.activeConnectionLastValidatedAt.delete(connectionKey);
+        this.clearConnectionState(connectionKey);
       }
     }
 
@@ -956,11 +940,7 @@ class McpClient {
           },
           "Client ping failed, creating fresh client",
         );
-        this.activeConnections.delete(connectionKey);
-        this.activeConnectionServerState.delete(connectionKey);
-        this.toolNameCache.delete(connectionKey);
-        this.pendingHttpSessionMetadata.delete(connectionKey);
-        this.activeConnectionLastValidatedAt.delete(connectionKey);
+        this.clearConnectionState(connectionKey);
         // If the transport carries a stored session ID the session is likely
         // stale (e.g. Playwright pod restarted).  Delete it from the DB so
         // the retry path creates a truly fresh connection instead of reading
@@ -1078,6 +1058,22 @@ class McpClient {
       Date.now() - lastValidatedAt >=
       ACTIVE_CONNECTION_PING_VALIDATION_INTERVAL_MS
     );
+  }
+
+  private clearConnectionState(connectionKey: string): void {
+    this.activeConnections.delete(connectionKey);
+    this.activeConnectionServerState.delete(connectionKey);
+    this.toolNameCache.delete(connectionKey);
+    this.pendingHttpSessionMetadata.delete(connectionKey);
+    this.activeConnectionLastValidatedAt.delete(connectionKey);
+  }
+
+  private clearAllConnectionState(): void {
+    this.activeConnections.clear();
+    this.activeConnectionServerState.clear();
+    this.toolNameCache.clear();
+    this.pendingHttpSessionMetadata.clear();
+    this.activeConnectionLastValidatedAt.clear();
   }
 
   /**
@@ -2171,10 +2167,7 @@ class McpClient {
         } catch {
           // Ignore close errors during refresh teardown.
         }
-        this.activeConnections.delete(connectionKey);
-        this.activeConnectionServerState.delete(connectionKey);
-        this.pendingHttpSessionMetadata.delete(connectionKey);
-        this.activeConnectionLastValidatedAt.delete(connectionKey);
+        this.clearConnectionState(connectionKey);
       }
 
       const refreshed = await refreshOAuthToken(secretId, catalogId);
@@ -2677,10 +2670,7 @@ class McpClient {
     });
 
     await Promise.all([...disconnectPromises, ...activeDisconnectPromises]);
-    this.activeConnections.clear();
-    this.activeConnectionServerState.clear();
-    this.pendingHttpSessionMetadata.clear();
-    this.activeConnectionLastValidatedAt.clear();
+    this.clearAllConnectionState();
   }
 
   async invalidateConnectionsForServer(
@@ -2707,11 +2697,7 @@ class McpClient {
           }
         }
 
-        this.activeConnections.delete(connectionKey);
-        this.activeConnectionServerState.delete(connectionKey);
-        this.toolNameCache.delete(connectionKey);
-        this.pendingHttpSessionMetadata.delete(connectionKey);
-        this.activeConnectionLastValidatedAt.delete(connectionKey);
+        this.clearConnectionState(connectionKey);
         await McpHttpSessionModel.deleteStaleSession(connectionKey).catch(
           (error) => {
             logger.warn(

--- a/platform/frontend/src/app/settings/roles/page.test.tsx
+++ b/platform/frontend/src/app/settings/roles/page.test.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const mockUserSearchableSelect = vi.fn(
+  (_props: {
+    users: Array<{
+      userId: string;
+      name?: string | null;
+      email?: string | null;
+    }>;
+    placeholder?: string;
+    searchPlaceholder?: string;
+  }) => <div data-testid="user-searchable-select" />,
+);
+
+vi.mock("@/lib/config/config", () => ({
+  default: {
+    enterpriseFeatures: {
+      core: false,
+    },
+  },
+}));
+
+vi.mock("@/components/roles/roles-list", () => ({
+  RolesList: () => <div>roles list</div>,
+}));
+
+vi.mock("@/components/user-searchable-select", () => ({
+  UserSearchableSelect: (
+    props: Parameters<typeof mockUserSearchableSelect>[0],
+  ) => mockUserSearchableSelect(props),
+}));
+
+vi.mock("@/lib/impersonation.query", () => ({
+  useCanImpersonate: () => true,
+  useImpersonationCandidates: () => ({
+    data: [
+      {
+        id: "user-1",
+        name: "Ada Lovelace",
+        email: "ada@example.com",
+        role: "member",
+      },
+      {
+        id: "user-2",
+        name: "Grace Hopper",
+        email: "grace@example.com",
+        role: null,
+      },
+    ],
+    isLoading: false,
+  }),
+  useImpersonateUser: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+describe("RolesSettingsPage", () => {
+  it("uses the searchable user select for role debugging", async () => {
+    const { default: RolesSettingsPage } = await import("./page");
+
+    render(<RolesSettingsPage />);
+
+    expect(screen.getByTestId("user-searchable-select")).toBeInTheDocument();
+    expect(mockUserSearchableSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        users: [
+          {
+            userId: "user-1",
+            name: "Ada Lovelace · member",
+            email: "ada@example.com",
+          },
+          {
+            userId: "user-2",
+            name: "Grace Hopper",
+            email: "grace@example.com",
+          },
+        ],
+        placeholder: "Select a user",
+        searchPlaceholder: "Search users by name or email",
+      }),
+    );
+  });
+});

--- a/platform/frontend/src/app/settings/roles/page.tsx
+++ b/platform/frontend/src/app/settings/roles/page.tsx
@@ -5,13 +5,7 @@ import { Eye } from "lucide-react";
 import { useState } from "react";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
 import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { UserSearchableSelect } from "@/components/user-searchable-select";
 import config from "@/lib/config/config";
 import {
   useCanImpersonate,
@@ -29,6 +23,13 @@ function RoleDebuggerCallout() {
   const { data: candidates, isLoading } = useImpersonationCandidates();
   const { mutate: impersonate, isPending } = useImpersonateUser();
   const [selectedUserId, setSelectedUserId] = useState<string>("");
+  const userOptions = (candidates ?? []).map((candidate) => ({
+    userId: candidate.id,
+    name: candidate.role
+      ? `${candidate.name} · ${candidate.role}`
+      : candidate.name,
+    email: candidate.email,
+  }));
 
   if (!canImpersonate) return null;
 
@@ -40,31 +41,22 @@ function RoleDebuggerCallout() {
         or when you click <em>Return to admin</em> in the banner.
       </p>
       <div className="mt-3 flex items-center gap-2">
-        <Select
+        <UserSearchableSelect
           value={selectedUserId}
           onValueChange={setSelectedUserId}
+          users={userOptions}
           disabled={isLoading || !candidates || candidates.length === 0}
-        >
-          <SelectTrigger className="w-72">
-            <SelectValue
-              placeholder={
-                isLoading
-                  ? "Loading users…"
-                  : !candidates || candidates.length === 0
-                    ? "No users available"
-                    : "Select a user"
-              }
-            />
-          </SelectTrigger>
-          <SelectContent>
-            {(candidates ?? []).map((candidate) => (
-              <SelectItem key={candidate.id} value={candidate.id}>
-                {candidate.name}
-                {candidate.role ? ` · ${candidate.role}` : ""}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+          placeholder={
+            isLoading
+              ? "Loading users..."
+              : !candidates || candidates.length === 0
+                ? "No users available"
+                : "Select a user"
+          }
+          searchPlaceholder="Search users by name or email"
+          className="w-72"
+          emptyMessage="No matching users found."
+        />
         <Button
           size="sm"
           variant="outline"


### PR DESCRIPTION
## Summary
- skip cached MCP client ping checks for clients validated within the last 30 seconds
- keep idle-client validation and existing failure recovery paths for stale connections
- switch the role debugger user picker to the searchable user select component