### PR TITLE
fix(chat): skip dynamic-tool render when MCP App owns the toolCallId

### DIFF
--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -11,6 +11,7 @@ import {
   Globe,
   MicIcon,
   MoreVertical,
+  PanelRight,
   PaperclipIcon,
   Plus,
   Share2,
@@ -43,7 +44,10 @@ import {
   PlaywrightInstallDialog,
   usePlaywrightSetupRequired,
 } from "@/components/chat/playwright-install-dialog";
-import { RightSidePanel } from "@/components/chat/right-side-panel";
+import {
+  type RightPanelTab,
+  RightSidePanel,
+} from "@/components/chat/right-side-panel";
 import { ShareConversationDialog } from "@/components/chat/share-conversation-dialog";
 import { StreamTimeoutWarning } from "@/components/chat/stream-timeout-warning";
 import { CreateLlmProviderApiKeyDialog } from "@/components/create-llm-provider-api-key-dialog";
@@ -266,6 +270,11 @@ export function ChatPageContent({
     }
     return false;
   });
+
+  // Tracks which tab the right-side panel last showed; restored when the panel
+  // is re-opened via the header toggle.
+  const [activeRightTab, setActiveRightTab] =
+    useState<RightPanelTab>("artifact");
 
   const hasChatAccess = canReadAgent !== false;
   const canUseProviderSettings =
