### PR TITLE
fix(catalog): cascade on static header value changes

### DIFF
--- a/platform/backend/src/services/mcp-reinstall.test.ts
+++ b/platform/backend/src/services/mcp-reinstall.test.ts
@@ -816,6 +816,92 @@ describe("mcp-reinstall", () => {
       );
     });
 
+    test("static header `default` value change returns false (pod restart needed, auto path)", () => {
+      // `userConfigChangedBreakingly` would naively skip a `default`
+      // change as cosmetic, but for a static header-mapped userConfig
+      // entry (no install/preset prompt) `default` IS the actual runtime
+      // header value the form writes from the admin's input. A change
+      // there must route through the auto path so pods restart and pick
+      // up the new value — install owners don't need to re-supply
+      // anything.
+      const oldConfig = {
+        ...baseLocal([]),
+        userConfig: {
+          header_x_region: {
+            type: "string",
+            title: "x-region",
+            description: "",
+            required: false,
+            headerName: "x-region",
+            sensitive: false,
+            promptOnInstallation: false,
+            default: "us-east-1",
+          },
+        },
+      } as InternalMcpCatalog;
+      const newConfig = {
+        ...baseLocal([]),
+        userConfig: {
+          header_x_region: {
+            type: "string",
+            title: "x-region",
+            description: "",
+            required: false,
+            headerName: "x-region",
+            sensitive: false,
+            promptOnInstallation: false,
+            default: "eu-west-1",
+          },
+        },
+      } as InternalMcpCatalog;
+
+      expect(onlyForwardCompatibleEnvDiff(oldConfig, newConfig)).toBe(false);
+      // Not a re-prompt — admin provides the value, install just needs
+      // a restart to pick it up.
+      expect(requiresNewUserInputForReinstall(oldConfig, newConfig)).toBe(
+        false,
+      );
+    });
+
+    test("prompted header `default` value change returns true (placeholder text, not runtime)", () => {
+      // For a prompted header, `default` is just a placeholder shown
+      // to the user at install time — they always supply their own
+      // value. Changing the placeholder text is cosmetic and must NOT
+      // trigger a cascade.
+      const oldConfig = {
+        ...baseLocal([]),
+        userConfig: {
+          header_x_api_key: {
+            type: "string",
+            title: "x-api-key",
+            description: "",
+            required: false,
+            headerName: "x-api-key",
+            sensitive: false,
+            promptOnInstallation: true,
+            default: "your-key-here",
+          },
+        },
+      } as InternalMcpCatalog;
+      const newConfig = {
+        ...baseLocal([]),
+        userConfig: {
+          header_x_api_key: {
+            type: "string",
+            title: "x-api-key",
+            description: "",
+            required: false,
+            headerName: "x-api-key",
+            sensitive: false,
+            promptOnInstallation: true,
+            default: "your-api-key",
+          },
+        },
+      } as InternalMcpCatalog;
+
+      expect(onlyForwardCompatibleEnvDiff(oldConfig, newConfig)).toBe(true);
+    });
+
     test("snapshot-shape asymmetry (toolCount present on one side) does not over-fire", () => {
       // When the parent PUT loop cascades to children, the old snapshot
       // comes from `findChildren()` (with `attachListMetadata` adding

--- a/platform/backend/src/services/mcp-reinstall.ts
+++ b/platform/backend/src/services/mcp-reinstall.ts
@@ -263,10 +263,23 @@ function userConfigChangedBreakingly(
     if (String(p.type ?? "") !== String(n.type ?? "")) return true; // Type changed
     if (String(p.headerName ?? "") !== String(n.headerName ?? "")) return true; // Routing changed
     if (Boolean(p.sensitive) !== Boolean(n.sensitive)) return true; // Storage moved
-    // Note: deliberately NOT checking `default`, `description`, `title`,
-    // `valuePrefix` etc. — those are cosmetic / template defaults that
-    // don't affect install validity. If a default value matters to your
-    // pod, change it via a runtime field (env value) instead.
+    // Static header value rotation. For a static header-mapped userConfig
+    // entry (no install/preset prompt), `default` IS the runtime header
+    // value the form transform writes from the admin's input — changing it
+    // changes what installs send on the wire. For prompted entries
+    // `default` is just a placeholder/template, so we still skip those.
+    if (
+      String(p.headerName ?? "") !== "" &&
+      !p.promptOnInstallation &&
+      !p.promptOnPreset &&
+      !n.promptOnInstallation &&
+      !n.promptOnPreset &&
+      String(p.default ?? "") !== String(n.default ?? "")
+    ) {
+      return true;
+    }
+    // Note: `description`, `title`, `valuePrefix` remain cosmetic — they
+    // don't change what installs send.
   }
 
   // Added required field → existing installs are missing it.

--- a/platform/frontend/src/app/mcp/registry/_parts/cascade-decision.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/cascade-decision.test.ts
@@ -452,6 +452,52 @@ describe("userConfigChangedBreakingly — forward-compat leaf predicate", () => 
       ),
     ).toBe(true);
   });
