### PR TITLE
test(e2e): unskip "bogus image" install test

### DIFF
--- a/platform/e2e-tests/tests/mcp-install.spec.ts
+++ b/platform/e2e-tests/tests/mcp-install.spec.ts
@@ -91,7 +91,6 @@ test.describe("MCP Install", () => {
     adminPage,
     extractCookieHeaders,
   }) => {
-    test.skip();
     // Increase timeout to 4 minutes to allow for K8s deployment attempts
     test.setTimeout(240_000);
     const CATALOG_ITEM_NAME = "e2e__bogus_image_test";


### PR DESCRIPTION
## Summary
- Remove the `test.skip()` from the "Local server with bogus image shows error, logs, and can be fixed" test in `mcp-install.spec.ts`
- Revives the coverage that #4848 had to drop after #4775's `test.fail()` wrapper started flipping to "Expected to fail, but passed" once the underlying K8s pod-deletion race resolved on its own

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>