### PR TITLE
fix(mcp): artifact_write graceful fallback for Slack invocations

### DIFF
--- a/platform/backend/src/archestra-mcp-server/chat.ts
+++ b/platform/backend/src/archestra-mcp-server/chat.ts
@@ -218,8 +218,17 @@ const registry = defineArchestraTools([
             );
           }
         } else {
-          return errorResult(
-            "This tool requires conversation context. It can only be used within an active chat conversation or scheduled run.",
+          // When invoked via integrations without conversation context
+          // (e.g. Slack), return the content as a success with a note that
+          // persistence is not available. This allows the agent to continue
+          // without a hard failure.
+          logger.warn(
+            { agentId: contextAgent.id, contentLength: args.content.length },
+            "artifact_write called without conversation context (e.g. Slack invocation) — returning content inline",
+          );
+          return structuredSuccessResult(
+            { success: true, characterCount: args.content.length, persisted: false },
+            `Artifact content generated (${args.content.length} characters) but could not be persisted — no conversation context available. The content has been produced inline above.`,
           );
         }
 


### PR DESCRIPTION
## Summary

Fixes `artifact_write` tool failures when agents are invoked via Slack.

## Problem

When an agent is invoked via Slack, there's no `conversationId` in the execution context (Slack uses threads, not web conversations). The tool returned a hard error:

> This tool requires conversation context.

This caused subagent delegation to fail and produced confusing behavior.

## Solution

Instead of erroring, return a success result with `persisted: false`. The agent can continue its work and present the content inline. A warning is logged for observability.

This is the minimal non-breaking fix. A follow-up could persist artifacts to a Slack-specific store, but this unblocks the immediate workflow.

## Testing

- Verified that normal chat and scheduled-run paths still persist as before
- The new path only triggers when both `conversationId` and `scheduleTriggerRunId` are absent

Closes #4716