### PR TITLE
fix(slack): handle 50+ blocks by splitting into batches

### DIFF
--- a/platform/backend/src/agents/chatops/slack-provider.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.ts
@@ -342,16 +342,41 @@ class SlackProvider implements ChatOpsProvider {
       });
     }
 
-    const result = await this.client.chat.postMessage({
-      channel: options.originalMessage.channelId,
-      text: options.footer
-        ? `${options.text}\n\n${options.footer}`
-        : options.text,
-      blocks,
-      thread_ts: options.originalMessage.threadId,
-    });
+    // Slack API rejects messages with more than 50 blocks.
+    // Split into batches and send sequentially in the same thread.
+    const SLACK_BLOCK_LIMIT = 50;
+    const fallbackText = options.footer
+      ? `${options.text}\n\n${options.footer}`
+      : options.text;
 
-    return (result.ts as string) || "";
+    let resultTs = "";
+
+    if (blocks.length <= SLACK_BLOCK_LIMIT) {
+      const result = await this.client.chat.postMessage({
+        channel: options.originalMessage.channelId,
+        text: fallbackText,
+        blocks,
+        thread_ts: options.originalMessage.threadId,
+      });
+      resultTs = (result.ts as string) || "";
+    } else {
+      // Send blocks in batches of SLACK_BLOCK_LIMIT
+      for (let i = 0; i < blocks.length; i += SLACK_BLOCK_LIMIT) {
+        const batch = blocks.slice(i, i + SLACK_BLOCK_LIMIT);
+        const isFirst = i === 0;
+        const result = await this.client.chat.postMessage({
+          channel: options.originalMessage.channelId,
+          text: isFirst ? fallbackText : "(continued)",
+          blocks: batch,
+          thread_ts: options.originalMessage.threadId,
+        });
+        if (isFirst) {
+          resultTs = (result.ts as string) || "";
+        }
+      }
+    }
+
+    return resultTs;
   }
 
   async addApprovalRequestForm(


### PR DESCRIPTION
## Summary

Fixes the `invalid_blocks` error when agent responses produce more than 50 Slack blocks.

## Problem

Slack API has a hard limit of 50 blocks per message. When a response contains many markdown tables (e.g. 55 tables), `splitSlackMarkdownText` produces 50+ markdown blocks, and `chat.postMessage` fails with `invalid_blocks`.

## Solution

After assembling the blocks array in `sendReply`, check if it exceeds 50. If so, send in sequential batches within the same thread. Each batch stays under the limit and the conversation remains coherent.

## Testing

- Tested locally with a mock response containing 60 markdown blocks — all sent successfully in 2 messages
- Responses under 50 blocks are sent as before (no behavior change)

Closes #4724