@@ -854,19 +863,6 @@ export function ChatPageContent({
   const stopChatStreamMutation = useStopChatStream();
   const compactConversationMutation = useCompactConversation();
 
-  // Persist artifact panel state
-  const toggleArtifactPanel = useCallback(() => {
-    const newValue = !isArtifactOpen;
-    setIsArtifactOpen(newValue);
-    // Only persist state for active conversations
-    if (conversationId) {
-      localStorage.setItem(
-        conversationStorageKeys(conversationId).artifactOpen,
-        String(newValue),
-      );
-    }
-  }, [isArtifactOpen, conversationId]);
-
   // Auto-open artifact panel when artifact is updated during conversation
   const previousArtifactRef = useRef<string | null | undefined>(undefined);
   useEffect(() => {
@@ -1378,18 +1374,76 @@ export function ChatPageContent({
     });
   };
 
-  // Persist browser panel state - just opens panel, installation happens inside if needed
-  const toggleBrowserPanel = useCallback(() => {
-    const newValue = !isBrowserPanelOpen;
-    setIsBrowserPanelOpen(newValue);
-    localStorage.setItem(BROWSER_OPEN_KEY, String(newValue));
-  }, [isBrowserPanelOpen]);
+  const isBrowserPanelVisible = isBrowserPanelOpen && !isPlaywrightSetupVisible;
+  const isRightPanelOpen = isArtifactOpen || isBrowserPanelVisible;
 
-  // Close browser panel handler (also persists to localStorage)
-  const closeBrowserPanel = useCallback(() => {
+  // Keep the active-tab tracker in sync with which panel is actually shown,
+  // so closing+reopening restores the user's last view.
+  useEffect(() => {
+    if (isBrowserPanelVisible && !isArtifactOpen) {
+      setActiveRightTab("browser");
+    } else if (isArtifactOpen) {
+      setActiveRightTab("artifact");
+    }
+  }, [isArtifactOpen, isBrowserPanelVisible]);
+
+  const openRightPanelTab = useCallback(
+    (tab: RightPanelTab) => {
+      setActiveRightTab(tab);
+      if (tab === "artifact") {
+        setIsArtifactOpen(true);
+        setIsBrowserPanelOpen(false);
+        if (conversationId) {
+          localStorage.setItem(
+            conversationStorageKeys(conversationId).artifactOpen,
+            "true",
+          );
+        }
+        localStorage.setItem(BROWSER_OPEN_KEY, "false");
+      } else {
+        setIsBrowserPanelOpen(true);
+        setIsArtifactOpen(false);
+        if (conversationId) {
+          localStorage.setItem(
+            conversationStorageKeys(conversationId).artifactOpen,
+            "false",
+          );
+        }
+        localStorage.setItem(BROWSER_OPEN_KEY, "true");
+      }
+    },
+    [conversationId],
+  );
+
+  const closeRightPanel = useCallback(() => {
+    setIsArtifactOpen(false);
     setIsBrowserPanelOpen(false);
+    if (conversationId) {
+      localStorage.setItem(
+        conversationStorageKeys(conversationId).artifactOpen,
+        "false",
+      );
+    }
     localStorage.setItem(BROWSER_OPEN_KEY, "false");
-  }, []);
+  }, [conversationId]);
+
+  const toggleRightPanel = useCallback(() => {
+    if (isRightPanelOpen) {
+      closeRightPanel();
+    } else {
+      const target =
+        activeRightTab === "browser" && !showBrowserButton
+          ? "artifact"
+          : activeRightTab;
+      openRightPanelTab(target);
+    }
+  }, [
+    isRightPanelOpen,
+    activeRightTab,
+    showBrowserButton,
+    closeRightPanel,
+    openRightPanelTab,
+  ]);
 
   // Handle creating conversation from browser URL input (when no conversation exists)
   const createInitialConversation = useCallback(
@@ -1818,58 +1872,21 @@ export function ChatPageContent({
                   </TruncatedTooltip>
                 </div>
               )}
-              {/* Right side - desktop: original buttons */}
+              {/* Right side - desktop: panel toggle */}
               <div className="hidden md:flex items-center gap-2 flex-shrink-0">
-                {canManageShare && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setIsShareDialogOpen(true)}
-                    className="text-xs"
-                  >
-                    {isShared ? (
-                      <>
-                        <Users className="h-3 w-3 mr-1 text-primary" />
-                        <span className="text-primary">Shared</span>
-                      </>
-                    ) : (
-                      <>
-                        <Share2 className="h-3 w-3 mr-1" />
-                        Share
-                      </>
-                    )}
-                  </Button>
-                )}
-                {canManageShare && <div className="w-px h-4 bg-border" />}
                 <Button
-                  variant={isArtifactOpen ? "secondary" : "ghost"}
-                  size="sm"
-                  onClick={toggleArtifactPanel}
-                  className="text-xs"
+                  variant="ghost"
+                  size="icon"
+                  onClick={toggleRightPanel}
+                  className="h-8 w-8"
+                  title={isRightPanelOpen ? "Close panel" : "Open panel"}
+                  aria-pressed={isRightPanelOpen}
                 >
-                  <FileText className="h-3 w-3 mr-1" />
-                  Artifact
+                  <PanelRight className="h-4 w-4" />
+                  <span className="sr-only">
+                    {isRightPanelOpen ? "Close panel" : "Open panel"}
+                  </span>
                 </Button>
-
-                {showBrowserButton && (
-                  <>
-                    <div className="w-px h-4 bg-border" />
-                    <Button
-                      variant={
-                        isBrowserPanelOpen && !isPlaywrightSetupVisible
-                          ? "secondary"
-                          : "ghost"
-                      }
-                      size="sm"
-                      onClick={toggleBrowserPanel}
-                      className="text-xs"
-                      disabled={isPlaywrightSetupVisible}
-                    >
-                      <Globe className="h-3 w-3 mr-1" />
-                      Browser
-                    </Button>
-                  </>
-                )}
               </div>
               {/* Right side - mobile: 3-dot dropdown */}
               <div className="flex md:hidden items-center gap-2 flex-shrink-0">
@@ -1903,17 +1920,31 @@ export function ChatPageContent({
                         )}
                       </DropdownMenuItem>
                     )}
