### PR TITLE
chore(ci): surface auth rate-limit diagnostic in e2e job

### DIFF
--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -221,6 +221,23 @@ jobs:
           platform-context: ./platform
           mcp-server-base-image-tag: ${{ steps.load-mcp-server-base-image.outputs.image-tag }}
 
+      # TEMPORARY — remove with the [auth-diagnostic] startup log once the
+      # setup-teams 429 flake is resolved. Surfaces the runtime auth
+      # rate-limit config: the [auth-diagnostic] startup log only reaches the
+      # failure/flaky dump via --tail=200, which misses startup, so read it
+      # directly here on every run.
+      - name: Diagnose auth rate-limit config (temporary)
+        run: |
+          POD=$(kubectl get pod -l app.kubernetes.io/name=archestra-platform \
+            -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+          echo "=== ARCHESTRA_AUTH_RATE_LIMIT_DISABLED in pod env ==="
+          kubectl exec "$POD" -c archestra-platform -- \
+            printenv ARCHESTRA_AUTH_RATE_LIMIT_DISABLED || echo "(printenv failed / not set)"
+          echo "=== [auth-diagnostic] startup log (full backend log) ==="
+          kubectl logs -l app.kubernetes.io/name=archestra-platform \
+            -c archestra-platform 2>/dev/null | grep -i 'auth-diagnostic' \
+            || echo "(no [auth-diagnostic] line found)"
+
       - name: Run all non-quickstart E2E tests
         id: e2e
         continue-on-error: true


### PR DESCRIPTION
## Summary

Companion to the merged `[auth-diagnostic]` startup log (#5098). That log is emitted to the backend pod's stdout on every boot, but it never reaches CI: the e2e job only retrieves backend logs in its failure/flaky dump, and that dump uses `--tail=200` — which shows end-of-run activity, never a startup-time line. So the value is produced but not captured, and a clean run dumps nothing at all.

This adds a temporary diagnostic step right after the platform deploy in the main e2e job that reads the value **directly on every run**, independent of flaky/failure and log-tail:

- `kubectl exec` the backend pod and `printenv ARCHESTRA_AUTH_RATE_LIMIT_DISABLED` — whether the flag is literally in the running pod's env.
- `kubectl logs` the **full** backend log (no `--tail`) and `grep` for the `[auth-diagnostic]` line — what `config.authRateLimitDisabled` actually parsed to.

Together these resolve the contradiction (flag wired into the pod per `helm template`, yet better-auth's limiter 429s sign-in) by replacing source-deduction with an observed runtime value. Every command is guarded (`|| echo` / `|| true`), so the step cannot fail the job. To be removed together with the startup log once the `setup-teams` 429 is resolved.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>