### PR TITLE
fix(e2e): scope addCustomSelfHostedCatalogItem to the new env-var sub-dialog (#4696 follow-up)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ __pycache__/
 .claude/*.lock
 .turbo/
 
+# playwright-cli runtime cache (snapshots, console logs, screenshots)
+.playwright-cli/
+

--- a/platform/e2e-tests/utils/mcp-catalog.ts
+++ b/platform/e2e-tests/utils/mcp-catalog.ts
@@ -49,23 +49,52 @@ export async function addCustomSelfHostedCatalogItem({
     .getByRole("textbox", { name: "Arguments (one per line)" })
     .fill(`-c\n${singleLineCommand}`);
   if (envVars) {
+    // Since #4696, env-var add/edit lives in its own <StandardDialog>
+    // (`environment-variable-dialog.tsx`) opened by the "Add Variable"
+    // button. All the env-var-specific inputs scope to that sub-dialog
+    // now — not the parent "Add MCP Server" dialog.
     await createDialog.getByRole("button", { name: "Add Variable" }).click();
-    await createDialog
-      .getByRole("textbox", { name: "API_KEY" })
-      .fill(envVars.key);
+    const envVarDialog = page.getByRole("dialog", {
+      name: /Add environment variable/i,
+    });
+    await expect(envVarDialog).toBeVisible({ timeout: 15_000 });
+
+    // The key input's accessible name is now "Key" (the Label) — the old
+    // "API_KEY" was placeholder text on the same input.
+    await envVarDialog.getByRole("textbox", { name: "Key" }).fill(envVars.key);
+
     if (envVars.isSecret) {
-      await createDialog
+      await envVarDialog
         .getByTestId(E2eTestId.SelectEnvironmentVariableType)
         .click();
       await page.getByRole("option", { name: "Secret" }).click();
     }
-    if (envVars.promptOnInstallation) {
-      await createDialog
+
+    // Scope is now a 3-option dropdown (installation/preset/static),
+    // defaulting to "installation". The PromptOnInstallationCheckbox
+    // testid is reused on the dropdown trigger for backwards compat.
+    //
+    // Logic inversion vs. the old checkbox: the old default was "not
+    // prompted" (checkbox unchecked) and the helper toggled IT ON for
+    // prompted envs. The new default is "Prompt at installation", so we
+    // only need to act when the caller wants something other than that
+    // — i.e. when promptOnInstallation is false (we want Static) or
+    // when a vault reference is being set (vault picker only appears
+    // for static-scoped secret values).
+    const wantsStaticScope =
+      !envVars.promptOnInstallation || !!envVars.vaultSecret;
+    if (wantsStaticScope) {
+      await envVarDialog
         .getByTestId(E2eTestId.PromptOnInstallationCheckbox)
-        .click({ force: true });
+        .click();
+      await page.getByRole("option", { name: "Static" }).click();
     }
+
     if (envVars.vaultSecret) {
-      await createDialog.getByText("Set Secret").click();
+      // Button text changed: "Set Secret" → "Set external secret".
+      await envVarDialog
+        .getByRole("button", { name: /Set external secret/i })
+        .click();
       const externalSecretDialog = page.getByRole("dialog", {
         name: /Set external secret/i,
       });
@@ -91,6 +120,11 @@ export async function addCustomSelfHostedCatalogItem({
         .click();
       await expect(externalSecretDialog).not.toBeVisible({ timeout: 15_000 });
     }
+
+    // Confirm and close the env-var sub-dialog so the parent "Add MCP
+    // Server" form re-takes focus before we click "Add Server".
+    await envVarDialog.getByRole("button", { name: "Add variable" }).click();
+    await expect(envVarDialog).not.toBeVisible({ timeout: 15_000 });
   }
   if (scope && scope !== "personal") {
     await createDialog


### PR DESCRIPTION
## Bug

PR #4696 ("chore: move env var and header add/edit into dialogs with read-only catalog tables") moved the env-var add/edit UI from the parent **Add MCP Server to the Private Registry** dialog into a dedicated `<StandardDialog>` opened by the **Add Variable** button.

The shared e2e helper `addCustomSelfHostedCatalogItem` (used by multiple specs — `dynamic-credentials.spec.ts`, `static-credentials-management.spec.ts`, `credentials-with-vault.ee.spec.ts`) still scoped its env-var inputs to the parent dialog, so every test that exercised it timed out:

```
TimeoutError: locator.fill: Timeout 15000ms exceeded.
  - waiting for getByRole('dialog', { name: /Add MCP Server to the Private Registry/i })
                .getByRole('textbox', { name: 'API_KEY' })
        at utils/mcp-catalog.ts:54
```

## Fix

Scope all env-var-specific interactions to the new sub-dialog `getByRole('dialog', { name: /Add environment variable/i })`. Three notable changes vs. the old structure:

| Concern | Old | New |
|---|---|---|
| Key textbox accessible name | `'API_KEY'` (placeholder used as accessible name because there was no Label) | `'Key'` (the new `<Label htmlFor="env-var-key">`) |
| Scope control | Single checkbox (default unchecked = "not prompted"); helper toggled ON for prompted envs | 3-option dropdown (installation/preset/static); defaults to "Prompt at installation". Helper now only acts when the caller wants something **other** than installation (i.e. `promptOnInstallation === false` → pick **Static**) |
| Vault picker button text | `Set Secret` | `Set external secret` |
| Sub-dialog lifecycle | n/a — inputs were inline in parent | Must be explicitly confirmed via the **Add variable** button before clicking **Add Server** on the parent, otherwise focus races may leave the sub-dialog open |

The `SelectEnvironmentVariableType` and `PromptOnInstallationCheckbox` testids are reused on the new sub-dialog elements (the latter on the scope dropdown trigger) — backwards-compatible naming the upstream PR was kind enough to keep.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>