### PR TITLE
feat: show descriptive connector file indexing failures

### DIFF
--- a/platform/backend/src/knowledge-base/embedder.test.ts
+++ b/platform/backend/src/knowledge-base/embedder.test.ts
@@ -145,6 +145,9 @@ describe("EmbeddingService", () => {
 
     const updated = await KbDocumentModel.findById(doc.id);
     expect(updated?.embeddingStatus).toBe("failed");
+    expect(updated?.metadata).toMatchObject({
+      embeddingError: "unknown",
+    });
   });
 
   test("no chunks marks document as completed with chunkCount 0", async ({
@@ -293,7 +296,56 @@ describe("EmbeddingService", () => {
 
     const updated = await KbDocumentModel.findById(doc.id);
     expect(updated?.embeddingStatus).toBe("failed");
+    expect(updated?.metadata).toMatchObject({
+      embeddingError: "provider_unavailable",
+    });
     expect(mockEmbeddingsCreate).toHaveBeenCalledTimes(3);
+  });
+
+  test("classifies rate limit failures for document embeddings", async ({
+    makeOrganization,
+    makeKnowledgeBase,
+    makeKnowledgeBaseConnector,
+  }) => {
+    const org = await makeOrganization();
+    const kb = await makeKnowledgeBase(org.id);
+    const connector = await makeKnowledgeBaseConnector(kb.id, org.id);
+
+    const doc = await KbDocumentModel.create({
+      connectorId: connector.id,
+      organizationId: org.id,
+      title: "Rate Limited Doc",
+      content: "Content",
+      contentHash: "hash-rate-limited",
+      embeddingStatus: "pending",
+    });
+
+    await KbChunkModel.insertMany([
+      {
+        documentId: doc.id,
+        content: "Chunk",
+        chunkIndex: 0,
+      },
+    ]);
+
+    const OpenAIMod = (await import("openai")).default;
+    const rateLimitError = Object.assign(new Error("Rate limited"), {
+      status: 429,
+    });
+    Object.setPrototypeOf(rateLimitError, OpenAIMod.APIError.prototype);
+
+    mockEmbeddingsCreate
+      .mockRejectedValueOnce(rateLimitError)
+      .mockRejectedValueOnce(rateLimitError)
+      .mockRejectedValueOnce(rateLimitError);
+
+    await embeddingService.processDocument(doc.id, makeEmbeddingContext());
+
+    const updated = await KbDocumentModel.findById(doc.id);
+    expect(updated?.embeddingStatus).toBe("failed");
+    expect(updated?.metadata).toMatchObject({
+      embeddingError: "rate_limited",
+    });
   });
 
   test("processDocuments batches chunks from multiple documents into single API call", async ({

--- a/platform/backend/src/knowledge-base/embedder.ts
+++ b/platform/backend/src/knowledge-base/embedder.ts
@@ -2,12 +2,15 @@ import { addNomicTaskPrefix, EMBEDDING_BATCH_SIZE } from "@shared";
 import logger from "@/logging";
 import { KbChunkModel, KbDocumentModel } from "@/models";
 import {
+  AzureEmbeddingError,
   callEmbedding,
+  GeminiEmbeddingError,
   type EmbeddingApiResponse,
   type EmbeddingInput,
   getEmbeddingDiscriminator,
   getEmbeddingRetryDelayMs,
   isRetryableEmbeddingError,
+  OpenAIEmbeddingError,
 } from "./embedding-clients";
 import {
   buildEmbeddingInteraction,
@@ -20,6 +23,16 @@ import {
 
 const RETRY_MAX_ATTEMPTS = 3;
 const RETRY_BASE_DELAY_MS = 1000;
+const EMBEDDING_ERROR_METADATA_KEY = "embeddingError";
+
+type EmbeddingErrorCode =
+  | "invalid_credentials"
+  | "network_error"
+  | "provider_misconfigured"
+  | "provider_unavailable"
+  | "rate_limited"
+  | "unsupported_input"
+  | "unknown";
 
 class EmbeddingService {
   async processDocument(
@@ -40,7 +53,10 @@ class EmbeddingService {
       return;
     }
 
-    await KbDocumentModel.update(documentId, { embeddingStatus: "processing" });
+    await KbDocumentModel.update(documentId, {
+      embeddingStatus: "processing",
+      metadata: clearEmbeddingError(document.metadata),
+    });
 
     try {
       const chunks = await KbChunkModel.findByDocument(documentId);
@@ -49,6 +65,7 @@ class EmbeddingService {
         await KbDocumentModel.update(documentId, {
           embeddingStatus: "completed",
           chunkCount: 0,
+          metadata: clearEmbeddingError(document.metadata),
         });
         return;
       }
@@ -82,6 +99,7 @@ class EmbeddingService {
       await KbDocumentModel.update(documentId, {
         embeddingStatus: "completed",
         chunkCount: chunks.length,
+        metadata: clearEmbeddingError(document.metadata),
       });
 
       logger.info(
@@ -91,6 +109,10 @@ class EmbeddingService {
     } catch (error) {
       await KbDocumentModel.update(documentId, {
         embeddingStatus: "failed",
+        metadata: setEmbeddingError(
+          document.metadata,
+          classifyEmbeddingError(error),
+        ),
       });
       logger.error(
         {
@@ -151,6 +173,7 @@ class EmbeddingService {
 
       await KbDocumentModel.update(documentId, {
         embeddingStatus: "processing",
+        metadata: clearEmbeddingError(document.metadata),
       });
 
       const chunks = await KbChunkModel.findByDocument(documentId);
@@ -159,6 +182,7 @@ class EmbeddingService {
         await KbDocumentModel.update(documentId, {
           embeddingStatus: "completed",
           chunkCount: 0,
+          metadata: clearEmbeddingError(document.metadata),
         });
         continue;
       }
@@ -187,6 +211,9 @@ class EmbeddingService {
       for (const { documentId } of docChunkMap) {
         await KbDocumentModel.update(documentId, {
           embeddingStatus: "pending",
+          metadata: clearEmbeddingError(
+            documentsById.get(documentId)?.metadata,
+          ),
         });
       }
       return;
@@ -195,6 +222,7 @@ class EmbeddingService {
     const ctx = orgConfig.config;
     const embeddingResults = new Map<string, number[]>();
     const failedChunkIds = new Set<string>();
+    const batchErrors = new Map<string, unknown>();
 
     for (let i = 0; i < allChunks.length; i += EMBEDDING_BATCH_SIZE) {
       const batch = allChunks.slice(i, i + EMBEDDING_BATCH_SIZE);
@@ -223,6 +251,7 @@ class EmbeddingService {
         );
         for (const chunk of batch) {
           failedChunkIds.add(chunk.chunkId);
+          batchErrors.set(chunk.chunkId, error);
         }
       }
     }
@@ -240,6 +269,12 @@ class EmbeddingService {
       if (anyFailed) {
         await KbDocumentModel.update(documentId, {
           embeddingStatus: "failed",
+          metadata: setEmbeddingError(
+            documentsById.get(documentId)?.metadata,
+            classifyEmbeddingError(
+              findFirstFailedEmbeddingError(batchErrors, chunkIds),
+            ),
+          ),
         });
         logger.error(
           { documentId, runId: connectorRunId },
@@ -249,6 +284,7 @@ class EmbeddingService {
         await KbDocumentModel.update(documentId, {
           embeddingStatus: "completed",
           chunkCount,
+          metadata: clearEmbeddingError(documentsById.get(documentId)?.metadata),
         });
         logger.info(
           { documentId, runId: connectorRunId, chunkCount },
@@ -317,6 +353,101 @@ class EmbeddingService {
 }
 
 export const embeddingService = new EmbeddingService();
+
+function classifyEmbeddingError(error: unknown): EmbeddingErrorCode {
+  if (isNetworkEmbeddingError(error)) {
+    return "network_error";
+  }
+
+  const status = getEmbeddingErrorStatus(error);
+  const message = getEmbeddingErrorMessage(error);
+
+  if (status === 401 || status === 403) {
+    return "invalid_credentials";
+  }
+  if (status === 429) {
+    return "rate_limited";
+  }
+  if (status !== undefined && status >= 500) {
+    return "provider_unavailable";
+  }
+  if (status === 400) {
+    if (
+      /do not support image inputs|cannot process this file content|multimodal embedding model/i.test(
+        message,
+      )
+    ) {
+      return "unsupported_input";
+    }
+    if (
+      /base url|deployment|resource|endpoint|misconfigured|model settings/i.test(
+        message,
+      )
+    ) {
+      return "provider_misconfigured";
+    }
+  }
+
+  return "unknown";
+}
+
+function getEmbeddingErrorStatus(error: unknown): number | undefined {
+  if (
+    error instanceof OpenAIEmbeddingError ||
+    error instanceof AzureEmbeddingError ||
+    error instanceof GeminiEmbeddingError
+  ) {
+    return error.status;
+  }
+  return undefined;
+}
+
+function getEmbeddingErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isNetworkEmbeddingError(error: unknown): boolean {
+  if (!(error instanceof Error) || !("code" in error)) {
+    return false;
+  }
+  const code = (error as Error & { code?: string }).code;
+  return typeof code === "string";
+}
+
+function clearEmbeddingError(
+  metadata: Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+  if (!metadata || !(EMBEDDING_ERROR_METADATA_KEY in metadata)) {
+    return metadata ?? {};
+  }
+
+  const nextMetadata = { ...metadata };
+  delete nextMetadata[EMBEDDING_ERROR_METADATA_KEY];
+  return nextMetadata;
+}
+
+function setEmbeddingError(
+  metadata: Record<string, unknown> | null | undefined,
+  errorCode: EmbeddingErrorCode,
+): Record<string, unknown> {
+  return {
+    ...(metadata ?? {}),
+    [EMBEDDING_ERROR_METADATA_KEY]: errorCode,
+  };
+}
+
+function findFirstFailedEmbeddingError(
+  batchErrors: Map<string, unknown>,
+  chunkIds: string[],
+): unknown {
+  for (const chunkId of chunkIds) {
+    const error = batchErrors.get(chunkId);
+    if (error !== undefined) {
+      return error;
+    }
+  }
+  return new Error("Unknown embedding failure");
+}
 
 // ===== Internal helpers =====
 

--- a/platform/backend/src/routes/knowledge-base-file-upload.test.ts
+++ b/platform/backend/src/routes/knowledge-base-file-upload.test.ts
@@ -2,7 +2,7 @@ import { eq } from "drizzle-orm";
 import JSZip from "jszip";
 import db, { schema } from "@/database";
 import * as fileProcessor from "@/knowledge-base/connectors/file-upload/file-processor";
-import { KbUploadedFileModel, KnowledgeBaseConnectorModel } from "@/models";
+import { KbDocumentModel, KbUploadedFileModel, KnowledgeBaseConnectorModel } from "@/models";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test, vi } from "@/test";
@@ -465,6 +465,7 @@ describe("connector file upload routes", () => {
         mimeType: "text/plain",
       });
       expect(file).toHaveProperty("embeddingStatus");
+      expect(file).toHaveProperty("embeddingError");
       expect(file).toHaveProperty("createdAt");
     });
 
@@ -519,6 +520,47 @@ describe("connector file upload routes", () => {
       expect(listBody.data[0]).toHaveProperty("id");
       expect(listBody.data[0]).toHaveProperty("contentHash");
       expect(listBody.data[0]).toHaveProperty("embeddingStatus");
+      expect(listBody.data[0]).toHaveProperty("embeddingError");
+    });
+
+    test("includes embeddingError when indexing fails after upload", async () => {
+      const { payload } = buildJsonBody([
+        {
+          name: "embeddings.txt",
+          content: Buffer.from("Embedding error test"),
+          mimeType: "text/plain",
+        },
+      ]);
+
+      const uploadResponse = await app.inject({
+        method: "POST",
+        url: `/api/connectors/${fileUploadConnector.id}/files`,
+        payload,
+      });
+
+      const fileId = uploadResponse.json().results[0].fileId as string;
+      await KbDocumentModel.create({
+        connectorId: fileUploadConnector.id,
+        organizationId,
+        sourceId: fileId,
+        title: "embeddings.txt",
+        content: "Embedding error test",
+        contentHash: "embedding-error-test-hash",
+        embeddingStatus: "failed",
+        metadata: { embeddingError: "rate_limited" },
+      });
+
+      const listResponse = await app.inject({
+        method: "GET",
+        url: `/api/connectors/${fileUploadConnector.id}/files`,
+      });
+
+      expect(listResponse.statusCode).toBe(200);
+      expect(listResponse.json().data[0]).toMatchObject({
+        id: fileId,
+        embeddingStatus: "failed",
+        embeddingError: "rate_limited",
+      });
     });
   });
 

--- a/platform/backend/src/routes/knowledge-base.ts
+++ b/platform/backend/src/routes/knowledge-base.ts
@@ -1063,6 +1063,7 @@ const knowledgeBaseRoutes: FastifyPluginAsyncZod = async (fastify) => {
     processingStatus: z.string(),
     processingError: z.string().nullable(),
     embeddingStatus: EmbeddingStatusSchema,
+    embeddingError: z.string().nullable(),
   });
 
   fastify.post(
@@ -1322,6 +1323,7 @@ const knowledgeBaseRoutes: FastifyPluginAsyncZod = async (fastify) => {
           processingStatus: file.processingStatus,
           processingError: file.processingError ?? null,
           embeddingStatus: doc?.embeddingStatus ?? "pending",
+          embeddingError: getEmbeddingError(doc?.metadata),
         };
       });
 
@@ -1367,6 +1369,7 @@ const knowledgeBaseRoutes: FastifyPluginAsyncZod = async (fastify) => {
         processingStatus: file.processingStatus,
         processingError: file.processingError ?? null,
         embeddingStatus: doc?.embeddingStatus ?? "pending",
+        embeddingError: getEmbeddingError(doc?.metadata),
       });
     },
   );
@@ -1453,6 +1456,13 @@ function isContentHashConflict(error: unknown): boolean {
     current = (current as Record<string, unknown>).cause;
   }
   return false;
+}
+
+function getEmbeddingError(
+  metadata: Record<string, unknown> | null | undefined,
+): string | null {
+  const value = metadata?.embeddingError;
+  return typeof value === "string" ? value : null;
 }
 
 async function loadConnectorCredentials(

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-file-status.test.ts
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-file-status.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  getConnectorFileStatusMeta,
+  getEmbeddingErrorMessage,
+} from "./connector-file-status";
+
+describe("connector-file-status", () => {
+  it("prefers processing failures over embedding status", () => {
+    expect(
+      getConnectorFileStatusMeta({
+        processingStatus: "failed",
+        embeddingStatus: "failed",
+        processingError: "Could not extract text from PDF",
+        embeddingError: "rate_limited",
+      }),
+    ).toEqual({
+      label: "Processing Failed",
+      tooltip: "Could not extract text from PDF",
+      variant: "destructive",
+    });
+  });
+
+  it("maps failed embedding status to a descriptive tooltip", () => {
+    expect(
+      getConnectorFileStatusMeta({
+        embeddingStatus: "failed",
+        embeddingError: "rate_limited",
+      }),
+    ).toEqual({
+      label: "Indexing Failed",
+      tooltip: getEmbeddingErrorMessage("rate_limited"),
+      variant: "destructive",
+    });
+  });
+
+  it("shows spinner metadata for indexing", () => {
+    expect(
+      getConnectorFileStatusMeta({
+        embeddingStatus: "processing",
+      }),
+    ).toEqual({
+      label: "Indexing...",
+      tooltip: "Generating embeddings for this file.",
+      variant: "secondary",
+      showSpinner: true,
+    });
+  });
+});

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-file-status.ts
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-file-status.ts
@@ -1,0 +1,132 @@
+type ConnectorFileStatusVariant = "default" | "secondary" | "destructive";
+
+type ConnectorFileProcessingStatus = "pending" | "processing" | "failed";
+type ConnectorFileEmbeddingStatus =
+  | "pending"
+  | "processing"
+  | "completed"
+  | "failed";
+
+export const CONNECTOR_FILE_EMBEDDING_ERROR_MESSAGES = {
+  invalid_credentials:
+    "The embedding provider rejected the credentials. Check the configured API key or token.",
+  network_error:
+    "Archestra could not reach the embedding provider. Check network access and try again.",
+  provider_misconfigured:
+    "The embedding provider is misconfigured. Verify the base URL, deployment, and model settings.",
+  provider_unavailable:
+    "The embedding provider returned a server-side failure. Try again in a few minutes.",
+  rate_limited:
+    "The embedding provider rate limited this request. Try again after the limit resets.",
+  unsupported_input:
+    "The selected embedding model cannot process this file content. Use a compatible embedding model and try again.",
+  unknown:
+    "Archestra could not generate embeddings for this file. Check the embedding provider logs and try again.",
+} as const;
+
+export type ConnectorFileEmbeddingError =
+  keyof typeof CONNECTOR_FILE_EMBEDDING_ERROR_MESSAGES;
+
+export type ConnectorFileStatusMeta = {
+  label: string;
+  tooltip?: string;
+  variant: ConnectorFileStatusVariant;
+  showSpinner?: boolean;
+};
+
+export function getConnectorFileStatusMeta(params: {
+  processingStatus?: string | null;
+  embeddingStatus?: string | null;
+  processingError?: string | null;
+  embeddingError?: string | null;
+}): ConnectorFileStatusMeta {
+  const processingStatus = normalizeProcessingStatus(params.processingStatus);
+  if (processingStatus) {
+    switch (processingStatus) {
+      case "pending":
+        return {
+          label: "Queued",
+          tooltip: "File is queued for text extraction.",
+          variant: "secondary",
+        };
+      case "processing":
+        return {
+          label: "Extracting...",
+          tooltip: "Extracting text from the uploaded file.",
+          variant: "secondary",
+          showSpinner: true,
+        };
+      case "failed":
+        return {
+          label: "Processing Failed",
+          tooltip:
+            params.processingError ??
+            "Archestra could not extract text from this file.",
+          variant: "destructive",
+        };
+    }
+  }
+
+  const embeddingStatus = normalizeEmbeddingStatus(params.embeddingStatus);
+  switch (embeddingStatus) {
+    case "completed":
+      return { label: "Indexed", variant: "default" };
+    case "pending":
+      return { label: "Pending", variant: "secondary" };
+    case "processing":
+      return {
+        label: "Indexing...",
+        tooltip: "Generating embeddings for this file.",
+        variant: "secondary",
+        showSpinner: true,
+      };
+    case "failed":
+      return {
+        label: "Indexing Failed",
+        tooltip: getEmbeddingErrorMessage(params.embeddingError),
+        variant: "destructive",
+      };
+    default:
+      return {
+        label: params.embeddingStatus ?? "Unknown",
+        variant: "secondary",
+      };
+  }
+}
+
+export function getEmbeddingErrorMessage(
+  embeddingError?: string | null,
+): string {
+  if (!embeddingError) {
+    return CONNECTOR_FILE_EMBEDDING_ERROR_MESSAGES.unknown;
+  }
+
+  return (
+    CONNECTOR_FILE_EMBEDDING_ERROR_MESSAGES[
+      embeddingError as ConnectorFileEmbeddingError
+    ] ?? CONNECTOR_FILE_EMBEDDING_ERROR_MESSAGES.unknown
+  );
+}
+
+function normalizeProcessingStatus(
+  status?: string | null,
+): ConnectorFileProcessingStatus | null {
+  if (status === "pending" || status === "processing" || status === "failed") {
+    return status;
+  }
+  return null;
+}
+
+function normalizeEmbeddingStatus(
+  status?: string | null,
+): ConnectorFileEmbeddingStatus {
+  if (
+    status === "pending" ||
+    status === "processing" ||
+    status === "completed" ||
+    status === "failed"
+  ) {
+    return status;
+  }
+  return "pending";
+}

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-files-section.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-files-section.tsx
@@ -10,6 +10,7 @@ import {
   useState,
   useTransition,
 } from "react";
+import { getConnectorFileStatusMeta } from "@/app/knowledge/connectors/_parts/connector-file-status";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
@@ -37,76 +38,41 @@ function FileStatusBadge({
   processingStatus,
   embeddingStatus,
   processingError,
+  embeddingError,
 }: {
   processingStatus?: string;
   embeddingStatus: string;
   processingError?: string | null;
+  embeddingError?: string | null;
 }) {
-  if (processingStatus && processingStatus !== "completed") {
-    const variants = {
-      pending: "secondary",
-      processing: "secondary",
-      failed: "destructive",
-    } as const;
+  const statusMeta = getConnectorFileStatusMeta({
+    processingStatus,
+    embeddingStatus,
+    processingError,
+    embeddingError,
+  });
 
-    const labels = {
-      pending: "Queued",
-      processing: "Extracting…",
-      failed: "Processing Failed",
-    };
+  const badge = (
+    <Badge
+      variant={statusMeta.variant}
+      className={statusMeta.tooltip ? "capitalize text-xs cursor-help" : "capitalize text-xs"}
+    >
+      {statusMeta.showSpinner ? (
+        <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+      ) : null}
+      {statusMeta.label}
+    </Badge>
+  );
 
-    const variant =
-      variants[processingStatus as keyof typeof variants] ?? "secondary";
-    const label =
-      labels[processingStatus as keyof typeof labels] ?? processingStatus;
-
-    return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Badge variant={variant} className="capitalize text-xs cursor-help">
-            {processingStatus === "processing" && (
-              <Loader2 className="h-3 w-3 mr-1 animate-spin" />
-            )}
-            {label}
-          </Badge>
-        </TooltipTrigger>
-        <TooltipContent>
-          {processingStatus === "failed" && processingError
-            ? processingError
-            : processingStatus === "pending"
-              ? "File is queued for text extraction"
-              : "Extracting text from file…"}
-        </TooltipContent>
-      </Tooltip>
-    );
+  if (!statusMeta.tooltip) {
+    return badge;
   }
 
-  const variants = {
-    completed: "default",
-    pending: "secondary",
-    processing: "secondary",
-    failed: "destructive",
-  } as const;
-
-  const labels = {
-    completed: "Indexed",
-    pending: "Pending",
-    processing: "Indexing…",
-    failed: "Failed",
-  };
-
   return (
-    <Badge
-      variant={
-        variants[embeddingStatus as keyof typeof variants] ?? "secondary"
-      }
-      className="capitalize text-xs"
-    >
-      {embeddingStatus === "processing" && (
-        <Loader2 className="h-3 w-3 mr-1 animate-spin" />
-      )}
-      {labels[embeddingStatus as keyof typeof labels] ?? embeddingStatus}
-    </Badge>
+    <Tooltip>
+      <TooltipTrigger asChild>{badge}</TooltipTrigger>
+      <TooltipContent>{statusMeta.tooltip}</TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -125,6 +91,7 @@ function FileStatusCell({
       processingStatus={current.processingStatus}
       embeddingStatus={current.embeddingStatus}
       processingError={current.processingError}
+      embeddingError={current.embeddingError}
     />
   );
 }
@@ -327,7 +294,7 @@ export function ConnectorFilesSection({
       <div className="relative">
         <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
         <Input
-          placeholder="Search files by name…"
+          placeholder="Search files by name..."
           value={searchInput}
           onChange={(e) => setSearchInput(e.target.value)}
           className="pl-9 h-9"
@@ -382,7 +349,7 @@ export function ConnectorFilesSection({
         </p>
         <p className="text-xs text-muted-foreground mt-1">
           Supports .txt, .md, .csv, .json, .xml, .html, .pdf, .doc, .docx, .zip
-          — max {MAX_FILE_SIZE_MB} MB each
+          - max {MAX_FILE_SIZE_MB} MB each
         </p>
       </button>
     </div>

--- a/platform/frontend/src/lib/knowledge/connector-files.query.ts
+++ b/platform/frontend/src/lib/knowledge/connector-files.query.ts
@@ -4,8 +4,12 @@ import { type archestraApiTypes, archestraApiClient as client } from "@shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
-export type UploadedFile =
+type UploadedFileApiShape =
   archestraApiTypes.GetConnectorFilesResponses["200"]["data"][number];
+
+export type UploadedFile = UploadedFileApiShape & {
+  embeddingError?: string | null;
+};
 
 type UploadResult =
   archestraApiTypes.UploadConnectorFilesResponses["200"]["results"][number];


### PR DESCRIPTION
## Summary

This makes connector file failures more descriptive for knowledge base uploads.

Changes:
- classify embedding failures and store the reason in `kb_documents.metadata.embeddingError`
- return `embeddingError` from connector file list and single-file APIs
- show clearer file status labels/tooltips in the connector files UI for indexing failures

## Why

Fixes #5033.

This issue asks for more descriptive failed states instead of showing a generic `Failed` badge when embedding/indexing fails.

## Notes

- This keeps the change scoped by reusing existing document metadata instead of introducing a schema migration.
- `connector-files.query.ts` is widened locally so the frontend can consume `embeddingError` without waiting for regenerated API types.

## Verification

Passed locally:
- backend: `src/knowledge-base/embedder.test.ts`
- backend: `src/routes/knowledge-base-file-upload.test.ts`
- frontend: `src/app/knowledge/connectors/_parts/connector-file-status.test.ts`