### PR TITLE
Fix blocked tool result policy bypass when context starts sensitive

### DIFF
--- a/platform/backend/src/guardrails/trusted-data.test.ts
+++ b/platform/backend/src/guardrails/trusted-data.test.ts
@@ -410,6 +410,57 @@ describe("trusted-data evaluation (provider-agnostic)", () => {
       });
     });
 
+    test("applies blocked tool result policies when context starts untrusted", async () => {
+      await TrustedDataPolicyModel.create({
+        toolId,
+        conditions: [
+          { key: "emails[*].from", operator: "contains", value: "hacker" },
+        ],
+        action: "block_always",
+        description: "Block hacker emails",
+      });
+
+      const commonMessages: CommonMessage[] = [
+        { role: "user", content: "Read the issue" },
+        {
+          role: "tool",
+          toolCalls: [
+            {
+              id: "call_sensitive",
+              name: "get_emails",
+              content: {
+                emails: [{ from: "hacker@evil.com", subject: "raw secret" }],
+              },
+              isError: false,
+            },
+          ],
+        },
+      ];
+
+      const result = await evaluateIfContextIsTrusted(
+        commonMessages,
+        agentId,
+        organizationId,
+        undefined,
+        true,
+        "restrictive",
+        { teamIds: [] },
+        undefined,
+        undefined,
+        "agent_configured_untrusted",
+      );
+
+      expect(result.contextIsTrusted).toBe(false);
+      expect(result.toolResultUpdates).toEqual({
+        call_sensitive:
+          "[Content blocked by policy: Data blocked by policy: Block hacker emails]",
+      });
+      expect(result.unsafeContextBoundary).toEqual({
+        kind: "preexisting_untrusted",
+        reason: "agent_configured_untrusted",
+      });
+    });
+
     test("handles multiple tool calls with mixed trust", async () => {
       // Create policies
       await TrustedDataPolicyModel.create({

--- a/platform/backend/src/guardrails/trusted-data.ts
+++ b/platform/backend/src/guardrails/trusted-data.ts
@@ -59,29 +59,26 @@ export async function evaluateIfContextIsTrusted(
 
   const toolResultUpdates: ToolResultUpdates = {};
   const dualLlmAnalyses: DualLlmAnalysis[] = [];
-  let hasUntrustedData = false;
+  let hasUntrustedData = considerContextUntrusted;
   let usedDualLlm = false;
-  let unsafeContextBoundary: UnsafeContextBoundary | undefined;
+  let unsafeContextBoundary: UnsafeContextBoundary | undefined =
+    considerContextUntrusted
+      ? {
+          kind: "preexisting_untrusted",
+          reason:
+            initialUntrustedReason ??
+            UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
+        }
+      : undefined;
 
-  // If agent configured to consider context untrusted from the beginning,
-  // mark context as untrusted immediately and skip evaluation
+  // If agent configured context as untrusted from the beginning, preserve that
+  // state while still evaluating tool results so blocked policies can redact
+  // model-facing data before the provider request is sent.
   if (considerContextUntrusted) {
     logger.debug(
       { agentId },
       "[trustedData] evaluateIfContextIsTrusted: context marked untrusted by agent config",
     );
-    return {
-      toolResultUpdates: {},
-      contextIsTrusted: false,
-      usedDualLlm: false,
-      dualLlmAnalyses: [],
-      unsafeContextBoundary: {
-        kind: "preexisting_untrusted",
-        reason:
-          initialUntrustedReason ??
-          UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
-      },
-    };
   }
 
   // First, collect all tool calls from all messages
@@ -111,12 +108,12 @@ export async function evaluateIfContextIsTrusted(
 
   if (allToolCalls.length === 0) {
     logger.debug(
-      { agentId },
-      "[trustedData] evaluateIfContextIsTrusted: no tool calls found, context is trusted",
+      { agentId, contextIsTrusted: !hasUntrustedData },
+      "[trustedData] evaluateIfContextIsTrusted: no tool calls found",
     );
     return {
       toolResultUpdates,
-      contextIsTrusted: true,
+      contextIsTrusted: !hasUntrustedData,
       usedDualLlm: false,
       dualLlmAnalyses: [],
       unsafeContextBoundary,


### PR DESCRIPTION
Fixes #4225

## Summary
When an agent is configured to treat context as sensitive from the start of chat, the trusted-data evaluator returned early and skipped tool-result policy enforcement.

That allowed blocked tool results to remain in the model-facing request instead of being replaced.

## What changed
- preserve the preexisting untrusted boundary without returning early
- continue evaluating tool results even when context starts untrusted
- allow blocked tool-result policies to replace sensitive content before the request is sent to the model
- add a regression test covering blocked tool-result policies in pre-untrusted context

## Notes
I was not able to run the full local test suite in this environment because `pnpm` was unavailable locally, but the patch is narrowly scoped and includes a regression test for the reported scenario.