### PR TITLE
Add database-level soft delete support

### DIFF
--- a/platform/backend/src/database/migrations/0235_soft_delete_all_objects.sql
+++ b/platform/backend/src/database/migrations/0235_soft_delete_all_objects.sql
@@ -1,0 +1,120 @@
+CREATE OR REPLACE FUNCTION archestra_install_soft_delete(
+  target_schema text,
+  target_table text
+) RETURNS void AS $$
+DECLARE
+  qualified_table text := format('%I.%I', target_schema, target_table);
+BEGIN
+  EXECUTE format(
+    'ALTER TABLE %s ADD COLUMN IF NOT EXISTS deleted_at timestamp',
+    qualified_table
+  );
+
+  EXECUTE format(
+    'CREATE INDEX IF NOT EXISTS %I ON %s (deleted_at)',
+    target_table || '_deleted_at_idx',
+    qualified_table
+  );
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_attribute
+    WHERE attrelid = qualified_table::regclass
+      AND attisdropped
+  ) THEN
+    RETURN;
+  END IF;
+
+  EXECUTE format('DROP RULE IF EXISTS archestra_soft_delete ON %s', qualified_table);
+  EXECUTE format(
+    'CREATE RULE archestra_soft_delete AS ON DELETE TO %s DO INSTEAD
+      UPDATE %s SET deleted_at = COALESCE(deleted_at, clock_timestamp())
+      WHERE ctid = OLD.ctid
+      RETURNING OLD.*',
+    qualified_table,
+    qualified_table
+  );
+
+  EXECUTE format('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', qualified_table);
+  EXECUTE format('ALTER TABLE %s FORCE ROW LEVEL SECURITY', qualified_table);
+
+  EXECUTE format(
+    'DROP POLICY IF EXISTS archestra_select_not_deleted ON %s',
+    qualified_table
+  );
+  EXECUTE format(
+    'CREATE POLICY archestra_select_not_deleted ON %s
+      FOR SELECT USING (deleted_at IS NULL)',
+    qualified_table
+  );
+
+  EXECUTE format(
+    'DROP POLICY IF EXISTS archestra_insert_all ON %s',
+    qualified_table
+  );
+  EXECUTE format(
+    'CREATE POLICY archestra_insert_all ON %s
+      FOR INSERT WITH CHECK (true)',
+    qualified_table
+  );
+
+  EXECUTE format(
+    'DROP POLICY IF EXISTS archestra_update_all ON %s',
+    qualified_table
+  );
+  EXECUTE format(
+    'CREATE POLICY archestra_update_all ON %s
+      FOR UPDATE USING (true) WITH CHECK (true)',
+    qualified_table
+  );
+
+  EXECUTE format(
+    'DROP POLICY IF EXISTS archestra_delete_all ON %s',
+    qualified_table
+  );
+  EXECUTE format(
+    'CREATE POLICY archestra_delete_all ON %s
+      FOR DELETE USING (true)',
+    qualified_table
+  );
+END;
+$$ LANGUAGE plpgsql;--> statement-breakpoint
+DO $$
+DECLARE
+  table_record record;
+BEGIN
+  FOR table_record IN
+    SELECT schemaname, tablename
+    FROM pg_tables
+    WHERE schemaname = 'public'
+      AND tablename NOT LIKE 'drizzle_%'
+      AND tablename <> 'keyv_cache'
+  LOOP
+    PERFORM archestra_install_soft_delete(
+      table_record.schemaname,
+      table_record.tablename
+    );
+  END LOOP;
+END
+$$;--> statement-breakpoint
+DROP FUNCTION archestra_install_soft_delete(text, text);--> statement-breakpoint
+CREATE OR REPLACE FUNCTION archestra_restore_soft_deleted(
+  target_table regclass,
+  target_id text
+) RETURNS boolean AS $$
+DECLARE
+  restored_count integer;
+BEGIN
+  EXECUTE format(
+    'UPDATE %s
+      SET deleted_at = NULL
+      WHERE id::text = $1
+        AND deleted_at IS NOT NULL',
+    target_table
+  )
+  USING target_id;
+
+  GET DIAGNOSTICS restored_count = ROW_COUNT;
+  RETURN restored_count > 0;
+END;
+$$ LANGUAGE plpgsql;

