### PR TITLE
fix: persist tool approval state across page refreshes (#4030)

### DIFF
--- a/platform/backend/src/models/message.ts
+++ b/platform/backend/src/models/message.ts
@@ -251,6 +251,37 @@ class MessageModel {
     }
     return await run(executor);
   }
+  /**
+   * Bulk-update message content for messages that have been modified
+   * (e.g., tool approval state changes, tool results added in-place).
+   */
+  static async bulkUpdateContent(
+    messages: Array<{ id: string; content: unknown; conversationId: string }>,
+  ): Promise<void> {
+    if (messages.length === 0) {
+      return;
+    }
+
+    await Promise.all(
+      messages.map(async (msg) => {
+        await db
+          .update(schema.messagesTable)
+          .set({
+            content: msg.content,
+            updatedAt: new Date(),
+          })
+          .where(eq(schema.messagesTable.id, msg.id));
+      }),
+    );
+
+    // Update conversation's updatedAt for all affected conversations
+    const uniqueConversationIds = [
+      ...new Set(messages.map((m) => m.conversationId)),
+    ];
+    await Promise.all(
+      uniqueConversationIds.map((id) => MessageModel.touchConversation(id)),
+    );
+  }
 }
 
 export default MessageModel;

--- a/platform/backend/src/routes/chat/routes.test.ts
+++ b/platform/backend/src/routes/chat/routes.test.ts
@@ -502,6 +502,150 @@ describe("getMessagesNotYetPersisted", () => {
   });
 });
 
