### PR TITLE
Add Anthropic workload identity federation support

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -772,6 +772,17 @@ These environment variables set the default base URL for each LLM provider. Per-
   - Default: `https://api.anthropic.com`
   - Use this to point to your own proxy or other custom endpoints
 
+- **Anthropic Workload Identity Federation (WIF)** - Enable Anthropic keyless authentication by exchanging an OIDC identity token for an Anthropic bearer token.
+  - **`ARCHESTRA_ANTHROPIC_WIF_ENABLED`** - Enable Anthropic WIF explicitly. If omitted, WIF is enabled when the required WIF settings below are present.
+  - **`ARCHESTRA_ANTHROPIC_WIF_FEDERATION_RULE_ID`** - Anthropic federation rule ID.
+  - **`ARCHESTRA_ANTHROPIC_WIF_ORGANIZATION_ID`** - Anthropic organization ID.
+  - **`ARCHESTRA_ANTHROPIC_WIF_SERVICE_ACCOUNT_ID`** - Anthropic service account ID.
+  - **`ARCHESTRA_ANTHROPIC_WIF_WORKSPACE_ID`** - Optional Anthropic workspace ID.
+  - **`ARCHESTRA_ANTHROPIC_WIF_IDENTITY_TOKEN_FILE`** - Path to the IdP-issued OIDC token file.
+  - **`ARCHESTRA_ANTHROPIC_WIF_IDENTITY_TOKEN`** - IdP-issued OIDC token value. Prefer the file variable for deployed workloads.
+  - **`ARCHESTRA_ANTHROPIC_WIF_TOKEN_URL`** - Optional token exchange endpoint override. Defaults to `<ARCHESTRA_ANTHROPIC_BASE_URL>/v1/oauth/token`.
+  - When both WIF and `ARCHESTRA_CHAT_ANTHROPIC_API_KEY` are configured, the API key takes precedence for environment-backed chat calls.
+
 - **`ARCHESTRA_ANTHROPIC_AZURE_FOUNDRY_ENTRA_ID_ENABLED`** - Enable Microsoft Entra ID authentication for Anthropic models deployed in Microsoft Foundry.
   - Default: `false`
   - Set `ARCHESTRA_ANTHROPIC_BASE_URL=https://<resource-name>.services.ai.azure.com/anthropic`

--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -74,6 +74,12 @@ Model Router translation is text-first. Anthropic, Gemini, and Cohere routes cur
 - **Authentication**: Pass your Anthropic API key in the `x-api-key` header
 - **Messages path**: `POST /v1/anthropic/{profile-id}/v1/messages`
 
