### PR TITLE
feat: default theme to light

### DIFF
--- a/platform/frontend/src/app/layout.tsx
+++ b/platform/frontend/src/app/layout.tsx
@@ -182,7 +182,7 @@ export default function RootLayout({
               <ChatProvider>
                 <ThemeProvider
                   attribute="class"
-                  defaultTheme="system"
+                  defaultTheme="light"
                   enableSystem
                   disableTransitionOnChange
                 >


### PR DESCRIPTION
Change `next-themes` default from `system` to `light` for new visitors. Existing users keep their stored choice; the "System" option remains available in the toggle.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>