### PR TITLE
fix(oauth): read ARCHESTRA_API_BASE_URL for public-origin host allowlist

### DIFF
--- a/platform/backend/src/config.test.ts
+++ b/platform/backend/src/config.test.ts
@@ -1228,7 +1228,7 @@ describe("getMCPGatewayOauthAllowedPublicHosts", () => {
 
   beforeEach(() => {
     process.env = { ...originalEnv };
-    delete process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL;
+    delete process.env.ARCHESTRA_API_BASE_URL;
   });
 
   afterEach(() => {
@@ -1237,7 +1237,7 @@ describe("getMCPGatewayOauthAllowedPublicHosts", () => {
 
   // ARCHESTRA_FRONTEND_URL is captured at module load (config.frontendBaseUrl),
   // so it can't be mutated per-test. We assert the function pulls that captured
-  // value through, and exercise the NEXT_PUBLIC_ARCHESTRA_API_BASE_URL path
+  // value through, and exercise the ARCHESTRA_API_BASE_URL path
   // (which is read fresh on every call) for the rest of the behavior.
 
   test("always includes the frontendBaseUrl host", () => {
@@ -1248,20 +1248,20 @@ describe("getMCPGatewayOauthAllowedPublicHosts", () => {
     );
   });
 
-  test("returns only the frontend host when NEXT_PUBLIC_ARCHESTRA_API_BASE_URL is unset", () => {
+  test("returns only the frontend host when ARCHESTRA_API_BASE_URL is unset", () => {
     const expected = new URL(config.frontendBaseUrl).host.toLowerCase();
     expect(getMCPGatewayOauthAllowedPublicHosts()).toEqual(new Set([expected]));
   });
 
-  test("includes a single NEXT_PUBLIC_ARCHESTRA_API_BASE_URL host", () => {
-    process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL = "https://api.example.com";
+  test("includes a single ARCHESTRA_API_BASE_URL host", () => {
+    process.env.ARCHESTRA_API_BASE_URL = "https://api.example.com";
     expect(getMCPGatewayOauthAllowedPublicHosts().has("api.example.com")).toBe(
       true,
     );
   });
 
-  test("splits comma-separated NEXT_PUBLIC_ARCHESTRA_API_BASE_URL", () => {
-    process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL =
+  test("splits comma-separated ARCHESTRA_API_BASE_URL", () => {
+    process.env.ARCHESTRA_API_BASE_URL =
       "https://api.example.com,https://internal.svc:9000";
     const hosts = getMCPGatewayOauthAllowedPublicHosts();
     expect(hosts.has("api.example.com")).toBe(true);
@@ -1269,7 +1269,7 @@ describe("getMCPGatewayOauthAllowedPublicHosts", () => {
   });
 
   test("strips default ports (80 for http, 443 for https)", () => {
-    process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL =
+    process.env.ARCHESTRA_API_BASE_URL =
       "https://api.example.com:443,http://other.example.com:80";
     const hosts = getMCPGatewayOauthAllowedPublicHosts();
     expect(hosts.has("api.example.com")).toBe(true);
@@ -1277,7 +1277,7 @@ describe("getMCPGatewayOauthAllowedPublicHosts", () => {
   });
 
   test("keeps explicit non-default ports", () => {
-    process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL =
+    process.env.ARCHESTRA_API_BASE_URL =
       "http://something.example:9000,https://api.example.com:8443";
     const hosts = getMCPGatewayOauthAllowedPublicHosts();
     expect(hosts.has("something.example:9000")).toBe(true);
@@ -1285,14 +1285,14 @@ describe("getMCPGatewayOauthAllowedPublicHosts", () => {
   });
 
   test("lowercases hostnames", () => {
-    process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL = "https://Api.Example.COM";
+    process.env.ARCHESTRA_API_BASE_URL = "https://Api.Example.COM";
     expect(getMCPGatewayOauthAllowedPublicHosts().has("api.example.com")).toBe(
       true,
     );
   });
 
   test("trims whitespace around comma-separated URLs", () => {
-    process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL =
+    process.env.ARCHESTRA_API_BASE_URL =
       "  https://api.example.com , https://internal.svc:9000  ";
     const hosts = getMCPGatewayOauthAllowedPublicHosts();
     expect(hosts.has("api.example.com")).toBe(true);
@@ -1300,7 +1300,7 @@ describe("getMCPGatewayOauthAllowedPublicHosts", () => {
   });
 
   test("ignores empty entries from extra commas", () => {
-    process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL =
+    process.env.ARCHESTRA_API_BASE_URL =
       "https://api.example.com,,https://internal.svc:9000";
     const hosts = getMCPGatewayOauthAllowedPublicHosts();
     expect(hosts.has("api.example.com")).toBe(true);
@@ -1308,8 +1308,7 @@ describe("getMCPGatewayOauthAllowedPublicHosts", () => {
   });
 
   test("ignores malformed URLs without failing", () => {
-    process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL =
-      "not-a-url,https://api.example.com";
+    process.env.ARCHESTRA_API_BASE_URL = "not-a-url,https://api.example.com";
     expect(getMCPGatewayOauthAllowedPublicHosts().has("api.example.com")).toBe(
       true,
     );

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -475,8 +475,11 @@ export const parseSampleRate = (
  * Hostnames that `getPublicRequestOrigin` is willing to return when forwarded
  * headers are trusted. Always contains the frontend origin (`frontendBaseUrl`,
  * which defaults to http://localhost:3000 when ARCHESTRA_FRONTEND_URL is
- * unset) plus every URL in `NEXT_PUBLIC_ARCHESTRA_API_BASE_URL` — the same
- * comma-separated list the frontend's `getExternalProxyUrls` reads.
+ * unset) plus every URL in `ARCHESTRA_API_BASE_URL` — the same
+ * comma-separated list the frontend's `getExternalProxyUrls` reads (after
+ * supervisord re-exports it as `NEXT_PUBLIC_ARCHESTRA_API_BASE_URL` for the
+ * Next.js process). The backend inherits the canonical `ARCHESTRA_API_BASE_URL`
+ * directly, so we read that here.
  *
  * Returned as a set of normalized `host` strings (lowercased; default ports
  * stripped — i.e. matching what `new URL(...).host` produces).
@@ -495,7 +498,7 @@ export const getMCPGatewayOauthAllowedPublicHosts = (): Set<string> => {
 
   addHostFromUrl(frontendBaseUrl);
 
-  const externalUrls = process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL?.trim();
+  const externalUrls = process.env.ARCHESTRA_API_BASE_URL?.trim();
   if (externalUrls) {
     for (const url of externalUrls.split(",")) {
       const trimmed = url.trim();

--- a/platform/backend/src/routes/auth.test.ts
+++ b/platform/backend/src/routes/auth.test.ts
@@ -405,10 +405,9 @@ describe("auth routes", () => {
     );
 
     const originalTrustProxy = config.api.trustProxy;
-    const originalAllowlist = process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL;
+    const originalAllowlist = process.env.ARCHESTRA_API_BASE_URL;
     config.api.trustProxy = true;
-    process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL =
-      "https://backend.example.com";
+    process.env.ARCHESTRA_API_BASE_URL = "https://backend.example.com";
     await app.close();
     app = await createAuthTestApp();
 
@@ -436,9 +435,9 @@ describe("auth routes", () => {
     } finally {
       config.api.trustProxy = originalTrustProxy;
       if (originalAllowlist === undefined) {
-        delete process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL;
+        delete process.env.ARCHESTRA_API_BASE_URL;
       } else {
-        process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL = originalAllowlist;
+        process.env.ARCHESTRA_API_BASE_URL = originalAllowlist;
       }
     }
   });
@@ -545,10 +544,9 @@ describe("auth routes", () => {
     );
 
     const originalTrustProxy = config.api.trustProxy;
-    const originalAllowlist = process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL;
+    const originalAllowlist = process.env.ARCHESTRA_API_BASE_URL;
     config.api.trustProxy = true;
-    process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL =
-      "https://gateway.example.com";
+    process.env.ARCHESTRA_API_BASE_URL = "https://gateway.example.com";
     await app.close();
     app = await createAuthTestApp();
 
@@ -577,9 +575,9 @@ describe("auth routes", () => {
     } finally {
       config.api.trustProxy = originalTrustProxy;
       if (originalAllowlist === undefined) {
-        delete process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL;
+        delete process.env.ARCHESTRA_API_BASE_URL;
       } else {
-        process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL = originalAllowlist;
+        process.env.ARCHESTRA_API_BASE_URL = originalAllowlist;
       }
     }
   });

--- a/platform/backend/src/routes/mcp-gateway.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.test.ts
@@ -199,9 +199,8 @@ describe("MCP Gateway (stateless mode)", () => {
   test("uses forwarded public origin in WWW-Authenticate when proxy trust is enabled", async ({
     makeAgent,
   }) => {
-    const originalAllowlist = process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL;
-    process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL =
-      "https://gateway.example.com";
+    const originalAllowlist = process.env.ARCHESTRA_API_BASE_URL;
+    process.env.ARCHESTRA_API_BASE_URL = "https://gateway.example.com";
     const proxyApp = Fastify({
       trustProxy: true,
     }).withTypeProvider<ZodTypeProvider>();
@@ -241,9 +240,9 @@ describe("MCP Gateway (stateless mode)", () => {
     } finally {
       await proxyApp.close();
       if (originalAllowlist === undefined) {
-        delete process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL;
+        delete process.env.ARCHESTRA_API_BASE_URL;
       } else {
-        process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL = originalAllowlist;
+        process.env.ARCHESTRA_API_BASE_URL = originalAllowlist;
       }
     }
   });
@@ -251,9 +250,8 @@ describe("MCP Gateway (stateless mode)", () => {
   test("uses forwarded public origin when CIDR proxy trust matches the remote address", async ({
     makeAgent,
   }) => {
-    const originalAllowlist = process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL;
-    process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL =
-      "https://gateway.example.com";
+    const originalAllowlist = process.env.ARCHESTRA_API_BASE_URL;
+    process.env.ARCHESTRA_API_BASE_URL = "https://gateway.example.com";
     const proxyApp = Fastify({
       trustProxy: "127.0.0.1/32",
     }).withTypeProvider<ZodTypeProvider>();
@@ -293,9 +291,9 @@ describe("MCP Gateway (stateless mode)", () => {
     } finally {
       await proxyApp.close();
       if (originalAllowlist === undefined) {
-        delete process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL;
+        delete process.env.ARCHESTRA_API_BASE_URL;
       } else {
-        process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL = originalAllowlist;
+        process.env.ARCHESTRA_API_BASE_URL = originalAllowlist;
       }
     }
   });

--- a/platform/backend/src/routes/oauth-server.test.ts
+++ b/platform/backend/src/routes/oauth-server.test.ts
@@ -193,7 +193,7 @@ describe("OAuth Server - Well-Known Endpoints", () => {
           ...originalEnv,
           ARCHESTRA_TRUST_PROXY: "true",
           // Public origins used by tests in this describe.
-          NEXT_PUBLIC_ARCHESTRA_API_BASE_URL:
+          ARCHESTRA_API_BASE_URL:
             "https://gateway.example.com,https://archestra.example.com",
         };
         proxyApp = Fastify({


### PR DESCRIPTION
## Summary

- The MCP gateway OAuth host allowlist in `getMCPGatewayOauthAllowedPublicHosts` was reading `NEXT_PUBLIC_ARCHESTRA_API_BASE_URL`, but the backend process never sees that env var.
- The canonical name everywhere else (`Dockerfile`, `.env.example`, `helm/archestra/values.yaml`, `.github/values-staging.yaml`, `dev/Tiltfile.dev`) is `ARCHESTRA_API_BASE_URL`. Supervisord rewrites it to `NEXT_PUBLIC_ARCHESTRA_API_BASE_URL` **only inside the `[program:frontend]` block** so Next.js can expose it to the browser. The backend program inherits the plain `ARCHESTRA_API_BASE_URL` from the pod env directly.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>