### PR TITLE
fix(ci): bump Helm install timeout to 15m

### DIFF
--- a/.github/actions/setup-archestra-platform/action.yml
+++ b/.github/actions/setup-archestra-platform/action.yml
@@ -317,7 +317,7 @@ runs:
           --set "archestra.image=${PLATFORM_IMAGE_TAG}" \
           ${MCP_SET_FLAG} \
           ${EXTRA_SET_FLAGS} \
-          --atomic --timeout=7m
+          --atomic --timeout=15m
 
         # Wait for e2e-tests to complete (should already be done by now)
         if [ -n "${E2E_PID}" ]; then


### PR DESCRIPTION
## Summary
- Follow-up to #4643 (4m → 7m). 7m still isn't enough for the Readonly Vault E2E job.
- Observed: platform pod stuck in `PodInitializing` for the full 7m window — the atomic Helm install rolled back before the init containers (`vault-secrets`, `setup-postgres-extensions`, `wait-for-postgres`) finished on slow merge-queue runners.
- Raise the ceiling to 15m so a slow-but-progressing init sequence has room to complete. A healthy install still finishes in ~2m, so this only affects the degraded case.

## Notes
- This is a ceiling bump, not a root-cause fix. If the init containers are genuinely *hung* (not just slow), 15m only delays the failure — a separate investigation into the `vault-secrets` init behavior may still be needed.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>