### PR TITLE
fix(mcp-catalog): credentials view shows wrong preset labels

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/manage-users-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/manage-users-dialog.tsx
@@ -179,14 +179,15 @@ export function ManageUsersContent({
     plural: presetPlural,
     singular: presetSingular,
     configured: presetTermConfigured,
+    defaultLabel,
   } = usePresetEntityName();
 
   // Map of presetId → preset row. Parent is the "default" preset.
   const presetEntries = [
-    { id: catalogId, name: "default", isDefault: true },
+    { id: catalogId, name: defaultLabel, isDefault: true },
     ...childPresets.map((c) => ({
       id: c.id,
-      name: c.name,
+      name: c.childName ?? c.name,
       isDefault: false,
     })),
   ];

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -167,7 +167,7 @@ export function McpServerCard({
   // Gate the Install button when the default preset (the parent catalog
   // itself) has unfilled preset-scoped fields and the current user cannot
   // edit them — clicking Install would land on Step 1 and 403 on save.
-  const { singular: presetSingular } = usePresetEntityName();
+  const { singular: presetSingular, defaultLabel } = usePresetEntityName();
   const presetSingularLower = presetSingular.toLowerCase();
   const { canEdit: canEditPresets } = useCanEditCatalogPresets(
     variant !== "builtin" ? item : null,
@@ -295,9 +295,9 @@ export function McpServerCard({
     personalServersAcrossPresets.length > 0 || !!personalServer;
 
   const presetNameByCatalogId = new Map<string, string>();
-  presetNameByCatalogId.set(item.id, item.name);
+  presetNameByCatalogId.set(item.id, defaultLabel);
   for (const p of presets) {
-    presetNameByCatalogId.set(p.id, p.name);
+    presetNameByCatalogId.set(p.id, p.childName ?? p.name);
   }
 
   // Iterate over presets (the parent catalog item + its child presets) and pick
@@ -375,7 +375,7 @@ export function McpServerCard({
     ...s,
     presetLabel:
       s.catalogId === item.id
-        ? "default"
+        ? defaultLabel
         : (presetNameByCatalogId.get(s.catalogId) ?? null),
   }));
 
@@ -392,7 +392,7 @@ export function McpServerCard({
         name: s.name,
         presetLabel:
           s.catalogId === item.id
-            ? "default"
+            ? defaultLabel
             : (presetNameByCatalogId.get(s.catalogId) ?? null),
       })),
     );
@@ -468,7 +468,7 @@ export function McpServerCard({
           name: s.name,
           presetLabel:
             s.catalogId === item.id
-              ? "default"
+              ? defaultLabel
               : (presetNameByCatalogId.get(s.catalogId) ?? null),
         })),
         { alsoReinstallCatalog: true },

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-settings-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-settings-dialog.tsx
@@ -209,10 +209,14 @@ export function McpServerSettingsDialog({
   // ManageUsersContent (filters credential sections). Hidden unless the org
   // has the preset term configured AND the catalog has ≥ 1 preset child.
   // The literal "All" is a sentinel for "no filter".
-  const presetLabelOptions = ["All", "default", ...presets.map((p) => p.name)];
+  const presetLabelOptions = [
+    "All",
+    presetEntityName.defaultLabel,
+    ...presets.map((p) => p.childName ?? p.name),
+  ];
   const presetIdByLabel = new Map<string, string>([
-    ["default", item.id],
-    ...presets.map((p) => [p.name, p.id] as const),
+    [presetEntityName.defaultLabel, item.id],
+    ...presets.map((p) => [p.childName ?? p.name, p.id] as const),
   ]);
   const [pageSelectedPreset, setPageSelectedPreset] = useState<string>("All");
   // Keep the selector in sync when the dialog opens deep-linked to a
@@ -223,8 +227,14 @@ export function McpServerSettingsDialog({
     const init = clickedServerId ?? logsInitialServerId;
     if (!init) return;
     const found = installs.find((i) => i.id === init);
-    if (found) setPageSelectedPreset(found.presetLabel ?? "default");
-  }, [clickedServerId, logsInitialServerId, installs]);
+    if (found)
+      setPageSelectedPreset(found.presetLabel ?? presetEntityName.defaultLabel);
+  }, [
+    clickedServerId,
+    logsInitialServerId,
+    installs,
+    presetEntityName.defaultLabel,
+  ]);
   const presetSelectorVisible =
     presetEntityName.configured &&
     presets.length > 0 &&
@@ -443,7 +453,7 @@ export function McpServerSettingsDialog({
                   }
                   onControlledPresetFilterChange={(presetId) => {
                     if (presetId === "all") {
-                      setPageSelectedPreset("default");
+                      setPageSelectedPreset(presetEntityName.defaultLabel);
                       return;
                     }
                     for (const [label, id] of presetIdByLabel) {


### PR DESCRIPTION
1. Fix using presets name in MCP modal filters
2. Fix using configured name for the default env.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>