### PR TITLE
docs(schemas): codify conversation_ vs chat_ prefix guidance

### DIFF
--- a/platform/backend/src/database/schemas/index.ts
+++ b/platform/backend/src/database/schemas/index.ts
@@ -27,6 +27,16 @@
  *      virtual_api_key_provider_api_key, virtual_api_key_team
  *
  * New tables must be plural. Tables not listed in (1) or (2) must be plural.
+ *
+ * Prefix guidance (judgment-based, not lint-enforced): a table scoped to a
+ * single conversation should use the `conversation_` prefix so it sits with
+ * its siblings (`conversation_compactions`, `conversation_enabled_tools`,
+ * `conversation_shares`, `conversation_attachments`). Reserve `chat_` for
+ * feature/runtime concerns, not durable conversation children. A
+ * `conversation_id` column is a strong signal but not a law — two standing
+ * exceptions carry `conversation_id` without the prefix:
+ *   - messages — a top-level entity named for itself, not a conversation child
+ *   - chat_active_runs — ephemeral run state predating this guidance
  */
 export { default as a2aContextsTable } from "./a2a-context";
 export { default as a2aMessagesTable } from "./a2a-message";


### PR DESCRIPTION
## Summary

The table-naming policy in `schemas/index.ts` documents plural snake_case but says nothing about the `conversation_` vs `chat_` prefix — which is how `chat_attachments` ended up mis-prefixed (it's a durable child of a conversation and belongs in the `conversation_*` family, fixed in a separate rename). This adds a judgment-based guideline next to the plural rule: a table scoped to a single conversation uses the `conversation_` prefix; `chat_` is reserved for feature/runtime concerns. It notes that a `conversation_id` column is a strong signal but not a hard rule, and documents the two standing exceptions that carry `conversation_id` without the prefix — `messages` (a top-level entity named for itself) and `chat_active_runs` (ephemeral run state) — so a contributor adding a new table doesn't infer the wrong rule from them.

Comment-only; no code or schema changes.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>