### PR TITLE
fix(ci): cap E2E platform/worker CPU requests to fit the runner

### DIFF
--- a/.github/values-ci.yaml
+++ b/.github/values-ci.yaml
@@ -11,8 +11,23 @@ archestra:
   # other against a fresh CI database.
   replicaCount: 1
 
+  # Override the chart's production CPU requests (2 vCPU per pod) for CI.
+  # On the resource-constrained E2E runners, 1 platform + 2 workers at 2 vCPU
+  # each reserves 6 vCPU before PostgreSQL and the e2e dependency pods are
+  # scheduled — which intermittently leaves no room, so PostgreSQL or the
+  # platform pod gets FailedScheduling ("Insufficient cpu") and the deploy
+  # stalls until the Helm timeout. CPU requests are only a scheduling
+  # reservation (there is no CPU limit), so a smaller request still lets the
+  # pods burst as needed while letting everything fit on the node.
+  resources:
+    requests:
+      cpu: "500m"
+
   worker:
     replicaCount: 2
+    resources:
+      requests:
+        cpu: "500m"
 
   # Environment variables for e2e testing
   env:


### PR DESCRIPTION
## Summary

The Helm chart requests **2 vCPU per pod** for both the platform and worker — a production Fastify recommendation. `.github/values-ci.yaml` overrode `replicaCount` (1 platform + 2 workers) but **not** `resources`, so the E2E deploy reserved **6 vCPU** before PostgreSQL and the e2e dependency pods (vault, wiremock, keycloak, 3 MCP servers) were scheduled.

On the **8-vCPU** Readonly Vault runner that intermittently left no room. When PostgreSQL or the platform pod couldn't be scheduled:
- `FailedScheduling: 0/1 nodes are available: 1 Insufficient cpu`
- the platform pod's `setup-postgres-extensions` / `wait-for-postgres` init containers then blocked waiting for a PostgreSQL that never came up
- the atomic Helm install stalled until its timeout → the recurring `INSTALLATION FAILED: ... context deadline exceeded` with the pod stuck in `PodInitializing`

This is why it was **intermittent** (scheduling depends on pod creation order), why **only Readonly Vault** hit it (the main E2E job runs on a 16-vCPU runner), and why bumping the Helm timeout didn't help — the pod literally couldn't be scheduled.

## Change
Override `archestra` and `archestra.worker` CPU **requests** to `500m` in `values-ci.yaml` (6 vCPU → 1.5 vCPU reserved). CPU requests are only a scheduling reservation and the chart sets **no CPU limit**, so pods still burst as needed — this only frees headroom so every pod schedules. Memory requests/limits and **all production defaults are untouched** (CI values file only).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>