### PR TITLE
docs(models): add class-level overviews for catalog + mcp_server

### DIFF
--- a/platform/backend/src/models/internal-mcp-catalog.ts
+++ b/platform/backend/src/models/internal-mcp-catalog.ts
@@ -26,6 +26,20 @@ import McpCatalogTeamModel from "./mcp-catalog-team";
 import McpServerModel from "./mcp-server";
 import SecretModel from "./secret";
 
+/**
+ * Data-access layer for `internal_mcp_catalog` — the org's private registry
+ * of MCP server templates (root rows) and their child **presets** (rows
+ * with a non-NULL `parentCatalogItemId` that inherit the parent's template
+ * columns and overlay their own preset field values / secrets).
+ *
+ * Owns CRUD for both flavors, name composition for child rows
+ * (`${parent.name}-${childName}`), persistence of preset field values and
+ * the per-row preset secret bundle, validation of incoming values against
+ * the parent's `userConfig` / `localConfig.environment` schema, and joins
+ * against labels and team assignments. Mutations on a parent that need to
+ * fan out to downstream installs go through the cascade helpers exposed
+ * here.
+ */
 class InternalMcpCatalogModel {
   static async create(
     catalogItem: InsertInternalMcpCatalog,

--- a/platform/backend/src/models/mcp-server.ts
+++ b/platform/backend/src/models/mcp-server.ts
@@ -21,6 +21,17 @@ import ToolModel from "./tool";
 // Alias for users table to avoid conflict with the owner LEFT JOIN
 const assignedUsersTable = alias(schema.usersTable, "assigned_users");
 
+/**
+ * Data-access layer for `mcp_server` — an installation of an
+ * `internal_mcp_catalog` row (root template or child **preset**) by a
+ * specific principal. A single catalog item can back many installs across
+ * different scopes (personal/team/org); each install carries its own
+ * per-install env values, secret bundle, and lifecycle state.
+ *
+ * Owns CRUD, scope-aware K8s-safe server-name construction, secret-bundle
+ * linkage, agent-tool fan-out, and coordination with
+ * `McpServerRuntimeManager` for pod (re)deploys and teardown.
+ */
 class McpServerModel {
   /**
    * Construct the full server name. Local servers append a scope-specific


### PR DESCRIPTION
Adds class-level JSDoc overviews to the two MCP data-access layers so new contributors can orient themselves without having to reverse-engineer the table from CRUD code.

- `InternalMcpCatalogModel` — explains that the registry holds both **root templates** and their **child "presets"** (rows with a non-NULL `parentCatalogItemId` that inherit the parent's template columns and overlay their own preset field values + secrets). Lists the model's main responsibilities: dual-flavor CRUD, child-name composition, preset value persistence, value validation against parent schemas, and cascade helpers.
- `McpServerModel` — explains that a row represents an **installation** of either a root catalog item or one of its child presets, that a single catalog item can back many installs across personal/team/org scopes, and that each install carries its own env values + secret bundle + lifecycle state. Lists responsibilities: CRUD, scope-aware K8s-safe naming, secret linkage, agent-tool fan-out, and runtime-manager coordination.

Docs-only — no schema, runtime, or test behavior changes.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>