### PR TITLE
fix(mcp-registry): forward existing scope into remote reinstall dialog

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -1081,6 +1081,10 @@ export function InternalMCPCatalog({
     } else if (hasPromptedUserConfig) {
       setSelectedCatalogItem(catalogItem);
       setReinstallServerId(installedServer.id);
+      setReinstallServerTeamId(installedServer.teamId ?? null);
+      setReinstallServerScope(
+        (installedServer as unknown as { scope?: McpServerInstallScope }).scope,
+      );
       openDialog("remote-install");
     } else {
       setCatalogItemForReinstall(catalogItem);
@@ -1533,6 +1537,8 @@ export function InternalMCPCatalog({
           setSelectedCatalogItem(null);
           setReauthServerId(null);
           setReinstallServerId(null);
+          setReinstallServerTeamId(null);
+          setReinstallServerScope(undefined);
           setPreselectedTeamId(null);
           setPreselectedCatalogId(null);
           setInstallPersonalOnly(false);
@@ -1547,6 +1553,8 @@ export function InternalMCPCatalog({
         }
         isReauth={!!reauthServerId}
         isReinstall={!!reinstallServerId && !reauthServerId}
+        existingTeamId={reinstallServerTeamId}
+        existingScope={reinstallServerScope}
         preselectedTeamId={preselectedTeamId}
         preselectedCatalogId={preselectedCatalogId}
         personalOnly={installPersonalOnly}

--- a/platform/frontend/src/app/mcp/registry/_parts/remote-server-install-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/remote-server-install-dialog.tsx
@@ -91,6 +91,10 @@ interface RemoteServerInstallDialogProps {
    * the existing install needs values for them.
    */
   isReinstall?: boolean;
+  /** Scope of the install being reinstalled (locks the scope picker). */
+  existingScope?: McpServerInstallScope;
+  /** Team of the install being reinstalled (null for personal/org). */
+  existingTeamId?: string | null;
   /** Pre-select a specific team in the credential type selector */
   preselectedTeamId?: string | null;
   /**
@@ -112,6 +116,8 @@ export function RemoteServerInstallDialog({
   isInstalling,
   isReauth = false,
   isReinstall = false,
+  existingScope,
+  existingTeamId,
   preselectedTeamId,
   preselectedCatalogId,
   personalOnly = false,
@@ -483,6 +489,9 @@ export function RemoteServerInstallDialog({
         catalogId={selectedCatalogId || catalogItem?.id}
         onScopeChange={setScope}
         onCanInstallChange={setCanInstall}
+        isReinstall={isReinstall}
+        existingScope={existingScope}
+        existingTeamId={existingTeamId}
         preselectedTeamId={preselectedTeamId}
         personalOnly={personalOnly}
         orgOnly={orgOnly}

--- a/platform/frontend/tests-integration/mcp-reinstall.spec.ts
+++ b/platform/frontend/tests-integration/mcp-reinstall.spec.ts
@@ -1,3 +1,4 @@
+import { makeUserPermissions } from "../src/mocks/data/auth";
 import { makeCatalogItem } from "../src/mocks/data/catalog";
 import { makeInstalledServer } from "../src/mocks/data/servers";
 import { expect, test } from "./fixtures";
@@ -77,6 +78,98 @@ test.describe("Reinstall remote MCP server", () => {
     await headerField.fill("fresh-header-value");
 
     await dialog.getByRole("button", { name: "Reinstall" }).click();
+    await expect(dialog).toBeHidden();
+  });
+
+  test("member without team/org install permission can still reinstall their personal remote install", async ({
+    page,
+    mcpRegistryPage,
+    mswControl,
+  }) => {
+    // Regression: the dialog forwards the existing personal scope into the
+    // credential-type selector so that, in reinstall mode, it locks rather
+    // than re-evaluates `canInstall`. Without the fix a member whose only
+    // install is the (already-used) personal one had `canInstall=false`
+    // for every scope and the Submit button was hidden.
+    const remoteCatalog = makeCatalogItem({
+      id: "test-remote-member-reinstall",
+      name: "test-remote-member-reinstall",
+      serverType: "remote",
+      serverUrl: "https://example.test/mcp",
+      userConfig: {
+        header_x_api_key: {
+          type: "string",
+          title: "X-API-Key",
+          description: "Newly-required header",
+          promptOnInstallation: true,
+          required: true,
+          sensitive: true,
+          headerName: "X-API-Key",
+        },
+      },
+      toolCount: 1,
+    });
+    const flaggedInstall = makeInstalledServer({
+      id: "test-server-remote-member-flagged",
+      name: "test-remote-member-reinstall",
+      catalogId: remoteCatalog.id,
+      serverType: "remote",
+      scope: "personal",
+      reinstallRequired: true,
+      users: ["test-user-admin"],
+    });
+
+    // Member-like role: can update their own installs (so the card's
+    // Reinstall button is clickable) but cannot create team / org installs.
+    await mswControl.use({
+      method: "get",
+      url: "/api/user/permissions",
+      body: makeUserPermissions({
+        mcpServerInstallation: ["read", "create", "update"],
+      }),
+    });
+    await mswControl.use({
+      method: "get",
+      url: "/api/internal_mcp_catalog",
+      body: [remoteCatalog],
+    });
+    await mswControl.use({
+      method: "get",
+      url: "/api/mcp_server",
+      body: [flaggedInstall],
+    });
+    await mswControl.use({
+      method: "post",
+      url: "/api/mcp_server/:id/reinstall",
+      body: {
+        ...flaggedInstall,
+        reinstallRequired: false,
+        localInstallationStatus: "pending",
+      },
+    });
+
+    await mcpRegistryPage.goto();
+    await expect(mcpRegistryPage.heading).toBeVisible();
+    await expect(
+      mcpRegistryPage.cardForCatalogItem(remoteCatalog.name),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Reinstall" }).click();
+
+    const dialog = page
+      .getByRole("dialog")
+      .filter({ hasText: /Reinstall Server/ });
+    await expect(dialog).toBeVisible();
+    await dialog
+      .getByRole("textbox", { name: /X-API-Key/i })
+      .fill("member-fresh-value");
+
+    // The Submit button must render even though the member has no
+    // `mcpServerInstallation: update` / `admin`. Without the fix it was
+    // missing because canInstall fell through to false.
+    const submit = dialog.getByRole("button", { name: "Reinstall" });
+    await expect(submit).toBeVisible();
+    await submit.click();
     await expect(dialog).toBeHidden();
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #4913. Regular members got the Reinstall button on their own personal remote install card but the dialog inside hid its Submit button: the scope picker (`SelectMcpServerCredentialTypeAndTeams`) recomputed `canInstall` from scratch as if this were a fresh install, found personal "already used" by the existing install, and was rejected on team / org for lack of `mcpServerInstallation: update` (team) and `admin` (org). End-user effect: a member who clicked Reinstall could see the new-credential fields but had nothing to click to submit them.

The picker already exposes `isReinstall` + `existingScope` + `existingTeamId` to lock to the existing scope (used by the local reinstall flow since day one). This PR plumbs the same three props through `RemoteServerInstallDialog` from `InternalMCPCatalog`, captures them in the remote branch of `handleReinstall`, and clears them on dialog close. The local flow is unchanged.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>