### PR TITLE
fix(e2e): make quickstart spec robust in onboarding branch

### DIFF
--- a/platform/e2e-tests/tests/quickstart.spec.ts
+++ b/platform/e2e-tests/tests/quickstart.spec.ts
@@ -71,6 +71,9 @@ test.describe("Quickstart", { tag: "@quickstart" }, () => {
           name: "Quickstart Key",
           apiKey: "sk-quickstart-test",
           providerOptionName: "OpenAI OpenAI",
+          // Quickstart dialog redirects to /chat on success; the api-keys list
+          // row never renders here.
+          waitForRow: false,
         });
       } else {
         await expect(chatPrompt).toBeVisible({ timeout: 15_000 });
@@ -79,9 +82,24 @@ test.describe("Quickstart", { tag: "@quickstart" }, () => {
       // 3. Chat is immediately ready — model and key are auto-selected
       await expectChatReady(page);
 
-      // 4. Send a message and get mocked response
-      // Message must contain "chat-ui-e2e-test" to match WireMock stub
+      // 4. Send a message and get mocked response.
+      // Message must contain "chat-ui-e2e-test" to match WireMock stub.
+      // Listen for the POST /api/chat response (headers only — SSE
+      // body still streams afterwards) so a 5xx surfaces as a network
+      // error in <30s instead of a 90s "text not visible" UI timeout.
+      const chatResponsePromise = page.waitForResponse(
+        (response) =>
+          response.request().method() === "POST" &&
+          /\/api\/chat(?:\?|$)/.test(response.url()),
+        { timeout: 30_000 },
+      );
       await sendChatMessage(page, "chat-ui-e2e-test quickstart: Hello!");
+      const chatResponse = await chatResponsePromise;
+      if (!chatResponse.ok()) {
+        throw new Error(
+          `POST /api/chat returned ${chatResponse.status()}: ${await chatResponse.text()}`,
+        );
+      }
 
       await expect(
         page.getByText("This is a mocked response for the chat UI e2e test."),

--- a/platform/e2e-tests/utils/llm-provider-api-keys.ts
+++ b/platform/e2e-tests/utils/llm-provider-api-keys.ts
@@ -28,6 +28,10 @@ export async function createLlmProviderApiKey(
     providerOptionName?: string | RegExp;
     scope?: "personal" | "org";
     baseUrl?: string;
+    // The row assertion only applies when the caller is on the API keys
+    // management page. Quickstart-style flows host the create dialog on /chat
+    // and redirect back to /chat on success, where ChatApiKeyRow does not exist.
+    waitForRow?: boolean;
   },
 ): Promise<void> {
   const addApiKeyButton = page
@@ -67,9 +71,11 @@ export async function createLlmProviderApiKey(
   await expect(page.getByText("API key created successfully")).toBeVisible({
     timeout: 30_000,
   });
-  await expect(
-    page.getByTestId(`${E2eTestId.ChatApiKeyRow}-${params.name}`),
-  ).toBeVisible({ timeout: 30_000 });
+  if (params.waitForRow !== false) {
+    await expect(
+      page.getByTestId(`${E2eTestId.ChatApiKeyRow}-${params.name}`),
+    ).toBeVisible({ timeout: 30_000 });
+  }
 }
 
 export async function createVirtualKey(


### PR DESCRIPTION
## Summary

The quickstart e2e spec branches on which readiness state appears first on `/chat`: an empty-state onboarding dialog, or a pre-warmed chat surface. The onboarding branch reused `createLlmProviderApiKey`, which after `Test & Create` waits for `chat-api-key-row-<name>` — a test-id that only renders on `/llm/model-providers/api-keys`. The quickstart dialog's `onSuccess` instead redirects back to `/chat`, so the assertion always timed out at 30s and the test failed any time it took the onboarding path.

Gating the row assertion behind an opt-in `waitForRow` param keeps both existing callers (`virtual-api-keys.spec.ts`, `llm-provider-api-keys.spec.ts` — both already on the management page) on the stricter behavior, while letting the quickstart caller skip the inapplicable check and fall through to the existing `expectChatReady` step.

Also keeps the `POST /api/chat` `waitForResponse` sniff already on this branch: a 5xx now surfaces immediately with the response body instead of cascading into a 90s "expected text not visible" timeout further down the spec.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>