### PR TITLE
fix(ci): align Helm install timeout with backend startup probe budget

### DIFF
--- a/.github/actions/setup-archestra-platform/action.yml
+++ b/.github/actions/setup-archestra-platform/action.yml
@@ -317,7 +317,7 @@ runs:
           --set "archestra.image=${PLATFORM_IMAGE_TAG}" \
           ${MCP_SET_FLAG} \
           ${EXTRA_SET_FLAGS} \
-          --atomic --timeout=4m
+          --atomic --timeout=7m
 
         # Wait for e2e-tests to complete (should already be done by now)
         if [ -n "${E2E_PID}" ]; then


### PR DESCRIPTION
## Summary
- `setup-archestra-platform` installs the platform with `--atomic --timeout=4m`, but the backend startup probe budget is ~5m (`initialDelaySeconds=5` + `periodSeconds=10` × `failureThreshold=30`).
- When the pod takes >4m to come up — observed intermittently on busy runners and reliably on the Readonly Vault job where Vault must initialize first — Helm rolls back even though the probe would have succeeded another minute later.
- Bump to `--timeout=7m` so Helm waits out the probe's full budget plus cushion.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>