### PR TITLE
Add documented Anthropic workload identity auth

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -242,10 +242,10 @@ Chart-managed diagnostics PVCs are validated conservatively. If more than one di
 - `archestra.nodeSelector` - Node selector for scheduling pods on specific nodes (e.g., specific node pools or instance types). These values are also inherited by MCP server pods as defaults.
 - `archestra.tolerations` - Tolerations for scheduling pods on nodes with specific taints (e.g., dedicated nodes, GPU nodes, spot instances). These values are also inherited by MCP server pods as defaults. See [Kubernetes docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
 - `archestra.deploymentStrategy` - Deployment strategy configuration (default: RollingUpdate with `maxUnavailable: 25%` and `maxSurge: 25%`)
-- `archestra.resources` - CPU and memory requests/limits for the container (default: 2 vCPU request, 2Gi memory request, 3Gi memory limit)
+- `archestra.resources` - CPU and memory requests/limits for the container (default: 2Gi request, 3Gi limit for memory)
 - `archestra.horizontalPodAutoscaler` - Optional HPA for the main `archestra-platform` Deployment. When enabled, the chart defaults to `minReplicas: 2`, `maxReplicas: 10`, a memory utilization target of 70%, immediate scale-up, and a 5-minute scale-down stabilization window.
 - `archestra.worker.replicaCount` - Manual replica count for the separate worker Deployment
-- `archestra.worker.resources` - Resource requests/limits for worker pods (default: 2 vCPU request, 1Gi memory request, 2Gi memory limit)
+- `archestra.worker.resources` - Resource requests/limits for worker pods (default: 1Gi request, 2Gi limit for memory)
 - `archestra.worker.deploymentStrategy` - Rolling update strategy for worker pods (default: `maxUnavailable: 25%`, `maxSurge: 25%`)
 
 #### HorizontalPodAutoscaler
@@ -256,11 +256,11 @@ Default behavior when enabled:
 
 - Maintains at least 2 web pods
 - Scales up to 10 web pods
-- Uses memory utilization as the default scaling signal
+- Uses memory utilization because the chart defines memory requests by default
 - Scales up aggressively (up to 100% or 2 pods per minute)
 - Scales down conservatively with a 5-minute stabilization window
 
-If you prefer CPU-driven scaling, override `archestra.horizontalPodAutoscaler.metrics` with a CPU target instead.
+If your cluster has reliable CPU requests for the platform pods and you prefer request-rate-driven scaling, override `archestra.horizontalPodAutoscaler.metrics` with a CPU target instead.
 
 #### Existing Scaling Controls
 
@@ -431,7 +431,7 @@ The Helm chart deploys a separate worker `Deployment` for processing background 
 
 - `archestra.worker.enabled` - Deploy a separate worker Deployment (default: true)
 - `archestra.worker.replicaCount` - Number of worker pod replicas (default: 1)
-- `archestra.worker.resources` - Resource requests/limits for worker pods (default: 2 vCPU request, 1Gi memory request, 2Gi memory limit)
+- `archestra.worker.resources` - Resource requests/limits for worker pods (default: 1Gi request, 2Gi limit)
 - `archestra.worker.deploymentStrategy` - Deployment strategy (default: RollingUpdate with `maxUnavailable: 25%` and `maxSurge: 25%`)
 - `archestra.worker.podAnnotations` - Pod annotations (inherits from `archestra.podAnnotations` if not set)
 - `archestra.worker.nodeSelector` - Node selector (inherits from `archestra.nodeSelector` if not set)
@@ -632,11 +632,6 @@ The following environment variables can be used to configure Archestra Platform.
   - Default: Internal PostgreSQL (Docker) or managed instance (Helm)
   - Required for production deployments with external database
 
-- **`ARCHESTRA_DATABASE_POOL_MAX`** - Maximum number of PostgreSQL connections per backend pod.
-  - Default: `50`
-  - Range: `1`–`500`
-  - Tune this when you have many concurrent users or long-running chat streams. The backend opens at most `ARCHESTRA_DATABASE_POOL_MAX` connections per pod, so coordinate with PostgreSQL `max_connections` to ensure `pods × ARCHESTRA_DATABASE_POOL_MAX < max_connections` with headroom for admin sessions. On managed Postgres (e.g. AWS RDS, Cloud SQL) the server limit is typically several thousand and rarely the binding constraint.
-
 - **`ARCHESTRA_API_BASE_URL`** - Archestra API Base URL(s) for connecting to Archestra's LLM Proxy, MCP Gateway and A2A Gateway.
 
   This URL is displayed in the UI connection instructions to help users configure their agents. It doesn\'t affect internal routing (Archestra frontend communicates with backend via `http://localhost:9000`).
@@ -726,33 +721,17 @@ The following environment variables can be used to configure Archestra Platform.
 
 - **`ARCHESTRA_SECRETS_MANAGER`** - Secrets storage backend for managing sensitive data (API keys, tokens, etc.)
   - Default: `DB` (database storage)
-  - Options: `DB`, `VAULT`, or `READONLY_VAULT`
-  - Note: When set to `VAULT` or `READONLY_VAULT`, requires `ARCHESTRA_HASHICORP_VAULT_ADDR` and the credentials for the selected auth method. See [Secrets Management](/docs/platform-secrets-management) for the full configuration reference (KV version, secret path prefix, auth methods).
+  - Options: `DB` or `Vault`
+  - Note: When set to `Vault`, requires `HASHICORP_VAULT_ADDR` and `HASHICORP_VAULT_TOKEN` to be configured
 
 - **`ARCHESTRA_HASHICORP_VAULT_ADDR`** - HashiCorp Vault server address
-  - Required when: `ARCHESTRA_SECRETS_MANAGER=VAULT` or `READONLY_VAULT`
+  - Required when: `ARCHESTRA_SECRETS_MANAGER=Vault`
   - Example: `http://localhost:8200`
   - Note: System falls back to database storage if Vault is configured but credentials are missing
 
-- **`ARCHESTRA_HASHICORP_VAULT_AUTH_METHOD`** - Authentication method used to connect to Vault.
-  - Default: `TOKEN`
-  - Options: `TOKEN`, `K8S`, `AWS`
-  - See [Vault Authentication](/docs/platform-secrets-management#vault-authentication) for the per-method env vars (`ARCHESTRA_HASHICORP_VAULT_TOKEN`, `..._K8S_ROLE`, `..._AWS_ROLE`, etc.).
-
-- **`ARCHESTRA_HASHICORP_VAULT_KV_VERSION`** - Version of Vault's KV secrets engine.
-  - Default: `2`
-  - Options: `1` or `2`
-  - Applies to both `VAULT` and `READONLY_VAULT` modes. Changes the default secret path prefix and the API paths used for read/write/list/delete.
-
-- **`ARCHESTRA_HASHICORP_VAULT_SECRET_PATH`** - Path prefix for Archestra-managed secrets in Vault.
-  - Default: `secret/data/archestra` (KV v2) or `secret/archestra` (KV v1)
-  - Use it to store secrets under a custom path.
-  - KV v2 example: `kv/data/platform/archestra` (resolves to `kv/data/platform/archestra/{secretName}`)
-  - KV v1 example: `kv/platform/archestra` (resolves to `kv/platform/archestra/{secretName}`)
-
-- **`ARCHESTRA_HASHICORP_VAULT_SECRET_METADATA_PATH`** - Override path prefix for KV v2 metadata operations (list, delete).
-  - Default: derived from `ARCHESTRA_HASHICORP_VAULT_SECRET_PATH` by replacing `/data/` with `/metadata/`.
-  - Only needed when your prefix doesn't follow the `/data/` ↔ `/metadata/` convention.
+- **`ARCHESTRA_HASHICORP_VAULT_TOKEN`** - HashiCorp Vault authentication token
+  - Required when: `ARCHESTRA_SECRETS_MANAGER=Vault`
+  - Note: System falls back to database storage if Vault is configured but credentials are missing
 
 - **`ARCHESTRA_DATABASE_URL_VAULT_REF`** - Read the database connection string from Vault instead of environment variables.
   - Optional: Only used when `ARCHESTRA_SECRETS_MANAGER=READONLY_VAULT`
@@ -777,6 +756,29 @@ These environment variables set the default base URL for each LLM provider. Per-
   - Set `ARCHESTRA_ANTHROPIC_BASE_URL=https://<resource-name>.services.ai.azure.com/anthropic`
   - Uses Azure Identity `DefaultAzureCredential` with token scope `https://ai.azure.com/.default`
   - Claude deployments must already exist in the Azure resource. Microsoft lists additional Claude prerequisites: paid eligible subscription, supported region, Azure Marketplace access for partner models, permission to subscribe to model offerings, and Contributor or Owner role on the resource group. Azure also requires Anthropic deployment metadata: `industry`, `organizationName`, and `countryCode`.
+
+- **`ARCHESTRA_ANTHROPIC_FEDERATION_RULE_ID`** - Anthropic Workload Identity Federation rule ID.
+  - Required when using Anthropic Workload Identity Federation
+  - Example: `fdrl_...`
+
+- **`ARCHESTRA_ANTHROPIC_ORGANIZATION_ID`** - Anthropic organization UUID for token exchange.
+  - Required when using Anthropic Workload Identity Federation
+
+- **`ARCHESTRA_ANTHROPIC_SERVICE_ACCOUNT_ID`** - Anthropic service account targeted by the federation rule.
+  - Required when using Anthropic Workload Identity Federation
+  - Example: `svac_...`
+
+- **`ARCHESTRA_ANTHROPIC_WORKSPACE_ID`** - Workspace to scope the minted Anthropic token to.
+  - Optional unless the federation rule can target multiple workspaces
+  - Example: `wrkspc_...`
+
+- **`ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN_FILE`** - Path to the OIDC JWT projected into the Archestra backend container.
+  - Required unless `ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN` is set
+  - Recommended for Kubernetes projected service account tokens because the file can rotate automatically
+
+- **`ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN`** - Inline OIDC JWT for token exchange.
+  - Required only when `ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN_FILE` is not set
+  - Prefer the file form for production deployments
 
 - **`ARCHESTRA_GEMINI_BASE_URL`** - Override the Google Gemini API base URL.
   - Default: `https://generativelanguage.googleapis.com`

--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -84,6 +84,25 @@ Azure requires Anthropic deployment metadata when creating Claude deployments: `
 
 See Microsoft's [Claude on Foundry guide](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/how-to/use-foundry-models-claude) for the Azure endpoint and authentication details.
 
+### Anthropic Workload Identity Federation
+
+Use Workload Identity Federation when Archestra should call Anthropic with short-lived OIDC-derived bearer tokens instead of a static Anthropic API key. Configure a federation issuer, rule, and service account in Claude Console, then inject the federation rule, organization, service account, optional workspace, and identity token source into the Archestra backend.
+
+Archestra reads the identity token from `ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN_FILE` or `ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN`, exchanges it for an Anthropic access token, caches the access token until shortly before expiry, and sends `Authorization: Bearer <token>` to Anthropic. Per-request Anthropic API keys still take precedence.
+
+Set `ARCHESTRA_ANTHROPIC_BASE_URL=https://api.anthropic.com` unless you are targeting a compatible Anthropic endpoint. Then set:
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `ARCHESTRA_ANTHROPIC_FEDERATION_RULE_ID` | Yes | Federation rule ID, for example `fdrl_...` |
+| `ARCHESTRA_ANTHROPIC_ORGANIZATION_ID` | Yes | Anthropic organization UUID |
+| `ARCHESTRA_ANTHROPIC_SERVICE_ACCOUNT_ID` | Yes | Anthropic service account ID, for example `svac_...` |
+| `ARCHESTRA_ANTHROPIC_WORKSPACE_ID` | No | Workspace ID, for example `wrkspc_...`; use when the rule can target multiple workspaces |
+| `ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN_FILE` | One token source required | Path to a projected OIDC JWT, recommended for Kubernetes and other rotating token sources |
+| `ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN` | One token source required | Inline OIDC JWT, useful for local smoke tests |
+
+See [deployment configuration](/docs/platform-deployment#llm-provider-configuration) for the environment-variable reference and Anthropic's [Workload Identity Federation guide](https://platform.claude.com/docs/en/manage-claude/workload-identity-federation) for issuer and rule setup.
+
 ## Google Gemini
 
 Archestra supports both the [Google AI Studio](https://ai.google.dev/) (Gemini Developer API) and [Vertex AI](https://cloud.google.com/vertex-ai) implementations of the Gemini API.
@@ -677,7 +696,7 @@ Known region prefixes: `us`, `eu`, `ap`, `global`.
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `ARCHESTRA_AZURE_OPENAI_BASE_URL` | No | Default Azure OpenAI resource URL or Foundry v1 URL. Not required when Azure provider keys are configured in the UI with their own Base URL. |
+| `ARCHESTRA_AZURE_OPENAI_BASE_URL` | Yes | Azure OpenAI deployment URL or Foundry v1 URL |
 | `ARCHESTRA_AZURE_OPENAI_API_VERSION` | No | Azure OpenAI API version (default: `2024-02-01`) |
 | `ARCHESTRA_AZURE_OPENAI_RESPONSES_API_VERSION` | No | Azure Responses API version (default: `2025-04-01-preview`) |
 | `ARCHESTRA_AZURE_OPENAI_ENTRA_ID_ENABLED` | No | Set to `true` to use Microsoft Entra ID instead of an Azure API key |
@@ -693,18 +712,14 @@ To use Azure OpenAI without storing an API key, set:
 
 ```bash
 ARCHESTRA_AZURE_OPENAI_ENTRA_ID_ENABLED=true
-```
-
-Then create an Azure provider key in Archestra with no API key value and set its Base URL to one of the Azure resource endpoints below.
-
-```bash
-https://<resource-name>.openai.azure.com/openai
+ARCHESTRA_AZURE_OPENAI_BASE_URL=https://<resource-name>.openai.azure.com/openai/deployments/<deployment-name>
 ```
 
 For Foundry v1, use:
 
 ```bash
-https://<resource-name>.services.ai.azure.com/openai/v1
+ARCHESTRA_AZURE_OPENAI_ENTRA_ID_ENABLED=true
+ARCHESTRA_AZURE_OPENAI_BASE_URL=https://<resource-name>.services.ai.azure.com/openai/v1
 ```
 
 Archestra uses Azure Identity `DefaultAzureCredential`. Deployment URLs use the `https://cognitiveservices.azure.com/.default` token scope. Foundry v1 URLs use `https://ai.azure.com/.default`. Assign the workload identity, managed identity, service principal, or local Azure CLI user a role that can invoke the Azure resource.
@@ -754,25 +769,20 @@ archestra:
     azure.workload.identity/use: "true"
   env:
     ARCHESTRA_AZURE_OPENAI_ENTRA_ID_ENABLED: "true"
+    ARCHESTRA_AZURE_OPENAI_BASE_URL: "https://<resource-name>.services.ai.azure.com/openai/v1"
 ```
 
 See Microsoft's [AKS Workload ID deployment guide](https://learn.microsoft.com/en-us/azure/aks/workload-identity-deploy-cluster) for the full cluster, service account, and federated credential setup.
 
 ### Base URL Format
 
-For Azure OpenAI resources, use the shared resource-level OpenAI URL:
+For Azure OpenAI deployment URLs, include the deployment name:
 
 ```
-https://<resource-name>.openai.azure.com/openai
+https://<resource-name>.openai.azure.com/openai/deployments/<deployment-name>
 ```
 
-Archestra discovers deployments from `/openai/deployments` and routes each request to the deployment named in the request `model` field.
-Do not configure a deployment-specific URL such as `https://<resource-name>.openai.azure.com/openai/deployments/<deployment-name>`.
-If your Foundry project has its own OpenAI endpoint, use the same resource-level format with the project hostname:
-
-```
-https://<project-name>.openai.azure.com/openai
-```
+For example: `https://my-company.openai.azure.com/openai/deployments/gpt-4o`
 
 For Microsoft Foundry v1, use the OpenAI-compatible API root:
 
@@ -780,21 +790,15 @@ For Microsoft Foundry v1, use the OpenAI-compatible API root:
 https://<resource-name>.services.ai.azure.com/openai/v1
 ```
 
-The same formats apply when configuring a Base URL in the API key settings UI.
+The same format applies when configuring a Base URL in the API key settings UI.
 
-### Deployment Discovery and RBAC
+### Notes
 
-- For Entra ID configurations, Archestra first tries Azure deployment discovery. If the inference endpoint cannot list deployments, Archestra uses Azure management APIs to find the Cognitive Services account and list its deployments.
-- Some Foundry project endpoints are backed by a parent Azure AI Services account, for example `/providers/Microsoft.CognitiveServices/accounts/<account-name>/projects/<project-name>`. Archestra resolves the project to its parent account before listing deployments.
-- For Azure OpenAI resource URLs, Archestra does not fall back to the available model catalog because that catalog includes undeployed models.
-- For built-in Azure RBAC, assign `Cognitive Services OpenAI User` at the backing Azure AI Services resource when possible. Use the full ARM resource scope, for example `/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.CognitiveServices/accounts/<resource-name>`. For the narrowest access, use a custom role with `Microsoft.Resources/subscriptions/read`, `Microsoft.Resources/subscriptions/resources/read`, `Microsoft.CognitiveServices/accounts/read`, and `Microsoft.CognitiveServices/accounts/deployments/read`.
-
-### Routing Notes
-
-- **API Version**: Azure OpenAI resource URLs use `ARCHESTRA_AZURE_OPENAI_API_VERSION` for Chat Completions and model discovery. Azure `/responses` requests use `ARCHESTRA_AZURE_OPENAI_RESPONSES_API_VERSION`. Foundry v1 URLs do not use either query parameter.
-- **Microsoft Entra ID**: When `ARCHESTRA_AZURE_OPENAI_ENTRA_ID_ENABLED=true`, Azure provider keys can omit the API key value and Archestra sends `Authorization: Bearer <token>` to Azure OpenAI instead of `api-key`.
+- **API Version**: Deployment URLs use `ARCHESTRA_AZURE_OPENAI_API_VERSION` for Chat Completions and model discovery. Azure `/responses` requests use `ARCHESTRA_AZURE_OPENAI_RESPONSES_API_VERSION`. Foundry v1 URLs do not use either query parameter.
+- **Microsoft Entra ID**: When `ARCHESTRA_AZURE_OPENAI_ENTRA_ID_ENABLED=true`, Archestra creates a system provider key at startup and sends `Authorization: Bearer <token>` to Azure OpenAI instead of `api-key`.
 - **Grok on Azure**: Grok models sold directly by Azure use the Foundry v1 OpenAI-compatible Chat Completions API. The model must be deployed in the Azure resource before Archestra can route to it.
 - **Claude on Azure**: Claude models on Microsoft Foundry use Anthropic's Messages API shape, not the OpenAI-compatible Azure route. Configure the Anthropic provider section above.
-- **Multiple Deployments**: Azure OpenAI is the main provider that exposes multiple deployment names behind one resource-level credential. One Azure provider key should represent the Azure resource or Foundry v1 endpoint, not an individual deployment. After model sync, select the deployment by model name.
+- **Multiple Deployments**: With deployment URLs, create separate API key entries in Settings, each with its own deployment URL as the Base URL. With Foundry v1, send the deployed model name in the request `model` field.
+- **Deployment URL configuration**: Keep using the deployment-specific base URL format shown above. Archestra derives the correct upstream endpoint automatically for both `/chat/completions` and `/responses` requests.
 - **Responses API model field**: For Azure `/responses` requests, send the deployment name in the `model` field. Archestra will route the request to Azure's `/openai/responses` endpoint while preserving the configured deployment URL for discovery and management.
 - **OpenAI-compatible API**: Azure AI Foundry supports both Chat Completions and Responses-style request flows through Archestra.

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -7,6 +7,13 @@ SUBDOMAIN=n8n
 # LLM Provider Base URLs
 ARCHESTRA_OPENAI_BASE_URL=https://api.openai.com/v1
 ARCHESTRA_ANTHROPIC_BASE_URL=https://api.anthropic.com
+# Anthropic Workload Identity Federation (optional keyless auth)
+# ARCHESTRA_ANTHROPIC_FEDERATION_RULE_ID=fdrl_...
+# ARCHESTRA_ANTHROPIC_ORGANIZATION_ID=00000000-0000-0000-0000-000000000000
+# ARCHESTRA_ANTHROPIC_SERVICE_ACCOUNT_ID=svac_...
+# ARCHESTRA_ANTHROPIC_WORKSPACE_ID=wrkspc_...
+# ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN_FILE=/var/run/secrets/anthropic.com/token
+# ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN=eyJhbGciOiJSUzI1NiIs...
 ARCHESTRA_GEMINI_BASE_URL=https://generativelanguage.googleapis.com
 # Cohere Base URL (uses https://api.cohere.ai by default)
 ARCHESTRA_COHERE_BASE_URL=https://api.cohere.ai

--- a/platform/backend/src/clients/anthropic-workload-identity.ts
+++ b/platform/backend/src/clients/anthropic-workload-identity.ts
@@ -1,0 +1,292 @@
+import fs from "node:fs/promises";
+
+const GRANT_TYPE_JWT_BEARER = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+const TOKEN_ENDPOINT = "/v1/oauth/token";
+const OAUTH_API_BETA_HEADER = "oauth-2025-04-20";
+const FEDERATION_BETA_HEADER = "oidc-federation-2026-04-01";
+const ADVISORY_REFRESH_THRESHOLD_SECONDS = 120;
+const MAX_IDENTITY_TOKEN_BYTES = 16 * 1024;
+
+type Fetch = typeof globalThis.fetch;
+
+type AnthropicWorkloadIdentityConfig = {
+  federationRuleId: string;
+  organizationId: string;
+  serviceAccountId: string;
+  workspaceId?: string;
+  identityToken?: string;
+  identityTokenFile?: string;
+};
+
+type CachedToken = {
+  token: string;
+  expiresAtMs: number;
+};
+
+const tokenCaches = new Map<string, Promise<CachedToken> | CachedToken>();
+
+export function isAnthropicWorkloadIdentityEnabled(): boolean {
+  const config = getAnthropicWorkloadIdentityConfig();
+  return Boolean(
+    config.federationRuleId &&
+      config.organizationId &&
+      config.serviceAccountId &&
+      (config.identityToken || config.identityTokenFile),
+  );
+}
+
+export async function getAnthropicWorkloadIdentityAuthHeaders(
+  baseUrl: string | undefined,
+): Promise<Record<string, string>> {
+  return {
+    Authorization: `Bearer ${await getAnthropicWorkloadIdentityToken(
+      baseUrl || "https://api.anthropic.com",
+    )}`,
+    "anthropic-beta": OAUTH_API_BETA_HEADER,
+  };
+}
+
+export function createAnthropicWorkloadIdentityFetch(
+  baseUrl: string | undefined,
+  upstreamFetch?: Fetch,
+): Fetch {
+  const resolvedBaseUrl = baseUrl || "https://api.anthropic.com";
+  const fetchForUpstream = upstreamFetch ?? globalThis.fetch.bind(globalThis);
+
+  return async (input, init = {}) => {
+    const token = await getAnthropicWorkloadIdentityToken(resolvedBaseUrl);
+    const headers = new Headers(init.headers);
+    headers.set("Authorization", `Bearer ${token}`);
+    appendAnthropicBeta(headers, OAUTH_API_BETA_HEADER);
+
+    return fetchForUpstream(input, {
+      ...init,
+      headers,
+    });
+  };
+}
+
+function getAnthropicWorkloadIdentityConfig(): AnthropicWorkloadIdentityConfig {
+  const identityToken = process.env.ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN?.trim();
+  const identityTokenFile =
+    process.env.ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN_FILE?.trim();
+  return {
+    federationRuleId:
+      process.env.ARCHESTRA_ANTHROPIC_FEDERATION_RULE_ID?.trim() ?? "",
+    organizationId:
+      process.env.ARCHESTRA_ANTHROPIC_ORGANIZATION_ID?.trim() ?? "",
+    serviceAccountId:
+      process.env.ARCHESTRA_ANTHROPIC_SERVICE_ACCOUNT_ID?.trim() ?? "",
+    workspaceId:
+      process.env.ARCHESTRA_ANTHROPIC_WORKSPACE_ID?.trim() || undefined,
+    identityToken: identityToken || undefined,
+    identityTokenFile: identityTokenFile || undefined,
+  };
+}
+
+async function getAnthropicWorkloadIdentityToken(
+  baseUrl: string,
+): Promise<string> {
+  const config = getAnthropicWorkloadIdentityConfig();
+  const cacheKey = JSON.stringify({
+    baseUrl,
+    federationRuleId: config.federationRuleId,
+    organizationId: config.organizationId,
+    serviceAccountId: config.serviceAccountId,
+    workspaceId: config.workspaceId,
+    identityTokenFile: config.identityTokenFile,
+    hasInlineToken: Boolean(config.identityToken),
+  });
+
+  const cached = tokenCaches.get(cacheKey);
+  if (cached) {
+    const token = cached instanceof Promise ? await cached : cached;
+    if (
+      token.expiresAtMs - Date.now() >
+      ADVISORY_REFRESH_THRESHOLD_SECONDS * 1000
+    ) {
+      return token.token;
+    }
+  }
+
+  const pending = exchangeAnthropicWorkloadIdentityToken(baseUrl, config);
+  tokenCaches.set(cacheKey, pending);
+
+  try {
+    const token = await pending;
+    tokenCaches.set(cacheKey, token);
+    return token.token;
+  } catch (error) {
+    tokenCaches.delete(cacheKey);
+    throw error;
+  }
+}
+
+async function exchangeAnthropicWorkloadIdentityToken(
+  baseUrl: string,
+  config: AnthropicWorkloadIdentityConfig,
+): Promise<CachedToken> {
+  assertWorkloadIdentityConfig(config);
+  requireSecureTokenEndpoint(baseUrl);
+
+  const assertion = await readIdentityToken(config);
+  if (Buffer.byteLength(assertion, "utf8") > MAX_IDENTITY_TOKEN_BYTES) {
+    throw new Error(
+      "Anthropic identity token exceeds the 16 KiB Workload Identity Federation assertion limit",
+    );
+  }
+
+  const body: Record<string, string> = {
+    grant_type: GRANT_TYPE_JWT_BEARER,
+    assertion,
+    federation_rule_id: config.federationRuleId,
+    organization_id: config.organizationId,
+    service_account_id: config.serviceAccountId,
+  };
+
+  if (config.workspaceId) {
+    body.workspace_id = config.workspaceId;
+  }
+
+  const response = await globalThis.fetch(`${baseUrl}${TOKEN_ENDPOINT}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "anthropic-beta": `${OAUTH_API_BETA_HEADER},${FEDERATION_BETA_HEADER}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const requestId = response.headers.get("request-id");
+
+  if (!response.ok) {
+    const errorBody = await response.text().catch(() => "");
+    throw new Error(
+      `Anthropic Workload Identity Federation token exchange failed with status ${
+        response.status
+      }${requestId ? ` (request-id ${requestId})` : ""}: ${redactTokenError(
+        errorBody,
+      )}`,
+    );
+  }
+
+  const payload = (await response.json()) as {
+    access_token?: unknown;
+    expires_in?: unknown;
+    token_type?: unknown;
+  };
+
+  if (
+    typeof payload.access_token !== "string" ||
+    !payload.access_token ||
+    typeof payload.expires_in !== "number" ||
+    !Number.isFinite(payload.expires_in)
+  ) {
+    throw new Error("Anthropic WIF token exchange response is missing fields");
+  }
+
+  if (
+    typeof payload.token_type === "string" &&
+    payload.token_type.toLowerCase() !== "bearer"
+  ) {
+    throw new Error(
+      `Anthropic WIF token exchange returned unsupported token_type "${payload.token_type}"`,
+    );
+  }
+
+  return {
+    token: payload.access_token,
+    expiresAtMs: Date.now() + payload.expires_in * 1000,
+  };
+}
+
+function assertWorkloadIdentityConfig(
+  config: AnthropicWorkloadIdentityConfig,
+): void {
+  const missing: string[] = [];
+  if (!config.federationRuleId) {
+    missing.push("ARCHESTRA_ANTHROPIC_FEDERATION_RULE_ID");
+  }
+  if (!config.organizationId) {
+    missing.push("ARCHESTRA_ANTHROPIC_ORGANIZATION_ID");
+  }
+  if (!config.serviceAccountId) {
+    missing.push("ARCHESTRA_ANTHROPIC_SERVICE_ACCOUNT_ID");
+  }
+  if (!config.identityToken && !config.identityTokenFile) {
+    missing.push(
+      "ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN or ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN_FILE",
+    );
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Anthropic Workload Identity Federation is missing required environment variables: ${missing.join(
+        ", ",
+      )}`,
+    );
+  }
+}
+
+async function readIdentityToken(
+  config: AnthropicWorkloadIdentityConfig,
+): Promise<string> {
+  if (config.identityToken) {
+    return config.identityToken;
+  }
+
+  if (!config.identityTokenFile) {
+    throw new Error("Anthropic Workload Identity Federation token is missing");
+  }
+
+  const token = (await fs.readFile(config.identityTokenFile, "utf8")).trim();
+  if (!token) {
+    throw new Error(
+      `Anthropic identity token file is empty: ${config.identityTokenFile}`,
+    );
+  }
+  return token;
+}
+
+function requireSecureTokenEndpoint(baseUrl: string): void {
+  const url = new URL(baseUrl);
+  if (url.protocol === "https:") return;
+
+  const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (
+    url.protocol === "http:" &&
+    (host === "localhost" || host === "127.0.0.1" || host === "::1")
+  ) {
+    return;
+  }
+
+  throw new Error(
+    `Refusing to send Anthropic Workload Identity Federation assertion to non-HTTPS endpoint: ${baseUrl}`,
+  );
+}
+
+function appendAnthropicBeta(headers: Headers, beta: string): void {
+  const current = headers.get("anthropic-beta");
+  if (!current) {
+    headers.set("anthropic-beta", beta);
+    return;
+  }
+
+  const values = current.split(",").map((value) => value.trim());
+  if (!values.includes(beta)) {
+    headers.set("anthropic-beta", `${current},${beta}`);
+  }
+}
+
+function redactTokenError(body: string): string {
+  try {
+    const parsed = JSON.parse(body) as Record<string, unknown>;
+    return JSON.stringify({
+      error: parsed.error,
+      error_description: parsed.error_description,
+      error_uri: parsed.error_uri,
+    });
+  } catch {
+    return body.slice(0, 2000);
+  }
+}

--- a/platform/backend/src/routes/chat/model-fetchers/anthropic.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/anthropic.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.stubEnv(
+  "ARCHESTRA_DATABASE_URL",
+  "postgresql://archestra:archestra@localhost:5432/archestra_test",
+);
+
+vi.mock("@/clients/azure-openai-credentials", () => ({
+  getAzureAiFoundryBearerTokenProvider: vi.fn(),
+  isAnthropicAzureFoundryEntraIdEnabled: vi.fn(() => false),
+}));
+
+const { fetchAnthropicModels } = await import("./anthropic");
+
+describe("fetchAnthropicModels", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  test("uses Workload Identity Federation when no API key is supplied", async () => {
+    vi.stubEnv("ARCHESTRA_ANTHROPIC_FEDERATION_RULE_ID", "fdrl_models_test");
+    vi.stubEnv(
+      "ARCHESTRA_ANTHROPIC_ORGANIZATION_ID",
+      "00000000-0000-0000-0000-000000000000",
+    );
+    vi.stubEnv("ARCHESTRA_ANTHROPIC_SERVICE_ACCOUNT_ID", "svac_models_test");
+    vi.stubEnv("ARCHESTRA_ANTHROPIC_WORKSPACE_ID", "wrkspc_models_test");
+    vi.stubEnv("ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN", "jwt-for-model-fetcher");
+
+    const upstreamFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url.endsWith("/v1/oauth/token")) {
+          return new Response(
+            JSON.stringify({
+              access_token: "sk-ant-oat01-models",
+              token_type: "Bearer",
+              expires_in: 3600,
+              scope: "workspace:developer",
+            }),
+          );
+        }
+
+        expect(url).toBe("https://api.anthropic.com/v1/models?limit=100");
+        const headers = new Headers(init?.headers);
+        expect(headers.get("Authorization")).toBe("Bearer sk-ant-oat01-models");
+        expect(headers.get("anthropic-beta")).toContain("oauth-2025-04-20");
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: "claude-sonnet-4-6",
+                display_name: "Claude Sonnet 4.6",
+                created_at: "2026-05-01T00:00:00Z",
+              },
+            ],
+          }),
+        );
+      });
+
+    await expect(
+      fetchAnthropicModels("", "https://api.anthropic.com"),
+    ).resolves.toEqual([
+      {
+        id: "claude-sonnet-4-6",
+        displayName: "Claude Sonnet 4.6",
+        provider: "anthropic",
+        createdAt: "2026-05-01T00:00:00Z",
+      },
+    ]);
+
+    expect(upstreamFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/platform/backend/src/routes/chat/model-fetchers/anthropic.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/anthropic.ts
@@ -1,4 +1,8 @@
 import {
+  getAnthropicWorkloadIdentityAuthHeaders,
+  isAnthropicWorkloadIdentityEnabled,
+} from "@/clients/anthropic-workload-identity";
+import {
   getAzureAiFoundryBearerTokenProvider,
   isAnthropicAzureFoundryEntraIdEnabled,
 } from "@/clients/azure-openai-credentials";
@@ -18,7 +22,7 @@ export async function fetchAnthropicModels(
   const response = await fetch(url, {
     headers: {
       ...(extraHeaders ?? {}),
-      ...(await getAnthropicAuthHeaders(apiKey)),
+      ...(await getAnthropicAuthHeaders(apiKey, baseUrl)),
       "anthropic-version": "2023-06-01",
     },
   });
@@ -46,15 +50,20 @@ export async function fetchAnthropicModels(
 
 async function getAnthropicAuthHeaders(
   apiKey: string | undefined,
+  baseUrl: string | undefined,
 ): Promise<Record<string, string>> {
   if (apiKey) {
     return { "x-api-key": apiKey };
   }
 
-  if (!isAnthropicAzureFoundryEntraIdEnabled()) {
-    return { "x-api-key": "" };
+  if (isAnthropicAzureFoundryEntraIdEnabled()) {
+    const tokenProvider = getAzureAiFoundryBearerTokenProvider();
+    return { Authorization: `Bearer ${await tokenProvider()}` };
   }
 
-  const tokenProvider = getAzureAiFoundryBearerTokenProvider();
-  return { Authorization: `Bearer ${await tokenProvider()}` };
+  if (isAnthropicWorkloadIdentityEnabled()) {
+    return getAnthropicWorkloadIdentityAuthHeaders(baseUrl);
+  }
+
+  return { "x-api-key": "" };
 }

--- a/platform/backend/src/routes/proxy/adapters/anthropic-workload-identity.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic-workload-identity.test.ts
@@ -1,0 +1,125 @@
+import type AnthropicProvider from "@anthropic-ai/sdk";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/observability", () => ({
+  metrics: { llm: { getObservableFetch: vi.fn() } },
+}));
+
+vi.mock("@/clients/azure-openai-credentials", () => ({
+  getAzureAiFoundryBearerTokenProvider: vi.fn(),
+  isAnthropicAzureFoundryEntraIdEnabled: vi.fn(() => false),
+}));
+
+vi.stubEnv(
+  "ARCHESTRA_DATABASE_URL",
+  "postgresql://archestra:archestra@localhost:5432/archestra_test",
+);
+
+const { anthropicAdapterFactory } = await import("./anthropic");
+
+describe("anthropicAdapterFactory Workload Identity Federation", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  test("creates a keyless client that exchanges OIDC identity for Anthropic bearer auth", async () => {
+    vi.stubEnv("ARCHESTRA_ANTHROPIC_FEDERATION_RULE_ID", "fdrl_test");
+    vi.stubEnv(
+      "ARCHESTRA_ANTHROPIC_ORGANIZATION_ID",
+      "00000000-0000-0000-0000-000000000000",
+    );
+    vi.stubEnv("ARCHESTRA_ANTHROPIC_SERVICE_ACCOUNT_ID", "svac_test");
+    vi.stubEnv("ARCHESTRA_ANTHROPIC_WORKSPACE_ID", "wrkspc_test");
+    vi.stubEnv("ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN", "jwt-from-idp");
+
+    const upstreamFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        const url = String(input);
+        if (url.endsWith("/v1/oauth/token")) {
+          return new Response(
+            JSON.stringify({
+              access_token: "sk-ant-oat01-token",
+              token_type: "Bearer",
+              expires_in: 3600,
+              scope: "workspace:developer",
+            }),
+            { headers: { "request-id": "req-token" } },
+          );
+        }
+
+        return new Response("{}");
+      });
+
+    const client = anthropicAdapterFactory.createClient(undefined, {
+      baseUrl: "https://api.anthropic.com",
+      defaultHeaders: {},
+      source: "api",
+    }) as AnthropicProvider & {
+      _options?: {
+        defaultHeaders?: Record<string, string>;
+        fetch?: typeof globalThis.fetch;
+      };
+    };
+
+    expect(client._options?.defaultHeaders?.Authorization).toBe(
+      "Bearer <anthropic-wif-managed>",
+    );
+
+    const fetch = client._options?.fetch;
+    expect(fetch).toBeDefined();
+
+    await fetch?.("https://api.anthropic.com/v1/messages", {
+      headers: { "anthropic-version": "2023-06-01" },
+    });
+
+    expect(upstreamFetch).toHaveBeenCalledTimes(2);
+
+    const tokenRequest = upstreamFetch.mock.calls[0];
+    expect(tokenRequest?.[0]).toBe("https://api.anthropic.com/v1/oauth/token");
+    const tokenHeaders = new Headers(tokenRequest?.[1]?.headers);
+    expect(tokenHeaders.get("anthropic-beta")).toContain(
+      "oidc-federation-2026-04-01",
+    );
+    expect(JSON.parse(String(tokenRequest?.[1]?.body))).toMatchObject({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion: "jwt-from-idp",
+      federation_rule_id: "fdrl_test",
+      organization_id: "00000000-0000-0000-0000-000000000000",
+      service_account_id: "svac_test",
+      workspace_id: "wrkspc_test",
+    });
+
+    const messageRequest = upstreamFetch.mock.calls[1];
+    const messageHeaders = new Headers(messageRequest?.[1]?.headers);
+    expect(messageHeaders.get("Authorization")).toBe(
+      "Bearer sk-ant-oat01-token",
+    );
+    expect(messageHeaders.get("anthropic-beta")).toContain("oauth-2025-04-20");
+  });
+
+  test("does not use workload identity when a request supplies an API key", () => {
+    vi.stubEnv("ARCHESTRA_ANTHROPIC_FEDERATION_RULE_ID", "fdrl_test");
+    vi.stubEnv(
+      "ARCHESTRA_ANTHROPIC_ORGANIZATION_ID",
+      "00000000-0000-0000-0000-000000000000",
+    );
+    vi.stubEnv("ARCHESTRA_ANTHROPIC_SERVICE_ACCOUNT_ID", "svac_test");
+    vi.stubEnv("ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN", "jwt-from-idp");
+
+    const client = anthropicAdapterFactory.createClient("sk-ant-api-key", {
+      baseUrl: "https://api.anthropic.com",
+      defaultHeaders: {},
+      source: "api",
+    }) as AnthropicProvider & {
+      _options?: {
+        apiKey?: unknown;
+        defaultHeaders?: Record<string, string>;
+      };
+    };
+
+    expect(client._options?.apiKey).toBe("sk-ant-api-key");
+    expect(client._options?.defaultHeaders?.Authorization).toBeUndefined();
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -3,6 +3,10 @@ import { ArchestraInternalErrorCode } from "@shared";
 import { encode as toonEncode } from "@toon-format/toon";
 import { get } from "lodash-es";
 import {
+  createAnthropicWorkloadIdentityFetch,
+  isAnthropicWorkloadIdentityEnabled,
+} from "@/clients/anthropic-workload-identity";
+import {
   getAzureAiFoundryBearerTokenProvider,
   isAnthropicAzureFoundryEntraIdEnabled,
 } from "@/clients/azure-openai-credentials";
@@ -902,7 +906,7 @@ export async function convertToolResultsToToon(
                   },
                   "convertToolResultsToToon: compressed (string content)",
                 );
-                logger.trace(
+                logger.debug(
                   {
                     toolCallId: contentBlock.tool_use_id,
                     before: noncompressed,
@@ -984,7 +988,7 @@ export async function convertToolResultsToToon(
                       },
                       "convertToolResultsToToon: compressed (array content)",
                     );
-                    logger.trace(
+                    logger.debug(
                       {
                         toolCallId: contentBlock.tool_use_id,
                         before: noncompressed,
@@ -1168,6 +1172,23 @@ export const anthropicAdapterFactory: LLMProvider<
           ...options.defaultHeaders,
           // The fetch wrapper replaces this sentinel with a fresh Entra ID token on every request.
           Authorization: "Bearer <entra-id-managed>",
+        },
+      });
+    }
+
+    if (!apiKey && isAnthropicWorkloadIdentityEnabled()) {
+      return new AnthropicProvider({
+        apiKey: null,
+        authToken: null,
+        baseURL: options.baseUrl,
+        fetch: createAnthropicWorkloadIdentityFetch(
+          options.baseUrl,
+          customFetch,
+        ),
+        defaultHeaders: {
+          ...options.defaultHeaders,
+          // The fetch wrapper replaces this sentinel with a short-lived Anthropic WIF token.
+          Authorization: "Bearer <anthropic-wif-managed>",
         },
       });
     }

--- a/platform/backend/src/services/system-key-manager.ts
+++ b/platform/backend/src/services/system-key-manager.ts
@@ -1,4 +1,5 @@
 import type { SupportedProvider } from "@shared";
+import { isAnthropicWorkloadIdentityEnabled } from "@/clients/anthropic-workload-identity";
 import {
   isAnthropicAzureFoundryEntraIdEnabled,
   isAzureOpenAiEntraIdEnabled,
@@ -35,9 +36,9 @@ interface KeylessProviderConfig {
 /**
  * Manages system API keys for truly keyless providers.
  *
- * Currently Vertex AI, Azure OpenAI (with Entra ID), and Bedrock (with IAM auth)
- * qualify as keyless because they use cloud provider credentials instead of API
- * keys.
+ * Currently Vertex AI, Azure OpenAI (with Entra ID), Anthropic WIF, and
+ * Bedrock (with IAM auth) qualify as keyless because they use cloud provider
+ * credentials instead of API keys.
  *
  * System keys are auto-created when a keyless provider is enabled via environment config,
  * and auto-deleted when the provider is disabled.
@@ -72,6 +73,20 @@ class SystemKeyManager {
       isEnabled: () =>
         isAnthropicAzureFoundryEntraIdEnabled() &&
         isAzureAiFoundryBaseUrl(config.llm.anthropic.baseUrl),
+      customFetch: async () => {
+        const models = await fetchAnthropicModels(
+          "",
+          config.llm.anthropic.baseUrl,
+        );
+        return models.map((m) => ({ id: m.id, displayName: m.displayName }));
+      },
+    },
+    {
+      provider: "anthropic",
+      name: "Anthropic Workload Identity Federation",
+      isEnabled: () =>
+        !isAnthropicAzureFoundryEntraIdEnabled() &&
+        isAnthropicWorkloadIdentityEnabled(),
       customFetch: async () => {
         const models = await fetchAnthropicModels(
           "",


### PR DESCRIPTION
## Summary
- Add Anthropic Workload Identity Federation support for keyless auth using `ARCHESTRA_ANTHROPIC_*` variables.
- Wire WIF into Anthropic proxy adapter and model fetcher (while preserving explicit API key and Azure Foundry Entra ID precedence).
- Add WIF-backed Anthropic keyless system-key sync.
- Document env vars and setup in deployment + supported providers docs.
- Add focused backend tests for adapter/model-fetcher WIF flows.

## Notes
- This follows the previously reviewed closed implementation pattern from #4483, rebased onto current `main`.

## Validation
- I did not run local `pnpm` test/lint/type-check in this Codex environment (no local checkout runtime here).

Closes #4468
/claim #4468