--- a/platform/backend/src/database/migrations/0235_soft_delete_all_objects.test.ts
+++ b/platform/backend/src/database/migrations/0235_soft_delete_all_objects.test.ts
@@ -1,0 +1,41 @@
+import { sql } from "drizzle-orm";
+import db from "@/database";
+import { describe, expect, test } from "@/test";
+
+describe("0235 migration: soft delete all objects", () => {
+  test("installs soft-delete metadata, rule, and select policy on application tables", async () => {
+    const columns = await db.execute<{ column_name: string }>(sql`
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'team'
+        AND column_name = 'deleted_at'
+    `);
+    const rules = await db.execute<{ rulename: string }>(sql`
+      SELECT rulename
+      FROM pg_rules
+      WHERE schemaname = 'public'
+        AND tablename = 'team'
+        AND rulename = 'archestra_soft_delete'
+    `);
+    const policies = await db.execute<{ policyname: string }>(sql`
+      SELECT policyname
+      FROM pg_policies
+      WHERE schemaname = 'public'
+        AND tablename = 'team'
+        AND policyname = 'archestra_select_not_deleted'
+    `);
+    const restoreFunctions = await db.execute<{ proname: string }>(sql`
+      SELECT proname
+      FROM pg_proc
+      WHERE proname = 'archestra_restore_soft_deleted'
+    `);
+
+    expect(columns.rows[0]?.column_name).toBe("deleted_at");
+    expect(rules.rows[0]?.rulename).toBe("archestra_soft_delete");
+    expect(policies.rows[0]?.policyname).toBe("archestra_select_not_deleted");
+    expect(restoreFunctions.rows[0]?.proname).toBe(
+      "archestra_restore_soft_deleted",
+    );
+  });
+});

--- a/platform/backend/src/database/migrations/meta/_journal.json
+++ b/platform/backend/src/database/migrations/meta/_journal.json
@@ -1646,6 +1646,13 @@
       "when": 1778189799447,
       "tag": "0234_cool_colossus",
       "breakpoints": true
+    },
+    {
+      "idx": 235,
+      "version": "7",
+      "when": 1778190000000,
+      "tag": "0235_soft_delete_all_objects",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Closes #4464

 Summary

Adds a broad database-level soft delete mechanism for application tables.

This migration:
- Adds a `deleted_at` timestamp column to public application tables.
- Adds an index on `deleted_at`.
- Installs a PostgreSQL `ON DELETE DO INSTEAD` rule that turns deletes into `deleted_at = clock_timestamp()`.
- Enables row-level security and a default select policy so normal queries only return rows where `deleted_at IS NULL`.
- Leaves insert/update/delete policies permissive to preserve current write behavior.
- Skips rule/RLS installation for legacy tables with dropped columns, while still adding `deleted_at` and the index, because PostgreSQL cannot create the rewrite rule with `RETURNING OLD.*` on those table shapes.
- Adds `archestra_restore_soft_deleted(...)` as a database helper for future restore/recycle-bin flows.

Testing

```bash
DATABASE_URL='postgresql://test:test@localhost:5432/test' pnpm --dir backend test src/database/migrations/0235_soft_delete_all_objects.test.ts --run --reporter verbose
```

Result:

```text
Test Files  1 passed (1)
Tests       1 passed (1)
```

Also checked:

```bash
biome check backend/src/database/migrations/0235_soft_delete_all_objects.test.ts backend/src/database/migrations/0235_soft_delete_all_objects.sql backend/src/database/migrations/meta/_journal.json
git diff --check
```

Demo

I attached a short demo video in the PR conversation.

The demo shows the intended user-visible behavior:
- A team is visible before deletion.
- The existing delete action hides it from normal UI/API views.
- The database row is preserved with `deleted_at` set.
- Clearing `deleted_at` through the restore helper makes the same object visible again.
Notes / Scope

This PR opens with the database-level rule + RLS approach so maintainers can confirm whether this is the preferred generic implementation path before expanding coverage further.

Validated locally:
- Migration installs `deleted_at`.
- Migration installs the delete rewrite rule.
- Migration installs the default select policy.
- Restore helper exists.
- Targeted migration test passes.
- Biome check passes for changed files.
- `git diff --check` passes.

Not yet validated:
- Full backend test suite.
- Docker quickstart UI.
- Production PostgreSQL load/performance behavior.
- Every object type end-to-end.

A future follow-up can add retention/purge policies for high-volume tables if needed.

