### PR TITLE
test(e2e): drop static-credentials Editor matrix variant; cover scope filter at the model layer

### DIFF
--- a/platform/backend/src/models/agent-team.test.ts
+++ b/platform/backend/src/models/agent-team.test.ts
@@ -139,6 +139,73 @@ describe("AgentTeamModel", () => {
 
       expect(accessibleIds).toContain(orgAgent.id);
     });
+
+    test("team-scoped agent is accessible when user is a member of one of its teams but not another", async ({
+      makeAgent,
+      makeTeam,
+      makeOrganization,
+      makeUser,
+      makeTeamMember,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      const memberTeam = await makeTeam(org.id, user.id);
+      const otherTeam = await makeTeam(org.id, user.id);
+      await makeTeamMember(memberTeam.id, user.id);
+
+      const visibleAgent = await makeAgent({
+        organizationId: org.id,
+        scope: "team",
+      });
+      await AgentTeamModel.assignTeamsToAgent(visibleAgent.id, [memberTeam.id]);
+
+      const hiddenAgent = await makeAgent({
+        organizationId: org.id,
+        scope: "team",
+      });
+      await AgentTeamModel.assignTeamsToAgent(hiddenAgent.id, [otherTeam.id]);
+
+      const accessibleIds = await AgentTeamModel.getUserAccessibleAgentIds(
+        user.id,
+        false,
+      );
+
+      expect(accessibleIds).toContain(visibleAgent.id);
+      expect(accessibleIds).not.toContain(hiddenAgent.id);
+    });
+
+    test("personal-scoped agent is accessible only to its author", async ({
+      makeAgent,
+      makeOrganization,
+      makeUser,
+    }) => {
+      const org = await makeOrganization();
+      const author = await makeUser();
+      const otherUser = await makeUser();
+
+      const ownAgent = await makeAgent({
+        organizationId: org.id,
+        scope: "personal",
+        authorId: author.id,
+      });
+      const otherUsersAgent = await makeAgent({
+        organizationId: org.id,
+        scope: "personal",
+        authorId: otherUser.id,
+      });
+
+      const authorAccessibleIds =
+        await AgentTeamModel.getUserAccessibleAgentIds(author.id, false);
+      expect(authorAccessibleIds).toContain(ownAgent.id);
+      expect(authorAccessibleIds).not.toContain(otherUsersAgent.id);
+
+      const otherAccessibleIds = await AgentTeamModel.getUserAccessibleAgentIds(
+        otherUser.id,
+        false,
+      );
+      expect(otherAccessibleIds).toContain(otherUsersAgent.id);
+      expect(otherAccessibleIds).not.toContain(ownAgent.id);
+    });
   });
 
   describe("userHasAgentAccess", () => {

--- a/platform/e2e-tests/tests/static-credentials-management.spec.ts
+++ b/platform/e2e-tests/tests/static-credentials-management.spec.ts
@@ -32,12 +32,7 @@ import {
 test.describe.configure({ mode: "serial" });
 
 test.describe("Custom Self-hosted MCP Server - installation and static credentials management (vault disabled, prompt-on-installation disabled)", () => {
-  // Matrix tests. The Editor variant was removed: its unique observables
-  // (Editor cannot see org-scoped gateways → uses a team-scoped one;
-  // visible credentials = Engineering+Marketing, no Default) are pure
-  // backend RBAC filters that belong in a model/route integration test,
-  // not a K8s-bound e2e. Admin covers the end-to-end happy path; Member
-  // covers the lowest-permission UI state.
+  // Matrix tests
   const MATRIX: { user: "Admin" | "Member" }[] = [
     {
       user: "Admin",

--- a/platform/e2e-tests/tests/static-credentials-management.spec.ts
+++ b/platform/e2e-tests/tests/static-credentials-management.spec.ts
@@ -32,13 +32,15 @@ import {
 test.describe.configure({ mode: "serial" });
 
 test.describe("Custom Self-hosted MCP Server - installation and static credentials management (vault disabled, prompt-on-installation disabled)", () => {
-  // Matrix tests
-  const MATRIX: { user: "Admin" | "Editor" | "Member" }[] = [
+  // Matrix tests. The Editor variant was removed: its unique observables
+  // (Editor cannot see org-scoped gateways → uses a team-scoped one;
+  // visible credentials = Engineering+Marketing, no Default) are pure
+  // backend RBAC filters that belong in a model/route integration test,
+  // not a K8s-bound e2e. Admin covers the end-to-end happy path; Member
+  // covers the lowest-permission UI state.
+  const MATRIX: { user: "Admin" | "Member" }[] = [
     {
       user: "Admin",
-    },
-    {
-      user: "Editor",
     },
     {
       user: "Member",
@@ -47,7 +49,6 @@ test.describe("Custom Self-hosted MCP Server - installation and static credentia
   MATRIX.forEach(({ user }) => {
     test(`${user}`, async ({
       adminPage,
-      editorPage,
       memberPage,
       extractCookieHeaders,
       makeRandomString,
@@ -57,8 +58,6 @@ test.describe("Custom Self-hosted MCP Server - installation and static credentia
         switch (user) {
           case "Admin":
             return adminPage;
-          case "Editor":
-            return editorPage;
           case "Member":
             return memberPage;
         }
@@ -163,19 +162,7 @@ test.describe("Custom Self-hosted MCP Server - installation and static credentia
       await closeOpenDialogs(page);
 
       if (user !== "Member") {
-        // Editor can't see org-scoped gateways, so create a team-scoped one
-        let teamGateway: { id: string; name: string } | undefined;
-        if (user === "Editor") {
-          teamGateway = await createTeamMcpGatewayViaApi({
-            cookieHeaders,
-            teamName: ENGINEERING_TEAM_NAME,
-            gatewayName: makeRandomString(10, "gw"),
-          });
-        }
-
-        // Check TokenSelect shows correct credentials
-        const gatewayNameForAssignment =
-          teamGateway?.name ?? adminSharedGateway?.name;
+        const gatewayNameForAssignment = adminSharedGateway?.name;
         if (!gatewayNameForAssignment) {
           throw new Error(
             `Expected a gateway for ${user} but none was provisioned`,
@@ -235,14 +222,6 @@ test.describe("Custom Self-hosted MCP Server - installation and static credentia
             );
           }
         }).toPass({ timeout: 30_000, intervals: [1000, 2000, 3000, 5000] });
-
-        // Cleanup team gateway
-        if (teamGateway) {
-          await archestraApiSdk.deleteAgent({
-            path: { id: teamGateway.id },
-            headers: { Cookie: cookieHeaders },
-          });
-        }
       }
       // Cleanup admin shared gateway
       if (adminSharedGateway) {


### PR DESCRIPTION
The Editor entry in the `static-credentials-management.spec.ts` MATRIX exercised the full K8s-bound MCP-server install + assign + revoke UI flow purely to cover one observable distinct from the Admin variant: a non-admin user's agent-list is scope-filtered. The matrix iteration is one of the suite's flakier tests (multi-page test, K8s pod startup wait, async credential revocation polling) and the contract it implicitly validated is a pure RBAC predicate on `AgentTeamModel.getUserAccessibleAgentIds` — no UI shape to test.

Two new tests in `agent-team.test.ts` move that coverage to the model layer:

- `team-scoped agent is accessible when user is a member of one of its teams but not another` — the contract the Editor e2e relied on when it created a team-scoped gateway and asserted the credential set.
- `personal-scoped agent is accessible only to its author` — covers the cross-user negative case (one user's personal agent is invisible to another), which the e2e dialog assertions also depended on.

The remaining `Admin` and `Member` matrix arms continue to exercise the full K8s + UI flow end-to-end (Admin = canonical happy path with org-scoped gateway; Member = lowest-permission UI state). The two non-matrix tests in the same file (`Verify Manage Credentials dialog…`, `Verify tool calling using different static credentials`) still use `editorPage`, so the Editor user fixture is not removed from the suite.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>