### PR TITLE
fix(e2e): wait for backend deletion before asserting revoke in static-credentials

### DIFF
--- a/platform/e2e-tests/tests/static-credentials-management.spec.ts
+++ b/platform/e2e-tests/tests/static-credentials-management.spec.ts
@@ -26,6 +26,7 @@ import {
   saveOpenProfileDialog,
   settleRegistryAfterInstall,
   verifyToolCallResultViaApi,
+  waitForMcpServerAbsent,
   waitForMcpServerReadyById,
   waitForMcpServerToolsDiscovered,
 } from "../utils";
@@ -210,6 +211,16 @@ test.describe("Custom Self-hosted MCP Server - installation and static credentia
         // button: the row order isn't guaranteed, so a position-based click
         // can revoke the team credential instead, leaving ADMIN_EMAIL present
         // and failing the assertion below.
+        const personalServerId = visibleServersResponse.data?.find(
+          (server) =>
+            server.catalogId === newCatalogItem.id &&
+            !server.teamDetails &&
+            server.ownerEmail === ADMIN_EMAIL,
+        )?.id;
+        expect(
+          personalServerId,
+          "Could not resolve the admin's personal MCP server id to revoke",
+        ).toBeTruthy();
         await goToPage(page, "/mcp/registry");
         await openManageCredentialsDialog(page, catalogItemName);
         await page
@@ -218,8 +229,18 @@ test.describe("Custom Self-hosted MCP Server - installation and static credentia
         await page.waitForLoadState("domcontentloaded");
         await closeOpenDialogs(page);
 
-        // And we check that the credential is revoked
-        // Use polling to handle async credential revocation in CI
+        // Revoking deletes the backing MCP server via async K8s pod teardown,
+        // which keeps the server in getMcpServers (and the dialog) until
+        // teardown completes. Wait for the backend to actually drop it (404)
+        // before asserting the UI, so the assertion isn't racing teardown
+        // latency under CI load — the cause of the prior flake.
+        if (personalServerId) {
+          await waitForMcpServerAbsent(page, personalServerId);
+        }
+
+        // And we check the dialog reflects the revoke. The backend already
+        // confirmed deletion above, so this only waits on the UI refetch —
+        // not on K8s teardown.
         const expectedCredentialsAfterRevoke = {
           Admin: [ADMIN_EMAIL, DEFAULT_TEAM_NAME],
           Editor: [EDITOR_EMAIL, ENGINEERING_TEAM_NAME],
@@ -241,7 +262,7 @@ test.describe("Custom Self-hosted MCP Server - installation and static credentia
               remainingCredential,
             );
           }
-        }).toPass({ timeout: 30_000, intervals: [1000, 2000, 3000, 5000] });
+        }).toPass({ timeout: 15_000, intervals: [1000, 2000, 3000, 5000] });
       }
       // Cleanup admin shared gateway
       if (adminSharedGateway) {

--- a/platform/e2e-tests/utils/mcp-registry.ts
+++ b/platform/e2e-tests/utils/mcp-registry.ts
@@ -132,6 +132,35 @@ export async function waitForMcpServerReadyById(
   );
 }
 
+export async function waitForMcpServerAbsent(
+  page: Page,
+  mcpServerId: string,
+  options?: { timeoutMs?: number },
+): Promise<void> {
+  const timeoutMs = options?.timeoutMs ?? 60_000;
+  const start = Date.now();
+  let delay = 500;
+  let lastStatus: number | null = null;
+  while (Date.now() - start < timeoutMs) {
+    const response = await page.request.get(
+      `${UI_BASE_URL}/api/mcp_server/${mcpServerId}`,
+      { headers: { Origin: UI_BASE_URL } },
+    );
+    lastStatus = response.status();
+    // Revoking a credential deletes its MCP server via async K8s pod
+    // teardown; the row (and thus a 200) persists until teardown finishes.
+    // A 404 is the authoritative "actually gone" signal.
+    if (lastStatus === 404) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    delay = Math.min(delay * 1.5, 5000);
+  }
+  throw new Error(
+    `MCP server ${mcpServerId} was not deleted (never returned 404) within ${timeoutMs}ms (last status: ${lastStatus ?? "n/a"})`,
+  );
+}
+
 export async function waitForMcpServerToolsDiscovered(
   page: Page,
   catalogItemName?: string,


### PR DESCRIPTION
## Summary

Builds on #5090. That PR made the static-credentials Admin revoke deterministic (force-click + revoke-by-test-id), but the test stayed *flaky* — it polled the Manage Credentials dialog for 30s expecting the revoked credential to disappear, and that poll raced the async work a revoke triggers.

Revoking a credential deletes its backing MCP server, which is an **async K8s pod teardown**. `getMcpServers` (and therefore the dialog) keep returning the server until teardown completes; under CI load that exceeds the 30s UI poll window, then the test-level retry passes — so it surfaced as flaky (`["admin@example.com","Default Team"]` still present on the initial attempt) rather than a hard failure.

The test now captures the admin's personal MCP server id before revoking, then waits on the authoritative backend signal — `GET /api/mcp_server/:id` returning `404` (new `waitForMcpServerAbsent` helper, mirroring the existing `waitForMcpServerReadyById`) — before asserting the dialog. The UI assertion is preserved (it still verifies the dialog refetches and drops the row) but is now decoupled from teardown latency, so its timeout drops to 15s.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>