### PR TITLE
fix(orchestrator): preserve plain preset env vars across auto redeploy

### DIFF
--- a/platform/backend/src/k8s/mcp-server-runtime/manager.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager.test.ts
@@ -3,7 +3,7 @@ import { PassThrough } from "node:stream";
 import * as k8s from "@kubernetes/client-node";
 import { vi } from "vitest";
 import type * as originalConfigModule from "@/config";
-import { beforeEach, describe, expect, test } from "@/test";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { McpServer } from "@/types";
 
 // Mock fs module first
@@ -845,6 +845,246 @@ describe("McpServerRuntimeManager", () => {
 
       cleanup();
     });
+  });
+
+  describe("startServer - success auto redeploy", () => {
+    // Auto redeploy fires when a catalog edit doesn't require new user
+    // input — `cascadeReinstallForCatalog → autoReinstallServer →
+    // McpServerRuntimeManager.restartServer(id) → startServer(mcpServer)`
+    // (manager.ts:558). Crucially, `restartServer` calls `startServer`
+    // with NO `environmentValues`, so startServer must reconstruct every
+    // previously-supplied env value from persistent state alone.
+    //
+    // The 10 cases below cover the full env-var matrix:
+    //   scope    : static / promptOnInstallation / promptOnPreset
+    //   type     : plain_text / secret
+    //   required : true / false   (only meaningful for prompted/preset;
+    //                              for static the value is admin-set,
+    //                              required has no runtime effect)
+    //
+    // The user report ("Not required prompted envs missing after auto
+    // re-install") singled out the optional+plain+prompted cell — but
+    // the bug actually drops every plain prompted/preset value
+    // regardless of `required`. Per-row tests make it obvious which
+    // cells are red without requiring readers to scan a giant diff.
+    //
+    // STATIC_PLAIN is the one row whose contract is "must NOT be in
+    // environmentValues" — it bypasses the map entirely and reaches the
+    // pod via envDef.value at deployment-build time (k8s-deployment.ts:
+    // 1318). Encoded as `expected: undefined`.
+
+    let manager: import("./manager").McpServerRuntimeManager;
+    let mcpServer: McpServer;
+    let envValues: Record<string, string> | undefined;
+    let mockLoadFromDefault: ReturnType<typeof vi.spyOn>;
+    let mockMakeApiClient: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(async () => {
+      mockCreateK8sSecret.mockClear();
+      mockStartOrCreateDeployment.mockClear();
+      mockCreateDockerRegistrySecrets.mockClear();
+      mockK8sDeploymentInstances.length = 0;
+
+      // Stage what was persisted at install time:
+      //   - install Secret bag holds every secret-typed prompted/preset value
+      //   - catalog row's presetFieldValues holds plain preset values
+      //   - plain prompted values have no persistence layer today; we stage
+      //     them in the bag to model the post-fix world. The fix can either
+      //     widen the bag or add a dedicated `mcp_server.environmentValues`
+      //     jsonb column — either satisfies these assertions.
+      const mockGetSecret = vi.fn().mockResolvedValue({
+        secret: {
+          USER_REQ_SECRET: "user-req-sec-stored",
+          USER_OPT_SECRET: "user-opt-sec-stored",
+          USER_REQ_PLAIN: "user-req-plain-stored",
+          USER_OPT_PLAIN: "user-opt-plain-stored",
+          PRESET_REQ_SECRET: "preset-req-sec-stored",
+          PRESET_OPT_SECRET: "preset-opt-sec-stored",
+        },
+      });
+      const { secretManager } = await import("@/secrets-manager");
+      vi.mocked(secretManager).mockReturnValue({
+        getSecret: mockGetSecret,
+      } as unknown as ReturnType<typeof secretManager>);
+
+      const InternalMcpCatalogModel = (
+        await import("@/models/internal-mcp-catalog")
+      ).default;
+      vi.mocked(InternalMcpCatalogModel.findById).mockResolvedValue({
+        id: "catalog-1",
+        serverType: "local",
+        localConfig: {
+          environment: [
+            // Static — admin-set on catalog row, `required` has no runtime
+            // effect (value isn't user-supplied).
+            {
+              key: "STATIC_PLAIN",
+              type: "plain_text",
+              promptOnInstallation: false,
+              value: "static-plain-from-catalog",
+            },
+            {
+              key: "STATIC_SECRET",
+              type: "secret",
+              promptOnInstallation: false,
+              value: "static-secret-from-catalog",
+            },
+            // promptOnInstallation × required × type
+            {
+              key: "USER_REQ_SECRET",
+              type: "secret",
+              promptOnInstallation: true,
+              required: true,
+            },
+            {
+              key: "USER_OPT_SECRET",
+              type: "secret",
+              promptOnInstallation: true,
+              required: false,
+            },
+            {
+              key: "USER_REQ_PLAIN",
+              type: "plain_text",
+              promptOnInstallation: true,
+              required: true,
+            },
+            {
+              key: "USER_OPT_PLAIN",
+              type: "plain_text",
+              promptOnInstallation: true,
+              required: false,
+            },
+            // promptOnPreset × required × type
+            {
+              key: "PRESET_REQ_SECRET",
+              type: "secret",
+              promptOnPreset: true,
+              required: true,
+            },
+            {
+              key: "PRESET_OPT_SECRET",
+              type: "secret",
+              promptOnPreset: true,
+              required: false,
+            },
+            {
+              key: "PRESET_REQ_PLAIN",
+              type: "plain_text",
+              promptOnPreset: true,
+              required: true,
+            },
+            {
+              key: "PRESET_OPT_PLAIN",
+              type: "plain_text",
+              promptOnPreset: true,
+              required: false,
+            },
+          ],
+        },
+        localConfigSecretId: null,
+        // Plain preset values live on the catalog row, not the install bag.
+        presetFieldValues: {
+          PRESET_REQ_PLAIN: "preset-req-plain-stored",
+          PRESET_OPT_PLAIN: "preset-opt-plain-stored",
+        },
+        presetSecretId: null,
+      } as unknown as Awaited<
+        ReturnType<typeof InternalMcpCatalogModel.findById>
+      >);
+
+      mockLoadFromDefault = vi
+        .spyOn(k8s.KubeConfig.prototype, "loadFromDefault")
+        .mockImplementation(() => {});
+      mockMakeApiClient = vi
+        .spyOn(k8s.KubeConfig.prototype, "makeApiClient")
+        .mockReturnValue({} as k8s.CoreV1Api);
+
+      const { McpServerRuntimeManager } = await import("./manager");
+      manager = new McpServerRuntimeManager();
+      const managerAny = manager as unknown as {
+        k8sAttach: unknown;
+        k8sLog: unknown;
+        k8sExec: unknown;
+      };
+      managerAny.k8sAttach = {};
+      managerAny.k8sLog = {};
+      managerAny.k8sExec = {};
+
+      mcpServer = {
+        id: "server-1",
+        name: "test-server",
+        catalogId: "catalog-1",
+        secretId: "install-secret-bag",
+        ownerId: null,
+        reinstallRequired: false,
+        localInstallationStatus: "idle",
+        localInstallationError: null,
+        oauthRefreshError: null,
+        oauthRefreshFailedAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        serverType: "local",
+        teamId: null,
+      } as McpServer;
+
+      // Auto redeploy: startServer is invoked with no environmentValues,
+      // exactly as McpServerRuntimeManager.restartServer does.
+      await manager.startServer(mcpServer);
+      envValues = mockK8sDeploymentInstances[0]?.options.environmentValues as
+        | Record<string, string>
+        | undefined;
+    });
+
+    afterEach(() => {
+      mockLoadFromDefault?.mockRestore();
+      mockMakeApiClient?.mockRestore();
+    });
+
+    // The `expected` column is `undefined` for cells whose contract is
+    // "must NOT be in environmentValues" (i.e. STATIC_PLAIN — flows via
+    // envDef.value, never touches the env-values map). All other cells
+    // assert their value is present and correct.
+    test.each`
+      key                    | expected                        | via
+      ${"STATIC_PLAIN"}      | ${undefined}                    | ${"bypasses env-values; flows via envDef.value"}
+      ${"STATIC_SECRET"}     | ${"static-secret-from-catalog"} | ${"catalog static-secret merge (manager.ts:259-277)"}
+      ${"USER_REQ_SECRET"}   | ${"user-req-sec-stored"}        | ${"install Secret bag (prompted+secret, required)"}
+      ${"USER_OPT_SECRET"}   | ${"user-opt-sec-stored"}        | ${"install Secret bag (prompted+secret, optional)"}
+      ${"PRESET_REQ_SECRET"} | ${"preset-req-sec-stored"}      | ${"install Secret bag (preset+secret, required)"}
+      ${"PRESET_OPT_SECRET"} | ${"preset-opt-sec-stored"}      | ${"install Secret bag (preset+secret, optional)"}
+      ${"PRESET_REQ_PLAIN"}  | ${"preset-req-plain-stored"}    | ${"catalog.presetFieldValues overlay (this PR)"}
+      ${"PRESET_OPT_PLAIN"}  | ${"preset-opt-plain-stored"}    | ${"catalog.presetFieldValues overlay (this PR)"}
+    `(
+      "auto redeploy preserves $key — $via",
+      ({ key, expected }: { key: string; expected: string | undefined }) => {
+        if (expected === undefined) {
+          expect(envValues).not.toHaveProperty(key);
+        } else {
+          expect(envValues?.[key]).toBe(expected);
+        }
+      },
+    );
+
+    // Pending Bug B (separate PR): plain `promptOnInstallation` env vars
+    // have no per-install persistence layer, so they're dropped from the
+    // pod spec on every auto-redeploy. The fix needs either a new
+    // `mcp_server.environment_values` jsonb column (cleanest) or a wider
+    // install Secret bag — both require a separate review surface.
+    //
+    // `test.fails.each` marks these as expected-to-fail. When Bug B is
+    // fixed, the assertions will pass, and vitest will report THESE
+    // marker tests as failing — forcing the developer to remove the
+    // `.fails` suffix and demote them into the table above.
+    test.fails.each`
+      key                 | expected                   | via
+      ${"USER_REQ_PLAIN"} | ${"user-req-plain-stored"} | ${"prompted+plain, required (BUG B: no persistence today)"}
+      ${"USER_OPT_PLAIN"} | ${"user-opt-plain-stored"} | ${"prompted+plain, optional (BUG B: no persistence today)"}
+    `(
+      "auto redeploy preserves $key — $via [PENDING FIX #2]",
+      ({ key, expected }: { key: string; expected: string }) => {
+        expect(envValues?.[key]).toBe(expected);
+      },
+    );
   });
 });
 

