### PR TITLE
fix(e2e): scope sign-out test to a throwaway admin session

### DIFF
--- a/platform/backend/src/database/schemas/index.ts
+++ b/platform/backend/src/database/schemas/index.ts
@@ -1,3 +1,33 @@
+/**
+ * SQL table names use plural snake_case (`agents`, `mcp_servers`, `conversations`).
+ * File names stay singular kebab-case (`mcp-server.ts`); TS exports below are
+ * always `${plural}Table` regardless of the underlying SQL name.
+ *
+ * Two singular-name exceptions exist:
+ *
+ * 1. Library-owned (permanent — better-auth defines these, do not rename):
+ *      account, apikey, invitation, jwks, member, organization, session, team,
+ *      team_member, two_factor, user, verification,
+ *      oauth_access_token, oauth_client, oauth_consent, oauth_refresh_token
+ *
+ * 2. Status-quo drift (app-code singular names predating this policy — eligible
+ *    to be renamed to plural in future migrations):
+ *      a2a_context, a2a_message, a2a_task, a2a_task_approval_request,
+ *      agent_connector_assignment, agent_knowledge_base, agent_team,
+ *      chatops_channel_binding, chatops_processed_message,
+ *      chatops_thread_agent_override,
+ *      conversation_share_team, conversation_share_user,
+ *      identity_provider, incoming_email_subscription, internal_mcp_catalog,
+ *      knowledge_base_connector_assignment, limit_model_usage,
+ *      mcp_catalog_team, mcp_preset_entry, mcp_server,
+ *      mcp_server_installation_request, mcp_server_user,
+ *      organization_role, processed_email, secret,
+ *      site_notification, skill_team,
+ *      team_external_group, team_token, team_vault_folder, user_token,
+ *      virtual_api_key_provider_api_key, virtual_api_key_team
+ *
+ * New tables must be plural. Tables not listed in (1) or (2) must be plural.
+ */
 export { default as a2aContextsTable } from "./a2a-context";
 export { default as a2aMessagesTable } from "./a2a-message";
 export { default as a2aTasksTable } from "./a2a-task";

--- a/platform/e2e-tests/tests/auth-redirect.spec.ts
+++ b/platform/e2e-tests/tests/auth-redirect.spec.ts
@@ -1,29 +1,36 @@
 import { ADMIN_EMAIL, ADMIN_PASSWORD, UI_BASE_URL } from "../consts";
 import { expect, test } from "../fixtures";
-import { loginViaUi } from "../utils";
+import { loginViaApi, loginViaUi } from "../utils";
 
 test.describe("Authentication redirect flows", {
   tag: ["@firefox", "@webkit"],
 }, () => {
-  test("sign-out works and redirects to sign-in page", async ({
-    adminPage,
-    goToPage,
-  }) => {
-    // Navigate to app
-    await goToPage(adminPage, "/chat");
+  test("sign-out works and redirects to sign-in page", async ({ browser }) => {
+    // Build a throwaway admin session instead of reusing adminAuthFile.
+    // Every chromium test starts with a copy of the same admin cookie, all
+    // mapped to one better-auth session row; signing out from the shared
+    // session deletes that row and 401s every concurrent admin-using spec.
+    // A fresh loginViaApi here creates an independent session row that this
+    // test alone owns and can safely revoke.
+    const context = await browser.newContext({ storageState: undefined });
+    const page = await context.newPage();
 
-    // Click on the user profile button to open dropdown
-    await adminPage.getByRole("button", { name: ADMIN_EMAIL }).click();
+    try {
+      const signedIn = await loginViaApi(page, ADMIN_EMAIL, ADMIN_PASSWORD);
+      expect(signedIn, "Admin sign-in failed").toBe(true);
 
-    // Click sign out option in the dropdown
-    await adminPage.getByRole("menuitem", { name: /sign out/i }).click();
+      await page.goto(`${UI_BASE_URL}/chat`, {
+        waitUntil: "domcontentloaded",
+      });
 
-    // Should be redirected to sign-out page which handles the sign-out
-    await adminPage.waitForURL(/\/auth\/sign-out/);
+      await page.getByRole("button", { name: ADMIN_EMAIL }).click();
+      await page.getByRole("menuitem", { name: /sign out/i }).click();
 
-    // The sign-out page should render (better-auth handles the actual sign-out)
-    // After sign-out completes, the page should show the sign-out confirmation or redirect
-    await expect(adminPage.locator("body")).toBeVisible({ timeout: 10000 });
+      await page.waitForURL(/\/auth\/sign-out/, { timeout: 15_000 });
+      await page.waitForURL(/\/auth\/sign-in/, { timeout: 15_000 });
+    } finally {
+      await context.close();
+    }
   });
 
   test("redirectTo parameter preserves original URL after sign-in", async ({


### PR DESCRIPTION
## Summary

The chromium e2e project binds `storageState: adminAuthFile`, and `adminPage` in `fixtures.ts` hands every test a copy of the same admin cookie. All those copies map to the one better-auth session row written by `auth.admin.setup.ts`. The sign-out test in `auth-redirect.spec.ts:8` used `adminPage` and clicked the UI sign-out menu, which deletes that shared row server-side and 401s every other parallel chromium spec that's holding the same cookie.

That race is the root cause of a recurring MQ flake group surfaced over the last two days:

- `static-credentials-management.spec.ts:46` (Admin variant) failing with `Failed to get teams: {"type":"api_authentication_error"}` and `MCP server <id> status fetch returned 401`, surviving all three Playwright retries.
- `dynamic-credentials.spec.ts:18` failing the same way.

Two independent MQ runs of #5053 (`qs` dep bump, zero test code changed) failed on the **identical** test set — a clean signal that the cause is suite parallelism, not data.

Rewrite the one offender to build a fresh browser context and authenticate via `loginViaApi`. That sign-in returns a new, independent session row this test alone owns and can safely revoke; the shared admin session is untouched. Same pattern the other tests in this file already use (lines 36+).

Also tighten the sign-out test while in here: drop click-narration comments, give `waitForURL` explicit timeouts, and replace the `body.toBeVisible` weak assertion with a `waitForURL` on the `/auth/sign-in` redirect the test name already promises.

If a second session-mutating test ever appears, the right move is to promote this pattern to a worker-scoped auth fixture per the [Playwright docs' "one account per parallel worker"](https://playwright.dev/docs/auth#moderate-one-account-per-parallel-worker) guidance (needs N admin-equivalent accounts seeded). For one offender, the surgical fix dominates.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>