### PR TITLE
chore: move envFrom and Secret Files add/edit into dialogs

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/custom-server-request-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/custom-server-request-dialog.tsx
@@ -289,7 +289,6 @@ export function CustomServerRequestDialog({
                     )}
                   />
                   <EnvironmentVariablesFormField
-                    control={form.control}
                     fields={fields}
                     append={append}
                     remove={remove}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -1119,7 +1119,6 @@ export function McpCatalogForm({
             {currentServerType === "local" && (
               <div className="space-y-4">
                 <EnvironmentVariablesFormField
-                  control={form.control}
                   fields={fields}
                   append={append}
                   remove={remove}

--- a/platform/frontend/src/components/env-from-dialog.tsx
+++ b/platform/frontend/src/components/env-from-dialog.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { StandardDialog } from "@/components/standard-dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export type EnvFromType = "secret" | "configMap";
+
+export interface EnvFromDraft {
+  type: EnvFromType;
+  name: string;
+  prefix: string;
+}
+
+interface EnvFromDialogProps {
+  open: boolean;
+  mode: "add" | "edit";
+  initial: EnvFromDraft | null;
+  onClose: () => void;
+  onConfirm: (draft: EnvFromDraft) => void;
+}
+
+const EMPTY_DRAFT: EnvFromDraft = { type: "secret", name: "", prefix: "" };
+
+export function EnvFromDialog({
+  open,
+  mode,
+  initial,
+  onClose,
+  onConfirm,
+}: EnvFromDialogProps) {
+  const [draft, setDraft] = useState<EnvFromDraft>(initial ?? EMPTY_DRAFT);
+
+  useEffect(() => {
+    if (open) setDraft(initial ?? EMPTY_DRAFT);
+  }, [open, initial]);
+
+  const canSubmit = draft.name.trim().length > 0;
+
+  return (
+    <StandardDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+      size="small"
+      title={mode === "add" ? "Add source" : "Edit source"}
+      description={
+        mode === "add"
+          ? "Inject all keys from an existing k8s Secret or ConfigMap as environment variables."
+          : undefined
+      }
+      footer={
+        <>
+          <Button type="button" variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={!canSubmit}
+            onClick={() =>
+              onConfirm({
+                ...draft,
+                name: draft.name.trim(),
+                prefix: draft.prefix.trim(),
+              })
+            }
+          >
+            {mode === "add" ? "Add source" : "Save"}
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="env-from-type">Type</Label>
+          <Select
+            value={draft.type}
+            onValueChange={(v) =>
+              setDraft((prev) => ({ ...prev, type: v as EnvFromType }))
+            }
+          >
+            <SelectTrigger id="env-from-type">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="secret">Secret</SelectItem>
+              <SelectItem value="configMap">ConfigMap</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="env-from-name">Name</Label>
+          <Input
+            id="env-from-name"
+            value={draft.name}
+            onChange={(e) =>
+              setDraft((prev) => ({ ...prev, name: e.target.value }))
+            }
+            placeholder="my-k8s-secret"
+            className="font-mono"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="env-from-prefix">Prefix (optional)</Label>
+          <Input
+            id="env-from-prefix"
+            value={draft.prefix}
+            onChange={(e) =>
+              setDraft((prev) => ({ ...prev, prefix: e.target.value }))
+            }
+            placeholder="e.g. MY_PREFIX_"
+            className="font-mono"
+          />
+        </div>
+      </div>
+    </StandardDialog>
+  );
+}

--- a/platform/frontend/src/components/environment-variables-form-field.tsx
+++ b/platform/frontend/src/components/environment-variables-form-field.tsx
@@ -1,18 +1,9 @@
 "use client";
 
 import { parseVaultReference } from "@shared";
-import { CheckCircle2, Key, Loader2, Plus, Trash2 } from "lucide-react";
-import {
-  lazy,
-  Suspense,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { Key, Loader2, Plus, Trash2 } from "lucide-react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import type {
-  Control,
-  ControllerRenderProps,
   FieldArrayWithId,
   FieldPath,
   FieldValues,
@@ -23,36 +14,22 @@ import type {
   UseFormWatch,
 } from "react-hook-form";
 import {
+  EnvFromDialog,
+  type EnvFromDraft,
+  type EnvFromType,
+} from "@/components/env-from-dialog";
+import {
   EnvironmentVariableDialog,
   type EnvVarDraft,
 } from "@/components/environment-variable-dialog";
 import { EnvironmentVariablesReadOnlyTable } from "@/components/environment-variables-read-only-table";
 import {
-  FieldScopeSelect,
-  type FieldScopeValue,
-} from "@/components/field-scope-select";
+  SecretFileDialog,
+  type SecretFileDraft,
+} from "@/components/secret-file-dialog";
 import { StandardDialog } from "@/components/standard-dialog";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
-import {
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
-import { MCP_SECRET_AUTOCOMPLETE } from "@/lib/mcp/mcp-form-autocomplete";
+import { FormDescription, FormLabel } from "@/components/ui/form";
 
 const ExternalSecretSelector = lazy(
   () =>
@@ -67,7 +44,6 @@ interface ExternalSecretValue {
 }
 
 interface EnvironmentVariablesFormFieldProps<TFieldValues extends FieldValues> {
-  control: Control<TFieldValues>;
   // biome-ignore lint/suspicious/noExplicitAny: Generic field array types require any for flexibility
   fields: FieldArrayWithId<TFieldValues, any, "id">[];
   // biome-ignore lint/suspicious/noExplicitAny: Generic field array types require any for flexibility
@@ -122,7 +98,6 @@ interface EnvironmentVariablesFormFieldProps<TFieldValues extends FieldValues> {
 export function EnvironmentVariablesFormField<
   TFieldValues extends FieldValues,
 >({
-  control,
   fields,
   append,
   remove,
@@ -141,6 +116,12 @@ export function EnvironmentVariablesFormField<
     number | null
   >(null);
   const [envVarDialog, setEnvVarDialog] = useState<
+    { mode: "add" } | { mode: "edit"; index: number } | null
+  >(null);
+  const [envFromDialog, setEnvFromDialog] = useState<
+    { mode: "add" } | { mode: "edit"; index: number } | null
+  >(null);
+  const [secretFileDialog, setSecretFileDialog] = useState<
     { mode: "add" } | { mode: "edit"; index: number } | null
   >(null);
 
@@ -270,9 +251,7 @@ export function EnvironmentVariablesFormField<
               type="button"
               variant="outline"
               size="sm"
-              onClick={() =>
-                envFrom.append({ type: "secret", name: "", prefix: "" })
-              }
+              onClick={() => setEnvFromDialog({ mode: "add" })}
             >
               <Plus className="h-4 w-4" />
               Add Source
@@ -284,70 +263,94 @@ export function EnvironmentVariablesFormField<
               No sources configured.
             </div>
           ) : (
-            <FormDescription className="text-xs">
-              Inject all keys from existing k8s Secrets or ConfigMaps as
-              environment variables.
-            </FormDescription>
+            <>
+              <FormDescription className="mb-4 text-xs">
+                Inject all keys from existing k8s Secrets or ConfigMaps as
+                environment variables.
+              </FormDescription>
+              <div>
+                <div className="grid grid-cols-[160px_1fr_1fr_auto] gap-3 border-b py-2.5 px-4 text-xs font-medium text-foreground">
+                  <div>Type</div>
+                  <div>Name</div>
+                  <div>Prefix</div>
+                  <div className="w-9" />
+                </div>
+                {envFrom.fields.map((field, index) => {
+                  const type = envFrom.watch(
+                    `${envFrom.fieldNamePrefix}.${index}.type`,
+                  ) as EnvFromType | undefined;
+                  const name = envFrom.watch(
+                    `${envFrom.fieldNamePrefix}.${index}.name`,
+                  ) as string | undefined;
+                  const prefix = envFrom.watch(
+                    `${envFrom.fieldNamePrefix}.${index}.prefix`,
+                  ) as string | undefined;
+                  return (
+                    // biome-ignore lint/a11y/useSemanticElements: row contains a nested delete <button>
+                    <div
+                      key={field.id}
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => setEnvFromDialog({ mode: "edit", index })}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          setEnvFromDialog({ mode: "edit", index });
+                        }
+                      }}
+                      className="group grid grid-cols-[160px_1fr_1fr_auto] gap-3 items-center border-b py-3 px-4 text-xs last:border-b-0 cursor-pointer hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                      <div className="text-muted-foreground">
+                        {type === "configMap" ? "ConfigMap" : "Secret"}
+                      </div>
+                      <div className="font-mono">
+                        {name || (
+                          <span className="text-muted-foreground italic">
+                            unnamed
+                          </span>
+                        )}
+                      </div>
+                      <div className="font-mono text-muted-foreground">
+                        {prefix || <span className="italic">—</span>}
+                      </div>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="opacity-60 group-hover:opacity-100"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          envFrom.remove(index);
+                        }}
+                        aria-label="Remove source"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  );
+                })}
+              </div>
+            </>
           )}
 
-          {envFrom.fields.map((field, index) => (
-            <div key={field.id} className="border rounded-lg p-3 space-y-3">
-              <div className="flex items-center justify-between gap-2">
-                <Select
-                  value={envFrom.watch(
-                    `${envFrom.fieldNamePrefix}.${index}.type`,
-                  )}
-                  onValueChange={(val) =>
-                    envFrom.setValue(
-                      `${envFrom.fieldNamePrefix}.${index}.type`,
-                      val,
-                      { shouldDirty: true },
-                    )
-                  }
-                >
-                  <SelectTrigger className="w-[200px]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="secret">Secret</SelectItem>
-                    <SelectItem value="configMap">ConfigMap</SelectItem>
-                  </SelectContent>
-                </Select>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => envFrom.remove(index)}
-                >
-                  <Trash2 className="h-4 w-4 text-muted-foreground hover:text-destructive" />
-                </Button>
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-1">
-                  <Label className="text-xs">
-                    Name <span className="text-destructive">*</span>
-                  </Label>
-                  <Input
-                    placeholder="my-k8s-secret"
-                    className="font-mono"
-                    {...envFrom.register(
-                      `${envFrom.fieldNamePrefix}.${index}.name`,
-                    )}
-                  />
-                </div>
-                <div className="space-y-1">
-                  <Label className="text-xs">Prefix (optional)</Label>
-                  <Input
-                    placeholder="e.g. MY_PREFIX_"
-                    className="font-mono"
-                    {...envFrom.register(
-                      `${envFrom.fieldNamePrefix}.${index}.prefix`,
-                    )}
-                  />
-                </div>
-              </div>
-            </div>
-          ))}
+          <EnvFromDialog
+            open={envFromDialog !== null}
+            mode={envFromDialog?.mode === "edit" ? "edit" : "add"}
+            initial={
+              envFromDialog?.mode === "edit"
+                ? readEnvFromRowAsDraft(envFrom, envFromDialog.index)
+                : null
+            }
+            onClose={() => setEnvFromDialog(null)}
+            onConfirm={(draft) => {
+              if (envFromDialog?.mode === "add") {
+                envFrom.append(draft);
+              } else if (envFromDialog?.mode === "edit") {
+                applyEnvFromDraftToRow(envFrom, envFromDialog.index, draft);
+              }
+              setEnvFromDialog(null);
+            }}
+          />
         </div>
       )}
 
