### PR TITLE
fix: reject empty OpenRouter stop responses

### DIFF
--- a/platform/backend/src/routes/proxy/adapters/openrouter.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/openrouter.test.ts
@@ -1,0 +1,112 @@
+import { ApiError } from "@shared";
+import { describe, expect, test } from "@/test";
+import type { Openrouter } from "@/types";
+import { openrouterAdapterFactory } from "./openrouter";
+
+function createResponse(
+  message: Openrouter.Types.ChatCompletionsResponse["choices"][0]["message"],
+): Openrouter.Types.ChatCompletionsResponse {
+  return {
+    id: "chatcmpl-test",
+    object: "chat.completion",
+    created: 0,
+    model: "openrouter/free-model",
+    choices: [
+      {
+        index: 0,
+        message,
+        logprobs: null,
+        finish_reason: "stop",
+      },
+    ],
+    usage: {
+      prompt_tokens: 10,
+      completion_tokens: 0,
+      total_tokens: 10,
+    },
+  };
+}
+
+function expectRetryableEmptyResponseError(error: unknown): void {
+  expect(error).toBeInstanceOf(ApiError);
+  expect((error as ApiError).statusCode).toBe(503);
+  expect((error as Error).message).toBe(
+    "OpenRouter returned an empty response without content or tool calls",
+  );
+}
+
+describe("OpenrouterResponseAdapter", () => {
+  test("rejects empty stop responses as retryable upstream failures", () => {
+    const response = createResponse({
+      role: "assistant",
+      content: null,
+      refusal: null,
+    });
+
+    let thrown: unknown;
+    try {
+      openrouterAdapterFactory.createResponseAdapter(response);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expectRetryableEmptyResponseError(thrown);
+  });
+
+  test("allows stop responses with text", () => {
+    const response = createResponse({
+      role: "assistant",
+      content: "hello",
+      refusal: null,
+    });
+
+    const adapter = openrouterAdapterFactory.createResponseAdapter(response);
+
+    expect(adapter.getText()).toBe("hello");
+  });
+});
+
+describe("OpenrouterStreamAdapter", () => {
+  test("rejects empty streamed stop responses before stream end is written", () => {
+    const adapter = openrouterAdapterFactory.createStreamAdapter();
+
+    const stopChunk: Openrouter.Types.ChatCompletionChunk = {
+      id: "chatcmpl-test",
+      object: "chat.completion.chunk",
+      created: 0,
+      model: "openrouter/free-model",
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+    };
+
+    let thrown: unknown;
+    try {
+      adapter.processChunk(stopChunk);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expectRetryableEmptyResponseError(thrown);
+  });
+
+  test("allows streamed stop responses after text", () => {
+    const adapter = openrouterAdapterFactory.createStreamAdapter();
+
+    adapter.processChunk({
+      id: "chatcmpl-test",
+      object: "chat.completion.chunk",
+      created: 0,
+      model: "openrouter/free-model",
+      choices: [{ index: 0, delta: { content: "hello" }, finish_reason: null }],
+    });
+
+    expect(() =>
+      adapter.processChunk({
+        id: "chatcmpl-test",
+        object: "chat.completion.chunk",
+        created: 0,
+        model: "openrouter/free-model",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      }),
+    ).not.toThrow();
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/openrouter.ts
+++ b/platform/backend/src/routes/proxy/adapters/openrouter.ts
@@ -4,7 +4,7 @@
  * OpenRouter exposes an OpenAI-compatible API at https://openrouter.ai/api/v1
  * and recommends attribution headers (HTTP-Referer, X-OpenRouter-Title).
  */
-import { ArchestraInternalErrorCode } from "@shared";
+import { ApiError, ArchestraInternalErrorCode } from "@shared";
 import { get } from "lodash-es";
 import OpenAIProvider from "openai";
 import type {
@@ -21,6 +21,7 @@ import type {
   LLMResponseAdapter,
   LLMStreamAdapter,
   Openrouter,
+  StreamAccumulatorState,
 } from "@/types";
 import {
   OpenAIRequestAdapter,
@@ -103,6 +104,7 @@ class OpenrouterResponseAdapter
   private delegate: OpenAIResponseAdapter;
 
   constructor(response: OpenrouterResponse) {
+    assertOpenrouterResponseHasOutput(response);
     this.delegate = new OpenAIResponseAdapter(response);
   }
 
@@ -150,7 +152,9 @@ class OpenrouterStreamAdapter
   }
 
   processChunk(chunk: OpenrouterStreamChunk) {
-    return this.delegate.processChunk(chunk);
+    const result = this.delegate.processChunk(chunk);
+    assertOpenrouterStreamChunkHasOutput(this.delegate.state, chunk);
+    return result;
   }
   getSSEHeaders() {
     return this.delegate.getSSEHeaders();
@@ -313,3 +317,52 @@ export const openrouterAdapterFactory: LLMProvider<
     return "Internal server error";
   },
 };
+
+function assertOpenrouterResponseHasOutput(response: OpenrouterResponse): void {
+  const choice = response.choices[0];
+  if (!choice || choice.finish_reason !== "stop") {
+    return;
+  }
+
+  const { message } = choice;
+  if (
+    hasText(message.content) ||
+    hasRefusal(message.refusal) ||
+    (message.tool_calls?.length ?? 0) > 0 ||
+    message.function_call
+  ) {
+    return;
+  }
+
+  throwEmptyOpenrouterResponseError();
+}
+
+function assertOpenrouterStreamChunkHasOutput(
+  state: StreamAccumulatorState,
+  chunk: OpenrouterStreamChunk,
+): void {
+  if (chunk.choices[0]?.finish_reason !== "stop") {
+    return;
+  }
+
+  if (state.text.length > 0 || state.toolCalls.length > 0) {
+    return;
+  }
+
+  throwEmptyOpenrouterResponseError();
+}
+
+function hasText(content: string | null | undefined): boolean {
+  return typeof content === "string" && content.length > 0;
+}
+
+function hasRefusal(refusal: string | null | undefined): boolean {
+  return typeof refusal === "string" && refusal.length > 0;
+}
+
+function throwEmptyOpenrouterResponseError(): never {
+  throw new ApiError(
+    503,
+    "OpenRouter returned an empty response without content or tool calls",
+  );
+}


### PR DESCRIPTION
## Summary
- reject OpenRouter stop responses that contain no text, refusal, or tool calls
- raise a 503 so upstream chat clients retry instead of silently completing
- add adapter coverage for streaming and non-streaming empty responses

## Tests
- ARCHESTRA_DATABASE_URL=postgres://test:test@localhost:5432/test pnpm --filter @backend test src/routes/proxy/adapters/openrouter.test.ts
- pnpm --filter @backend type-check
- pnpm exec biome check backend/src/routes/proxy/adapters/openrouter.ts backend/src/routes/proxy/adapters/openrouter.test.ts
- git diff --check

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>