### PR TITLE
chore(claude): extract migration conflict recipe into a skill

### DIFF
--- a/.claude/skills/resolve-conflicts/SKILL.md
+++ b/.claude/skills/resolve-conflicts/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: resolve-conflicts
+description: Resolve merge conflicts in this repo — Drizzle migration number collisions (meta/_journal.json, meta/<NNNN>_snapshot.json), and related generated files like shared/hey-api/**/sdk.gen.ts. Use when git reports a merge conflict in any of these files, or when `drizzle-kit check` fails after a merge.
+---
+
+# Resolving Migration Merge Conflicts (migration number collision)
+# When main has landed migrations that collide with your branch's migration number
+# (conflicts in meta/_journal.json and meta/<NNNN>_snapshot.json), renumber YOUR
+# migration to come AFTER main's. Never edit main's migrations. Steps:
+#   1. Take main's side for the journal and colliding snapshot:
+#        git checkout --theirs -- backend/src/database/migrations/meta/_journal.json \
+#          backend/src/database/migrations/meta/<NNNN>_snapshot.json
+#        git add the same two files
+#      (Resolve any conflict in generated files like shared/hey-api/.../sdk.gen.ts
+#       enough to parse — they get regenerated below.)
+#   2. Renumber your migration SQL to the next free number, preserving history:
+#        git mv backend/src/database/migrations/<OLD>_<name>.sql \
+#               backend/src/database/migrations/<NEW>_<name>.sql
+#   3. Regenerate the snapshot + journal entry: `cd backend && pnpm db:generate`
+#      This emits a fresh <NEW>_<random>.sql, meta/<NEW>_snapshot.json, and a
+#      journal entry tagged <NEW>_<random>.
+#   4. Delete the generated <NEW>_<random>.sql (its ALTER statements are identical
+#      to your file's schema portion) and KEEP your hand-written <NEW>_<name>.sql.
+#      IMPORTANT: keep any data-migration logic (DO $$ blocks, UPDATE/INSERT) from
+#      your original file — db:generate only emits schema DDL, not data migration.
+#   5. Rename the journal tag <NEW>_<random> -> <NEW>_<name> to match your file.
+#   6. Verify: `cd backend && npx drizzle-kit check` must print "Everything's fine".
+#   7. Regenerate any conflicted generated clients from the merged spec, e.g.
+#        cd shared && CODEGEN=true pnpm codegen:api-client

--- a/platform/CLAUDE.md
+++ b/platform/CLAUDE.md
@@ -93,31 +93,6 @@ drizzle-kit check    # Check consistency of generated SQL migrations history
 # This creates an empty SQL file tracked by Drizzle's journal. Add your SQL, then run:
 #   npx drizzle-kit check
 
-# Resolving Migration Merge Conflicts (migration number collision)
-# When main has landed migrations that collide with your branch's migration number
-# (conflicts in meta/_journal.json and meta/<NNNN>_snapshot.json), renumber YOUR
-# migration to come AFTER main's. Never edit main's migrations. Steps:
-#   1. Take main's side for the journal and colliding snapshot:
-#        git checkout --theirs -- backend/src/database/migrations/meta/_journal.json \
-#          backend/src/database/migrations/meta/<NNNN>_snapshot.json
-#        git add the same two files
-#      (Resolve any conflict in generated files like shared/hey-api/.../sdk.gen.ts
-#       enough to parse — they get regenerated below.)
-#   2. Renumber your migration SQL to the next free number, preserving history:
-#        git mv backend/src/database/migrations/<OLD>_<name>.sql \
-#               backend/src/database/migrations/<NEW>_<name>.sql
-#   3. Regenerate the snapshot + journal entry: `cd backend && pnpm db:generate`
-#      This emits a fresh <NEW>_<random>.sql, meta/<NEW>_snapshot.json, and a
-#      journal entry tagged <NEW>_<random>.
-#   4. Delete the generated <NEW>_<random>.sql (its ALTER statements are identical
-#      to your file's schema portion) and KEEP your hand-written <NEW>_<name>.sql.
-#      IMPORTANT: keep any data-migration logic (DO $$ blocks, UPDATE/INSERT) from
-#      your original file — db:generate only emits schema DDL, not data migration.
-#   5. Rename the journal tag <NEW>_<random> -> <NEW>_<name> to match your file.
-#   6. Verify: `cd backend && npx drizzle-kit check` must print "Everything's fine".
-#   7. Regenerate any conflicted generated clients from the merged spec, e.g.
-#        cd shared && CODEGEN=true pnpm codegen:api-client
-
 # Database Connection
 # PostgreSQL is running in Kubernetes (managed by Tilt)
 # Connect to database:


### PR DESCRIPTION
## Summary

- Moves the 24-line "Resolving Migration Merge Conflicts" procedure out of `platform/CLAUDE.md` (always loaded into every Claude Code conversation) into a project-local skill at `.claude/skills/resolve-conflicts/` that loads on demand when the conflict scenario actually comes up.
- Reclaims ~450 tokens from every conversation's preloaded context. `platform/CLAUDE.md` drops from 547 → 522 lines (34,726 → 32,985 chars).
- The skill auto-fires on `_journal.json` / `sdk.gen.ts` / `drizzle-kit check` mentions via its `description` frontmatter field, so no pointer is needed back in `CLAUDE.md`.
- Procedure text inside the skill is the **verbatim** original block — only frontmatter was added.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>