@@ -359,18 +362,7 @@ export function EnvironmentVariablesFormField<
             type="button"
             variant="outline"
             size="sm"
-            onClick={() =>
-              (append as (value: unknown) => void)({
-                key: "",
-                type: "secret",
-                value: "",
-                promptOnInstallation: true,
-                promptOnPreset: false,
-                required: false,
-                description: "",
-                mounted: true,
-              })
-            }
+            onClick={() => setSecretFileDialog({ mode: "add" })}
           >
             <Plus className="h-4 w-4" />
             Add Secret File
@@ -396,226 +388,63 @@ export function EnvironmentVariablesFormField<
 
           return (
             <>
-              <FormDescription>
+              <FormDescription className="mb-4 text-xs">
                 Secrets mounted as files at /secrets/&lt;key&gt;.
               </FormDescription>
-              <div className="border rounded-lg">
-                <div className="grid grid-cols-[1.5fr_1.1fr_0.7fr_2fr_2.5fr_auto] gap-2 p-3 bg-muted/50 border-b">
-                  <div className="text-xs font-medium">Key</div>
-                  <div className="text-xs font-medium">Scope</div>
-                  <div className="text-xs font-medium">Required</div>
-                  <div className="text-xs font-medium">Value</div>
-                  <div className="text-xs font-medium">Description</div>
-                  <div className="w-9" />
-                </div>
-                {secretFileIndices.map((index) => {
-                  const field = fields[index];
-                  const promptOnInstallation = form.watch(
-                    `${fieldNamePrefix}.${index}.promptOnInstallation` as FieldPath<TFieldValues>,
-                  );
-                  const promptOnPreset = form.watch(
-                    `${fieldNamePrefix}.${index}.promptOnPreset` as FieldPath<TFieldValues>,
-                  );
-                  const scope: FieldScopeValue = promptOnInstallation
-                    ? "installation"
-                    : promptOnPreset
-                      ? "preset"
-                      : "static";
-                  const setScope = (next: FieldScopeValue) => {
-                    form.setValue(
-                      `${fieldNamePrefix}.${index}.promptOnInstallation` as FieldPath<TFieldValues>,
-                      (next === "installation") as PathValue<
-                        TFieldValues,
-                        FieldPath<TFieldValues>
-                      >,
-                      { shouldDirty: true },
-                    );
-                    form.setValue(
-                      `${fieldNamePrefix}.${index}.promptOnPreset` as FieldPath<TFieldValues>,
-                      (next === "preset") as PathValue<
-                        TFieldValues,
-                        FieldPath<TFieldValues>
-                      >,
-                      { shouldDirty: true },
-                    );
-                    if (next !== "installation") {
-                      form.setValue(
-                        `${fieldNamePrefix}.${index}.required` as FieldPath<TFieldValues>,
-                        false as PathValue<
-                          TFieldValues,
-                          FieldPath<TFieldValues>
-                        >,
-                        { shouldDirty: true },
-                      );
-                    }
-                  };
-                  return (
-                    <div
-                      key={field.id}
-                      className="grid grid-cols-[1.5fr_1.1fr_0.7fr_2fr_2.5fr_auto] gap-2 p-3 items-start border-b last:border-b-0"
-                    >
-                      <FormField
-                        control={control}
-                        name={
-                          `${fieldNamePrefix}.${index}.key` as FieldPath<TFieldValues>
-                        }
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormControl>
-                              <Input
-                                placeholder="TLS_CERT"
-                                className="font-mono"
-                                {...field}
-                              />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                      <FieldScopeSelect
-                        value={scope}
-                        onChange={setScope}
-                        disableInstallation={disablePromptOnInstallation}
-                        disabledReason={disablePromptOnInstallationReason}
-                      />
-                      <FormField
-                        control={control}
-                        name={
-                          `${fieldNamePrefix}.${index}.required` as FieldPath<TFieldValues>
-                        }
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormControl>
-                              <div className="flex items-center h-10">
-                                <Checkbox
-                                  checked={field.value}
-                                  onCheckedChange={field.onChange}
-                                  disabled={scope !== "installation"}
-                                />
-                              </div>
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                      {(() => {
-                        if (scope === "installation") {
-                          return (
-                            <div className="flex items-center h-10">
-                              <p className="text-xs text-muted-foreground">
-                                Prompted at installation
-                              </p>
-                            </div>
-                          );
-                        }
-
-                        if (scope === "preset") {
-                          return (
-                            <div className="flex items-center h-10">
-                              <p className="text-xs text-muted-foreground">
-                                Set per preset
-                              </p>
-                            </div>
-                          );
-                        }
-
-                        if (useExternalSecretsManager) {
-                          const formValue = form.watch(
-                            `${fieldNamePrefix}.${index}.value` as FieldPath<TFieldValues>,
-                          ) as string | undefined;
-
-                          return (
-                            <div className="flex items-center h-10">
-                              {formValue ? (
-                                <Button
-                                  type="button"
-                                  variant="ghost"
-                                  size="sm"
-                                  className="h-8 px-2 text-xs font-mono text-green-600 hover:text-green-700"
-                                  onClick={() =>
-                                    setDialogOpenForEnvIndex(index)
-                                  }
-                                >
-                                  <CheckCircle2 className="h-3 w-3 mr-1" />
-                                  <span className="truncate max-w-[120px]">
-                                    {parseVaultReference(formValue).key}
-                                  </span>
-                                </Button>
-                              ) : (
-                                <Button
-                                  type="button"
-                                  variant="outline"
-                                  size="sm"
-                                  className="h-8 text-xs"
-                                  onClick={() =>
-                                    setDialogOpenForEnvIndex(index)
-                                  }
-                                >
-                                  <Key className="h-3 w-3 mr-1" />
-                                  Set secret
-                                </Button>
-                              )}
-                            </div>
-                          );
-                        }
-
-                        const rowKey = form.watch(
-                          `${fieldNamePrefix}.${index}.key` as FieldPath<TFieldValues>,
-                        ) as string | undefined;
-                        const hasStoredSecret =
-                          !!rowKey &&
-                          secretKeysWithStoredValue?.has(rowKey) === true;
-
-                        return (
-                          <FormField
-                            control={control}
-                            name={
-                              `${fieldNamePrefix}.${index}.value` as FieldPath<TFieldValues>
-                            }
-                            render={({ field }) => (
-                              <AutoResizeSecretTextarea
-                                field={field}
-                                placeholder={
-                                  hasStoredSecret ? "••••••••" : undefined
-                                }
-                              />
-                            )}
-                          />
-                        );
-                      })()}
-                      <FormField
-                        control={control}
-                        name={
-                          `${fieldNamePrefix}.${index}.description` as FieldPath<TFieldValues>
-                        }
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormControl>
-                              <Textarea
-                                placeholder="Optional description"
-                                className="text-xs resize-y min-h-10"
-                                {...field}
-                              />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => remove(index)}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  );
-                })}
-              </div>
+              <EnvironmentVariablesReadOnlyTable
+                form={form}
+                fields={fields}
+                rowIndexes={secretFileIndices}
+                fieldNamePrefix={fieldNamePrefix}
+                useExternalSecretsManager={useExternalSecretsManager}
+                secretKeysWithStoredValue={secretKeysWithStoredValue}
+                showType={false}
+                keyLabel="File"
+                removeAriaLabel="Remove secret file"
+                onEdit={(index) => setSecretFileDialog({ mode: "edit", index })}
+                onDelete={(index) => remove(index)}
+              />
             </>
           );
         })()}
