### PR TITLE
feat(dev-stack): hydrate parallel stack's DB from main

### DIFF
--- a/platform/backend/package.json
+++ b/platform/backend/package.json
@@ -27,6 +27,7 @@
     "db:clean": "tsx --tsconfig standalone-scripts.tsconfig.json src/standalone-scripts/clean-db-on-dev.ts",
     "code-runtime:bench": "tsdown --config tsdown.code-runtime-benchmark.config.ts --logLevel error && ARCHESTRA_LOGGING_LEVEL=${ARCHESTRA_LOGGING_LEVEL:-warn} node --enable-source-maps dist/code-runtime-benchmark/code-runtime-benchmark.mjs",
     "db:seed:mock-data": "tsx --tsconfig standalone-scripts.tsconfig.json src/standalone-scripts/seed-mock-data.ts",
+    "db:copy-providers-from": "tsx --tsconfig standalone-scripts.tsconfig.json src/standalone-scripts/copy-providers-from.ts",
     "codegen:access-control-docs": "tsx --tsconfig standalone-scripts.tsconfig.json src/standalone-scripts/codegen-access-control-docs.ts",
     "codegen:archestra-mcp-server-docs": "tsx --tsconfig standalone-scripts.tsconfig.json src/standalone-scripts/codegen-archestra-mcp-server-docs.ts",
     "codegen:openapi": "tsx --tsconfig standalone-scripts.tsconfig.json src/standalone-scripts/codegen-openapi.ts",

--- a/platform/backend/package.json
+++ b/platform/backend/package.json
@@ -27,7 +27,7 @@
     "db:clean": "tsx --tsconfig standalone-scripts.tsconfig.json src/standalone-scripts/clean-db-on-dev.ts",
     "code-runtime:bench": "tsdown --config tsdown.code-runtime-benchmark.config.ts --logLevel error && ARCHESTRA_LOGGING_LEVEL=${ARCHESTRA_LOGGING_LEVEL:-warn} node --enable-source-maps dist/code-runtime-benchmark/code-runtime-benchmark.mjs",
     "db:seed:mock-data": "tsx --tsconfig standalone-scripts.tsconfig.json src/standalone-scripts/seed-mock-data.ts",
-    "db:copy-providers-from": "tsx --tsconfig standalone-scripts.tsconfig.json src/standalone-scripts/copy-providers-from.ts",
+    "db:hydrate-from": "tsx --tsconfig standalone-scripts.tsconfig.json src/standalone-scripts/hydrate-from.ts",
     "codegen:access-control-docs": "tsx --tsconfig standalone-scripts.tsconfig.json src/standalone-scripts/codegen-access-control-docs.ts",
     "codegen:archestra-mcp-server-docs": "tsx --tsconfig standalone-scripts.tsconfig.json src/standalone-scripts/codegen-archestra-mcp-server-docs.ts",
     "codegen:openapi": "tsx --tsconfig standalone-scripts.tsconfig.json src/standalone-scripts/codegen-openapi.ts",

