### PR TITLE
fix: make conversation compaction migration idempotent

### DIFF
--- a/platform/backend/src/database/migrations/0245_tired_puck.sql
+++ b/platform/backend/src/database/migrations/0245_tired_puck.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "conversation_compactions" (
+CREATE TABLE IF NOT EXISTS "conversation_compactions" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"conversation_id" uuid NOT NULL,
 	"summary" text NOT NULL,
@@ -11,5 +11,10 @@ CREATE TABLE "conversation_compactions" (
 	"created_at" timestamp DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-ALTER TABLE "conversation_compactions" ADD CONSTRAINT "conversation_compactions_conversation_id_conversations_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."conversations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-CREATE INDEX "conversation_compactions_conversation_id_created_at_idx" ON "conversation_compactions" USING btree ("conversation_id","created_at");
+DO $$ BEGIN
+ ALTER TABLE "conversation_compactions" ADD CONSTRAINT "conversation_compactions_conversation_id_conversations_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."conversations"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "conversation_compactions_conversation_id_created_at_idx" ON "conversation_compactions" USING btree ("conversation_id","created_at");


### PR DESCRIPTION
## Summary
- Make the shipped conversation compaction migration tolerate an already-created table, FK, and index.
- This unblocks databases where the migration partially applied before Drizzle recorded it.
- Existing databases that already recorded the migration will not rerun it.

## Notes
- This edits a shipped migration intentionally because a follow-up migration cannot run while the original migration is failing.
- Drizzle records migration hashes, but migration execution is ordered by recorded migration timestamp; this patch keeps the final schema unchanged.

## Verification
- ARCHESTRA_DATABASE_URL=postgresql://archestra:archestra_dev_password@localhost:5432/archestra_dev pnpm --dir backend exec drizzle-kit check

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>