### PR TITLE
feat: ability to specify cron-expression for a scheduled agent

### DIFF
--- a/docs/pages/platform-agent-triggers-schedule.md
+++ b/docs/pages/platform-agent-triggers-schedule.md
@@ -3,7 +3,7 @@ title: Scheduled Tasks
 category: Agents
 order: 3
 description: Run agents automatically on a repeating schedule
-lastUpdated: 2026-05-07
+lastUpdated: 2026-05-26
 ---
 
 <!--
@@ -15,6 +15,10 @@ Check ../docs_writer_prompt.md before changing this file.
 Scheduled Tasks run an agent automatically on a repeating schedule. Each run sends the configured prompt to the agent and records the full conversation. The task always runs under the permissions of the user who created it.
 
 Common use cases: daily standup preparation (fetching tasks and summarizing progress before a daily meeting), or first-line support triage (periodically processing incoming support requests).
+
+## Schedule
+
+The Hourly and Daily presets cover the common cases. For anything else, the Custom option accepts a standard 5-field cron expression (`minute hour day month weekday`), evaluated in the creator's timezone. For example, `*/15 * * * *` runs every fifteen minutes and `0 9 1 * *` runs at 09:00 on the first of each month.
 
 ## Chat Follow-up
 

--- a/platform/frontend/src/app/scheduled-tasks/schedule-trigger.utils.test.ts
+++ b/platform/frontend/src/app/scheduled-tasks/schedule-trigger.utils.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCronFromSchedule,
+  buildScheduleTriggerPayload,
+  DEFAULT_FORM_STATE,
+  isValidCronExpression,
+  parseCronToMode,
+} from "./schedule-trigger.utils";
+
+describe("parseCronToMode", () => {
+  it("maps a plain hourly expression to the hourly preset", () => {
+    expect(parseCronToMode("0 * * * *").mode).toBe("hourly");
+  });
+
+  it("maps a daily weekday expression to the daily preset", () => {
+    expect(parseCronToMode("0 9 * * 1-5")).toEqual({
+      mode: "daily",
+      hour: "9",
+      minute: "0",
+      days: [1, 2, 3, 4, 5],
+    });
+  });
+
+  it("expands a daily wildcard weekday to all seven days", () => {
+    expect(parseCronToMode("30 8 * * *")).toEqual({
+      mode: "daily",
+      hour: "8",
+      minute: "30",
+      days: [0, 1, 2, 3, 4, 5, 6],
+    });
+  });
+
+  it("parses comma-separated weekdays for the daily preset", () => {
+    expect(parseCronToMode("0 9 * * 1,3,5").days).toEqual([1, 3, 5]);
+  });
+
+  it.each([
+    ["a stepped minute", "*/15 * * * *"],
+    ["a stepped hour", "0 */2 * * *"],
+    ["a day-of-month constraint", "0 9 1 * *"],
+    ["a month constraint", "0 9 * 6 *"],
+    ["a stepped weekday", "0 9 * * */2"],
+    ["a six-field expression", "0 0 9 * * 1-5"],
+    ["a non-numeric field", "0 9 * * MON"],
+  ])("routes %s to the custom tab", (_label, expression) => {
+    expect(parseCronToMode(expression).mode).toBe("custom");
+  });
+
+  it("round-trips daily and hourly presets through buildCronFromSchedule", () => {
+    for (const expression of ["0 * * * *", "0 9 * * 1-5", "30 8 * * *"]) {
+      const parsed = parseCronToMode(expression);
+      // `custom` is never produced for these inputs, so the cast is safe.
+      const rebuilt = buildCronFromSchedule(
+        parsed.mode as "hourly" | "daily",
+        parsed.hour,
+        parsed.minute,
+        parsed.days,
+      );
+      expect(parseCronToMode(rebuilt).mode).toBe(parsed.mode);
+    }
+  });
+});
+
+describe("buildCronFromSchedule", () => {
+  it("builds an hourly expression at the given minute", () => {
+    expect(buildCronFromSchedule("hourly", "9", "0", [1, 2])).toBe("0 * * * *");
+  });
+
+  it("collapses a full week to a wildcard weekday", () => {
+    expect(
+      buildCronFromSchedule("daily", "9", "0", [0, 1, 2, 3, 4, 5, 6]),
+    ).toBe("0 9 * * *");
+  });
+
+  it("sorts and joins a weekday subset", () => {
+    expect(buildCronFromSchedule("daily", "9", "0", [5, 1, 3])).toBe(
+      "0 9 * * 1,3,5",
+    );
+  });
+});
+
+describe("isValidCronExpression", () => {
+  it.each([
+    "0 9 * * 1-5",
+    "*/15 * * * *",
+    "0 0 1 * *",
+  ])("accepts the valid expression %s", (expression) => {
+    expect(isValidCronExpression(expression)).toBe(true);
+  });
+
+  it.each([
+    "",
+    "   ",
+    "not a cron",
+    "0 9 * *",
+    "99 99 * * *",
+  ])("rejects the invalid expression %j", (expression) => {
+    expect(isValidCronExpression(expression)).toBe(false);
+  });
+});
+
+describe("buildScheduleTriggerPayload", () => {
+  const validForm = () => ({
+    ...DEFAULT_FORM_STATE(),
+    name: "Daily summary",
+    agentId: "agent-1",
+    messageTemplate: "Do the thing",
+  });
+
+  it("returns a trimmed payload when all fields are valid", () => {
+    const payload = buildScheduleTriggerPayload({
+      ...validForm(),
+      name: "  Daily summary  ",
+      cronExpression: "  0 9 * * 1-5  ",
+    });
+    expect(payload).toMatchObject({
+      name: "Daily summary",
+      cronExpression: "0 9 * * 1-5",
+    });
+  });
+
+  it("returns null when the cron expression is invalid", () => {
+    expect(
+      buildScheduleTriggerPayload({
+        ...validForm(),
+        cronExpression: "not a cron",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when a required field is missing", () => {
+    expect(
+      buildScheduleTriggerPayload({ ...validForm(), messageTemplate: "" }),
+    ).toBeNull();
+  });
+});

--- a/platform/frontend/src/app/scheduled-tasks/schedule-trigger.utils.ts
+++ b/platform/frontend/src/app/scheduled-tasks/schedule-trigger.utils.ts
@@ -1,4 +1,5 @@
 import type { UseMutationResult } from "@tanstack/react-query";
+import { Cron } from "croner";
 import type { ScheduleTriggerRunStatus } from "@/lib/schedule-trigger.query";
 
 export type AgentOption = {
@@ -23,6 +24,97 @@ export const DEFAULT_FORM_STATE = (): ScheduleTriggerFormState => ({
   messageTemplate: "",
 });
 
+export type ScheduleMode = "hourly" | "daily" | "custom";
+
+const DEFAULT_DAILY_SCHEDULE = {
+  hour: "9",
+  minute: "0",
+  days: [1, 2, 3, 4, 5],
+};
+
+/**
+ * Maps a cron expression onto the Schedule section's UI state. Expressions that
+ * fit the simple "hourly" or "daily" presets open in those tabs; anything else
+ * (steps, day-of-month, named fields, 6-part, …) opens in the "custom" tab so it
+ * round-trips untouched instead of being silently rewritten by a preset.
+ */
+export function parseCronToMode(cron: string): {
+  mode: ScheduleMode;
+  hour: string;
+  minute: string;
+  days: number[];
+} {
+  const parts = cron.trim().split(/\s+/);
+
+  if (parts.length !== 5) {
+    return { mode: "custom", ...DEFAULT_DAILY_SCHEDULE };
+  }
+
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = parts;
+  const isPlainInt = (value: string) => /^\d+$/.test(value);
+
+  // Hourly preset: fixed minute, every hour/day/month/weekday -> "0 * * * *".
+  if (
+    isPlainInt(minute) &&
+    hour === "*" &&
+    dayOfMonth === "*" &&
+    month === "*" &&
+    dayOfWeek === "*"
+  ) {
+    return { mode: "hourly", ...DEFAULT_DAILY_SCHEDULE };
+  }
+
+  // Daily preset: fixed minute+hour, every day/month, simple weekday pattern.
+  if (
+    isPlainInt(minute) &&
+    isPlainInt(hour) &&
+    dayOfMonth === "*" &&
+    month === "*"
+  ) {
+    const days = parseDayOfWeekField(dayOfWeek);
+    if (days && days.length > 0) {
+      return { mode: "daily", hour, minute, days };
+    }
+  }
+
+  return { mode: "custom", ...DEFAULT_DAILY_SCHEDULE };
+}
+
+export function buildCronFromSchedule(
+  mode: Exclude<ScheduleMode, "custom">,
+  hour: string,
+  minute: string,
+  days: number[],
+): string {
+  switch (mode) {
+    case "hourly":
+      return `${minute} * * * *`;
+    case "daily": {
+      const sorted = [...days].sort((a, b) => a - b);
+      const dayOfWeek =
+        sorted.length === 7 || sorted.length === 0 ? "*" : sorted.join(",");
+      return `${minute} ${hour} * * ${dayOfWeek}`;
+    }
+  }
+}
+
+/**
+ * Validates a cron expression the same way the backend does: croner in 5-part
+ * mode. Used to gate form submission and surface inline errors in the custom tab.
+ */
+export function isValidCronExpression(expression: string): boolean {
+  const trimmed = expression.trim();
+  if (!trimmed) {
+    return false;
+  }
+  try {
+    new Cron(trimmed, { mode: "5-part" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function buildScheduleTriggerPayload(
   formState: ScheduleTriggerFormState,
 ) {
@@ -39,7 +131,8 @@ export function buildScheduleTriggerPayload(
     !payload.agentId ||
     !payload.cronExpression ||
     !payload.timezone ||
-    !payload.messageTemplate
+    !payload.messageTemplate ||
+    !isValidCronExpression(payload.cronExpression)
   ) {
     return null;
   }
@@ -104,4 +197,33 @@ export function getRunNowTrackingState(params: {
 
 export function getScheduleTriggerRunSessionId(runId: string): string {
   return `scheduled-${runId}`;
+}
+
+/**
+ * Parses a cron day-of-week field into weekday numbers (0-6), supporting only
+ * simple values, comma lists, and ascending ranges. Returns null for anything
+ * else (steps, names, …) so the caller routes the expression to the custom tab.
+ */
+function parseDayOfWeekField(dayOfWeek: string): number[] | null {
+  if (dayOfWeek === "*") {
+    return [0, 1, 2, 3, 4, 5, 6];
+  }
+
+  const days: number[] = [];
+  for (const part of dayOfWeek.split(",")) {
+    if (/^[0-6]$/.test(part)) {
+      days.push(Number(part));
+    } else if (/^[0-6]-[0-6]$/.test(part)) {
+      const [start, end] = part.split("-").map(Number);
+      if (start > end) {
+        return null;
+      }
+      for (let day = start; day <= end; day++) {
+        days.push(day);
+      }
+    } else {
+      return null;
+    }
+  }
+  return days;
 }

--- a/platform/frontend/src/app/scheduled-tasks/schedule-triggers-client.tsx
+++ b/platform/frontend/src/app/scheduled-tasks/schedule-triggers-client.tsx
@@ -77,10 +77,14 @@ import { formatRelativeTimeFromNow } from "@/lib/utils/date-time";
 import { formatCronSchedule } from "@/lib/utils/format-cron";
 import {
   type AgentOption,
+  buildCronFromSchedule,
   buildScheduleTriggerPayload,
   DEFAULT_FORM_STATE,
   getActiveMutationVariable,
   getRunNowTrackingState,
+  isValidCronExpression,
+  parseCronToMode,
+  type ScheduleMode,
   type ScheduleTriggerFormState,
 } from "./schedule-trigger.utils";
 
@@ -1084,8 +1088,6 @@ function ScheduleTriggerCreateButton({
   );
 }
 
-type ScheduleMode = "hourly" | "daily";
-
 const WEEKDAYS = [
   { label: "Mon", value: 1 },
   { label: "Tue", value: 2 },
@@ -1100,74 +1102,6 @@ const HOURS = Array.from({ length: 24 }, (_, i) => ({
   value: String(i),
   label: `${String(i).padStart(2, "0")}:00`,
 }));
-
-function parseCronToMode(cron: string): {
-  mode: ScheduleMode;
-  hour: string;
-  minute: string;
-  days: number[];
-} {
-  const parts = cron.trim().split(/\s+/);
-  const defaults = {
-    hour: "9",
-    minute: "0",
-    days: [1, 2, 3, 4, 5],
-  };
-
-  if (parts.length !== 5) {
-    return { mode: "daily", ...defaults };
-  }
-
-  const [min, hr, , , dow] = parts;
-
-  // Hourly: "0 * * * *" or "N * * * *"
-  if (hr === "*" && dow === "*") {
-    return { mode: "hourly", ...defaults };
-  }
-
-  // Daily: specific hour, days pattern
-  if (hr !== "*" && !hr.includes("/")) {
-    const dayList =
-      dow === "*"
-        ? [0, 1, 2, 3, 4, 5, 6]
-        : dow.split(",").flatMap((part) => {
-            if (part.includes("-")) {
-              const [start, end] = part.split("-").map(Number);
-              const result: number[] = [];
-              for (let i = start; i <= end; i++) result.push(i);
-              return result;
-            }
-            return [Number(part)];
-          });
-
-    return {
-      mode: "daily",
-      hour: hr,
-      minute: min,
-      days: dayList,
-    };
-  }
-
-  return { mode: "daily", ...defaults };
-}
-
-function buildCronFromSchedule(
-  mode: ScheduleMode,
-  hour: string,
-  minute: string,
-  days: number[],
-): string {
-  switch (mode) {
-    case "hourly":
-      return `${minute} * * * *`;
-    case "daily": {
-      const sorted = [...days].sort((a, b) => a - b);
-      const dowPart =
-        sorted.length === 7 || sorted.length === 0 ? "*" : sorted.join(",");
-      return `${minute} ${hour} * * ${dowPart}`;
-    }
-  }
-}
 
 function ScheduleSection({
   cronExpression,
@@ -1191,6 +1125,10 @@ function ScheduleSection({
       newMinute: string,
       newDays: number[],
     ) => {
+      // In custom mode the raw input drives cronExpression directly; presets do not.
+      if (newMode === "custom") {
+        return;
+      }
       onCronExpressionChange(
         buildCronFromSchedule(newMode, newHour, newMinute, newDays),
       );
@@ -1222,7 +1160,7 @@ function ScheduleSection({
       <Label>Schedule</Label>
 
       <div className="flex gap-1 rounded-md border p-1">
-        {(["hourly", "daily"] as const).map((m) => (
+        {(["hourly", "daily", "custom"] as const).map((m) => (
           <button
             key={m}
             type="button"
@@ -1272,6 +1210,37 @@ function ScheduleSection({
               ))}
             </SelectContent>
           </Select>
+        </div>
+      )}
+
+      {mode === "custom" && (
+        <div className="space-y-2">
+          <Label htmlFor="dialog-cron">Cron expression</Label>
+          <Input
+            id="dialog-cron"
+            value={cronExpression}
+            onChange={(event) => onCronExpressionChange(event.target.value)}
+            placeholder="0 9 * * 1-5"
+            className={cn(
+              "font-mono",
+              cronExpression.trim() &&
+                !isValidCronExpression(cronExpression) &&
+                "border-destructive focus-visible:ring-destructive",
+            )}
+          />
+          {!cronExpression.trim() ? (
+            <p className="text-xs text-muted-foreground">
+              Standard 5-field cron: minute hour day month weekday
+            </p>
+          ) : isValidCronExpression(cronExpression) ? (
+            <p className="text-xs text-muted-foreground">
+              {formatCronSchedule(cronExpression)}
+            </p>
+          ) : (
+            <p className="text-xs text-destructive">
+              Not a valid cron expression
+            </p>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
Adds a Custom crontab to the Schedule section of the New task dialog, alongside the existing Hourly/Daily presets. 

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>