### PR TITLE
fix: raise Next.js middleware body limit to 50 MB for file uploads

### DIFF
--- a/platform/frontend/next.config.ts
+++ b/platform/frontend/next.config.ts
@@ -41,8 +41,10 @@ const nextConfig: NextConfig = {
   },
   experimental: {
     proxyTimeout: 300000, // 5 minutes in milliseconds - prevents SSE stream timeout
-    middlewareClientMaxBodySize:
-      process.env.ARCHESTRA_MIDDLEWARE_BODY_LIMIT || "50mb",
+    middlewareClientMaxBodySize: process.env.ARCHESTRA_API_BODY_LIMIT
+      ? Number(process.env.ARCHESTRA_API_BODY_LIMIT) ||
+        process.env.ARCHESTRA_API_BODY_LIMIT
+      : 50 * 1024 * 1024, // 50MB default
   },
   httpAgentOptions: {
     keepAlive: true,

--- a/platform/frontend/next.config.ts
+++ b/platform/frontend/next.config.ts
@@ -41,6 +41,8 @@ const nextConfig: NextConfig = {
   },
   experimental: {
     proxyTimeout: 300000, // 5 minutes in milliseconds - prevents SSE stream timeout
+    middlewareClientMaxBodySize:
+      process.env.ARCHESTRA_MIDDLEWARE_BODY_LIMIT || "50mb",
   },
   httpAgentOptions: {
     keepAlive: true,


### PR DESCRIPTION
Fixes https://github.com/archestra-ai/archestra/issues/4735

## Problem

Next.js middleware has a hardcoded 10 MB body limit (`middlewareClientMaxBodySize` defaults to 10 MB). Uploading files between 10–50 MB through the UI fails with a 413 error, even though the backend accepts up to 50 MB. Direct `curl` to the backend succeeds — the limit is purely in the frontend middleware.

## Fix

Added `middlewareClientMaxBodySize` to the existing `experimental` block in `next.config.ts`:

```ts
experimental: {
  proxyTimeout: 300000,
  middlewareClientMaxBodySize:
    process.env.ARCHESTRA_MIDDLEWARE_BODY_LIMIT || "50mb",
},
```

- Default: `50mb` — matches backend default
- Configurable via `ARCHESTRA_MIDDLEWARE_BODY_LIMIT` env var for deployments that need a different value

## Testing

**Before:** Upload a 10–50 MB PDF through the UI → 413 `Request body exceeded 10MB`  
**After:** Upload succeeds, file reaches the backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)