### PR TITLE
fix(chatops): split Slack replies to stay under 50-block expansion cap

### DIFF
--- a/platform/backend/src/agents/chatops/slack-provider.test.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.test.ts
@@ -492,6 +492,137 @@ describe("SlackProvider.sendReply", () => {
       thread_ts: "1111111111.000000",
     });
   });
+
+  test("splits into thread follow-ups when markdown expansion would exceed Slack's 50-block cap", async () => {
+    const provider = createProvider();
+    const postMessage = vi
+      .fn()
+      .mockResolvedValueOnce({ ts: "1000.000001" })
+      .mockResolvedValueOnce({ ts: "1000.000002" })
+      .mockResolvedValueOnce({ ts: "1000.000003" })
+      .mockResolvedValueOnce({ ts: "1000.000004" });
+    // biome-ignore lint/suspicious/noExplicitAny: test-only — mock Slack client
+    (provider as any).client = { chat: { postMessage } };
+
+    // Mirrors the actual repro from prod logs: 1 H1 + 55 sections of
+    // (H2 heading + 5-row table). Slack expands the markdown block into one
+    // Block Kit block per heading and one per table → 1 + 55*2 = 111 expanded
+    // blocks, which exceeds Slack's 50-per-message cap.
+    const section = (n: number) =>
+      `## Table ${n}\n| A | B | C |\n|---|---|---|\n| 1 | 2 | 3 |\n| 4 | 5 | 6 |\n| 7 | 8 | 9 |`;
+    const text = `# 55 Markdown Tables\n\n${Array.from({ length: 55 }, (_, i) =>
+      section(i + 1),
+    ).join("\n\n")}`;
+
+    const result = await provider.sendReply({
+      originalMessage: {
+        messageId: "9999999999.000000",
+        channelId: "C12345",
+        workspaceId: "T12345",
+        threadId: "1111111111.000000",
+        senderId: "U_SENDER",
+        senderName: "Test User",
+        text: "give me 55 tables",
+        rawText: "give me 55 tables",
+        timestamp: new Date(),
+        isThreadReply: false,
+      },
+      text,
+      footer: "🤖 Agent",
+    });
+
+    // First message's ts is returned to callers.
+    expect(result).toBe("1000.000001");
+
+    // Must have split into at least 2 messages (single message would expand
+    // to 111+ blocks server-side and Slack would reject with invalid_blocks).
+    const callCount = postMessage.mock.calls.length;
+    expect(callCount).toBeGreaterThanOrEqual(2);
+
+    // All messages thread under the original thread.
+    for (const [args] of postMessage.mock.calls) {
+      expect(args.thread_ts).toBe("1111111111.000000");
+      expect(args.channel).toBe("C12345");
+    }
+
+    // Non-final messages carry a "continued in a message below" context block.
+    for (let i = 0; i < callCount - 1; i++) {
+      const args = postMessage.mock.calls[i][0];
+      const lastBlock = args.blocks[args.blocks.length - 1];
+      expect(lastBlock).toEqual({
+        type: "context",
+        elements: [
+          {
+            type: "plain_text",
+            text: "continued in a message below",
+            emoji: true,
+          },
+        ],
+      });
+    }
+
+    // Final message carries the agent footer.
+    const finalArgs = postMessage.mock.calls[callCount - 1][0];
+    const finalFooter = finalArgs.blocks[finalArgs.blocks.length - 1];
+    expect(finalFooter).toEqual({
+      type: "context",
+      elements: [{ type: "plain_text", text: "🤖 Agent", emoji: true }],
+    });
+
+    // Every section's heading should appear exactly once across the split
+    // messages — no content lost, no duplication.
+    const allMarkdownText = postMessage.mock.calls
+      .flatMap(([args]) => args.blocks)
+      .filter((b: { type: string }) => b.type === "markdown")
+      .map((b: { text: string }) => b.text)
+      .join("\n\n");
+    for (let i = 1; i <= 55; i++) {
+      const occurrences = allMarkdownText.split(`## Table ${i}\n`).length - 1;
+      expect(occurrences).toBe(1);
+    }
+  });
+
+  test("follow-ups thread under the first message when the original wasn't a thread", async () => {
+    const provider = createProvider();
+    const postMessage = vi
+      .fn()
+      .mockResolvedValueOnce({ ts: "2000.000001" })
+      .mockResolvedValueOnce({ ts: "2000.000002" })
+      .mockResolvedValueOnce({ ts: "2000.000003" });
+    // biome-ignore lint/suspicious/noExplicitAny: test-only — mock Slack client
+    (provider as any).client = { chat: { postMessage } };
+
+    const section = (n: number) =>
+      `## Table ${n}\n| A | B |\n|---|---|\n| 1 | 2 |`;
+    const text = Array.from({ length: 55 }, (_, i) => section(i + 1)).join(
+      "\n\n",
+    );
+
+    await provider.sendReply({
+      originalMessage: {
+        messageId: "9999999999.000000",
+        channelId: "C12345",
+        workspaceId: "T12345",
+        // No threadId — first post lands top-level.
+        senderId: "U_SENDER",
+        senderName: "Test User",
+        text: "long reply",
+        rawText: "long reply",
+        timestamp: new Date(),
+        isThreadReply: false,
+      },
+      text,
+    });
+
+    expect(postMessage.mock.calls.length).toBeGreaterThanOrEqual(2);
+    const firstArgs = postMessage.mock.calls[0][0];
+    const secondArgs = postMessage.mock.calls[1][0];
+
+    // First post is top-level (no thread).
+    expect(firstArgs.thread_ts).toBeUndefined();
+    // Subsequent posts thread under the first message's ts.
+    expect(secondArgs.thread_ts).toBe("2000.000001");
+  });
 });
 
 // =============================================================================

