### PR TITLE
feat: support JSON format in MCP server arguments textarea

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/custom-server-request-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/custom-server-request-dialog.tsx
@@ -4,8 +4,31 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import type { archestraApiTypes } from "@shared";
 import { EnvironmentVariableSchema } from "@shared";
 import { Loader2 } from "lucide-react";
+import { useState } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { z } from "zod";
+
+function parseArgumentsString(value: string): string[] {
+  const trimmed = value.trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith("[") || trimmed.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed.filter(
+          (a: unknown) => typeof a === "string" && a.length > 0,
+        );
+      }
+    } catch {
+      // Fall through to line-by-line
+    }
+  }
+  return trimmed
+    .split("\n")
+    .map((arg) => arg.trim())
+    .filter((arg) => arg.length > 0);
+}
+
 import { EnvironmentVariablesFormField } from "@/components/environment-variables-form-field";
 import { Button } from "@/components/ui/button";
 import {
@@ -71,6 +94,38 @@ export function CustomServerRequestDialog({
   isOpen: boolean;
   onClose: () => void;
 }) {
+  const [argumentsMode, setArgumentsMode] = useState<"line" | "json">("line");
+
+  const switchArgumentsMode = (mode: "line" | "json") => {
+    const currentValue = form.getValues("arguments") || "";
+    if (mode === argumentsMode) return;
+
+    if (mode === "json" && currentValue.trim()) {
+      const lines = currentValue
+        .split("\n")
+        .map((arg: string) => arg.trim())
+        .filter((arg: string) => arg.length > 0);
+      form.setValue("arguments", JSON.stringify(lines, null, 2), {
+        shouldDirty: true,
+      });
+    } else if (mode === "line" && currentValue.trim()) {
+      try {
+        const parsed = JSON.parse(currentValue);
+        if (Array.isArray(parsed)) {
+          form.setValue(
+            "arguments",
+            parsed.filter((a: unknown) => typeof a === "string").join("\n"),
+            { shouldDirty: true },
+          );
+        }
+      } catch {
+        // If not valid JSON, keep as-is
+      }
+    }
+
+    setArgumentsMode(mode);
+  };
+
   const form = useForm<CustomServerRequestFormValues>({
     // biome-ignore lint/suspicious/noExplicitAny: Version mismatch between @hookform/resolvers and Zod
     resolver: zodResolver(customServerRequestSchema as any),
@@ -119,10 +174,7 @@ export function CustomServerRequestDialog({
             serverType: "local" as const,
             localConfig: {
               command: values.command,
-              arguments: values.arguments
-                .split("\n")
-                .map((arg) => arg.trim())
-                .filter((arg) => arg.length > 0),
+              arguments: parseArgumentsString(values.arguments),
               environment:
                 values.environment.length > 0 ? values.environment : undefined,
             },
@@ -276,10 +328,34 @@ export function CustomServerRequestDialog({
                     name="arguments"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>Arguments (one per line)</FormLabel>
+                        <FormLabel>
+                          <div className="flex items-center gap-2">
+                            Arguments
+                            <div className="flex rounded-md border">
+                              <button
+                                type="button"
+                                className={`px-2 py-0.5 text-xs rounded-l-md ${argumentsMode === "line" ? "bg-primary text-primary-foreground" : "hover:bg-muted"}`}
+                                onClick={() => switchArgumentsMode("line")}
+                              >
+                                Line by line
+                              </button>
+                              <button
+                                type="button"
+                                className={`px-2 py-0.5 text-xs rounded-r-md ${argumentsMode === "json" ? "bg-primary text-primary-foreground" : "hover:bg-muted"}`}
+                                onClick={() => switchArgumentsMode("json")}
+                              >
+                                JSON
+                              </button>
+                            </div>
+                          </div>
+                        </FormLabel>
                         <FormControl>
                           <Textarea
-                            placeholder={`/path/to/server.js\n--verbose`}
+                            placeholder={
+                              argumentsMode === "json"
+                                ? `["--verbose", "--port", "3000"]`
+                                : `/path/to/server.js\n--verbose`
+                            }
                             rows={3}
                             {...field}
                           />

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -403,6 +403,39 @@ export function McpCatalogForm({
     }
   }, [authMethod, defaultIdentityProviderId, form, selectedIdentityProviderId]);
 
+  // Arguments input mode state (line-by-line or JSON)
+  const [argumentsMode, setArgumentsMode] = useState<"line" | "json">("line");
+
+  const switchArgumentsMode = (mode: "line" | "json") => {
+    const currentValue = form.getValues("localConfig.arguments") || "";
+    if (mode === argumentsMode) return;
+
+    if (mode === "json" && currentValue.trim()) {
+      const lines = currentValue
+        .split("\n")
+        .map((arg: string) => arg.trim())
+        .filter((arg: string) => arg.length > 0);
+      form.setValue("localConfig.arguments", JSON.stringify(lines, null, 2), {
+        shouldDirty: true,
+      });
+    } else if (mode === "line" && currentValue.trim()) {
+      try {
+        const parsed = JSON.parse(currentValue);
+        if (Array.isArray(parsed)) {
+          form.setValue(
+            "localConfig.arguments",
+            parsed.filter((a: unknown) => typeof a === "string").join("\n"),
+            { shouldDirty: true },
+          );
+        }
+      } catch {
+        // If not valid JSON, keep as-is
+      }
+    }
+
+    setArgumentsMode(mode);
+  };
+
   // BYOS (Bring Your Own Secrets) state for OAuth
   const [oauthVaultTeamId, setOauthVaultTeamId] = useState<string | null>(null);
   const [oauthVaultSecretPath, setOauthVaultSecretPath] = useState<
@@ -1005,12 +1038,34 @@ export function McpCatalogForm({
                     render={({ field }) => (
                       <FormItem>
                         <FormLabel>
-                          Arguments (one per line)
-                          <ReinstallHint show={isArgumentsDirty} />
+                          <div className="flex items-center gap-2">
+                            Arguments
+                            <div className="flex rounded-md border">
+                              <button
+                                type="button"
+                                className={`px-2 py-0.5 text-xs rounded-l-md ${argumentsMode === "line" ? "bg-primary text-primary-foreground" : "hover:bg-muted"}`}
+                                onClick={() => switchArgumentsMode("line")}
+                              >
+                                Line by line
+                              </button>
+                              <button
+                                type="button"
+                                className={`px-2 py-0.5 text-xs rounded-r-md ${argumentsMode === "json" ? "bg-primary text-primary-foreground" : "hover:bg-muted"}`}
+                                onClick={() => switchArgumentsMode("json")}
+                              >
+                                JSON
+                              </button>
+                            </div>
+                            <ReinstallHint show={isArgumentsDirty} />
+                          </div>
                         </FormLabel>
                         <FormControl>
                           <Textarea
-                            placeholder={`/path/to/server.js\n--verbose`}
+                            placeholder={
+                              argumentsMode === "json"
+                                ? `["--verbose", "--port", "3000"]`
+                                : `/path/to/server.js\n--verbose`
+                            }
                             className="font-mono min-h-20"
                             {...field}
                           />

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
@@ -34,13 +34,32 @@ export function transformFormToApiData(
 
   // Handle local configuration
   if (values.serverType === "local" && values.localConfig) {
-    // Parse arguments string into array
-    const argumentsArray = values.localConfig.arguments
-      ? values.localConfig.arguments
+    // Parse arguments string into array (supports both line-by-line and JSON format)
+    let argumentsArray: string[] = [];
+    if (values.localConfig.arguments) {
+      const trimmed = values.localConfig.arguments.trim();
+      if (trimmed.startsWith("[") || trimmed.startsWith("{")) {
+        try {
+          const parsed = JSON.parse(trimmed);
+          if (Array.isArray(parsed)) {
+            argumentsArray = parsed.filter(
+              (a: unknown) => typeof a === "string" && a.length > 0,
+            );
+          }
+        } catch {
+          // If JSON parse fails, fall back to line-by-line
+          argumentsArray = trimmed
+            .split("\n")
+            .map((arg) => arg.trim())
+            .filter((arg) => arg.length > 0);
+        }
+      } else {
+        argumentsArray = trimmed
           .split("\n")
           .map((arg) => arg.trim())
-          .filter((arg) => arg.length > 0)
-      : [];
+          .filter((arg) => arg.length > 0);
+      }
+    }
 
     data.localConfig = {
       command: values.localConfig.command || undefined,


### PR DESCRIPTION
## Fix: Support JSON format in MCP server arguments textarea

Closes #3859

### Problem
Currently in the "Arguments" textarea, only one-line-per-argument format is supported. Most MCP server catalogs display args in JSON format (e.g., ["--verbose", "--port", "3000"]), making it cumbersome to manually convert between formats.

### Solution
Added a **Line by line / JSON** mode toggle to the Arguments textarea:

- **Line by line mode** (default): Original behavior, one argument per line
- **JSON mode**: Accepts JSON array format like ["--verbose", "--port", "3000"]

### Changes
1. **mcp-catalog-form.tsx**: Added mode toggle UI + auto-convert between formats when switching
2. **mcp-catalog-form.utils.ts**: Updated 	ransformFormToApiData() to auto-detect and parse JSON arrays
3. **custom-server-request-dialog.tsx**: Same mode toggle + JSON parsing support

### Behavior
- Switching from LineJSON: auto-converts lines to JSON array
- Switching from JSONLine: auto-converts JSON array to line-separated
- On submit: auto-detects format (starts with [ or {) and parses accordingly
- If JSON parse fails, gracefully falls back to line-by-line parsing
- Backward compatible: existing line-by-line input works exactly as before

### Testing
- Line-by-line input  correctly parsed as before
- JSON array input  correctly parsed to string array
- Mode switching  auto-converts content
- Invalid JSON  falls back to line-by-line