+
+        <SecretFileDialog
+          open={secretFileDialog !== null}
+          mode={secretFileDialog?.mode === "edit" ? "edit" : "add"}
+          initial={
+            secretFileDialog?.mode === "edit"
+              ? readSecretFileRowAsDraft(
+                  form,
+                  fieldNamePrefix,
+                  secretFileDialog.index,
+                )
+              : null
+          }
+          existingKeys={readOtherSecretFileKeys(
+            form,
+            fieldNamePrefix,
+            fields,
+            secretFileDialog?.mode === "edit" ? secretFileDialog.index : null,
+          )}
+          secretKeysWithStoredValue={secretKeysWithStoredValue}
+          useExternalSecretsManager={useExternalSecretsManager}
+          disableInstallation={disablePromptOnInstallation}
+          disableInstallationReason={disablePromptOnInstallationReason}
+          onClose={() => setSecretFileDialog(null)}
+          onConfirm={(draft) => {
+            if (secretFileDialog?.mode === "add") {
+              (append as (value: unknown) => void)(secretFileDraftToRow(draft));
+            } else if (secretFileDialog?.mode === "edit") {
+              applySecretFileDraftToRow(
+                form,
+                fieldNamePrefix,
+                secretFileDialog.index,
+                draft,
+              );
+            }
+            setSecretFileDialog(null);
+          }}
+        />
       </div>
 
       {/* External Secret Selection Dialog */}
