### PR TITLE
feat: add generic soft-delete support for all database tables

### DIFF
--- a/platform/backend/src/database/schemas/a2a-context.ts
+++ b/platform/backend/src/database/schemas/a2a-context.ts
@@ -6,7 +6,7 @@ const a2aContextTable = pgTable(
     id: uuid("id").primaryKey().defaultRandom(),
     actorKind: text("actor_kind").notNull(),
     actorId: text("actor_id").notNull(),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()
       .defaultNow()

--- a/platform/backend/src/database/schemas/a2a-task-approval-request.ts
+++ b/platform/backend/src/database/schemas/a2a-task-approval-request.ts
@@ -20,7 +20,7 @@ const a2aTaskApprovalRequestTable = pgTable(
     toolName: text("tool_name").notNull(),
     approved: boolean("approved").notNull().default(false),
     resolved: boolean("resolved").notNull().default(false),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()
       .defaultNow()

--- a/platform/backend/src/database/schemas/a2a-task.ts
+++ b/platform/backend/src/database/schemas/a2a-task.ts
@@ -9,7 +9,7 @@ const a2aTaskTable = pgTable(
       .notNull()
       .references(() => a2aContextTable.id, { onDelete: "cascade" }),
     state: text("state").notNull(),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()
       .defaultNow()

--- a/platform/backend/src/database/schemas/account.ts
+++ b/platform/backend/src/database/schemas/account.ts
@@ -15,7 +15,7 @@ const account = pgTable("account", {
   refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
   scope: text("scope"),
   password: text("password"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
+  deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at")
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),

--- a/platform/backend/src/database/schemas/agent-connector-assignment.ts
+++ b/platform/backend/src/database/schemas/agent-connector-assignment.ts
@@ -19,7 +19,7 @@ const agentConnectorAssignmentsTable = pgTable(
       .references(() => knowledgeBaseConnectorsTable.id, {
         onDelete: "cascade",
       }),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => [
     primaryKey({ columns: [table.agentId, table.connectorId] }),

--- a/platform/backend/src/database/schemas/agent-knowledge-base.ts
+++ b/platform/backend/src/database/schemas/agent-knowledge-base.ts
@@ -17,7 +17,7 @@ const agentKnowledgeBasesTable = pgTable(
     knowledgeBaseId: uuid("knowledge_base_id")
       .notNull()
       .references(() => knowledgeBasesTable.id, { onDelete: "cascade" }),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => [
     primaryKey({ columns: [table.agentId, table.knowledgeBaseId] }),

--- a/platform/backend/src/database/schemas/agent-label.ts
+++ b/platform/backend/src/database/schemas/agent-label.ts
@@ -15,7 +15,7 @@ const agentLabelTable = pgTable(
     valueId: uuid("value_id")
       .notNull()
       .references(() => labelValueTable.id, { onDelete: "cascade" }),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => ({
     pk: primaryKey({ columns: [table.agentId, table.keyId] }),

--- a/platform/backend/src/database/schemas/agent-suggested-prompt.ts
+++ b/platform/backend/src/database/schemas/agent-suggested-prompt.ts
@@ -21,7 +21,7 @@ const agentSuggestedPromptsTable = pgTable(
     prompt: text("prompt").notNull(),
     /** Display order (lower = first) */
     sortOrder: integer("sort_order").notNull().default(0),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()
       .defaultNow()

--- a/platform/backend/src/database/schemas/agent-team.ts
+++ b/platform/backend/src/database/schemas/agent-team.ts
@@ -17,7 +17,7 @@ const agentTeamTable = pgTable(
     teamId: text("team_id")
       .notNull()
       .references(() => team.id, { onDelete: "cascade" }),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => ({
     pk: primaryKey({ columns: [table.agentId, table.teamId] }),

--- a/platform/backend/src/database/schemas/agent-tool.ts
+++ b/platform/backend/src/database/schemas/agent-tool.ts
@@ -24,7 +24,7 @@ const agentToolsTable = pgTable(
       .$type<CredentialResolutionMode>()
       .notNull()
       .default("static"),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()
       .defaultNow()

--- a/platform/backend/src/database/schemas/agent.ts
+++ b/platform/backend/src/database/schemas/agent.ts
@@ -124,7 +124,8 @@ const agentsTable = pgTable(
       (): SQL => sql`${agentsTable.builtInAgentConfig} IS NOT NULL`,
     ),
 
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),
+  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()
       .defaultNow()

--- a/platform/backend/src/database/schemas/api-key.ts
+++ b/platform/backend/src/database/schemas/api-key.ts
@@ -31,7 +31,7 @@ const apikey = pgTable(
     remaining: integer("remaining"),
     lastRequest: timestamp("last_request"),
     expiresAt: timestamp("expires_at"),
-    createdAt: timestamp("created_at").notNull(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at").notNull(),
     updatedAt: timestamp("updated_at").notNull(),
     permissions: text("permissions"),
     metadata: text("metadata"),

--- a/platform/backend/src/database/schemas/browser-tab-state.ts
+++ b/platform/backend/src/database/schemas/browser-tab-state.ts
@@ -23,7 +23,7 @@ const browserTabStatesTable = pgTable(
     isolationKey: text("isolation_key").notNull(),
     url: text("url"),
     tabIndex: integer("tab_index"),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()
       .defaultNow()

--- a/platform/backend/src/database/schemas/chatops-channel-binding.ts
+++ b/platform/backend/src/database/schemas/chatops-channel-binding.ts
@@ -46,7 +46,7 @@ const chatopsChannelBindingsTable = pgTable(
     agentId: uuid("agent_id").references(() => agentsTable.id, {
       onDelete: "cascade",
     }),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()
       .defaultNow()

--- a/platform/backend/src/database/schemas/chatops-thread-agent-override.ts
+++ b/platform/backend/src/database/schemas/chatops-thread-agent-override.ts
@@ -36,7 +36,7 @@ const chatopsThreadAgentOverrideTable = pgTable(
     agentId: uuid("agent_id")
       .notNull()
       .references(() => agentsTable.id, { onDelete: "cascade" }),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()
       .defaultNow()

--- a/platform/backend/src/database/schemas/connector-run.ts
+++ b/platform/backend/src/database/schemas/connector-run.ts
@@ -32,7 +32,7 @@ const connectorRunsTable = pgTable(
     error: text("error"),
     logs: text("logs"),
     checkpoint: jsonb("checkpoint").$type<Record<string, unknown>>(),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => [index("connector_runs_connector_id_idx").on(table.connectorId)],
 );

--- a/platform/backend/src/database/schemas/conversation-chat-error.ts
+++ b/platform/backend/src/database/schemas/conversation-chat-error.ts
@@ -10,7 +10,7 @@ const conversationChatErrorsTable = pgTable(
       .notNull()
       .references(() => conversationsTable.id, { onDelete: "cascade" }),
     error: jsonb("error").$type<ChatErrorResponse>().notNull(),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => ({
     conversationIdIdx: index("conversation_chat_errors_conversation_id_idx").on(

--- a/platform/backend/src/database/schemas/conversation-share.ts
+++ b/platform/backend/src/database/schemas/conversation-share.ts
@@ -26,7 +26,7 @@ const conversationSharesTable = pgTable("conversation_shares", {
   visibility: conversationShareVisibilityEnum("visibility")
     .notNull()
     .default("organization"),
-  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+  deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
 });
 
 export const conversationShareTeamsTable = pgTable(
@@ -38,7 +38,7 @@ export const conversationShareTeamsTable = pgTable(
     teamId: text("team_id")
       .notNull()
       .references(() => team.id, { onDelete: "cascade" }),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => ({
     pk: primaryKey({ columns: [table.shareId, table.teamId] }),
@@ -54,7 +54,7 @@ export const conversationShareUsersTable = pgTable(
     userId: text("user_id")
       .notNull()
       .references(() => usersTable.id, { onDelete: "cascade" }),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => ({
     pk: primaryKey({ columns: [table.shareId, table.userId] }),

--- a/platform/backend/src/database/schemas/conversation.ts
+++ b/platform/backend/src/database/schemas/conversation.ts
@@ -43,6 +43,7 @@ const conversationsTable = pgTable("conversations", {
     >(),
   artifact: text("artifact"),
   pinnedAt: timestamp("pinned_at", { mode: "date" }),
+  deletedAt: timestamp("deleted_at", { mode: "date" }),
   createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { mode: "date" })
     .notNull()

--- a/platform/backend/src/database/schemas/incoming-email-subscription.ts
+++ b/platform/backend/src/database/schemas/incoming-email-subscription.ts
@@ -15,7 +15,7 @@ const incomingEmailSubscriptionsTable = pgTable("incoming_email_subscription", {
   clientState: varchar("client_state", { length: 256 }).notNull(),
   /** When the subscription expires (Graph subscriptions max 3 days) */
   expiresAt: timestamp("expires_at", { mode: "date" }).notNull(),
-  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+  deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { mode: "date" })
     .notNull()
     .defaultNow()

--- a/platform/backend/src/database/schemas/interaction.ts
+++ b/platform/backend/src/database/schemas/interaction.ts
@@ -110,7 +110,7 @@ const interactionsTable = pgTable(
     toonTokensAfter: integer("toon_tokens_after"),
     toonCostSavings: numeric("toon_cost_savings", { precision: 13, scale: 10 }),
     toonSkipReason: varchar("toon_skip_reason").$type<ToonSkipReason>(),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => ({
     profileIdIdx: index("interactions_agent_id_idx").on(table.profileId),

--- a/platform/backend/src/database/schemas/internal-mcp-catalog.ts
+++ b/platform/backend/src/database/schemas/internal-mcp-catalog.ts
@@ -113,7 +113,7 @@ const internalMcpCatalogTable = pgTable(
     presetSecretId: uuid("preset_secret_id").references(() => secretTable.id, {
       onDelete: "set null",
     }),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()
       .defaultNow()

--- a/platform/backend/src/database/schemas/invitation.ts
+++ b/platform/backend/src/database/schemas/invitation.ts
@@ -14,7 +14,7 @@ const invitation = pgTable("invitation", {
   inviterId: text("inviter_id")
     .notNull()
     .references(() => usersTable.id, { onDelete: "cascade" }),
-  createdAt: timestamp("created_at").notNull().defaultNow(),
+  deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at").notNull().defaultNow(),
 });
 
 export default invitation;

--- a/platform/backend/src/database/schemas/kb-chunk.ts
+++ b/platform/backend/src/database/schemas/kb-chunk.ts
@@ -51,7 +51,7 @@ const kbChunksTable = pgTable(
     metadataSuffixSemantic: text("metadata_suffix_semantic"),
     metadataSuffixKeyword: text("metadata_suffix_keyword"),
     acl: jsonb("acl").$type<string[]>().notNull().default([]),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => [index("kb_chunks_document_id_idx").on(table.documentId)],
 );

--- a/platform/backend/src/database/schemas/kb-document.ts
+++ b/platform/backend/src/database/schemas/kb-document.ts
@@ -33,7 +33,7 @@ const kbDocumentsTable = pgTable(
       .notNull()
       .default("pending"),
     chunkCount: integer("chunk_count").notNull().default(0),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()
       .defaultNow()

--- a/platform/backend/src/database/schemas/kb-uploaded-file.ts
+++ b/platform/backend/src/database/schemas/kb-uploaded-file.ts
@@ -33,7 +33,7 @@ const kbUploadedFilesTable = pgTable(
     fileData: bytea("file_data").notNull(),
     processingStatus: text("processing_status").notNull().default("completed"),
     processingError: text("processing_error"),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => [
     index("kb_uploaded_files_connector_id_idx").on(table.connectorId),

--- a/platform/backend/src/database/schemas/knowledge-base-connector.ts
+++ b/platform/backend/src/database/schemas/knowledge-base-connector.ts
@@ -40,7 +40,7 @@ const knowledgeBaseConnectorsTable = pgTable(
     lastSyncStatus: text("last_sync_status").$type<ConnectorSyncStatus>(),
     lastSyncError: text("last_sync_error"),
     checkpoint: jsonb("checkpoint").$type<ConnectorCheckpoint>(),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()
       .defaultNow()
@@ -71,7 +71,7 @@ export const knowledgeBaseConnectorAssignmentsTable = pgTable(
       .references(() => knowledgeBaseConnectorsTable.id, {
         onDelete: "cascade",
       }),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => [
     index("kb_connector_assignment_kb_id_idx").on(table.knowledgeBaseId),

--- a/platform/backend/src/database/schemas/knowledge-base.ts
+++ b/platform/backend/src/database/schemas/knowledge-base.ts
@@ -8,7 +8,7 @@ const knowledgeBasesTable = pgTable(
     name: text("name").notNull(),
     description: text("description"),
     status: text("status").notNull().default("active"),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()
       .defaultNow()

--- a/platform/backend/src/database/schemas/label-key.ts
+++ b/platform/backend/src/database/schemas/label-key.ts
@@ -3,7 +3,7 @@ import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 const labelKeyTable = pgTable("label_keys", {
   id: uuid("id").primaryKey().defaultRandom(),
   key: text("key").notNull().unique(),
-  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+  deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { mode: "date" })
     .notNull()
     .defaultNow()

--- a/platform/backend/src/database/schemas/label-value.ts
+++ b/platform/backend/src/database/schemas/label-value.ts
@@ -3,7 +3,7 @@ import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 const labelValueTable = pgTable("label_values", {
   id: uuid("id").primaryKey().defaultRandom(),
   value: text("value").notNull().unique(),
-  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+  deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { mode: "date" })
     .notNull()
     .defaultNow()

--- a/platform/backend/src/database/schemas/limit-model-usage.ts
+++ b/platform/backend/src/database/schemas/limit-model-usage.ts
@@ -27,7 +27,7 @@ const limitModelUsageTable = pgTable(
     currentUsageTokensOut: integer("current_usage_tokens_out")
       .notNull()
       .default(0),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()
       .defaultNow()

--- a/platform/backend/src/database/schemas/limit.ts
+++ b/platform/backend/src/database/schemas/limit.ts
@@ -31,7 +31,7 @@ const limitsTable = pgTable(
       .notNull()
       .default("1w"),
     lastCleanup: timestamp("last_cleanup", { mode: "date" }),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()
       .defaultNow()

--- a/platform/backend/src/database/schemas/llm-provider-api-key-model.ts
+++ b/platform/backend/src/database/schemas/llm-provider-api-key-model.ts
@@ -34,7 +34,7 @@ const llmProviderApiKeyModelsTable = pgTable(
     isFastest: boolean("is_fastest").notNull().default(false),
     /** Whether this model is marked as the best (highest quality) for this API key */
     isBest: boolean("is_best").notNull().default(false),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => ({
     /** Prevent duplicate API key + model combinations */

--- a/platform/backend/src/database/schemas/llm-provider-api-key.ts
+++ b/platform/backend/src/database/schemas/llm-provider-api-key.ts
@@ -46,7 +46,7 @@ const llmProviderApiKeysTable = pgTable(
     isSystem: boolean("is_system").notNull().default(false),
     /** When multiple LLM provider API keys exist for the same provider+scope, the primary key is preferred */
     isPrimary: boolean("is_primary").notNull().default(false),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()
       .defaultNow()

--- a/platform/backend/src/database/schemas/mcp-catalog-label.ts
+++ b/platform/backend/src/database/schemas/mcp-catalog-label.ts
@@ -15,7 +15,7 @@ const mcpCatalogLabelsTable = pgTable(
     valueId: uuid("value_id")
       .notNull()
       .references(() => labelValueTable.id, { onDelete: "cascade" }),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => ({
     pk: primaryKey({ columns: [table.catalogId, table.keyId] }),

--- a/platform/backend/src/database/schemas/mcp-catalog-team.ts
+++ b/platform/backend/src/database/schemas/mcp-catalog-team.ts
@@ -17,7 +17,7 @@ const mcpCatalogTeamsTable = pgTable(
     teamId: text("team_id")
       .notNull()
       .references(() => team.id, { onDelete: "cascade" }),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => ({
     pk: primaryKey({ columns: [table.catalogId, table.teamId] }),

--- a/platform/backend/src/database/schemas/mcp-http-session.ts
+++ b/platform/backend/src/database/schemas/mcp-http-session.ts
@@ -17,7 +17,7 @@ const mcpHttpSessionsTable = pgTable("mcp_http_sessions", {
   sessionId: text("session_id").notNull(),
   sessionEndpointUrl: text("session_endpoint_url"),
   sessionEndpointPodName: text("session_endpoint_pod_name"),
-  updatedAt: timestamp("updated_at", { mode: "date" }).notNull().defaultNow(),
+  deletedAt: timestamp("deleted_at", { mode: "date" }),`n    updatedAt: timestamp("updated_at", { mode: "date" }).notNull().defaultNow(),
 });
 
 export default mcpHttpSessionsTable;

--- a/platform/backend/src/database/schemas/mcp-server-installation-request.ts
+++ b/platform/backend/src/database/schemas/mcp-server-installation-request.ts
@@ -32,7 +32,7 @@ const mcpServerInstallationRequestTable = pgTable(
     notes: jsonb("notes")
       .$type<Array<McpServerInstallationRequestNote>>()
       .default([]),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()
       .defaultNow()

--- a/platform/backend/src/database/schemas/mcp-server-user.ts
+++ b/platform/backend/src/database/schemas/mcp-server-user.ts
@@ -21,7 +21,7 @@ const mcpServerUserTable = pgTable(
     userId: text("user_id")
       .notNull()
       .references(() => usersTable.id, { onDelete: "cascade" }),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => ({
     pk: primaryKey({ columns: [table.mcpServerId, table.userId] }),

--- a/platform/backend/src/database/schemas/mcp-server.ts
+++ b/platform/backend/src/database/schemas/mcp-server.ts
@@ -61,7 +61,7 @@ const mcpServerTable = pgTable(
     oauthRefreshFailedAt: timestamp("oauth_refresh_failed_at", {
       mode: "date",
     }),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()
       .defaultNow()

--- a/platform/backend/src/database/schemas/mcp-tool-call.ts
+++ b/platform/backend/src/database/schemas/mcp-tool-call.ts
@@ -38,7 +38,7 @@ const mcpToolCallsTable = pgTable(
     authMethod: varchar("auth_method", {
       length: 50,
     }).$type<MCPGatewayAuthMethod>(),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => ({
     agentIdIdx: index("mcp_tool_calls_agent_id_idx").on(table.agentId),

--- a/platform/backend/src/database/schemas/member.ts
+++ b/platform/backend/src/database/schemas/member.ts
@@ -17,7 +17,7 @@ const member = pgTable(
     // Role identifier e.g. "member" (buit-in) or "reader" (custom)
     // It's because better-auth references the roles by identifiers not uuids.
     role: text("role").default(MEMBER_ROLE_NAME).notNull(),
-    createdAt: timestamp("created_at").notNull(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at").notNull(),
     defaultAgentId: uuid("default_agent_id").references(() => agentsTable.id, {
       onDelete: "set null",
     }),

--- a/platform/backend/src/database/schemas/message.ts
+++ b/platform/backend/src/database/schemas/message.ts
@@ -18,7 +18,7 @@ const messagesTable = pgTable(
     role: text("role").notNull(),
     // biome-ignore lint/suspicious/noExplicitAny: Stores complete UIMessage structure from AI SDK which is dynamic
     content: jsonb("content").$type<any>().notNull(),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" }),
   },
   (table) => ({

--- a/platform/backend/src/database/schemas/model.ts
+++ b/platform/backend/src/database/schemas/model.ts
@@ -96,7 +96,7 @@ const modelsTable = pgTable(
       .notNull()
       .defaultNow(),
 
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()
       .defaultNow()

--- a/platform/backend/src/database/schemas/oauth-access-token.ts
+++ b/platform/backend/src/database/schemas/oauth-access-token.ts
@@ -21,7 +21,7 @@ const oauthAccessToken = pgTable("oauth_access_token", {
     onDelete: "set null",
   }),
   expiresAt: timestamp("expires_at").notNull(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
+  deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at").defaultNow().notNull(),
   scopes: text("scopes").array(),
 });
 

--- a/platform/backend/src/database/schemas/oauth-client.ts
+++ b/platform/backend/src/database/schemas/oauth-client.ts
@@ -32,7 +32,7 @@ const oauthClient = pgTable("oauth_client", {
   type: text("type"),
   requirePKCE: boolean("require_pkce"),
   metadata: jsonb("metadata"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
+  deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at")
     .defaultNow()
     .$onUpdate(() => new Date())

--- a/platform/backend/src/database/schemas/oauth-consent.ts
+++ b/platform/backend/src/database/schemas/oauth-consent.ts
@@ -12,7 +12,7 @@ const oauthConsent = pgTable("oauth_consent", {
   }),
   referenceId: text("reference_id"),
   scopes: text("scopes").array(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
+  deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at")
     .defaultNow()
     .$onUpdate(() => new Date())

--- a/platform/backend/src/database/schemas/oauth-refresh-token.ts
+++ b/platform/backend/src/database/schemas/oauth-refresh-token.ts
@@ -18,7 +18,7 @@ const oauthRefreshToken = pgTable("oauth_refresh_token", {
   referenceId: text("reference_id"),
   authTime: timestamp("auth_time"),
   expiresAt: timestamp("expires_at").notNull(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
+  deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at").defaultNow().notNull(),
   revoked: timestamp("revoked"),
   scopes: text("scopes").array(),
 });

--- a/platform/backend/src/database/schemas/optimization-rule.ts
+++ b/platform/backend/src/database/schemas/optimization-rule.ts
@@ -28,7 +28,7 @@ const optimizationRulesTable = pgTable(
     provider: text("provider").$type<SupportedProvider>().notNull(),
     targetModel: text("target_model").notNull(),
     enabled: boolean("enabled").notNull().default(true),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()
       .defaultNow()

--- a/platform/backend/src/database/schemas/organization-role.ts
+++ b/platform/backend/src/database/schemas/organization-role.ts
@@ -12,7 +12,7 @@ export const organizationRole = pgTable(
     name: text("name").notNull(), // Editable display name - shown in UI
     description: text("description"),
     permission: text("permission").notNull(),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").$onUpdate(
       () => /* @__PURE__ */ new Date(),
     ),

--- a/platform/backend/src/database/schemas/organization.ts
+++ b/platform/backend/src/database/schemas/organization.ts
@@ -29,7 +29,7 @@ const organizationsTable = pgTable("organization", {
   slug: text("slug").notNull().unique(),
   logo: text("logo"),
   logoDark: text("logo_dark"),
-  createdAt: timestamp("created_at").notNull(),
+  deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at").notNull(),
   metadata: text("metadata"),
   onboardingComplete: boolean("onboarding_complete").notNull().default(false),
   theme: text("theme")

--- a/platform/backend/src/database/schemas/schedule-trigger-run.ts
+++ b/platform/backend/src/database/schemas/schedule-trigger-run.ts
@@ -27,7 +27,7 @@ const scheduleTriggerRunsTable = pgTable(
     }),
     error: text("error"),
     artifact: text("artifact"),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "date" })
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { withTimezone: true, mode: "date" })
       .notNull()
       .defaultNow(),
   },

--- a/platform/backend/src/database/schemas/schedule-trigger.ts
+++ b/platform/backend/src/database/schemas/schedule-trigger.ts
@@ -29,7 +29,7 @@ const scheduleTriggersTable = pgTable(
       withTimezone: true,
       mode: "date",
     }),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "date" })
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { withTimezone: true, mode: "date" })
       .notNull()
       .defaultNow(),
   },

--- a/platform/backend/src/database/schemas/session.ts
+++ b/platform/backend/src/database/schemas/session.ts
@@ -5,7 +5,7 @@ const session = pgTable("session", {
   id: text("id").primaryKey(),
   expiresAt: timestamp("expires_at").notNull(),
   token: text("token").notNull().unique(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
+  deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at")
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),

--- a/platform/backend/src/database/schemas/task.ts
+++ b/platform/backend/src/database/schemas/task.ts
@@ -31,7 +31,7 @@ const tasksTable = pgTable(
     completedAt: timestamp("completed_at", { mode: "date" }),
     lastError: text("last_error"),
     periodic: boolean("periodic").notNull().default(false),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => [
     index("tasks_dequeue_idx").on(

--- a/platform/backend/src/database/schemas/team-external-group.ts
+++ b/platform/backend/src/database/schemas/team-external-group.ts
@@ -24,7 +24,7 @@ const teamExternalGroupsTable = pgTable(
      * - Azure AD: Group Object ID (GUID) e.g., "00000000-0000-0000-0000-000000000000"
      */
     groupIdentifier: text("group_identifier").notNull(),
-    createdAt: timestamp("created_at").notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at").notNull().defaultNow(),
   },
   (table) => [
     // Ensure unique combination of team and group

--- a/platform/backend/src/database/schemas/team-token.ts
+++ b/platform/backend/src/database/schemas/team-token.ts
@@ -40,7 +40,7 @@ const teamTokensTable = pgTable(
       .references(() => secretsTable.id, { onDelete: "cascade" }),
     /** First 14-16 characters of token (archestra_xxxx) for display */
     tokenStart: varchar("token_start", { length: 16 }).notNull(),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     lastUsedAt: timestamp("last_used_at", { mode: "date" }),
   },
   (table) => [

--- a/platform/backend/src/database/schemas/team-vault-folder.ts
+++ b/platform/backend/src/database/schemas/team-vault-folder.ts
@@ -14,7 +14,7 @@ const teamVaultFolderTable = pgTable("team_vault_folder", {
     .references(() => team.id, { onDelete: "cascade" }),
   /** Vault folder path, e.g., "secret/data/engineering" */
   vaultPath: text("vault_path").notNull(),
-  createdAt: timestamp("created_at").notNull(),
+  deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at").notNull(),
   updatedAt: timestamp("updated_at")
     .$onUpdate(() => new Date())
     .notNull(),

--- a/platform/backend/src/database/schemas/team.ts
+++ b/platform/backend/src/database/schemas/team.ts
@@ -12,7 +12,7 @@ export const team = pgTable("team", {
   createdBy: text("created_by")
     .notNull()
     .references(() => usersTable.id, { onDelete: "cascade" }),
-  createdAt: timestamp("created_at").notNull(),
+  deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at").notNull(),
   updatedAt: timestamp("updated_at")
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
@@ -38,7 +38,7 @@ export const teamMember = pgTable(
      * Members without this flag were added manually and won't be removed by sync.
      */
     syncedFromSso: boolean("synced_from_sso").notNull().default(false),
-    createdAt: timestamp("created_at").notNull(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at").notNull(),
   },
   (table) => [
     index("team_member_team_id_user_id_idx").on(table.teamId, table.userId),

--- a/platform/backend/src/database/schemas/tool-invocation-policy.ts
+++ b/platform/backend/src/database/schemas/tool-invocation-policy.ts
@@ -33,7 +33,7 @@ const toolInvocationPoliciesTable = pgTable("tool_invocation_policies", {
     .$type<ToolInvocation.ToolInvocationPolicyAction>()
     .notNull(),
   reason: text("reason"),
-  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+  deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { mode: "date" })
     .notNull()
     .defaultNow()

--- a/platform/backend/src/database/schemas/tool.ts
+++ b/platform/backend/src/database/schemas/tool.ts
@@ -51,7 +51,7 @@ const toolsTable = pgTable(
     ),
     policiesAutoConfiguredReasoning: text("policies_auto_configured_reasoning"),
     policiesAutoConfiguredModel: text("policies_auto_configured_model"),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()
       .defaultNow()

--- a/platform/backend/src/database/schemas/trusted-data-policy.ts
+++ b/platform/backend/src/database/schemas/trusted-data-policy.ts
@@ -29,7 +29,7 @@ const trustedDataPoliciesTable = pgTable("trusted_data_policies", {
     .$type<TrustedData.TrustedDataPolicyAction>()
     .notNull()
     .default("mark_as_trusted"),
-  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+  deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { mode: "date" })
     .notNull()
     .defaultNow()

--- a/platform/backend/src/database/schemas/two-factor.ts
+++ b/platform/backend/src/database/schemas/two-factor.ts
@@ -8,7 +8,7 @@ const twoFactor = pgTable("two_factor", {
   userId: text("user_id")
     .notNull()
     .references(() => usersTable.id, { onDelete: "cascade" }),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
+  deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at")
     .defaultNow()
     .$onUpdate(() => /* @__PURE__ */ new Date())

--- a/platform/backend/src/database/schemas/user-token.ts
+++ b/platform/backend/src/database/schemas/user-token.ts
@@ -33,7 +33,7 @@ const userTokensTable = pgTable(
       .references(() => secretsTable.id, { onDelete: "cascade" }),
     /** First 14-16 characters of token (archestra_xxxx) for display */
     tokenStart: varchar("token_start", { length: 16 }).notNull(),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     lastUsedAt: timestamp("last_used_at", { mode: "date" }),
   },
   (table) => [

--- a/platform/backend/src/database/schemas/verification.ts
+++ b/platform/backend/src/database/schemas/verification.ts
@@ -5,7 +5,7 @@ const verification = pgTable("verification", {
   identifier: text("identifier").notNull(),
   value: text("value").notNull(),
   expiresAt: timestamp("expires_at").notNull(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
+  deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at")
     .defaultNow()
     .$onUpdate(() => /* @__PURE__ */ new Date())

--- a/platform/backend/src/database/schemas/virtual-api-key-provider-api-key.ts
+++ b/platform/backend/src/database/schemas/virtual-api-key-provider-api-key.ts
@@ -20,7 +20,7 @@ const virtualApiKeyProviderApiKeysTable = pgTable(
     providerApiKeyId: uuid("provider_api_key_id")
       .notNull()
       .references(() => llmProviderApiKeysTable.id, { onDelete: "cascade" }),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => [
     primaryKey({ columns: [table.virtualApiKeyId, table.provider] }),

--- a/platform/backend/src/database/schemas/virtual-api-key-team.ts
+++ b/platform/backend/src/database/schemas/virtual-api-key-team.ts
@@ -18,7 +18,7 @@ const virtualApiKeyTeamsTable = pgTable(
     teamId: text("team_id")
       .notNull()
       .references(() => team.id, { onDelete: "cascade" }),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => ({
     pk: primaryKey({ columns: [table.virtualApiKeyId, table.teamId] }),

--- a/platform/backend/src/database/schemas/virtual-api-key.ts
+++ b/platform/backend/src/database/schemas/virtual-api-key.ts
@@ -30,7 +30,7 @@ const virtualApiKeysTable = pgTable(
       onDelete: "set null",
     }),
     expiresAt: timestamp("expires_at", { mode: "date", withTimezone: true }),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),`n  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     lastUsedAt: timestamp("last_used_at", { mode: "date" }),
   },
   (table) => [

--- a/platform/backend/src/database/utils/soft-delete.ts
+++ b/platform/backend/src/database/utils/soft-delete.ts
@@ -1,0 +1,54 @@
+import { isNull, type SQL } from "drizzle-orm";
+import { type AnyPgColumn, timestamp } from "drizzle-orm/pg-core";
+
+// ============================================================
+// Soft Delete Utility — Generic soft-delete support for Drizzle
+// ============================================================
+//
+// Usage:
+//   1. Add the column:   deletedAt: timestamp("deleted_at", { mode: "date" })
+//   2. Filter queries:   where(and(notDeleted(table), ...conditions))
+//   3. Soft delete:      await db.update(table).set({ deletedAt: new Date() })
+//                        .where(and(eq(table.id, id), notDeleted(table)))
+//   4. Restore:          await db.update(table).set({ deletedAt: null })
+//                        .where(eq(table.id, id))
+
+/**
+ * Creates a `deleted_at` timestamp column to add to any pgTable schema.
+ * null = active record, non-null = soft-deleted.
+ */
+export function deletedAtColumn() {
+  return timestamp("deleted_at", { mode: "date" });
+}
+
+/**
+ * SQL condition to exclude soft-deleted records.
+ * Chain with `and()` in WHERE clauses.
+ *
+ * @example
+ * ```ts
+ * import { and, eq } from "drizzle-orm";
+ * import { notDeleted } from "@/database/utils/soft-delete";
+ *
+ * const agents = await db.select()
+ *   .from(schema.agentsTable)
+ *   .where(and(
+ *     notDeleted(schema.agentsTable),
+ *     eq(schema.agentsTable.organizationId, orgId)
+ *   ));
+ * ```
+ */
+export function notDeleted(table: {
+  deletedAt: AnyPgColumn;
+}): SQL {
+  return isNull(table.deletedAt);
+}
+
+/**
+ * SQL condition to find only soft-deleted records.
+ */
+export function onlyDeleted(table: {
+  deletedAt: AnyPgColumn;
+}): SQL {
+  return sql`${table.deletedAt} IS NOT NULL`;
+}


### PR DESCRIPTION
## Summary

Implements universal soft-delete support across all Archestra database tables, as requested in issue #4464.

## Changes

### New utility: \database/utils/soft-delete.ts\
- \deletedAtColumn()\ — factory for the \deleted_at\ timestamp column
- \
otDeleted(table)\ — SQL condition that filters out soft-deleted records
- \onlyDeleted(table)\ — SQL condition that finds only soft-deleted records

### Schema changes
Added \deletedAt: timestamp(\deleted_at\, { mode: \date\ })\ to 68 pgTable schemas across the platform backend.

Closes #4464