### PR TITLE
fix: support Azure knowledge embeddings

### DIFF
--- a/platform/backend/src/knowledge-base/embedder.ts
+++ b/platform/backend/src/knowledge-base/embedder.ts
@@ -6,6 +6,7 @@ import {
   type EmbeddingApiResponse,
   type EmbeddingInput,
   getEmbeddingDiscriminator,
+  getEmbeddingRetryDelayMs,
   isRetryableEmbeddingError,
 } from "./embedding-clients";
 import {
@@ -294,7 +295,10 @@ class EmbeddingService {
           throw error;
         }
 
-        const delayMs = RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+        const delayMs = getEmbeddingRetryDelayMs(
+          error,
+          RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
+        );
         logger.warn(
           {
             attempt,

--- a/platform/backend/src/knowledge-base/embedding-clients/azure.test.ts
+++ b/platform/backend/src/knowledge-base/embedding-clients/azure.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, vi } from "vitest";
+import { describe, expect, test } from "@/test";
+
+const mockEmbeddingsCreate = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    object: "list",
+    data: [{ object: "embedding", embedding: [0.1, 0.2], index: 0 }],
+    model: "text-embedding-3-small",
+    usage: { prompt_tokens: 4, total_tokens: 4 },
+  }),
+);
+const mockOpenAIConstructor = vi.hoisted(() => vi.fn());
+
+vi.mock("openai", () => {
+  class MockOpenAI {
+    static APIError = class APIError extends Error {
+      status: number;
+      constructor(status: number, message: string) {
+        super(message);
+        this.status = status;
+      }
+    };
+
+    embeddings = { create: mockEmbeddingsCreate };
+
+    constructor(options: unknown) {
+      mockOpenAIConstructor(options);
+    }
+  }
+  return { default: MockOpenAI };
+});
+
+const mockIsAzureOpenAiEntraIdEnabled = vi.hoisted(() => vi.fn());
+const mockGetAzureOpenAiBearerTokenProvider = vi.hoisted(() => vi.fn());
+
+vi.mock("@/clients/azure-openai-credentials", () => ({
+  getAzureOpenAiBearerTokenProvider: mockGetAzureOpenAiBearerTokenProvider,
+  isAzureOpenAiEntraIdEnabled: mockIsAzureOpenAiEntraIdEnabled,
+}));
+
+vi.mock("@/config", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/config")>();
+  return {
+    ...original,
+    default: {
+      ...original.default,
+      llm: {
+        ...original.default.llm,
+        azure: {
+          ...original.default.llm.azure,
+          apiVersion: "2024-02-01",
+          baseUrl: "https://fallback-resource.openai.azure.com/openai",
+        },
+      },
+    },
+  };
+});
+
+import { type AzureEmbeddingError, callAzureEmbedding } from "./azure";
+
+describe("callAzureEmbedding", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    mockEmbeddingsCreate.mockClear();
+    mockOpenAIConstructor.mockClear();
+    mockIsAzureOpenAiEntraIdEnabled.mockReset();
+    mockGetAzureOpenAiBearerTokenProvider.mockReset();
+  });
+
+  test("uses Azure deployment-scoped embeddings endpoint with api-key auth", async () => {
+    mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(false);
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await callAzureEmbedding({
+      inputs: ["hello"],
+      model: "text-embedding-3-small",
+      apiKey: "azure-key",
+      baseUrl: "https://resource.openai.azure.com/openai",
+      dimensions: 1536,
+    });
+
+    expect(response.data[0].embedding).toEqual([0.1, 0.2]);
+    expect(mockOpenAIConstructor).toHaveBeenCalledWith({
+      apiKey: "azure-key",
+      baseURL:
+        "https://resource.openai.azure.com/openai/deployments/text-embedding-3-small",
+      defaultHeaders: { "api-key": "azure-key" },
+      fetch: expect.any(Function),
+    });
+    expect(mockEmbeddingsCreate).toHaveBeenCalledWith({
+      model: "text-embedding-3-small",
+      input: ["hello"],
+      dimensions: 1536,
+    });
+
+    const [{ fetch }] = mockOpenAIConstructor.mock.calls[0] as [
+      { fetch: typeof globalThis.fetch },
+    ];
+    await fetch("https://resource.openai.azure.com/openai/test?existing=1");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://resource.openai.azure.com/openai/test?existing=1&api-version=2024-02-01",
+      undefined,
+    );
+
+    vi.unstubAllGlobals();
+  });
+
+  test("uses Azure Entra bearer auth for keyless embedding config", async () => {
+    mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(true);
+    const tokenProvider = vi.fn().mockResolvedValue("entra-token");
+    mockGetAzureOpenAiBearerTokenProvider.mockReturnValue(tokenProvider);
+
+    await callAzureEmbedding({
+      inputs: ["hello"],
+      model: "text-embedding-3-large",
+      apiKey: "unused",
+      baseUrl: "https://resource.openai.azure.com/openai",
+    });
+
+    expect(mockGetAzureOpenAiBearerTokenProvider).toHaveBeenCalledWith(
+      "https://resource.openai.azure.com/openai",
+    );
+    expect(mockOpenAIConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: "unused",
+        baseURL:
+          "https://resource.openai.azure.com/openai/deployments/text-embedding-3-large",
+        defaultHeaders: { Authorization: "Bearer entra-token" },
+      }),
+    );
+  });
+
+  test("preserves Azure OpenAI v1 base URLs without api-version injection", async () => {
+    mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(false);
+
+    await callAzureEmbedding({
+      inputs: ["hello"],
+      model: "text-embedding-3-small",
+      apiKey: "azure-key",
+      baseUrl: "https://resource.services.ai.azure.com/openai/v1",
+    });
+
+    expect(mockOpenAIConstructor).toHaveBeenCalledWith({
+      apiKey: "azure-key",
+      baseURL: "https://resource.services.ai.azure.com/openai/v1",
+      defaultHeaders: { "api-key": "azure-key" },
+      fetch: undefined,
+    });
+  });
+
+  test("rejects image inputs", async () => {
+    await expect(
+      callAzureEmbedding({
+        inputs: [{ mimeType: "image/png", data: "abc" }],
+        model: "text-embedding-3-small",
+        apiKey: "azure-key",
+        baseUrl: "https://resource.openai.azure.com/openai",
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining("do not support image inputs"),
+    } satisfies Partial<AzureEmbeddingError>);
+  });
+});

