### PR TITLE
fix(frontend): raise Next dev proxy body limit to match backend

### DIFF
--- a/platform/frontend/next.config.ts
+++ b/platform/frontend/next.config.ts
@@ -44,6 +44,12 @@ const nextConfig: NextConfig = {
   },
   experimental: {
     proxyTimeout: 300000, // 5 minutes in milliseconds - prevents SSE stream timeout
+    // Next defaults the proxy body limit to 10MB; raise it to the backend's
+    // 70MB bodyLimit so chat attachment uploads (50MB user cap + ~33% base64
+    // overhead + conversation history) aren't silently truncated. Truncation
+    // leaves the backend hung waiting for the missing tail of Content-Length,
+    // surfacing as a 5-minute "Internal Server Error".
+    proxyClientMaxBodySize: "70mb",
   },
   httpAgentOptions: {
     keepAlive: true,


### PR DESCRIPTION
## Summary

Chat attachment uploads above 10MB silently failed with "Internal Server Error" after a 5-minute hang. Next.js dev's `proxyClientMaxBodySize` defaults to 10MB and truncates bodies above that threshold while still forwarding the original `Content-Length` header to the upstream — leaving the backend waiting for the missing tail until `proxyTimeout` (300s) killed the connection. With this change, the 50MB user-facing cap on chat attachments is reachable end-to-end (50MB binary + ~33% base64 overhead + conversation history fits within the 70MB ceiling shared between Next and the backend's `bodyLimit`).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>