### PR TITLE
fix: evaluate blocked tool result policies when context starts untrusted

### DIFF
--- a/platform/backend/src/guardrails/trusted-data.ts
+++ b/platform/backend/src/guardrails/trusted-data.ts
@@ -64,23 +64,19 @@ export async function evaluateIfContextIsTrusted(
   let unsafeContextBoundary: UnsafeContextBoundary | undefined;
 
   // If agent configured to consider context untrusted from the beginning,
-  // mark context as untrusted immediately and skip evaluation
+  // mark context as untrusted but still evaluate tool result policies
+  // so that blocked results are properly replaced.
   if (considerContextUntrusted) {
     logger.debug(
       { agentId },
       "[trustedData] evaluateIfContextIsTrusted: context marked untrusted by agent config",
     );
-    return {
-      toolResultUpdates: {},
-      contextIsTrusted: false,
-      usedDualLlm: false,
-      dualLlmAnalyses: [],
-      unsafeContextBoundary: {
-        kind: "preexisting_untrusted",
-        reason:
-          initialUntrustedReason ??
-          UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
-      },
+    hasUntrustedData = true;
+    unsafeContextBoundary = {
+      kind: "preexisting_untrusted",
+      reason:
+        initialUntrustedReason ??
+        UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
     };
   }
 


### PR DESCRIPTION
When `considerContextUntrusted` is true (i.e. "Treat context as sensitive from the start of chat" is enabled), `evaluateIfContextIsTrusted` returns early with empty `toolResultUpdates`. This means blocked Tool Result Policies never get evaluated — the raw tool output goes straight to the model.

The fix is straightforward: instead of returning early, set the untrusted flags and let the function continue into the policy evaluation loop. That way blocked results still get replaced with `[Content blocked by policy]` even when context is pre-marked untrusted.

Repro from the issue:
1. Set up a tool with Tool Call Policy = allowed, Tool Result Policy = blocked
2. Enable "Treat context as sensitive from the start of chat"
3. Before this fix: raw tool result leaks to model. After: result is properly blocked.

Single file change, ~15 lines. The early return becomes a flag assignment so the rest of the function runs normally.

Closes #4225