### PR TITLE
chore: clean Next dev cache on Tilt down

### DIFF
--- a/platform/Tiltfile
+++ b/platform/Tiltfile
@@ -8,6 +8,9 @@ load('ext://dotenv', 'dotenv')
 
 is_prod = os.getenv('PROD') == 'true'
 
+if config.tilt_subcommand == 'down':
+  local('pnpm cleanup:dev:caches', command_bat='pnpm cleanup:dev:caches')
+
 # Check if .env exists, if not copy from .env.example
 if not os.path.exists('.env'):
   local('cp .env.example .env', command_bat='copy .env.example .env')

--- a/platform/package.json
+++ b/platform/package.json
@@ -26,6 +26,7 @@
     "check:ci": "turbo check:ci",
     "license-check": "tsx standalone-scripts/license-check.ts",
     "codegen": "CODEGEN=true turbo codegen && python3 dev/grafana/generate-pg-dashboard-variants.py",
+    "cleanup:dev:caches": "tsx standalone-scripts/cleanup-dev-caches.ts",
     "db:generate": "turbo db:generate --ui=tui",
     "db:migrate": "turbo db:migrate",
     "db:push": "turbo db:push",

--- a/platform/standalone-scripts/cleanup-dev-caches.ts
+++ b/platform/standalone-scripts/cleanup-dev-caches.ts
@@ -1,0 +1,77 @@
+import { rm } from "node:fs/promises";
+import path from "node:path";
+
+export type CleanupDevCachesOptions = {
+  rootDir?: string;
+  dryRun?: boolean;
+  log?: (message: string) => void;
+};
+
+export type CleanupDevCachesResult = {
+  removed: string[];
+  failed: Array<{ target: string; error: unknown }>;
+};
+
+export const devCacheTargets = ["frontend/.next/dev/cache"] as const;
+
+export async function cleanupDevCaches(
+  options: CleanupDevCachesOptions = {},
+): Promise<CleanupDevCachesResult> {
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  const log = options.log ?? console.log;
+  const removed: string[] = [];
+  const failed: Array<{ target: string; error: unknown }> = [];
+
+  for (const target of devCacheTargets) {
+    const targetPath = path.resolve(rootDir, target);
+
+    if (!isPathInside(rootDir, targetPath)) {
+      failed.push({
+        target,
+        error: new Error(`Refusing to remove path outside root: ${targetPath}`),
+      });
+      continue;
+    }
+
+    try {
+      if (options.dryRun) {
+        log(`[dry-run] Would remove ${target}`);
+      } else {
+        await rm(targetPath, { force: true, recursive: true });
+        log(`Removed ${target}`);
+      }
+      removed.push(target);
+    } catch (error) {
+      failed.push({ target, error });
+    }
+  }
+
+  return { removed, failed };
+}
+
+async function main() {
+  const args = new Set(process.argv.slice(2));
+
+  const result = await cleanupDevCaches({
+    dryRun: args.has("--dry-run"),
+  });
+
+  if (result.failed.length > 0) {
+    for (const failure of result.failed) {
+      console.error(`Failed to remove ${failure.target}:`, failure.error);
+    }
+    process.exitCode = 1;
+  }
+}
+
+function isPathInside(rootDir: string, targetPath: string) {
+  const relativePath = path.relative(rootDir, targetPath);
+  return (
+    relativePath === "" ||
+    (!relativePath.startsWith("..") && !path.isAbsolute(relativePath))
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  void main();
+}


### PR DESCRIPTION
## What changed

- Added `pnpm cleanup:dev:caches` to remove the large generated Next dev cache at `frontend/.next/dev/cache`.
- Wired the root `Tiltfile` to run that script when `config.tilt_subcommand == "down"`.

## Why

`frontend/.next/dev/cache` can grow very large during local development. On my machine it was `107G`, while the other generated project caches we checked were only a few dozen MB combined. Cleaning just this directory during `tilt down` reclaims meaningful space without deleting low-value artifacts like test reports or Turbo caches.