### PR TITLE
fix: honor keyless azure chat provider keys

### DIFF
--- a/platform/backend/src/clients/llm-client.test.ts
+++ b/platform/backend/src/clients/llm-client.test.ts
@@ -1,15 +1,19 @@
 import {
+  CHAT_API_KEY_ID_HEADER,
   EXTERNAL_AGENT_ID_HEADER,
+  PROVIDER_BASE_URL_HEADER,
   SESSION_ID_HEADER,
   SOURCE_HEADER,
   UNTRUSTED_CONTEXT_HEADER,
   USER_ID_HEADER,
 } from "@shared";
 import { vi } from "vitest";
+import { ConversationModel, LlmProviderApiKeyModel } from "@/models";
 import { describe, expect, it, test } from "@/test";
 
 // Mock the gemini-client module before importing llm-client
 const mockIsVertexAiEnabled = vi.hoisted(() => vi.fn(() => false));
+const mockIsAzureOpenAiEntraIdEnabled = vi.hoisted(() => vi.fn(() => false));
 const mockCreateAnthropic = vi.hoisted(() =>
   vi.fn(({ headers }: { headers?: Record<string, string> }) =>
     vi.fn((modelName: string) => ({
@@ -22,6 +26,14 @@ const mockCreateAnthropic = vi.hoisted(() =>
 vi.mock("@/clients/gemini-client", () => ({
   isVertexAiEnabled: mockIsVertexAiEnabled,
 }));
+vi.mock("@/clients/azure-openai-credentials", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/clients/azure-openai-credentials")>();
+  return {
+    ...actual,
+    isAzureOpenAiEntraIdEnabled: mockIsAzureOpenAiEntraIdEnabled,
+  };
+});
 vi.mock("@ai-sdk/anthropic", () => ({
   createAnthropic: mockCreateAnthropic,
 }));
@@ -54,6 +66,7 @@ vi.mock("@ai-sdk/openai", async (importOriginal) => {
 import {
   createDirectLLMModel,
   createLLMModel,
+  createLLMModelForAgent,
   detectProviderFromModel,
 } from "./llm-client";
 
@@ -439,6 +452,76 @@ describe("createDirectLLMModel", () => {
 });
 
 describe("createLLMModel", () => {
+  test("uses an explicit keyless Azure conversation key and forwards its inference URL to the proxy", async ({
+    makeOrganization,
+    makeUser,
+    makeSecret,
+    makeAgent,
+  }) => {
+    mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(true);
+
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const agent = await makeAgent({ name: "Azure Chat Agent", teams: [] });
+    const fallbackSecret = await makeSecret({
+      secret: { apiKey: "sk-fallback" },
+    });
+
+    const fallbackKey = await LlmProviderApiKeyModel.create({
+      organizationId: org.id,
+      secretId: fallbackSecret.id,
+      name: "Fallback Azure Key",
+      provider: "azure",
+      scope: "org",
+      baseUrl: "https://fallback.example.com/openai",
+      inferenceBaseUrl: "https://fallback-runtime.example.com/openai",
+    });
+    const selectedKey = await LlmProviderApiKeyModel.create({
+      organizationId: org.id,
+      secretId: null,
+      name: "Selected Keyless Azure Key",
+      provider: "azure",
+      scope: "org",
+      baseUrl: "https://discovery.example.com/openai",
+      inferenceBaseUrl: "https://runtime.example.com/openai",
+    });
+    const conversation = await ConversationModel.create({
+      agentId: agent.id,
+      userId: user.id,
+      organizationId: org.id,
+      title: "Azure Chat Conversation",
+      selectedModel: "gpt-4o",
+      selectedProvider: "azure",
+      chatApiKeyId: selectedKey.id,
+    });
+
+    const result = await createLLMModelForAgent({
+      organizationId: org.id,
+      userId: user.id,
+      agentId: agent.id,
+      model: "gpt-4o",
+      provider: "azure",
+      conversationId: conversation.id,
+      source: "chat",
+    });
+
+    expect(result.apiKeySource).toBe("org");
+    expect(capturedCreateOpenAIOptions.apiKey).toBeUndefined();
+    expect(capturedCreateOpenAIOptions.headers).toEqual(
+      expect.objectContaining({
+        [CHAT_API_KEY_ID_HEADER]: selectedKey.id,
+        [PROVIDER_BASE_URL_HEADER]: "https://runtime.example.com/openai",
+      }),
+    );
+    expect(capturedCreateOpenAIOptions.headers).not.toEqual(
+      expect.objectContaining({
+        [CHAT_API_KEY_ID_HEADER]: fallbackKey.id,
+        [PROVIDER_BASE_URL_HEADER]:
+          "https://fallback-runtime.example.com/openai",
+      }),
+    );
+  });
+
   test("sets the untrusted-context header only when contextIsTrusted is false", () => {
     createLLMModel({
       provider: "anthropic",

--- a/platform/backend/src/clients/llm-client.test.ts
+++ b/platform/backend/src/clients/llm-client.test.ts
@@ -7,6 +7,7 @@ import {
   UNTRUSTED_CONTEXT_HEADER,
   USER_ID_HEADER,
 } from "@shared";
+import { streamText } from "ai";
 import { vi } from "vitest";
 import { ConversationModel, LlmProviderApiKeyModel } from "@/models";
 import { describe, expect, it, test } from "@/test";
@@ -506,7 +507,7 @@ describe("createLLMModel", () => {
     });
 
     expect(result.apiKeySource).toBe("org");
-    expect(capturedCreateOpenAIOptions.apiKey).toBeUndefined();
+    expect(capturedCreateOpenAIOptions.apiKey).toBe("EMPTY");
     expect(capturedCreateOpenAIOptions.headers).toEqual(
       expect.objectContaining({
         [CHAT_API_KEY_ID_HEADER]: selectedKey.id,
@@ -519,6 +520,43 @@ describe("createLLMModel", () => {
         [PROVIDER_BASE_URL_HEADER]:
           "https://fallback-runtime.example.com/openai",
       }),
+    );
+
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        [
+          'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":0,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}',
+          'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":0,"model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+          "data: [DONE]",
+          "",
+        ].join("\n\n"),
+        {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        },
+      );
+    });
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+
+    try {
+      const streamResult = streamText({
+        model: result.model,
+        prompt: "hello",
+      });
+
+      await expect(streamResult.text).resolves.toBe("ok");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(fetchMock).toHaveBeenCalled();
+    const firstFetchCall = fetchMock.mock.calls[0] as unknown as Parameters<
+      typeof globalThis.fetch
+    >;
+    const [, fetchInit] = firstFetchCall;
+    expect(new Headers(fetchInit?.headers).get("authorization")).toBe(
+      "Bearer EMPTY",
     );
   });
 

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -488,8 +488,13 @@ const providerModelConfigs: Record<SupportedProvider, ProviderModelConfig> = {
         fetch: providedFetch,
       });
       const normalizedApiKey = normalizeAzureApiKey(apiKey);
+      const sdkApiKey =
+        normalizedApiKey ??
+        (isAzureOpenAiEntraIdEnabled()
+          ? KEYLESS_PROVIDER_API_KEY_PLACEHOLDER
+          : undefined);
       return createOpenAI({
-        apiKey: normalizedApiKey,
+        apiKey: sdkApiKey,
         baseURL,
         headers: normalizedApiKey
           ? { ...headers, "api-key": normalizedApiKey }

--- a/platform/backend/src/models/llm-provider-api-key.ts
+++ b/platform/backend/src/models/llm-provider-api-key.ts
@@ -388,7 +388,7 @@ class LlmProviderApiKeyModel {
       if (
         conversationKey &&
         conversationKey.provider === provider &&
-        conversationKey.secretId
+        canUseProviderApiKey(conversationKey)
       ) {
         // If conversation's key matches agent's configured key, skip user access check
         if (
@@ -414,7 +414,11 @@ class LlmProviderApiKeyModel {
     //    (no user permission check — permission flows through agent access)
     if (agentLlmApiKeyId) {
       const agentKey = await LlmProviderApiKeyModel.findById(agentLlmApiKeyId);
-      if (agentKey && agentKey.provider === provider && agentKey.secretId) {
+      if (
+        agentKey &&
+        agentKey.provider === provider &&
+        canUseProviderApiKey(agentKey)
+      ) {
         return agentKey;
       }
     }
@@ -732,6 +736,18 @@ function parseVaultReferenceFromSecret(
     };
   }
   return null;
+}
+
+function canUseProviderApiKey(
+  apiKey: Pick<LlmProviderApiKey, "provider" | "secretId">,
+): boolean {
+  if (apiKey.secretId) {
+    return true;
+  }
+
+  return getProvidersWithOptionalApiKey({
+    azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+  }).includes(apiKey.provider);
 }
 
 export default LlmProviderApiKeyModel;

--- a/platform/backend/src/utils/llm-api-key-resolution.test.ts
+++ b/platform/backend/src/utils/llm-api-key-resolution.test.ts
@@ -1,7 +1,24 @@
-import { describe, expect, test } from "@/test";
+import { vi } from "vitest";
+import { LlmProviderApiKeyModel } from "@/models";
+import { beforeEach, describe, expect, test } from "@/test";
 import { resolveProviderApiKey } from "@/utils/llm-api-key-resolution";
 
+const mockIsAzureOpenAiEntraIdEnabled = vi.hoisted(() => vi.fn(() => false));
+
+vi.mock("@/clients/azure-openai-credentials", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/clients/azure-openai-credentials")>();
+  return {
+    ...actual,
+    isAzureOpenAiEntraIdEnabled: mockIsAzureOpenAiEntraIdEnabled,
+  };
+});
+
 describe("resolveProviderApiKey", () => {
+  beforeEach(() => {
+    mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(false);
+  });
+
   test("resolves personal key for user", async ({
     makeOrganization,
     makeUser,
@@ -109,6 +126,102 @@ describe("resolveProviderApiKey", () => {
     });
 
     expect(result.apiKey).toBe("sk-runtime-base");
+    expect(result.baseUrl).toBe("https://runtime.example.com/openai");
+  });
+
+  test("resolves an explicit keyless Azure conversation key", async ({
+    makeOrganization,
+    makeUser,
+    makeSecret,
+    makeAgent,
+    makeConversation,
+  }) => {
+    mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(true);
+
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const agent = await makeAgent({ name: "Azure Chat Agent", teams: [] });
+    const fallbackSecret = await makeSecret({
+      secret: { apiKey: "sk-fallback" },
+    });
+
+    await LlmProviderApiKeyModel.create({
+      organizationId: org.id,
+      secretId: fallbackSecret.id,
+      name: "Fallback Azure Key",
+      provider: "azure",
+      scope: "org",
+      baseUrl: "https://fallback.example.com/openai",
+      inferenceBaseUrl: "https://fallback-runtime.example.com/openai",
+    });
+    const selectedKey = await LlmProviderApiKeyModel.create({
+      organizationId: org.id,
+      secretId: null,
+      name: "Selected Keyless Azure Key",
+      provider: "azure",
+      scope: "org",
+      baseUrl: "https://discovery.example.com/openai",
+      inferenceBaseUrl: "https://runtime.example.com/openai",
+    });
+    const conversation = await makeConversation(agent.id, {
+      userId: user.id,
+      organizationId: org.id,
+      chatApiKeyId: selectedKey.id,
+    });
+
+    const result = await resolveProviderApiKey({
+      organizationId: org.id,
+      userId: user.id,
+      provider: "azure",
+      conversationId: conversation.id,
+    });
+
+    expect(result.apiKey).toBeUndefined();
+    expect(result.chatApiKeyId).toBe(selectedKey.id);
+    expect(result.baseUrl).toBe("https://runtime.example.com/openai");
+  });
+
+  test("resolves an explicit keyless Azure agent key", async ({
+    makeOrganization,
+    makeUser,
+    makeSecret,
+  }) => {
+    mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(true);
+
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const fallbackSecret = await makeSecret({
+      secret: { apiKey: "sk-fallback" },
+    });
+
+    await LlmProviderApiKeyModel.create({
+      organizationId: org.id,
+      secretId: fallbackSecret.id,
+      name: "Fallback Azure Key",
+      provider: "azure",
+      scope: "org",
+      baseUrl: "https://fallback.example.com/openai",
+      inferenceBaseUrl: "https://fallback-runtime.example.com/openai",
+    });
+    const agentKey = await LlmProviderApiKeyModel.create({
+      organizationId: org.id,
+      secretId: null,
+      name: "Agent Keyless Azure Key",
+      provider: "azure",
+      scope: "org",
+      baseUrl: "https://discovery.example.com/openai",
+      inferenceBaseUrl: "https://runtime.example.com/openai",
+    });
+
+    const result = await resolveProviderApiKey({
+      organizationId: org.id,
+      userId: user.id,
+      provider: "azure",
+      agentLlmApiKeyId: agentKey.id,
+    });
+
+    expect(result.apiKey).toBeUndefined();
+    expect(result.chatApiKeyId).toBe(agentKey.id);
     expect(result.baseUrl).toBe("https://runtime.example.com/openai");
   });
 


### PR DESCRIPTION
## Summary

- Honor explicitly selected keyless Azure provider keys for chat conversations and agent defaults.
- Preserve the selected key inference URL when building the chat proxy client, instead of falling back to another Azure key that has a stored secret.
- Add regression coverage for resolver behavior and chat client proxy headers.