### PR TITLE
fix(guardrails): enforce block policies when context starts untrusted

### DIFF
--- a/platform/backend/src/guardrails/trusted-data.test.ts
+++ b/platform/backend/src/guardrails/trusted-data.test.ts
@@ -410,6 +410,156 @@ describe("trusted-data evaluation (provider-agnostic)", () => {
       });
     });
 
+    test("enforces block policy when context starts untrusted", async () => {
+      await TrustedDataPolicyModel.create({
+        toolId,
+        conditions: [
+          { key: "emails[*].from", operator: "contains", value: "hacker" },
+        ],
+        action: "block_always",
+        description: "Block hacker emails",
+      });
+
+      const commonMessages: CommonMessage[] = [
+        { role: "user" },
+        { role: "assistant" },
+        {
+          role: "tool",
+          toolCalls: [
+            {
+              id: "call_456",
+              name: "get_emails",
+              content: {
+                emails: [
+                  { from: "hacker@company.com", subject: "Suspicious" },
+                ],
+              },
+              isError: false,
+            },
+          ],
+        },
+      ];
+
+      const result = await evaluateIfContextIsTrusted(
+        commonMessages,
+        agentId,
+        organizationId,
+        undefined,
+        true,
+        "restrictive",
+        { teamIds: [] },
+      );
+
+      // Context should remain untrusted and blocked results replaced
+      expect(result.contextIsTrusted).toBe(false);
+      expect(result.toolResultUpdates).toEqual({
+        call_456:
+          "[Content blocked by policy: Data blocked by policy: Block hacker emails]",
+      });
+      expect(result.unsafeContextBoundary).toEqual({
+        kind: "preexisting_untrusted",
+        reason: "agent_configured_untrusted",
+      });
+    });
+
+    test("skips dual-LLM sanitization when context starts untrusted", async () => {
+      await TrustedDataPolicyModel.create({
+        toolId,
+        conditions: [{ key: "source", operator: "equal", value: "external" }],
+        action: "sanitize_with_dual_llm",
+        description: "Sanitize external data",
+      });
+
+      const createSpy = vi.spyOn(DualLlmSubagent, "create").mockResolvedValue({
+        processWithMainAgent: vi.fn().mockResolvedValue({
+          toolCallId: "call_dual",
+          conversations: [],
+          result: "Sanitized summary",
+        }),
+      } as unknown as DualLlmSubagent);
+
+      const commonMessages: CommonMessage[] = [
+        { role: "user" },
+        {
+          role: "tool",
+          toolCalls: [
+            {
+              id: "call_dual",
+              name: "get_emails",
+              content: { source: "external", payload: "raw" },
+              isError: false,
+            },
+          ],
+        },
+      ];
+
+      const result = await evaluateIfContextIsTrusted(
+        commonMessages,
+        agentId,
+        organizationId,
+        undefined,
+        true,
+        "restrictive",
+        { teamIds: [] },
+      );
+
+      // Dual LLM should NOT be invoked — trust cannot be recovered
+      expect(createSpy).not.toHaveBeenCalled();
+      expect(result.contextIsTrusted).toBe(false);
+      expect(result.usedDualLlm).toBe(false);
+      expect(result.toolResultUpdates).toEqual({});
+
+      createSpy.mockRestore();
+    });
+
+    test("ignores mark_as_trusted policy when context starts untrusted", async () => {
+      await TrustedDataPolicyModel.create({
+        toolId,
+        conditions: [
+          {
+            key: "emails[*].from",
+            operator: "endsWith",
+            value: "@trusted.com",
+          },
+        ],
+        action: "mark_as_trusted",
+        description: "Allow trusted emails",
+      });
+
+      const commonMessages: CommonMessage[] = [
+        { role: "assistant" },
+        {
+          role: "tool",
+          toolCalls: [
+            {
+              id: "call_123",
+              name: "get_emails",
+              content: {
+                emails: [
+                  { from: "user@trusted.com", subject: "Hello" },
+                ],
+              },
+              isError: false,
+            },
+          ],
+        },
+      ];
+
+      const result = await evaluateIfContextIsTrusted(
+        commonMessages,
+        agentId,
+        organizationId,
+        undefined,
+        true,
+        "restrictive",
+        { teamIds: [] },
+      );
+
+      // Context should stay untrusted; no tool result updates applied
+      expect(result.contextIsTrusted).toBe(false);
+      expect(result.toolResultUpdates).toEqual({});
+    });
+
     test("handles multiple tool calls with mixed trust", async () => {
       // Create policies
       await TrustedDataPolicyModel.create({

--- a/platform/backend/src/guardrails/trusted-data.ts
+++ b/platform/backend/src/guardrails/trusted-data.ts
@@ -64,23 +64,19 @@ export async function evaluateIfContextIsTrusted(
   let unsafeContextBoundary: UnsafeContextBoundary | undefined;
 
   // If agent configured to consider context untrusted from the beginning,
-  // mark context as untrusted immediately and skip evaluation
+  // mark context as untrusted but still evaluate tool result policies so
+  // blocked results are replaced before reaching the model.
   if (considerContextUntrusted) {
     logger.debug(
       { agentId },
       "[trustedData] evaluateIfContextIsTrusted: context marked untrusted by agent config",
     );
-    return {
-      toolResultUpdates: {},
-      contextIsTrusted: false,
-      usedDualLlm: false,
-      dualLlmAnalyses: [],
-      unsafeContextBoundary: {
-        kind: "preexisting_untrusted",
-        reason:
-          initialUntrustedReason ??
-          UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
-      },
+    hasUntrustedData = true;
+    unsafeContextBoundary = {
+      kind: "preexisting_untrusted",
+      reason:
+        initialUntrustedReason ??
+        UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
     };
   }
 
@@ -116,7 +112,7 @@ export async function evaluateIfContextIsTrusted(
     );
     return {
       toolResultUpdates,
-      contextIsTrusted: true,
+      contextIsTrusted: !hasUntrustedData,
       usedDualLlm: false,
       dualLlmAnalyses: [],
       unsafeContextBoundary,
@@ -169,7 +165,9 @@ export async function evaluateIfContextIsTrusted(
 
     const { isTrusted, isBlocked, shouldSanitizeWithDualLlm, reason } =
       evaluation;
-    let toolResultIsTrusted = isTrusted;
+    // When context starts untrusted, trust cannot be recovered — only block
+    // policies are enforced. Skip mark_as_trusted and sanitize_with_dual_llm.
+    let toolResultIsTrusted = considerContextUntrusted ? false : isTrusted;
     logger.debug(
       {
         agentId,
@@ -198,7 +196,7 @@ export async function evaluateIfContextIsTrusted(
         toolCallId,
         toolName,
       });
-    } else if (shouldSanitizeWithDualLlm) {
+    } else if (shouldSanitizeWithDualLlm && !considerContextUntrusted) {
       if (!usedDualLlm && onDualLlmStart) {
         logger.debug(
           { agentId, toolCallId },


### PR DESCRIPTION
## Problem

When an agent has **'Treat context as sensitive from the start of chat'** enabled, the  function in  returned immediately with empty , skipping all tool result policy evaluation.

This caused **blocked tool results to bypass the block policy** and be sent raw to the model.

### Repro
1. Configure a tool with a  Tool Result Policy.
2. Enable **'Treat context as sensitive from the start of chat'** on the agent.
3. Trigger the tool via chat.
4. **Expected:** tool result is replaced with .
5. **Actual:** raw tool result is sent to the model.

## Solution

- Remove the early return when  is .
- Still collect tool calls and evaluate bulk policies.
- Force  to  so trust cannot be recovered (skips  and ).
- Only  policies are enforced — blocked results are replaced before reaching the model.
- Fix the no-tool-calls path to respect the  flag.

## Tests

Added 4 regression tests:
- 
- 
- 
- Existing  still passes

All 24 tests in  pass.

/claim #4225

Fixes #4225