### PR TITLE
docs(schemas): codify plural snake_case SQL table naming policy

### DIFF
--- a/platform/backend/src/database/schemas/index.ts
+++ b/platform/backend/src/database/schemas/index.ts
@@ -1,3 +1,33 @@
+/**
+ * SQL table names use plural snake_case (`agents`, `mcp_servers`, `conversations`).
+ * File names stay singular kebab-case (`mcp-server.ts`); TS exports below are
+ * always `${plural}Table` regardless of the underlying SQL name.
+ *
+ * Two singular-name exceptions exist:
+ *
+ * 1. Library-owned (permanent — better-auth defines these, do not rename):
+ *      account, apikey, invitation, jwks, member, organization, session, team,
+ *      team_member, two_factor, user, verification,
+ *      oauth_access_token, oauth_client, oauth_consent, oauth_refresh_token
+ *
+ * 2. Status-quo drift (app-code singular names predating this policy — eligible
+ *    to be renamed to plural in future migrations):
+ *      a2a_context, a2a_message, a2a_task, a2a_task_approval_request,
+ *      agent_connector_assignment, agent_knowledge_base, agent_team,
+ *      chatops_channel_binding, chatops_processed_message,
+ *      chatops_thread_agent_override,
+ *      conversation_share_team, conversation_share_user,
+ *      identity_provider, incoming_email_subscription, internal_mcp_catalog,
+ *      knowledge_base_connector_assignment, limit_model_usage,
+ *      mcp_catalog_team, mcp_preset_entry, mcp_server,
+ *      mcp_server_installation_request, mcp_server_user,
+ *      organization_role, processed_email, secret,
+ *      site_notification, skill_team,
+ *      team_external_group, team_token, team_vault_folder, user_token,
+ *      virtual_api_key_provider_api_key, virtual_api_key_team
+ *
+ * New tables must be plural. Tables not listed in (1) or (2) must be plural.
+ */
 export { default as a2aContextsTable } from "./a2a-context";
 export { default as a2aMessagesTable } from "./a2a-message";
 export { default as a2aTasksTable } from "./a2a-task";


### PR DESCRIPTION
## Summary

Of 88 `pgTable("...")` declarations in `platform/backend/src/database/schemas/`, 16 are singular because `better-auth` defines them, 33 are singular from accumulated drift, and 39 are plural. There has been no written rule for which form to pick on a new schema, so each new table added a coin-flip of inconsistency — `mcp_server` (singular) sits next to `mcp_tool_calls` and `mcp_http_sessions` (plural); `agents` (plural) next to `agent_team`, `agent_label`, `agent_knowledge_base` (singular).

The barrel `schemas/index.ts` is the file every new schema must touch in order to register its `Table` export, which makes it the natural single source of truth for the convention. A header block now declares plural snake_case as the SQL form, with two named exception lists — library-owned tables (permanent) and status-quo drift (eligible for future rename) — and a closing line that forbids new tables from joining either list. List (2) is fixed-size and can only shrink, so the header doubles as a migration tracker for future plural renames.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>