### PR TITLE
refactor: move zod version pin into pnpm-workspace catalog

### DIFF
--- a/platform/backend/package.json
+++ b/platform/backend/package.json
@@ -142,7 +142,7 @@
     "quick-lru": "^7.3.0",
     "tiktoken": "^1.0.22",
     "ws": "^8.20.1",
-    "zod": "^4.3.4"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@electric-sql/pglite": "^0.3.16",

--- a/platform/frontend/package.json
+++ b/platform/frontend/package.json
@@ -102,7 +102,7 @@
     "streamdown": "^2.4.0",
     "tailwind-merge": "^3.5.0",
     "use-stick-to-bottom": "^1.1.3",
-    "zod": "^4.3.4"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     typescript:
       specifier: ^6.0.2
       version: 6.0.2
+    zod:
+      specifier: ^4.3.4
+      version: 4.3.6
 
 overrides:
   '@fastify/reply-from': '>=12.6.2'
@@ -416,7 +419,7 @@ importers:
         specifier: ^8.20.1
         version: 8.20.1
       zod:
-        specifier: ^4.3.4
+        specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
       '@electric-sql/pglite':
@@ -742,7 +745,7 @@ importers:
         specifier: ^1.1.3
         version: 1.1.3(react@19.2.4)
       zod:
-        specifier: ^4.3.4
+        specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
       '@playwright/test':
@@ -827,7 +830,7 @@ importers:
         specifier: 1.5.5
         version: 1.5.5(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.1)(@types/pg@8.18.0)(kysely@0.28.17)(pg@8.20.0))(mongodb@7.1.0(@aws-sdk/credential-providers@3.1009.0)(socks@2.8.7))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.0(@noble/hashes@2.0.1))(msw@2.14.6(@types/node@25.5.0)(typescript@6.0.2))(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)))
       zod:
-        specifier: ^4.3.4
+        specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
       '@hey-api/openapi-ts':

--- a/platform/pnpm-workspace.yaml
+++ b/platform/pnpm-workspace.yaml
@@ -14,3 +14,4 @@ catalog:
   # 2026-04-28, or re-check `npm view @typescript/native-preview dist-tags`
   # and pick the newest version at least 7 days old.
   "@typescript/native-preview": 7.0.0-dev.20260415.1
+  zod: ^4.3.4

--- a/platform/shared/package.json
+++ b/platform/shared/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "ai": "^6.0.116",
     "better-auth": "1.5.5",
-    "zod": "^4.3.4"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@hey-api/openapi-ts": "^0.94.0",


### PR DESCRIPTION
## Summary

backend, frontend, and shared each declare \`zod\` independently and must be kept in lockstep — a zod bump today is a three-file change. Catalog the version under \`pnpm-workspace.yaml\` so a bump touches one line, matching how \`typescript\` and \`@typescript/native-preview\` are already handled.

No version change: zod stays at \`^4.3.4\` and resolves to the same \`4.3.6\` in the lockfile.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>