### PR TITLE
feat(staging): enable chat secret scan

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -48,6 +48,7 @@ archestra:
     ARCHESTRA_AGENTS_INCOMING_EMAIL_OUTLOOK_WEBHOOK_URL: "https://backend.archestra.dev/api/webhooks/incoming-email"
     ARCHESTRA_CHAT_DEFAULT_PROVIDER: "anthropic"
     ARCHESTRA_CHAT_DEFAULT_MODEL: "claude-opus-4-5-20251101"
+    ARCHESTRA_CHAT_SECRET_SCAN_ENABLED: "true"
 
   diagnostics:
     enabled: true


### PR DESCRIPTION
## Summary

- Sets `ARCHESTRA_CHAT_SECRET_SCAN_ENABLED=true` in `.github/values-staging.yaml` to enable the frontend pre-send sensitive data detection on staging.

The feature itself was merged in #5024. This PR flips the flag on for the staging environment so it can be validated before a wider rollout.

## Test plan
- [ ] Deploy to staging and open the chat composer
- [ ] Paste a fake secret (e.g. `ghp_` + 36 chars) and confirm the warning dialog appears before sending
- [ ] Confirm normal messages send without any dialog

https://claude.ai/code/session_01D59pPxcaTyT6hDu63Ykyhi

---
_Generated by [Claude Code](https://claude.ai/code/session_01D59pPxcaTyT6hDu63Ykyhi)_

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>