@@ -728,51 +557,112 @@ function applyDraftToRow<TFieldValues extends FieldValues>(
   set("description", draft.description);
 }
 
-const MAX_TEXTAREA_HEIGHT = 128;
+type EnvFromApi = NonNullable<
+  EnvironmentVariablesFormFieldProps<FieldValues>["envFrom"]
+>;
 
-function AutoResizeSecretTextarea({
-  field,
-  placeholder,
-}: {
-  // biome-ignore lint/suspicious/noExplicitAny: Generic field types
-  field: ControllerRenderProps<any, any>;
-  placeholder?: string;
-}) {
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+function readEnvFromRowAsDraft(
+  envFrom: EnvFromApi,
+  index: number,
+): EnvFromDraft {
+  const prefix = envFrom.fieldNamePrefix;
+  return {
+    type: (envFrom.watch(`${prefix}.${index}.type`) as EnvFromType) ?? "secret",
+    name: (envFrom.watch(`${prefix}.${index}.name`) as string) ?? "",
+    prefix: (envFrom.watch(`${prefix}.${index}.prefix`) as string) ?? "",
+  };
+}
 
-  const adjustHeight = useCallback(() => {
-    const textarea = textareaRef.current;
-    if (textarea) {
-      textarea.style.height = "auto";
-      textarea.style.height = `${Math.min(textarea.scrollHeight, MAX_TEXTAREA_HEIGHT)}px`;
-    }
-  }, []);
+function applyEnvFromDraftToRow(
+  envFrom: EnvFromApi,
+  index: number,
+  draft: EnvFromDraft,
+) {
+  const p = envFrom.fieldNamePrefix;
+  envFrom.setValue(`${p}.${index}.type`, draft.type, { shouldDirty: true });
+  envFrom.setValue(`${p}.${index}.name`, draft.name, { shouldDirty: true });
+  envFrom.setValue(`${p}.${index}.prefix`, draft.prefix, {
+    shouldDirty: true,
+  });
+}
 
-  useEffect(() => {
-    adjustHeight();
-  }, [adjustHeight]);
+function readSecretFileRowAsDraft<TFieldValues extends FieldValues>(
+  form: { watch: UseFormWatch<TFieldValues> },
+  prefix: string,
+  index: number,
+): SecretFileDraft {
+  const get = <T,>(name: string): T =>
+    form.watch(`${prefix}.${index}.${name}` as FieldPath<TFieldValues>) as T;
+  const promptOnInstallation = Boolean(get<boolean>("promptOnInstallation"));
+  const promptOnPreset = Boolean(get<boolean>("promptOnPreset"));
+  return {
+    key: get<string>("key") ?? "",
+    scope: promptOnInstallation
+      ? "installation"
+      : promptOnPreset
+        ? "preset"
+        : "static",
+    required: Boolean(get<boolean>("required")),
+    value: get<string>("value") ?? "",
+    description: get<string>("description") ?? "",
+  };
+}
 
-  return (
-    <FormItem>
-      <FormControl>
-        <Textarea
-          className="font-mono text-xs resize-none min-h-10 max-h-32 overflow-y-auto"
-          rows={1}
-          autoComplete={MCP_SECRET_AUTOCOMPLETE}
-          placeholder={placeholder}
-          {...field}
-          ref={(el) => {
-            textareaRef.current = el;
-            if (typeof field.ref === "function") {
-              field.ref(el);
-            }
-          }}
-          onInput={adjustHeight}
-        />
-      </FormControl>
-      <FormMessage />
-    </FormItem>
-  );
+function readOtherSecretFileKeys<TFieldValues extends FieldValues>(
+  form: { watch: UseFormWatch<TFieldValues> },
+  prefix: string,
+  // biome-ignore lint/suspicious/noExplicitAny: field arrays require generic any
+  fields: FieldArrayWithId<TFieldValues, any, "id">[],
+  excludeIndex: number | null,
+): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < fields.length; i++) {
+    if (i === excludeIndex) continue;
+    const mounted = form.watch(
+      `${prefix}.${i}.mounted` as FieldPath<TFieldValues>,
+    );
+    if (!mounted) continue;
+    const k = form.watch(`${prefix}.${i}.key` as FieldPath<TFieldValues>) as
+      | string
+      | undefined;
+    if (k?.trim()) out.push(k.trim());
+  }
+  return out;
+}
+
+function secretFileDraftToRow(draft: SecretFileDraft) {
+  return {
+    key: draft.key,
+    type: "secret" as const,
+    value: draft.scope === "static" ? draft.value : "",
+    promptOnInstallation: draft.scope === "installation",
+    promptOnPreset: draft.scope === "preset",
+    required: draft.scope === "installation" ? draft.required : false,
+    description: draft.description,
+    mounted: true,
+  };
+}
+
+function applySecretFileDraftToRow<TFieldValues extends FieldValues>(
+  form: { setValue: UseFormSetValue<TFieldValues> },
+  prefix: string,
+  index: number,
+  draft: SecretFileDraft,
+) {
+  const set = (name: string, value: unknown) =>
+    form.setValue(
+      `${prefix}.${index}.${name}` as FieldPath<TFieldValues>,
+      value as PathValue<TFieldValues, FieldPath<TFieldValues>>,
+      { shouldDirty: true },
+    );
+  set("key", draft.key);
+  set("type", "secret");
+  set("value", draft.scope === "static" ? draft.value : "");
+  set("promptOnInstallation", draft.scope === "installation");
+  set("promptOnPreset", draft.scope === "preset");
+  set("required", draft.scope === "installation" ? draft.required : false);
+  set("description", draft.description);
+  set("mounted", true);
 }
 
 interface ExternalSecretDialogProps {

--- a/platform/frontend/src/components/environment-variables-read-only-table.tsx
+++ b/platform/frontend/src/components/environment-variables-read-only-table.tsx
@@ -21,6 +21,9 @@ interface EnvironmentVariablesReadOnlyTableProps<
   fieldNamePrefix: string;
   useExternalSecretsManager?: boolean;
   secretKeysWithStoredValue?: Set<string>;
+  showType?: boolean;
+  keyLabel?: string;
+  removeAriaLabel?: string;
   onEdit: (index: number) => void;
   onDelete: (index: number) => void;
 }
