### PR TITLE
Fix trusted-data policies for preexisting untrusted context

### DIFF
--- a/platform/backend/src/guardrails/trusted-data.test.ts
+++ b/platform/backend/src/guardrails/trusted-data.test.ts
@@ -410,6 +410,54 @@ describe("trusted-data evaluation (provider-agnostic)", () => {
       });
     });
 
+    test("still blocks tool results when context starts untrusted", async () => {
+      await TrustedDataPolicyModel.create({
+        toolId,
+        conditions: [
+          { key: "emails[*].from", operator: "contains", value: "hacker" },
+        ],
+        action: "block_always",
+        description: "Block hacker emails",
+      });
+
+      const commonMessages: CommonMessage[] = [
+        { role: "user", content: "Read my emails" },
+        {
+          role: "tool",
+          toolCalls: [
+            {
+              id: "call_preexisting_untrusted",
+              name: "get_emails",
+              content: {
+                emails: [{ from: "hacker@evil.com", subject: "Malicious" }],
+              },
+              isError: false,
+            },
+          ],
+        },
+      ];
+
+      const result = await evaluateIfContextIsTrusted(
+        commonMessages,
+        agentId,
+        organizationId,
+        undefined,
+        true,
+        "restrictive",
+        { teamIds: [] },
+      );
+
+      expect(result.contextIsTrusted).toBe(false);
+      expect(result.toolResultUpdates).toEqual({
+        call_preexisting_untrusted:
+          "[Content blocked by policy: Data blocked by policy: Block hacker emails]",
+      });
+      expect(result.unsafeContextBoundary).toEqual({
+        kind: "preexisting_untrusted",
+        reason: "agent_configured_untrusted",
+      });
+    });
+
     test("handles multiple tool calls with mixed trust", async () => {
       // Create policies
       await TrustedDataPolicyModel.create({

--- a/platform/backend/src/guardrails/trusted-data.ts
+++ b/platform/backend/src/guardrails/trusted-data.ts
@@ -64,23 +64,19 @@ export async function evaluateIfContextIsTrusted(
   let unsafeContextBoundary: UnsafeContextBoundary | undefined;
 
   // If agent configured to consider context untrusted from the beginning,
-  // mark context as untrusted immediately and skip evaluation
+  // mark context as untrusted immediately. Tool result policies still need to
+  // run below so blocked or sanitized tool results are not sent to the model.
   if (considerContextUntrusted) {
     logger.debug(
       { agentId },
       "[trustedData] evaluateIfContextIsTrusted: context marked untrusted by agent config",
     );
-    return {
-      toolResultUpdates: {},
-      contextIsTrusted: false,
-      usedDualLlm: false,
-      dualLlmAnalyses: [],
-      unsafeContextBoundary: {
-        kind: "preexisting_untrusted",
-        reason:
-          initialUntrustedReason ??
-          UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
-      },
+    hasUntrustedData = true;
+    unsafeContextBoundary = {
+      kind: "preexisting_untrusted",
+      reason:
+        initialUntrustedReason ??
+        UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
     };
   }
 
@@ -112,11 +108,11 @@ export async function evaluateIfContextIsTrusted(
   if (allToolCalls.length === 0) {
     logger.debug(
       { agentId },
-      "[trustedData] evaluateIfContextIsTrusted: no tool calls found, context is trusted",
+      "[trustedData] evaluateIfContextIsTrusted: no tool calls found",
     );
     return {
       toolResultUpdates,
-      contextIsTrusted: true,
+      contextIsTrusted: !hasUntrustedData,
       usedDualLlm: false,
       dualLlmAnalyses: [],
       unsafeContextBoundary,


### PR DESCRIPTION
## Summary

Fixes #4225.

/claim #4225

When an agent starts with `considerContextUntrusted`, trusted-data evaluation returned early before processing tool-result policies. That let blocked tool outputs remain unchanged in the request context.

This change preserves the preexisting unsafe context boundary, but continues evaluating tool-result policies so blocked/sanitized results are still applied before the model receives them.

## Tests

```bash
ARCHESTRA_DATABASE_URL=postgres://unit:test@localhost:5432/unit COREPACK_HOME=/Users/poplify/Documents/Codex/2026-05-21/you-are-an-autonomous-ai-agent/.corepack corepack pnpm --filter @backend test src/guardrails/trusted-data.test.ts
```

Result: 1 test file passed, 22 tests passed.

```bash
ARCHESTRA_DATABASE_URL=postgres://unit:test@localhost:5432/unit COREPACK_HOME=/Users/poplify/Documents/Codex/2026-05-21/you-are-an-autonomous-ai-agent/.corepack corepack pnpm exec biome check backend/src/guardrails/trusted-data.ts backend/src/guardrails/trusted-data.test.ts
```

Result: checked 2 files, no fixes applied.
