### PR TITLE
fix(mcp-gateway): stop caching negative auth results to break the 401 race

### DIFF
--- a/platform/backend/src/routes/mcp-gateway.utils.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.test.ts
@@ -134,6 +134,47 @@ describe("validateMCPGatewayToken", () => {
       expect(result).toBeNull();
     });
 
+    test("does not cache negative per-profile auth results", async ({
+      makeOrganization,
+      makeUser,
+      makeTeam,
+      makeAgent,
+    }) => {
+      // Regression coverage for the "negative cache treadmill": when a
+      // per-profile auth check returned null, the result used to be cached
+      // for several seconds. A retry inside that window would refresh the
+      // cached null, turning a transient race (e.g. a profile/team binding
+      // created milliseconds after the first call) into a sticky 401.
+      // The contract is now: failures bypass the cache, so each call
+      // re-evaluates against fresh DB state.
+      const org = await makeOrganization();
+      const user = await makeUser();
+      const team1 = await makeTeam(org.id, user.id, { name: "Team 1" });
+      const team2 = await makeTeam(org.id, user.id, { name: "Team 2" });
+      const agent = await makeAgent({ teams: [team2.id], scope: "team" });
+      const { value } = await TeamTokenModel.create({
+        organizationId: org.id,
+        name: "Team 1 Token",
+        teamId: team1.id,
+      });
+
+      const teamHasAgentAccessSpy = vi.spyOn(
+        AgentTeamModel,
+        "teamHasAgentAccess",
+      );
+
+      const firstResult = await validateMCPGatewayToken(agent.id, value);
+      const secondResult = await validateMCPGatewayToken(agent.id, value);
+
+      expect(firstResult).toBeNull();
+      expect(secondResult).toBeNull();
+      // Both calls must re-run the per-profile check; if negative caching
+      // were reintroduced this would drop to 1.
+      expect(teamHasAgentAccessSpy).toHaveBeenCalledTimes(2);
+
+      teamHasAgentAccessSpy.mockRestore();
+    });
+
     test("reuses resolved team tokens across profiles", async ({
       makeOrganization,
     }) => {

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -121,7 +121,6 @@ type ResolvedArchestraToken =
     };
 
 const TOKEN_AUTH_CACHE_TTL_MS = 30_000;
-const TOKEN_AUTH_CACHE_NULL_TTL_MS = 5_000;
 const TOKEN_AUTH_CACHE_MAX_ENTRIES = 1_000;
 const tokenAuthCache = new LRUCacheManager<TokenAuthResult | null>({
   maxSize: TOKEN_AUTH_CACHE_MAX_ENTRIES,
@@ -1210,22 +1209,41 @@ function cacheTokenAuthResult(
   cacheKey: string,
   result: TokenAuthResult | null,
 ): void {
-  tokenAuthCache.set(
-    cacheKey,
-    result,
-    result ? TOKEN_AUTH_CACHE_TTL_MS : TOKEN_AUTH_CACHE_NULL_TTL_MS,
-  );
+  // Negative results are intentionally NOT cached. Caching auth failures
+  // creates a "cache treadmill" where every retry refreshes the negative
+  // entry: a transient race during agent/IdP creation fails the first
+  // call, the failure is cached, the test/client retries within the cache
+  // TTL window, that retry finds (and refreshes) the cached `null`, and
+  // the cycle repeats forever (or until the polling budget is exhausted).
+  //
+  // This was the root cause of intermittent 401s in CI for the JWKS /
+  // enterprise-managed-credentials e2e suites — those tests create an
+  // identity provider + agent + IdP-binding within milliseconds of the
+  // first gateway call, and the negative cache kept the early failure
+  // sticky long after the underlying state stabilized.
+  //
+  // The defensive benefit of negative caching (less DB load on rejected
+  // tokens) is small: invalid-token requests already pay an upstream
+  // auth-rate-limit cost, and the validator's DB lookups are indexed and
+  // fast. Skipping the cache for failures lets every request re-evaluate
+  // against fresh state — eliminating the race entirely.
+  if (result === null) {
+    return;
+  }
+  tokenAuthCache.set(cacheKey, result, TOKEN_AUTH_CACHE_TTL_MS);
 }
 
 function cacheRawArchestraToken(
   rawTokenHash: string,
   result: ResolvedArchestraToken | null,
 ): void {
-  rawArchestraTokenCache.set(
-    rawTokenHash,
-    result,
-    result ? TOKEN_AUTH_CACHE_TTL_MS : TOKEN_AUTH_CACHE_NULL_TTL_MS,
-  );
+  // Same rationale as cacheTokenAuthResult: don't cache failures, to
+  // avoid the negative-cache treadmill that turns a transient creation
+  // race into a sticky 5-second window of 401s.
+  if (result === null) {
+    return;
+  }
+  rawArchestraTokenCache.set(rawTokenHash, result, TOKEN_AUTH_CACHE_TTL_MS);
 }
 
 function buildTokenHashes(profileId: string, tokenValue: string): TokenHashes {


### PR DESCRIPTION
## Problem

E2E suites that exercise the MCP gateway right after creating an agent / identity-provider / IdP-binding intermittently failed in CI with `Unauthorized: Invalid token for this profile`. The failures clustered in the JWKS / enterprise-managed-credentials paths but the underlying race could in principle hit any negative auth path.

## Root cause: "negative cache treadmill"

`mcp-gateway.utils.ts` cached both raw-token resolution and per-profile auth verdicts in `LRUCacheManager`. Negative results (`null`) were cached for `TOKEN_AUTH_CACHE_NULL_TTL_MS = 5_000` ms, and **every retry refreshed that entry**:

1. `t = 0 ms` request arrives microseconds before the agent ↔ team / IdP-binding row commits → returns `null` → `cache.set(null, ttl=5s)`
2. `t = 200 ms` retry → cache HIT, returns `null` → `cache.set(null, ttl=5s)` — TTL clock resets
3. …repeat indefinitely until the test's polling budget runs out

The underlying state stabilized within a handful of milliseconds, but the cache kept the early failure sticky for the entire retry window.

## Fix

Skip writing to the cache when the result is `null` in both code paths:

- `cacheTokenAuthResult` (per-profile auth, keyed on `profileId+tokenHash`)
- `cacheRawArchestraToken` (raw-token resolution, keyed on `tokenHash`)

Positive results are still cached for the full `TOKEN_AUTH_CACHE_TTL_MS = 30_000` ms — that's where the real DB-load benefit lives. Negative paths already pay the upstream auth-rate-limit cost and the validator's DB lookups are indexed, so re-evaluating every failed request is cheap and eliminates the race entirely.

The unused `TOKEN_AUTH_CACHE_NULL_TTL_MS` constant is removed.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>