--- a/platform/backend/src/standalone-scripts/copy-providers-from.ts
+++ b/platform/backend/src/standalone-scripts/copy-providers-from.ts
@@ -1,0 +1,146 @@
+/**
+ * Copy LLM-provider rows (secrets, models, chat_api_keys/llm_provider_api_keys,
+ * api_key_models) from a SOURCE Postgres into the TARGET Postgres (the one this
+ * backend is configured for). Used by `pnpm dev:stack:copy-providers` to make a
+ * fresh parallel dev stack immediately usable for chat/agents/proxy without
+ * re-entering API keys.
+ *
+ * Source connection: SOURCE_DATABASE_URL env var.
+ * Target connection: ARCHESTRA_DATABASE_URL env var (the standard one).
+ *
+ * Ownership rewrite: every copied chat_api_keys row is reassigned to the target
+ * admin (`admin@example.com`)'s user and organization with scope='personal' and
+ * teamId=null. Source orgs/users/teams aren't mirrored — the parallel stack is
+ * a sandbox where only admin exists.
+ *
+ * Idempotent: every INSERT uses ON CONFLICT DO NOTHING, so re-runs top up rows
+ * the target is missing and never delete rows the dev added by hand.
+ *
+ * Encryption: secrets are inserted verbatim. Decryption requires the target's
+ * ARCHESTRA_AUTH_SECRET to match the source's. `pnpm dev:stack:up` copies the
+ * source .env (which carries ARCHESTRA_AUTH_SECRET) into the parallel worktree,
+ * so that precondition is satisfied by the default flow.
+ */
+
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/node-postgres";
+import pg from "pg";
+import * as schema from "@/database/schemas";
+
+const sourceUrl = process.env.SOURCE_DATABASE_URL;
+const targetUrl = process.env.ARCHESTRA_DATABASE_URL;
+
+if (!sourceUrl) {
+  console.error("ERROR: SOURCE_DATABASE_URL is not set");
+  process.exit(1);
+}
+if (!targetUrl) {
+  console.error("ERROR: ARCHESTRA_DATABASE_URL is not set");
+  process.exit(1);
+}
+if (sourceUrl === targetUrl) {
+  console.error(
+    "ERROR: SOURCE_DATABASE_URL and ARCHESTRA_DATABASE_URL are the same",
+  );
+  process.exit(1);
+}
+
+const sourcePool = new pg.Pool({ connectionString: sourceUrl });
+const targetPool = new pg.Pool({ connectionString: targetUrl });
+const source = drizzle(sourcePool, { schema });
+const target = drizzle(targetPool, { schema });
+
+try {
+  // Resolve target admin's user + org. Without a member row the user can't own
+  // a chat_api_key (organization_id is NOT NULL), so we fail loudly if either
+  // is missing rather than guessing.
+  const adminRows = await target
+    .select({
+      userId: schema.usersTable.id,
+      organizationId: schema.membersTable.organizationId,
+    })
+    .from(schema.usersTable)
+    .innerJoin(
+      schema.membersTable,
+      eq(schema.membersTable.userId, schema.usersTable.id),
+    )
+    .where(eq(schema.usersTable.email, "admin@example.com"))
+    .limit(1);
+
+  if (adminRows.length === 0) {
+    console.error(
+      "ERROR: no admin@example.com user with a membership in the target DB. " +
+        "Has the parallel stack finished booting and seeding the default admin?",
+    );
+    process.exit(1);
+  }
+
+  const { userId: targetUserId, organizationId: targetOrgId } = adminRows[0];
+
+  // Read source-side rows.
+  const [secrets, models, providerKeys, apiKeyModels] = await Promise.all([
+    source.select().from(schema.secretsTable),
+    source.select().from(schema.modelsTable),
+    source.select().from(schema.llmProviderApiKeysTable),
+    source.select().from(schema.llmProviderApiKeyModelsTable),
+  ]);
+
+  const rewrittenKeys = providerKeys.map((k) => ({
+    ...k,
+    organizationId: targetOrgId,
+    userId: targetUserId,
+    teamId: null,
+    scope: "personal" as const,
+  }));
+
+  let copiedSecrets = 0;
+  let copiedModels = 0;
+  let copiedKeys = 0;
+  let copiedKeyModels = 0;
+
+  await target.transaction(async (tx) => {
+    if (secrets.length) {
+      const result = await tx
+        .insert(schema.secretsTable)
+        .values(secrets)
+        .onConflictDoNothing()
+        .returning({ id: schema.secretsTable.id });
+      copiedSecrets = result.length;
+    }
+    if (models.length) {
+      const result = await tx
+        .insert(schema.modelsTable)
+        .values(models)
+        .onConflictDoNothing()
+        .returning({ id: schema.modelsTable.id });
+      copiedModels = result.length;
+    }
+    if (rewrittenKeys.length) {
+      const result = await tx
+        .insert(schema.llmProviderApiKeysTable)
+        .values(rewrittenKeys)
+        .onConflictDoNothing()
+        .returning({ id: schema.llmProviderApiKeysTable.id });
+      copiedKeys = result.length;
+    }
+    if (apiKeyModels.length) {
+      const result = await tx
+        .insert(schema.llmProviderApiKeyModelsTable)
+        .values(apiKeyModels)
+        .onConflictDoNothing()
+        .returning({ apiKeyId: schema.llmProviderApiKeyModelsTable.apiKeyId });
+      copiedKeyModels = result.length;
+    }
+  });
+
+  console.log(
+    `✅ Copied: ${copiedSecrets}/${secrets.length} secrets, ` +
+      `${copiedModels}/${models.length} models, ` +
+      `${copiedKeys}/${providerKeys.length} provider keys, ` +
+      `${copiedKeyModels}/${apiKeyModels.length} key/model links ` +
+      `(rows already present were skipped via ON CONFLICT DO NOTHING)`,
+  );
+} finally {
+  await sourcePool.end();
+  await targetPool.end();
+}

