### PR TITLE
feat(openrouter): first-class provider support

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -129683,6 +129683,9 @@
                       "isFastest": {
                         "type": "boolean"
                       },
+                      "isFree": {
+                        "type": "boolean"
+                      },
                       "embeddingDimensions": {
                         "nullable": true,
                         "allOf": [
@@ -129696,7 +129699,8 @@
                       "id",
                       "dbId",
                       "displayName",
-                      "provider"
+                      "provider",
+                      "isFree"
                     ],
                     "additionalProperties": false
                   }
@@ -130394,6 +130398,9 @@
                           "models_dev",
                           "default"
                         ]
+                      },
+                      "isFree": {
+                        "type": "boolean"
                       }
                     },
                     "required": [
@@ -130422,7 +130429,8 @@
                       "pricePerMillionInput",
                       "pricePerMillionOutput",
                       "isCustomPrice",
-                      "priceSource"
+                      "priceSource",
+                      "isFree"
                     ],
                     "additionalProperties": false
                   }

--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -264,7 +264,7 @@ You can generate an API key from the [Groq Console](https://console.groq.com/key
 | ---------------------------------- | -------- | --------------------------------------------------------------------------- |
 | `ARCHESTRA_OPENROUTER_BASE_URL`    | No       | OpenRouter API base URL (default: `https://openrouter.ai/api/v1`)           |
 | `ARCHESTRA_CHAT_OPENROUTER_API_KEY`| No       | Default API key for OpenRouter (can be overridden per conversation/team/org)|
-| `ARCHESTRA_OPENROUTER_REFERER`     | No       | Attribution header `HTTP-Referer` sent to OpenRouter (recommended)          |
+| `ARCHESTRA_OPENROUTER_REFERER`     | No       | Attribution header `HTTP-Referer` sent to OpenRouter (default: `https://archestra.ai`) |
 | `ARCHESTRA_OPENROUTER_TITLE`       | No       | Attribution header `X-Title` sent to OpenRouter (recommended)               |
 
 ### Getting an API Key

--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -265,7 +265,8 @@ You can generate an API key from the [Groq Console](https://console.groq.com/key
 | `ARCHESTRA_OPENROUTER_BASE_URL`    | No       | OpenRouter API base URL (default: `https://openrouter.ai/api/v1`)           |
 | `ARCHESTRA_CHAT_OPENROUTER_API_KEY`| No       | Default API key for OpenRouter (can be overridden per conversation/team/org)|
 | `ARCHESTRA_OPENROUTER_REFERER`     | No       | Attribution header `HTTP-Referer` sent to OpenRouter (default: `https://archestra.ai`) |
-| `ARCHESTRA_OPENROUTER_TITLE`       | No       | Attribution header `X-Title` sent to OpenRouter (recommended)               |
+| `ARCHESTRA_OPENROUTER_TITLE`       | No       | App name sent to OpenRouter as `X-OpenRouter-Title` (recommended)           |
+| `ARCHESTRA_OPENROUTER_CATEGORIES`  | No       | Comma-separated OpenRouter marketplace categories sent as `X-OpenRouter-Categories` (default: `general-chat,personal-agent`) |
 
 ### Getting an API Key
 

--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -246,7 +246,7 @@ You can generate an API key from the [Groq Console](https://console.groq.com/key
 
 ## OpenRouter
 
-[OpenRouter](https://openrouter.ai/) provides access to many models via a single OpenAI-compatible API, with optional attribution headers for ranking and analytics.
+[OpenRouter](https://openrouter.ai/) provides access to many models - including **free** ones - via a single OpenAI-compatible API, with optional attribution headers for ranking and analytics.
 
 ### Supported OpenRouter APIs
 
@@ -273,13 +273,19 @@ You can generate an API key from the [OpenRouter dashboard](https://openrouter.a
 
 ### Popular Models
 
-- `openrouter/auto`
-- `openrouter/openai/gpt-4o-mini`
+- `openrouter/auto` - OpenRouter's Auto Router; picks the best model per request, billed at that model's rate. Marked "Fastest", pinned to the top of the picker.
+- `openrouter/free` - OpenRouter's Free Models Router; see below.
+- `~`-prefixed ids such as `~anthropic/claude-sonnet-latest` are OpenRouter "latest" aliases that always redirect to the newest model in a family. They sync and behave like ordinary models, and are shown with a "Latest" badge in the picker.
 
-### Important Notes
+### Free Models
 
-- **OpenAI-compatible API**: OpenRouter uses the OpenAI Chat Completions request/response format.
-- **Attribution headers**: OpenRouter recommends sending `HTTP-Referer` and `X-Title` headers. Archestra can be configured to send these automatically via `ARCHESTRA_OPENROUTER_REFERER` and `ARCHESTRA_OPENROUTER_TITLE`.
+OpenRouter exposes `:free` model variants that cost nothing. An OpenRouter API key is still required to use them, but OpenRouter doesn't charge for requests that route to free models. Model providers may use the data from free model requests to improve their models, so it may be not suitable for sensitive data.
+
+**Free Models Router** (`openrouter/free`) is OpenRouter's built-in router that picks a free model per request, filtering for the features the request needs (tool calling, structured outputs, image input). 
+
+When an OpenRouter key is added to an organization that has no default model configured, Archestra sets the Free Models Router as the organization default, giving a zero-cost starting point. An explicitly chosen default is never overridden.
+
+Dynamic-pricing routers (`openrouter/auto`) report no fixed per-token price, so the pricing is dynamic.
 
 ## Mistral AI
 

--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -281,7 +281,7 @@ You can generate an API key from the [OpenRouter dashboard](https://openrouter.a
 
 OpenRouter exposes `:free` model variants that cost nothing. An OpenRouter API key is still required to use them, but OpenRouter doesn't charge for requests that route to free models. Model providers may use the data from free model requests to improve their models, so it may be not suitable for sensitive data.
 
-**Free Models Router** (`openrouter/free`) is OpenRouter's built-in router that picks a free model per request, filtering for the features the request needs (tool calling, structured outputs, image input). 
+**Free Models Router** (`openrouter/free`) is OpenRouter's [built-in router](https://openrouter.ai/openrouter/free) that picks a free model per request, filtering for the features the request needs (tool calling, structured outputs, image input). 
 
 When an OpenRouter key is added to an organization that has no default model configured, Archestra sets the Free Models Router as the organization default, giving a zero-cost starting point. An explicitly chosen default is never overridden.
 

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -99,7 +99,7 @@ export function createDirectLLMModel({
     apiKey,
     modelName,
     baseURL,
-    headers: mergeProviderHeaders(cfg),
+    headers: providerHeaders(cfg),
   });
 }
 
@@ -320,13 +320,13 @@ type ProviderModelConfig = {
   extraHeaders?: Record<string, string>;
 };
 
-/** Merge static provider headers with per-request headers (request headers win). */
-function mergeProviderHeaders(
+/** Static provider headers (e.g. OpenRouter attribution), or undefined when none. */
+function providerHeaders(
   cfg: ProviderModelConfig,
-  requestHeaders?: Record<string, string>,
 ): Record<string, string> | undefined {
-  const merged = { ...cfg.extraHeaders, ...requestHeaders };
-  return Object.keys(merged).length > 0 ? merged : undefined;
+  return cfg.extraHeaders && Object.keys(cfg.extraHeaders).length > 0
+    ? cfg.extraHeaders
+    : undefined;
 }
 
 /**

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -98,6 +98,7 @@ export function createDirectLLMModel({
     apiKey,
     modelName,
     baseURL,
+    headers: mergeProviderHeaders(cfg),
   });
 }
 
@@ -314,7 +315,18 @@ type ProviderModelConfig = {
   apiKeyRequiredMessage?: string;
   /** Path suffix appended to proxy base URL for proxied calls (e.g. "/v1" for anthropic) */
   proxiedPathSuffix?: string;
+  /** Static headers always sent to the provider (e.g. OpenRouter attribution). */
+  extraHeaders?: Record<string, string>;
 };
+
+/** Merge static provider headers with per-request headers (request headers win). */
+function mergeProviderHeaders(
+  cfg: ProviderModelConfig,
+  requestHeaders?: Record<string, string>,
+): Record<string, string> | undefined {
+  const merged = { ...cfg.extraHeaders, ...requestHeaders };
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
 
 /**
  * Unified registry of model configs for each provider.
@@ -390,6 +402,16 @@ const providerModelConfigs: Record<SupportedProvider, ProviderModelConfig> = {
     defaultBaseUrl: config.llm.openrouter.baseUrl,
     apiKeyRequiredMessage:
       "OpenRouter API key is required. Please configure ARCHESTRA_CHAT_OPENROUTER_API_KEY.",
+    // OpenRouter attribution headers — sent on the direct path; the LLM proxy
+    // adapter sets the same headers independently for proxied calls.
+    extraHeaders: {
+      ...(config.llm.openrouter.referer
+        ? { "HTTP-Referer": config.llm.openrouter.referer }
+        : {}),
+      ...(config.llm.openrouter.title
+        ? { "X-Title": config.llm.openrouter.title }
+        : {}),
+    },
   },
 
   perplexity: {

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -33,6 +33,7 @@ import {
   isBedrockIamAuthEnabled,
 } from "@/clients/bedrock-credentials";
 import { isVertexAiEnabled } from "@/clients/gemini-client";
+import { openRouterAttributionHeaders } from "@/clients/openrouter-attribution";
 import config from "@/config";
 import logger from "@/logging";
 import { ApiError } from "@/types";
@@ -402,16 +403,7 @@ const providerModelConfigs: Record<SupportedProvider, ProviderModelConfig> = {
     defaultBaseUrl: config.llm.openrouter.baseUrl,
     apiKeyRequiredMessage:
       "OpenRouter API key is required. Please configure ARCHESTRA_CHAT_OPENROUTER_API_KEY.",
-    // OpenRouter attribution headers — sent on the direct path; the LLM proxy
-    // adapter sets the same headers independently for proxied calls.
-    extraHeaders: {
-      ...(config.llm.openrouter.referer
-        ? { "HTTP-Referer": config.llm.openrouter.referer }
-        : {}),
-      ...(config.llm.openrouter.title
-        ? { "X-Title": config.llm.openrouter.title }
-        : {}),
-    },
+    extraHeaders: openRouterAttributionHeaders(),
   },
 
   perplexity: {

--- a/platform/backend/src/clients/openrouter-attribution.test.ts
+++ b/platform/backend/src/clients/openrouter-attribution.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "@/test";
+import { openRouterAttributionHeaders } from "./openrouter-attribution";
+
+describe("openRouterAttributionHeaders", () => {
+  test("sends the referer and both title header names", () => {
+    const headers = openRouterAttributionHeaders();
+
+    expect(headers["HTTP-Referer"]).toBeTruthy();
+    // X-OpenRouter-Title is the current name; X-Title is the legacy alias.
+    expect(headers["X-OpenRouter-Title"]).toBeTruthy();
+    expect(headers["X-Title"]).toBe(headers["X-OpenRouter-Title"]);
+  });
+
+  test("sends the marketplace categories", () => {
+    const headers = openRouterAttributionHeaders();
+
+    expect(headers["X-OpenRouter-Categories"]).toBe(
+      "general-chat,personal-agent",
+    );
+  });
+});

--- a/platform/backend/src/clients/openrouter-attribution.ts
+++ b/platform/backend/src/clients/openrouter-attribution.ts
@@ -1,18 +1,20 @@
 import config from "@/config";
 
 /**
- * OpenRouter attribution headers (`HTTP-Referer`, `X-Title`) for ranking and
- * analytics. Shared by the direct path (`createDirectLLMModel`) and the LLM
- * proxy adapter so both attribute requests identically. Either header is
- * omitted when its config value is unset.
+ * OpenRouter attribution headers for ranking and analytics. Shared by the
+ * direct path (`createDirectLLMModel`) and the LLM proxy adapter so both
+ * attribute requests identically. Each header is omitted when its config
+ * value is unset.
+ *
+ * `X-OpenRouter-Title` is the current header name; `X-Title` is the legacy
+ * alias OpenRouter still accepts — both are sent so attribution survives
+ * either name being phased out.
  */
 export function openRouterAttributionHeaders(): Record<string, string> {
+  const { referer, title, categories } = config.llm.openrouter;
   return {
-    ...(config.llm.openrouter.referer
-      ? { "HTTP-Referer": config.llm.openrouter.referer }
-      : {}),
-    ...(config.llm.openrouter.title
-      ? { "X-Title": config.llm.openrouter.title }
-      : {}),
+    ...(referer ? { "HTTP-Referer": referer } : {}),
+    ...(title ? { "X-OpenRouter-Title": title, "X-Title": title } : {}),
+    ...(categories ? { "X-OpenRouter-Categories": categories } : {}),
   };
 }

--- a/platform/backend/src/clients/openrouter-attribution.ts
+++ b/platform/backend/src/clients/openrouter-attribution.ts
@@ -1,0 +1,18 @@
+import config from "@/config";
+
+/**
+ * OpenRouter attribution headers (`HTTP-Referer`, `X-Title`) for ranking and
+ * analytics. Shared by the direct path (`createDirectLLMModel`) and the LLM
+ * proxy adapter so both attribute requests identically. Either header is
+ * omitted when its config value is unset.
+ */
+export function openRouterAttributionHeaders(): Record<string, string> {
+  return {
+    ...(config.llm.openrouter.referer
+      ? { "HTTP-Referer": config.llm.openrouter.referer }
+      : {}),
+    ...(config.llm.openrouter.title
+      ? { "X-Title": config.llm.openrouter.title }
+      : {}),
+  };
+}

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -603,6 +603,10 @@ const config = {
         process.env.ARCHESTRA_OPENROUTER_REFERER?.trim() ||
         "https://archestra.ai",
       title: process.env.ARCHESTRA_OPENROUTER_TITLE || DEFAULT_APP_NAME,
+      // Comma-separated OpenRouter marketplace categories for app attribution.
+      categories:
+        process.env.ARCHESTRA_OPENROUTER_CATEGORIES?.trim() ||
+        "general-chat,personal-agent",
     },
     anthropic: {
       baseUrl:

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -597,10 +597,11 @@ const config = {
       baseUrl:
         process.env.ARCHESTRA_OPENROUTER_BASE_URL ||
         "https://openrouter.ai/api/v1",
+      // OpenRouter attribution must always identify the product, never the
+      // deployment host (which would leak `localhost`/internal URLs).
       referer:
-        process.env.ARCHESTRA_OPENROUTER_REFERER ||
-        process.env.ARCHESTRA_FRONTEND_URL?.trim() ||
-        frontendBaseUrl,
+        process.env.ARCHESTRA_OPENROUTER_REFERER?.trim() ||
+        "https://archestra.ai",
       title: process.env.ARCHESTRA_OPENROUTER_TITLE || DEFAULT_APP_NAME,
     },
     anthropic: {

--- a/platform/backend/src/models/llm-provider-api-key-model.test.ts
+++ b/platform/backend/src/models/llm-provider-api-key-model.test.ts
@@ -27,10 +27,10 @@ describe("LlmProviderApiKeyModelLinkModel", () => {
       });
 
       const fallbackFirstModel = await ModelModel.create({
-        externalId: "openai/gpt-4.1-mini",
+        externalId: "openai/gpt-5.4-mini",
         provider: "openai",
-        modelId: "gpt-4.1-mini",
-        description: "GPT-4.1 Mini",
+        modelId: "gpt-5.4-mini",
+        description: "GPT-5.4 Mini",
         contextLength: 128000,
         inputModalities: ["text"],
         outputModalities: ["text"],
@@ -40,10 +40,10 @@ describe("LlmProviderApiKeyModelLinkModel", () => {
         lastSyncedAt: new Date(),
       });
       const fallbackSecondModel = await ModelModel.create({
-        externalId: "openai/o3",
+        externalId: "openai/gpt-5.4",
         provider: "openai",
-        modelId: "o3",
-        description: "o3",
+        modelId: "gpt-5.4",
+        description: "GPT-5.4",
         contextLength: 200000,
         inputModalities: ["text"],
         outputModalities: ["text"],
@@ -53,10 +53,10 @@ describe("LlmProviderApiKeyModelLinkModel", () => {
         lastSyncedAt: new Date(),
       });
       const bestCandidateModel = await ModelModel.create({
-        externalId: "openai/gpt-4.1",
+        externalId: "openai/gpt-5.5",
         provider: "openai",
-        modelId: "gpt-4.1",
-        description: "GPT-4.1",
+        modelId: "gpt-5.5",
+        description: "GPT-5.5",
         contextLength: 128000,
         inputModalities: ["text"],
         outputModalities: ["text"],
@@ -86,7 +86,7 @@ describe("LlmProviderApiKeyModelLinkModel", () => {
         ]);
 
       expect(bestModels.get(bestMarkedKey.id)?.id).toBe(bestCandidateModel.id);
-      expect(bestModels.get(fallbackKey.id)?.id).toBe(fallbackFirstModel.id);
+      expect(bestModels.get(fallbackKey.id)?.id).toBe(fallbackSecondModel.id);
     });
   });
 
@@ -115,10 +115,10 @@ describe("LlmProviderApiKeyModelLinkModel", () => {
 
       // Create a model and link it
       const model = await ModelModel.create({
-        externalId: "openai/gpt-4o",
+        externalId: "openai/gpt-5.5",
         provider: "openai",
-        modelId: "gpt-4o",
-        description: "GPT-4o",
+        modelId: "gpt-5.5",
+        description: "GPT-5.5",
         contextLength: 128000,
         inputModalities: ["text"],
         outputModalities: ["text"],
@@ -153,10 +153,10 @@ describe("LlmProviderApiKeyModelLinkModel", () => {
         provider: "openai",
       });
       const linkedModel = await ModelModel.create({
-        externalId: "openai/gpt-4o",
+        externalId: "openai/gpt-5.5",
         provider: "openai",
-        modelId: "gpt-4o",
-        description: "GPT-4o",
+        modelId: "gpt-5.5",
+        description: "GPT-5.5",
         contextLength: 128000,
         inputModalities: ["text"],
         outputModalities: ["text"],
@@ -171,10 +171,10 @@ describe("LlmProviderApiKeyModelLinkModel", () => {
 
       // Create an orphaned model (no API key link)
       await ModelModel.create({
-        externalId: "openai/gpt-3.5-turbo",
+        externalId: "openai/gpt-5.4-mini",
         provider: "openai",
-        modelId: "gpt-3.5-turbo",
-        description: "GPT-3.5 Turbo",
+        modelId: "gpt-5.4-mini",
+        description: "GPT-5.4 Mini",
         contextLength: 16000,
         inputModalities: ["text"],
         outputModalities: ["text"],
@@ -190,7 +190,7 @@ describe("LlmProviderApiKeyModelLinkModel", () => {
       // Only the linked model should be returned
       expect(result).toHaveLength(1);
       expect(result[0].model.id).toBe(linkedModel.id);
-      expect(result[0].model.modelId).toBe("gpt-4o");
+      expect(result[0].model.modelId).toBe("gpt-5.5");
     });
 
     test("orphaned models appear after API key deletion due to cascade", async ({
@@ -206,10 +206,10 @@ describe("LlmProviderApiKeyModelLinkModel", () => {
         provider: "anthropic",
       });
       const model = await ModelModel.create({
-        externalId: "anthropic/claude-3-sonnet",
+        externalId: "anthropic/claude-opus-4-7",
         provider: "anthropic",
-        modelId: "claude-3-sonnet",
-        description: "Claude 3 Sonnet",
+        modelId: "claude-opus-4-7",
+        description: "Claude Opus 4.7",
         contextLength: 200000,
         inputModalities: ["text"],
         outputModalities: ["text"],
@@ -254,10 +254,10 @@ describe("LlmProviderApiKeyModelLinkModel", () => {
       });
 
       const model = await ModelModel.create({
-        externalId: "openai/gpt-4.1",
+        externalId: "openai/gpt-5.5",
         provider: "openai",
-        modelId: "gpt-4.1",
-        description: "GPT-4.1",
+        modelId: "gpt-5.5",
+        description: "GPT-5.5",
         contextLength: 128000,
         inputModalities: ["text"],
         outputModalities: ["text"],

--- a/platform/backend/src/routes/chat/model-fetchers/openrouter.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/openrouter.test.ts
@@ -120,4 +120,115 @@ describe("fetchOpenrouterModels", () => {
     );
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
+
+  test("captures pricing, context length and tool calling from /models", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: [
+              {
+                id: "openai/gpt-4o-mini",
+                name: "GPT-4o mini",
+                context_length: 128000,
+                pricing: { prompt: "0.00000015", completion: "0.0000006" },
+                supported_parameters: ["tools", "tool_choice", "max_tokens"],
+              },
+            ],
+          }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [] }),
+      });
+
+    const [model] = await fetchOpenrouterModels("test-api-key");
+
+    expect(model.displayName).toBe("GPT-4o mini");
+    expect(model.capabilities).toEqual({
+      contextLength: 128000,
+      supportsToolCalling: true,
+      promptPricePerToken: "0.00000015",
+      completionPricePerToken: "0.0000006",
+    });
+  });
+
+  test("marks :free models as zero-priced and detects missing tool calling", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: [
+              {
+                id: "deepseek/deepseek-chat-v3.1:free",
+                context_length: 64000,
+                pricing: { prompt: "0", completion: "0" },
+                supported_parameters: ["max_tokens"],
+              },
+            ],
+          }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [] }),
+      });
+
+    const [model] = await fetchOpenrouterModels("test-api-key");
+
+    expect(model.capabilities).toEqual({
+      contextLength: 64000,
+      supportsToolCalling: false,
+      promptPricePerToken: "0",
+      completionPricePerToken: "0",
+    });
+  });
+
+  test("normalizes negative dynamic-router pricing to unknown", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: [
+              {
+                id: "openrouter/auto",
+                context_length: 2000000,
+                pricing: { prompt: "-1", completion: "-1" },
+                supported_parameters: ["tools"],
+              },
+            ],
+          }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [] }),
+      });
+
+    const [model] = await fetchOpenrouterModels("test-api-key");
+
+    expect(model.capabilities).toEqual({
+      contextLength: 2000000,
+      supportsToolCalling: true,
+      promptPricePerToken: null,
+      completionPricePerToken: null,
+    });
+  });
+
+  test("leaves capabilities undefined when /models carries no metadata", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [{ id: "openrouter/auto" }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [] }),
+      });
+
+    const [model] = await fetchOpenrouterModels("test-api-key");
+
+    expect(model.capabilities).toBeUndefined();
+  });
 });

--- a/platform/backend/src/routes/chat/model-fetchers/openrouter.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/openrouter.ts
@@ -2,13 +2,23 @@ import { z } from "zod";
 import config from "@/config";
 import logger from "@/logging";
 import { fetchModelsWithBearerAuth } from "./openai-compatible";
-import type { ModelInfo } from "./types";
+import type { FetchedModelCapabilities, ModelInfo } from "./types";
 
 const OpenRouterGenerationModelsResponseSchema = z.object({
   data: z.array(
     z.object({
       id: z.string(),
+      name: z.string().optional(),
       created: z.number().optional(),
+      context_length: z.number().optional(),
+      pricing: z
+        .object({
+          prompt: z.string().optional(),
+          completion: z.string().optional(),
+        })
+        .partial()
+        .optional(),
+      supported_parameters: z.array(z.string()).optional(),
     }),
   ),
 });
@@ -57,17 +67,15 @@ export async function fetchOpenrouterModels(
     throw generationResult.reason;
   }
 
-  const modelsById = new Map<
-    string,
-    OpenRouterGenerationModel | OpenRouterEmbeddingModel
-  >();
+  // Embedding models override generation models on id collision (last write wins).
+  const modelsById = new Map<string, ModelInfo>();
   for (const model of generationResult.value.data) {
-    modelsById.set(model.id, model);
+    modelsById.set(model.id, toGenerationModelInfo(model));
   }
 
   if (embeddingResult.status === "fulfilled") {
     for (const model of embeddingResult.value.data) {
-      modelsById.set(model.id, model);
+      modelsById.set(model.id, toEmbeddingModelInfo(model));
     }
   } else {
     logger.warn(
@@ -81,12 +89,68 @@ export async function fetchOpenrouterModels(
     );
   }
 
-  return Array.from(modelsById.values()).map((model) => ({
+  return Array.from(modelsById.values());
+}
+
+function toGenerationModelInfo(model: OpenRouterGenerationModel): ModelInfo {
+  return {
     id: model.id,
-    displayName: "name" in model && model.name ? model.name : model.id,
+    displayName: model.name ?? model.id,
     provider: "openrouter",
     createdAt: model.created
       ? new Date(model.created * 1000).toISOString()
       : undefined,
-  }));
+    capabilities: toFetchedCapabilities(model),
+  };
+}
+
+function toEmbeddingModelInfo(model: OpenRouterEmbeddingModel): ModelInfo {
+  return {
+    id: model.id,
+    displayName: model.name ?? model.id,
+    provider: "openrouter",
+    createdAt: model.created
+      ? new Date(model.created * 1000).toISOString()
+      : undefined,
+  };
+}
+
+/**
+ * Map OpenRouter's per-model metadata into the generic fetcher capability shape.
+ * OpenRouter already reports pricing as per-token USD strings. Returns undefined
+ * when the response carries no metadata, so models.dev enrichment still applies.
+ */
+function toFetchedCapabilities(
+  model: OpenRouterGenerationModel,
+): FetchedModelCapabilities | undefined {
+  if (
+    model.pricing == null &&
+    model.context_length == null &&
+    model.supported_parameters == null
+  ) {
+    return undefined;
+  }
+
+  return {
+    contextLength: model.context_length ?? null,
+    supportsToolCalling: model.supported_parameters
+      ? model.supported_parameters.some(
+          (param) => param === "tools" || param === "tool_choice",
+        )
+      : null,
+    promptPricePerToken: normalizePrice(model.pricing?.prompt),
+    completionPricePerToken: normalizePrice(model.pricing?.completion),
+  };
+}
+
+/**
+ * OpenRouter reports a negative per-token price (e.g. "-1") for its dynamic
+ * routers, where the real cost depends on the model the request is routed to.
+ * Treat that as unknown pricing rather than a literal negative price.
+ */
+function normalizePrice(price: string | undefined): string | null {
+  if (price == null) {
+    return null;
+  }
+  return Number(price) < 0 ? null : price;
 }

--- a/platform/backend/src/routes/chat/model-fetchers/types.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/types.ts
@@ -1,15 +1,27 @@
 import type { SupportedProvider } from "@shared";
-import type { ModelCapabilities } from "@/types";
 
 export const PLACEHOLDER_API_KEY = "EMPTY";
 export const PLACEHOLDER_BEARER_TOKEN = `Bearer ${PLACEHOLDER_API_KEY}`;
+
+/**
+ * Capabilities a fetcher can read straight from a provider's models endpoint.
+ * Kept minimal and separate from the API-facing `ModelCapabilities`: a fetcher
+ * only reports raw provider facts, not computed/price-source fields. Fed into
+ * `resolveModelCapabilities` as the highest-priority tier during model sync.
+ */
+export interface FetchedModelCapabilities {
+  contextLength?: number | null;
+  supportsToolCalling?: boolean | null;
+  promptPricePerToken?: string | null;
+  completionPricePerToken?: string | null;
+}
 
 export interface ModelInfo {
   id: string;
   displayName: string;
   provider: SupportedProvider;
   createdAt?: string;
-  capabilities?: ModelCapabilities;
+  capabilities?: FetchedModelCapabilities;
 }
 
 export type ModelFetcher = (

--- a/platform/backend/src/routes/chat/routes.test.ts
+++ b/platform/backend/src/routes/chat/routes.test.ts
@@ -26,6 +26,7 @@ vi.mock("@/models/llm-provider-api-key-model", () => ({
   default: { getFastestModel: mockGetFastestModel },
 }));
 
+import { FAST_MODELS } from "@shared";
 import { archestraMcpBranding } from "@/archestra-mcp-server";
 import { createDirectLLMModel } from "@/clients/llm-client";
 import {
@@ -755,7 +756,7 @@ describe("generateConversationTitle", () => {
 
     expect(mockGetFastestModel).not.toHaveBeenCalled();
     expect(createDirectLLMModel).toHaveBeenCalledWith(
-      expect.objectContaining({ modelName: "claude-haiku-4-5-20251001" }),
+      expect.objectContaining({ modelName: FAST_MODELS.anthropic }),
     );
   });
 
@@ -774,7 +775,7 @@ describe("generateConversationTitle", () => {
 
     expect(mockGetFastestModel).toHaveBeenCalledWith("api-key-456");
     expect(createDirectLLMModel).toHaveBeenCalledWith(
-      expect.objectContaining({ modelName: "gpt-4o-mini" }),
+      expect.objectContaining({ modelName: FAST_MODELS.openai }),
     );
   });
 
@@ -793,7 +794,7 @@ describe("generateConversationTitle", () => {
 
     expect(mockGetFastestModel).toHaveBeenCalledWith("api-key-789");
     expect(createDirectLLMModel).toHaveBeenCalledWith(
-      expect.objectContaining({ modelName: "gemini-2.0-flash-001" }),
+      expect.objectContaining({ modelName: FAST_MODELS.gemini }),
     );
   });
 });

--- a/platform/backend/src/routes/llm-provider-api-keys.ts
+++ b/platform/backend/src/routes/llm-provider-api-keys.ts
@@ -441,6 +441,25 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
             "Failed to sync models for new API key",
           );
         }
+
+        try {
+          await modelSyncService.maybeAutoSetOrgDefaultModel({
+            organizationId,
+            apiKeyId: createdApiKey.id,
+            provider: body.provider,
+          });
+        } catch (error) {
+          // Auto-default selection is best-effort; never block key creation.
+          logger.error(
+            {
+              apiKeyId: createdApiKey.id,
+              provider: body.provider,
+              errorMessage:
+                error instanceof Error ? error.message : String(error),
+            },
+            "Failed to auto-select org default model for new API key",
+          );
+        }
       }
 
       return reply.send(createdApiKey);

--- a/platform/backend/src/routes/llm-provider-models.ts
+++ b/platform/backend/src/routes/llm-provider-models.ts
@@ -1,5 +1,6 @@
 import {
   EmbeddingDimensionsSchema,
+  isFreeModel,
   isProviderApiKeyOptional,
   RouteId,
   SupportedProvidersSchema,
@@ -40,6 +41,8 @@ const LlmModelSchema = z.object({
   capabilities: ModelCapabilitiesSchema.optional(),
   isBest: z.boolean().optional(),
   isFastest: z.boolean().optional(),
+  /** True when the provider charges nothing for this model (both prices are zero). */
+  isFree: z.boolean(),
   embeddingDimensions: EmbeddingDimensionsSchema.nullable().optional(),
 });
 
@@ -142,6 +145,7 @@ const llmModelsRoutes: FastifyPluginAsyncZod = async (fastify) => {
           capabilities: ModelModel.toCapabilities(model),
           isBest,
           isFastest,
+          isFree: isFreeModel(model),
           embeddingDimensions: model.embeddingDimensions,
         }));
 
@@ -209,6 +213,7 @@ const llmModelsRoutes: FastifyPluginAsyncZod = async (fastify) => {
             pricePerMillionOutput: pricing.pricePerMillionOutput,
             isCustomPrice: pricing.isCustomPrice,
             priceSource: pricing.priceSource,
+            isFree: isFreeModel(model),
           };
         }),
         ...unlinkedLlmProxyModels.map((model) => {
@@ -222,6 +227,7 @@ const llmModelsRoutes: FastifyPluginAsyncZod = async (fastify) => {
             pricePerMillionOutput: pricing.pricePerMillionOutput,
             isCustomPrice: pricing.isCustomPrice,
             priceSource: pricing.priceSource,
+            isFree: isFreeModel(model),
           };
         }),
       ];

