### PR TITLE
fix(chat): persist tool-approval outcomes across page reload

### DIFF
--- a/platform/backend/src/models/message.ts
+++ b/platform/backend/src/models/message.ts
@@ -153,6 +153,33 @@ class MessageModel {
     return updatedMessage;
   }
 
+  /**
+   * Replace a message's full content. Used when a turn changes after it was
+   * first persisted — e.g. a tool call that has since been approved or declined.
+   */
+  static async updateContent(
+    messageId: string,
+    content: Message["content"],
+  ): Promise<Message> {
+    // Validate the row exists so the return type holds — `.returning()`
+    // would otherwise yield `undefined` for an unknown id.
+    const message = await MessageModel.findById(messageId);
+    if (!message) {
+      throw new Error("Message not found");
+    }
+
+    const [updatedMessage] = await db
+      .update(schema.messagesTable)
+      .set({
+        content,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.messagesTable.id, messageId))
+      .returning();
+
+    return updatedMessage;
+  }
+
   static async deleteAfterMessage(
     conversationId: string,
     messageId: string,

--- a/platform/backend/src/routes/chat/routes.test.ts
+++ b/platform/backend/src/routes/chat/routes.test.ts
@@ -29,6 +29,9 @@ vi.mock("@/models/llm-provider-api-key-model", () => ({
 import { FAST_MODELS } from "@shared";
 import { archestraMcpBranding } from "@/archestra-mcp-server";
 import { createDirectLLMModel } from "@/clients/llm-client";
+import ConversationModel from "@/models/conversation";
+import MessageModel from "@/models/message";
+import { test } from "@/test";
 import type { ChatMessage } from "@/types";
 import {
   __test,
@@ -591,6 +594,199 @@ describe("getMessagesNotYetPersisted", () => {
       "user-2",
       "assistant-2",
     ]);
+  });
+});
+
+describe("persistNewMessages", () => {
+  // Regression coverage for #4030: approving or declining a tool and then
+  // reloading must restore the resolved turn. The real flow persists four
+  // times — the user message and the assistant turn are saved during the
+  // first request, then the approval resume re-sends the same turn, which
+  // must update the existing assistant row in place rather than appending
+  // duplicate rows and orphaning the original approval-requested row.
+  const userMessage = {
+    id: "user-1",
+    role: "user",
+    parts: [{ type: "text", text: "Run the print test tool." }],
+  };
+
+  const printToolPart = {
+    type: "tool-print_test",
+    toolCallId: "call-1",
+    input: {},
+  };
+
+  const approvalRequested = {
+    id: "assistant-1",
+    role: "assistant",
+    parts: [{ ...printToolPart, state: "approval-requested" }],
+  };
+
+  // The approval resume re-sends the assistant turn with the answer applied.
+  const approvalResponded = {
+    id: "assistant-1",
+    role: "assistant",
+    parts: [{ ...printToolPart, state: "approval-responded" }],
+  };
+
+  const resolvedCases = [
+    {
+      decision: "approved",
+      toolState: "output-available",
+      resolvedAssistant: {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            ...printToolPart,
+            state: "output-available",
+            output: { result: ["archestra-4030-repro"] },
+          },
+          { type: "text", text: "The print test tool ran successfully." },
+        ],
+      },
+    },
+    {
+      decision: "declined",
+      toolState: "output-denied",
+      resolvedAssistant: {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          { ...printToolPart, state: "output-denied" },
+          { type: "text", text: "Understood, I will not run that tool." },
+        ],
+      },
+    },
+  ];
+
+  for (const testCase of resolvedCases) {
+    test(`reconciles the resolved turn after a tool call is ${testCase.decision}, without duplicate rows (#4030)`, async ({
+      makeUser,
+      makeOrganization,
+      makeMember,
+      makeAgent,
+    }) => {
+      const user = await makeUser();
+      const organization = await makeOrganization();
+      await makeMember(user.id, organization.id, { role: "admin" });
+      const agent = await makeAgent({
+        organizationId: organization.id,
+        authorId: user.id,
+        scope: "personal",
+      });
+      const conversation = await ConversationModel.create({
+        userId: user.id,
+        organizationId: organization.id,
+        agentId: agent.id,
+        selectedModel: "gpt-4o",
+        selectedProvider: "openai",
+      });
+
+      // First request: the user message is persisted early, then the
+      // assistant turn is persisted on finish while the tool waits for
+      // approval.
+      await __test.persistNewMessages(
+        conversation.id,
+        [userMessage],
+        "earlyUserMsg",
+      );
+      await __test.persistNewMessages(
+        conversation.id,
+        [userMessage, approvalRequested],
+        "onFinish",
+      );
+
+      // Resume request: the client re-sends the answered turn. The early
+      // persist must not duplicate it, and the finish persist must update
+      // the existing assistant row to its resolved state.
+      await __test.persistNewMessages(
+        conversation.id,
+        [userMessage, approvalResponded],
+        "earlyUserMsg",
+      );
+      await __test.persistNewMessages(
+        conversation.id,
+        [userMessage, testCase.resolvedAssistant],
+        "onFinish",
+      );
+
+      const stored = await MessageModel.findByConversation(conversation.id);
+      expect(stored.filter((row) => row.role === "user")).toHaveLength(1);
+
+      const assistantRows = stored.filter((row) => row.role === "assistant");
+      expect(assistantRows).toHaveLength(1);
+
+      const storedParts: Array<Record<string, unknown>> =
+        assistantRows[0]?.content?.parts ?? [];
+      const resolvedToolPart = storedParts.find(
+        (part) => part.toolCallId === "call-1",
+      );
+      expect(resolvedToolPart?.state).toBe(testCase.toolState);
+      expect(storedParts.some((part) => part.type === "text")).toBe(true);
+    });
+  }
+});
+
+describe("getMessagesWithChangedContent", () => {
+  it("only updates rows still in approval-requested state, matched by toolCallId", () => {
+    // The narrow scope: this update path resolves an approval-requested tool
+    // call by toolCallId. Unrelated content changes on other rows are ignored
+    // so a client can't repurpose this path to overwrite earlier messages —
+    // those edits still go through updateTextPartAndDeleteSubsequent.
+    const changed = __test.getMessagesWithChangedContent({
+      existingMessages: [
+        {
+          id: "db-text",
+          content: {
+            id: "user-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          },
+        },
+        {
+          id: "db-pending",
+          content: {
+            id: "assistant-1",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-print_test",
+                toolCallId: "call-1",
+                state: "approval-requested",
+                input: {},
+              },
+            ],
+          },
+        },
+      ],
+      uiMessages: [
+        // Unrelated text edit — must be ignored.
+        {
+          id: "user-1",
+          role: "user",
+          parts: [{ type: "text", text: "hello (edited)" }],
+        },
+        // Resolved version of the approval-requested call.
+        {
+          id: "assistant-1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-print_test",
+              toolCallId: "call-1",
+              state: "output-available",
+              input: {},
+              output: { ok: true },
+            },
+            { type: "text", text: "done" },
+          ],
+        },
+      ],
+    });
+
+    expect(changed).toHaveLength(1);
+    expect(changed[0]?.id).toBe("db-pending");
   });
 });
 

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -13,6 +13,7 @@ import {
   convertToModelMessages,
   createUIMessageStream,
   createUIMessageStreamResponse,
+  generateId,
   generateText,
   hasToolCall,
   stepCountIs,
@@ -803,6 +804,14 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 writer.merge(
                   result.toUIMessageStream({
                     originalMessages: messages as UIMessage[],
+                    // Give the streamed assistant message a stable id. Without
+                    // generateMessageId the AI SDK leaves the response message
+                    // id empty, so the persisted assistant row can't be matched
+                    // when the approval resume re-sends the turn — the resolved
+                    // turn is appended as new rows while the original
+                    // approval-requested row is orphaned and re-renders a stale
+                    // prompt on reload (#4030).
+                    generateMessageId: generateId,
                     onError: (error) => {
                       if (chatErrorHandled) {
                         return serializedChatError;
@@ -2443,7 +2452,7 @@ async function persistNewMessages(
   context: string,
 ): Promise<number> {
   try {
-    // Get existing messages count to know how many are new
+    // Fetch existing messages to classify incoming ones as new or changed
     const existingMessages =
       await MessageModel.findByConversation(conversationId);
     const uiMessages = messages as ChatMessage[];
@@ -2452,61 +2461,88 @@ async function persistNewMessages(
       uiMessages,
     });
 
-    if (newMessages.length === 0) {
+    // Tool approvals resolve after the assistant message is first persisted.
+    // Only the onFinish persist carries the server-authoritative final
+    // messages, so content updates are applied from that path alone.
+    const changedMessages: Array<{ id: string; content: ChatMessage }> =
+      context === "onFinish"
+        ? getMessagesWithChangedContent({ existingMessages, uiMessages })
+        : [];
+
+    if (newMessages.length === 0 && changedMessages.length === 0) {
       return 0;
     }
 
-    // Check if last message has empty parts and strip it if so
-    let messagesToSave = newMessages;
-    if (newMessages[newMessages.length - 1].parts?.length === 0) {
-      messagesToSave = newMessages.slice(0, -1);
+    let persistedCount = 0;
+
+    if (newMessages.length > 0) {
+      // Check if last message has empty parts and strip it if so
+      let messagesToSave = newMessages;
+      if (newMessages[newMessages.length - 1].parts?.length === 0) {
+        messagesToSave = newMessages.slice(0, -1);
+      }
+
+      if (messagesToSave.length > 0) {
+        let messagesToStore: ChatMessage[];
+
+        // Strip base64 images and large browser tool results before storing
+        if (context === "onFinish") {
+          // Log size reduction only for onFinish (where we have complete messages)
+          const beforeSize = estimateMessagesSize(messagesToSave);
+          messagesToStore = normalizeChatMessages(messagesToSave);
+          const afterSize = estimateMessagesSize(messagesToStore);
+
+          logger.info(
+            {
+              messageCount: messagesToSave.length,
+              beforeSizeKB: Math.round(beforeSize.length / 1024),
+              afterSizeKB: Math.round(afterSize.length / 1024),
+              savedKB: Math.round(
+                (beforeSize.length - afterSize.length) / 1024,
+              ),
+              sizeEstimateReliable:
+                !beforeSize.isEstimated && !afterSize.isEstimated,
+            },
+            "[Chat] Stripped messages before saving to DB",
+          );
+        } else {
+          // For onError, just strip without detailed logging
+          messagesToStore = normalizeChatMessages(messagesToSave);
+        }
+
+        const now = Date.now();
+        const messageData = messagesToStore.map((msg, index) => ({
+          conversationId,
+          role: msg.role ?? "assistant",
+          content: msg,
+          createdAt: new Date(now + index),
+        }));
+
+        await MessageModel.bulkCreate(messageData);
+        persistedCount += messagesToSave.length;
+
+        logger.info(
+          `Appended ${messagesToSave.length} new messages to conversation ${conversationId} (${context})`,
+        );
+      }
     }
 
-    if (messagesToSave.length === 0) {
-      return 0;
-    }
-
-    let messagesToStore: ChatMessage[];
-
-    // Strip base64 images and large browser tool results before storing
-    if (context === "onFinish") {
-      // Log size reduction only for onFinish (where we have complete messages)
-      const beforeSize = estimateMessagesSize(messagesToSave);
-      messagesToStore = normalizeChatMessages(messagesToSave);
-      const afterSize = estimateMessagesSize(messagesToStore);
-
-      logger.info(
-        {
-          messageCount: messagesToSave.length,
-          beforeSizeKB: Math.round(beforeSize.length / 1024),
-          afterSizeKB: Math.round(afterSize.length / 1024),
-          savedKB: Math.round((beforeSize.length - afterSize.length) / 1024),
-          sizeEstimateReliable:
-            !beforeSize.isEstimated && !afterSize.isEstimated,
-        },
-        "[Chat] Stripped messages before saving to DB",
+    // Persist content updates for messages that already exist but changed
+    // (e.g. an assistant turn whose tool call was approved or declined).
+    for (const changedMessage of changedMessages) {
+      await MessageModel.updateContent(
+        changedMessage.id,
+        changedMessage.content,
       );
-    } else {
-      // For onError, just strip without detailed logging
-      messagesToStore = normalizeChatMessages(messagesToSave);
     }
 
-    // Append only new messages with timestamps
-    const now = Date.now();
-    const messageData = messagesToStore.map((msg, index) => ({
-      conversationId,
-      role: msg.role ?? "assistant",
-      content: msg,
-      createdAt: new Date(now + index),
-    }));
+    if (changedMessages.length > 0) {
+      logger.info(
+        `Updated ${changedMessages.length} changed messages in conversation ${conversationId} (${context})`,
+      );
+    }
 
-    await MessageModel.bulkCreate(messageData);
-
-    logger.info(
-      `Appended ${messagesToSave.length} new messages to conversation ${conversationId} (${context})`,
-    );
-
-    return messagesToSave.length;
+    return persistedCount + changedMessages.length;
   } catch (error) {
     logger.error(
       { error, conversationId, context },
@@ -2597,6 +2633,77 @@ function getMessagesNotYetPersisted(params: {
 
     return true;
   });
+}
+
+const TERMINAL_TOOL_STATES: ReadonlySet<string> = new Set([
+  "output-available",
+  "output-error",
+  "output-denied",
+]);
+
+/**
+ * Returns the stored rows that should be overwritten in place by an incoming
+ * message — specifically, an assistant turn whose tool call is still in
+ * `approval-requested` state and whose `toolCallId` arrives in a terminal
+ * state (`output-available`, `output-error`, `output-denied`).
+ *
+ * Scoped tightly to the approval-resolution flow so this update path cannot
+ * be repurposed to overwrite arbitrary earlier messages whose parts happen
+ * to differ — those edits still go through `updateTextPartAndDeleteSubsequent`.
+ */
+function getMessagesWithChangedContent(params: {
+  existingMessages: Array<{ id: string; content: unknown }>;
+  uiMessages: ChatMessage[];
+}): Array<{ id: string; content: ChatMessage }> {
+  // Index stored rows by the toolCallId of any approval-requested tool part
+  // they carry — those are the only rows this update path can target.
+  const pendingByToolCallId = new Map<
+    string,
+    { id: string; content: unknown }
+  >();
+  for (const existing of params.existingMessages) {
+    if (typeof existing.content !== "object" || existing.content === null) {
+      continue;
+    }
+    const parts = (existing.content as { parts?: unknown }).parts;
+    if (!Array.isArray(parts)) continue;
+    for (const part of parts) {
+      if (
+        typeof part === "object" &&
+        part !== null &&
+        (part as { state?: unknown }).state === "approval-requested" &&
+        typeof (part as { toolCallId?: unknown }).toolCallId === "string"
+      ) {
+        pendingByToolCallId.set(
+          (part as { toolCallId: string }).toolCallId,
+          existing,
+        );
+      }
+    }
+  }
+  if (pendingByToolCallId.size === 0) {
+    return [];
+  }
+
+  const changedMessages: Array<{ id: string; content: ChatMessage }> = [];
+  for (const incoming of normalizeChatMessages(params.uiMessages)) {
+    for (const part of incoming.parts ?? []) {
+      const state = (part as { state?: unknown }).state;
+      if (typeof state !== "string" || !TERMINAL_TOOL_STATES.has(state)) {
+        continue;
+      }
+      const toolCallId = (part as { toolCallId?: unknown }).toolCallId;
+      if (typeof toolCallId !== "string") continue;
+      const stored = pendingByToolCallId.get(toolCallId);
+      if (!stored) continue;
+      changedMessages.push({ id: stored.id, content: incoming });
+      // Each approval-requested row resolves at most once per sweep.
+      pendingByToolCallId.delete(toolCallId);
+      break;
+    }
+  }
+
+  return changedMessages;
 }
 
 function getMessageContentId(content: unknown): string | null {
@@ -3157,6 +3264,8 @@ async function validateChatApiKeyAccess(
 
 export const __test = {
   getMessagesNotYetPersisted,
+  getMessagesWithChangedContent,
+  persistNewMessages,
   prepareMessagesForProvider,
 };
 


### PR DESCRIPTION
## Summary

In the Web UI chat, approving or declining an MCP tool call and then reloading
the page lost the resolved turn — the approval prompt re-appeared as if the tool
were still pending. Approve→reload and decline→reload now restore the resolved
conversation.

## Root cause

`routes.ts` called `toUIMessageStream(...)` without `generateMessageId`, so the
streamed assistant turn was persisted with an empty `content.id`. Message
persistence dedupes by id, so the approve/decline resume re-appended the turn
instead of matching it — orphaning the original `approval-requested` row, which
rendered a stale prompt on reload.

## Changes

- Pass `generateMessageId` to `toUIMessageStream` so the streamed assistant
  message gets a stable id.
- `persistNewMessages` updates the existing row when a turn's content changed
  (`MessageModel.updateContent`) instead of only appending.
- Detect a changed turn by comparing message `parts`, not the whole message — a
  reload re-keys ids to DB UUIDs.
- Add a backend persistence-path regression test for the approve/decline-resume
  sequence.

close https://github.com/archestra-ai/archestra/issues/4030
/claim #4030 
