### PR TITLE
fix(mcp-server): merge & validate userConfig against effective state on reinstall

### DIFF
--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -1485,6 +1485,160 @@ describe("mcp server inspect route", () => {
     await drainPendingReinstall(mcpServer.id);
   });
 
+  // Required userConfig fields already on the install's secret bag are
+  // satisfied by the merged effective state — without this, a partial
+  // reinstall would 400 before the bag merge could preserve the stored
+  // value (mirrors the env-side fix earlier in this file).
+  test("reinstall accepts a body that omits required userConfig fields already on the install's secret bag", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Remote Reinstall Required UserConfig From Bag",
+      serverType: "remote",
+      serverUrl: "http://localhost:30082/mcp",
+      userConfig: {
+        header_existing: {
+          type: "string",
+          title: "x-existing",
+          description: "Existing header set at original install",
+          promptOnInstallation: true,
+          required: true,
+          sensitive: false,
+          headerName: "x-existing",
+        },
+        header_new: {
+          type: "string",
+          title: "x-new",
+          description: "New header added in a catalog edit",
+          promptOnInstallation: true,
+          required: true,
+          sensitive: false,
+          headerName: "x-new",
+        },
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    await db
+      .update(schema.mcpServersTable)
+      .set({ serverType: "remote" })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    const existingBag = await secretManager().createSecret(
+      { header_existing: "on-the-bag" },
+      `${mcpServer.name}-existing-bag`,
+    );
+    await db
+      .update(schema.mcpServersTable)
+      .set({ secretId: existingBag.id })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: {
+        userConfigValues: { header_new: "user-fills-only-the-new-one" },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const [updatedServer] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    expect(updatedServer?.secretId).toBeTruthy();
+
+    const storedSecret = await secretManager().getSecret(
+      updatedServer.secretId!,
+    );
+    expect(storedSecret?.secret).toMatchObject({
+      header_existing: "on-the-bag",
+      header_new: "user-fills-only-the-new-one",
+    });
+
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const [serverRow] = await db
+        .select()
+        .from(schema.mcpServersTable)
+        .where(eq(schema.mcpServersTable.id, mcpServer.id));
+      if (serverRow?.localInstallationStatus !== "pending") break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  });
+
+  // An explicit empty string for an OPTIONAL userConfig field signals
+  // delete. Omission preserves the bag entry; "" removes it.
+  test("reinstall body with empty string for an optional userConfig field deletes it from the bag", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Remote Reinstall Optional UserConfig Clear",
+      serverType: "remote",
+      serverUrl: "http://localhost:30082/mcp",
+      userConfig: {
+        header_optional: {
+          type: "string",
+          title: "x-optional",
+          description: "Optional header the user can clear",
+          promptOnInstallation: true,
+          required: false,
+          sensitive: false,
+          headerName: "x-optional",
+        },
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    await db
+      .update(schema.mcpServersTable)
+      .set({ serverType: "remote" })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    const existingBag = await secretManager().createSecret(
+      { header_optional: "to-be-cleared", unrelated_key: "keep-me" },
+      `${mcpServer.name}-existing-bag`,
+    );
+    await db
+      .update(schema.mcpServersTable)
+      .set({ secretId: existingBag.id })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: { userConfigValues: { header_optional: "" } },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const [updatedServer] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    const storedSecret = await secretManager().getSecret(
+      updatedServer.secretId!,
+    );
+    expect(storedSecret?.secret).not.toHaveProperty("header_optional");
+    // Unrelated bag entries (OAuth tokens, etc) must stay put.
+    expect(storedSecret?.secret).toMatchObject({ unrelated_key: "keep-me" });
+
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const [serverRow] = await db
+        .select()
+        .from(schema.mcpServersTable)
+        .where(eq(schema.mcpServersTable.id, mcpServer.id));
+      if (serverRow?.localInstallationStatus !== "pending") break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  });
+
   test("automatically retries protected remote MCP server installation with an exchanged enterprise-managed credential", async ({
     makeAccount,
     makeIdentityProvider,

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -1164,6 +1164,187 @@ describe("mcp server inspect route", () => {
     await drainPendingReinstall(mcpServer.id);
   });
 
+  // A partial reinstall (user fills only a newly-added required header) must
+  // not 400 on a required header whose value is already on the install's bag.
+  test("reinstall accepts a body that omits required userConfig fields already on the install's secret bag", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Remote Reinstall Required UserConfig From Bag",
+      serverType: "remote",
+      serverUrl: "http://localhost:30082/mcp",
+      userConfig: {
+        header_existing: {
+          type: "string",
+          title: "x-existing",
+          description: "Existing header set at original install",
+          promptOnInstallation: true,
+          required: true,
+          sensitive: false,
+          headerName: "x-existing",
+        },
+        header_new: {
+          type: "string",
+          title: "x-new",
+          description: "New header added in a catalog edit",
+          promptOnInstallation: true,
+          required: true,
+          sensitive: false,
+          headerName: "x-new",
+        },
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    await db
+      .update(schema.mcpServersTable)
+      .set({ serverType: "remote" })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    const existingBag = await secretManager().createSecret(
+      { header_existing: "on-the-bag" },
+      `${mcpServer.name}-existing-bag`,
+    );
+    await db
+      .update(schema.mcpServersTable)
+      .set({ secretId: existingBag.id })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: {
+        userConfigValues: { header_new: "user-fills-only-the-new-one" },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const [updatedServer] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    expect(updatedServer?.secretId).toBeTruthy();
+
+    const storedSecret = await secretManager().getSecret(
+      updatedServer.secretId!,
+    );
+    expect(storedSecret?.secret).toMatchObject({
+      header_existing: "on-the-bag",
+      header_new: "user-fills-only-the-new-one",
+    });
+
+    await drainPendingReinstall(mcpServer.id);
+  });
+
+  // An explicit empty string clears an optional userConfig field from the bag
+  // while leaving unrelated entries (OAuth tokens, etc.) untouched.
+  test("reinstall body with empty string for an optional userConfig field deletes it from the bag", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Remote Reinstall Optional UserConfig Clear",
+      serverType: "remote",
+      serverUrl: "http://localhost:30082/mcp",
+      userConfig: {
+        header_optional: {
+          type: "string",
+          title: "x-optional",
+          description: "Optional header the user can clear",
+          promptOnInstallation: true,
+          required: false,
+          sensitive: false,
+          headerName: "x-optional",
+        },
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    await db
+      .update(schema.mcpServersTable)
+      .set({ serverType: "remote" })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    const existingBag = await secretManager().createSecret(
+      { header_optional: "to-be-cleared", unrelated_key: "keep-me" },
+      `${mcpServer.name}-existing-bag`,
+    );
+    await db
+      .update(schema.mcpServersTable)
+      .set({ secretId: existingBag.id })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: { userConfigValues: { header_optional: "" } },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const [updatedServer] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    const storedSecret = await secretManager().getSecret(
+      updatedServer.secretId!,
+    );
+    expect(storedSecret?.secret).not.toHaveProperty("header_optional");
+    // Unrelated bag entries (OAuth tokens, etc.) must stay put.
+    expect(storedSecret?.secret).toMatchObject({ unrelated_key: "keep-me" });
+
+    await drainPendingReinstall(mcpServer.id);
+  });
+
+  // Required-userConfig validation runs even on an empty body, so a newly-added
+  // required connection setting that nothing satisfies fails fast with 400
+  // rather than starting the server on stale config.
+  test("reinstall with an empty body 400s when a required userConfig field is unsatisfied", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Remote Reinstall Empty Body Missing UserConfig",
+      serverType: "remote",
+      serverUrl: "http://localhost:30082/mcp",
+      userConfig: {
+        header_required: {
+          type: "string",
+          title: "x-required",
+          description: "Required header with no value anywhere yet",
+          promptOnInstallation: true,
+          required: true,
+          sensitive: false,
+          headerName: "x-required",
+        },
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    await db
+      .update(schema.mcpServersTable)
+      .set({ serverType: "remote" })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: { userConfigValues: {} },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error.message).toContain("header_required");
+  });
+
   // Regression: reinstall of a local MCP server with a newly-added prompted
   // plain_text env var used to land the value only in the K8s secret bag.
   // On the next pod start, the secret-typed-only filter dropped it, and the

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -1401,7 +1401,7 @@ describe("mcp server inspect route", () => {
     const response = await app.inject({
       method: "POST",
       url: `/api/mcp_server/${mcpServer.id}/reinstall`,
-      payload: { userConfigValues: {} },
+      payload: {},
     });
 
     expect(response.statusCode).toBe(400);

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -1302,6 +1302,69 @@ describe("mcp server inspect route", () => {
     await drainPendingReinstall(mcpServer.id);
   });
 
+  // A whitespace-only submission for a required userConfig field passes
+  // validation via the existing-bag fallback; it must not then overwrite the
+  // stored header with whitespace.
+  test("reinstall ignores a whitespace-only userConfig submission and keeps the stored value", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Remote Reinstall Whitespace UserConfig",
+      serverType: "remote",
+      serverUrl: "http://localhost:30082/mcp",
+      userConfig: {
+        header_required: {
+          type: "string",
+          title: "x-required",
+          description: "Required header already set at install",
+          promptOnInstallation: true,
+          required: true,
+          sensitive: false,
+          headerName: "x-required",
+        },
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    await db
+      .update(schema.mcpServersTable)
+      .set({ serverType: "remote" })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    const existingBag = await secretManager().createSecret(
+      { header_required: "valid-value" },
+      `${mcpServer.name}-existing-bag`,
+    );
+    await db
+      .update(schema.mcpServersTable)
+      .set({ secretId: existingBag.id })
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    await McpServerUserModel.assignUserToMcpServer(mcpServer.id, user.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/reinstall`,
+      payload: { userConfigValues: { header_required: "   " } },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const [updatedServer] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, mcpServer.id));
+    const storedSecret = await secretManager().getSecret(
+      updatedServer.secretId!,
+    );
+    expect(storedSecret?.secret).toMatchObject({
+      header_required: "valid-value",
+    });
+
+    await drainPendingReinstall(mcpServer.id);
+  });
+
   // Required-userConfig validation runs even on an empty body, so a newly-added
   // required connection setting that nothing satisfies fails fast with 400
   // rather than starting the server on stale config.

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -1676,6 +1676,11 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           }
         }
 
+        // Validate required userConfig fields against the effective post-
+        // merge state for non-BYOS — a required header already on the
+        // install's bag stays satisfied when the body only carries newly-
+        // added fields. BYOS still validates against the body alone (the
+        // user re-supplies all vault references on each reinstall).
         if (catalogItem.userConfig) {
           const requiredUserConfigFields = Object.entries(
             catalogItem.userConfig,
@@ -1685,8 +1690,18 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
 
           const missingUserConfigFields = requiredUserConfigFields.filter(
             ([fieldName]) => {
-              const value = userConfigValues?.[fieldName];
-              return !value?.trim();
+              const submitted = userConfigValues?.[fieldName];
+              if (isByosVault) {
+                return !submitted?.trim();
+              }
+              if (submitted === "") {
+                return true;
+              }
+              if (typeof submitted === "string" && submitted.trim()) {
+                return false;
+              }
+              const existing = existingSecrets[fieldName];
+              return typeof existing !== "string" || !existing.trim();
             },
           );
 
@@ -1729,14 +1744,34 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
             await McpServerModel.update(id, { secretId: secret.id });
           }
         } else {
-          // Non-BYOS mode: merge new values with the existing bag fetched
-          // above for validation.
-          const mergedSecrets = {
+          // Non-BYOS: merge new values with the existing bag (fetched
+          // above for validation), treating empty string in
+          // `userConfigValues` as the delete signal for that key.
+          // Omission preserves the existing entry.
+          const mergedSecrets: Record<string, unknown> = {
             ...existingSecrets,
             ...catalogStaticUserConfigValues,
             ...(environmentValues ?? {}),
-            ...(installUserConfigValues ?? {}),
           };
+          for (const [fieldName, fieldConfig] of Object.entries(
+            catalogItem.userConfig ?? {},
+          )) {
+            // Static catalog-only headers (headerName + promptOnInstallation
+            // === false) can't be overridden by an installer request — the
+            // catalog static spread above wins.
+            if (
+              fieldConfig?.headerName &&
+              fieldConfig?.promptOnInstallation === false
+            ) {
+              continue;
+            }
+            const submitted = userConfigValues?.[fieldName];
+            if (submitted === "") {
+              delete mergedSecrets[fieldName];
+            } else if (typeof submitted === "string") {
+              mergedSecrets[fieldName] = submitted;
+            }
+          }
 
           if (mcpServer.secretId) {
             await secretManager().updateSecret(

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -1895,10 +1895,14 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
             }
             const submitted = userConfigValues?.[fieldName];
             if (submitted === "") {
+              // Explicit clear.
               delete mergedSecrets[fieldName];
-            } else if (typeof submitted === "string") {
+            } else if (typeof submitted === "string" && submitted.trim()) {
               mergedSecrets[fieldName] = submitted;
             }
+            // A whitespace-only submission is treated as "no change" (matching
+            // validation's existing-bag fallback) so an accidental blank can't
+            // clobber a valid stored header.
           }
 
           if (mcpServer.secretId) {

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -1774,6 +1774,46 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
         }
       }
 
+      // Validate required userConfig (connection-setting) fields on the same
+      // terms as env vars above. For non-BYOS a field already on the install's
+      // bag stays satisfied when the body omits it, so a partial reinstall that
+      // only touches env doesn't 400 on an unchanged stored header; "" is an
+      // explicit clear. BYOS validates against the body alone since vault
+      // references are re-supplied on every reinstall.
+      if (catalogItem.userConfig) {
+        const requiredUserConfigFields = Object.entries(
+          catalogItem.userConfig,
+        ).filter(([_fieldName, fieldConfig]) => {
+          return fieldConfig.promptOnInstallation && fieldConfig.required;
+        });
+
+        const missingUserConfigFields = requiredUserConfigFields.filter(
+          ([fieldName]) => {
+            const submitted = userConfigValues?.[fieldName];
+            if (isByosVault) {
+              return !submitted?.trim();
+            }
+            if (submitted === "") {
+              return true;
+            }
+            if (typeof submitted === "string" && submitted.trim()) {
+              return false;
+            }
+            const existing = existingSecrets[fieldName];
+            return typeof existing !== "string" || !existing.trim();
+          },
+        );
+
+        if (missingUserConfigFields.length > 0) {
+          throw new ApiError(
+            400,
+            `Missing required connection settings: ${missingUserConfigFields
+              .map(([fieldName]) => fieldName)
+              .join(", ")}`,
+          );
+        }
+      }
+
       // New env/userConfig values land in this install's secret bag. The
       // runtime reload below reads `secretId` to pick them up.
       if (
@@ -1788,30 +1828,6 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           userConfigValues,
         });
 
-        if (catalogItem.userConfig) {
-          const requiredUserConfigFields = Object.entries(
-            catalogItem.userConfig,
-          ).filter(([_fieldName, fieldConfig]) => {
-            return fieldConfig.promptOnInstallation && fieldConfig.required;
-          });
-
-          const missingUserConfigFields = requiredUserConfigFields.filter(
-            ([fieldName]) => {
-              const value = userConfigValues?.[fieldName];
-              return !value?.trim();
-            },
-          );
-
-          if (missingUserConfigFields.length > 0) {
-            throw new ApiError(
-              400,
-              `Missing required connection settings: ${missingUserConfigFields
-                .map(([fieldName]) => fieldName)
-                .join(", ")}`,
-            );
-          }
-        }
-
         // Update or create secret with new values
         if (isByosVault) {
           // BYOS mode: values are vault references
@@ -1823,17 +1839,34 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
             );
           }
 
+          // BYOS vault bags hold only vault references. Plain (non-secret) env
+          // values are literals that belong on the install row's column
+          // (persisted below); spreading them here would have vault resolution
+          // misread a literal as a `path#key` reference. Restrict the env
+          // contribution to secret-typed keys.
+          const secretEnvKeys = new Set(
+            (catalogItem.localConfig?.environment ?? [])
+              .filter((envDef) => envDef.type === "secret")
+              .map((envDef) => envDef.key),
+          );
+          const submittedSecretEnv: Record<string, string> = {};
+          for (const [key, value] of Object.entries(submittedEnv)) {
+            if (secretEnvKeys.has(key)) {
+              submittedSecretEnv[key] = value;
+            }
+          }
+
           if (mcpServer.secretId) {
             await secretManager().updateSecret(mcpServer.secretId, {
               ...catalogStaticUserConfigValues,
-              ...submittedEnv,
+              ...submittedSecretEnv,
               ...(installUserConfigValues ?? {}),
             });
           } else {
             const secret = await secretManager().createSecret(
               {
                 ...catalogStaticUserConfigValues,
-                ...submittedEnv,
+                ...submittedSecretEnv,
                 ...(installUserConfigValues ?? {}),
               },
               `${mcpServer.name}-vault-secret`,
@@ -1841,14 +1874,32 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
             await McpServerModel.update(id, { secretId: secret.id });
           }
         } else {
-          // Non-BYOS mode: merge new values with the existing bag fetched
-          // above for validation.
-          const mergedSecrets = {
+          // Non-BYOS: merge new values with the existing bag (fetched above for
+          // validation). userConfig is applied per field so an empty string is
+          // an explicit clear and an omitted field preserves the stored value;
+          // static catalog-only headers are owned by the catalog static spread
+          // and can't be overridden by an installer request.
+          const mergedSecrets: Record<string, unknown> = {
             ...existingSecrets,
             ...catalogStaticUserConfigValues,
             ...submittedEnv,
-            ...(installUserConfigValues ?? {}),
           };
+          for (const [fieldName, fieldConfig] of Object.entries(
+            catalogItem.userConfig ?? {},
+          )) {
+            if (
+              fieldConfig?.headerName &&
+              fieldConfig?.promptOnInstallation === false
+            ) {
+              continue;
+            }
+            const submitted = userConfigValues?.[fieldName];
+            if (submitted === "") {
+              delete mergedSecrets[fieldName];
+            } else if (typeof submitted === "string") {
+              mergedSecrets[fieldName] = submitted;
+            }
+          }
 
           if (mcpServer.secretId) {
             await secretManager().updateSecret(


### PR DESCRIPTION
## Summary

A reinstall that re-supplied only a newly-added required connection setting (a `userConfig` header) used to fail with `400 Missing required connection settings` for an *unrelated* required header whose value was already stored on the install — because required-userConfig validation checked the request body alone. It now validates against the merged effective state (the request plus what's already on the install's secret bag), so a partial reinstall succeeds and only a genuinely-unsatisfied required field is rejected — now caught even on an empty body, instead of starting the server on stale config and failing later. This brings userConfig in line with the env-var handling on reinstall.

## Behavior

- **Required userConfig validated against merged state.** A required header already on the install's bag need not be re-supplied; an empty body still `400`s a required field that nothing satisfies. BYOS validates against the body alone, since vault references are re-supplied on every reinstall.
- **Per-field non-BYOS merge.** An empty string clears the field from the bag, an omitted field preserves the stored value, and unrelated bag entries (OAuth tokens, static catalog headers) are left untouched.
- **BYOS vault bag holds only references.** Only secret-typed env values go into the vault bag; plain env values are literals that live on the install row's column, so storing them in the bag (where resolution treats entries as `path#key` references) is avoided.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
