### PR TITLE
chore(auth): temporary startup log for rate-limit-disable flag

### DIFF
--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -408,6 +408,21 @@ export const auth = betterAuth({
   },
 });
 
+// TEMPORARY DIAGNOSTIC — remove once the setup-teams 429 flake is resolved.
+// The e2e env sets ARCHESTRA_AUTH_RATE_LIMIT_DISABLED=true and the chart
+// renders it into the pod, yet better-auth's limiter still 429s sign-in under
+// CI parallelism. Log the runtime-effective flag so a CI pod log reveals
+// whether the disable actually takes effect at construction time, instead of
+// us deducing it from source. (better-auth derives rateLimit.enabled directly
+// from this, so the parsed flag is the decisive value.)
+logger.info(
+  {
+    rawEnv: process.env.ARCHESTRA_AUTH_RATE_LIMIT_DISABLED ?? null,
+    authRateLimitDisabled: config.authRateLimitDisabled,
+  },
+  "[auth-diagnostic] startup rate-limit config",
+);
+
 function getBetterAuthLogLevel(
   logLevel: string,
 ): "debug" | "info" | "warn" | "error" | undefined {


### PR DESCRIPTION
## Summary

Diagnostic-only, temporary. The e2e environment sets `ARCHESTRA_AUTH_RATE_LIMIT_DISABLED=true`, the helm chart renders it into the backend pod (verified via `helm template` at the failing commit), and reading better-auth's source top to bottom — `config.ts` parse → `better-auth.ts` spread → `create-context` `enabled = options.rateLimit?.enabled ?? isProduction` → `rate-limiter` `if (!ctx.rateLimit.enabled) return` — every link says the limiter is disabled. Yet better-auth's limiter still 429s `/api/auth/sign-in/email` under CI parallelism, which is the recurring `setup-teams` flake (the sign-in retries exhaust against 429s and the setup fails, then recovers on retry).

That's a contradiction static analysis can't resolve without observing the pod's runtime config. This adds a single `info`-level startup log of the parsed flag (`config.authRateLimitDisabled`) and the raw env value, so one CI run's backend startup log shows definitively whether the disable takes effect at construction time:

- `authRateLimitDisabled: true` → flag is effective, so the 429 originates somewhere the source reading doesn't cover, and the investigation redirects there.
- `authRateLimitDisabled: false` (or `rawEnv` not `"true"`) → the flag isn't landing at runtime; root cause confirmed and the real fix follows.

It logs only booleans / the flag string — no secrets. To be removed once the `setup-teams` 429 is resolved.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>