### PR TITLE
fix(mcp-catalog): count installs across presets in delete dialog

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -1494,13 +1494,6 @@ export function InternalMCPCatalog({
       <DeleteCatalogDialog
         item={deletingItem}
         onClose={() => setDeletingItem(null)}
-        installationCount={
-          deletingItem
-            ? installedServers?.filter(
-                (server) => server.catalogId === deletingItem.id,
-              ).length || 0
-            : 0
-        }
       />
 
       <RemoteServerInstallDialog

--- a/platform/frontend/src/app/mcp/registry/_parts/delete-catalog-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/delete-catalog-dialog.tsx
@@ -1,22 +1,28 @@
 import type { archestraApiTypes } from "@shared";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
-import { useDeleteInternalMcpCatalogItem } from "@/lib/mcp/internal-mcp-catalog.query";
+import {
+  useCatalogPresets,
+  useDeleteInternalMcpCatalogItem,
+} from "@/lib/mcp/internal-mcp-catalog.query";
+import { useMcpServers } from "@/lib/mcp/mcp-server.query";
+import { usePresetEntityName } from "@/lib/organization.query";
 
 interface DeleteCatalogDialogProps {
   item: archestraApiTypes.GetInternalMcpCatalogResponses["200"][number] | null;
   onClose: () => void;
   /** Called only after a successful deletion (before onClose). */
   onDeleted?: () => void;
-  installationCount: number;
 }
 
 export function DeleteCatalogDialog({
   item,
   onClose,
   onDeleted,
-  installationCount,
 }: DeleteCatalogDialogProps) {
   const deleteMutation = useDeleteInternalMcpCatalogItem();
+  const { data: presets = [] } = useCatalogPresets(item?.id ?? null);
+  const { data: installedServers = [] } = useMcpServers();
+  const { singular, plural } = usePresetEntityName();
 
   const handleConfirm = async () => {
     if (!item) return;
@@ -25,12 +31,26 @@ export function DeleteCatalogDialog({
     onClose();
   };
 
-  const ConfirmationContent = ({ name }: { name: string }) => (
-    <span>
-      Are you sure you want to delete{" "}
-      <span className="font-semibold break-all">"{name}"</span>?
-    </span>
+  // Deleting a parent catalog item cascade-deletes its child presets and
+  // uninstalls every server across the parent and the children. Count all of
+  // them, plus how many distinct envs (parent + presets) actually hold installs.
+  const envCatalogIds = item ? [item.id, ...presets.map((p) => p.id)] : [];
+  const relevantInstalls = installedServers.filter((s) =>
+    envCatalogIds.includes(s.catalogId),
   );
+  const installationCount = relevantInstalls.length;
+  const envsWithInstalls = new Set(relevantInstalls.map((s) => s.catalogId))
+    .size;
+
+  const envTerm = envsWithInstalls === 1 ? singular : plural;
+  const showEnvBreakdown = presets.length > 0 && envsWithInstalls > 0;
+
+  const question = item ? (
+    <p>
+      Are you sure you want to delete{" "}
+      <span className="font-semibold break-all">"{item.name}"</span>?
+    </p>
+  ) : null;
 
   return (
     <DeleteConfirmDialog
@@ -40,16 +60,24 @@ export function DeleteCatalogDialog({
       description={
         item ? (
           installationCount > 0 ? (
-            <span className="block space-y-3">
-              <ConfirmationContent name={item.name} />
-              <span className="block text-sm">
+            <div className="space-y-2">
+              {question}
+              <p className="text-sm text-muted-foreground">
                 There are currently <strong>{installationCount}</strong>{" "}
-                installation(s) of this server. Deleting this catalog entry will
-                also uninstall all associated servers.
-              </span>
-            </span>
+                {installationCount === 1 ? "installation" : "installations"} of
+                this server
+                {showEnvBreakdown ? (
+                  <>
+                    {" "}
+                    across <strong>{envsWithInstalls}</strong>{" "}
+                    {envTerm.toLowerCase()}
+                  </>
+                ) : null}
+                . Deleting this catalog item will uninstall all of them.
+              </p>
+            </div>
           ) : (
-            <ConfirmationContent name={item.name} />
+            question
           )
         ) : (
           ""

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-settings-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-settings-dialog.tsx
@@ -159,7 +159,6 @@ export function McpServerSettingsDialog({
     navItems.push({
       id: "presets",
       label: presetEntityName.plural,
-      badge: presets.length + 1,
     });
   }
   if (showConnections) {

--- a/platform/frontend/src/app/mcp/registry/_parts/reinstall-confirmation-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/reinstall-confirmation-dialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { RefreshCw } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -12,6 +11,7 @@ import {
   DialogStickyFooter,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { usePresetEntityName } from "@/lib/organization.query";
 
 interface ReinstallTarget {
   id: string;
@@ -36,6 +36,12 @@ export function ReinstallConfirmationDialog({
   isReinstalling,
   targets = [],
 }: ReinstallConfirmationDialogProps) {
+  const { plural: presetPlural } = usePresetEntityName();
+
+  const installationCount = targets.length;
+  const envCount = new Set(targets.map((t) => t.presetLabel)).size;
+  const showEnvBreakdown = envCount > 1;
+
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
@@ -43,37 +49,28 @@ export function ReinstallConfirmationDialog({
           <DialogTitle>Reinstall Required</DialogTitle>
           <DialogDescription>
             The configuration for <strong>{serverName}</strong> has been
-            updated. The server needs to be reinstalled for the changes to take
-            effect.
+            updated.{" "}
+            {installationCount > 0 ? (
+              <>
+                <strong>{installationCount}</strong>{" "}
+                {installationCount === 1 ? "installation" : "installations"}
+                {showEnvBreakdown ? (
+                  <>
+                    {" "}
+                    across <strong>{envCount}</strong>{" "}
+                    {presetPlural.toLowerCase()}
+                  </>
+                ) : null}{" "}
+                will be reinstalled for the changes to take effect.
+              </>
+            ) : (
+              <>
+                The server needs to be reinstalled for the changes to take
+                effect.
+              </>
+            )}
           </DialogDescription>
         </DialogHeader>
-
-        {targets.length > 0 && (
-          <div className="space-y-2">
-            <p className="text-sm font-medium">
-              The following {targets.length === 1 ? "install" : "installs"} will
-              be reinstalled:
-            </p>
-            <ul className="space-y-1.5">
-              {targets.map((t) => (
-                <li
-                  key={t.id}
-                  className="flex items-center gap-2 text-sm text-muted-foreground"
-                >
-                  {t.presetLabel && (
-                    <Badge
-                      variant="secondary"
-                      className="text-[10px] font-medium"
-                    >
-                      {t.presetLabel}
-                    </Badge>
-                  )}
-                  <span className="font-mono text-xs truncate">{t.name}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
 
         <DialogForm onSubmit={onConfirm}>
           <DialogStickyFooter className="border-t-0 shadow-none">


### PR DESCRIPTION
## Summary

- Delete Catalog Item dialog under-reported installation count: it filtered `installedServers` by the parent catalog's id only, missing installations against child preset catalog rows that the backend `InternalMcpCatalogModel.delete` also cascade-uninstalls.
---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>