### PR TITLE
chore(claude): auto-format platform/ edits via Biome PostToolUse hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,18 @@
   "attribution": {
     "commit": "",
     "pr": ""
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | { read -r f; case \"$f\" in \"$CLAUDE_PROJECT_DIR\"/platform/*) cd \"$CLAUDE_PROJECT_DIR/platform\" && pnpm exec biome check --write --files-ignore-unknown=true --no-errors-on-unmatched \"$f\" ;; esac; } || true"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
Adds a `PostToolUse` hook to `.claude/settings.json` so Claude Code `Write|Edit|MultiEdit` operations on files under `platform/` are auto-formatted with `pnpm exec biome check --write`. Without it, Claude-driven edits land unformatted and contributors have to remember a follow-up Biome run; with it, those edits arrive matching the same formatter the team already uses locally and in CI.

The hook reads the edited path from the tool payload via `jq`, guards on `"$CLAUDE_PROJECT_DIR"/platform/*` so edits outside that workspace are no-ops, and ends in `|| true` so a formatter failure can't block the tool result Claude returns.

Hooks are loaded at session start, so the behavior only kicks in for Claude Code sessions started after this merges.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>