### PR TITLE
feat(frontend): accept JSON for MCP server config in args textarea

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -94,7 +94,10 @@ import {
   formSchema,
   type McpCatalogFormValues,
 } from "./mcp-catalog-form.types";
-import { transformCatalogItemToFormValues } from "./mcp-catalog-form.utils";
+import {
+  parseFullServerConfig,
+  transformCatalogItemToFormValues,
+} from "./mcp-catalog-form.utils";
 
 const { useIdentityProviders } = config.enterpriseFeatures.core
   ? // biome-ignore lint/style/noRestrictedImports: conditional EE query import for IdP selector
@@ -999,16 +1002,80 @@ export function McpCatalogForm({
                     render={({ field }) => (
                       <FormItem>
                         <FormLabel>
-                          Arguments (one per line)
+                          Arguments (one per line or JSON array)
                           <ReinstallHint show={isArgumentsDirty} />
                         </FormLabel>
                         <FormControl>
                           <Textarea
-                            placeholder={`/path/to/server.js\n--verbose`}
+                            placeholder={`/path/to/server.js\n--verbose\n\nor: ["server.js", "--verbose"]`}
                             className="font-mono min-h-20"
                             {...field}
+                            onPaste={(event) => {
+                              // Smart paste: if the user pastes a full MCP
+                              // server config object (the shape published by
+                              // most catalogs), populate Command / Arguments /
+                              // Environment in one step instead of dumping the
+                              // JSON text into the Arguments textarea.
+                              const pasted =
+                                event.clipboardData.getData("text");
+                              const parsed = parseFullServerConfig(pasted);
+                              if (!parsed) return;
+
+                              event.preventDefault();
+
+                              if (parsed.command !== undefined) {
+                                form.setValue(
+                                  "localConfig.command",
+                                  parsed.command,
+                                  { shouldDirty: true, shouldValidate: true },
+                                );
+                              }
+
+                              if (parsed.args !== undefined) {
+                                form.setValue(
+                                  "localConfig.arguments",
+                                  parsed.args.join("\n"),
+                                  { shouldDirty: true, shouldValidate: true },
+                                );
+                              }
+
+                              if (parsed.env && parsed.env.length > 0) {
+                                const existing =
+                                  form.getValues("localConfig.environment") ??
+                                  [];
+                                const existingKeys = new Set(
+                                  existing.map((e) => e.key),
+                                );
+                                const additions = parsed.env
+                                  .filter((e) => !existingKeys.has(e.key))
+                                  .map((e) => ({
+                                    key: e.key,
+                                    type: "plain_text" as const,
+                                    value: e.value,
+                                    promptOnInstallation: false,
+                                    required: false,
+                                    description: "",
+                                  }));
+                                if (additions.length > 0) {
+                                  form.setValue(
+                                    "localConfig.environment",
+                                    [...existing, ...additions],
+                                    {
+                                      shouldDirty: true,
+                                      shouldValidate: true,
+                                    },
+                                  );
+                                }
+                              }
+                            }}
                           />
                         </FormControl>
+                        <FormDescription>
+                          Paste a single argument per line, a JSON array (e.g.{" "}
+                          <code>["server.js", "--verbose"]</code>), or a full
+                          MCP server config object to auto-populate Command,
+                          Arguments, and Environment.
+                        </FormDescription>
                         <FormMessage />
                       </FormItem>
                     )}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
@@ -860,3 +860,185 @@ describe("transformFormToApiData - secret env var preservation", () => {
     expect(env[1]?.value ?? "").toBe("");
   });
 });