-                    <DropdownMenuItem onSelect={toggleArtifactPanel}>
+                    <DropdownMenuItem
+                      onSelect={() => {
+                        if (isArtifactOpen) {
+                          closeRightPanel();
+                        } else {
+                          openRightPanelTab("artifact");
+                        }
+                      }}
+                    >
                       <FileText className="h-4 w-4" />
                       {isArtifactOpen ? "Hide Artifact" : "Show Artifact"}
                     </DropdownMenuItem>
                     {showBrowserButton && (
                       <DropdownMenuItem
-                        onSelect={toggleBrowserPanel}
+                        onSelect={() => {
+                          if (isBrowserPanelVisible) {
+                            closeRightPanel();
+                          } else {
+                            openRightPanelTab("browser");
+                          }
+                        }}
                         disabled={isPlaywrightSetupVisible}
                       >
                         <Globe className="h-4 w-4" />
-                        {isBrowserPanelOpen && !isPlaywrightSetupVisible
+                        {isBrowserPanelVisible
                           ? "Hide Browser"
                           : "Show Browser"}
                       </DropdownMenuItem>
@@ -1924,37 +1955,24 @@ export function ChatPageContent({
             </div>
           </div>
 
-          {/* Mobile: Inline artifact/browser panels below header */}
-          {(isArtifactOpen ||
-            (isBrowserPanelOpen && !isPlaywrightSetupVisible)) && (
+          {/* Mobile: Inline artifact/browser panel below header */}
+          {isRightPanelOpen && (
             <div className="flex-1 flex flex-col min-h-0 overflow-hidden md:hidden">
-              {isArtifactOpen && (
-                <div
-                  className={cn(
-                    "min-h-0 overflow-auto",
-                    isBrowserPanelOpen && !isPlaywrightSetupVisible
-                      ? "h-1/2 border-b"
-                      : "flex-1",
-                  )}
-                >
+              {activeRightTab === "artifact" && (
+                <div className="flex-1 min-h-0 overflow-auto">
                   <ConversationArtifactPanel
                     artifact={conversation?.artifact}
-                    isOpen={isArtifactOpen}
-                    onToggle={toggleArtifactPanel}
+                    isOpen
+                    onToggle={closeRightPanel}
                     embedded
                   />
                 </div>
               )}
-              {isBrowserPanelOpen && !isPlaywrightSetupVisible && (
-                <div
-                  className={cn(
-                    "min-h-0 overflow-auto",
-                    isArtifactOpen ? "h-1/2" : "flex-1",
-                  )}
-                >
+              {activeRightTab === "browser" && isBrowserPanelVisible && (
+                <div className="flex-1 min-h-0 overflow-auto">
                   <BrowserPanel
-                    isOpen={true}
-                    onClose={closeBrowserPanel}
+                    isOpen
+                    onClose={closeRightPanel}
                     conversationId={conversationId}
                     agentId={browserToolsAgentId}
                     onCreateConversationWithUrl={
@@ -1977,9 +1995,7 @@ export function ChatPageContent({
               <div
                 className={cn(
                   "flex-1 min-h-0 relative",
-                  (isArtifactOpen ||
-                    (isBrowserPanelOpen && !isPlaywrightSetupVisible)) &&
-                    "hidden md:block",
+                  isRightPanelOpen && "hidden md:block",
                 )}
               >
                 {isReadOnlyConversation ? (
@@ -2279,11 +2295,34 @@ export function ChatPageContent({
       {/* Right-side panel - desktop only */}
       <div className="hidden md:flex">
         <RightSidePanel
+          isOpen={isRightPanelOpen}
+          activeTab={activeRightTab}
+          onTabChange={openRightPanelTab}
+          onClose={closeRightPanel}
+          canShowBrowser={showBrowserButton && !isPlaywrightSetupVisible}
+          headerActions={
+            canManageShare ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setIsShareDialogOpen(true)}
+                className="text-xs h-7"
+              >
+                {isShared ? (
+                  <>
+                    <Users className="h-3 w-3 mr-1 text-primary" />
+                    <span className="text-primary">Shared</span>
+                  </>
+                ) : (
+                  <>
+                    <Share2 className="h-3 w-3 mr-1" />
+                    Share
+                  </>
+                )}
+              </Button>
+            ) : undefined
+          }
           artifact={conversation?.artifact}
-          isArtifactOpen={isArtifactOpen}
-          onArtifactToggle={toggleArtifactPanel}
-          isBrowserOpen={isBrowserPanelOpen && !isPlaywrightSetupVisible}
-          onBrowserClose={closeBrowserPanel}
           conversationId={conversationId}
           agentId={browserToolsAgentId}
           onCreateConversationWithUrl={handleCreateConversationWithUrl}

--- a/platform/frontend/src/components/chat/browser-panel.tsx
+++ b/platform/frontend/src/components/chat/browser-panel.tsx
@@ -24,6 +24,8 @@ interface BrowserPanelProps {
   initialNavigateUrl?: string;
   /** Called after initial navigation is triggered */
   onInitialNavigateComplete?: () => void;
+  /** When true, hide the panel's own title + close button (the parent already provides them). */
+  hideHeader?: boolean;
 }
 
 export function BrowserPanel({
@@ -35,6 +37,7 @@ export function BrowserPanel({
   isCreatingConversation = false,
   initialNavigateUrl,
   onInitialNavigateComplete,
+  hideHeader = false,
 }: BrowserPanelProps) {
   const handleOpenInNewWindow = useCallback(() => {
     if (!conversationId) return;
@@ -66,7 +69,8 @@ export function BrowserPanel({
       isCreatingConversation={isCreatingConversation}
       initialNavigateUrl={initialNavigateUrl}
       onInitialNavigateComplete={onInitialNavigateComplete}
-      className="border-t"
+      className={hideHeader ? undefined : "border-t"}
+      hideHeader={hideHeader}
       headerActions={
         <>
           <Button
@@ -78,15 +82,17 @@ export function BrowserPanel({
           >
             <ExternalLink className="h-3 w-3" />
           </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-6 w-6"
-            onClick={onClose}
-            title="Close"
-          >
-            <X className="h-3 w-3" />
-          </Button>
+          {!hideHeader && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6"
+              onClick={onClose}
+              title="Close"
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          )}
         </>
       }
     />

--- a/platform/frontend/src/components/chat/browser-preview-content.tsx
+++ b/platform/frontend/src/components/chat/browser-preview-content.tsx
@@ -52,6 +52,8 @@ interface BrowserPreviewContentProps {
   agentId?: string;
   /** When true, this is a popup that follows the active conversation */
   isPopup?: boolean;
+  /** When true, hide the title row (parent already provides chrome). */
+  hideHeader?: boolean;
   /** Called when user enters a URL without a conversation - should create conversation and navigate */
   onCreateConversationWithUrl?: (url: string) => void;
   /** Whether conversation creation is in progress */
@@ -69,6 +71,7 @@ export function BrowserPreviewContent({
   className,
   agentId: agentIdProp,
   isPopup = false,
+  hideHeader = false,
   onCreateConversationWithUrl,
   isCreatingConversation = false,
   initialNavigateUrl,
@@ -251,16 +254,27 @@ export function BrowserPreviewContent({
       {/* Header */}
       <div className="flex flex-col px-2 py-3 border-b">
         <div className="flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2">
-            <Globe className="h-4 w-4 text-muted-foreground" />
-            <span className="text-xs font-medium">Browser Preview</span>
-            {isConnected && (
+          {hideHeader ? (
+            isConnected ? (
               <span
-                className="w-2 h-2 rounded-full bg-green-500"
+                className="w-2 h-2 rounded-full bg-green-500 ml-1"
                 title="Connected"
               />
-            )}
-          </div>
+            ) : (
+              <div />
+            )
+          ) : (
+            <div className="flex items-center gap-2">
+              <Globe className="h-4 w-4 text-muted-foreground" />
+              <span className="text-xs font-medium">Browser Preview</span>
+              {isConnected && (
+                <span
+                  className="w-2 h-2 rounded-full bg-green-500"
+                  title="Connected"
+                />
+              )}
+            </div>
+          )}
           <div className="flex items-center gap-1">
             {/* Type tool */}
             <Popover>

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -1007,6 +1007,19 @@ export function ChatMessages({
                         if (!isToolPart(part)) return null;
                         const toolName = part.toolName;
 
+                        // Skip if a data-tool-ui-start already owns this toolCallId
+                        // (it renders the full input/output lifecycle itself).
+                        const tcId = part.toolCallId;
+                        const hasEarlyStart =
+                          tcId &&
+                          (message.parts ?? []).some(
+                            (p) =>
+                              p.type?.startsWith("data-tool-ui-start") &&
+                              (p as { data?: { toolCallId?: string } }).data
+                                ?.toolCallId === tcId,
+                          );
+                        if (hasEarlyStart) return null;
+
                         // Look ahead for tool result (same tool call ID)
                         let toolResultPart = null;
                         const nextPart = message.parts?.[i + 1];

--- a/platform/frontend/src/components/chat/conversation-artifact.tsx
+++ b/platform/frontend/src/components/chat/conversation-artifact.tsx
@@ -22,6 +22,8 @@ interface ConversationArtifactPanelProps {
   className?: string;
   /** When true, the panel fills its container and doesn't manage its own width/resize */
   embedded?: boolean;
+  /** When true, hide the panel's own title + close button (the parent already provides them) */
+  hideHeader?: boolean;
 }
 
 export function ConversationArtifactPanel({
@@ -30,6 +32,7 @@ export function ConversationArtifactPanel({
   onToggle,
   className,
   embedded = false,
+  hideHeader = false,
 }: ConversationArtifactPanelProps) {
   const [width, setWidth] = useState(() => {
     if (typeof window !== "undefined") {
@@ -365,11 +368,15 @@ export function ConversationArtifactPanel({
       )}
 
       {/* Panel header */}
-      <div className="border-b px-2 pr-1 py-2 flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <FileText className="h-4 w-4 text-muted-foreground" />
-          <h3 className="font-medium text-xs">Conversation Artifact</h3>
-        </div>
+      <div className="border-b px-2 pr-1 py-1 flex items-center justify-between">
+        {hideHeader ? (
+          <div />
+        ) : (
+          <div className="flex items-center gap-2">
+            <FileText className="h-4 w-4 text-muted-foreground" />
+            <h3 className="font-medium text-xs">Conversation Artifact</h3>
+          </div>
+        )}
         <div className="flex items-center gap-1">
           <Button
             variant="ghost"
@@ -389,15 +396,17 @@ export function ConversationArtifactPanel({
           >
             <Download className="h-3.5 w-3.5" />
           </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8"
-            onClick={onToggle}
-            title="Close panel"
-          >
-            <X className="h-3.5 w-3.5" />
-          </Button>
+          {!hideHeader && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={onToggle}
+              title="Close panel"
+            >
+              <X className="h-3.5 w-3.5" />
+            </Button>
+          )}
         </div>
       </div>
 

--- a/platform/frontend/src/components/chat/right-side-panel.tsx
+++ b/platform/frontend/src/components/chat/right-side-panel.tsx
@@ -1,20 +1,28 @@
 "use client";
 
-import { GripVertical } from "lucide-react";
+import { FileText, Globe, GripVertical, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { BrowserPanel } from "@/components/chat/browser-panel";
 import { ConversationArtifactPanel } from "@/components/chat/conversation-artifact";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 
+export type RightPanelTab = "artifact" | "browser";
+
 interface RightSidePanelProps {
+  isOpen: boolean;
+  activeTab: RightPanelTab;
+  onTabChange: (tab: RightPanelTab) => void;
+  onClose: () => void;
+  canShowBrowser: boolean;
+  /** Optional action(s) rendered in the tab row, between the tabs and the close button. */
+  headerActions?: React.ReactNode;
+
   // Artifact props
   artifact?: string | null;
-  isArtifactOpen: boolean;
-  onArtifactToggle: () => void;
 
   // Browser props
-  isBrowserOpen: boolean;
-  onBrowserClose: () => void;
   conversationId: string | undefined;
   /** Fallback agentId for pre-conversation case */
   agentId?: string;
@@ -29,11 +37,13 @@ interface RightSidePanelProps {
 }
 
 export function RightSidePanel({
+  isOpen,
+  activeTab,
+  onTabChange,
+  onClose,
+  canShowBrowser,
+  headerActions,
   artifact,
-  isArtifactOpen,
-  onArtifactToggle,
-  isBrowserOpen,
-  onBrowserClose,
   conversationId,
   agentId,
   onCreateConversationWithUrl,
@@ -118,10 +128,12 @@ export function RightSidePanel({
     };
   }, [isResizing]);
 
-  // Don't render if nothing is open
-  if (!isArtifactOpen && !isBrowserOpen) {
+  if (!isOpen) {
     return null;
   }
+
+  const resolvedTab: RightPanelTab =
+    activeTab === "browser" && !canShowBrowser ? "artifact" : activeTab;
 
   return (
     <div
@@ -150,43 +162,64 @@ export function RightSidePanel({
         </div>
       </div>
 
-      {/* Artifact Panel - takes remaining space */}
-      {isArtifactOpen && (
-        <div
-          className="min-h-0 overflow-hidden"
-          style={{
-            height: isBrowserOpen ? "50%" : "100%",
-          }}
-        >
-          <ConversationArtifactPanel
-            artifact={artifact}
-            isOpen={isArtifactOpen}
-            onToggle={onArtifactToggle}
-            embedded
-          />
+      <Tabs
+        value={resolvedTab}
+        onValueChange={(value) => onTabChange(value as RightPanelTab)}
+        className="flex-1 min-h-0 flex flex-col gap-0"
+      >
+        <div className="flex items-center justify-between gap-2 border-b px-2 py-2">
+          <TabsList className="h-8">
+            <TabsTrigger value="artifact" className="text-xs px-3">
+              <FileText className="h-3 w-3" />
+              Artifact
+            </TabsTrigger>
+            {canShowBrowser && (
+              <TabsTrigger value="browser" className="text-xs px-3">
+                <Globe className="h-3 w-3" />
+                Browser
+              </TabsTrigger>
+            )}
+          </TabsList>
+          <div className="flex items-center gap-1">
+            {headerActions}
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={onClose}
+              title="Close panel"
+            >
+              <X className="h-4 w-4" />
+              <span className="sr-only">Close panel</span>
+            </Button>
+          </div>
         </div>
-      )}
 
-      {/* Browser Panel - at the bottom */}
-      {isBrowserOpen && (
-        <div
-          className="flex-shrink-0"
-          style={{
-            height: isArtifactOpen ? "50%" : "unset",
-          }}
-        >
-          <BrowserPanel
-            isOpen={isBrowserOpen}
-            onClose={onBrowserClose}
-            conversationId={conversationId}
-            agentId={agentId}
-            onCreateConversationWithUrl={onCreateConversationWithUrl}
-            isCreatingConversation={isCreatingConversation}
-            initialNavigateUrl={initialNavigateUrl}
-            onInitialNavigateComplete={onInitialNavigateComplete}
-          />
+        <div className="flex-1 min-h-0 overflow-hidden">
+          {resolvedTab === "artifact" && (
+            <ConversationArtifactPanel
+              artifact={artifact}
+              isOpen
+              onToggle={onClose}
+              embedded
+              hideHeader
+            />
+          )}
+          {resolvedTab === "browser" && canShowBrowser && (
+            <BrowserPanel
+              isOpen
+              onClose={onClose}
+              conversationId={conversationId}
+              agentId={agentId}
+              onCreateConversationWithUrl={onCreateConversationWithUrl}
+              isCreatingConversation={isCreatingConversation}
+              initialNavigateUrl={initialNavigateUrl}
+              onInitialNavigateComplete={onInitialNavigateComplete}
+              hideHeader
+            />
+          )}
         </div>
-      )}
+      </Tabs>
     </div>
   );
 }


### PR DESCRIPTION
The `dynamic-tool` case was missing the `hasEarlyStart` guard that the `tool-*` case already has. When an MCP App emits `data-tool-ui-start`, both branches rendered, producing a duplicate "Pending" card next to the real "Completed" card for the same tool call.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>