### PR TITLE
fix(catalog): auto-seeded Authorization header defaults to sensitive

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -358,6 +358,10 @@ export function McpCatalogForm({
         (header) => header.includeBearerPrefix,
       );
       if (!hasAuthHeader) {
+        // Bearer-token credential — always sensitive. The Add Header
+        // dialog forces this choice on manual additions, but the
+        // token-auth flow seeds the row programmatically and so must
+        // own the default itself.
         appendAdditionalHeader({
           fieldName: undefined,
           headerName: "Authorization",
@@ -367,6 +371,7 @@ export function McpCatalogForm({
           value: "",
           description: "",
           includeBearerPrefix: true,
+          sensitive: true,
         });
       }
     }


### PR DESCRIPTION
## Summary

When a user picks **Token header** auth on a remote MCP catalog item, the form seeds an `Authorization` row in the headers section so they can fill in their bearer token at install time. The seed was omitting the `sensitive` flag, so the row landed as a plain-text header — the user's token would persist in the plaintext catalog jsonb instead of the per-installation secret bag.

Token credentials are sensitive by definition; this seed has to own the correct default itself because the user never sees the per-row Sensitive toggle on this auto-add path (the dialog where they'd normally pick it is bypassed).

## Steps to reproduce (before this PR)

1. Add MCP Server → Custom → Remote
2. Auth method: **Token header**
3. Headers section auto-adds `Authorization` row
4. Open the row's edit dialog → Sensitive switch is **off** ❌

## After this PR

Step 4 — Sensitive switch is **on** ✔

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>