+### Anthropic Workload Identity Federation
+
+Archestra can use Anthropic Workload Identity Federation for keyless Anthropic calls. Configure the Anthropic federation rule, organization, service account, and identity token source with the `ARCHESTRA_ANTHROPIC_WIF_*` environment variables listed in [LLM Provider Configuration](/docs/platform-deployment#llm-provider-configuration).
+
+When WIF is enabled and no Anthropic API key is configured, Archestra exchanges the workload identity token for an Anthropic bearer token and refreshes it before expiry. Stored Anthropic API keys and `ARCHESTRA_CHAT_ANTHROPIC_API_KEY` continue to take precedence. Use WIF for deployments where static Anthropic API keys should not be stored in Archestra.
+
 ### Anthropic on Microsoft Foundry
 
 Claude models deployed in Microsoft Foundry use the Anthropic Messages API at `https://<resource>.services.ai.azure.com/anthropic`. Set `ARCHESTRA_ANTHROPIC_BASE_URL` to that `/anthropic` base URL. For keyless Microsoft Entra ID authentication, also set `ARCHESTRA_ANTHROPIC_AZURE_FOUNDRY_ENTRA_ID_ENABLED=true`; Archestra sends a bearer token scoped to `https://ai.azure.com/.default`.

--- a/platform/backend/src/clients/anthropic-workload-identity.test.ts
+++ b/platform/backend/src/clients/anthropic-workload-identity.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mockConfig = vi.hoisted(() => ({
+  llm: {
+    anthropic: {
+      baseUrl: "https://api.anthropic.com",
+      workloadIdentity: {
+        enabled: true,
+        tokenUrl: "",
+        federationRuleId: "fdrl_test",
+        organizationId: "00000000-0000-0000-0000-000000000000",
+        serviceAccountId: "svac_test",
+        workspaceId: "wrkspc_test",
+        identityToken: "idp-jwt",
+        identityTokenFile: "",
+      },
+    },
+  },
+}));
+
+vi.mock("@/config", () => ({
+  default: mockConfig,
+}));
+
+import {
+  __test,
+  createAnthropicWorkloadIdentityFetch,
+  isAnthropicWorkloadIdentityEnabled,
+} from "./anthropic-workload-identity";
+
+describe("anthropic workload identity", () => {
+  beforeEach(() => {
+    __test.resetTokenCache();
+    mockConfig.llm.anthropic.workloadIdentity.enabled = true;
+    mockConfig.llm.anthropic.workloadIdentity.federationRuleId = "fdrl_test";
+    mockConfig.llm.anthropic.workloadIdentity.organizationId =
+      "00000000-0000-0000-0000-000000000000";
+    mockConfig.llm.anthropic.workloadIdentity.serviceAccountId = "svac_test";
+    mockConfig.llm.anthropic.workloadIdentity.workspaceId = "wrkspc_test";
+    mockConfig.llm.anthropic.workloadIdentity.identityToken = "idp-jwt";
+    mockConfig.llm.anthropic.workloadIdentity.identityTokenFile = "";
+  });
+
+  test("requires enabled workload identity config and an identity token source", () => {
+    expect(isAnthropicWorkloadIdentityEnabled()).toBe(true);
+
+    mockConfig.llm.anthropic.workloadIdentity.identityToken = "";
+    expect(isAnthropicWorkloadIdentityEnabled()).toBe(false);
+
+    mockConfig.llm.anthropic.workloadIdentity.identityTokenFile =
+      "/var/run/secrets/anthropic.com/token";
+    expect(isAnthropicWorkloadIdentityEnabled()).toBe(true);
+  });
+
+  test("exchanges the identity token and injects bearer auth", async () => {
+    const fetchMock = vi.fn(
+      async (
+        input: Parameters<typeof globalThis.fetch>[0],
+        _init?: Parameters<typeof globalThis.fetch>[1],
+      ) => {
+        if (String(input).endsWith("/v1/oauth/token")) {
+          return new Response(
+            JSON.stringify({
+              access_token: "anthropic-access-token",
+              token_type: "Bearer",
+              expires_in: 3600,
+            }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          );
+        }
+
+        return new Response("{}", { status: 200 });
+      },
+    );
+
+    const wrappedFetch = createAnthropicWorkloadIdentityFetch(
+      fetchMock as unknown as typeof globalThis.fetch,
+    );
+    await wrappedFetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "anthropic-version": "2023-06-01",
+        "x-api-key": "ARCHESTRA_ANTHROPIC_WIF_KEYLESS",
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const tokenRequest = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(tokenRequest.body as string)).toEqual({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion: "idp-jwt",
+      federation_rule_id: "fdrl_test",
+      organization_id: "00000000-0000-0000-0000-000000000000",
+      service_account_id: "svac_test",
+      workspace_id: "wrkspc_test",
+    });
+
+    const providerRequest = fetchMock.mock.calls[1]?.[1] as RequestInit;
+    const headers = new Headers(providerRequest.headers);
+    expect(headers.get("authorization")).toBe("Bearer anthropic-access-token");
+    expect(headers.has("x-api-key")).toBe(false);
+  });
+});

--- a/platform/backend/src/clients/anthropic-workload-identity.ts
+++ b/platform/backend/src/clients/anthropic-workload-identity.ts
@@ -1,0 +1,154 @@
+import { readFile } from "node:fs/promises";
+import config from "@/config";
+
+const ANTHROPIC_WIF_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+const TOKEN_REFRESH_SKEW_MS = 120_000;
+
+export const ANTHROPIC_WIF_API_KEY_PLACEHOLDER =
+  "ARCHESTRA_ANTHROPIC_WIF_KEYLESS";
+
+type CachedToken = {
+  accessToken: string;
+  expiresAtMs: number;
+};
+
+let cachedToken: CachedToken | null = null;
+let pendingExchange: Promise<CachedToken> | null = null;
+
+export function isAnthropicWorkloadIdentityEnabled(): boolean {
+  const wif = config.llm.anthropic.workloadIdentity;
+  return (
+    wif.enabled &&
+    Boolean(wif.federationRuleId) &&
+    Boolean(wif.organizationId) &&
+    Boolean(wif.serviceAccountId) &&
+    Boolean(wif.identityToken || wif.identityTokenFile)
+  );
+}
+
+export function createAnthropicWorkloadIdentityFetch(
+  baseFetch: typeof globalThis.fetch | undefined,
+): typeof globalThis.fetch {
+  return async (input, init) => {
+    const fetchFn = baseFetch ?? globalThis.fetch;
+    const headers = new Headers(init?.headers);
+    headers.delete("x-api-key");
+    headers.set(
+      "Authorization",
+      `Bearer ${await getAnthropicWorkloadIdentityBearerToken(fetchFn)}`,
+    );
+
+    return fetchFn(input, {
+      ...init,
+      headers,
+    });
+  };
+}
+
+export async function getAnthropicWorkloadIdentityBearerToken(
+  fetchFn: typeof globalThis.fetch = globalThis.fetch,
+): Promise<string> {
+  const now = Date.now();
+  if (cachedToken && cachedToken.expiresAtMs - TOKEN_REFRESH_SKEW_MS > now) {
+    return cachedToken.accessToken;
+  }
+
+  if (!pendingExchange) {
+    pendingExchange = exchangeAnthropicWorkloadIdentityToken(fetchFn).finally(
+      () => {
+        pendingExchange = null;
+      },
+    );
+  }
+
+  cachedToken = await pendingExchange;
+  return cachedToken.accessToken;
+}
+
+async function exchangeAnthropicWorkloadIdentityToken(
+  fetchFn: typeof globalThis.fetch,
+): Promise<CachedToken> {
+  const wif = config.llm.anthropic.workloadIdentity;
+  const assertion = await getIdentityToken();
+  const response = await fetchFn(getTokenUrl(), {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      grant_type: ANTHROPIC_WIF_GRANT_TYPE,
+      assertion,
+      federation_rule_id: wif.federationRuleId,
+      organization_id: wif.organizationId,
+      service_account_id: wif.serviceAccountId,
+      ...(wif.workspaceId ? { workspace_id: wif.workspaceId } : {}),
+    }),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text().catch(() => "");
+    throw new Error(
+      `Anthropic workload identity token exchange failed with status ${response.status}: ${errorBody}`,
+    );
+  }
+
+  const tokenResponse = (await response.json()) as {
+    access_token?: unknown;
+    token_type?: unknown;
+    expires_in?: unknown;
+  };
+  if (typeof tokenResponse.access_token !== "string") {
+    throw new Error(
+      "Anthropic workload identity token response was missing access_token",
+    );
+  }
+  if (
+    tokenResponse.token_type &&
+    String(tokenResponse.token_type).toLowerCase() !== "bearer"
+  ) {
+    throw new Error(
+      "Anthropic workload identity token response was not a bearer token",
+    );
+  }
+
+  const expiresInSeconds =
+    typeof tokenResponse.expires_in === "number" &&
+    Number.isFinite(tokenResponse.expires_in)
+      ? tokenResponse.expires_in
+      : 3600;
+
+  return {
+    accessToken: tokenResponse.access_token,
+    expiresAtMs: Date.now() + expiresInSeconds * 1000,
+  };
+}
+
+async function getIdentityToken(): Promise<string> {
+  const { identityToken, identityTokenFile } =
+    config.llm.anthropic.workloadIdentity;
+  if (identityToken) {
+    return identityToken;
+  }
+  if (identityTokenFile) {
+    return (await readFile(identityTokenFile, "utf8")).trim();
+  }
+  throw new Error(
+    "Anthropic workload identity requires ARCHESTRA_ANTHROPIC_WIF_IDENTITY_TOKEN or ARCHESTRA_ANTHROPIC_WIF_IDENTITY_TOKEN_FILE",
+  );
+}
+
+function getTokenUrl(): string {
+  const wif = config.llm.anthropic.workloadIdentity;
+  if (wif.tokenUrl) {
+    return wif.tokenUrl;
+  }
+
+  return `${config.llm.anthropic.baseUrl.replace(/\/+$/, "")}/v1/oauth/token`;
+}
+
+export const __test = {
+  resetTokenCache() {
+    cachedToken = null;
+    pendingExchange = null;
+  },
+};

