### PR TITLE
test(mcp-server): capture two reinstall bugs from user reports

### DIFF
--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -1166,6 +1166,112 @@ describe("mcp server inspect route", () => {
     }
   });
 
+  // Bug capture: reinstall of a LOCAL MCP server with a newly-added
+  // prompted plain_text env var stores the user-entered value in the
+  // K8s Secret bag but never updates `mcp_server.environmentValues`.
+  // On the next auto-redeploy (or any subsequent restart),
+  // `startServer` reconstructs the deployment env by:
+  //   1) overlaying `mcp_server.environmentValues` for plain prompted
+  //      values (added in #4709 to fix the install-time gap), and
+  //   2) reading secret-typed values from the install Secret bag.
+  // For plain prompted values added at reinstall time, neither source
+  // has the value: the install row's column was never updated
+  // (this bug), and the secret-typed-only filter at
+  // `manager.ts:226-231` drops plain values when loading from the
+  // Secret bag.
+  //
+  // End-user symptom: admin adds a new required prompted plain_text
+  // env var to a local catalog, clicks Reinstall on their install,
+  // enters the value in the dialog, pod restarts — but the new env
+  // var has no value in the pod (`kubectl exec ... env` shows it
+  // missing). All tool calls relying on the var fail.
+  //
+  // Live-reproduced today on SQL1 (personal install). The team-scope
+  // install on the same catalog had `environmentValues` populated
+  // (created via the install route) and worked correctly — the bug
+  // only bites installs whose subsequent state is touched only by
+  // the reinstall route.
+  //
+  // The mirror of the install-route fix at line 705-723 (build
+  // `installEnvironmentValues` from prompted plain values, persist
+  // via `McpServerModel.update`) is missing from the reinstall
+  // route. Adding it inside the existing
+  // `if (mcpServer.serverType === "local" && (envValues || ucValues))`
+  // block — after the secret update, before `McpServerModel.update(
+  // { localInstallationStatus: "pending" })` — would close this gap.
+  test.fails("[bug] reinstall of a local MCP server persists plain prompted env values into mcp_server.environmentValues", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Local Reinstall Plain Prompted Env",
+      serverType: "local",
+      localConfig: {
+        command: "node",
+        arguments: ["server.js"],
+        environment: [
+          {
+            key: "PROMPTED_PLAIN_VALUE",
+            type: "plain_text",
+            promptOnInstallation: true,
+            required: true,
+          },
+        ],
+        transportType: "streamable-http",
+        httpPort: 8080,
+        httpPath: "/mcp",
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    // Simulate an install row that lacks `environmentValues` for the
+    // newly-added prompted var (mirrors the live-reproduced state on
+    // SQL1's personal install, which had `environment_values = {}`).
+    await db
+      .update(schema.mcpServersTable)
+      .set({ environmentValues: {} })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: {
+        environmentValues: {
+          PROMPTED_PLAIN_VALUE: "user-entered-at-reinstall",
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const [updatedServer] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+    expect(updatedServer?.environmentValues).toMatchObject({
+      PROMPTED_PLAIN_VALUE: "user-entered-at-reinstall",
+    });
+
+    // Drain the route's setImmediate-deferred reinstall (same
+    // hygiene pattern as the bug-1 test above).
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const [serverRow] = await db
+        .select()
+        .from(schema.mcpServersTable)
+        .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+      if (serverRow?.localInstallationStatus !== "pending") {
+        break;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  });
+
   test("automatically retries protected remote MCP server installation with an exchanged enterprise-managed credential", async ({
     makeAccount,
     makeIdentityProvider,

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -1061,6 +1061,111 @@ describe("mcp server inspect route", () => {
     expect(connectAndGetToolsMock).not.toHaveBeenCalled();
   });
 
+  // Bug capture: reinstall of a REMOTE MCP server does not persist
+  // `userConfigValues` from the request body. The route's value-
+  // persistence branch in `backend/src/routes/mcp-server.ts:1598-1602`
+  // is gated on `mcpServer.serverType === "local"` — for remote
+  // installs, the body's `userConfigValues` is silently dropped and
+  // the secret is never updated. End-user symptom: admin edits a
+  // remote catalog to add a new required header, clicks Reinstall,
+  // the pod restarts but the new header has no value, all tool calls
+  // start failing 401/403.
+  //
+  // Mirrors the existing local-server test
+  // ("reinstalls a local MCP server with prompted header user config")
+  // and the remote-reauth test
+  // ("re-authenticates a remote MCP server with provided user config values")
+  // both of which persist values correctly via their respective code
+  // paths. Reinstall-on-remote is the missing third case.
+  //
+  // Marked `test.fails` because the assertion is the correct behavior
+  // the route should have. When the bug is fixed, this test will pass
+  // and Vitest will fail with "test was expected to fail, but passed"
+  // — that's the cue to remove the `test.fails` marker.
+  test.fails("[bug] reinstall of a remote MCP server persists userConfigValues into the install's secret", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Remote Reinstall With New Required Header",
+      serverType: "remote",
+      serverUrl: "http://localhost:30082/mcp",
+      userConfig: {
+        header_x_api_key: {
+          type: "string",
+          title: "x-api-key",
+          description: "Newly-required header added on a catalog edit",
+          promptOnInstallation: true,
+          required: true,
+          sensitive: true,
+          headerName: "x-api-key",
+        },
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    // makeMcpServer hardcodes `serverType: "local"`. The route gates its
+    // value-persistence branch on the install row's serverType, not the
+    // catalog's, so we have to force it here for the bug to actually
+    // reproduce. Without this update the install is treated as local
+    // and the local branch persists the value — the bug doesn't appear.
+    await db
+      .update(schema.mcpServersTable)
+      .set({ serverType: "remote" })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: {
+        userConfigValues: {
+          header_x_api_key: "fresh-header-value",
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const [updatedServer] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+    expect(updatedServer?.secretId).toBeTruthy();
+    if (!updatedServer?.secretId) {
+      throw new Error("Expected reinstall to persist a secretId");
+    }
+
+    const storedSecret = await secretManager().getSecret(
+      updatedServer.secretId,
+    );
+    expect(storedSecret?.secret).toMatchObject({
+      header_x_api_key: "fresh-header-value",
+    });
+
+    // Drain the route's setImmediate-deferred reinstall so background
+    // work doesn't leak into the next test in the file. The local-
+    // reinstall test above uses 200ms total, but the remote path runs
+    // autoReinstallServer with a tool-fetch that takes longer when
+    // mocks aren't pre-primed — give it 2s so we don't leak a
+    // "pending" install whose async error fires inside the next test.
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const [serverRow] = await db
+        .select()
+        .from(schema.mcpServersTable)
+        .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+      if (serverRow?.localInstallationStatus !== "pending") {
+        break;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  });
+
   test("automatically retries protected remote MCP server installation with an exchanged enterprise-managed credential", async ({
     makeAccount,
     makeIdentityProvider,


### PR DESCRIPTION
**Draft.** Two `test.fails`-marked integration tests documenting two distinct bugs in the MCP server reinstall flow, both reported by the same user in the same end-user scenario.

No code fix — just failing tests that assert the correct behavior, so each bug shows up as a known issue in test output (`2 expected fail`). When someone fixes either route, the corresponding test will start passing and Vitest will report "expected to fail, but passed" — that's the cue to remove the `test.fails` marker.

---

### Bug 1 — remote reinstall drops `userConfigValues`

**Scenario.** Admin adds a new required header to a *remote* MCP catalog → cascade fires manual mode → admin clicks Reinstall → pod restarts but the new header has no value in transit, all tool calls start failing 401/403.

**Root cause.** `backend/src/routes/mcp-server.ts:1598-1602` gates the value-persistence branch on `mcpServer.serverType === "local"`. For remote installs the body's `userConfigValues` is silently dropped, no secret update happens. The route still triggers `autoReinstallServer` via `setImmediate`, so the pod *does* restart — just without the new value.

**Also broken on the frontend side:** `frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx:1054-1057` unconditionally opens the simple confirmation dialog for remote, regardless of whether a new prompted field needs collecting. So the user never gets a chance to type the value either.

Test: `[bug] reinstall of a remote MCP server persists userConfigValues into the install's secret`

---

### Bug 2 — local reinstall drops plain prompted env values

**Scenario.** Admin adds a new required prompted `plain_text` env var to a *local* MCP catalog → admin clicks Reinstall → enters value in the dialog → pod restarts but `kubectl exec ... env` shows the new var missing.

**Root cause.** The install route at `mcp-server.ts:705-723` correctly persists plain prompted values into `mcp_server.environmentValues` (added in PR #4709, commit `f9b52924a`). The reinstall route at `mcp-server.ts:1598-1722` was not updated with the same logic — plain prompted values entered at reinstall time go ONLY into the install Secret bag. Then on the subsequent restart, `manager.ts:226-231`'s `.filter((e) => e.type === "secret")` drops plain values when reloading from the bag, and `mcp_server.environmentValues` (the other source) is empty. End result: the value is persisted SOMEWHERE but never makes it to the pod.

**Live-reproduced today on SQL1.** Two installs of the same catalog: the team-scope install (created via the install route) had `environment_values` correctly populated and worked. The personal install (whose state was touched only by the reinstall route) had `environment_values = {}` and showed the bug — pod env had only `DB_PASSWORD` (the original install's secret-typed var) after a reinstall with multiple plain prompted values entered.

Test: `[bug] reinstall of a local MCP server persists plain prompted env values into mcp_server.environmentValues`

---

### Why two PRs are needed eventually

Bug 1's fix is multi-file: route persistence branch on `mcp-server.ts:1598`, frontend dialog routing for remote, possibly an `isReinstall` mode on `remote-server-install-dialog.tsx`. Bug 2's fix is a tight mirror of `mcp-server.ts:705-723` placed inside the existing local reinstall block. Separate concerns, separate PRs — but the tests live together here because they both document failures in the same user-reported reinstall flow.

### Test-hygiene notes folded into each test

1. `makeMcpServer` hardcodes `serverType: "local"` and doesn't expose it as an override. The Bug 1 test has to `db.update` to force `serverType: "remote"` after the fixture creates it — without this, the bug doesn't reproduce because the install gets treated as local.

2. The reinstall route fires `autoReinstallServer` via `setImmediate` and returns 200 immediately. Both tests use the same polling loop pattern as the existing local-reinstall tests to drain background work — without it, the next test in the file inherits a "pending" install whose async error fires inside it, causing unrelated tests to fail intermittently.

### Verification

`pnpm vitest run src/routes/mcp-server.test.ts` reports `44 passed | 2 expected fail` — both new tests correctly fail their assertions (good — the bugs exist), `test.fails` marks them as expected, no inter-test pollution.