+describe("getMessagesWithChangedContent", () => {
+  it("detects messages with new tool result parts added after approval", () => {
+    const changed = __test.getMessagesWithChangedContent({
+      existingMessages: [
+        {
+          id: "msg-1",
+          content: {
+            id: "msg-1",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-mcp__search",
+                toolCallId: "tc-1",
+                state: "approval-requested",
+                approval: { id: "ap-1" },
+                input: { query: "test" },
+              },
+            ],
+          },
+        },
+      ],
+      uiMessages: [
+        {
+          id: "msg-1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-mcp__search",
+              toolCallId: "tc-1",
+              state: "output-available",
+              approval: { id: "ap-1" },
+              input: { query: "test" },
+              output: { results: ["a", "b"] },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(changed).toHaveLength(1);
+    expect(changed[0].id).toBe("msg-1");
+  });
+
+  it("detects messages where approval state changed from requested to denied", () => {
+    const changed = __test.getMessagesWithChangedContent({
+      existingMessages: [
+        {
+          id: "msg-2",
+          content: {
+            id: "msg-2",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-mcp__write",
+                toolCallId: "tc-2",
+                state: "approval-requested",
+                approval: { id: "ap-2" },
+                input: { path: "/tmp/test" },
+              },
+            ],
+          },
+        },
+      ],
+      uiMessages: [
+        {
+          id: "msg-2",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-mcp__write",
+              toolCallId: "tc-2",
+              state: "denied",
+              approval: { id: "ap-2" },
+              input: { path: "/tmp/test" },
+              errorText: "Tool execution was denied by the user.",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(changed).toHaveLength(1);
+    expect(changed[0].id).toBe("msg-2");
+  });
+
+  it("returns empty array when messages are unchanged", () => {
+    const unchangedContent = {
+      id: "msg-3",
+      role: "assistant" as const,
+      parts: [{ type: "text" as const, text: "Hello!" }],
+    };
+
+    const changed = __test.getMessagesWithChangedContent({
+      existingMessages: [
+        { id: "msg-3", content: unchangedContent },
+      ],
+      uiMessages: [
+        { id: "msg-3", role: "assistant", parts: [{ type: "text", text: "Hello!" }] },
+      ],
+    });
+
+    expect(changed).toHaveLength(0);
+  });
+
+  it("matches by content ID when message IDs were re-keyed to DB UUIDs", () => {
+    const changed = __test.getMessagesWithChangedContent({
+      existingMessages: [
+        {
+          id: "db-uuid-123",
+          content: {
+            id: "original-nanoid",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-mcp__search",
+                toolCallId: "tc-3",
+                state: "approval-requested",
+                input: {},
+              },
+            ],
+          },
+        },
+      ],
+      uiMessages: [
+        {
+          id: "original-nanoid",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-mcp__search",
+              toolCallId: "tc-3",
+              state: "output-available",
+              input: {},
+              output: { data: "result" },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(changed).toHaveLength(1);
+  });
+});
+
 describe("extractFirstMessages", () => {
   it("extracts first user message from parts", () => {
     const messages = [

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -2079,8 +2079,29 @@ async function persistNewMessages(
       uiMessages,
     });
 
+    // Detect existing messages whose content has changed (e.g., tool approval
+    // state updates, tool results added in-place after approval). These need
+    // to be UPDATEd, not INSERTed.
+    const changedMessages = getMessagesWithChangedContent({
+      existingMessages,
+      uiMessages,
+    });
+
+    // Update changed messages first (approval state, tool results, etc.)
+    if (changedMessages.length > 0) {
+      const normalized = changedMessages.map((msg) => ({
+        id: msg.id,
+        content: normalizeChatMessages([msg])[0] ?? msg,
+        conversationId,
+      }));
+      await MessageModel.bulkUpdateContent(normalized);
+      logger.info(
+        `Updated ${changedMessages.length} changed messages in conversation ${conversationId} (${context})`,
+      );
+    }
+
     if (newMessages.length === 0) {
-      return 0;
+      return changedMessages.length;
     }
 
     // Check if last message has empty parts and strip it if so
@@ -2090,7 +2111,7 @@ async function persistNewMessages(
     }
 
     if (messagesToSave.length === 0) {
-      return 0;
+      return changedMessages.length;
     }
 
     let messagesToStore: ChatMessage[];
@@ -2129,11 +2150,12 @@ async function persistNewMessages(
 
     await MessageModel.bulkCreate(messageData);
 
+    const totalPersisted = messagesToSave.length + changedMessages.length;
     logger.info(
-      `Appended ${messagesToSave.length} new messages to conversation ${conversationId} (${context})`,
+      `Persisted ${messagesToSave.length} new + ${changedMessages.length} updated messages in conversation ${conversationId} (${context})`,
     );
 
-    return messagesToSave.length;
+    return totalPersisted;
   } catch (error) {
     logger.error(
       { error, conversationId, context },
@@ -2166,6 +2188,65 @@ function getSerializableChatError(error: ChatErrorResponse): ChatErrorResponse {
   } catch {
     return getMinimalFrontendError(error);
   }
+}
+
+/**
+ * Detect existing messages whose content has changed since they were persisted.
+ * This handles cases like tool approval state updates, tool results added
+ * in-place after approval, etc.
+ */
+function getMessagesWithChangedContent(params: {
+  existingMessages: Array<{ id: string; content: unknown }>;
+  uiMessages: ChatMessage[];
+}): ChatMessage[] {
+  const existingById = new Map<string, { id: string; content: unknown }>();
+
+  for (const message of params.existingMessages) {
+    existingById.set(message.id, message);
+    // Also index by content ID for messages whose IDs were re-keyed
+    const contentId =
+      typeof message.content === "object" &&
+      message.content !== null &&
+      "id" in message.content &&
+      typeof (message.content as Record<string, unknown>).id === "string"
+        ? ((message.content as Record<string, unknown>).id as string)
+        : null;
+    if (contentId) {
+      existingById.set(contentId, message);
+    }
+  }
+
+  const changed: ChatMessage[] = [];
+
+  for (const uiMsg of params.uiMessages) {
+    if (!uiMsg.id || typeof uiMsg.id !== "string") continue;
+
+    const existing = existingById.get(uiMsg.id);
+    if (!existing) continue;
+
+    // Compare the number of parts — if the UI message has more parts than
+    // the persisted one, it means new content was added (e.g., tool result
+    // after approval).
+    const existingContent = existing.content as Record<string, unknown>;
+    const existingParts = Array.isArray(existingContent?.parts)
+      ? existingContent.parts
+      : [];
+    const uiParts = Array.isArray(uiMsg.parts) ? uiMsg.parts : [];
+
+    if (uiParts.length !== existingParts.length) {
+      changed.push(uiMsg);
+      continue;
+    }
+
+    // Compare JSON serialization for deeper changes (approval state, etc.)
+    const existingJson = JSON.stringify(existingContent);
+    const uiJson = JSON.stringify(uiMsg);
+    if (existingJson !== uiJson) {
+      changed.push(uiMsg);
+    }
+  }
+
+  return changed;
 }
 
 function getMessagesNotYetPersisted(params: {
@@ -2691,6 +2772,7 @@ async function validateChatApiKeyAccess(
 
 export const __test = {
   getMessagesNotYetPersisted,
+  getMessagesWithChangedContent,
   prepareMessagesForProvider,
 };
 


### PR DESCRIPTION
## Problem

When a tool with `require_approval` policy is approved/declined in chat, the tool result renders correctly in-session. After page refresh, the approval banner reappears because the updated message (with tool result / denied state) was never persisted to the DB.

Clicking Approve/Decline again errors since the decision was already recorded server-side.

## Root Cause

`persistNewMessages()` in `routes.ts` determines what to save by comparing message IDs against existing DB rows. When approval updates an existing message's parts in-place (same ID, new content — e.g. tool result appended, state changed from `approval-requested` to `output-available`), the message is filtered out as "already persisted."

## Fix

**1. `MessageModel.bulkUpdateContent()`** — new method that UPDATEs existing message content by ID, used for messages whose parts changed after initial persistence.

**2. `getMessagesWithChangedContent()`** — compares incoming UI messages against existing DB messages by ID, detects content diffs (part count changes, state changes, new tool outputs). Returns messages that need UPDATE rather than INSERT.

**3. `persistNewMessages()` updated** — now calls both:
- `bulkUpdateContent()` for changed existing messages (approval state, tool results)
- `bulkCreate()` for truly new messages (assistant responses, user messages)

## Scope

- Only touches persistence layer — no UI changes
- 3 files: `message.ts` (model), `routes.ts` (persistence logic), `routes.test.ts` (tests)
- The multi-tab concurrent approval issue raised by @VadimLarinTech is intentionally out of scope — that needs a backend-side execution guard (idempotency key on MCP execution), which is a separate concern

Fixes #4030