@@ -32,8 +35,10 @@ const TYPE_LABEL: Record<string, string> = {
   number: "Number",
 };
 
-const GRID_CLASS =
+const GRID_WITH_TYPE =
   "grid grid-cols-[1.4fr_0.8fr_0.6fr_2fr_2.5fr_auto] gap-3 px-4";
+const GRID_WITHOUT_TYPE =
+  "grid grid-cols-[1.4fr_0.6fr_2fr_2.5fr_auto] gap-3 px-4";
 
 export function EnvironmentVariablesReadOnlyTable<
   TFieldValues extends FieldValues,
@@ -44,16 +49,20 @@ export function EnvironmentVariablesReadOnlyTable<
   fieldNamePrefix,
   useExternalSecretsManager = false,
   secretKeysWithStoredValue,
+  showType = true,
+  keyLabel = "Key",
+  removeAriaLabel = "Remove variable",
   onEdit,
   onDelete,
 }: EnvironmentVariablesReadOnlyTableProps<TFieldValues>) {
+  const gridClass = showType ? GRID_WITH_TYPE : GRID_WITHOUT_TYPE;
   return (
     <div>
       <div
-        className={`${GRID_CLASS} border-b py-2.5 text-xs font-medium text-foreground`}
+        className={`${gridClass} border-b py-2.5 text-xs font-medium text-foreground`}
       >
-        <div>Key</div>
-        <div>Type</div>
+        <div>{keyLabel}</div>
+        {showType && <div>Type</div>}
         <div>Required</div>
         <div>Value</div>
         <div>Description</div>
@@ -111,16 +120,18 @@ export function EnvironmentVariablesReadOnlyTable<
                 onEdit(index);
               }
             }}
