### PR TITLE
feat: preset filter on catalog Logs/Inspector/Shell/Credentials pages

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -144,6 +144,11 @@ export function InternalMCPCatalog({
   const [preselectedTeamId, setPreselectedTeamId] = useState<string | null>(
     null,
   );
+  // Pre-selected preset (child) catalog id when launching install from a
+  // specific preset card on the Credentials page. Null = install into parent.
+  const [preselectedCatalogId, setPreselectedCatalogId] = useState<
+    string | null
+  >(null);
   // When true, install dialog hides the team selector (personal connection only)
   const [installPersonalOnly, setInstallPersonalOnly] = useState(false);
   // When true, install dialog forces the organization-wide scope
@@ -416,6 +421,7 @@ export function InternalMCPCatalog({
   ) => {
     if (!options?.preserveInstallTarget) {
       setPreselectedTeamId(null);
+      setPreselectedCatalogId(null);
       setInstallPersonalOnly(false);
       setInstallOrgOnly(false);
     }
@@ -442,6 +448,7 @@ export function InternalMCPCatalog({
   ) => {
     if (!options?.preserveInstallTarget) {
       setPreselectedTeamId(null);
+      setPreselectedCatalogId(null);
       setInstallPersonalOnly(false);
       setInstallOrgOnly(false);
     }
@@ -524,14 +531,18 @@ export function InternalMCPCatalog({
   // Install directly without opening a dialog (works for personal, team, and org)
   const handleDirectInstall = async (
     catalogItem: CatalogItem,
-    target?: { teamId?: string; scope?: McpServerInstallScope },
+    target?: {
+      teamId?: string;
+      scope?: McpServerInstallScope;
+      presetCatalogId?: string;
+    },
   ) => {
     setInstallingItemId(catalogItem.id);
     const scope: McpServerInstallScope =
       target?.scope ?? (target?.teamId ? "team" : "personal");
     const result = await installMutation.mutateAsync({
       name: catalogItem.name,
-      catalogId: catalogItem.id,
+      catalogId: target?.presetCatalogId ?? catalogItem.id,
       scope,
       ...(scope === "team" && target?.teamId ? { teamId: target.teamId } : {}),
       dontShowToast: true,
@@ -553,10 +564,14 @@ export function InternalMCPCatalog({
   };
 
   // Add personal connection: skip dialog if no config needed, otherwise open dialog with personalOnly
-  const handleAddPersonalConnection = (catalogItem: CatalogItem) => {
+  const handleAddPersonalConnection = (
+    catalogItem: CatalogItem,
+    presetCatalogId?: string,
+  ) => {
     if (canDirectInstall(catalogItem)) {
-      handleDirectInstall(catalogItem);
+      handleDirectInstall(catalogItem, { presetCatalogId });
     } else {
+      setPreselectedCatalogId(presetCatalogId ?? null);
       setInstallPersonalOnly(true);
       if (catalogItem.serverType === "local") {
         handleInstallLocalServer(catalogItem, {
@@ -574,10 +589,16 @@ export function InternalMCPCatalog({
   const handleAddSharedConnection = (
     catalogItem: CatalogItem,
     teamId: string,
+    presetCatalogId?: string,
   ) => {
     if (canDirectInstall(catalogItem)) {
-      handleDirectInstall(catalogItem, { teamId, scope: "team" });
+      handleDirectInstall(catalogItem, {
+        teamId,
+        scope: "team",
+        presetCatalogId,
+      });
     } else {
+      setPreselectedCatalogId(presetCatalogId ?? null);
       setPreselectedTeamId(teamId);
       if (catalogItem.serverType === "local") {
         handleInstallLocalServer(catalogItem, {
@@ -593,10 +614,14 @@ export function InternalMCPCatalog({
 
   // Add organization connection: skip dialog if no config needed, otherwise
   // open dialog with scope locked to org.
-  const handleAddOrgConnection = (catalogItem: CatalogItem) => {
+  const handleAddOrgConnection = (
+    catalogItem: CatalogItem,
+    presetCatalogId?: string,
+  ) => {
     if (canDirectInstall(catalogItem)) {
-      handleDirectInstall(catalogItem, { scope: "org" });
+      handleDirectInstall(catalogItem, { scope: "org", presetCatalogId });
     } else {
+      setPreselectedCatalogId(presetCatalogId ?? null);
       setInstallOrgOnly(true);
       if (catalogItem.serverType === "local") {
         handleInstallLocalServer(catalogItem, {
@@ -1265,13 +1290,15 @@ export function InternalMCPCatalog({
                     }}
                     onDelete={() => setDeletingItem(item)}
                     onCancelInstallation={handleCancelInstallation}
-                    onAddPersonalConnection={() =>
-                      handleAddPersonalConnection(item)
+                    onAddPersonalConnection={(presetCatalogId) =>
+                      handleAddPersonalConnection(item, presetCatalogId)
                     }
-                    onAddSharedConnection={(teamId) =>
-                      handleAddSharedConnection(item, teamId)
+                    onAddSharedConnection={(teamId, presetCatalogId) =>
+                      handleAddSharedConnection(item, teamId, presetCatalogId)
                     }
-                    onAddOrgConnection={() => handleAddOrgConnection(item)}
+                    onAddOrgConnection={(presetCatalogId) =>
+                      handleAddOrgConnection(item, presetCatalogId)
+                    }
                     isBuiltInPlaywright={isPlaywrightCatalogItem(item.id)}
                   />
                 );
@@ -1323,13 +1350,15 @@ export function InternalMCPCatalog({
                     }}
                     onDelete={() => setDeletingItem(item)}
                     onCancelInstallation={handleCancelInstallation}
-                    onAddPersonalConnection={() =>
-                      handleAddPersonalConnection(item)
+                    onAddPersonalConnection={(presetCatalogId) =>
+                      handleAddPersonalConnection(item, presetCatalogId)
                     }
-                    onAddSharedConnection={(teamId) =>
-                      handleAddSharedConnection(item, teamId)
+                    onAddSharedConnection={(teamId, presetCatalogId) =>
+                      handleAddSharedConnection(item, teamId, presetCatalogId)
                     }
-                    onAddOrgConnection={() => handleAddOrgConnection(item)}
+                    onAddOrgConnection={(presetCatalogId) =>
+                      handleAddOrgConnection(item, presetCatalogId)
+                    }
                     isBuiltInPlaywright={isPlaywrightCatalogItem(item.id)}
                   />
                 );
@@ -1429,6 +1458,7 @@ export function InternalMCPCatalog({
           setSelectedCatalogItem(null);
           setReauthServerId(null);
           setPreselectedTeamId(null);
+          setPreselectedCatalogId(null);
           setInstallPersonalOnly(false);
           setInstallOrgOnly(false);
         }}
@@ -1437,6 +1467,7 @@ export function InternalMCPCatalog({
         isInstalling={installMutation.isPending || reauthMutation.isPending}
         isReauth={!!reauthServerId}
         preselectedTeamId={preselectedTeamId}
+        preselectedCatalogId={preselectedCatalogId}
         personalOnly={installPersonalOnly}
         orgOnly={installOrgOnly}
       />
@@ -1455,6 +1486,7 @@ export function InternalMCPCatalog({
           setSelectedCatalogItem(null);
           setReauthServerId(null);
           setPreselectedTeamId(null);
+          setPreselectedCatalogId(null);
           setInstallPersonalOnly(false);
           setInstallOrgOnly(false);
         }}
@@ -1483,6 +1515,7 @@ export function InternalMCPCatalog({
           closeDialog("no-auth");
           setNoAuthCatalogItem(null);
           setPreselectedTeamId(null);
+          setPreselectedCatalogId(null);
           setInstallPersonalOnly(false);
           setInstallOrgOnly(false);
         }}
@@ -1490,6 +1523,7 @@ export function InternalMCPCatalog({
         catalogItem={noAuthCatalogItem}
         isInstalling={installMutation.isPending}
         preselectedTeamId={preselectedTeamId}
+        preselectedCatalogId={preselectedCatalogId}
         personalOnly={installPersonalOnly}
         orgOnly={installOrgOnly}
       />
@@ -1505,6 +1539,7 @@ export function InternalMCPCatalog({
             setReinstallServerScope(undefined);
             setReauthServerId(null);
             setPreselectedTeamId(null);
+            setPreselectedCatalogId(null);
             setInstallPersonalOnly(false);
             setInstallOrgOnly(false);
           }}
@@ -1520,6 +1555,7 @@ export function InternalMCPCatalog({
           existingScope={reinstallServerScope}
           isReauth={!!reauthServerId}
           preselectedTeamId={preselectedTeamId}
+          preselectedCatalogId={preselectedCatalogId}
           personalOnly={installPersonalOnly}
           orgOnly={installOrgOnly}
         />
@@ -1530,26 +1566,26 @@ export function InternalMCPCatalog({
           isOpen={isDialogOpened("manage")}
           onClose={handleManageDialogClose}
           catalogId={manageCatalogId}
-          onAddPersonalConnection={() => {
+          onAddPersonalConnection={(presetCatalogId) => {
             const catalogItem = catalogItems?.find(
               (item) => item.id === manageCatalogId,
             );
             if (!catalogItem) return;
-            handleAddPersonalConnection(catalogItem);
+            handleAddPersonalConnection(catalogItem, presetCatalogId);
           }}
-          onAddSharedConnection={(teamId) => {
+          onAddSharedConnection={(teamId, presetCatalogId) => {
             const catalogItem = catalogItems?.find(
               (item) => item.id === manageCatalogId,
             );
             if (!catalogItem) return;
-            handleAddSharedConnection(catalogItem, teamId);
+            handleAddSharedConnection(catalogItem, teamId, presetCatalogId);
           }}
-          onAddOrgConnection={() => {
+          onAddOrgConnection={(presetCatalogId) => {
             const catalogItem = catalogItems?.find(
               (item) => item.id === manageCatalogId,
             );
             if (!catalogItem) return;
-            handleAddOrgConnection(catalogItem);
+            handleAddOrgConnection(catalogItem, presetCatalogId);
           }}
         />
       )}

--- a/platform/frontend/src/app/mcp/registry/_parts/local-server-install-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/local-server-install-dialog.tsx
@@ -113,6 +113,12 @@ interface LocalServerInstallDialogProps {
   isReauth?: boolean;
   /** Pre-select a specific team in the credential type selector */
   preselectedTeamId?: string | null;
+  /**
+   * Pre-select a preset (child catalog) in the InstallPresetPicker when the
+   * dialog opens. Used when launching install from a specific preset card on
+   * the Credentials page. Falls back to the parent's id when unset.
+   */
+  preselectedCatalogId?: string | null;
   /** When true, only personal installation is allowed */
   personalOnly?: boolean;
   /** When true, only organization-wide installation is allowed */
@@ -130,6 +136,7 @@ export function LocalServerInstallDialog({
   existingScope,
   isReauth = false,
   preselectedTeamId,
+  preselectedCatalogId,
   personalOnly: personalOnlyProp = false,
   orgOnly = false,
 }: LocalServerInstallDialogProps) {
@@ -148,7 +155,7 @@ export function LocalServerInstallDialog({
     catalogItem?.localConfig?.serviceAccount,
   );
   const [selectedCatalogId, setSelectedCatalogId] = useState<string>(
-    catalogItem?.id ?? "",
+    preselectedCatalogId ?? catalogItem?.id ?? "",
   );
   const [presetFallbackValues, setPresetFallbackValues] = useState<
     Record<string, string>
@@ -158,10 +165,10 @@ export function LocalServerInstallDialog({
 
   useEffect(() => {
     if (isOpen && catalogItem) {
-      setSelectedCatalogId(catalogItem.id);
+      setSelectedCatalogId(preselectedCatalogId ?? catalogItem.id);
       setPresetFallbackValues({});
     }
-  }, [isOpen, catalogItem]);
+  }, [isOpen, catalogItem, preselectedCatalogId]);
   const userConfig =
     (catalogItem?.userConfig as UserConfigType | null | undefined) || {};
   const promptableUserConfig = Object.fromEntries(

--- a/platform/frontend/src/app/mcp/registry/_parts/manage-users-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/manage-users-dialog.tsx
@@ -84,12 +84,16 @@ interface ManageUsersDialogProps {
   onClose: () => void;
   label?: string;
   catalogId: string;
-  /** Called when user wants to add a personal connection */
-  onAddPersonalConnection?: () => void;
+  /**
+   * Called when user wants to add a personal connection. `presetCatalogId`
+   * is set when the user clicked Install on a specific preset card; falls
+   * back to the parent catalog.
+   */
+  onAddPersonalConnection?: (presetCatalogId?: string) => void;
   /** Called when user wants to add a team connection for a specific team */
-  onAddSharedConnection?: (teamId: string) => void;
+  onAddSharedConnection?: (teamId: string, presetCatalogId?: string) => void;
   /** Called when user wants to add an organization-wide connection */
-  onAddOrgConnection?: () => void;
+  onAddOrgConnection?: (presetCatalogId?: string) => void;
   /** Deployment statuses keyed by server ID */
   deploymentStatuses?: Record<string, McpDeploymentStatusEntry>;
   /** Called when user clicks a pod name to open the debug dialog */
@@ -134,12 +138,19 @@ interface ManageUsersContentProps {
   onClose: () => void;
   label?: string;
   catalogId: string;
-  onAddPersonalConnection?: () => void;
-  onAddSharedConnection?: (teamId: string) => void;
-  onAddOrgConnection?: () => void;
+  onAddPersonalConnection?: (presetCatalogId?: string) => void;
+  onAddSharedConnection?: (teamId: string, presetCatalogId?: string) => void;
+  onAddOrgConnection?: (presetCatalogId?: string) => void;
   deploymentStatuses?: Record<string, McpDeploymentStatusEntry>;
   onOpenPodLogs?: (serverId: string) => void;
   hideHeader?: boolean;
+  /**
+   * Externally-controlled preset filter id ("all" or a presetId). When set,
+   * the internal preset Select is hidden and the parent owns the value
+   * (used by the settings dialog so the selector can live in its page header).
+   */
+  controlledPresetFilter?: string;
+  onControlledPresetFilterChange?: (value: string) => void;
 }
 
 export function ManageUsersContent({
@@ -153,7 +164,10 @@ export function ManageUsersContent({
   deploymentStatuses = {},
   onOpenPodLogs,
   hideHeader = false,
+  controlledPresetFilter,
+  onControlledPresetFilterChange,
 }: ManageUsersContentProps) {
+  const isPresetFilterControlled = controlledPresetFilter !== undefined;
   // Subscribe to live mcp-servers query to get fresh data. We fetch all
   // servers (no catalogId filter) and split by preset client-side so we can
   // group rows by the preset/default they were installed from.
@@ -161,7 +175,11 @@ export function ManageUsersContent({
     useMcpServers();
   const { data: catalogItems } = useInternalMcpCatalog({});
   const { data: childPresets = [] } = useCatalogPresets(catalogId);
-  const { plural: presetPlural } = usePresetEntityName();
+  const {
+    plural: presetPlural,
+    singular: presetSingular,
+    configured: presetTermConfigured,
+  } = usePresetEntityName();
 
   // Map of presetId → preset row. Parent is the "default" preset.
   const presetEntries = [
@@ -179,8 +197,15 @@ export function ManageUsersContent({
   );
 
   // Filter dropdown state — "all" or a specific presetId.
-  const [selectedPresetFilter, setSelectedPresetFilter] =
+  // When `controlledPresetFilter` is supplied, the parent owns this state.
+  const [internalSelectedPresetFilter, setInternalSelectedPresetFilter] =
     useState<string>("all");
+  const selectedPresetFilter = isPresetFilterControlled
+    ? (controlledPresetFilter ?? "all")
+    : internalSelectedPresetFilter;
+  const setSelectedPresetFilter = isPresetFilterControlled
+    ? (next: string) => onControlledPresetFilterChange?.(next)
+    : setInternalSelectedPresetFilter;
   const visiblePresets =
     selectedPresetFilter === "all"
       ? presetEntries
@@ -419,71 +444,28 @@ export function ManageUsersContent({
       )}
 
       <div className={hideHeader ? "space-y-4 px-4 py-4" : "space-y-4 pb-4"}>
-        {(() => {
-          const defaultPresetServers = allServers.filter(
-            (s) => s.catalogId === catalogId,
-          );
-          const defaultSplit = splitByScope(defaultPresetServers);
-          return (
-            <div className="flex items-center justify-end gap-2">
-              {presetEntries.length > 1 && (
-                <Select
-                  value={selectedPresetFilter}
-                  onValueChange={setSelectedPresetFilter}
-                >
-                  <SelectTrigger className="w-[200px]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All {presetPlural}</SelectItem>
-                    {presetEntries.map((p) => (
-                      <SelectItem key={p.id} value={p.id}>
-                        {p.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              )}
-              <InstallMenuButton
-                onAddPersonal={
-                  hasAddCallbacks &&
-                  onAddPersonalConnection &&
-                  !defaultSplit.myPersonalServer
-                    ? () => {
-                        onClose();
-                        onAddPersonalConnection();
-                      }
-                    : undefined
-                }
-                onAddForTeam={
-                  hasAddCallbacks && onAddSharedConnection
-                    ? (teamId) => {
-                        onClose();
-                        onAddSharedConnection(teamId);
-                      }
-                    : undefined
-                }
-                onAddForOrg={
-                  hasAddCallbacks &&
-                  onAddOrgConnection &&
-                  !defaultSplit.hasOrgConnection
-                    ? () => {
-                        onClose();
-                        onAddOrgConnection();
-                      }
-                    : undefined
-                }
-                availableTeamsForShared={defaultSplit.availableTeamsForShared}
-                addOrgDisabled={!hasMcpServerAdminPermission}
-                addOrgDisabledReason={
-                  !hasMcpServerAdminPermission
-                    ? "Only organization admins can install organization-wide"
-                    : undefined
-                }
-              />
-            </div>
-          );
-        })()}
+        {/* Legacy in-content preset filter — only shown when the standalone
+            dialog renders (no external page header to host the selector). */}
+        {presetEntries.length > 1 && !isPresetFilterControlled && (
+          <div className="flex items-center justify-end gap-2">
+            <Select
+              value={selectedPresetFilter}
+              onValueChange={setSelectedPresetFilter}
+            >
+              <SelectTrigger className="w-[200px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All {presetPlural}</SelectItem>
+                {presetEntries.map((p) => (
+                  <SelectItem key={p.id} value={p.id}>
+                    {p.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
 
         {visiblePresets.map((preset) => {
           const presetServers = allServers.filter(
@@ -491,12 +473,71 @@ export function ManageUsersContent({
           );
           const split = splitByScope(presetServers);
           const hasContent = presetServers.length > 0;
+          // Annotate the card title with the configured preset term only
+          // when the org has set one AND non-default presets actually exist.
+          // Without both, the title row carries only the install button.
+          const showAnnotatedTitle =
+            presetTermConfigured && childPresets.length > 0;
+          // Pass undefined for default so the install flow targets the parent
+          // catalog directly (matches pre-preset behaviour).
+          const installPresetCatalogId = preset.isDefault
+            ? undefined
+            : preset.id;
 
           return (
             <Card key={preset.id}>
               <CardContent className="p-0">
-                <div className="flex items-center gap-2 border-b px-4 py-2.5">
-                  <span className="text-sm font-semibold">{preset.name}</span>
+                <div className="flex items-center justify-between gap-2 border-b px-4 py-2.5">
+                  {showAnnotatedTitle ? (
+                    <span className="text-sm font-semibold">
+                      <span className="text-muted-foreground font-normal">
+                        {presetSingular}:{" "}
+                      </span>
+                      {preset.name}
+                    </span>
+                  ) : (
+                    <span />
+                  )}
+                  <InstallMenuButton
+                    onAddPersonal={
+                      hasAddCallbacks &&
+                      onAddPersonalConnection &&
+                      !split.myPersonalServer
+                        ? () => {
+                            onClose();
+                            onAddPersonalConnection(installPresetCatalogId);
+                          }
+                        : undefined
+                    }
+                    onAddForTeam={
+                      hasAddCallbacks && onAddSharedConnection
+                        ? (teamId) => {
+                            onClose();
+                            onAddSharedConnection(
+                              teamId,
+                              installPresetCatalogId,
+                            );
+                          }
+                        : undefined
+                    }
+                    onAddForOrg={
+                      hasAddCallbacks &&
+                      onAddOrgConnection &&
+                      !split.hasOrgConnection
+                        ? () => {
+                            onClose();
+                            onAddOrgConnection(installPresetCatalogId);
+                          }
+                        : undefined
+                    }
+                    availableTeamsForShared={split.availableTeamsForShared}
+                    addOrgDisabled={!hasMcpServerAdminPermission}
+                    addOrgDisabledReason={
+                      !hasMcpServerAdminPermission
+                        ? "Only organization admins can install organization-wide"
+                        : undefined
+                    }
+                  />
                 </div>
                 {hasContent ? (
                   <UnifiedConnectionsTable

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-logs-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-logs-dialog.tsx
@@ -122,6 +122,13 @@ interface McpLogsContentProps {
   controlledTab?: McpLogsTab;
   /** When true, hides the tab bar (use with controlledTab) */
   hideTabBar?: boolean;
+  /**
+   * Externally-controlled preset filter. When provided, takes ownership of
+   * the preset state from this component (used by the settings dialog so the
+   * selector can live in its page header).
+   */
+  controlledSelectedPreset?: string | null;
+  onSelectedPresetChange?: (preset: string) => void;
   onReinstall?: (serverId: string) => void | Promise<void>;
   initialServerId?: string | null;
 }
@@ -135,9 +142,12 @@ export function McpLogsContent({
   hideHeader = false,
   controlledTab,
   hideTabBar = false,
+  controlledSelectedPreset,
+  onSelectedPresetChange,
   onReinstall,
   initialServerId = null,
 }: McpLogsContentProps) {
+  const isPresetControlled = controlledSelectedPreset !== undefined;
   const [internalTab, setInternalTab] = useState<McpLogsTab>("logs");
   const activeTab = controlledTab ?? internalTab;
   const setActiveTab = (tab: McpLogsTab) => {
@@ -164,8 +174,17 @@ export function McpLogsContent({
 
   // State for selected installation
   const [serverId, setServerId] = useState<string | null>(null);
-  // State for selected preset (used to filter installs across all tabs)
-  const [selectedPreset, setSelectedPreset] = useState<string | null>(null);
+  // State for selected preset (used to filter installs across all tabs).
+  // When `controlledSelectedPreset` is provided, the parent owns this state.
+  const [internalSelectedPreset, setInternalSelectedPreset] = useState<
+    string | null
+  >(null);
+  const selectedPreset = isPresetControlled
+    ? (controlledSelectedPreset ?? null)
+    : internalSelectedPreset;
+  const setSelectedPreset = isPresetControlled
+    ? (next: string) => onSelectedPresetChange?.(next)
+    : setInternalSelectedPreset;
 
   // Distinct preset labels represented across the installs we received.
   const distinctPresets = useMemo(() => {
@@ -190,25 +209,37 @@ export function McpLogsContent({
     return installs[0]?.presetLabel ?? "default";
   }, [installs, initialServerId]);
 
-  // Reset when dialog closes so the next open picks up a fresh initialServerId
+  // Reset when dialog closes so the next open picks up a fresh initialServerId.
+  // Only resets internal preset state — the parent owns it when controlled.
   useEffect(() => {
     if (!isActive) {
       setServerId(null);
-      setSelectedPreset(null);
+      if (!isPresetControlled) setInternalSelectedPreset(null);
     }
-  }, [isActive]);
+  }, [isActive, isPresetControlled]);
 
-  // Default the preset selector when the dialog opens.
+  // Default the preset selector when the dialog opens. Skipped when the
+  // parent controls the preset value.
   useEffect(() => {
+    if (isPresetControlled) return;
     if (isActive && !selectedPreset && distinctPresets.length > 0) {
       setSelectedPreset(initialPreset);
     }
-  }, [isActive, selectedPreset, distinctPresets, initialPreset]);
+  }, [
+    isActive,
+    isPresetControlled,
+    selectedPreset,
+    distinctPresets,
+    initialPreset,
+    setSelectedPreset,
+  ]);
 
   // Filter installs by selected preset. Until selectedPreset is set (one tick
   // on first open) we show everything to avoid a flash of "no installs".
+  // The literal "All" is the no-filter sentinel used by the settings dialog
+  // when "All" is picked in the page header.
   const filteredInstalls = useMemo(() => {
-    if (!selectedPreset) return installs;
+    if (!selectedPreset || selectedPreset === "All") return installs;
     return installs.filter(
       (i) => (i.presetLabel ?? "default") === selectedPreset,
     );
@@ -744,7 +775,7 @@ interface PresetSelectorProps {
   setSelectedPreset: (label: string) => void;
 }
 
-function PresetSelector({
+export function PresetSelector({
   presets,
   selectedPreset,
   setSelectedPreset,

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -99,12 +99,16 @@ export type McpServerCardProps = {
   onEdit: () => void;
   onDelete: () => void;
   onCancelInstallation?: (serverId: string) => void;
-  /** Called when user wants to add a personal connection from manage dialog */
-  onAddPersonalConnection?: () => void;
+  /**
+   * Called when user wants to add a personal connection from manage dialog.
+   * `presetCatalogId` is set when the user clicked Install on a specific
+   * preset card on the Credentials page; falls back to the parent catalog.
+   */
+  onAddPersonalConnection?: (presetCatalogId?: string) => void;
   /** Called when user wants to add a team connection for a specific team */
-  onAddSharedConnection?: (teamId: string) => void;
+  onAddSharedConnection?: (teamId: string, presetCatalogId?: string) => void;
   /** Called when user wants to add an organization-wide connection */
-  onAddOrgConnection?: () => void;
+  onAddOrgConnection?: (presetCatalogId?: string) => void;
   /** When true, renders as a built-in Playwright server (non-editable, personal-only) */
   isBuiltInPlaywright?: boolean;
 };

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-settings-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-settings-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { E2eTestId, type McpDeploymentStatusEntry } from "@shared";
 import { AlertCircle, PlugZap, RefreshCw, XIcon } from "lucide-react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
 import { Button } from "@/components/ui/button";
 import {
@@ -32,7 +32,11 @@ import {
 } from "./deployment-status";
 import { EditCatalogContent } from "./edit-catalog-dialog";
 import { ManageUsersContent } from "./manage-users-dialog";
-import { McpLogsContent, type McpLogsTab } from "./mcp-logs-dialog";
+import {
+  McpLogsContent,
+  type McpLogsTab,
+  PresetSelector,
+} from "./mcp-logs-dialog";
 import type { CatalogItem } from "./mcp-server-card";
 import { PresetsSection } from "./presets-section";
 import { YamlConfigContent } from "./yaml-config-dialog";
@@ -64,9 +68,9 @@ interface McpServerSettingsDialogProps {
   showInspector: boolean;
   showYaml: boolean;
   // Connections
-  onAddPersonalConnection?: () => void;
-  onAddSharedConnection?: (teamId: string) => void;
-  onAddOrgConnection?: () => void;
+  onAddPersonalConnection?: (presetCatalogId?: string) => void;
+  onAddSharedConnection?: (teamId: string, presetCatalogId?: string) => void;
+  onAddOrgConnection?: (presetCatalogId?: string) => void;
   // Debug
   installs: {
     id: string;
@@ -200,6 +204,36 @@ export function McpServerSettingsDialog({
     ...PAGE_TITLES,
     presets: presetEntityName.plural,
   };
+
+  // Preset filter shown in the slim page header on Logs/Inspector/Shell and
+  // Credentials. Drives both McpLogsContent (filters the pod selector) and
+  // ManageUsersContent (filters credential sections). Hidden unless the org
+  // has the preset term configured AND the catalog has ≥ 1 preset child.
+  // The literal "All" is a sentinel for "no filter".
+  const presetLabelOptions = ["All", "default", ...presets.map((p) => p.name)];
+  const presetIdByLabel = new Map<string, string>([
+    ["default", item.id],
+    ...presets.map((p) => [p.name, p.id] as const),
+  ]);
+  const [pageSelectedPreset, setPageSelectedPreset] = useState<string>("All");
+  // Keep the selector in sync when the dialog opens deep-linked to a
+  // specific pod (e.g. from the chat log button or the per-install reinstall
+  // banner) — otherwise the user might land on a preset that doesn't contain
+  // that pod and see it disappear from the dropdown.
+  useEffect(() => {
+    const init = clickedServerId ?? logsInitialServerId;
+    if (!init) return;
+    const found = installs.find((i) => i.id === init);
+    if (found) setPageSelectedPreset(found.presetLabel ?? "default");
+  }, [clickedServerId, logsInitialServerId, installs]);
+  const presetSelectorVisible =
+    presetEntityName.configured &&
+    presets.length > 0 &&
+    (isDebugPage || validPage === "connections");
+  const credentialsControlledFilter =
+    pageSelectedPreset === "All"
+      ? "all"
+      : (presetIdByLabel.get(pageSelectedPreset) ?? "all");
 
   // Configuration dirty state tracking
   const [isConfigDirty, setIsConfigDirty] = useState(false);
@@ -344,15 +378,24 @@ export function McpServerSettingsDialog({
             {/* Content header */}
             <div className="flex min-h-[72px] shrink-0 items-center justify-between border-b px-4 py-4">
               <h2 className="text-lg font-semibold">{pageTitles[validPage]}</h2>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 rounded-xs opacity-70 hover:opacity-100"
-                onClick={handleClose}
-              >
-                <XIcon className="h-4 w-4" />
-                <span className="sr-only">Close</span>
-              </Button>
+              <div className="flex items-center gap-2">
+                {presetSelectorVisible && (
+                  <PresetSelector
+                    presets={presetLabelOptions}
+                    selectedPreset={pageSelectedPreset}
+                    setSelectedPreset={setPageSelectedPreset}
+                  />
+                )}
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 rounded-xs opacity-70 hover:opacity-100"
+                  onClick={handleClose}
+                >
+                  <XIcon className="h-4 w-4" />
+                  <span className="sr-only">Close</span>
+                </Button>
+              </div>
             </div>
 
             {/* Content body */}
@@ -391,6 +434,23 @@ export function McpServerSettingsDialog({
                   onAddOrgConnection={onAddOrgConnection}
                   deploymentStatuses={deploymentStatuses}
                   hideHeader
+                  controlledPresetFilter={
+                    presetSelectorVisible
+                      ? credentialsControlledFilter
+                      : undefined
+                  }
+                  onControlledPresetFilterChange={(presetId) => {
+                    if (presetId === "all") {
+                      setPageSelectedPreset("default");
+                      return;
+                    }
+                    for (const [label, id] of presetIdByLabel) {
+                      if (id === presetId) {
+                        setPageSelectedPreset(label);
+                        return;
+                      }
+                    }
+                  }}
                   onOpenPodLogs={
                     showDebug
                       ? (podServerId: string) => {
@@ -435,6 +495,10 @@ export function McpServerSettingsDialog({
                       hideHeader
                       hideTabBar
                       controlledTab={DEBUG_TAB_MAP[validPage]}
+                      controlledSelectedPreset={
+                        presetSelectorVisible ? pageSelectedPreset : undefined
+                      }
+                      onSelectedPresetChange={setPageSelectedPreset}
                       onReinstall={() => onReinstall()}
                       initialServerId={clickedServerId ?? logsInitialServerId}
                     />

--- a/platform/frontend/src/app/mcp/registry/_parts/no-auth-install-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/no-auth-install-dialog.tsx
@@ -32,6 +32,11 @@ interface NoAuthInstallDialogProps {
   isInstalling: boolean;
   /** Pre-select a specific team in the credential type selector */
   preselectedTeamId?: string | null;
+  /**
+   * Pre-select a preset (child catalog) in the InstallPresetPicker when the
+   * dialog opens. Falls back to the parent's id when unset.
+   */
+  preselectedCatalogId?: string | null;
   /** When true, only personal installation is allowed */
   personalOnly?: boolean;
   /** When true, only organization-wide installation is allowed */
@@ -45,6 +50,7 @@ export function NoAuthInstallDialog({
   catalogItem,
   isInstalling,
   preselectedTeamId,
+  preselectedCatalogId,
   personalOnly = false,
   orgOnly = false,
 }: NoAuthInstallDialogProps) {
@@ -56,14 +62,16 @@ export function NoAuthInstallDialog({
   );
   const [canInstall, setCanInstall] = useState(true);
   const [selectedCatalogId, setSelectedCatalogId] = useState<string>(
-    catalogItem?.id ?? "",
+    preselectedCatalogId ?? catalogItem?.id ?? "",
   );
   const { data: presets = [] } = useCatalogPresets(catalogItem?.id ?? null);
   const hasPresets = presets.length > 0;
 
   useEffect(() => {
-    if (isOpen && catalogItem) setSelectedCatalogId(catalogItem.id);
-  }, [isOpen, catalogItem]);
+    if (isOpen && catalogItem) {
+      setSelectedCatalogId(preselectedCatalogId ?? catalogItem.id);
+    }
+  }, [isOpen, catalogItem, preselectedCatalogId]);
 
   const handleInstall = useCallback(async () => {
     if (!selectedCatalogId) return;

--- a/platform/frontend/src/app/mcp/registry/_parts/remote-server-install-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/remote-server-install-dialog.tsx
@@ -86,6 +86,11 @@ interface RemoteServerInstallDialogProps {
   isReauth?: boolean;
   /** Pre-select a specific team in the credential type selector */
   preselectedTeamId?: string | null;
+  /**
+   * Pre-select a preset (child catalog) in the InstallPresetPicker when the
+   * dialog opens. Falls back to the parent's id when unset.
+   */
+  preselectedCatalogId?: string | null;
   /** When true, only personal installation is allowed */
   personalOnly?: boolean;
   /** When true, only organization-wide installation is allowed */
@@ -100,6 +105,7 @@ export function RemoteServerInstallDialog({
   isInstalling,
   isReauth = false,
   preselectedTeamId,
+  preselectedCatalogId,
   personalOnly = false,
   orgOnly = false,
 }: RemoteServerInstallDialogProps) {
@@ -112,7 +118,7 @@ export function RemoteServerInstallDialog({
   );
   const [canInstall, setCanInstall] = useState(true);
   const [selectedCatalogId, setSelectedCatalogId] = useState<string>(
-    catalogItem?.id ?? "",
+    preselectedCatalogId ?? catalogItem?.id ?? "",
   );
   const [presetFallbackValues, setPresetFallbackValues] = useState<
     Record<string, string>
@@ -122,10 +128,10 @@ export function RemoteServerInstallDialog({
 
   useEffect(() => {
     if (isOpen && catalogItem) {
-      setSelectedCatalogId(catalogItem.id);
+      setSelectedCatalogId(preselectedCatalogId ?? catalogItem.id);
       setPresetFallbackValues({});
     }
-  }, [isOpen, catalogItem]);
+  }, [isOpen, catalogItem, preselectedCatalogId]);
 
   // Vault team selection (separate from install team for personal + BYOS)
   const [vaultTeamId, setVaultTeamId] = useState<string | null>(null);


### PR DESCRIPTION
## Summary

- Surfaces a small preset selector in the slim page header of the catalog settings dialog on **Logs**, **Inspector**, **Shell**, and **Credentials** — visible only when the org has the preset term configured AND the catalog has ≥ 1 preset child. Includes an **All** no-filter option.
- **Credentials** polish: per-card Install button (top-of-page row removed), card title annotated as `<singular>: <preset>` only when the preset term is configured and non-default presets exist, otherwise the title row carries just the Install button. Per-card Install pre-selects the preset in the install dialog via a new `preselectedCatalogId` prop threaded through Local/Remote/NoAuth install dialogs.
- No backend changes: each preset already maps 1:1 to an `mcp_server` row, so `getOrLoadDeployment(mcpServerId)` and `/api/mcp_server/:id/inspect` naturally resolve to the right pod and preset overlay.


---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>