### PR TITLE
ci(e2e): capture init-container logs in E2E failure diagnostics

### DIFF
--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -247,8 +247,17 @@ jobs:
           echo "=== Kubernetes Services ==="
           kubectl get services || true
 
-          echo "=== Archestra Platform Logs ==="
-          kubectl logs -l app.kubernetes.io/name=archestra-platform --tail=200 || true
+          echo "=== Archestra Platform Logs (main container) ==="
+          kubectl logs -l app.kubernetes.io/name=archestra-platform -c archestra-platform --tail=200 2>/dev/null || true
+
+          echo "=== Platform Init Container: vault-secrets ==="
+          kubectl logs -l app.kubernetes.io/name=archestra-platform -c vault-secrets --tail=200 2>/dev/null || true
+
+          echo "=== Platform Init Container: setup-postgres-extensions ==="
+          kubectl logs -l app.kubernetes.io/name=archestra-platform -c setup-postgres-extensions --tail=200 2>/dev/null || true
+
+          echo "=== Platform Init Container: wait-for-postgres ==="
+          kubectl logs -l app.kubernetes.io/name=archestra-platform -c wait-for-postgres --tail=200 2>/dev/null || true
 
           echo "=== PostgreSQL Logs ==="
           kubectl logs -l app.kubernetes.io/name=postgresql --tail=200 || true
@@ -365,8 +374,17 @@ jobs:
           echo "=== Kubernetes Services ==="
           kubectl get services || true
 
-          echo "=== Archestra Platform Logs ==="
-          kubectl logs -l app.kubernetes.io/name=archestra-platform --tail=200 || true
+          echo "=== Archestra Platform Logs (main container) ==="
+          kubectl logs -l app.kubernetes.io/name=archestra-platform -c archestra-platform --tail=200 2>/dev/null || true
+
+          echo "=== Platform Init Container: vault-secrets ==="
+          kubectl logs -l app.kubernetes.io/name=archestra-platform -c vault-secrets --tail=200 2>/dev/null || true
+
+          echo "=== Platform Init Container: setup-postgres-extensions ==="
+          kubectl logs -l app.kubernetes.io/name=archestra-platform -c setup-postgres-extensions --tail=200 2>/dev/null || true
+
+          echo "=== Platform Init Container: wait-for-postgres ==="
+          kubectl logs -l app.kubernetes.io/name=archestra-platform -c wait-for-postgres --tail=200 2>/dev/null || true
 
           echo "=== PostgreSQL Logs ==="
           kubectl logs -l app.kubernetes.io/name=postgresql --tail=200 || true


### PR DESCRIPTION
## Summary
- When the platform pod is stuck in `PodInitializing` (observed repeatedly on the Readonly Vault job), the "Show logs on failure" step only fetched **main-container** logs — which return nothing because that container never started. The actual blocker is in the init containers, and we had no visibility into it.
- Adds per-init-container log collection for `vault-secrets`, `setup-postgres-extensions`, and `wait-for-postgres` to both the main E2E and Readonly Vault diagnostic steps.
- Scopes the main-container log fetch with `-c archestra-platform` so it's explicit.
- The existing `kubectl describe pod` already surfaces init-container *events*; this adds the *logs* so the next failure shows exactly which init container blocked and why.

## Context
The Readonly Vault E2E job has intermittently failed with `INSTALLATION FAILED: ... context deadline exceeded`, with the pod stuck in `PodInitializing` for the full Helm timeout window. Without init-container logs we can only guess whether it's slow-but-progressing or genuinely hung. This makes the next occurrence actionable.