+  test("static header `default` value change → true (it's the runtime header)", () => {
+    const base = {
+      type: "string",
+      required: false,
+      headerName: "x-region",
+      sensitive: false,
+      promptOnInstallation: false,
+    };
+    expect(
+      userConfigChangedBreakingly(
+        { h1: { ...base, default: "us-east-1" } },
+        { h1: { ...base, default: "eu-west-1" } },
+      ),
+    ).toBe(true);
+  });
+  test("prompted header `default` value change → false (just a placeholder)", () => {
+    const base = {
+      type: "string",
+      required: false,
+      headerName: "x-api-key",
+      sensitive: false,
+      promptOnInstallation: true,
+    };
+    expect(
+      userConfigChangedBreakingly(
+        { h1: { ...base, default: "placeholder-a" } },
+        { h1: { ...base, default: "placeholder-b" } },
+      ),
+    ).toBe(false);
+  });
+  test("preset header `default` value change → false (value lives in the bag, not `default`)", () => {
+    const base = {
+      type: "string",
+      required: false,
+      headerName: "x-region",
+      sensitive: false,
+      promptOnInstallation: false,
+      promptOnPreset: true,
+    };
+    expect(
+      userConfigChangedBreakingly(
+        { h1: { ...base, default: "us-east-1" } },
+        { h1: { ...base, default: "eu-west-1" } },
+      ),
+    ).toBe(false);
+  });
 });
 
 // Regression: `prev` comes from the catalog API (extra fields like id,

