### PR TITLE
test(e2e): probe backend readiness before the setup-teams API chain

### DIFF
--- a/platform/e2e-tests/auth.teams.setup.ts
+++ b/platform/e2e-tests/auth.teams.setup.ts
@@ -23,6 +23,37 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
+ * Poll `/api/auth/get-session` until the backend serves 2xx. The endpoint
+ * is public and returns 200 with a null user when unauthenticated, so a
+ * non-2xx response signals the backend is still warming up (or down).
+ */
+async function waitForBackendReady(request: APIRequestContext): Promise<void> {
+  const start = Date.now();
+  const timeoutMs = 60_000;
+  let delay = 500;
+  let lastError: string | null = null;
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const response = await request.get(
+        `${UI_BASE_URL}/api/auth/get-session`,
+        { headers: { Origin: UI_BASE_URL } },
+      );
+      if (response.ok()) {
+        return;
+      }
+      lastError = `${response.status()} ${await response.text()}`;
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+    }
+    await sleep(delay);
+    delay = Math.min(delay * 1.5, 5000);
+  }
+  throw new Error(
+    `Backend did not respond OK to GET /api/auth/get-session within ${timeoutMs}ms (last: ${lastError ?? "n/a"})`,
+  );
+}
+
+/**
  * Sign in a user via API and return true if successful
  * Handles rate limiting (429) with exponential backoff retry
  */
@@ -306,6 +337,11 @@ async function assertAdminPermissions(
 
 // Setup teams - runs after users are created
 setup("setup teams and assignments", async ({ page }) => {
+  // Single up-front backend readiness probe; the signOut→signIn→GET chain
+  // below has no warm-up tolerance, so transient connection / 5xx during
+  // pod warmup intermittently aborted the chain mid-flight.
+  await waitForBackendReady(page.request);
+
   await signOut(page.request);
   await page.context().clearCookies();
 

--- a/platform/e2e-tests/auth.teams.setup.ts
+++ b/platform/e2e-tests/auth.teams.setup.ts
@@ -29,7 +29,9 @@ function sleep(ms: number): Promise<void> {
  */
 async function waitForBackendReady(request: APIRequestContext): Promise<void> {
   const start = Date.now();
-  const timeoutMs = 60_000;
+  // Capped well under the project's 60s per-test timeout so the rest of
+  // the setup (signOut, signIn, teams creation, assignments) keeps headroom.
+  const timeoutMs = 30_000;
   let delay = 500;
   let lastError: string | null = null;
   while (Date.now() - start < timeoutMs) {


### PR DESCRIPTION
The `setup teams and assignments` setup project signs out, signs back in as admin, and then walks a chain of GETs and POSTs against the teams / members / orgs APIs. The first call (`signOut`) and the GET-only helpers (`getSessionUserEmail`, `getTeams`, `getTeamMembers`) have no warm-up tolerance — a transient 5xx during the first request abort the chain mid-flight, and the GETs that silently swallow failures into `null` / `[]` then cascade into POST conflicts on the next attempt. Because every chromium test depends on this setup project, one flaky setup invocation cascades to "did not run" on the entire chromium tree.

Existing per-call retries on `signInUser`, `createTeamIfNotExists`, and `addUserToTeamIfNotMember` mitigate the noisier endpoints individually but don't help the first hit against a warming backend. This change moves the warm-up wait into a single up-front poll of `/api/auth/get-session` (a public endpoint that returns 2xx with a null user when unauthenticated, so a non-2xx response unambiguously signals "backend not ready"). Bounded at 60s with exponential backoff capped at 5s; on timeout it throws with the last observed error so the failure mode is diagnostic.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>