### PR TITLE
fix: allow large chat uploads through frontend proxy

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -775,10 +775,10 @@ The following environment variables can be used to configure Archestra Platform.
   - Values: `true`, `false`, or a comma-separated list of trusted proxy IPs/CIDRs (e.g. `10.0.0.0/8,172.16.0.0/12`)
   - Example: `ARCHESTRA_TRUST_PROXY=true`
 
-- **`ARCHESTRA_API_BODY_LIMIT`** - Maximum request body size for LLM proxy and chat routes.
-  - Default: `50MB` (52428800 bytes)
+- **`ARCHESTRA_API_BODY_LIMIT`** - Maximum request body size for LLM proxy, chat routes, and frontend middleware uploads.
+  - Default: `70MB` (73400320 bytes)
   - Format: Numeric bytes (e.g., `52428800`) or human-readable (e.g., `50MB`, `100KB`, `1GB`)
-  - Note: Increase this if you have conversations with very large context windows (100k+ tokens) or large file attachments in chat
+  - Note: Increase this if you have conversations with very large context windows (100k+ tokens) or large file attachments in chat. Chat attachments are encoded in the request body, so the default allows for encoding overhead on files up to about 50 MB.
 
 - **`ARCHESTRA_FRONTEND_URL`** - Setting this variable enables origin validation for CORS and authentication. When set, only requests from this origin (and any in `ARCHESTRA_AUTH_ADDITIONAL_TRUSTED_ORIGINS`) are allowed. When not set, all origins are accepted.
   - Example: `https://frontend.example.com`

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -262,7 +262,7 @@ export const parseBodyLimit = (
   return defaultValue;
 };
 
-const DEFAULT_BODY_LIMIT = 50 * 1024 * 1024; // 50MB
+const DEFAULT_BODY_LIMIT = 70 * 1024 * 1024; // 70MB
 
 const DEFAULT_DATABASE_POOL_MAX = 50;
 const MAX_DATABASE_POOL_MAX = 500;

