### PR TITLE
ci(e2e): capture postgres pod state in E2E failure diagnostics

### DIFF
--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -277,6 +277,15 @@ jobs:
           echo "=== Describe Platform Pod ==="
           kubectl describe pod -l app.kubernetes.io/name=archestra-platform || true
 
+          echo "=== Describe PostgreSQL Pod ==="
+          kubectl describe pod -l app.kubernetes.io/name=postgresql || true
+
+          echo "=== PostgreSQL StatefulSet & PVCs ==="
+          kubectl get statefulset,pvc -l app.kubernetes.io/name=postgresql -o wide || true
+
+          echo "=== Recent Cluster Events ==="
+          kubectl get events --sort-by=.lastTimestamp -A 2>/dev/null | tail -60 || true
+
       - name: Cleanup Kind cluster
         if: always()
         run: kind delete cluster --name archestra-ci-cluster || true
@@ -403,6 +412,15 @@ jobs:
 
           echo "=== Describe Platform Pod ==="
           kubectl describe pod -l app.kubernetes.io/name=archestra-platform || true
+
+          echo "=== Describe PostgreSQL Pod ==="
+          kubectl describe pod -l app.kubernetes.io/name=postgresql || true
+
+          echo "=== PostgreSQL StatefulSet & PVCs ==="
+          kubectl get statefulset,pvc -l app.kubernetes.io/name=postgresql -o wide || true
+
+          echo "=== Recent Cluster Events ==="
+          kubectl get events --sort-by=.lastTimestamp -A 2>/dev/null | tail -60 || true
 
       - name: Cleanup Kind cluster
         if: always()


### PR DESCRIPTION
## Summary

When the platform pod is stuck in `PodInitializing`, the E2E "Show logs on failure" steps showed nothing about *why* PostgreSQL was unavailable — only the platform pod itself.

Add to both the main E2E and Readonly Vault diagnostic steps:
- `kubectl describe pod` for PostgreSQL
- PostgreSQL StatefulSet / PVC status
- recent cluster events (`kubectl get events --sort-by=.lastTimestamp -A`)

So a scheduling failure (`FailedScheduling: Insufficient cpu`), PVC-binding stall, or image-pull error is visible directly in the job log instead of having to be inferred.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>