--- a/platform/backend/src/clients/llm-client.test.ts
+++ b/platform/backend/src/clients/llm-client.test.ts
@@ -15,13 +15,37 @@ import { describe, expect, it, test } from "@/test";
 // Mock the gemini-client module before importing llm-client
 const mockIsVertexAiEnabled = vi.hoisted(() => vi.fn(() => false));
 const mockIsAzureOpenAiEntraIdEnabled = vi.hoisted(() => vi.fn(() => false));
+const mockIsAnthropicWorkloadIdentityEnabled = vi.hoisted(() =>
+  vi.fn(() => false),
+);
+const mockCreateAnthropicWorkloadIdentityFetch = vi.hoisted(() =>
+  vi.fn((fetch?: typeof globalThis.fetch) => fetch ?? globalThis.fetch),
+);
+const capturedCreateAnthropicOptions = vi.hoisted(() => ({
+  apiKey: undefined as string | undefined,
+  fetch: undefined as typeof globalThis.fetch | undefined,
+  headers: undefined as Record<string, string> | undefined,
+}));
 const mockCreateAnthropic = vi.hoisted(() =>
-  vi.fn(({ headers }: { headers?: Record<string, string> }) =>
-    vi.fn((modelName: string) => ({
-      provider: "anthropic",
-      modelName,
+  vi.fn(
+    ({
+      apiKey,
+      fetch,
       headers,
-    })),
+    }: {
+      apiKey?: string;
+      fetch?: typeof globalThis.fetch;
+      headers?: Record<string, string>;
+    }) => {
+      capturedCreateAnthropicOptions.apiKey = apiKey;
+      capturedCreateAnthropicOptions.fetch = fetch;
+      capturedCreateAnthropicOptions.headers = headers;
+      return vi.fn((modelName: string) => ({
+        provider: "anthropic",
+        modelName,
+        headers,
+      }));
+    },
   ),
 );
 vi.mock("@/clients/gemini-client", () => ({
@@ -35,6 +59,12 @@ vi.mock("@/clients/azure-openai-credentials", async (importOriginal) => {
     isAzureOpenAiEntraIdEnabled: mockIsAzureOpenAiEntraIdEnabled,
   };
 });
+vi.mock("@/clients/anthropic-workload-identity", () => ({
+  ANTHROPIC_WIF_API_KEY_PLACEHOLDER: "ARCHESTRA_ANTHROPIC_WIF_KEYLESS",
+  createAnthropicWorkloadIdentityFetch:
+    mockCreateAnthropicWorkloadIdentityFetch,
+  isAnthropicWorkloadIdentityEnabled: mockIsAnthropicWorkloadIdentityEnabled,
+}));
 vi.mock("@ai-sdk/anthropic", () => ({
   createAnthropic: mockCreateAnthropic,
 }));
@@ -186,6 +216,26 @@ describe("createDirectLLMModel", () => {
     ).toThrow(
       "Anthropic API key is required. Please configure ANTHROPIC_API_KEY.",
     );
+  });
+
+  it("creates an anthropic model without API key when workload identity is enabled", () => {
+    mockIsAnthropicWorkloadIdentityEnabled.mockReturnValue(true);
+    mockCreateAnthropicWorkloadIdentityFetch.mockClear();
+
+    const model = createDirectLLMModel({
+      provider: "anthropic",
+      apiKey: undefined,
+      modelName: "claude-3-5-haiku-20241022",
+      baseUrl: null,
+    });
+
+    expect(model).toBeDefined();
+    expect(capturedCreateAnthropicOptions.apiKey).toBe(
+      "ARCHESTRA_ANTHROPIC_WIF_KEYLESS",
+    );
+    expect(mockCreateAnthropicWorkloadIdentityFetch).toHaveBeenCalled();
+
+    mockIsAnthropicWorkloadIdentityEnabled.mockReturnValue(false);
   });
 
   it("throws descriptive error for openai provider without API key", () => {
@@ -502,6 +552,36 @@ describe("createLLMModel", () => {
     expect(new Headers(fetchInit?.headers).get("authorization")).toBe(
       "Bearer EMPTY",
     );
+  });
+
+  test("allows anthropic chat without a provider key when workload identity is enabled", async ({
+    makeOrganization,
+    makeUser,
+    makeAgent,
+  }) => {
+    mockIsAnthropicWorkloadIdentityEnabled.mockReturnValue(true);
+    mockCreateAnthropicWorkloadIdentityFetch.mockClear();
+
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const agent = await makeAgent({ name: "Anthropic WIF Agent", teams: [] });
+
+    const result = await createLLMModelForAgent({
+      organizationId: org.id,
+      userId: user.id,
+      agentId: agent.id,
+      model: "claude-3-5-haiku-20241022",
+      provider: "anthropic",
+      source: "chat",
+    });
+
+    expect(result.apiKeySource).toBe("environment");
+    expect(capturedCreateAnthropicOptions.apiKey).toBe(
+      "ARCHESTRA_ANTHROPIC_WIF_KEYLESS",
+    );
+    expect(mockCreateAnthropicWorkloadIdentityFetch).not.toHaveBeenCalled();
+
+    mockIsAnthropicWorkloadIdentityEnabled.mockReturnValue(false);
   });
 
   test("sets the untrusted-context header only when contextIsTrusted is false", () => {

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -21,6 +21,11 @@ import {
   USER_ID_HEADER,
 } from "@shared";
 import type { streamText } from "ai";
+import {
+  ANTHROPIC_WIF_API_KEY_PLACEHOLDER,
+  createAnthropicWorkloadIdentityFetch,
+  isAnthropicWorkloadIdentityEnabled,
+} from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import {
   createAzureFetchWithApiVersion,
@@ -62,6 +67,9 @@ export function isApiKeyRequired(
   apiKey: string | undefined,
 ): boolean {
   if (apiKey) return false;
+  if (provider === "anthropic" && isAnthropicWorkloadIdentityEnabled()) {
+    return false;
+  }
   // Gemini with Vertex AI doesn't require an API key
   if (provider === "gemini" && isVertexAiEnabled()) return false;
   return !!providerModelConfigs[provider].apiKeyRequiredMessage;
@@ -86,7 +94,7 @@ export function createDirectLLMModel({
   if (!cfg) {
     throw new ApiError(400, `Unsupported provider: ${provider}`);
   }
-  if (cfg.apiKeyRequiredMessage && !apiKey) {
+  if (cfg.apiKeyRequiredMessage && isApiKeyRequired(provider, apiKey)) {
     throw new ApiError(400, cfg.apiKeyRequiredMessage);
   }
   const resolvedBaseUrl = baseUrl ?? cfg.defaultBaseUrl;
@@ -244,6 +252,8 @@ export async function createLLMModelForAgent(params: {
   const isOllama = provider === "ollama";
   const isAzureWithEntra =
     provider === "azure" && isAzureOpenAiEntraIdEnabled();
+  const isAnthropicWithWorkloadIdentity =
+    provider === "anthropic" && isAnthropicWorkloadIdentityEnabled();
 
   logger.info(
     {
@@ -254,6 +264,7 @@ export async function createLLMModelForAgent(params: {
       isVllm,
       isOllama,
       isAzureWithEntra,
+      isAnthropicWithWorkloadIdentity,
     },
     "Using LLM provider API key",
   );
@@ -264,7 +275,8 @@ export async function createLLMModelForAgent(params: {
     !isBedrockWithIamAuth &&
     !isVllm &&
     !isOllama &&
-    !isAzureWithEntra
+    !isAzureWithEntra &&
+    !isAnthropicWithWorkloadIdentity
   ) {
     throw new ApiError(
       400,
@@ -326,8 +338,21 @@ const providerModelConfigs: Record<SupportedProvider, ProviderModelConfig> = {
   // --- Native SDK providers (use their own SDK, call client(modelName)) ---
 
   anthropic: {
-    createModel: ({ apiKey, modelName, baseURL, headers, fetch }) =>
-      createAnthropic({ apiKey, baseURL, headers, fetch })(modelName),
+    createModel: ({ apiKey, modelName, baseURL, headers, fetch }) => {
+      const useWorkloadIdentity =
+        !apiKey && isAnthropicWorkloadIdentityEnabled();
+      return createAnthropic({
+        apiKey: useWorkloadIdentity
+          ? ANTHROPIC_WIF_API_KEY_PLACEHOLDER
+          : apiKey,
+        baseURL,
+        headers,
+        fetch:
+          useWorkloadIdentity && !headers
+            ? createAnthropicWorkloadIdentityFetch(fetch)
+            : fetch,
+      })(modelName);
+    },
     defaultBaseUrl: config.llm.anthropic.baseUrl,
     apiKeyRequiredMessage:
       "Anthropic API key is required. Please configure ANTHROPIC_API_KEY.",

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -41,6 +41,22 @@ const frontendBaseUrl =
 const DEFAULT_POSTHOG_KEY = "phc_FFZO7LacnsvX2exKFWehLDAVaXLBfoBaJypdOuYoTk7";
 const DEFAULT_POSTHOG_HOST = "https://eu.i.posthog.com";
 
+const isAnthropicWifImplicitlyEnabled = (): boolean =>
+  Boolean(
+    process.env.ARCHESTRA_ANTHROPIC_WIF_FEDERATION_RULE_ID &&
+      process.env.ARCHESTRA_ANTHROPIC_WIF_ORGANIZATION_ID &&
+      process.env.ARCHESTRA_ANTHROPIC_WIF_SERVICE_ACCOUNT_ID &&
+      (process.env.ARCHESTRA_ANTHROPIC_WIF_IDENTITY_TOKEN ||
+        process.env.ARCHESTRA_ANTHROPIC_WIF_IDENTITY_TOKEN_FILE),
+  );
+
+const isAnthropicWifEnabled = (): boolean => {
+  const explicit = process.env.ARCHESTRA_ANTHROPIC_WIF_ENABLED;
+  return explicit === undefined
+    ? isAnthropicWifImplicitlyEnabled()
+    : explicit === "true";
+};
+
 /**
  * Determines OTLP authentication headers based on environment variables
  * Returns undefined if authentication is not properly configured
@@ -609,6 +625,21 @@ const config = {
       azureFoundryEntraIdEnabled:
         process.env.ARCHESTRA_ANTHROPIC_AZURE_FOUNDRY_ENTRA_ID_ENABLED ===
         "true",
+      workloadIdentity: {
+        enabled: isAnthropicWifEnabled(),
+        tokenUrl: process.env.ARCHESTRA_ANTHROPIC_WIF_TOKEN_URL || "",
+        federationRuleId:
+          process.env.ARCHESTRA_ANTHROPIC_WIF_FEDERATION_RULE_ID || "",
+        organizationId:
+          process.env.ARCHESTRA_ANTHROPIC_WIF_ORGANIZATION_ID || "",
+        serviceAccountId:
+          process.env.ARCHESTRA_ANTHROPIC_WIF_SERVICE_ACCOUNT_ID || "",
+        workspaceId: process.env.ARCHESTRA_ANTHROPIC_WIF_WORKSPACE_ID || "",
+        identityToken:
+          process.env.ARCHESTRA_ANTHROPIC_WIF_IDENTITY_TOKEN || "",
+        identityTokenFile:
+          process.env.ARCHESTRA_ANTHROPIC_WIF_IDENTITY_TOKEN_FILE || "",
+      },
     },
     gemini: {
       baseUrl:

--- a/platform/backend/src/models/llm-provider-api-key.ts
+++ b/platform/backend/src/models/llm-provider-api-key.ts
@@ -5,6 +5,7 @@ import {
   type SupportedProvider,
 } from "@shared";
 import { and, asc, desc, eq, ilike, inArray, or, sql } from "drizzle-orm";
+import { isAnthropicWorkloadIdentityEnabled } from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import db, { schema } from "@/database";
 import { computeSecretStorageType } from "@/secrets-manager/utils";
@@ -274,6 +275,8 @@ class LlmProviderApiKeyModel {
         schema.llmProviderApiKeysTable.provider,
         getProvidersWithOptionalApiKey({
           azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+          anthropicWorkloadIdentityEnabled:
+            isAnthropicWorkloadIdentityEnabled(),
         }),
       ),
     );
@@ -430,6 +433,8 @@ class LlmProviderApiKeyModel {
         schema.llmProviderApiKeysTable.provider,
         getProvidersWithOptionalApiKey({
           azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+          anthropicWorkloadIdentityEnabled:
+            isAnthropicWorkloadIdentityEnabled(),
         }),
       ),
     );
@@ -747,6 +752,7 @@ function canUseProviderApiKey(
 
   return getProvidersWithOptionalApiKey({
     azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+    anthropicWorkloadIdentityEnabled: isAnthropicWorkloadIdentityEnabled(),
   }).includes(apiKey.provider);
 }
 

--- a/platform/backend/src/routes/chat/model-fetchers/anthropic.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/anthropic.ts
@@ -1,4 +1,8 @@
 import {
+  getAnthropicWorkloadIdentityBearerToken,
+  isAnthropicWorkloadIdentityEnabled,
+} from "@/clients/anthropic-workload-identity";
+import {
   getAzureAiFoundryBearerTokenProvider,
   isAnthropicAzureFoundryEntraIdEnabled,
 } from "@/clients/azure-openai-credentials";
@@ -52,6 +56,12 @@ async function getAnthropicAuthHeaders(
   }
 
   if (!isAnthropicAzureFoundryEntraIdEnabled()) {
+    if (isAnthropicWorkloadIdentityEnabled()) {
+      return {
+        Authorization: `Bearer ${await getAnthropicWorkloadIdentityBearerToken()}`,
+      };
+    }
+
     return { "x-api-key": "" };
   }
 

--- a/platform/backend/src/routes/chat/model-fetchers/registry.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/registry.test.ts
@@ -118,6 +118,67 @@ describe("provider fetcher registry", () => {
     expect(models[0].id).toBe("deepseek-chat");
   });
 
+  test("Anthropic model discovery prefers configured API keys over WIF", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id);
+    const secret = await makeSecret({ secret: { apiKey: "anthropic-key" } });
+    await makeLlmProviderApiKey(org.id, secret.id, { provider: "anthropic" });
+    const originalWorkloadIdentity = {
+      ...config.llm.anthropic.workloadIdentity,
+    };
+
+    try {
+      Object.assign(config.llm.anthropic.workloadIdentity, {
+        enabled: true,
+        federationRuleId: "fdrl_test",
+        organizationId: "00000000-0000-0000-0000-000000000000",
+        serviceAccountId: "svac_test",
+        identityToken: "idp-jwt",
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: [
+              {
+                id: "claude-sonnet-4-5",
+                display_name: "Claude Sonnet 4.5",
+                created_at: "2026-05-20T00:00:00Z",
+              },
+            ],
+          }),
+      });
+
+      const models = await fetchModelsForProvider({
+        provider: "anthropic",
+        organizationId: org.id,
+        userId: user.id,
+        userTeamIds: [],
+      });
+
+      expect(models).toHaveLength(1);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch.mock.calls[0][1].headers).toMatchObject({
+        "x-api-key": "anthropic-key",
+      });
+      expect(mockFetch.mock.calls[0][1].headers).not.toHaveProperty(
+        "Authorization",
+      );
+    } finally {
+      Object.assign(
+        config.llm.anthropic.workloadIdentity,
+        originalWorkloadIdentity,
+      );
+    }
+  });
+
   test("returns empty array when provider has no API key", async ({
     makeOrganization,
     makeUser,

--- a/platform/backend/src/routes/chat/model-fetchers/registry.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/registry.ts
@@ -1,4 +1,5 @@
 import type { SupportedProvider } from "@shared";
+import { isAnthropicWorkloadIdentityEnabled } from "@/clients/anthropic-workload-identity";
 import { isBedrockIamAuthEnabled } from "@/clients/bedrock-credentials";
 import { isVertexAiEnabled } from "@/clients/gemini-client";
 import config, { getProviderEnvApiKey } from "@/config";
@@ -39,6 +40,8 @@ export async function fetchModelsForProvider(params: {
 
   const vertexAiEnabled = provider === "gemini" && isVertexAiEnabled();
   const bedrockIamEnabled = provider === "bedrock" && isBedrockIamAuthEnabled();
+  const anthropicWifEnabled =
+    provider === "anthropic" && isAnthropicWorkloadIdentityEnabled();
   const isKeylessProviderEnabled =
     (provider === "vllm" && config.llm.vllm.enabled) ||
     (provider === "ollama" && config.llm.ollama.enabled);
@@ -48,6 +51,7 @@ export async function fetchModelsForProvider(params: {
     !apiKey &&
     !vertexAiEnabled &&
     !bedrockIamEnabled &&
+    !anthropicWifEnabled &&
     !isKeylessProviderEnabled &&
     !isBedrockEnabled
   ) {
@@ -65,6 +69,8 @@ export async function fetchModelsForProvider(params: {
       models = await fetchGeminiModelsViaVertexAi();
     } else if (provider === "bedrock" && bedrockIamEnabled) {
       models = await fetchBedrockModelsViaIam();
+    } else if (provider === "anthropic" && anthropicWifEnabled) {
+      models = await modelFetchers[provider]("");
     } else {
       models = await modelFetchers[provider](apiKey || PLACEHOLDER_API_KEY);
     }

--- a/platform/backend/src/routes/chat/model-fetchers/registry.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/registry.ts
@@ -41,7 +41,7 @@ export async function fetchModelsForProvider(params: {
   const vertexAiEnabled = provider === "gemini" && isVertexAiEnabled();
   const bedrockIamEnabled = provider === "bedrock" && isBedrockIamAuthEnabled();
   const anthropicWifEnabled =
-    provider === "anthropic" && isAnthropicWorkloadIdentityEnabled();
+    provider === "anthropic" && !apiKey && isAnthropicWorkloadIdentityEnabled();
   const isKeylessProviderEnabled =
     (provider === "vllm" && config.llm.vllm.enabled) ||
     (provider === "ollama" && config.llm.ollama.enabled);

--- a/platform/backend/src/routes/llm-provider-api-keys.test.ts
+++ b/platform/backend/src/routes/llm-provider-api-keys.test.ts
@@ -19,6 +19,10 @@ vi.mock("@/clients/azure-openai-credentials", () => ({
   getAzureOpenAiBearerTokenProvider: vi.fn(),
 }));
 
+vi.mock("@/clients/anthropic-workload-identity", () => ({
+  isAnthropicWorkloadIdentityEnabled: vi.fn(() => false),
+}));
+
 // Mock auth for permission checks
 vi.mock("@/auth", () => ({
   hasPermission: vi.fn(),

--- a/platform/backend/src/routes/llm-provider-api-keys.ts
+++ b/platform/backend/src/routes/llm-provider-api-keys.ts
@@ -9,6 +9,7 @@ import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { capitalize } from "lodash-es";
 import { z } from "zod";
 import { hasPermission, userHasPermission } from "@/auth";
+import { isAnthropicWorkloadIdentityEnabled } from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import {
   type BedrockSigV4Credentials,
@@ -249,6 +250,8 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 isProviderApiKeyOptional({
                   provider: data.provider,
                   azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+                  anthropicWorkloadIdentityEnabled:
+                    isAnthropicWorkloadIdentityEnabled(),
                 }) || data.apiKey
               );
             },
@@ -387,6 +390,8 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
         !isProviderApiKeyOptional({
           provider: body.provider,
           azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+          anthropicWorkloadIdentityEnabled:
+            isAnthropicWorkloadIdentityEnabled(),
         })
       ) {
         throw new ApiError(
@@ -418,6 +423,8 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
         isProviderApiKeyOptional({
           provider: body.provider,
           azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+          anthropicWorkloadIdentityEnabled:
+            isAnthropicWorkloadIdentityEnabled(),
         });
       if (canSync) {
         try {
@@ -727,6 +734,8 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
           !isProviderApiKeyOptional({
             provider: apiKeyFromDB.provider,
             azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+            anthropicWorkloadIdentityEnabled:
+              isAnthropicWorkloadIdentityEnabled(),
           })
         ) {
           throw new ApiError(

--- a/platform/backend/src/routes/llm-provider-models.ts
+++ b/platform/backend/src/routes/llm-provider-models.ts
@@ -6,6 +6,7 @@ import {
 } from "@shared";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
+import { isAnthropicWorkloadIdentityEnabled } from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import { isBedrockIamAuthEnabled } from "@/clients/bedrock-credentials";
 import { isVertexAiEnabled } from "@/clients/gemini-client";
@@ -301,6 +302,8 @@ export async function syncModelsForVisibleApiKeys(params: {
           !isProviderApiKeyOptional({
             provider: apiKey.provider,
             azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+            anthropicWorkloadIdentityEnabled:
+              isAnthropicWorkloadIdentityEnabled(),
           })
         ) {
           if (apiKey.secretId) {

--- a/platform/backend/src/routes/proxy/adapters/anthropic-azure-foundry.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic-azure-foundry.test.ts
@@ -1,6 +1,16 @@
 import type AnthropicProvider from "@anthropic-ai/sdk";
 import { describe, expect, test, vi } from "vitest";
 
+const mockIsAnthropicAzureFoundryEntraIdEnabled = vi.hoisted(() =>
+  vi.fn(() => true),
+);
+const mockIsAnthropicWorkloadIdentityEnabled = vi.hoisted(() =>
+  vi.fn(() => false),
+);
+const mockCreateAnthropicWorkloadIdentityFetch = vi.hoisted(() =>
+  vi.fn((fetch?: typeof globalThis.fetch) => fetch ?? globalThis.fetch),
+);
+
 vi.mock("@/observability", () => ({
   metrics: { llm: { getObservableFetch: vi.fn() } },
 }));
@@ -9,7 +19,14 @@ vi.mock("@/clients/azure-openai-credentials", () => ({
   getAzureAiFoundryBearerTokenProvider: vi.fn(
     () => async () => "azure-foundry-token",
   ),
-  isAnthropicAzureFoundryEntraIdEnabled: vi.fn(() => true),
+  isAnthropicAzureFoundryEntraIdEnabled:
+    mockIsAnthropicAzureFoundryEntraIdEnabled,
+}));
+
+vi.mock("@/clients/anthropic-workload-identity", () => ({
+  createAnthropicWorkloadIdentityFetch:
+    mockCreateAnthropicWorkloadIdentityFetch,
+  isAnthropicWorkloadIdentityEnabled: mockIsAnthropicWorkloadIdentityEnabled,
 }));
 
 import { anthropicAdapterFactory } from "./anthropic";
@@ -49,5 +66,30 @@ describe("anthropicAdapterFactory Azure Foundry", () => {
     expect(headers.get("Authorization")).toBe("Bearer azure-foundry-token");
 
     upstreamFetch.mockRestore();
+  });
+
+  test("creates a keyless client that injects Anthropic workload identity auth", () => {
+    mockIsAnthropicAzureFoundryEntraIdEnabled.mockReturnValue(false);
+    mockIsAnthropicWorkloadIdentityEnabled.mockReturnValue(true);
+    mockCreateAnthropicWorkloadIdentityFetch.mockClear();
+
+    const client = anthropicAdapterFactory.createClient(undefined, {
+      baseUrl: "https://api.anthropic.com",
+      defaultHeaders: {},
+      source: "api",
+    }) as AnthropicProvider & {
+      _options?: {
+        defaultHeaders?: Record<string, string>;
+        fetch?: typeof globalThis.fetch;
+      };
+    };
+
+    expect(client._options?.defaultHeaders?.Authorization).toBe(
+      "Bearer <anthropic-wif-managed>",
+    );
+    expect(mockCreateAnthropicWorkloadIdentityFetch).toHaveBeenCalled();
+
+    mockIsAnthropicAzureFoundryEntraIdEnabled.mockReturnValue(true);
+    mockIsAnthropicWorkloadIdentityEnabled.mockReturnValue(false);
   });
 });

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -3,6 +3,10 @@ import { ArchestraInternalErrorCode } from "@shared";
 import { encode as toonEncode } from "@toon-format/toon";
 import { get } from "lodash-es";
 import {
+  createAnthropicWorkloadIdentityFetch,
+  isAnthropicWorkloadIdentityEnabled,
+} from "@/clients/anthropic-workload-identity";
+import {
   getAzureAiFoundryBearerTokenProvider,
   isAnthropicAzureFoundryEntraIdEnabled,
 } from "@/clients/azure-openai-credentials";
@@ -1168,6 +1172,20 @@ export const anthropicAdapterFactory: LLMProvider<
           ...options.defaultHeaders,
           // The fetch wrapper replaces this sentinel with a fresh Entra ID token on every request.
           Authorization: "Bearer <entra-id-managed>",
+        },
+      });
+    }
+
+    if (!apiKey && isAnthropicWorkloadIdentityEnabled()) {
+      return new AnthropicProvider({
+        apiKey: null,
+        authToken: null,
+        baseURL: options.baseUrl,
+        fetch: createAnthropicWorkloadIdentityFetch(customFetch),
+        defaultHeaders: {
+          ...options.defaultHeaders,
+          // The fetch wrapper replaces this sentinel with a fresh Anthropic WIF token.
+          Authorization: "Bearer <anthropic-wif-managed>",
         },
       });
     }

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -21,6 +21,10 @@ import {
 } from "@shared";
 import type { FastifyReply, FastifyRequest } from "fastify";
 import { LRUCacheManager } from "@/cache-manager";
+import {
+  ANTHROPIC_WIF_API_KEY_PLACEHOLDER,
+  isAnthropicWorkloadIdentityEnabled,
+} from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import config from "@/config";
 import logger from "@/logging";
@@ -332,6 +336,15 @@ export async function handleLLMProxy<
   // 2. Extract API key from headers if not already resolved via JWKS
   if (!authOverride && !wasJwksAuthenticated) {
     apiKey = provider.extractApiKey(headers);
+  }
+
+  if (
+    isLoopbackAddress(request.ip) &&
+    providerName === "anthropic" &&
+    isAnthropicWorkloadIdentityEnabled() &&
+    apiKey === ANTHROPIC_WIF_API_KEY_PLACEHOLDER
+  ) {
+    apiKey = undefined;
   }
 
   // 3. Resolve platform-managed virtual API keys.
@@ -1568,6 +1581,7 @@ function shouldUseKeylessProviderApiKey(params: {
   return isProviderApiKeyOptional({
     provider: row.provider,
     azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+    anthropicWorkloadIdentityEnabled: isAnthropicWorkloadIdentityEnabled(),
   });
 }
 

--- a/platform/backend/src/utils/llm-api-key-resolution.ts
+++ b/platform/backend/src/utils/llm-api-key-resolution.ts
@@ -1,4 +1,5 @@
 import { isProviderApiKeyOptional, type SupportedProvider } from "@shared";
+import { isAnthropicWorkloadIdentityEnabled } from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import { getProviderEnvApiKey } from "@/config";
 import { LlmProviderApiKeyModel, TeamModel } from "@/models";
@@ -73,6 +74,7 @@ export async function resolveProviderApiKey(params: {
       isProviderApiKeyOptional({
         provider,
         azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+        anthropicWorkloadIdentityEnabled: isAnthropicWorkloadIdentityEnabled(),
       })
     ) {
       return {

--- a/platform/shared/model-constants.test.ts
+++ b/platform/shared/model-constants.test.ts
@@ -26,10 +26,31 @@ describe("provider API key optional helpers", () => {
     ).toBe(true);
   });
 
+  test("treats Anthropic as optional only when workload identity is enabled", () => {
+    expect(isProviderApiKeyOptional({ provider: "anthropic" })).toBe(false);
+    expect(
+      isProviderApiKeyOptional({
+        provider: "anthropic",
+        anthropicWorkloadIdentityEnabled: false,
+      }),
+    ).toBe(false);
+    expect(
+      isProviderApiKeyOptional({
+        provider: "anthropic",
+        anthropicWorkloadIdentityEnabled: true,
+      }),
+    ).toBe(true);
+  });
+
   test("lists providers with optional API keys", () => {
     expect(getProvidersWithOptionalApiKey()).toEqual(["ollama", "vllm"]);
     expect(
       getProvidersWithOptionalApiKey({ azureEntraIdEnabled: true }),
     ).toEqual(["ollama", "vllm", "azure"]);
+    expect(
+      getProvidersWithOptionalApiKey({
+        anthropicWorkloadIdentityEnabled: true,
+      }),
+    ).toEqual(["ollama", "vllm", "anthropic"]);
   });
 });

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -96,19 +96,26 @@ const PROVIDERS_WITH_OPTIONAL_API_KEY = new Set<SupportedProvider>([
 export function isProviderApiKeyOptional(params: {
   provider: SupportedProvider;
   azureEntraIdEnabled?: boolean;
+  anthropicWorkloadIdentityEnabled?: boolean;
 }): boolean {
   return (
     PROVIDERS_WITH_OPTIONAL_API_KEY.has(params.provider) ||
-    (params.provider === "azure" && params.azureEntraIdEnabled === true)
+    (params.provider === "azure" && params.azureEntraIdEnabled === true) ||
+    (params.provider === "anthropic" &&
+      params.anthropicWorkloadIdentityEnabled === true)
   );
 }
 
 export function getProvidersWithOptionalApiKey(params?: {
   azureEntraIdEnabled?: boolean;
+  anthropicWorkloadIdentityEnabled?: boolean;
 }): SupportedProvider[] {
   const providers = [...PROVIDERS_WITH_OPTIONAL_API_KEY];
   if (params?.azureEntraIdEnabled === true) {
     providers.push("azure");
+  }
+  if (params?.anthropicWorkloadIdentityEnabled === true) {
+    providers.push("anthropic");
   }
   return providers;
 }


### PR DESCRIPTION
/claim #4468

## Summary
- Add Anthropic Workload Identity Federation token exchange and bearer-token injection for direct SDK calls, proxy calls, and model discovery.
- Allow Anthropic to be configured as a keyless provider when WIF is enabled, while preserving API-key precedence.
- Document the `ARCHESTRA_ANTHROPIC_WIF_*` environment variables in deployment and provider docs.

Closes #4468.

## Tests
- `DATABASE_URL=postgresql://test:test@localhost:5432/test pnpm --dir platform/backend test src/clients/anthropic-workload-identity.test.ts src/clients/llm-client.test.ts src/routes/proxy/adapters/anthropic-azure-foundry.test.ts src/routes/chat/model-fetchers/registry.test.ts`
- `pnpm --dir platform/shared test model-constants.test.ts`
- `DATABASE_URL=postgresql://test:test@localhost:5432/test pnpm --dir platform/backend type-check`
- `pnpm --dir platform/shared type-check`
- `pnpm --dir platform exec biome check ...` on touched files
- `git diff --check`