### PR TITLE
docs(platform-deployment): add Crossplane provider section

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -621,6 +621,45 @@ export ARCHESTRA_BASE_URL="https://api.archestra.example.com"
 
 For complete documentation, examples, and resource reference, visit the [Archestra Terraform Provider Documentation](https://registry.terraform.io/providers/archestra-ai/archestra/latest/docs).
 
+### Crossplane
+
+The same resources are also available as a Crossplane v1/v2 provider for teams that prefer GitOps-style reconciliation on Kubernetes. The xpkg is [upjet](https://github.com/crossplane/upjet)-generated from the Terraform provider's schema and published from the same release tag, so the two stay version-locked.
+
+**Install the provider**:
+
+```yaml
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-archestra
+spec:
+  package: xpkg.upbound.io/archestra/provider-archestra:v1.1.4
+```
+
+**Configure credentials** (the API key is the same one used by the Terraform provider — see [API Reference](/docs/platform-api-reference#authentication)):
+
+```bash
+kubectl create secret generic archestra-creds \
+  -n crossplane-system \
+  --from-literal=credentials='{"api_key":"arch_...","base_url":"https://api.archestra.example.com"}'
+```
+
+```yaml
+apiVersion: archestra.crossplane.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: archestra-creds
+      key: credentials
+```
+
+For supported resources, examples, and the contributor flow, see the [Crossplane provider README](https://github.com/archestra-ai/terraform-provider-archestra/blob/main/crossplane/README.md). Resource coverage is partial — current state and the gap vs. the Terraform provider are tracked on the [coverage badge](https://github.com/archestra-ai/terraform-provider-archestra#archestra-provider).
+
 ## Environment Variables
 
 The following environment variables can be used to configure Archestra Platform.


### PR DESCRIPTION
The Infrastructure-as-Code section of the platform deployment guide only mentioned the Terraform provider. Adds a sibling subsection under \"Infrastructure as Code\" covering:

- xpkg install (\`xpkg.upbound.io/archestra/provider-archestra\`)
- ProviderConfig wiring, including that it uses the same API key as the Terraform provider
- Pointer to [\`crossplane/README.md\`](https://github.com/archestra-ai/terraform-provider-archestra/blob/main/crossplane/README.md) for the supported-resources list, examples, and contributor flow
- Note on partial coverage with a link to the coverage badge

Cross-references the same source-of-truth content that's now in the terraform-provider-archestra repo's root README and crossplane subtree README.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>