### PR TITLE
fix(settings): hide free model filter for non-openrouter

### DIFF
--- a/platform/frontend/src/app/llm/model-providers/models/models-page-utils.test.ts
+++ b/platform/frontend/src/app/llm/model-providers/models/models-page-utils.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  canFilterFreeModelsForApiKey,
+  filterModelsForPage,
+  type ModelsPageAvailableApiKey,
+  type ModelsPageFilterableModel,
+} from "./models-page-utils";
+
+const availableApiKeys = [
+  ["openrouter-key", { provider: "openrouter" }],
+  ["openai-key", { provider: "openai" }],
+] as const satisfies readonly ModelsPageAvailableApiKey[];
+
+const models = [
+  {
+    modelId: "openrouter/free",
+    provider: "openrouter",
+    apiKeys: [{ id: "openrouter-key" }],
+    embeddingDimensions: null,
+    isFree: true,
+  },
+  {
+    modelId: "openrouter/paid",
+    provider: "openrouter",
+    apiKeys: [{ id: "openrouter-key" }],
+    embeddingDimensions: null,
+    isFree: false,
+  },
+  {
+    modelId: "gpt-4o",
+    provider: "openai",
+    apiKeys: [{ id: "openai-key" }],
+    embeddingDimensions: null,
+    isFree: false,
+  },
+] as const satisfies readonly ModelsPageFilterableModel[];
+
+describe("canFilterFreeModelsForApiKey", () => {
+  it("allows the free-model filter only for all models with OpenRouter or a selected OpenRouter key", () => {
+    expect(
+      canFilterFreeModelsForApiKey({
+        availableApiKeys,
+        apiKeyFilter: "all",
+      }),
+    ).toBe(true);
+    expect(
+      canFilterFreeModelsForApiKey({
+        availableApiKeys,
+        apiKeyFilter: "openrouter-key",
+      }),
+    ).toBe(true);
+    expect(
+      canFilterFreeModelsForApiKey({
+        availableApiKeys,
+        apiKeyFilter: "openai-key",
+      }),
+    ).toBe(false);
+    expect(
+      canFilterFreeModelsForApiKey({
+        availableApiKeys,
+        apiKeyFilter: "unknown-key",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("filterModelsForPage", () => {
+  it("does not apply a stale free-model filter to a selected non-OpenRouter API key", () => {
+    const canFilterFreeModels = canFilterFreeModelsForApiKey({
+      availableApiKeys,
+      apiKeyFilter: "openai-key",
+    });
+
+    const result = filterModelsForPage({
+      models,
+      search: "",
+      apiKeyFilter: "openai-key",
+      modelTypeFilter: "all",
+      freeOnly: true,
+      canFilterFreeModels,
+    });
+
+    expect(result.map((model) => model.modelId)).toEqual(["gpt-4o"]);
+  });
+
+  it("applies the free-model filter to a selected OpenRouter API key", () => {
+    const canFilterFreeModels = canFilterFreeModelsForApiKey({
+      availableApiKeys,
+      apiKeyFilter: "openrouter-key",
+    });
+
+    const result = filterModelsForPage({
+      models,
+      search: "",
+      apiKeyFilter: "openrouter-key",
+      modelTypeFilter: "all",
+      freeOnly: true,
+      canFilterFreeModels,
+    });
+
+    expect(result.map((model) => model.modelId)).toEqual(["openrouter/free"]);
+  });
+});

--- a/platform/frontend/src/app/llm/model-providers/models/models-page-utils.ts
+++ b/platform/frontend/src/app/llm/model-providers/models/models-page-utils.ts
@@ -1,0 +1,74 @@
+import { compareModelsForDisplay } from "@shared";
+
+export type ModelsPageModelTypeFilter = "all" | "chat" | "embedding";
+
+export type ModelsPageAvailableApiKey = readonly [string, { provider: string }];
+
+export type ModelsPageFilterableModel = {
+  modelId: string;
+  provider: string;
+  apiKeys: readonly { id: string }[];
+  embeddingDimensions: number | null;
+  isFree: boolean;
+  isBest?: boolean | null;
+};
+
+export function canFilterFreeModelsForApiKey(params: {
+  availableApiKeys: readonly ModelsPageAvailableApiKey[];
+  apiKeyFilter: string;
+}): boolean {
+  const { availableApiKeys, apiKeyFilter } = params;
+
+  if (apiKeyFilter === "all") {
+    return availableApiKeys.some(([, key]) => key.provider === "openrouter");
+  }
+
+  const selectedApiKey = availableApiKeys.find(([id]) => id === apiKeyFilter);
+  return selectedApiKey?.[1].provider === "openrouter";
+}
+
+export function filterModelsForPage<
+  T extends ModelsPageFilterableModel,
+>(params: {
+  models: readonly T[];
+  search: string;
+  apiKeyFilter: string;
+  modelTypeFilter: ModelsPageModelTypeFilter;
+  freeOnly: boolean;
+  canFilterFreeModels: boolean;
+}): T[] {
+  const {
+    models,
+    search,
+    apiKeyFilter,
+    modelTypeFilter,
+    freeOnly,
+    canFilterFreeModels,
+  } = params;
+  let result = models;
+
+  if (search) {
+    const query = search.toLowerCase();
+    result = result.filter((model) =>
+      model.modelId.toLowerCase().includes(query),
+    );
+  }
+  if (apiKeyFilter !== "all") {
+    result = result.filter((model) =>
+      model.apiKeys.some((key) => key.id === apiKeyFilter),
+    );
+  }
+  if (modelTypeFilter === "embedding") {
+    result = result.filter((model) => model.embeddingDimensions !== null);
+  } else if (modelTypeFilter === "chat") {
+    result = result.filter((model) => model.embeddingDimensions === null);
+  }
+  if (freeOnly && canFilterFreeModels) {
+    result = result.filter((model) => model.isFree);
+  }
+
+  return [...result].sort(
+    (a, b) =>
+      a.provider.localeCompare(b.provider) || compareModelsForDisplay(a, b),
+  );
+}

--- a/platform/frontend/src/app/llm/model-providers/models/page.tsx
+++ b/platform/frontend/src/app/llm/model-providers/models/page.tsx
@@ -2,7 +2,6 @@
 
 import {
   type archestraApiTypes,
-  compareModelsForDisplay,
   INPUT_MODALITY_OPTIONS,
   isOpenRouterLatestAlias,
   type ModelInputModality,
@@ -75,6 +74,11 @@ import {
 import { useLlmProviderApiKeys } from "@/lib/llm-provider-api-keys.query";
 import { formatContextLength } from "@/lib/utils";
 import { useSetModelProvidersAction } from "../layout";
+import {
+  canFilterFreeModelsForApiKey,
+  filterModelsForPage,
+  type ModelsPageModelTypeFilter,
+} from "./models-page-utils";
 
 export default function ModelsPage() {
   const { data: models = [], isPending, refetch } = useModelsWithApiKeys();
@@ -84,9 +88,8 @@ export default function ModelsPage() {
   const [isRefreshingModels, setIsRefreshingModels] = useState(false);
   const [search, setSearch] = useState("");
   const [apiKeyFilter, setApiKeyFilter] = useState<string>("all");
-  const [modelTypeFilter, setModelTypeFilter] = useState<
-    "all" | "chat" | "embedding"
-  >("all");
+  const [modelTypeFilter, setModelTypeFilter] =
+    useState<ModelsPageModelTypeFilter>("all");
   const [freeOnly, setFreeOnly] = useState(false);
   const [editingModel, setEditingModel] = useState<ModelWithApiKeys | null>(
     null,
@@ -110,46 +113,36 @@ export default function ModelsPage() {
     );
   }, [models]);
 
-  // "free only" is an openrouter-specific filter — free models are otherwise
-  // a non-concept, so the toggle shows whenever openrouter is set up.
-  const hasOpenRouterModels = useMemo(
-    () => availableApiKeys.some(([, key]) => key.provider === "openrouter"),
-    [availableApiKeys],
+  const canFilterFreeModels = useMemo(
+    () => canFilterFreeModelsForApiKey({ availableApiKeys, apiKeyFilter }),
+    [availableApiKeys, apiKeyFilter],
   );
 
-  const filteredModels = useMemo(() => {
-    let result = models;
-    if (search) {
-      const q = search.toLowerCase();
-      result = result.filter((m) => m.modelId.toLowerCase().includes(q));
+  useEffect(() => {
+    if (!canFilterFreeModels && freeOnly) {
+      setFreeOnly(false);
     }
-    if (apiKeyFilter !== "all") {
-      result = result.filter((m) =>
-        m.apiKeys.some((k) => k.id === apiKeyFilter),
-      );
-    }
-    if (modelTypeFilter === "embedding") {
-      result = result.filter((m) => m.embeddingDimensions !== null);
-    } else if (modelTypeFilter === "chat") {
-      result = result.filter((m) => m.embeddingDimensions === null);
-    }
-    if (freeOnly && hasOpenRouterModels) {
-      result = result.filter((m) => m.isFree);
-    }
-    // Group by provider, then apply the shared model ordering within each
-    // group (routers, recommended, then the rest alphabetically).
-    return [...result].sort(
-      (a, b) =>
-        a.provider.localeCompare(b.provider) || compareModelsForDisplay(a, b),
-    );
-  }, [
-    models,
-    search,
-    apiKeyFilter,
-    modelTypeFilter,
-    freeOnly,
-    hasOpenRouterModels,
-  ]);
+  }, [canFilterFreeModels, freeOnly]);
+
+  const filteredModels = useMemo(
+    () =>
+      filterModelsForPage({
+        models,
+        search,
+        apiKeyFilter,
+        modelTypeFilter,
+        freeOnly,
+        canFilterFreeModels,
+      }),
+    [
+      models,
+      search,
+      apiKeyFilter,
+      modelTypeFilter,
+      freeOnly,
+      canFilterFreeModels,
+    ],
+  );
 
   const handleRefresh = useCallback(async () => {
     setIsRefreshingModels(true);
@@ -415,7 +408,7 @@ export default function ModelsPage() {
                 },
               ]}
             />
-            {hasOpenRouterModels && (
+            {canFilterFreeModels && (
               <div className="flex items-center gap-2">
                 <Switch
                   id="models-free-only"
@@ -445,7 +438,7 @@ export default function ModelsPage() {
             search ||
               apiKeyFilter !== "all" ||
               modelTypeFilter !== "all" ||
-              (hasOpenRouterModels && freeOnly),
+              (canFilterFreeModels && freeOnly),
           )}
           filteredEmptyMessage="No models match your filters. Try adjusting your search."
           onClearFilters={() => {

--- a/platform/frontend/src/app/settings/agents/page.test.tsx
+++ b/platform/frontend/src/app/settings/agents/page.test.tsx
@@ -13,9 +13,11 @@ let mockApiKeys: Array<{
   scope: string;
 }> = [];
 let mockAgents: Array<{ id: string; name: string; icon?: string | null }> = [];
-const mockSearchableSelect = vi.fn((props: { value: string }) => (
-  <div>{props.value}</div>
-));
+const mockSearchableSelect = vi.fn(
+  ({ value, placeholder }: { value: string; placeholder?: string }) => (
+    <div>{value || placeholder}</div>
+  ),
+);
 
 vi.mock("next/link", () => ({
   default: ({
@@ -37,17 +39,11 @@ vi.mock("@/components/llm-provider-api-key-form", () => ({
       icon: "/openai.svg",
       name: "OpenAI",
     },
+    openrouter: {
+      icon: "/openrouter.svg",
+      name: "OpenRouter",
+    },
   },
-}));
-
-vi.mock("@/components/llm-model-select", () => ({
-  LlmModelSearchableSelect: ({
-    value,
-    placeholder,
-  }: {
-    value: string;
-    placeholder: string;
-  }) => <div>{value || placeholder}</div>,
 }));
 
 vi.mock("@/components/llm-provider-options", () => ({
@@ -222,6 +218,27 @@ describe("AgentSettingsPage", () => {
 
     expect(screen.getByText("Select API key first...")).toBeInTheDocument();
     expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
+  });
+
+  it("hides the free-model filter for non-OpenRouter API keys", () => {
+    renderPage();
+
+    expect(screen.queryByText("Free models only")).not.toBeInTheDocument();
+  });
+
+  it("shows the free-model filter for OpenRouter API keys", () => {
+    mockApiKeys = [
+      {
+        id: "key-1",
+        name: "openrouter - org",
+        provider: "openrouter",
+        scope: "org",
+      },
+    ];
+
+    renderPage();
+
+    expect(screen.getByText("Free models only")).toBeInTheDocument();
   });
 
   it("uses the shared profile filter renderer for org agent rows in the default agent dropdown", () => {

--- a/platform/frontend/src/app/settings/agents/page.tsx
+++ b/platform/frontend/src/app/settings/agents/page.tsx
@@ -173,6 +173,7 @@ export default function AgentSettingsPage() {
     () => availableKeys.find((key) => key.id === selectedApiKeyId) ?? null,
     [availableKeys, selectedApiKeyId],
   );
+  const canFilterFreeModels = selectedApiKey?.provider === "openrouter";
 
   const agentItems = useMemo(() => {
     const items: AgentSelectItem[] = [
@@ -270,7 +271,7 @@ export default function AgentSettingsPage() {
                   value={defaultModel}
                   onValueChange={setDefaultModel}
                   options={modelItems}
-                  freeFilterable
+                  freeFilterable={canFilterFreeModels}
                   placeholder={
                     !selectedApiKeyId
                       ? "Select API key first..."

--- a/platform/frontend/src/components/llm-model-select.tsx
+++ b/platform/frontend/src/components/llm-model-select.tsx
@@ -10,7 +10,7 @@ import {
 } from "@shared";
 import { Layers, Sparkles } from "lucide-react";
 import Image from "next/image";
-import { type ReactNode, useMemo, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { SearchableMultiSelect } from "@/components/searchable-multi-select";
 import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
@@ -273,6 +273,13 @@ export function LlmModelSearchableSelect(props: LlmModelSearchableSelectProps) {
   } = props;
 
   const [freeOnly, setFreeOnly] = useState(false);
+  // drop a stale free-only filter when the caller hides the toggle, so it
+  // does not silently re-apply once the toggle becomes available again.
+  useEffect(() => {
+    if (!freeFilterable && freeOnly) {
+      setFreeOnly(false);
+    }
+  }, [freeFilterable, freeOnly]);
   // Shared ordering: routers, then recommended models, then the rest
   // alphabetically — identical across every model picker, unless the caller
   // imposes its own order (preserveOrder).


### PR DESCRIPTION
## Summary
- Hide the settings/agents free-model toggle unless the selected API key provider is OpenRouter
- Add behavior coverage for non-OpenRouter vs OpenRouter settings

## Tests
- pnpm --filter @frontend test -- src/app/settings/agents/page.test.tsx
- pnpm --filter @frontend type-check

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>