### PR TITLE
fix: Bedrock empty assistant step messages

### DIFF
--- a/platform/backend/src/routes/chat/routes.test.ts
+++ b/platform/backend/src/routes/chat/routes.test.ts
@@ -1,3 +1,4 @@
+import { convertToModelMessages } from "ai";
 import { describe, expect, it, vi } from "vitest";
 
 // Mock the ai module before importing chat routes
@@ -266,6 +267,53 @@ describe("prepareMessagesForProvider", () => {
     });
 
     expect(messages[0].parts).toContainEqual(
+      expect.objectContaining({
+        type: "text",
+        text: expect.stringMatching(/\S/),
+      }),
+    );
+  });
+
+  it("pads empty bedrock assistant step blocks before later tool calls", async () => {
+    const messages = __test.prepareMessagesForProvider({
+      provider: "bedrock",
+      messages: [
+        {
+          role: "assistant",
+          parts: [
+            { type: "text", text: "" },
+            { type: "step-start" },
+            {
+              type: "tool-search",
+              toolCallId: "call_123",
+              toolName: "search",
+              state: "input-available",
+              input: { q: "query" },
+            },
+          ],
+        },
+      ],
+    });
+
+    const stepStartIndex = messages[0].parts?.findIndex(
+      (part) => part.type === "step-start",
+    );
+    expect(stepStartIndex).toBeGreaterThan(0);
+    expect(messages[0].parts?.[stepStartIndex! - 1]).toEqual(
+      expect.objectContaining({
+        type: "text",
+        text: expect.stringMatching(/\S/),
+      }),
+    );
+
+    const modelMessages = await convertToModelMessages(
+      messages as Parameters<typeof convertToModelMessages>[0],
+    );
+    const assistantMessages = modelMessages.filter(
+      (message) => message.role === "assistant",
+    );
+    expect(assistantMessages).toHaveLength(2);
+    expect(assistantMessages[0]?.content).toContainEqual(
       expect.objectContaining({
         type: "text",
         text: expect.stringMatching(/\S/),

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -2185,25 +2185,81 @@ function ensureBedrockUserMessageHasTextPart(
   };
 }
 
-// Bedrock also rejects messages whose content array is empty after the AI SDK
-// drops empty text blocks and reasoning blocks without a signature ("The
-// content field in the Message object at messages.N is empty"). Pad with
-// placeholder text so turn alternation is preserved.
+/**
+ * Workaround for AI SDK Bedrock conversion sending empty assistant content.
+ *
+ * The AI SDK can split assistant UI messages at `step-start` boundaries, then
+ * drop provider-invisible parts during Bedrock conversion and send
+ * `content: []`. Keep this until the upstream provider fix is released:
+ * https://github.com/vercel/ai/issues/15248
+ * https://github.com/vercel/ai/pull/15250
+ */
 function ensureBedrockMessageHasContent(message: ChatMessage): ChatMessage {
   if (message.role === "system" || message.role === "tool") {
     return message;
+  }
+  if (message.role === "assistant") {
+    return ensureBedrockAssistantMessageHasContent(message);
   }
   if (message.parts?.some(producesBedrockContentBlock)) {
     return message;
   }
 
-  const placeholder = {
-    type: "text",
-    text: BEDROCK_EMPTY_CONTENT_PLACEHOLDER_TEXT,
-  };
   return {
     ...message,
-    parts: message.parts ? [...message.parts, placeholder] : [placeholder],
+    parts: message.parts
+      ? [...message.parts, createBedrockEmptyContentPlaceholder()]
+      : [createBedrockEmptyContentPlaceholder()],
+  };
+}
+
+function ensureBedrockAssistantMessageHasContent(
+  message: ChatMessage,
+): ChatMessage {
+  if (!message.parts?.length) {
+    return {
+      ...message,
+      parts: [createBedrockEmptyContentPlaceholder()],
+    };
+  }
+
+  let changed = false;
+  let blockHasAnyPart = false;
+  let blockHasContent = false;
+  const parts: ChatMessagePart[] = [];
+
+  const padCurrentBlockIfEmpty = () => {
+    if (blockHasAnyPart && !blockHasContent) {
+      parts.push(createBedrockEmptyContentPlaceholder());
+      changed = true;
+    }
+    blockHasAnyPart = false;
+    blockHasContent = false;
+  };
+
+  for (const part of message.parts) {
+    if (part.type === "step-start") {
+      padCurrentBlockIfEmpty();
+      parts.push(part);
+      continue;
+    }
+
+    parts.push(part);
+    blockHasAnyPart = true;
+    if (producesBedrockContentBlock(part)) {
+      blockHasContent = true;
+    }
+  }
+
+  padCurrentBlockIfEmpty();
+
+  return changed ? { ...message, parts } : message;
+}
+
+function createBedrockEmptyContentPlaceholder(): ChatMessagePart {
+  return {
+    type: "text",
+    text: BEDROCK_EMPTY_CONTENT_PLACEHOLDER_TEXT,
   };
 }
 


### PR DESCRIPTION
## Summary
- Normalize Bedrock assistant messages at each AI SDK step boundary so empty intermediate steps receive placeholder text before provider conversion.
- Preserve existing handling for user document messages and assistant messages that already produce Bedrock-visible content.
- Add regression coverage for an empty assistant step followed by a later tool call.

## Why
The previous Bedrock guard checked the outer UI message as a whole. The AI SDK can split one assistant UI message into multiple provider messages at `step-start`, which means one empty step can still become an empty provider message even when a later step has valid content.