--- a/platform/backend/src/routes/proxy/adapters/openrouter.ts
+++ b/platform/backend/src/routes/proxy/adapters/openrouter.ts
@@ -11,6 +11,7 @@ import type {
   ChatCompletionCreateParamsNonStreaming,
   ChatCompletionCreateParamsStreaming,
 } from "openai/resources/chat/completions/completions";
+import { openRouterAttributionHeaders } from "@/clients/openrouter-attribution";
 import config from "@/config";
 import { metrics } from "@/observability";
 import type {
@@ -243,21 +244,12 @@ export const openrouterAdapterFactory: LLMProvider<
         )
       : undefined;
 
-    const attributionHeaders: Record<string, string> = {
-      ...(config.llm.openrouter.referer
-        ? { "HTTP-Referer": config.llm.openrouter.referer }
-        : {}),
-      ...(config.llm.openrouter.title
-        ? { "X-Title": config.llm.openrouter.title }
-        : {}),
-    };
-
     return new OpenAIProvider({
       apiKey: rawApiKey,
       baseURL: options.baseUrl ?? config.llm.openrouter.baseUrl,
       fetch: customFetch,
       defaultHeaders: {
-        ...attributionHeaders,
+        ...openRouterAttributionHeaders(),
         ...(options.defaultHeaders ?? {}),
       },
     });

--- a/platform/backend/src/routes/proxy/adapters/openrouter.ts
+++ b/platform/backend/src/routes/proxy/adapters/openrouter.ts
@@ -2,7 +2,7 @@
  * OpenRouter LLM Proxy Adapter - OpenAI-compatible
  *
  * OpenRouter exposes an OpenAI-compatible API at https://openrouter.ai/api/v1
- * and recommends attribution headers (HTTP-Referer, X-Title).
+ * and recommends attribution headers (HTTP-Referer, X-OpenRouter-Title).
  */
 import { ArchestraInternalErrorCode } from "@shared";
 import { get } from "lodash-es";

--- a/platform/backend/src/services/model-sync.test.ts
+++ b/platform/backend/src/services/model-sync.test.ts
@@ -1,7 +1,8 @@
-import type { SupportedProvider } from "@shared";
+import { OPENROUTER_FREE_MODEL_ID, type SupportedProvider } from "@shared";
 import { vi } from "vitest";
 import LlmProviderApiKeyModelLinkModel from "@/models/llm-provider-api-key-model";
 import ModelModel from "@/models/model";
+import OrganizationModel from "@/models/organization";
 import { modelFetchers } from "@/routes/chat/model-fetchers";
 import { afterEach, describe, expect, test } from "@/test";
 import { modelSyncService, resolveModelCapabilities } from "./model-sync";
