### PR TITLE
fix: subagent artifact user context

### DIFF
--- a/platform/backend/src/archestra-mcp-server/delegation.test.ts
+++ b/platform/backend/src/archestra-mcp-server/delegation.test.ts
@@ -119,6 +119,71 @@ describe("delegation tool execution", () => {
     );
   });
 
+  test("uses the caller user when the gateway token is not user-scoped", async ({
+    makeAgent,
+    makeAgentTool,
+    makeMember,
+    makeOrganization,
+    makeUser,
+  }) => {
+    const organization = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, organization.id, { role: "admin" });
+    testAgent = await makeAgent({
+      name: "Parent Agent",
+      agentType: "agent",
+      organizationId: organization.id,
+      scope: "personal",
+      authorId: user.id,
+    });
+    const targetAgent = await makeAgent({
+      name: "Delegated Agent",
+      agentType: "agent",
+      organizationId: organization.id,
+      scope: "personal",
+      authorId: user.id,
+    });
+    const delegationTool = await ToolModel.findOrCreateDelegationTool(
+      targetAgent.id,
+    );
+    await makeAgentTool(testAgent.id, delegationTool.id);
+
+    mockExecuteA2AMessage.mockResolvedValue({
+      messageId: "subagent-message-user-context",
+      text: "Handled by subagent",
+      finishReason: "stop",
+    });
+
+    const result = await executeArchestraTool(
+      `${AGENT_TOOL_PREFIX}${slugify(targetAgent.name)}`,
+      { message: "Write the requested artifact." },
+      {
+        agent: { id: testAgent.id, name: testAgent.name },
+        agentId: testAgent.id,
+        organizationId: organization.id,
+        userId: user.id,
+        conversationId: crypto.randomUUID(),
+        tokenAuth: {
+          tokenId: crypto.randomUUID(),
+          teamId: null,
+          isOrganizationToken: true,
+          organizationId: organization.id,
+          isUserToken: false,
+        },
+      },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(mockExecuteA2AMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: targetAgent.id,
+        message: "Write the requested artifact.",
+        organizationId: organization.id,
+        userId: user.id,
+      }),
+    );
+  });
+
   test("leaves trust propagation unset when the parent context was never evaluated", async ({
     makeAgent,
     makeAgentTool,

--- a/platform/backend/src/archestra-mcp-server/delegation.ts
+++ b/platform/backend/src/archestra-mcp-server/delegation.ts
@@ -115,9 +115,10 @@ export async function handleDelegation(
     return errorResult("Agent not found or not configured for delegation.");
   }
 
-  // Check user has access if user token is being used
-  const userId = tokenAuth?.userId;
-  if (userId && organizationId) {
+  // Check user access when a real caller is available. The caller user can be
+  // present even when the selected gateway token is team/org scoped.
+  const userId = context.userId ?? tokenAuth?.userId;
+  if (userId && userId !== "system" && organizationId) {
     const isAgentAdmin = await userHasPermission(
       userId,
       organizationId,

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -1099,6 +1099,7 @@ export async function getChatMcpTools({
           agent: { id: agentId, name: agentName },
           agentId,
           organizationId,
+          userId,
           conversationId,
           chatOpsBindingId,
           chatOpsThreadId,


### PR DESCRIPTION
## Summary

Fixes delegated agents losing the caller user context when executing from chat with a team- or organization-scoped gateway token.

## Root Cause

Agent delegation execution derived the child agent user from `tokenAuth.userId`. That field is only present for personal user tokens. When the selected gateway token was team- or organization-scoped, the delegated agent ran as `system`, so built-in tools that update user-owned conversation state could not update the active conversation.

## Changes

- Pass the chat caller `userId` into the Archestra context used for agent delegation tools.
- Prefer `context.userId` over token metadata when executing a delegation.
- Keep access checks for real callers, while preserving the existing `system` fallback for system-triggered executions.
- Add regression coverage for delegation execution with a non-user-scoped token and real caller user.