### PR TITLE
fix: allow large chat uploads (limits-only)

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -775,10 +775,10 @@ The following environment variables can be used to configure Archestra Platform.
   - Values: `true`, `false`, or a comma-separated list of trusted proxy IPs/CIDRs (e.g. `10.0.0.0/8,172.16.0.0/12`)
   - Example: `ARCHESTRA_TRUST_PROXY=true`
 
-- **`ARCHESTRA_API_BODY_LIMIT`** - Maximum request body size for LLM proxy and chat routes.
-  - Default: `50MB` (52428800 bytes)
-  - Format: Numeric bytes (e.g., `52428800`) or human-readable (e.g., `50MB`, `100KB`, `1GB`)
-  - Note: Increase this if you have conversations with very large context windows (100k+ tokens) or large file attachments in chat
+- **`ARCHESTRA_API_BODY_LIMIT`** - Maximum request body size accepted by the backend for LLM proxy and chat routes.
+  - Default: `70MB` (73400320 bytes)
+  - Format: Numeric bytes (e.g., `73400320`) or human-readable (e.g., `70MB`, `100KB`, `1GB`)
+  - Note: Increase this if you have conversations with very large context windows (100k+ tokens) or large file attachments in chat. Chat attachments are base64-encoded inline, so the default leaves room for files up to about 50MB. The frontend Next.js proxy keeps a permissive static ceiling so the backend remains the single runtime knob for body size.
 
 - **`ARCHESTRA_FRONTEND_URL`** - Setting this variable enables origin validation for CORS and authentication. When set, only requests from this origin (and any in `ARCHESTRA_AUTH_ADDITIONAL_TRUSTED_ORIGINS`) are allowed. When not set, all origins are accepted.
   - Example: `https://frontend.example.com`

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -262,7 +262,7 @@ export const parseBodyLimit = (
   return defaultValue;
 };
 
-const DEFAULT_BODY_LIMIT = 50 * 1024 * 1024; // 50MB
+const DEFAULT_BODY_LIMIT = 70 * 1024 * 1024; // 70MB
 
 const DEFAULT_DATABASE_POOL_MAX = 50;
 const MAX_DATABASE_POOL_MAX = 500;

--- a/platform/frontend/next.config.ts
+++ b/platform/frontend/next.config.ts
@@ -44,6 +44,10 @@ const nextConfig: NextConfig = {
   },
   experimental: {
     proxyTimeout: 300000, // 5 minutes in milliseconds - prevents SSE stream timeout
+    // Static high ceiling so the Next.js proxy doesn't truncate large uploads
+    // (default is 10MB). The backend's ARCHESTRA_API_BODY_LIMIT is the actual
+    // runtime knob; this just keeps the proxy from being the first wall.
+    proxyClientMaxBodySize: "200mb",
   },
   httpAgentOptions: {
     keepAlive: true,

--- a/platform/frontend/src/next-config.test.ts
+++ b/platform/frontend/src/next-config.test.ts
@@ -11,6 +11,12 @@ describe("next config rewrites", () => {
     delete process.env.VERSION;
   });
 
+  it("keeps a permissive proxy body ceiling so large uploads aren't truncated", async () => {
+    const { default: nextConfig } = await import("../next.config");
+
+    expect(nextConfig.experimental?.proxyClientMaxBodySize).toBe("200mb");
+  });
+
   it("uses sanitized VERSION as the deployment id", async () => {
     process.env.VERSION = "v1.2.41+build.5";
 


### PR DESCRIPTION
Closes #4735.

Alternative to #4996 — same root cause, narrower change set.

Next.js's default `proxyClientMaxBodySize` is 10MB and the backend's Fastify `bodyLimit` was 50MB, so encoded chat attachments past ~7MB on-wire silently truncate at the frontend proxy or get rejected by the backend. This PR lifts both walls.

Differences from #4996:

- Omits the `normalizeChatMessagesForStorage` change that replaces `data:` URL file parts with placeholder text before persisting. Stripping permanently loses file content for every chat persisted while it's live, conflicts with chat-resume (#4219) when reloading restores placeholders into the prompt, and would be obsoleted by #4408's blob-storage approach. Database bloat from large attachments is a real concern but better solved by #4408's pointer model than by irreversible deletion of user data.
- Makes `proxyClientMaxBodySize` a static 200MB instead of reading `ARCHESTRA_API_BODY_LIMIT`. In Next's standalone output mode (`output: "standalone"`) the config is JSON-serialized into the bundle at build time (`__NEXT_PRIVATE_STANDALONE_CONFIG`), so an operator raising the env at K8s runtime would still hit the build-time value on the frontend. The backend env var remains the sole runtime knob; the frontend keeps a permissive ceiling that doesn't need per-deployment tuning.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>