### PR TITLE
feat(dev-stack): auto-copy .env from the main worktree

### DIFF
--- a/platform/frontend/playwright.config.ts
+++ b/platform/frontend/playwright.config.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/platform/frontend/playwright.config.ts
+++ b/platform/frontend/playwright.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/platform/scripts/dev-stack.sh
+++ b/platform/scripts/dev-stack.sh
@@ -60,9 +60,12 @@ cmd_up() {
     # directory). `git worktree list --porcelain` is documented to list the
     # main worktree first. Skip auto-copy if we ARE the main worktree, since
     # there's nowhere to copy from.
+    # `sed -n 's/^worktree //p' | head -n1` strips the "worktree " prefix and
+    # keeps the rest of the line verbatim — awk '{print $2}' would truncate
+    # paths that contain spaces.
     local main_worktree main_env
     main_worktree=$(git -C "$platform_dir" worktree list --porcelain 2>/dev/null \
-      | awk '/^worktree / {print $2; exit}')
+      | sed -n 's/^worktree //p' | head -n1)
     main_env="$main_worktree/platform/.env"
     if [ -n "$main_worktree" ] && [ "$main_env" != "$env_file" ] && [ -f "$main_env" ]; then
       echo "→ Auto-copying .env from main worktree: $main_env" >&2

--- a/platform/scripts/dev-stack.sh
+++ b/platform/scripts/dev-stack.sh
@@ -56,13 +56,27 @@ cmd_up() {
   local env_file="$platform_dir/.env"
 
   if [ ! -f "$env_file" ]; then
-    cat >&2 <<EOF
+    # Auto-copy from the main worktree (the original clone, where .git is a
+    # directory). `git worktree list --porcelain` is documented to list the
+    # main worktree first. Skip auto-copy if we ARE the main worktree, since
+    # there's nowhere to copy from.
+    local main_worktree main_env
+    main_worktree=$(git -C "$platform_dir" worktree list --porcelain 2>/dev/null \
+      | awk '/^worktree / {print $2; exit}')
+    main_env="$main_worktree/platform/.env"
+    if [ -n "$main_worktree" ] && [ "$main_env" != "$env_file" ] && [ -f "$main_env" ]; then
+      echo "→ Auto-copying .env from main worktree: $main_env" >&2
+      cp "$main_env" "$env_file"
+    else
+      cat >&2 <<EOF
 ERROR: $env_file not found.
 
-Copy it from your main worktree first, e.g.:
-  cp <main-worktree>/platform/.env $env_file
+Tried auto-copying from the main worktree but no source was available.
+Bootstrap .env in the main worktree first, e.g.:
+  cp ${main_worktree:-<main-worktree>}/platform/.env.example ${main_worktree:-<main-worktree>}/platform/.env
 EOF
-    exit 1
+      exit 1
+    fi
   fi
 
   if [ -z "$namespace" ]; then


### PR DESCRIPTION
## Summary

Follow-up to #5020. `pnpm dev:stack:up` previously required the caller (agent or developer) to manually `cp <main>/platform/.env <new-worktree>/platform/.env` before invoking the script — both PR descriptions and `dev-stack.sh --help` say so explicitly. Auto-doing that step removes one piece of out-of-band glue from the parallel-stack workflow.

## What it does

When `platform/.env` isn't present in the current worktree, the script copies it from the **main worktree** — git's term for the original clone, the one where `.git` is a directory and not a file pointing at one. It's identified deterministically:

```bash
git worktree list --porcelain | awk '/^worktree / {print $2; exit}'
```

`git worktree list` is documented to enumerate the main worktree first.

## Failure mode

If the main worktree itself has no `platform/.env`, the script fails with the existing clear bootstrap-instructions error (`cp .env.example .env`), pointing at the main worktree's path.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>