### PR TITLE
fix: hoist zod so @hookform/resolvers/zod can resolve zod/v4/core

### DIFF
--- a/platform/.npmrc
+++ b/platform/.npmrc
@@ -115,3 +115,9 @@ minimum-release-age-exclude[]=@opentelemetry/instrumentation-winston
 public-hoist-pattern[]=*import-in-the-middle*
 public-hoist-pattern[]=*require-in-the-middle*
 public-hoist-pattern[]=shiki
+
+# @hookform/resolvers/zod statically imports `zod/v4/core` but doesn't declare
+# zod as a peer dep, so pnpm's isolated layout doesn't make zod resolvable
+# from the resolvers package. Hoisting zod to root node_modules lets Node's
+# parent-walk find it.
+public-hoist-pattern[]=zod


### PR DESCRIPTION
## Summary

Every page that transitively pulls in `@hookform/resolvers/zod` (login form, MCP-registry custom-server dialog, agents page redirect target, etc.) currently 500s on local dev with `Module not found: Can't resolve 'zod/v4/core'`.

`@hookform/resolvers@5.2.2/zod/dist/zod.mjs` statically imports `zod/v4/core` but the package only declares `react-hook-form` as a peer dependency. Under pnpm's isolated layout zod is therefore never placed in the resolvers package's resolution path, regardless of how many workspaces depend on zod directly.

Adding `zod` to `public-hoist-pattern` puts it at root `node_modules/zod` so Node's parent-walk finds it from inside the resolvers' isolated `.pnpm/@hookform+resolvers@.../node_modules/` subtree.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>