### PR TITLE
fix(backend): swallow transient pg errors at process level

### DIFF
--- a/platform/backend/src/database/index.ts
+++ b/platform/backend/src/database/index.ts
@@ -3,7 +3,7 @@ import { drizzle } from "drizzle-orm/node-postgres";
 import pg from "pg";
 import config from "@/config";
 import logger from "@/logging";
-import { wrapPoolWithRetry } from "./retry";
+import { installDbErrorSafetyNet, wrapPoolWithRetry } from "./retry";
 import * as schema from "./schemas";
 import {
   DATABASE_URL_VAULT_REF_ENV,
@@ -64,6 +64,7 @@ export async function initializeDatabase(): Promise<void> {
   });
 
   instrumentDrizzleClient(db, { dbSystem: "postgresql" });
+  installDbErrorSafetyNet();
   logger.info(
     { poolMax: config.database.poolMax },
     "Database connection pool initialized",

--- a/platform/backend/src/database/retry.test.ts
+++ b/platform/backend/src/database/retry.test.ts
@@ -1,7 +1,12 @@
 import { vi } from "vitest";
 import { afterEach, describe, expect, test } from "@/test";
 
-import { isTransientDbError, withDbRetry, wrapPoolWithRetry } from "./retry";
+import {
+  installDbErrorSafetyNet,
+  isTransientDbError,
+  withDbRetry,
+  wrapPoolWithRetry,
+} from "./retry";
 
 // Suppress logger output during tests
 vi.mock("@/logging", () => ({
@@ -9,6 +14,7 @@ vi.mock("@/logging", () => ({
     warn: vi.fn(),
     error: vi.fn(),
     info: vi.fn(),
+    fatal: vi.fn(),
   },
 }));
 
@@ -329,5 +335,76 @@ describe("wrapPoolWithRetry", () => {
     expect(result).toEqual({ rows: [{ id: 1 }], rowCount: 1 });
     // Should be 2 (1 initial + 1 retry), NOT 4+ from double-wrapped retries
     expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("installDbErrorSafetyNet", () => {
+  // installDbErrorSafetyNet is idempotent (module-scoped flag), so capture
+  // the handlers once via a process.on spy on the first install, then drive
+  // them directly. Tests are independent because each invokes a captured
+  // handler reference, not a live process event.
+  const processOnSpy = vi.spyOn(process, "on");
+  installDbErrorSafetyNet();
+  const uncaughtHandler = processOnSpy.mock.calls.find(
+    ([event]) => event === "uncaughtException",
+  )?.[1] as (err: unknown) => void;
+  const rejectionHandler = processOnSpy.mock.calls.find(
+    ([event]) => event === "unhandledRejection",
+  )?.[1] as (reason: unknown) => void;
+  processOnSpy.mockRestore();
+
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  function armExit(): void {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`process.exit called with ${code}`);
+    }) as never);
+  }
+
+  afterEach(() => {
+    processExitSpy?.mockRestore();
+  });
+
+  test("registers handlers for uncaughtException and unhandledRejection", () => {
+    expect(uncaughtHandler).toBeDefined();
+    expect(rejectionHandler).toBeDefined();
+  });
+
+  test("swallows transient pg errors on uncaughtException without exiting", () => {
+    armExit();
+    uncaughtHandler(new Error("Connection terminated unexpectedly"));
+    uncaughtHandler(new Error("read ECONNRESET"));
+    expect(processExitSpy).not.toHaveBeenCalled();
+  });
+
+  test("exits on non-transient uncaughtException", () => {
+    armExit();
+    expect(() => uncaughtHandler(new Error("Something unrelated"))).toThrow(
+      /process\.exit called with 1/,
+    );
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+
+  test("swallows transient pg rejections on unhandledRejection without exiting", () => {
+    armExit();
+    rejectionHandler(new Error("Connection terminated"));
+    expect(processExitSpy).not.toHaveBeenCalled();
+  });
+
+  test("exits on non-transient unhandledRejection", () => {
+    armExit();
+    expect(() => rejectionHandler(new Error("not a connection error"))).toThrow(
+      /process\.exit called with 1/,
+    );
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+
+  test("is idempotent — second call does not register new handlers", () => {
+    const spy = vi.spyOn(process, "on");
+    installDbErrorSafetyNet();
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
   });
 });

--- a/platform/backend/src/database/retry.ts
+++ b/platform/backend/src/database/retry.ts
@@ -183,3 +183,52 @@ export function wrapPoolWithRetry(pool: {
 
   (pool as Record<symbol, unknown>)[RETRY_WRAPPED] = true;
 }
+
+let dbErrorSafetyNetInstalled = false;
+
+/**
+ * Install process-level handlers that swallow transient pg connection errors
+ * instead of letting them crash the backend.
+ *
+ * pg.Pool already emits `error` for idle-client failures, and createPool()
+ * installs a listener for that. Yet in practice errors still escape — observed
+ * during a Postgres OOMKilled restart, where the `BoundPool` emitted an
+ * `error` event that surfaced as an uncaught exception, terminating the
+ * Node process with exit code 1.
+ *
+ * This safety net inspects every `uncaughtException` / `unhandledRejection`
+ * via {@link isTransientDbError}. Transient pg/socket errors are logged and
+ * swallowed — the next pool.query() reconnects naturally. All other errors
+ * fall through to the default behavior (log + exit) so we never mask real
+ * bugs.
+ *
+ * Idempotent — multiple calls are no-ops.
+ */
+export function installDbErrorSafetyNet(): void {
+  if (dbErrorSafetyNetInstalled) return;
+  dbErrorSafetyNetInstalled = true;
+
+  process.on("uncaughtException", (err) => {
+    if (isTransientDbError(err)) {
+      logger.error(
+        { err },
+        "Swallowed transient DB error at process level; pool will reconnect",
+      );
+      return;
+    }
+    logger.fatal({ err }, "Uncaught exception, exiting");
+    process.exit(1);
+  });
+
+  process.on("unhandledRejection", (reason) => {
+    if (isTransientDbError(reason)) {
+      logger.error(
+        { err: reason },
+        "Swallowed transient DB rejection at process level; pool will reconnect",
+      );
+      return;
+    }
+    logger.fatal({ err: reason }, "Unhandled promise rejection, exiting");
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

A Postgres OOMKilled restart in dev terminated the backend Node process with exit code 1 — a pg `BoundPool` emitted an `error` event that escaped the pool's idle-client listener and surfaced as `Unhandled 'error' event`. pg-pool would have reconnected on its own; the process didn't survive to give it the chance. This installs `uncaughtException` / `unhandledRejection` handlers that route errors through the existing `isTransientDbError` matcher: known connection-level errors (ECONNRESET, ECONNREFUSED, EPIPE, ETIMEDOUT, "Connection terminated", pg SQLSTATE 08xxx/57Pxx) are logged and swallowed; everything else falls through to log-fatal-and-exit so real bugs aren't masked.

Wired into `initializeDatabase()` so it loads with the pool. Idempotent.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>