### PR TITLE
fix(frontend): raise proxy body limit headroom to 200MB

### DIFF
--- a/platform/frontend/next.config.ts
+++ b/platform/frontend/next.config.ts
@@ -44,12 +44,14 @@ const nextConfig: NextConfig = {
   },
   experimental: {
     proxyTimeout: 300000, // 5 minutes in milliseconds - prevents SSE stream timeout
-    // Next defaults the proxy body limit to 10MB; raise it to the backend's
-    // 70MB bodyLimit so chat attachment uploads (50MB user cap + ~33% base64
-    // overhead + conversation history) aren't silently truncated. Truncation
-    // leaves the backend hung waiting for the missing tail of Content-Length,
-    // surfacing as a 5-minute "Internal Server Error".
-    proxyClientMaxBodySize: "70mb",
+    // Next defaults the proxy body limit to 10MB; raise it well above the
+    // backend's 70MB default so an operator who increases ARCHESTRA_API_BODY_LIMIT
+    // at runtime doesn't also have to rebuild the FE image. (next.config.ts is
+    // evaluated at build time in `output: "standalone"` mode, so this value is
+    // baked into the image — making it env-driven would silently drift from
+    // the backend's runtime value.) Anything the proxy lets through still gets
+    // sized-checked by the backend's bodyLimit, which is the authoritative cap.
+    proxyClientMaxBodySize: "200mb",
   },
   httpAgentOptions: {
     keepAlive: true,


### PR DESCRIPTION
## Summary

`output: "standalone"` bakes `next.config.ts` evaluation into the build, so `proxyClientMaxBodySize` can't be driven by a runtime env var without silently drifting from the backend's `ARCHESTRA_API_BODY_LIMIT`. Pinning the FE at the backend's 70MB default forced anyone raising the backend limit at runtime to also rebuild the FE image. Raise the FE proxy ceiling to 200MB so operators can lift `ARCHESTRA_API_BODY_LIMIT` up to that value on a running deployment without an FE rebuild — the backend's `bodyLimit` remains the authoritative cap (uploads above it return a clean 413).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>