### PR TITLE
chore: backport xml hotfix

### DIFF
--- a/platform/package.json
+++ b/platform/package.json
@@ -60,7 +60,7 @@
       "kysely": "0.28.17",
       "lodash": ">=4.18.0",
       "lodash-es": "4.18.1",
-      "fast-xml-parser": "5.7.0",
+      "fast-xml-parser": "5.7.2",
       "fast-xml-builder": ">=1.1.7",
       "fast-uri": ">=3.1.2",
       "ajv": "8.18.0",

--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -34,7 +34,7 @@ overrides:
   kysely: 0.28.17
   lodash: '>=4.18.0'
   lodash-es: 4.18.1
-  fast-xml-parser: 5.7.0
+  fast-xml-parser: 5.7.2
   fast-xml-builder: '>=1.1.7'
   fast-uri: '>=3.1.2'
   ajv: 8.18.0
@@ -7102,8 +7102,8 @@ packages:
   fast-xml-builder@1.1.8:
     resolution: {integrity: sha512-sDVBc2gg8pSKvcbE8rBmOyjSGQf0AdsbqvHeIOv3D/uYNoV4eCReQXyDF8Pdv8+m1FHazACypSz2hR7O2S1LLw==}
 
-  fast-xml-parser@5.7.0:
-    resolution: {integrity: sha512-MTcrUoRQ1GSQ9iG3QJzBGquYYYeA7piZaJoIWbPFGbRn6Jj6z7xgoAyi4DrZX4y2ZIQQBF59gc/zmvvejjgoFQ==}
+  fast-xml-parser@5.7.2:
+    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
     hasBin: true
 
   fastify-metrics@12.1.0:
@@ -10739,7 +10739,7 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.11':
     dependencies:
       '@smithy/types': 4.13.1
-      fast-xml-parser: 5.7.0
+      fast-xml-parser: 5.7.2
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.3': {}
@@ -11111,7 +11111,7 @@ snapshots:
       '@better-fetch/fetch': 1.1.21
       better-auth: 1.6.5(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(kysely@0.28.17)(pg@8.20.0))(mongodb@7.1.0(@aws-sdk/credential-providers@3.1009.0)(socks@2.8.7))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@29.0.0(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)))
       better-call: 1.3.5(zod@4.3.6)
-      fast-xml-parser: 5.7.0
+      fast-xml-parser: 5.7.2
       jose: 6.2.1
       samlify: 2.10.2
       tldts: 6.1.86
@@ -17082,7 +17082,7 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.5.0
 
-  fast-xml-parser@5.7.0:
+  fast-xml-parser@5.7.2:
     dependencies:
       '@nodable/entities': 2.1.0
       fast-xml-builder: 1.1.8


### PR DESCRIPTION
## Summary
- Backport of #4675 to main: bump `fast-xml-parser` override to `5.7.2` in `platform/package.json` and refresh the lockfile.

## Test plan
- [ ] `pnpm install` runs cleanly from `platform/`

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>