-            className={`${GRID_CLASS} group items-center border-b py-3 text-xs last:border-b-0 cursor-pointer hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring`}
+            className={`${gridClass} group items-center border-b py-3 text-xs last:border-b-0 cursor-pointer hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring`}
           >
             <div className="font-mono">
               {key || (
                 <span className="text-muted-foreground italic">unnamed</span>
               )}
             </div>
-            <div className="text-muted-foreground">
-              {TYPE_LABEL[type] ?? type}
-            </div>
+            {showType && (
+              <div className="text-muted-foreground">
+                {TYPE_LABEL[type] ?? type}
+              </div>
+            )}
             <div>
               {scope === "installation" && required ? (
                 <Check className="h-3.5 w-3.5 text-foreground" />
@@ -149,7 +160,7 @@ export function EnvironmentVariablesReadOnlyTable<
                 e.stopPropagation();
                 onDelete(index);
               }}
-              aria-label="Remove variable"
+              aria-label={removeAriaLabel}
             >
               <Trash2 className="h-4 w-4" />
             </Button>

--- a/platform/frontend/src/components/secret-file-dialog.tsx
+++ b/platform/frontend/src/components/secret-file-dialog.tsx
@@ -1,0 +1,405 @@
+"use client";
+
+import { parseVaultReference } from "@shared";
+import { CheckCircle2, Info, Key, Loader2 } from "lucide-react";
+import { lazy, Suspense, useEffect, useMemo, useState } from "react";
+import {
+  FieldScopeSelect,
+  type FieldScopeValue,
+} from "@/components/field-scope-select";
+import { StandardDialog } from "@/components/standard-dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { MCP_SECRET_AUTOCOMPLETE } from "@/lib/mcp/mcp-form-autocomplete";
+
+const ExternalSecretSelector = lazy(
+  () =>
+    // biome-ignore lint/style/noRestrictedImports: lazy loading
+    import("@/components/external-secret-selector.ee"),
+);
+
+export interface SecretFileDraft {
+  key: string;
+  scope: FieldScopeValue;
+  required: boolean;
+  value: string;
+  description: string;
+}
+
+interface SecretFileDialogProps {
+  open: boolean;
+  mode: "add" | "edit";
+  initial: SecretFileDraft | null;
+  existingKeys: string[];
+  secretKeysWithStoredValue?: Set<string>;
+  useExternalSecretsManager?: boolean;
+  disableInstallation?: boolean;
+  disableInstallationReason?: string;
+  onClose: () => void;
+  onConfirm: (draft: SecretFileDraft) => void;
+}
+
+const EMPTY_DRAFT: SecretFileDraft = {
+  key: "",
+  scope: "installation",
+  required: false,
+  value: "",
+  description: "",
+};
+
+export function SecretFileDialog({
+  open,
+  mode,
+  initial,
+  existingKeys,
+  secretKeysWithStoredValue,
+  useExternalSecretsManager = false,
+  disableInstallation = false,
+  disableInstallationReason,
+  onClose,
+  onConfirm,
+}: SecretFileDialogProps) {
+  const [draft, setDraft] = useState<SecretFileDraft>(initial ?? EMPTY_DRAFT);
+  const [vaultDialogOpen, setVaultDialogOpen] = useState(false);
+
+  useEffect(() => {
+    if (open) setDraft(initial ?? EMPTY_DRAFT);
+  }, [open, initial]);
+
+  const trimmedKey = draft.key.trim();
+  const duplicate = useMemo(
+    () => existingKeys.includes(trimmedKey) && trimmedKey.length > 0,
+    [existingKeys, trimmedKey],
+  );
+
+  const hasStoredSecret =
+    mode === "edit" && secretKeysWithStoredValue?.has(trimmedKey) === true;
+
+  const isVaultRef =
+    useExternalSecretsManager &&
+    draft.scope === "static" &&
+    draft.value.length > 0;
+
+  const valueRequired = draft.scope === "static" && !hasStoredSecret;
+  const canSubmit =
+    trimmedKey.length > 0 &&
+    !duplicate &&
+    (!valueRequired || draft.value.trim().length > 0);
+
+  function updateDraft(patch: Partial<SecretFileDraft>) {
+    setDraft((prev) => {
+      const next = { ...prev, ...patch };
+      if (patch.scope && patch.scope !== "installation") next.required = false;
+      if (patch.scope && patch.scope !== "static") next.value = "";
+      return next;
+    });
+  }
+
+  return (
+    <StandardDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+      size="small"
+      title={mode === "add" ? "Add secret file" : "Edit secret file"}
+      description={
+        mode === "add"
+          ? "Mounted as a file at /secrets/<key> inside the server pod."
+          : undefined
+      }
+      footer={
+        <>
+          <Button type="button" variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={!canSubmit}
+            onClick={() => onConfirm({ ...draft, key: trimmedKey })}
+          >
+            {mode === "add" ? "Add file" : "Save"}
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="secret-file-key">File name</Label>
+          <Input
+            id="secret-file-key"
+            value={draft.key}
+            onChange={(e) => updateDraft({ key: e.target.value })}
+            placeholder="TLS_CERT"
+            className="font-mono"
+          />
+          {duplicate && (
+            <p className="text-xs text-destructive">
+              A secret file named &quot;{trimmedKey}&quot; already exists.
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <Label>Scope</Label>
+          <FieldScopeSelect
+            value={draft.scope}
+            onChange={(scope) => updateDraft({ scope })}
+            disableInstallation={disableInstallation}
+            disabledReason={disableInstallationReason}
+          />
+        </div>
+
+        {draft.scope === "installation" && (
+          <ScopeCallout
+            title="The user provides this when installing"
+            body={
+              <>
+                They&apos;ll see a field labeled{" "}
+                <span className="font-mono">
+                  &quot;{trimmedKey || "FILE_NAME"}&quot;
+                </span>{" "}
+                and your description below as the helper text.
+              </>
+            }
+          />
+        )}
+        {draft.scope === "preset" && (
+          <ScopeCallout
+            title="An admin sets this for each preset"
+            body="Each preset that uses this server supplies its own value."
+          />
+        )}
+        {draft.scope === "static" && (
+          <StaticValueEditor
+            draft={draft}
+            hasStoredSecret={hasStoredSecret}
+            isVaultRef={isVaultRef}
+            useExternalSecretsManager={useExternalSecretsManager}
+            onOpenVault={() => setVaultDialogOpen(true)}
+            onClearVault={() => updateDraft({ value: "" })}
+            onValueChange={(value) => updateDraft({ value })}
+          />
+        )}
+
+        {draft.scope === "installation" && (
+          <div className="flex items-center justify-between gap-3 rounded-md border border-border p-3">
+            <div className="space-y-0.5">
+              <div className="text-sm font-medium">Required file</div>
+              <div className="text-xs text-muted-foreground">
+                Block installation until the user supplies a value.
+              </div>
+            </div>
+            <Switch
+              checked={draft.required}
+              onCheckedChange={(required) => updateDraft({ required })}
+              aria-label="Required file"
+            />
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <Label htmlFor="secret-file-description">Description</Label>
+          <Textarea
+            id="secret-file-description"
+            value={draft.description}
+            onChange={(e) => updateDraft({ description: e.target.value })}
+            placeholder="Optional description"
+            rows={2}
+          />
+        </div>
+      </div>
+
+      {useExternalSecretsManager && vaultDialogOpen && (
+        <VaultPickerDialog
+          envKey={trimmedKey || "field"}
+          initialValue={isVaultRef ? draft.value : undefined}
+          onClose={() => setVaultDialogOpen(false)}
+          onConfirm={(ref) => {
+            updateDraft({ value: ref });
+            setVaultDialogOpen(false);
+          }}
+        />
+      )}
+    </StandardDialog>
+  );
+}
+
+function ScopeCallout({
+  title,
+  body,
+}: {
+  title: string;
+  body: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-start gap-3 rounded-md border border-primary/20 bg-primary/5 p-3">
+      <Info className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+      <div className="space-y-0.5 text-xs">
+        <div className="font-medium text-foreground">{title}</div>
+        <div className="text-muted-foreground">{body}</div>
+      </div>
+    </div>
+  );
+}
+
+function StaticValueEditor({
+  draft,
+  hasStoredSecret,
+  isVaultRef,
+  useExternalSecretsManager,
+  onOpenVault,
+  onClearVault,
+  onValueChange,
+}: {
+  draft: SecretFileDraft;
+  hasStoredSecret: boolean;
+  isVaultRef: boolean;
+  useExternalSecretsManager: boolean;
+  onOpenVault: () => void;
+  onClearVault: () => void;
+  onValueChange: (value: string) => void;
+}) {
+  if (useExternalSecretsManager) {
+    return (
+      <div className="space-y-2">
+        <Label>Vault secret</Label>
+        {isVaultRef ? (
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 px-2 text-xs font-mono text-green-600 hover:text-green-700"
+              onClick={onOpenVault}
+            >
+              <CheckCircle2 className="h-3 w-3 mr-1" />
+              <span className="truncate max-w-[200px]">
+                {parseVaultReference(draft.value).key}
+              </span>
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 text-xs"
+              onClick={onClearVault}
+            >
+              Clear
+            </Button>
+          </div>
+        ) : (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 text-xs"
+            onClick={onOpenVault}
+          >
+            <Key className="h-3 w-3 mr-1" />
+            Set secret
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor="secret-file-value">File contents</Label>
+      <Textarea
+        id="secret-file-value"
+        value={draft.value}
+        onChange={(e) => onValueChange(e.target.value)}
+        placeholder={hasStoredSecret ? "••••••••" : "Paste the secret here..."}
+        rows={6}
+        className="font-mono text-xs"
+        autoComplete={MCP_SECRET_AUTOCOMPLETE}
+      />
+      {hasStoredSecret && (
+        <p className="text-xs text-muted-foreground">
+          A value is already stored. Leave blank to keep it, or paste a new
+          value to replace.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function VaultPickerDialog({
+  envKey,
+  initialValue,
+  onClose,
+  onConfirm,
+}: {
+  envKey: string;
+  initialValue: string | undefined;
+  onClose: () => void;
+  onConfirm: (ref: string) => void;
+}) {
+  const parsed = initialValue ? parseVaultReference(initialValue) : null;
+  const [teamId, setTeamId] = useState<string | null>(null);
+  const [secretPath, setSecretPath] = useState<string | null>(
+    parsed?.path ?? null,
+  );
+  const [secretKey, setSecretKey] = useState<string | null>(
+    parsed?.key ?? null,
+  );
+
+  return (
+    <StandardDialog
+      open
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+      size="small"
+      title={
+        <span className="flex items-center gap-2">
+          <Key className="h-5 w-5" />
+          Set external secret
+          <span className="font-mono text-muted-foreground">{envKey}</span>
+        </span>
+      }
+      description="Select a secret from your team's external Vault to use for this file."
+      footer={
+        <>
+          <Button type="button" variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={() => {
+              if (secretPath && secretKey) {
+                onConfirm(`${secretPath}#${secretKey}`);
+              }
+            }}
+            disabled={!secretPath || !secretKey}
+          >
+            Confirm
+          </Button>
+        </>
+      }
+    >
+      <Suspense
+        fallback={
+          <div className="flex h-24 items-center justify-center text-muted-foreground">
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Loading...
+          </div>
+        }
+      >
+        <ExternalSecretSelector
+          selectedTeamId={teamId}
+          selectedSecretPath={secretPath}
+          selectedSecretKey={secretKey}
+          onTeamChange={setTeamId}
+          onSecretChange={setSecretPath}
+          onSecretKeyChange={setSecretKey}
+        />
+      </Suspense>
+    </StandardDialog>
+  );
+}


### PR DESCRIPTION
## Summary

Continues the catalog-form refactor from #4696 by applying the same modal-add + read-only-table pattern to the last two inline-editable lists in `EnvironmentVariablesFormField`:

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>