### PR TITLE
fix(chat): make model search match human-readable names

### DIFF
--- a/platform/frontend/src/components/chat/model-selector.tsx
+++ b/platform/frontend/src/components/chat/model-selector.tsx
@@ -872,6 +872,13 @@ export function ModelSelector({
                     <ModelSelectorItem
                       key={modelValue}
                       value={modelValue}
+                      // value is provider:dbId (a UUID) for stable selection,
+                      // so search must match human-readable terms via keywords
+                      keywords={[
+                        model.displayName,
+                        model.id,
+                        providerDisplayNames[provider],
+                      ]}
                       onSelect={() => handleSelectModel(modelValue)}
                       className="group"
                     >


### PR DESCRIPTION
## Problem

Searching in the chat model selector returns "No models found" for virtually any query.

## Cause

cmdk filters list items by their `value` prop. #4829 changed each item's value from the model id to `provider:dbId`, where `dbId` is the `models` table UUID. Search now scored queries against `anthropic:3f9c1a7e-…`, so human-readable input never matched. The value must stay `provider:dbId` — it's what selection parsing relies on.

## Fix

Pass a `keywords` prop (display name, model id, provider name) to each item so cmdk's filter matches readable terms while the value stays unique.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>