### PR TITLE
feat: add site announcements and maintenance mode

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -666,6 +666,11 @@ The following environment variables can be used to configure Archestra Platform.
   - Requires wildcard DNS (`*.mcp.example.com`) and wildcard TLS certificate pointing to the backend
   - See [MCP Apps Sandbox](#mcp-apps-sandbox) for setup instructions
 
+- **`ARCHESTRA_MAINTENANCE_MODE_MESSAGE`** - Enables deployment maintenance mode and displays this message to users instead of the main application.
+  - Default: unset (maintenance mode disabled)
+  - Example: `Archestra is being upgraded and will be back in a few minutes.`
+  - API routes, static assets, websocket paths, and the maintenance page itself are not rewritten
+
 - **`ARCHESTRA_GLOBAL_TOOL_POLICY`** - Controls how tool invocation is treated across the LLM proxy.
   - Default: `permissive`
   - Values: `permissive` or `restrictive`

--- a/platform/backend/src/database/migrations/0249_site_announcement.sql
+++ b/platform/backend/src/database/migrations/0249_site_announcement.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "site_announcement" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" text NOT NULL,
+	"markdown" text NOT NULL,
+	"expires_at" timestamp,
+	"created_by_user_id" text,
+	"updated_by_user_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "site_announcement_organization_unique" UNIQUE("organization_id")
+);
+--> statement-breakpoint
+ALTER TABLE "site_announcement" ADD CONSTRAINT "site_announcement_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "site_announcement" ADD CONSTRAINT "site_announcement_created_by_user_id_user_id_fk" FOREIGN KEY ("created_by_user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "site_announcement" ADD CONSTRAINT "site_announcement_updated_by_user_id_user_id_fk" FOREIGN KEY ("updated_by_user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "site_announcement_org_idx" ON "site_announcement" USING btree ("organization_id");

--- a/platform/backend/src/database/migrations/meta/_journal.json
+++ b/platform/backend/src/database/migrations/meta/_journal.json
@@ -1744,6 +1744,13 @@
       "when": 1779363279761,
       "tag": "0248_massive_sleeper",
       "breakpoints": true
+    },
+    {
+      "idx": 249,
+      "version": "7",
+      "when": 1779276000000,
+      "tag": "0249_site_announcement",
+      "breakpoints": true
     }
   ]
 }

--- a/platform/backend/src/database/schemas/index.ts
+++ b/platform/backend/src/database/schemas/index.ts
@@ -70,6 +70,7 @@ export { default as secretsTable } from "./secret";
 export { default as sessionsTable } from "./session";
 export { default as skillsTable } from "./skill";
 export { default as skillFilesTable } from "./skill-file";
+export { default as siteAnnouncementsTable } from "./site-announcement";
 export { default as tasksTable } from "./task";
 export { team as teamsTable, teamMember as teamMembersTable } from "./team";
 export { default as teamExternalGroupsTable } from "./team-external-group";

--- a/platform/backend/src/database/schemas/site-announcement.ts
+++ b/platform/backend/src/database/schemas/site-announcement.ts
@@ -1,0 +1,42 @@
+import {
+  index,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uuid,
+} from "drizzle-orm/pg-core";
+import organizationsTable from "./organization";
+import usersTable from "./user";
+
+const siteAnnouncementsTable = pgTable(
+  "site_announcement",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizationsTable.id, { onDelete: "cascade" }),
+    markdown: text("markdown").notNull(),
+    expiresAt: timestamp("expires_at", { mode: "date" }),
+    createdByUserId: text("created_by_user_id").references(
+      () => usersTable.id,
+      {
+        onDelete: "set null",
+      },
+    ),
+    updatedByUserId: text("updated_by_user_id").references(
+      () => usersTable.id,
+      {
+        onDelete: "set null",
+      },
+    ),
+    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { mode: "date" }).notNull().defaultNow(),
+  },
+  (table) => [
+    unique("site_announcement_organization_unique").on(table.organizationId),
+    index("site_announcement_org_idx").on(table.organizationId),
+  ],
+);
+
+export default siteAnnouncementsTable;

--- a/platform/backend/src/models/index.ts
+++ b/platform/backend/src/models/index.ts
@@ -54,6 +54,7 @@ export { default as SecretModel } from "./secret";
 export { default as SessionModel } from "./session";
 export { default as SkillModel } from "./skill";
 export { default as SkillFileModel } from "./skill-file";
+export { default as SiteAnnouncementModel } from "./site-announcement";
 export { default as StatisticsModel } from "./statistics";
 export { default as TaskModel } from "./task";
 export { default as TeamModel } from "./team";

