### PR TITLE
feat(chatops): enrich Slack LLM context with channel id, workspace id, and permalink

### DIFF
--- a/platform/backend/src/agents/chatops/chatops-manager.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.ts
@@ -716,7 +716,27 @@ export class ChatOpsManager {
           ? "MS Teams"
           : provider.providerId;
     const threadIdForPrefix = message.threadId ?? message.messageId;
-    const systemPrefix = `(${providerLabel} conversation, thread id: ${threadIdForPrefix})`;
+    let systemPrefix = `(${providerLabel} conversation, thread id: ${threadIdForPrefix})`;
+    if (provider.providerId === "slack") {
+      const permalink = provider.getMessagePermalink
+        ? await provider.getMessagePermalink({
+            channelId: message.channelId,
+            messageId: threadIdForPrefix,
+          })
+        : null;
+      const contextLines = [
+        `Slack conversation context:`,
+        `- Channel ID: ${message.channelId}`,
+        `- Thread message ts: ${threadIdForPrefix}`,
+      ];
+      if (message.workspaceId) {
+        contextLines.push(`- Workspace ID: ${message.workspaceId}`);
+      }
+      if (permalink) {
+        contextLines.push(`- Thread permalink: ${permalink}`);
+      }
+      systemPrefix = contextLines.join("\n");
+    }
 
     let fullMessage = `${systemPrefix}\n\n${cleanedMessageText}`;
     if (contextMessages.length > 0) {

--- a/platform/backend/src/agents/chatops/slack-provider.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.ts
@@ -661,6 +661,30 @@ class SlackProvider implements ChatOpsProvider {
     }
   }
 
+  async getMessagePermalink(params: {
+    channelId: string;
+    messageId: string;
+  }): Promise<string | null> {
+    if (!this.client) return null;
+    try {
+      const result = await this.client.chat.getPermalink({
+        channel: params.channelId,
+        message_ts: params.messageId,
+      });
+      return (result.permalink as string | undefined) ?? null;
+    } catch (error) {
+      logger.warn(
+        {
+          error: errorMessage(error),
+          channelId: params.channelId,
+          messageId: params.messageId,
+        },
+        "[SlackProvider] Failed to fetch chat.getPermalink",
+      );
+      return null;
+    }
+  }
+
   async getUserEmail(userId: string): Promise<string | null> {
     if (!this.client) {
       logger.warn("[SlackProvider] Client not initialized, cannot get email");

--- a/platform/backend/src/types/chatops.ts
+++ b/platform/backend/src/types/chatops.ts
@@ -355,6 +355,19 @@ export interface ChatOpsProvider {
   getThreadHistory(params: ThreadHistoryParams): Promise<ChatThreadMessage[]>;
 
   /**
+   * Get a permalink to a specific message in the provider's web UI.
+   * Used to surface a clickable thread URL in the LLM context so tools
+   * can reference the originating conversation.
+   * @param params.channelId - The channel ID containing the message
+   * @param params.messageId - The message ID (Slack ts) to link to
+   * @returns Permalink URL, or null if unavailable
+   */
+  getMessagePermalink?(params: {
+    channelId: string;
+    messageId: string;
+  }): Promise<string | null>;
+
+  /**
    * Get user's email address from their provider-specific ID
    * Used for security validation to verify the user exists in Archestra
    * @param userId - The user's ID in the provider's system (e.g., AAD Object ID for MS Teams)


### PR DESCRIPTION
Replaces the single-line Slack prefix with a structured context block so tools can pick up `channel ID`, `thread message ts`, `workspace ID`, and `thread permalink` directly instead of guessing.

- Adds optional `getMessagePermalink` to `ChatOpsProvider`, implemented for Slack via `chat.getPermalink`.
- MS Teams behavior is unchanged.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>