### PR TITLE
fix(frontend): increase proxy upload body limit

### DIFF
--- a/platform/frontend/next.config.ts
+++ b/platform/frontend/next.config.ts
@@ -8,6 +8,11 @@ const platformPkg = JSON.parse(
   readFileSync(resolve(import.meta.dirname, "../package.json"), "utf-8"),
 ) as { name: string; version: string };
 
+type ExperimentalConfig = NonNullable<NextConfig["experimental"]>;
+
+const proxyClientMaxBodySize = (process.env.ARCHESTRA_MIDDLEWARE_BODY_LIMIT ||
+  "50mb") as ExperimentalConfig["proxyClientMaxBodySize"];
+
 const nextConfig: NextConfig = {
   allowedDevOrigins: getAllowedDevOrigins(),
   env: {
@@ -41,6 +46,7 @@ const nextConfig: NextConfig = {
   },
   experimental: {
     proxyTimeout: 300000, // 5 minutes in milliseconds - prevents SSE stream timeout
+    proxyClientMaxBodySize,
   },
   httpAgentOptions: {
     keepAlive: true,


### PR DESCRIPTION
Fixes #4741

## What changed

Configured Next.js `experimental.proxyClientMaxBodySize` to default to `50mb`, while allowing override through `ARCHESTRA_MIDDLEWARE_BODY_LIMIT`.

Used `proxyClientMaxBodySize` instead of `middlewareClientMaxBodySize` because the current Next.js type definitions mark `middlewareClientMaxBodySize` as deprecated in favor of `proxyClientMaxBodySize`.

## Why

The backend supports larger uploads, but the frontend proxy layer was still using the default 10MB request body limit, causing uploads above 10MB to fail before reaching the backend.

## Testing

- Ran `pnpm lint`
- Ran `pnpm type-check`