### PR TITLE
fix: evaluate blocked tool result policies for untrusted contexts

### DIFF
--- a/platform/backend/src/guardrails/trusted-data.test.ts
+++ b/platform/backend/src/guardrails/trusted-data.test.ts
@@ -410,6 +410,57 @@ describe("trusted-data evaluation (provider-agnostic)", () => {
       });
     });
 
+    test("evaluates blocked tool result policies when context starts untrusted", async () => {
+      await TrustedDataPolicyModel.create({
+        toolId,
+        conditions: [
+          { key: "emails[*].from", operator: "contains", value: "hacker" },
+        ],
+        action: "block_always",
+        description: "Block hacker emails",
+      });
+
+      const commonMessages: CommonMessage[] = [
+        { role: "user", content: "Read this issue" },
+        {
+          role: "tool",
+          toolCalls: [
+            {
+              id: "call_untrusted_blocked",
+              name: "get_emails",
+              content: {
+                emails: [{ from: "hacker@company.com", subject: "Secret" }],
+              },
+              isError: false,
+            },
+          ],
+        },
+      ];
+
+      const result = await evaluateIfContextIsTrusted(
+        commonMessages,
+        agentId,
+        organizationId,
+        undefined,
+        true,
+        "restrictive",
+        { teamIds: [] },
+        undefined,
+        undefined,
+        "inherited_from_parent",
+      );
+
+      expect(result.contextIsTrusted).toBe(false);
+      expect(result.toolResultUpdates).toEqual({
+        call_untrusted_blocked:
+          "[Content blocked by policy: Data blocked by policy: Block hacker emails]",
+      });
+      expect(result.unsafeContextBoundary).toEqual({
+        kind: "preexisting_untrusted",
+        reason: "inherited_from_parent",
+      });
+    });
+
     test("handles multiple tool calls with mixed trust", async () => {
       // Create policies
       await TrustedDataPolicyModel.create({

--- a/platform/backend/src/guardrails/trusted-data.ts
+++ b/platform/backend/src/guardrails/trusted-data.ts
@@ -59,29 +59,23 @@ export async function evaluateIfContextIsTrusted(
 
   const toolResultUpdates: ToolResultUpdates = {};
   const dualLlmAnalyses: DualLlmAnalysis[] = [];
-  let hasUntrustedData = false;
+  let hasUntrustedData = considerContextUntrusted;
   let usedDualLlm = false;
-  let unsafeContextBoundary: UnsafeContextBoundary | undefined;
+  let unsafeContextBoundary: UnsafeContextBoundary | undefined =
+    considerContextUntrusted
+      ? {
+          kind: "preexisting_untrusted",
+          reason:
+            initialUntrustedReason ??
+            UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
+        }
+      : undefined;
 
-  // If agent configured to consider context untrusted from the beginning,
-  // mark context as untrusted immediately and skip evaluation
   if (considerContextUntrusted) {
     logger.debug(
       { agentId },
-      "[trustedData] evaluateIfContextIsTrusted: context marked untrusted by agent config",
+      "[trustedData] evaluateIfContextIsTrusted: context marked untrusted by agent config; continuing policy evaluation",
     );
-    return {
-      toolResultUpdates: {},
-      contextIsTrusted: false,
-      usedDualLlm: false,
-      dualLlmAnalyses: [],
-      unsafeContextBoundary: {
-        kind: "preexisting_untrusted",
-        reason:
-          initialUntrustedReason ??
-          UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
-      },
-    };
   }
 
   // First, collect all tool calls from all messages
@@ -116,7 +110,7 @@ export async function evaluateIfContextIsTrusted(
     );
     return {
       toolResultUpdates,
-      contextIsTrusted: true,
+      contextIsTrusted: !hasUntrustedData,
       usedDualLlm: false,
       dualLlmAnalyses: [],
       unsafeContextBoundary,


### PR DESCRIPTION
## What changed

- Keep contexts marked as untrusted when `considerContextUntrusted` is enabled, but continue evaluating trusted-data policies for tool results.
- Preserve the preexisting unsafe boundary for already-untrusted contexts.
- Add regression coverage for blocked Tool Result Policies when context starts untrusted.

## Why this fixes the issue

Previously `evaluateIfContextIsTrusted` returned early when an agent was configured to treat context as sensitive from the start. That skipped Tool Result Policy evaluation and left `toolResultUpdates` empty, so blocked tool results could still be sent to the model-facing request.

This change initializes the context as untrusted, keeps the existing boundary metadata, and still runs the normal tool-result policy evaluation so blocked results are replaced before adapters apply the request updates.

## How it was tested

Using Node v24.14.0 because the local system Node v20.18.0 is below the repo's declared engine requirement.

- `ARCHESTRA_DATABASE_URL=postgresql://test:test@localhost:5432/test vitest src/guardrails/trusted-data.test.ts --run`
- `biome check backend/src/guardrails/trusted-data.ts backend/src/guardrails/trusted-data.test.ts`
- `tsgo --noEmit --project backend/tsconfig.json`
- `git diff --check`

## Limitations

No UI changes. This is scoped to the provider-agnostic trusted-data evaluation path and existing adapter update flow.

Closes #4225

/claim #4225