### PR TITLE
deps: `starlette==1.0.0` BadHost CVE-2026-48710

### DIFF
--- a/platform/mcp_server_docker_image/pyproject.toml
+++ b/platform/mcp_server_docker_image/pyproject.toml
@@ -6,6 +6,8 @@ dependencies = [
   "mcp[cli]>=1.2.0",
   "httpx",
   "fastapi",
+  # starlette <= 1.0.0: CVE-2026-48710 (BadHost host-header path confusion)
+  "starlette>=1.0.1",
   "uvicorn",
   "requests>=2.31.0",
   "python-dotenv>=1.0.0",

--- a/platform/mcp_server_docker_image/requirements.lock
+++ b/platform/mcp_server_docker_image/requirements.lock
@@ -656,10 +656,11 @@ sse-starlette==3.3.3 \
     --hash=sha256:72a95d7575fd5129bd0ae15275ac6432bb35ac542fdebb82889c24bb9f3f4049 \
     --hash=sha256:c5abb5082a1cc1c6294d89c5290c46b5f67808cfdb612b7ec27e8ba061c22e8d
     # via mcp
-starlette==1.0.0 \
-    --hash=sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149 \
-    --hash=sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b
+starlette==1.1.0 \
+    --hash=sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382 \
+    --hash=sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f
     # via
+    #   archestra-mcp-server-python-deps (pyproject.toml)
     #   fastapi
     #   mcp
     #   sse-starlette


### PR DESCRIPTION
## Summary
- Add an explicit `starlette>=1.0.1` constraint for the MCP server base image Python dependencies
- Regenerate `requirements.lock`, which now pins `starlette==1.1.0`

## Why
`starlette<=1.0.0` is affected by CVE-2026-48710 / BadHost. The MCP server base image lockfile previously pinned `starlette==1.0.0`.