--- a/platform/backend/src/models/site-announcement.ts
+++ b/platform/backend/src/models/site-announcement.ts
@@ -1,0 +1,73 @@
+import { and, eq, gt, isNull, or, sql } from "drizzle-orm";
+import db, { schema } from "@/database";
+
+class SiteAnnouncementModel {
+  static async getForOrganization(organizationId: string) {
+    const [row] = await db
+      .select()
+      .from(schema.siteAnnouncementsTable)
+      .where(eq(schema.siteAnnouncementsTable.organizationId, organizationId))
+      .limit(1);
+
+    return row ?? null;
+  }
+
+  static async getActiveForOrganization(organizationId: string) {
+    const now = new Date();
+    const [row] = await db
+      .select()
+      .from(schema.siteAnnouncementsTable)
+      .where(
+        and(
+          eq(schema.siteAnnouncementsTable.organizationId, organizationId),
+          or(
+            isNull(schema.siteAnnouncementsTable.expiresAt),
+            gt(schema.siteAnnouncementsTable.expiresAt, now),
+          ),
+        ),
+      )
+      .limit(1);
+
+    return row ?? null;
+  }
+
+  static async upsert(params: {
+    organizationId: string;
+    markdown: string;
+    expiresAt: Date | null;
+    userId: string;
+  }) {
+    const [row] = await db
+      .insert(schema.siteAnnouncementsTable)
+      .values({
+        organizationId: params.organizationId,
+        markdown: params.markdown,
+        expiresAt: params.expiresAt,
+        createdByUserId: params.userId,
+        updatedByUserId: params.userId,
+      })
+      .onConflictDoUpdate({
+        target: schema.siteAnnouncementsTable.organizationId,
+        set: {
+          markdown: params.markdown,
+          expiresAt: params.expiresAt,
+          updatedByUserId: params.userId,
+          updatedAt: sql`now()`,
+        },
+      })
+      .returning();
+
+    return row;
+  }
+
+  static async delete(organizationId: string): Promise<boolean> {
+    const deleted = await db
+      .delete(schema.siteAnnouncementsTable)
+      .where(eq(schema.siteAnnouncementsTable.organizationId, organizationId))
+      .returning({ id: schema.siteAnnouncementsTable.id });
+
+    return deleted.length > 0;
+  }
+}
+
+export default SiteAnnouncementModel;

--- a/platform/backend/src/routes/index.ts
+++ b/platform/backend/src/routes/index.ts
@@ -54,6 +54,7 @@ export { default as zhipuaiProxyRoutes } from "./proxy/routes/zhipuai";
 export { default as scheduleTriggerRoutes } from "./schedule-trigger";
 export { default as secretsRoutes } from "./secrets";
 export { default as skillRoutes } from "./skill";
+export { default as siteAnnouncementRoutes } from "./site-announcement";
 export { default as statisticsRoutes } from "./statistics";
 export { default as teamRoutes } from "./team";
 export { default as tokenRoutes } from "./token";

