### PR TITLE
fix: return 413 for body-too-large, enrich error logs

### DIFF
--- a/platform/backend/src/server.test.ts
+++ b/platform/backend/src/server.test.ts
@@ -399,6 +399,42 @@ describe("createFastifyInstance", () => {
       expect(body.error.type).toBe("api_validation_error");
       expect(typeof body.error.message).toBe("string");
     });
+
+    test("returns 413 with body-too-large message when payload exceeds limit", async () => {
+      const app = createFastifyInstance();
+      const loggerWarnSpy = vi.spyOn(app.log, "warn");
+
+      // Route-scoped bodyLimit keeps the test payload small while still
+      // exercising the FST_ERR_CTP_BODY_TOO_LARGE branch.
+      app.post("/test-413", { bodyLimit: 100 }, async () => ({ ok: true }));
+
+      const oversized = "x".repeat(500);
+      const response = await app.inject({
+        method: "POST",
+        url: "/test-413",
+        headers: { "content-type": "application/json" },
+        payload: JSON.stringify({ data: oversized }),
+      });
+
+      expect(response.statusCode).toBe(413);
+      const body = response.json();
+      expect(body.error.type).toBe("api_payload_too_large_error");
+      expect(body.error.message).toMatch(/Request body too large/);
+      expect(body.error.message).toMatch(/ARCHESTRA_API_BODY_LIMIT/);
+
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 413,
+          code: "FST_ERR_CTP_BODY_TOO_LARGE",
+          bodyLimit: expect.any(Number),
+          method: "POST",
+          url: "/test-413",
+        }),
+        "HTTP 413 request body too large",
+      );
+
+      loggerWarnSpy.mockRestore();
+    });
   });
 
   describe("logging verification", () => {
@@ -418,7 +454,12 @@ describe("createFastifyInstance", () => {
       });
 
       expect(loggerErrorSpy).toHaveBeenCalledWith(
-        { error: "Server error", statusCode: 500 },
+        expect.objectContaining({
+          error: "Server error",
+          statusCode: 500,
+          method: "GET",
+          url: "/test-500-logging",
+        }),
         "HTTP 50x request error occurred",
       );
 
@@ -441,7 +482,12 @@ describe("createFastifyInstance", () => {
       });
 
       expect(loggerInfoSpy).toHaveBeenCalledWith(
-        { error: "Not found", statusCode: 404 },
+        expect.objectContaining({
+          error: "Not found",
+          statusCode: 404,
+          method: "GET",
+          url: "/test-400-logging",
+        }),
         "HTTP 40x request error occurred",
       );
 
@@ -485,17 +531,21 @@ describe("createFastifyInstance", () => {
       });
 
       expect(loggerErrorSpy).toHaveBeenCalledWith(
-        { error: "Success with error", statusCode: 200 },
+        expect.objectContaining({
+          error: "Success with error",
+          statusCode: 200,
+          method: "GET",
+          url: "/test-low-status-logging",
+        }),
         "HTTP request error occurred",
       );
 
       loggerErrorSpy.mockRestore();
     });
 
