### PR TITLE
fix(agent): prevent accidental dismissal of form by outside click or escape button press

### DIFF
--- a/platform/frontend/src/components/agent-dialog.test.tsx
+++ b/platform/frontend/src/components/agent-dialog.test.tsx
@@ -224,13 +224,26 @@ vi.mock("@/components/ui/command", () => ({
   ),
 }));
 
+let capturedOnInteractOutside: ((e: Event) => void) | undefined;
+let capturedOnEscapeKeyDown: ((e: KeyboardEvent) => void) | undefined;
+
 vi.mock("@/components/ui/dialog", () => ({
   Dialog: ({ children }: { children?: React.ReactNode }) => (
     <div>{children}</div>
   ),
-  DialogContent: ({ children }: { children?: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
+  DialogContent: ({
+    children,
+    onInteractOutside,
+    onEscapeKeyDown,
+  }: {
+    children?: React.ReactNode;
+    onInteractOutside?: (e: Event) => void;
+    onEscapeKeyDown?: (e: KeyboardEvent) => void;
+  }) => {
+    capturedOnInteractOutside = onInteractOutside;
+    capturedOnEscapeKeyDown = onEscapeKeyDown;
+    return <div>{children}</div>;
+  },
   DialogForm: ({
     children,
     onSubmit,
@@ -409,6 +422,44 @@ describe("AgentDialog delegation state", () => {
     await waitFor(() => {
       expect(screen.getByText("Subagents (1)")).toBeInTheDocument();
     });
+  });
+});
+
+describe("AgentDialog dismiss behaviour", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedOnInteractOutside = undefined;
+    capturedOnEscapeKeyDown = undefined;
+    useHasPermissionsMock.mockImplementation(() => ({ data: true }));
+    useProfileMock.mockReturnValue({ data: null, refetch: vi.fn() });
+    useInternalAgentsMock.mockReturnValue({ data: [] });
+    useAgentDelegationsMock.mockReturnValue({ data: [], isFetched: true });
+  });
+
+  it("blocks outside-click dismissal", () => {
+    const onOpenChange = vi.fn();
+    render(
+      <AgentDialog open={true} onOpenChange={onOpenChange} agentType="agent" />,
+    );
+
+    const event = { preventDefault: vi.fn() } as unknown as Event;
+    capturedOnInteractOutside?.(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("blocks Escape-key dismissal", () => {
+    const onOpenChange = vi.fn();
+    render(
+      <AgentDialog open={true} onOpenChange={onOpenChange} agentType="agent" />,
+    );
+
+    const event = { preventDefault: vi.fn() } as unknown as KeyboardEvent;
+    capturedOnEscapeKeyDown?.(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 });
 

--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -1117,7 +1117,11 @@ export function AgentDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-5xl h-[90vh] flex flex-col overflow-hidden">
+      <DialogContent
+        className="max-w-5xl h-[90vh] flex flex-col overflow-hidden"
+        onInteractOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <div className="flex items-start justify-between gap-4 pr-6">
             <div className="min-w-0 flex-1">


### PR DESCRIPTION
Problem:
Clicking outside the agent dialog or pressing Escape dismisses it immediately, losing all unsaved configuration with no warning.

Fix:
Added onInteractOutside and onEscapeKeyDown handlers to DialogContent in agent-dialog.tsx that call e.preventDefault(), blocking both dismiss paths.

Testing:
Before: Click outside the agent dialog or press Escape mid-configuration → dialog closes, all unsaved changes lost.
After: Click outside or press Escape → dialog stays open, form data preserved.