--- a/platform/backend/src/routes/site-announcement.test.ts
+++ b/platform/backend/src/routes/site-announcement.test.ts
@@ -1,0 +1,139 @@
+import type { FastifyInstanceWithZod } from "@/server";
+import { createFastifyInstance } from "@/server";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import type { User } from "@/types";
+
+describe("site announcement routes", () => {
+  let app: FastifyInstanceWithZod;
+  let user: User;
+  let organizationId: string;
+
+  beforeEach(async ({ makeOrganization, makeUser }) => {
+    user = await makeUser();
+    const organization = await makeOrganization();
+    organizationId = organization.id;
+
+    app = createFastifyInstance();
+    app.addHook("onRequest", async (request) => {
+      (request as typeof request & { user: User }).user = user;
+      (
+        request as typeof request & {
+          organizationId: string;
+        }
+      ).organizationId = organizationId;
+    });
+
+    const { default: siteAnnouncementRoutes } = await import(
+      "./site-announcement"
+    );
+    await app.register(siteAnnouncementRoutes);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  test("creates and returns the active announcement", async () => {
+    const response = await app.inject({
+      method: "PUT",
+      url: "/api/site-announcement",
+      payload: {
+        markdown: "**Heads up:** [status](https://example.com)",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      organizationId,
+      markdown: "**Heads up:** [status](https://example.com)",
+    });
+
+    const activeResponse = await app.inject({
+      method: "GET",
+      url: "/api/site-announcement/active",
+    });
+
+    expect(activeResponse.statusCode).toBe(200);
+    expect(activeResponse.json()).toMatchObject({
+      organizationId,
+      markdown: "**Heads up:** [status](https://example.com)",
+    });
+  });
+
+  test("replaces the existing announcement instead of creating another", async () => {
+    await app.inject({
+      method: "PUT",
+      url: "/api/site-announcement",
+      payload: {
+        markdown: "First announcement",
+        expiresAt: null,
+      },
+    });
+
+    const response = await app.inject({
+      method: "PUT",
+      url: "/api/site-announcement",
+      payload: {
+        markdown: "Second announcement",
+        expiresAt: null,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const getResponse = await app.inject({
+      method: "GET",
+      url: "/api/site-announcement",
+    });
+
+    expect(getResponse.statusCode).toBe(200);
+    expect(getResponse.json().markdown).toBe("Second announcement");
+  });
+
+  test("does not return expired announcements as active", async () => {
+    await app.inject({
+      method: "PUT",
+      url: "/api/site-announcement",
+      payload: {
+        markdown: "Expired announcement",
+        expiresAt: "2000-01-01T00:00:00.000Z",
+      },
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/site-announcement/active",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toBeNull();
+  });
+
+  test("deletes the announcement", async () => {
+    await app.inject({
+      method: "PUT",
+      url: "/api/site-announcement",
+      payload: {
+        markdown: "Temporary announcement",
+        expiresAt: null,
+      },
+    });
+
+    const deleteResponse = await app.inject({
+      method: "DELETE",
+      url: "/api/site-announcement",
+    });
+
+    expect(deleteResponse.statusCode).toBe(200);
+    expect(deleteResponse.json()).toEqual({ success: true });
+
+    const getResponse = await app.inject({
+      method: "GET",
+      url: "/api/site-announcement",
+    });
+
+    expect(getResponse.statusCode).toBe(200);
+    expect(getResponse.json()).toBeNull();
+  });
+});

--- a/platform/backend/src/routes/site-announcement.ts
+++ b/platform/backend/src/routes/site-announcement.ts
@@ -1,0 +1,95 @@
+import { RouteId } from "@shared";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { SiteAnnouncementModel } from "@/models";
+import {
+  ApiError,
+  constructResponseSchema,
+  DeleteObjectResponseSchema,
+  SelectSiteAnnouncementSchema,
+  UpsertSiteAnnouncementSchema,
+} from "@/types";
+
+const NullableSiteAnnouncementSchema = SelectSiteAnnouncementSchema.nullable();
+
+const siteAnnouncementRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  fastify.get(
+    "/api/site-announcement",
+    {
+      schema: {
+        operationId: RouteId.GetSiteAnnouncement,
+        description:
+          "Get the configured site announcement for the organization",
+        tags: ["Site Announcement"],
+        response: constructResponseSchema(NullableSiteAnnouncementSchema),
+      },
+    },
+    async ({ organizationId }, reply) => {
+      const announcement =
+        await SiteAnnouncementModel.getForOrganization(organizationId);
+      return reply.send(announcement);
+    },
+  );
+
+  fastify.get(
+    "/api/site-announcement/active",
+    {
+      schema: {
+        operationId: RouteId.GetActiveSiteAnnouncement,
+        description: "Get the current unexpired site announcement",
+        tags: ["Site Announcement"],
+        response: constructResponseSchema(NullableSiteAnnouncementSchema),
+      },
+    },
+    async ({ organizationId }, reply) => {
+      const announcement =
+        await SiteAnnouncementModel.getActiveForOrganization(organizationId);
+      return reply.send(announcement);
+    },
+  );
+
+  fastify.put(
+    "/api/site-announcement",
+    {
+      schema: {
+        operationId: RouteId.UpsertSiteAnnouncement,
+        description:
+          "Create or replace the organization-wide site announcement",
+        tags: ["Site Announcement"],
+        body: UpsertSiteAnnouncementSchema,
+        response: constructResponseSchema(SelectSiteAnnouncementSchema),
+      },
+    },
+    async ({ organizationId, user, body }, reply) => {
+      const announcement = await SiteAnnouncementModel.upsert({
+        organizationId,
+        userId: user.id,
+        markdown: body.markdown,
+        expiresAt: body.expiresAt,
+      });
+
+      return reply.send(announcement);
+    },
+  );
+
+  fastify.delete(
+    "/api/site-announcement",
+    {
+      schema: {
+        operationId: RouteId.DeleteSiteAnnouncement,
+        description: "Delete the organization-wide site announcement",
+        tags: ["Site Announcement"],
+        response: constructResponseSchema(DeleteObjectResponseSchema),
+      },
+    },
+    async ({ organizationId }, reply) => {
+      const deleted = await SiteAnnouncementModel.delete(organizationId);
+      if (!deleted) {
+        throw new ApiError(404, "Site announcement not found");
+      }
+
+      return reply.send({ success: true });
+    },
+  );
+};
+
+export default siteAnnouncementRoutes;

--- a/platform/backend/src/types/index.ts
+++ b/platform/backend/src/types/index.ts
@@ -55,6 +55,7 @@ export * from "./secret";
 export * from "./secrets-manager";
 export * from "./session";
 export * from "./skill";
+export * from "./site-announcement";
 export * from "./statistics";
 export * from "./task";
 export * from "./team";

--- a/platform/backend/src/types/site-announcement.ts
+++ b/platform/backend/src/types/site-announcement.ts
@@ -1,0 +1,17 @@
+import { createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+import { schema } from "@/database";
+
+export const SelectSiteAnnouncementSchema = createSelectSchema(
+  schema.siteAnnouncementsTable,
+);
+
+export const UpsertSiteAnnouncementSchema = z.object({
+  markdown: z.string().trim().min(1).max(2000),
+  expiresAt: z.coerce.date().nullable(),
+});
+
+export type SiteAnnouncement = z.infer<typeof SelectSiteAnnouncementSchema>;
+export type UpsertSiteAnnouncement = z.infer<
+  typeof UpsertSiteAnnouncementSchema
+>;

--- a/platform/frontend/src/app/_parts/app-shell.tsx
+++ b/platform/frontend/src/app/_parts/app-shell.tsx
@@ -9,6 +9,7 @@ import {
   useNavigationStatus,
 } from "@/components/navigation-status-provider";
 import { OnboardingDialogWrapper } from "@/components/onboarding-dialog-wrapper";
+import { SiteAnnouncementBanner } from "@/components/site-announcement-banner";
 import {
   SidebarCircleToggle,
   SidebarProvider,
@@ -77,6 +78,7 @@ export function AppShell({ children }: AppShellProps) {
         <NavAwareSidebarCircleToggle />
         <main className="h-screen w-full flex flex-col bg-background min-w-0 relative">
           <ImpersonationBanner />
+          <SiteAnnouncementBanner />
           <header className="h-14 border-b border-border flex md:hidden items-center justify-between px-6 bg-card/50 backdrop-blur supports-backdrop-filter:bg-card/50">
             <SidebarTrigger className="cursor-pointer hover:bg-accent transition-colors rounded-md p-2 -ml-2" />
             <div

--- a/platform/frontend/src/app/maintenance/page.tsx
+++ b/platform/frontend/src/app/maintenance/page.tsx
@@ -1,0 +1,24 @@
+const DEFAULT_MAINTENANCE_MESSAGE =
+  "Archestra is temporarily unavailable while maintenance is in progress.";
+
+export default function MaintenancePage() {
+  const message =
+    process.env.ARCHESTRA_MAINTENANCE_MODE_MESSAGE?.trim() ||
+    DEFAULT_MAINTENANCE_MESSAGE;
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background px-6 py-12 text-foreground">
+      <section className="w-full max-w-xl space-y-6 text-center">
+        <div className="space-y-3">
+          <p className="text-sm font-medium text-muted-foreground">
+            Maintenance mode
+          </p>
+          <h1 className="text-3xl font-semibold tracking-normal sm:text-4xl">
+            We&apos;ll be back shortly
+          </h1>
+        </div>
+        <p className="text-base leading-7 text-muted-foreground">{message}</p>
+      </section>
+    </main>
+  );
+}

--- a/platform/frontend/src/app/settings/organization/_components/site-announcement-card.tsx
+++ b/platform/frontend/src/app/settings/organization/_components/site-announcement-card.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { Save, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { WithPermissions } from "@/components/roles/with-permissions";
+import { SettingsCardHeader } from "@/components/settings/settings-block";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  useDeleteSiteAnnouncement,
+  useSiteAnnouncement,
+  useUpsertSiteAnnouncement,
+} from "@/lib/site-announcement.query";
+
+function toDateTimeLocal(value: string | null | undefined) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  const offsetMs = date.getTimezoneOffset() * 60 * 1000;
+  return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
+}
+
+function fromDateTimeLocal(value: string) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+export function SiteAnnouncementCard() {
+  const { data: announcement, isPending } = useSiteAnnouncement();
+  const upsertMutation = useUpsertSiteAnnouncement();
+  const deleteMutation = useDeleteSiteAnnouncement();
+  const [markdown, setMarkdown] = useState("");
+  const [expiresAt, setExpiresAt] = useState("");
+
+  useEffect(() => {
+    setMarkdown(announcement?.markdown ?? "");
+    setExpiresAt(toDateTimeLocal(announcement?.expiresAt));
+  }, [announcement]);
+
+  const hasChanges = useMemo(
+    () =>
+      markdown !== (announcement?.markdown ?? "") ||
+      expiresAt !== toDateTimeLocal(announcement?.expiresAt),
+    [announcement, expiresAt, markdown],
+  );
+
+  const isSaving = upsertMutation.isPending || deleteMutation.isPending;
+  const canSave = markdown.trim().length > 0 && hasChanges;
+
+  return (
+    <Card>
+      <SettingsCardHeader
+        title="Site announcement"
+        description="Show one organization-wide announcement at the top of the app. Markdown links, bold, and italic text are supported."
+      />
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="site-announcement-markdown">Announcement</Label>
+          <Textarea
+            id="site-announcement-markdown"
+            placeholder="Example: **Maintenance tonight** from 9-10 PM. [Status page](https://status.example.com)"
+            value={markdown}
+            onChange={(event) => setMarkdown(event.target.value)}
+            maxLength={2000}
+            rows={4}
+            disabled={isPending || isSaving}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="site-announcement-expires-at">Expiration</Label>
+          <Input
+            id="site-announcement-expires-at"
+            type="datetime-local"
+            value={expiresAt}
+            onChange={(event) => setExpiresAt(event.target.value)}
+            disabled={isPending || isSaving}
+          />
+        </div>
+        <WithPermissions
+          permissions={{ siteAnnouncement: ["create", "update"] }}
+          noPermissionHandle="tooltip"
+        >
+          {({ hasPermission }) => (
+            <div className="flex flex-wrap justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setMarkdown(announcement?.markdown ?? "");
+                  setExpiresAt(toDateTimeLocal(announcement?.expiresAt));
+                }}
+                disabled={!hasPermission || isSaving || !hasChanges}
+              >
+                Reset
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => deleteMutation.mutate()}
+                disabled={!hasPermission || isSaving || !announcement}
+              >
+                <Trash2 className="h-4 w-4" />
+                Delete
+              </Button>
+              <Button
+                type="button"
+                onClick={() =>
+                  upsertMutation.mutate({
+                    markdown: markdown.trim(),
+                    expiresAt: fromDateTimeLocal(expiresAt),
+                  })
+                }
+                disabled={!hasPermission || isSaving || !canSave}
+              >
+                <Save className="h-4 w-4" />
+                Save
+              </Button>
+            </div>
+          )}
+        </WithPermissions>
+      </CardContent>
+    </Card>
+  );
+}

--- a/platform/frontend/src/app/settings/organization/page.tsx
+++ b/platform/frontend/src/app/settings/organization/page.tsx
@@ -38,6 +38,7 @@ import {
   validateOnboardingWizard,
 } from "./_components/onboarding-wizards-editor.utils";
 import { OrganizationTokenSection } from "./_components/organization-token-section";
+import { SiteAnnouncementCard } from "./_components/site-announcement-card";
 import { ThemeSelector } from "./_components/theme-selector";
 
 export default function OrganizationSettingsPage() {
@@ -404,6 +405,8 @@ export default function OrganizationSettingsPage() {
               />
             </CardContent>
           </Card>
+
+          <SiteAnnouncementCard />
         </SettingsSectionStack>
       </div>
 

--- a/platform/frontend/src/components/site-announcement-banner.tsx
+++ b/platform/frontend/src/components/site-announcement-banner.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { Components } from "react-markdown";
+import ReactMarkdown from "react-markdown";
+import { useActiveSiteAnnouncement } from "@/lib/site-announcement.query";
+
+const markdownComponents: Components = {
+  p: ({ children }) => <span>{children}</span>,
+  a: ({ children, href }) => (
+    <a
+      href={href}
+      className="font-medium underline underline-offset-2 hover:text-primary"
+      target="_blank"
+      rel="noreferrer"
+    >
+      {children}
+    </a>
+  ),
+  strong: ({ children }) => (
+    <strong className="font-semibold">{children}</strong>
+  ),
+  em: ({ children }) => <em>{children}</em>,
+};
+
+export function SiteAnnouncementBanner() {
+  const { data: announcement, isPending } = useActiveSiteAnnouncement();
+
+  if (isPending || !announcement?.markdown) {
+    return null;
+  }
+
+  return (
+    <div className="w-full border-b border-border bg-amber-50 px-4 py-2 text-sm text-amber-950 dark:bg-amber-950/25 dark:text-amber-100">
+      <div className="mx-auto flex max-w-5xl items-center justify-center text-center leading-5 [&_*]:inline">
+        <ReactMarkdown
+          allowedElements={["p", "a", "strong", "em", "text"]}
+          unwrapDisallowed
+          components={markdownComponents}
+        >
+          {announcement.markdown}
+        </ReactMarkdown>
+      </div>
+    </div>
+  );
+}

--- a/platform/frontend/src/lib/site-announcement.query.ts
+++ b/platform/frontend/src/lib/site-announcement.query.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+export type SiteAnnouncement = {
+  id: string;
+  organizationId: string;
+  markdown: string;
+  expiresAt: string | null;
+  createdByUserId: string | null;
+  updatedByUserId: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export const siteAnnouncementKeys = {
+  all: ["site-announcement"] as const,
+  current: () => [...siteAnnouncementKeys.all, "current"] as const,
+  active: () => [...siteAnnouncementKeys.all, "active"] as const,
+};
+
+async function fetchSiteAnnouncement(path: string) {
+  const response = await fetch(path);
+  if (response.status === 403 || response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error("Failed to load site announcement");
+  }
+  return (await response.json()) as SiteAnnouncement | null;
+}
+
+export function useSiteAnnouncement() {
+  return useQuery({
+    queryKey: siteAnnouncementKeys.current(),
+    queryFn: () => fetchSiteAnnouncement("/api/site-announcement"),
+    retry: false,
+  });
+}
+
+export function useActiveSiteAnnouncement() {
+  return useQuery({
+    queryKey: siteAnnouncementKeys.active(),
+    queryFn: () => fetchSiteAnnouncement("/api/site-announcement/active"),
+    retry: false,
+    throwOnError: false,
+  });
+}
+
+export function useUpsertSiteAnnouncement() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: {
+      markdown: string;
+      expiresAt: string | null;
+    }) => {
+      const response = await fetch("/api/site-announcement", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!response.ok) {
+        throw new Error("Failed to save site announcement");
+      }
+      return (await response.json()) as SiteAnnouncement;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: siteAnnouncementKeys.all });
+      toast.success("Site announcement saved");
+    },
+    onError: () => {
+      toast.error("Failed to save site announcement");
+    },
+  });
+}
+
+export function useDeleteSiteAnnouncement() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      const response = await fetch("/api/site-announcement", {
+        method: "DELETE",
+      });
+      if (!response.ok && response.status !== 404) {
+        throw new Error("Failed to delete site announcement");
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: siteAnnouncementKeys.all });
+      toast.success("Site announcement deleted");
+    },
+    onError: () => {
+      toast.error("Failed to delete site announcement");
+    },
+  });
+}

