### PR TITLE
fix: subagent save persistence

### DIFF
--- a/platform/backend/src/routes/agent.test.ts
+++ b/platform/backend/src/routes/agent.test.ts
@@ -5,7 +5,7 @@ import {
   TOOL_QUERY_KNOWLEDGE_SOURCES_SHORT_NAME,
 } from "@shared";
 import { vi } from "vitest";
-import { ToolModel } from "@/models";
+import { AgentToolModel, ToolModel } from "@/models";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
@@ -199,6 +199,52 @@ describe("agent routes", () => {
       const agent = response.json();
       expect(agent).toHaveProperty("id");
       expect(agent.name).toBe(updatedName);
+    });
+
+    test("should preserve subagent delegations when updating agent fields", async ({
+      makeAgent,
+    }) => {
+      const sourceAgent = await makeAgent({
+        name: `Source Agent ${crypto.randomUUID().slice(0, 8)}`,
+        organizationId,
+        scope: "personal",
+        authorId: user.id,
+        agentType: "agent",
+      });
+      const targetAgent = await makeAgent({
+        name: `Target Agent ${crypto.randomUUID().slice(0, 8)}`,
+        organizationId,
+        scope: "personal",
+        authorId: user.id,
+        agentType: "agent",
+      });
+      await AgentToolModel.assignDelegation(sourceAgent.id, targetAgent.id);
+
+      const response = await app.inject({
+        method: "PUT",
+        url: `/api/agents/${sourceAgent.id}`,
+        payload: {
+          description: "Updated description",
+          labels: [],
+          teams: [],
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const agent = response.json();
+      expect(
+        agent.tools.some(
+          (tool: { delegateToAgentId: string | null }) =>
+            tool.delegateToAgentId === targetAgent.id,
+        ),
+      ).toBe(true);
+
+      const delegations = await AgentToolModel.getDelegationTargets(
+        sourceAgent.id,
+      );
+      expect(delegations.map((delegation) => delegation.id)).toContain(
+        targetAgent.id,
+      );
     });
 
     test("should update systemPrompt and suggestedPrompts", async ({

--- a/platform/frontend/src/components/agent-dialog.test.tsx
+++ b/platform/frontend/src/components/agent-dialog.test.tsx
@@ -7,17 +7,41 @@ import { AgentDialog } from "./agent-dialog";
 const {
   pendingSaveChanges,
   useAvailableLlmProviderApiKeysMock,
+  useAgentDelegationsMock,
   useHasPermissionsMock,
   useInternalAgentsMock,
   useLlmModelsByProviderMock,
+  useProfileMock,
+  useSyncAgentDelegationsMock,
+  useUpdateProfileMock,
 } = vi.hoisted(() => ({
   pendingSaveChanges: vi.fn(
     () => new Promise<void>((resolve) => setTimeout(resolve, 50)),
   ),
-  useInternalAgentsMock: vi.fn(() => ({ data: [] })),
+  useInternalAgentsMock: vi.fn((): { data: unknown[] } => ({ data: [] })),
+  useProfileMock: vi.fn(
+    (): { data: unknown | null; refetch: ReturnType<typeof vi.fn> } => ({
+      data: null,
+      refetch: vi.fn(),
+    }),
+  ),
   useAvailableLlmProviderApiKeysMock: vi.fn(() => ({ data: [] })),
   useLlmModelsByProviderMock: vi.fn(() => ({ modelsByProvider: {} })),
   useHasPermissionsMock: vi.fn((..._args: unknown[]) => ({ data: true })),
+  useUpdateProfileMock: vi.fn(() => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  })),
+  useAgentDelegationsMock: vi.fn(
+    (): { data: unknown[]; isFetched: boolean } => ({
+      data: [],
+      isFetched: true,
+    }),
+  ),
+  useSyncAgentDelegationsMock: vi.fn(() => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  })),
 }));
 
 vi.mock("@tanstack/react-query", async () => {
@@ -38,19 +62,13 @@ vi.mock("@/lib/agent.query", () => ({
     isPending: false,
   }),
   useInternalAgents: useInternalAgentsMock,
-  useProfile: () => ({ data: null, refetch: vi.fn() }),
-  useUpdateProfile: () => ({
-    mutateAsync: vi.fn(),
-    isPending: false,
-  }),
+  useProfile: useProfileMock,
+  useUpdateProfile: useUpdateProfileMock,
 }));
 
 vi.mock("@/lib/agent-tools.query", () => ({
-  useAgentDelegations: () => ({ data: [] }),
-  useSyncAgentDelegations: () => ({
-    mutateAsync: vi.fn(),
-    isPending: false,
-  }),
+  useAgentDelegations: useAgentDelegationsMock,
+  useSyncAgentDelegations: useSyncAgentDelegationsMock,
 }));
 
 vi.mock("@/lib/auth/auth.query", () => ({
@@ -307,6 +325,92 @@ vi.mock("@/components/ui/tooltip", () => ({
     <div>{children}</div>
   ),
 }));
+
+const baseAgent = {
+  id: "00000000-0000-4000-8000-000000000001",
+  organizationId: "00000000-0000-4000-8000-000000000010",
+  name: "Existing Agent",
+  builtIn: false,
+  icon: null,
+  description: null,
+  systemPrompt: null,
+  agentType: "agent" as const,
+  toolExposureMode: "full" as const,
+  scope: "personal" as const,
+  isDefault: false,
+  isPersonalGateway: false,
+  teams: [],
+  tools: [],
+  labels: [],
+  authorId: "00000000-0000-4000-8000-000000000020",
+  authorName: "Test User",
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  knowledgeBaseIds: [],
+  connectorIds: [],
+  suggestedPrompts: [],
+  llmApiKeyId: null,
+  llmModel: null,
+  considerContextUntrusted: false,
+  identityProviderId: null,
+  builtInAgentConfig: null,
+  passthroughHeaders: null,
+  toolAssignmentMode: "manual" as const,
+  incomingEmailEnabled: false,
+  incomingEmailSecurityMode: "public" as const,
+  incomingEmailAllowedDomain: null,
+  slug: null,
+};
+
+const targetAgent = {
+  ...baseAgent,
+  id: "00000000-0000-4000-8000-000000000002",
+  name: "Target Agent",
+};
+
+describe("AgentDialog delegation state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useHasPermissionsMock.mockImplementation(() => ({ data: true }));
+    useProfileMock.mockReturnValue({ data: null, refetch: vi.fn() });
+    useInternalAgentsMock.mockReturnValue({ data: [targetAgent] });
+    useAgentDelegationsMock.mockReturnValue({
+      data: [targetAgent],
+      isFetched: true,
+    });
+  });
+
+  it("keeps selected subagents when fresh agent data refetches", async () => {
+    const { rerender } = render(
+      <AgentDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        agentType="agent"
+        agent={baseAgent}
+      />,
+    );
+
+    await screen.findByText("Subagents (1)");
+
+    useProfileMock.mockReturnValue({
+      data: { ...baseAgent, description: "Refetched description" },
+      refetch: vi.fn(),
+    });
+
+    rerender(
+      <AgentDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        agentType="agent"
+        agent={baseAgent}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Subagents (1)")).toBeInTheDocument();
+    });
+  });
+});
 
 describe.skip("AgentDialog", () => {
   beforeEach(() => {

--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -541,9 +541,8 @@ export function AgentDialog({
   const deleteAgent = useDeleteProfile();
   const updateAgent = useUpdateProfile();
   const syncDelegations = useSyncAgentDelegations();
-  const { data: currentDelegations = [] } = useAgentDelegations(
-    agentType !== "llm_proxy" ? agent?.id : undefined,
-  );
+  const { data: currentDelegations = [], isFetched: delegationsFetched } =
+    useAgentDelegations(agentType !== "llm_proxy" ? agent?.id : undefined);
   const { data: canReadIdentityProviders } = useHasPermissions({
     identityProvider: ["read"],
   });
@@ -695,8 +694,6 @@ export function AgentDialog({
         setSuggestedPromptsOpen(false);
         setLlmApiKeyId(agentData.llmApiKeyId);
         setLlmModel(agentData.llmModel);
-        // Reset delegation targets - will be populated by the next useEffect when data loads
-        setSelectedDelegationTargetIds([]);
         setAssignedTeamIds(agentData.teams.map((t) => t.id));
         setLabels(agentData.labels);
         setConsiderContextUntrusted(agentData.considerContextUntrusted);
@@ -749,17 +746,19 @@ export function AgentDialog({
     }
   }, [open, agent, freshAgent, refetchAgent]);
 
-  // Sync selectedDelegationTargetIds with currentDelegations when data loads
+  // Sync selectedDelegationTargetIds with currentDelegations when data loads.
+  // Agent refetches can update freshAgent after delegations have loaded; keeping
+  // delegations out of the agent reset path avoids clearing them on save.
   const currentDelegationIds = currentDelegations.map((a) => a.id).join(",");
   const agentId = agent?.id;
 
   useEffect(() => {
-    if (open && agentId && currentDelegationIds) {
+    if (open && agentId && delegationsFetched) {
       setSelectedDelegationTargetIds(
         currentDelegationIds.split(",").filter(Boolean),
       );
     }
-  }, [open, agentId, currentDelegationIds]);
+  }, [open, agentId, currentDelegationIds, delegationsFetched]);
 
   // LLM Configuration: computed values and bidirectional auto-linking
   // (same reactive pattern as prompt input: LlmProviderApiKeySelector + onProviderChange)


### PR DESCRIPTION
## Summary

Fixes a dialog state reset that could clear an agent's selected subagents after saving.

## Root Cause

The agent edit dialog refetches fresh agent data when opened. That refetch could arrive after the delegations query had already populated the selected subagent IDs, and the form reset path would set the selected delegation IDs back to an empty array. Saving from that state synced an empty delegation list and removed the existing subagents.

## Changes

- Keep delegation selection out of the generic agent reset path.
- Use the fetched delegations query as the source of truth for selected subagent IDs.
- Add frontend regression coverage for preserving selected subagents across fresh agent refetches.
- Add backend coverage that ordinary agent updates preserve delegation rows.