--- a/platform/backend/src/k8s/mcp-server-runtime/manager.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager.ts
@@ -276,6 +276,38 @@ export class McpServerRuntimeManager {
         }
       }
 
+      // Plain (non-secret) preset env values live on the catalog row's
+      // `presetFieldValues` jsonb — they have no per-install persistence
+      // layer because they're authoritative on the catalog itself. The
+      // install route reads them at install time and merges into
+      // `environmentValues`, but on restart that map is undefined; without
+      // overlaying them here the deployment env builder would emit no value
+      // for these env vars (only the secret-typed ones survive via the
+      // install Secret bag). Result: every cascade reinstall (admin edit
+      // OR child preset PATCH) silently drops plain preset env values
+      // from the rebuilt pod spec.
+      //
+      // Re-overlaying from the catalog row on every restart also means
+      // edits to the preset (or admin edits to default-preset values on
+      // the parent) propagate naturally on the next restart — no manual
+      // reinstall needed.
+      if (
+        catalogItem?.localConfig?.environment &&
+        catalogItem.presetFieldValues
+      ) {
+        for (const envDef of catalogItem.localConfig.environment) {
+          if (envDef.promptOnPreset && envDef.type !== "secret") {
+            const presetValue = catalogItem.presetFieldValues[envDef.key];
+            if (presetValue != null) {
+              if (!effectiveEnvironmentValues) {
+                effectiveEnvironmentValues = {};
+              }
+              effectiveEnvironmentValues[envDef.key] = String(presetValue);
+            }
+          }
+        }
+      }
+
       const k8sDeployment = new K8sDeployment({
         mcpServer,
         k8sApi: this.k8sApi,


### PR DESCRIPTION
## Bug

When an MCP server is auto-reinstalled (cascade from a parent catalog edit OR a child preset PATCH), every plain-text `promptOnPreset` env var disappears from the rebuilt pod spec. Secret-typed preset values survive (they live in the install K8s Secret bag), but plain values live on the catalog row's `presetFieldValues` jsonb and are never read back at restart.

Reproducible scenario:

1. Catalog item with at least one plain `promptOnPreset` env (e.g. `DIALECT_PACKAGES`, `type: plain_text`).
2. Create a preset and set a value for that env.
3. Install the preset.
4. Trigger any auto-redeploy (parent description edit, or PATCH the preset itself).
5. Pod env: the plain preset env is **missing**. Secret-typed preset envs are still present via `secretKeyRef`.

## Mechanism

```
restartServer → startServer(mcpServer)        ← no environmentValues
              → fallback fills effectiveEnvironmentValues from
                  install Secret bag (secret-typed only)
              → pre-existing static-secret merge block at L259
                  (handles only !promptOnInstallation && type=secret)
              → plain preset values match no branch → undefined
              → K8sDeployment env builder skips emission for plain
                  vars when value is undefined
                  (k8s-deployment.ts:1336)
```

## Fix

Add a small overlay block in `startServer` right after the existing static-secret merge. Same shape: iterate `envDef`s, match by flag, write into `effectiveEnvironmentValues`.

```ts
// Plain (non-secret) preset env values live on the catalog row's
// `presetFieldValues` jsonb — re-overlay them on every restart so
// cascade reinstalls (and admin edits to the preset) reach the pod.
if (catalogItem?.localConfig?.environment && catalogItem.presetFieldValues) {
  for (const envDef of catalogItem.localConfig.environment) {
    if (envDef.promptOnPreset && envDef.type !== "secret") {
      const presetValue = catalogItem.presetFieldValues[envDef.key];
      if (presetValue != null) {
        if (!effectiveEnvironmentValues) effectiveEnvironmentValues = {};
        effectiveEnvironmentValues[envDef.key] = String(presetValue);
      }
    }
  }
}
```

Beneficial side effect: re-reading from the catalog on every restart means edits to a preset propagate naturally on the next restart, no manual reinstall needed.

## Tests

New parametrized matrix in `manager.test.ts` (`describe("startServer - success auto redeploy")`) covers all **3 scopes × 2 types × 2 required = 10 cells** of the env-var matrix. `test.each` template-literal tables make per-cell pass/fail visible in the test name itself.

After this PR:
- **8 cells pass** normally — all secret-typed cells (live in install Secret bag) plus `STATIC_PLAIN` (correctly absent from `environmentValues`; flows via `envDef.value`) plus `STATIC_SECRET` (existing static-secret merge) plus the **two new `PRESET_*_PLAIN` cells** that this fix makes pass.
- **2 cells marked `test.fails.each`** — `USER_REQ_PLAIN` and `USER_OPT_PLAIN`. These are **Bug B** (plain `promptOnInstallation` env vars have NO persistence layer at all — needs a separate change with a migration). `.fails` makes CI green now AND ensures that when Bug B is fixed, the tests start passing → vitest reports the `.fails` markers as failing → forces the next author to remove `.fails` and demote them into the regular table.

## Verification

End-to-end against a real K8s pod (kind, my Canary):

**Before the fix:**
```
$ kubectl get deploy mcp-sql1-staging-… -o jsonpath='{.spec.template.spec.containers[0].env}'
[
  { "name": "DB_PASSWORD", "valueFrom": { "secretKeyRef": {…} } }
]
```
(`DB_DIALECT_PACKAGES` — the plain preset env — missing.)

**After the fix:**
```
[
  { "name": "DB_DIALECT_PACKAGES", "value": "psycopg2-binary,pymysql" },
  { "name": "DB_PASSWORD", "valueFrom": { "secretKeyRef": {…} } }
]
```

Local CI:
- `pnpm vitest run …auto redeploy` → 8 passed + 2 expected fail
- `pnpm lint` clean
- `pnpm type-check` clean

## Out of scope (Bug B follow-up)

This PR fixes the **preset path** only. The companion bug — plain `promptOnInstallation` env vars dropped on auto-redeploy because they have no per-install persistence layer at all — needs either (a) a new `mcp_server.environment_values` jsonb column or (b) a wider install Secret bag. Both require a migration and a separate review surface. The two parametrized `test.fails.each` cells in this PR pin that work as a definition of done.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>