### PR TITLE
Show limits reset countdown in cleanup column

### DIFF
--- a/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import LimitsPage, { getLimitModels } from "./page";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import LimitsPage, { getLimitModels, getLimitResetLabel } from "./page";
 
 const mockSetCostsAction = vi.fn();
 const mockUseLimits = vi.fn();
@@ -310,6 +310,10 @@ describe("LimitsPage", () => {
     });
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("shows a settings notice when a default user limit is configured", () => {
     render(<LimitsPage />);
 
@@ -366,6 +370,37 @@ describe("LimitsPage", () => {
     render(<LimitsPage />);
     const modelsBadge = screen.getByTestId("limits-table-models-badge");
     expect(modelsBadge).toHaveTextContent("All models");
+  });
+
+  it("shows a reset countdown badge in the cleanup column", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:30:00Z"));
+    mockUseLimits.mockReturnValue({
+      data: [
+        {
+          id: "limit-1",
+          entityType: "organization",
+          entityId: "org-1",
+          limitType: "token_cost",
+          limitValue: 1000,
+          model: null,
+          mcpServerName: null,
+          toolName: null,
+          cleanupInterval: "1h",
+          lastCleanup: "2026-01-01T00:00:00Z",
+          createdAt: "2026-01-01",
+          updatedAt: "2026-01-01",
+          modelUsage: [],
+        },
+      ],
+      isPending: false,
+    });
+
+    render(<LimitsPage />);
+
+    expect(screen.getByTestId("limits-table-reset-badge")).toHaveTextContent(
+      "resets in 30m",
+    );
   });
 
   it("shows multiple model badges for limits with multiple models", () => {
@@ -528,5 +563,40 @@ describe("LimitsPage", () => {
     render(<LimitsPage />);
     const row = screen.getByTestId("data-table-row-limit-proxy");
     expect(row).toHaveTextContent("Unknown LLM proxy");
+  });
+});
+
+describe("getLimitResetLabel", () => {
+  it("returns null when the limit has not been cleaned up yet", () => {
+    expect(getLimitResetLabel({ lastCleanup: null } as never, "1h")).toBeNull();
+  });
+
+  it("formats future resets by minutes, hours, and days", () => {
+    const now = new Date("2026-01-01T00:00:00Z");
+
+    expect(
+      getLimitResetLabel(
+        { lastCleanup: "2026-01-01T00:30:00Z" } as never,
+        "1h",
+        now,
+      ),
+    ).toBe("resets in 2h");
+    expect(
+      getLimitResetLabel(
+        { lastCleanup: "2026-01-01T00:00:00Z" } as never,
+        "24h",
+        now,
+      ),
+    ).toBe("resets in 1d");
+  });
+
+  it("shows resets soon for overdue cleanup windows", () => {
+    expect(
+      getLimitResetLabel(
+        { lastCleanup: "2026-01-01T00:00:00Z" } as never,
+        "1h",
+        new Date("2026-01-01T02:00:00Z"),
+      ),
+    ).toBe("resets soon");
   });
 });

--- a/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
@@ -1,6 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import LimitsPage, { getLimitModels, getLimitResetLabel } from "./page";
+import LimitsPage, {
+  getLimitModels,
+  getLimitResetAtLabel,
+  getLimitResetLabel,
+} from "./page";
 
 const mockSetCostsAction = vi.fn();
 const mockUseLimits = vi.fn();
@@ -401,6 +405,9 @@ describe("LimitsPage", () => {
     expect(screen.getByTestId("limits-table-reset-badge")).toHaveTextContent(
       "resets in 30m",
     );
+    expect(screen.getByText(/next reset:/i)).toHaveTextContent(
+      /Jan 1, 1:00 AM|Jan 1, 01:00/,
+    );
   });
 
   it("shows multiple model badges for limits with multiple models", () => {
@@ -598,5 +605,25 @@ describe("getLimitResetLabel", () => {
         new Date("2026-01-01T02:00:00Z"),
       ),
     ).toBe("resets soon");
+  });
+});
+
+describe("getLimitResetAtLabel", () => {
+  it("returns null when the reset time cannot be calculated", () => {
+    expect(
+      getLimitResetAtLabel({ lastCleanup: null } as never, "1h"),
+    ).toBeNull();
+    expect(
+      getLimitResetAtLabel({ lastCleanup: "not-a-date" } as never, "1h"),
+    ).toBeNull();
+  });
+
+  it("formats the exact reset time", () => {
+    expect(
+      getLimitResetAtLabel(
+        { lastCleanup: "2026-01-01T00:00:00Z" } as never,
+        "1h",
+      ),
+    ).toMatch(/Jan 1, 1:00 AM|Jan 1, 01:00/);
   });
 });

