### PR TITLE
feat: polish chat ui

### DIFF
--- a/platform/backend/package.json
+++ b/platform/backend/package.json
@@ -26,6 +26,7 @@
     "db:studio": "drizzle-kit studio",
     "db:clean": "tsx --tsconfig standalone-scripts.tsconfig.json src/standalone-scripts/clean-db-on-dev.ts",
     "db:seed:mock-data": "tsx --tsconfig standalone-scripts.tsconfig.json src/standalone-scripts/seed-mock-data.ts",
+    "db:seed:chat-scenarios": "tsx --tsconfig standalone-scripts.tsconfig.json src/standalone-scripts/seed-chat-scenarios.ts",
     "codegen:access-control-docs": "tsx --tsconfig standalone-scripts.tsconfig.json src/standalone-scripts/codegen-access-control-docs.ts",
     "codegen:archestra-mcp-server-docs": "tsx --tsconfig standalone-scripts.tsconfig.json src/standalone-scripts/codegen-archestra-mcp-server-docs.ts",
     "codegen:openapi": "tsx --tsconfig standalone-scripts.tsconfig.json src/standalone-scripts/codegen-openapi.ts",

--- a/platform/backend/src/standalone-scripts/chat-scenarios.ts
+++ b/platform/backend/src/standalone-scripts/chat-scenarios.ts
@@ -92,7 +92,7 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
           },
           {
             type: "file",
-            url: "https://example.test/incident-report.png",
+            url: "https://placehold.co/600x400",
             mediaType: "image/png",
             filename: "incident-report.png",
           },