--- a/platform/frontend/src/proxy.test.ts
+++ b/platform/frontend/src/proxy.test.ts
@@ -22,12 +22,15 @@ describe("proxy", () => {
     ARCHESTRA_FRONTEND_URL: process.env.ARCHESTRA_FRONTEND_URL,
     ARCHESTRA_INTERNAL_API_BASE_URL:
       process.env.ARCHESTRA_INTERNAL_API_BASE_URL,
+    ARCHESTRA_MAINTENANCE_MODE_MESSAGE:
+      process.env.ARCHESTRA_MAINTENANCE_MODE_MESSAGE,
   };
 
   beforeEach(() => {
     // Reset env vars before each test
     delete process.env.ARCHESTRA_FRONTEND_URL;
     delete process.env.ARCHESTRA_INTERNAL_API_BASE_URL;
+    delete process.env.ARCHESTRA_MAINTENANCE_MODE_MESSAGE;
     // Suppress console.log during tests
     vi.spyOn(console, "log").mockImplementation(() => {});
   });
@@ -44,6 +47,12 @@ describe("proxy", () => {
         originalEnv.ARCHESTRA_INTERNAL_API_BASE_URL;
     } else {
       delete process.env.ARCHESTRA_INTERNAL_API_BASE_URL;
+    }
+    if (originalEnv.ARCHESTRA_MAINTENANCE_MODE_MESSAGE) {
+      process.env.ARCHESTRA_MAINTENANCE_MODE_MESSAGE =
+        originalEnv.ARCHESTRA_MAINTENANCE_MODE_MESSAGE;
+    } else {
+      delete process.env.ARCHESTRA_MAINTENANCE_MODE_MESSAGE;
     }
     vi.restoreAllMocks();
   });
