### PR TITLE
chore(tilt): second frontend dev server on :3010 for Playwright MSW tests

### DIFF
--- a/platform/.gitignore
+++ b/platform/.gitignore
@@ -3,6 +3,7 @@ dist
 node_modules
 build
 .next
+.next-*
 next-env.d.ts
 
 # Logs

--- a/platform/dev/Tiltfile.dev
+++ b/platform/dev/Tiltfile.dev
@@ -98,6 +98,27 @@ else:
     serve_env=frontend_env_vars
   )
 
+  # Second frontend instance dedicated to Playwright integration tests
+  # (frontend/tests-integration). Uses MSW for all API calls, so it does NOT
+  # need the backend or DB. Runs on :3010 with a separate .next-pw dist dir
+  # so the lock at <distDir>/dev/lock doesn't collide with the main dev
+  # server's `.next/dev/lock`. Pointing the SDK base URL at an unreachable
+  # port surfaces any escaped (un-mocked) request as ECONNREFUSED instead of
+  # silently hitting the real backend.
+  local_resource(
+    dev_resource_name + '-frontend-int-tests',
+    serve_cmd='trap "pkill -TERM -P $$" EXIT INT TERM; cd ../frontend && pnpm exec next dev -H 127.0.0.1 -p 3010 & wait $!',
+    serve_cmd_bat='cd ..\\frontend && pnpm exec next dev -H 127.0.0.1 -p 3010',
+    labels=['dev'],
+    deps=['../.env'],
+    serve_env={
+      'NEXT_DIST_DIR': '.next-pw',
+      'NEXT_PUBLIC_API_MOCKING': 'enabled',
+      'ARCHESTRA_INTERNAL_API_BASE_URL': 'http://127.0.0.1:1',
+      'NEXT_PUBLIC_SENTRY_DSN': '',
+    }
+  )
+
 # Port-forward for MCP servers using streamable-http transport
 # Docker Desktop / kind K8s don't expose NodePorts on localhost, so we use
 # kubectl port-forward (which goes through the K8s API server) to make them accessible.

--- a/platform/frontend/next.config.ts
+++ b/platform/frontend/next.config.ts
@@ -13,6 +13,9 @@ const nextConfig: NextConfig = {
   env: {
     NEXT_PUBLIC_APP_VERSION: platformPkg.version,
   },
+  // Lets a second `next dev` (e.g. the Playwright MSW server on :3010) run
+  // alongside the main one without colliding on `.next/dev/lock`.
+  distDir: process.env.NEXT_DIST_DIR || ".next",
   output: "standalone",
   // Version skew protection during rolling deployments.
   // https://nextjs.org/docs/app/api-reference/config/next-config-js/deploymentId

--- a/platform/frontend/tsconfig.json
+++ b/platform/frontend/tsconfig.json
@@ -37,7 +37,9 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
+    ".next/dev/types/**/*.ts",
+    ".next-pw/types/**/*.ts",
+    ".next-pw/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary

Lets contributors run `frontend/tests-integration/*.spec.ts` against a Playwright-only Next dev server while the regular tilt-managed `pnpm-dev-frontend` is still serving the app on :3000.

Next 16 added a per-directory lock (`<distDir>/dev/lock`) that refuses to start a second `next dev` in the same project — `pnpm test:integration` would die with *"Another next dev server is already running"*. This change:

- adds `distDir: process.env.NEXT_DIST_DIR || ".next"` in `next.config.ts`, so the second instance can claim its own lock at `.next-pw/dev/lock`
- adds a `pnpm-dev-frontend-int-tests` Tilt resource that boots `next dev -p 3010` with `NEXT_DIST_DIR=.next-pw`, `NEXT_PUBLIC_API_MOCKING=enabled`, and an unreachable `ARCHESTRA_INTERNAL_API_BASE_URL` (so any request that escapes MSW fails loudly instead of silently hitting the real backend)
- has no `resource_deps`: MSW services every API call, so the backend pod and DB are not part of the dependency chain
- gitignores `.next-*` so the new dist directory isn't accidentally committed

`pnpm test:integration` continues to work locally via `reuseExistingServer: true` — Playwright connects to the running tilt server on :3010. CI is unchanged: `IS_CI` flips `reuseExistingServer` to `false`, Playwright spawns its own server, and `distDir` falls back to `.next` since `NEXT_DIST_DIR` isn't set in the workflow env.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>