### PR TITLE
chore: remove tooltip arrows and add default offset

### DIFF
--- a/platform/frontend/src/components/ui/tooltip.tsx
+++ b/platform/frontend/src/components/ui/tooltip.tsx
@@ -36,9 +36,9 @@ function TooltipTrigger({
 
 function TooltipContent({
   className,
-  sideOffset = 0,
+  sideOffset = 6,
   children,
-  noArrow = false,
+  noArrow = true,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content> & {
   noArrow?: boolean;


### PR DESCRIPTION
## Summary
- Flip `TooltipContent` defaults in `frontend/src/components/ui/tooltip.tsx` so arrows are hidden globally (`noArrow = true`)
- Bump default `sideOffset` from `0` → `6` so tooltips no longer sit flush against their trigger now that the arrow no longer provides visual spacing
---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>