@@ -91,6 +100,84 @@ describe("proxy", () => {
       const request = createMockRequest({
         method: "GET",
         url: "/settings",
+      });
+
+      const response = proxy(request);
+
+      expect(response.headers.get("x-middleware-next")).toBe("1");
+    });
+  });
+
+  describe("maintenance mode", () => {
+    it("should rewrite page requests to the maintenance page", () => {
+      process.env.ARCHESTRA_MAINTENANCE_MODE_MESSAGE =
+        "Deploying a database migration";
+
+      const request = createMockRequest({
+        method: "GET",
+        url: "/chat",
+      });
+
+      const response = proxy(request);
+
+      expect(response.headers.get("x-middleware-next")).toBeNull();
+      expect(response.headers.get("x-middleware-rewrite")).toContain(
+        "/maintenance",
+      );
+    });
+
+    it("should rewrite root to the maintenance page before the chat redirect", () => {
+      process.env.ARCHESTRA_MAINTENANCE_MODE_MESSAGE =
+        "Deploying a database migration";
+
+      const request = createMockRequest({
+        method: "GET",
+        url: "/",
+      });
+
+      const response = proxy(request);
+
+      expect(response.status).not.toBe(307);
+      expect(response.headers.get("x-middleware-rewrite")).toContain(
+        "/maintenance",
+      );
+    });
+
+    it("should not rewrite the maintenance page itself", () => {
+      process.env.ARCHESTRA_MAINTENANCE_MODE_MESSAGE =
+        "Deploying a database migration";
+
+      const request = createMockRequest({
+        method: "GET",
+        url: "/maintenance",
+      });
+
+      const response = proxy(request);
+
+      expect(response.headers.get("x-middleware-next")).toBe("1");
+    });
+
+    it("should not rewrite API requests", () => {
+      process.env.ARCHESTRA_MAINTENANCE_MODE_MESSAGE =
+        "Deploying a database migration";
+
+      const request = createMockRequest({
+        method: "GET",
+        url: "/api/config/public",
+      });
+
+      const response = proxy(request);
+
+      expect(response.headers.get("x-middleware-next")).toBe("1");
+    });
+
+    it("should not rewrite Next.js assets", () => {
+      process.env.ARCHESTRA_MAINTENANCE_MODE_MESSAGE =
+        "Deploying a database migration";
+
+      const request = createMockRequest({
+        method: "GET",
+        url: "/_next/static/chunk.js",
       });
 
       const response = proxy(request);

--- a/platform/frontend/src/proxy.ts
+++ b/platform/frontend/src/proxy.ts
@@ -2,6 +2,17 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
 export function proxy(req: NextRequest) {
+  const maintenanceMessage = getMaintenanceModeMessage();
+  if (
+    maintenanceMessage &&
+    !isMaintenanceModeBypassPath(req.nextUrl.pathname)
+  ) {
+    const maintenanceUrl = req.nextUrl.clone();
+    maintenanceUrl.pathname = "/maintenance";
+    maintenanceUrl.search = "";
+    return NextResponse.rewrite(maintenanceUrl);
+  }
+
   // Redirect root to /chat before any client components render
   if (req.nextUrl.pathname === "/") {
     return NextResponse.redirect(new URL("/chat", req.url));
@@ -68,5 +79,21 @@ const isSamlCallback = (req: NextRequest) => {
   // Match SAML ACS callback URLs: /api/auth/sso/saml2/sp/acs/*
   return (
     req.method === "POST" && pathname.startsWith("/api/auth/sso/saml2/sp/acs/")
+  );
+};
+
+const getMaintenanceModeMessage = (): string => {
+  return process.env.ARCHESTRA_MAINTENANCE_MODE_MESSAGE?.trim() ?? "";
+};
+
+const isMaintenanceModeBypassPath = (pathname: string): boolean => {
+  return (
+    pathname === "/maintenance" ||
+    pathname === "/favicon.ico" ||
+    pathname.startsWith("/_next/") ||
+    pathname.startsWith("/api/") ||
+    pathname.startsWith("/v1/") ||
+    pathname.startsWith("/ws") ||
+    pathname.startsWith("/_sandbox/")
   );
 };

--- a/platform/shared/access-control.ts
+++ b/platform/shared/access-control.ts
@@ -65,6 +65,7 @@ export const allAvailableActions: Record<Resource, Action[]> = {
   identityProvider: ["read", "create", "update", "delete"],
   secret: ["read", "update"],
   organizationSettings: ["read", "update"],
+  siteAnnouncement: ["read", "create", "update", "delete"],
 
   // UI behavior resources
   simpleView: ["enable"],
@@ -118,6 +119,7 @@ export const editorPermissions: Record<Resource, Action[]> = {
   identityProvider: ["read"],
   secret: ["read"],
   organizationSettings: ["read", "update"],
+  siteAnnouncement: ["read", "create", "update", "delete"],
 
   // UI behavior resources
   simpleView: [],
@@ -171,6 +173,7 @@ export const memberPermissions: Record<Resource, Action[]> = {
   identityProvider: [],
   secret: [],
   organizationSettings: [],
+  siteAnnouncement: ["read"],
 
   // UI behavior resources
   simpleView: ["enable"],
@@ -333,6 +336,10 @@ export const permissionDescriptions: Record<string, string> = {
     "View organization settings (appearance, authentication, etc)",
   "organizationSettings:update":
     "Customize organization appearance, authentication, etc",
+  "siteAnnouncement:read": "View active site announcements",
+  "siteAnnouncement:create": "Create site announcements",
+  "siteAnnouncement:update": "Update site announcements",
+  "siteAnnouncement:delete": "Delete site announcements",
   "knowledgeSource:read": "View Knowledge Bases and Connectors",
   "knowledgeSource:create": "Create Knowledge Bases and Connectors",
   "knowledgeSource:update": "Modify Knowledge Bases and Connectors",
@@ -875,6 +882,18 @@ export const requiredEndpointPermissionsMap: Partial<
   },
   [RouteId.UpdateKnowledgeSettings]: {
     knowledgeSettings: ["update"],
+  },
+  [RouteId.GetSiteAnnouncement]: {
+    siteAnnouncement: ["read"],
+  },
+  [RouteId.GetActiveSiteAnnouncement]: {
+    siteAnnouncement: ["read"],
+  },
+  [RouteId.UpsertSiteAnnouncement]: {
+    siteAnnouncement: ["create", "update"],
+  },
+  [RouteId.DeleteSiteAnnouncement]: {
+    siteAnnouncement: ["delete"],
   },
   [RouteId.DropEmbeddingConfig]: {
     knowledgeSettings: ["update"],

--- a/platform/shared/permission.types.ts
+++ b/platform/shared/permission.types.ts
@@ -47,6 +47,7 @@ export const resources = [
   "agentSettings",
   "agentTrigger",
   "scheduledTask",
+  "siteAnnouncement",
   /**
    * Better-auth access control resource - needed for organization role management
    * See: https://github.com/better-auth/better-auth/issues/2336#issuecomment-2820620809
@@ -105,6 +106,7 @@ export const resourceLabels: Record<Resource, string> = {
   agentSettings: "Agent Settings",
   agentTrigger: "Agent Triggers",
   scheduledTask: "Scheduled Tasks",
+  siteAnnouncement: "Site Announcements",
   simpleView: "Simple View",
   chatAgentPicker: "Chat Agent Picker",
   chatProviderSettings: "Chat Provider Settings",
@@ -120,6 +122,7 @@ export const resourceDescriptions: Record<Resource, string> = {
   chat: "Chat conversations",
   agentTrigger: "Agent triggers (Slack, MS Teams, incoming emails)",
   scheduledTask: "Scheduled agent tasks that run on a schedule",
+  siteAnnouncement: "Organization-wide site announcements",
   llmProviderApiKey: "LLM provider API keys and their visibility",
   llmVirtualKey: "LLM virtual keys and their visibility",
   llmOauthClient: "OAuth clients authorized to call LLM proxies",
@@ -203,6 +206,7 @@ export const resourceCategories: Record<string, Resource[]> = {
     "secret",
     "apiKey",
     "organizationSettings",
+    "siteAnnouncement",
   ],
 };
 

--- a/platform/shared/routes.ts
+++ b/platform/shared/routes.ts
@@ -133,6 +133,12 @@ export const RouteId = {
   UpdateRole: "updateRole",
   DeleteRole: "deleteRole",
 
+  // Site Announcement Routes
+  GetSiteAnnouncement: "getSiteAnnouncement",
+  GetActiveSiteAnnouncement: "getActiveSiteAnnouncement",
+  UpsertSiteAnnouncement: "upsertSiteAnnouncement",
+  DeleteSiteAnnouncement: "deleteSiteAnnouncement",
+
   // Tool Routes
   GetTools: "getTools",
   GetToolsWithAssignments: "getToolsWithAssignments",


### PR DESCRIPTION
## Summary

Fixes #4463.

This adds the two deployment communication controls requested in the issue:

- deployment maintenance mode configured by `ARCHESTRA_MAINTENANCE_MODE_MESSAGE`
- an organization-wide site announcement bar shown in the app shell, to the right of the sidebar
- a Site announcement editor in Organization settings with markdown-like text, links, and an expiration date/time
- RBAC resource/actions for `siteAnnouncement` (`read`, `create`, `update`, `delete`)
- a single-announcement data model enforced by one row per organization

## Implementation notes

### Maintenance mode

When `ARCHESTRA_MAINTENANCE_MODE_MESSAGE` is set to a non-empty string, page requests rewrite to `/maintenance`. The maintenance page displays the configured message. API, websocket, sandbox, static asset, favicon, and `/maintenance` paths bypass the rewrite so health/runtime traffic is not blocked.

The new environment variable is documented in `docs/pages/platform-deployment.md`.

### Site announcements

The announcement bar is rendered inside the main app area after the impersonation banner, so it does not appear above the sidebar. The editor supports basic markdown-style links/emphasis through the existing `react-markdown` dependency, and active announcements are hidden after expiration. Users without `siteAnnouncement:read` receive no banner data from the API.

## Tests

After rebasing onto the latest available `main` locally:

- `corepack pnpm --filter "@frontend" test src/proxy.test.ts` — 23 passed
- `$env:ARCHESTRA_DATABASE_URL='postgresql://test:test@localhost:5432/test'; corepack pnpm --filter "@backend" test src/routes/site-announcement.test.ts` — 4 passed
- `corepack pnpm --filter "@backend" type-check` — passed
- `corepack pnpm --filter "@shared" type-check` — passed

Note: `corepack pnpm --filter "@frontend" type-check` is currently blocked after the latest upstream `main` changes by existing integration/MSW test typing errors outside this PR's files.