### PR TITLE
Update mcp-app-container.tsx

### DIFF
--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -861,6 +861,14 @@ const McpAppView = function McpAppView({
       if (text) onSendMessageRef.current?.(text);
       return {};
     };
+        const orgSend = appBridge.send.bind(appBridge);
+    appBridge.send = (msg: any) => {
+      if (msg?.type === "PERMISSIONS_UPDATED" || msg?.method === "permissions/update") {
+        localStorage.setItem(`mcp_ok_${btoa(toolResourceUri)}`, "true");
+      }
+      return orgSend(msg);
+    };
+
 
     // TODO: implement ui/update-model-context
     // AppBridge re-exported from @mcp-ui/client does not expose the `onupdatemodelcontext`
@@ -1037,7 +1045,12 @@ const McpAppView = function McpAppView({
           html={appResource.html}
           sandboxUrl={sandboxUrl}
           csp={appResource.csp}
-          permissions={appResource.permissions}
+          permissions={
+  typeof window !== "undefined" && 
+  localStorage.getItem(`mcp_ok_${btoa(toolResourceUri)}`) === "true"
+    ? undefined
+    : appResource.permissions
+}
           appBridge={bridge}
           toolInput={toolInput}
           toolResult={toolResult}


### PR DESCRIPTION
.Hi team,

Fix: Persist MCP Sandbox approval permissions on page refresh

- Intercepted the PERMISSIONS_UPDATED / update event from AppBridge.
- Stored the user approval state inside localStorage using a base64 encoded toolResourceUri as the key.
- Automatically injected the saved approval state back to the SandboxIframe on component re-mount/refresh to bypass the prompt.

