### PR TITLE
fix(frontend): gate Sentry init on production environment

### DIFF
--- a/platform/frontend/sentry.edge.config.ts
+++ b/platform/frontend/sentry.edge.config.ts
@@ -4,19 +4,17 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
-import { getFrontendEdgeSentryOptions } from "./sentry.shared";
+import {
+  getFrontendEdgeSentryOptions,
+  isAllowedSentryEnvironment,
+} from "./sentry.shared";
 
 // Use process.env directly since config module uses next-runtime-env which is not available during build
 const dsn = process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_FRONTEND_DSN || "";
+const environment =
+  process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_ENVIRONMENT?.toLowerCase() ||
+  process.env.NODE_ENV?.toLowerCase();
 
-// Only initialize Sentry if DSN is configured
-if (dsn) {
-  Sentry.init(
-    getFrontendEdgeSentryOptions({
-      dsn,
-      environment:
-        process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_ENVIRONMENT?.toLowerCase() ||
-        process.env.NODE_ENV?.toLowerCase(),
-    }),
-  );
+if (dsn && isAllowedSentryEnvironment(environment)) {
+  Sentry.init(getFrontendEdgeSentryOptions({ dsn, environment }));
 }

--- a/platform/frontend/sentry.server.config.ts
+++ b/platform/frontend/sentry.server.config.ts
@@ -3,19 +3,17 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
-import { getFrontendServerSentryOptions } from "./sentry.shared";
+import {
+  getFrontendServerSentryOptions,
+  isAllowedSentryEnvironment,
+} from "./sentry.shared";
 
 // Use process.env directly since config module uses next-runtime-env which is not available during build
 const dsn = process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_FRONTEND_DSN || "";
+const environment =
+  process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_ENVIRONMENT?.toLowerCase() ||
+  process.env.NODE_ENV?.toLowerCase();
 
-// Only initialize Sentry if DSN is configured
-if (dsn) {
-  Sentry.init(
-    getFrontendServerSentryOptions({
-      dsn,
-      environment:
-        process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_ENVIRONMENT?.toLowerCase() ||
-        process.env.NODE_ENV?.toLowerCase(),
-    }),
-  );
+if (dsn && isAllowedSentryEnvironment(environment)) {
+  Sentry.init(getFrontendServerSentryOptions({ dsn, environment }));
 }

--- a/platform/frontend/sentry.shared.ts
+++ b/platform/frontend/sentry.shared.ts
@@ -3,6 +3,20 @@ import type { BrowserOptions, EdgeOptions, NodeOptions } from "@sentry/nextjs";
 const FRONTEND_BROWSER_TRACES_SAMPLE_RATE = 0.05;
 const FRONTEND_SERVER_TRACES_SAMPLE_RATE = 0.02;
 
+// Sentry only initializes when the resolved environment is exactly `production`
+// — resolved from `NEXT_PUBLIC_ARCHESTRA_SENTRY_ENVIRONMENT`, falling back to
+// `NODE_ENV`. Dev laptops (`NODE_ENV=development`), ad-hoc per-machine names,
+// and typos are silenced. Preview / branch deploys that build with
+// `NODE_ENV=production` and no override will count as production; set
+// `NEXT_PUBLIC_ARCHESTRA_SENTRY_ENVIRONMENT` to a distinct value (e.g.
+// `preview`) to silence them. Extend this allowlist when a new deployment
+// environment should report events.
+export function isAllowedSentryEnvironment(
+  environment: string | undefined,
+): boolean {
+  return environment === "production";
+}
+
 export function getFrontendBrowserSentryOptions(
   params: Pick<BrowserOptions, "dsn" | "environment">,
 ): BrowserOptions {

--- a/platform/frontend/src/instrumentation-client.ts
+++ b/platform/frontend/src/instrumentation-client.ts
@@ -4,14 +4,16 @@
 
 import * as Sentry from "@sentry/nextjs";
 import config from "@/lib/config/config";
-import { getFrontendBrowserSentryOptions } from "../sentry.shared";
+import {
+  getFrontendBrowserSentryOptions,
+  isAllowedSentryEnvironment,
+} from "../sentry.shared";
 
 const {
   sentry: { dsn, environment },
 } = config;
 
-// Only initialize Sentry if DSN is configured
-if (dsn) {
+if (dsn && isAllowedSentryEnvironment(environment)) {
   const browserOptions = getFrontendBrowserSentryOptions({ dsn, environment });
 
   Sentry.init({


### PR DESCRIPTION
## Summary

Frontend was sending error-monitoring events from every environment that had a DSN configured — including developer laptops with their own custom environment names. The result was recurring noise unrelated to any application defect, mostly `TypeError: fetch failed` from local backends being momentarily unreachable.

This PR moves the gate into Sentry config (where it belongs) instead of filtering errors in application code. `Sentry.init` now requires both DSN **and** an `environment` value of `production`. Allowlist beats denylist here because unknown environments fail-closed by default — a new env name or a typo no longer ships events accidentally. New deployment environments (e.g. a future `staging`) need an explicit allowlist entry.