### PR TITLE
fix: address compaction PR review findings

### DIFF
--- a/platform/backend/src/models/conversation-compaction.ts
+++ b/platform/backend/src/models/conversation-compaction.ts
@@ -1,4 +1,4 @@
-import { desc, eq } from "drizzle-orm";
+import { asc, desc, eq } from "drizzle-orm";
 import db, { schema } from "@/database";
 import type { InsertConversationCompaction } from "@/types/conversation-compaction";
 
@@ -36,7 +36,7 @@ class ConversationCompactionModel {
       .where(
         eq(schema.conversationCompactionsTable.conversationId, conversationId),
       )
-      .orderBy(schema.conversationCompactionsTable.createdAt);
+      .orderBy(asc(schema.conversationCompactionsTable.createdAt));
   }
 
   static async deleteByConversation(

--- a/platform/backend/src/models/interaction.ts
+++ b/platform/backend/src/models/interaction.ts
@@ -903,7 +903,7 @@ class InteractionModel {
           source: sql<InteractionSource | null>`CASE WHEN COUNT(DISTINCT ${schema.interactionsTable.source}) = 1 THEN MAX(${schema.interactionsTable.source}) ELSE NULL END`,
           sources: sql<
             InteractionSource[]
-          >`ARRAY_REMOVE(ARRAY_AGG(DISTINCT ${schema.interactionsTable.source}), NULL)`,
+          >`ARRAY_REMOVE(ARRAY_AGG(DISTINCT ${schema.interactionsTable.source} ORDER BY ${schema.interactionsTable.source}), NULL)`,
           // For single interactions (no session), return the interaction ID for direct navigation
           interactionId: sql<string>`CASE WHEN MAX(${schema.interactionsTable.sessionId}) IS NULL THEN MAX(${schema.interactionsTable.id}::text) ELSE NULL END`,
           requestCount: count(),

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -542,7 +542,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   userId: user.id,
                   agentId: conversation.agentId,
                   provider,
-                  selectedModel: conversation.selectedModel,
+                  selectedModel,
                   agentLlmApiKeyId: agent.llmApiKeyId,
                   messages: normalizedMessagesForLLM,
                   systemPrompt,

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -1049,53 +1049,64 @@ export function ChatPageContent({
       (result.conversation.messages ?? []) as UIMessage[],
     );
 
-    if (result.status === "created") {
-      if (result.compaction) {
-        recordContextCompaction?.({
-          compactionId: result.compaction.id,
-          originalTokenEstimate: result.compaction.originalTokenEstimate,
-          compactedTokenEstimate: result.compaction.compactedTokenEstimate,
-        });
+    switch (result.status) {
+      case "created": {
+        if (result.compaction) {
+          recordContextCompaction?.({
+            compactionId: result.compaction.id,
+            originalTokenEstimate: result.compaction.originalTokenEstimate,
+            compactedTokenEstimate: result.compaction.compactedTokenEstimate,
+          });
+        }
+
+        setManualCompactionFeedback(null);
+        return;
       }
+      case "existing": {
+        if (result.compaction) {
+          recordContextCompaction?.({
+            compactionId: result.compaction.id,
+            originalTokenEstimate: result.compaction.originalTokenEstimate,
+            compactedTokenEstimate: result.compaction.compactedTokenEstimate,
+          });
+        }
 
-      setManualCompactionFeedback(null);
-      return;
-    }
-
-    if (result.status === "existing") {
-      if (result.compaction) {
-        recordContextCompaction?.({
-          compactionId: result.compaction.id,
-          originalTokenEstimate: result.compaction.originalTokenEstimate,
-          compactedTokenEstimate: result.compaction.compactedTokenEstimate,
+        setManualCompactionFeedback({
+          status: "skipped",
+          message: getManualCompactionSkippedMessage(
+            result.reason,
+            result.status,
+          ),
         });
+        return;
       }
-
-      setManualCompactionFeedback({
-        status: "skipped",
-        message: getManualCompactionSkippedMessage(
-          result.reason,
-          result.status,
-        ),
-      });
-      return;
+      case "skipped": {
+        setManualCompactionFeedback({
+          status: "skipped",
+          message: getManualCompactionSkippedMessage(
+            result.reason,
+            result.status,
+          ),
+        });
+        return;
+      }
+      case "failed": {
+        setManualCompactionFeedback({
+          status: "failed",
+          message: "Context compaction failed.",
+        });
+        return;
+      }
+      default: {
+        // compile-time guard: a new status must be handled explicitly above
+        result.status satisfies never;
+        setManualCompactionFeedback({
+          status: "failed",
+          message: "Context compaction failed.",
+        });
+        return;
+      }
     }
-
-    if (result.status === "skipped") {
-      setManualCompactionFeedback({
-        status: "skipped",
-        message: getManualCompactionSkippedMessage(
-          result.reason,
-          result.status,
-        ),
-      });
-      return;
-    }
-
-    setManualCompactionFeedback({
-      status: "failed",
-      message: "Context compaction failed.",
-    });
   }, [
     compactConversationMutation,
     conversationId,

--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -592,6 +592,34 @@ describe("ArchestraPromptInput", () => {
       );
     });
 
+    it("keeps the queued follow-up in the queue when submitting it fails", () => {
+      const onSubmit = vi.fn(() => {
+        throw new Error("submit failed");
+      });
+      mockControllerState.value = "Retain on failure";
+
+      const { rerender } = render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          onSubmit={onSubmit}
+          status="streaming"
+        />,
+      );
+
+      fireEvent.submit(screen.getByTestId("prompt-input"));
+
+      rerender(
+        <ArchestraPromptInput
+          {...defaultProps}
+          onSubmit={onSubmit}
+          status="ready"
+        />,
+      );
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(screen.getByText("Retain on failure")).toBeInTheDocument();
+    });
+
     it("does not submit queued follow-ups after switching conversations", () => {
       const onConversationASubmit = vi.fn();
       const onConversationBSubmit = vi.fn();

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -392,7 +392,14 @@ const PromptInputContent = ({
     setQueuedMessages((current) =>
       current.filter((message) => message.id !== nextMessage.id),
     );
-    submitQueuedMessage(nextMessage);
+    try {
+      submitQueuedMessage(nextMessage);
+    } catch {
+      // restore the message so a failed send is not lost silently; the
+      // sending guard stays set so we do not retry in a tight loop — the
+      // next ready transition (guard reset on status change) picks it up
+      setQueuedMessages((current) => [nextMessage, ...current]);
+    }
   }, [visibleQueuedMessages, status, submitQueuedMessage]);
 
   const selectSlashCommand = useCallback(


### PR DESCRIPTION
Follow-up to #4535 (merged via the merge queue before the review fixes could land). Addresses the automated review findings on that PR.

## Changes
- **Bug**: auto-compaction in the streaming route passed the deprecated `conversation.selectedModel` column (defaults to `gpt-4o`) instead of the resolved `selectedModel`, so `shouldAutoCompact()` checked the threshold against the wrong model's context length. Now passes the resolved value (matching the manual compact route).
- **Queued message loss**: a queued follow-up was removed from the queue before submission; if the send threw, it was lost silently. It is now restored to the queue on failure. The sending guard is intentionally left set so it does not retry in a tight loop — the next ready transition picks it up.
- **Exhaustive status handling**: `handleCompactConversation` now uses a `switch` with a `result.status satisfies never` guard, so a new compaction status fails at compile time instead of silently falling through.
- **Deterministic aggregation**: the `sources` aggregation orders by `source` (`ARRAY_AGG(DISTINCT source ORDER BY source)`).
- **Explicit ordering**: `ConversationCompactionModel.findByConversation` orders by `createdAt` with explicit `asc(...)`.

## Testing
- Added a regression test: a queued follow-up stays in the queue (and `onSubmit` is called exactly once) when its send throws.
- `tsgo --noEmit` clean (backend + frontend), Biome clean.
- Vitest: prompt-input (17), context-compaction (27), chat routes + stream (43), interaction model (70) — all pass.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>