### PR TITLE
fix(presets): preset edit silently fails when row carries orphan keys from past scope flips

### DIFF
--- a/platform/backend/src/models/internal-mcp-catalog.ts
+++ b/platform/backend/src/models/internal-mcp-catalog.ts
@@ -509,7 +509,7 @@ class InternalMcpCatalogModel {
     fieldValues: PresetFieldValues | undefined,
   ): void {
     if (!fieldValues) return;
-    const presetKeys = this.getPresetScopedKeys(parent);
+    const presetKeys = InternalMcpCatalogModel.getPresetScopedKeys(parent);
     const offenders = Object.keys(fieldValues).filter(
       (key) => !presetKeys.has(key),
     );
@@ -541,7 +541,7 @@ class InternalMcpCatalogModel {
     fieldValues: PresetFieldValues | undefined,
   ): PresetFieldValues {
     if (!fieldValues) return {};
-    const presetKeys = this.getPresetScopedKeys(parent);
+    const presetKeys = InternalMcpCatalogModel.getPresetScopedKeys(parent);
     const filtered: PresetFieldValues = {};
     const dropped: string[] = [];
     for (const [key, value] of Object.entries(fieldValues)) {

--- a/platform/backend/src/models/internal-mcp-catalog.ts
+++ b/platform/backend/src/models/internal-mcp-catalog.ts
@@ -10,6 +10,7 @@ import {
   or,
 } from "drizzle-orm";
 import db, { schema } from "@/database";
+import logger from "@/logging";
 import { secretManager } from "@/secrets-manager";
 import {
   ENTERPRISE_MANAGED_CLIENT_SECRET_OVERRIDE_SECRET_KEY,
@@ -474,24 +475,41 @@ class InternalMcpCatalogModel {
   }
 
   /**
-   * Validate a `presetFieldValues` payload against a parent's userConfig and
-   * localConfig.environment field-scope flags. Only fields flagged
-   * `promptOnPreset: true` are allowed; throws an Error listing offenders
-   * when any other key is present.
+   * Compute the set of field keys (env-var keys + userConfig field names)
+   * that the parent currently exposes as `promptOnPreset: true`. Used by
+   * both the strict validator and the lenient filter below.
+   */
+  static getPresetScopedKeys(parent: InternalMcpCatalog): Set<string> {
+    const keys = new Set<string>();
+    for (const [key, field] of Object.entries(parent.userConfig ?? {})) {
+      if (field.promptOnPreset) keys.add(key);
+    }
+    for (const env of parent.localConfig?.environment ?? []) {
+      if (env.promptOnPreset) keys.add(env.key);
+    }
+    return keys;
+  }
+
+  /**
+   * Validate a `presetFieldValues` payload against a parent's currently
+   * preset-scoped fields. Only fields flagged `promptOnPreset: true` are
+   * allowed; throws an Error listing offenders when any other key is present.
+   *
+   * Use for *create-time* paths where a non-preset key in the payload almost
+   * certainly indicates a typo or stale frontend that should fail loudly:
+   *   - POST /api/internal_mcp_catalog/:id/children (createChild)
+   *   - POST /api/mcp_server (install — frontend builds payload from current scope)
+   *
+   * Do NOT use for PATCH update on existing children — those routes must
+   * tolerate orphan keys left over from past scope flips. See
+   * `filterFieldValuesToPresetScope` below.
    */
   static validateFieldValuesAgainstCatalog(
     parent: InternalMcpCatalog,
     fieldValues: PresetFieldValues | undefined,
   ): void {
     if (!fieldValues) return;
-    const presetKeys = new Set<string>();
-    for (const [key, field] of Object.entries(parent.userConfig ?? {})) {
-      if (field.promptOnPreset) presetKeys.add(key);
-    }
-    for (const env of parent.localConfig?.environment ?? []) {
-      if (env.promptOnPreset) presetKeys.add(env.key);
-    }
-
+    const presetKeys = this.getPresetScopedKeys(parent);
     const offenders = Object.keys(fieldValues).filter(
       (key) => !presetKeys.has(key),
     );
@@ -500,6 +518,46 @@ class InternalMcpCatalogModel {
         `Fields not configured for preset overrides: ${offenders.join(", ")}`,
       );
     }
+  }
+
+  /**
+   * Return a sanitized copy of `fieldValues` that contains only keys
+   * currently flagged `promptOnPreset: true` on the parent. Keys that are no
+   * longer preset-scoped (orphans left by a past scope flip on the parent —
+   * the cascade syncs the parent's localConfig template down but does not
+   * scrub children's `preset_field_values` jsonb) are silently dropped.
+   *
+   * Use for *update* paths on existing children — when an admin opens the
+   * preset editor the frontend copies the row's full presetFieldValues into
+   * local state and re-sends them on save, so without this filter every
+   * "Save" after a parent scope flip would 400 and silently drop the user's
+   * new value (PR #4402, user-reported).
+   *
+   * As a beneficial side effect, every successful PATCH that round-trips
+   * through this filter garbage-collects the orphans from the row's jsonb.
+   */
+  static filterFieldValuesToPresetScope(
+    parent: InternalMcpCatalog,
+    fieldValues: PresetFieldValues | undefined,
+  ): PresetFieldValues {
+    if (!fieldValues) return {};
+    const presetKeys = this.getPresetScopedKeys(parent);
+    const filtered: PresetFieldValues = {};
+    const dropped: string[] = [];
+    for (const [key, value] of Object.entries(fieldValues)) {
+      if (presetKeys.has(key)) {
+        filtered[key] = value;
+      } else {
+        dropped.push(key);
+      }
+    }
+    if (dropped.length > 0) {
+      logger.info(
+        { catalogId: parent.id, droppedKeys: dropped },
+        "Dropped orphan preset keys from PATCH payload (no longer promptOnPreset on parent)",
+      );
+    }
+    return filtered;
   }
 
   static async delete(id: string): Promise<boolean> {

--- a/platform/backend/src/routes/internal-mcp-catalog.children-stale-preset-keys.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.children-stale-preset-keys.test.ts
@@ -1,0 +1,267 @@
+import { type Mock, vi } from "vitest";
+import { InternalMcpCatalogModel } from "@/models";
+import { secretManager } from "@/secrets-manager";
+import type { FastifyInstanceWithZod } from "@/server";
+import { createFastifyInstance } from "@/server";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import type { User } from "@/types";
+
+vi.mock("@/auth", () => ({
+  hasPermission: vi.fn(),
+}));
+
+import { hasPermission } from "@/auth";
+
+const mockHasPermission = hasPermission as Mock;
+
+/**
+ * Reproduces the user-reported bug:
+ *
+ *   1. Edit preset "staging", set DB_PASSWORD = "passwordstaging3"
+ *   2. Delete installation
+ *   3. Reinstall, choose "staging" preset
+ *   4. Fill any other env
+ *   5. Check pod env in Shell — DB_PASSWORD is NOT "passwordstaging3"
+ *
+ * Why the new password value never lands on the catalog row: when a
+ * parent's field scope flips from `promptOnPreset: true` to non-preset
+ * (admin edits the catalog), the cascade syncs the parent's localConfig
+ * template down to children but does NOT scrub their preset_field_values
+ * jsonb. The child row keeps an orphaned entry for the now-non-preset key.
+ *
+ * The next time the user opens the preset editor:
+ *   - Local state initializes from `preset.presetFieldValues` → carries the orphan.
+ *   - User types a value into a still-valid preset field (DB_PASSWORD).
+ *   - Save sends the entire local state (orphan + new value) via PATCH.
+ *   - `validateFieldValuesAgainstCatalog` rejects the whole payload because
+ *     the orphan key is not in the parent's currently-preset-scoped keys
+ *     → 400 "Fields not configured for preset overrides: <orphan>".
+ *   - Save silently fails. The new DB_PASSWORD value never reaches the
+ *     secret bag. The next install reads the stale value.
+ *
+ * This test pins the DESIRED behavior at the route layer — PATCH must
+ * tolerate orphaned keys (silently dropping them is fine) and persist any
+ * still-valid field values from the same payload. Multiple fix shapes
+ * satisfy this contract:
+ *   (a) backend validator silently drops keys that are no longer
+ *       preset-scoped on the parent;
+ *   (b) backend cascade scrubs orphans from children when a parent's
+ *       field scope flips (then the orphan never reaches the editor in
+ *       the first place);
+ *   (c) frontend filters the save payload to currently-preset-scoped keys.
+ *
+ * Either (a) alone or (b) alone makes this test green; together they're
+ * defense-in-depth. (c) cannot be exercised here (it's a frontend concern).
+ */
+describe("PATCH /api/internal_mcp_catalog/:catalogId/children/:childId — tolerates stale preset keys", () => {
+  let app: FastifyInstanceWithZod;
+  let user: User;
+  let organizationId: string;
+
+  beforeEach(async ({ makeOrganization, makeUser }) => {
+    vi.clearAllMocks();
+    mockHasPermission.mockResolvedValue({ success: true, error: null });
+
+    user = await makeUser();
+    const organization = await makeOrganization();
+    organizationId = organization.id;
+
+    app = createFastifyInstance();
+    app.addHook("onRequest", async (request) => {
+      (request as typeof request & { user: unknown }).user = user;
+      (request as typeof request & { organizationId: string }).organizationId =
+        organizationId;
+    });
+
+    const { default: routes } = await import("./internal-mcp-catalog");
+    await app.register(routes);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await app.close();
+  });
+
+  test("editing a preset persists the new value even when the payload still carries keys from a former preset field", async () => {
+    // ── 1. Parent starts with TWO preset-scoped envs.
+    const parent = await createCatalog({
+      name: "stale-keys-parent",
+      serverType: "local",
+      localConfig: {
+        command: "node",
+        arguments: ["server.js"],
+        environment: [
+          {
+            key: "DIALECT_PACKAGES",
+            type: "plain_text",
+            promptOnInstallation: false,
+            promptOnPreset: true,
+            required: false,
+          },
+          {
+            key: "DB_PASSWORD",
+            type: "secret",
+            promptOnInstallation: false,
+            promptOnPreset: true,
+            required: false,
+          },
+        ],
+        transportType: "streamable-http",
+        httpPort: 8080,
+        httpPath: "/mcp",
+      },
+    });
+
+    // ── 2. Create the staging child preset with values for both.
+    const child = await createChild(parent.id, {
+      childName: "staging",
+      presetFieldValues: {
+        DIALECT_PACKAGES: "psycopg2-binary,pymysql",
+        DB_PASSWORD: "old-password",
+      },
+    });
+
+    // ── 3. Admin edits the parent: DIALECT_PACKAGES is no longer
+    //    preset-scoped (becomes a static env with a fixed value).
+    //    The cascade syncs the new template to children.
+    const flipResponse = await app.inject({
+      method: "PUT",
+      url: `/api/internal_mcp_catalog/${parent.id}`,
+      payload: {
+        ...stripCascadeIgnored(parent),
+        localConfig: {
+          ...parent.localConfig,
+          environment: [
+            {
+              key: "DIALECT_PACKAGES",
+              type: "plain_text",
+              promptOnInstallation: false,
+              // promptOnPreset removed → no longer a preset-scoped field
+              required: false,
+              value: "psycopg2-binary",
+            },
+            // DB_PASSWORD stays preset-scoped
+            {
+              key: "DB_PASSWORD",
+              type: "secret",
+              promptOnInstallation: false,
+              promptOnPreset: true,
+              required: false,
+            },
+          ],
+        },
+      },
+    });
+    expect(flipResponse.statusCode).toBe(200);
+
+    // ── 4. Confirm the orphan exists on the child row (this is the
+    //    real-world precondition that the editor would carry into local
+    //    state and re-send on save).
+    const childAfterFlip = await loadRaw(child.id);
+    expect(childAfterFlip.presetFieldValues).toHaveProperty(
+      "DIALECT_PACKAGES",
+      "psycopg2-binary,pymysql",
+    );
+
+    // ── 5. The user opens the editor (loads orphan + valid keys into
+    //    local state), types a NEW DB_PASSWORD, and clicks Save. The
+    //    frontend posts the full local state — which includes the
+    //    orphaned DIALECT_PACKAGES.
+    const patchResponse = await app.inject({
+      method: "PATCH",
+      url: `/api/internal_mcp_catalog/${parent.id}/children/${child.id}`,
+      payload: {
+        presetFieldValues: {
+          DIALECT_PACKAGES: "psycopg2-binary,pymysql", // ← orphan from former scope
+          DB_PASSWORD: "passwordstaging3", // ← the value the user typed
+        },
+      },
+    });
+
+    // ── 6. The PATCH must succeed. (Today: 400 with
+    //     "Fields not configured for preset overrides: DIALECT_PACKAGES".)
+    expect(patchResponse.statusCode).toBe(200);
+
+    // ── 7. The new DB_PASSWORD must have landed in the secret bag.
+    //     Without this, the next install reads the stale value and the
+    //     pod's env shows the old password — exactly the user-reported
+    //     symptom in step 6 of the repro.
+    const childAfterPatch = await loadRaw(child.id);
+    const presetSecretId = childAfterPatch.presetSecretId;
+    if (!presetSecretId) throw new Error("expected presetSecretId");
+
+    const bag = await secretManager().getSecret(presetSecretId);
+    expect(bag?.secret).toMatchObject({ DB_PASSWORD: "passwordstaging3" });
+  });
+
+  // ===========================================================================
+  // Helpers
+  // ===========================================================================
+
+  async function createCatalog(payload: Record<string, unknown>): Promise<{
+    id: string;
+    name: string;
+    serverType: string;
+    localConfig: Record<string, unknown>;
+  }> {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/internal_mcp_catalog",
+      payload,
+    });
+    if (response.statusCode !== 200) {
+      throw new Error(
+        `createCatalog failed: ${response.statusCode} ${response.body}`,
+      );
+    }
+    return response.json();
+  }
+
+  async function createChild(
+    parentId: string,
+    body: { childName: string; presetFieldValues: Record<string, unknown> },
+  ): Promise<{ id: string }> {
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/internal_mcp_catalog/${parentId}/children`,
+      payload: body,
+    });
+    if (response.statusCode !== 200) {
+      throw new Error(
+        `createChild failed: ${response.statusCode} ${response.body}`,
+      );
+    }
+    return response.json();
+  }
+
+  async function loadRaw(id: string) {
+    const row = await InternalMcpCatalogModel.findById(id, {
+      expandSecrets: false,
+      userId: user.id,
+      isAdmin: true,
+      organizationId,
+    });
+    if (!row) throw new Error(`row ${id} not found`);
+    return row;
+  }
+});
+
+/**
+ * The PUT route's body schema rejects keys that are locked-after-creation
+ * (organizationId, authorId, multitenant, parentCatalogItemId). Strip them
+ * from a previously-fetched catalog row before re-posting it as a PUT body.
+ */
+function stripCascadeIgnored(parent: Record<string, unknown>) {
+  const {
+    id: _id,
+    organizationId: _o,
+    authorId: _a,
+    multitenant: _m,
+    parentCatalogItemId: _p,
+    childName: _c,
+    createdAt: _ca,
+    updatedAt: _u,
+    ...rest
+  } = parent as Record<string, unknown>;
+  return rest;
+}

--- a/platform/backend/src/routes/internal-mcp-catalog.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.ts
@@ -1226,19 +1226,28 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
         throw new ApiError(404, "Child catalog item not found");
       }
 
+      const updates: Record<string, unknown> = {};
       if (presetFieldValues !== undefined) {
-        try {
-          InternalMcpCatalogModel.validateFieldValuesAgainstCatalog(
+        // Lenient filter (not the strict validator used on create / install):
+        // when a parent edit flips a field's scope from `promptOnPreset:
+        // true` to non-preset, the cascade syncs the parent's localConfig
+        // template down to children but does NOT scrub their existing
+        // `preset_field_values` jsonb. The frontend's preset editor copies
+        // the row's full presetFieldValues into local state and re-sends
+        // them on save, so without this filter every PATCH after a parent
+        // scope flip would 400 ("Fields not configured for preset
+        // overrides: …") and silently drop the user's new value.
+        //
+        // As a beneficial side effect, every successful PATCH garbage-
+        // collects the orphan keys from the row's jsonb (see Model.update
+        // call below — `presetFieldValues` is replaced wholesale with the
+        // filtered set).
+        const sanitized =
+          InternalMcpCatalogModel.filterFieldValuesToPresetScope(
             parent,
             presetFieldValues,
           );
-        } catch (e) {
-          throw new ApiError(400, (e as Error).message);
-        }
-      }
 
-      const updates: Record<string, unknown> = {};
-      if (presetFieldValues !== undefined) {
         const { nonSecretFieldValues, presetSecretId } =
           await partitionPresetFieldValuesAndUpsertSecrets({
             parent,
@@ -1246,7 +1255,7 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
               name: originalChild.name,
               presetSecretId: originalChild.presetSecretId,
             },
-            incoming: presetFieldValues,
+            incoming: sanitized,
           });
         updates.presetFieldValues = nonSecretFieldValues;
         if (presetSecretId !== originalChild.presetSecretId) {


### PR DESCRIPTION
## Bug

Editing a preset's value silently fails to save when the catalog row carries orphan entries in `preset_field_values` from past scope flips. The user's typed value never reaches the secret bag, and the next install reads the stale value.

User-visible repro:

1. Set up a parent with two preset env vars (e.g. `DIALECT_PACKAGES` plain + `DB_PASSWORD` secret).
2. Create the `staging` preset with values for both.
3. Edit the parent: flip `DIALECT_PACKAGES` from preset to non-preset (static).
   The cascade syncs the parent's `localConfig` template down to the child but **does NOT scrub the child's `preset_field_values` jsonb** — the orphan stays.
4. Open the staging preset's editor, change `DB_PASSWORD` to a new value, click **Save changes**. The dialog closes — looks like it worked.
5. Delete the install, re-install with the staging preset selected.
6. Check the pod env: `DB_PASSWORD` is the **old** value, not the one just typed.

## Root cause

```
useEffect: setFieldValues({ ...preset.presetFieldValues })
  → carries orphan into local state

user types: setFieldValues(prev => ({ ...prev, DB_PASSWORD: 'new' }))
  → state now has { DIALECT_PACKAGES: <orphan>, DB_PASSWORD: <new> }

save: PATCH /api/internal_mcp_catalog/:id/children/:childId
  → body.presetFieldValues = entire local state

backend: validateFieldValuesAgainstCatalog
  → sees DIALECT_PACKAGES is no longer promptOnPreset on parent
  → throws "Fields not configured for preset overrides: DIALECT_PACKAGES"
  → route returns 400, ENTIRE payload rejected
  → DB_PASSWORD never written to secret bag
```

The frontend's `hey-api`-generated SDK doesn't reliably throw on 4xx, so the user often sees a misleading success toast (or a quick error toast they miss as the dialog closes).

## Fix

Split the validator's contract so each call site picks the semantics it needs:

| Method | Semantics | Used by |
|---|---|---|
| `validateFieldValuesAgainstCatalog` (existing, refactored) | **Strict** — throws on orphan keys | `POST /children` (createChild), `POST /mcp_server` (install) — orphans cannot naturally occur here, and typos should still be caught loudly |
| `filterFieldValuesToPresetScope` (new) | **Lenient** — silently drops orphan keys, logs which ones via `logger.info` | `PATCH /children/:childId` (updateChild) — orphans naturally accumulate from past scope flips |

Both share a `getPresetScopedKeys(parent)` helper, so the definition of "preset key" stays in one place — no drift risk between the two methods.

## Side benefit: orphans get garbage-collected

The PATCH route's call to `partitionPresetFieldValuesAndUpsertSecrets` ends with `Model.update(child, { presetFieldValues: nonSecretFieldValues })` — which **replaces** the row's jsonb wholesale. Because the input has been through the lenient filter, the new jsonb only contains currently-valid keys. **Every successful PATCH naturally cleans up its row's orphans.** No separate scrub task needed.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>