### PR TITLE
chore(dev): support parallel local dev instances

### DIFF
--- a/platform/dev/Tiltfile.database
+++ b/platform/dev/Tiltfile.database
@@ -1,12 +1,17 @@
 # Database resources
 load('ext://helm_remote', 'helm_remote')
 
+# Env-driven so a parallel Tilt session (separate worktree) doesn't collide.
+pg_namespace = os.getenv('ARCHESTRA_K8S_NAMESPACE', 'archestra-dev')
+pg_host_port = os.getenv('ARCHESTRA_POSTGRES_HOST_PORT', '5432')
+pg_metrics_host_port = os.getenv('ARCHESTRA_POSTGRES_METRICS_HOST_PORT', '9187')
+
 # PostgreSQL database for local development
 # https://dev.to/flodev/use-tilt-to-provide-easy-to-setup-development-environments-4n9d
 helm_remote(
   'postgresql',
   repo_url='https://charts.bitnami.com/bitnami',
-  namespace='archestra-dev',
+  namespace=pg_namespace,
   create_namespace=True,
   set=[
     'auth.database=archestra_dev',
@@ -44,7 +49,7 @@ helm_remote(
   ]
 )
 
-k8s_resource('postgresql', port_forwards=['5432:5432', '9187:9187'], labels=['database'])
+k8s_resource('postgresql', port_forwards=[pg_host_port + ':5432', pg_metrics_host_port + ':9187'], labels=['database'])
 
 # Database cleanup button (manual trigger only, for development)
 local_resource(

--- a/platform/dev/Tiltfile.dev
+++ b/platform/dev/Tiltfile.dev
@@ -127,7 +127,13 @@ else:
     serve_env={
       'NEXT_DIST_DIR': '.next-pw',
       'NEXT_PUBLIC_API_MOCKING': 'enabled',
+      # Both must be pinned: the SSR path reads ARCHESTRA_INTERNAL_API_BASE_URL,
+      # the browser bundle reads NEXT_PUBLIC_ARCHESTRA_INTERNAL_API_BASE_URL.
+      # If only the server var is overridden, a .env value for the public mirror
+      # (e.g. set by `dev:stack:up`) reaches the browser and defeats the
+      # fail-loudly behavior for escaped client-side fetches.
       'ARCHESTRA_INTERNAL_API_BASE_URL': 'http://127.0.0.1:1',
+      'NEXT_PUBLIC_ARCHESTRA_INTERNAL_API_BASE_URL': 'http://127.0.0.1:1',
       'NEXT_PUBLIC_SENTRY_DSN': '',
     }
   )

--- a/platform/dev/Tiltfile.dev
+++ b/platform/dev/Tiltfile.dev
@@ -21,6 +21,14 @@ k8s_resource(
 is_prod = os.getenv('PROD') == 'true'
 dev_resource_name = 'pnpm-prod' if is_prod else 'pnpm-dev'
 
+# Env-driven so a parallel Tilt session (separate worktree) doesn't collide.
+frontend_port = os.getenv('ARCHESTRA_FRONTEND_PORT', '3000')
+frontend_int_tests_port = os.getenv('ARCHESTRA_FRONTEND_INT_TESTS_PORT', '3010')
+# Same namespace the backend's K8s MCP orchestrator uses to spawn MCP server
+# pods; the port-forwarder below has to watch the same namespace or services
+# won't be reachable on localhost in a parallel stack.
+mcp_namespace = os.getenv('ARCHESTRA_ORCHESTRATOR_K8S_NAMESPACE', 'default')
+
 # Build env dict to sync ARCHESTRA_* to NEXT_PUBLIC_ARCHESTRA_* for frontend
 # This is rebuilt on each Tiltfile evaluation (triggered by .env changes)
 def get_frontend_env():
@@ -88,6 +96,8 @@ else:
   )
 
   # Frontend dev server - waits for backend to be ready
+  frontend_serve_env = dict(frontend_env_vars)
+  frontend_serve_env['PORT'] = frontend_port
   local_resource(
     dev_resource_name + '-frontend',
     serve_cmd='trap "pkill -TERM -P $$" EXIT INT TERM; pnpm dev --filter @frontend & wait $!',
@@ -95,7 +105,7 @@ else:
     labels=['dev'],
     resource_deps=[dev_resource_name + '-backend'],
     deps=['../.env'],
-    serve_env=frontend_env_vars
+    serve_env=frontend_serve_env
   )
 
   # Second frontend instance dedicated to Playwright integration tests
@@ -107,8 +117,8 @@ else:
   # silently hitting the real backend.
   local_resource(
     dev_resource_name + '-frontend-int-tests',
-    serve_cmd='trap "pkill -TERM -P $$" EXIT INT TERM; cd ../frontend && pnpm exec next dev -H 127.0.0.1 -p 3010 & wait $!',
-    serve_cmd_bat='cd ..\\frontend && pnpm exec next dev -H 127.0.0.1 -p 3010',
+    serve_cmd='trap "pkill -TERM -P $$" EXIT INT TERM; cd ../frontend && pnpm exec next dev -H 127.0.0.1 -p ' + frontend_int_tests_port + ' & wait $!',
+    serve_cmd_bat='cd ..\\frontend && pnpm exec next dev -H 127.0.0.1 -p ' + frontend_int_tests_port,
     labels=['dev'],
     deps=['../.env'],
     serve_env={
@@ -128,9 +138,9 @@ local_resource(
   'mcp-http-port-forward',
   serve_cmd='''
     trap "kill 0" EXIT INT TERM
-    echo "Watching for MCP server NodePort services..."
+    echo "Watching for MCP server NodePort services in namespace ''' + mcp_namespace + '''..."
     while true; do
-      SERVICES=$(kubectl get svc -l app=mcp-server -n default -o jsonpath='{range .items[*]}{.metadata.name}:{.spec.ports[0].nodePort}:{.spec.ports[0].port} {end}' 2>/dev/null)
+      SERVICES=$(kubectl get svc -l app=mcp-server -n ''' + mcp_namespace + ''' -o jsonpath='{range .items[*]}{.metadata.name}:{.spec.ports[0].nodePort}:{.spec.ports[0].port} {end}' 2>/dev/null)
       for ENTRY in $SERVICES; do
         SVC_NAME=$(echo "$ENTRY" | cut -d: -f1)
         NODE_PORT=$(echo "$ENTRY" | cut -d: -f2)
@@ -138,10 +148,10 @@ local_resource(
         if [ "$NODE_PORT" != "null" ] && [ -n "$NODE_PORT" ] && [ -n "$SVC_NAME" ]; then
           if ! lsof -i :"$NODE_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
             # Check that service has ready endpoints before attempting port-forward
-            ENDPOINTS=$(kubectl get endpoints "$SVC_NAME" -n default -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null)
+            ENDPOINTS=$(kubectl get endpoints "$SVC_NAME" -n ''' + mcp_namespace + ''' -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null)
             if [ -n "$ENDPOINTS" ]; then
               echo "Port-forwarding $SVC_NAME: localhost:$NODE_PORT -> $CONTAINER_PORT"
-              kubectl port-forward "svc/$SVC_NAME" "$NODE_PORT:$CONTAINER_PORT" -n default &
+              kubectl port-forward "svc/$SVC_NAME" "$NODE_PORT:$CONTAINER_PORT" -n ''' + mcp_namespace + ''' &
             fi
           fi
         fi

--- a/platform/dev/Tiltfile.dev
+++ b/platform/dev/Tiltfile.dev
@@ -1,9 +1,20 @@
 # Development + pre-requisite resources
 
+# Env-driven so a parallel Tilt session (separate worktree) doesn't collide.
+# Defined up here so the MCP RBAC block below can render into the right
+# namespace.
+frontend_port = os.getenv('ARCHESTRA_FRONTEND_PORT', '3000')
+frontend_int_tests_port = os.getenv('ARCHESTRA_FRONTEND_INT_TESTS_PORT', '3010')
+# Same namespace the backend's K8s MCP orchestrator uses to spawn MCP server
+# pods. The MCP RBAC, the port-forwarder, and the orchestrator all have to
+# agree on this — otherwise pods land in one namespace, the SA they need lives
+# in another, and the port-forwarder watches a third.
+mcp_namespace = os.getenv('ARCHESTRA_ORCHESTRATOR_K8S_NAMESPACE', 'default')
+
 # MCP Server RBAC resources for local development
 # Render from Helm chart and filter to only RBAC resources (avoid duplication)
 k8s_yaml(local(
-  'helm template archestra-platform ../helm/archestra --namespace default --set archestra.orchestrator.kubernetes.mcpServerRbac.create=true --show-only templates/mcp-serviceaccount.yaml',
+  'helm template archestra-platform ../helm/archestra --namespace ' + mcp_namespace + ' --set archestra.orchestrator.kubernetes.mcpServerRbac.create=true --show-only templates/mcp-serviceaccount.yaml',
   quiet=True
 ))
 
@@ -11,23 +22,15 @@ k8s_resource(
   new_name='mcp-rbac',
   labels=['dev'],
   objects=[
-    'archestra-platform-mcp-k8s-operator:serviceaccount:default',
-    'archestra-platform-mcp-server-operator:role:default',
-    'archestra-platform-mcp-server-operator:rolebinding:default'
+    'archestra-platform-mcp-k8s-operator:serviceaccount:' + mcp_namespace,
+    'archestra-platform-mcp-server-operator:role:' + mcp_namespace,
+    'archestra-platform-mcp-server-operator:rolebinding:' + mcp_namespace
   ]
 )
 
 # Define is_prod locally (same logic as main Tiltfile)
 is_prod = os.getenv('PROD') == 'true'
 dev_resource_name = 'pnpm-prod' if is_prod else 'pnpm-dev'
-
-# Env-driven so a parallel Tilt session (separate worktree) doesn't collide.
-frontend_port = os.getenv('ARCHESTRA_FRONTEND_PORT', '3000')
-frontend_int_tests_port = os.getenv('ARCHESTRA_FRONTEND_INT_TESTS_PORT', '3010')
-# Same namespace the backend's K8s MCP orchestrator uses to spawn MCP server
-# pods; the port-forwarder below has to watch the same namespace or services
-# won't be reachable on localhost in a parallel stack.
-mcp_namespace = os.getenv('ARCHESTRA_ORCHESTRATOR_K8S_NAMESPACE', 'default')
 
 # Build env dict to sync ARCHESTRA_* to NEXT_PUBLIC_ARCHESTRA_* for frontend
 # This is rebuilt on each Tiltfile evaluation (triggered by .env changes)

--- a/platform/frontend/playwright.config.ts
+++ b/platform/frontend/playwright.config.ts
@@ -1,6 +1,31 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig, devices } from "@playwright/test";
 
 const IS_CI = !!process.env.CI;
+// Mirrors ARCHESTRA_FRONTEND_INT_TESTS_PORT in dev/Tiltfile.dev so a parallel
+// Tilt session (separate worktree) runs tests against its own MSW frontend
+// instead of the main worktree's :3010. `pnpm dev:stack:up` writes the value
+// to platform/.env, so we fall back to reading it from there when the env var
+// isn't already exported into the Playwright process.
+const INT_TESTS_PORT = readIntTestsPort() ?? "3010";
+const INT_TESTS_URL = `http://127.0.0.1:${INT_TESTS_PORT}`;
+
+function readIntTestsPort(): string | undefined {
+  if (process.env.ARCHESTRA_FRONTEND_INT_TESTS_PORT) {
+    return process.env.ARCHESTRA_FRONTEND_INT_TESTS_PORT;
+  }
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const content = readFileSync(resolve(here, "../.env"), "utf8");
+    return content.match(
+      /^\s*ARCHESTRA_FRONTEND_INT_TESTS_PORT\s*=\s*(\S+)/m,
+    )?.[1];
+  } catch {
+    return undefined;
+  }
+}
 
 export default defineConfig({
   testDir: "./tests-integration",
@@ -21,7 +46,7 @@ export default defineConfig({
     ? [["github"], ["html", { open: "never" }]]
     : [["list"], ["html", { open: "never" }]],
   use: {
-    baseURL: "http://127.0.0.1:3010",
+    baseURL: INT_TESTS_URL,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
     video: "retain-on-failure",
@@ -31,8 +56,8 @@ export default defineConfig({
   expect: { timeout: 10_000 },
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
   webServer: {
-    command: "next dev -H 127.0.0.1 -p 3010",
-    url: "http://127.0.0.1:3010",
+    command: `next dev -H 127.0.0.1 -p ${INT_TESTS_PORT}`,
+    url: INT_TESTS_URL,
     reuseExistingServer: !IS_CI,
     timeout: 120_000,
     env: {

--- a/platform/package.json
+++ b/platform/package.json
@@ -32,7 +32,9 @@
     "db:push": "turbo db:push",
     "db:studio": "turbo db:studio",
     "db:seed:mock-data": "turbo db:seed:mock-data",
-    "cleanup:dev:k8s": "kubectl delete namespace archestra-dev"
+    "cleanup:dev:k8s": "kubectl delete namespace archestra-dev",
+    "dev:stack:up": "scripts/dev-stack.sh up",
+    "dev:stack:down": "scripts/dev-stack.sh down"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.6",

--- a/platform/scripts/dev-stack.sh
+++ b/platform/scripts/dev-stack.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+#
+# Run a parallel Archestra dev stack in the current platform/ directory.
+# Picks free random ports, derives a K8s namespace, rewrites the local .env
+# with the parallel-instance overrides, and runs `tilt up` so this stack can
+# coexist with another `tilt up` in a different worktree.
+#
+# This script does NOT create or remove git worktrees. The caller (a human or
+# an agent) sets up the worktree and copies platform/.env into it first:
+#
+#   git worktree add ../archestra-parallel-foo -b parallel/foo
+#   cp <main>/platform/.env ../archestra-parallel-foo/platform/.env
+#   cd ../archestra-parallel-foo/platform
+#   pnpm dev:stack:up --detach
+#
+# Usage:
+#   dev-stack.sh up   [--detach] [--namespace NAME]
+#   dev-stack.sh down
+#
+# `up`:   without --detach, execs `tilt up` in the foreground (Ctrl+C stops
+#         it). With --detach, runs Tilt in the background via nohup, writes
+#         a PID file, and returns once the frontend responds.
+# `down`: kills the detached Tilt (if any) and runs `tilt down`.
+#
+# `--namespace` overrides the auto-derived K8s namespace (default:
+# `archestra-dev-<sanitized-branch-name>`).
+
+set -euo pipefail
+
+usage() {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+require_platform_cwd() {
+  if [ ! -f "Tiltfile" ] || [ ! -d "dev" ]; then
+    echo "ERROR: run from a platform/ directory (no Tiltfile in $(pwd))" >&2
+    exit 1
+  fi
+}
+
+cmd_up() {
+  local detach=false namespace=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --detach)    detach=true; shift ;;
+      --namespace) namespace="${2:?--namespace needs a value}"; shift 2 ;;
+      -h|--help)   usage 0 ;;
+      *)           echo "unknown arg: $1" >&2; usage 1 ;;
+    esac
+  done
+
+  require_platform_cwd
+  local platform_dir; platform_dir="$(pwd)"
+  local worktree_dir; worktree_dir="$(cd .. && pwd)"
+  local env_file="$platform_dir/.env"
+
+  if [ ! -f "$env_file" ]; then
+    cat >&2 <<EOF
+ERROR: $env_file not found.
+
+Copy it from your main worktree first, e.g.:
+  cp <main-worktree>/platform/.env $env_file
+EOF
+    exit 1
+  fi
+
+  if [ -z "$namespace" ]; then
+    local branch; branch="$(git -C "$platform_dir" branch --show-current 2>/dev/null || true)"
+    if [ -z "$branch" ]; then
+      echo "ERROR: not on a git branch (detached HEAD?). Pass --namespace explicitly." >&2
+      exit 1
+    fi
+    # K8s namespace rules: lowercase alphanumeric + dashes, ≤63 chars, must
+    # start AND end with alphanumeric. Cap the derived portion at 49 chars so
+    # the full `archestra-dev-<x>` stays within 63, strip trailing dashes (a
+    # branch like `feature/foo_` sanitizes to `feature-foo-`), and fall back
+    # to `auto` if sanitization produces an empty string.
+    local sanitized
+    sanitized=$(echo "$branch" | tr '[:upper:]/_' '[:lower:]--' | tr -dc 'a-z0-9-' | head -c 49 | sed 's/-*$//')
+    if [ -z "$sanitized" ]; then
+      sanitized="auto"
+    fi
+    namespace="archestra-dev-${sanitized}"
+  fi
+
+  local frontend_port backend_port metrics_port pg_port pg_metrics_port int_tests_port tilt_port
+  frontend_port=$(pick_port)
+  backend_port=$(pick_port)
+  metrics_port=$(pick_port)
+  pg_port=$(pick_port)
+  pg_metrics_port=$(pick_port)
+  int_tests_port=$(pick_port)
+  tilt_port=$(pick_port)
+
+  echo "→ Rewriting $env_file with parallel-instance overrides" >&2
+  # ARCHESTRA_ORCHESTRATOR_K8S_NAMESPACE is overridden too so MCP server pods
+  # (when the K8s orchestrator is enabled) don't share resource names with the
+  # main stack's pods in `default`. The orchestrator's RBAC is still only
+  # provisioned in `default` by dev/Tiltfile.dev, so a parallel stack that
+  # actively uses the K8s MCP runtime needs RBAC applied to the new namespace
+  # by hand. Most parallel-stack users don't enable the K8s orchestrator and
+  # this override just prevents accidental collisions.
+  # NEXT_PUBLIC_ARCHESTRA_INTERNAL_API_BASE_URL is rewritten alongside the
+  # ARCHESTRA_INTERNAL_API_BASE_URL it mirrors: Tiltfile.dev's sync only fills
+  # NEXT_PUBLIC_* when the file doesn't already set it, so leaving an inherited
+  # value in place would point the parallel frontend at the main backend.
+  ARCHESTRA_DATABASE_URL="postgresql://archestra:archestra_dev_password@localhost:${pg_port}/archestra_dev?schema=public" \
+  ARCHESTRA_INTERNAL_API_BASE_URL="http://localhost:${backend_port}" \
+  NEXT_PUBLIC_ARCHESTRA_INTERNAL_API_BASE_URL="http://localhost:${backend_port}" \
+  ARCHESTRA_FRONTEND_URL="http://localhost:${frontend_port}" \
+  ARCHESTRA_METRICS_PORT="$metrics_port" \
+  ARCHESTRA_K8S_NAMESPACE="$namespace" \
+  ARCHESTRA_ORCHESTRATOR_K8S_NAMESPACE="$namespace" \
+  ARCHESTRA_POSTGRES_HOST_PORT="$pg_port" \
+  ARCHESTRA_POSTGRES_METRICS_HOST_PORT="$pg_metrics_port" \
+  ARCHESTRA_FRONTEND_PORT="$frontend_port" \
+  ARCHESTRA_FRONTEND_INT_TESTS_PORT="$int_tests_port" \
+  python3 - "$env_file" <<'PYEOF'
+import os, re, sys
+keys = [
+  "ARCHESTRA_DATABASE_URL",
+  "ARCHESTRA_INTERNAL_API_BASE_URL",
+  "NEXT_PUBLIC_ARCHESTRA_INTERNAL_API_BASE_URL",
+  "ARCHESTRA_FRONTEND_URL",
+  "ARCHESTRA_METRICS_PORT",
+  "ARCHESTRA_K8S_NAMESPACE",
+  "ARCHESTRA_ORCHESTRATOR_K8S_NAMESPACE",
+  "ARCHESTRA_POSTGRES_HOST_PORT",
+  "ARCHESTRA_POSTGRES_METRICS_HOST_PORT",
+  "ARCHESTRA_FRONTEND_PORT",
+  "ARCHESTRA_FRONTEND_INT_TESTS_PORT",
+]
+overrides = {k: os.environ[k] for k in keys}
+path = sys.argv[1]
+with open(path) as f:
+    lines = f.readlines()
+pat = re.compile(r'^\s*([A-Z0-9_]+)\s*=')
+seen, out = set(), []
+for line in lines:
+    m = pat.match(line)
+    if m and m.group(1) in overrides:
+        out.append(f'{m.group(1)}={overrides[m.group(1)]}\n')
+        seen.add(m.group(1))
+    else:
+        out.append(line)
+missing = [k for k in keys if k not in seen]
+if missing:
+    if out and not out[-1].endswith('\n'):
+        out.append('\n')
+    for k in missing:
+        out.append(f'{k}={overrides[k]}\n')
+with open(path, 'w') as f:
+    f.writelines(out)
+PYEOF
+
+  cat >&2 <<EOF
+
+================================================================
+  Parallel Archestra dev stack
+================================================================
+  Frontend:    http://localhost:${frontend_port}
+  Backend:     http://localhost:${backend_port}
+  Metrics:     http://localhost:${metrics_port}/metrics
+  Tilt UI:     http://localhost:${tilt_port}
+  Postgres:    localhost:${pg_port}
+  K8s ns:      ${namespace}
+  Platform:    ${platform_dir}
+
+  Tear down:   pnpm dev:stack:down    (from this directory)
+================================================================
+
+EOF
+
+  if [ "$detach" = "true" ]; then
+    local log_file="$worktree_dir/.dev-stack.log"
+    local pid_file="$worktree_dir/.dev-stack.pid"
+    echo "→ Launching tilt up in background (logs: $log_file)" >&2
+    nohup tilt up --port="$tilt_port" >"$log_file" 2>&1 &
+    local tilt_pid=$!
+    echo "$tilt_pid" >"$pid_file"
+    echo "→ Waiting for frontend on :${frontend_port} (can take several minutes on first run)" >&2
+    local i
+    for i in $(seq 1 240); do
+      if curl -sf -o /dev/null "http://localhost:${frontend_port}/"; then
+        echo "✅ Frontend up at http://localhost:${frontend_port}" >&2
+        return 0
+      fi
+      if ! kill -0 "$tilt_pid" 2>/dev/null; then
+        echo "❌ Tilt exited before frontend came up. Check ${log_file}" >&2
+        return 1
+      fi
+      sleep 2
+    done
+    echo "⚠ Timeout waiting for frontend; Tilt still running. Check ${log_file}" >&2
+    return 1
+  else
+    exec tilt up --port="$tilt_port"
+  fi
+}
+
+cmd_down() {
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -h|--help) usage 0 ;;
+      *)         echo "unknown arg: $1" >&2; usage 1 ;;
+    esac
+  done
+
+  require_platform_cwd
+  local worktree_dir; worktree_dir="$(cd .. && pwd)"
+  local pid_file="$worktree_dir/.dev-stack.pid"
+
+  if [ -f "$pid_file" ]; then
+    local pid; pid="$(cat "$pid_file")"
+    if kill -0 "$pid" 2>/dev/null; then
+      echo "→ Stopping background Tilt process (pid $pid)" >&2
+      kill "$pid" 2>/dev/null || true
+      local i
+      for i in $(seq 1 10); do
+        kill -0 "$pid" 2>/dev/null || break
+        sleep 1
+      done
+      kill -KILL "$pid" 2>/dev/null || true
+    fi
+    rm -f "$pid_file"
+  fi
+
+  echo "→ Running tilt down" >&2
+  tilt down || echo "⚠ tilt down reported errors" >&2
+  echo "✅ Parallel dev stack stopped." >&2
+}
+
+pick_port() {
+  python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()'
+}
+
+if [ $# -lt 1 ]; then usage 1; fi
+subcommand="$1"; shift
+case "$subcommand" in
+  up)        cmd_up "$@" ;;
+  down)      cmd_down "$@" ;;
+  -h|--help) usage 0 ;;
+  *)         echo "unknown subcommand: $subcommand" >&2; usage 1 ;;
+esac

--- a/platform/turbo.json
+++ b/platform/turbo.json
@@ -10,7 +10,8 @@
     },
     "dev": {
       "persistent": true,
-      "cache": false
+      "cache": false,
+      "passThroughEnv": ["PORT"]
     },
     "start": {
       "persistent": true,


### PR DESCRIPTION
## Summary

Today only one `tilt up` can run at a time, because `dev/Tiltfile.database` hardcodes the Postgres namespace + host port-forwards, `dev/Tiltfile.dev` hardcodes the integration-tests frontend port and the MCP port-forwarder's namespace, `frontend/playwright.config.ts` hardcodes the same `:3010`, and `turbo.json`'s `dev` task strips `PORT` from `pnpm dev --filter @frontend`. This makes side-by-side workflows (running two branches at once for review, smoke-testing migrations against a fresh DB while keeping main running, agent-driven parallel work in a worktree) impossible without hand-patching files.

This PR makes those values env-driven with defaults equal to the historical hardcoded values, so `tilt up` from `main` is byte-identical. A second `tilt up` runs from a git worktree with its own `.env` overriding the new vars — wrapped by a `dev-stack.sh` script and surfaced as pnpm aliases.

## Usage

The caller (agent or developer) creates a git worktree and copies `.env` into it:

```bash
git worktree add ../archestra-parallel-foo -b parallel/foo
cp <main>/platform/.env ../archestra-parallel-foo/platform/.env
cd ../archestra-parallel-foo/platform
```

Then bring up an isolated parallel dev stack from inside that worktree's `platform/`:

```bash
pnpm dev:stack:up --detach
```

The script picks 7 free random ports, derives a K8s namespace from the current branch name (e.g. `parallel/foo` → `archestra-dev-parallel-foo`, override with `--namespace NAME`), rewrites `./.env` in place with all the overrides, then `tilt up`s on its own Tilt UI port. With `--detach` it backgrounds Tilt and returns once the frontend responds; without `--detach` it execs `tilt up` so logs stream and Ctrl+C stops the stack.

Tear down (also from the worktree's `platform/`):

```bash
pnpm dev:stack:down
```

This kills the detached Tilt (if any) and runs `tilt down`. Worktree cleanup (`git worktree remove` + branch delete) is the caller's responsibility.

## Known follow-up not in this PR

`database-gui` (Drizzle Studio) still hardcodes port `4983`, so a parallel `tilt up` sees a port collision on that resource. Non-blocking for the frontend+backend+pg+MCP workflow; same env-driven pattern would fix it.