### PR TITLE
fix(ui): resolve radix dialog missing aria-describedby warning

### DIFF
--- a/platform/frontend/src/app/scheduled-tasks/schedule-triggers-client.tsx
+++ b/platform/frontend/src/app/scheduled-tasks/schedule-triggers-client.tsx
@@ -1280,7 +1280,10 @@ function ScheduleTriggerFormDialog({
 }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md max-h-[85vh] flex flex-col overflow-hidden">
+      <DialogContent
+        aria-describedby={undefined}
+        className="max-w-md max-h-[85vh] flex flex-col overflow-hidden"
+      >
         <DialogHeader>
           <DialogTitle>{isEditing ? "Edit task" : "New task"}</DialogTitle>
         </DialogHeader>

--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -1128,7 +1128,10 @@ export function AgentDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-5xl h-[90vh] flex flex-col overflow-hidden">
+      <DialogContent
+        aria-describedby={undefined}
+        className="max-w-5xl h-[90vh] flex flex-col overflow-hidden"
+      >
         <DialogHeader>
           <div className="flex items-start justify-between gap-4 pr-6">
             <div className="min-w-0 flex-1">

--- a/platform/frontend/src/components/ui/dialog.tsx
+++ b/platform/frontend/src/components/ui/dialog.tsx
@@ -76,6 +76,7 @@ function DialogContent({
       <DialogOverlay />
       <DialogPrimitive.Content
         data-slot="dialog-content"
+        aria-describedby={undefined}
         className={cn(
           // Please keep this class when updating dialog component
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 flex w-full translate-x-[-50%] translate-y-[-50%] flex-col rounded-lg border pt-4 shadow-lg duration-200 max-w-4xl max-h-[90dvh]",

--- a/platform/frontend/src/components/ui/dialog.tsx
+++ b/platform/frontend/src/components/ui/dialog.tsx
@@ -76,7 +76,6 @@ function DialogContent({
       <DialogOverlay />
       <DialogPrimitive.Content
         data-slot="dialog-content"
-        aria-describedby={undefined}
         className={cn(
           // Please keep this class when updating dialog component
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 flex w-full translate-x-[-50%] translate-y-[-50%] flex-col rounded-lg border pt-4 shadow-lg duration-200 max-w-4xl max-h-[90dvh]",


### PR DESCRIPTION
Closes #5008

Suppresses the Radix UI Dialog accessibility warning by explicitly setting aria-describedby={undefined} on DialogPrimitive.Content. This resolves the console warning when a custom description or DialogDescription is not explicitly provided.