### PR TITLE
fix(e2e): anchor model-selector displayName fallback regex

### DIFF
--- a/platform/e2e-tests/utils/chat-ui.ts
+++ b/platform/e2e-tests/utils/chat-ui.ts
@@ -159,8 +159,11 @@ export async function selectRuntimeModelFromDialog(
 function buildModelOptionPattern(model: RuntimeChatModel): RegExp {
   const displayName = escapeRegExp(model.displayName);
   const modelId = escapeRegExp(model.id);
+  // Lone-name alternatives use (?![-\w]) so e.g. id "sonar" does not match a
+  // sibling option's "sonar-deep-research". Without this guard the click-time
+  // fallback could land on the wrong model.
   return new RegExp(
-    `${displayName}\\s*\\(${modelId}\\)|${modelId}|${displayName}`,
+    `${displayName}\\s*\\(${modelId}\\)|${modelId}(?![-\\w])|${displayName}(?![-\\w])`,
     "i",
   );
 }


### PR DESCRIPTION
Follow-up to #4919. The lone-name alternatives in `buildModelOptionPattern` matched anywhere in option text, so `id: "sonar"` could match inside a sibling option's `sonar-deep-research`. If `exactModelOption` (substring `(id)`) ever reports not-visible mid-render, the click-time fallback in `selectRuntimeModelFromDialog` would then click the wrong model and the chat test would proceed against the wrong selection.

Add `(?![-\w])` to the lone-`modelId` and lone-`displayName` alternatives so they only match at a real token boundary. The `displayName (modelId)` alternative is unchanged — it already anchored via the literal parentheses.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>