### PR TITLE
chore(claude): teach resolve-conflicts skill to preserve data-migration tails

### DIFF
--- a/.claude/skills/resolve-conflicts/SKILL.md
+++ b/.claude/skills/resolve-conflicts/SKILL.md
@@ -1,29 +1,177 @@
 ---
 name: resolve-conflicts
-description: Resolve merge conflicts in this repo — Drizzle migration number collisions (meta/_journal.json, meta/<NNNN>_snapshot.json), and related generated files like shared/hey-api/**/sdk.gen.ts. Use when git reports a merge conflict in any of these files, or when `drizzle-kit check` fails after a merge.
+description: Resolve merge/rebase conflicts in this repo — Drizzle migration number collisions (platform/backend/src/database/migrations/meta/_journal.json, meta/<NNNN>_snapshot.json), preserving any hand-written data-migration tail (UPDATE/INSERT/DO $$). Use when git reports a conflict in those files, when `drizzle-kit check` fails after a merge, or when conflicted generated clients under platform/shared/hey-api/** need to be reconciled.
 ---
 
-# Resolving Migration Merge Conflicts (migration number collision)
-# When main has landed migrations that collide with your branch's migration number
-# (conflicts in meta/_journal.json and meta/<NNNN>_snapshot.json), renumber YOUR
-# migration to come AFTER main's. Never edit main's migrations. Steps:
-#   1. Take main's side for the journal and colliding snapshot:
-#        git checkout --theirs -- backend/src/database/migrations/meta/_journal.json \
-#          backend/src/database/migrations/meta/<NNNN>_snapshot.json
-#        git add the same two files
-#      (Resolve any conflict in generated files like shared/hey-api/.../sdk.gen.ts
-#       enough to parse — they get regenerated below.)
-#   2. Renumber your migration SQL to the next free number, preserving history:
-#        git mv backend/src/database/migrations/<OLD>_<name>.sql \
-#               backend/src/database/migrations/<NEW>_<name>.sql
-#   3. Regenerate the snapshot + journal entry: `cd backend && pnpm db:generate`
-#      This emits a fresh <NEW>_<random>.sql, meta/<NEW>_snapshot.json, and a
-#      journal entry tagged <NEW>_<random>.
-#   4. Delete the generated <NEW>_<random>.sql (its ALTER statements are identical
-#      to your file's schema portion) and KEEP your hand-written <NEW>_<name>.sql.
-#      IMPORTANT: keep any data-migration logic (DO $$ blocks, UPDATE/INSERT) from
-#      your original file — db:generate only emits schema DDL, not data migration.
-#   5. Rename the journal tag <NEW>_<random> -> <NEW>_<name> to match your file.
-#   6. Verify: `cd backend && npx drizzle-kit check` must print "Everything's fine".
-#   7. Regenerate any conflicted generated clients from the merged spec, e.g.
-#        cd shared && CODEGEN=true pnpm codegen:api-client
+# Resolving Drizzle migration merge conflicts
+
+When main has landed migrations that collide with your branch's migration
+number, you must renumber YOUR migration to come AFTER main's. Never edit
+main's migrations.
+
+`pnpm db:generate` emits ONLY schema DDL diffed against the latest snapshot.
+Any data-migration tail (UPDATE, INSERT, DO $$ blocks, mutating CTEs) is NOT
+regenerated. The procedure below regenerates fresh DDL against main's
+snapshot, then re-appends your saved data-migration tail.
+
+All paths below are relative to the **repo root**, not `platform/`. Run the
+shell commands from the repo root unless a step explicitly `cd`s elsewhere
+(this skill overrides the platform-CLAUDE-default of running from
+`platform/`).
+
+## Variables
+
+- `<COLLIDING>` — the 4-digit number both branches claimed (e.g. `0220`).
+- `<your_name>` — your migration's descriptive slug (e.g. for
+  `0220_luxuriant_silver_sable.sql`, it is `luxuriant_silver_sable`).
+- `<NEW>` — the next free 4-digit number Drizzle picks in step 4 (e.g. `0221`).
+
+## Procedure
+
+### 1. Extract your data-migration tail
+
+Read `platform/backend/src/database/migrations/<COLLIDING>_<your_name>.sql`.
+Copy the whole file to `/tmp/<COLLIDING>_<your_name>.original.sql` as a
+backup. Then save just the data-migration statements to
+`/tmp/<your_name>.data.sql`, each separated by `--> statement-breakpoint`.
+
+Statements to save (Drizzle does NOT regenerate these):
+- `UPDATE …`
+- `INSERT INTO …` (when used for data, not as part of `CREATE TABLE`)
+- `DO $$ … END $$;` blocks
+- `WITH … (INSERT|UPDATE|DELETE) …` CTEs
+
+Statements to DISCARD (Drizzle WILL regenerate these):
+- `ALTER TABLE …`, `ALTER COLUMN …`
+- `CREATE TABLE/INDEX/TYPE/EXTENSION …`
+- `DROP TABLE/COLUMN/INDEX …`
+
+If the file has no data-migration tail, `/tmp/<your_name>.data.sql` is empty
+and step 5 is a no-op.
+
+### 2. Take main's side for the conflicted journal + snapshot
+
+The flag depends on the git operation in progress — `git rebase` and `git
+merge` invert "ours" vs. "theirs". Run `git status` to check which is
+running:
+
+- `git rebase upstream` → main is **`--ours`** (rebase checks out
+  upstream's tip before replaying your commits, so `HEAD = main`):
+  ```
+  git checkout --ours -- \
+    platform/backend/src/database/migrations/meta/_journal.json \
+    platform/backend/src/database/migrations/meta/<COLLIDING>_snapshot.json
+  ```
+- `git merge upstream` → main is **`--theirs`** (HEAD stays on your
+  branch; upstream is the incoming side):
+  ```
+  git checkout --theirs -- \
+    platform/backend/src/database/migrations/meta/_journal.json \
+    platform/backend/src/database/migrations/meta/<COLLIDING>_snapshot.json
+  ```
+
+Then stage:
+
+```
+git add \
+  platform/backend/src/database/migrations/meta/_journal.json \
+  platform/backend/src/database/migrations/meta/<COLLIDING>_snapshot.json
+```
+
+**Verify you took the right side**: the last `tag` in `_journal.json`
+should be **main's** latest tag, NOT `<COLLIDING>_<your_name>`. If you see
+your own tag, you took the wrong side — re-run step 2 with the opposite
+flag.
+
+**Before step 4**, resolve ALL TypeScript files that still have conflict
+markers (`<<<<<<<`, `=======`, `>>>>>>>`) — not just hey-api files. Step 4
+runs `drizzle-kit generate`, which uses esbuild to walk every file reachable
+from your schemas (shared utilities, generated SDK, anything imported
+transitively). One unresolved `<<<<<<<` anywhere along that import graph
+makes `drizzle-kit generate` exit with `ERROR: Unexpected "<<"`. For files
+that will be regenerated in step 8 (e.g. `platform/shared/hey-api/**`),
+resolving with `git checkout --ours` or `--theirs` just-enough-to-parse is
+fine; for hand-written code, resolve properly. Run `git status` and check
+for any `UU` entries; resolve each before continuing.
+
+### 3. Delete your old SQL file
+
+```
+git rm -f platform/backend/src/database/migrations/<COLLIDING>_<your_name>.sql
+```
+
+(The file is staged from the in-progress rebase/merge; plain `git rm`
+refuses to remove staged files, so `-f` is needed.)
+
+### 4. Regenerate the migration with your descriptive name
+
+```
+cd platform/backend && pnpm exec drizzle-kit generate --name=<your_name>
+```
+
+Drizzle picks the next free `<NEW>`, emits `<NEW>_<your_name>.sql` with
+schema-only DDL diffed against main's snapshot, writes
+`meta/<NEW>_snapshot.json`, and appends a journal entry tagged
+`<NEW>_<your_name>`. The `--name=` flag means the filename and tag are
+right the first time — no journal-tag rename needed.
+
+If Drizzle reports "No schema changes, nothing to migrate", your branch was
+pure-data; generate a custom empty migration instead:
+
+```
+cd platform/backend && pnpm exec drizzle-kit generate --custom --name=<your_name>
+```
+
+### 5. Append the saved data-migration tail
+
+Skip this step if `/tmp/<your_name>.data.sql` is empty.
+
+```
+printf '\n--> statement-breakpoint\n' \
+  >> platform/backend/src/database/migrations/<NEW>_<your_name>.sql
+cat /tmp/<your_name>.data.sql \
+  >> platform/backend/src/database/migrations/<NEW>_<your_name>.sql
+```
+
+Schema DDL must run before the data migration so column references resolve.
+
+### 6. Verify journal/snapshot/SQL consistency
+
+```
+cd platform/backend && pnpm exec drizzle-kit check
+```
+
+Must print **"Everything's fine"**. If it reports drift, compare
+`/tmp/<COLLIDING>_<your_name>.original.sql` against the regenerated SQL and
+either (a) restore a missed data-migration statement to the tail, or
+(b) update your schema files so the regenerated DDL matches what your
+original SQL did.
+
+### 7. (Optional) Apply locally to confirm it runs
+
+```
+cd platform/backend && pnpm db:migrate
+```
+
+### 8. Regenerate conflicted generated clients (only if hey-api files conflicted)
+
+Skip this step unless step 2 surfaced conflicts under `platform/shared/hey-api/`
+(check `git status` from step 2 — if no hey-api paths were unmerged, jump to
+step 9).
+
+```
+cd platform/shared && CODEGEN=true pnpm codegen:api-client
+```
+
+### 9. Stage and continue
+
+```
+git add \
+  platform/backend/src/database/migrations/<NEW>_<your_name>.sql \
+  platform/backend/src/database/migrations/meta/<NEW>_snapshot.json \
+  platform/backend/src/database/migrations/meta/_journal.json
+```
+
+Also stage `platform/shared/hey-api` if step 8 ran.
+
+Then continue the rebase/merge.


### PR DESCRIPTION
## Summary

The `resolve-conflicts` skill's old recipe said to **keep your hand-written SQL** and discard the file Drizzle regenerated. After a rebase onto a newer main snapshot, the hand-written DDL is diffed against the wrong baseline and can drift from the schema files — silently, in ways `drizzle-kit check` may not catch. Invert the flow: **regenerate fresh DDL against main's snapshot, then re-append the saved data-migration tail** (`UPDATE` / `INSERT` / `DO $$` / mutating CTEs).

While in the file, fix three smaller defects discovered during validation:

- Every path was prefixed `backend/`; migrations actually live at `platform/backend/`.
- During `git rebase`, `--theirs` selects YOUR commit, not main's. Old skill used `--theirs` for both `rebase` and `merge`, which silently took the wrong side under rebase. Skill now documents `--ours` for rebase, `--theirs` for merge, with a self-verification step that reads back the journal's last tag.
- `drizzle-kit generate --name=<your_name>` makes the filename and journal tag correct on first emit; the old post-hoc journal-tag rename step is gone.
- `git rm -f` (not `git rm`) — the colliding SQL is always staged mid-rebase, and plain `git rm` refuses staged files.
- Step 8 (SDK regen) is now conditional on hey-api files actually being among the conflicted set.
- Step 2 instructs resolving **all** conflicted TypeScript files before step 4, not just `hey-api/sdk.gen.ts`. Drizzle-kit's esbuild walks the full import graph; one stray `<<<<<<<` anywhere makes `generate` exit with `ERROR: Unexpected "<<"`. This was discovered while running the new skill against PR #4183.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>