### PR TITLE
fix(chat): owner-only authz on stop endpoint

### DIFF
--- a/platform/backend/src/routes/chat/active-run-routes.test.ts
+++ b/platform/backend/src/routes/chat/active-run-routes.test.ts
@@ -1,4 +1,8 @@
-import { MessageModel } from "@/models";
+import {
+  ConversationModel,
+  ConversationShareModel,
+  MessageModel,
+} from "@/models";
 import ActiveChatRunModel from "@/models/chat-active-run";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
@@ -124,6 +128,50 @@ describe("chat active-run routes", () => {
     const run = await ActiveChatRunModel.findRunningByConversation(
       inaccessibleConversation.id,
     );
+    expect(run?.stopRequestedAt).toBeNull();
+  });
+
+  test("stop returns 404 when a share-only user tries to stop the owner's stream", async ({
+    makeMember,
+    makeUser,
+  }) => {
+    const owner = user;
+    await makeMember(owner.id, organizationId);
+    const sharee = await makeUser();
+    await makeMember(sharee.id, organizationId);
+
+    await ConversationShareModel.upsert({
+      conversationId,
+      organizationId,
+      createdByUserId: owner.id,
+      visibility: "user",
+      teamIds: [],
+      userIds: [sharee.id],
+    });
+    await ActiveChatRunModel.create({
+      conversationId,
+      userId: owner.id,
+      organizationId,
+    });
+
+    // Guard against a silent test-setup regression: if the share stops granting
+    // read access, the assertion below would pass for the wrong reason.
+    const accessibleAsSharee = await ConversationModel.findAccessibleById({
+      id: conversationId,
+      userId: sharee.id,
+      organizationId,
+    });
+    expect(accessibleAsSharee).not.toBeNull();
+
+    user = sharee;
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/chat/conversations/${conversationId}/stop`,
+    });
+
+    expect(response.statusCode).toBe(404);
+    const run =
+      await ActiveChatRunModel.findRunningByConversation(conversationId);
     expect(run?.stopRequestedAt).toBeNull();
   });
 

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -994,7 +994,10 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
       },
     },
     async ({ params: { id }, user, organizationId }, reply) => {
-      const conversation = await ConversationModel.findAccessibleById({
+      // Owner-only: stop is a mutation on someone else's in-flight LLM work, so
+      // share-access (which is enough to read or reconnect to the stream) must
+      // not be enough to abort it.
+      const conversation = await ConversationModel.findById({
         id,
         userId: user.id,
         organizationId,


### PR DESCRIPTION
## Summary

Closes a follow-up gap left from #4219: a user who only has share-access to a conversation could `POST /api/chat/conversations/:id/stop` and abort the owner's in-flight LLM call. Stop is a mutation on another user's work — share visibility (which is enough to read messages and reconnect to the SSE stream via `GET /active-run`) must not authorize aborting that work.

The stop endpoint now uses `ConversationModel.findById` (owner-only) instead of `findAccessibleById` (owner OR sharee). A share-only requester now receives `404` with no DB mutation, identical to the cross-org and non-existent-conversation paths already covered by the existing tests.

Read and reconnect paths (`GET /conversations/:id`, `GET /conversations/:id/active-run`) are intentionally unchanged — sharees can still view and resume the stream, they just can't terminate it.