--- a/platform/backend/src/standalone-scripts/copy-providers-from.ts
+++ b/platform/backend/src/standalone-scripts/copy-providers-from.ts
@@ -106,11 +106,28 @@ try {
   // Collapsing scope to 'personal' means many source keys can flatten onto
   // the same (org, provider, scope='personal', user_id) tuple — the partial
   // unique index `chat_api_keys_primary_personal_unique` allows only one
-  // `isPrimary=true` row in that bucket. Keep `isPrimary=true` for the FIRST
-  // copied key per provider; demote the rest. Force `isSystem=false` because
-  // target seeds its own system key per provider (the
-  // `chat_api_keys_system_unique` partial index would otherwise collide).
-  const seenPrimaryProviders = new Set<string>();
+  // `isPrimary=true` row in that bucket. Pre-seed the "already-primary"
+  // providers from target's existing rows (the dev may have already added a
+  // primary by hand) AND track within the source set; only keep
+  // `isPrimary=true` when neither already claims it, otherwise demote. Force
+  // `isSystem=false` because target seeds its own system key per provider
+  // (the `chat_api_keys_system_unique` partial index would otherwise collide).
+  const existingTargetPrimaryProviders = new Set(
+    (
+      await target
+        .select({ provider: schema.llmProviderApiKeysTable.provider })
+        .from(schema.llmProviderApiKeysTable)
+        .where(
+          and(
+            eq(schema.llmProviderApiKeysTable.organizationId, targetOrgId),
+            eq(schema.llmProviderApiKeysTable.userId, targetUserId),
+            eq(schema.llmProviderApiKeysTable.scope, "personal"),
+            eq(schema.llmProviderApiKeysTable.isPrimary, true),
+          ),
+        )
+    ).map((r) => r.provider),
+  );
+  const seenPrimaryProviders = new Set<string>(existingTargetPrimaryProviders);
   const rewrittenKeys = providerKeys.map((k) => {
     const keepPrimary = k.isPrimary && !seenPrimaryProviders.has(k.provider);
     if (keepPrimary) seenPrimaryProviders.add(k.provider);

--- a/platform/backend/src/standalone-scripts/copy-providers-from.ts
+++ b/platform/backend/src/standalone-scripts/copy-providers-from.ts
@@ -22,7 +22,7 @@
  * so that precondition is satisfied by the default flow.
  */
 
-import { eq, inArray } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import pg from "pg";
 import * as schema from "@/database/schemas";
@@ -77,21 +77,49 @@ try {
 
   const { userId: targetUserId, organizationId: targetOrgId } = adminRows[0];
 
-  // Read source-side rows.
-  const [secrets, models, providerKeys, apiKeyModels] = await Promise.all([
-    source.select().from(schema.secretsTable),
+  // Read source-side rows. The `secret` table also stores OAuth tokens,
+  // virtual-API-key secrets, etc. — we only want the rows referenced by
+  // provider keys, otherwise we'd import orphan credentials into target.
+  const [models, providerKeys, apiKeyModels] = await Promise.all([
     source.select().from(schema.modelsTable),
     source.select().from(schema.llmProviderApiKeysTable),
     source.select().from(schema.llmProviderApiKeyModelsTable),
   ]);
+  const referencedSecretIds = Array.from(
+    new Set(
+      providerKeys
+        .map((k) => k.secretId)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  );
+  const secrets = referencedSecretIds.length
+    ? await source
+        .select()
+        .from(schema.secretsTable)
+        .where(inArray(schema.secretsTable.id, referencedSecretIds))
+    : [];
 
-  const rewrittenKeys = providerKeys.map((k) => ({
-    ...k,
-    organizationId: targetOrgId,
-    userId: targetUserId,
-    teamId: null,
-    scope: "personal" as const,
-  }));
+  // Collapsing scope to 'personal' means many source keys can flatten onto
+  // the same (org, provider, scope='personal', user_id) tuple — the partial
+  // unique index `chat_api_keys_primary_personal_unique` allows only one
+  // `isPrimary=true` row in that bucket. Keep `isPrimary=true` for the FIRST
+  // copied key per provider; demote the rest. Force `isSystem=false` because
+  // target seeds its own system key per provider (the
+  // `chat_api_keys_system_unique` partial index would otherwise collide).
+  const seenPrimaryProviders = new Set<string>();
+  const rewrittenKeys = providerKeys.map((k) => {
+    const keepPrimary = k.isPrimary && !seenPrimaryProviders.has(k.provider);
+    if (keepPrimary) seenPrimaryProviders.add(k.provider);
+    return {
+      ...k,
+      organizationId: targetOrgId,
+      userId: targetUserId,
+      teamId: null,
+      scope: "personal" as const,
+      isPrimary: keepPrimary,
+      isSystem: false,
+    };
+  });
 
   let copiedSecrets = 0;
   let copiedModels = 0;
@@ -124,34 +152,62 @@ try {
       copiedKeys = result.length;
     }
     if (apiKeyModels.length) {
-      // Filter link rows to those whose api_key_id AND model_id are actually
-      // present in target. Without this, a source key whose insert was
-      // skipped (because target already had a logically-equivalent key under
-      // a different UUID and the unique index on org/provider/scope/user_id
-      // blocked the new row) leaves a dangling source api_key_id in the link
-      // rows, and the link insert aborts the whole transaction on an FK
-      // violation. Same for models.
+      // For keys we filter by what landed in target (a source key whose
+      // insert was skipped by a unique-index conflict has no target row to
+      // FK to). For models we have to REMAP — `models_provider_model_unique`
+      // means target may already have a logically-equivalent row under a
+      // different UUID, in which case the source row was skipped but the
+      // link should still resolve to target's existing UUID instead of
+      // being dropped.
       const sourceKeyIds = providerKeys.map((k) => k.id);
-      const sourceModelIds = models.map((m) => m.id);
-      const [presentKeys, presentModels] = await Promise.all([
+      const sourceProviders = Array.from(
+        new Set(models.map((m) => m.provider)),
+      );
+      const sourceModelIds = Array.from(new Set(models.map((m) => m.modelId)));
+      const [presentKeys, targetMatchingModels] = await Promise.all([
         sourceKeyIds.length
           ? tx
               .select({ id: schema.llmProviderApiKeysTable.id })
               .from(schema.llmProviderApiKeysTable)
               .where(inArray(schema.llmProviderApiKeysTable.id, sourceKeyIds))
           : Promise.resolve([] as { id: string }[]),
-        sourceModelIds.length
+        sourceProviders.length && sourceModelIds.length
           ? tx
-              .select({ id: schema.modelsTable.id })
+              .select({
+                id: schema.modelsTable.id,
+                provider: schema.modelsTable.provider,
+                modelId: schema.modelsTable.modelId,
+              })
               .from(schema.modelsTable)
-              .where(inArray(schema.modelsTable.id, sourceModelIds))
-          : Promise.resolve([] as { id: string }[]),
+              .where(
+                and(
+                  inArray(schema.modelsTable.provider, sourceProviders),
+                  inArray(schema.modelsTable.modelId, sourceModelIds),
+                ),
+              )
+          : Promise.resolve(
+              [] as { id: string; provider: string; modelId: string }[],
+            ),
       ]);
       const presentKeyIds = new Set(presentKeys.map((r) => r.id));
-      const presentModelIds = new Set(presentModels.map((r) => r.id));
-      const linkable = apiKeyModels.filter(
-        (l) => presentKeyIds.has(l.apiKeyId) && presentModelIds.has(l.modelId),
+      const targetModelByCompound = new Map(
+        targetMatchingModels.map((t) => [`${t.provider}:${t.modelId}`, t.id]),
       );
+      const sourceToTargetModelId = new Map<string, string>();
+      for (const sm of models) {
+        const tid = targetModelByCompound.get(`${sm.provider}:${sm.modelId}`);
+        if (tid) sourceToTargetModelId.set(sm.id, tid);
+      }
+      const linkable = apiKeyModels
+        .filter(
+          (l) =>
+            presentKeyIds.has(l.apiKeyId) &&
+            sourceToTargetModelId.has(l.modelId),
+        )
+        .map((l) => ({
+          ...l,
+          modelId: sourceToTargetModelId.get(l.modelId)!,
+        }));
       if (linkable.length) {
         const result = await tx
           .insert(schema.llmProviderApiKeyModelsTable)

--- a/platform/backend/src/standalone-scripts/copy-providers-from.ts
+++ b/platform/backend/src/standalone-scripts/copy-providers-from.ts
@@ -26,20 +26,21 @@ import { and, eq, inArray } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import pg from "pg";
 import * as schema from "@/database/schemas";
+import logger from "@/logging";
 
 const sourceUrl = process.env.SOURCE_DATABASE_URL;
 const targetUrl = process.env.ARCHESTRA_DATABASE_URL;
 
 if (!sourceUrl) {
-  console.error("ERROR: SOURCE_DATABASE_URL is not set");
+  logger.error("ERROR: SOURCE_DATABASE_URL is not set");
   process.exit(1);
 }
 if (!targetUrl) {
-  console.error("ERROR: ARCHESTRA_DATABASE_URL is not set");
+  logger.error("ERROR: ARCHESTRA_DATABASE_URL is not set");
   process.exit(1);
 }
 if (sourceUrl === targetUrl) {
-  console.error(
+  logger.error(
     "ERROR: SOURCE_DATABASE_URL and ARCHESTRA_DATABASE_URL are the same",
   );
   process.exit(1);
@@ -68,7 +69,7 @@ try {
     .limit(1);
 
   if (adminRows.length === 0) {
-    console.error(
+    logger.error(
       "ERROR: no admin@example.com user with a membership in the target DB. " +
         "Has the parallel stack finished booting and seeding the default admin?",
     );
@@ -198,16 +199,12 @@ try {
         const tid = targetModelByCompound.get(`${sm.provider}:${sm.modelId}`);
         if (tid) sourceToTargetModelId.set(sm.id, tid);
       }
-      const linkable = apiKeyModels
-        .filter(
-          (l) =>
-            presentKeyIds.has(l.apiKeyId) &&
-            sourceToTargetModelId.has(l.modelId),
-        )
-        .map((l) => ({
-          ...l,
-          modelId: sourceToTargetModelId.get(l.modelId)!,
-        }));
+      const linkable = apiKeyModels.flatMap((l) => {
+        if (!presentKeyIds.has(l.apiKeyId)) return [];
+        const remappedModelId = sourceToTargetModelId.get(l.modelId);
+        if (!remappedModelId) return [];
+        return [{ ...l, modelId: remappedModelId }];
+      });
       if (linkable.length) {
         const result = await tx
           .insert(schema.llmProviderApiKeyModelsTable)
@@ -221,7 +218,7 @@ try {
     }
   });
 
-  console.log(
+  logger.info(
     `✅ Copied: ${copiedSecrets}/${secrets.length} secrets, ` +
       `${copiedModels}/${models.length} models, ` +
       `${copiedKeys}/${providerKeys.length} provider keys, ` +

--- a/platform/backend/src/standalone-scripts/copy-providers-from.ts
+++ b/platform/backend/src/standalone-scripts/copy-providers-from.ts
@@ -54,7 +54,10 @@ const target = drizzle(targetPool, { schema });
 try {
   // Resolve target admin's user + org. Without a member row the user can't own
   // a chat_api_key (organization_id is NOT NULL), so we fail loudly if either
-  // is missing rather than guessing.
+  // is missing rather than guessing. The admin email is overridable in .env;
+  // matches the seeder in backend startup.
+  const adminEmail =
+    process.env.ARCHESTRA_AUTH_ADMIN_EMAIL || "admin@example.com";
   const adminRows = await target
     .select({
       userId: schema.usersTable.id,
@@ -65,13 +68,13 @@ try {
       schema.membersTable,
       eq(schema.membersTable.userId, schema.usersTable.id),
     )
-    .where(eq(schema.usersTable.email, "admin@example.com"))
+    .where(eq(schema.usersTable.email, adminEmail))
     .limit(1);
 
   if (adminRows.length === 0) {
     logger.error(
-      "ERROR: no admin@example.com user with a membership in the target DB. " +
-        "Has the parallel stack finished booting and seeding the default admin?",
+      `ERROR: no ${adminEmail} user with a membership in the target DB. ` +
+        "Has the parallel stack finished booting and seeded the default admin?",
     );
     process.exit(1);
   }

--- a/platform/backend/src/standalone-scripts/copy-providers-from.ts
+++ b/platform/backend/src/standalone-scripts/copy-providers-from.ts
@@ -22,7 +22,7 @@
  * so that precondition is satisfied by the default flow.
  */
 
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import pg from "pg";
 import * as schema from "@/database/schemas";
@@ -124,12 +124,44 @@ try {
       copiedKeys = result.length;
     }
     if (apiKeyModels.length) {
-      const result = await tx
-        .insert(schema.llmProviderApiKeyModelsTable)
-        .values(apiKeyModels)
-        .onConflictDoNothing()
-        .returning({ apiKeyId: schema.llmProviderApiKeyModelsTable.apiKeyId });
-      copiedKeyModels = result.length;
+      // Filter link rows to those whose api_key_id AND model_id are actually
+      // present in target. Without this, a source key whose insert was
+      // skipped (because target already had a logically-equivalent key under
+      // a different UUID and the unique index on org/provider/scope/user_id
+      // blocked the new row) leaves a dangling source api_key_id in the link
+      // rows, and the link insert aborts the whole transaction on an FK
+      // violation. Same for models.
+      const sourceKeyIds = providerKeys.map((k) => k.id);
+      const sourceModelIds = models.map((m) => m.id);
+      const [presentKeys, presentModels] = await Promise.all([
+        sourceKeyIds.length
+          ? tx
+              .select({ id: schema.llmProviderApiKeysTable.id })
+              .from(schema.llmProviderApiKeysTable)
+              .where(inArray(schema.llmProviderApiKeysTable.id, sourceKeyIds))
+          : Promise.resolve([] as { id: string }[]),
+        sourceModelIds.length
+          ? tx
+              .select({ id: schema.modelsTable.id })
+              .from(schema.modelsTable)
+              .where(inArray(schema.modelsTable.id, sourceModelIds))
+          : Promise.resolve([] as { id: string }[]),
+      ]);
+      const presentKeyIds = new Set(presentKeys.map((r) => r.id));
+      const presentModelIds = new Set(presentModels.map((r) => r.id));
+      const linkable = apiKeyModels.filter(
+        (l) => presentKeyIds.has(l.apiKeyId) && presentModelIds.has(l.modelId),
+      );
+      if (linkable.length) {
+        const result = await tx
+          .insert(schema.llmProviderApiKeyModelsTable)
+          .values(linkable)
+          .onConflictDoNothing()
+          .returning({
+            apiKeyId: schema.llmProviderApiKeyModelsTable.apiKeyId,
+          });
+        copiedKeyModels = result.length;
+      }
     }
   });
 

--- a/platform/backend/src/standalone-scripts/hydrate-from.ts
+++ b/platform/backend/src/standalone-scripts/hydrate-from.ts
@@ -25,7 +25,7 @@
  * worktree, so that precondition is satisfied by the default flow.
  */
 
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import pg from "pg";
 import * as schema from "@/database/schemas";
@@ -160,10 +160,25 @@ try {
       copiedSecrets = result.length;
     }
     if (models.length) {
+      // Models hit `models_provider_model_unique` when target already has the
+      // same (provider, modelId) under a different UUID. ON CONFLICT DO
+      // NOTHING would preserve target's row — including target's DEFAULT
+      // values for fields the source admin actually edited (custom prices,
+      // ignored flag). Upsert just those admin-editable columns from source
+      // so hydrating carries the admin's intent across. Catalog columns
+      // (externalId, contextLength, modalities, pricing-from-models.dev) are
+      // left as-is because target's models.dev sync may be fresher.
       const result = await tx
         .insert(schema.modelsTable)
         .values(models)
-        .onConflictDoNothing()
+        .onConflictDoUpdate({
+          target: [schema.modelsTable.provider, schema.modelsTable.modelId],
+          set: {
+            customPricePerMillionInput: sql`excluded.custom_price_per_million_input`,
+            customPricePerMillionOutput: sql`excluded.custom_price_per_million_output`,
+            ignored: sql`excluded.ignored`,
+          },
+        })
         .returning({ id: schema.modelsTable.id });
       copiedModels = result.length;
     }

--- a/platform/backend/src/standalone-scripts/hydrate-from.ts
+++ b/platform/backend/src/standalone-scripts/hydrate-from.ts
@@ -1,25 +1,28 @@
 /**
- * Copy LLM-provider rows (secrets, models, chat_api_keys/llm_provider_api_keys,
- * api_key_models) from a SOURCE Postgres into the TARGET Postgres (the one this
- * backend is configured for). Used by `pnpm dev:stack:copy-providers` to make a
- * fresh parallel dev stack immediately usable for chat/agents/proxy without
- * re-entering API keys.
+ * Hydrate a parallel dev stack's database with admin-configured rows from a
+ * SOURCE Postgres so chat / agents / proxy work without re-entering keys.
+ * Invoked via `pnpm dev:stack:hydrate`. The "hydrate" verb is deliberately
+ * generic: today this copies the LLM-provider tables (secret, models,
+ * chat_api_keys/llm_provider_api_keys, api_key_models), but future categories
+ * (policies, agents, optimization rules) can be added here without renaming
+ * the command.
  *
  * Source connection: SOURCE_DATABASE_URL env var.
  * Target connection: ARCHESTRA_DATABASE_URL env var (the standard one).
  *
- * Ownership rewrite: every copied chat_api_keys row is reassigned to the target
- * admin (`admin@example.com`)'s user and organization with scope='personal' and
- * teamId=null. Source orgs/users/teams aren't mirrored — the parallel stack is
- * a sandbox where only admin exists.
+ * Ownership rewrite: every copied chat_api_keys row is reassigned to the
+ * target admin (env-driven via ARCHESTRA_AUTH_ADMIN_EMAIL, default
+ * `admin@example.com`)'s user and organization with scope='personal' and
+ * teamId=null. Source orgs/users/teams aren't mirrored — the parallel stack
+ * is a sandbox where only admin exists.
  *
- * Idempotent: every INSERT uses ON CONFLICT DO NOTHING, so re-runs top up rows
- * the target is missing and never delete rows the dev added by hand.
+ * Idempotent: every INSERT uses ON CONFLICT DO NOTHING, so re-runs top up
+ * rows the target is missing and never delete rows the dev added by hand.
  *
  * Encryption: secrets are inserted verbatim. Decryption requires the target's
  * ARCHESTRA_AUTH_SECRET to match the source's. `pnpm dev:stack:up` copies the
- * source .env (which carries ARCHESTRA_AUTH_SECRET) into the parallel worktree,
- * so that precondition is satisfied by the default flow.
+ * source .env (which carries ARCHESTRA_AUTH_SECRET) into the parallel
+ * worktree, so that precondition is satisfied by the default flow.
  */
 
 import { and, eq, inArray } from "drizzle-orm";

--- a/platform/backend/src/standalone-scripts/hydrate-from.ts
+++ b/platform/backend/src/standalone-scripts/hydrate-from.ts
@@ -25,7 +25,7 @@
  * worktree, so that precondition is satisfied by the default flow.
  */
 
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, not, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import pg from "pg";
 import * as schema from "@/database/schemas";
@@ -115,19 +115,28 @@ try {
   // `isPrimary=true` when neither already claims it, otherwise demote. Force
   // `isSystem=false` because target seeds its own system key per provider
   // (the `chat_api_keys_system_unique` partial index would otherwise collide).
+  //
+  // Exclude rows whose UUID matches a source key — on re-hydrate those are
+  // our own previous copies, not a dev-added primary, and demoting them
+  // would clobber a key we're about to re-upsert.
+  const sourceKeyIds = providerKeys.map((k) => k.id);
+  const primaryFilters = [
+    eq(schema.llmProviderApiKeysTable.organizationId, targetOrgId),
+    eq(schema.llmProviderApiKeysTable.userId, targetUserId),
+    eq(schema.llmProviderApiKeysTable.scope, "personal"),
+    eq(schema.llmProviderApiKeysTable.isPrimary, true),
+  ];
+  if (sourceKeyIds.length) {
+    primaryFilters.push(
+      not(inArray(schema.llmProviderApiKeysTable.id, sourceKeyIds)),
+    );
+  }
   const existingTargetPrimaryProviders = new Set(
     (
       await target
         .select({ provider: schema.llmProviderApiKeysTable.provider })
         .from(schema.llmProviderApiKeysTable)
-        .where(
-          and(
-            eq(schema.llmProviderApiKeysTable.organizationId, targetOrgId),
-            eq(schema.llmProviderApiKeysTable.userId, targetUserId),
-            eq(schema.llmProviderApiKeysTable.scope, "personal"),
-            eq(schema.llmProviderApiKeysTable.isPrimary, true),
-          ),
-        )
+        .where(and(...primaryFilters))
     ).map((r) => r.provider),
   );
   const seenPrimaryProviders = new Set<string>(existingTargetPrimaryProviders);
@@ -152,10 +161,20 @@ try {
 
   await target.transaction(async (tx) => {
     if (secrets.length) {
+      // Re-hydrate after the source admin rotated a secret would otherwise
+      // skip the row (same PK) and leave target with the stale/revoked
+      // payload. Upsert the payload so rotations propagate.
       const result = await tx
         .insert(schema.secretsTable)
         .values(secrets)
-        .onConflictDoNothing()
+        .onConflictDoUpdate({
+          target: schema.secretsTable.id,
+          set: {
+            secret: sql`excluded.secret`,
+            isVault: sql`excluded.is_vault`,
+            isByosVault: sql`excluded.is_byos_vault`,
+          },
+        })
         .returning({ id: schema.secretsTable.id });
       copiedSecrets = result.length;
     }
@@ -183,10 +202,30 @@ try {
       copiedModels = result.length;
     }
     if (rewrittenKeys.length) {
+      // Re-hydrate after the source admin renamed a key, swapped its
+      // secret, or tweaked the base URLs / extra headers would otherwise
+      // skip the row (same PK) and leave the stale config. Upsert the
+      // source-owned columns on PK conflict. Target-created keys (dev
+      // added by hand) have target-side UUIDs and never match this
+      // conflict target, so they're untouched. Ownership columns
+      // (organization_id / user_id / team_id / scope) and isSystem aren't
+      // re-set because they're always our chosen values. isPrimary uses
+      // `excluded.is_primary` so the demotion logic above applies on
+      // re-hydrate too.
       const result = await tx
         .insert(schema.llmProviderApiKeysTable)
         .values(rewrittenKeys)
-        .onConflictDoNothing()
+        .onConflictDoUpdate({
+          target: schema.llmProviderApiKeysTable.id,
+          set: {
+            name: sql`excluded.name`,
+            secretId: sql`excluded.secret_id`,
+            baseUrl: sql`excluded.base_url`,
+            inferenceBaseUrl: sql`excluded.inference_base_url`,
+            extraHeaders: sql`excluded.extra_headers`,
+            isPrimary: sql`excluded.is_primary`,
+          },
+        })
         .returning({ id: schema.llmProviderApiKeysTable.id });
       copiedKeys = result.length;
     }
@@ -198,7 +237,6 @@ try {
       // different UUID, in which case the source row was skipped but the
       // link should still resolve to target's existing UUID instead of
       // being dropped.
-      const sourceKeyIds = providerKeys.map((k) => k.id);
       const sourceProviders = Array.from(
         new Set(models.map((m) => m.provider)),
       );

--- a/platform/package.json
+++ b/platform/package.json
@@ -34,7 +34,8 @@
     "db:seed:mock-data": "turbo db:seed:mock-data",
     "cleanup:dev:k8s": "kubectl delete namespace archestra-dev",
     "dev:stack:up": "scripts/dev-stack.sh up",
-    "dev:stack:down": "scripts/dev-stack.sh down"
+    "dev:stack:down": "scripts/dev-stack.sh down",
+    "dev:stack:copy-providers": "scripts/dev-stack.sh copy-providers"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.6",

--- a/platform/package.json
+++ b/platform/package.json
@@ -35,7 +35,7 @@
     "cleanup:dev:k8s": "kubectl delete namespace archestra-dev",
     "dev:stack:up": "scripts/dev-stack.sh up",
     "dev:stack:down": "scripts/dev-stack.sh down",
-    "dev:stack:copy-providers": "scripts/dev-stack.sh copy-providers"
+    "dev:stack:hydrate": "scripts/dev-stack.sh hydrate"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.6",

--- a/platform/scripts/dev-stack.sh
+++ b/platform/scripts/dev-stack.sh
@@ -286,7 +286,7 @@ cmd_copy_providers() {
   # differs. Read each from its own .env. Default to 5432 for the main
   # worktree (`tilt up` from main doesn't set ARCHESTRA_POSTGRES_HOST_PORT).
   # `|| true` keeps pipefail from aborting on grep-finds-nothing.
-  local main_pg_port parallel_pg_port
+  local main_pg_port parallel_pg_port target_admin_email
   main_pg_port=$( { grep -E '^ARCHESTRA_POSTGRES_HOST_PORT=' "$main_env" || true; } \
     | tail -n1 | cut -d= -f2- | tr -d '"')
   main_pg_port="${main_pg_port:-5432}"
@@ -296,6 +296,12 @@ cmd_copy_providers() {
     echo "ERROR: $platform_dir/.env has no ARCHESTRA_POSTGRES_HOST_PORT. Has 'up' run yet?" >&2
     exit 1
   fi
+  # tsx doesn't auto-load .env, so the backend script's
+  # process.env.ARCHESTRA_AUTH_ADMIN_EMAIL would otherwise be undefined. Pull
+  # it from the target worktree's .env here and forward it explicitly. Empty
+  # value is fine — the backend script falls back to "admin@example.com".
+  target_admin_email=$( { grep -E '^ARCHESTRA_AUTH_ADMIN_EMAIL=' "$platform_dir/.env" || true; } \
+    | tail -n1 | cut -d= -f2- | tr -d '"')
 
   local source_url="postgresql://archestra:archestra_dev_password@localhost:${main_pg_port}/archestra_dev"
   local target_url="postgresql://archestra:archestra_dev_password@localhost:${parallel_pg_port}/archestra_dev"
@@ -303,6 +309,7 @@ cmd_copy_providers() {
   echo "→ Copying provider data from main (:${main_pg_port}) -> parallel (:${parallel_pg_port})" >&2
   SOURCE_DATABASE_URL="$source_url" \
   ARCHESTRA_DATABASE_URL="$target_url" \
+  ARCHESTRA_AUTH_ADMIN_EMAIL="$target_admin_email" \
     pnpm --filter @backend db:copy-providers-from
 }
 

--- a/platform/scripts/dev-stack.sh
+++ b/platform/scripts/dev-stack.sh
@@ -14,22 +14,25 @@
 #   pnpm dev:stack:up --detach
 #
 # Usage:
-#   dev-stack.sh up              [--detach] [--namespace NAME]
+#   dev-stack.sh up           [--detach] [--namespace NAME]
 #   dev-stack.sh down
-#   dev-stack.sh copy-providers
+#   dev-stack.sh hydrate
 #
 # `up`:   without --detach, execs `tilt up` in the foreground (Ctrl+C stops
 #         it). With --detach, runs Tilt in the background via nohup, writes
 #         a PID file, and returns once the frontend responds.
 # `down`: kills the detached Tilt (if any) and runs `tilt down`.
-# `copy-providers`:
-#         copies LLM-provider rows (secret / chat_api_keys / models /
-#         api_key_models) from the main worktree's database into the
-#         current worktree's database, rewriting ownership to the
-#         current admin so the providers are immediately usable. Run
-#         after `up --detach` has finished. Idempotent via ON CONFLICT
-#         DO NOTHING — re-runs top up new keys main has gained without
-#         deleting anything you added by hand.
+# `hydrate`:
+#         fills the parallel stack's database with admin-configured rows
+#         from the main worktree's database so chat / agents / proxy work
+#         without re-entering keys. Today copies the LLM-provider rows
+#         (secret / chat_api_keys / models / api_key_models) with
+#         ownership rewritten to the parallel admin; the verb is
+#         deliberately generic so other categories (policies, agents,
+#         optimization rules) can be added without renaming. Run after
+#         `up --detach` finishes. Idempotent via ON CONFLICT DO NOTHING —
+#         re-runs top up new rows main has gained without deleting
+#         anything you added by hand.
 #
 # `--namespace` overrides the auto-derived K8s namespace (default:
 # `archestra-dev-<sanitized-branch-name>`).
@@ -257,7 +260,7 @@ cmd_down() {
   echo "✅ Parallel dev stack stopped." >&2
 }
 
-cmd_copy_providers() {
+cmd_hydrate() {
   while [ $# -gt 0 ]; do
     case "$1" in
       -h|--help) usage 0 ;;
@@ -273,7 +276,7 @@ cmd_copy_providers() {
   main_worktree=$(git -C "$platform_dir" worktree list --porcelain 2>/dev/null \
     | sed -n 's/^worktree //p' | head -n1)
   if [ -z "$main_worktree" ] || [ "$main_worktree/platform" = "$platform_dir" ]; then
-    echo "ERROR: copy-providers must be run from a NON-main worktree (the parallel stack)." >&2
+    echo "ERROR: hydrate must be run from a NON-main worktree (the parallel stack)." >&2
     exit 1
   fi
   local main_env="$main_worktree/platform/.env"
@@ -310,7 +313,7 @@ cmd_copy_providers() {
   SOURCE_DATABASE_URL="$source_url" \
   ARCHESTRA_DATABASE_URL="$target_url" \
   ARCHESTRA_AUTH_ADMIN_EMAIL="$target_admin_email" \
-    pnpm --filter @backend db:copy-providers-from
+    pnpm --filter @backend db:hydrate-from
 }
 
 pick_port() {
@@ -322,7 +325,7 @@ subcommand="$1"; shift
 case "$subcommand" in
   up)             cmd_up "$@" ;;
   down)           cmd_down "$@" ;;
-  copy-providers) cmd_copy_providers "$@" ;;
+  hydrate)        cmd_hydrate "$@" ;;
   -h|--help) usage 0 ;;
   *)         echo "unknown subcommand: $subcommand" >&2; usage 1 ;;
 esac

--- a/platform/scripts/dev-stack.sh
+++ b/platform/scripts/dev-stack.sh
@@ -14,13 +14,22 @@
 #   pnpm dev:stack:up --detach
 #
 # Usage:
-#   dev-stack.sh up   [--detach] [--namespace NAME]
+#   dev-stack.sh up              [--detach] [--namespace NAME]
 #   dev-stack.sh down
+#   dev-stack.sh copy-providers
 #
 # `up`:   without --detach, execs `tilt up` in the foreground (Ctrl+C stops
 #         it). With --detach, runs Tilt in the background via nohup, writes
 #         a PID file, and returns once the frontend responds.
 # `down`: kills the detached Tilt (if any) and runs `tilt down`.
+# `copy-providers`:
+#         copies LLM-provider rows (secret / chat_api_keys / models /
+#         api_key_models) from the main worktree's database into the
+#         current worktree's database, rewriting ownership to the
+#         current admin so the providers are immediately usable. Run
+#         after `up --detach` has finished. Idempotent via ON CONFLICT
+#         DO NOTHING — re-runs top up new keys main has gained without
+#         deleting anything you added by hand.
 #
 # `--namespace` overrides the auto-derived K8s namespace (default:
 # `archestra-dev-<sanitized-branch-name>`).
@@ -248,6 +257,55 @@ cmd_down() {
   echo "✅ Parallel dev stack stopped." >&2
 }
 
+cmd_copy_providers() {
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -h|--help) usage 0 ;;
+      *)         echo "unknown arg: $1" >&2; usage 1 ;;
+    esac
+  done
+
+  require_platform_cwd
+  local platform_dir; platform_dir="$(pwd)"
+
+  # Resolve the main worktree (same logic as up's auto-copy of .env).
+  local main_worktree
+  main_worktree=$(git -C "$platform_dir" worktree list --porcelain 2>/dev/null \
+    | sed -n 's/^worktree //p' | head -n1)
+  if [ -z "$main_worktree" ] || [ "$main_worktree/platform" = "$platform_dir" ]; then
+    echo "ERROR: copy-providers must be run from a NON-main worktree (the parallel stack)." >&2
+    exit 1
+  fi
+  local main_env="$main_worktree/platform/.env"
+  if [ ! -f "$main_env" ]; then
+    echo "ERROR: main worktree at $main_worktree has no platform/.env to read pg port from." >&2
+    exit 1
+  fi
+
+  # Both stacks reuse the same DB user/password/name; only the host port
+  # differs. Read each from its own .env. Default to 5432 for the main
+  # worktree (`tilt up` from main doesn't set ARCHESTRA_POSTGRES_HOST_PORT).
+  # `|| true` keeps pipefail from aborting on grep-finds-nothing.
+  local main_pg_port parallel_pg_port
+  main_pg_port=$( { grep -E '^ARCHESTRA_POSTGRES_HOST_PORT=' "$main_env" || true; } \
+    | tail -n1 | cut -d= -f2- | tr -d '"')
+  main_pg_port="${main_pg_port:-5432}"
+  parallel_pg_port=$( { grep -E '^ARCHESTRA_POSTGRES_HOST_PORT=' "$platform_dir/.env" || true; } \
+    | tail -n1 | cut -d= -f2- | tr -d '"')
+  if [ -z "$parallel_pg_port" ]; then
+    echo "ERROR: $platform_dir/.env has no ARCHESTRA_POSTGRES_HOST_PORT. Has 'up' run yet?" >&2
+    exit 1
+  fi
+
+  local source_url="postgresql://archestra:archestra_dev_password@localhost:${main_pg_port}/archestra_dev"
+  local target_url="postgresql://archestra:archestra_dev_password@localhost:${parallel_pg_port}/archestra_dev"
+
+  echo "→ Copying provider data from main (:${main_pg_port}) -> parallel (:${parallel_pg_port})" >&2
+  SOURCE_DATABASE_URL="$source_url" \
+  ARCHESTRA_DATABASE_URL="$target_url" \
+    pnpm --filter @backend db:copy-providers-from
+}
+
 pick_port() {
   python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()'
 }
@@ -255,8 +313,9 @@ pick_port() {
 if [ $# -lt 1 ]; then usage 1; fi
 subcommand="$1"; shift
 case "$subcommand" in
-  up)        cmd_up "$@" ;;
-  down)      cmd_down "$@" ;;
+  up)             cmd_up "$@" ;;
+  down)           cmd_down "$@" ;;
+  copy-providers) cmd_copy_providers "$@" ;;
   -h|--help) usage 0 ;;
   *)         echo "unknown subcommand: $subcommand" >&2; usage 1 ;;
 esac


### PR DESCRIPTION
## Summary

Follow-up to #5020 and #5027. Spinning up a parallel dev stack with `pnpm dev:stack:up` leaves the parallel DB empty, so the chat UI shows the "Add API Key" prompt instead of being immediately usable. New subcommand `pnpm dev:stack:hydrate` fills the parallel stack with admin-configured rows from the main worktree's database so chat / agents / proxy work without re-entering keys.

The verb `hydrate` is deliberately generic: today it copies the LLM-provider tables (`secret`, `chat_api_keys`, `models`, `api_key_models`), but future categories (policies, agents, optimization rules) can be added here without renaming the command.

## Usage

```bash
pnpm dev:stack:up --detach            # spawn parallel stack
pnpm dev:stack:hydrate                # fill the parallel DB from main's
# chat UI in the parallel stack now shows its input box, not "Add API Key"
```

## Failure modes (handled in the backend script)

- Either DB unreachable → `pg` Pool throws connection error with the URL it tried
- No admin user in target (custom `ARCHESTRA_AUTH_ADMIN_EMAIL` mismatched, or stack hasn't seeded yet) → script exits with "no {email} user with a membership in the target DB"
- No keys in main → reports `Copied: 0/0` for every table and exits 0
- Unique-constraint conflicts on re-run → counted, reported as `0/N` per table