### PR TITLE
fix(frontend): disable browser/password-manager autofill on dialog forms

### DIFF
--- a/platform/frontend/src/app/agents/skills/_parts/import-skills-dialog.tsx
+++ b/platform/frontend/src/app/agents/skills/_parts/import-skills-dialog.tsx
@@ -545,6 +545,9 @@ export function ImportSkillsDialog({
               onChange={(e) => setRepoUrl(e.target.value)}
               placeholder="github.com/owner/repo"
               autoFocus
+              autoComplete="off"
+              data-1p-ignore
+              data-lpignore="true"
             />
             <p className="text-sm text-muted-foreground">
               Any directory containing a{" "}
@@ -566,6 +569,9 @@ export function ImportSkillsDialog({
               value={path}
               onChange={(e) => setPath(e.target.value)}
               placeholder="packages/skills"
+              autoComplete="off"
+              data-1p-ignore
+              data-lpignore="true"
             />
             <p className="text-sm text-muted-foreground">
               Restrict the scan to <code className="font-mono">SKILL.md</code>{" "}
@@ -585,6 +591,9 @@ export function ImportSkillsDialog({
               value={githubToken}
               onChange={(e) => setGithubToken(e.target.value)}
               placeholder="ghp_…"
+              autoComplete="new-password"
+              data-1p-ignore
+              data-lpignore="true"
             />
             <p className="text-sm text-muted-foreground">
               Required for private repositories. Used only for this import and

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-dialog-config.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-dialog-config.tsx
@@ -550,6 +550,9 @@ const INLINE_CONFIG_FIELDS: Record<
                     ? "user@example.com"
                     : "Required for basic auth, leave empty for PAT"
                 }
+                autoComplete="off"
+                data-1p-ignore
+                data-lpignore="true"
                 {...field}
               />
             </FormControl>
@@ -620,6 +623,9 @@ const INLINE_CONFIG_FIELDS: Record<
                     ? "user@example.com"
                     : "Required for basic auth, leave empty for PAT"
                 }
+                autoComplete="off"
+                data-1p-ignore
+                data-lpignore="true"
                 {...field}
               />
             </FormControl>
@@ -880,6 +886,9 @@ const INLINE_CONFIG_FIELDS: Record<
                   ? "user@example.com"
                   : "Leave empty to keep existing credentials"
               }
+              autoComplete="off"
+              data-1p-ignore
+              data-lpignore="true"
               {...field}
             />
           </FormControl>

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/create-connector-dialog.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/create-connector-dialog.tsx
@@ -386,6 +386,9 @@ export function CreateConnectorDialog({
                             <Input
                               type="password"
                               placeholder={apiTokenPlaceholder}
+                              autoComplete="new-password"
+                              data-1p-ignore
+                              data-lpignore="true"
                               {...field}
                             />
                           </FormControl>

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/edit-connector-dialog.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/edit-connector-dialog.tsx
@@ -299,6 +299,9 @@ export function EditConnectorDialog({
                       <Input
                         type="password"
                         placeholder={apiTokenPlaceholder}
+                        autoComplete="new-password"
+                        data-1p-ignore
+                        data-lpignore="true"
                         {...field}
                       />
                     </FormControl>

--- a/platform/frontend/src/components/llm-provider-api-key-form.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.tsx
@@ -521,6 +521,9 @@ export function LlmProviderApiKeyForm({
                 id="llm-provider-api-key-name"
                 placeholder={providerConfig.name}
                 disabled={isPending}
+                autoComplete="off"
+                data-1p-ignore
+                data-lpignore="true"
                 {...form.register("name")}
               />
             </div>
@@ -642,6 +645,9 @@ export function LlmProviderApiKeyForm({
                     type="password"
                     placeholder={providerConfig.placeholder}
                     disabled={isPending}
+                    autoComplete="new-password"
+                    data-1p-ignore
+                    data-lpignore="true"
                     className={
                       showConfiguredStyling ? "border-green-500 pr-10" : ""
                     }

--- a/platform/frontend/src/components/ui/dialog.tsx
+++ b/platform/frontend/src/components/ui/dialog.tsx
@@ -199,6 +199,7 @@ function DialogStickyFooter({
 function DialogForm({
   className,
   onSubmit,
+  autoComplete = "off",
   ...props
 }: React.ComponentProps<"form"> & {
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
@@ -207,6 +208,7 @@ function DialogForm({
     <form
       data-slot="dialog-form"
       className={cn("contents", className)}
+      autoComplete={autoComplete}
       onSubmit={(e) => {
         e.preventDefault();
         onSubmit(e);


### PR DESCRIPTION
Browsers were autofilling Name/Email/Token fields in the GitHub skill import, LLM API key, and connector dialogs. DialogForm now defaults to autocomplete="off", and the email/password inputs that browsers ignore the form-level hint for are tagged individually (incl. 1Password and LastPass ignore attributes).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>