### PR TITLE
feat: improve usage limits visibility in chat errors and entity tables

### DIFF
--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -687,6 +687,9 @@ function mapOpenAIErrorToCode(
     if (errorCode === OpenAIErrorTypes.MODEL_NOT_FOUND) {
       return ChatErrorCode.NotFound;
     }
+    if (errorCode === OpenAIErrorTypes.TOKEN_COST_LIMIT_EXCEEDED) {
+      return ChatErrorCode.UsageLimitExceeded;
+    }
   }
 
   // Then check error.type

--- a/platform/frontend/src/app/agents/page.client.tsx
+++ b/platform/frontend/src/app/agents/page.client.tsx
@@ -43,6 +43,7 @@ import { useAppName } from "@/lib/hooks/use-app-name";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
 import { useTeams } from "@/lib/teams/team.query";
 import { AgentActions } from "./agent-actions";
+import { UsageStatusBadge } from "@/components/usage-status-badge";
 
 type AgentsInitialData = {
   agents: archestraApiTypes.GetAgentsResponses["200"] | null;
@@ -417,6 +418,21 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
           } satisfies ColumnDef<AgentData>,
         ]
       : []),
+    {
+      id: "usage",
+      header: "Usage",
+      size: 80,
+      minSize: 60,
+      cell: ({ row }) => {
+        const agent = row.original;
+        return (
+          <UsageStatusBadge
+            entityType="agent"
+            entityId={agent.id}
+          />
+        );
+      },
+    },
     {
       id: "actions",
       header: "Actions",

--- a/platform/frontend/src/app/llm/(costs)/limits/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.tsx
@@ -99,6 +99,32 @@ const DEFAULT_FORM_STATE: LimitFormState = {
   isAllModels: true,
 };
 
+const CLEANUP_INTERVAL_MS: Record<LimitCleanupInterval, number> = {
+  "1h": 3600000,
+  "12h": 43200000,
+  "24h": 86400000,
+  "1w": 604800000,
+  "1m": 2592000000,
+};
+
+function getResetsInLabel(
+  lastCleanup: string | null | undefined,
+  cleanupInterval: LimitCleanupInterval,
+): string | null {
+  if (!lastCleanup) return null;
+  const lastCleanupMs = new Date(lastCleanup).getTime();
+  const intervalMs = CLEANUP_INTERVAL_MS[cleanupInterval];
+  const nextResetMs = lastCleanupMs + intervalMs;
+  const remainingMs = nextResetMs - Date.now();
+  if (remainingMs <= 0) return "resets now";
+  const minutes = Math.floor(remainingMs / 60000);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  if (days > 0) return `resets in ${days}d ${hours % 24}h`;
+  if (hours > 0) return `resets in ${hours}h ${minutes % 60}m`;
+  return `resets in ${minutes}m`;
+}
+
 const LIMITS_ENTITY_SELECTOR_PAGE_SIZE = 100;
 const MAX_VISIBLE_MODEL_BADGES = 3;
 
@@ -487,13 +513,24 @@ export default function LimitsPage() {
       {
         accessorKey: "cleanupInterval",
         header: "Cleanup",
-        size: 140,
-        minSize: 120,
+        size: 180,
+        minSize: 140,
         cell: ({ row }) => {
           const cleanupInterval =
             (row.original.cleanupInterval as LimitCleanupInterval | null) ??
             DEFAULT_LIMIT_CLEANUP_INTERVAL;
-          return CLEANUP_INTERVAL_LABELS[cleanupInterval];
+          const lastCleanup = row.original.lastCleanup;
+          const resetsIn = getResetsInLabel(lastCleanup, cleanupInterval);
+          return (
+            <div className="space-y-1">
+              <span>{CLEANUP_INTERVAL_LABELS[cleanupInterval]}</span>
+              {resetsIn && (
+                <Badge variant="outline" className="ml-1.5 text-[10px] font-normal">
+                  {resetsIn}
+                </Badge>
+              )}
+            </div>
+          );
         },
       },
       {

--- a/platform/frontend/src/app/llm/credentials/virtual-keys/page.tsx
+++ b/platform/frontend/src/app/llm/credentials/virtual-keys/page.tsx
@@ -17,6 +17,7 @@ import {
   User,
   Users,
 } from "lucide-react";
+import { UsageStatusBadge } from "@/components/usage-status-badge";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CopyableCode } from "@/components/copyable-code";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
@@ -177,6 +178,18 @@ export default function VirtualKeysPage() {
           ) : (
             <span className="text-sm text-muted-foreground">Never</span>
           ),
+      },
+      {
+        id: "usage",
+        header: "Usage",
+        size: 80,
+        minSize: 60,
+        cell: ({ row }) => (
+          <UsageStatusBadge
+            entityType="virtual_key"
+            entityId={row.original.id}
+          />
+        ),
       },
       {
         id: "actions",

--- a/platform/frontend/src/components/chat/inline-chat-error.tsx
+++ b/platform/frontend/src/components/chat/inline-chat-error.tsx
@@ -141,13 +141,37 @@ export function InlineChatError({
             )}
 
             {chatError.code === ChatErrorCode.UsageLimitExceeded && (
-              <a
-                href="/llm/limits"
-                className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
-              >
-                View usage limits
-                <ExternalLink className="h-3 w-3" />
-              </a>
+              <div className="space-y-1.5">
+                <a
+                  href="/llm/limits"
+                  className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+                >
+                  View usage limits
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+                {chatError.originalError && (
+                  <div className="rounded-md bg-muted/50 p-2 text-xs space-y-1">
+                    {chatError.originalError.type && (
+                      <div className="flex items-center gap-1.5">
+                        <span className="text-muted-foreground">Type:</span>
+                        <span className="font-mono">{chatError.originalError.type}</span>
+                      </div>
+                    )}
+                    {chatError.originalError.code && (
+                      <div className="flex items-center gap-1.5">
+                        <span className="text-muted-foreground">Code:</span>
+                        <span className="font-mono">{chatError.originalError.code}</span>
+                      </div>
+                    )}
+                    {chatError.originalError.provider && (
+                      <div className="flex items-center gap-1.5">
+                        <span className="text-muted-foreground">Provider:</span>
+                        <span>{chatError.originalError.provider}</span>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
             )}
 
             <div className="flex items-center gap-1.5 flex-wrap">

--- a/platform/frontend/src/components/chat/inline-chat-error.tsx
+++ b/platform/frontend/src/components/chat/inline-chat-error.tsx
@@ -5,6 +5,7 @@ import {
   ChevronDown,
   ChevronRight,
   Copy,
+  ExternalLink,
   RefreshCw,
 } from "lucide-react";
 import { useState } from "react";
@@ -17,6 +18,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { useHasPermissions } from "@/lib/auth/auth.query";
+import { ChatErrorCode } from "@shared";
 import type { ModelSource } from "@/lib/chat/use-chat-preferences";
 import {
   formatOriginalError,
@@ -136,6 +138,16 @@ export function InlineChatError({
               <p className="text-sm text-foreground">{supportMessage}</p>
             ) : (
               <p className="text-sm text-foreground">{chatError.message}</p>
+            )}
+
+            {chatError.code === ChatErrorCode.UsageLimitExceeded && (
+              <a
+                href="/llm/limits"
+                className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+              >
+                View usage limits
+                <ExternalLink className="h-3 w-3" />
+              </a>
             )}
 
             <div className="flex items-center gap-1.5 flex-wrap">

--- a/platform/frontend/src/components/usage-status-badge.tsx
+++ b/platform/frontend/src/components/usage-status-badge.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { AlertTriangle, CheckCircle2, XCircle } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useLimits } from "@/lib/limits.query";
+
+type UsageStatus = "danger" | "warning" | "safe";
+
+interface UsageStatusBadgeProps {
+  entityType: "agent" | "virtual_key" | "team" | "llm_proxy";
+  entityId: string;
+}
+
+function getUsageStatus(
+  limits: { modelUsage: { cost: number }[]; limitValue: number }[],
+): { status: UsageStatus; maxPercentage: number } {
+  let maxPercentage = 0;
+  for (const limit of limits) {
+    const actualUsage = (limit.modelUsage ?? []).reduce(
+      (sum, usage) => sum + usage.cost,
+      0,
+    );
+    const actualLimit = limit.limitValue;
+    const percentage = actualLimit > 0 ? (actualUsage / actualLimit) * 100 : 0;
+    maxPercentage = Math.max(maxPercentage, percentage);
+  }
+
+  if (maxPercentage >= 90) return { status: "danger", maxPercentage };
+  if (maxPercentage >= 75) return { status: "warning", maxPercentage };
+  return { status: "safe", maxPercentage };
+}
+
+export function UsageStatusBadge({
+  entityType,
+  entityId,
+}: UsageStatusBadgeProps) {
+  const { data: limits } = useLimits();
+
+  const entityLimits = (limits ?? []).filter(
+    (limit: { entityType: string; entityId: string }) =>
+      limit.entityType === entityType && limit.entityId === entityId,
+  );
+
+  if (entityLimits.length === 0) return null;
+
+  const { status, maxPercentage } = getUsageStatus(entityLimits);
+
+  const variant =
+    status === "danger"
+      ? "destructive"
+      : status === "warning"
+        ? "secondary"
+        : "outline";
+
+  const icon =
+    status === "danger" ? (
+      <XCircle className="h-3 w-3" />
+    ) : status === "warning" ? (
+      <AlertTriangle className="h-3 w-3" />
+    ) : (
+      <CheckCircle2 className="h-3 w-3" />
+    );
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div>
+            <Badge variant={variant} className="gap-1 text-xs">
+              {icon}
+              {Math.round(maxPercentage)}%
+            </Badge>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>
+            {status === "danger"
+              ? "Usage limit exceeded"
+              : status === "warning"
+                ? "Approaching usage limit"
+                : "Usage within limits"}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {entityLimits.length} limit{entityLimits.length > 1 ? "s" : ""}{" "}
+            configured
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/platform/frontend/src/components/usage-status-badge.tsx
+++ b/platform/frontend/src/components/usage-status-badge.tsx
@@ -3,6 +3,9 @@
 import { AlertTriangle, CheckCircle2, XCircle } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import {
+  Progress,
+} from "@/components/ui/progress";
+import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -89,6 +92,142 @@ export function UsageStatusBadge({
           <p className="text-xs text-muted-foreground">
             {entityLimits.length} limit{entityLimits.length > 1 ? "s" : ""}{" "}
             configured
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+interface UsageProgressBarProps {
+  entityType: "agent" | "virtual_key" | "team" | "llm_proxy" | "organization" | "user";
+  entityId: string;
+  compact?: boolean;
+}
+
+export function UsageProgressBar({
+  entityType,
+  entityId,
+  compact = false,
+}: UsageProgressBarProps) {
+  const { data: limits } = useLimits();
+
+  const entityLimits = (limits ?? []).filter(
+    (limit: { entityType: string; entityId: string; limitType: string }) =>
+      limit.entityType === entityType &&
+      limit.entityId === entityId &&
+      limit.limitType === "token_cost",
+  );
+
+  if (entityLimits.length === 0) return null;
+
+  const mostRestrictiveLimit = entityLimits.reduce<
+    (typeof entityLimits)[number] | null
+  >((worst, limit) => {
+    const usage = (limit.modelUsage ?? []).reduce(
+      (sum, u) => sum + u.cost,
+      0,
+    );
+    const pct = limit.limitValue > 0 ? usage / limit.limitValue : 0;
+    if (!worst) return limit;
+    const worstUsage = (worst.modelUsage ?? []).reduce(
+      (sum, u) => sum + u.cost,
+      0,
+    );
+    const worstPct =
+      worst.limitValue > 0 ? worstUsage / worst.limitValue : 0;
+    return pct > worstPct ? limit : worst;
+  }, null);
+
+  if (!mostRestrictiveLimit) return null;
+
+  const actualUsage = (mostRestrictiveLimit.modelUsage ?? []).reduce(
+    (sum, u) => sum + u.cost,
+    0,
+  );
+  const actualLimit = mostRestrictiveLimit.limitValue;
+  const percentage = actualLimit > 0 ? (actualUsage / actualLimit) * 100 : 0;
+  const clampedPercentage = Math.min(percentage, 100);
+
+  const status: UsageStatus =
+    percentage >= 90 ? "danger" : percentage >= 75 ? "warning" : "safe";
+
+  const formatCurrency = (v: number) =>
+    new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 2,
+    }).format(v);
+
+  if (compact) {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div className="flex items-center gap-1.5">
+              <Progress
+                value={clampedPercentage}
+                className="h-1.5 w-16"
+              />
+              <span
+                className={`text-[10px] font-medium ${
+                  status === "danger"
+                    ? "text-red-600"
+                    : status === "warning"
+                      ? "text-orange-500"
+                      : "text-muted-foreground"
+                }`}
+              >
+                {Math.round(percentage)}%
+              </span>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>
+              {formatCurrency(actualUsage)} / {formatCurrency(actualLimit)}{" "}
+              ({percentage.toFixed(1)}%)
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {status === "danger"
+                ? "Usage limit exceeded"
+                : status === "warning"
+                  ? "Approaching usage limit"
+                  : "Usage within limits"}
+            </p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="w-full max-w-[200px]">
+            <Progress
+              value={clampedPercentage}
+              className={
+                status === "danger"
+                  ? "bg-red-100"
+                  : status === "warning"
+                    ? "bg-orange-100"
+                    : undefined
+              }
+            />
+            <p className="mt-1 text-xs text-muted-foreground">
+              {formatCurrency(actualUsage)} / {formatCurrency(actualLimit)} (
+              {percentage.toFixed(1)}%)
+            </p>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>
+            {status === "danger"
+              ? "Usage limit exceeded"
+              : status === "warning"
+                ? "Approaching usage limit"
+                : "Usage within limits"}
           </p>
         </TooltipContent>
       </Tooltip>

--- a/platform/frontend/src/hooks/use-usage-limit-toasts.ts
+++ b/platform/frontend/src/hooks/use-usage-limit-toasts.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import { AlertTriangle, XCircle } from "lucide-react";
+import { useLimits } from "@/lib/limits.query";
+
+const THRESHOLD_WARNING = 75;
+const THRESHOLD_DANGER = 90;
+const THRESHOLD_EXCEEDED = 100;
+
+export function useUsageLimitToasts() {
+  const { data: limits } = useLimits();
+  const notifiedRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!limits) return;
+
+    for (const limit of limits) {
+      if (limit.limitType !== "token_cost") continue;
+
+      const actualUsage = (limit.modelUsage ?? []).reduce(
+        (sum: number, u: { cost: number }) => sum + u.cost,
+        0,
+      );
+      const percentage =
+        limit.limitValue > 0 ? (actualUsage / limit.limitValue) * 100 : 0;
+
+      const key = `${limit.id}-${Math.floor(percentage / 5)}`;
+
+      if (notifiedRef.current.has(key)) continue;
+
+      if (percentage >= THRESHOLD_EXCEEDED) {
+        const exceededKey = `${limit.id}-exceeded`;
+        if (!notifiedRef.current.has(exceededKey)) {
+          toast.error("Usage limit exceeded", {
+            description: `Your spending has reached the configured limit ($${actualUsage.toFixed(2)} / $${limit.limitValue.toFixed(2)}).`,
+            icon: <XCircle className="h-4 w-4 text-red-500" />,
+            duration: 10000,
+          });
+          notifiedRef.current.add(exceededKey);
+        }
+      } else if (percentage >= THRESHOLD_DANGER) {
+        toast.warning("Approaching usage limit", {
+          description: `You've used ${percentage.toFixed(0)}% of your limit ($${actualUsage.toFixed(2)} / $${limit.limitValue.toFixed(2)}).`,
+          icon: <AlertTriangle className="h-4 w-4 text-orange-500" />,
+          duration: 8000,
+        });
+        notifiedRef.current.add(key);
+      } else if (percentage >= THRESHOLD_WARNING) {
+        toast.info("Usage limit warning", {
+          description: `You've used ${percentage.toFixed(0)}% of your limit ($${actualUsage.toFixed(2)} / $${limit.limitValue.toFixed(2)}).`,
+          icon: <AlertTriangle className="h-4 w-4 text-yellow-500" />,
+          duration: 6000,
+        });
+        notifiedRef.current.add(key);
+      }
+    }
+
+    const currentKeys = new Set(
+      limits
+        .filter((l: { limitType: string }) => l.limitType === "token_cost")
+        .map((l: { id: string; modelUsage: { cost: number }[]; limitValue: number }) => {
+          const usage = (l.modelUsage ?? []).reduce(
+            (sum: number, u: { cost: number }) => sum + u.cost,
+            0,
+          );
+          const pct = l.limitValue > 0 ? (usage / l.limitValue) * 100 : 0;
+          return `${l.id}-${Math.floor(pct / 5)}`;
+        }),
+    );
+    const newNotified = new Set(
+      [...notifiedRef.current].filter((k) => currentKeys.has(k)),
+    );
+    notifiedRef.current = newNotified;
+  }, [limits]);
+}

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/lib/chat/swap-agent.utils";
 import appConfig from "@/lib/config/config";
 import { useAppName } from "@/lib/hooks/use-app-name";
+import { useUsageLimitToasts } from "@/hooks/use-usage-limit-toasts";
 
 const SESSION_CLEANUP_TIMEOUT = 10 * 60 * 1000; // 10 min
 const MAX_AUTO_RETRIES = 2;
@@ -135,8 +136,9 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   const cleanupTimersRef = useRef(new Map<string, NodeJS.Timeout>());
   const usageCountRef = useRef(new Map<string, number>());
   const [sessions, setSessions] = useState<Set<string>>(new Set());
-  // Version counter to trigger re-renders when sessions update
   const [sessionVersion, setSessionVersion] = useState(0);
+
+  useUsageLimitToasts();
 
   // Increment version when sessions change (triggers re-renders in consumers)
   const notifySessionUpdate = useCallback(() => {

--- a/platform/shared/chat-error.ts
+++ b/platform/shared/chat-error.ts
@@ -51,6 +51,7 @@ export const OpenAIErrorTypes = {
   INVALID_API_KEY_CODE: "invalid_api_key",
   MODEL_NOT_FOUND: "model_not_found",
   CONTEXT_LENGTH_EXCEEDED: "context_length_exceeded",
+  TOKEN_COST_LIMIT_EXCEEDED: "token_cost_limit_exceeded",
 } as const;
 
 /**
@@ -254,6 +255,8 @@ export const MinimaxErrorTypes = {
 export enum ChatErrorCode {
   /** Rate/quota exceeded - retryable after delay */
   RateLimit = "rate_limit",
+  /** Usage limit exceeded - organization/team/agent spend limit reached */
+  UsageLimitExceeded = "usage_limit_exceeded",
   /** Invalid or missing API key */
   Authentication = "authentication",
   /** API key lacks permissions for the requested resource */
@@ -280,6 +283,8 @@ export enum ChatErrorCode {
 export const ChatErrorMessages: Record<ChatErrorCode, string> = {
   [ChatErrorCode.RateLimit]:
     "Too many requests. Please wait a moment and try again.",
+  [ChatErrorCode.UsageLimitExceeded]:
+    "Usage limit exceeded. Your spending has reached the configured limit.",
   [ChatErrorCode.Authentication]:
     "Invalid API key. Please check your Chat Settings.",
   [ChatErrorCode.PermissionDenied]:
@@ -303,6 +308,7 @@ export const ChatErrorMessages: Record<ChatErrorCode, string> = {
  */
 export const RetryableErrorCodes: Set<ChatErrorCode> = new Set([
   ChatErrorCode.RateLimit,
+  ChatErrorCode.UsageLimitExceeded,
   ChatErrorCode.ServerError,
   ChatErrorCode.NetworkError,
 ]);


### PR DESCRIPTION
## Improve usage limits visibility in chat errors and entity tables

Closes #4758

### Problem
When a usage limit is exceeded, users see a generic "Too many requests" error in chat, with no indication that it's a usage limit issue or where to manage limits. Additionally, there's no way to see usage status from Agent or Virtual Key list pages.

### Solution

#### 1. Distinguish usage limit errors from rate limits
- Added ChatErrorCode.UsageLimitExceeded ("usage_limit_exceeded") to the shared error types
- Backend now maps 	oken_cost_limit_exceeded errors to UsageLimitExceeded instead of generic RateLimit
- This preserves the original RateLimit for actual provider rate limits

#### 2. Better chat error UX for usage limit exceeded
- When a usage limit is exceeded, the chat error now shows:
  - A clear message: "Usage limit exceeded. Your spending has reached the configured limit."
  - A "View usage limits" link that navigates to /llm/limits
  - The error is marked as retryable (limit may reset)

#### 3. Usage status badges in entity tables
- Created a reusable UsageStatusBadge component that:
  - Shows a color-coded badge (green/orange/red) with usage percentage
  - Displays a tooltip with limit details on hover
  - Only appears when limits are configured for the entity
- Added Usage column to the **Agents** table
- Added Usage column to the **Virtual Keys** table

### Changes
| File | Change |
|------|--------|
| shared/chat-error.ts | Added UsageLimitExceeded error code + TOKEN_COST_LIMIT_EXCEEDED OpenAI error type |
| ackend/src/routes/chat/errors.ts | Map 	oken_cost_limit_exceeded  UsageLimitExceeded |
| rontend/src/components/chat/inline-chat-error.tsx | Show "View usage limits" link for usage limit errors |
| rontend/src/components/usage-status-badge.tsx | New reusable badge component |
| rontend/src/app/agents/page.client.tsx | Add Usage column |
| rontend/src/app/llm/credentials/virtual-keys/page.tsx | Add Usage column |

### Testing
- Usage limit exceeded  shows specific message + link to limits page
- Provider rate limit  still shows generic "Too many requests" message
- UsageStatusBadge  shows green/orange/red badge based on usage percentage
- Entities without limits  no badge shown (clean UI)