### PR TITLE
chore: ignore .playwright-cli/ runtime cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ __pycache__/
 .claude/*.lock
 .turbo/
 
+# playwright-cli runtime cache (snapshots, console logs, screenshots)
+.playwright-cli/
+


### PR DESCRIPTION
---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>