### PR TITLE
test(e2e): probe MCP install status by id for the static-credentials team-install path

### DIFF
--- a/platform/e2e-tests/tests/static-credentials-management.spec.ts
+++ b/platform/e2e-tests/tests/static-credentials-management.spec.ts
@@ -26,6 +26,7 @@ import {
   saveOpenProfileDialog,
   settleRegistryAfterInstall,
   verifyToolCallResultViaApi,
+  waitForMcpServerReadyById,
   waitForMcpServerToolsDiscovered,
 } from "../utils";
 
@@ -125,7 +126,22 @@ test.describe("Custom Self-hosted MCP Server - installation and static credentia
             `Failed to install shared connection for ${user}: ${JSON.stringify(installResponse.error)}`,
           );
         }
+        const installedServerId = installResponse.data?.id;
+        if (!installedServerId) {
+          throw new Error(
+            `Install response for ${user} missing server id: ${JSON.stringify(installResponse.data)}`,
+          );
+        }
         await settleRegistryAfterInstall(page);
+        // The API install path doesn't refresh the registry DOM, so probe
+        // the backend installation status by ID first — surfaces a backend
+        // install error as a real error instead of a 120s DOM-poll timeout,
+        // and disambiguates from the same-named personal install above.
+        await waitForMcpServerReadyById(page, installedServerId);
+        // Follow with the existing DOM wait. This is the implicit "everything
+        // settled" signal the rest of the test relies on (TanStack Query
+        // refetch cycle has propagated to the registry view, so the gateway-
+        // edit dialog below sees the new tools in its catalog).
         await waitForMcpServerToolsDiscovered(page, catalogItemName);
       }
 

--- a/platform/e2e-tests/utils/mcp-registry.ts
+++ b/platform/e2e-tests/utils/mcp-registry.ts
@@ -96,7 +96,8 @@ export async function waitForMcpServerReadyById(
       `${UI_BASE_URL}/api/mcp_server/${mcpServerId}`,
       { headers: { Origin: UI_BASE_URL } },
     );
-    if (response.status() === 404) {
+    const status = response.status();
+    if (status === 404) {
       lastObserved = "not-found";
     } else if (response.ok()) {
       const server = (await response.json()) as {
@@ -112,6 +113,16 @@ export async function waitForMcpServerReadyById(
           `MCP server ${mcpServerId} install failed: ${server.localInstallationError ?? "unknown error"}`,
         );
       }
+    } else if (status >= 400 && status < 500) {
+      // Permanent client errors (401 unauthorized, 403 forbidden) — fail
+      // fast rather than retrying to the 120s timeout.
+      throw new Error(
+        `MCP server ${mcpServerId} status fetch returned ${status}: ${await response.text()}`,
+      );
+    } else {
+      // 5xx — keep polling, but record so the final timeout message is
+      // diagnostic rather than the previous-iteration's stale value.
+      lastObserved = `transient-${status}`;
     }
     await new Promise((resolve) => setTimeout(resolve, delay));
     delay = Math.min(delay * 1.5, 5000);

--- a/platform/e2e-tests/utils/mcp-registry.ts
+++ b/platform/e2e-tests/utils/mcp-registry.ts
@@ -4,6 +4,7 @@ import {
   getManageCredentialsAddToTeamOptionTestId,
   getManageCredentialsButtonTestId,
 } from "@shared";
+import { UI_BASE_URL } from "../consts";
 import { expect, goToPage } from "../fixtures";
 import { clickButton, closeOpenDialogs } from "./dialogs";
 import { openManageCredentialsDialog } from "./mcp-gateway";
@@ -70,6 +71,54 @@ export async function waitForMcpServerCard(
   await page
     .getByTestId(`${E2eTestId.McpServerCard}-${catalogItemName}`)
     .waitFor({ state: "visible", timeout: 30_000 });
+}
+
+/**
+ * Poll `GET /api/mcp_server/:id` until `localInstallationStatus` reaches
+ * `"success"`. Used when the install path went via the API (so the
+ * registry DOM doesn't refresh on its own and `waitForMcpServerToolsDiscovered`
+ * has nothing to react to). Fails fast on backend `"error"` status with the
+ * error message attached; treats a 404 as "row not yet visible, keep
+ * polling" to absorb a brief window between the install POST returning
+ * and the row becoming queryable.
+ */
+export async function waitForMcpServerReadyById(
+  page: Page,
+  mcpServerId: string,
+  options?: { timeoutMs?: number },
+): Promise<void> {
+  const timeoutMs = options?.timeoutMs ?? 120_000;
+  const start = Date.now();
+  let delay = 500;
+  let lastObserved: string | null = null;
+  while (Date.now() - start < timeoutMs) {
+    const response = await page.request.get(
+      `${UI_BASE_URL}/api/mcp_server/${mcpServerId}`,
+      { headers: { Origin: UI_BASE_URL } },
+    );
+    if (response.status() === 404) {
+      lastObserved = "not-found";
+    } else if (response.ok()) {
+      const server = (await response.json()) as {
+        localInstallationStatus?: string;
+        localInstallationError?: string | null;
+      };
+      lastObserved = server.localInstallationStatus ?? "unknown";
+      if (lastObserved === "success") {
+        return;
+      }
+      if (lastObserved === "error") {
+        throw new Error(
+          `MCP server ${mcpServerId} install failed: ${server.localInstallationError ?? "unknown error"}`,
+        );
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    delay = Math.min(delay * 1.5, 5000);
+  }
+  throw new Error(
+    `MCP server ${mcpServerId} did not reach localInstallationStatus="success" within ${timeoutMs}ms (last observed: ${lastObserved ?? "n/a"})`,
+  );
 }
 
 export async function waitForMcpServerToolsDiscovered(


### PR DESCRIPTION
The static-credentials Admin matrix installs the same catalog item twice — once via UI (personal scope) and once via API (team scope). After the API install, the existing wait was `waitForMcpServerToolsDiscovered(page, catalogItemName)`, which polls the registry DOM for an `mcp-server-tools-count` element scoped by name. Two issues with that signal in this exact flow:

- The page isn't navigated after the API call, so the registry DOM only refreshes via TanStack Query's eventual refetch — a probabilistic signal rather than a deterministic one for a state change the backend has already committed.
- Both installs share `catalogItemName`, so the name-scoped DOM probe can match the wrong card (the personal install that was already ready), returning "ready" before the team install's row has even rendered.

`utils/mcp-registry.ts` gains `waitForMcpServerReadyById`. It polls `GET /api/mcp_server/:id` until `localInstallationStatus === "success"` (treating 404 as "row not yet visible, keep polling" to absorb the window between the install POST returning and the row becoming queryable) and throws on `localInstallationStatus === "error"` with the backend's `localInstallationError` attached — turning the previous 120s DOM-poll timeout into an immediate diagnostic on backend install failure.

In `static-credentials-management.spec.ts`, called with the install response's `id` after the team-scope install, followed by the existing `waitForMcpServerToolsDiscovered` as the "TanStack Query refetch cycle has propagated to the registry view" gate the rest of the matrix depends on.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>