--- a/platform/frontend/src/app/mcp/registry/_parts/cascade-decision.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/cascade-decision.ts
@@ -303,9 +303,11 @@ function onlyForwardCompatibleDiff(
 
 /**
  * Mirror of backend `userConfigChangedBreakingly`. True when a
- * userConfig field change invalidates existing installs (added required, removed
- * any, type/headerName/sensitive flip, required false → true). Pure
- * cosmetic changes (description, title, default value) are not breaking.
+ * userConfig field change invalidates existing installs (added required,
+ * removed any, type/headerName/sensitive flip, required false → true, or
+ * a static header-mapped field's `default` value changes). For prompted
+ * fields, `default` is just a placeholder shown at install time, so
+ * changes there stay non-breaking.
  */
 export function userConfigChangedBreakingly(
   prev: Record<string, unknown> | null | undefined,
@@ -321,6 +323,19 @@ export function userConfigChangedBreakingly(
     if (String(p.type ?? "") !== String(n.type ?? "")) return true;
     if (String(p.headerName ?? "") !== String(n.headerName ?? "")) return true;
     if (Boolean(p.sensitive) !== Boolean(n.sensitive)) return true;
+    // Static header value rotation — `default` is the runtime header
+    // value for static header-mapped entries (the form writes the admin's
+    // input straight into `default` when promptOnInstallation is false).
+    if (
+      String(p.headerName ?? "") !== "" &&
+      !p.promptOnInstallation &&
+      !p.promptOnPreset &&
+      !n.promptOnInstallation &&
+      !n.promptOnPreset &&
+      String(p.default ?? "") !== String(n.default ?? "")
+    ) {
+      return true;
+    }
   }
   for (const [key, n] of Object.entries(nextMap)) {
     if (key in prevMap) continue;

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -2378,6 +2378,7 @@ type AdditionalHeader = {
   description?: string;
   includeBearerPrefix?: boolean;
   promptOnInstallation?: boolean;
+  promptOnPreset?: boolean;
 };
 
 /**
@@ -2410,6 +2411,7 @@ function deriveAdditionalHeaders(userConfig: unknown): AdditionalHeader[] {
         cfg.promptOnInstallation === undefined
           ? true
           : Boolean(cfg.promptOnInstallation),
+      promptOnPreset: Boolean(cfg.promptOnPreset),
     });
   }
   return out;
@@ -2427,11 +2429,15 @@ function deriveAdditionalHeaders(userConfig: unknown): AdditionalHeader[] {
  *   - required true → false  → installs still valid → false
  *   - headerName change      → routing changes → true
  *   - sensitive flag flip    → storage bucket moved → true
+ *   - STATIC header `value`  → that's the actual runtime header sent on
+ *     the wire (form writes it into `userConfig[field].default` when
+ *     promptOnInstallation is false). Change there → installs would
+ *     keep sending the old value → true
  *
- * Deliberately ignored (mirror of backend's "deliberately NOT checking"
- * comment in `userConfigChangedBreakingly`):
- *   - `value` (becomes `default` in userConfig) — cosmetic / template
- *     default, doesn't affect install validity
+ * Deliberately ignored:
+ *   - `value` on prompted headers (becomes `default` in userConfig) —
+ *     just a placeholder shown at install time, doesn't affect what's
+ *     actually sent
  *   - `includeBearerPrefix` (becomes `valuePrefix: "Bearer "`) — cosmetic
  *     wire-format detail; doesn't move storage
  *   - `description`, `title` — pure metadata
@@ -2457,6 +2463,14 @@ function additionalHeadersChangeRequiresReinstall(
     if (!p.required && Boolean(n.required)) return true; // Became required
     if ((p.headerName ?? "") !== (n.headerName ?? "")) return true; // Routing
     if (Boolean(p.sensitive) !== Boolean(n.sensitive)) return true; // Storage
+    // Static header value rotation. `value` only matters at runtime
+    // when the header is fully static (no install or preset prompt) —
+    // for prompted headers it's just a placeholder.
+    const wasStatic = !p.promptOnInstallation && !p.promptOnPreset;
+    const isStatic = !n.promptOnInstallation && !n.promptOnPreset;
+    if (wasStatic && isStatic && (p.value ?? "") !== (n.value ?? "")) {
+      return true;
+    }
   }
   for (const [key, n] of nextMap) {
     if (prevMap.has(key)) continue;

--- a/platform/shared/cascade-scenarios.ts
+++ b/platform/shared/cascade-scenarios.ts
@@ -479,6 +479,19 @@ export const CASCADE_SCENARIOS: CascadeScenario[] = [
     rationale:
       "Header routing changed. The pod and gateway need to be in sync on which header carries the value; reinstall realigns them.",
   },
+  {
+    id: "change-static-header-value",
+    shape: "hdrprobeDockerOnly",
+    userAction:
+      "Admin edits a static header's value (no install prompt, no preset prompt)",
+    edit: modifyUserConfigField("header_x_static_token", {
+      default: "rotated-token-value",
+    }),
+    expected: "auto",
+    sharedPredicate: "non-metadata-diff",
+    rationale:
+      "For a static header-mapped userConfig entry (no install/preset prompt), the form writes the admin's value into `userConfig[field].default` — that IS the runtime header sent on the wire. Changing it means installs would keep sending the old value until pods restart. The auto path is correct (no re-prompt needed; admin already provided the value). Caught by `userConfigChangedBreakingly` on both sides. Distinct from prompted headers where `default` is just a placeholder.",
+  },
 
   // ── identity / nothing-changed sanity ─────────────────────────────
   {

--- a/platform/shared/catalog-shape-fixtures.ts
+++ b/platform/shared/catalog-shape-fixtures.ts
@@ -145,6 +145,10 @@ export const CATALOG_SHAPES = {
         required: false,
         sensitive: false,
         headerName: "x-static-token",
+        // The form writes static header values into `default`. Having
+        // one in the baseline lets the `change-static-header-value`
+        // scenario exercise the "default rotated" path.
+        default: "initial-token-value",
       },
     },
     oauthConfig: null,


### PR DESCRIPTION
The cascade gate's `userConfigChangedBreakingly` skipped `default` changes as cosmetic, with the rationale that `default` is just a template hint. That's true for **prompted** headers — the user supplies the runtime value at install time — but not for **static** headers. The form transform at `frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts:810` writes a static header's admin-entered value directly into `userConfig[field].default` whenever `promptOnInstallation: false`, so `default` IS the runtime header sent on the wire.

Before this commit, an admin rotating a static API token, region identifier, or any other static header value would save without any cascade firing. The frontend confirm bar stayed silent, the backend gate took the forward-compatible exit, and pods kept sending the old value indefinitely (until something unrelated triggered a reinstall).

Fix: in both `userConfigChangedBreakingly` (`backend/src/services/mcp-reinstall.ts` + the `frontend/src/app/mcp/registry/_parts/cascade-decision.ts` mirror) and the per-field `additionalHeadersChangeRequiresReinstall` hint (`mcp-catalog-form.tsx`), add a check that returns true when both sides are static header-mapped (no install prompt, no preset prompt) and `default` / `value` differs. The auto-reinstall path is correct here — admin already provided the value, install owners don't need to re-input anything; pods just need to restart to pick it up.

Narrow by design: prompted-header `default` changes stay non-breaking (it's a placeholder), and preset-scoped header value changes still flow through the preset-bag rotation paths (not `default`).

New tests lock the contract. Backend: static-default change → `onlyForwardCompatibleEnvDiff` returns false; prompted-default change still returns true (cosmetic). Frontend: 3 new `userConfigChangedBreakingly` leaf-predicate tests (static yes, prompted no, preset no). Shared: new `change-static-header-value` scenario in `cascade-scenarios.ts` exercises the path through backend + frontend + shared matrix consistently — the contract layer asserts both sides agree. The `hdrprobeDockerOnly` fixture seeds a `default` on its static header so the scenario has something to rotate; the local `AdditionalHeader` type in `mcp-catalog-form.tsx` gains a `promptOnPreset?: boolean` field so the per-field hint can read it.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>