### PR TITLE
feat: length-aware entropy threshold and URL skip in sensitive data detector

### DIFF
--- a/platform/frontend/src/lib/sensitive-data/entropy-detector.test.ts
+++ b/platform/frontend/src/lib/sensitive-data/entropy-detector.test.ts
@@ -126,4 +126,40 @@ describe("entropyDetector", () => {
     expect(regexFindings.length).toBeGreaterThan(0);
     expect(scan(text, regexFindings)).toEqual([]);
   });
+
+  it("flags short random-looking tokens (~21 chars) that absolute thresholds would miss", () => {
+    // 21 chars caps max entropy at log2(21) ≈ 4.39, so a fixed 4.5 threshold
+    // could never fire. ratio-based threshold (0.85) handles this length.
+    const token = "O1W7NxAA5bi7PWmQUNsks";
+    const found = scan(`leaked: ${token}`);
+    expect(found).toHaveLength(1);
+    expect(found[0].internalLabel).toBe("high-entropy-token");
+  });
+
+  it("flags tokens containing punctuation that would split a stricter candidate regex", () => {
+    // %, # are not in [A-Za-z0-9+/=_-]; without the \S{20,} candidate the
+    // string would be split into sub-20 fragments and never scored.
+    const token = "jmqK34hrlH6%ZQ#7D2HIm";
+    const found = scan(token);
+    expect(found).toHaveLength(1);
+    expect(found[0].internalLabel).toBe("high-entropy-token");
+  });
+
+  it("skips URLs even when they contain high-entropy path segments", () => {
+    // doc IDs in URLs look random; flagging them is annoying since users
+    // routinely paste links. regex layer still catches keys-with-prefix in URLs.
+    const url =
+      "https://docs.google.com/document/d/1aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789abcdef/edit";
+    expect(scan(url)).toEqual([]);
+  });
+
+  it("does not flag long natural-language compound words", () => {
+    // exotic place names / Finnish / camelCase identifiers reach ~0.7-0.82
+    // ratio — under the 0.85 threshold by a comfortable margin.
+    const text =
+      "Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch " +
+      "Lentokonesuihkuturbiinimoottoriapumekaanikkoaliupseerioppilas " +
+      "getUserByEmailAndOrganizationIdFromDatabase";
+    expect(scan(text)).toEqual([]);
+  });
 });

--- a/platform/frontend/src/lib/sensitive-data/entropy-detector.ts
+++ b/platform/frontend/src/lib/sensitive-data/entropy-detector.ts
@@ -8,11 +8,19 @@ import {
 const ENTROPY_DETECTOR_ID = detectorId("entropy");
 const INTERNAL_LABEL = "high-entropy-token";
 
-const CANDIDATE_PATTERN = /[A-Za-z0-9+/=_-]{20,}/g;
+const CANDIDATE_PATTERN = /\S{20,}/g;
 const HEX_ONLY_PATTERN = /^[0-9a-fA-F]+$/;
+// matches RFC 3986 scheme followed by "://" — skip these to avoid false
+// positives on URLs (e.g. Google Docs URLs contain high-entropy document IDs).
+const URL_LIKE_PATTERN = /^[a-z][a-z0-9+.-]*:\/\//i;
 
-const BASE64_ENTROPY_THRESHOLD = 4.5;
-const HEX_ENTROPY_THRESHOLD = 3.5;
+// fraction of the theoretical max entropy a token must reach. an absolute
+// threshold (e.g. 4.5 bits) is unreachable for shorter random tokens because
+// max entropy is capped by log2(min(len, alphabet)). a ratio works uniformly
+// across lengths.
+const ENTROPY_RATIO_THRESHOLD = 0.85;
+const HEX_ALPHABET_SIZE = 16;
+const NON_HEX_ALPHABET_SIZE = 64;
 
 export function shannonEntropy(s: string): number {
   if (s.length === 0) return 0;
@@ -52,19 +60,17 @@ export const entropyDetector: Detector = {
       const startIndex = match.index;
       const endIndex = startIndex + token.length;
 
-      if (!overlapsExisting(startIndex, endIndex, existing)) {
-        const threshold = HEX_ONLY_PATTERN.test(token)
-          ? HEX_ENTROPY_THRESHOLD
-          : BASE64_ENTROPY_THRESHOLD;
-
-        if (shannonEntropy(token) >= threshold) {
-          findings.push({
-            detectorId: ENTROPY_DETECTOR_ID,
-            internalLabel: INTERNAL_LABEL,
-            startIndex,
-            endIndex,
-          });
-        }
+      if (
+        !URL_LIKE_PATTERN.test(token) &&
+        !overlapsExisting(startIndex, endIndex, existing) &&
+        isHighEntropy(token)
+      ) {
+        findings.push({
+          detectorId: ENTROPY_DETECTOR_ID,
+          internalLabel: INTERNAL_LABEL,
+          startIndex,
+          endIndex,
+        });
       }
       match = pattern.exec(text);
     }
@@ -72,6 +78,15 @@ export const entropyDetector: Detector = {
     return findings;
   },
 };
+
+function isHighEntropy(token: string): boolean {
+  const alphabetSize = HEX_ONLY_PATTERN.test(token)
+    ? HEX_ALPHABET_SIZE
+    : NON_HEX_ALPHABET_SIZE;
+  const maxEntropy = Math.log2(Math.min(token.length, alphabetSize));
+  if (maxEntropy === 0) return false;
+  return shannonEntropy(token) / maxEntropy >= ENTROPY_RATIO_THRESHOLD;
+}
 
 function overlapsExisting(
   start: number,


### PR DESCRIPTION
## Summary
- Replaces the fixed `BASE64_ENTROPY_THRESHOLD = 4.5` / `HEX_ENTROPY_THRESHOLD = 3.5` with a single ratio-based check: a token must reach ≥ 85% of the theoretical max entropy for its length and alphabet. The absolute thresholds were unreachable for short random tokens because max entropy is capped at `log2(min(len, alphabet))`, so 21-30 char API keys slipped through.
- Widens the candidate regex from `/[A-Za-z0-9+/=_-]{20,}/g` to `/\S{20,}/g` so password-style strings containing punctuation (e.g. `jmqK34hrlH6%ZQ#7D2HIm`) aren't split into sub-20-char fragments and silently ignored.
- Adds a protocol-prefix skip (`^[a-z][a-z0-9+.-]*:\/\//i`) so long URLs (Google Docs links, etc.) aren't flagged. The regex layer still catches keys-with-known-prefix embedded in URLs.

## Calibration
Tested against a corpus of natural-language exotic words (Welsh / Finnish / Hungarian / Maori place names), long identifiers, file paths, UUIDs, base64-encoded prose, and realistic randomly-generated API keys.

- Worst non-secret false positive: `Cholmondeley-Smythe` at ratio 0.817 (under threshold).
- Easiest real random token: `exaTJdFjIrq7Sy4KF88a08JtLMJeRQ` at 0.892 (now flagged).
- Clean ~0.06 gap between the two.

## Test plan
- [ ] `pnpm vitest run src/lib/sensitive-data` — 49/49 passing locally
- [ ] Paste a 21-30 char random token into the chat composer with the feature flag on; dialog appears
- [ ] Paste a long Google Docs URL; dialog does not appear
- [ ] Paste a long exotic compound word; dialog does not appear

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>