--- a/platform/backend/src/knowledge-base/embedding-clients/azure.test.ts
+++ b/platform/backend/src/knowledge-base/embedding-clients/azure.test.ts
@@ -165,6 +165,58 @@ describe("callAzureEmbedding", () => {
     });
   });
 
+  test("preserves Azure retry-after from rate-limit errors", async () => {
+    mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(false);
+    const OpenAI = (await import("openai")).default;
+    const MockApiError = OpenAI.APIError as unknown as new (
+      status: number,
+      message: string,
+    ) => Error & { status: number };
+    const error = Object.assign(
+      new MockApiError(429, "Please retry after 60 seconds."),
+      {
+        headers: { "retry-after": "45" },
+      },
+    );
+    mockEmbeddingsCreate.mockRejectedValueOnce(error);
+
+    await expect(
+      callAzureEmbedding({
+        inputs: ["hello"],
+        model: "text-embedding-3-small",
+        apiKey: "azure-key",
+        baseUrl: "https://resource.openai.azure.com/openai",
+      }),
+    ).rejects.toMatchObject({
+      status: 429,
+      retryAfterMs: 45_000,
+    } satisfies Partial<AzureEmbeddingError>);
+  });
+
+  test("falls back to Azure retry-after message when header is missing", async () => {
+    mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(false);
+    const OpenAI = (await import("openai")).default;
+    const MockApiError = OpenAI.APIError as unknown as new (
+      status: number,
+      message: string,
+    ) => Error & { status: number };
+    mockEmbeddingsCreate.mockRejectedValueOnce(
+      new MockApiError(429, "Please retry after 60 seconds."),
+    );
+
+    await expect(
+      callAzureEmbedding({
+        inputs: ["hello"],
+        model: "text-embedding-3-small",
+        apiKey: "azure-key",
+        baseUrl: "https://resource.openai.azure.com/openai",
+      }),
+    ).rejects.toMatchObject({
+      status: 429,
+      retryAfterMs: 60_000,
+    } satisfies Partial<AzureEmbeddingError>);
+  });
+
   test("rejects image inputs", async () => {
     await expect(
       callAzureEmbedding({

--- a/platform/backend/src/knowledge-base/embedding-clients/azure.test.ts
+++ b/platform/backend/src/knowledge-base/embedding-clients/azure.test.ts
@@ -149,6 +149,22 @@ describe("callAzureEmbedding", () => {
     });
   });
 
+  test("throws on invalid Azure base URL", async () => {
+    mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(false);
+
+    await expect(
+      callAzureEmbedding({
+        inputs: ["hello"],
+        model: "text-embedding-3-small",
+        apiKey: "azure-key",
+        baseUrl: "https://not-azure.example.com/something",
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining("Azure embedding base URL"),
+    });
+  });
+
   test("rejects image inputs", async () => {
     await expect(
       callAzureEmbedding({

--- a/platform/backend/src/knowledge-base/embedding-clients/azure.ts
+++ b/platform/backend/src/knowledge-base/embedding-clients/azure.ts
@@ -152,11 +152,17 @@ function extractRetryAfterMs(
 }
 
 function getHeaderValue(
-  headers: Headers | Record<string, unknown> | undefined,
+  headers:
+    | Headers
+    | Record<string, unknown>
+    | { get(name: string): string | null | undefined }
+    | undefined,
   name: string,
 ): string | undefined {
   if (!headers) return undefined;
-  if (headers instanceof Headers) return headers.get(name) ?? undefined;
+  if ("get" in headers && typeof headers.get === "function") {
+    return headers.get(name) ?? undefined;
+  }
 
   const lowerName = name.toLowerCase();
   for (const [key, value] of Object.entries(headers)) {

--- a/platform/backend/src/knowledge-base/embedding-clients/azure.ts
+++ b/platform/backend/src/knowledge-base/embedding-clients/azure.ts
@@ -17,6 +17,7 @@ export class AzureEmbeddingError extends Error {
   constructor(
     public readonly status: number,
     message: string,
+    public readonly retryAfterMs?: number,
   ) {
     super(message);
     this.name = "AzureEmbeddingError";
@@ -88,7 +89,11 @@ export async function callAzureEmbedding(params: {
     };
   } catch (err: unknown) {
     if (err instanceof OpenAI.APIError) {
-      throw new AzureEmbeddingError(err.status ?? 500, err.message);
+      throw new AzureEmbeddingError(
+        err.status ?? 500,
+        err.message,
+        extractRetryAfterMs(err),
+      );
     }
     throw err;
   }
@@ -127,3 +132,36 @@ async function getAzureEmbeddingAuthHeaders(params: {
 }
 
 const KEYLESS_AZURE_API_KEY = "unused";
+
+function extractRetryAfterMs(
+  error: InstanceType<typeof OpenAI.APIError>,
+): number | undefined {
+  const retryAfterHeader = getHeaderValue(error.headers, "retry-after");
+  const retryAfterSeconds = Number.parseInt(retryAfterHeader ?? "", 10);
+  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
+    return retryAfterSeconds * 1000;
+  }
+
+  const retryAfterMatch = error.message.match(/retry after\s+(\d+)\s+seconds/i);
+  if (!retryAfterMatch) return undefined;
+
+  const retryAfterFromMessage = Number.parseInt(retryAfterMatch[1], 10);
+  return Number.isFinite(retryAfterFromMessage) && retryAfterFromMessage >= 0
+    ? retryAfterFromMessage * 1000
+    : undefined;
+}
+
+function getHeaderValue(
+  headers: Headers | Record<string, unknown> | undefined,
+  name: string,
+): string | undefined {
+  if (!headers) return undefined;
+  if (headers instanceof Headers) return headers.get(name) ?? undefined;
+
+  const lowerName = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() !== lowerName) continue;
+    return Array.isArray(value) ? String(value[0]) : String(value);
+  }
+  return undefined;
+}

--- a/platform/backend/src/knowledge-base/embedding-clients/azure.ts
+++ b/platform/backend/src/knowledge-base/embedding-clients/azure.ts
@@ -1,0 +1,129 @@
+import { isNomicModel } from "@shared";
+import OpenAI from "openai";
+import {
+  getAzureOpenAiBearerTokenProvider,
+  isAzureOpenAiEntraIdEnabled,
+} from "@/clients/azure-openai-credentials";
+import {
+  buildAzureDeploymentBaseUrl,
+  createAzureFetchWithApiVersion,
+  normalizeAzureApiKey,
+  shouldUseAzureOpenAiApiVersion,
+} from "@/clients/azure-url";
+import config from "@/config";
+import type { EmbeddingApiResponse, EmbeddingInput } from "./types";
+
+export class AzureEmbeddingError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AzureEmbeddingError";
+  }
+}
+
+export async function callAzureEmbedding(params: {
+  inputs: EmbeddingInput[];
+  model: string;
+  apiKey: string;
+  baseUrl?: string | null;
+  dimensions?: number;
+}): Promise<EmbeddingApiResponse> {
+  const { inputs, model, apiKey, baseUrl, dimensions } = params;
+  const texts = inputs.map((input) => {
+    if (typeof input === "string") return input;
+    throw new AzureEmbeddingError(
+      400,
+      "Azure OpenAI embeddings do not support image inputs. Configure a multimodal embedding model to embed images.",
+    );
+  });
+
+  const baseURL = buildAzureDeploymentBaseUrl({
+    baseUrl: baseUrl ?? config.llm.azure.baseUrl,
+    deploymentName: model,
+  });
+  if (!baseURL) {
+    throw new AzureEmbeddingError(
+      400,
+      "Azure embedding base URL must point to an Azure OpenAI resource, v1 endpoint, or deployment endpoint.",
+    );
+  }
+
+  const auth = await getAzureEmbeddingAuthHeaders({ apiKey, baseUrl });
+  const fetchWithVersion = shouldUseAzureOpenAiApiVersion(baseUrl ?? baseURL)
+    ? createAzureFetchWithApiVersion({
+        apiVersion: config.llm.azure.apiVersion,
+      })
+    : undefined;
+
+  const client = new OpenAI({
+    apiKey: auth.openAiApiKey,
+    baseURL,
+    defaultHeaders: auth.headers,
+    fetch: fetchWithVersion,
+  });
+
+  try {
+    const response = await client.embeddings.create({
+      model,
+      input: texts,
+      ...(dimensions !== undefined && !isNomicModel(model)
+        ? { dimensions }
+        : {}),
+    });
+
+    return {
+      object: response.object,
+      data: response.data.map((item) => ({
+        object: item.object,
+        embedding: item.embedding,
+        index: item.index,
+      })),
+      model: response.model,
+      usage: {
+        prompt_tokens: response.usage.prompt_tokens,
+        total_tokens: response.usage.total_tokens,
+      },
+    };
+  } catch (err: unknown) {
+    if (err instanceof OpenAI.APIError) {
+      throw new AzureEmbeddingError(err.status ?? 500, err.message);
+    }
+    throw err;
+  }
+}
+
+async function getAzureEmbeddingAuthHeaders(params: {
+  apiKey: string;
+  baseUrl?: string | null;
+}): Promise<{
+  headers: Record<string, string>;
+  openAiApiKey: string;
+}> {
+  const normalizedApiKey = normalizeAzureApiKey(params.apiKey);
+  if (normalizedApiKey && normalizedApiKey !== KEYLESS_AZURE_API_KEY) {
+    return {
+      headers: { "api-key": normalizedApiKey },
+      openAiApiKey: normalizedApiKey,
+    };
+  }
+
+  if (!isAzureOpenAiEntraIdEnabled()) {
+    return {
+      headers: { "api-key": normalizedApiKey ?? "" },
+      openAiApiKey: normalizedApiKey ?? KEYLESS_AZURE_API_KEY,
+    };
+  }
+
+  const tokenProvider = getAzureOpenAiBearerTokenProvider(
+    params.baseUrl ?? undefined,
+  );
+  const token = await tokenProvider();
+  return {
+    headers: { Authorization: `Bearer ${token}` },
+    openAiApiKey: KEYLESS_AZURE_API_KEY,
+  };
+}
+
+const KEYLESS_AZURE_API_KEY = "unused";

--- a/platform/backend/src/knowledge-base/embedding-clients/index.test.ts
+++ b/platform/backend/src/knowledge-base/embedding-clients/index.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "@/test";
 import {
+  AzureEmbeddingError,
   GeminiEmbeddingError,
+  getEmbeddingRetryDelayMs,
   isRetryableEmbeddingError,
   OpenAIEmbeddingError,
 } from "./index";
@@ -34,5 +36,22 @@ describe("isRetryableEmbeddingError", () => {
     expect(isRetryableEmbeddingError(timeout)).toBe(true);
     expect(isRetryableEmbeddingError(reset)).toBe(true);
     expect(isRetryableEmbeddingError(invalidArg)).toBe(false);
+  });
+});
+
+describe("getEmbeddingRetryDelayMs", () => {
+  test("honors Azure retry-after delays", () => {
+    expect(
+      getEmbeddingRetryDelayMs(
+        new AzureEmbeddingError(429, "rate limited", 60_000),
+        1_000,
+      ),
+    ).toBe(60_000);
+  });
+
+  test("falls back when provider error has no retry-after delay", () => {
+    expect(
+      getEmbeddingRetryDelayMs(new OpenAIEmbeddingError(429, "rate"), 2_000),
+    ).toBe(2_000);
   });
 });

--- a/platform/backend/src/knowledge-base/embedding-clients/index.test.ts
+++ b/platform/backend/src/knowledge-base/embedding-clients/index.test.ts
@@ -10,6 +10,9 @@ import {
 describe("isRetryableEmbeddingError", () => {
   test("returns true for retryable provider status codes", () => {
     expect(
+      isRetryableEmbeddingError(new AzureEmbeddingError(429, "rate")),
+    ).toBe(true);
+    expect(
       isRetryableEmbeddingError(new GeminiEmbeddingError(429, "rate")),
     ).toBe(true);
     expect(
@@ -18,6 +21,9 @@ describe("isRetryableEmbeddingError", () => {
   });
 
   test("returns false for non-retryable provider status codes", () => {
+    expect(isRetryableEmbeddingError(new AzureEmbeddingError(400, "bad"))).toBe(
+      false,
+    );
     expect(
       isRetryableEmbeddingError(new GeminiEmbeddingError(400, "bad")),
     ).toBe(false);

--- a/platform/backend/src/knowledge-base/embedding-clients/index.ts
+++ b/platform/backend/src/knowledge-base/embedding-clients/index.ts
@@ -80,3 +80,17 @@ export function isRetryableEmbeddingError(error: unknown): boolean {
   }
   return false;
 }
+
+export function getEmbeddingRetryDelayMs(
+  error: unknown,
+  fallbackDelayMs: number,
+): number {
+  if (
+    error instanceof AzureEmbeddingError &&
+    error.retryAfterMs !== undefined
+  ) {
+    return error.retryAfterMs;
+  }
+
+  return fallbackDelayMs;
+}

--- a/platform/backend/src/knowledge-base/embedding-clients/index.ts
+++ b/platform/backend/src/knowledge-base/embedding-clients/index.ts
@@ -2,13 +2,14 @@ import type {
   SupportedProvider,
   SupportedProviderDiscriminator,
 } from "@shared";
+import { AzureEmbeddingError, callAzureEmbedding } from "./azure";
 import { callGeminiEmbedding, GeminiEmbeddingError } from "./gemini";
 import { callOpenAIEmbedding, OpenAIEmbeddingError } from "./openai";
 import type { EmbeddingApiResponse, EmbeddingInput } from "./types";
 
 export type { EmbeddingApiResponse, EmbeddingInput };
 /** @public — re-exported for testability */
-export { GeminiEmbeddingError, OpenAIEmbeddingError };
+export { AzureEmbeddingError, GeminiEmbeddingError, OpenAIEmbeddingError };
 
 const RETRYABLE_NETWORK_ERROR_CODES = new Set([
   "ECONNABORTED",
@@ -44,6 +45,10 @@ export async function callEmbedding(params: {
     return callGeminiEmbedding(rest);
   }
 
+  if (provider === "azure") {
+    return callAzureEmbedding(rest);
+  }
+
   return callOpenAIEmbedding(rest);
 }
 
@@ -62,6 +67,7 @@ export function getEmbeddingDiscriminator(
  */
 export function isRetryableEmbeddingError(error: unknown): boolean {
   if (
+    error instanceof AzureEmbeddingError ||
     error instanceof GeminiEmbeddingError ||
     error instanceof OpenAIEmbeddingError
   ) {


### PR DESCRIPTION
## Summary
- add an Azure-specific knowledge embedding client that uses deployment-scoped Azure OpenAI embedding URLs
- support Azure API key and keyless Entra ID auth for RAG embedding calls
- route Azure embedding requests through the Azure client instead of the generic OpenAI-compatible client