### PR TITLE
fix(catalog): keep user's Sensitive choice when switching header scope

### DIFF
--- a/platform/frontend/src/components/header-dialog.tsx
+++ b/platform/frontend/src/components/header-dialog.tsx
@@ -106,13 +106,10 @@ export function HeaderDialog({
         next.value = "";
       }
       // Server-side validator rejects sensitive + static, so force it off.
-      // When flipping *into* preset, default sensitive on — preset values
-      // otherwise land in plaintext jsonb and there's no other UI escape
-      // hatch. User can toggle it back off explicitly.
+      // Other scopes leave the user's Sensitive toggle alone — it's an
+      // independent concern from where the value lives.
       if (patch.scope === "static") {
         next.sensitive = false;
-      } else if (patch.scope === "preset" && prev.scope !== "preset") {
-        next.sensitive = true;
       }
       return next;
     });


### PR DESCRIPTION
The Add/Edit Header dialog silently flipped the **Sensitive** toggle to **on** whenever the user changed the **Scope** dropdown from `Installation` or `Static` to `Preset`. The user's deliberate toggle choice was lost without any indication, and the env-var dialog — which never auto-flips `type` on scope change — set up a mental model the header dialog contradicted.

Root cause: a "convenience" branch in `updateDraft` (`frontend/src/components/header-dialog.tsx:114-115`) set `next.sensitive = true` on any non-preset → preset transition. The original intent (preset values land in plaintext jsonb on the catalog row, so credentials probably want to be sensitive) is real, but the dialog wasn't the right place to enforce it — overriding the user's choice hides their intent rather than informs.

Fix: drop the override branch. The remaining `scope === "static" → sensitive: false` branch stays, because the server validator rejects `sensitive: true` for static headers.

Verified manually in the Add Header dialog: Sensitive off → switch scope to Preset → stays off. Static (forces off) → Preset → stays off. Sensitive on, bounce scope `Preset` → `Installation` → `Preset` → stays on. Env-var dialog unaffected (no equivalent branch). `pnpm --filter @frontend lint` and `type-check` clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>