### PR TITLE
fix(mcp-server): persist & validate prompted env values on local-server reinstall

### DIFF
--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -66,6 +66,28 @@ vi.mock("@/k8s/mcp-server-runtime", () => ({
   },
 }));
 
+// Wait for the reinstall route's `setImmediate`-scheduled background work
+// to flip the install row off "pending". Fails the test if it doesn't —
+// without this assertion a stalled async reinstall would exit the polling
+// loop silently and leak into the next test in the file.
+async function drainPendingReinstall(mcpServerId: string): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const [serverRow] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServerId));
+
+    if (serverRow?.localInstallationStatus !== "pending") {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(
+    `drainPendingReinstall(${mcpServerId}) timed out after 2s — background reinstall did not complete`,
+  );
+}
+
 describe("mcp server inspect route", () => {
   let app: FastifyInstanceWithZod;
   let user: User;
@@ -1133,18 +1155,7 @@ describe("mcp server inspect route", () => {
     // autoReinstallServer with a tool-fetch that takes longer when
     // mocks aren't pre-primed — give it 2s so we don't leak a
     // "pending" install whose async error fires inside the next test.
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      const [serverRow] = await db
-        .select()
-        .from(schema.mcpServersTable)
-        .where(eq(schema.mcpServersTable.id, mcpServer.id));
-
-      if (serverRow?.localInstallationStatus !== "pending") {
-        break;
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 20));
-    }
+    await drainPendingReinstall(mcpServer.id);
   });
 
   // Regression: reinstall of a local MCP server with a newly-added prompted
@@ -1208,18 +1219,7 @@ describe("mcp server inspect route", () => {
       PROMPTED_PLAIN_VALUE: "user-entered-at-reinstall",
     });
 
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      const [serverRow] = await db
-        .select()
-        .from(schema.mcpServersTable)
-        .where(eq(schema.mcpServersTable.id, mcpServer.id));
-
-      if (serverRow?.localInstallationStatus !== "pending") {
-        break;
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 20));
-    }
+    await drainPendingReinstall(mcpServer.id);
   });
 
   // Regression: the install dialog drops empty fields before submitting,
@@ -1287,18 +1287,7 @@ describe("mcp server inspect route", () => {
       NEW_REQUIRED_VAR: "user-fills-only-this",
     });
 
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      const [serverRow] = await db
-        .select()
-        .from(schema.mcpServersTable)
-        .where(eq(schema.mcpServersTable.id, mcpServer.id));
-
-      if (serverRow?.localInstallationStatus !== "pending") {
-        break;
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 20));
-    }
+    await drainPendingReinstall(mcpServer.id);
   });
 
   // Required plain env vars already on the row are satisfied by the merged
@@ -1363,17 +1352,7 @@ describe("mcp server inspect route", () => {
       NEW_REQUIRED: "user-fills-only-this",
     });
 
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      const [serverRow] = await db
-        .select()
-        .from(schema.mcpServersTable)
-        .where(eq(schema.mcpServersTable.id, mcpServer.id));
-
-      if (serverRow?.localInstallationStatus !== "pending") {
-        break;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 20));
-    }
+    await drainPendingReinstall(mcpServer.id);
   });
 
   // An explicit empty string for a prompted plain key clears it from the