--- a/platform/frontend/src/app/llm/(costs)/limits/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.tsx
@@ -165,6 +165,15 @@ function formatNumericInput(value: string) {
   return Number(value).toLocaleString("en-US");
 }
 
+function formatResetAtLabel(resetAt: Date) {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(resetAt);
+}
+
 export default function LimitsPage() {
   const setActionButton = useSetCostsAction();
   const { data: limits = [], isPending } = useLimits();
@@ -501,17 +510,30 @@ export default function LimitsPage() {
             (row.original.cleanupInterval as LimitCleanupInterval | null) ??
             DEFAULT_LIMIT_CLEANUP_INTERVAL;
           const resetLabel = getLimitResetLabel(row.original, cleanupInterval);
+          const resetAtLabel = getLimitResetAtLabel(
+            row.original,
+            cleanupInterval,
+          );
           return (
             <div className="flex flex-col items-start gap-1">
               <span>{CLEANUP_INTERVAL_LABELS[cleanupInterval]}</span>
               {resetLabel && (
-                <Badge
-                  variant="outline"
-                  className="text-xs font-normal text-muted-foreground"
-                  data-testid="limits-table-reset-badge"
-                >
-                  {resetLabel}
-                </Badge>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Badge
+                      variant="outline"
+                      className="cursor-default text-xs font-normal text-muted-foreground"
+                      data-testid="limits-table-reset-badge"
+                    >
+                      {resetLabel}
+                    </Badge>
+                  </TooltipTrigger>
+                  {resetAtLabel && (
+                    <TooltipContent>
+                      <span>Next reset: {resetAtLabel}</span>
+                    </TooltipContent>
+                  )}
+                </Tooltip>
               )}
             </div>
           );
@@ -955,6 +977,32 @@ export function getLimitResetLabel(
   cleanupInterval: LimitCleanupInterval,
   now = new Date(),
 ): string | null {
+  const resetAt = getLimitResetAt(limit, cleanupInterval);
+  if (!resetAt) {
+    return null;
+  }
+
+  const remainingMs = resetAt.getTime() - now.getTime();
+
+  if (remainingMs <= 0) {
+    return "resets soon";
+  }
+
+  return `resets in ${formatRelativeDuration(remainingMs)}`;
+}
+
+export function getLimitResetAtLabel(
+  limit: Pick<LimitData, "lastCleanup">,
+  cleanupInterval: LimitCleanupInterval,
+): string | null {
+  const resetAt = getLimitResetAt(limit, cleanupInterval);
+  return resetAt ? formatResetAtLabel(resetAt) : null;
+}
+
+function getLimitResetAt(
+  limit: Pick<LimitData, "lastCleanup">,
+  cleanupInterval: LimitCleanupInterval,
+): Date | null {
   if (!limit.lastCleanup) {
     return null;
   }
@@ -964,14 +1012,7 @@ export function getLimitResetLabel(
     return null;
   }
 
-  const resetAtMs = lastCleanupMs + CLEANUP_INTERVAL_MS[cleanupInterval];
-  const remainingMs = resetAtMs - now.getTime();
-
-  if (remainingMs <= 0) {
-    return "resets soon";
-  }
-
-  return `resets in ${formatRelativeDuration(remainingMs)}`;
+  return new Date(lastCleanupMs + CLEANUP_INTERVAL_MS[cleanupInterval]);
 }
 
 function formatRelativeDuration(durationMs: number) {

--- a/platform/frontend/src/app/llm/(costs)/limits/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.tsx
@@ -101,6 +101,13 @@ const DEFAULT_FORM_STATE: LimitFormState = {
 
 const LIMITS_ENTITY_SELECTOR_PAGE_SIZE = 100;
 const MAX_VISIBLE_MODEL_BADGES = 3;
+const CLEANUP_INTERVAL_MS: Record<LimitCleanupInterval, number> = {
+  "1h": 60 * 60 * 1000,
+  "12h": 12 * 60 * 60 * 1000,
+  "24h": 24 * 60 * 60 * 1000,
+  "1w": 7 * 24 * 60 * 60 * 1000,
+  "1m": 30 * 24 * 60 * 60 * 1000,
+};
 
 const ENTITY_TYPE_ITEMS: Array<{
   value: LimitFormEntityType;
@@ -487,13 +494,27 @@ export default function LimitsPage() {
       {
         accessorKey: "cleanupInterval",
         header: "Cleanup",
-        size: 140,
+        size: 180,
         minSize: 120,
         cell: ({ row }) => {
           const cleanupInterval =
             (row.original.cleanupInterval as LimitCleanupInterval | null) ??
             DEFAULT_LIMIT_CLEANUP_INTERVAL;
-          return CLEANUP_INTERVAL_LABELS[cleanupInterval];
+          const resetLabel = getLimitResetLabel(row.original, cleanupInterval);
+          return (
+            <div className="flex flex-col items-start gap-1">
+              <span>{CLEANUP_INTERVAL_LABELS[cleanupInterval]}</span>
+              {resetLabel && (
+                <Badge
+                  variant="outline"
+                  className="text-xs font-normal text-muted-foreground"
+                  data-testid="limits-table-reset-badge"
+                >
+                  {resetLabel}
+                </Badge>
+              )}
+            </div>
+          );
         },
       },
       {
@@ -927,4 +948,43 @@ export function getLimitModels(limit: LimitData): string[] {
   return Array.isArray(limit.model)
     ? limit.model.filter((model): model is string => typeof model === "string")
     : [];
+}
+
+export function getLimitResetLabel(
+  limit: Pick<LimitData, "lastCleanup">,
+  cleanupInterval: LimitCleanupInterval,
+  now = new Date(),
+): string | null {
+  if (!limit.lastCleanup) {
+    return null;
+  }
+
+  const lastCleanupMs = new Date(limit.lastCleanup).getTime();
+  if (Number.isNaN(lastCleanupMs)) {
+    return null;
+  }
+
+  const resetAtMs = lastCleanupMs + CLEANUP_INTERVAL_MS[cleanupInterval];
+  const remainingMs = resetAtMs - now.getTime();
+
+  if (remainingMs <= 0) {
+    return "resets soon";
+  }
+
+  return `resets in ${formatRelativeDuration(remainingMs)}`;
+}
+
+function formatRelativeDuration(durationMs: number) {
+  const minutes = Math.ceil(durationMs / (60 * 1000));
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+
+  const hours = Math.ceil(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h`;
+  }
+
+  const days = Math.ceil(hours / 24);
+  return `${days}d`;
 }


### PR DESCRIPTION
## Summary

Adds the Limits-page countdown badge requested in #4758 for the Cleanup column.

This is intentionally a narrow slice of the larger issue: it only shows `resets in X` for limits that have a `lastCleanup` timestamp, leaving the broader chat/proxy/usage-column work untouched.

/claim #4758

## Changes

- Derive a reset label from `lastCleanup` and cleanup interval.
- Show the label as a small badge below the existing cleanup interval.
- Omit the badge for missing/invalid cleanup timestamps.
- Show `resets soon` when the cleanup window is overdue.
- Add focused test coverage for the helper and table rendering.

## Verification

```bash
corepack pnpm --dir frontend test -- src/app/llm/\(costs\)/limits/page.test.tsx --run
```

Result: 160 test files passed, 1409 tests passed, 4 skipped.
