### PR TITLE
fix(mcp-registry): gate catalog "Use as Template" on mcpRegistry:create

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/archestra-catalog-tab.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/archestra-catalog-tab.tsx
@@ -65,7 +65,7 @@ export function ArchestraCatalogTab({
   const { data: availableCategories = [] } = useMcpServerCategories();
 
   const { data: userIsMcpServerAdmin = false } = useHasPermissions({
-    mcpServerInstallation: ["admin"],
+    mcpRegistry: ["create"],
   });
 
   // Use server-side search and category filtering

--- a/platform/frontend/src/app/mcp/registry/_parts/archestra-catalog-tab.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/archestra-catalog-tab.tsx
@@ -64,10 +64,6 @@ export function ArchestraCatalogTab({
   // Fetch available categories
   const { data: availableCategories = [] } = useMcpServerCategories();
 
-  const { data: userIsMcpServerAdmin = false } = useHasPermissions({
-    mcpServerInstallation: ["admin"],
-  });
-
   const { data: userAllowedToCreateCatalogItem = false } = useHasPermissions({
     mcpRegistry: ["create"],
   });
@@ -235,7 +231,6 @@ export function ArchestraCatalogTab({
                     onRequestInstallation={handleRequestInstallation}
                     onOpenReadme={setReadmeServer}
                     isInCatalog={catalogServerNames.has(server.name)}
-                    userIsMcpServerAdmin={userIsMcpServerAdmin}
                     userAllowedToCreateCatalogItem={
                       userAllowedToCreateCatalogItem
                     }
@@ -287,7 +282,6 @@ function ServerCard({
   onRequestInstallation,
   onOpenReadme,
   isInCatalog,
-  userIsMcpServerAdmin,
   userAllowedToCreateCatalogItem,
 }: {
   server: archestraCatalogTypes.ArchestraMcpServerManifest;
@@ -301,7 +295,6 @@ function ServerCard({
     server: archestraCatalogTypes.ArchestraMcpServerManifest,
   ) => void;
   isInCatalog: boolean;
-  userIsMcpServerAdmin: boolean;
   userAllowedToCreateCatalogItem: boolean;
 }) {
   return (

--- a/platform/frontend/src/app/mcp/registry/_parts/archestra-catalog-tab.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/archestra-catalog-tab.tsx
@@ -65,6 +65,10 @@ export function ArchestraCatalogTab({
   const { data: availableCategories = [] } = useMcpServerCategories();
 
   const { data: userIsMcpServerAdmin = false } = useHasPermissions({
+    mcpServerInstallation: ["admin"],
+  });
+
+  const { data: userAllowedToCreateCatalogItem = false } = useHasPermissions({
     mcpRegistry: ["create"],
   });
 
@@ -232,6 +236,9 @@ export function ArchestraCatalogTab({
                     onOpenReadme={setReadmeServer}
                     isInCatalog={catalogServerNames.has(server.name)}
                     userIsMcpServerAdmin={userIsMcpServerAdmin}
+                    userAllowedToCreateCatalogItem={
+                      userAllowedToCreateCatalogItem
+                    }
                   />
                 ))}
               </div>
@@ -281,6 +288,7 @@ function ServerCard({
   onOpenReadme,
   isInCatalog,
   userIsMcpServerAdmin,
+  userAllowedToCreateCatalogItem,
 }: {
   server: archestraCatalogTypes.ArchestraMcpServerManifest;
   onSelectServer: (
@@ -294,6 +302,7 @@ function ServerCard({
   ) => void;
   isInCatalog: boolean;
   userIsMcpServerAdmin: boolean;
+  userAllowedToCreateCatalogItem: boolean;
 }) {
   return (
     <Card className="flex flex-col">
@@ -382,7 +391,7 @@ function ServerCard({
           </div>
           <Button
             onClick={() =>
-              userIsMcpServerAdmin
+              userAllowedToCreateCatalogItem
                 ? onSelectServer(server)
                 : onRequestInstallation(server)
             }
@@ -393,7 +402,7 @@ function ServerCard({
           >
             {isInCatalog
               ? "Added"
-              : userIsMcpServerAdmin
+              : userAllowedToCreateCatalogItem
                 ? "Use as Template"
                 : "Request to add to internal registry"}
           </Button>


### PR DESCRIPTION
## Summary

- The catalog tab branched between **"Use as Template"** (direct create) and **"Request to add to internal registry"** using `mcpServerInstallation:["admin"]`.
- The direct path actually submits to `CreateInternalMcpCatalogItem`, which the access-control map gates on `mcpRegistry:["create"]` (`platform/shared/access-control.ts:516-517`).
- The previous gate was overly restrictive: predefined `editor` holds `mcpRegistry: ["read", "create", "update", "delete"]` (`access-control.ts:103`) but lacks `mcpServerInstallation:admin`, so the catalog tab forced them into the request workflow even though they were already authorized to call `POST /api/internal_mcp_catalog` directly.
- This PR aligns the UI gate with the route gate by switching the permission check in `archestra-catalog-tab.tsx` from `mcpServerInstallation:["admin"]` to `mcpRegistry:["create"]`. The variable name is left as-is to keep the diff to one line.

### Behavior after fix

| Role | Sees in catalog tab |
| --- | --- |
| Predefined `admin` (has `mcpRegistry:create`) | "Use as Template" — unchanged |
| Predefined `editor` (has `mcpRegistry:create`) | "Use as Template" — **changed**, matches their actual authorization |
| Predefined `member` (only `mcpRegistry:read`) | "Request to add to internal registry" — unchanged |
---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>