### PR TITLE
fix(mcp-catalog): truncate long values in env vars and headers tables

### DIFF
--- a/platform/frontend/src/components/environment-variables-form-field.tsx
+++ b/platform/frontend/src/components/environment-variables-form-field.tsx
@@ -303,14 +303,14 @@ export function EnvironmentVariablesFormField<
                       <div className="text-muted-foreground">
                         {type === "configMap" ? "ConfigMap" : "Secret"}
                       </div>
-                      <div className="font-mono">
+                      <div className="min-w-0 truncate font-mono">
                         {name || (
                           <span className="text-muted-foreground italic">
                             unnamed
                           </span>
                         )}
                       </div>
-                      <div className="font-mono text-muted-foreground">
+                      <div className="min-w-0 truncate font-mono text-muted-foreground">
                         {prefix || <span className="italic">—</span>}
                       </div>
                       <Button

--- a/platform/frontend/src/components/environment-variables-read-only-table.tsx
+++ b/platform/frontend/src/components/environment-variables-read-only-table.tsx
@@ -123,7 +123,7 @@ export function EnvironmentVariablesReadOnlyTable<
             }}
             className={`${gridClass} group items-center border-b py-3 text-xs last:border-b-0 cursor-pointer hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring`}
           >
-            <div className="font-mono">
+            <div className="min-w-0 truncate font-mono">
               {key || (
                 <span className="text-muted-foreground italic">unnamed</span>
               )}
@@ -140,7 +140,7 @@ export function EnvironmentVariablesReadOnlyTable<
                 <span className="text-muted-foreground">—</span>
               )}
             </div>
-            <div className="min-w-0">
+            <div className="min-w-0 truncate">
               <ValueCell
                 scope={scope}
                 type={type}
@@ -149,7 +149,7 @@ export function EnvironmentVariablesReadOnlyTable<
                 useExternalSecretsManager={useExternalSecretsManager}
               />
             </div>
-            <div className="line-clamp-2 text-muted-foreground">
+            <div className="min-w-0 line-clamp-2 text-muted-foreground">
               {description || <span className="italic">no description</span>}
             </div>
             <Button

--- a/platform/frontend/src/components/headers-read-only-table.tsx
+++ b/platform/frontend/src/components/headers-read-only-table.tsx
@@ -99,12 +99,12 @@ export function HeadersReadOnlyTable<TFieldValues extends FieldValues>({
             }}
             className={`${GRID_CLASS} group items-center border-b py-3 text-xs last:border-b-0 cursor-pointer hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring`}
           >
-            <div className="font-mono">
+            <div className="min-w-0 truncate font-mono">
               {headerName || (
                 <span className="text-muted-foreground italic">unnamed</span>
               )}
             </div>
-            <div className="min-w-0">
+            <div className="min-w-0 truncate">
               <ValueCell scope={scope} value={value} />
             </div>
             <div>
@@ -128,7 +128,7 @@ export function HeadersReadOnlyTable<TFieldValues extends FieldValues>({
                 <span className="text-muted-foreground">—</span>
               )}
             </div>
-            <div className="line-clamp-2 text-muted-foreground">
+            <div className="min-w-0 line-clamp-2 text-muted-foreground">
               {description || <span className="italic">no description</span>}
             </div>
             <Button


### PR DESCRIPTION
## Summary

Long unbroken strings in the MCP catalog config form's tables broke the column layout:
- Long **Keys / Header names** pushed sibling columns left (Type, Required, Value, Description shifted out of alignment).
- Long **Values** overflowed visually into the Description column.


<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>