### PR TITLE
fix(permission-button): keep icon-size square when tooltipped

### DIFF
--- a/platform/frontend/src/components/ui/permission-button.tsx
+++ b/platform/frontend/src/components/ui/permission-button.tsx
@@ -55,8 +55,8 @@ export function PermissionButton({
     return (
       <Tooltip>
         <TooltipTrigger asChild>
-          <span className={className}>
-            <Button {...props} className={cn(className, "w-full")}>
+          <span className={cn("inline-flex", className)}>
+            <Button {...props} className={className}>
               {children}
             </Button>
           </span>
@@ -79,7 +79,7 @@ export function PermissionButton({
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className={cn("cursor-not-allowed", className)}>
+        <span className={cn("inline-flex cursor-not-allowed", className)}>
           <Button
             onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
               // Prevent action when disabled
@@ -87,7 +87,7 @@ export function PermissionButton({
               e.stopPropagation();
             }}
             {...props}
-            className={cn(className, "w-full")}
+            className={className}
             disabled
           >
             {children}


### PR DESCRIPTION
fix squeezed action buttons 
<img width="2494" height="240" alt="image" src="https://github.com/user-attachments/assets/fd919130-4fcd-42d2-81fe-71997d653600" />

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>