### PR TITLE
test(e2e): instrument MCP gateway JWT readiness loop; close initialize JSON-RPC trap

### DIFF
--- a/platform/e2e-tests/utils/mcp-gateway.ts
+++ b/platform/e2e-tests/utils/mcp-gateway.ts
@@ -177,7 +177,7 @@ export async function initializeMcpSession(
     token: string;
   },
 ): Promise<void> {
-  await makeApiRequest({
+  const response = await makeApiRequest({
     request,
     method: "post",
     urlSuffix: `${MCP_GATEWAY_URL_SUFFIX}/${options.profileId}`,
@@ -193,6 +193,22 @@ export async function initializeMcpSession(
       },
     },
   });
+
+  // MCP gateway can return 200 with a JSON-RPC `{ "error": {...} }` body when
+  // auth fails — `makeApiRequest` only throws on HTTP-level errors, so without
+  // this check `initializeMcpSession` would silently succeed on a JWT
+  // verification failure. Today this is masked because every caller of
+  // `waitForMcpGatewayJwtReady` also runs `listMcpTools` (which does check the
+  // body) — fixing it here closes the latent trap for any future
+  // `requireToolsListed: false` caller.
+  const initResult = (await response.json()) as {
+    error?: { message?: string; code?: number };
+  };
+  if (initResult.error) {
+    throw new Error(
+      `MCP initialize failed: ${initResult.error.message} (code: ${initResult.error.code})`,
+    );
+  }
 }
 
 export async function waitForGatewayIdentityProviderReady(params: {
@@ -312,6 +328,12 @@ export async function waitForMcpGatewayJwtReady(params: {
     15_000, 15_000, 15_000, 15_000, 15_000, 15_000,
   ];
   let lastError: unknown;
+  // Track every distinct failure mode encountered so the final throw points
+  // at the actual cause instead of just the last attempt's error. The real
+  // flake mode (cold JWKS vs. IdP-config not propagated vs. transient 5xx)
+  // is otherwise invisible across the ~161s retry window.
+  const seenErrors = new Map<string, number>();
+  const seenStates = new Map<string, number>();
 
   for (const delayMs of delaysMs) {
     if (delayMs > 0) {
@@ -340,18 +362,30 @@ export async function waitForMcpGatewayJwtReady(params: {
       if (matches) {
         return tools;
       }
+
+      const stateKey = params.expectedToolName
+        ? `missing-tool:${params.expectedToolName} (count=${tools.length})`
+        : `empty-tools-list`;
+      seenStates.set(stateKey, (seenStates.get(stateKey) ?? 0) + 1);
     } catch (error) {
       lastError = error;
+      const msg = error instanceof Error ? error.message : String(error);
+      seenErrors.set(msg, (seenErrors.get(msg) ?? 0) + 1);
     }
   }
 
-  throw (
-    lastError ??
-    new Error(
-      params.expectedToolName
-        ? `Tool ${params.expectedToolName} was not available via JWT auth`
-        : "MCP Gateway did not become ready for external JWT auth",
-    )
+  const errorSummary = [
+    ...[...seenErrors.entries()].map(([m, n]) => `[error×${n}] ${m}`),
+    ...[...seenStates.entries()].map(([m, n]) => `[state×${n}] ${m}`),
+  ].join(" | ");
+
+  const headline = params.expectedToolName
+    ? `Tool ${params.expectedToolName} was not available via JWT auth`
+    : "MCP Gateway did not become ready for external JWT auth";
+
+  const lastMsg = lastError instanceof Error ? lastError.message : "";
+  throw new Error(
+    `${headline} — ${delaysMs.length} attempts over ~${Math.round(delaysMs.reduce((a, b) => a + b, 0) / 1000)}s. ${errorSummary || "(no failure signal captured)"}${lastMsg && !errorSummary.includes(lastMsg) ? ` Last: ${lastMsg}` : ""}`,
   );
 }
 


### PR DESCRIPTION
The two `.ee.spec.ts` gateway tests (`mcp-gateway-jwks.ee` and `mcp-gateway-jwt-propagation.ee`) share `waitForMcpGatewayJwtReady` as their readiness primitive. A prior commit already extended its backoff from ~80s to ~150s, but the loop still discards every error except the last one — when a flake fires, the failure message is a single point-in-time error with no signal on whether the cause was a transient 5xx, a stale IdP-config read, or the cold JWKS fetch the docstring claims.

Two changes in `utils/mcp-gateway.ts`:

- `initializeMcpSession` now parses the response body and throws on a JSON-RPC `error` payload. Today this is masked because every caller of `waitForMcpGatewayJwtReady` also runs `listMcpTools` (which does check the body), so a JWT-rejected initialize is caught one RTT downstream. Closes the latent trap for any future `requireToolsListed: false` caller — `initialize` returning HTTP 200 with `{"error":{...}}` would otherwise silently succeed on auth failure.

- `waitForMcpGatewayJwtReady` aggregates every distinct error message and tools-list state it observes across the ~161s retry window, with occurrence counts, and includes them in the final throw. A real flake now reports as e.g. `[error×3] 401 JWT verify failed | [error×1] 502 Bad Gateway | [state×1] empty-tools-list` instead of a single stale "last error". No change to retry budget or semantics — every error is still treated as retryable.

The intent is observability, not a direct flake-rate reduction: without it, debugging the next CI failure of either spec means parsing the playwright trace by hand to figure out which of the three plausible causes (JWKS cold-start vs. IdP-config replication lag vs. real backend error) actually fired. With it, the failure message names the cause.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>