--- a/platform/backend/src/agents/chatops/slack-provider.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.ts
@@ -321,39 +321,71 @@ class SlackProvider implements ChatOpsProvider {
       throw new Error("SlackProvider not initialized");
     }
 
-    // Slack's native markdown block preserves standard markdown from LLMs
-    // better than converting to mrkdwn first.
-    // biome-ignore lint/suspicious/noExplicitAny: Block Kit types are complex; shape is correct
-    const blocks: any[] = splitSlackMarkdownText(options.text).map((text) => ({
-      type: "markdown",
-      text,
-    }));
+    // Slack expands `markdown` blocks server-side into Block Kit primitives
+    // (one per heading, table, list, code block, paragraph) and rejects any
+    // chat.postMessage whose expanded blocks[] exceeds 50. splitSlackMarkdownText
+    // chunks the text so each chunk's estimated expansion stays under that cap;
+    // we post one message per chunk and thread the follow-ups so the user sees
+    // the full reply. Non-final messages reserve their footer slot for a
+    // "continued in a message below" hint.
+    const chunks = splitSlackMarkdownText(options.text);
 
-    if (options.footer) {
-      blocks.push({
-        type: "context",
-        elements: [
-          {
-            type: "plain_text",
-            text: options.footer,
-            emoji: true,
-          },
-        ],
-      });
+    let firstTs = "";
+    for (let i = 0; i < chunks.length; i++) {
+      const isFinal = i === chunks.length - 1;
+      const chunkText = chunks[i];
+
+      // biome-ignore lint/suspicious/noExplicitAny: Block Kit types are complex; shape is correct
+      const blocks: any[] = [{ type: "markdown", text: chunkText }];
+
+      if (!isFinal) {
+        blocks.push({
+          type: "context",
+          elements: [
+            {
+              type: "plain_text",
+              text: "continued in a message below",
+              emoji: true,
+            },
+          ],
+        });
+      } else if (options.footer) {
+        blocks.push({
+          type: "context",
+          elements: [{ type: "plain_text", text: options.footer, emoji: true }],
+        });
+      }
+
+      const fallbackText =
+        isFinal && options.footer
+          ? `${chunkText}\n\n${options.footer}`
+          : chunkText;
+
+      // Follow-ups thread under the first message when the original wasn't a
+      // thread, so we don't spam the channel with N top-level posts.
+      const threadTs =
+        options.originalMessage.threadId ?? (firstTs || undefined);
+
+      const postArgs = {
+        channel: options.originalMessage.channelId,
+        text: fallbackText,
+        blocks,
+        thread_ts: threadTs,
+      };
+      logger.debug(
+        {
+          postArgs,
+          part: i + 1,
+          of: chunks.length,
+          estimatedRenderedBlocks: estimateRenderedBlocks(chunkText),
+        },
+        "[SlackProvider] chat.postMessage (sendReply)",
+      );
+      const result = await this.client.chat.postMessage(postArgs);
+      if (i === 0) firstTs = (result.ts as string) || "";
     }
 
-    const postArgs = {
-      channel: options.originalMessage.channelId,
-      text: options.footer
-        ? `${options.text}\n\n${options.footer}`
-        : options.text,
-      blocks,
-      thread_ts: options.originalMessage.threadId,
-    };
-    logger.debug({ postArgs }, "[SlackProvider] chat.postMessage (sendReply)");
-    const result = await this.client.chat.postMessage(postArgs);
-
-    return (result.ts as string) || "";
+    return firstTs;
   }
 
   async addApprovalRequestForm(
@@ -1647,34 +1679,194 @@ function decodeSlackEntities(text: string): string {
     .replace(/&amp;/g, "&");
 }
 
-function splitSlackMarkdownText(text: string): string[] {
-  const MARKDOWN_BLOCK_LIMIT = 12_000;
+// Slack's `markdown` block has a 12,000-char limit per block.
+const MARKDOWN_BLOCK_CHAR_LIMIT = 12_000;
 
-  if (text.length <= MARKDOWN_BLOCK_LIMIT) {
+// Slack rejects chat.postMessage with more than 50 expanded blocks. Each
+// sendReply message reserves 1 slot for a context footer (continuation hint
+// or agent footer), so the markdown block's expansion is bounded to 45 — 4
+// under the 49 ceiling for safety against estimator drift.
+const MAX_ESTIMATED_RENDERED_BLOCKS = 45;
+
+/**
+ * Estimate how many Block Kit blocks Slack will produce when rendering this
+ * text inside a `markdown` block. Slack expands markdown server-side: each
+ * heading, table, list, code block, and paragraph becomes its own block.
+ *
+ * Returns a conservative upper bound (≥ 1) used by splitSlackMarkdownText to
+ * keep each message under Slack's 50-block-per-message cap.
+ */
+function estimateRenderedBlocks(text: string): number {
+  const lines = text.split("\n");
+  let count = 0;
+  let inCodeBlock = false;
+  let inTable = false;
+  let inList = false;
+  let pendingParagraph = false;
+
+  const flushParagraph = () => {
+    if (pendingParagraph) {
+      count += 1;
+      pendingParagraph = false;
+    }
+  };
+  const flushTable = () => {
+    if (inTable) {
+      count += 1;
+      inTable = false;
+    }
+  };
+  const flushList = () => {
+    if (inList) {
+      count += 1;
+      inList = false;
+    }
+  };
+
+  for (const line of lines) {
+    if (line.trim().startsWith("```")) {
+      if (inCodeBlock) {
+        count += 1;
+        inCodeBlock = false;
+      } else {
+        flushParagraph();
+        flushTable();
+        flushList();
+        inCodeBlock = true;
+      }
+      continue;
+    }
+    if (inCodeBlock) continue;
+
+    const trimmed = line.trim();
+
+    if (trimmed === "") {
+      flushParagraph();
+      flushTable();
+      flushList();
+      continue;
+    }
+
+    if (/^#{1,6}\s/.test(trimmed)) {
+      flushParagraph();
+      flushTable();
+      flushList();
+      count += 1;
+      continue;
+    }
+
+    if (trimmed.startsWith("|")) {
+      if (!inTable) {
+        flushParagraph();
+        flushList();
+        inTable = true;
+      }
+      continue;
+    }
+    if (inTable) flushTable();
+
+    if (/^[-*+]\s/.test(trimmed) || /^\d+\.\s/.test(trimmed)) {
+      if (!inList) {
+        flushParagraph();
+        inList = true;
+      }
+      continue;
+    }
+    if (inList) flushList();
+
+    pendingParagraph = true;
+  }
+
+  flushParagraph();
+  flushTable();
+  flushList();
+  if (inCodeBlock) count += 1;
+
+  return Math.max(count, 1);
+}
+
+/**
+ * Split text into chunks where each chunk fits in one Slack message:
+ * - text length ≤ MARKDOWN_BLOCK_CHAR_LIMIT (the markdown block's char cap)
+ * - estimated rendered blocks ≤ MAX_ESTIMATED_RENDERED_BLOCKS (under Slack's
+ *   50-block-per-message cap, after reserving 1 slot for a footer)
+ *
+ * Splits at paragraph (`\n\n`) boundaries to preserve markdown structure. A
+ * single paragraph that exceeds the char limit falls back to a line-based hard
+ * split; oversized-by-blocks paragraphs are exceedingly rare in LLM output
+ * (would require dozens of headings with no blank lines between them) and are
+ * also passed through hard-split as a best effort.
+ */
+function splitSlackMarkdownText(text: string): string[] {
+  if (
+    text.length <= MARKDOWN_BLOCK_CHAR_LIMIT &&
+    estimateRenderedBlocks(text) <= MAX_ESTIMATED_RENDERED_BLOCKS
+  ) {
     return [text];
   }
 
+  const paragraphs = text.split(/\n\n+/);
+  const chunks: string[] = [];
+  let buffer: string[] = [];
+  let bufferChars = 0;
+  let bufferBlocks = 0;
+
+  const flushBuffer = () => {
+    if (buffer.length > 0) {
+      chunks.push(buffer.join("\n\n"));
+      buffer = [];
+      bufferChars = 0;
+      bufferBlocks = 0;
+    }
+  };
+
+  for (const para of paragraphs) {
+    if (para.length === 0) continue;
+    const paraBlocks = estimateRenderedBlocks(para);
+
+    if (
+      para.length > MARKDOWN_BLOCK_CHAR_LIMIT ||
+      paraBlocks > MAX_ESTIMATED_RENDERED_BLOCKS
+    ) {
+      flushBuffer();
+      for (const sub of hardSplitOversizedParagraph(para)) {
+        chunks.push(sub);
+      }
+      continue;
+    }
+
+    const sep = buffer.length > 0 ? 2 : 0;
+    const wouldExceedChars =
+      bufferChars + sep + para.length > MARKDOWN_BLOCK_CHAR_LIMIT;
+    const wouldExceedBlocks =
+      bufferBlocks + paraBlocks > MAX_ESTIMATED_RENDERED_BLOCKS;
+
+    if (buffer.length > 0 && (wouldExceedChars || wouldExceedBlocks)) {
+      flushBuffer();
+    }
+
+    buffer.push(para);
+    bufferChars += (buffer.length > 1 ? 2 : 0) + para.length;
+    bufferBlocks += paraBlocks;
+  }
+
+  flushBuffer();
+  return chunks.length > 0 ? chunks : [text];
+}
+
+function hardSplitOversizedParagraph(text: string): string[] {
   const chunks: string[] = [];
   let remaining = text;
-
   while (remaining.length > 0) {
-    if (remaining.length <= MARKDOWN_BLOCK_LIMIT) {
+    if (remaining.length <= MARKDOWN_BLOCK_CHAR_LIMIT) {
       chunks.push(remaining);
       break;
     }
-
-    let splitAt = remaining.lastIndexOf("\n\n", MARKDOWN_BLOCK_LIMIT);
-    if (splitAt <= 0) {
-      splitAt = remaining.lastIndexOf("\n", MARKDOWN_BLOCK_LIMIT);
-    }
-    if (splitAt <= 0) {
-      splitAt = MARKDOWN_BLOCK_LIMIT;
-    }
-
+    let splitAt = remaining.lastIndexOf("\n", MARKDOWN_BLOCK_CHAR_LIMIT);
+    if (splitAt <= 0) splitAt = MARKDOWN_BLOCK_CHAR_LIMIT;
     chunks.push(remaining.slice(0, splitAt));
     remaining = remaining.slice(splitAt).trim();
   }
-
   return chunks;
 }
 


### PR DESCRIPTION
## Summary
- Slack's `markdown` block expands server-side into Block Kit primitives (heading, table, list, code block, paragraph each become their own block). `chat.postMessage` rejects requests whose expanded `blocks[]` exceeds 50 with `invalid_blocks`. The old messhage splitter only bounded per-block char length, so a single `markdown` block could blow past the cap (e.g. a reply containing many headings + tables).
- Added `estimateRenderedBlocks(text)` that estimates counts the markdown structural elements Slack will turn into separate blocks.
- Rewrote `splitSlackMarkdownText` to bound each chunk by both the 12 000-char per-block limit **and** an estimated expansion of ≤ 45 — under Slack's 50 cap with headroom for the context footer and estimator drift.
- `SlackProvider.sendReply` now posts one message per chunk (1 `markdown` block + 1 `context` block). Non-final messages get a "continued in a message below" hint; the final message keeps the agent footer when provided. Follow-ups thread under the first message when the original wasn't a thread. `sendReply` still returns the first message's `ts` so caller-side interaction tracking is unchanged.
- Debug log now includes `part`, `of`, and `estimatedRenderedBlocks` so future expansion-related rejections are diagnosable from logs alone.


---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>