### PR TITLE
fix: useConversation broken cache

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -64847,6 +64847,44 @@
             "in": "query",
             "name": "search",
             "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "includePreviewMessages",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "pinned",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 0,
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            "in": "query",
+            "name": "offset",
+            "required": false
           }
         ],
         "responses": {
@@ -64855,155 +64893,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
-                      },
-                      "userId": {
-                        "type": "string"
-                      },
-                      "organizationId": {
-                        "type": "string"
-                      },
-                      "agentId": {
-                        "nullable": true,
-                        "type": "string",
-                        "format": "uuid",
-                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
-                      },
-                      "chatApiKeyId": {
-                        "nullable": true,
-                        "type": "string",
-                        "format": "uuid",
-                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
-                      },
-                      "title": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "selectedModel": {
-                        "type": "string"
-                      },
-                      "selectedProvider": {
-                        "nullable": true,
-                        "type": "string",
-                        "enum": [
-                          "openai",
-                          "gemini",
-                          "anthropic",
-                          "bedrock",
-                          "cohere",
-                          "cerebras",
-                          "mistral",
-                          "perplexity",
-                          "groq",
-                          "xai",
-                          "openrouter",
-                          "vllm",
-                          "ollama",
-                          "zhipuai",
-                          "deepseek",
-                          "minimax",
-                          "azure"
-                        ]
-                      },
-                      "hasCustomToolSelection": {
-                        "type": "boolean"
-                      },
-                      "todoList": {
-                        "nullable": true,
-                        "anyOf": [
-                          {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "boolean"
-                              },
-                              {
-                                "type": "string",
-                                "nullable": true,
-                                "enum": [
-                                  null
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "type": "object",
-                            "additionalProperties": {}
-                          },
-                          {
-                            "type": "array",
-                            "items": {}
-                          }
-                        ]
-                      },
-                      "artifact": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "pinnedAt": {
-                        "nullable": true,
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "agent": {
-                        "nullable": true,
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "systemPrompt": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "agentType": {
-                            "type": "string",
-                            "enum": [
-                              "profile",
-                              "mcp_gateway",
-                              "llm_proxy",
-                              "agent"
-                            ]
-                          },
-                          "llmApiKeyId": {
-                            "nullable": true,
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "name",
-                          "systemPrompt",
-                          "agentType",
-                          "llmApiKeyId"
-                        ],
-                        "additionalProperties": false
-                      },
-                      "share": {
-                        "nullable": true,
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
                         "type": "object",
                         "properties": {
                           "id": {
@@ -65011,156 +64905,350 @@
                             "format": "uuid",
                             "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
                           },
-                          "visibility": {
+                          "userId": {
+                            "type": "string"
+                          },
+                          "organizationId": {
+                            "type": "string"
+                          },
+                          "agentId": {
+                            "nullable": true,
+                            "type": "string",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                          },
+                          "chatApiKeyId": {
+                            "nullable": true,
+                            "type": "string",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                          },
+                          "title": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "selectedModel": {
+                            "type": "string"
+                          },
+                          "selectedProvider": {
+                            "nullable": true,
                             "type": "string",
                             "enum": [
-                              "organization",
-                              "team",
-                              "user"
+                              "openai",
+                              "gemini",
+                              "anthropic",
+                              "bedrock",
+                              "cohere",
+                              "cerebras",
+                              "mistral",
+                              "perplexity",
+                              "groq",
+                              "xai",
+                              "openrouter",
+                              "vllm",
+                              "ollama",
+                              "zhipuai",
+                              "deepseek",
+                              "minimax",
+                              "azure"
                             ]
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "visibility"
-                        ],
-                        "additionalProperties": false
-                      },
-                      "messages": {
-                        "type": "array",
-                        "items": {}
-                      },
-                      "chatErrors": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string",
-                              "format": "uuid",
-                              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                          },
+                          "hasCustomToolSelection": {
+                            "type": "boolean"
+                          },
+                          "todoList": {
+                            "nullable": true,
+                            "anyOf": [
+                              {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "enum": [
+                                      null
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "additionalProperties": {}
+                              },
+                              {
+                                "type": "array",
+                                "items": {}
+                              }
+                            ]
+                          },
+                          "artifact": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "pinnedAt": {
+                            "nullable": true,
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "agent": {
+                            "nullable": true,
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "systemPrompt": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "agentType": {
+                                "type": "string",
+                                "enum": [
+                                  "profile",
+                                  "mcp_gateway",
+                                  "llm_proxy",
+                                  "agent"
+                                ]
+                              },
+                              "llmApiKeyId": {
+                                "nullable": true,
+                                "type": "string"
+                              }
                             },
-                            "conversationId": {
-                              "type": "string",
-                              "format": "uuid",
-                              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                            "required": [
+                              "id",
+                              "name",
+                              "systemPrompt",
+                              "agentType",
+                              "llmApiKeyId"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "share": {
+                            "nullable": true,
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid",
+                                "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                              },
+                              "visibility": {
+                                "type": "string",
+                                "enum": [
+                                  "organization",
+                                  "team",
+                                  "user"
+                                ]
+                              }
                             },
-                            "error": {
+                            "required": [
+                              "id",
+                              "visibility"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "messages": {
+                            "type": "array",
+                            "items": {}
+                          },
+                          "chatErrors": {
+                            "type": "array",
+                            "items": {
                               "type": "object",
                               "properties": {
-                                "code": {
+                                "id": {
                                   "type": "string",
-                                  "enum": [
-                                    "rate_limit",
-                                    "authentication",
-                                    "permission_denied",
-                                    "invalid_request",
-                                    "not_found",
-                                    "context_too_long",
-                                    "content_filtered",
-                                    "server_error",
-                                    "network_error",
-                                    "unknown"
-                                  ]
+                                  "format": "uuid",
+                                  "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
                                 },
-                                "message": {
-                                  "type": "string"
+                                "conversationId": {
+                                  "type": "string",
+                                  "format": "uuid",
+                                  "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
                                 },
-                                "isRetryable": {
-                                  "type": "boolean"
-                                },
-                                "sessionId": {
-                                  "type": "string"
-                                },
-                                "traceId": {
-                                  "type": "string"
-                                },
-                                "spanId": {
-                                  "type": "string"
-                                },
-                                "originalError": {
+                                "error": {
                                   "type": "object",
                                   "properties": {
-                                    "provider": {
+                                    "code": {
                                       "type": "string",
                                       "enum": [
-                                        "openai",
-                                        "gemini",
-                                        "anthropic",
-                                        "bedrock",
-                                        "cohere",
-                                        "cerebras",
-                                        "mistral",
-                                        "perplexity",
-                                        "groq",
-                                        "xai",
-                                        "openrouter",
-                                        "vllm",
-                                        "ollama",
-                                        "zhipuai",
-                                        "deepseek",
-                                        "minimax",
-                                        "azure"
+                                        "rate_limit",
+                                        "authentication",
+                                        "permission_denied",
+                                        "invalid_request",
+                                        "not_found",
+                                        "context_too_long",
+                                        "content_filtered",
+                                        "server_error",
+                                        "network_error",
+                                        "unknown"
                                       ]
-                                    },
-                                    "status": {
-                                      "type": "number"
                                     },
                                     "message": {
                                       "type": "string"
                                     },
-                                    "type": {
+                                    "isRetryable": {
+                                      "type": "boolean"
+                                    },
+                                    "sessionId": {
                                       "type": "string"
                                     },
-                                    "raw": {}
+                                    "traceId": {
+                                      "type": "string"
+                                    },
+                                    "spanId": {
+                                      "type": "string"
+                                    },
+                                    "originalError": {
+                                      "type": "object",
+                                      "properties": {
+                                        "provider": {
+                                          "type": "string",
+                                          "enum": [
+                                            "openai",
+                                            "gemini",
+                                            "anthropic",
+                                            "bedrock",
+                                            "cohere",
+                                            "cerebras",
+                                            "mistral",
+                                            "perplexity",
+                                            "groq",
+                                            "xai",
+                                            "openrouter",
+                                            "vllm",
+                                            "ollama",
+                                            "zhipuai",
+                                            "deepseek",
+                                            "minimax",
+                                            "azure"
+                                          ]
+                                        },
+                                        "status": {
+                                          "type": "number"
+                                        },
+                                        "message": {
+                                          "type": "string"
+                                        },
+                                        "type": {
+                                          "type": "string"
+                                        },
+                                        "raw": {}
+                                      },
+                                      "additionalProperties": false
+                                    }
                                   },
+                                  "required": [
+                                    "code",
+                                    "message",
+                                    "isRetryable"
+                                  ],
                                   "additionalProperties": false
+                                },
+                                "createdAt": {
+                                  "type": "string",
+                                  "format": "date-time"
                                 }
                               },
                               "required": [
-                                "code",
-                                "message",
-                                "isRetryable"
+                                "id",
+                                "conversationId",
+                                "error",
+                                "createdAt"
                               ],
                               "additionalProperties": false
-                            },
-                            "createdAt": {
-                              "type": "string",
-                              "format": "date-time"
                             }
-                          },
-                          "required": [
-                            "id",
-                            "conversationId",
-                            "error",
-                            "createdAt"
-                          ],
-                          "additionalProperties": false
-                        }
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "userId",
+                          "organizationId",
+                          "agentId",
+                          "chatApiKeyId",
+                          "title",
+                          "selectedModel",
+                          "selectedProvider",
+                          "hasCustomToolSelection",
+                          "todoList",
+                          "artifact",
+                          "pinnedAt",
+                          "createdAt",
+                          "updatedAt",
+                          "agent",
+                          "share",
+                          "messages",
+                          "chatErrors"
+                        ],
+                        "additionalProperties": false
                       }
                     },
-                    "required": [
-                      "id",
-                      "userId",
-                      "organizationId",
-                      "agentId",
-                      "chatApiKeyId",
-                      "title",
-                      "selectedModel",
-                      "selectedProvider",
-                      "hasCustomToolSelection",
-                      "todoList",
-                      "artifact",
-                      "pinnedAt",
-                      "createdAt",
-                      "updatedAt",
-                      "agent",
-                      "share",
-                      "messages",
-                      "chatErrors"
-                    ],
-                    "additionalProperties": false
-                  }
+                    "pagination": {
+                      "type": "object",
+                      "properties": {
+                        "currentPage": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 9007199254740991
+                        },
+                        "limit": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 9007199254740991
+                        },
+                        "total": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
+                        },
+                        "totalPages": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
+                        },
+                        "hasNext": {
+                          "type": "boolean"
+                        },
+                        "hasPrev": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "currentPage",
+                        "limit",
+                        "total",
+                        "totalPages",
+                        "hasNext",
+                        "hasPrev"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "pagination"
+                  ],
+                  "additionalProperties": false
                 }
               }
             }

--- a/platform/backend/src/models/conversation.test.ts
+++ b/platform/backend/src/models/conversation.test.ts
@@ -164,6 +164,136 @@ describe("ConversationModel", () => {
     expect(conversations.every((c) => Array.isArray(c.messages))).toBe(true);
   });
 
+  test("findAllPaginated returns pagination metadata", async ({
+    makeUser,
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const user = await makeUser();
+    const org = await makeOrganization();
+    const agent = await makeAgent({ name: "Paginated Agent", teams: [] });
+
+    await ConversationModel.create({
+      userId: user.id,
+      organizationId: org.id,
+      agentId: agent.id,
+      title: "First",
+      selectedModel: "claude-3-haiku-20240307",
+    });
+    await ConversationModel.create({
+      userId: user.id,
+      organizationId: org.id,
+      agentId: agent.id,
+      title: "Second",
+      selectedModel: "claude-3-haiku-20240307",
+    });
+
+    const result = await ConversationModel.findAllPaginated({
+      userId: user.id,
+      organizationId: org.id,
+      pagination: { limit: 1, offset: 0 },
+    });
+
+    expect(result.data).toHaveLength(1);
+    expect(result.pagination).toEqual({
+      currentPage: 1,
+      limit: 1,
+      total: 2,
+      totalPages: 2,
+      hasNext: true,
+      hasPrev: false,
+    });
+  });
+
+  test("findAllPaginated filters pinned conversations", async ({
+    makeUser,
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const user = await makeUser();
+    const org = await makeOrganization();
+    const agent = await makeAgent({ name: "Pinned Filter Agent", teams: [] });
+
+    const pinned = await ConversationModel.create({
+      userId: user.id,
+      organizationId: org.id,
+      agentId: agent.id,
+      title: "Pinned",
+      selectedModel: "claude-3-haiku-20240307",
+    });
+    const unpinned = await ConversationModel.create({
+      userId: user.id,
+      organizationId: org.id,
+      agentId: agent.id,
+      title: "Unpinned",
+      selectedModel: "claude-3-haiku-20240307",
+    });
+
+    await ConversationModel.update(pinned.id, user.id, org.id, {
+      pinnedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    const pinnedResult = await ConversationModel.findAllPaginated({
+      userId: user.id,
+      organizationId: org.id,
+      pagination: { limit: 10, offset: 0 },
+      pinned: true,
+    });
+    const unpinnedResult = await ConversationModel.findAllPaginated({
+      userId: user.id,
+      organizationId: org.id,
+      pagination: { limit: 10, offset: 0 },
+      pinned: false,
+    });
+
+    expect(pinnedResult.data.map((conversation) => conversation.id)).toEqual([
+      pinned.id,
+    ]);
+    expect(unpinnedResult.data.map((conversation) => conversation.id)).toEqual([
+      unpinned.id,
+    ]);
+  });
+
+  test("findAllPaginated sorts pinned conversations first when pinned filter is omitted", async ({
+    makeUser,
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const user = await makeUser();
+    const org = await makeOrganization();
+    const agent = await makeAgent({ name: "Pinned Sort Agent", teams: [] });
+
+    const pinned = await ConversationModel.create({
+      userId: user.id,
+      organizationId: org.id,
+      agentId: agent.id,
+      title: "Older Pinned",
+      selectedModel: "claude-3-haiku-20240307",
+    });
+    const recent = await ConversationModel.create({
+      userId: user.id,
+      organizationId: org.id,
+      agentId: agent.id,
+      title: "Newer Unpinned",
+      selectedModel: "claude-3-haiku-20240307",
+    });
+
+    await ConversationModel.update(pinned.id, user.id, org.id, {
+      pinnedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    const result = await ConversationModel.findAllPaginated({
+      userId: user.id,
+      organizationId: org.id,
+      pagination: { limit: 2, offset: 0 },
+    });
+
+    expect(result.data.map((conversation) => conversation.id)).toEqual([
+      pinned.id,
+      recent.id,
+    ]);
+  });
+
   test("can update a conversation", async ({
     makeUser,
     makeOrganization,
@@ -1231,6 +1361,58 @@ describe("ConversationModel", () => {
     expect(Array.isArray(results[0].messages)).toBe(true);
     expect(results[0].messages.length).toBeGreaterThan(0);
     expect(results[0].messages[0].parts[0].text).toBe("Python tutorial");
+  });
+
+  test("findAllPaginated only includes preview messages when requested", async ({
+    makeUser,
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const user = await makeUser();
+    const org = await makeOrganization();
+    const agent = await makeAgent({
+      name: "Preview Toggle Agent",
+      teams: [],
+    });
+
+    const conversation = await ConversationModel.create({
+      userId: user.id,
+      organizationId: org.id,
+      agentId: agent.id,
+      title: "Preview Test Conversation",
+      selectedModel: "claude-3-haiku-20240307",
+    });
+
+    await MessageModel.create({
+      conversationId: conversation.id,
+      role: "user",
+      content: {
+        id: "temp-preview",
+        role: "user",
+        parts: [{ type: "text", text: "Python preview content" }],
+      },
+    });
+
+    const withoutPreview = await ConversationModel.findAllPaginated({
+      userId: user.id,
+      organizationId: org.id,
+      pagination: { limit: 10, offset: 0 },
+      searchQuery: "Python",
+      includePreviewMessages: false,
+    });
+    const withPreview = await ConversationModel.findAllPaginated({
+      userId: user.id,
+      organizationId: org.id,
+      pagination: { limit: 10, offset: 0 },
+      searchQuery: "Python",
+      includePreviewMessages: true,
+    });
+
+    expect(withoutPreview.data[0].messages).toEqual([]);
+    expect(withPreview.data[0].messages).toHaveLength(1);
+    expect(withPreview.data[0].messages[0].parts[0].text).toBe(
+      "Python preview content",
+    );
   });
 
   test("findAll without search query returns empty messages arrays", async ({

--- a/platform/backend/src/models/conversation.ts
+++ b/platform/backend/src/models/conversation.ts
@@ -1,14 +1,23 @@
+import type { PaginationQuery } from "@shared";
 import {
   and,
+  count,
   desc,
   eq,
   getTableColumns,
   ilike,
+  inArray,
   isNotNull,
+  isNull,
   or,
+  type SQL,
   sql,
 } from "drizzle-orm";
 import db, { schema } from "@/database";
+import {
+  createPaginatedResult,
+  type PaginatedResult,
+} from "@/database/utils/pagination";
 import type {
   Conversation,
   InsertConversation,
@@ -38,59 +47,72 @@ class ConversationModel {
   }
 
   /**
-   * Maximum number of conversations to return in search results.
-   * Prevents unbounded result sets for common search terms.
-   */
-  private static readonly SEARCH_RESULT_LIMIT = 50;
-
-  /**
    * Maximum number of messages to load per conversation for preview snippets.
    * Prevents memory issues with conversations that have hundreds of messages.
    */
   private static readonly MESSAGES_PER_CONVERSATION_LIMIT = 10;
 
-  /**
-   * Get all conversations for a user without messages.
-   * Messages are fetched separately via findById when a conversation is opened.
-   * This significantly improves performance for the conversations list.
-   *
-   * When searching, a limited number of messages ARE included to enable preview snippets.
-   * Search results are also limited to prevent unbounded result sets.
-   *
-   * Note: Title search uses the conversations_title_trgm_idx index (created in 0116).
-   * Message content search uses the messages_content_trgm_idx index (created in 0117).
-   *
-   * @param searchQuery - Optional search string to filter conversations by title or message content
-   */
   static async findAll(
     userId: string,
     organizationId: string,
     searchQuery?: string,
   ): Promise<Conversation[]> {
-    const trimmedSearch = searchQuery?.trim();
+    const result = await ConversationModel.findAllPaginated({
+      userId,
+      organizationId,
+      pagination: { limit: 100, offset: 0 },
+      searchQuery,
+      includePreviewMessages: !!searchQuery?.trim(),
+    });
 
-    // Build WHERE conditions
-    const conditions = [
+    return result.data;
+  }
+
+  /**
+   * Get paginated conversations for a user.
+   * Messages are excluded by default and fetched only for preview snippets.
+   *
+   * Note: Title search uses the conversations_title_trgm_idx index (created in 0116).
+   * Message content search uses the messages_content_trgm_idx index (created in 0117).
+   */
+  static async findAllPaginated(params: {
+    userId: string;
+    organizationId: string;
+    pagination: PaginationQuery;
+    searchQuery?: string;
+    includePreviewMessages?: boolean;
+    pinned?: boolean;
+  }): Promise<PaginatedResult<Conversation>> {
+    const {
+      userId,
+      organizationId,
+      pagination,
+      searchQuery,
+      includePreviewMessages = false,
+      pinned,
+    } = params;
+    const trimmedSearch = searchQuery?.trim();
+    const searchPattern = trimmedSearch
+      ? `%${escapeLikePattern(trimmedSearch)}%`
+      : undefined;
+
+    const conditions: SQL[] = [
       eq(schema.conversationsTable.userId, userId),
       eq(schema.conversationsTable.organizationId, organizationId),
     ];
 
-    // Add search filter if provided
-    if (trimmedSearch) {
-      // Escape LIKE special characters (%, _, \) to prevent unexpected pattern matching
-      const escapedSearch = escapeLikePattern(trimmedSearch);
-      const searchPattern = `%${escapedSearch}%`;
+    if (pinned === true) {
+      conditions.push(isNotNull(schema.conversationsTable.pinnedAt));
+    } else if (pinned === false) {
+      conditions.push(isNull(schema.conversationsTable.pinnedAt));
+    }
 
-      // 1. Conversation title (text column) - uses conversations_title_trgm_idx
-      // 2. Message content (JSONB cast to text) - uses messages_content_trgm_idx
+    if (searchPattern) {
       const searchConditions = or(
-        // Search in title (handles null titles gracefully)
         and(
           isNotNull(schema.conversationsTable.title),
           ilike(schema.conversationsTable.title, searchPattern),
         ),
-        // Search through messages JSONB content
-        // Uses EXISTS for early termination
         sql`EXISTS (
           SELECT 1 FROM ${schema.messagesTable}
           WHERE ${schema.messagesTable.conversationId} = ${schema.conversationsTable.id}
@@ -103,18 +125,19 @@ class ConversationModel {
       }
     }
 
-    // Include messages only during search for preview snippets
-    if (trimmedSearch) {
-      // Escape search pattern for message subquery
-      const escapedSearch = escapeLikePattern(trimmedSearch);
-      const searchPattern = `%${escapedSearch}%`;
+    const whereClause = and(...conditions);
+    const orderByClause =
+      pinned === undefined
+        ? [
+            sql`CASE WHEN ${schema.conversationsTable.pinnedAt} IS NOT NULL THEN 0 ELSE 1 END`,
+            desc(schema.conversationsTable.updatedAt),
+          ]
+        : [desc(schema.conversationsTable.updatedAt)];
 
-      // Use a lateral join to limit messages per conversation for preview
-      // This prevents loading hundreds of messages for conversations with long histories
-      const rows = await db
+    const [rows, totalResult] = await Promise.all([
+      db
         .select({
           conversation: getTableColumns(schema.conversationsTable),
-          message: getTableColumns(schema.messagesTable),
           share: {
             id: schema.conversationSharesTable.id,
             visibility: schema.conversationSharesTable.visibility,
@@ -133,119 +156,48 @@ class ConversationModel {
           eq(schema.conversationsTable.agentId, schema.agentsTable.id),
         )
         .leftJoin(
-          schema.messagesTable,
-          and(
-            eq(
-              schema.conversationsTable.id,
-              schema.messagesTable.conversationId,
-            ),
-            // Only include messages that match the search pattern (for relevance)
-            // or the first few messages (for context)
-            sql`(
-              ${schema.messagesTable.content}::text ILIKE ${searchPattern}
-              OR ${schema.messagesTable.id} IN (
-                SELECT m.id FROM ${schema.messagesTable} m
-                WHERE m.conversation_id = ${schema.conversationsTable.id}
-                ORDER BY m.created_at
-                LIMIT ${ConversationModel.MESSAGES_PER_CONVERSATION_LIMIT}
-              )
-            )`,
-          ),
-        )
-        .leftJoin(
           schema.conversationSharesTable,
           eq(
             schema.conversationsTable.id,
             schema.conversationSharesTable.conversationId,
           ),
         )
-        .where(and(...conditions))
-        .orderBy(
-          desc(schema.conversationsTable.updatedAt),
-          schema.messagesTable.createdAt,
-        )
-        .limit(
-          ConversationModel.SEARCH_RESULT_LIMIT *
-            ConversationModel.MESSAGES_PER_CONVERSATION_LIMIT,
-        );
+        .where(whereClause)
+        .orderBy(...orderByClause)
+        .limit(pagination.limit)
+        .offset(pagination.offset),
+      db
+        .select({ count: count() })
+        .from(schema.conversationsTable)
+        .where(whereClause),
+    ]);
 
-      // Group messages by conversation
-      const conversationMap = new Map<string, Conversation>();
+    const conversations: Conversation[] = rows.map((row) => ({
+      ...row.conversation,
+      agent: row.agent,
+      share: row.share?.id ? row.share : null,
+      messages: [],
+      chatErrors: [],
+    }));
 
-      for (const row of rows) {
-        const conversationId = row.conversation.id;
+    if (includePreviewMessages && conversations.length > 0) {
+      const messagesByConversationId =
+        await ConversationModel.findPreviewMessagesByConversationIds({
+          conversationIds: conversations.map((conversation) => conversation.id),
+          searchPattern,
+        });
 
-        if (!conversationMap.has(conversationId)) {
-          // Stop adding new conversations if we've reached the limit
-          if (conversationMap.size >= ConversationModel.SEARCH_RESULT_LIMIT) {
-            continue;
-          }
-          conversationMap.set(conversationId, {
-            ...row.conversation,
-            agent: row.agent,
-            share: row.share?.id ? row.share : null,
-            messages: [],
-            chatErrors: [],
-          });
-        }
-
-        const conversation = conversationMap.get(conversationId);
-        if (conversation && row?.message?.content) {
-          // Limit messages per conversation for preview
-          if (
-            conversation.messages.length <
-            ConversationModel.MESSAGES_PER_CONVERSATION_LIMIT
-          ) {
-            // Merge database UUID into message content
-            conversation.messages.push({
-              ...row.message.content,
-              id: row.message.id,
-            });
-          }
-        }
+      for (const conversation of conversations) {
+        conversation.messages =
+          messagesByConversationId.get(conversation.id) ?? [];
       }
-
-      return Array.from(conversationMap.values());
-    } else {
-      // Non-search case: exclude messages for performance
-      const rows = await db
-        .select({
-          conversation: getTableColumns(schema.conversationsTable),
-          share: {
-            id: schema.conversationSharesTable.id,
-            visibility: schema.conversationSharesTable.visibility,
-          },
-          agent: {
-            id: schema.agentsTable.id,
-            name: schema.agentsTable.name,
-            systemPrompt: schema.agentsTable.systemPrompt,
-            agentType: schema.agentsTable.agentType,
-            llmApiKeyId: schema.agentsTable.llmApiKeyId,
-          },
-        })
-        .from(schema.conversationsTable)
-        .leftJoin(
-          schema.agentsTable,
-          eq(schema.conversationsTable.agentId, schema.agentsTable.id),
-        )
-        .leftJoin(
-          schema.conversationSharesTable,
-          eq(
-            schema.conversationsTable.id,
-            schema.conversationSharesTable.conversationId,
-          ),
-        )
-        .where(and(...conditions))
-        .orderBy(desc(schema.conversationsTable.updatedAt));
-
-      return rows.map((row) => ({
-        ...row.conversation,
-        agent: row.agent,
-        share: row.share?.id ? row.share : null,
-        messages: [], // Messages fetched separately via findById
-        chatErrors: [],
-      }));
     }
+
+    return createPaginatedResult(
+      conversations,
+      totalResult[0]?.count ?? 0,
+      pagination,
+    );
   }
 
   static async findById({
@@ -504,6 +456,72 @@ class ConversationModel {
       .limit(1);
 
     return result[0]?.agentId ?? null;
+  }
+
+  private static async findPreviewMessagesByConversationIds({
+    conversationIds,
+    searchPattern,
+  }: {
+    conversationIds: string[];
+    searchPattern?: string;
+  }): Promise<Map<string, Conversation["messages"]>> {
+    if (conversationIds.length === 0) {
+      return new Map();
+    }
+
+    const firstMessagesCondition = sql`${schema.messagesTable.id} IN (
+      SELECT m.id FROM messages m
+      WHERE m.conversation_id = ${schema.messagesTable.conversationId}
+      ORDER BY m.created_at
+      LIMIT ${ConversationModel.MESSAGES_PER_CONVERSATION_LIMIT}
+    )`;
+
+    const previewCondition = searchPattern
+      ? or(
+          sql`${schema.messagesTable.content}::text ILIKE ${searchPattern}`,
+          firstMessagesCondition,
+        )
+      : firstMessagesCondition;
+
+    const rows = await db
+      .select({
+        id: schema.messagesTable.id,
+        conversationId: schema.messagesTable.conversationId,
+        content: schema.messagesTable.content,
+      })
+      .from(schema.messagesTable)
+      .where(
+        and(
+          inArray(schema.messagesTable.conversationId, conversationIds),
+          previewCondition,
+        ),
+      )
+      .orderBy(
+        schema.messagesTable.conversationId,
+        schema.messagesTable.createdAt,
+      );
+
+    const messagesByConversationId = new Map<
+      string,
+      Conversation["messages"]
+    >();
+
+    for (const row of rows) {
+      const messages = messagesByConversationId.get(row.conversationId) ?? [];
+      if (
+        messages.length >= ConversationModel.MESSAGES_PER_CONVERSATION_LIMIT
+      ) {
+        continue;
+      }
+
+      messages.push({
+        ...row.content,
+        id: row.id,
+      });
+      messagesByConversationId.set(row.conversationId, messages);
+    }
+
+    return messagesByConversationId;
   }
 }
 

--- a/platform/backend/src/routes/chat/conversation-routes.test.ts
+++ b/platform/backend/src/routes/chat/conversation-routes.test.ts
@@ -64,6 +64,53 @@ describe("chat conversation and message routes", () => {
     });
   });
 
+  test("lists conversations with pagination and pinned filtering", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent({
+      organizationId,
+      authorId: currentUser.id,
+      scope: "personal",
+    });
+    const pinned = await ConversationModel.create({
+      userId: currentUser.id,
+      organizationId,
+      agentId: agent.id,
+      title: "Pinned chat",
+      selectedModel: "gpt-4o",
+      selectedProvider: "openai",
+    });
+    await ConversationModel.create({
+      userId: currentUser.id,
+      organizationId,
+      agentId: agent.id,
+      title: "Recent chat",
+      selectedModel: "gpt-4o",
+      selectedProvider: "openai",
+    });
+    await ConversationModel.update(pinned.id, currentUser.id, organizationId, {
+      pinnedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/chat/conversations?limit=10&offset=0&pinned=false",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      data: [{ title: "Recent chat", pinnedAt: null, messages: [] }],
+      pagination: {
+        currentPage: 1,
+        limit: 10,
+        total: 1,
+        totalPages: 1,
+        hasNext: false,
+        hasPrev: false,
+      },
+    });
+  });
+
   test("pins and unpins a conversation", async ({ makeAgent }) => {
     const agent = await makeAgent({
       organizationId,

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -1,7 +1,9 @@
 import {
   buildUserSystemPromptContext,
   type ChatErrorResponse,
+  createPaginatedResponseSchema,
   isSupportedProvider,
+  PaginationQuerySchema,
   RouteId,
   type SupportedProvider,
   TimeInMs,
@@ -116,6 +118,12 @@ function getMinimalFrontendError(errorForFrontend: ChatErrorResponse) {
     ...(errorForFrontend.spanId ? { spanId: errorForFrontend.spanId } : {}),
   };
 }
+
+const BooleanQuerySchema = z.preprocess((value) => {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return value;
+}, z.boolean());
 
 const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
   fastify.post(
@@ -876,20 +884,30 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
         description:
           "List all conversations for current user with agent details. Optionally filter by search query.",
         tags: ["Chat"],
-        querystring: z.object({
-          search: z.string().optional(),
-        }),
-        response: constructResponseSchema(z.array(SelectConversationSchema)),
+        querystring: z
+          .object({
+            search: z.string().optional(),
+            includePreviewMessages: BooleanQuerySchema.default(false),
+            pinned: BooleanQuerySchema.optional(),
+          })
+          .merge(PaginationQuerySchema),
+        response: constructResponseSchema(
+          createPaginatedResponseSchema(SelectConversationSchema),
+        ),
       },
     },
     async (request, reply) => {
-      const { search } = request.query;
+      const { search, includePreviewMessages, pinned, limit, offset } =
+        request.query;
       return reply.send(
-        await ConversationModel.findAll(
-          request.user.id,
-          request.organizationId,
-          search,
-        ),
+        await ConversationModel.findAllPaginated({
+          userId: request.user.id,
+          organizationId: request.organizationId,
+          pagination: { limit, offset },
+          searchQuery: search,
+          includePreviewMessages,
+          pinned,
+        }),
       );
     },
   );

--- a/platform/frontend/src/app/_parts/chat-sidebar-section.test.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.test.tsx
@@ -8,7 +8,10 @@ global.ResizeObserver = vi.fn().mockImplementation(() => ({
   disconnect: vi.fn(),
 }));
 
-const mockRouterPush = vi.fn();
+const { mockRouterPush, mockUseConversations } = vi.hoisted(() => ({
+  mockRouterPush: vi.fn(),
+  mockUseConversations: vi.fn(),
+}));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockRouterPush }),
@@ -50,10 +53,7 @@ let mockConversations: Array<{
 }> = [];
 
 vi.mock("@/lib/chat/chat.query", () => ({
-  useConversations: () => ({
-    data: mockConversations,
-    isLoading: false,
-  }),
+  useConversations: mockUseConversations,
   useUpdateConversation: () => ({ mutateAsync: vi.fn() }),
   useDeleteConversation: () => ({
     mutateAsync: vi.fn(),
@@ -175,10 +175,49 @@ function makeConv(
   };
 }
 
+function makeConversationsResponse(
+  conversations: typeof mockConversations,
+  limit: number,
+  total = conversations.length,
+) {
+  return {
+    data: conversations,
+    pagination: {
+      currentPage: 1,
+      limit,
+      total,
+      totalPages: total > 0 ? Math.ceil(total / limit) : 0,
+      hasNext: conversations.length < total,
+      hasPrev: false,
+    },
+  };
+}
+
 describe("ChatSidebarSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockConversations = [];
+    mockUseConversations.mockImplementation(
+      ({ pinned, limit }: { pinned?: boolean; limit: number }) => {
+        const filteredConversations =
+          pinned === true
+            ? mockConversations.filter((conversation) => conversation.pinnedAt)
+            : pinned === false
+              ? mockConversations.filter(
+                  (conversation) => !conversation.pinnedAt,
+                )
+              : mockConversations;
+
+        return {
+          data: makeConversationsResponse(
+            filteredConversations.slice(0, limit),
+            limit,
+            filteredConversations.length,
+          ),
+          isLoading: false,
+        };
+      },
+    );
   });
 
   it("does not render when no conversations exist", () => {
@@ -207,11 +246,38 @@ describe("ChatSidebarSection", () => {
     expect(screen.queryByText("Chat Four")).not.toBeInTheDocument();
     expect(screen.queryByText("Chat Five")).not.toBeInTheDocument();
 
-    // Should show "More" to open search
     expect(screen.getByText("More")).toBeInTheDocument();
   });
 
-  it("shows only pinned chats when 3 are pinned (no recent unpinned)", () => {
+  it("loads pinned and recent chats with separate optimized queries", () => {
+    mockConversations = [
+      makeConv("c1", "Pinned One", {
+        pinnedAt: "2026-01-05T00:00:00Z",
+      }),
+      makeConv("c2", "Recent One"),
+    ];
+
+    render(<ChatSidebarSection />);
+
+    expect(mockUseConversations).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: 100,
+        offset: 0,
+        pinned: true,
+        includePreviewMessages: false,
+      }),
+    );
+    expect(mockUseConversations).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: 3,
+        offset: 0,
+        pinned: false,
+        includePreviewMessages: false,
+      }),
+    );
+  });
+
+  it("shows pinned chats plus recent unpinned chats", () => {
     mockConversations = [
       makeConv("c1", "Pinned One", {
         pinnedAt: "2026-01-05T00:00:00Z",
@@ -235,14 +301,12 @@ describe("ChatSidebarSection", () => {
     expect(screen.getByText("Pinned Two")).toBeInTheDocument();
     expect(screen.getByText("Pinned Three")).toBeInTheDocument();
 
-    // Unpinned should NOT show (all 3 slots taken by pinned)
-    expect(screen.queryByText("Unpinned One")).not.toBeInTheDocument();
+    expect(screen.getByText("Unpinned One")).toBeInTheDocument();
 
-    // Should show "More" to open search
-    expect(screen.getByText("More")).toBeInTheDocument();
+    expect(screen.queryByText("More")).not.toBeInTheDocument();
   });
 
-  it("fills remaining slots with recent chats when fewer than 3 are pinned", () => {
+  it("shows up to 3 recent chats in addition to pinned chats", () => {
     mockConversations = [
       makeConv("c1", "Pinned Chat", {
         pinnedAt: "2026-01-05T00:00:00Z",
@@ -255,19 +319,15 @@ describe("ChatSidebarSection", () => {
 
     render(<ChatSidebarSection />);
 
-    // 1 pinned + 2 recent = 3 total
     expect(screen.getByText("Pinned Chat")).toBeInTheDocument();
     expect(screen.getByText("Recent One")).toBeInTheDocument();
     expect(screen.getByText("Recent Two")).toBeInTheDocument();
+    expect(screen.getByText("Recent Three")).toBeInTheDocument();
 
-    // 3rd recent should NOT show (only 2 remaining slots)
-    expect(screen.queryByText("Recent Three")).not.toBeInTheDocument();
-
-    // Should show "More" to open search
-    expect(screen.getByText("More")).toBeInTheDocument();
+    expect(screen.queryByText("More")).not.toBeInTheDocument();
   });
 
-  it("shows 2 pinned + 1 recent when 2 are pinned", () => {
+  it("shows 2 pinned + up to 3 recent", () => {
     mockConversations = [
       makeConv("c1", "Pinned A", {
         pinnedAt: "2026-01-05T00:00:00Z",
@@ -283,13 +343,10 @@ describe("ChatSidebarSection", () => {
 
     render(<ChatSidebarSection />);
 
-    // 2 pinned + 1 recent = 3 total
     expect(screen.getByText("Pinned A")).toBeInTheDocument();
     expect(screen.getByText("Pinned B")).toBeInTheDocument();
     expect(screen.getByText("Recent A")).toBeInTheDocument();
-
-    // 2nd recent should not show
-    expect(screen.queryByText("Recent B")).not.toBeInTheDocument();
+    expect(screen.getByText("Recent B")).toBeInTheDocument();
   });
 
   it("does not show 'More' when total conversations fit in slots", () => {

--- a/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
@@ -52,7 +52,8 @@ import {
 import { useStableConversations } from "@/lib/hooks/use-stable-conversations";
 import { cn } from "@/lib/utils";
 
-const SIDEBAR_CHAT_SLOTS = 3;
+const SIDEBAR_PINNED_LIMIT = 100;
+const SIDEBAR_RECENT_LIMIT = 3;
 const MAX_TITLE_LENGTH = 100;
 
 function AISparkleIcon({ isAnimating = false }: { isAnimating?: boolean }) {
@@ -71,9 +72,43 @@ export function ChatSidebarSection() {
   const { data: canReadConversation } = useHasPermissions({
     chat: ["read"],
   });
-  const { data: conversations = [], isLoading } = useConversations({
-    enabled: isAuthenticated && canReadConversation === true,
-  });
+  const conversationsQueryEnabled =
+    isAuthenticated && canReadConversation === true;
+  const { data: pinnedConversationsResponse, isLoading: isLoadingPinned } =
+    useConversations({
+      enabled: conversationsQueryEnabled,
+      limit: SIDEBAR_PINNED_LIMIT,
+      offset: 0,
+      pinned: true,
+      includePreviewMessages: false,
+    });
+  const { data: recentConversationsResponse, isLoading: isLoadingRecent } =
+    useConversations({
+      enabled: conversationsQueryEnabled,
+      limit: SIDEBAR_RECENT_LIMIT,
+      offset: 0,
+      pinned: false,
+      includePreviewMessages: false,
+    });
+  const pinnedConversations = pinnedConversationsResponse?.data ?? [];
+  const recentConversations = recentConversationsResponse?.data ?? [];
+  const isLoading = isLoadingPinned || isLoadingRecent;
+  const conversations = useMemo(() => {
+    const seenIds = new Set<string>();
+    return [...pinnedConversations, ...recentConversations].filter(
+      (conversation) => {
+        if (seenIds.has(conversation.id)) {
+          return false;
+        }
+        seenIds.add(conversation.id);
+        return true;
+      },
+    );
+  }, [pinnedConversations, recentConversations]);
+  const hasMoreConversations =
+    !!pinnedConversationsResponse?.pagination.hasNext ||
+    (recentConversationsResponse?.pagination.total ?? 0) >
+      recentConversations.length;
   const updateConversationMutation = useUpdateConversation();
   const deleteConversationMutation = useDeleteConversation();
   const generateTitleMutation = useGenerateConversationTitle();
@@ -106,23 +141,16 @@ export function ChatSidebarSection() {
   // re-fetches after mutations that bump updatedAt. Order resets on page refresh.
   const stableConversations = useStableConversations(conversations);
 
-  // Split conversations into pinned and unpinned.
-  // Default view shows exactly SIDEBAR_CHAT_SLOTS items:
-  // pinned chats first, then recent unpinned to fill remaining slots.
-  // No re-sorting here — stable order from useStableConversations is preserved
-  // for both pinned and unpinned groups to prevent jumping.
+  // Split conversations into pinned and recent unpinned groups while preserving
+  // the stable order from useStableConversations to prevent sidebar jumping.
   const { pinnedChats, recentUnpinnedChats } = useMemo(() => {
-    const pinned = stableConversations
-      .filter((c) => c.pinnedAt)
-      .slice(0, SIDEBAR_CHAT_SLOTS);
-
+    const pinned = stableConversations.filter((c) => c.pinnedAt);
     const pinnedIds = new Set(pinned.map((c) => c.id));
     const unpinned = stableConversations.filter((c) => !pinnedIds.has(c.id));
-    const remainingSlots = Math.max(0, SIDEBAR_CHAT_SLOTS - pinned.length);
 
     return {
       pinnedChats: pinned,
-      recentUnpinnedChats: unpinned.slice(0, remainingSlots),
+      recentUnpinnedChats: unpinned,
     };
   }, [stableConversations]);
 
@@ -415,8 +443,7 @@ export function ChatSidebarSection() {
           <>
             {pinnedChats.map((conv) => renderConversationItem(conv, true))}
             {recentUnpinnedChats.map((conv) => renderConversationItem(conv))}
-            {conversations.length >
-              pinnedChats.length + recentUnpinnedChats.length && (
+            {hasMoreConversations && (
               <SidebarMenuSubItem>
                 <SidebarMenuSubButton
                   className="cursor-pointer text-sidebar-foreground/70"

--- a/platform/frontend/src/components/conversation-search-palette.test.tsx
+++ b/platform/frontend/src/components/conversation-search-palette.test.tsx
@@ -12,12 +12,14 @@ const {
   mockRouterPush,
   mockUsePathname,
   mockDeleteMutate,
-  mockUseConversations,
+  mockUseConversationsInfinite,
+  mockFetchNextPage,
 } = vi.hoisted(() => ({
   mockRouterPush: vi.fn(),
   mockUsePathname: vi.fn(),
   mockDeleteMutate: vi.fn(),
-  mockUseConversations: vi.fn(),
+  mockUseConversationsInfinite: vi.fn(),
+  mockFetchNextPage: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -51,7 +53,7 @@ vi.mock("@/lib/chat/chat-utils", () => ({
 }));
 
 vi.mock("@/lib/chat/chat.query", () => ({
-  useConversations: mockUseConversations,
+  useConversationsInfinite: mockUseConversationsInfinite,
   useDeleteConversation: () => ({
     mutate: mockDeleteMutate,
   }),
@@ -93,8 +95,16 @@ vi.mock("@/components/ui/command", () => ({
       onChange={(e) => onValueChange(e.target.value)}
     />
   ),
-  CommandList: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
+  CommandList: ({
+    children,
+    onScroll,
+  }: {
+    children: React.ReactNode;
+    onScroll?: React.UIEventHandler<HTMLDivElement>;
+  }) => (
+    <div data-testid="command-list" onScroll={onScroll}>
+      {children}
+    </div>
   ),
   CommandEmpty: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
@@ -146,23 +156,40 @@ describe("ConversationSearchPalette", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUsePathname.mockReturnValue("/chat");
-    mockUseConversations.mockReturnValue({
-      data: [
-        {
-          id: "conv-1",
-          title: "First conversation",
-          updatedAt: new Date().toISOString(),
-          messages: [],
-        },
-        {
-          id: "conv-2",
-          title: "Second conversation",
-          updatedAt: new Date().toISOString(),
-          messages: [],
-        },
-      ],
+    mockUseConversationsInfinite.mockReturnValue({
+      data: {
+        pages: [
+          {
+            data: [
+              {
+                id: "conv-1",
+                title: "First conversation",
+                updatedAt: new Date().toISOString(),
+                messages: [],
+              },
+              {
+                id: "conv-2",
+                title: "Second conversation",
+                updatedAt: new Date().toISOString(),
+                messages: [],
+              },
+            ],
+            pagination: {
+              currentPage: 1,
+              limit: 20,
+              total: 2,
+              totalPages: 1,
+              hasNext: false,
+              hasPrev: false,
+            },
+          },
+        ],
+      },
       isLoading: false,
       isFetching: false,
+      hasNextPage: false,
+      fetchNextPage: mockFetchNextPage,
+      isFetchingNextPage: false,
     });
     capturedOnValueChange = null;
   });
@@ -172,13 +199,13 @@ describe("ConversationSearchPalette", () => {
       <ConversationSearchPalette {...defaultProps} open={false} />,
     );
 
-    expect(mockUseConversations).toHaveBeenLastCalledWith(
+    expect(mockUseConversationsInfinite).toHaveBeenLastCalledWith(
       expect.objectContaining({ enabled: false }),
     );
 
     rerender(<ConversationSearchPalette {...defaultProps} open={true} />);
 
-    expect(mockUseConversations).toHaveBeenLastCalledWith(
+    expect(mockUseConversationsInfinite).toHaveBeenLastCalledWith(
       expect.objectContaining({ enabled: true }),
     );
   });
@@ -188,6 +215,80 @@ describe("ConversationSearchPalette", () => {
 
     expect(screen.getByText("First conversation")).toBeInTheDocument();
     expect(screen.getByText("Second conversation")).toBeInTheDocument();
+  });
+
+  it("enables preview messages only for searched conversations", () => {
+    render(<ConversationSearchPalette {...defaultProps} />);
+
+    expect(mockUseConversationsInfinite).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        search: "",
+        includePreviewMessages: false,
+      }),
+    );
+
+    fireEvent.change(screen.getByTestId("command-input"), {
+      target: { value: "first" },
+    });
+
+    expect(mockUseConversationsInfinite).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        search: "first",
+        includePreviewMessages: true,
+      }),
+    );
+  });
+
+  it("fetches the next page when scrolling near the bottom", () => {
+    mockUseConversationsInfinite.mockReturnValue({
+      data: {
+        pages: [
+          {
+            data: [
+              {
+                id: "conv-1",
+                title: "First conversation",
+                updatedAt: new Date().toISOString(),
+                messages: [],
+              },
+            ],
+            pagination: {
+              currentPage: 1,
+              limit: 20,
+              total: 30,
+              totalPages: 2,
+              hasNext: true,
+              hasPrev: false,
+            },
+          },
+        ],
+      },
+      isLoading: false,
+      isFetching: false,
+      hasNextPage: true,
+      fetchNextPage: mockFetchNextPage,
+      isFetchingNextPage: false,
+    });
+
+    render(<ConversationSearchPalette {...defaultProps} />);
+
+    const commandList = screen.getByTestId("command-list");
+    Object.defineProperty(commandList, "scrollHeight", {
+      configurable: true,
+      value: 100,
+    });
+    Object.defineProperty(commandList, "scrollTop", {
+      configurable: true,
+      value: 50,
+    });
+    Object.defineProperty(commandList, "clientHeight", {
+      configurable: true,
+      value: 50,
+    });
+
+    fireEvent.scroll(commandList);
+
+    expect(mockFetchNextPage).toHaveBeenCalled();
   });
 
   it("redirects to /chat when deleting the currently viewed conversation", () => {

--- a/platform/frontend/src/components/conversation-search-palette.tsx
+++ b/platform/frontend/src/components/conversation-search-palette.tsx
@@ -46,7 +46,7 @@ import {
 import { useIsAuthenticated } from "@/lib/auth/auth.hook";
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import {
-  useConversations,
+  useConversationsInfinite,
   useDeleteConversation,
   usePinConversation,
 } from "@/lib/chat/chat.query";
@@ -236,13 +236,22 @@ export function ConversationSearchPalette({
 
   // Fetch conversations with backend search
   const {
-    data: conversations = [],
+    data: conversationsPages,
     isLoading,
     isFetching,
-  } = useConversations({
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useConversationsInfinite({
     enabled: open && isAuthenticated && canReadConversation === true,
     search: debouncedSearch,
+    includePreviewMessages: debouncedSearch.trim().length > 0,
+    limit: 20,
   });
+  const conversations = useMemo(
+    () => conversationsPages?.pages.flatMap((page) => page.data) ?? [],
+    [conversationsPages],
+  );
 
   // Show skeleton during typing or initial fetch
   const isSearching = searchQuery.trim().length > 0;
@@ -320,6 +329,19 @@ export function ConversationSearchPalette({
       pinMutation.mutate({ id: conversationId, pinned: !conv.pinnedAt });
     },
     [pinMutation, conversations],
+  );
+
+  const handleListScroll = useCallback(
+    (event: React.UIEvent<HTMLDivElement>) => {
+      const target = event.currentTarget;
+      const remainingScroll =
+        target.scrollHeight - target.scrollTop - target.clientHeight;
+
+      if (remainingScroll < 80 && hasNextPage && !isFetchingNextPage) {
+        fetchNextPage();
+      }
+    },
+    [fetchNextPage, hasNextPage, isFetchingNextPage],
   );
 
   // Keyboard shortcuts for search palette
@@ -511,7 +533,7 @@ export function ConversationSearchPalette({
         value={searchQuery}
         onValueChange={setSearchQuery}
       />
-      <CommandList className="max-h-[500px]">
+      <CommandList className="max-h-[500px]" onScroll={handleListScroll}>
         {isLoading && !isSearching ? (
           <div className="py-6 text-center text-sm text-muted-foreground">
             Loading conversations...
@@ -587,9 +609,16 @@ export function ConversationSearchPalette({
               conversations.length === 0 ? (
                 <CommandEmpty>No conversations found.</CommandEmpty>
               ) : (
-                <CommandGroup heading="Search Results">
-                  {conversations.map((conv) => renderConversationItem(conv))}
-                </CommandGroup>
+                <>
+                  <CommandGroup heading="Search Results">
+                    {conversations.map((conv) => renderConversationItem(conv))}
+                  </CommandGroup>
+                  {isFetchingNextPage && (
+                    <div className="py-3 text-center text-xs text-muted-foreground">
+                      Loading more chats...
+                    </div>
+                  )}
+                </>
               )
             ) : groupedConversations ? (
               <>
@@ -631,6 +660,11 @@ export function ConversationSearchPalette({
                 {conversations.length === 0 && (
                   <div className="py-4 text-center text-sm text-muted-foreground">
                     No recent chats
+                  </div>
+                )}
+                {isFetchingNextPage && (
+                  <div className="py-3 text-center text-xs text-muted-foreground">
+                    Loading more chats...
                   </div>
                 )}
               </>

--- a/platform/frontend/src/lib/chat/chat.query.ts
+++ b/platform/frontend/src/lib/chat/chat.query.ts
@@ -5,7 +5,9 @@ import {
   PLAYWRIGHT_MCP_SERVER_NAME,
 } from "@shared";
 import {
+  type InfiniteData,
   keepPreviousData,
+  useInfiniteQuery,
   useMutation,
   useQuery,
   useQueryClient,
@@ -37,6 +39,75 @@ const {
   bulkAssignTools,
   stopChatStream,
 } = archestraApiSdk;
+
+type ConversationListResponse =
+  archestraApiTypes.GetChatConversationsResponses["200"];
+type ConversationListQuery = NonNullable<
+  archestraApiTypes.GetChatConversationsData["query"]
+>;
+
+function emptyConversationsResponse(limit: number): ConversationListResponse {
+  return {
+    data: [],
+    pagination: {
+      currentPage: 1,
+      limit,
+      total: 0,
+      totalPages: 0,
+      hasNext: false,
+      hasPrev: false,
+    },
+  };
+}
+
+function removeConversationFromCachedData<T>(
+  cachedData: T,
+  deletedId: string,
+): T {
+  if (!cachedData) {
+    return cachedData;
+  }
+
+  if (Array.isArray(cachedData)) {
+    return cachedData.filter(
+      (conversation) => conversation.id !== deletedId,
+    ) as T;
+  }
+
+  if (
+    typeof cachedData === "object" &&
+    "data" in cachedData &&
+    Array.isArray(cachedData.data)
+  ) {
+    return {
+      ...cachedData,
+      data: cachedData.data.filter(
+        (conversation) => conversation.id !== deletedId,
+      ),
+    };
+  }
+
+  if (
+    typeof cachedData === "object" &&
+    "pages" in cachedData &&
+    Array.isArray(cachedData.pages)
+  ) {
+    const infiniteData = cachedData as unknown as InfiniteData<
+      ConversationListResponse,
+      number
+    >;
+
+    return {
+      ...infiniteData,
+      pages: infiniteData.pages.map((page) => ({
+        ...page,
+        data: page.data.filter((conversation) => conversation.id !== deletedId),
+      })),
+    } as T;
+  }
+
+  return cachedData;
+}
 
 export function mergeUpdatedConversationIntoCache(
   oldConversation:
@@ -112,29 +183,98 @@ export function useConversation(conversationId?: string) {
 export function useConversations({
   enabled = true,
   search,
+  includePreviewMessages = false,
+  pinned,
+  limit = 20,
+  offset = 0,
 }: {
   enabled?: boolean;
   search?: string;
+  includePreviewMessages?: boolean;
+  pinned?: boolean;
+  limit?: number;
+  offset?: number;
 }) {
   return useQuery({
-    queryKey: ["conversations", search],
+    queryKey: [
+      "conversations",
+      { search, includePreviewMessages, pinned, limit, offset },
+    ],
     queryFn: async () => {
-      if (!enabled) return [];
       const trimmedSearch = search?.trim();
 
-      const { data, error } = await getChatConversations({
-        query: trimmedSearch ? { search: trimmedSearch } : undefined,
-      });
+      const query: ConversationListQuery = {
+        limit,
+        offset,
+        includePreviewMessages,
+        ...(trimmedSearch ? { search: trimmedSearch } : {}),
+        ...(pinned !== undefined ? { pinned } : {}),
+      };
+
+      const { data, error } = await getChatConversations({ query });
 
       if (error) {
         handleApiError(error);
-        return [];
+        return emptyConversationsResponse(limit);
       }
-      return data;
+      return (data ??
+        emptyConversationsResponse(limit)) as ConversationListResponse;
     },
     staleTime: search ? 0 : 2_000, // No stale time for searches, 2 seconds otherwise
     gcTime: 10 * 60 * 1000,
     refetchOnWindowFocus: false,
+    enabled,
+  });
+}
+
+export function useConversationsInfinite({
+  enabled = true,
+  search,
+  includePreviewMessages = false,
+  pinned,
+  limit = 20,
+}: {
+  enabled?: boolean;
+  search?: string;
+  includePreviewMessages?: boolean;
+  pinned?: boolean;
+  limit?: number;
+}) {
+  return useInfiniteQuery({
+    queryKey: [
+      "conversations",
+      "infinite",
+      { search, includePreviewMessages, pinned, limit },
+    ],
+    queryFn: async ({ pageParam = 0 }) => {
+      const trimmedSearch = search?.trim();
+      const query: ConversationListQuery = {
+        limit,
+        offset: pageParam,
+        includePreviewMessages,
+        ...(trimmedSearch ? { search: trimmedSearch } : {}),
+        ...(pinned !== undefined ? { pinned } : {}),
+      };
+
+      const { data, error } = await getChatConversations({ query });
+
+      if (error) {
+        handleApiError(error);
+        return emptyConversationsResponse(limit);
+      }
+
+      return (data ??
+        emptyConversationsResponse(limit)) as ConversationListResponse;
+    },
+    getNextPageParam: (lastPage) =>
+      lastPage.pagination.hasNext
+        ? lastPage.pagination.currentPage * lastPage.pagination.limit
+        : undefined,
+    initialPageParam: 0,
+    staleTime: search ? 0 : 2_000,
+    gcTime: 10 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    enabled,
   });
 }
 
@@ -266,14 +406,13 @@ export function useDeleteConversation() {
       await queryClient.cancelQueries({ queryKey: ["conversations"] });
 
       // Snapshot all conversation list caches (one per search query) for rollback
-      const previousQueries = queryClient.getQueriesData<{ id: string }[]>({
+      const previousQueries = queryClient.getQueriesData({
         queryKey: ["conversations"],
       });
 
       // Optimistically remove the conversation from every cached list
-      queryClient.setQueriesData<{ id: string }[]>(
-        { queryKey: ["conversations"] },
-        (old) => (old ? old.filter((c) => c.id !== deletedId) : old),
+      queryClient.setQueriesData({ queryKey: ["conversations"] }, (old) =>
+        removeConversationFromCachedData(old, deletedId),
       );
 
       return { previousQueries };

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -18821,6 +18821,10 @@ export type GetChatConversationsData = {
     path?: never;
     query?: {
         search?: string;
+        includePreviewMessages?: boolean;
+        pinned?: boolean;
+        limit?: number;
+        offset?: number;
     };
     url: '/api/chat/conversations';
 };
@@ -18894,56 +18898,66 @@ export type GetChatConversationsResponses = {
     /**
      * Default Response
      */
-    200: Array<{
-        id: string;
-        userId: string;
-        organizationId: string;
-        agentId: string | null;
-        chatApiKeyId: string | null;
-        title: string | null;
-        selectedModel: string;
-        selectedProvider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
-        hasCustomToolSelection: boolean;
-        todoList: string | number | boolean | null | {
-            [key: string]: unknown;
-        } | Array<unknown> | null;
-        artifact: string | null;
-        pinnedAt: string | null;
-        createdAt: string;
-        updatedAt: string;
-        agent: {
+    200: {
+        data: Array<{
             id: string;
-            name: string;
-            systemPrompt: string | null;
-            agentType: 'profile' | 'mcp_gateway' | 'llm_proxy' | 'agent';
-            llmApiKeyId: string | null;
-        } | null;
-        share: {
-            id: string;
-            visibility: 'organization' | 'team' | 'user';
-        } | null;
-        messages: Array<unknown>;
-        chatErrors: Array<{
-            id: string;
-            conversationId: string;
-            error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
-                message: string;
-                isRetryable: boolean;
-                sessionId?: string;
-                traceId?: string;
-                spanId?: string;
-                originalError?: {
-                    provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
-                    status?: number;
-                    message?: string;
-                    type?: string;
-                    raw?: unknown;
-                };
-            };
+            userId: string;
+            organizationId: string;
+            agentId: string | null;
+            chatApiKeyId: string | null;
+            title: string | null;
+            selectedModel: string;
+            selectedProvider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
+            hasCustomToolSelection: boolean;
+            todoList: string | number | boolean | null | {
+                [key: string]: unknown;
+            } | Array<unknown> | null;
+            artifact: string | null;
+            pinnedAt: string | null;
             createdAt: string;
+            updatedAt: string;
+            agent: {
+                id: string;
+                name: string;
+                systemPrompt: string | null;
+                agentType: 'profile' | 'mcp_gateway' | 'llm_proxy' | 'agent';
+                llmApiKeyId: string | null;
+            } | null;
+            share: {
+                id: string;
+                visibility: 'organization' | 'team' | 'user';
+            } | null;
+            messages: Array<unknown>;
+            chatErrors: Array<{
+                id: string;
+                conversationId: string;
+                error: {
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    message: string;
+                    isRetryable: boolean;
+                    sessionId?: string;
+                    traceId?: string;
+                    spanId?: string;
+                    originalError?: {
+                        provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
+                        status?: number;
+                        message?: string;
+                        type?: string;
+                        raw?: unknown;
+                    };
+                };
+                createdAt: string;
+            }>;
         }>;
-    }>;
+        pagination: {
+            currentPage: number;
+            limit: number;
+            total: number;
+            totalPages: number;
+            hasNext: boolean;
+            hasPrev: boolean;
+        };
+    };
 };
 
 export type GetChatConversationsResponse = GetChatConversationsResponses[keyof GetChatConversationsResponses];


### PR DESCRIPTION
## Summary

Fixes #4680.

This fixes the conversation list cache issue where disabled `useConversations` consumers could populate the shared conversations cache with an empty list, causing the chat search / More palette to show `No recent chats` even when the sidebar had conversations.

While touching this flow, this also applies the Boy Scout rule and makes the conversations list endpoint and consumers more scalable:
- adds paginated `GET /api/chat/conversations`
- adds `pinned` filtering
- adds optional preview message loading
- optimizes sidebar fetching
- switches conversation search to infinite pagination

The original issue could be reverted to a much smaller one-line style fix if needed, but this version cleans up the surrounding data flow so the same class of cache/performance issue is less likely to come back.

## Changes

- Passes `enabled` through to TanStack Query so disabled conversation queries do not execute or populate cache.
- Changes `GET /api/chat/conversations` to return `{ data, pagination }`.
- Adds query params:
  - `limit`
  - `offset`
  - `pinned`
  - `includePreviewMessages`
  - `search`
- Adds paginated conversation lookup with pinned-first ordering when no `pinned` filter is provided.
- Supports `pinned=true` and `pinned=false` filtering.
- Loads preview messages only when explicitly requested.
- Updates sidebar to fetch:
  - pinned conversations separately
  - latest unpinned conversations with `limit=3`
- Updates command palette to use infinite pagination and request preview messages only during search.
- Keeps search debounced to avoid excessive backend requests.

## Testing

- Added backend tests for pagination, pinned filtering, pinned-first ordering, and preview message behavior.
- Added route coverage for paginated conversation responses.
- Updated frontend tests for sidebar split queries and command palette infinite loading.
- Verified:
  - backend targeted tests pass
  - frontend targeted tests pass
  - backend type-check passes
  - frontend type-check passes
  - targeted Biome checks pass