@@ -298,6 +299,184 @@ describe("ModelSyncService", () => {
     expect(capabilities.inputModalities).toEqual(["text", "image"]);
     expect(capabilities.outputModalities).toEqual([]);
     expect(capabilities.supportsToolCalling).toBe(false);
+  });
+
+  test("prefers fetcher capabilities over models.dev with per-field fallthrough", () => {
+    const capabilities = resolveModelCapabilities({
+      provider: "openrouter",
+      modelId: "deepseek/deepseek-chat-v3.1:free",
+      capabilities: {
+        description: "DeepSeek V3.1",
+        contextLength: 32000,
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        supportsToolCalling: false,
+        promptPricePerToken: "0.0000002",
+        completionPricePerToken: "0.0000008",
+      },
+      fetched: {
+        contextLength: 64000,
+        supportsToolCalling: true,
+        promptPricePerToken: "0",
+        completionPricePerToken: "0",
+      },
+    });
+
+    // Fetcher wins on the fields it carries.
+    expect(capabilities.contextLength).toBe(64000);
+    expect(capabilities.supportsToolCalling).toBe(true);
+    expect(capabilities.promptPricePerToken).toBe("0");
+    expect(capabilities.completionPricePerToken).toBe("0");
+    // models.dev still fills fields the fetcher does not carry.
+    expect(capabilities.description).toBe("DeepSeek V3.1");
+    expect(capabilities.inputModalities).toEqual(["text"]);
+  });
+
+  test("persists fetcher pricing so :free models sync as zero-priced", async ({
+    makeOrganization,
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    const org = await makeOrganization();
+    const secret = await makeSecret({ secret: { apiKey: "openrouter-key" } });
+    const apiKey = await makeLlmProviderApiKey(org.id, secret.id, {
+      provider: "openrouter",
+    });
+
+    modelFetchers.openrouter = async () => [
+      {
+        id: "deepseek/deepseek-chat-v3.1:free",
+        displayName: "DeepSeek V3.1 (free)",
+        provider: "openrouter" as SupportedProvider,
+        capabilities: {
+          contextLength: 64000,
+          supportsToolCalling: true,
+          promptPricePerToken: "0",
+          completionPricePerToken: "0",
+        },
+      },
+    ];
+
+    await modelSyncService.syncModelsForApiKey({
+      apiKeyId: apiKey.id,
+      provider: "openrouter",
+      apiKeyValue: "openrouter-key",
+    });
+
+    const model = await ModelModel.findByProviderAndModelId(
+      "openrouter",
+      "deepseek/deepseek-chat-v3.1:free",
+    );
+    expect(Number(model?.promptPricePerToken)).toBe(0);
+    expect(Number(model?.completionPricePerToken)).toBe(0);
+    expect(model?.contextLength).toBe(64000);
+    expect(model?.supportsToolCalling).toBe(true);
+  });
+
+  test("auto-selects the Free Models Router as the org default for a new OpenRouter key", async ({
+    makeOrganization,
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    const org = await makeOrganization();
+    const secret = await makeSecret({ secret: { apiKey: "openrouter-key" } });
+    const apiKey = await makeLlmProviderApiKey(org.id, secret.id, {
+      provider: "openrouter",
+    });
+
+    modelFetchers.openrouter = async () => [
+      {
+        id: "deepseek/deepseek-chat-v3.1:free",
+        displayName: "DeepSeek V3.1 (free)",
+        provider: "openrouter" as SupportedProvider,
+        capabilities: {
+          contextLength: 64000,
+          supportsToolCalling: true,
+          promptPricePerToken: "0",
+          completionPricePerToken: "0",
+        },
+      },
+      {
+        id: OPENROUTER_FREE_MODEL_ID,
+        displayName: "Free Models Router",
+        provider: "openrouter" as SupportedProvider,
+        capabilities: {
+          contextLength: 200000,
+          supportsToolCalling: true,
+          promptPricePerToken: "0",
+          completionPricePerToken: "0",
+        },
+      },
+    ];
+
+    await modelSyncService.syncModelsForApiKey({
+      apiKeyId: apiKey.id,
+      provider: "openrouter",
+      apiKeyValue: "openrouter-key",
+    });
+    await modelSyncService.maybeAutoSetOrgDefaultModel({
+      organizationId: org.id,
+      apiKeyId: apiKey.id,
+      provider: "openrouter",
+    });
+
+    const routerModel = await ModelModel.findByProviderAndModelId(
+      "openrouter",
+      OPENROUTER_FREE_MODEL_ID,
+    );
+    const updatedOrg = await OrganizationModel.getById(org.id);
+    expect(updatedOrg?.defaultModelId).toBe(routerModel?.id);
+    expect(updatedOrg?.defaultLlmApiKeyId).toBe(apiKey.id);
+  });
+
+  test("does not override an existing org default model", async ({
+    makeOrganization,
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    const org = await makeOrganization();
+    const secret = await makeSecret({ secret: { apiKey: "openrouter-key" } });
+    const apiKey = await makeLlmProviderApiKey(org.id, secret.id, {
+      provider: "openrouter",
+    });
+
+    modelFetchers.openrouter = async () => [
+      {
+        id: OPENROUTER_FREE_MODEL_ID,
+        displayName: "Free Models Router",
+        provider: "openrouter" as SupportedProvider,
+        capabilities: {
+          contextLength: 200000,
+          supportsToolCalling: true,
+          promptPricePerToken: "0",
+          completionPricePerToken: "0",
+        },
+      },
+    ];
+    await modelSyncService.syncModelsForApiKey({
+      apiKeyId: apiKey.id,
+      provider: "openrouter",
+      apiKeyValue: "openrouter-key",
+    });
+
+    const routerModel = await ModelModel.findByProviderAndModelId(
+      "openrouter",
+      OPENROUTER_FREE_MODEL_ID,
+    );
+    if (!routerModel) throw new Error("router model not synced");
+    await OrganizationModel.patch(org.id, {
+      defaultModelId: routerModel.id,
+      defaultLlmApiKeyId: apiKey.id,
+    });
+
+    // A non-openrouter provider must never trigger an auto-default.
+    await modelSyncService.maybeAutoSetOrgDefaultModel({
+      organizationId: org.id,
+      apiKeyId: apiKey.id,
+      provider: "openai",
+    });
+    const unchanged = await OrganizationModel.getById(org.id);
+    expect(unchanged?.defaultModelId).toBe(routerModel.id);
   });
 
   test("infers dimensions for Azure OpenAI embedding deployments", async ({

--- a/platform/backend/src/services/model-sync.ts
+++ b/platform/backend/src/services/model-sync.ts
@@ -1,5 +1,6 @@
 import {
   MODELS_DEV_PROVIDER_MAP,
+  OPENROUTER_FREE_MODEL_ID,
   type SupportedEmbeddingDimension,
   type SupportedProvider,
 } from "@shared";
@@ -8,8 +9,13 @@ import {
   modelsDevClient,
 } from "@/clients/models-dev-client";
 import logger from "@/logging";
-import { LlmProviderApiKeyModelLinkModel, ModelModel } from "@/models";
+import {
+  LlmProviderApiKeyModelLinkModel,
+  ModelModel,
+  OrganizationModel,
+} from "@/models";
 import { modelFetchers } from "@/routes/chat/model-fetchers";
+import type { FetchedModelCapabilities } from "@/routes/chat/model-fetchers/types";
 import type {
   CreateModel,
   ModelInputModality,
@@ -176,6 +182,44 @@ class ModelSyncService {
 
     return results;
   }
+
+  /**
+   * Give a fresh organization a zero-cost default: when an OpenRouter key is
+   * added and no default model is configured, point the org default at
+   * OpenRouter's Free Models Router. Never overrides an explicit user choice.
+   */
+  async maybeAutoSetOrgDefaultModel(params: {
+    organizationId: string;
+    apiKeyId: string;
+    provider: SupportedProvider;
+  }): Promise<void> {
+    const { organizationId, apiKeyId, provider } = params;
+    if (provider !== "openrouter") {
+      return;
+    }
+
+    const org = await OrganizationModel.getById(organizationId);
+    if (!org || org.defaultModelId || org.defaultLlmApiKeyId) {
+      return;
+    }
+
+    const routerModel = await ModelModel.findByProviderAndModelId(
+      "openrouter",
+      OPENROUTER_FREE_MODEL_ID,
+    );
+    if (!routerModel) {
+      return;
+    }
+
+    await OrganizationModel.patch(organizationId, {
+      defaultModelId: routerModel.id,
+      defaultLlmApiKeyId: apiKeyId,
+    });
+    logger.info(
+      { organizationId, apiKeyId, modelId: routerModel.modelId },
+      "Auto-selected OpenRouter Free Models Router as the organization default model",
+    );
+  }
 }
 
 // Export singleton instance
@@ -197,7 +241,7 @@ interface ProviderModelCapabilities {
 
 export function buildModelsToUpsert(params: {
   provider: SupportedProvider;
-  models: Array<{ id: string }>;
+  models: Array<{ id: string; capabilities?: FetchedModelCapabilities }>;
   modelsDevData: ModelsDevApiResponse;
 }): CreateModel[] {
   const { provider, models, modelsDevData } = params;
@@ -208,6 +252,7 @@ export function buildModelsToUpsert(params: {
       provider,
       modelId: model.id,
       capabilities: capabilitiesMap.get(model.id),
+      fetched: model.capabilities,
     });
 
     return {
@@ -273,30 +318,43 @@ function inferEmbeddingDimensions(
 export function resolveModelCapabilities(params: {
   provider: SupportedProvider;
   modelId: string;
+  /** Capabilities from models.dev enrichment. */
   capabilities?: ProviderModelCapabilities;
+  /** Capabilities read directly from the provider's models endpoint. Highest priority. */
+  fetched?: FetchedModelCapabilities;
 }): ProviderModelCapabilities {
-  const { provider, modelId, capabilities } = params;
+  const { provider, modelId, capabilities, fetched } = params;
   const inferredCapabilities = inferModelCapabilities({
     provider,
     modelId,
   });
 
+  // Priority per field: fetcher -> models.dev -> hardcoded inference.
   return normalizeKnownModelCapabilities({
     provider,
     modelId,
     capabilities: {
       description: capabilities?.description ?? null,
       contextLength:
-        capabilities?.contextLength ?? inferredCapabilities.contextLength,
+        fetched?.contextLength ??
+        capabilities?.contextLength ??
+        inferredCapabilities.contextLength,
       inputModalities:
         capabilities?.inputModalities ?? inferredCapabilities.inputModalities,
       outputModalities:
         capabilities?.outputModalities ?? inferredCapabilities.outputModalities,
       supportsToolCalling:
+        fetched?.supportsToolCalling ??
         capabilities?.supportsToolCalling ??
         inferredCapabilities.supportsToolCalling,
-      promptPricePerToken: capabilities?.promptPricePerToken ?? null,
-      completionPricePerToken: capabilities?.completionPricePerToken ?? null,
+      promptPricePerToken:
+        fetched?.promptPricePerToken ??
+        capabilities?.promptPricePerToken ??
+        null,
+      completionPricePerToken:
+        fetched?.completionPricePerToken ??
+        capabilities?.completionPricePerToken ??
+        null,
     },
   });
 }

--- a/platform/backend/src/types/model.ts
+++ b/platform/backend/src/types/model.ts
@@ -198,5 +198,7 @@ export const ModelWithApiKeysSchema = SelectModelSchema.extend({
   isCustomPrice: z.boolean(),
   /** Source of the effective price */
   priceSource: PriceSourceSchema,
+  /** True when the provider charges nothing for this model (both raw prices are zero). */
+  isFree: z.boolean(),
 });
 export type ModelWithApiKeys = z.infer<typeof ModelWithApiKeysSchema>;

--- a/platform/backend/src/utils/llm-resolution.test.ts
+++ b/platform/backend/src/utils/llm-resolution.test.ts
@@ -1,4 +1,8 @@
-import { FAST_MODELS, type SupportedProvider } from "@shared";
+import {
+  FAST_MODELS,
+  OPENROUTER_FREE_MODEL_ID,
+  type SupportedProvider,
+} from "@shared";
 import { vi } from "vitest";
 import { isVertexAiEnabled } from "@/clients/gemini-client";
 import {
@@ -616,5 +620,21 @@ describe("resolveFastModelName", () => {
     const result = await resolveFastModelName("openai", "key-789");
 
     expect(result).toBe(FAST_MODELS.openai);
+  });
+
+  test("always uses the free router for OpenRouter, bypassing the DB lookup", async () => {
+    const getFastestModel = vi.spyOn(
+      LlmProviderApiKeyModelLinkModel,
+      "getFastestModel",
+    );
+
+    expect(await resolveFastModelName("openrouter", undefined)).toBe(
+      OPENROUTER_FREE_MODEL_ID,
+    );
+    expect(await resolveFastModelName("openrouter", "key-123")).toBe(
+      OPENROUTER_FREE_MODEL_ID,
+    );
+    // openrouter/auto (the marked "fastest" model) is paid — never resolved here.
+    expect(getFastestModel).not.toHaveBeenCalled();
   });
 });

--- a/platform/backend/src/utils/llm-resolution.test.ts
+++ b/platform/backend/src/utils/llm-resolution.test.ts
@@ -1,4 +1,4 @@
-import type { SupportedProvider } from "@shared";
+import { FAST_MODELS, type SupportedProvider } from "@shared";
 import { vi } from "vitest";
 import { isVertexAiEnabled } from "@/clients/gemini-client";
 import {
@@ -576,8 +576,7 @@ describe("resolveFastModelName", () => {
   test("returns hardcoded FAST_MODELS fallback when no chatApiKeyId", async () => {
     const result = await resolveFastModelName("anthropic", undefined);
 
-    // Should return the hardcoded fast model for anthropic
-    expect(result).toBe("claude-haiku-4-5-20251001");
+    expect(result).toBe(FAST_MODELS.anthropic);
   });
 
   test("returns fastest model from DB when chatApiKeyId is provided", async () => {
@@ -605,7 +604,7 @@ describe("resolveFastModelName", () => {
 
     const result = await resolveFastModelName("openai", "key-456");
 
-    expect(result).toBe("gpt-4o-mini");
+    expect(result).toBe(FAST_MODELS.openai);
   });
 
   test("falls back to hardcoded model when DB lookup throws", async () => {
@@ -616,6 +615,6 @@ describe("resolveFastModelName", () => {
 
     const result = await resolveFastModelName("openai", "key-789");
 
-    expect(result).toBe("gpt-4o-mini");
+    expect(result).toBe(FAST_MODELS.openai);
   });
 });

--- a/platform/backend/src/utils/llm-resolution.ts
+++ b/platform/backend/src/utils/llm-resolution.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_MODELS,
   FAST_MODELS,
   type ModelSelection,
+  OPENROUTER_FREE_MODEL_ID,
   resolveModelSelection,
   type SupportedProvider,
   SupportedProvidersSchema,
@@ -241,6 +242,13 @@ export async function resolveFastModelName(
   provider: SupportedProvider,
   chatApiKeyId: string | undefined,
 ): Promise<string> {
+  // OpenRouter meta calls always go through the free router: the "fastest"
+  // marker is openrouter/auto, which is paid and fails outright on a
+  // zero-balance free-only key.
+  if (provider === "openrouter") {
+    return OPENROUTER_FREE_MODEL_ID;
+  }
+
   if (!chatApiKeyId) {
     const fallback = FAST_MODELS[provider];
     logger.debug(

--- a/platform/frontend/src/app/llm/model-providers/models/page.tsx
+++ b/platform/frontend/src/app/llm/model-providers/models/page.tsx
@@ -2,10 +2,10 @@
 
 import {
   type archestraApiTypes,
+  compareModelsForDisplay,
   INPUT_MODALITY_OPTIONS,
   type ModelInputModality,
   type ModelOutputModality,
-  OPENROUTER_FREE_MODEL_ID,
   OUTPUT_MODALITY_OPTIONS,
   SUPPORTED_EMBEDDING_DIMENSIONS,
 } from "@shared";
@@ -34,7 +34,6 @@ import {
   EmbeddingModelBadge,
   FastestModelBadge,
   FreeModelBadge,
-  FreeRouterModelBadge,
   LatestModelBadge,
   UnknownCapabilitiesBadge,
 } from "@/components/model-badges";
@@ -106,11 +105,11 @@ export default function ModelsPage() {
     } else if (modelTypeFilter === "chat") {
       result = result.filter((m) => m.embeddingDimensions === null);
     }
-    // Stable sort so rows don't jump when data refetches after edits
+    // Group by provider, then apply the shared model ordering within each
+    // group (routers, recommended, then the rest alphabetically).
     return [...result].sort(
       (a, b) =>
-        a.provider.localeCompare(b.provider) ||
-        a.modelId.localeCompare(b.modelId),
+        a.provider.localeCompare(b.provider) || compareModelsForDisplay(a, b),
     );
   }, [models, search, apiKeyFilter, modelTypeFilter]);
 
@@ -183,15 +182,13 @@ export default function ModelsPage() {
         header: "Model ID",
         cell: ({ row }) => {
           const { modelId, provider, isFree } = row.original;
-          const isFreeRouter = modelId === OPENROUTER_FREE_MODEL_ID;
           const isLatestAlias =
             provider === "openrouter" && modelId.startsWith("~");
           return (
             <div className="min-w-0 space-y-2">
               <span className="font-mono text-sm">{modelId}</span>
               <div className="mt-0.5 flex flex-wrap items-center gap-2">
-                {isFreeRouter && <FreeRouterModelBadge />}
-                {isFree && !isFreeRouter && <FreeModelBadge />}
+                {isFree && <FreeModelBadge />}
                 {isLatestAlias && <LatestModelBadge />}
                 {row.original.isFastest && <FastestModelBadge />}
                 {row.original.isBest && <BestModelBadge />}

--- a/platform/frontend/src/app/llm/model-providers/models/page.tsx
+++ b/platform/frontend/src/app/llm/model-providers/models/page.tsx
@@ -54,6 +54,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { SearchableSelect } from "@/components/ui/searchable-select";
 import {
   Select,
@@ -86,33 +87,10 @@ export default function ModelsPage() {
   const [modelTypeFilter, setModelTypeFilter] = useState<
     "all" | "chat" | "embedding"
   >("all");
+  const [freeOnly, setFreeOnly] = useState(false);
   const [editingModel, setEditingModel] = useState<ModelWithApiKeys | null>(
     null,
   );
-
-  const filteredModels = useMemo(() => {
-    let result = models;
-    if (search) {
-      const q = search.toLowerCase();
-      result = result.filter((m) => m.modelId.toLowerCase().includes(q));
-    }
-    if (apiKeyFilter !== "all") {
-      result = result.filter((m) =>
-        m.apiKeys.some((k) => k.id === apiKeyFilter),
-      );
-    }
-    if (modelTypeFilter === "embedding") {
-      result = result.filter((m) => m.embeddingDimensions !== null);
-    } else if (modelTypeFilter === "chat") {
-      result = result.filter((m) => m.embeddingDimensions === null);
-    }
-    // Group by provider, then apply the shared model ordering within each
-    // group (routers, recommended, then the rest alphabetically).
-    return [...result].sort(
-      (a, b) =>
-        a.provider.localeCompare(b.provider) || compareModelsForDisplay(a, b),
-    );
-  }, [models, search, apiKeyFilter, modelTypeFilter]);
 
   const availableApiKeys = useMemo(() => {
     const keyMap = new Map<
@@ -131,6 +109,49 @@ export default function ModelsPage() {
       a[1].name.localeCompare(b[1].name),
     );
   }, [models]);
+
+  // "free only" is an openrouter-specific filter — free models are otherwise
+  // a non-concept, so the toggle shows only when an openrouter key is active.
+  const isOpenRouterSelected = useMemo(
+    () =>
+      availableApiKeys.find(([id]) => id === apiKeyFilter)?.[1].provider ===
+      "openrouter",
+    [availableApiKeys, apiKeyFilter],
+  );
+
+  const filteredModels = useMemo(() => {
+    let result = models;
+    if (search) {
+      const q = search.toLowerCase();
+      result = result.filter((m) => m.modelId.toLowerCase().includes(q));
+    }
+    if (apiKeyFilter !== "all") {
+      result = result.filter((m) =>
+        m.apiKeys.some((k) => k.id === apiKeyFilter),
+      );
+    }
+    if (modelTypeFilter === "embedding") {
+      result = result.filter((m) => m.embeddingDimensions !== null);
+    } else if (modelTypeFilter === "chat") {
+      result = result.filter((m) => m.embeddingDimensions === null);
+    }
+    if (freeOnly && isOpenRouterSelected) {
+      result = result.filter((m) => m.isFree);
+    }
+    // Group by provider, then apply the shared model ordering within each
+    // group (routers, recommended, then the rest alphabetically).
+    return [...result].sort(
+      (a, b) =>
+        a.provider.localeCompare(b.provider) || compareModelsForDisplay(a, b),
+    );
+  }, [
+    models,
+    search,
+    apiKeyFilter,
+    modelTypeFilter,
+    freeOnly,
+    isOpenRouterSelected,
+  ]);
 
   const handleRefresh = useCallback(async () => {
     setIsRefreshingModels(true);
@@ -396,6 +417,21 @@ export default function ModelsPage() {
                 },
               ]}
             />
+            {isOpenRouterSelected && (
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="models-free-only"
+                  checked={freeOnly}
+                  onCheckedChange={setFreeOnly}
+                />
+                <Label
+                  htmlFor="models-free-only"
+                  className="text-sm text-muted-foreground"
+                >
+                  Free only
+                </Label>
+              </div>
+            )}
           </div>
         )}
         <DataTable
@@ -408,13 +444,17 @@ export default function ModelsPage() {
           hideSelectedCount
           isLoading={isPending}
           hasActiveFilters={Boolean(
-            search || apiKeyFilter !== "all" || modelTypeFilter !== "all",
+            search ||
+              apiKeyFilter !== "all" ||
+              modelTypeFilter !== "all" ||
+              (isOpenRouterSelected && freeOnly),
           )}
           filteredEmptyMessage="No models match your filters. Try adjusting your search."
           onClearFilters={() => {
             setSearch("");
             setApiKeyFilter("all");
             setModelTypeFilter("all");
+            setFreeOnly(false);
           }}
           emptyMessage={
             apiKeys.length === 0

--- a/platform/frontend/src/app/llm/model-providers/models/page.tsx
+++ b/platform/frontend/src/app/llm/model-providers/models/page.tsx
@@ -111,12 +111,10 @@ export default function ModelsPage() {
   }, [models]);
 
   // "free only" is an openrouter-specific filter — free models are otherwise
-  // a non-concept, so the toggle shows only when an openrouter key is active.
-  const isOpenRouterSelected = useMemo(
-    () =>
-      availableApiKeys.find(([id]) => id === apiKeyFilter)?.[1].provider ===
-      "openrouter",
-    [availableApiKeys, apiKeyFilter],
+  // a non-concept, so the toggle shows whenever openrouter is set up.
+  const hasOpenRouterModels = useMemo(
+    () => availableApiKeys.some(([, key]) => key.provider === "openrouter"),
+    [availableApiKeys],
   );
 
   const filteredModels = useMemo(() => {
@@ -135,7 +133,7 @@ export default function ModelsPage() {
     } else if (modelTypeFilter === "chat") {
       result = result.filter((m) => m.embeddingDimensions === null);
     }
-    if (freeOnly && isOpenRouterSelected) {
+    if (freeOnly && hasOpenRouterModels) {
       result = result.filter((m) => m.isFree);
     }
     // Group by provider, then apply the shared model ordering within each
@@ -150,7 +148,7 @@ export default function ModelsPage() {
     apiKeyFilter,
     modelTypeFilter,
     freeOnly,
-    isOpenRouterSelected,
+    hasOpenRouterModels,
   ]);
 
   const handleRefresh = useCallback(async () => {
@@ -417,7 +415,7 @@ export default function ModelsPage() {
                 },
               ]}
             />
-            {isOpenRouterSelected && (
+            {hasOpenRouterModels && (
               <div className="flex items-center gap-2">
                 <Switch
                   id="models-free-only"
@@ -447,7 +445,7 @@ export default function ModelsPage() {
             search ||
               apiKeyFilter !== "all" ||
               modelTypeFilter !== "all" ||
-              (isOpenRouterSelected && freeOnly),
+              (hasOpenRouterModels && freeOnly),
           )}
           filteredEmptyMessage="No models match your filters. Try adjusting your search."
           onClearFilters={() => {

--- a/platform/frontend/src/app/llm/model-providers/models/page.tsx
+++ b/platform/frontend/src/app/llm/model-providers/models/page.tsx
@@ -4,6 +4,7 @@ import {
   type archestraApiTypes,
   compareModelsForDisplay,
   INPUT_MODALITY_OPTIONS,
+  isOpenRouterLatestAlias,
   type ModelInputModality,
   type ModelOutputModality,
   OUTPUT_MODALITY_OPTIONS,
@@ -182,8 +183,7 @@ export default function ModelsPage() {
         header: "Model ID",
         cell: ({ row }) => {
           const { modelId, provider, isFree } = row.original;
-          const isLatestAlias =
-            provider === "openrouter" && modelId.startsWith("~");
+          const isLatestAlias = isOpenRouterLatestAlias(provider, modelId);
           return (
             <div className="min-w-0 space-y-2">
               <span className="font-mono text-sm">{modelId}</span>

--- a/platform/frontend/src/app/llm/model-providers/models/page.tsx
+++ b/platform/frontend/src/app/llm/model-providers/models/page.tsx
@@ -68,6 +68,7 @@ import {
   useUpdateModel,
 } from "@/lib/llm-models.query";
 import { useLlmProviderApiKeys } from "@/lib/llm-provider-api-keys.query";
+import { formatContextLength } from "@/lib/utils";
 import { useSetModelProvidersAction } from "../layout";
 
 export default function ModelsPage() {
@@ -905,17 +906,6 @@ function ModalitySelectField<T extends string>(params: {
       </div>
     </div>
   );
-}
-
-function formatContextLength(contextLength: number | null): string {
-  if (contextLength === null) return "-";
-  if (contextLength >= 1000000) {
-    return `${(contextLength / 1000000).toFixed(contextLength % 1000000 === 0 ? 0 : 1)}M`;
-  }
-  if (contextLength >= 1000) {
-    return `${(contextLength / 1000).toFixed(contextLength % 1000 === 0 ? 0 : 1)}K`;
-  }
-  return contextLength.toString();
 }
 
 function hasUnknownCapabilities(model: ModelWithApiKeys): boolean {

--- a/platform/frontend/src/app/llm/model-providers/models/page.tsx
+++ b/platform/frontend/src/app/llm/model-providers/models/page.tsx
@@ -5,6 +5,7 @@ import {
   INPUT_MODALITY_OPTIONS,
   type ModelInputModality,
   type ModelOutputModality,
+  OPENROUTER_FREE_MODEL_ID,
   OUTPUT_MODALITY_OPTIONS,
   SUPPORTED_EMBEDDING_DIMENSIONS,
 } from "@shared";
@@ -32,6 +33,9 @@ import {
   BestModelBadge,
   EmbeddingModelBadge,
   FastestModelBadge,
+  FreeModelBadge,
+  FreeRouterModelBadge,
+  LatestModelBadge,
   UnknownCapabilitiesBadge,
 } from "@/components/model-badges";
 import { SearchInput } from "@/components/search-input";
@@ -177,18 +181,27 @@ export default function ModelsPage() {
         accessorKey: "modelId",
         size: 280,
         header: "Model ID",
-        cell: ({ row }) => (
-          <div className="min-w-0 space-y-2">
-            <span className="font-mono text-sm">{row.original.modelId}</span>
-            <div className="mt-0.5 flex flex-wrap items-center gap-2">
-              {row.original.isFastest && <FastestModelBadge />}
-              {row.original.isBest && <BestModelBadge />}
-              {row.original.embeddingDimensions !== null && (
-                <EmbeddingModelBadge />
-              )}
+        cell: ({ row }) => {
+          const { modelId, provider, isFree } = row.original;
+          const isFreeRouter = modelId === OPENROUTER_FREE_MODEL_ID;
+          const isLatestAlias =
+            provider === "openrouter" && modelId.startsWith("~");
+          return (
+            <div className="min-w-0 space-y-2">
+              <span className="font-mono text-sm">{modelId}</span>
+              <div className="mt-0.5 flex flex-wrap items-center gap-2">
+                {isFreeRouter && <FreeRouterModelBadge />}
+                {isFree && !isFreeRouter && <FreeModelBadge />}
+                {isLatestAlias && <LatestModelBadge />}
+                {row.original.isFastest && <FastestModelBadge />}
+                {row.original.isBest && <BestModelBadge />}
+                {row.original.embeddingDimensions !== null && (
+                  <EmbeddingModelBadge />
+                )}
+              </div>
             </div>
-          </div>
-        ),
+          );
+        },
       },
       {
         accessorKey: "apiKeys",

--- a/platform/frontend/src/app/settings/agents/page.tsx
+++ b/platform/frontend/src/app/settings/agents/page.tsx
@@ -162,6 +162,8 @@ export default function AgentSettingsPage() {
       value: model.dbId,
       model: model.displayName ?? model.id,
       provider: model.provider,
+      isFree: model.isFree,
+      isFastest: model.isFastest,
     }));
   }, [allModels]);
 
@@ -266,6 +268,7 @@ export default function AgentSettingsPage() {
                   value={defaultModel}
                   onValueChange={setDefaultModel}
                   options={modelItems}
+                  freeFilterable
                   placeholder={
                     !selectedApiKeyId
                       ? "Select API key first..."

--- a/platform/frontend/src/app/settings/agents/page.tsx
+++ b/platform/frontend/src/app/settings/agents/page.tsx
@@ -158,13 +158,17 @@ export default function AgentSettingsPage() {
 
   const modelItems = useMemo(() => {
     if (!allModels) return [];
-    return allModels.map((model) => ({
-      value: model.dbId,
-      model: model.displayName ?? model.id,
-      provider: model.provider,
-      isFree: model.isFree,
-      isFastest: model.isFastest,
-    }));
+    return allModels
+      .map((model) => ({
+        value: model.dbId,
+        model: model.displayName ?? model.id,
+        modelId: model.id,
+        provider: model.provider,
+        isFree: model.isFree,
+        isFastest: model.isFastest,
+        isBest: model.isBest,
+      }))
+      .sort((a, b) => a.model.localeCompare(b.model));
   }, [allModels]);
 
   const selectedApiKey = useMemo(

--- a/platform/frontend/src/app/settings/agents/page.tsx
+++ b/platform/frontend/src/app/settings/agents/page.tsx
@@ -158,17 +158,15 @@ export default function AgentSettingsPage() {
 
   const modelItems = useMemo(() => {
     if (!allModels) return [];
-    return allModels
-      .map((model) => ({
-        value: model.dbId,
-        model: model.displayName ?? model.id,
-        modelId: model.id,
-        provider: model.provider,
-        isFree: model.isFree,
-        isFastest: model.isFastest,
-        isBest: model.isBest,
-      }))
-      .sort((a, b) => a.model.localeCompare(b.model));
+    return allModels.map((model) => ({
+      value: model.dbId,
+      model: model.displayName ?? model.id,
+      modelId: model.id,
+      provider: model.provider,
+      isFree: model.isFree,
+      isFastest: model.isFastest,
+      isBest: model.isBest,
+    }));
   }, [allModels]);
 
   const selectedApiKey = useMemo(

--- a/platform/frontend/src/app/settings/llm/page.tsx
+++ b/platform/frontend/src/app/settings/llm/page.tsx
@@ -95,6 +95,8 @@ export default function LlmSettingsPage() {
     provider: model.provider,
     pricePerMillionInput: model.pricePerMillionInput ?? "0",
     pricePerMillionOutput: model.pricePerMillionOutput ?? "0",
+    isFree: model.isFree,
+    isFastest: model.isFastest,
   }));
 
   // Sync state when both organization and teams data are loaded

--- a/platform/frontend/src/app/settings/llm/page.tsx
+++ b/platform/frontend/src/app/settings/llm/page.tsx
@@ -97,6 +97,7 @@ export default function LlmSettingsPage() {
     pricePerMillionOutput: model.pricePerMillionOutput ?? "0",
     isFree: model.isFree,
     isFastest: model.isFastest,
+    isBest: model.isBest,
   }));
 
   // Sync state when both organization and teams data are loaded

--- a/platform/frontend/src/components/chat/model-selector.tsx
+++ b/platform/frontend/src/components/chat/model-selector.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  compareModelsForDisplay,
   E2eTestId,
   type ModelInputModality,
   providerDisplayNames,
@@ -34,7 +35,11 @@ import {
   ModelSelectorTrigger,
 } from "@/components/ai-elements/model-selector";
 import { PromptInputButton } from "@/components/ai-elements/prompt-input";
-import { UnknownCapabilitiesBadge } from "@/components/model-badges";
+import {
+  FreeModelBadge,
+  LatestModelBadge,
+  UnknownCapabilitiesBadge,
+} from "@/components/model-badges";
 import { Button } from "@/components/ui/button";
 import { DialogClose } from "@/components/ui/dialog";
 import { Toggle } from "@/components/ui/toggle";
@@ -143,6 +148,19 @@ function parseModelValue(
     provider: value.substring(0, colonIndex) as SupportedProvider,
     modelId: value.substring(colonIndex + 1),
   };
+}
+
+/** Shared model ordering (routers, recommended, then the rest alphabetically). */
+function compareLlmModels(a: LlmModel, b: LlmModel): number {
+  return compareModelsForDisplay(
+    { modelId: a.id, isBest: a.isBest },
+    { modelId: b.id, isBest: b.isBest },
+  );
+}
+
+/** True for OpenRouter "~...-latest" aliases that always track the newest model. */
+function isLatestAliasModel(provider: SupportedProvider, modelId: string) {
+  return provider === "openrouter" && modelId.startsWith("~");
 }
 
 /**
@@ -839,51 +857,57 @@ export function ModelSelector({
                 key={provider}
                 heading={providerDisplayNames[provider]}
               >
-                {filteredModelsByProvider[provider]?.map((model) => {
-                  // Use provider:modelId format for unique keys/values
-                  // This prevents issues when different providers have models with the same ID
-                  const modelValue = createModelValue(provider, model.dbId);
-                  return (
-                    <ModelSelectorItem
-                      key={modelValue}
-                      value={modelValue}
-                      onSelect={() => handleSelectModel(modelValue)}
-                      className="group"
-                    >
-                      <ModelSelectorLogo
-                        provider={providerToLogoProvider[provider]}
-                      />
-                      <ModelSelectorName>
-                        {model.displayName}{" "}
-                        <span className="text-xs text-muted-foreground font-mono">
-                          ({model.id})
-                        </span>
-                        <CopyModelIdButton modelId={model.id} />
-                      </ModelSelectorName>
-                      <div className="ml-auto flex items-center gap-2">
-                        <ModelCapabilityBadges
-                          capabilities={model.capabilities}
+                {[...(filteredModelsByProvider[provider] ?? [])]
+                  .sort(compareLlmModels)
+                  .map((model) => {
+                    // Use provider:modelId format for unique keys/values
+                    // This prevents issues when different providers have models with the same ID
+                    const modelValue = createModelValue(provider, model.dbId);
+                    return (
+                      <ModelSelectorItem
+                        key={modelValue}
+                        value={modelValue}
+                        onSelect={() => handleSelectModel(modelValue)}
+                        className="group"
+                      >
+                        <ModelSelectorLogo
+                          provider={providerToLogoProvider[provider]}
                         />
-                        <ContextLengthIndicator
-                          contextLength={model.capabilities?.contextLength}
-                        />
-                        <PricingIndicator
-                          pricePerMillionInput={
-                            model.capabilities?.pricePerMillionInput
-                          }
-                          pricePerMillionOutput={
-                            model.capabilities?.pricePerMillionOutput
-                          }
-                        />
-                        {selectedModel === model.dbId ? (
-                          <CheckIcon className="size-4" />
-                        ) : (
-                          <div className="size-4" />
+                        <ModelSelectorName>
+                          {model.displayName}{" "}
+                          <span className="text-xs text-muted-foreground font-mono">
+                            ({model.id})
+                          </span>
+                          <CopyModelIdButton modelId={model.id} />
+                        </ModelSelectorName>
+                        {model.isFree && <FreeModelBadge />}
+                        {isLatestAliasModel(provider, model.id) && (
+                          <LatestModelBadge />
                         )}
-                      </div>
-                    </ModelSelectorItem>
-                  );
-                })}
+                        <div className="ml-auto flex items-center gap-2">
+                          <ModelCapabilityBadges
+                            capabilities={model.capabilities}
+                          />
+                          <ContextLengthIndicator
+                            contextLength={model.capabilities?.contextLength}
+                          />
+                          <PricingIndicator
+                            pricePerMillionInput={
+                              model.capabilities?.pricePerMillionInput
+                            }
+                            pricePerMillionOutput={
+                              model.capabilities?.pricePerMillionOutput
+                            }
+                          />
+                          {selectedModel === model.dbId ? (
+                            <CheckIcon className="size-4" />
+                          ) : (
+                            <div className="size-4" />
+                          )}
+                        </div>
+                      </ModelSelectorItem>
+                    );
+                  })}
               </ModelSelectorGroup>
             ))}
           </ModelSelectorList>

--- a/platform/frontend/src/components/chat/model-selector.tsx
+++ b/platform/frontend/src/components/chat/model-selector.tsx
@@ -3,6 +3,7 @@
 import {
   compareModelsForDisplay,
   E2eTestId,
+  isOpenRouterLatestAlias,
   type ModelInputModality,
   providerDisplayNames,
   type SupportedProvider,
@@ -156,11 +157,6 @@ function compareLlmModels(a: LlmModel, b: LlmModel): number {
     { modelId: a.id, isBest: a.isBest },
     { modelId: b.id, isBest: b.isBest },
   );
-}
-
-/** True for OpenRouter "~...-latest" aliases that always track the newest model. */
-function isLatestAliasModel(provider: SupportedProvider, modelId: string) {
-  return provider === "openrouter" && modelId.startsWith("~");
 }
 
 /**
@@ -623,6 +619,17 @@ export function ModelSelector({
     return Object.keys(filteredModelsByProvider) as SupportedProvider[];
   }, [filteredModelsByProvider]);
 
+  // Sort once per data change rather than on every render inside the JSX map.
+  const sortedModelsByProvider = useMemo(() => {
+    const sorted: Partial<Record<SupportedProvider, LlmModel[]>> = {};
+    for (const provider of filteredProviders) {
+      sorted[provider] = [...(filteredModelsByProvider[provider] ?? [])].sort(
+        compareLlmModels,
+      );
+    }
+    return sorted;
+  }, [filteredModelsByProvider, filteredProviders]);
+
   // Find the provider for a given model
   const getProviderForModel = (model: string): SupportedProvider | null => {
     for (const provider of availableProviders) {
@@ -857,57 +864,55 @@ export function ModelSelector({
                 key={provider}
                 heading={providerDisplayNames[provider]}
               >
-                {[...(filteredModelsByProvider[provider] ?? [])]
-                  .sort(compareLlmModels)
-                  .map((model) => {
-                    // Use provider:modelId format for unique keys/values
-                    // This prevents issues when different providers have models with the same ID
-                    const modelValue = createModelValue(provider, model.dbId);
-                    return (
-                      <ModelSelectorItem
-                        key={modelValue}
-                        value={modelValue}
-                        onSelect={() => handleSelectModel(modelValue)}
-                        className="group"
-                      >
-                        <ModelSelectorLogo
-                          provider={providerToLogoProvider[provider]}
+                {(sortedModelsByProvider[provider] ?? []).map((model) => {
+                  // Use provider:modelId format for unique keys/values
+                  // This prevents issues when different providers have models with the same ID
+                  const modelValue = createModelValue(provider, model.dbId);
+                  return (
+                    <ModelSelectorItem
+                      key={modelValue}
+                      value={modelValue}
+                      onSelect={() => handleSelectModel(modelValue)}
+                      className="group"
+                    >
+                      <ModelSelectorLogo
+                        provider={providerToLogoProvider[provider]}
+                      />
+                      <ModelSelectorName>
+                        {model.displayName}{" "}
+                        <span className="text-xs text-muted-foreground font-mono">
+                          ({model.id})
+                        </span>
+                        <CopyModelIdButton modelId={model.id} />
+                      </ModelSelectorName>
+                      {model.isFree && <FreeModelBadge />}
+                      {isOpenRouterLatestAlias(provider, model.id) && (
+                        <LatestModelBadge />
+                      )}
+                      <div className="ml-auto flex items-center gap-2">
+                        <ModelCapabilityBadges
+                          capabilities={model.capabilities}
                         />
-                        <ModelSelectorName>
-                          {model.displayName}{" "}
-                          <span className="text-xs text-muted-foreground font-mono">
-                            ({model.id})
-                          </span>
-                          <CopyModelIdButton modelId={model.id} />
-                        </ModelSelectorName>
-                        {model.isFree && <FreeModelBadge />}
-                        {isLatestAliasModel(provider, model.id) && (
-                          <LatestModelBadge />
+                        <ContextLengthIndicator
+                          contextLength={model.capabilities?.contextLength}
+                        />
+                        <PricingIndicator
+                          pricePerMillionInput={
+                            model.capabilities?.pricePerMillionInput
+                          }
+                          pricePerMillionOutput={
+                            model.capabilities?.pricePerMillionOutput
+                          }
+                        />
+                        {selectedModel === model.dbId ? (
+                          <CheckIcon className="size-4" />
+                        ) : (
+                          <div className="size-4" />
                         )}
-                        <div className="ml-auto flex items-center gap-2">
-                          <ModelCapabilityBadges
-                            capabilities={model.capabilities}
-                          />
-                          <ContextLengthIndicator
-                            contextLength={model.capabilities?.contextLength}
-                          />
-                          <PricingIndicator
-                            pricePerMillionInput={
-                              model.capabilities?.pricePerMillionInput
-                            }
-                            pricePerMillionOutput={
-                              model.capabilities?.pricePerMillionOutput
-                            }
-                          />
-                          {selectedModel === model.dbId ? (
-                            <CheckIcon className="size-4" />
-                          ) : (
-                            <div className="size-4" />
-                          )}
-                        </div>
-                      </ModelSelectorItem>
-                    );
-                  })}
+                      </div>
+                    </ModelSelectorItem>
+                  );
+                })}
               </ModelSelectorGroup>
             ))}
           </ModelSelectorList>

--- a/platform/frontend/src/components/chat/model-selector.tsx
+++ b/platform/frontend/src/components/chat/model-selector.tsx
@@ -51,7 +51,7 @@ import {
   useLlmModelsByProvider,
   useSyncLlmModels,
 } from "@/lib/llm-models.query";
-import { cn } from "@/lib/utils";
+import { cn, formatContextLength } from "@/lib/utils";
 
 /** Modalities that can be filtered (excludes "text" since all models support it) */
 type FilterableModality = Exclude<ModelInputModality, "text">;
@@ -219,20 +219,6 @@ function ModelCapabilityBadges({
       </div>
     </TooltipProvider>
   );
-}
-
-/**
- * Formats a context length number into a human-readable string.
- * e.g., 128000 -> "128K", 1000000 -> "1M"
- */
-function formatContextLength(contextLength: number): string {
-  if (contextLength >= 1_000_000) {
-    return `${(contextLength / 1_000_000).toFixed(contextLength % 1_000_000 === 0 ? 0 : 1)}M`;
-  }
-  if (contextLength >= 1_000) {
-    return `${(contextLength / 1_000).toFixed(contextLength % 1_000 === 0 ? 0 : 1)}K`;
-  }
-  return contextLength.toString();
 }
 
 /**

--- a/platform/frontend/src/components/llm-model-picker.test.tsx
+++ b/platform/frontend/src/components/llm-model-picker.test.tsx
@@ -79,7 +79,7 @@ describe("LlmModelPicker", () => {
       expect(onValueChange).toHaveBeenCalledWith("gpt-4o");
     });
 
-    it("auto-selects the first model (alphabetical) when autoSelectFirst is true", () => {
+    it("auto-selects first model when autoSelectFirst is true", () => {
       const onValueChange = vi.fn();
 
       render(
@@ -92,7 +92,7 @@ describe("LlmModelPicker", () => {
         />,
       );
 
-      expect(onValueChange).toHaveBeenCalledWith("claude-3.5-sonnet");
+      expect(onValueChange).toHaveBeenCalledWith("gpt-4o");
     });
 
     it("shows 'Add pricing' link when no models have pricing", () => {

--- a/platform/frontend/src/components/llm-model-picker.test.tsx
+++ b/platform/frontend/src/components/llm-model-picker.test.tsx
@@ -79,7 +79,7 @@ describe("LlmModelPicker", () => {
       expect(onValueChange).toHaveBeenCalledWith("gpt-4o");
     });
 
-    it("auto-selects first model when autoSelectFirst is true", () => {
+    it("auto-selects the first model (alphabetical) when autoSelectFirst is true", () => {
       const onValueChange = vi.fn();
 
       render(
@@ -92,7 +92,7 @@ describe("LlmModelPicker", () => {
         />,
       );
 
-      expect(onValueChange).toHaveBeenCalledWith("gpt-4o");
+      expect(onValueChange).toHaveBeenCalledWith("claude-3.5-sonnet");
     });
 
     it("shows 'Add pricing' link when no models have pricing", () => {

--- a/platform/frontend/src/components/llm-model-picker.tsx
+++ b/platform/frontend/src/components/llm-model-picker.tsx
@@ -19,6 +19,8 @@ export type ModelPricing = Array<{
   model: string;
   pricePerMillionInput: string;
   pricePerMillionOutput: string;
+  isFree?: boolean;
+  isFastest?: boolean;
 }>;
 
 export type SortDirection = "asc" | "desc";
@@ -42,6 +44,8 @@ type SharedProps = {
   autoSelectFirst?: boolean;
   sortDirection?: SortDirection;
   includeAllOption?: boolean;
+  /** Show a "Free only" toggle in the editable searchable select. */
+  freeFilterable?: boolean;
 };
 
 type SingleSelectProps = SharedProps & {
@@ -61,8 +65,14 @@ type MultiSelectProps = SharedProps & {
 export type LlmModelPickerProps = SingleSelectProps | MultiSelectProps;
 
 export function LlmModelPicker(props: LlmModelPickerProps) {
-  const { models, editable, autoSelectFirst, sortDirection, includeAllOption } =
-    props;
+  const {
+    models,
+    editable,
+    autoSelectFirst,
+    sortDirection,
+    includeAllOption,
+    freeFilterable,
+  } = props;
 
   const sortedModels = sortDirection
     ? sortModelsByPrice(models, sortDirection)
@@ -117,6 +127,8 @@ export function LlmModelPicker(props: LlmModelPickerProps) {
     provider: price.provider as SupportedProvider,
     pricePerMillionInput: price.pricePerMillionInput,
     pricePerMillionOutput: price.pricePerMillionOutput,
+    isFree: "isFree" in price ? price.isFree : undefined,
+    isFastest: "isFastest" in price ? price.isFastest : undefined,
   }));
 
   if (!editable) {
@@ -218,6 +230,7 @@ export function LlmModelPicker(props: LlmModelPickerProps) {
         placeholder="Select target model..."
         className="w-full"
         showPricing
+        freeFilterable={freeFilterable}
       />
     );
   }
@@ -253,6 +266,7 @@ export function LlmModelPicker(props: LlmModelPickerProps) {
       placeholder="Select target models..."
       className="w-full"
       showPricing
+      freeFilterable={freeFilterable}
       maxSelected={props.maxSelected}
       maxBadgeDisplay={props.maxBadgeDisplay}
       includeAllOption={includeAllOption}

--- a/platform/frontend/src/components/llm-model-picker.tsx
+++ b/platform/frontend/src/components/llm-model-picker.tsx
@@ -75,11 +75,11 @@ export function LlmModelPicker(props: LlmModelPickerProps) {
     freeFilterable,
   } = props;
 
-  // With an explicit price sort, keep it; otherwise order the rest
-  // alphabetically (the select then pins routers and recommended models).
+  // `sortDirection` price-sorts for `autoSelectFirst`; the dropdown itself is
+  // ordered by the shared model ordering inside LlmModelSearchableSelect.
   const sortedModels = sortDirection
     ? sortModelsByPrice(models, sortDirection)
-    : [...models].sort((a, b) => a.model.localeCompare(b.model));
+    : models;
 
   const isSingle = !props.multiple;
   const value = isSingle ? props.value : props.value;
@@ -236,6 +236,7 @@ export function LlmModelPicker(props: LlmModelPickerProps) {
         className="w-full"
         showPricing
         freeFilterable={freeFilterable}
+        preserveOrder={sortDirection !== undefined}
       />
     );
   }
@@ -272,6 +273,7 @@ export function LlmModelPicker(props: LlmModelPickerProps) {
       className="w-full"
       showPricing
       freeFilterable={freeFilterable}
+      preserveOrder={sortDirection !== undefined}
       maxSelected={props.maxSelected}
       maxBadgeDisplay={props.maxBadgeDisplay}
       includeAllOption={includeAllOption}

--- a/platform/frontend/src/components/llm-model-picker.tsx
+++ b/platform/frontend/src/components/llm-model-picker.tsx
@@ -131,9 +131,9 @@ export function LlmModelPicker(props: LlmModelPickerProps) {
     provider: price.provider as SupportedProvider,
     pricePerMillionInput: price.pricePerMillionInput,
     pricePerMillionOutput: price.pricePerMillionOutput,
-    isFree: "isFree" in price ? price.isFree : undefined,
-    isFastest: "isFastest" in price ? price.isFastest : undefined,
-    isBest: "isBest" in price ? price.isBest : undefined,
+    isFree: price.isFree,
+    isFastest: price.isFastest,
+    isBest: price.isBest,
   }));
 
   if (!editable) {

--- a/platform/frontend/src/components/llm-model-picker.tsx
+++ b/platform/frontend/src/components/llm-model-picker.tsx
@@ -21,6 +21,7 @@ export type ModelPricing = Array<{
   pricePerMillionOutput: string;
   isFree?: boolean;
   isFastest?: boolean;
+  isBest?: boolean;
 }>;
 
 export type SortDirection = "asc" | "desc";
@@ -74,9 +75,11 @@ export function LlmModelPicker(props: LlmModelPickerProps) {
     freeFilterable,
   } = props;
 
+  // With an explicit price sort, keep it; otherwise order the rest
+  // alphabetically (the select then pins routers and recommended models).
   const sortedModels = sortDirection
     ? sortModelsByPrice(models, sortDirection)
-    : models;
+    : [...models].sort((a, b) => a.model.localeCompare(b.model));
 
   const isSingle = !props.multiple;
   const value = isSingle ? props.value : props.value;
@@ -124,11 +127,13 @@ export function LlmModelPicker(props: LlmModelPickerProps) {
   const options = modelsWithCurrent.map((price) => ({
     value: price.model,
     model: price.model,
+    modelId: price.model,
     provider: price.provider as SupportedProvider,
     pricePerMillionInput: price.pricePerMillionInput,
     pricePerMillionOutput: price.pricePerMillionOutput,
     isFree: "isFree" in price ? price.isFree : undefined,
     isFastest: "isFastest" in price ? price.isFastest : undefined,
+    isBest: "isBest" in price ? price.isBest : undefined,
   }));
 
   if (!editable) {

--- a/platform/frontend/src/components/llm-model-select.test.tsx
+++ b/platform/frontend/src/components/llm-model-select.test.tsx
@@ -103,7 +103,7 @@ describe("LlmModelSearchableSelect", () => {
     expect(screen.getByText("free-model")).toBeInTheDocument();
   });
 
-  it("renders a distinct Free Router badge for the OpenRouter free router", async () => {
+  it("renders the unified Free badge for the OpenRouter free router", async () => {
     const user = userEvent.setup();
     render(
       <LlmModelSearchableSelect
@@ -121,9 +121,7 @@ describe("LlmModelSearchableSelect", () => {
     );
 
     await user.click(screen.getByRole("combobox"));
-    expect(screen.getByText("Free Router")).toBeInTheDocument();
-    // The generic green "Free" badge is replaced, not duplicated.
-    expect(screen.queryByText("Free")).not.toBeInTheDocument();
+    expect(screen.getByText("Free")).toBeInTheDocument();
   });
 
   it("renders a Latest badge for OpenRouter ~latest aliases", async () => {
@@ -232,6 +230,6 @@ describe("LlmModelSearchableSelect", () => {
     );
 
     await user.click(screen.getByRole("combobox"));
-    expect(screen.getByText("Free Router")).toBeInTheDocument();
+    expect(screen.getByText("Free")).toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/components/llm-model-select.test.tsx
+++ b/platform/frontend/src/components/llm-model-select.test.tsx
@@ -186,4 +186,52 @@ describe("LlmModelSearchableSelect", () => {
       auto.compareDocumentPosition(other) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
+
+  it("orders recommended models above the rest", async () => {
+    const user = userEvent.setup();
+    render(
+      <LlmModelSearchableSelect
+        value=""
+        onValueChange={vi.fn()}
+        options={[
+          { value: "z", model: "zzz/model", provider: "openrouter" },
+          {
+            value: "best",
+            model: "best/model",
+            provider: "openrouter",
+            isBest: true,
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    const best = screen.getByText("best/model");
+    const rest = screen.getByText("zzz/model");
+    expect(
+      best.compareDocumentPosition(rest) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("detects the free router by modelId when the label is a display name", async () => {
+    const user = userEvent.setup();
+    render(
+      <LlmModelSearchableSelect
+        value=""
+        onValueChange={vi.fn()}
+        options={[
+          {
+            value: "models-table-uuid",
+            model: "Free Models Router",
+            modelId: OPENROUTER_FREE_MODEL_ID,
+            provider: "openrouter",
+            isFree: true,
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByText("Free Router")).toBeInTheDocument();
+  });
 });

--- a/platform/frontend/src/components/llm-model-select.test.tsx
+++ b/platform/frontend/src/components/llm-model-select.test.tsx
@@ -1,3 +1,4 @@
+import { OPENROUTER_AUTO_MODEL_ID, OPENROUTER_FREE_MODEL_ID } from "@shared";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
@@ -47,5 +48,142 @@ describe("LlmModelSearchableSelect", () => {
       "break-words",
     );
     expect(screen.getByText(modelName)).not.toHaveClass("truncate");
+  });
+
+  it("renders a Free badge for zero-cost models", async () => {
+    const user = userEvent.setup();
+    render(
+      <LlmModelSearchableSelect
+        value=""
+        onValueChange={vi.fn()}
+        options={[
+          {
+            value: "free-1",
+            model: "free-model",
+            provider: "openrouter",
+            isFree: true,
+          },
+          { value: "paid-1", model: "paid-model", provider: "openai" },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByText("Free")).toBeInTheDocument();
+  });
+
+  it("filters to free models when 'Free only' is enabled", async () => {
+    const user = userEvent.setup();
+    render(
+      <LlmModelSearchableSelect
+        value=""
+        onValueChange={vi.fn()}
+        freeFilterable
+        options={[
+          {
+            value: "free-1",
+            model: "free-model",
+            provider: "openrouter",
+            isFree: true,
+          },
+          { value: "paid-1", model: "paid-model", provider: "openai" },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByText("paid-model")).toBeInTheDocument();
+    expect(screen.getByText("free-model")).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    await user.click(screen.getByLabelText("Free models only"));
+    await user.click(screen.getByRole("combobox"));
+
+    expect(screen.queryByText("paid-model")).not.toBeInTheDocument();
+    expect(screen.getByText("free-model")).toBeInTheDocument();
+  });
+
+  it("renders a distinct Free Router badge for the OpenRouter free router", async () => {
+    const user = userEvent.setup();
+    render(
+      <LlmModelSearchableSelect
+        value=""
+        onValueChange={vi.fn()}
+        options={[
+          {
+            value: OPENROUTER_FREE_MODEL_ID,
+            model: OPENROUTER_FREE_MODEL_ID,
+            provider: "openrouter",
+            isFree: true,
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByText("Free Router")).toBeInTheDocument();
+    // The generic green "Free" badge is replaced, not duplicated.
+    expect(screen.queryByText("Free")).not.toBeInTheDocument();
+  });
+
+  it("renders a Latest badge for OpenRouter ~latest aliases", async () => {
+    const user = userEvent.setup();
+    render(
+      <LlmModelSearchableSelect
+        value=""
+        onValueChange={vi.fn()}
+        options={[
+          {
+            value: "alias",
+            model: "~anthropic/claude-sonnet-latest",
+            provider: "openrouter",
+          },
+          {
+            value: "pinned",
+            model: "anthropic/claude-sonnet-4.6",
+            provider: "openrouter",
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByText("Latest")).toBeInTheDocument();
+  });
+
+  it("pins the routers to the top of the list", async () => {
+    const user = userEvent.setup();
+    render(
+      <LlmModelSearchableSelect
+        value=""
+        onValueChange={vi.fn()}
+        options={[
+          { value: "a", model: "aaa/model", provider: "openrouter" },
+          {
+            value: OPENROUTER_AUTO_MODEL_ID,
+            model: OPENROUTER_AUTO_MODEL_ID,
+            provider: "openrouter",
+          },
+          {
+            value: OPENROUTER_FREE_MODEL_ID,
+            model: OPENROUTER_FREE_MODEL_ID,
+            provider: "openrouter",
+            isFree: true,
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    const free = screen.getByText(OPENROUTER_FREE_MODEL_ID);
+    const auto = screen.getByText(OPENROUTER_AUTO_MODEL_ID);
+    const other = screen.getByText("aaa/model");
+    // The free router precedes the auto router, which precedes everything else.
+    expect(
+      free.compareDocumentPosition(auto) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      auto.compareDocumentPosition(other) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });

--- a/platform/frontend/src/components/llm-model-select.tsx
+++ b/platform/frontend/src/components/llm-model-select.tsx
@@ -3,6 +3,7 @@
 import type { PopoverContentProps } from "@radix-ui/react-popover";
 import {
   compareModelsForDisplay,
+  isOpenRouterLatestAlias,
   OPENROUTER_AUTO_MODEL_ID,
   providerDisplayNames,
   type SupportedProvider,
@@ -67,9 +68,8 @@ function modelIdOf(option: LlmModelSelectOption): string {
 /** Renders the Free / Latest / Fastest / custom badges shared across the option views. */
 function ModelBadges({ option }: { option: LlmModelSelectOption }) {
   const id = modelIdOf(option);
-  // OpenRouter "~...-latest" ids are aliases that always point at the newest
-  // model in a family — the badge tells users the selection auto-updates.
-  const isLatestAlias = option.provider === "openrouter" && id.startsWith("~");
+  // the badge tells users an alias selection auto-updates to the newest model.
+  const isLatestAlias = isOpenRouterLatestAlias(option.provider, id);
   return (
     <>
       {option.isFree && (

--- a/platform/frontend/src/components/llm-model-select.tsx
+++ b/platform/frontend/src/components/llm-model-select.tsx
@@ -41,6 +41,12 @@ export type LlmModelSelectOption = {
   value: string;
   model: string;
   provider: SupportedProvider;
+  /**
+   * The provider's native model id (e.g. `openrouter/free`). `model` is a
+   * display label and may be a friendly name, so router/badge detection and
+   * ordering key off this. Falls back to `model` when omitted.
+   */
+  modelId?: string;
   description?: string;
   pricePerMillionInput?: string | null;
   pricePerMillionOutput?: string | null;
@@ -49,15 +55,22 @@ export type LlmModelSelectOption = {
   isFree?: boolean;
   /** Provider's lowest-latency model — rendered with a "Fastest" badge. */
   isFastest?: boolean;
+  /** Provider's highest-quality ("recommended") model — sorted near the top. */
+  isBest?: boolean;
 };
+
+/** The provider's native model id, used for badge detection and ordering. */
+function modelIdOf(option: LlmModelSelectOption): string {
+  return option.modelId ?? option.model;
+}
 
 /** Renders the Free Router / Free / Latest / Fastest / custom badges shared across the option views. */
 function ModelBadges({ option }: { option: LlmModelSelectOption }) {
-  const isFreeRouter = option.model === OPENROUTER_FREE_MODEL_ID;
+  const id = modelIdOf(option);
+  const isFreeRouter = id === OPENROUTER_FREE_MODEL_ID;
   // OpenRouter "~...-latest" ids are aliases that always point at the newest
   // model in a family — the badge tells users the selection auto-updates.
-  const isLatestAlias =
-    option.provider === "openrouter" && option.model.startsWith("~");
+  const isLatestAlias = option.provider === "openrouter" && id.startsWith("~");
   return (
     <>
       {isFreeRouter && (
@@ -264,16 +277,15 @@ export function LlmModelSearchableSelect(props: LlmModelSearchableSelectProps) {
   } = props;
 
   const [freeOnly, setFreeOnly] = useState(false);
-  // Pin the OpenRouter routers to the top so the zero-cost on-ramp is the first
-  // thing users see; everything else keeps its incoming order (stable sort).
+  // Order: routers first, then recommended models, then the rest in their
+  // incoming order. The sort is stable, so each consumer controls how the
+  // remaining models are arranged (e.g. alphabetically or by price).
   const visibleOptions = useMemo(() => {
     const filtered =
       freeFilterable && freeOnly
         ? options.filter((option) => option.isFree)
         : options;
-    return [...filtered].sort(
-      (a, b) => routerSortRank(a.model) - routerSortRank(b.model),
-    );
+    return [...filtered].sort((a, b) => modelSortRank(a) - modelSortRank(b));
   }, [options, freeFilterable, freeOnly]);
 
   const selectElement = props.multiple ? (
@@ -392,15 +404,18 @@ export function LlmModelSearchableSelect(props: LlmModelSearchableSelectProps) {
   );
 }
 
-/** Routers sort first (free, then auto); every other model keeps its order. */
-function routerSortRank(modelId: string): number {
-  switch (modelId) {
+/**
+ * Tiered order: free router (0), auto router (1), recommended models (2),
+ * everything else (3). Within a tier the stable sort preserves input order.
+ */
+function modelSortRank(option: LlmModelSelectOption): number {
+  switch (modelIdOf(option)) {
     case OPENROUTER_FREE_MODEL_ID:
       return 0;
     case OPENROUTER_AUTO_MODEL_ID:
       return 1;
     default:
-      return 2;
+      return option.isBest ? 2 : 3;
   }
 }
 
@@ -410,7 +425,7 @@ function formatPricing(option: LlmModelSelectOption) {
   // OpenRouter's Auto Router has no fixed price — it bills at the routed
   // model's rate. A negative price is the same "dynamic" sentinel.
   if (
-    option.model === OPENROUTER_AUTO_MODEL_ID ||
+    modelIdOf(option) === OPENROUTER_AUTO_MODEL_ID ||
     Number(input) < 0 ||
     Number(output) < 0
   ) {

--- a/platform/frontend/src/components/llm-model-select.tsx
+++ b/platform/frontend/src/components/llm-model-select.tsx
@@ -1,13 +1,20 @@
 "use client";
 
 import type { PopoverContentProps } from "@radix-ui/react-popover";
-import { providerDisplayNames, type SupportedProvider } from "@shared";
-import { Layers } from "lucide-react";
+import {
+  OPENROUTER_AUTO_MODEL_ID,
+  OPENROUTER_FREE_MODEL_ID,
+  providerDisplayNames,
+  type SupportedProvider,
+} from "@shared";
+import { Layers, RefreshCw, Sparkles } from "lucide-react";
 import Image from "next/image";
-import type { ReactNode } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 import { SearchableMultiSelect } from "@/components/searchable-multi-select";
 import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
 import { SearchableSelect } from "@/components/ui/searchable-select";
+import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 
 const PROVIDER_LOGO_NAME: Record<SupportedProvider, string> = {
@@ -38,7 +45,57 @@ export type LlmModelSelectOption = {
   pricePerMillionInput?: string | null;
   pricePerMillionOutput?: string | null;
   badge?: ReactNode;
+  /** Provider charges nothing for this model — rendered with a green "Free" badge. */
+  isFree?: boolean;
+  /** Provider's lowest-latency model — rendered with a "Fastest" badge. */
+  isFastest?: boolean;
 };
+
+/** Renders the Free Router / Free / Latest / Fastest / custom badges shared across the option views. */
+function ModelBadges({ option }: { option: LlmModelSelectOption }) {
+  const isFreeRouter = option.model === OPENROUTER_FREE_MODEL_ID;
+  // OpenRouter "~...-latest" ids are aliases that always point at the newest
+  // model in a family — the badge tells users the selection auto-updates.
+  const isLatestAlias =
+    option.provider === "openrouter" && option.model.startsWith("~");
+  return (
+    <>
+      {isFreeRouter && (
+        <Badge
+          variant="outline"
+          className="shrink-0 gap-1 text-xs border-green-300 bg-green-100 text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-300"
+        >
+          <Sparkles className="h-3 w-3" />
+          Free Router
+        </Badge>
+      )}
+      {option.isFree && !isFreeRouter && (
+        <Badge
+          variant="outline"
+          className="shrink-0 text-xs border-green-300 bg-green-100 text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-300"
+        >
+          Free
+        </Badge>
+      )}
+      {isLatestAlias && (
+        <Badge variant="outline" className="shrink-0 gap-1 text-xs">
+          <RefreshCw className="h-3 w-3" />
+          Latest
+        </Badge>
+      )}
+      {option.isFastest && (
+        <Badge variant="outline" className="shrink-0 text-xs">
+          Fastest
+        </Badge>
+      )}
+      {option.badge && (
+        <Badge variant="outline" className="shrink-0 text-xs">
+          {option.badge}
+        </Badge>
+      )}
+    </>
+  );
+}
 
 export function LlmModelOptionLabel({
   option,
@@ -67,11 +124,7 @@ export function LlmModelOptionLabel({
           >
             {option.model}
           </span>
-          {option.badge && (
-            <Badge variant="outline" className="shrink-0 text-xs">
-              {option.badge}
-            </Badge>
-          )}
+          <ModelBadges option={option} />
         </div>
         {showPricing && (
           <div className="truncate text-xs text-muted-foreground">
@@ -106,11 +159,7 @@ function LlmModelSelectedValue({
           className="shrink-0 rounded dark:invert"
         />
         <span className="truncate">{option.model}</span>
-        {option.badge && (
-          <Badge variant="outline" className="shrink-0 text-xs">
-            {option.badge}
-          </Badge>
-        )}
+        <ModelBadges option={option} />
       </div>
     );
   }
@@ -127,11 +176,7 @@ function LlmModelSelectedValue({
       <div className="min-w-0">
         <div className="flex items-center gap-2">
           <span className="truncate">{option.model}</span>
-          {option.badge && (
-            <Badge variant="outline" className="shrink-0 text-xs">
-              {option.badge}
-            </Badge>
-          )}
+          <ModelBadges option={option} />
         </div>
         {showPricing && (
           <div className="truncate text-xs text-muted-foreground">
@@ -175,6 +220,8 @@ type SharedProps = {
   popoverSide?: PopoverContentProps["side"];
   popoverAlign?: PopoverContentProps["align"];
   popoverAvoidCollisions?: PopoverContentProps["avoidCollisions"];
+  /** Show a "Free only" toggle that filters the list to zero-cost models. */
+  freeFilterable?: boolean;
 };
 
 type SingleSelectProps = SharedProps & {
@@ -213,56 +260,66 @@ export function LlmModelSearchableSelect(props: LlmModelSearchableSelectProps) {
     popoverSide,
     popoverAlign,
     popoverAvoidCollisions,
+    freeFilterable = false,
   } = props;
 
-  if (props.multiple) {
-    return (
-      <SearchableMultiSelect
-        value={props.value}
-        onValueChange={props.onValueChange}
-        placeholder={placeholder}
-        searchPlaceholder={searchPlaceholder}
-        disabled={disabled}
-        className={cn("w-full", className)}
-        emptyMessage={emptyMessage}
-        contentClassName={popoverContentClassName}
-        listClassName={popoverListClassName}
-        contentSide={popoverSide}
-        contentAlign={popoverAlign}
-        contentAvoidCollisions={popoverAvoidCollisions}
-        maxSelected={props.maxSelected}
-        maxBadgeDisplay={props.maxBadgeDisplay}
-        items={[
-          ...(includeAllOption
-            ? [
-                {
-                  value: "all",
-                  label: allLabel,
-                  searchText: allLabel,
-                  content: <AllModelsOptionLabel label={allLabel} />,
-                  selectedContent: <AllModelsSelectedBadge label={allLabel} />,
-                },
-              ]
-            : []),
-          ...options.map((option) => ({
-            value: option.value,
-            label: option.model,
-            searchText: `${providerDisplayNames[option.provider]} ${option.model}`,
-            content: (
-              <LlmModelOptionLabel
-                option={option}
-                showPricing={showPricing}
-                truncateModelName={truncateOptionLabels}
-              />
-            ),
-            selectedContent: <LlmModelSelectedBadge option={option} />,
-          })),
-        ]}
-      />
+  const [freeOnly, setFreeOnly] = useState(false);
+  // Pin the OpenRouter routers to the top so the zero-cost on-ramp is the first
+  // thing users see; everything else keeps its incoming order (stable sort).
+  const visibleOptions = useMemo(() => {
+    const filtered =
+      freeFilterable && freeOnly
+        ? options.filter((option) => option.isFree)
+        : options;
+    return [...filtered].sort(
+      (a, b) => routerSortRank(a.model) - routerSortRank(b.model),
     );
-  }
+  }, [options, freeFilterable, freeOnly]);
 
-  return (
+  const selectElement = props.multiple ? (
+    <SearchableMultiSelect
+      value={props.value}
+      onValueChange={props.onValueChange}
+      placeholder={placeholder}
+      searchPlaceholder={searchPlaceholder}
+      disabled={disabled}
+      className={cn("w-full", className)}
+      emptyMessage={emptyMessage}
+      contentClassName={popoverContentClassName}
+      listClassName={popoverListClassName}
+      contentSide={popoverSide}
+      contentAlign={popoverAlign}
+      contentAvoidCollisions={popoverAvoidCollisions}
+      maxSelected={props.maxSelected}
+      maxBadgeDisplay={props.maxBadgeDisplay}
+      items={[
+        ...(includeAllOption
+          ? [
+              {
+                value: "all",
+                label: allLabel,
+                searchText: allLabel,
+                content: <AllModelsOptionLabel label={allLabel} />,
+                selectedContent: <AllModelsSelectedBadge label={allLabel} />,
+              },
+            ]
+          : []),
+        ...visibleOptions.map((option) => ({
+          value: option.value,
+          label: option.model,
+          searchText: `${providerDisplayNames[option.provider]} ${option.model}`,
+          content: (
+            <LlmModelOptionLabel
+              option={option}
+              showPricing={showPricing}
+              truncateModelName={truncateOptionLabels}
+            />
+          ),
+          selectedContent: <LlmModelSelectedBadge option={option} />,
+        })),
+      ]}
+    />
+  ) : (
     <SearchableSelect
       value={props.value}
       onValueChange={props.onValueChange}
@@ -290,7 +347,7 @@ export function LlmModelSearchableSelect(props: LlmModelSearchableSelectProps) {
               },
             ]
           : []),
-        ...options.map((option) => ({
+        ...visibleOptions.map((option) => ({
           value: option.value,
           label: option.model,
           searchText: `${providerDisplayNames[option.provider]} ${option.model}`,
@@ -309,11 +366,56 @@ export function LlmModelSearchableSelect(props: LlmModelSearchableSelectProps) {
       ]}
     />
   );
+
+  if (!freeFilterable) {
+    return selectElement;
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <Switch
+          id="llm-model-free-only"
+          checked={freeOnly}
+          onCheckedChange={setFreeOnly}
+          disabled={disabled}
+        />
+        <Label
+          htmlFor="llm-model-free-only"
+          className="text-xs text-muted-foreground"
+        >
+          Free models only
+        </Label>
+      </div>
+      {selectElement}
+    </div>
+  );
+}
+
+/** Routers sort first (free, then auto); every other model keeps its order. */
+function routerSortRank(modelId: string): number {
+  switch (modelId) {
+    case OPENROUTER_FREE_MODEL_ID:
+      return 0;
+    case OPENROUTER_AUTO_MODEL_ID:
+      return 1;
+    default:
+      return 2;
+  }
 }
 
 function formatPricing(option: LlmModelSelectOption) {
   const input = option.pricePerMillionInput ?? "0";
   const output = option.pricePerMillionOutput ?? "0";
+  // OpenRouter's Auto Router has no fixed price — it bills at the routed
+  // model's rate. A negative price is the same "dynamic" sentinel.
+  if (
+    option.model === OPENROUTER_AUTO_MODEL_ID ||
+    Number(input) < 0 ||
+    Number(output) < 0
+  ) {
+    return "Dynamic pricing";
+  }
   return `$${input} / $${output} per 1M tokens`;
 }
 

--- a/platform/frontend/src/components/llm-model-select.tsx
+++ b/platform/frontend/src/components/llm-model-select.tsx
@@ -2,12 +2,12 @@
 
 import type { PopoverContentProps } from "@radix-ui/react-popover";
 import {
+  compareModelsForDisplay,
   OPENROUTER_AUTO_MODEL_ID,
-  OPENROUTER_FREE_MODEL_ID,
   providerDisplayNames,
   type SupportedProvider,
 } from "@shared";
-import { Layers, RefreshCw, Sparkles } from "lucide-react";
+import { Layers, Sparkles } from "lucide-react";
 import Image from "next/image";
 import { type ReactNode, useMemo, useState } from "react";
 import { SearchableMultiSelect } from "@/components/searchable-multi-select";
@@ -64,35 +64,25 @@ function modelIdOf(option: LlmModelSelectOption): string {
   return option.modelId ?? option.model;
 }
 
-/** Renders the Free Router / Free / Latest / Fastest / custom badges shared across the option views. */
+/** Renders the Free / Latest / Fastest / custom badges shared across the option views. */
 function ModelBadges({ option }: { option: LlmModelSelectOption }) {
   const id = modelIdOf(option);
-  const isFreeRouter = id === OPENROUTER_FREE_MODEL_ID;
   // OpenRouter "~...-latest" ids are aliases that always point at the newest
   // model in a family — the badge tells users the selection auto-updates.
   const isLatestAlias = option.provider === "openrouter" && id.startsWith("~");
   return (
     <>
-      {isFreeRouter && (
+      {option.isFree && (
         <Badge
           variant="outline"
           className="shrink-0 gap-1 text-xs border-green-300 bg-green-100 text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-300"
         >
           <Sparkles className="h-3 w-3" />
-          Free Router
-        </Badge>
-      )}
-      {option.isFree && !isFreeRouter && (
-        <Badge
-          variant="outline"
-          className="shrink-0 text-xs border-green-300 bg-green-100 text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-300"
-        >
           Free
         </Badge>
       )}
       {isLatestAlias && (
-        <Badge variant="outline" className="shrink-0 gap-1 text-xs">
-          <RefreshCw className="h-3 w-3" />
+        <Badge variant="outline" className="shrink-0 text-xs">
           Latest
         </Badge>
       )}
@@ -235,6 +225,11 @@ type SharedProps = {
   popoverAvoidCollisions?: PopoverContentProps["avoidCollisions"];
   /** Show a "Free only" toggle that filters the list to zero-cost models. */
   freeFilterable?: boolean;
+  /**
+   * Keep the incoming option order instead of applying the shared model
+   * ordering. Used when the caller imposes its own order (e.g. by price).
+   */
+  preserveOrder?: boolean;
 };
 
 type SingleSelectProps = SharedProps & {
@@ -274,19 +269,28 @@ export function LlmModelSearchableSelect(props: LlmModelSearchableSelectProps) {
     popoverAlign,
     popoverAvoidCollisions,
     freeFilterable = false,
+    preserveOrder = false,
   } = props;
 
   const [freeOnly, setFreeOnly] = useState(false);
-  // Order: routers first, then recommended models, then the rest in their
-  // incoming order. The sort is stable, so each consumer controls how the
-  // remaining models are arranged (e.g. alphabetically or by price).
+  // Shared ordering: routers, then recommended models, then the rest
+  // alphabetically — identical across every model picker, unless the caller
+  // imposes its own order (preserveOrder).
   const visibleOptions = useMemo(() => {
     const filtered =
       freeFilterable && freeOnly
         ? options.filter((option) => option.isFree)
         : options;
-    return [...filtered].sort((a, b) => modelSortRank(a) - modelSortRank(b));
-  }, [options, freeFilterable, freeOnly]);
+    if (preserveOrder) {
+      return filtered;
+    }
+    return [...filtered].sort((a, b) =>
+      compareModelsForDisplay(
+        { modelId: modelIdOf(a), isBest: a.isBest },
+        { modelId: modelIdOf(b), isBest: b.isBest },
+      ),
+    );
+  }, [options, freeFilterable, freeOnly, preserveOrder]);
 
   const selectElement = props.multiple ? (
     <SearchableMultiSelect
@@ -402,21 +406,6 @@ export function LlmModelSearchableSelect(props: LlmModelSearchableSelectProps) {
       {selectElement}
     </div>
   );
-}
-
-/**
- * Tiered order: free router (0), auto router (1), recommended models (2),
- * everything else (3). Within a tier the stable sort preserves input order.
- */
-function modelSortRank(option: LlmModelSelectOption): number {
-  switch (modelIdOf(option)) {
-    case OPENROUTER_FREE_MODEL_ID:
-      return 0;
-    case OPENROUTER_AUTO_MODEL_ID:
-      return 1;
-    default:
-      return option.isBest ? 2 : 3;
-  }
 }
 
 function formatPricing(option: LlmModelSelectOption) {

--- a/platform/frontend/src/components/model-badges.tsx
+++ b/platform/frontend/src/components/model-badges.tsx
@@ -1,5 +1,28 @@
-import { Fingerprint, Star, Zap } from "lucide-react";
+import { Fingerprint, RefreshCw, Sparkles, Star, Zap } from "lucide-react";
 import { InlineTag } from "@/components/ui/inline-tag";
+
+const GREEN_TAG =
+  "text-green-700 dark:text-green-400 bg-green-100 dark:bg-green-950";
+
+export function FreeModelBadge() {
+  return <InlineTag className={GREEN_TAG}>free</InlineTag>;
+}
+
+export function FreeRouterModelBadge() {
+  return (
+    <InlineTag icon={<Sparkles />} className={GREEN_TAG}>
+      free router
+    </InlineTag>
+  );
+}
+
+export function LatestModelBadge() {
+  return (
+    <InlineTag icon={<RefreshCw />} className="text-muted-foreground bg-muted">
+      latest
+    </InlineTag>
+  );
+}
 
 export function UnknownCapabilitiesBadge() {
   return (

--- a/platform/frontend/src/components/model-badges.tsx
+++ b/platform/frontend/src/components/model-badges.tsx
@@ -1,26 +1,20 @@
-import { Fingerprint, RefreshCw, Sparkles, Star, Zap } from "lucide-react";
+import { Fingerprint, Sparkles, Star, Zap } from "lucide-react";
 import { InlineTag } from "@/components/ui/inline-tag";
 
-const GREEN_TAG =
-  "text-green-700 dark:text-green-400 bg-green-100 dark:bg-green-950";
-
 export function FreeModelBadge() {
-  return <InlineTag className={GREEN_TAG}>free</InlineTag>;
-}
-
-export function FreeRouterModelBadge() {
   return (
-    <InlineTag icon={<Sparkles />} className={GREEN_TAG}>
-      free router
+    <InlineTag
+      icon={<Sparkles />}
+      className="text-green-700 dark:text-green-400 bg-green-100 dark:bg-green-950"
+    >
+      free
     </InlineTag>
   );
 }
 
 export function LatestModelBadge() {
   return (
-    <InlineTag icon={<RefreshCw />} className="text-muted-foreground bg-muted">
-      latest
-    </InlineTag>
+    <InlineTag className="text-muted-foreground bg-muted">latest</InlineTag>
   );
 }
 

--- a/platform/frontend/src/lib/utils/format-context-length.test.ts
+++ b/platform/frontend/src/lib/utils/format-context-length.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { formatContextLength } from "./format-context-length";
+
+describe("formatContextLength", () => {
+  it("renders sub-thousand values verbatim", () => {
+    expect(formatContextLength(512)).toBe("512");
+  });
+
+  it("renders thousands with a K suffix", () => {
+    expect(formatContextLength(200_000)).toBe("200K");
+    expect(formatContextLength(262_144)).toBe("262.1K");
+  });
+
+  it("renders millions with an M suffix", () => {
+    expect(formatContextLength(2_000_000)).toBe("2M");
+    expect(formatContextLength(1_100_000)).toBe("1.1M");
+  });
+
+  it("drops a trailing .0 so values render consistently", () => {
+    // 1_000_000 and 1_048_576 must both read as "1M", not "1M" vs "1.0M".
+    expect(formatContextLength(1_000_000)).toBe("1M");
+    expect(formatContextLength(1_048_576)).toBe("1M");
+  });
+
+  it("renders a dash for unknown context length", () => {
+    expect(formatContextLength(null)).toBe("-");
+    expect(formatContextLength(undefined)).toBe("-");
+  });
+});

--- a/platform/frontend/src/lib/utils/format-context-length.ts
+++ b/platform/frontend/src/lib/utils/format-context-length.ts
@@ -1,0 +1,22 @@
+/**
+ * Formats a context length into a compact human-readable string.
+ * e.g. 128000 -> "128K", 1000000 -> "1M", 1048576 -> "1M", 262144 -> "262.1K".
+ * A trailing ".0" is dropped so values render consistently ("1M", not "1.0M").
+ */
+export function formatContextLength(
+  contextLength: number | null | undefined,
+): string {
+  if (contextLength == null) return "-";
+  if (contextLength >= 1_000_000) {
+    return `${trimTrailingZero(contextLength / 1_000_000)}M`;
+  }
+  if (contextLength >= 1_000) {
+    return `${trimTrailingZero(contextLength / 1_000)}K`;
+  }
+  return contextLength.toString();
+}
+
+/** One decimal place, with a trailing ".0" removed (1.0 -> "1", 1.1 -> "1.1"). */
+function trimTrailingZero(value: number): string {
+  return value.toFixed(1).replace(/\.0$/, "");
+}

--- a/platform/frontend/src/lib/utils/index.ts
+++ b/platform/frontend/src/lib/utils/index.ts
@@ -4,6 +4,7 @@ export {
   formatRelativeTime,
   formatRelativeTimeFromNow,
 } from "./date-time";
+export { formatContextLength } from "./format-context-length";
 export { formatCronSchedule } from "./format-cron";
 export {
   computeHandlebarsReplaceOffsets,

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -34183,6 +34183,7 @@ export type GetLlmModelsResponses = {
         };
         isBest?: boolean;
         isFastest?: boolean;
+        isFree: boolean;
         embeddingDimensions?: EmbeddingDimensions | null;
     }>;
 };
@@ -34381,6 +34382,7 @@ export type GetModelsWithApiKeysResponses = {
         pricePerMillionOutput: string | null;
         isCustomPrice: boolean;
         priceSource: 'custom' | 'models_dev' | 'default';
+        isFree: boolean;
     }>;
 };
 

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -129,14 +129,16 @@ export const PERPLEXITY_MODELS = [
 /**
  * MiniMax model definitions — single source of truth.
  * MiniMax does not provide a /v1/models endpoint, so models are maintained here.
- * @see https://www.minimaxi.com/en/news
+ * @see https://platform.minimax.io/docs/guides/models-intro
  */
 export const MINIMAX_MODELS = [
-  { id: "MiniMax-M2", displayName: "MiniMax-M2" },
-  { id: "MiniMax-M2.1", displayName: "MiniMax-M2.1" },
-  { id: "MiniMax-M2.1-lightning", displayName: "MiniMax-M2.1-lightning" },
+  { id: "MiniMax-M2.7", displayName: "MiniMax-M2.7" },
+  { id: "MiniMax-M2.7-highspeed", displayName: "MiniMax-M2.7-highspeed" },
   { id: "MiniMax-M2.5", displayName: "MiniMax-M2.5" },
   { id: "MiniMax-M2.5-highspeed", displayName: "MiniMax-M2.5-highspeed" },
+  { id: "MiniMax-M2.1", displayName: "MiniMax-M2.1" },
+  { id: "MiniMax-M2.1-highspeed", displayName: "MiniMax-M2.1-highspeed" },
+  { id: "MiniMax-M2", displayName: "MiniMax-M2" },
 ] as const;
 
 /**
@@ -164,14 +166,25 @@ export const DEFAULT_PROVIDER_BASE_URLS: Record<SupportedProvider, string> = {
 };
 
 /**
+ * OpenRouter's built-in "Auto Router" — routes each request to a model OpenRouter
+ * picks dynamically, billed at that model's rate. Not free.
+ */
+export const OPENROUTER_AUTO_MODEL_ID = "openrouter/auto";
+
+/**
+ * OpenRouter's built-in "Free Models Router" — routes each request to a free
+ * model OpenRouter picks, filtering for the features the request needs. Always
+ * zero-cost; used as the auto-default for fresh OpenRouter organizations.
+ */
+export const OPENROUTER_FREE_MODEL_ID = "openrouter/free";
+
+/**
  * Pattern-based model markers per provider.
  * Patterns are substrings that model IDs must contain (case-insensitive).
  * Used to identify "fastest" (lightweight, low latency) and "best" (highest quality) models.
  *
  * IMPORTANT: Patterns are checked in array order (first match wins).
  * More specific patterns should come before general ones.
- *
- * Note: For OpenAI "best", we use "4o-2" to match "gpt-4o-2024..." but NOT "gpt-4o-mini-...".
  */
 export const MODEL_MARKER_PATTERNS: Record<
   SupportedProvider,
@@ -181,86 +194,79 @@ export const MODEL_MARKER_PATTERNS: Record<
   }
 > = {
   anthropic: {
-    fastest: ["haiku-4", "haiku"],
-    best: ["opus-4-6", "opus-4-5", "opus-4", "opus", "sonnet"],
+    fastest: ["haiku-4-5-20251001", "haiku-4-5"],
+    best: ["opus-4-7"],
   },
   openai: {
-    fastest: ["gpt-4o-mini", "gpt-3.5"],
-    best: [
-      "gpt-5.4",
-      "gpt-5.3",
-      "gpt-5.2",
-      "gpt-5",
-      "o3",
-      "o1",
-      "4o-2",
-      "gpt-4-turbo",
-    ],
+    fastest: ["gpt-5.4-nano", "gpt-5.4-mini"],
+    best: ["gpt-5.5-pro", "gpt-5.5"],
   },
   gemini: {
-    fastest: ["flash"],
-    best: ["pro", "ultra"],
+    fastest: ["gemini-3.1-flash-lite", "gemini-3.5-flash"],
+    best: ["gemini-3.1-pro-preview"],
   },
   cerebras: {
-    fastest: ["llama-3.3-70b"],
-    best: ["llama-3.3-70b"],
+    fastest: ["llama3.1-8b"],
+    best: ["zai-glm-4.7"],
   },
   cohere: {
-    fastest: ["command-light"],
-    best: ["command-r-plus", "command-r"],
+    fastest: ["command-r7b-12-2024"],
+    best: ["command-a-plus-05-2026"],
   },
   mistral: {
-    fastest: ["mistral-small", "ministral"],
-    best: ["mistral-large"],
+    fastest: ["mistral-small-2603"],
+    best: ["mistral-medium-2604"],
   },
   perplexity: {
     fastest: ["sonar"],
-    best: ["sonar-pro", "sonar-reasoning-pro", "sonar-reasoning"],
+    best: ["sonar-deep-research", "sonar-reasoning-pro", "sonar-pro"],
   },
   groq: {
-    fastest: ["llama-3.1-8b", "gemma2-9b"],
-    best: ["llama-3.3-70b", "llama-3.1-70b"],
+    fastest: ["openai/gpt-oss-20b", "llama-3.1-8b-instant"],
+    best: ["openai/gpt-oss-120b"],
   },
   xai: {
-    fastest: ["fast", "grok-code"],
-    best: ["grok-4"],
+    fastest: ["grok-4.3"],
+    best: ["grok-4.3"],
   },
   openrouter: {
     fastest: ["openrouter/auto"],
     best: [
-      "openai/gpt-4.1",
-      "openai/gpt-4o",
-      "anthropic/claude-3.7",
-      "anthropic/claude-3-opus",
+      "anthropic/claude-opus-4.7",
+      "openai/gpt-5.5-pro",
+      "openai/gpt-5.5",
+      "google/gemini-3.1-pro-preview",
+      "x-ai/grok-4.3",
+      "deepseek/deepseek-v4-pro",
     ],
   },
   ollama: {
-    fastest: ["llama3.2", "phi"],
-    best: ["llama3.1", "mixtral"],
+    fastest: ["gpt-oss:20b", "llama3.2:3b", "phi4-mini"],
+    best: ["gpt-oss:120b", "llama4:maverick", "llama4:scout", "qwen3:235b"],
   },
   vllm: {
-    fastest: ["llama3.2", "phi"],
-    best: ["llama3.1", "mixtral"],
+    fastest: ["gpt-oss-20b", "llama-3.2-3b", "phi-4-mini"],
+    best: ["gpt-oss-120b", "llama-4-maverick", "llama-4-scout", "qwen3-235b"],
   },
   zhipuai: {
-    fastest: ["glm-4-flash", "glm-flash"],
-    best: ["glm-4-plus", "glm-4"],
+    fastest: ["glm-4.7-flash"],
+    best: ["glm-5.1"],
   },
   deepseek: {
-    fastest: ["deepseek-chat"],
-    best: ["deepseek-reasoner"],
+    fastest: ["deepseek-v4-flash"],
+    best: ["deepseek-v4-pro"],
   },
   minimax: {
-    fastest: ["minimax-m2.5-highspeed", "minimax-m2.1-lightning"],
-    best: ["minimax-m2.5", "minimax-m2.1", "minimax-m2"],
+    fastest: ["minimax-m2.7-highspeed"],
+    best: ["minimax-m2.7"],
   },
   azure: {
-    fastest: ["gpt-4o-mini"],
-    best: ["gpt-4o", "o3"],
+    fastest: ["gpt-5.4-nano", "gpt-5.4-mini"],
+    best: ["gpt-5.5"],
   },
   bedrock: {
-    fastest: ["nova-lite", "nova-micro", "haiku"],
-    best: ["opus", "sonnet", "nova-pro"],
+    fastest: ["amazon.nova-2-lite-v1:0", "amazon.nova-lite-v1:0"],
+    best: ["anthropic.claude-opus-4-7"],
   },
 };
 
@@ -273,22 +279,22 @@ export const MODEL_MARKER_PATTERNS: Record<
  */
 export const FAST_MODELS: Record<SupportedProvider, string> = {
   anthropic: "claude-haiku-4-5-20251001",
-  openai: "gpt-4o-mini",
+  openai: "gpt-5.4-mini",
   openrouter: "openrouter/auto",
-  gemini: "gemini-2.0-flash-001",
-  cerebras: "llama-3.3-70b", // Cerebras focuses on speed, all their models are fast
-  cohere: "command-light", // Cohere's fast model
+  gemini: "gemini-3.5-flash",
+  cerebras: "llama3.1-8b", // cerebras focuses on speed, all their models are fast
+  cohere: "command-r7b-12-2024", // cohere's fast model
   vllm: "default", // vLLM uses whatever model is deployed
-  ollama: "llama3.2", // Common fast model for Ollama
-  zhipuai: "glm-4-flash", // Zhipu's fast model
-  minimax: "MiniMax-M2.5-highspeed", // MiniMax's fastest model
-  deepseek: "deepseek-chat", // DeepSeek's fast model
-  bedrock: "amazon.nova-lite-v1:0", // Bedrock's fast model, available in all regions for on-demand inference
-  mistral: "mistral-small-latest", // Mistral's fast model
-  perplexity: "sonar", // Perplexity's fast model
-  groq: "llama-3.1-8b-instant", // Groq's fast model
-  xai: "grok-code-fast-1", // xAI's fast model
-  azure: "gpt-4o-mini",
+  ollama: "llama3.2", // common fast model for Ollama
+  zhipuai: "glm-4.7-flash", // zhipu's fast model
+  minimax: "MiniMax-M2.7-highspeed", // minimax's fastest model
+  deepseek: "deepseek-v4-flash", // deepSeek's fast model
+  bedrock: "amazon.nova-2-lite-v1:0", // bedrock's fast model
+  mistral: "mistral-small-2603", // mistral's fast model
+  perplexity: "sonar", // perplexity's fast model
+  groq: "llama-3.1-8b-instant", // groq's fast model
+  xai: "grok-4.3", // xAI's fast model
+  azure: "gpt-5.4-mini",
 };
 
 /**
@@ -296,23 +302,23 @@ export const FAST_MODELS: Record<SupportedProvider, string> = {
  * Using Record<SupportedProvider, string> ensures a compile-time error when a new provider is added.
  */
 export const DEFAULT_MODELS: Record<SupportedProvider, string> = {
-  anthropic: "claude-opus-4-6-20250918",
-  openai: "gpt-5.4",
+  anthropic: "claude-opus-4-7",
+  openai: "gpt-5.5",
   openrouter: "openrouter/auto",
-  gemini: "gemini-2.5-pro",
-  cohere: "command-r-08-2024",
-  groq: "llama-3.1-8b-instant",
-  xai: "grok-4",
+  gemini: "gemini-3.1-pro-preview",
+  cohere: "command-a-plus-05-2026",
+  groq: "openai/gpt-oss-120b",
+  xai: "grok-4.3",
   ollama: "llama3.2",
   vllm: "default",
-  cerebras: "llama-4-scout-17b-16e-instruct",
-  mistral: "mistral-large-latest",
+  cerebras: "zai-glm-4.7",
+  mistral: "mistral-medium-2604",
   perplexity: "sonar-pro",
-  zhipuai: "glm-4-plus",
-  deepseek: "deepseek-chat",
-  bedrock: "anthropic.claude-opus-4-1-20250805-v1:0",
-  minimax: "MiniMax-M2.5",
-  azure: "gpt-4o",
+  zhipuai: "glm-5.1",
+  deepseek: "deepseek-v4-pro",
+  bedrock: "anthropic.claude-opus-4-7",
+  minimax: "MiniMax-M2.7",
+  azure: "gpt-5.5",
 };
 /**
  * Maps models.dev provider IDs to Archestra provider names.

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -179,6 +179,12 @@ export const OPENROUTER_AUTO_MODEL_ID = "openrouter/auto";
 export const OPENROUTER_FREE_MODEL_ID = "openrouter/free";
 
 /**
+ * Prefix of OpenRouter "latest" alias ids (e.g. `~anthropic/claude-sonnet-latest`)
+ * that always redirect to the newest model in a family.
+ */
+export const OPENROUTER_LATEST_ALIAS_PREFIX = "~";
+
+/**
  * Pattern-based model markers per provider.
  * Patterns are substrings that model IDs must contain (case-insensitive).
  * Used to identify "fastest" (lightweight, low latency) and "best" (highest quality) models.

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -136,9 +136,6 @@ export const MINIMAX_MODELS = [
   { id: "MiniMax-M2.7-highspeed", displayName: "MiniMax-M2.7-highspeed" },
   { id: "MiniMax-M2.5", displayName: "MiniMax-M2.5" },
   { id: "MiniMax-M2.5-highspeed", displayName: "MiniMax-M2.5-highspeed" },
-  { id: "MiniMax-M2.1", displayName: "MiniMax-M2.1" },
-  { id: "MiniMax-M2.1-highspeed", displayName: "MiniMax-M2.1-highspeed" },
-  { id: "MiniMax-M2", displayName: "MiniMax-M2" },
 ] as const;
 
 /**

--- a/platform/shared/model-resolution.test.ts
+++ b/platform/shared/model-resolution.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   deriveModelSource,
+  isFreeModel,
   type ModelSelection,
   type ModelSource,
   pickBestModel,
@@ -216,4 +217,34 @@ describe("deriveModelSource", () => {
       ).toBe(c.expected);
     });
   }
+});
+
+describe("isFreeModel", () => {
+  test("is true only when both prices are known and zero", () => {
+    expect(
+      isFreeModel({ promptPricePerToken: "0", completionPricePerToken: "0" }),
+    ).toBe(true);
+    expect(
+      isFreeModel({
+        promptPricePerToken: "0.000000000000",
+        completionPricePerToken: "0",
+      }),
+    ).toBe(true);
+  });
+
+  test("is false for paid, dynamic, or unknown pricing", () => {
+    expect(
+      isFreeModel({
+        promptPricePerToken: "0.0000015",
+        completionPricePerToken: "0",
+      }),
+    ).toBe(false);
+    // openrouter/auto reports dynamic pricing as -1.
+    expect(
+      isFreeModel({ promptPricePerToken: "-1", completionPricePerToken: "-1" }),
+    ).toBe(false);
+    expect(
+      isFreeModel({ promptPricePerToken: null, completionPricePerToken: "0" }),
+    ).toBe(false);
+  });
 });

--- a/platform/shared/model-resolution.test.ts
+++ b/platform/shared/model-resolution.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "vitest";
 import {
+  OPENROUTER_AUTO_MODEL_ID,
+  OPENROUTER_FREE_MODEL_ID,
+} from "./model-constants";
+import {
+  compareModelsForDisplay,
+  type DisplayOrderModel,
   deriveModelSource,
   isFreeModel,
   type ModelSelection,
@@ -246,5 +252,28 @@ describe("isFreeModel", () => {
     expect(
       isFreeModel({ promptPricePerToken: null, completionPricePerToken: "0" }),
     ).toBe(false);
+  });
+});
+
+describe("compareModelsForDisplay", () => {
+  test("orders routers, then recommended, then the rest alphabetically", () => {
+    const models: DisplayOrderModel[] = [
+      { modelId: "zzz/model" },
+      { modelId: "aaa/model" },
+      { modelId: OPENROUTER_AUTO_MODEL_ID },
+      { modelId: "openai/gpt-5.5", isBest: true },
+      { modelId: OPENROUTER_FREE_MODEL_ID },
+      { modelId: "anthropic/claude", isBest: true },
+    ];
+    expect(
+      [...models].sort(compareModelsForDisplay).map((m) => m.modelId),
+    ).toEqual([
+      OPENROUTER_FREE_MODEL_ID,
+      OPENROUTER_AUTO_MODEL_ID,
+      "anthropic/claude",
+      "openai/gpt-5.5",
+      "aaa/model",
+      "zzz/model",
+    ]);
   });
 });

--- a/platform/shared/model-resolution.ts
+++ b/platform/shared/model-resolution.ts
@@ -14,6 +14,11 @@
  * handling to do here.
  */
 
+import {
+  OPENROUTER_AUTO_MODEL_ID,
+  OPENROUTER_FREE_MODEL_ID,
+} from "./model-constants";
+
 /** A (model, key) pair stored at one level of the resolution chain. */
 export interface ModelSelection {
   modelId: string | null | undefined;
@@ -107,6 +112,32 @@ export function isFreeModel(model: ModelPricing): boolean {
     Number(model.promptPricePerToken) === 0 &&
     Number(model.completionPricePerToken) === 0
   );
+}
+
+/** A model as it appears in a selection list, for display ordering. */
+export interface DisplayOrderModel {
+  modelId: string;
+  isBest?: boolean | null;
+}
+
+/**
+ * Comparator for ordering models in selection UIs. Shared so every picker —
+ * chat selector, settings selects, the models management table — lists models
+ * identically: routers first (free, then auto), then provider-recommended
+ * models, then the rest, each tier sorted alphabetically by model id.
+ */
+export function compareModelsForDisplay(
+  a: DisplayOrderModel,
+  b: DisplayOrderModel,
+): number {
+  const rankDiff = displayOrderRank(a) - displayOrderRank(b);
+  return rankDiff !== 0 ? rankDiff : a.modelId.localeCompare(b.modelId);
+}
+
+function displayOrderRank(model: DisplayOrderModel): number {
+  if (model.modelId === OPENROUTER_FREE_MODEL_ID) return 0;
+  if (model.modelId === OPENROUTER_AUTO_MODEL_ID) return 1;
+  return model.isBest ? 2 : 3;
 }
 
 /**

--- a/platform/shared/model-resolution.ts
+++ b/platform/shared/model-resolution.ts
@@ -85,6 +85,30 @@ export function pickBestModel<T extends { isBest?: boolean }>(
   return models.find((m) => m.isBest) ?? models[0];
 }
 
+/** Per-token USD prices for a model, as stored on the `models` table. */
+export interface ModelPricing {
+  promptPricePerToken: string | null;
+  completionPricePerToken: string | null;
+}
+
+/**
+ * A model is "free" only when both per-token prices are known and exactly zero.
+ * Null pricing means unknown, not free. Shared by the backend (auto-default) and
+ * the frontend (badge, filter).
+ */
+export function isFreeModel(model: ModelPricing): boolean {
+  if (
+    model.promptPricePerToken == null ||
+    model.completionPricePerToken == null
+  ) {
+    return false;
+  }
+  return (
+    Number(model.promptPricePerToken) === 0 &&
+    Number(model.completionPricePerToken) === 0
+  );
+}
+
 /**
  * Determine where the selected model came from, purely by comparison with the
  * configured defaults — no stored state.

--- a/platform/shared/model-resolution.ts
+++ b/platform/shared/model-resolution.ts
@@ -17,6 +17,8 @@
 import {
   OPENROUTER_AUTO_MODEL_ID,
   OPENROUTER_FREE_MODEL_ID,
+  OPENROUTER_LATEST_ALIAS_PREFIX,
+  type SupportedProvider,
 } from "./model-constants";
 
 /** A (model, key) pair stored at one level of the resolution chain. */
@@ -111,6 +113,20 @@ export function isFreeModel(model: ModelPricing): boolean {
   return (
     Number(model.promptPricePerToken) === 0 &&
     Number(model.completionPricePerToken) === 0
+  );
+}
+
+/**
+ * True for OpenRouter "latest" alias ids (`~vendor/model-latest`) that always
+ * track the newest model in a family. Shared by every picker for the badge.
+ */
+export function isOpenRouterLatestAlias(
+  provider: SupportedProvider,
+  modelId: string,
+): boolean {
+  return (
+    provider === "openrouter" &&
+    modelId.startsWith(OPENROUTER_LATEST_ALIAS_PREFIX)
   );
 }
 


### PR DESCRIPTION
## Summary

Makes OpenRouter a first-class provider in the platform.

- **Rich metadata** — `fetchOpenrouterModels` now reads pricing, context length, and tool-calling support straight from OpenRouter's `/models`. Negative ("dynamic") router pricing is normalized to unknown so cost math never goes negative and the UI no longer shows `$-1000000.00`.
- **Native free router** — fresh OpenRouter organizations with no default model are auto-defaulted to OpenRouter's built-in `openrouter/free` Free Models Router (zero-cost, server-side feature filtering and failover). An explicit user default is never overridden.
- **Picker UX** — the `openrouter/free` and `openrouter/auto` routers are pinned to the top of every model picker. `openrouter/free` gets a green "Free Router" badge; `:free` models get a "Free" badge; `~…-latest` aliases get a "Latest" badge. A "Free models only" toggle filters the list.
- **Attribution** — `HTTP-Referer` / `X-Title` are now sent on the direct path (title generation etc.), not just the proxied path.
- **Defaults refresh** — `MODEL_MARKER_PATTERNS` and related test fixtures updated to current model versions.

## Testing

- `pnpm type-check`, `pnpm lint` — clean across all workspaces
- Full `pnpm test` — passing (backend, frontend, shared)
- New unit/component tests for free-model detection, router pinning, badges, and dynamic-price handling

## Notes

- No DB migration, no new env vars.
- `docs/openapi.json` / `types.gen.ts` regenerated for the new `isFree` field.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>