--- a/platform/backend/src/standalone-scripts/chat-scenarios.ts
+++ b/platform/backend/src/standalone-scripts/chat-scenarios.ts
@@ -24,20 +24,28 @@ const baseTimestamp = "2026-04-23T10:00:00.000Z";
 export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
   {
     id: "timeline-errors",
-    title: "Timeline errors",
+    title: "Retry after provider error",
     messages: [
-      userMessage("timeline-user-1", "first try", baseTimestamp),
-      userMessage("timeline-user-2", "try again", "2026-04-23T10:02:00.000Z"),
+      userMessage(
+        "timeline-user-1",
+        "Can you summarize the last deployment health check?",
+        baseTimestamp,
+      ),
+      userMessage(
+        "timeline-user-2",
+        "The previous response failed. Please try the deployment summary again.",
+        "2026-04-23T10:02:00.000Z",
+      ),
     ],
     chatErrors: [
       chatError("timeline-error-1", "2026-04-23T10:01:00.000Z", {
-        message: "Provider failed",
+        message: "The model provider returned a temporary error.",
       }),
     ],
   },
   {
     id: "compact-tools",
-    title: "Compact tools",
+    title: "Release triage with compact tools",
     messages: [
       assistantMessage(
         "compact-tools-assistant",
@@ -46,31 +54,45 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
             type: "tool-demo__list_issues",
             toolCallId: "compact-call-1",
             state: "input-available",
-            input: { owner: "demo-owner", repo: "demo-repo" },
+            input: { owner: "example-org", repo: "checkout-service" },
           },
           {
             type: "tool-demo__list_issues",
             toolCallId: "compact-call-1",
             state: "output-available",
-            input: { owner: "demo-owner", repo: "demo-repo" },
-            output: { issues: [{ number: 1, title: "Demo issue" }] },
+            input: { owner: "example-org", repo: "checkout-service" },
+            output: {
+              issues: [
+                {
+                  number: 128,
+                  title: "Retry queue depth is elevated after deploy",
+                },
+              ],
+            },
           },
           {
             type: "tool-demo__list_pull_requests",
             toolCallId: "compact-call-2",
             state: "input-available",
-            input: { owner: "demo-owner", repo: "demo-repo" },
+            input: { owner: "example-org", repo: "checkout-service" },
           },
           {
             type: "tool-demo__list_pull_requests",
             toolCallId: "compact-call-2",
             state: "output-available",
-            input: { owner: "demo-owner", repo: "demo-repo" },
-            output: { pullRequests: [{ number: 7, title: "Demo PR" }] },
+            input: { owner: "example-org", repo: "checkout-service" },
+            output: {
+              pullRequests: [
+                {
+                  number: 42,
+                  title: "Add queue drain metric to release dashboard",
+                },
+              ],
+            },
           },
           {
             type: "text",
-            text: "Checked the current issues and pull requests.",
+            text: "I found one active issue about retry queue depth and one related pull request adding dashboard coverage.",
           },
         ] as UIMessage["parts"],
         baseTimestamp,
@@ -79,7 +101,7 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
   },
   {
     id: "file-variants",
-    title: "File variants",
+    title: "Incident files",
     messages: [
       {
         id: "file-user-with-text",
@@ -88,13 +110,13 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
         parts: [
           {
             type: "text",
-            text: "Please review the attached incident files.",
+            text: "Please review these incident materials before I send the follow-up.",
           },
           {
             type: "file",
             url: "https://placehold.co/600x400",
             mediaType: "image/png",
-            filename: "incident-report.png",
+            filename: "latency-dashboard.png",
           },
         ],
       } as UIMessage,
@@ -105,7 +127,7 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
         parts: [
           {
             type: "file",
-            url: "https://example.test/network-trace.txt",
+            url: "https://example.test/artifacts/network-trace.txt",
             mediaType: "text/plain",
             filename: "network-trace.txt",
           },
@@ -116,19 +138,19 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
         [
           {
             type: "file",
-            url: "https://example.test/runbook.pdf",
+            url: "https://example.test/artifacts/rollback-runbook.pdf",
             mediaType: "application/pdf",
-            filename: "runbook.pdf",
+            filename: "rollback-runbook.pdf",
           },
           {
             type: "file",
-            url: "https://example.test/trace.csv",
+            url: "https://example.test/artifacts/request-sample.csv",
             mediaType: "text/csv",
-            filename: "trace.csv",
+            filename: "request-sample.csv",
           },
           {
             type: "text",
-            text: "I reviewed the attached files.",
+            text: "The dashboard and trace sample point to a short latency spike during rollout, while the rollback runbook has the recovery steps the on-call team followed.",
           },
         ] as UIMessage["parts"],
         "2026-04-23T10:00:02.000Z",
@@ -137,7 +159,7 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
   },
   {
     id: "sdk-message-parts",
-    title: "SDK message parts",
+    title: "Sourced answer with SDK parts",
     messages: [
       assistantMessage(
         "sdk-parts-assistant",
@@ -145,39 +167,39 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
           { type: "step-start" },
           {
             type: "reasoning",
-            text: "Checking SDK reasoning before composing the answer.",
+            text: "Comparing the runbook with the published release notes before giving a short recommendation.",
             state: "done",
           },
           {
             type: "text",
-            text: "The SDK message parts rendered correctly.",
+            text: "The safest next step is to pause the rollout, drain the retry queue below the alert threshold, and then resume with the patched health-check configuration.",
           },
           {
             type: "source-url",
-            sourceId: "sdk-source-1",
-            url: "https://example.test/sdk-source",
-            title: "SDK Source",
+            sourceId: "release-notes-2026-04",
+            url: "https://example.test/releases/2026-04-checkout",
+            title: "Checkout release notes",
           },
           {
             type: "source-url",
-            sourceId: "sdk-source-1",
-            url: "https://example.test/sdk-source-duplicate",
-            title: "SDK Source Duplicate",
+            sourceId: "release-notes-2026-04",
+            url: "https://example.test/releases/2026-04-checkout?duplicate=true",
+            title: "Checkout release notes duplicate",
           },
           {
             type: "source-document",
-            sourceId: "sdk-doc-1",
+            sourceId: "rollout-runbook-v3",
             mediaType: "application/pdf",
-            title: "SDK Source Document",
-            filename: "sdk-source-document.pdf",
+            title: "Rollout recovery runbook",
+            filename: "rollout-recovery-runbook.pdf",
           },
           {
             type: "data-heartbeat",
-            data: { timestamp: 1 },
+            data: { timestamp: 1, phase: "source-review" },
           },
           {
             type: "data-token-usage",
-            data: { inputTokens: 7, outputTokens: 11, totalTokens: 18 },
+            data: { inputTokens: 812, outputTokens: 94, totalTokens: 906 },
           },
         ] as UIMessage["parts"],
         baseTimestamp,
@@ -186,7 +208,7 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
   },
   {
     id: "dynamic-tool",
-    title: "Dynamic tool",
+    title: "Dynamic web search",
     messages: [
       assistantMessage(
         "dynamic-tool-assistant",
@@ -196,23 +218,26 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
             toolName: "web_search",
             toolCallId: "dynamic-call-1",
             state: "input-available",
-            input: { query: "release notes" },
+            input: { query: "checkout service April release retry queue" },
           },
           {
             type: "dynamic-tool",
             toolName: "web_search",
             toolCallId: "dynamic-call-1",
             state: "output-available",
-            input: { query: "release notes" },
+            input: { query: "checkout service April release retry queue" },
             output: {
               results: [
-                { title: "Release notes", url: "https://example.test" },
+                {
+                  title: "April checkout release notes",
+                  url: "https://example.test/releases/checkout-april",
+                },
               ],
             },
           },
           {
             type: "text",
-            text: "I checked the release notes.",
+            text: "The release notes mention a retry backoff change, so I would inspect queue drain metrics before rolling forward.",
           },
         ] as UIMessage["parts"],
         baseTimestamp,
@@ -221,11 +246,11 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
   },
   {
     id: "system-and-thinking",
-    title: "System and thinking",
+    title: "System prompt and thinking",
     messages: [
       systemMessage(
         "system-thinking-system",
-        "Use demo credentials only.",
+        "Use only the sandbox workspace and avoid making changes unless the operator approves them.",
         baseTimestamp,
       ),
       assistantMessage(
@@ -233,11 +258,11 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
         [
           {
             type: "text",
-            text: "<think>Need to inspect config first.</think>Use the demo credentials only.",
+            text: "<think>Confirm the target workspace and avoid side effects.</think>I will inspect the sandbox workspace first and keep the response read-only until you approve an action.",
           },
           {
             type: "reasoning",
-            text: "Double-checking the demo environment details.",
+            text: "Checking the request boundary and confirming that this turn should not mutate production data.",
             state: "done",
           },
         ] as UIMessage["parts"],
@@ -247,7 +272,7 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
   },
   {
     id: "tool-states",
-    title: "Tool states",
+    title: "Tool states and approval",
     messages: [
       assistantMessage(
         "tool-states-assistant",
@@ -257,16 +282,20 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
             data: {
               toolCallId: "tool-ui-call-1",
               toolName: "demo__open_pull_request",
-              uiResourceUri: "ui://demo/pr-view",
-              html: "<div>Pull request preview</div>",
+              uiResourceUri: "ui://demo/release-pr-view",
+              html: "<div>Release pull request preview</div>",
             },
           } as never,
           {
             type: "tool-demo__open_pull_request",
             toolCallId: "tool-ui-call-1",
             state: "output-available",
-            input: { owner: "demo-owner", repo: "demo-repo", number: 42 },
-            output: { ok: true, title: "Pull request preview" },
+            input: {
+              owner: "example-org",
+              repo: "checkout-service",
+              number: 42,
+            },
+            output: { ok: true, title: "Release pull request preview" },
           },
           {
             type: "tool-archestra__todo_write",
@@ -274,8 +303,11 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
             state: "approval-requested",
             input: {
               todos: [
-                { content: "Find demo tools", status: "completed" },
-                { content: "Request approval", status: "pending" },
+                { content: "Review rollout pull request", status: "completed" },
+                {
+                  content: "Ask operator before updating checklist",
+                  status: "pending",
+                },
               ],
             },
             approval: { id: "approval-1" },
@@ -284,12 +316,12 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
             type: "tool-archestra__swap_agent",
             toolCallId: "swap-call",
             state: "output-available",
-            input: { agent_name: "Demo Agent" },
+            input: { agent_name: "Release Coordinator" },
             output: { ok: true },
           },
           {
             type: "text",
-            text: "Tool previews are ready.",
+            text: "The pull request preview is ready, and the checklist update is waiting for approval.",
           },
         ] as UIMessage["parts"],
         baseTimestamp,
@@ -298,7 +330,7 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
   },
   {
     id: "auth-states",
-    title: "Auth states",
+    title: "Authentication states",
     messages: [
       assistantMessage(
         "auth-states-tool-errors",
@@ -313,9 +345,10 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
               _meta: {
                 archestraError: {
                   type: "auth_expired",
-                  message: 'Expired or invalid authentication for "Demo MCP".',
+                  message:
+                    'Expired or invalid authentication for "Issue Tracker".',
                   catalogId: "demo-catalog",
-                  catalogName: "Demo MCP",
+                  catalogName: "Issue Tracker",
                   serverId: "demo-server",
                   reauthUrl:
                     "http://localhost:3000/mcp/registry?reauth=demo-catalog&server=demo-server",
@@ -333,9 +366,10 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
               _meta: {
                 archestraError: {
                   type: "assigned_credential_unavailable",
-                  message: "Assigned credential unavailable",
+                  message:
+                    "Assigned credential is unavailable for this workspace.",
                   catalogId: "demo-assigned-catalog",
-                  catalogName: "Demo Remote MCP",
+                  catalogName: "Remote Change Manager",
                 },
               },
             },
@@ -348,7 +382,7 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
         [
           {
             type: "text",
-            text: 'Authentication required for "Demo MCP".\n\nNo credentials were found for your account (user: demo-user).\nTo set up your credentials, visit this URL: http://localhost:3000/mcp/registry?install=demo-catalog',
+            text: 'Authentication required for "Issue Tracker".\n\nNo credentials were found for this sandbox account.\nTo set up credentials, visit this URL: http://localhost:3000/mcp/registry?install=demo-catalog',
           },
         ] as UIMessage["parts"],
         "2026-04-23T10:00:01.000Z",
@@ -357,7 +391,7 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
   },
   {
     id: "unsafe-and-policy",
-    title: "Unsafe and policy denied",
+    title: "Unsafe context and policy denial",
     messages: [
       assistantMessage(
         "unsafe-tool-assistant",
@@ -366,9 +400,10 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
             type: "tool-demo__read_note",
             toolCallId: "unsafe-call",
             state: "output-available",
-            input: { folder: "demo" },
+            input: { folder: "incident-notes" },
             output: {
-              content: "DEMO_SECRET = demo-value",
+              content:
+                "Internal incident note contains sensitive deployment credentials.",
               unsafeContextBoundary: {
                 kind: "tool_result",
                 reason: "tool_result_marked_untrusted",
@@ -379,7 +414,7 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
           },
           {
             type: "text",
-            text: "Unsafe context is now active.",
+            text: "I found an internal note that must be treated as sensitive context before any follow-up tools are invoked.",
           },
         ] as UIMessage["parts"],
         baseTimestamp,
@@ -389,7 +424,7 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
         [
           {
             type: "text",
-            text: "\nI tried to invoke the demo__print_secret tool with the following arguments: {}.\n\nHowever, I was denied by a tool invocation policy:\n\nTool invocation blocked: context contains sensitive data",
+            text: "\nI tried to invoke the demo__send_incident_update tool with the following arguments: {}.\n\nHowever, I was denied by a tool invocation policy:\n\nTool invocation blocked: context contains sensitive data",
           },
         ] as UIMessage["parts"],
         "2026-04-23T10:00:01.000Z",
@@ -398,16 +433,16 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
   },
   {
     id: "mega-conversation",
-    title: "Mega conversation",
+    title: "Full incident workflow",
     messages: [
       systemMessage(
         "mega-system",
-        "Always prefer the demo environment first.",
+        "Prefer read-only inspection first and keep all identifiers fictional in summaries.",
         "2026-04-23T09:57:00.000Z",
       ),
       userMessage(
         "mega-user-text",
-        "Show me every chat block and feature.",
+        "Walk me through the failed checkout rollout and prepare a safe operator summary.",
         "2026-04-23T09:58:00.000Z",
       ),
       assistantMessage(
@@ -415,11 +450,11 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
         [
           {
             type: "text",
-            text: "<think>Gathering every render branch.</think>Here is the combined demo.",
+            text: "<think>Gather rollout status, attachments, tools, and policy state.</think>I will combine the deployment notes, attached artifacts, and tool results into a concise operator summary.",
           },
           {
             type: "reasoning",
-            text: "Streaming reasoning block inside the mega conversation.",
+            text: "Sequencing the investigation so tool output, files, and final summary appear in a realistic order.",
             state: "done",
           },
         ] as UIMessage["parts"],
@@ -430,19 +465,19 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
         [
           {
             type: "file",
-            url: "https://example.test/mega-summary.pdf",
+            url: "https://example.test/artifacts/operator-summary.pdf",
             mediaType: "application/pdf",
-            filename: "mega-summary.pdf",
+            filename: "operator-summary.pdf",
           },
           {
             type: "file",
-            url: "https://example.test/mega-results.csv",
+            url: "https://example.test/artifacts/retry-queue-sample.csv",
             mediaType: "text/csv",
-            filename: "mega-results.csv",
+            filename: "retry-queue-sample.csv",
           },
           {
             type: "text",
-            text: "Attached the generated summary and results.",
+            text: "I attached the operator summary draft and the retry queue sample used for the analysis.",
           },
         ] as UIMessage["parts"],
         "2026-04-23T09:59:10.000Z",
@@ -454,26 +489,40 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
             type: "tool-demo__list_issues",
             toolCallId: "mega-call-1",
             state: "input-available",
-            input: { owner: "demo-owner", repo: "demo-repo" },
+            input: { owner: "example-org", repo: "checkout-service" },
           },
           {
             type: "tool-demo__list_issues",
             toolCallId: "mega-call-1",
             state: "output-available",
-            input: { owner: "demo-owner", repo: "demo-repo" },
-            output: { issues: [{ number: 1, title: "Demo issue" }] },
+            input: { owner: "example-org", repo: "checkout-service" },
+            output: {
+              issues: [
+                {
+                  number: 128,
+                  title: "Retry queue depth is elevated after deploy",
+                },
+              ],
+            },
           },
           {
             type: "dynamic-tool",
             toolName: "web_search",
             toolCallId: "mega-dynamic-call-1",
             state: "output-available",
-            input: { query: "mega scenario release notes" },
-            output: { results: [{ title: "Mega release notes" }] },
+            input: { query: "checkout rollout retry queue release notes" },
+            output: {
+              results: [
+                {
+                  title: "Checkout rollout release notes",
+                  url: "https://example.test/releases/checkout-rollout",
+                },
+              ],
+            },
           },
           {
             type: "text",
-            text: "Compact and dynamic tool branches completed.",
+            text: "The open issue and release notes both point to the retry backoff change, so the summary should call out queue drain monitoring before resuming rollout.",
           },
         ] as UIMessage["parts"],
         "2026-04-23T09:59:20.000Z",
@@ -481,7 +530,7 @@ export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
     ],
     chatErrors: [
       chatError("mega-error", "2026-04-23T09:58:15.000Z", {
-        message: "Previous attempt failed",
+        message: "The first summary attempt timed out while waiting for tools.",
       }),
     ],
   },

--- a/platform/backend/src/standalone-scripts/chat-scenarios.ts
+++ b/platform/backend/src/standalone-scripts/chat-scenarios.ts
@@ -1,0 +1,547 @@
+import {
+  type archestraApiTypes,
+  ChatErrorCode,
+  type ChatErrorResponse,
+} from "@shared";
+import type { UIMessage } from "ai";
+
+export type SeededChatPreviewScenario = {
+  id: string;
+  title: string;
+  messages: UIMessage[];
+  chatErrors?: SeededChatPreviewError[];
+  unsafeContextBoundary?: archestraApiTypes.GetInteractionResponses["200"]["unsafeContextBoundary"];
+};
+
+export type SeededChatPreviewError = {
+  id: string;
+  createdAt: string;
+  error: ChatErrorResponse;
+};
+
+const baseTimestamp = "2026-04-23T10:00:00.000Z";
+
+export const seededChatPreviewScenarios: SeededChatPreviewScenario[] = [
+  {
+    id: "timeline-errors",
+    title: "Timeline errors",
+    messages: [
+      userMessage("timeline-user-1", "first try", baseTimestamp),
+      userMessage("timeline-user-2", "try again", "2026-04-23T10:02:00.000Z"),
+    ],
+    chatErrors: [
+      chatError("timeline-error-1", "2026-04-23T10:01:00.000Z", {
+        message: "Provider failed",
+      }),
+    ],
+  },
+  {
+    id: "compact-tools",
+    title: "Compact tools",
+    messages: [
+      assistantMessage(
+        "compact-tools-assistant",
+        [
+          {
+            type: "tool-demo__list_issues",
+            toolCallId: "compact-call-1",
+            state: "input-available",
+            input: { owner: "demo-owner", repo: "demo-repo" },
+          },
+          {
+            type: "tool-demo__list_issues",
+            toolCallId: "compact-call-1",
+            state: "output-available",
+            input: { owner: "demo-owner", repo: "demo-repo" },
+            output: { issues: [{ number: 1, title: "Demo issue" }] },
+          },
+          {
+            type: "tool-demo__list_pull_requests",
+            toolCallId: "compact-call-2",
+            state: "input-available",
+            input: { owner: "demo-owner", repo: "demo-repo" },
+          },
+          {
+            type: "tool-demo__list_pull_requests",
+            toolCallId: "compact-call-2",
+            state: "output-available",
+            input: { owner: "demo-owner", repo: "demo-repo" },
+            output: { pullRequests: [{ number: 7, title: "Demo PR" }] },
+          },
+          {
+            type: "text",
+            text: "Checked the current issues and pull requests.",
+          },
+        ] as UIMessage["parts"],
+        baseTimestamp,
+      ),
+    ],
+  },
+  {
+    id: "file-variants",
+    title: "File variants",
+    messages: [
+      {
+        id: "file-user-with-text",
+        role: "user",
+        metadata: { createdAt: baseTimestamp },
+        parts: [
+          {
+            type: "text",
+            text: "Please review the attached incident files.",
+          },
+          {
+            type: "file",
+            url: "https://example.test/incident-report.png",
+            mediaType: "image/png",
+            filename: "incident-report.png",
+          },
+        ],
+      } as UIMessage,
+      {
+        id: "file-user-only",
+        role: "user",
+        metadata: { createdAt: "2026-04-23T10:00:01.000Z" },
+        parts: [
+          {
+            type: "file",
+            url: "https://example.test/network-trace.txt",
+            mediaType: "text/plain",
+            filename: "network-trace.txt",
+          },
+        ],
+      } as UIMessage,
+      assistantMessage(
+        "file-assistant",
+        [
+          {
+            type: "file",
+            url: "https://example.test/runbook.pdf",
+            mediaType: "application/pdf",
+            filename: "runbook.pdf",
+          },
+          {
+            type: "file",
+            url: "https://example.test/trace.csv",
+            mediaType: "text/csv",
+            filename: "trace.csv",
+          },
+          {
+            type: "text",
+            text: "I reviewed the attached files.",
+          },
+        ] as UIMessage["parts"],
+        "2026-04-23T10:00:02.000Z",
+      ),
+    ],
+  },
+  {
+    id: "sdk-message-parts",
+    title: "SDK message parts",
+    messages: [
+      assistantMessage(
+        "sdk-parts-assistant",
+        [
+          { type: "step-start" },
+          {
+            type: "reasoning",
+            text: "Checking SDK reasoning before composing the answer.",
+            state: "done",
+          },
+          {
+            type: "text",
+            text: "The SDK message parts rendered correctly.",
+          },
+          {
+            type: "source-url",
+            sourceId: "sdk-source-1",
+            url: "https://example.test/sdk-source",
+            title: "SDK Source",
+          },
+          {
+            type: "source-url",
+            sourceId: "sdk-source-1",
+            url: "https://example.test/sdk-source-duplicate",
+            title: "SDK Source Duplicate",
+          },
+          {
+            type: "source-document",
+            sourceId: "sdk-doc-1",
+            mediaType: "application/pdf",
+            title: "SDK Source Document",
+            filename: "sdk-source-document.pdf",
+          },
+          {
+            type: "data-heartbeat",
+            data: { timestamp: 1 },
+          },
+          {
+            type: "data-token-usage",
+            data: { inputTokens: 7, outputTokens: 11, totalTokens: 18 },
+          },
+        ] as UIMessage["parts"],
+        baseTimestamp,
+      ),
+    ],
+  },
+  {
+    id: "dynamic-tool",
+    title: "Dynamic tool",
+    messages: [
+      assistantMessage(
+        "dynamic-tool-assistant",
+        [
+          {
+            type: "dynamic-tool",
+            toolName: "web_search",
+            toolCallId: "dynamic-call-1",
+            state: "input-available",
+            input: { query: "release notes" },
+          },
+          {
+            type: "dynamic-tool",
+            toolName: "web_search",
+            toolCallId: "dynamic-call-1",
+            state: "output-available",
+            input: { query: "release notes" },
+            output: {
+              results: [
+                { title: "Release notes", url: "https://example.test" },
+              ],
+            },
+          },
+          {
+            type: "text",
+            text: "I checked the release notes.",
+          },
+        ] as UIMessage["parts"],
+        baseTimestamp,
+      ),
+    ],
+  },
+  {
+    id: "system-and-thinking",
+    title: "System and thinking",
+    messages: [
+      systemMessage(
+        "system-thinking-system",
+        "Use demo credentials only.",
+        baseTimestamp,
+      ),
+      assistantMessage(
+        "system-thinking-assistant",
+        [
+          {
+            type: "text",
+            text: "<think>Need to inspect config first.</think>Use the demo credentials only.",
+          },
+          {
+            type: "reasoning",
+            text: "Double-checking the demo environment details.",
+            state: "done",
+          },
+        ] as UIMessage["parts"],
+        "2026-04-23T10:00:01.000Z",
+      ),
+    ],
+  },
+  {
+    id: "tool-states",
+    title: "Tool states",
+    messages: [
+      assistantMessage(
+        "tool-states-assistant",
+        [
+          {
+            type: "data-tool-ui-start",
+            data: {
+              toolCallId: "tool-ui-call-1",
+              toolName: "demo__open_pull_request",
+              uiResourceUri: "ui://demo/pr-view",
+              html: "<div>Pull request preview</div>",
+            },
+          } as never,
+          {
+            type: "tool-demo__open_pull_request",
+            toolCallId: "tool-ui-call-1",
+            state: "output-available",
+            input: { owner: "demo-owner", repo: "demo-repo", number: 42 },
+            output: { ok: true, title: "Pull request preview" },
+          },
+          {
+            type: "tool-archestra__todo_write",
+            toolCallId: "todo-approval-call",
+            state: "approval-requested",
+            input: {
+              todos: [
+                { content: "Find demo tools", status: "completed" },
+                { content: "Request approval", status: "pending" },
+              ],
+            },
+            approval: { id: "approval-1" },
+          },
+          {
+            type: "tool-archestra__swap_agent",
+            toolCallId: "swap-call",
+            state: "output-available",
+            input: { agent_name: "Demo Agent" },
+            output: { ok: true },
+          },
+          {
+            type: "text",
+            text: "Tool previews are ready.",
+          },
+        ] as UIMessage["parts"],
+        baseTimestamp,
+      ),
+    ],
+  },
+  {
+    id: "auth-states",
+    title: "Auth states",
+    messages: [
+      assistantMessage(
+        "auth-states-tool-errors",
+        [
+          {
+            type: "tool-demo_server__get_server_info",
+            toolCallId: "auth-expired-call",
+            state: "output-available",
+            input: {},
+            output: {
+              isError: true,
+              _meta: {
+                archestraError: {
+                  type: "auth_expired",
+                  message: 'Expired or invalid authentication for "Demo MCP".',
+                  catalogId: "demo-catalog",
+                  catalogName: "Demo MCP",
+                  serverId: "demo-server",
+                  reauthUrl:
+                    "http://localhost:3000/mcp/registry?reauth=demo-catalog&server=demo-server",
+                },
+              },
+            },
+          },
+          {
+            type: "tool-demo_remote__issue_write",
+            toolCallId: "assigned-credential-call",
+            state: "output-available",
+            input: {},
+            output: {
+              isError: true,
+              _meta: {
+                archestraError: {
+                  type: "assigned_credential_unavailable",
+                  message: "Assigned credential unavailable",
+                  catalogId: "demo-assigned-catalog",
+                  catalogName: "Demo Remote MCP",
+                },
+              },
+            },
+          },
+        ] as UIMessage["parts"],
+        baseTimestamp,
+      ),
+      assistantMessage(
+        "auth-states-text",
+        [
+          {
+            type: "text",
+            text: 'Authentication required for "Demo MCP".\n\nNo credentials were found for your account (user: demo-user).\nTo set up your credentials, visit this URL: http://localhost:3000/mcp/registry?install=demo-catalog',
+          },
+        ] as UIMessage["parts"],
+        "2026-04-23T10:00:01.000Z",
+      ),
+    ],
+  },
+  {
+    id: "unsafe-and-policy",
+    title: "Unsafe and policy denied",
+    messages: [
+      assistantMessage(
+        "unsafe-tool-assistant",
+        [
+          {
+            type: "tool-demo__read_note",
+            toolCallId: "unsafe-call",
+            state: "output-available",
+            input: { folder: "demo" },
+            output: {
+              content: "DEMO_SECRET = demo-value",
+              unsafeContextBoundary: {
+                kind: "tool_result",
+                reason: "tool_result_marked_untrusted",
+                toolCallId: "unsafe-call",
+                toolName: "demo__read_note",
+              },
+            },
+          },
+          {
+            type: "text",
+            text: "Unsafe context is now active.",
+          },
+        ] as UIMessage["parts"],
+        baseTimestamp,
+      ),
+      assistantMessage(
+        "unsafe-policy-denied-assistant",
+        [
+          {
+            type: "text",
+            text: "\nI tried to invoke the demo__print_secret tool with the following arguments: {}.\n\nHowever, I was denied by a tool invocation policy:\n\nTool invocation blocked: context contains sensitive data",
+          },
+        ] as UIMessage["parts"],
+        "2026-04-23T10:00:01.000Z",
+      ),
+    ],
+  },
+  {
+    id: "mega-conversation",
+    title: "Mega conversation",
+    messages: [
+      systemMessage(
+        "mega-system",
+        "Always prefer the demo environment first.",
+        "2026-04-23T09:57:00.000Z",
+      ),
+      userMessage(
+        "mega-user-text",
+        "Show me every chat block and feature.",
+        "2026-04-23T09:58:00.000Z",
+      ),
+      assistantMessage(
+        "mega-thinking",
+        [
+          {
+            type: "text",
+            text: "<think>Gathering every render branch.</think>Here is the combined demo.",
+          },
+          {
+            type: "reasoning",
+            text: "Streaming reasoning block inside the mega conversation.",
+            state: "done",
+          },
+        ] as UIMessage["parts"],
+        "2026-04-23T09:59:00.000Z",
+      ),
+      assistantMessage(
+        "mega-files",
+        [
+          {
+            type: "file",
+            url: "https://example.test/mega-summary.pdf",
+            mediaType: "application/pdf",
+            filename: "mega-summary.pdf",
+          },
+          {
+            type: "file",
+            url: "https://example.test/mega-results.csv",
+            mediaType: "text/csv",
+            filename: "mega-results.csv",
+          },
+          {
+            type: "text",
+            text: "Attached the generated summary and results.",
+          },
+        ] as UIMessage["parts"],
+        "2026-04-23T09:59:10.000Z",
+      ),
+      assistantMessage(
+        "mega-tools",
+        [
+          {
+            type: "tool-demo__list_issues",
+            toolCallId: "mega-call-1",
+            state: "input-available",
+            input: { owner: "demo-owner", repo: "demo-repo" },
+          },
+          {
+            type: "tool-demo__list_issues",
+            toolCallId: "mega-call-1",
+            state: "output-available",
+            input: { owner: "demo-owner", repo: "demo-repo" },
+            output: { issues: [{ number: 1, title: "Demo issue" }] },
+          },
+          {
+            type: "dynamic-tool",
+            toolName: "web_search",
+            toolCallId: "mega-dynamic-call-1",
+            state: "output-available",
+            input: { query: "mega scenario release notes" },
+            output: { results: [{ title: "Mega release notes" }] },
+          },
+          {
+            type: "text",
+            text: "Compact and dynamic tool branches completed.",
+          },
+        ] as UIMessage["parts"],
+        "2026-04-23T09:59:20.000Z",
+      ),
+    ],
+    chatErrors: [
+      chatError("mega-error", "2026-04-23T09:58:15.000Z", {
+        message: "Previous attempt failed",
+      }),
+    ],
+  },
+];
+
+export const seededChatPreviewScenariosById = new Map(
+  seededChatPreviewScenarios.map((scenario) => [scenario.id, scenario]),
+);
+
+export function userMessage(
+  id: string,
+  text: string,
+  createdAt: string,
+): UIMessage {
+  return {
+    id,
+    role: "user",
+    metadata: { createdAt },
+    parts: [{ type: "text", text }],
+  } as UIMessage;
+}
+
+export function assistantMessage(
+  id: string,
+  parts: UIMessage["parts"],
+  createdAt: string,
+): UIMessage {
+  return {
+    id,
+    role: "assistant",
+    metadata: { createdAt },
+    parts,
+  } as UIMessage;
+}
+
+export function systemMessage(
+  id: string,
+  text: string,
+  createdAt: string,
+): UIMessage {
+  return {
+    id,
+    role: "system",
+    metadata: { createdAt },
+    parts: [{ type: "text", text }],
+  } as UIMessage;
+}
+
+function chatError(
+  id: string,
+  createdAt: string,
+  params: { message: string },
+): SeededChatPreviewError {
+  return {
+    id,
+    createdAt,
+    error: {
+      code: ChatErrorCode.ServerError,
+      message: params.message,
+      isRetryable: true,
+    },
+  };
+}

--- a/platform/backend/src/standalone-scripts/seed-chat-scenarios-service.ts
+++ b/platform/backend/src/standalone-scripts/seed-chat-scenarios-service.ts
@@ -1,0 +1,310 @@
+import type { SupportedProvider } from "@shared";
+import { and, eq, like } from "drizzle-orm";
+import db, { schema } from "@/database";
+import { seedDefaultUserAndOrg } from "@/database/seed";
+import logger from "@/logging";
+import {
+  AgentModel,
+  ConversationModel,
+  LlmProviderApiKeyModel,
+  LlmProviderApiKeyModelLinkModel,
+  MemberModel,
+  OrganizationModel,
+} from "@/models";
+import type {
+  Agent,
+  Conversation,
+  InsertConversationChatError,
+  InsertMessage,
+  LlmProviderApiKey,
+  Organization,
+} from "@/types";
+import {
+  type SeededChatPreviewScenario,
+  seededChatPreviewScenarios,
+  seededChatPreviewScenariosById,
+} from "./chat-scenarios";
+
+export const DEBUG_CHAT_TITLE_PREFIX = "[Debug seed]";
+export const DEFAULT_CHAT_BASE_URL = "http://localhost:3000";
+
+export type SeedChatScenariosOptions = {
+  scenarioId?: string;
+  keepExisting?: boolean;
+  chatBaseUrl?: string;
+};
+
+export type SeededChatScenarioResult = {
+  scenarioId: string;
+  conversationId: string;
+  url: string;
+};
+
+type SeedChatLlmSelection = {
+  chatApiKeyId?: string;
+  selectedModel: string;
+  selectedProvider: SupportedProvider;
+};
+
+export async function seedChatScenarios(
+  options: SeedChatScenariosOptions = {},
+): Promise<SeededChatScenarioResult[]> {
+  const scenarios = resolveScenarios(options.scenarioId);
+  const user = await seedDefaultUserAndOrg();
+  const organization = await OrganizationModel.getOrCreateDefaultOrganization();
+  const agent = await findDefaultChatAgent({
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const llmSelection = await resolveSeedLlmSelection(organization);
+
+  if (!options.keepExisting) {
+    await deleteSeededConversations({
+      titlePrefix: DEBUG_CHAT_TITLE_PREFIX,
+      userId: user.id,
+      organizationId: organization.id,
+    });
+  }
+
+  const results: SeededChatScenarioResult[] = [];
+
+  for (const scenario of scenarios) {
+    const conversation = await createScenarioConversation({
+      scenario,
+      user,
+      organizationId: organization.id,
+      agent,
+      llmSelection,
+    });
+    const url = buildConversationUrl({
+      baseUrl: options.chatBaseUrl ?? DEFAULT_CHAT_BASE_URL,
+      conversationId: conversation.id,
+    });
+
+    results.push({
+      scenarioId: scenario.id,
+      conversationId: conversation.id,
+      url,
+    });
+  }
+
+  logger.info(
+    {
+      count: results.length,
+      keepExisting: options.keepExisting ?? false,
+      scenarioId: options.scenarioId,
+      urls: results.map((result) => result.url),
+    },
+    "Seeded chat debug scenarios",
+  );
+
+  return results;
+}
+
+function resolveScenarios(
+  scenarioId: string | undefined,
+): SeededChatPreviewScenario[] {
+  if (!scenarioId) {
+    return seededChatPreviewScenarios;
+  }
+
+  const scenario = seededChatPreviewScenariosById.get(scenarioId);
+  if (!scenario) {
+    const validScenarioIds = seededChatPreviewScenarios
+      .map((candidate) => candidate.id)
+      .join(", ");
+    throw new Error(
+      `Unknown chat scenario "${scenarioId}". Valid scenarios: ${validScenarioIds}`,
+    );
+  }
+
+  return [scenario];
+}
+
+async function findDefaultChatAgent(params: {
+  userId: string;
+  organizationId: string;
+}): Promise<Agent> {
+  await AgentModel.ensurePersonalChatAgent(params);
+
+  const defaultAgentId = await MemberModel.getDefaultAgentId(
+    params.userId,
+    params.organizationId,
+  );
+  if (!defaultAgentId) {
+    throw new Error(
+      "Default chat agent is unavailable after ensuring the personal chat agent",
+    );
+  }
+
+  const agent = await AgentModel.findById(defaultAgentId, params.userId, true);
+  if (!agent || agent.organizationId !== params.organizationId) {
+    throw new Error(
+      "Default chat agent could not be loaded for chat scenario seeding",
+    );
+  }
+
+  return agent;
+}
+
+async function resolveSeedLlmSelection(
+  organization: Organization,
+): Promise<SeedChatLlmSelection> {
+  const apiKey = await findSeedLlmProviderKey(organization);
+  if (!apiKey) {
+    return {
+      selectedModel: "gpt-4o",
+      selectedProvider: "openai",
+    };
+  }
+
+  const bestModel = await LlmProviderApiKeyModelLinkModel.getBestModel(
+    apiKey.id,
+  );
+
+  return {
+    chatApiKeyId: apiKey.id,
+    selectedModel:
+      bestModel?.modelId ?? organization.defaultLlmModel ?? "gpt-4o",
+    selectedProvider:
+      bestModel?.provider ?? organization.defaultLlmProvider ?? apiKey.provider,
+  };
+}
+
+async function findSeedLlmProviderKey(
+  organization: Organization,
+): Promise<LlmProviderApiKey | null> {
+  if (organization.defaultLlmApiKeyId) {
+    const defaultApiKey = await LlmProviderApiKeyModel.findById(
+      organization.defaultLlmApiKeyId,
+    );
+    if (defaultApiKey?.organizationId === organization.id) {
+      return defaultApiKey;
+    }
+  }
+
+  const [firstApiKey] = await LlmProviderApiKeyModel.findByOrganizationId(
+    organization.id,
+  );
+  return firstApiKey ?? null;
+}
+
+async function createScenarioConversation(params: {
+  scenario: SeededChatPreviewScenario;
+  user: { id: string };
+  organizationId: string;
+  agent: Agent;
+  llmSelection: SeedChatLlmSelection;
+}): Promise<Conversation> {
+  const conversation = await ConversationModel.create({
+    userId: params.user.id,
+    organizationId: params.organizationId,
+    agentId: params.agent.id,
+    title: `${DEBUG_CHAT_TITLE_PREFIX} ${params.scenario.title}`,
+    chatApiKeyId: params.llmSelection.chatApiKeyId,
+    selectedModel: params.llmSelection.selectedModel,
+    selectedProvider: params.llmSelection.selectedProvider,
+  });
+
+  await bulkInsertSeedMessages(
+    params.scenario.messages.map((message, index) => ({
+      conversationId: conversation.id,
+      role: message.role,
+      content: message,
+      createdAt: getMessageCreatedAt(message, index),
+    })),
+  );
+
+  await bulkInsertSeedChatErrors(
+    (params.scenario.chatErrors ?? []).map((chatError) => ({
+      conversationId: conversation.id,
+      error: chatError.error,
+      createdAt: new Date(chatError.createdAt),
+    })),
+  );
+
+  const seededConversation = await ConversationModel.findById({
+    id: conversation.id,
+    userId: params.user.id,
+    organizationId: params.organizationId,
+  });
+
+  if (!seededConversation) {
+    throw new Error(`Failed to load seeded conversation ${conversation.id}`);
+  }
+
+  return seededConversation;
+}
+
+async function deleteSeededConversations(params: {
+  titlePrefix: string;
+  userId: string;
+  organizationId: string;
+}): Promise<void> {
+  await db
+    .delete(schema.conversationsTable)
+    .where(
+      and(
+        eq(schema.conversationsTable.userId, params.userId),
+        eq(schema.conversationsTable.organizationId, params.organizationId),
+        like(schema.conversationsTable.title, `${params.titlePrefix}%`),
+      ),
+    );
+}
+
+async function bulkInsertSeedMessages(
+  messages: Array<InsertMessage & { createdAt: Date }>,
+): Promise<void> {
+  if (messages.length === 0) {
+    return;
+  }
+
+  await db.insert(schema.messagesTable).values(messages);
+
+  const uniqueConversationIds = [
+    ...new Set(messages.map((message) => message.conversationId)),
+  ];
+  await Promise.all(
+    uniqueConversationIds.map((conversationId) =>
+      touchConversation(conversationId),
+    ),
+  );
+}
+
+async function bulkInsertSeedChatErrors(
+  chatErrors: Array<InsertConversationChatError & { createdAt: Date }>,
+): Promise<void> {
+  if (chatErrors.length === 0) {
+    return;
+  }
+
+  await db.insert(schema.conversationChatErrorsTable).values(chatErrors);
+}
+
+async function touchConversation(conversationId: string): Promise<void> {
+  await db
+    .update(schema.conversationsTable)
+    .set({ updatedAt: new Date() })
+    .where(eq(schema.conversationsTable.id, conversationId));
+}
+
+function getMessageCreatedAt(message: { metadata?: unknown }, index: number) {
+  if (
+    typeof message.metadata === "object" &&
+    message.metadata !== null &&
+    "createdAt" in message.metadata &&
+    typeof message.metadata.createdAt === "string"
+  ) {
+    return new Date(message.metadata.createdAt);
+  }
+
+  return new Date(Date.UTC(2026, 3, 23, 10, 0, index));
+}
+
+function buildConversationUrl(params: {
+  baseUrl: string;
+  conversationId: string;
+}): string {
+  const baseUrl = params.baseUrl.replace(/\/$/, "");
+  return `${baseUrl}/chat/${params.conversationId}`;
+}

--- a/platform/backend/src/standalone-scripts/seed-chat-scenarios.test.ts
+++ b/platform/backend/src/standalone-scripts/seed-chat-scenarios.test.ts
@@ -1,0 +1,300 @@
+import db, { schema } from "@/database";
+import { seedDefaultUserAndOrg } from "@/database/seed";
+import {
+  AgentModel,
+  ConversationChatErrorModel,
+  ConversationModel,
+  LlmProviderApiKeyModel,
+  LlmProviderApiKeyModelLinkModel,
+  MemberModel,
+  ModelModel,
+  OrganizationModel,
+} from "@/models";
+import { describe, expect, test } from "@/test";
+import { seededChatPreviewScenarios } from "./chat-scenarios";
+import { parseSeedChatScenariosArgs } from "./seed-chat-scenarios";
+import {
+  DEBUG_CHAT_TITLE_PREFIX,
+  seedChatScenarios,
+} from "./seed-chat-scenarios-service";
+
+describe("seed chat scenarios", () => {
+  test("uses the member default agent and creates one conversation per scenario", async () => {
+    const results = await seedChatScenarios({
+      chatBaseUrl: "http://localhost:3000",
+    });
+
+    expect(results).toHaveLength(seededChatPreviewScenarios.length);
+    expect(results[0].url).toMatch(/^http:\/\/localhost:3000\/chat\//);
+
+    const [organization] = await db.select().from(schema.organizationsTable);
+    const [user] = await db.select().from(schema.usersTable);
+    const defaultAgentId = await MemberModel.getDefaultAgentId(
+      user.id,
+      organization.id,
+    );
+    const agents = await AgentModel.findByOrganizationId(organization.id, {
+      agentType: "agent",
+    });
+
+    expect(defaultAgentId).toEqual(expect.any(String));
+    expect(
+      agents.some((agent) => agent.name === "Debug Conversation Renderer"),
+    ).toBe(false);
+
+    const conversations = await ConversationModel.findAll(
+      user.id,
+      organization.id,
+    );
+    const seededConversations = conversations.filter((conversation) =>
+      conversation.title?.startsWith(DEBUG_CHAT_TITLE_PREFIX),
+    );
+
+    expect(seededConversations).toHaveLength(seededChatPreviewScenarios.length);
+    expect(
+      seededConversations.every(
+        (conversation) => conversation.agentId === defaultAgentId,
+      ),
+    ).toBe(true);
+  });
+
+  test("persists UIMessage content, message roles, and chat error timestamps", async () => {
+    const [result] = await seedChatScenarios({
+      scenarioId: "timeline-errors",
+    });
+    const [organization] = await db.select().from(schema.organizationsTable);
+    const [user] = await db.select().from(schema.usersTable);
+
+    const conversation = await ConversationModel.findById({
+      id: result.conversationId,
+      userId: user.id,
+      organizationId: organization.id,
+    });
+
+    expect(conversation).toMatchObject({
+      title: `${DEBUG_CHAT_TITLE_PREFIX} Timeline errors`,
+      messages: [
+        expect.objectContaining({
+          id: expect.any(String),
+          role: "user",
+          parts: [{ type: "text", text: "first try" }],
+          metadata: { createdAt: "2026-04-23T10:00:00.000Z" },
+        }),
+        expect.objectContaining({
+          id: expect.any(String),
+          role: "user",
+          parts: [{ type: "text", text: "try again" }],
+          metadata: { createdAt: "2026-04-23T10:02:00.000Z" },
+        }),
+      ],
+    });
+
+    const chatErrors = await ConversationChatErrorModel.findByConversation(
+      result.conversationId,
+    );
+
+    expect(chatErrors).toHaveLength(1);
+    expect(chatErrors[0]).toMatchObject({
+      conversationId: result.conversationId,
+      error: {
+        code: "server_error",
+        message: "Provider failed",
+        isRetryable: true,
+      },
+    });
+    expect(chatErrors[0].createdAt.toISOString()).toBe(
+      "2026-04-23T10:01:00.000Z",
+    );
+  });
+
+  test("rerun without keepExisting replaces prior debug conversations", async () => {
+    const firstResults = await seedChatScenarios({
+      scenarioId: "timeline-errors",
+    });
+    const secondResults = await seedChatScenarios({
+      scenarioId: "timeline-errors",
+    });
+    const [organization] = await db.select().from(schema.organizationsTable);
+    const [user] = await db.select().from(schema.usersTable);
+
+    expect(secondResults[0].conversationId).not.toBe(
+      firstResults[0].conversationId,
+    );
+
+    const conversations = await ConversationModel.findAll(
+      user.id,
+      organization.id,
+    );
+    const seededConversations = conversations.filter((conversation) =>
+      conversation.title?.startsWith(DEBUG_CHAT_TITLE_PREFIX),
+    );
+
+    expect(seededConversations).toHaveLength(1);
+    expect(seededConversations[0].id).toBe(secondResults[0].conversationId);
+  });
+
+  test("keepExisting preserves previous debug conversations", async () => {
+    const firstResults = await seedChatScenarios({
+      scenarioId: "timeline-errors",
+    });
+    const secondResults = await seedChatScenarios({
+      scenarioId: "timeline-errors",
+      keepExisting: true,
+    });
+    const [organization] = await db.select().from(schema.organizationsTable);
+    const [user] = await db.select().from(schema.usersTable);
+
+    const conversations = await ConversationModel.findAll(
+      user.id,
+      organization.id,
+    );
+    const seededConversationIds = conversations
+      .filter((conversation) =>
+        conversation.title?.startsWith(DEBUG_CHAT_TITLE_PREFIX),
+      )
+      .map((conversation) => conversation.id);
+
+    expect(seededConversationIds).toEqual(
+      expect.arrayContaining([
+        firstResults[0].conversationId,
+        secondResults[0].conversationId,
+      ]),
+    );
+  });
+
+  test("uses the organization default LLM key when present", async () => {
+    const { user, organization } = await getDefaultLocalUserAndOrganization();
+    await createProviderKeyWithBestModel({
+      organizationId: organization.id,
+      keyName: "Fallback key",
+      provider: "anthropic",
+      modelId: "claude-3-5-haiku-latest",
+    });
+    const defaultKey = await createProviderKeyWithBestModel({
+      organizationId: organization.id,
+      keyName: "Default key",
+      provider: "openai",
+      modelId: "gpt-4o-mini",
+    });
+    await OrganizationModel.patch(organization.id, {
+      defaultLlmApiKeyId: defaultKey.id,
+    });
+
+    const [result] = await seedChatScenarios({
+      scenarioId: "timeline-errors",
+    });
+
+    const conversation = await ConversationModel.findById({
+      id: result.conversationId,
+      userId: user.id,
+      organizationId: organization.id,
+    });
+
+    expect(conversation).toMatchObject({
+      chatApiKeyId: defaultKey.id,
+      selectedModel: "gpt-4o-mini",
+      selectedProvider: "openai",
+    });
+  });
+
+  test("falls back to the first organization LLM key", async () => {
+    const { user, organization } = await getDefaultLocalUserAndOrganization();
+    const firstKey = await createProviderKeyWithBestModel({
+      organizationId: organization.id,
+      keyName: "First key",
+      provider: "anthropic",
+      modelId: "claude-3-5-haiku-latest",
+    });
+
+    const [result] = await seedChatScenarios({
+      scenarioId: "timeline-errors",
+    });
+
+    const conversation = await ConversationModel.findById({
+      id: result.conversationId,
+      userId: user.id,
+      organizationId: organization.id,
+    });
+
+    expect(conversation).toMatchObject({
+      chatApiKeyId: firstKey.id,
+      selectedModel: "claude-3-5-haiku-latest",
+      selectedProvider: "anthropic",
+    });
+  });
+
+  test("still seeds render-only conversations when no LLM key exists", async () => {
+    const [result] = await seedChatScenarios({
+      scenarioId: "timeline-errors",
+    });
+    const [organization] = await db.select().from(schema.organizationsTable);
+    const [user] = await db.select().from(schema.usersTable);
+
+    const conversation = await ConversationModel.findById({
+      id: result.conversationId,
+      userId: user.id,
+      organizationId: organization.id,
+    });
+
+    expect(conversation).toMatchObject({
+      chatApiKeyId: null,
+      selectedModel: "gpt-4o",
+      selectedProvider: "openai",
+    });
+  });
+
+  test("unknown scenario fails with a clear error", async () => {
+    await expect(
+      seedChatScenarios({ scenarioId: "does-not-exist" }),
+    ).rejects.toThrow('Unknown chat scenario "does-not-exist"');
+  });
+
+  test("parses CLI arguments", () => {
+    expect(
+      parseSeedChatScenariosArgs([
+        "--scenario",
+        "timeline-errors",
+        "--keep-existing",
+        "--chat-base-url",
+        "http://localhost:3001",
+      ]),
+    ).toEqual({
+      scenarioId: "timeline-errors",
+      keepExisting: true,
+      chatBaseUrl: "http://localhost:3001",
+    });
+  });
+});
+
+async function getDefaultLocalUserAndOrganization() {
+  const user = await seedDefaultUserAndOrg();
+  const organization = await OrganizationModel.getOrCreateDefaultOrganization();
+
+  return { user, organization };
+}
+
+async function createProviderKeyWithBestModel(params: {
+  organizationId: string;
+  keyName: string;
+  provider: "anthropic" | "openai";
+  modelId: string;
+}) {
+  const apiKey = await LlmProviderApiKeyModel.create({
+    organizationId: params.organizationId,
+    name: params.keyName,
+    provider: params.provider,
+    scope: "org",
+  });
+  const model = await ModelModel.create({
+    externalId: `${params.provider}/${params.modelId}`,
+    provider: params.provider,
+    modelId: params.modelId,
+    inputModalities: null,
+    outputModalities: null,
+  });
+  await LlmProviderApiKeyModelLinkModel.linkModelsToApiKey(apiKey.id, [
+    model.id,
+  ]);
+
+  return apiKey;
+}

--- a/platform/backend/src/standalone-scripts/seed-chat-scenarios.test.ts
+++ b/platform/backend/src/standalone-scripts/seed-chat-scenarios.test.ts
@@ -72,18 +72,28 @@ describe("seed chat scenarios", () => {
     });
 
     expect(conversation).toMatchObject({
-      title: `${DEBUG_CHAT_TITLE_PREFIX} Timeline errors`,
+      title: `${DEBUG_CHAT_TITLE_PREFIX} Retry after provider error`,
       messages: [
         expect.objectContaining({
           id: expect.any(String),
           role: "user",
-          parts: [{ type: "text", text: "first try" }],
+          parts: [
+            {
+              type: "text",
+              text: "Can you summarize the last deployment health check?",
+            },
+          ],
           metadata: { createdAt: "2026-04-23T10:00:00.000Z" },
         }),
         expect.objectContaining({
           id: expect.any(String),
           role: "user",
-          parts: [{ type: "text", text: "try again" }],
+          parts: [
+            {
+              type: "text",
+              text: "The previous response failed. Please try the deployment summary again.",
+            },
+          ],
           metadata: { createdAt: "2026-04-23T10:02:00.000Z" },
         }),
       ],
@@ -98,12 +108,46 @@ describe("seed chat scenarios", () => {
       conversationId: result.conversationId,
       error: {
         code: "server_error",
-        message: "Provider failed",
+        message: "The model provider returned a temporary error.",
         isRetryable: true,
       },
     });
     expect(chatErrors[0].createdAt.toISOString()).toBe(
       "2026-04-23T10:01:00.000Z",
+    );
+  });
+
+  test("persists source URL and source document UI message parts", async () => {
+    const [result] = await seedChatScenarios({
+      scenarioId: "sdk-message-parts",
+    });
+    const [organization] = await db.select().from(schema.organizationsTable);
+    const [user] = await db.select().from(schema.usersTable);
+
+    const conversation = await ConversationModel.findById({
+      id: result.conversationId,
+      userId: user.id,
+      organizationId: organization.id,
+    });
+
+    const parts = conversation?.messages[0]?.parts ?? [];
+
+    expect(parts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "source-url",
+          sourceId: "release-notes-2026-04",
+          url: "https://example.test/releases/2026-04-checkout",
+          title: "Checkout release notes",
+        }),
+        expect.objectContaining({
+          type: "source-document",
+          sourceId: "rollout-runbook-v3",
+          mediaType: "application/pdf",
+          title: "Rollout recovery runbook",
+          filename: "rollout-recovery-runbook.pdf",
+        }),
+      ]),
     );
   });
 

--- a/platform/backend/src/standalone-scripts/seed-chat-scenarios.ts
+++ b/platform/backend/src/standalone-scripts/seed-chat-scenarios.ts
@@ -1,0 +1,77 @@
+import { pathToFileURL } from "node:url";
+import { initializeDatabase } from "@/database";
+import logger from "@/logging";
+import {
+  DEFAULT_CHAT_BASE_URL,
+  type SeedChatScenariosOptions,
+  seedChatScenarios,
+} from "./seed-chat-scenarios-service";
+
+export function parseSeedChatScenariosArgs(
+  args: string[],
+): SeedChatScenariosOptions {
+  const options: SeedChatScenariosOptions = {};
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+
+    if (arg === "--keep-existing") {
+      options.keepExisting = true;
+      continue;
+    }
+
+    if (arg === "--scenario") {
+      const scenarioId = args[index + 1];
+      if (!scenarioId || scenarioId.startsWith("--")) {
+        throw new Error("--scenario requires a scenario id");
+      }
+      options.scenarioId = scenarioId;
+      index++;
+      continue;
+    }
+
+    if (arg === "--chat-base-url") {
+      const chatBaseUrl = args[index + 1];
+      if (!chatBaseUrl || chatBaseUrl.startsWith("--")) {
+        throw new Error("--chat-base-url requires a URL");
+      }
+      options.chatBaseUrl = chatBaseUrl;
+      index++;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+export async function main(args = process.argv.slice(2)): Promise<void> {
+  const options = parseSeedChatScenariosArgs(args);
+  await initializeDatabase();
+
+  const results = await seedChatScenarios({
+    chatBaseUrl: DEFAULT_CHAT_BASE_URL,
+    ...options,
+  });
+
+  logger.info("\nSeeded chat debug conversations:");
+  for (const result of results) {
+    logger.info(`- ${result.scenarioId}: ${result.url}`);
+  }
+}
+
+const isDirectRun =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectRun) {
+  main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      logger.error(
+        { error: error instanceof Error ? error.message : String(error) },
+        "Failed to seed chat debug scenarios",
+      );
+      process.exit(1);
+    });
+}

--- a/platform/dev/Tiltfile.database
+++ b/platform/dev/Tiltfile.database
@@ -66,6 +66,16 @@ local_resource(
 )
 
 local_resource(
+  'db-seed-chat-scenarios',
+  cmd='pnpm db:seed:chat-scenarios',
+  dir='../backend',
+  resource_deps=['pnpm-install', 'postgresql', 'db-migrate'],
+  trigger_mode=TRIGGER_MODE_MANUAL,
+  auto_init=False,
+  labels=['database']
+)
+
+local_resource(
   'db-migrate',
   # NOTE: we need to cd into the backend directory to run the migrate command
   # because otherwise if we run the command from this directory, it is run via turbo, which does not properly

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -198,6 +198,7 @@ export function ChatPageContent({
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const autoSendTriggeredRef = useRef(false);
   const oauthReauthResumeTriggeredRef = useRef(false);
+  const focusLastMessageRef = useRef<(() => void) | null>(null);
   // Store pending URL for browser navigation after conversation is created
   const [pendingBrowserUrl, setPendingBrowserUrl] = useState<
     string | undefined
@@ -864,6 +865,10 @@ export function ChatPageContent({
   );
   const latestTodoWriteToolState = useMemo(
     () => getLatestTodoWriteToolState(messages),
+    [messages],
+  );
+  const userMessageHistory = useMemo(
+    () => getUserMessageHistory(messages),
     [messages],
   );
   const sendMessage = chatSession?.sendMessage;
@@ -1813,6 +1818,8 @@ export function ChatPageContent({
                     agentId={currentProfileId || initialAgentId || undefined}
                     messages={messages}
                     status={status}
+                    promptTextareaRef={textareaRef}
+                    focusLastMessageRef={focusLastMessageRef}
                     optimisticToolCalls={optimisticToolCalls}
                     isLoadingConversation={isLoadingConversation}
                     onMessagesUpdate={setMessages}
@@ -1961,6 +1968,10 @@ export function ChatPageContent({
                         }
                         currentProvider={currentProvider}
                         textareaRef={textareaRef}
+                        onNavigateToLastMessage={() =>
+                          focusLastMessageRef.current?.()
+                        }
+                        userMessageHistory={userMessageHistory}
                         onProviderChange={handleProviderChange}
                         allowFileUploads={
                           organization?.allowChatFileUploads ?? false
@@ -2075,6 +2086,10 @@ export function ChatPageContent({
                       agentId={newChatAgentId}
                       currentProvider={initialProvider}
                       textareaRef={textareaRef}
+                      onNavigateToLastMessage={() =>
+                        focusLastMessageRef.current?.()
+                      }
+                      userMessageHistory={userMessageHistory}
                       initialApiKeyId={initialApiKeyId}
                       onApiKeyChange={setInitialApiKeyId}
                       onProviderChange={handleInitialProviderChange}
@@ -2272,6 +2287,22 @@ function getMessageText(message: UIMessage) {
     .filter((part) => part.type === "text")
     .map((part) => part.text)
     .join("\n");
+}
+
+function getUserMessageHistory(messages: UIMessage[]) {
+  return messages.flatMap((message) => {
+    if (message.role !== "user") {
+      return [];
+    }
+
+    return message.parts.flatMap((part) => {
+      if (part.type !== "text" || !part.text.trim()) {
+        return [];
+      }
+
+      return [part.text];
+    });
+  });
 }
 
 function hasCreatedAtMetadata(message: UIMessage) {

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -39,6 +39,7 @@ import { ButtonWithTooltip } from "@/components/button-with-tooltip";
 import { BrowserPanel } from "@/components/chat/browser-panel";
 import { ChatLinkButton } from "@/components/chat/chat-help-link";
 import { ChatMessages } from "@/components/chat/chat-messages";
+import { getLatestTodoWriteToolState } from "@/components/chat/chat-messages.utils";
 import { ConversationArtifactPanel } from "@/components/chat/conversation-artifact";
 import { InitialAgentSelector } from "@/components/chat/initial-agent-selector";
 import { OnboardingWizardButton } from "@/components/chat/onboarding-wizard-button";
@@ -49,6 +50,7 @@ import {
 import { RightSidePanel } from "@/components/chat/right-side-panel";
 import { ShareConversationDialog } from "@/components/chat/share-conversation-dialog";
 import { StreamTimeoutWarning } from "@/components/chat/stream-timeout-warning";
+import { TodoWriteTool } from "@/components/chat/todo-write-tool";
 import { CreateLlmProviderApiKeyDialog } from "@/components/create-llm-provider-api-key-dialog";
 import type { LlmProviderApiKeyFormValues } from "@/components/llm-provider-api-key-form";
 import { LoadingSpinner } from "@/components/loading";
@@ -859,6 +861,10 @@ export function ChatPageContent({
           })
         : persistedConversationMessages,
     [chatSession?.messages, persistedConversationMessages],
+  );
+  const latestTodoWriteToolState = useMemo(
+    () => getLatestTodoWriteToolState(messages),
+    [messages],
   );
   const sendMessage = chatSession?.sendMessage;
   const status = chatSession?.status ?? "ready";
@@ -1923,6 +1929,26 @@ export function ChatPageContent({
                 activeAgentId && (
                   <div className="sticky bottom-0 bg-background border-t p-4">
                     <div className="max-w-4xl mx-auto space-y-3">
+                      {latestTodoWriteToolState && (
+                        <TodoWriteTool
+                          part={latestTodoWriteToolState.part}
+                          toolResultPart={
+                            latestTodoWriteToolState.toolResultPart
+                          }
+                          errorText={latestTodoWriteToolState.errorText}
+                          onToolApprovalResponse={
+                            addToolApprovalResponse
+                              ? ({ id, approved, reason }) => {
+                                  addToolApprovalResponse({
+                                    id,
+                                    approved,
+                                    reason,
+                                  });
+                                }
+                              : undefined
+                          }
+                        />
+                      )}
                       <ArchestraPromptInput
                         onSubmit={handleSubmit}
                         status={status}

--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -1,11 +1,13 @@
 import { E2eTestId } from "@shared";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockUseOrganization, mockUseChatPlaceholder } = vi.hoisted(() => ({
-  mockUseOrganization: vi.fn(),
-  mockUseChatPlaceholder: vi.fn(),
-}));
+const { mockUseOrganization, mockUseChatPlaceholder, mockPromptInputSetInput } =
+  vi.hoisted(() => ({
+    mockUseOrganization: vi.fn(),
+    mockUseChatPlaceholder: vi.fn(),
+    mockPromptInputSetInput: vi.fn(),
+  }));
 
 // Mock ResizeObserver which is used by Radix UI components
 global.ResizeObserver = vi.fn().mockImplementation(() => ({
@@ -83,14 +85,29 @@ vi.mock("@/components/ai-elements/prompt-input", () => ({
       Submit {status ?? "unset"}
     </button>
   ),
-  PromptInputTextarea: ({ placeholder }: { placeholder?: string }) => (
-    <textarea placeholder={placeholder} />
+  PromptInputTextarea: ({
+    placeholder,
+    onChange,
+    onKeyDown,
+    "data-testid": testId,
+  }: {
+    placeholder?: string;
+    onChange?: React.ChangeEventHandler<HTMLTextAreaElement>;
+    onKeyDown?: React.KeyboardEventHandler<HTMLTextAreaElement>;
+    "data-testid"?: string;
+  }) => (
+    <textarea
+      data-testid={testId}
+      placeholder={placeholder}
+      onChange={onChange}
+      onKeyDown={onKeyDown}
+    />
   ),
   PromptInputTools: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="prompt-tools">{children}</div>
   ),
   usePromptInputController: () => ({
-    textInput: { setInput: vi.fn() },
+    textInput: { value: "", setInput: mockPromptInputSetInput },
     attachments: { files: [] },
   }),
   usePromptInputAttachments: () => ({
@@ -193,6 +210,10 @@ describe("ArchestraPromptInput", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    window.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    });
     mockUseOrganization.mockReturnValue({
       data: null,
       isLoading: false,
@@ -200,6 +221,11 @@ describe("ArchestraPromptInput", () => {
     mockUseChatPlaceholder.mockReturnValue({
       placeholder: "Animated placeholder",
       isAnimating: true,
+    });
+    mockUseHasPermissions.mockReturnValue({
+      data: false,
+      isPending: false,
+      isLoading: false,
     });
   });
 
@@ -336,6 +362,114 @@ describe("ArchestraPromptInput", () => {
       );
       // Should not have a settings link
       expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Keyboard history", () => {
+    it("cycles through user message history with arrow keys at textarea boundaries", () => {
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          userMessageHistory={["first prompt", "second prompt"]}
+        />,
+      );
+
+      const textarea = screen.getByTestId(
+        E2eTestId.ChatPromptTextarea,
+      ) as HTMLTextAreaElement;
+      mockPromptInputSetInput.mockClear();
+
+      textarea.value = "draft";
+      textarea.setSelectionRange(0, 0);
+      fireEvent.keyDown(textarea, { key: "ArrowUp" });
+      expect(mockPromptInputSetInput).toHaveBeenLastCalledWith("second prompt");
+
+      textarea.value = "second prompt";
+      textarea.setSelectionRange(0, 0);
+      fireEvent.keyDown(textarea, { key: "ArrowUp" });
+      expect(mockPromptInputSetInput).toHaveBeenLastCalledWith("first prompt");
+
+      textarea.value = "first prompt";
+      textarea.setSelectionRange("first prompt".length, "first prompt".length);
+      fireEvent.keyDown(textarea, { key: "ArrowDown" });
+      expect(mockPromptInputSetInput).toHaveBeenLastCalledWith("second prompt");
+
+      textarea.value = "second prompt";
+      textarea.setSelectionRange(
+        "second prompt".length,
+        "second prompt".length,
+      );
+      fireEvent.keyDown(textarea, { key: "ArrowDown" });
+      expect(mockPromptInputSetInput).toHaveBeenLastCalledWith("draft");
+    });
+
+    it("does not cycle history when the caret is inside textarea content", () => {
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          userMessageHistory={["previous prompt"]}
+        />,
+      );
+
+      const textarea = screen.getByTestId(
+        E2eTestId.ChatPromptTextarea,
+      ) as HTMLTextAreaElement;
+      mockPromptInputSetInput.mockClear();
+
+      textarea.value = "current draft";
+      textarea.setSelectionRange(4, 4);
+      fireEvent.keyDown(textarea, { key: "ArrowUp" });
+
+      expect(mockPromptInputSetInput).not.toHaveBeenCalledWith(
+        "previous prompt",
+      );
+    });
+
+    it("resets history navigation after manual input changes", () => {
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          userMessageHistory={["first prompt", "second prompt"]}
+        />,
+      );
+
+      const textarea = screen.getByTestId(
+        E2eTestId.ChatPromptTextarea,
+      ) as HTMLTextAreaElement;
+      mockPromptInputSetInput.mockClear();
+
+      textarea.value = "draft";
+      textarea.setSelectionRange(0, 0);
+      fireEvent.keyDown(textarea, { key: "ArrowUp" });
+      expect(mockPromptInputSetInput).toHaveBeenLastCalledWith("second prompt");
+
+      fireEvent.change(textarea, { target: { value: "manual edit" } });
+      textarea.value = "manual edit";
+      textarea.setSelectionRange("manual edit".length, "manual edit".length);
+      fireEvent.keyDown(textarea, { key: "ArrowDown" });
+
+      expect(mockPromptInputSetInput).toHaveBeenCalledTimes(1);
+    });
+
+    it("navigates to the last message with shift arrow up at the start of the textarea", () => {
+      const onNavigateToLastMessage = vi.fn();
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          onNavigateToLastMessage={onNavigateToLastMessage}
+        />,
+      );
+
+      const textarea = screen.getByTestId(
+        E2eTestId.ChatPromptTextarea,
+      ) as HTMLTextAreaElement;
+      mockPromptInputSetInput.mockClear();
+
+      textarea.value = "draft";
+      textarea.setSelectionRange(0, 0);
+      fireEvent.keyDown(textarea, { key: "ArrowUp", shiftKey: true });
+
+      expect(onNavigateToLastMessage).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -10,7 +10,7 @@ import {
 } from "@shared";
 import type { ChatStatus } from "ai";
 import { MoreVerticalIcon, PaperclipIcon, XIcon } from "lucide-react";
-import type { FormEvent } from "react";
+import type { FormEvent, KeyboardEvent } from "react";
 import { useCallback, useEffect, useRef } from "react";
 import { toast } from "sonner";
 import { ModelSelectorLogo } from "@/components/ai-elements/model-selector";
@@ -111,6 +111,10 @@ interface ArchestraPromptInputProps {
   modelSource?: ModelSource | null;
   /** Callback to reset user model override back to agent/org default */
   onResetModelOverride?: () => void;
+  /** Focus the last navigable conversation message from the prompt textarea */
+  onNavigateToLastMessage?: () => void;
+  /** Chronological text history from user messages in the current conversation */
+  userMessageHistory?: string[];
 }
 
 // Inner component that has access to the controller context
@@ -141,6 +145,8 @@ const PromptInputContent = ({
   onModelSelectorOpenChange,
   modelSource,
   onResetModelOverride,
+  onNavigateToLastMessage,
+  userMessageHistory = [],
 }: Omit<ArchestraPromptInputProps, "onSubmit"> & {
   onSubmit: ArchestraPromptInputProps["onSubmit"];
 }) => {
@@ -191,6 +197,13 @@ const PromptInputContent = ({
     : `archestra_chat_draft_new_${agentId}`;
 
   const isRestored = useRef(false);
+  const historyIndexRef = useRef<number | null>(null);
+  const historyDraftRef = useRef("");
+
+  const resetHistoryNavigation = useCallback(() => {
+    historyIndexRef.current = null;
+    historyDraftRef.current = "";
+  }, []);
 
   // Restore draft on mount or conversation change
   useEffect(() => {
@@ -248,10 +261,11 @@ const PromptInputContent = ({
 
   const handleWrappedSubmit = useCallback(
     (message: PromptInputMessage, e: FormEvent<HTMLFormElement>) => {
+      resetHistoryNavigation();
       localStorage.removeItem(storageKey);
       onSubmit(message, e);
     },
-    [onSubmit, storageKey],
+    [onSubmit, resetHistoryNavigation, storageKey],
   );
 
   const handleFileError = useCallback(
@@ -270,6 +284,105 @@ const PromptInputContent = ({
     [showFileUploadButton],
   );
   const submitStatus = status === "error" ? "ready" : status;
+
+  const setPromptInputFromHistory = useCallback(
+    (
+      value: string,
+      target: HTMLTextAreaElement,
+      caretPosition: "start" | "end",
+    ) => {
+      controller.textInput.setInput(value);
+      requestAnimationFrame(() => {
+        const position = caretPosition === "start" ? 0 : value.length;
+        target.setSelectionRange(position, position);
+      });
+    },
+    [controller.textInput],
+  );
+
+  const handlePromptTextareaKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (
+        (event.key !== "ArrowUp" && event.key !== "ArrowDown") ||
+        event.nativeEvent.isComposing
+      ) {
+        return;
+      }
+
+      const isAtStart =
+        event.currentTarget.selectionStart === 0 &&
+        event.currentTarget.selectionEnd === 0;
+      const isAtEnd =
+        event.currentTarget.selectionStart ===
+          event.currentTarget.value.length &&
+        event.currentTarget.selectionEnd === event.currentTarget.value.length;
+
+      if (event.shiftKey) {
+        if (event.key !== "ArrowUp" || !onNavigateToLastMessage || !isAtStart) {
+          return;
+        }
+
+        event.preventDefault();
+        onNavigateToLastMessage();
+        return;
+      }
+
+      if (event.key === "ArrowUp") {
+        if (!isAtStart || userMessageHistory.length === 0) {
+          return;
+        }
+
+        event.preventDefault();
+        const nextIndex =
+          historyIndexRef.current === null
+            ? userMessageHistory.length - 1
+            : Math.max(0, historyIndexRef.current - 1);
+
+        if (historyIndexRef.current === null) {
+          historyDraftRef.current = event.currentTarget.value;
+        }
+
+        historyIndexRef.current = nextIndex;
+        setPromptInputFromHistory(
+          userMessageHistory[nextIndex],
+          event.currentTarget,
+          "start",
+        );
+        return;
+      }
+
+      if (!isAtEnd || historyIndexRef.current === null) {
+        return;
+      }
+
+      event.preventDefault();
+      const nextIndex = historyIndexRef.current + 1;
+
+      if (nextIndex >= userMessageHistory.length) {
+        const draft = historyDraftRef.current;
+        resetHistoryNavigation();
+        setPromptInputFromHistory(draft, event.currentTarget, "end");
+        return;
+      }
+
+      historyIndexRef.current = nextIndex;
+      setPromptInputFromHistory(
+        userMessageHistory[nextIndex],
+        event.currentTarget,
+        "end",
+      );
+    },
+    [
+      onNavigateToLastMessage,
+      resetHistoryNavigation,
+      setPromptInputFromHistory,
+      userMessageHistory,
+    ],
+  );
+
+  const handlePromptTextareaChange = useCallback(() => {
+    resetHistoryNavigation();
+  }, [resetHistoryNavigation]);
 
   return (
     <PromptInput
@@ -302,6 +415,8 @@ const PromptInputContent = ({
             disabled={submitDisabled}
             disableEnterSubmit={status !== "ready" && status !== "error"}
             data-testid={E2eTestId.ChatPromptTextarea}
+            onChange={handlePromptTextareaChange}
+            onKeyDown={handlePromptTextareaKeyDown}
           />
         )}
       </PromptInputBody>
@@ -636,6 +751,8 @@ const ArchestraPromptInput = ({
   onModelSelectorOpenChange,
   modelSource,
   onResetModelOverride,
+  onNavigateToLastMessage,
+  userMessageHistory,
 }: ArchestraPromptInputProps) => {
   return (
     <div className="flex size-full flex-col justify-end">
@@ -667,6 +784,8 @@ const ArchestraPromptInput = ({
           onModelSelectorOpenChange={onModelSelectorOpenChange}
           modelSource={modelSource}
           onResetModelOverride={onResetModelOverride}
+          onNavigateToLastMessage={onNavigateToLastMessage}
+          userMessageHistory={userMessageHistory}
         />
       </PromptInputProvider>
     </div>

--- a/platform/frontend/src/components/ai-elements/message.tsx
+++ b/platform/frontend/src/components/ai-elements/message.tsx
@@ -11,7 +11,7 @@ export type MessageProps = HTMLAttributes<HTMLDivElement> & {
 export const Message = ({ className, from, ...props }: MessageProps) => (
   <div
     className={cn(
-      "group flex w-full items-end justify-end gap-2 py-2",
+      "group flex w-full items-end justify-end gap-2",
       from === "user" ? "is-user" : "is-assistant flex-row-reverse justify-end",
       className,
     )}
@@ -20,15 +20,15 @@ export const Message = ({ className, from, ...props }: MessageProps) => (
 );
 
 const messageContentVariants = cva(
-  "is-user:dark flex flex-col gap-2 overflow-x-auto rounded-lg text-sm",
+  "is-user:dark flex flex-col gap-2 overflow-x-auto text-sm",
   {
     variants: {
       variant: {
         contained: [
           "max-w-[80%] px-4 py-3",
-          "group-[.is-user]:bg-primary group-[.is-user]:text-primary-foreground",
+          "group-[.is-user]:bg-primary group-[.is-user]:text-primary-foreground group-[.is-user]:rounded-lg",
           "group-[.is-user]:[&_a]:text-primary-foreground group-[.is-user]:[&_a]:underline group-[.is-user]:[&_a]:underline-offset-2 group-[.is-user]:[&_a]:decoration-primary-foreground/50 group-[.is-user]:[&_a]:hover:decoration-primary-foreground",
-          "group-[.is-assistant]:bg-secondary group-[.is-assistant]:text-secondary-foreground",
+          "group-[.is-assistant]:bg-none group-[.is-assistant]:text-foreground group-[.is-assistant]:px-0 group-[.is-assistant]:py-0",
         ],
         flat: [
           "group-[.is-user]:max-w-[80%] group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",

--- a/platform/frontend/src/components/ai-elements/prompt-input.test.tsx
+++ b/platform/frontend/src/components/ai-elements/prompt-input.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { FormEvent } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  PromptInput,
+  type PromptInputMessage,
+  PromptInputProvider,
+  PromptInputTextarea,
+} from "./prompt-input";
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+describe("PromptInputTextarea", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls external keydown handlers without breaking enter submit", async () => {
+    const onKeyDown = vi.fn();
+    const onSubmit = vi.fn(
+      (_message: PromptInputMessage, event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+      },
+    );
+
+    render(
+      <PromptInputProvider initialInput="Hello">
+        <PromptInput onSubmit={onSubmit}>
+          <PromptInputTextarea aria-label="Message" onKeyDown={onKeyDown} />
+          <button type="submit">Send</button>
+        </PromptInput>
+      </PromptInputProvider>,
+    );
+
+    fireEvent.keyDown(screen.getByLabelText("Message"), { key: "Enter" });
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+  });
+});

--- a/platform/frontend/src/components/ai-elements/prompt-input.tsx
+++ b/platform/frontend/src/components/ai-elements/prompt-input.tsx
@@ -875,6 +875,7 @@ export type PromptInputTextareaProps = ComponentProps<
 
 export const PromptInputTextarea = ({
   onChange,
+  onKeyDown,
   className,
   placeholder = "What would you like to know?",
   disableEnterSubmit = false,
@@ -889,6 +890,11 @@ export const PromptInputTextarea = ({
   const isMobile = useIsMobile();
 
   const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
+    onKeyDown?.(e);
+    if (e.defaultPrevented) {
+      return;
+    }
+
     if (e.key === "Enter") {
       if (isComposing || e.nativeEvent.isComposing) {
         return;

--- a/platform/frontend/src/components/ai-elements/reasoning.tsx
+++ b/platform/frontend/src/components/ai-elements/reasoning.tsx
@@ -45,7 +45,7 @@ export const Reasoning = memo(
     className,
     isStreaming = false,
     open,
-    defaultOpen = true,
+    defaultOpen,
     onOpenChange,
     duration: durationProp,
     children,
@@ -53,7 +53,7 @@ export const Reasoning = memo(
   }: ReasoningProps) => {
     const [isOpen, setIsOpen] = useControllableState({
       prop: open,
-      defaultProp: defaultOpen,
+      defaultProp: defaultOpen ?? isStreaming,
       onChange: onOpenChange,
     });
     const [duration, setDuration] = useControllableState({
@@ -98,7 +98,7 @@ export const Reasoning = memo(
         value={{ isStreaming, isOpen, setIsOpen, duration }}
       >
         <Collapsible
-          className={cn("not-prose mb-4", className)}
+          className={cn("not-prose", className)}
           onOpenChange={handleOpenChange}
           open={isOpen}
           {...props}
@@ -113,13 +113,12 @@ export const Reasoning = memo(
 export type ReasoningTriggerProps = ComponentProps<typeof CollapsibleTrigger>;
 
 const getThinkingMessage = (isStreaming: boolean, duration?: number) => {
-  if (isStreaming || duration === 0) {
-    return <p>Thinking...</p>;
-  }
-  if (duration === undefined) {
-    return <p>Thought for a few seconds</p>;
-  }
-  return <p>Thought for {duration} seconds</p>;
+  return (
+    <p>
+      {isStreaming ? "Thinking" : "Thought"} for{" "}
+      {(duration ?? 0 > 1) ? duration : "a few"} seconds
+    </p>
+  );
 };
 
 export const ReasoningTrigger = memo(
@@ -161,7 +160,7 @@ export const ReasoningContent = memo(
   ({ className, children, ...props }: ReasoningContentProps) => (
     <CollapsibleContent
       className={cn(
-        "mt-4 text-sm",
+        "text-sm px-6",
         "data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 text-muted-foreground outline-none data-[state=closed]:animate-out data-[state=open]:animate-in",
         className,
       )}

--- a/platform/frontend/src/components/ai-elements/tool.tsx
+++ b/platform/frontend/src/components/ai-elements/tool.tsx
@@ -47,7 +47,7 @@ export const Tool = ({
       <Collapsible
         defaultOpen={false}
         open={open}
-        className={cn("not-prose mb-4 w-full rounded-md border", className)}
+        className={cn("not-prose w-full rounded-md border", className)}
         onOpenChange={handleOpenChange}
         {...props}
       >
@@ -163,7 +163,7 @@ export const ToolContent = ({
   const { hasOpened } = useContext(ToolContext);
 
   const resolvedClassName = cn(
-    "data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 text-popover-foreground outline-none data-[state=closed]:animate-out data-[state=open]:animate-in",
+    "data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 text-popover-foreground outline-none data-[state=closed]:animate-out data-[state=open]:animate-in p-4 pt-0 flex flex-col gap-1",
     forceMount &&
       "overflow-hidden data-[state=closed]:max-h-0 data-[state=open]:max-h-[5000px]",
     className,
@@ -194,11 +194,11 @@ export const ToolInput = ({ className, input, ...props }: ToolInputProps) => {
   return (
     <Collapsible
       defaultOpen={false}
-      className={cn("space-y-2 overflow-hidden p-4", className)}
+      className={cn("space-y-2 overflow-hidden", className)}
       {...props}
     >
       <div className="space-y-2">
-        <CollapsibleTrigger className="group flex w-full items-center justify-between gap-2 cursor-pointer">
+        <CollapsibleTrigger className="group flex w-full items-center gap-2 cursor-pointer">
           <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
             Parameters
           </h4>
@@ -265,7 +265,7 @@ export const ToolOutput = ({
   // Note: In Dual LLM context, "user" = Main Profile (questions), "assistant" = Quarantined Profile (answers)
   if (conversations && conversations.length > 0) {
     return (
-      <div className={cn("space-y-2 p-4", className)} {...props}>
+      <div className={cn("space-y-2", className)} {...props}>
         <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
           {label ?? "Conversation"}
         </h4>
@@ -380,11 +380,7 @@ export const ToolOutput = ({
   }
 
   return (
-    <div
-      ref={containerRef}
-      className={cn("space-y-2 p-4", className)}
-      {...props}
-    >
+    <div ref={containerRef} className={cn("space-y-2", className)} {...props}>
       <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
         {labelText}
       </h4>

--- a/platform/frontend/src/components/chat/chat-messages.test.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.test.tsx
@@ -1,10 +1,18 @@
 import type { UIMessage } from "@ai-sdk/react";
+import { SWAP_AGENT_POKE_TEXT } from "@shared";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/components/ai-elements/conversation", () => ({
-  Conversation: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
+  Conversation: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement> & {
+    children: React.ReactNode;
+  }) => (
+    <div data-testid="conversation" {...props}>
+      {children}
+    </div>
   ),
   ConversationContent: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
@@ -194,6 +202,115 @@ import { ChatMessages } from "./chat-messages";
 describe("ChatMessages", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    HTMLElement.prototype.scrollIntoView = vi.fn();
+  });
+
+  it("moves focus between messages with shift arrow navigation", () => {
+    const messages = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "First user message" }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "First assistant message" }],
+      },
+      {
+        id: "user-2",
+        role: "user",
+        parts: [{ type: "text", text: "Second user message" }],
+      },
+    ] as UIMessage[];
+
+    render(
+      <ChatMessages
+        conversationId="conv-1"
+        messages={messages}
+        status="ready"
+      />,
+    );
+
+    const firstMessage = screen.getByLabelText("Message 1 of 3");
+    const secondMessage = screen.getByLabelText("Message 2 of 3");
+    const thirdMessage = screen.getByLabelText("Message 3 of 3");
+
+    firstMessage.focus();
+    fireEvent.keyDown(firstMessage, { key: "ArrowDown", shiftKey: true });
+    expect(secondMessage).toHaveFocus();
+
+    fireEvent.keyDown(secondMessage, { key: "ArrowDown", shiftKey: true });
+    expect(thirdMessage).toHaveFocus();
+
+    fireEvent.keyDown(thirdMessage, { key: "ArrowUp", shiftKey: true });
+    expect(secondMessage).toHaveFocus();
+  });
+
+  it("returns focus to the prompt textarea from the last message with shift arrow down", () => {
+    const promptTextarea = document.createElement("textarea");
+    document.body.appendChild(promptTextarea);
+    const promptTextareaRef = { current: promptTextarea };
+
+    const messages = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "First user message" }],
+      },
+    ] as UIMessage[];
+
+    render(
+      <ChatMessages
+        conversationId="conv-1"
+        messages={messages}
+        status="ready"
+        promptTextareaRef={promptTextareaRef}
+      />,
+    );
+
+    const message = screen.getByLabelText("Message 1 of 1");
+    message.focus();
+    fireEvent.keyDown(message, { key: "ArrowDown", shiftKey: true });
+
+    expect(promptTextarea).toHaveFocus();
+    promptTextarea.remove();
+  });
+
+  it("does not include hidden swap poke messages in keyboard navigation", () => {
+    const messages = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Visible user message" }],
+      },
+      {
+        id: "swap-poke",
+        role: "user",
+        parts: [{ type: "text", text: SWAP_AGENT_POKE_TEXT }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "Visible assistant message" }],
+      },
+    ] as UIMessage[];
+
+    render(
+      <ChatMessages
+        conversationId="conv-1"
+        messages={messages}
+        status="ready"
+      />,
+    );
+
+    expect(screen.getByLabelText("Message 1 of 2")).toHaveTextContent(
+      "Visible user message",
+    );
+    expect(screen.getByLabelText("Message 2 of 2")).toHaveTextContent(
+      "Visible assistant message",
+    );
+    expect(screen.queryByText(SWAP_AGENT_POKE_TEXT)).not.toBeInTheDocument();
   });
 
   it("renders URL and document source parts for assistant messages", () => {

--- a/platform/frontend/src/components/chat/chat-messages.test.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.test.tsx
@@ -753,7 +753,7 @@ describe("ChatMessages", () => {
     expect(screen.getByText('{"issue":1}')).toBeInTheDocument();
   });
 
-  it("renders branded built-in todo_write with the specialized todo tool UI", () => {
+  it("does not render branded built-in todo_write in the message timeline", () => {
     const messages = [
       {
         id: "assistant-1",
@@ -780,7 +780,7 @@ describe("ChatMessages", () => {
       />,
     );
 
-    expect(screen.getByText("todo-write-tool")).toBeInTheDocument();
+    expect(screen.queryByText("todo-write-tool")).not.toBeInTheDocument();
     expect(
       screen.queryByText("tool-sparky__todo_write"),
     ).not.toBeInTheDocument();

--- a/platform/frontend/src/components/chat/chat-messages.test.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.test.tsx
@@ -196,6 +196,91 @@ describe("ChatMessages", () => {
     vi.clearAllMocks();
   });
 
+  it("renders URL and document source parts for assistant messages", () => {
+    const messages = [
+      {
+        id: "assistant-sources",
+        role: "assistant",
+        parts: [
+          {
+            type: "text",
+            text: "The incident report matches the deployment window.",
+          },
+          {
+            type: "source-url",
+            sourceId: "source-runbook",
+            url: "https://example.test/runbooks/deployments",
+            title: "Deployment Runbook",
+          },
+          {
+            type: "source-document",
+            sourceId: "source-pdf",
+            mediaType: "application/pdf",
+            title: "Incident Review Packet",
+            filename: "incident-review.pdf",
+          },
+        ],
+      },
+    ] as UIMessage[];
+
+    render(
+      <ChatMessages
+        conversationId="conv-1"
+        messages={messages}
+        status="ready"
+      />,
+    );
+
+    expect(screen.getByText("Sources")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Deployment Runbook/i }),
+    ).toHaveAttribute("href", "https://example.test/runbooks/deployments");
+    expect(screen.getByText("Incident Review Packet")).toBeInTheDocument();
+    expect(screen.getByText("incident-review.pdf")).toBeInTheDocument();
+  });
+
+  it("deduplicates repeated source parts by source id", () => {
+    const messages = [
+      {
+        id: "assistant-duplicate-sources",
+        role: "assistant",
+        parts: [
+          {
+            type: "text",
+            text: "I found one authoritative source.",
+          },
+          {
+            type: "source-url",
+            sourceId: "source-release-notes",
+            url: "https://example.test/releases/2026-04",
+            title: "April Release Notes",
+          },
+          {
+            type: "source-url",
+            sourceId: "source-release-notes",
+            url: "https://example.test/releases/2026-04?duplicate=true",
+            title: "April Release Notes Duplicate",
+          },
+        ],
+      },
+    ] as UIMessage[];
+
+    render(
+      <ChatMessages
+        conversationId="conv-1"
+        messages={messages}
+        status="ready"
+      />,
+    );
+
+    expect(
+      screen.getAllByRole("link", { name: /April Release Notes/i }),
+    ).toHaveLength(1);
+    expect(
+      screen.queryByText("April Release Notes Duplicate"),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders the swap divider for branded built-in swap tools", () => {
     const messages = [
       {

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -446,7 +446,7 @@ export function ChatMessages({
     >
       <ScrollToBottomOnSubmit status={status} />
       <ConversationContent>
-        <div className="max-w-4xl mx-auto relative pb-8">
+        <div className="max-w-4xl mx-auto relative pb-8 flex flex-col gap-2">
           <SensitiveContextStickyIndicator
             visible={showStickyUnsafeIndicator}
           />
@@ -488,7 +488,10 @@ export function ChatMessages({
             return (
               <div
                 key={message.id || idx}
-                className={cn(isDimmed && "opacity-40 transition-opacity")}
+                className={cn(
+                  isDimmed && "opacity-40 transition-opacity",
+                  "flex flex-col gap-2",
+                )}
               >
                 {(() => {
                   const { groupMap, consumedIndices } =
@@ -712,6 +715,11 @@ export function ChatMessages({
                                       <Reasoning
                                         key={parsedKey}
                                         className="w-full"
+                                        isStreaming={
+                                          status === "streaming" &&
+                                          i === message.parts.length - 1 &&
+                                          message.id === messages.at(-1)?.id
+                                        }
                                       >
                                         <ReasoningTrigger />
                                         <ReasoningContent>
@@ -825,7 +833,11 @@ export function ChatMessages({
 
                       case "reasoning":
                         return (
-                          <Reasoning key={partKey} className="w-full">
+                          <Reasoning
+                            key={partKey}
+                            className="w-full"
+                            isStreaming={part.state === "streaming"}
+                          >
                             <ReasoningTrigger />
                             <ReasoningContent>{part.text}</ReasoningContent>
                           </Reasoning>
@@ -886,10 +898,7 @@ export function ChatMessages({
                         const isPdf = filePart.mediaType === "application/pdf";
 
                         return (
-                          <div
-                            key={partKey}
-                            className="py-1 -mt-2 flex justify-start"
-                          >
+                          <div key={partKey} className="flex justify-start">
                             <div className="max-w-sm">
                               {isImage && (
                                 <img
@@ -913,10 +922,10 @@ export function ChatMessages({
                                   target="_blank"
                                   rel="noopener noreferrer"
                                   download={filePart.filename}
-                                  className="flex items-center gap-2 text-sm rounded-lg border bg-muted/50 p-2 hover:bg-muted transition-colors"
+                                  className="flex items-center gap-1 text-sm rounded-lg border bg-muted/50 p-2 hover:bg-muted transition-colors"
                                 >
                                   <svg
-                                    className="h-6 w-6 text-red-500"
+                                    className="h-4 w-4 text-red-500"
                                     fill="currentColor"
                                     viewBox="0 0 24 24"
                                   >
@@ -934,10 +943,10 @@ export function ChatMessages({
                                   target="_blank"
                                   rel="noopener noreferrer"
                                   download={filePart.filename}
-                                  className="flex items-center gap-2 text-sm rounded-lg border bg-muted/50 p-2 hover:bg-muted transition-colors"
+                                  className="flex items-center gap-1 text-sm rounded-lg border bg-muted/50 p-2 hover:bg-muted transition-colors"
                                 >
                                   <svg
-                                    className="h-5 w-5 text-muted-foreground"
+                                    className="h-4 w-4 text-muted-foreground"
                                     fill="none"
                                     stroke="currentColor"
                                     viewBox="0 0 24 24"
@@ -950,7 +959,7 @@ export function ChatMessages({
                                       d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"
                                     />
                                   </svg>
-                                  <span className="truncate">
+                                  <span className="font-medium truncate">
                                     {filePart.filename || "Attached file"}
                                   </span>
                                 </a>

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -31,7 +31,10 @@ import {
 import Link from "next/link";
 import {
   Fragment,
+  type KeyboardEvent,
+  type MutableRefObject,
   memo,
+  type RefObject,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -133,6 +136,8 @@ interface ChatMessagesProps {
   agentId?: string;
   messages: UIMessage[];
   status: ChatStatus;
+  promptTextareaRef?: RefObject<HTMLTextAreaElement | null>;
+  focusLastMessageRef?: MutableRefObject<(() => void) | null>;
   optimisticToolCalls?: Array<{
     toolCallId: string;
     toolName: string;
@@ -199,6 +204,8 @@ export function ChatMessages({
   agentId,
   messages,
   status,
+  promptTextareaRef,
+  focusLastMessageRef,
   optimisticToolCalls = [],
   isLoadingConversation = false,
   onMessagesUpdate,
@@ -418,14 +425,6 @@ export function ChatMessages({
     [messages],
   );
 
-  if (messages.length === 0 && chatErrors.length === 0) {
-    // Don't show "start conversation" message while loading - prevents flash of empty state
-    if (isLoadingConversation) {
-      return null;
-    }
-    return null;
-  }
-
   // Find the index of the message being edited
   const editingMessageIndex = editingMessageId
     ? messages.findIndex((m) => m.id === editingMessageId)
@@ -450,17 +449,162 @@ export function ChatMessages({
     return nextMessage.role !== "assistant";
   });
   const timelineItems = buildMessageTimeline({ messages, chatErrors });
+  const navigableMessages = useMemo(
+    () =>
+      timelineItems.flatMap((item) => {
+        if (item.kind !== "message") {
+          return [];
+        }
+        if (item.message.role !== "user" && item.message.role !== "assistant") {
+          return [];
+        }
+        if (!isDebugging && isSwapAgentPokeMessage(item.message)) {
+          return [];
+        }
+        return [
+          {
+            messageId: getNavigableMessageId(
+              item.message.id,
+              item.messageIndex,
+            ),
+            messageIndex: item.messageIndex,
+          },
+        ];
+      }),
+    [timelineItems, isDebugging],
+  );
+  const navigableMessageIndexMap = useMemo(
+    () =>
+      new Map(
+        navigableMessages.map((message, index) => [
+          message.messageIndex,
+          index,
+        ]),
+      ),
+    [navigableMessages],
+  );
   const liveErrorMessage = error ? getInlineErrorMessage(error) : null;
   const hasRenderedLiveError =
     !!error &&
     chatErrors.some(
       (chatError) => chatError.error.message === liveErrorMessage,
     );
+  const [
+    isKeyboardMessageNavigationActive,
+    setIsKeyboardMessageNavigationActive,
+  ] = useState(false);
+
+  const handleConversationKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (
+        !event.shiftKey ||
+        (event.key !== "ArrowUp" && event.key !== "ArrowDown")
+      ) {
+        return;
+      }
+
+      const target = event.target;
+      if (!(target instanceof HTMLElement) || isTextEntryElement(target)) {
+        return;
+      }
+
+      const currentMessageElement = target.closest<HTMLElement>(
+        "[data-message-nav-id]",
+      );
+      if (!currentMessageElement) {
+        return;
+      }
+
+      const currentMessageId = currentMessageElement.dataset.messageNavId;
+      if (!currentMessageId) {
+        return;
+      }
+
+      const currentIndex = navigableMessages.findIndex(
+        (message) => message.messageId === currentMessageId,
+      );
+      if (currentIndex === -1) {
+        return;
+      }
+
+      setIsKeyboardMessageNavigationActive(true);
+
+      const offset = event.key === "ArrowDown" ? 1 : -1;
+      const nextMessage = navigableMessages[currentIndex + offset];
+      if (!nextMessage) {
+        if (
+          event.key === "ArrowDown" &&
+          currentIndex === navigableMessages.length - 1
+        ) {
+          const promptTextarea = promptTextareaRef?.current;
+          if (promptTextarea) {
+            event.preventDefault();
+            promptTextarea.focus();
+          }
+        }
+        return;
+      }
+
+      const nextMessageElement = event.currentTarget.querySelector<HTMLElement>(
+        `[data-message-nav-id="${nextMessage.messageId}"]`,
+      );
+      if (!nextMessageElement) {
+        return;
+      }
+
+      event.preventDefault();
+      nextMessageElement.focus({ preventScroll: true });
+      nextMessageElement.scrollIntoView({
+        block: "nearest",
+        inline: "nearest",
+      });
+    },
+    [navigableMessages, promptTextareaRef],
+  );
+
+  const focusLastNavigableMessage = useCallback(() => {
+    const lastMessage = navigableMessages.at(-1);
+    if (!lastMessage) {
+      return;
+    }
+
+    const messageElement = document.querySelector<HTMLElement>(
+      `[data-message-nav-id="${lastMessage.messageId}"]`,
+    );
+    messageElement?.focus({ preventScroll: true });
+    messageElement?.scrollIntoView({
+      block: "nearest",
+      inline: "nearest",
+    });
+    setIsKeyboardMessageNavigationActive(true);
+  }, [navigableMessages]);
+
+  useEffect(() => {
+    if (!focusLastMessageRef) {
+      return;
+    }
+
+    focusLastMessageRef.current = focusLastNavigableMessage;
+
+    return () => {
+      focusLastMessageRef.current = null;
+    };
+  }, [focusLastMessageRef, focusLastNavigableMessage]);
+
+  if (messages.length === 0 && chatErrors.length === 0) {
+    // Don't show "start conversation" message while loading - prevents flash of empty state
+    if (isLoadingConversation) {
+      return null;
+    }
+    return null;
+  }
 
   return (
     <Conversation
       className="h-full"
       resize={instantResize || initialLoad ? "instant" : "smooth"}
+      onKeyDown={handleConversationKeyDown}
+      onPointerDown={() => setIsKeyboardMessageNavigationActive(false)}
     >
       <ScrollToBottomOnSubmit status={status} />
       <ConversationContent>
@@ -493,6 +637,8 @@ export function ChatMessages({
 
             const isDimmed =
               editingMessageIndex !== -1 && idx > editingMessageIndex;
+            const navigableMessagePosition =
+              navigableMessageIndexMap.get(idx) ?? null;
             const previousSwapBoundaryLabel =
               message.role === "assistant"
                 ? getPreviousAssistantSwapBoundaryLabel({
@@ -504,9 +650,33 @@ export function ChatMessages({
                 : null;
 
             return (
-              <div
+              <article
                 key={message.id || idx}
+                data-message-nav-id={
+                  navigableMessagePosition !== null
+                    ? getNavigableMessageId(message.id, idx)
+                    : undefined
+                }
+                tabIndex={navigableMessagePosition !== null ? -1 : undefined}
+                aria-label={
+                  navigableMessagePosition !== null
+                    ? `Message ${navigableMessagePosition + 1} of ${navigableMessages.length}`
+                    : undefined
+                }
                 className={cn(
+                  navigableMessagePosition !== null &&
+                    "rounded-2xl transition-[background-color,box-shadow,opacity] duration-150 ease-out focus:outline-none motion-reduce:transform-none",
+                  navigableMessagePosition !== null &&
+                    isKeyboardMessageNavigationActive &&
+                    "focus:bg-accent/30 focus:shadow-sm focus:[&_[data-message-actions]]:opacity-100 focus:[&_[data-message-actions]]:pointer-events-auto",
+                  navigableMessagePosition !== null &&
+                    isKeyboardMessageNavigationActive &&
+                    message.role === "user" &&
+                    "focus:[&_[data-message-focus-surface]]:-translate-x-2",
+                  navigableMessagePosition !== null &&
+                    isKeyboardMessageNavigationActive &&
+                    message.role === "assistant" &&
+                    "focus:[&_[data-message-focus-surface]]:translate-x-2",
                   isDimmed && "opacity-40 transition-opacity",
                   "flex flex-col gap-2",
                 )}
@@ -1239,7 +1409,7 @@ export function ChatMessages({
                     suppressLabel={previousSwapBoundaryLabel}
                   />
                 )}
-              </div>
+              </article>
             );
           })}
           {/* Inline error display */}
@@ -2494,6 +2664,26 @@ function buildMessageTimeline(params: {
   }
 
   return timelineItems;
+}
+
+function getNavigableMessageId(
+  messageId: string | undefined,
+  messageIndex: number,
+): string {
+  return messageId ?? `message-${messageIndex}`;
+}
+
+function isTextEntryElement(element: HTMLElement): boolean {
+  const tagName = element.tagName.toLowerCase();
+  if (tagName === "input" || tagName === "textarea" || tagName === "select") {
+    return true;
+  }
+
+  if (element.isContentEditable) {
+    return true;
+  }
+
+  return !!element.closest("[contenteditable='true']");
 }
 
 function getMessageCreatedAt(message: UIMessage): number | null {

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -91,6 +91,7 @@ import {
   filterOptimisticToolCalls,
   hasTextPart,
   identifyCompactToolGroups,
+  isTodoWriteToolPart,
 } from "./chat-messages.utils";
 import { CompactToolGroup, type ToolIconMap } from "./compact-tool-call";
 import { EditableAssistantMessage } from "./editable-assistant-message";
@@ -112,7 +113,6 @@ import {
   getSwapAgentBoundaryLabel,
   SwapAgentBoundaryDivider,
 } from "./swap-agent-boundary";
-import { TodoWriteTool } from "./todo-write-tool";
 import { ToolErrorLogsButton } from "./tool-error-logs-button";
 import { ToolStatusRow } from "./tool-status-row";
 
@@ -1527,15 +1527,8 @@ const MessageTool = memo(
       ) : null;
     }
 
-    if (getToolShortName(toolName) === TOOL_TODO_WRITE_SHORT_NAME) {
-      return (
-        <TodoWriteTool
-          part={part}
-          toolResultPart={toolResultPart}
-          errorText={errorText}
-          onToolApprovalResponse={onToolApprovalResponse}
-        />
-      );
+    if (isTodoWriteToolPart(part)) {
+      return null;
     }
 
     if (authToolBody) {

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -14,8 +14,20 @@ import {
   TOOL_TODO_WRITE_FULL_NAME,
   TOOL_TODO_WRITE_SHORT_NAME,
 } from "@shared";
-import type { ChatStatus, DynamicToolUIPart, ToolUIPart } from "ai";
-import { BotIcon, CheckCircleIcon, ClockIcon } from "lucide-react";
+import type {
+  ChatStatus,
+  DynamicToolUIPart,
+  SourceDocumentUIPart,
+  SourceUrlUIPart,
+  ToolUIPart,
+} from "ai";
+import {
+  BotIcon,
+  CheckCircleIcon,
+  ClockIcon,
+  ExternalLinkIcon,
+  FileTextIcon,
+} from "lucide-react";
 import Link from "next/link";
 import {
   Fragment,
@@ -154,6 +166,8 @@ type TimelineItem =
   | { kind: "message"; message: UIMessage; messageIndex: number }
   | { kind: "chat-error"; chatError: PersistedChatError };
 
+type SourceUIPart = SourceUrlUIPart | SourceDocumentUIPart;
+
 // Type guards for tool parts
 // biome-ignore lint/suspicious/noExplicitAny: AI SDK message parts have dynamic structure
 function isToolPart(part: any): part is {
@@ -174,6 +188,10 @@ function isToolPart(part: any): part is {
       part.type?.startsWith("data-tool-ui-start") ||
       part.type === "dynamic-tool")
   );
+}
+
+function isSourcePart(part: UIMessage["parts"][number]): part is SourceUIPart {
+  return part.type === "source-url" || part.type === "source-document";
 }
 
 export function ChatMessages({
@@ -567,6 +585,26 @@ export function ChatMessages({
                     }
 
                     switch (part.type) {
+                      case "source-url":
+                      case "source-document": {
+                        if (message.role !== "assistant") {
+                          return null;
+                        }
+
+                        const firstSourcePartIndex =
+                          message.parts?.findIndex(isSourcePart) ?? -1;
+                        if (i !== firstSourcePartIndex) {
+                          return null;
+                        }
+
+                        return (
+                          <MessageSources
+                            key={partKey}
+                            parts={getDedupedSourceParts(message.parts ?? [])}
+                          />
+                        );
+                      }
+
                       case "text": {
                         // Skip empty text parts from assistant messages.
                         // OpenAI-compatible providers (Ollama, vLLM, etc.) may send empty content
@@ -1293,11 +1331,77 @@ function getMessagePartSignature(part: UIMessage["parts"][number]): string {
       return "text";
     case "reasoning":
       return "reasoning";
+    case "source-url":
+      return `source-url:${part.sourceId}`;
+    case "source-document":
+      return `source-document:${part.sourceId}`;
     case "file":
       return `file:${part.url}:${part.mediaType}:${part.filename ?? ""}`;
     default:
       return `part:${JSON.stringify(part)}`;
   }
+}
+
+function MessageSources({ parts }: { parts: SourceUIPart[] }) {
+  if (parts.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+      <span className="font-medium uppercase tracking-wide">Sources</span>
+      {parts.map((part) => {
+        if (part.type === "source-url") {
+          return (
+            <Link
+              key={part.sourceId}
+              href={part.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex max-w-[260px] items-center gap-1.5 rounded-md border bg-card px-2 py-1.5 text-foreground transition-colors hover:bg-accent"
+            >
+              <ExternalLinkIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <span className="truncate">{part.title || part.url}</span>
+            </Link>
+          );
+        }
+
+        return (
+          <div
+            key={part.sourceId}
+            className="inline-flex max-w-[300px] items-center gap-1.5 rounded-md border bg-card px-2 py-1.5 text-foreground"
+          >
+            <FileTextIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <span className="truncate">{part.title}</span>
+            {part.filename && (
+              <span className="truncate text-muted-foreground">
+                {part.filename}
+              </span>
+            )}
+            <span className="shrink-0 text-muted-foreground">
+              {part.mediaType}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function getDedupedSourceParts(
+  parts: UIMessage["parts"] | undefined,
+): SourceUIPart[] {
+  const sourceParts: SourceUIPart[] = [];
+  const seenSourceIds = new Set<string>();
+
+  for (const part of parts ?? []) {
+    if (!isSourcePart(part) || seenSourceIds.has(part.sourceId)) {
+      continue;
+    }
+
+    sourceParts.push(part);
+    seenSourceIds.add(part.sourceId);
+  }
+
+  return sourceParts;
 }
 
 // Custom hook to detect when streaming has stalled (>500ms without updates)

--- a/platform/frontend/src/components/chat/chat-messages.utils.test.ts
+++ b/platform/frontend/src/components/chat/chat-messages.utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractFileAttachments,
   filterOptimisticToolCalls,
+  getLatestTodoWriteToolState,
   hasTextPart,
   identifyCompactToolGroups,
 } from "./chat-messages.utils";
@@ -183,6 +184,114 @@ describe("filterOptimisticToolCalls", () => {
     expect(filterOptimisticToolCalls(messages, optimisticToolCalls)).toEqual([
       optimisticToolCalls[1],
     ]);
+  });
+});
+
+describe("getLatestTodoWriteToolState", () => {
+  it("returns null when no todo_write call exists", () => {
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-google__search",
+            toolCallId: "call_1",
+            state: "input-available",
+            input: { q: "weather" },
+          },
+        ],
+      },
+    ] as UIMessage[];
+
+    expect(getLatestTodoWriteToolState(messages)).toBeNull();
+  });
+
+  it("returns the newest todo_write call", () => {
+    const olderTodo = {
+      type: "tool-archestra__todo_write",
+      toolCallId: "call_1",
+      state: "output-available",
+      input: {
+        todos: [{ id: 1, content: "Older task", status: "completed" }],
+      },
+      output: { ok: true },
+    };
+    const newerTodo = {
+      type: "tool-archestra__todo_write",
+      toolCallId: "call_2",
+      state: "output-available",
+      input: {
+        todos: [{ id: 2, content: "Newer task", status: "in_progress" }],
+      },
+      output: { ok: true },
+    };
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [olderTodo],
+      },
+      {
+        id: "assistant-2",
+        role: "assistant",
+        parts: [newerTodo],
+      },
+    ] as UIMessage[];
+
+    expect(getLatestTodoWriteToolState(messages)?.part).toBe(newerTodo);
+  });
+
+  it("recognizes branded built-in todo_write names", () => {
+    const todoPart = {
+      type: "tool-sparky__todo_write",
+      toolCallId: "call_1",
+      state: "output-available",
+      input: {
+        todos: [{ id: 1, content: "Branded task", status: "pending" }],
+      },
+      output: { ok: true },
+    };
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [todoPart],
+      },
+    ] as UIMessage[];
+
+    expect(getLatestTodoWriteToolState(messages)?.part).toBe(todoPart);
+  });
+
+  it("preserves paired output and error text", () => {
+    const inputPart = {
+      type: "tool-archestra__todo_write",
+      toolCallId: "call_1",
+      state: "input-available",
+      input: {
+        todos: [{ id: 1, content: "Pair task", status: "pending" }],
+      },
+    };
+    const outputPart = {
+      type: "tool-archestra__todo_write",
+      toolCallId: "call_1",
+      state: "output-available",
+      output: { ok: false },
+      errorText: "Todo write failed",
+    };
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [inputPart, outputPart],
+      },
+    ] as UIMessage[];
+
+    const latestTodoState = getLatestTodoWriteToolState(messages);
+
+    expect(latestTodoState?.part).toBe(inputPart);
+    expect(latestTodoState?.toolResultPart).toBe(outputPart);
+    expect(latestTodoState?.errorText).toBe("Todo write failed");
   });
 });
 

--- a/platform/frontend/src/components/chat/chat-messages.utils.ts
+++ b/platform/frontend/src/components/chat/chat-messages.utils.ts
@@ -1,8 +1,12 @@
 import type { UIMessage } from "@ai-sdk/react";
-import type { ArchestraToolShortName } from "@shared";
+import {
+  type ArchestraToolShortName,
+  TOOL_TODO_WRITE_SHORT_NAME,
+} from "@shared";
 import type { DynamicToolUIPart, ToolUIPart } from "ai";
 import {
   getToolErrorText,
+  getToolNameFromPart,
   isCompactEligible,
 } from "@/lib/chat/chat-tools-display.utils";
 import type { FileAttachment } from "./editable-user-message";
@@ -22,6 +26,12 @@ export type CompactToolGroup = {
     toolResultPart: DynamicToolUIPart | ToolUIPart | null;
     errorText: string | undefined;
   }>;
+};
+
+export type LatestTodoWriteToolState = {
+  part: DynamicToolUIPart | ToolUIPart;
+  toolResultPart: DynamicToolUIPart | ToolUIPart | null;
+  errorText: string | undefined;
 };
 
 /**
@@ -193,6 +203,63 @@ export function identifyCompactToolGroups(
   return { groupMap, consumedIndices };
 }
 
+export function getLatestTodoWriteToolState(
+  messages: UIMessage[],
+): LatestTodoWriteToolState | null {
+  for (
+    let messageIndex = messages.length - 1;
+    messageIndex >= 0;
+    messageIndex--
+  ) {
+    const parts = messages[messageIndex].parts ?? [];
+
+    for (let partIndex = parts.length - 1; partIndex >= 0; partIndex--) {
+      const part = parts[partIndex];
+      if (!isToolPart(part) || !isTodoWriteToolPart(part)) {
+        continue;
+      }
+
+      const pairedPart = findPairedToolPart({
+        parts,
+        part,
+        partIndex,
+      });
+      const invocationPart =
+        isToolResultOnlyPart(part) && pairedPart ? pairedPart : part;
+      const toolResultPart =
+        invocationPart === part && pairedPart ? pairedPart : part;
+      const normalizedToolResultPart =
+        toolResultPart === invocationPart ? null : toolResultPart;
+
+      return {
+        part: invocationPart,
+        toolResultPart: normalizedToolResultPart,
+        errorText: getToolErrorText({
+          part: invocationPart,
+          toolResultPart: normalizedToolResultPart,
+        }),
+      };
+    }
+  }
+
+  return null;
+}
+
+export function isTodoWriteToolPart(part: {
+  type?: string;
+  toolName?: string;
+}): boolean {
+  const toolName = getToolNameFromPart(part);
+  if (!toolName) {
+    return false;
+  }
+
+  return (
+    toolName === TOOL_TODO_WRITE_SHORT_NAME ||
+    toolName.endsWith(`__${TOOL_TODO_WRITE_SHORT_NAME}`)
+  );
+}
+
 function isToolPart(part: unknown): part is DynamicToolUIPart | ToolUIPart {
   return (
     typeof part === "object" &&
@@ -213,6 +280,39 @@ function getToolName(part: DynamicToolUIPart | ToolUIPart): string | null {
   }
 
   return null;
+}
+
+function findPairedToolPart(params: {
+  parts: UIMessage["parts"];
+  part: DynamicToolUIPart | ToolUIPart;
+  partIndex: number;
+}): DynamicToolUIPart | ToolUIPart | null {
+  const { parts, part, partIndex } = params;
+  if (!part.toolCallId) {
+    return null;
+  }
+
+  const direction = isToolResultOnlyPart(part) ? -1 : 1;
+  for (
+    let index = partIndex + direction;
+    index >= 0 && index < parts.length;
+    index += direction
+  ) {
+    const candidate = parts[index];
+    if (!isToolPart(candidate)) {
+      continue;
+    }
+
+    if (candidate.toolCallId === part.toolCallId) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function isToolResultOnlyPart(part: DynamicToolUIPart | ToolUIPart): boolean {
+  return part.state === "output-available" && part.input === undefined;
 }
 
 function finalizeCurrentGroup(params: {

--- a/platform/frontend/src/components/chat/compact-tool-call.tsx
+++ b/platform/frontend/src/components/chat/compact-tool-call.tsx
@@ -130,7 +130,7 @@ export function CompactToolGroup({
   const expandedTool = tools.find((t) => t.key === expandedKey);
 
   return (
-    <div className="mb-1">
+    <div>
       <div className="flex flex-wrap gap-1.5 items-center">
         {tools.map((tool) => {
           const iconInfo = toolIconMap?.get(tool.toolName);

--- a/platform/frontend/src/components/chat/editable-assistant-message.tsx
+++ b/platform/frontend/src/components/chat/editable-assistant-message.tsx
@@ -166,7 +166,10 @@ export function EditableAssistantMessage({
 
   return (
     <Message from="assistant" className="group/message">
-      <div className="flex max-w-[80%] items-center justify-start gap-2">
+      <div
+        data-message-focus-surface
+        className="flex max-w-[80%] items-center justify-start gap-2 transition-transform duration-150 ease-out"
+      >
         <div className="min-w-0 flex-1">
           <MessageContent className="max-w-none">
             <Response isStreaming={isStreaming}>{text}</Response>

--- a/platform/frontend/src/components/chat/editable-assistant-message.tsx
+++ b/platform/frontend/src/components/chat/editable-assistant-message.tsx
@@ -180,7 +180,7 @@ export function EditableAssistantMessage({
             textToCopy={text}
             onEditClick={handleStartEdit}
             editDisabled={editDisabled}
-            className="shrink-0 opacity-0 group-hover/message:opacity-100 transition-opacity"
+            className="shrink-0 opacity-0 group-hover/message:opacity-100 group-focus-within/message:opacity-100 transition-opacity"
           />
         )}
       </div>

--- a/platform/frontend/src/components/chat/editable-assistant-message.tsx
+++ b/platform/frontend/src/components/chat/editable-assistant-message.tsx
@@ -120,45 +120,43 @@ export function EditableAssistantMessage({
       <Message from="assistant" className="relative pt-0">
         <MessageContent
           aria-label="Message content"
-          className="max-w-[70%] min-w-[50%] px-3 py-0 pt-3 ring-2 !bg-secondary/50 ring-primary/50"
+          className="max-w-[70%] min-w-[50%] px-4! py-3! rounded-lg! pt-3 ring-2 !bg-secondary/50 ring-primary/50"
         >
-          <div>
-            <Textarea
-              ref={textareaRef}
-              value={editedText}
-              onChange={(e) => setEditedText(e.target.value)}
-              onKeyDown={handleKeyDown}
-              onCompositionStart={() => setIsComposing(true)}
-              onCompositionEnd={() => setIsComposing(false)}
-              className="max-h-[240px] resize-none border-0 focus-visible:ring-0 shadow-none text-sm !bg-secondary"
-              disabled={isSaving}
-              placeholder="Edit this response..."
-            />
-            <div className="flex gap-2 py-3 justify-between items-start">
-              <div className="flex gap-2 items-start">
-                <Info className="h-3 w-3 text-muted-foreground shrink-0 mt-0.5" />
-                <span className="text-xs text-muted-foreground">
-                  Edit to correct errors or refine the context. This won't
-                  regenerate the conversation.
-                </span>
-              </div>
-              <div className="flex gap-2 shrink-0">
-                <Button
-                  size="sm"
-                  variant="outline-transparent"
-                  onClick={handleCancelEdit}
-                  disabled={isSaving}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  size="sm"
-                  onClick={handleSaveEdit}
-                  disabled={isSaving || editedText.trim() === ""}
-                >
-                  Save
-                </Button>
-              </div>
+          <Textarea
+            ref={textareaRef}
+            value={editedText}
+            onChange={(e) => setEditedText(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onCompositionStart={() => setIsComposing(true)}
+            onCompositionEnd={() => setIsComposing(false)}
+            className="max-h-[240px] resize-none border-0 focus-visible:ring-0 shadow-none text-sm !bg-secondary"
+            disabled={isSaving}
+            placeholder="Edit this response..."
+          />
+          <div className="flex gap-2 py-3 justify-between items-start">
+            <div className="flex gap-2 items-start">
+              <Info className="h-3 w-3 text-muted-foreground shrink-0 mt-0.5" />
+              <span className="text-xs text-muted-foreground">
+                Edit to correct errors or refine the context. This won't
+                regenerate the conversation.
+              </span>
+            </div>
+            <div className="flex gap-2 shrink-0">
+              <Button
+                size="sm"
+                variant="outline-transparent"
+                onClick={handleCancelEdit}
+                disabled={isSaving}
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                onClick={handleSaveEdit}
+                disabled={isSaving || editedText.trim() === ""}
+              >
+                Save
+              </Button>
             </div>
           </div>
         </MessageContent>

--- a/platform/frontend/src/components/chat/editable-user-message.tsx
+++ b/platform/frontend/src/components/chat/editable-user-message.tsx
@@ -203,7 +203,7 @@ export function EditableUserMessage({
       className="group/message"
       onMouseLeave={() => setIsRegenerateConfirming(false)}
     >
-      <div className="relative flex flex-col items-end pb-2 w-full">
+      <div className="relative flex flex-col items-end w-full">
         {/* Image attachments above the message bubble */}
         {imageAttachments.length > 0 && (
           <div className="flex flex-wrap gap-1 justify-end mb-2">

--- a/platform/frontend/src/components/chat/editable-user-message.tsx
+++ b/platform/frontend/src/components/chat/editable-user-message.tsx
@@ -251,7 +251,10 @@ export function EditableUserMessage({
         )}
         {/* Text message bubble - only show if there's text */}
         {text && (
-          <div className="flex max-w-[80%] items-center justify-end gap-2">
+          <div
+            data-message-focus-surface
+            className="flex max-w-[80%] items-center justify-end gap-2 transition-transform duration-150 ease-out"
+          >
             <MessageActions
               textToCopy={text}
               onEditClick={handleStartEdit}

--- a/platform/frontend/src/components/chat/editable-user-message.tsx
+++ b/platform/frontend/src/components/chat/editable-user-message.tsx
@@ -262,7 +262,7 @@ export function EditableUserMessage({
                 "shrink-0 transition-opacity",
                 isRegenerateConfirming
                   ? "opacity-100"
-                  : "opacity-0 group-hover/message:opacity-100",
+                  : "opacity-0 group-hover/message:opacity-100 group-focus-within/message:opacity-100",
               )}
             />
             <MessageContent className="max-w-none">

--- a/platform/frontend/src/components/chat/inline-chat-error.tsx
+++ b/platform/frontend/src/components/chat/inline-chat-error.tsx
@@ -89,144 +89,142 @@ export function InlineChatError({
 
   if (slimChatErrorUi) {
     return (
-      <Message from="assistant">
-        <MessageContent className="bg-destructive/10 border border-destructive/20 rounded-lg">
-          <div className="flex items-start gap-2 text-destructive">
-            <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
-            <div className="flex-1 space-y-2">
-              <p className="text-sm text-foreground">
-                {supportMessage ? supportMessage : chatError.message}
-              </p>
+      // <Message from="assistant">
+      //   <MessageContent className="bg-destructive/10 border border-destructive/20 rounded-lg">
+      <div className="flex items-start gap-2 text-destructive bg-destructive/10 border border-destructive/20 rounded-lg px-4 py-3">
+        <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+        <div className="flex-1 space-y-2">
+          <p className="text-sm text-foreground">
+            {supportMessage ? supportMessage : chatError.message}
+          </p>
 
-              <div className="flex items-center gap-1.5 flex-wrap">
-                {refEntries.map((entry) => (
-                  <span
-                    key={entry.label}
-                    className="inline-flex items-center gap-1 rounded bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground font-mono"
-                  >
-                    <span className="opacity-60">{entry.label}</span>
-                    <span>{entry.value}</span>
-                  </span>
-                ))}
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-5 w-5 p-0 text-muted-foreground hover:text-foreground"
-                  onClick={copyDebugInfo}
-                  aria-label="Copy error details"
-                  title="Copy error details"
-                >
-                  <Copy className="h-3 w-3" />
-                </Button>
-              </div>
-            </div>
+          <div className="flex items-center gap-1.5 flex-wrap">
+            {refEntries.map((entry) => (
+              <span
+                key={entry.label}
+                className="inline-flex items-center gap-1 rounded bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground font-mono"
+              >
+                <span className="opacity-60">{entry.label}</span>
+                <span>{entry.value}</span>
+              </span>
+            ))}
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-5 w-5 p-0 text-muted-foreground hover:text-foreground"
+              onClick={copyDebugInfo}
+              aria-label="Copy error details"
+              title="Copy error details"
+            >
+              <Copy className="h-3 w-3" />
+            </Button>
           </div>
-        </MessageContent>
-      </Message>
+        </div>
+      </div>
+      //   </MessageContent>
+      // </Message>
     );
   }
 
   return (
-    <Message from="assistant">
-      <MessageContent className="bg-destructive/10 border border-destructive/20 rounded-lg">
-        <div className="flex items-start gap-2 text-destructive">
-          <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
-          <div className="flex-1 space-y-2">
-            {supportMessage ? (
-              <p className="text-sm text-foreground">{supportMessage}</p>
-            ) : (
-              <p className="text-sm text-foreground">{chatError.message}</p>
-            )}
+    // <Message from="assistant">
+    //   <MessageContent className="bg-destructive/10 border border-destructive/20 rounded-lg">
+    <div className="flex items-start gap-2 text-destructive bg-destructive/10 border border-destructive/20 rounded-lg px-4 py-3">
+      <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+      <div className="flex-1 space-y-2">
+        {supportMessage ? (
+          <p className="text-sm text-foreground">{supportMessage}</p>
+        ) : (
+          <p className="text-sm text-foreground">{chatError.message}</p>
+        )}
 
-            <div className="flex items-center gap-1.5 flex-wrap">
-              {agentName && (
-                <span className="inline-flex items-center gap-1 rounded bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground font-mono">
-                  <span className="opacity-60">Agent</span>
-                  <span>{agentName}</span>
-                </span>
-              )}
-              {selectedModel && (
-                <span className="inline-flex items-center gap-1 rounded bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground font-mono">
-                  <span className="opacity-60">Model</span>
-                  <span>{selectedModel}</span>
-                </span>
-              )}
-              {chatError.originalError?.provider && (
-                <span className="inline-flex items-center gap-1 rounded bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground font-mono">
-                  <span className="opacity-60">Provider</span>
-                  <span>{chatError.originalError.provider}</span>
-                </span>
-              )}
-              <span className="inline-flex items-center gap-1 rounded bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground font-mono">
-                <span className="opacity-60">Model source</span>
-                <span>{formatModelSource(modelSource)}</span>
-              </span>
-              {refEntries.map((entry) => (
-                <span
-                  key={entry.label}
-                  className="inline-flex items-center gap-1 rounded bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground font-mono"
-                >
-                  <span className="opacity-60">{entry.label}</span>
-                  <span>{entry.value}</span>
-                </span>
-              ))}
+        <div className="flex items-center gap-1.5 flex-wrap">
+          {agentName && (
+            <span className="inline-flex items-center gap-1 rounded bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground font-mono">
+              <span className="opacity-60">Agent</span>
+              <span>{agentName}</span>
+            </span>
+          )}
+          {selectedModel && (
+            <span className="inline-flex items-center gap-1 rounded bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground font-mono">
+              <span className="opacity-60">Model</span>
+              <span>{selectedModel}</span>
+            </span>
+          )}
+          {chatError.originalError?.provider && (
+            <span className="inline-flex items-center gap-1 rounded bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground font-mono">
+              <span className="opacity-60">Provider</span>
+              <span>{chatError.originalError.provider}</span>
+            </span>
+          )}
+          <span className="inline-flex items-center gap-1 rounded bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground font-mono">
+            <span className="opacity-60">Model source</span>
+            <span>{formatModelSource(modelSource)}</span>
+          </span>
+          {refEntries.map((entry) => (
+            <span
+              key={entry.label}
+              className="inline-flex items-center gap-1 rounded bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground font-mono"
+            >
+              <span className="opacity-60">{entry.label}</span>
+              <span>{entry.value}</span>
+            </span>
+          ))}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-5 w-5 p-0 text-muted-foreground hover:text-foreground"
+            onClick={copyDebugInfo}
+            aria-label="Copy debug info"
+            title="Copy debug info"
+          >
+            <Copy className="h-3 w-3" />
+          </Button>
+        </div>
+
+        {isAdmin && (
+          <Collapsible open={isDetailsOpen} onOpenChange={setIsDetailsOpen}>
+            <CollapsibleTrigger asChild>
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-5 w-5 p-0 text-muted-foreground hover:text-foreground"
-                onClick={copyDebugInfo}
-                aria-label="Copy debug info"
-                title="Copy debug info"
+                className="h-auto p-0 text-xs text-muted-foreground hover:text-foreground"
               >
-                <Copy className="h-3 w-3" />
+                {isDetailsOpen ? (
+                  <ChevronDown className="h-3 w-3 mr-1" />
+                ) : (
+                  <ChevronRight className="h-3 w-3 mr-1" />
+                )}
+                Error Details
               </Button>
-            </div>
-
-            {isAdmin && (
-              <Collapsible open={isDetailsOpen} onOpenChange={setIsDetailsOpen}>
-                <CollapsibleTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-auto p-0 text-xs text-muted-foreground hover:text-foreground"
-                  >
-                    {isDetailsOpen ? (
-                      <ChevronDown className="h-3 w-3 mr-1" />
-                    ) : (
-                      <ChevronRight className="h-3 w-3 mr-1" />
-                    )}
-                    Error Details
-                  </Button>
-                </CollapsibleTrigger>
-                <CollapsibleContent className="space-y-2 mt-1">
-                  <div className="flex items-center gap-2">
-                    <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-muted text-muted-foreground">
-                      {chatError.code}
-                    </span>
-                    {chatError.isRetryable && (
-                      <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
-                        <RefreshCw className="h-3 w-3" />
-                        Retryable
-                      </span>
-                    )}
-                  </div>
-                  {supportMessage && (
-                    <p className="text-sm text-foreground">
-                      {chatError.message}
-                    </p>
-                  )}
-                  {chatError.originalError && (
-                    <pre className="max-h-48 overflow-auto rounded-md bg-muted/50 p-3 text-xs font-mono whitespace-pre-wrap break-words text-foreground">
-                      {formatOriginalError(chatError.originalError)}
-                    </pre>
-                  )}
-                </CollapsibleContent>
-              </Collapsible>
-            )}
-          </div>
-        </div>
-      </MessageContent>
-    </Message>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="space-y-2 mt-1">
+              <div className="flex items-center gap-2">
+                <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-muted text-muted-foreground">
+                  {chatError.code}
+                </span>
+                {chatError.isRetryable && (
+                  <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                    <RefreshCw className="h-3 w-3" />
+                    Retryable
+                  </span>
+                )}
+              </div>
+              {supportMessage && (
+                <p className="text-sm text-foreground">{chatError.message}</p>
+              )}
+              {chatError.originalError && (
+                <pre className="max-h-48 overflow-auto rounded-md bg-muted/50 p-3 text-xs font-mono whitespace-pre-wrap break-words text-foreground">
+                  {formatOriginalError(chatError.originalError)}
+                </pre>
+              )}
+            </CollapsibleContent>
+          </Collapsible>
+        )}
+      </div>
+    </div>
+    //   </MessageContent>
+    // </Message>
   );
 }
 

--- a/platform/frontend/src/components/chat/message-actions.tsx
+++ b/platform/frontend/src/components/chat/message-actions.tsx
@@ -33,6 +33,7 @@ export function MessageActions({
 
   return (
     <div
+      data-message-actions
       className={cn(
         "flex items-center gap-0.5 rounded-md border bg-background/95 shadow-sm p-0.5",
         className,

--- a/platform/frontend/src/components/chat/todo-write-tool.test.tsx
+++ b/platform/frontend/src/components/chat/todo-write-tool.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ToolUIPart } from "ai";
+import { describe, expect, it, vi } from "vitest";
+import { TodoWriteTool } from "./todo-write-tool";
+
+describe("TodoWriteTool", () => {
+  it("does not render when there are no todos, errors, or result", () => {
+    render(
+      <TodoWriteTool
+        part={makeTodoPart({ todos: [] })}
+        toolResultPart={null}
+      />,
+    );
+
+    expect(screen.queryByText("Tasks")).not.toBeInTheDocument();
+  });
+
+  it("renders expanded when a todo is pending", () => {
+    render(
+      <TodoWriteTool
+        part={makeTodoPart({
+          todos: [{ id: 1, content: "Plan the change", status: "pending" }],
+        })}
+        toolResultPart={{ output: { ok: true } } as ToolUIPart}
+      />,
+    );
+
+    expect(screen.getByText("0/1")).toBeInTheDocument();
+    expect(screen.getByText("Plan the change")).toBeInTheDocument();
+  });
+
+  it("renders collapsed when all todos are completed", () => {
+    render(
+      <TodoWriteTool
+        part={makeTodoPart({
+          todos: [{ id: 1, content: "Ship the change", status: "completed" }],
+        })}
+        toolResultPart={{ output: { ok: true } } as ToolUIPart}
+      />,
+    );
+
+    expect(screen.getByText("1/1")).toBeInTheDocument();
+    expect(screen.queryByText("Ship the change")).not.toBeInTheDocument();
+  });
+
+  it("allows the user to toggle the panel", () => {
+    render(
+      <TodoWriteTool
+        part={makeTodoPart({
+          todos: [{ id: 1, content: "Toggle me", status: "pending" }],
+        })}
+        toolResultPart={{ output: { ok: true } } as ToolUIPart}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Tasks/i }));
+
+    expect(screen.queryByText("Toggle me")).not.toBeInTheDocument();
+  });
+
+  it("recalculates open state when a newer todo state arrives", () => {
+    const { rerender } = render(
+      <TodoWriteTool
+        part={makeTodoPart({
+          toolCallId: "call_1",
+          todos: [{ id: 1, content: "First task", status: "pending" }],
+        })}
+        toolResultPart={{ output: { ok: true } } as ToolUIPart}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Tasks/i }));
+    expect(screen.queryByText("First task")).not.toBeInTheDocument();
+
+    rerender(
+      <TodoWriteTool
+        part={makeTodoPart({
+          toolCallId: "call_2",
+          todos: [{ id: 1, content: "Second task", status: "in_progress" }],
+        })}
+        toolResultPart={{ output: { ok: true } } as ToolUIPart}
+      />,
+    );
+
+    expect(screen.getByText("Second task")).toBeInTheDocument();
+  });
+
+  it("sends approval responses when approval is requested", () => {
+    const onToolApprovalResponse = vi.fn();
+    render(
+      <TodoWriteTool
+        part={
+          {
+            ...makeTodoPart({
+              todos: [{ id: 1, content: "Approve me", status: "pending" }],
+            }),
+            state: "approval-requested",
+            approval: { id: "approval_1" },
+          } as ToolUIPart
+        }
+        toolResultPart={null}
+        onToolApprovalResponse={onToolApprovalResponse}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+    expect(onToolApprovalResponse).toHaveBeenCalledWith({
+      id: "approval_1",
+      approved: true,
+    });
+  });
+});
+
+function makeTodoPart(params: {
+  toolCallId?: string;
+  todos: Array<{
+    id: number;
+    content: string;
+    status: "pending" | "in_progress" | "completed";
+  }>;
+}): ToolUIPart {
+  return {
+    type: "tool-archestra__todo_write",
+    toolCallId: params.toolCallId ?? "call_1",
+    state: "output-available",
+    input: { todos: params.todos },
+    output: { ok: true },
+  } as ToolUIPart;
+}

--- a/platform/frontend/src/components/chat/todo-write-tool.tsx
+++ b/platform/frontend/src/components/chat/todo-write-tool.tsx
@@ -8,7 +8,7 @@ import {
   Clock,
   ListTodo,
 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -22,6 +22,7 @@ interface TodoWriteToolProps {
   part: ToolUIPart | DynamicToolUIPart;
   toolResultPart: ToolUIPart | DynamicToolUIPart | null;
   errorText?: string;
+  className?: string;
   onToolApprovalResponse?: (params: {
     id: string;
     approved: boolean;
@@ -33,19 +34,49 @@ export function TodoWriteTool({
   part,
   toolResultPart,
   errorText,
+  className,
   onToolApprovalResponse,
 }: TodoWriteToolProps) {
-  const [isOpen, setIsOpen] = useState(true);
+  const contentId = useId();
 
-  // Extract todos from input
-  let todos: Todo[] = [];
-  try {
-    if (part.input && typeof part.input === "object" && "todos" in part.input) {
-      todos = part.input.todos as Todo[];
+  const todos = useMemo(() => {
+    try {
+      if (
+        part.input &&
+        typeof part.input === "object" &&
+        "todos" in part.input &&
+        Array.isArray(part.input.todos)
+      ) {
+        return part.input.todos as Todo[];
+      }
+    } catch (error) {
+      console.error("Failed to parse todos", error);
     }
-  } catch (error) {
-    console.error("Failed to parse todos", error);
-  }
+
+    return [];
+  }, [part.input]);
+
+  const defaultIsOpen =
+    todos.length === 0 || todos.some((todo) => todo.status !== "completed");
+  const todoStateKey = useMemo(
+    () =>
+      JSON.stringify({
+        toolCallId: part.toolCallId,
+        todos,
+        errorText,
+        state: part.state,
+      }),
+    [errorText, part.state, part.toolCallId, todos],
+  );
+  const [isOpen, setIsOpen] = useState(defaultIsOpen);
+
+  useEffect(() => {
+    if (!todoStateKey) {
+      return;
+    }
+
+    setIsOpen(defaultIsOpen);
+  }, [defaultIsOpen, todoStateKey]);
 
   // Count todos by status
   const completedCount = todos.filter((t) => t.status === "completed").length;
@@ -83,13 +114,13 @@ export function TodoWriteTool({
   }
 
   return (
-    <div className="mb-3 rounded-md border bg-card/50">
+    <div className={cn("rounded-md border bg-card/50", className)}>
       <button
         type="button"
         className="w-full px-3 py-2 border-b bg-muted/20 cursor-pointer hover:bg-muted/30 transition-colors text-left"
         onClick={() => setIsOpen(!isOpen)}
         aria-expanded={isOpen}
-        aria-controls="todo-list-content"
+        aria-controls={contentId}
       >
         <div className="flex items-center gap-2">
           <ListTodo className="w-3.5 h-3.5 text-muted-foreground" />
@@ -110,7 +141,7 @@ export function TodoWriteTool({
         </div>
       </button>
       {isOpen && (
-        <div id="todo-list-content" className="px-3 py-2">
+        <div id={contentId} className="px-3 py-2">
           {todos.length > 0 ? (
             <div className="space-y-0.5">
               {todos.map((todo) => (

--- a/platform/frontend/src/lib/chat/chat.query.ts
+++ b/platform/frontend/src/lib/chat/chat.query.ts
@@ -119,7 +119,6 @@ export function useConversations({
   return useQuery({
     queryKey: ["conversations", search],
     queryFn: async () => {
-      if (!enabled) return [];
       const trimmedSearch = search?.trim();
 
       const { data, error } = await getChatConversations({
@@ -135,6 +134,7 @@ export function useConversations({
     staleTime: search ? 0 : 2_000, // No stale time for searches, 2 seconds otherwise
     gcTime: 10 * 60 * 1000,
     refetchOnWindowFocus: false,
+    enabled,
   });
 }
 

--- a/platform/package.json
+++ b/platform/package.json
@@ -29,6 +29,7 @@
     "db:push": "turbo db:push",
     "db:studio": "turbo db:studio",
     "db:seed:mock-data": "turbo db:seed:mock-data",
+    "db:seed:chat-scenarios": "turbo db:seed:chat-scenarios",
     "cleanup:dev:k8s": "kubectl delete namespace archestra-dev"
   },
   "devDependencies": {

--- a/platform/turbo.json
+++ b/platform/turbo.json
@@ -73,6 +73,9 @@
     },
     "db:seed:mock-data": {
       "cache": false
+    },
+    "db:seed:chat-scenarios": {
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
## Summary

Part of https://github.com/archestra-ai/archestra/issues/3838.

This MR polishes the chat experience with richer AI-native UI patterns and better debugging support for chat UI development. It focuses on message readability, keyboard interaction, source rendering, tool-call presentation, and reusable seeded conversations for manually testing complex chat states.

## What changed
- Added seeded chat debug scenarios and a `db:seed:chat-scenarios` command for quickly previewing realistic chat states locally.
- Refined chat message rendering:
  - improved assistant/user message spacing and focus behavior
  - polished reasoning and tool-call blocks
  - improved inline chat error presentation
  - added support for rendering AI SDK source URL/document parts
- Moved the latest `todo_write` tool state into a sticky panel above the prompt so active task state remains visible while chatting.
- Added keyboard-first chat navigation:
  - `Shift + ArrowUp` from the prompt focuses the latest message
  - `Shift + ArrowUp/Down` moves between navigable messages
  - message actions become visible on keyboard focus
- Added prompt input history cycling with `ArrowUp/ArrowDown` for previous user messages.
- Expanded test coverage for prompt input behavior, chat message rendering, source parts, todo tool state extraction, sticky todo rendering, and chat scenario seeding.

## Testing

Targeted tests added/updated for:

- `frontend/src/app/chat/prompt-input.test.tsx`
- `frontend/src/components/ai-elements/prompt-input.test.tsx`
- `frontend/src/components/chat/chat-messages.test.tsx`
- `frontend/src/components/chat/chat-messages.utils.test.ts`
- `frontend/src/components/chat/todo-write-tool.test.tsx`
- `backend/src/standalone-scripts/seed-chat-scenarios.test.ts`