### PR TITLE
fix(e2e): make static-credentials Admin revoke deterministic

### DIFF
--- a/platform/e2e-tests/tests/static-credentials-management.spec.ts
+++ b/platform/e2e-tests/tests/static-credentials-management.spec.ts
@@ -3,6 +3,7 @@ import { archestraApiSdk } from "@shared";
 import {
   ADMIN_EMAIL,
   DEFAULT_TEAM_NAME,
+  E2eTestId,
   EDITOR_EMAIL,
   ENGINEERING_TEAM_NAME,
   MARKETING_TEAM_NAME,
@@ -13,7 +14,6 @@ import {
   addCustomSelfHostedCatalogItem,
   addSharedLocalConnection,
   assignCatalogCredentialToGateway,
-  clickButton,
   closeOpenDialogs,
   createSharedTestGatewayViaApi,
   createTeamMcpGatewayViaApi,
@@ -193,19 +193,28 @@ test.describe("Custom Self-hosted MCP Server - installation and static credentia
         await expect(visibleStaticCredentials).toHaveLength(
           expectedAssignableCredentials.length,
         );
+        // Force the click: the credential option list re-renders when the
+        // dropdown opens, detaching the node mid-click. Same DOM-detach race
+        // assignCatalogCredentialToGateway already handles this way.
         await page
           .getByRole("option", {
             name: expectedAssignableCredentials[0] ?? "",
           })
-          .click();
+          .click({ force: true });
         await page.keyboard.press("Escape");
         await page.waitForTimeout(200);
         await saveOpenProfileDialog(page);
 
-        // Then we revoke first credential in Manage Credentials dialog, then close dialog
+        // Revoke the admin's own (personal) credential, then close dialog.
+        // Target it by its deterministic test-id rather than the first Revoke
+        // button: the row order isn't guaranteed, so a position-based click
+        // can revoke the team credential instead, leaving ADMIN_EMAIL present
+        // and failing the assertion below.
         await goToPage(page, "/mcp/registry");
         await openManageCredentialsDialog(page, catalogItemName);
-        await clickButton({ page, options: { name: "Revoke" }, first: true });
+        await page
+          .getByTestId(`${E2eTestId.RevokeCredentialButton}-personal`)
+          .click();
         await page.waitForLoadState("domcontentloaded");
         await closeOpenDialogs(page);
 


### PR DESCRIPTION
## Summary

The Admin variant of `static-credentials-management.spec.ts` was the top merge-queue blocker after the auth-corruption fix (#5067) landed. It flaked with two alternating failure modes, both rooted in position-based assumptions about a dynamically-ordered, re-rendering credentials list:

- **Credential-assignment click** used a plain `.click()` on a Radix Select option. When the option list re-renders as the dropdown opens, the node detaches mid-click and Playwright times out with `element is not stable / element was detached from the DOM`. The sibling helper `assignCatalogCredentialToGateway` already handles the identical race with `.click({ force: true })`; this matches that established pattern.
- **Revoke step** clicked the *first* Revoke button and assumed it belonged to the admin's own credential. Row order isn't guaranteed, so it could revoke the team credential instead — leaving `ADMIN_EMAIL` in the list and failing the downstream "revoked credential is gone" assertion (`Received array: ["admin@example.com", "Default Team"]`). It now targets the admin's own credential by its deterministic test-id `revoke-credential-button-personal`.

The flake was masked until recently: the auth-corruption 401 (fixed in #5067) killed the test before it reached these steps. With that gone, the test's own latent ordering fragility surfaced as the next layer.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>