### PR TITLE
fix(helm): bound the postgres-wait init container loops

### DIFF
--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -256,8 +256,15 @@ Handles Vault secret injection, pgvector extension setup, and PostgreSQL readine
     - sh
     - -c
     - |
+      max_attempts={{ .Values.archestra.initContainers.waitForPostgres.timeoutSeconds | default 300 }}
+      attempt=0
       until pg_isready -h {{ include "archestra-platform.fullname" . }}-postgresql -U postgres; do
-        echo "Waiting for PostgreSQL..."
+        attempt=$((attempt + 1))
+        if [ "$attempt" -ge "$max_attempts" ]; then
+          echo "PostgreSQL did not become ready after ${max_attempts}s - giving up" >&2
+          exit 1
+        fi
+        echo "Waiting for PostgreSQL... (${attempt}/${max_attempts})"
         sleep 1
       done
       psql -h {{ include "archestra-platform.fullname" . }}-postgresql -U postgres -d {{ .Values.postgresql.auth.database }} -c "CREATE EXTENSION IF NOT EXISTS vector;"
@@ -300,8 +307,15 @@ Handles Vault secret injection, pgvector extension setup, and PostgreSQL readine
       esac
 
       echo "Waiting for PostgreSQL at ${HOST}:${PORT}..."
+      max_attempts={{ .Values.archestra.initContainers.waitForPostgres.timeoutSeconds | default 300 }}
+      attempt=0
       until nc -z "${HOST}" "${PORT}"; do
-        echo "PostgreSQL is unavailable - sleeping"
+        attempt=$((attempt + 1))
+        if [ "$attempt" -ge "$max_attempts" ]; then
+          echo "PostgreSQL at ${HOST}:${PORT} did not become reachable after ${max_attempts}s - giving up" >&2
+          exit 1
+        fi
+        echo "PostgreSQL is unavailable - sleeping (${attempt}/${max_attempts})"
         sleep 1
       done
       echo "PostgreSQL is up - continuing"

--- a/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
@@ -354,6 +354,34 @@ tests:
           path: spec.template.spec.initContainers[1].command[2]
           pattern: ".*nc -z.*"
 
+  - it: should bound the wait-for-postgres loop with the default timeout
+    documentIndex: 1
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].command[2]
+          pattern: "max_attempts=300"
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].command[2]
+          pattern: "did not become reachable after .* - giving up"
+
+  - it: should honor a custom waitForPostgres timeout in both postgres init containers
+    documentIndex: 1
+    set:
+      archestra.initContainers.waitForPostgres.timeoutSeconds: 60
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: wait-for-postgres
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].command[2]
+          pattern: "max_attempts=60"
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: setup-postgres-extensions
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "max_attempts=60"
+
   - it: should set ARCHESTRA_DATABASE_URL with postgres:// scheme
     documentIndex: 1
     set:

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -210,6 +210,12 @@ archestra:
     # or if you handle readiness checks in another way
     waitForPostgres:
       enabled: true
+      # Maximum seconds to wait for PostgreSQL to become reachable before the
+      # init container gives up and fails. Without a bound, a database that
+      # never comes up leaves the pod stuck in PodInitializing indefinitely
+      # (and any `helm install --atomic` hits its own timeout with no clear
+      # cause). The setup-postgres-extensions init container uses the same budget.
+      timeoutSeconds: 300
 
     # Vault secret injection init container
     # Similar to Vault Agent Injector (writes secrets to a shared volume) but:


### PR DESCRIPTION
## Summary

The `setup-postgres-extensions` and `wait-for-postgres` init containers looped on `pg_isready` / `nc -z` with **no upper bound**. When PostgreSQL never became reachable, the platform pod sat in `PodInitializing` indefinitely — and any `helm install --atomic` hit its own timeout with no signal pointing at the cause.

- Bound both loops with a configurable budget: `archestra.initContainers.waitForPostgres.timeoutSeconds` (default `300`). A slow-but-healthy database still succeeds; one that never appears now fails the init container fast with a clear message (`PostgreSQL did not become ready after 300s - giving up`) instead of hanging until Helm's deadline.
- Chart tests covering the default bound and the configurable override across both postgres init containers.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>