-    test("logs standard errors at error level", async () => {
+    test("logs standard errors at error level with request context", async () => {
       const app = createFastifyInstance();
 
-      // Mock the logger error method
       const loggerErrorSpy = vi.spyOn(app.log, "error");
 
       app.get("/test-standard-error-logging", async () => {
@@ -507,9 +557,14 @@ describe("createFastifyInstance", () => {
         url: "/test-standard-error-logging",
       });
 
-      // Standard errors should be logged at error level with 500 status
       expect(loggerErrorSpy).toHaveBeenCalledWith(
-        { error: "Standard error", statusCode: 500 },
+        expect.objectContaining({
+          error: "Standard error",
+          statusCode: 500,
+          method: "GET",
+          url: "/test-standard-error-logging",
+          stack: expect.any(String),
+        }),
         "HTTP 50x request error occurred",
       );
 

--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -27,7 +27,7 @@ import {
   LocalConfigEnvironmentDefaultSchema,
   SUPPORTED_EMBEDDING_DIMENSIONS,
 } from "@shared";
-import Fastify from "fastify";
+import Fastify, { type FastifyRequest } from "fastify";
 import metricsPlugin from "fastify-metrics";
 import {
   createJsonSchemaTransformObject,
@@ -298,6 +298,54 @@ export async function registerWorkerRoutes(fastify: FastifyInstanceWithZod) {
   fastify.register(routes.mcpGatewayRoutes);
 }
 
+/** Fastify code emitted when a request body exceeds the configured limit. */
+const BODY_TOO_LARGE_CODE = "FST_ERR_CTP_BODY_TOO_LARGE";
+
+/**
+ * Extract the route, URL, method, and a sample of headers we want correlated
+ * with every error log line. Without these, "HTTP 50x request error occurred"
+ * is unactionable — you can't tell which endpoint failed or how big the payload
+ * was.
+ */
+function buildRequestErrorContext(request: FastifyRequest) {
+  return {
+    method: request.method,
+    url: request.url,
+    route: request.routeOptions?.url,
+    routeId:
+      (request.routeOptions?.config as { operationId?: string } | undefined)
+        ?.operationId ?? undefined,
+    reqId: request.id,
+    contentLength: parseContentLength(request),
+    contentType: request.headers["content-type"],
+  };
+}
+
+function parseContentLength(request: FastifyRequest): number | undefined {
+  const raw = request.headers["content-length"];
+  if (typeof raw !== "string") return undefined;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function isBodyTooLargeError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const e = error as { code?: string; statusCode?: number };
+  return e.code === BODY_TOO_LARGE_CODE || e.statusCode === 413;
+}
+
+function formatBodyTooLargeMessage(params: {
+  limit: number;
+  contentLength?: number;
+}): string {
+  const limitMb = (params.limit / (1024 * 1024)).toFixed(0);
+  if (params.contentLength !== undefined) {
+    const gotMb = (params.contentLength / (1024 * 1024)).toFixed(1);
+    return `Request body too large: ${gotMb} MB (limit ${limitMb} MB). Use a smaller attachment, or raise ARCHESTRA_API_BODY_LIMIT.`;
+  }
+  return `Request body too large (limit ${limitMb} MB). Use a smaller attachment, or raise ARCHESTRA_API_BODY_LIMIT.`;
+}
+
 /**
  * Sets up logging and zod type provider + request validation & response serialization
  */
@@ -312,7 +360,9 @@ export const createFastifyInstance = () =>
     .setValidatorCompiler(validatorCompiler)
     .setSerializerCompiler(serializerCompiler)
     // https://fastify.dev/docs/latest/Reference/Server/#seterrorhandler
-    .setErrorHandler<ApiError | Error>(function (error, _request, reply) {
+    .setErrorHandler<ApiError | Error>(function (error, request, reply) {
+      const requestContext = buildRequestErrorContext(request);
+
       // Handle response serialization errors (when response doesn't match schema)
       if (isResponseSerializationError(error)) {
         const issues = error.cause?.issues ?? [];
@@ -324,6 +374,7 @@ export const createFastifyInstance = () =>
 
         this.log.error(
           {
+            ...requestContext,
             statusCode: 500,
             method: error.method,
             url: error.url,
@@ -356,7 +407,7 @@ export const createFastifyInstance = () =>
       if (hasZodFastifySchemaValidationErrors(error)) {
         const message = error.message || "Validation error";
         this.log.info(
-          { error: message, statusCode: 400 },
+          { ...requestContext, error: message, statusCode: 400 },
           "HTTP 400 validation error occurred",
         );
 
@@ -368,25 +419,50 @@ export const createFastifyInstance = () =>
         });
       }
 
+      // Handle Fastify "body too large" before the generic Error branch so it
+      // returns 413 (not 500) with a message that names the limit and observed
+      // size. The frontend chat-error mapper picks up `error.message`, so a
+      // useful text here flows straight into the UI.
+      if (isBodyTooLargeError(error)) {
+        const limit = config.api.bodyLimit;
+        const contentLength = parseContentLength(request);
+        const message = formatBodyTooLargeMessage({ limit, contentLength });
+
+        this.log.warn(
+          {
+            ...requestContext,
+            statusCode: 413,
+            code: (error as { code?: string }).code ?? BODY_TOO_LARGE_CODE,
+            bodyLimit: limit,
+            contentLength,
+          },
+          "HTTP 413 request body too large",
+        );
+
+        return reply.status(413).send({
+          error: {
+            message,
+            type: "api_payload_too_large_error",
+          },
+        });
+      }
+
       // Handle ApiError objects
       if (error instanceof ApiError) {
         const { statusCode, message, type, internalCode } = error;
+        const logPayload = {
+          ...requestContext,
+          error: message,
+          statusCode,
+          ...(internalCode && { internalCode }),
+        };
 
         if (statusCode >= 500) {
-          this.log.error(
-            { error: message, statusCode },
-            "HTTP 50x request error occurred",
-          );
+          this.log.error(logPayload, "HTTP 50x request error occurred");
         } else if (statusCode >= 400) {
-          this.log.info(
-            { error: message, statusCode },
-            "HTTP 40x request error occurred",
-          );
+          this.log.info(logPayload, "HTTP 40x request error occurred");
         } else {
-          this.log.error(
-            { error: message, statusCode },
-            "HTTP request error occurred",
-          );
+          this.log.error(logPayload, "HTTP request error occurred");
         }
 
         return reply.status(statusCode).send({
@@ -401,9 +477,16 @@ export const createFastifyInstance = () =>
       // Handle standard Error objects
       const message = error.message || "Internal server error";
       const statusCode = 500;
+      const errorCode = (error as { code?: string }).code;
 
       this.log.error(
-        { error: message, statusCode },
+        {
+          ...requestContext,
+          error: message,
+          statusCode,
+          ...(errorCode && { code: errorCode }),
+          stack: error.stack,
+        },
         "HTTP 50x request error occurred",
       );
 

--- a/platform/frontend/src/components/chat/chat-error.utils.test.ts
+++ b/platform/frontend/src/components/chat/chat-error.utils.test.ts
@@ -222,5 +222,45 @@ describe("chat-error.utils", () => {
         isRetryable: RetryableErrorCodes.has(ChatErrorCode.Unknown),
       });
     });
+
+    it("maps api_payload_too_large_error to InvalidRequest with backend message", () => {
+      const backendMessage =
+        "Request body too large: 65.0 MB (limit 50 MB). Use a smaller attachment, or raise ARCHESTRA_API_BODY_LIMIT.";
+      expect(
+        mapClientError(
+          new Error(
+            JSON.stringify({
+              error: {
+                message: backendMessage,
+                type: "api_payload_too_large_error",
+              },
+            }),
+          ),
+        ),
+      ).toEqual({
+        code: ChatErrorCode.InvalidRequest,
+        message: backendMessage,
+        isRetryable: RetryableErrorCodes.has(ChatErrorCode.InvalidRequest),
+      });
+    });
+
+    it("maps api_internal_server_error to retryable ServerError", () => {
+      expect(
+        mapClientError(
+          new Error(
+            JSON.stringify({
+              error: {
+                message: "Database connection failed",
+                type: "api_internal_server_error",
+              },
+            }),
+          ),
+        ),
+      ).toEqual({
+        code: ChatErrorCode.ServerError,
+        message: "Database connection failed",
+        isRetryable: RetryableErrorCodes.has(ChatErrorCode.ServerError),
+      });
+    });
   });
 });

--- a/platform/frontend/src/components/chat/chat-error.utils.ts
+++ b/platform/frontend/src/components/chat/chat-error.utils.ts
@@ -118,9 +118,24 @@ const CLIENT_ERROR_PATTERNS: Array<{
 ];
 
 /**
+ * Map backend ApiError `type` values to normalized ChatErrorCodes so the inline
+ * error card shows the right badge (code, retryable) regardless of which API
+ * route bounced the request. The backend message is shown verbatim — it's
+ * already user-friendly (e.g. "Request body too large: 65 MB (limit 50 MB)").
+ */
+const BACKEND_ERROR_TYPE_TO_CODE: Record<string, ChatErrorCode> = {
+  api_payload_too_large_error: ChatErrorCode.InvalidRequest,
+  api_validation_error: ChatErrorCode.InvalidRequest,
+  api_authentication_error: ChatErrorCode.Authentication,
+  api_authorization_error: ChatErrorCode.PermissionDenied,
+  api_not_found_error: ChatErrorCode.NotFound,
+  api_internal_server_error: ChatErrorCode.ServerError,
+};
+
+/**
  * Map unstructured errors to a ChatErrorResponse so they display with the
  * same styled error card. Recognizes known client-side patterns (network errors,
- * aborts) and falls back to a generic error for anything else.
+ * aborts), known backend error envelopes, and falls back to a generic error.
  */
 export function mapClientError(error: Error): ChatErrorResponse {
   const msg = error.message;
@@ -135,20 +150,28 @@ export function mapClientError(error: Error): ChatErrorResponse {
     }
   }
 
-  // Try to extract message from backend's { error: { message } } format
+  // Try to extract message + type from backend's { error: { message, type } } format
   let displayMessage = msg;
+  let backendType: string | undefined;
   try {
     const parsed = JSON.parse(msg);
     if (parsed?.error?.message) {
       displayMessage = parsed.error.message;
     }
+    if (typeof parsed?.error?.type === "string") {
+      backendType = parsed.error.type;
+    }
   } catch {
     // Not JSON, use as-is
   }
 
+  const mappedCode = backendType
+    ? BACKEND_ERROR_TYPE_TO_CODE[backendType]
+    : undefined;
+  const code = mappedCode ?? ChatErrorCode.Unknown;
   return {
-    code: ChatErrorCode.Unknown,
-    message: displayMessage || ChatErrorMessages[ChatErrorCode.Unknown],
-    isRetryable: RetryableErrorCodes.has(ChatErrorCode.Unknown),
+    code,
+    message: displayMessage || ChatErrorMessages[code],
+    isRetryable: RetryableErrorCodes.has(code),
   };
 }

--- a/platform/shared/types.ts
+++ b/platform/shared/types.ts
@@ -28,6 +28,7 @@ export const ApiErrorTypeSchema = z.enum([
   "api_not_found_error",
   "unknown_api_error",
   "api_conflict_error",
+  "api_payload_too_large_error",
 ]);
 
 /**
@@ -61,6 +62,9 @@ export class ApiError extends Error {
         break;
       case 409:
         this.type = "api_conflict_error";
+        break;
+      case 413:
+        this.type = "api_payload_too_large_error";
         break;
       default:
         this.type = "unknown_api_error";


### PR DESCRIPTION
Oversized request bodies were returning 500 with a terse `"Request body is too large"` log line and no useful details in the frontend chat UI.

- Detect `FST_ERR_CTP_BODY_TOO_LARGE` in the global Fastify error handler and return 413 with a message naming the limit and observed Content-Length.
- All error log branches now include `method`, `url`, `route`, `routeId`, `reqId`, `contentLength`, `contentType`. 413 logs add `bodyLimit` + Fastify code; generic Errors add `code` + `stack`.
- Frontend `mapClientError` maps backend `error.type` values (`api_payload_too_large_error`, etc.) to normalized `ChatErrorCode`s so the inline error card renders the right code/retryable badge with the backend message verbatim.

close https://github.com/archestra-ai/archestra/issues/4741

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>