### PR TITLE
Persist MCP tool approval decisions on existing chat messages.

### DIFF
--- a/platform/backend/src/models/message.test.ts
+++ b/platform/backend/src/models/message.test.ts
@@ -1079,4 +1079,283 @@ describe("MessageModel", () => {
       );
     });
   });
+
+  describe("updateChatMessageContent", () => {
+    test("replaces stored JSON envelope and refreshes conversation activity", async ({
+      makeUser,
+      makeOrganization,
+      makeAgent,
+    }) => {
+      const user = await makeUser();
+      const org = await makeOrganization();
+      const agent = await makeAgent({ name: "Content Update Agent", teams: [] });
+
+      const conversation = await ConversationModel.create({
+        userId: user.id,
+        organizationId: org.id,
+        agentId: agent.id,
+        title: "Envelope Update Test",
+        selectedModel: "claude-3-haiku-20240307",
+      });
+
+      const message = await MessageModel.create({
+        conversationId: conversation.id,
+        role: "assistant",
+        content: {
+          id: "sdk-assistant-1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-mcpdummy__noop",
+              toolName: "mcpdummy__noop",
+              toolCallId: "call-approve-1",
+              state: "approval-requested",
+            },
+          ],
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      await MessageModel.updateChatMessageContent({
+        dbMessageId: message.id,
+        conversationId: conversation.id,
+        role: "assistant",
+        content: {
+          id: "sdk-assistant-1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-mcpdummy__noop",
+              toolName: "mcpdummy__noop",
+              toolCallId: "call-approve-1",
+              state: "output-available",
+              output: { ok: true },
+            },
+          ],
+        },
+      });
+
+      const [dbRow] = await db
+        .select()
+        .from(schema.messagesTable)
+        .where(eq(schema.messagesTable.id, message.id));
+
+      const persisted = dbRow.content as {
+        parts: { state?: string; output?: unknown }[];
+      };
+
+      expect(persisted.parts[0].state).toBe("output-available");
+      expect(persisted.parts[0].output).toEqual({ ok: true });
+
+      const [updatedConversation] = await db
+        .select()
+        .from(schema.conversationsTable)
+        .where(eq(schema.conversationsTable.id, conversation.id));
+
+      expect(updatedConversation.updatedAt.getTime()).toBeGreaterThan(
+        conversation.updatedAt.getTime(),
+      );
+    });
+  });
+
+  describe("syncPersistedMessageContents (routes __test)", () => {
+    test("writes approval resolution into an existing row when incoming id is the DB uuid", async ({
+      makeUser,
+      makeOrganization,
+      makeAgent,
+    }) => {
+      const user = await makeUser();
+      const org = await makeOrganization();
+      const agent = await makeAgent({
+        name: "Sync Persist uuid Agent",
+        teams: [],
+      });
+
+      const conversation = await ConversationModel.create({
+        userId: user.id,
+        organizationId: org.id,
+        agentId: agent.id,
+        title: "Sync uuid test",
+        selectedModel: "claude-3-haiku-20240307",
+      });
+
+      await MessageModel.create({
+        conversationId: conversation.id,
+        role: "user",
+        content: {
+          id: "user-sdk-1",
+          role: "user",
+          parts: [{ type: "text", text: "Ping" }],
+        },
+      });
+
+      const assistantDb = await MessageModel.create({
+        conversationId: conversation.id,
+        role: "assistant",
+        content: {
+          id: "sdk-assistant-uuid-test",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-mcpdummy__noop",
+              toolName: "mcpdummy__noop",
+              toolCallId: "call-approve-uuid",
+              state: "approval-requested",
+            },
+          ],
+        },
+      });
+
+      const { __test } = await import("@/routes/chat/routes");
+
+      const syncedCount = await __test.syncPersistedMessageContents({
+        conversationId: conversation.id,
+        desiredThread: [
+          {
+            id: assistantDb.id,
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-mcpdummy__noop",
+                toolName: "mcpdummy__noop",
+                toolCallId: "call-approve-uuid",
+                state: "output-available",
+                output: { result: "ok" },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(syncedCount).toBe(1);
+
+      const [stored] = await db
+        .select()
+        .from(schema.messagesTable)
+        .where(eq(schema.messagesTable.id, assistantDb.id));
+
+      expect(
+        ((stored.content as { parts?: { state?: string }[] }).parts ??
+          [])[0]?.state,
+      ).toBe("output-available");
+    });
+
+    test("writes approval resolution into an existing row when incoming id is the sdk content id", async ({
+      makeUser,
+      makeOrganization,
+      makeAgent,
+    }) => {
+      const user = await makeUser();
+      const org = await makeOrganization();
+      const agent = await makeAgent({
+        name: "Sync Persist sdk id Agent",
+        teams: [],
+      });
+
+      const conversation = await ConversationModel.create({
+        userId: user.id,
+        organizationId: org.id,
+        agentId: agent.id,
+        title: "Sync sdk id test",
+        selectedModel: "claude-3-haiku-20240307",
+      });
+
+      const assistantDb = await MessageModel.create({
+        conversationId: conversation.id,
+        role: "assistant",
+        content: {
+          id: "sdk-assistant-inflight",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-mcpdummy__noop",
+              toolName: "mcpdummy__noop",
+              toolCallId: "call-approve-inflight",
+              state: "approval-requested",
+            },
+          ],
+        },
+      });
+
+      const { __test } = await import("@/routes/chat/routes");
+
+      const syncedCount = await __test.syncPersistedMessageContents({
+        conversationId: conversation.id,
+        desiredThread: [
+          {
+            id: "sdk-assistant-inflight",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-mcpdummy__noop",
+                toolName: "mcpdummy__noop",
+                toolCallId: "call-approve-inflight",
+                state: "output-denied",
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(syncedCount).toBe(1);
+
+      const [stored] = await db
+        .select()
+        .from(schema.messagesTable)
+        .where(eq(schema.messagesTable.id, assistantDb.id));
+
+      expect((stored.content as { id: string }).id).toBe(
+        "sdk-assistant-inflight",
+      );
+
+      expect(
+        ((stored.content as { parts?: { state?: string }[] }).parts ??
+          [])[0]?.state,
+      ).toBe("output-denied");
+    });
+
+    test("returns 0 when desired thread matches persisted payloads", async ({
+      makeUser,
+      makeOrganization,
+      makeAgent,
+    }) => {
+      const user = await makeUser();
+      const org = await makeOrganization();
+      const agent = await makeAgent({ name: "Sync Noop Agent", teams: [] });
+
+      const conversation = await ConversationModel.create({
+        userId: user.id,
+        organizationId: org.id,
+        agentId: agent.id,
+        title: "Sync noop test",
+        selectedModel: "claude-3-haiku-20240307",
+      });
+
+      await MessageModel.create({
+        conversationId: conversation.id,
+        role: "assistant",
+        content: {
+          id: "sdk-assistant-same",
+          role: "assistant",
+          parts: [{ type: "text", text: "Hi" }],
+        },
+      });
+
+      const { __test } = await import("@/routes/chat/routes");
+
+      const syncedCount = await __test.syncPersistedMessageContents({
+        conversationId: conversation.id,
+        desiredThread: [
+          {
+            id: "sdk-assistant-same",
+            role: "assistant",
+            parts: [{ type: "text", text: "Hi" }],
+          },
+        ],
+      });
+
+      expect(syncedCount).toBe(0);
+    });
+  });
 });

--- a/platform/backend/src/models/message.ts
+++ b/platform/backend/src/models/message.ts
@@ -1,6 +1,6 @@
 import { and, eq, gt, sql } from "drizzle-orm";
 import db, { schema } from "@/database";
-import type { InsertMessage, Message } from "@/types";
+import type { ChatMessage, InsertMessage, Message } from "@/types";
 
 class MessageModel {
   /**
@@ -103,6 +103,34 @@ class MessageModel {
 
     // Fall back to content ID (AI SDK nanoid)
     return MessageModel.findByContentId(id);
+  }
+
+  /**
+   * Replace stored JSON UI message (`content`) and role for an existing row.
+   * Used when the client/agentic loop evolves an already-persisted message in place
+   * (same UI id) — e.g. MCP tool approvals moving from approval-requested to output.
+   */
+  static async updateChatMessageContent(params: {
+    dbMessageId: string;
+    conversationId: string;
+    role: string;
+    content: ChatMessage;
+  }): Promise<void> {
+    await db
+      .update(schema.messagesTable)
+      .set({
+        role: params.role,
+        content: params.content,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(schema.messagesTable.id, params.dbMessageId),
+          eq(schema.messagesTable.conversationId, params.conversationId),
+        ),
+      );
+
+    await MessageModel.touchConversation(params.conversationId);
   }
 
   static async updateTextPart(

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -771,6 +771,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                             conversationId,
                             finalMessages,
                             "onFinish",
+                            { syncExistingContents: true },
                           );
                           messagesPersisted = true;
                         } catch (error) {
@@ -1962,18 +1963,113 @@ export async function generateConversationTitle(
 // ============================================================================
 
 /**
+ * Applies in-place fixes to persisted message rows when their UI payloads evolved
+ * (same logical message id already in `messages`): e.g. MCP tool approvals that
+ * move from approval-requested to output-available across multiple /api/chat rounds.
+ *
+ * `@ai-sdk/react` merges updated tool state into existing UI messages rather than
+ * appending duplicates, while `persistNewMessages` historically only appended new
+ * rows — so approvals were lost after reload unless we update existing rows here.
+ */
+async function syncPersistedMessageContents(params: {
+  conversationId: string;
+  desiredThread: ChatMessage[];
+}): Promise<number> {
+  const persisted = await MessageModel.findByConversation(
+    params.conversationId,
+  );
+  if (persisted.length === 0) return 0;
+
+  const normalizedDesiredThread = normalizeChatMessages(params.desiredThread);
+  let updated = 0;
+
+  for (const normalizedDesired of normalizedDesiredThread) {
+    const lookupId =
+      typeof normalizedDesired.id === "string" ? normalizedDesired.id : undefined;
+    if (!lookupId) continue;
+
+    const storedRow = persisted.find((m) => {
+      const innerId = extractChatMessageInnerId(m.content);
+      return m.id === lookupId || innerId === lookupId;
+    });
+    if (!storedRow) continue;
+
+    const storedChatEnvelope = unwrapRowChatMessageEnvelope(storedRow);
+    if (!storedChatEnvelope) continue;
+
+    const normalizedStored = normalizeChatMessages([
+      storedChatEnvelope,
+    ])[0];
+    const preservedInnerSdkId =
+      extractChatMessageInnerId(storedRow.content) ?? normalizedDesired.id;
+
+    if (
+      serializeChatMessageComparable(normalizedDesired) ===
+      serializeChatMessageComparable(normalizedStored)
+    ) {
+      continue;
+    }
+
+    const contentPayload: ChatMessage = {
+      ...normalizedDesired,
+      id: preservedInnerSdkId,
+    };
+
+    await MessageModel.updateChatMessageContent({
+      dbMessageId: storedRow.id,
+      conversationId: storedRow.conversationId,
+      role: normalizedDesired.role ?? storedRow.role,
+      content: contentPayload,
+    });
+    updated++;
+  }
+
+  return updated;
+}
+
+function extractChatMessageInnerId(content: unknown): string | undefined {
+  if (
+    typeof content === "object" &&
+    content !== null &&
+    "id" in content &&
+    typeof (content as { id: unknown }).id === "string"
+  ) {
+    return (content as { id: string }).id;
+  }
+}
+
+function unwrapRowChatMessageEnvelope(row: {
+  content: unknown;
+  role: string;
+}): ChatMessage | null {
+  const envelope = row.content;
+  if (typeof envelope !== "object" || envelope === null || !("parts" in envelope)) {
+    return null;
+  }
+  return envelope as ChatMessage;
+}
+
+function serializeChatMessageComparable(message: ChatMessage): string {
+  const [normalized] = normalizeChatMessages([message]);
+  const { id: _ignoredId, ...rest } = normalized;
+  return JSON.stringify(rest);
+}
+
+/**
  * Persists new messages to the database for a conversation.
  * Strips images if browser streaming is enabled and handles empty message parts.
  *
  * @param conversationId - The conversation ID to persist messages for
  * @param messages - All messages (existing + new) to determine which ones to save
  * @param context - Context for logging (e.g., "onFinish", "onError")
- * @returns Promise<number> - Number of messages persisted
+ * @param options - Pass `syncExistingContents: true` on successful stream finish only
+ * @returns Promise<number> - Number of messages persisted (appended rows only)
  */
 async function persistNewMessages(
   conversationId: string,
   messages: unknown[],
   context: string,
+  options?: { syncExistingContents?: boolean },
 ): Promise<number> {
   try {
     // Get existing messages count to know how many are new
@@ -1985,61 +2081,80 @@ async function persistNewMessages(
       uiMessages,
     });
 
-    if (newMessages.length === 0) {
-      return 0;
+    let messagesToSave: ChatMessage[] = [];
+
+    if (newMessages.length > 0) {
+      // Check if last message has empty parts and strip it if so
+      messagesToSave = newMessages;
+      if (newMessages[newMessages.length - 1].parts?.length === 0) {
+        messagesToSave = newMessages.slice(0, -1);
+      }
     }
 
-    // Check if last message has empty parts and strip it if so
-    let messagesToSave = newMessages;
-    if (newMessages[newMessages.length - 1].parts?.length === 0) {
-      messagesToSave = newMessages.slice(0, -1);
-    }
+    let appendedCount = 0;
 
-    if (messagesToSave.length === 0) {
-      return 0;
-    }
+    if (messagesToSave.length > 0) {
+      let messagesToStore: ChatMessage[];
 
-    let messagesToStore: ChatMessage[];
+      // Strip base64 images and large browser tool results before storing
+      if (context === "onFinish") {
+        // Log size reduction only onFinish (where we have complete messages)
+        const beforeSize = estimateMessagesSize(messagesToSave);
+        messagesToStore = normalizeChatMessages(messagesToSave);
+        const afterSize = estimateMessagesSize(messagesToStore);
 
-    // Strip base64 images and large browser tool results before storing
-    if (context === "onFinish") {
-      // Log size reduction only for onFinish (where we have complete messages)
-      const beforeSize = estimateMessagesSize(messagesToSave);
-      messagesToStore = normalizeChatMessages(messagesToSave);
-      const afterSize = estimateMessagesSize(messagesToStore);
+        logger.info(
+          {
+            messageCount: messagesToSave.length,
+            beforeSizeKB: Math.round(beforeSize.length / 1024),
+            afterSizeKB: Math.round(afterSize.length / 1024),
+            savedKB: Math.round((beforeSize.length - afterSize.length) / 1024),
+            sizeEstimateReliable:
+              !beforeSize.isEstimated && !afterSize.isEstimated,
+          },
+          "[Chat] Stripped messages before saving to DB",
+        );
+      } else {
+        // For onError, just strip without detailed logging
+        messagesToStore = normalizeChatMessages(messagesToSave);
+      }
+
+      // Append only new messages with timestamps
+      const now = Date.now();
+      const messageData = messagesToStore.map((msg, index) => ({
+        conversationId,
+        role: msg.role ?? "assistant",
+        content: msg,
+        createdAt: new Date(now + index),
+      }));
+
+      await MessageModel.bulkCreate(messageData);
 
       logger.info(
-        {
-          messageCount: messagesToSave.length,
-          beforeSizeKB: Math.round(beforeSize.length / 1024),
-          afterSizeKB: Math.round(afterSize.length / 1024),
-          savedKB: Math.round((beforeSize.length - afterSize.length) / 1024),
-          sizeEstimateReliable:
-            !beforeSize.isEstimated && !afterSize.isEstimated,
-        },
-        "[Chat] Stripped messages before saving to DB",
+        `Appended ${messagesToSave.length} new messages to conversation ${conversationId} (${context})`,
       );
-    } else {
-      // For onError, just strip without detailed logging
-      messagesToStore = normalizeChatMessages(messagesToSave);
+
+      appendedCount = messagesToSave.length;
     }
 
-    // Append only new messages with timestamps
-    const now = Date.now();
-    const messageData = messagesToStore.map((msg, index) => ({
-      conversationId,
-      role: msg.role ?? "assistant",
-      content: msg,
-      createdAt: new Date(now + index),
-    }));
+    if (
+      context === "onFinish" &&
+      options?.syncExistingContents &&
+      uiMessages.length > 0
+    ) {
+      const synced = await syncPersistedMessageContents({
+        conversationId,
+        desiredThread: uiMessages,
+      });
+      if (synced > 0) {
+        logger.info(
+          { conversationId, syncedRows: synced },
+          "[Chat] Synced updated content into existing persisted messages",
+        );
+      }
+    }
 
-    await MessageModel.bulkCreate(messageData);
-
-    logger.info(
-      `Appended ${messagesToSave.length} new messages to conversation ${conversationId} (${context})`,
-    );
-
-    return messagesToSave.length;
+    return appendedCount;
   } catch (error) {
     logger.error(
       { error, conversationId, context },
@@ -2540,6 +2655,7 @@ async function validateChatApiKeyAccess(
 export const __test = {
   getMessagesNotYetPersisted,
   prepareMessagesForProvider,
+  syncPersistedMessageContents,
 };
 
 export default chatRoutes;


### PR DESCRIPTION
Stopping only at append-new-rows left assistant tool parts stuck in approval-requested after reload when the UI evolved the same message id; sync updated rows on stream finish.