### PR TITLE
fix(catalog): default installation-scoped env vars and secret files to required

### DIFF
--- a/platform/frontend/src/components/environment-variable-dialog.tsx
+++ b/platform/frontend/src/components/environment-variable-dialog.tsx
@@ -59,14 +59,16 @@ interface EnvironmentVariableDialogProps {
   onConfirm: (draft: EnvVarDraft) => void;
 }
 
-const EMPTY_DRAFT: EnvVarDraft = {
-  key: "",
-  type: "plain_text",
-  scope: "installation",
-  required: false,
-  description: "",
-  value: "",
-};
+function makeEmptyDraft(disableInstallation: boolean): EnvVarDraft {
+  return {
+    key: "",
+    type: "plain_text",
+    scope: disableInstallation ? "static" : "installation",
+    required: !disableInstallation,
+    description: "",
+    value: "",
+  };
+}
 
 export function EnvironmentVariableDialog({
   open,
@@ -81,14 +83,16 @@ export function EnvironmentVariableDialog({
   onConfirm,
 }: EnvironmentVariableDialogProps) {
   const { singular } = usePresetEntityName();
-  const [draft, setDraft] = useState<EnvVarDraft>(initial ?? EMPTY_DRAFT);
+  const [draft, setDraft] = useState<EnvVarDraft>(
+    initial ?? makeEmptyDraft(disableInstallation),
+  );
   const [vaultDialogOpen, setVaultDialogOpen] = useState(false);
 
   useEffect(() => {
     if (open) {
-      setDraft(initial ?? EMPTY_DRAFT);
+      setDraft(initial ?? makeEmptyDraft(disableInstallation));
     }
-  }, [open, initial]);
+  }, [open, initial, disableInstallation]);
 
   const trimmedKey = draft.key.trim();
   const duplicate = useMemo(
@@ -118,7 +122,9 @@ export function EnvironmentVariableDialog({
   function updateDraft(patch: Partial<EnvVarDraft>) {
     setDraft((prev) => {
       const next = { ...prev, ...patch };
-      if (patch.scope && patch.scope !== "installation") {
+      if (patch.scope === "installation") {
+        next.required = true;
+      } else if (patch.scope) {
         next.required = false;
       }
       if (patch.scope && patch.scope !== "static") {

--- a/platform/frontend/src/components/field-scope-select.tsx
+++ b/platform/frontend/src/components/field-scope-select.tsx
@@ -24,7 +24,7 @@ interface FieldScopeSelectProps {
   allowPresetScope?: boolean;
   /** When true, "installation" is forbidden (e.g. multi-tenant servers). */
   disableInstallation?: boolean;
-  /** Tooltip copy when the trigger is wrapped in a disabled-reason tooltip. */
+  /** Tooltip copy shown when the disabled "Installation" option is hovered. */
   disabledReason?: string;
 }
 
@@ -37,7 +37,18 @@ export function FieldScopeSelect({
 }: FieldScopeSelectProps) {
   const { singular, configured } = usePresetEntityName();
   const showPresetScope = allowPresetScope && configured;
-  const select = (
+  const installationItem = (
+    <SelectItem
+      value="installation"
+      disabled={disableInstallation}
+      className={
+        disableInstallation ? "data-[disabled]:pointer-events-auto" : undefined
+      }
+    >
+      Installation
+    </SelectItem>
+  );
+  return (
     <Select
       value={value}
       onValueChange={(next) => onChange(next as FieldScopeValue)}
@@ -49,26 +60,19 @@ export function FieldScopeSelect({
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
-        <SelectItem value="installation" disabled={disableInstallation}>
-          Installation
-        </SelectItem>
+        {disableInstallation && disabledReason ? (
+          <Tooltip>
+            <TooltipTrigger asChild>{installationItem}</TooltipTrigger>
+            <TooltipContent side="right">
+              <p className="max-w-xs">{disabledReason}</p>
+            </TooltipContent>
+          </Tooltip>
+        ) : (
+          installationItem
+        )}
         {showPresetScope && <SelectItem value="preset">{singular}</SelectItem>}
         <SelectItem value="static">Static</SelectItem>
       </SelectContent>
     </Select>
   );
-
-  if (disableInstallation && disabledReason) {
-    return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <div className="w-full">{select}</div>
-        </TooltipTrigger>
-        <TooltipContent>
-          <p className="max-w-xs">{disabledReason}</p>
-        </TooltipContent>
-      </Tooltip>
-    );
-  }
-  return select;
 }

--- a/platform/frontend/src/components/secret-file-dialog.tsx
+++ b/platform/frontend/src/components/secret-file-dialog.tsx
@@ -43,13 +43,15 @@ interface SecretFileDialogProps {
   onConfirm: (draft: SecretFileDraft) => void;
 }
 
-const EMPTY_DRAFT: SecretFileDraft = {
-  key: "",
-  scope: "installation",
-  required: false,
-  value: "",
-  description: "",
-};
+function makeEmptyDraft(disableInstallation: boolean): SecretFileDraft {
+  return {
+    key: "",
+    scope: disableInstallation ? "static" : "installation",
+    required: !disableInstallation,
+    value: "",
+    description: "",
+  };
+}
 
 export function SecretFileDialog({
   open,
@@ -64,12 +66,14 @@ export function SecretFileDialog({
   onConfirm,
 }: SecretFileDialogProps) {
   const { singular } = usePresetEntityName();
-  const [draft, setDraft] = useState<SecretFileDraft>(initial ?? EMPTY_DRAFT);
+  const [draft, setDraft] = useState<SecretFileDraft>(
+    initial ?? makeEmptyDraft(disableInstallation),
+  );
   const [vaultDialogOpen, setVaultDialogOpen] = useState(false);
 
   useEffect(() => {
-    if (open) setDraft(initial ?? EMPTY_DRAFT);
-  }, [open, initial]);
+    if (open) setDraft(initial ?? makeEmptyDraft(disableInstallation));
+  }, [open, initial, disableInstallation]);
 
   const trimmedKey = draft.key.trim();
   const duplicate = useMemo(
@@ -94,7 +98,8 @@ export function SecretFileDialog({
   function updateDraft(patch: Partial<SecretFileDraft>) {
     setDraft((prev) => {
       const next = { ...prev, ...patch };
-      if (patch.scope && patch.scope !== "installation") next.required = false;
+      if (patch.scope === "installation") next.required = true;
+      else if (patch.scope) next.required = false;
       if (patch.scope && patch.scope !== "static") next.value = "";
       return next;
     });


### PR DESCRIPTION
## Summary

Three small UX fixes to the env-var / secret-file dialogs in the MCP catalog editor:

- **Required defaults to ON for "Installation" scope.** New env vars and secret files now open with the *Required variable* toggle on. Switching scope back to "Installation" after navigating away also re-applies the default, so the flag isn't silently left off.
- **Multi-tenant servers default to "Static" scope.** Previously the dialog opened on the disabled "Installation" option for multi-tenant servers, forcing the user to change it manually. New entries now open on "Static" with `required: false`.
- **Disabled-reason tooltip is scoped to the disabled item.** The "Multi-tenant servers share one deployment..." hint used to fire on hover anywhere near the scope select. It now only fires when the dropdown is open and the cursor is on the disabled "Installation" row.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>