### PR TITLE
fix: handle terminated chat streams as network errors

### DIFF
--- a/platform/backend/src/routes/chat/errors.test.ts
+++ b/platform/backend/src/routes/chat/errors.test.ts
@@ -1418,6 +1418,19 @@ describe("mapProviderError - Fallback behavior", () => {
     expect(result.originalError?.message).toBe("Standard error message");
   });
 
+  it("should map bare stream termination errors to retryable network errors", () => {
+    const error = new Error("terminated");
+    const result = mapProviderError(error, "openai");
+
+    expect(result.code).toBe(ChatErrorCode.NetworkError);
+    expect(result.isRetryable).toBe(true);
+    expect(result.message).toBe(ChatErrorMessages[ChatErrorCode.NetworkError]);
+    expect(result.originalError?.message).toBe(
+      "Upstream provider closed the connection unexpectedly",
+    );
+    expect(mockSentryCaptureException).not.toHaveBeenCalled();
+  });
+
   it("should handle string errors", () => {
     const result = mapProviderError("Simple string error", "openai");
 

--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -1516,6 +1516,11 @@ export function mapProviderError(
 
   // Map to error code using provider-specific mapper
   let errorCode = mapError(statusCode, parsedError);
+  const isTerminatedStream = isStreamTerminatedError(error);
+
+  if (isTerminatedStream) {
+    errorCode = ChatErrorCode.NetworkError;
+  }
 
   // An Archestra-normalized `internal_code` emitted by the adapter's
   // extractInternalCode takes precedence over the per-provider mapper. This
@@ -1537,15 +1542,17 @@ export function mapProviderError(
     (error instanceof Error ? error.name : undefined);
   const rawErrorJson = stringifyRawError(error);
 
-  captureRawProviderErrorInSentry({
-    provider,
-    statusCode,
-    parsedError,
-    errorCode,
-    errorMessage,
-    errorType,
-    rawErrorJson,
-  });
+  if (!isTerminatedStream) {
+    captureRawProviderErrorInSentry({
+      provider,
+      statusCode,
+      parsedError,
+      errorCode,
+      errorMessage,
+      errorType,
+      rawErrorJson,
+    });
+  }
 
   logger.info(
     {
@@ -1563,7 +1570,9 @@ export function mapProviderError(
     errorCode,
     provider,
     statusCode,
-    errorMessage,
+    isTerminatedStream
+      ? "Upstream provider closed the connection unexpectedly"
+      : errorMessage,
     errorType,
     {
       url: APICallError.isInstance(error)
@@ -1576,6 +1585,12 @@ export function mapProviderError(
         : undefined,
     },
   );
+}
+
+function isStreamTerminatedError(error: unknown): boolean {
+  // Node.js/undici stream termination can surface as a bare Error("terminated")
+  // when an upstream streamed response closes before the AI SDK finishes reading it.
+  return error instanceof Error && error.message === "terminated";
 }
 
 /**


### PR DESCRIPTION
## Summary

Maps bare terminated chat stream failures to the existing retryable network error category instead of the generic unknown category.

This keeps the user-facing chat error aligned with the likely cause: the upstream streamed response or an intermediate connection closed before the backend finished reading it.

## Impact

Users now see the standard connection error message for this transient stream-close case. The narrow terminated shape is also excluded from raw exception capture to reduce noise while preserving normal logs and frontend error handling.