@@ -1427,17 +1406,7 @@ describe("mcp server inspect route", () => {
 
     expect(updatedServer?.environmentValues).toEqual({});
 
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      const [serverRow] = await db
-        .select()
-        .from(schema.mcpServersTable)
-        .where(eq(schema.mcpServersTable.id, mcpServer.id));
-
-      if (serverRow?.localInstallationStatus !== "pending") {
-        break;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 20));
-    }
+    await drainPendingReinstall(mcpServer.id);
   });
 
   test("automatically retries protected remote MCP server installation with an exchanged enterprise-managed credential", async ({

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -1222,6 +1222,85 @@ describe("mcp server inspect route", () => {
     }
   });
 
+  // Regression: the install dialog drops empty fields before submitting,
+  // so a partial reinstall (user fills only the new prompted var, leaves
+  // the others blank because the dialog doesn't pre-fill from the row)
+  // must not erase entries already on `environmentValues`.
+  test("reinstall preserves existing plain env values that the request body did not carry", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Local Reinstall Partial Submission",
+      serverType: "local",
+      localConfig: {
+        command: "node",
+        arguments: ["server.js"],
+        environment: [
+          {
+            key: "EXISTING_VAR",
+            type: "plain_text",
+            promptOnInstallation: true,
+            required: false,
+          },
+          {
+            key: "NEW_REQUIRED_VAR",
+            type: "plain_text",
+            promptOnInstallation: true,
+            required: true,
+          },
+        ],
+        transportType: "streamable-http",
+        httpPort: 8080,
+        httpPath: "/mcp",
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    await db
+      .update(schema.mcpServersTable)
+      .set({ environmentValues: { EXISTING_VAR: "set-at-original-install" } })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: {
+        environmentValues: {
+          NEW_REQUIRED_VAR: "user-fills-only-this",
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const [updatedServer] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+    expect(updatedServer?.environmentValues).toMatchObject({
+      EXISTING_VAR: "set-at-original-install",
+      NEW_REQUIRED_VAR: "user-fills-only-this",
+    });
+
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const [serverRow] = await db
+        .select()
+        .from(schema.mcpServersTable)
+        .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+      if (serverRow?.localInstallationStatus !== "pending") {
+        break;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  });
+
   test("automatically retries protected remote MCP server installation with an exchanged enterprise-managed credential", async ({
     makeAccount,
     makeIdentityProvider,

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -1301,6 +1301,145 @@ describe("mcp server inspect route", () => {
     }
   });
 
+  // Required plain env vars already on the row are satisfied by the merged
+  // effective state — without this, a partial reinstall would 400 before
+  // the merge path could preserve the stored value.
+  test("reinstall accepts a body that omits required plain env vars already on the install row", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Local Reinstall Required From Row",
+      serverType: "local",
+      localConfig: {
+        command: "node",
+        arguments: ["server.js"],
+        environment: [
+          {
+            key: "EXISTING_REQUIRED",
+            type: "plain_text",
+            promptOnInstallation: true,
+            required: true,
+          },
+          {
+            key: "NEW_REQUIRED",
+            type: "plain_text",
+            promptOnInstallation: true,
+            required: true,
+          },
+        ],
+        transportType: "streamable-http",
+        httpPort: 8080,
+        httpPath: "/mcp",
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    await db
+      .update(schema.mcpServersTable)
+      .set({ environmentValues: { EXISTING_REQUIRED: "row-value" } })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: {
+        environmentValues: { NEW_REQUIRED: "user-fills-only-this" },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const [updatedServer] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+    expect(updatedServer?.environmentValues).toMatchObject({
+      EXISTING_REQUIRED: "row-value",
+      NEW_REQUIRED: "user-fills-only-this",
+    });
+
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const [serverRow] = await db
+        .select()
+        .from(schema.mcpServersTable)
+        .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+      if (serverRow?.localInstallationStatus !== "pending") {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  });
+
+  // An explicit empty string for a prompted plain key clears it from the
+  // row. Distinguishes "user wants to delete this value" from "user didn't
+  // touch this field" (the latter signaled by omitting the key entirely).
+  test("reinstall body with empty string for a plain env key clears that entry", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Local Reinstall Clear Via Empty String",
+      serverType: "local",
+      localConfig: {
+        command: "node",
+        arguments: ["server.js"],
+        environment: [
+          {
+            key: "OPTIONAL_PLAIN",
+            type: "plain_text",
+            promptOnInstallation: true,
+            required: false,
+          },
+        ],
+        transportType: "streamable-http",
+        httpPort: 8080,
+        httpPath: "/mcp",
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    await db
+      .update(schema.mcpServersTable)
+      .set({ environmentValues: { OPTIONAL_PLAIN: "to-be-cleared" } })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: { environmentValues: { OPTIONAL_PLAIN: "" } },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const [updatedServer] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+    expect(updatedServer?.environmentValues).toEqual({});
+
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const [serverRow] = await db
+        .select()
+        .from(schema.mcpServersTable)
+        .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+      if (serverRow?.localInstallationStatus !== "pending") {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  });
+
   test("automatically retries protected remote MCP server installation with an exchanged enterprise-managed credential", async ({
     makeAccount,
     makeIdentityProvider,

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -1147,6 +1147,81 @@ describe("mcp server inspect route", () => {
     }
   });
 
+  // Regression: reinstall of a local MCP server with a newly-added prompted
+  // plain_text env var used to land the value only in the K8s secret bag.
+  // On the next pod start, the secret-typed-only filter at manager.ts:226
+  // dropped it, and the install row's `environmentValues` column was empty,
+  // so neither source carried the value into the pod env.
+  test("reinstall of a local MCP server persists plain prompted env values into mcp_server.environmentValues", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Local Reinstall Plain Prompted Env",
+      serverType: "local",
+      localConfig: {
+        command: "node",
+        arguments: ["server.js"],
+        environment: [
+          {
+            key: "PROMPTED_PLAIN_VALUE",
+            type: "plain_text",
+            promptOnInstallation: true,
+            required: true,
+          },
+        ],
+        transportType: "streamable-http",
+        httpPort: 8080,
+        httpPath: "/mcp",
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    // Simulate the install state from before the catalog edit added the
+    // new prompted var (its environmentValues column has no entry for it).
+    await db
+      .update(schema.mcpServersTable)
+      .set({ environmentValues: {} })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: {
+        environmentValues: {
+          PROMPTED_PLAIN_VALUE: "user-entered-at-reinstall",
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const [updatedServer] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+    expect(updatedServer?.environmentValues).toMatchObject({
+      PROMPTED_PLAIN_VALUE: "user-entered-at-reinstall",
+    });
+
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const [serverRow] = await db
+        .select()
+        .from(schema.mcpServersTable)
+        .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+      if (serverRow?.localInstallationStatus !== "pending") {
+        break;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  });
+
   test("automatically retries protected remote MCP server installation with an exchanged enterprise-managed credential", async ({
     makeAccount,
     makeIdentityProvider,

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -1360,6 +1360,77 @@ describe("mcp server inspect route", () => {
     await drainPendingReinstall(mcpServer.id);
   });
 
+  // Same shape as the plain-env case above but for secret-typed required
+  // env vars: a partial reinstall body shouldn't be rejected when the
+  // missing secret is already on the install's secret bag.
+  test("reinstall accepts a body that omits required secret env vars already on the install's secret bag", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Local Reinstall Required Secret From Bag",
+      serverType: "local",
+      localConfig: {
+        command: "node",
+        arguments: ["server.js"],
+        environment: [
+          {
+            key: "EXISTING_SECRET",
+            type: "secret",
+            promptOnInstallation: true,
+            required: true,
+          },
+          {
+            key: "NEW_REQUIRED",
+            type: "plain_text",
+            promptOnInstallation: true,
+            required: true,
+          },
+        ],
+        transportType: "streamable-http",
+        httpPort: 8080,
+        httpPath: "/mcp",
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    const existingBag = await secretManager().createSecret(
+      { EXISTING_SECRET: "in-the-bag" },
+      `${mcpServer.name}-existing-bag`,
+    );
+    await db
+      .update(schema.mcpServersTable)
+      .set({ secretId: existingBag.id })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: {
+        environmentValues: { NEW_REQUIRED: "user-fills-only-the-new-one" },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const [updatedServer] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    const storedSecret = await secretManager().getSecret(
+      updatedServer.secretId!,
+    );
+    expect(storedSecret?.secret).toMatchObject({
+      EXISTING_SECRET: "in-the-bag",
+      NEW_REQUIRED: "user-fills-only-the-new-one",
+    });
+
+    await drainPendingReinstall(mcpServer.id);
+  });
+
   // An explicit empty string for a prompted plain key clears it from the
   // row. Distinguishes "user wants to delete this value" from "user didn't
   // touch this field" (the latter signaled by omitting the key entirely).

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -77,7 +77,12 @@ async function drainPendingReinstall(mcpServerId: string): Promise<void> {
       .from(schema.mcpServersTable)
       .where(eq(schema.mcpServersTable.id, mcpServerId));
 
-    if (serverRow?.localInstallationStatus !== "pending") {
+    if (!serverRow) {
+      throw new Error(
+        `drainPendingReinstall(${mcpServerId}): mcp_server row not found`,
+      );
+    }
+    if (serverRow.localInstallationStatus !== "pending") {
       return;
     }
 

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -1486,6 +1486,227 @@ describe("mcp server inspect route", () => {
     await drainPendingReinstall(mcpServer.id);
   });
 
+  // A whitespace-only submission for a required secret passes validation via
+  // the existing-bag fallback; it must not then overwrite the stored secret
+  // with whitespace, leaving the restarted server with broken credentials.
+  test("reinstall ignores a whitespace-only secret submission and keeps the stored secret", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Local Reinstall Whitespace Secret",
+      serverType: "local",
+      localConfig: {
+        command: "node",
+        arguments: ["server.js"],
+        environment: [
+          {
+            key: "API_SECRET",
+            type: "secret",
+            promptOnInstallation: true,
+            required: true,
+          },
+        ],
+        transportType: "streamable-http",
+        httpPort: 8080,
+        httpPath: "/mcp",
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    const existingBag = await secretManager().createSecret(
+      { API_SECRET: "valid-credential" },
+      `${mcpServer.name}-existing-bag`,
+    );
+    await db
+      .update(schema.mcpServersTable)
+      .set({ secretId: existingBag.id })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: { environmentValues: { API_SECRET: "   " } },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const [updatedServer] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    const storedSecret = await secretManager().getSecret(
+      updatedServer.secretId!,
+    );
+    expect(storedSecret?.secret).toMatchObject({
+      API_SECRET: "valid-credential",
+    });
+
+    await drainPendingReinstall(mcpServer.id);
+  });
+
+  // The plain-env column is rebuilt from the catalog's current plain prompted
+  // keys, so a var removed from the catalog or flipped to secret-typed can't
+  // survive as stale plaintext in the column (and thus in the pod env via the
+  // unconditional overlay).
+  test("reinstall prunes column keys no longer plain-prompted in the catalog", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Local Reinstall Prune Stale Column",
+      serverType: "local",
+      localConfig: {
+        command: "node",
+        arguments: ["server.js"],
+        environment: [
+          {
+            key: "KEPT_PLAIN",
+            type: "plain_text",
+            promptOnInstallation: true,
+            required: false,
+          },
+          {
+            key: "FLIPPED_TO_SECRET",
+            type: "secret",
+            promptOnInstallation: true,
+            required: false,
+          },
+        ],
+        transportType: "streamable-http",
+        httpPort: 8080,
+        httpPath: "/mcp",
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    await db
+      .update(schema.mcpServersTable)
+      .set({
+        environmentValues: {
+          KEPT_PLAIN: "old",
+          FLIPPED_TO_SECRET: "stale-plaintext",
+          REMOVED_FROM_CATALOG: "orphan",
+        },
+      })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: { environmentValues: { KEPT_PLAIN: "new" } },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const [updatedServer] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+    expect(updatedServer?.environmentValues).toEqual({ KEPT_PLAIN: "new" });
+
+    await drainPendingReinstall(mcpServer.id);
+  });
+
+  // Required-env validation runs even when the reinstall body is empty, so a
+  // newly-added required var that nothing satisfies fails fast with 400
+  // instead of only breaking later at pod start.
+  test("reinstall with an empty body 400s when a newly-added required env var is unsatisfied", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Local Reinstall Empty Body Missing Required",
+      serverType: "local",
+      localConfig: {
+        command: "node",
+        arguments: ["server.js"],
+        environment: [
+          {
+            key: "NEWLY_REQUIRED",
+            type: "plain_text",
+            promptOnInstallation: true,
+            required: true,
+          },
+        ],
+        transportType: "streamable-http",
+        httpPort: 8080,
+        httpPath: "/mcp",
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    await db
+      .update(schema.mcpServersTable)
+      .set({ environmentValues: {} })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: { environmentValues: {} },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error.message).toContain("NEWLY_REQUIRED");
+  });
+
+  // The hoisted validation must not over-reject: an empty body still succeeds
+  // when the required var is already satisfied on the install row.
+  test("reinstall with an empty body succeeds when required env vars are already on the row", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Local Reinstall Empty Body Satisfied",
+      serverType: "local",
+      localConfig: {
+        command: "node",
+        arguments: ["server.js"],
+        environment: [
+          {
+            key: "ALREADY_SET",
+            type: "plain_text",
+            promptOnInstallation: true,
+            required: true,
+          },
+        ],
+        transportType: "streamable-http",
+        httpPort: 8080,
+        httpPath: "/mcp",
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    await db
+      .update(schema.mcpServersTable)
+      .set({ environmentValues: { ALREADY_SET: "from-original-install" } })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: { environmentValues: {} },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    await drainPendingReinstall(mcpServer.id);
+  });
+
   test("installs a protected remote MCP server with an exchanged enterprise-managed credential on first discovery", async ({
     makeAccount,
     makeIdentityProvider,

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -1361,6 +1361,77 @@ describe("mcp server inspect route", () => {
     await drainPendingReinstall(mcpServer.id);
   });
 
+  // Same shape as the plain-env case above but for secret-typed required
+  // env vars: a partial reinstall body shouldn't be rejected when the
+  // missing secret is already on the install's secret bag.
+  test("reinstall accepts a body that omits required secret env vars already on the install's secret bag", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Local Reinstall Required Secret From Bag",
+      serverType: "local",
+      localConfig: {
+        command: "node",
+        arguments: ["server.js"],
+        environment: [
+          {
+            key: "EXISTING_SECRET",
+            type: "secret",
+            promptOnInstallation: true,
+            required: true,
+          },
+          {
+            key: "NEW_REQUIRED",
+            type: "plain_text",
+            promptOnInstallation: true,
+            required: true,
+          },
+        ],
+        transportType: "streamable-http",
+        httpPort: 8080,
+        httpPath: "/mcp",
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    const existingBag = await secretManager().createSecret(
+      { EXISTING_SECRET: "in-the-bag" },
+      `${mcpServer.name}-existing-bag`,
+    );
+    await db
+      .update(schema.mcpServersTable)
+      .set({ secretId: existingBag.id })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: {
+        environmentValues: { NEW_REQUIRED: "user-fills-only-the-new-one" },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const [updatedServer] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    const storedSecret = await secretManager().getSecret(
+      updatedServer.secretId!,
+    );
+    expect(storedSecret?.secret).toMatchObject({
+      EXISTING_SECRET: "in-the-bag",
+      NEW_REQUIRED: "user-fills-only-the-new-one",
+    });
+
+    await drainPendingReinstall(mcpServer.id);
+  });
+
   // An explicit empty string for a prompted plain key clears it from the
   // row. Distinguishes "user wants to delete this value" from "user didn't
   // touch this field" (the latter signaled by omitting the key entirely).

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -1302,6 +1302,145 @@ describe("mcp server inspect route", () => {
     }
   });
 
+  // Required plain env vars already on the row are satisfied by the merged
+  // effective state — without this, a partial reinstall would 400 before
+  // the merge path could preserve the stored value.
+  test("reinstall accepts a body that omits required plain env vars already on the install row", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Local Reinstall Required From Row",
+      serverType: "local",
+      localConfig: {
+        command: "node",
+        arguments: ["server.js"],
+        environment: [
+          {
+            key: "EXISTING_REQUIRED",
+            type: "plain_text",
+            promptOnInstallation: true,
+            required: true,
+          },
+          {
+            key: "NEW_REQUIRED",
+            type: "plain_text",
+            promptOnInstallation: true,
+            required: true,
+          },
+        ],
+        transportType: "streamable-http",
+        httpPort: 8080,
+        httpPath: "/mcp",
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    await db
+      .update(schema.mcpServersTable)
+      .set({ environmentValues: { EXISTING_REQUIRED: "row-value" } })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: {
+        environmentValues: { NEW_REQUIRED: "user-fills-only-this" },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const [updatedServer] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+    expect(updatedServer?.environmentValues).toMatchObject({
+      EXISTING_REQUIRED: "row-value",
+      NEW_REQUIRED: "user-fills-only-this",
+    });
+
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const [serverRow] = await db
+        .select()
+        .from(schema.mcpServersTable)
+        .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+      if (serverRow?.localInstallationStatus !== "pending") {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  });
+
+  // An explicit empty string for a prompted plain key clears it from the
+  // row. Distinguishes "user wants to delete this value" from "user didn't
+  // touch this field" (the latter signaled by omitting the key entirely).
+  test("reinstall body with empty string for a plain env key clears that entry", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Local Reinstall Clear Via Empty String",
+      serverType: "local",
+      localConfig: {
+        command: "node",
+        arguments: ["server.js"],
+        environment: [
+          {
+            key: "OPTIONAL_PLAIN",
+            type: "plain_text",
+            promptOnInstallation: true,
+            required: false,
+          },
+        ],
+        transportType: "streamable-http",
+        httpPort: 8080,
+        httpPath: "/mcp",
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    await db
+      .update(schema.mcpServersTable)
+      .set({ environmentValues: { OPTIONAL_PLAIN: "to-be-cleared" } })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: { environmentValues: { OPTIONAL_PLAIN: "" } },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const [updatedServer] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+    expect(updatedServer?.environmentValues).toEqual({});
+
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const [serverRow] = await db
+        .select()
+        .from(schema.mcpServersTable)
+        .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+      if (serverRow?.localInstallationStatus !== "pending") {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  });
+
   test("installs a protected remote MCP server with an exchanged enterprise-managed credential on first discovery", async ({
     makeAccount,
     makeIdentityProvider,

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -1662,8 +1662,10 @@ describe("mcp server inspect route", () => {
   });
 
   // The hoisted validation must not over-reject: an empty body still succeeds
-  // when the required var is already satisfied on the install row.
-  test("reinstall with an empty body succeeds when required env vars are already on the row", async ({
+  // when the required var is already satisfied on the install row. The column
+  // is also rebuilt on an empty body, so a stale key left by a catalog edit is
+  // pruned even when the (auto-cascade) reinstall carries no values.
+  test("reinstall with an empty body succeeds and prunes stale column keys", async ({
     makeInternalMcpCatalog,
     makeMcpServer,
   }) => {
@@ -1692,7 +1694,12 @@ describe("mcp server inspect route", () => {
     });
     await db
       .update(schema.mcpServersTable)
-      .set({ environmentValues: { ALREADY_SET: "from-original-install" } })
+      .set({
+        environmentValues: {
+          ALREADY_SET: "from-original-install",
+          REMOVED_FROM_CATALOG: "orphan",
+        },
+      })
       .where(eq(schema.mcpServersTable.id, mcpServer.id));
     await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
 
@@ -1703,6 +1710,15 @@ describe("mcp server inspect route", () => {
     });
 
     expect(response.statusCode).toBe(200);
+
+    const [updatedServer] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+    expect(updatedServer?.environmentValues).toEqual({
+      ALREADY_SET: "from-original-install",
+    });
 
     await drainPendingReinstall(mcpServer.id);
   });

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -1223,6 +1223,85 @@ describe("mcp server inspect route", () => {
     }
   });
 
+  // Regression: the install dialog drops empty fields before submitting,
+  // so a partial reinstall (user fills only the new prompted var, leaves
+  // the others blank because the dialog doesn't pre-fill from the row)
+  // must not erase entries already on `environmentValues`.
+  test("reinstall preserves existing plain env values that the request body did not carry", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Local Reinstall Partial Submission",
+      serverType: "local",
+      localConfig: {
+        command: "node",
+        arguments: ["server.js"],
+        environment: [
+          {
+            key: "EXISTING_VAR",
+            type: "plain_text",
+            promptOnInstallation: true,
+            required: false,
+          },
+          {
+            key: "NEW_REQUIRED_VAR",
+            type: "plain_text",
+            promptOnInstallation: true,
+            required: true,
+          },
+        ],
+        transportType: "streamable-http",
+        httpPort: 8080,
+        httpPath: "/mcp",
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    await db
+      .update(schema.mcpServersTable)
+      .set({ environmentValues: { EXISTING_VAR: "set-at-original-install" } })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: {
+        environmentValues: {
+          NEW_REQUIRED_VAR: "user-fills-only-this",
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const [updatedServer] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+    expect(updatedServer?.environmentValues).toMatchObject({
+      EXISTING_VAR: "set-at-original-install",
+      NEW_REQUIRED_VAR: "user-fills-only-this",
+    });
+
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const [serverRow] = await db
+        .select()
+        .from(schema.mcpServersTable)
+        .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+      if (serverRow?.localInstallationStatus !== "pending") {
+        break;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  });
+
   test("installs a protected remote MCP server with an exchanged enterprise-managed credential on first discovery", async ({
     makeAccount,
     makeIdentityProvider,

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -1148,6 +1148,81 @@ describe("mcp server inspect route", () => {
     }
   });
 
+  // Regression: reinstall of a local MCP server with a newly-added prompted
+  // plain_text env var used to land the value only in the K8s secret bag.
+  // On the next pod start, the secret-typed-only filter dropped it, and the
+  // install row's `environmentValues` column was empty, so neither source
+  // carried the value into the pod env.
+  test("reinstall of a local MCP server persists plain prompted env values into mcp_server.environmentValues", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Local Reinstall Plain Prompted Env",
+      serverType: "local",
+      localConfig: {
+        command: "node",
+        arguments: ["server.js"],
+        environment: [
+          {
+            key: "PROMPTED_PLAIN_VALUE",
+            type: "plain_text",
+            promptOnInstallation: true,
+            required: true,
+          },
+        ],
+        transportType: "streamable-http",
+        httpPort: 8080,
+        httpPath: "/mcp",
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    // Simulate the install state from before the catalog edit added the
+    // new prompted var (its environmentValues column has no entry for it).
+    await db
+      .update(schema.mcpServersTable)
+      .set({ environmentValues: {} })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: {
+        environmentValues: {
+          PROMPTED_PLAIN_VALUE: "user-entered-at-reinstall",
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const [updatedServer] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+    expect(updatedServer?.environmentValues).toMatchObject({
+      PROMPTED_PLAIN_VALUE: "user-entered-at-reinstall",
+    });
+
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const [serverRow] = await db
+        .select()
+        .from(schema.mcpServersTable)
+        .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+      if (serverRow?.localInstallationStatus !== "pending") {
+        break;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  });
+
   test("installs a protected remote MCP server with an exchanged enterprise-managed credential on first discovery", async ({
     makeAccount,
     makeIdentityProvider,

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -78,7 +78,12 @@ async function drainPendingReinstall(mcpServerId: string): Promise<void> {
       .from(schema.mcpServersTable)
       .where(eq(schema.mcpServersTable.id, mcpServerId));
 
-    if (serverRow?.localInstallationStatus !== "pending") {
+    if (!serverRow) {
+      throw new Error(
+        `drainPendingReinstall(${mcpServerId}): mcp_server row not found`,
+      );
+    }
+    if (serverRow.localInstallationStatus !== "pending") {
       return;
     }
 

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -67,6 +67,28 @@ vi.mock("@/k8s/mcp-server-runtime", () => ({
   },
 }));
 
+// Wait for the reinstall route's `setImmediate`-scheduled background work
+// to flip the install row off "pending". Fails the test if it doesn't —
+// without this assertion a stalled async reinstall would exit the polling
+// loop silently and leak into the next test in the file.
+async function drainPendingReinstall(mcpServerId: string): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const [serverRow] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServerId));
+
+    if (serverRow?.localInstallationStatus !== "pending") {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(
+    `drainPendingReinstall(${mcpServerId}) timed out after 2s — background reinstall did not complete`,
+  );
+}
+
 describe("mcp server inspect route", () => {
   let app: FastifyInstanceWithZod;
   let user: User;
@@ -1134,18 +1156,7 @@ describe("mcp server inspect route", () => {
     // autoReinstallServer with a tool-fetch that takes longer when
     // mocks aren't pre-primed — give it 2s so we don't leak a
     // "pending" install whose async error fires inside the next test.
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      const [serverRow] = await db
-        .select()
-        .from(schema.mcpServersTable)
-        .where(eq(schema.mcpServersTable.id, mcpServer.id));
-
-      if (serverRow?.localInstallationStatus !== "pending") {
-        break;
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 20));
-    }
+    await drainPendingReinstall(mcpServer.id);
   });
 
   // Regression: reinstall of a local MCP server with a newly-added prompted
@@ -1209,18 +1220,7 @@ describe("mcp server inspect route", () => {
       PROMPTED_PLAIN_VALUE: "user-entered-at-reinstall",
     });
 
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      const [serverRow] = await db
-        .select()
-        .from(schema.mcpServersTable)
-        .where(eq(schema.mcpServersTable.id, mcpServer.id));
-
-      if (serverRow?.localInstallationStatus !== "pending") {
-        break;
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 20));
-    }
+    await drainPendingReinstall(mcpServer.id);
   });
 
   // Regression: the install dialog drops empty fields before submitting,
@@ -1288,18 +1288,7 @@ describe("mcp server inspect route", () => {
       NEW_REQUIRED_VAR: "user-fills-only-this",
     });
 
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      const [serverRow] = await db
-        .select()
-        .from(schema.mcpServersTable)
-        .where(eq(schema.mcpServersTable.id, mcpServer.id));
-
-      if (serverRow?.localInstallationStatus !== "pending") {
-        break;
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 20));
-    }
+    await drainPendingReinstall(mcpServer.id);
   });
 
   // Required plain env vars already on the row are satisfied by the merged
@@ -1364,17 +1353,7 @@ describe("mcp server inspect route", () => {
       NEW_REQUIRED: "user-fills-only-this",
     });
 
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      const [serverRow] = await db
-        .select()
-        .from(schema.mcpServersTable)
-        .where(eq(schema.mcpServersTable.id, mcpServer.id));
-
-      if (serverRow?.localInstallationStatus !== "pending") {
-        break;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 20));
-    }
+    await drainPendingReinstall(mcpServer.id);
   });
 
   // An explicit empty string for a prompted plain key clears it from the
@@ -1428,17 +1407,7 @@ describe("mcp server inspect route", () => {
 
     expect(updatedServer?.environmentValues).toEqual({});
 
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      const [serverRow] = await db
-        .select()
-        .from(schema.mcpServersTable)
-        .where(eq(schema.mcpServersTable.id, mcpServer.id));
-
-      if (serverRow?.localInstallationStatus !== "pending") {
-        break;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 20));
-    }
+    await drainPendingReinstall(mcpServer.id);
   });
 
   test("installs a protected remote MCP server with an exchanged enterprise-managed credential on first discovery", async ({

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -1607,18 +1607,44 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           userConfig: catalogItem.userConfig,
           userConfigValues,
         });
-        // Validate required environment variables
+        // Build the post-merge plain-env view once: existing column,
+        // overridden by request body, with empty string treated as the
+        // delete signal. Reused below to validate required vars and to
+        // persist back to mcp_server.environmentValues.
+        const mergedPlainEnv: Record<string, string> = {
+          ...(mcpServer.environmentValues ?? {}),
+        };
+        for (const envDef of catalogItem.localConfig?.environment ?? []) {
+          if (envDef.promptOnInstallation && envDef.type !== "secret") {
+            const value = environmentValues?.[envDef.key];
+            if (value === "") {
+              delete mergedPlainEnv[envDef.key];
+            } else if (value !== undefined && value !== null) {
+              mergedPlainEnv[envDef.key] = String(value);
+            }
+          }
+        }
+
+        // Validate required environment variables against the effective
+        // post-merge state for plain types — a required var already on
+        // the row stays satisfied when the body only carries newly-added
+        // vars. Secret-typed required vars are still checked against the
+        // body alone; the existing secret bag is merged below but not
+        // consulted here.
         if (catalogItem.localConfig?.environment) {
           const requiredEnvVars = catalogItem.localConfig.environment.filter(
             (env) => env.promptOnInstallation && env.required,
           );
 
           const missingEnvVars = requiredEnvVars.filter((env) => {
-            const value = environmentValues?.[env.key];
+            const value =
+              env.type === "secret"
+                ? environmentValues?.[env.key]
+                : mergedPlainEnv[env.key];
             if (env.type === "boolean") {
               return !value;
             }
-            return !value?.trim();
+            return typeof value !== "string" || !value.trim();
           });
 
           if (missingEnvVars.length > 0) {
@@ -1720,29 +1746,14 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           "Updated MCP server secrets for reinstall",
         );
 
-        // Persist plain (non-secret) prompted env values onto the install
-        // row's column so startServer can overlay them on every (re)deploy —
-        // the runtime manager's secret-bag reload keeps only secret-typed
-        // keys, so plain values would otherwise vanish on pod restart.
-        //
-        // Merge instead of replace: the install dialog drops empty fields
-        // before submitting, so a partial reinstall (user adds the new
-        // required var, leaves other prompted-plain fields blank because
-        // the dialog doesn't pre-fill them) must not erase keys already
-        // on the row. Only override keys the request actually carried.
-        if (catalogItem.serverType === "local" && environmentValues) {
-          const merged: Record<string, string> = {
-            ...(mcpServer.environmentValues ?? {}),
-          };
-          for (const envDef of catalogItem.localConfig?.environment ?? []) {
-            if (envDef.promptOnInstallation && envDef.type !== "secret") {
-              const value = environmentValues[envDef.key];
-              if (value !== undefined && value !== null && value !== "") {
-                merged[envDef.key] = String(value);
-              }
-            }
-          }
-          await McpServerModel.update(id, { environmentValues: merged });
+        // Persist the merged plain-env view onto the install row's column
+        // so startServer can overlay it on every (re)deploy — the runtime
+        // manager's secret-bag reload keeps only secret-typed keys, so
+        // plain values would otherwise vanish on pod restart.
+        if (catalogItem.serverType === "local") {
+          await McpServerModel.update(id, {
+            environmentValues: mergedPlainEnv,
+          });
         }
       }
 

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -1720,25 +1720,29 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           "Updated MCP server secrets for reinstall",
         );
 
-        // Mirror of the install route's environmentValues persistence
-        // (lines 705-723). Plain (non-secret) prompted env values also
-        // need to land on the install row's column — `startServer`
-        // overlays it on every (re)deploy because the secret-typed-only
-        // filter at manager.ts:226 drops plain values when loading from
-        // the K8s secret bag.
+        // Persist plain (non-secret) prompted env values onto the install
+        // row's column so startServer can overlay them on every (re)deploy
+        // — the secret-typed-only filter at manager.ts:226 drops plain
+        // values when loading from the K8s secret bag.
+        //
+        // Merge instead of replace: the install dialog drops empty fields
+        // before submitting, so a partial reinstall (user adds the new
+        // required var, leaves other prompted-plain fields blank because
+        // the dialog doesn't pre-fill them) must not erase keys already
+        // on the row. Only override keys the request actually carried.
         if (catalogItem.serverType === "local" && environmentValues) {
-          const installEnvironmentValues: Record<string, string> = {};
+          const merged: Record<string, string> = {
+            ...(mcpServer.environmentValues ?? {}),
+          };
           for (const envDef of catalogItem.localConfig?.environment ?? []) {
             if (envDef.promptOnInstallation && envDef.type !== "secret") {
               const value = environmentValues[envDef.key];
               if (value !== undefined && value !== null && value !== "") {
-                installEnvironmentValues[envDef.key] = String(value);
+                merged[envDef.key] = String(value);
               }
             }
           }
-          await McpServerModel.update(id, {
-            environmentValues: installEnvironmentValues,
-          });
+          await McpServerModel.update(id, { environmentValues: merged });
         }
       }
 

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -1721,9 +1721,9 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
         );
 
         // Persist plain (non-secret) prompted env values onto the install
-        // row's column so startServer can overlay them on every (re)deploy
-        // — the secret-typed-only filter at manager.ts:226 drops plain
-        // values when loading from the K8s secret bag.
+        // row's column so startServer can overlay them on every (re)deploy —
+        // the runtime manager's secret-bag reload keeps only secret-typed
+        // keys, so plain values would otherwise vanish on pod restart.
         //
         // Merge instead of replace: the install dialog drops empty fields
         // before submitting, so a partial reinstall (user adds the new

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -1719,6 +1719,27 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           },
           "Updated MCP server secrets for reinstall",
         );
+
+        // Mirror of the install route's environmentValues persistence
+        // (lines 705-723). Plain (non-secret) prompted env values also
+        // need to land on the install row's column — `startServer`
+        // overlays it on every (re)deploy because the secret-typed-only
+        // filter at manager.ts:226 drops plain values when loading from
+        // the K8s secret bag.
+        if (catalogItem.serverType === "local" && environmentValues) {
+          const installEnvironmentValues: Record<string, string> = {};
+          for (const envDef of catalogItem.localConfig?.environment ?? []) {
+            if (envDef.promptOnInstallation && envDef.type !== "secret") {
+              const value = environmentValues[envDef.key];
+              if (value !== undefined && value !== null && value !== "") {
+                installEnvironmentValues[envDef.key] = String(value);
+              }
+            }
+          }
+          await McpServerModel.update(id, {
+            environmentValues: installEnvironmentValues,
+          });
+        }
       }
 
       // Update service account if provided

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -1625,22 +1625,41 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           }
         }
 
-        // Validate required environment variables against the effective
-        // post-merge state for plain types — a required var already on
-        // the row stays satisfied when the body only carries newly-added
-        // vars. Secret-typed required vars are still checked against the
-        // body alone; the existing secret bag is merged below but not
-        // consulted here.
+        // Fetch the existing secret bag once so validation below and the
+        // non-BYOS merge can both consult it. BYOS replaces the bag
+        // wholesale (vault references are re-supplied per request), so it
+        // doesn't need the existing state.
+        const existingSecrets: Record<string, unknown> =
+          !isByosVault && mcpServer.secretId
+            ? ((await secretManager().getSecret(mcpServer.secretId))?.secret ??
+              {})
+            : {};
+
+        // Validate required env vars against the effective post-merge state.
+        // Plain types come from `mergedPlainEnv` (column + body, empty =
+        // clear). Secret types in non-BYOS mode are satisfied by the existing
+        // bag if the body omits them; BYOS still requires the body alone.
         if (catalogItem.localConfig?.environment) {
           const requiredEnvVars = catalogItem.localConfig.environment.filter(
             (env) => env.promptOnInstallation && env.required,
           );
 
           const missingEnvVars = requiredEnvVars.filter((env) => {
-            const value =
-              env.type === "secret"
-                ? environmentValues?.[env.key]
-                : mergedPlainEnv[env.key];
+            if (env.type === "secret") {
+              const submitted = environmentValues?.[env.key];
+              if (isByosVault) {
+                return !submitted?.trim();
+              }
+              if (submitted === "") {
+                return true;
+              }
+              if (typeof submitted === "string" && submitted.trim()) {
+                return false;
+              }
+              const existing = existingSecrets[env.key];
+              return typeof existing !== "string" || !existing.trim();
+            }
+            const value = mergedPlainEnv[env.key];
             if (env.type === "boolean") {
               return !value;
             }
@@ -1710,12 +1729,8 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
             await McpServerModel.update(id, { secretId: secret.id });
           }
         } else {
-          // Non-BYOS mode: merge new values with existing secret
-          const existingSecrets = mcpServer.secretId
-            ? (await secretManager().getSecret(mcpServer.secretId))?.secret ||
-              {}
-            : {};
-
+          // Non-BYOS mode: merge new values with the existing bag fetched
+          // above for validation.
           const mergedSecrets = {
             ...existingSecrets,
             ...catalogStaticUserConfigValues,

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -1774,6 +1774,17 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
         }
       }
 
+      // Persist the merged plain-env view onto the install row's column so
+      // startServer can overlay it on every (re)deploy — the runtime manager's
+      // secret-bag reload keeps only secret-typed keys, so plain values would
+      // otherwise vanish on pod restart. Runs regardless of body contents so a
+      // catalog edit that removed a plain key (or flipped it to secret-typed)
+      // can't leave stale plaintext on the column even on an empty-body
+      // (auto-cascade) reinstall.
+      if (catalogItem.serverType === "local") {
+        await McpServerModel.update(id, { environmentValues: mergedPlainEnv });
+      }
+
       // New env/userConfig values land in this install's secret bag. The
       // runtime reload below reads `secretId` to pick them up.
       if (
@@ -1872,16 +1883,6 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           },
           "Updated MCP server secrets for reinstall",
         );
-
-        // Persist the merged plain-env view onto the install row's column
-        // so startServer can overlay it on every (re)deploy — the runtime
-        // manager's secret-bag reload keeps only secret-typed keys, so
-        // plain values would otherwise vanish on pod restart.
-        if (catalogItem.serverType === "local") {
-          await McpServerModel.update(id, {
-            environmentValues: mergedPlainEnv,
-          });
-        }
       }
 
       // Update service account if provided

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -1682,18 +1682,44 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           userConfig: catalogItem.userConfig,
           userConfigValues,
         });
-        // Validate required environment variables
+        // Build the post-merge plain-env view once: existing column,
+        // overridden by request body, with empty string treated as the
+        // delete signal. Reused below to validate required vars and to
+        // persist back to mcp_server.environmentValues.
+        const mergedPlainEnv: Record<string, string> = {
+          ...(mcpServer.environmentValues ?? {}),
+        };
+        for (const envDef of catalogItem.localConfig?.environment ?? []) {
+          if (envDef.promptOnInstallation && envDef.type !== "secret") {
+            const value = environmentValues?.[envDef.key];
+            if (value === "") {
+              delete mergedPlainEnv[envDef.key];
+            } else if (value !== undefined && value !== null) {
+              mergedPlainEnv[envDef.key] = String(value);
+            }
+          }
+        }
+
+        // Validate required environment variables against the effective
+        // post-merge state for plain types — a required var already on
+        // the row stays satisfied when the body only carries newly-added
+        // vars. Secret-typed required vars are still checked against the
+        // body alone; the existing secret bag is merged below but not
+        // consulted here.
         if (catalogItem.localConfig?.environment) {
           const requiredEnvVars = catalogItem.localConfig.environment.filter(
             (env) => env.promptOnInstallation && env.required,
           );
 
           const missingEnvVars = requiredEnvVars.filter((env) => {
-            const value = environmentValues?.[env.key];
+            const value =
+              env.type === "secret"
+                ? environmentValues?.[env.key]
+                : mergedPlainEnv[env.key];
             if (env.type === "boolean") {
               return !value;
             }
-            return !value?.trim();
+            return typeof value !== "string" || !value.trim();
           });
 
           if (missingEnvVars.length > 0) {
@@ -1795,29 +1821,14 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           "Updated MCP server secrets for reinstall",
         );
 
-        // Persist plain (non-secret) prompted env values onto the install
-        // row's column so startServer can overlay them on every (re)deploy —
-        // the runtime manager's secret-bag reload keeps only secret-typed
-        // keys, so plain values would otherwise vanish on pod restart.
-        //
-        // Merge instead of replace: the install dialog drops empty fields
-        // before submitting, so a partial reinstall (user adds the new
-        // required var, leaves other prompted-plain fields blank because
-        // the dialog doesn't pre-fill them) must not erase keys already
-        // on the row. Only override keys the request actually carried.
-        if (catalogItem.serverType === "local" && environmentValues) {
-          const merged: Record<string, string> = {
-            ...(mcpServer.environmentValues ?? {}),
-          };
-          for (const envDef of catalogItem.localConfig?.environment ?? []) {
-            if (envDef.promptOnInstallation && envDef.type !== "secret") {
-              const value = environmentValues[envDef.key];
-              if (value !== undefined && value !== null && value !== "") {
-                merged[envDef.key] = String(value);
-              }
-            }
-          }
-          await McpServerModel.update(id, { environmentValues: merged });
+        // Persist the merged plain-env view onto the install row's column
+        // so startServer can overlay it on every (re)deploy — the runtime
+        // manager's secret-bag reload keeps only secret-typed keys, so
+        // plain values would otherwise vanish on pod restart.
+        if (catalogItem.serverType === "local") {
+          await McpServerModel.update(id, {
+            environmentValues: mergedPlainEnv,
+          });
         }
       }
 

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -1669,6 +1669,111 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
         ],
       });
 
+      // Drop whitespace-only submissions for secret-typed env vars: such a
+      // value passes required-secret validation via the existing-bag fallback
+      // but would then clobber the stored secret with whitespace on merge,
+      // breaking the restarted server's credentials. "" is left intact as an
+      // explicit clear (required-secret validation still rejects it).
+      const submittedEnv: Record<string, string> = {
+        ...(environmentValues ?? {}),
+      };
+      for (const envDef of catalogItem.localConfig?.environment ?? []) {
+        if (envDef.type === "secret") {
+          const value = submittedEnv[envDef.key];
+          if (
+            typeof value === "string" &&
+            value !== "" &&
+            value.trim() === ""
+          ) {
+            delete submittedEnv[envDef.key];
+          }
+        }
+      }
+
+      // Build the post-merge plain-env view: existing column pruned to the
+      // catalog's current plain prompted keys (so a var removed from the
+      // catalog or flipped to secret-typed can't leave stale plaintext in the
+      // column or the pod env), then overridden by the request body with empty
+      // string treated as the delete signal. Reused to validate required vars
+      // and to persist back to mcp_server.environmentValues.
+      const plainPromptedKeys = new Set(
+        (catalogItem.localConfig?.environment ?? [])
+          .filter((env) => env.promptOnInstallation && env.type !== "secret")
+          .map((env) => env.key),
+      );
+      const mergedPlainEnv: Record<string, string> = {};
+      for (const [key, value] of Object.entries(
+        mcpServer.environmentValues ?? {},
+      )) {
+        if (plainPromptedKeys.has(key)) {
+          mergedPlainEnv[key] = value;
+        }
+      }
+      for (const envDef of catalogItem.localConfig?.environment ?? []) {
+        if (envDef.promptOnInstallation && envDef.type !== "secret") {
+          const value = submittedEnv[envDef.key];
+          if (value === "") {
+            delete mergedPlainEnv[envDef.key];
+          } else if (value !== undefined && value !== null) {
+            mergedPlainEnv[envDef.key] = String(value);
+          }
+        }
+      }
+
+      // Fetch the existing secret bag once so validation and the non-BYOS
+      // merge below can both consult it. BYOS replaces the bag wholesale
+      // (vault references are re-supplied per request), so it doesn't need
+      // the existing state.
+      const existingSecrets: Record<string, unknown> =
+        !isByosVault && mcpServer.secretId
+          ? ((await secretManager().getSecret(mcpServer.secretId))?.secret ??
+            {})
+          : {};
+
+      // Validate required env vars against the effective post-merge state
+      // regardless of whether the body carried values — an empty reinstall
+      // body must still 400 when a newly-added required var is unsatisfied
+      // rather than failing later at pod start. Plain types come from
+      // `mergedPlainEnv` (column + body, empty = clear); non-BYOS secret types
+      // are satisfied by the existing bag when the body omits them; BYOS
+      // requires the body alone.
+      if (catalogItem.localConfig?.environment) {
+        const requiredEnvVars = catalogItem.localConfig.environment.filter(
+          (env) => env.promptOnInstallation && env.required,
+        );
+
+        const missingEnvVars = requiredEnvVars.filter((env) => {
+          if (env.type === "secret") {
+            const submitted = submittedEnv[env.key];
+            if (isByosVault) {
+              return !submitted?.trim();
+            }
+            if (submitted === "") {
+              return true;
+            }
+            if (typeof submitted === "string" && submitted.trim()) {
+              return false;
+            }
+            const existing = existingSecrets[env.key];
+            return typeof existing !== "string" || !existing.trim();
+          }
+          const value = mergedPlainEnv[env.key];
+          if (env.type === "boolean") {
+            return !value;
+          }
+          return typeof value !== "string" || !value.trim();
+        });
+
+        if (missingEnvVars.length > 0) {
+          throw new ApiError(
+            400,
+            `Missing required environment variables: ${missingEnvVars
+              .map((env) => env.key)
+              .join(", ")}`,
+          );
+        }
+      }
+
       // New env/userConfig values land in this install's secret bag. The
       // runtime reload below reads `secretId` to pick them up.
       if (
@@ -1682,74 +1787,6 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           userConfig: catalogItem.userConfig,
           userConfigValues,
         });
-        // Build the post-merge plain-env view once: existing column,
-        // overridden by request body, with empty string treated as the
-        // delete signal. Reused below to validate required vars and to
-        // persist back to mcp_server.environmentValues.
-        const mergedPlainEnv: Record<string, string> = {
-          ...(mcpServer.environmentValues ?? {}),
-        };
-        for (const envDef of catalogItem.localConfig?.environment ?? []) {
-          if (envDef.promptOnInstallation && envDef.type !== "secret") {
-            const value = environmentValues?.[envDef.key];
-            if (value === "") {
-              delete mergedPlainEnv[envDef.key];
-            } else if (value !== undefined && value !== null) {
-              mergedPlainEnv[envDef.key] = String(value);
-            }
-          }
-        }
-
-        // Fetch the existing secret bag once so validation below and the
-        // non-BYOS merge can both consult it. BYOS replaces the bag
-        // wholesale (vault references are re-supplied per request), so it
-        // doesn't need the existing state.
-        const existingSecrets: Record<string, unknown> =
-          !isByosVault && mcpServer.secretId
-            ? ((await secretManager().getSecret(mcpServer.secretId))?.secret ??
-              {})
-            : {};
-
-        // Validate required env vars against the effective post-merge state.
-        // Plain types come from `mergedPlainEnv` (column + body, empty =
-        // clear). Secret types in non-BYOS mode are satisfied by the existing
-        // bag if the body omits them; BYOS still requires the body alone.
-        if (catalogItem.localConfig?.environment) {
-          const requiredEnvVars = catalogItem.localConfig.environment.filter(
-            (env) => env.promptOnInstallation && env.required,
-          );
-
-          const missingEnvVars = requiredEnvVars.filter((env) => {
-            if (env.type === "secret") {
-              const submitted = environmentValues?.[env.key];
-              if (isByosVault) {
-                return !submitted?.trim();
-              }
-              if (submitted === "") {
-                return true;
-              }
-              if (typeof submitted === "string" && submitted.trim()) {
-                return false;
-              }
-              const existing = existingSecrets[env.key];
-              return typeof existing !== "string" || !existing.trim();
-            }
-            const value = mergedPlainEnv[env.key];
-            if (env.type === "boolean") {
-              return !value;
-            }
-            return typeof value !== "string" || !value.trim();
-          });
-
-          if (missingEnvVars.length > 0) {
-            throw new ApiError(
-              400,
-              `Missing required environment variables: ${missingEnvVars
-                .map((env) => env.key)
-                .join(", ")}`,
-            );
-          }
-        }
 
         if (catalogItem.userConfig) {
           const requiredUserConfigFields = Object.entries(
@@ -1789,14 +1826,14 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           if (mcpServer.secretId) {
             await secretManager().updateSecret(mcpServer.secretId, {
               ...catalogStaticUserConfigValues,
-              ...(environmentValues ?? {}),
+              ...submittedEnv,
               ...(installUserConfigValues ?? {}),
             });
           } else {
             const secret = await secretManager().createSecret(
               {
                 ...catalogStaticUserConfigValues,
-                ...(environmentValues ?? {}),
+                ...submittedEnv,
                 ...(installUserConfigValues ?? {}),
               },
               `${mcpServer.name}-vault-secret`,
@@ -1809,7 +1846,7 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           const mergedSecrets = {
             ...existingSecrets,
             ...catalogStaticUserConfigValues,
-            ...(environmentValues ?? {}),
+            ...submittedEnv,
             ...(installUserConfigValues ?? {}),
           };
 

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -1795,25 +1795,29 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           "Updated MCP server secrets for reinstall",
         );
 
-        // Mirror of the install route's environmentValues persistence
-        // (lines 705-723). Plain (non-secret) prompted env values also
-        // need to land on the install row's column — `startServer`
-        // overlays it on every (re)deploy because the secret-typed-only
-        // filter at manager.ts:226 drops plain values when loading from
-        // the K8s secret bag.
+        // Persist plain (non-secret) prompted env values onto the install
+        // row's column so startServer can overlay them on every (re)deploy
+        // — the secret-typed-only filter at manager.ts:226 drops plain
+        // values when loading from the K8s secret bag.
+        //
+        // Merge instead of replace: the install dialog drops empty fields
+        // before submitting, so a partial reinstall (user adds the new
+        // required var, leaves other prompted-plain fields blank because
+        // the dialog doesn't pre-fill them) must not erase keys already
+        // on the row. Only override keys the request actually carried.
         if (catalogItem.serverType === "local" && environmentValues) {
-          const installEnvironmentValues: Record<string, string> = {};
+          const merged: Record<string, string> = {
+            ...(mcpServer.environmentValues ?? {}),
+          };
           for (const envDef of catalogItem.localConfig?.environment ?? []) {
             if (envDef.promptOnInstallation && envDef.type !== "secret") {
               const value = environmentValues[envDef.key];
               if (value !== undefined && value !== null && value !== "") {
-                installEnvironmentValues[envDef.key] = String(value);
+                merged[envDef.key] = String(value);
               }
             }
           }
-          await McpServerModel.update(id, {
-            environmentValues: installEnvironmentValues,
-          });
+          await McpServerModel.update(id, { environmentValues: merged });
         }
       }
 

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -1700,22 +1700,41 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           }
         }
 
-        // Validate required environment variables against the effective
-        // post-merge state for plain types — a required var already on
-        // the row stays satisfied when the body only carries newly-added
-        // vars. Secret-typed required vars are still checked against the
-        // body alone; the existing secret bag is merged below but not
-        // consulted here.
+        // Fetch the existing secret bag once so validation below and the
+        // non-BYOS merge can both consult it. BYOS replaces the bag
+        // wholesale (vault references are re-supplied per request), so it
+        // doesn't need the existing state.
+        const existingSecrets: Record<string, unknown> =
+          !isByosVault && mcpServer.secretId
+            ? ((await secretManager().getSecret(mcpServer.secretId))?.secret ??
+              {})
+            : {};
+
+        // Validate required env vars against the effective post-merge state.
+        // Plain types come from `mergedPlainEnv` (column + body, empty =
+        // clear). Secret types in non-BYOS mode are satisfied by the existing
+        // bag if the body omits them; BYOS still requires the body alone.
         if (catalogItem.localConfig?.environment) {
           const requiredEnvVars = catalogItem.localConfig.environment.filter(
             (env) => env.promptOnInstallation && env.required,
           );
 
           const missingEnvVars = requiredEnvVars.filter((env) => {
-            const value =
-              env.type === "secret"
-                ? environmentValues?.[env.key]
-                : mergedPlainEnv[env.key];
+            if (env.type === "secret") {
+              const submitted = environmentValues?.[env.key];
+              if (isByosVault) {
+                return !submitted?.trim();
+              }
+              if (submitted === "") {
+                return true;
+              }
+              if (typeof submitted === "string" && submitted.trim()) {
+                return false;
+              }
+              const existing = existingSecrets[env.key];
+              return typeof existing !== "string" || !existing.trim();
+            }
+            const value = mergedPlainEnv[env.key];
             if (env.type === "boolean") {
               return !value;
             }
@@ -1785,12 +1804,8 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
             await McpServerModel.update(id, { secretId: secret.id });
           }
         } else {
-          // Non-BYOS mode: merge new values with existing secret
-          const existingSecrets = mcpServer.secretId
-            ? (await secretManager().getSecret(mcpServer.secretId))?.secret ||
-              {}
-            : {};
-
+          // Non-BYOS mode: merge new values with the existing bag fetched
+          // above for validation.
           const mergedSecrets = {
             ...existingSecrets,
             ...catalogStaticUserConfigValues,

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -1774,17 +1774,6 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
         }
       }
 
-      // Persist the merged plain-env view onto the install row's column so
-      // startServer can overlay it on every (re)deploy — the runtime manager's
-      // secret-bag reload keeps only secret-typed keys, so plain values would
-      // otherwise vanish on pod restart. Runs regardless of body contents so a
-      // catalog edit that removed a plain key (or flipped it to secret-typed)
-      // can't leave stale plaintext on the column even on an empty-body
-      // (auto-cascade) reinstall.
-      if (catalogItem.serverType === "local") {
-        await McpServerModel.update(id, { environmentValues: mergedPlainEnv });
-      }
-
       // New env/userConfig values land in this install's secret bag. The
       // runtime reload below reads `secretId` to pick them up.
       if (
@@ -1883,6 +1872,18 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           },
           "Updated MCP server secrets for reinstall",
         );
+      }
+
+      // Persist the merged plain-env view onto the install row's column so
+      // startServer can overlay it on every (re)deploy — the runtime manager's
+      // secret-bag reload keeps only secret-typed keys, so plain values would
+      // otherwise vanish on pod restart. Runs after the secret writes above so
+      // a validation or secret-write failure aborts before the column is
+      // mutated, and outside the body-non-empty guard so a catalog edit that
+      // removed a plain key (or flipped it to secret-typed) is still pruned on
+      // an empty-body (auto-cascade) reinstall.
+      if (catalogItem.serverType === "local") {
+        await McpServerModel.update(id, { environmentValues: mergedPlainEnv });
       }
 
       // Update service account if provided

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -1794,6 +1794,27 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           },
           "Updated MCP server secrets for reinstall",
         );
+
+        // Mirror of the install route's environmentValues persistence
+        // (lines 705-723). Plain (non-secret) prompted env values also
+        // need to land on the install row's column — `startServer`
+        // overlays it on every (re)deploy because the secret-typed-only
+        // filter at manager.ts:226 drops plain values when loading from
+        // the K8s secret bag.
+        if (catalogItem.serverType === "local" && environmentValues) {
+          const installEnvironmentValues: Record<string, string> = {};
+          for (const envDef of catalogItem.localConfig?.environment ?? []) {
+            if (envDef.promptOnInstallation && envDef.type !== "secret") {
+              const value = environmentValues[envDef.key];
+              if (value !== undefined && value !== null && value !== "") {
+                installEnvironmentValues[envDef.key] = String(value);
+              }
+            }
+          }
+          await McpServerModel.update(id, {
+            environmentValues: installEnvironmentValues,
+          });
+        }
       }
 
       // Update service account if provided

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -1796,9 +1796,9 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
         );
 
         // Persist plain (non-secret) prompted env values onto the install
-        // row's column so startServer can overlay them on every (re)deploy
-        // — the secret-typed-only filter at manager.ts:226 drops plain
-        // values when loading from the K8s secret bag.
+        // row's column so startServer can overlay them on every (re)deploy —
+        // the runtime manager's secret-bag reload keeps only secret-typed
+        // keys, so plain values would otherwise vanish on pod restart.
         //
         // Merge instead of replace: the install dialog drops empty fields
         // before submitting, so a partial reinstall (user adds the new


### PR DESCRIPTION
## Summary

After an admin adds a required prompted `plain_text` env var to a local MCP catalog, the install card asks the user to reinstall; they enter the value and the pod restarts — but the new variable is absent from the pod environment, so every tool call that needs it fails. Reinstall now persists re-supplied prompted non-secret env values where the pod actually reads them on restart, so the value entered in the dialog reaches the running server and survives every later restart.

## Why it broke

Install persists a prompted plain-text env value to two places: the per-install secret bag and the server's `environment_values` column. On pod start the runtime reloads env from the secret bag but keeps only secret-typed keys there, so plain values have to come from the column to survive a restart. Reinstall updated only the secret bag and never the column — so as soon as any secret-typed var coexisted, the plain value was filtered out on reload and nothing carried it into the pod.

## Hardening in the same path

- Required env vars are validated against the merged effective state (values already retained on the install plus those re-supplied), so a partial reinstall that omits an already-stored required var succeeds, while an empty body still fails fast with `400` when a newly-required var is unsatisfied — rather than only breaking later at pod start.
- The persisted plain-env view is rebuilt from the catalog's current prompted non-secret keys, so a var removed from the catalog or flipped to secret-typed cannot linger as stale plaintext in the column or the pod env.
- A whitespace-only submission for a required secret no longer slips past validation via the existing-bag fallback and then overwrites the stored credential with whitespace.

Required `userConfig` (connection-setting) validation on partial reinstall is intentionally out of scope here and is handled in the stacked follow-up.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
