### PR TITLE
chore: gitignore .dev-stack.pid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__/
 .claude/worktrees/
 .claude/*.lock
 .turbo/
+.dev-stack.pid
 
 # playwright-cli runtime cache (snapshots, console logs, screenshots)
 .playwright-cli/


### PR DESCRIPTION
## Summary

The parallel local dev tooling added in #5020 writes a PID file to `.dev-stack.pid` at the repo root, so anyone who has run the dev stack ends up with that file showing as untracked in `git status`. Ignore it so it stops surfacing as accidental commit material.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>