+
+describe("parseArgumentsString", () => {
+  it("returns an empty array for empty / whitespace input", async () => {
+    const { parseArgumentsString } = await import("./mcp-catalog-form.utils");
+    expect(parseArgumentsString(undefined)).toEqual([]);
+    expect(parseArgumentsString(null)).toEqual([]);
+    expect(parseArgumentsString("")).toEqual([]);
+    expect(parseArgumentsString("   \n  ")).toEqual([]);
+  });
+
+  it("splits one-argument-per-line input on newlines and trims", async () => {
+    const { parseArgumentsString } = await import("./mcp-catalog-form.utils");
+    expect(parseArgumentsString("  server.js  \n  --verbose ")).toEqual([
+      "server.js",
+      "--verbose",
+    ]);
+  });
+
+  it("drops blank lines from one-per-line input", async () => {
+    const { parseArgumentsString } = await import("./mcp-catalog-form.utils");
+    expect(parseArgumentsString("server.js\n\n--verbose\n")).toEqual([
+      "server.js",
+      "--verbose",
+    ]);
+  });
+
+  it("parses a JSON array of strings as a list of arguments", async () => {
+    const { parseArgumentsString } = await import("./mcp-catalog-form.utils");
+    expect(parseArgumentsString('["server.js", "--verbose"]')).toEqual([
+      "server.js",
+      "--verbose",
+    ]);
+  });
+
+  it("trims and drops empty entries inside a JSON array", async () => {
+    const { parseArgumentsString } = await import("./mcp-catalog-form.utils");
+    expect(parseArgumentsString('["  server.js  ", "", "--verbose"]')).toEqual([
+      "server.js",
+      "--verbose",
+    ]);
+  });
+
+  it("falls back to newline parsing when the JSON array is malformed", async () => {
+    const { parseArgumentsString } = await import("./mcp-catalog-form.utils");
+    // Looks like a JSON array but isn't parseable - treat as text input.
+    expect(parseArgumentsString("[server.js, --verbose]")).toEqual([
+      "[server.js, --verbose]",
+    ]);
+  });
+
+  it("falls back to newline parsing when the JSON value is not an array of strings", async () => {
+    const { parseArgumentsString } = await import("./mcp-catalog-form.utils");
+    // Valid JSON but wrong shape (numbers, not strings).
+    expect(parseArgumentsString("[1, 2, 3]")).toEqual(["[1, 2, 3]"]);
+  });
+});
+
+describe("parseFullServerConfig", () => {
+  it("returns null for inputs that aren't JSON objects", async () => {
+    const { parseFullServerConfig } = await import("./mcp-catalog-form.utils");
+    expect(parseFullServerConfig("")).toBeNull();
+    expect(parseFullServerConfig("server.js\n--verbose")).toBeNull();
+    expect(parseFullServerConfig('["server.js"]')).toBeNull();
+    expect(parseFullServerConfig("not json")).toBeNull();
+  });
+
+  it("returns null when the object lacks any recognized MCP server fields", async () => {
+    const { parseFullServerConfig } = await import("./mcp-catalog-form.utils");
+    expect(parseFullServerConfig('{"name": "something"}')).toBeNull();
+  });
+
+  it("parses command / args / env from a full MCP server config", async () => {
+    const { parseFullServerConfig } = await import("./mcp-catalog-form.utils");
+    expect(
+      parseFullServerConfig(
+        JSON.stringify({
+          command: "node",
+          args: ["server.js", "--verbose"],
+          env: { API_KEY: "secret", DEBUG: "1" },
+        }),
+      ),
+    ).toEqual({
+      command: "node",
+      args: ["server.js", "--verbose"],
+      env: [
+        { key: "API_KEY", value: "secret" },
+        { key: "DEBUG", value: "1" },
+      ],
+    });
+  });
+
+  it("ignores malformed JSON gracefully", async () => {
+    const { parseFullServerConfig } = await import("./mcp-catalog-form.utils");
+    expect(parseFullServerConfig('{"command": "node"')).toBeNull();
+  });
+
+  it("coerces non-string env values to strings instead of dropping them", async () => {
+    const { parseFullServerConfig } = await import("./mcp-catalog-form.utils");
+    const result = parseFullServerConfig(
+      JSON.stringify({ env: { PORT: 8080, ENABLED: true, EMPTY: null } }),
+    );
+    expect(result?.env).toEqual([
+      { key: "PORT", value: "8080" },
+      { key: "ENABLED", value: "true" },
+      { key: "EMPTY", value: "" },
+    ]);
+  });
+
+  it("preserves the `type` field when present", async () => {
+    const { parseFullServerConfig } = await import("./mcp-catalog-form.utils");
+    expect(
+      parseFullServerConfig(JSON.stringify({ type: "stdio", command: "node" })),
+    ).toEqual({ command: "node", type: "stdio" });
+  });
+
+  it("drops args entries that are not strings", async () => {
+    const { parseFullServerConfig } = await import("./mcp-catalog-form.utils");
+    // If even one entry isn't a string the args list is unsafe - treat as missing.
+    const result = parseFullServerConfig(
+      JSON.stringify({ command: "node", args: ["server.js", 42] }),
+    );
+    expect(result).toEqual({ command: "node" });
+  });
+});
+
+describe("transformFormToApiData - JSON array arguments", () => {
+  function makeLocalValues(args: string): McpCatalogFormValues {
+    return {
+      name: "JSON Args MCP",
+      description: "",
+      icon: null,
+      serverType: "local",
+      serverUrl: "",
+      authMethod: "none",
+      includeBearerPrefix: true,
+      authHeaderName: "",
+      additionalHeaders: [],
+      oauthConfig: undefined,
+      enterpriseManagedConfig: null,
+      localConfig: {
+        command: "node",
+        arguments: args,
+        environment: [],
+        envFrom: [],
+        dockerImage: "",
+        transportType: "stdio",
+        httpPort: "",
+        httpPath: "",
+        serviceAccount: "",
+        imagePullSecrets: [],
+      },
+      deploymentSpecYaml: "",
+      originalDeploymentSpecYaml: "",
+      oauthClientSecretVaultPath: "",
+      oauthClientSecretVaultKey: "",
+      localConfigVaultPath: "",
+      localConfigVaultKey: "",
+      labels: [],
+      scope: "personal",
+      teams: [],
+    };
+  }
+
+  it("accepts a JSON array as the arguments field", () => {
+    const result = transformFormToApiData(
+      makeLocalValues('["server.js", "--verbose"]'),
+    );
+    expect(result.localConfig?.arguments).toEqual(["server.js", "--verbose"]);
+  });
+
+  it("still accepts the existing one-argument-per-line format", () => {
+    const result = transformFormToApiData(
+      makeLocalValues("server.js\n--verbose"),
+    );
+    expect(result.localConfig?.arguments).toEqual(["server.js", "--verbose"]);
+  });
+
+  it("returns undefined arguments when the field is empty", () => {
+    const result = transformFormToApiData(makeLocalValues("   "));
+    expect(result.localConfig?.arguments).toBeUndefined();
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
@@ -34,13 +34,9 @@ export function transformFormToApiData(
 
   // Handle local configuration
   if (values.serverType === "local" && values.localConfig) {
-    // Parse arguments string into array
-    const argumentsArray = values.localConfig.arguments
-      ? values.localConfig.arguments
-          .split("\n")
-          .map((arg) => arg.trim())
-          .filter((arg) => arg.length > 0)
-      : [];
+    // Parse arguments string into array. Accept either one-per-line text or a
+    // JSON array of strings, since most MCP catalogs display args in JSON form.
+    const argumentsArray = parseArgumentsString(values.localConfig.arguments);
 
     data.localConfig = {
       command: values.localConfig.command || undefined,
@@ -944,4 +940,142 @@ export function stripEnvVarQuotes(value: string): string {
   }
 
   return value;
+}
+
+/**
+ * Parse the user-entered arguments string into an array of arguments.
+ *
+ * Most MCP catalogs document server arguments as a JSON array of strings
+ * (e.g. `["server.js", "--verbose"]`). The form historically only supported
+ * one-argument-per-line text, forcing users to manually split JSON before
+ * pasting. This helper accepts either format:
+ *
+ *   - A JSON array of strings -> parsed verbatim, empty entries dropped
+ *   - One argument per line (any other input) -> split on newlines, trimmed
+ *
+ * Falsy / whitespace-only input returns an empty array.
+ */
+export function parseArgumentsString(
+  input: string | undefined | null,
+): string[] {
+  if (!input) {
+    return [];
+  }
+
+  const trimmed = input.trim();
+  if (trimmed.length === 0) {
+    return [];
+  }
+
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (
+        Array.isArray(parsed) &&
+        parsed.every((item) => typeof item === "string")
+      ) {
+        return (parsed as string[])
+          .map((arg) => arg.trim())
+          .filter((arg) => arg.length > 0);
+      }
+    } catch {
+      // Fall through to newline-based parsing below.
+    }
+  }
+
+  return input
+    .split("\n")
+    .map((arg) => arg.trim())
+    .filter((arg) => arg.length > 0);
+}
+
+export interface ParsedMcpServerConfig {
+  command?: string;
+  args?: string[];
+  env?: Array<{ key: string; value: string }>;
+  type?: string;
+}
+
+/**
+ * Detect whether a pasted string is a full MCP server config (a JSON object
+ * with fields like `command`, `args`, `env`, `type`) rather than just the
+ * arguments list. Most catalogs publish entries in this shape:
+ *
+ *     {
+ *       "command": "node",
+ *       "args": ["server.js"],
+ *       "env": { "API_KEY": "..." }
+ *     }
+ *
+ * When such a paste is detected, callers can pre-fill multiple form fields
+ * at once instead of dropping the JSON text into the Arguments textarea.
+ *
+ * Returns `null` if the input does not look like a server config object.
+ */
+export function parseFullServerConfig(
+  input: string,
+): ParsedMcpServerConfig | null {
+  if (!input) {
+    return null;
+  }
+
+  const trimmed = input.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  const hasKnownField =
+    "command" in obj || "args" in obj || "env" in obj || "type" in obj;
+  if (!hasKnownField) {
+    return null;
+  }
+
+  const result: ParsedMcpServerConfig = {};
+
+  if (typeof obj.command === "string") {
+    result.command = obj.command;
+  }
+
+  if (Array.isArray(obj.args) && obj.args.every((a) => typeof a === "string")) {
+    result.args = (obj.args as string[])
+      .map((a) => a.trim())
+      .filter((a) => a.length > 0);
+  }
+
+  if (obj.env && typeof obj.env === "object" && !Array.isArray(obj.env)) {
+    const env: Array<{ key: string; value: string }> = [];
+    for (const [key, rawValue] of Object.entries(obj.env)) {
+      if (key.trim().length === 0) continue;
+      // Catalogs sometimes use non-string values (numbers/booleans). Coerce
+      // them to strings rather than dropping them on the floor.
+      const value =
+        typeof rawValue === "string"
+          ? rawValue
+          : rawValue == null
+            ? ""
+            : String(rawValue);
+      env.push({ key, value });
+    }
+    if (env.length > 0) {
+      result.env = env;
+    }
+  }
+
+  if (typeof obj.type === "string") {
+    result.type = obj.type;
+  }
+
+  return result;
 }


### PR DESCRIPTION
## Summary
Fixes archestra-ai/archestra#3859

/claim archestra-ai/archestra#3859

Most public MCP catalogs publish server entries in JSON form (a JSON array of arguments, and often a full `{command, args, env}` object). The Arguments textarea previously only accepted one-argument-per-line text, forcing users to manually split JSON before pasting.

This adds three improvements to the MCP catalog form:

1. `transformFormToApiData` accepts either a JSON array of strings or the existing one-per-line text for the `arguments` field. Malformed JSON or JSON of the wrong shape transparently falls back to newline parsing, so no existing input regresses.
2. The Arguments textarea has a Smart Paste handler. When the user pastes a full MCP server config object (any of `command`, `args`, `env`, `type`), the form auto-populates Command, Arguments, and Environment instead of dumping the JSON text into the Arguments field. Existing environment entries are preserved; only new keys are appended.
3. Label, placeholder, and description are updated to advertise the new accepted formats.

Two pure helpers (`parseArgumentsString`, `parseFullServerConfig`) handle the parsing so they can be unit-tested in isolation. 18 new test cases cover the JSON array, full-config, malformed input, and fallback paths.

## Review & Testing Checklist for Human
- [ ] Paste a JSON args array into the Arguments textarea and verify the saved MCP config stores the expected args.
- [ ] Paste a full MCP server config object into the Arguments textarea and verify Command, Arguments, and Environment fields are populated correctly.
- [ ] Confirm malformed JSON still falls back to the existing one-argument-per-line behavior.

### Notes
Local check run: `ARCHESTRA_DATABASE_URL=... DATABASE_URL=... pnpm commit:check` passed after installing dependencies with Node 24 and pnpm 10.33.0.