--- a/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
+++ b/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest";
-import { normalizeChatMessages } from "./normalize-chat-messages";
+import {
+  normalizeChatMessages,
+  normalizeChatMessagesForStorage,
+} from "./normalize-chat-messages";
 
 describe("normalizeChatMessages", () => {
   test("dedupes duplicate tool parts with the same toolCallId", () => {
@@ -98,5 +101,53 @@ describe("normalizeChatMessages", () => {
     const result = normalizeChatMessages(messages);
 
     expect(result[0].parts).toHaveLength(2);
+  });
+
+  test("replaces data URL file parts when normalizing messages for storage", () => {
+    const messages = [
+      {
+        id: "msg1",
+        role: "user" as const,
+        parts: [
+          { type: "text", text: "Please inspect this file." },
+          {
+            type: "file",
+            url: "data:application/pdf;base64,abc123",
+            mediaType: "application/pdf",
+            filename: "test.pdf",
+          },
+        ],
+      },
+    ];
+
+    const result = normalizeChatMessagesForStorage(messages);
+
+    expect(result[0].parts).toEqual([
+      { type: "text", text: "Please inspect this file." },
+      {
+        type: "text",
+        text: "[File attachment omitted from stored chat history]",
+      },
+    ]);
+  });
+
+  test("preserves data URL file parts when normalizing messages for the model", () => {
+    const messages = [
+      {
+        id: "msg1",
+        role: "user" as const,
+        parts: [
+          {
+            type: "file",
+            url: "data:application/pdf;base64,abc123",
+            mediaType: "application/pdf",
+          },
+        ],
+      },
+    ];
+
+    const result = normalizeChatMessages(messages);
+
+    expect(result[0].parts).toEqual(messages[0].parts);
   });
 });

--- a/platform/backend/src/routes/chat/normalization/normalize-chat-messages.ts
+++ b/platform/backend/src/routes/chat/normalization/normalize-chat-messages.ts
@@ -9,6 +9,12 @@ export function normalizeChatMessages(messages: ChatMessage[]): ChatMessage[] {
   );
 }
 
+export function normalizeChatMessagesForStorage(
+  messages: ChatMessage[],
+): ChatMessage[] {
+  return stripDataUrlFileParts(normalizeChatMessages(messages));
+}
+
 function dedupeToolPartsFromMessages(messages: ChatMessage[]): ChatMessage[] {
   return messages.map((message) => {
     if (!message.parts || !Array.isArray(message.parts)) {
@@ -107,3 +113,33 @@ function getToolPartSignature(part: NonNullable<ChatMessage["parts"]>[number]) {
 function getToolPartState(part: ChatMessagePart) {
   return typeof part.state === "string" ? part.state : "unknown";
 }
+
+function stripDataUrlFileParts(messages: ChatMessage[]): ChatMessage[] {
+  return messages.map((message) => {
+    if (!message.parts?.length) {
+      return message;
+    }
+
+    let changed = false;
+    const parts = message.parts.map((part) => {
+      if (
+        part.type === "file" &&
+        typeof part.url === "string" &&
+        part.url.startsWith("data:")
+      ) {
+        changed = true;
+        return {
+          type: "text",
+          text: FILE_ATTACHMENT_STRIPPED_PLACEHOLDER,
+        };
+      }
+
+      return part;
+    });
+
+    return changed ? { ...message, parts } : message;
+  });
+}
+
+const FILE_ATTACHMENT_STRIPPED_PLACEHOLDER =
+  "[File attachment omitted from stored chat history]";

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -98,7 +98,10 @@ import {
   sanitizeChatErrorForFrontend,
 } from "./errors";
 import { injectSkillActivation } from "./inject-skill-activation";
-import { normalizeChatMessages } from "./normalization/normalize-chat-messages";
+import {
+  normalizeChatMessages,
+  normalizeChatMessagesForStorage,
+} from "./normalization/normalize-chat-messages";
 
 function getCorrelationLogFields(traceContext: {
   sessionId?: string;
@@ -2150,7 +2153,7 @@ async function persistNewMessages(
     if (context === "onFinish") {
       // Log size reduction only for onFinish (where we have complete messages)
       const beforeSize = estimateMessagesSize(messagesToSave);
-      messagesToStore = normalizeChatMessages(messagesToSave);
+      messagesToStore = normalizeChatMessagesForStorage(messagesToSave);
       const afterSize = estimateMessagesSize(messagesToStore);
 
       logger.info(
@@ -2166,7 +2169,7 @@ async function persistNewMessages(
       );
     } else {
       // For onError, just strip without detailed logging
-      messagesToStore = normalizeChatMessages(messagesToSave);
+      messagesToStore = normalizeChatMessagesForStorage(messagesToSave);
     }
 
     // Append only new messages with timestamps

--- a/platform/frontend/next.config.ts
+++ b/platform/frontend/next.config.ts
@@ -4,6 +4,10 @@ import { withSentryConfig } from "@sentry/nextjs";
 import { MCP_CATALOG_API_BASE_URL } from "@shared";
 import type { NextConfig } from "next";
 
+type ProxyClientMaxBodySize = NonNullable<
+  NonNullable<NextConfig["experimental"]>["proxyClientMaxBodySize"]
+>;
+
 const platformPkg = JSON.parse(
   readFileSync(resolve(import.meta.dirname, "../package.json"), "utf-8"),
 ) as { name: string; version: string };
@@ -44,6 +48,7 @@ const nextConfig: NextConfig = {
   },
   experimental: {
     proxyTimeout: 300000, // 5 minutes in milliseconds - prevents SSE stream timeout
+    proxyClientMaxBodySize: getProxyClientMaxBodySize(),
   },
   httpAgentOptions: {
     keepAlive: true,
@@ -103,6 +108,20 @@ function getAllowedDevOrigins(): string[] {
         return value;
       }
     });
+}
+
+function getProxyClientMaxBodySize(): ProxyClientMaxBodySize {
+  const bodyLimit = process.env.ARCHESTRA_API_BODY_LIMIT?.trim();
+
+  if (!bodyLimit) {
+    return "70mb";
+  }
+
+  if (/^\d+$/.test(bodyLimit)) {
+    return Number(bodyLimit);
+  }
+
+  return bodyLimit as ProxyClientMaxBodySize;
 }
 
 export default withSentryConfig(nextConfig, {

--- a/platform/frontend/src/next-config.test.ts
+++ b/platform/frontend/src/next-config.test.ts
@@ -7,8 +7,31 @@ vi.mock("@sentry/nextjs", () => ({
 describe("next config rewrites", () => {
   beforeEach(() => {
     vi.resetModules();
+    delete process.env.ARCHESTRA_API_BODY_LIMIT;
     delete process.env.ARCHESTRA_INTERNAL_API_BASE_URL;
     delete process.env.VERSION;
+  });
+
+  it("matches the backend request body limit for proxied client uploads by default", async () => {
+    const { default: nextConfig } = await import("../next.config");
+
+    expect(nextConfig.experimental?.proxyClientMaxBodySize).toBe("70mb");
+  });
+
+  it("uses ARCHESTRA_API_BODY_LIMIT for proxied client uploads when configured", async () => {
+    process.env.ARCHESTRA_API_BODY_LIMIT = "100mb";
+
+    const { default: nextConfig } = await import("../next.config");
+
+    expect(nextConfig.experimental?.proxyClientMaxBodySize).toBe("100mb");
+  });
+
+  it("supports numeric ARCHESTRA_API_BODY_LIMIT values as bytes for proxied client uploads", async () => {
+    process.env.ARCHESTRA_API_BODY_LIMIT = "52428800";
+
+    const { default: nextConfig } = await import("../next.config");
+
+    expect(nextConfig.experimental?.proxyClientMaxBodySize).toBe(52428800);
   });
 
   it("uses sanitized VERSION as the deployment id", async () => {


### PR DESCRIPTION
## Summary

- reuse `ARCHESTRA_API_BODY_LIMIT` for Next's proxied client request body limit
- raise the default API body limit to 70 MB so encoded chat attachments up to about 50 MB fit through the UI path
- strip data URL file payloads before persisting chat messages, while keeping them available to the model for the active turn
- update deployment docs for the shared body limit behavior

Fixes https://github.com/archestra-ai/archestra/issues/4735
Supersedes https://github.com/archestra-ai/archestra/pull/4744