### PR TITLE
fix: maintenance mode startup and file previews

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -82989,7 +82989,10 @@
                       "type": "string"
                     },
                     "status": {
-                      "type": "string"
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
                     },
                     "version": {
                       "type": "string"
@@ -83025,13 +83028,21 @@
                       "type": "string"
                     },
                     "status": {
-                      "type": "string"
+                      "type": "string",
+                      "enum": [
+                        "ok",
+                        "maintenance"
+                      ]
                     },
                     "version": {
                       "type": "string"
                     },
                     "database": {
-                      "type": "string"
+                      "type": "string",
+                      "enum": [
+                        "connected",
+                        "not_checked"
+                      ]
                     }
                   },
                   "required": [
@@ -83056,13 +83067,19 @@
                       "type": "string"
                     },
                     "status": {
-                      "type": "string"
+                      "type": "string",
+                      "enum": [
+                        "degraded"
+                      ]
                     },
                     "version": {
                       "type": "string"
                     },
                     "database": {
-                      "type": "string"
+                      "type": "string",
+                      "enum": [
+                        "disconnected"
+                      ]
                     }
                   },
                   "required": [

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -1327,7 +1327,6 @@ Uploaded [Knowledge Files](/docs/platform-knowledge-bases#files) store file byte
 - **`ARCHESTRA_MAINTENANCE_MODE_MESSAGE`** - Enables maintenance mode and displays a custom message to all users blocking access to the platform.
   - Default: Not set (maintenance mode disabled)
   - When set, all users are shown a full-screen maintenance overlay with the message instead of the normal application interface.
-  - Example: `ARCHESTRA_MAINTENANCE_MODE_MESSAGE="We are performing scheduled maintenance. Please check back in 30 minutes."`
 
 ### Enterprise Licensing
 

--- a/platform/.dockerignore
+++ b/platform/.dockerignore
@@ -5,7 +5,12 @@ node_modules
 # Build outputs
 dist
 .next
+**/.next
+**/.next-pw
 .turbo
+**/.turbo
+**/playwright-report
+**/tsconfig.tsbuildinfo
 
 # Development
 .tilt

--- a/platform/backend/src/routes/config.ts
+++ b/platform/backend/src/routes/config.ts
@@ -14,7 +14,7 @@ import { getByosVaultKvVersion, isByosEnabled } from "@/secrets-manager";
 import { EmailProviderTypeSchema, type GlobalToolPolicy } from "@/types";
 import { PUBLIC_CONFIG_PATH } from "./route-paths";
 
-const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
+export const publicConfigRoutes: FastifyPluginAsyncZod = async (fastify) => {
   fastify.get(
     PUBLIC_CONFIG_PATH,
     {
@@ -23,30 +23,18 @@ const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
         description: "Get public config",
         tags: ["Config"],
         response: {
-          200: z.strictObject({
-            disableBasicAuth: z.boolean(),
-            disableInvitations: z.boolean(),
-            maintenanceMode: z.string().nullable(),
-            analytics: z.strictObject({
-              enabled: z.boolean(),
-              posthog: z.strictObject({
-                key: z.string(),
-                host: z.string(),
-              }),
-            }),
-          }),
+          200: PublicConfigResponseSchema,
         },
       },
     },
     async (_request, reply) => {
-      return reply.send({
-        disableBasicAuth: config.auth.disableBasicAuth,
-        disableInvitations: config.auth.disableInvitations,
-        maintenanceMode: config.maintenanceMode,
-        analytics: config.analytics,
-      });
+      return reply.send(getPublicConfigResponse());
     },
   );
+};
+
+const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  await fastify.register(publicConfigRoutes);
 
   fastify.get(
     "/api/config",
@@ -156,6 +144,28 @@ const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
 };
 
 export default configRoutes;
+
+const PublicConfigResponseSchema = z.strictObject({
+  disableBasicAuth: z.boolean(),
+  disableInvitations: z.boolean(),
+  maintenanceMode: z.string().nullable(),
+  analytics: z.strictObject({
+    enabled: z.boolean(),
+    posthog: z.strictObject({
+      key: z.string(),
+      host: z.string(),
+    }),
+  }),
+});
+
+function getPublicConfigResponse(): z.infer<typeof PublicConfigResponseSchema> {
+  return {
+    disableBasicAuth: config.auth.disableBasicAuth,
+    disableInvitations: config.auth.disableInvitations,
+    maintenanceMode: config.maintenanceMode,
+    analytics: config.analytics,
+  };
+}
 
 /**
  * Get the ngrok domain from env var or from the file written by the

--- a/platform/backend/src/routes/health.ts
+++ b/platform/backend/src/routes/health.ts
@@ -18,7 +18,7 @@ const healthRoutes: FastifyPluginAsyncZod = async (fastify) => {
         response: {
           200: z.object({
             name: z.string(),
-            status: z.string(),
+            status: z.literal("ok"),
             version: z.string(),
           }),
         },
@@ -26,7 +26,7 @@ const healthRoutes: FastifyPluginAsyncZod = async (fastify) => {
     },
     async () => ({
       name,
-      status: "ok",
+      status: "ok" as const,
       version,
     }),
   );
@@ -43,35 +43,49 @@ const healthRoutes: FastifyPluginAsyncZod = async (fastify) => {
         response: {
           200: z.object({
             name: z.string(),
-            status: z.string(),
+            status: z.enum(["ok", "maintenance"]),
             version: z.string(),
-            database: z.string(),
+            database: z.enum(["connected", "not_checked"]),
           }),
           503: z.object({
             name: z.string(),
-            status: z.string(),
+            status: z.literal("degraded"),
             version: z.string(),
-            database: z.string(),
+            database: z.literal("disconnected"),
           }),
         },
       },
     },
     async (request, reply) => {
-      const dbHealthy = await isDatabaseHealthy();
+      // Maintenance mode must stay available while the database is offline or
+      // being upgraded, so readiness intentionally skips the DB probe here.
+      if (config.maintenanceMode) {
+        return reply.send({
+          name,
+          status: "maintenance",
+          version,
+          database: "not_checked",
+        });
+      }
 
-      const response = {
-        name,
-        status: dbHealthy ? "ok" : "degraded",
-        version,
-        database: dbHealthy ? "connected" : "disconnected",
-      };
+      const dbHealthy = await isDatabaseHealthy();
 
       if (!dbHealthy) {
         request.log.warn("Database health check failed for readiness probe");
-        return reply.status(503).send(response);
+        return reply.status(503).send({
+          name,
+          status: "degraded",
+          version,
+          database: "disconnected",
+        });
       }
 
-      return reply.send(response);
+      return reply.send({
+        name,
+        status: "ok",
+        version,
+        database: "connected",
+      });
     },
   );
 };

--- a/platform/backend/src/routes/knowledge-base.ts
+++ b/platform/backend/src/routes/knowledge-base.ts
@@ -1449,7 +1449,7 @@ const knowledgeBaseRoutes: FastifyPluginAsyncZod = async (fastify) => {
         "Content-Type": safeMime,
         "Content-Disposition": `${disposition}; filename="${encodeURIComponent(file.originalName)}"`,
         "X-Content-Type-Options": "nosniff",
-        "Content-Security-Policy": "default-src 'none'; sandbox",
+        "Content-Security-Policy": "default-src 'none'; frame-ancestors 'self'",
         "Cache-Control": "private, max-age=3600",
         "Content-Length": String(data.byteLength),
       });

--- a/platform/backend/src/routes/knowledge-files.test.ts
+++ b/platform/backend/src/routes/knowledge-files.test.ts
@@ -153,6 +153,9 @@ describe("knowledge file routes", () => {
     expect(preview.body).toBe("Preview content");
     expect(preview.headers["content-type"]).toContain("text/plain");
     expect(preview.headers["content-disposition"]).toContain("inline");
+    expect(preview.headers["content-security-policy"]).toBe(
+      "default-src 'none'; frame-ancestors 'self'",
+    );
 
     const download = await app.inject({
       method: "GET",

--- a/platform/backend/src/server.test.ts
+++ b/platform/backend/src/server.test.ts
@@ -24,6 +24,7 @@ vi.mock("@sentry/node", async (importOriginal) => {
   };
 });
 
+import config from "@/config";
 // Import after mock setup
 import { isDatabaseHealthy } from "@/database";
 import healthRoutes from "@/routes/health";
@@ -797,6 +798,31 @@ describe("health endpoints", () => {
       const body = response.json();
       expect(body.status).toBe("degraded");
       expect(body.database).toBe("disconnected");
+    });
+
+    test("returns 200 without checking the database in maintenance mode", async () => {
+      const originalMaintenanceMode = config.maintenanceMode;
+      config.maintenanceMode = "Scheduled maintenance";
+      mockIsDatabaseHealthy.mockClear();
+
+      try {
+        const app = createFastifyInstance();
+        await app.register(healthRoutes);
+
+        const response = await app.inject({
+          method: "GET",
+          url: "/ready",
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.json()).toMatchObject({
+          status: "maintenance",
+          database: "not_checked",
+        });
+        expect(mockIsDatabaseHealthy).not.toHaveBeenCalled();
+      } finally {
+        config.maintenanceMode = originalMaintenanceMode;
+      }
     });
   });
 });

--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -87,6 +87,7 @@ import {
 } from "@/types";
 import websocketService from "@/websocket";
 import * as routes from "./routes";
+import { publicConfigRoutes } from "./routes/config";
 import {
   HEALTH_PATH,
   MCP_GATEWAY_PREFIX,
@@ -826,6 +827,14 @@ const startWebServer = async () => {
     Sentry.setupFastifyErrorHandler(fastify);
   }
 
+  if (config.maintenanceMode) {
+    await registerMaintenanceModeRoutes(fastify);
+    await fastify.listen({ port, host });
+    fastify.log.info(`${name} started in maintenance mode on port ${port}`);
+    registerWebServerShutdown(fastify);
+    return;
+  }
+
   /**
    * The auth plugin is responsible for authentication and authorization checks
    *
@@ -997,93 +1006,110 @@ const startWebServer = async () => {
     websocketService.start(fastify.server);
     fastify.log.info("WebSocket service started");
 
-    // Graceful shutdown handling
-    const gracefulShutdown = async (signal: string) => {
-      fastify.log.info(`Received ${signal}, shutting down gracefully...`);
-
-      try {
-        // PRIORITY: Close servers FIRST to release ports immediately
-        // This prevents EADDRINUSE errors during hot-reload when the new server starts
-        // before cleanup operations complete
-
-        // Close metrics server (releases port 9050)
-        if (metricsServerInstance) {
-          await metricsServerInstance.close();
-          fastify.log.info("Metrics server closed");
-        }
-
-        // Close main server (releases port 9000)
-        await fastify.close();
-        fastify.log.info("Main server closed");
-
-        // Close WebSocket server
-        websocketService.stop();
-
-        // Clear email subscription renewal interval
-        clearInterval(emailRenewalIntervalId);
-        clearInterval(processedEmailCleanupIntervalId);
-        fastify.log.info("Email background job intervals cleared");
-
-        // Stop cache manager's background cleanup
-        cacheManager.shutdown();
-
-        // Stop accepting new code-runtime runs
-        await codeRuntimeService.shutdown();
-
-        // Stop task queue worker (waits for in-flight tasks to drain)
-        if (shouldRunWorker) {
-          await taskQueueService.stopWorker();
-        }
-
-        // Track which cleanup operations have completed
-        const completedCleanups = new Set<"emailProvider" | "chatOps">();
-
-        // Run remaining cleanup in parallel with a timeout to avoid blocking shutdown
-        const cleanupPromise = Promise.allSettled([
-          cleanupEmailProvider().then(() => {
-            completedCleanups.add("emailProvider");
-            fastify.log.info("Email provider cleanup completed");
-          }),
-          chatOpsManager.cleanup().then(() => {
-            completedCleanups.add("chatOps");
-            fastify.log.info("ChatOps provider cleanup completed");
-          }),
-        ]).then(() => "completed" as const);
-
-        // Wait for cleanup with timeout, then exit anyway
-        const allCleanupNames = ["emailProvider", "chatOps"] as const;
-        const result = await Promise.race([
-          cleanupPromise,
-          new Promise<"timeout">((resolve) =>
-            setTimeout(() => resolve("timeout"), SHUTDOWN_CLEANUP_TIMEOUT_MS),
-          ),
-        ]);
-
-        if (result === "timeout") {
-          const pendingCleanups = allCleanupNames.filter(
-            (name) => !completedCleanups.has(name),
-          );
-          fastify.log.warn(
-            { pendingCleanups },
-            "Cleanup timed out, proceeding with shutdown",
-          );
-        }
-
-        process.exit(0);
-      } catch (error) {
-        fastify.log.error({ error }, "Error during shutdown");
-        process.exit(1);
-      }
-    };
-
-    // Handle shutdown signals
-    process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
-    process.on("SIGINT", () => gracefulShutdown("SIGINT"));
+    registerWebServerShutdown(fastify, {
+      emailRenewalIntervalId,
+      processedEmailCleanupIntervalId,
+    });
   } catch (err) {
     fastify.log.error(err);
     process.exit(1);
   }
 };
+
+async function registerMaintenanceModeRoutes(
+  fastify: FastifyInstanceWithZod,
+): Promise<void> {
+  await fastify.register(fastifyCors, {
+    origin: corsOrigins,
+    methods: ["GET", "OPTIONS"],
+    allowedHeaders: [
+      "Content-Type",
+      "X-Requested-With",
+      "Cookie",
+      apiKeyAuthorizationHeaderName,
+    ],
+    exposedHeaders: ["Set-Cookie"],
+    credentials: true,
+  });
+  await fastify.register(routes.healthRoutes);
+  await fastify.register(publicConfigRoutes);
+}
+
+function registerWebServerShutdown(
+  fastify: FastifyInstanceWithZod,
+  intervalIds: {
+    emailRenewalIntervalId?: NodeJS.Timeout;
+    processedEmailCleanupIntervalId?: NodeJS.Timeout;
+  } = {},
+): void {
+  const gracefulShutdown = async (signal: string) => {
+    fastify.log.info(`Received ${signal}, shutting down gracefully...`);
+
+    try {
+      if (metricsServerInstance) {
+        await metricsServerInstance.close();
+        fastify.log.info("Metrics server closed");
+      }
+
+      await fastify.close();
+      fastify.log.info("Main server closed");
+
+      websocketService.stop();
+
+      if (intervalIds.emailRenewalIntervalId) {
+        clearInterval(intervalIds.emailRenewalIntervalId);
+      }
+      if (intervalIds.processedEmailCleanupIntervalId) {
+        clearInterval(intervalIds.processedEmailCleanupIntervalId);
+      }
+
+      cacheManager.shutdown();
+      await codeRuntimeService.shutdown();
+
+      if (shouldRunWorker) {
+        await taskQueueService.stopWorker();
+      }
+
+      const completedCleanups = new Set<"emailProvider" | "chatOps">();
+      const cleanupPromise = Promise.allSettled([
+        cleanupEmailProvider().then(() => {
+          completedCleanups.add("emailProvider");
+          fastify.log.info("Email provider cleanup completed");
+        }),
+        chatOpsManager.cleanup().then(() => {
+          completedCleanups.add("chatOps");
+          fastify.log.info("ChatOps provider cleanup completed");
+        }),
+      ]).then(() => "completed" as const);
+
+      const allCleanupNames = ["emailProvider", "chatOps"] as const;
+      const result = await Promise.race([
+        cleanupPromise,
+        new Promise<"timeout">((resolve) =>
+          setTimeout(() => resolve("timeout"), SHUTDOWN_CLEANUP_TIMEOUT_MS),
+        ),
+      ]);
+
+      if (result === "timeout") {
+        const pendingCleanups = allCleanupNames.filter(
+          (cleanupName) => !completedCleanups.has(cleanupName),
+        );
+        fastify.log.warn(
+          { pendingCleanups },
+          "Cleanup timed out, proceeding with shutdown",
+        );
+      }
+
+      process.exit(0);
+    } catch (error) {
+      fastify.log.error({ error }, "Error during shutdown");
+      process.exit(1);
+    }
+  };
+
+  process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
+  process.on("SIGINT", () => gracefulShutdown("SIGINT"));
+}
 
 /**
  * Starts the process in worker-only mode.

--- a/platform/docker/supervisord/supervisord.conf
+++ b/platform/docker/supervisord/supervisord.conf
@@ -26,7 +26,9 @@ pidfile=/var/run/supervisord.pid
 
 [program:backend]
 directory=/app/backend
-command=/bin/sh -c "sleep 5 && pnpm db:migrate && ./scripts/start-production.sh"
+# Maintenance mode must be able to boot when the external database is down for
+# planned work, so the Docker entrypoint skips migrations while the message is set.
+command=/bin/sh -c "if [ -n \"$ARCHESTRA_MAINTENANCE_MODE_MESSAGE\" ]; then ./scripts/start-production.sh; else sleep 5 && pnpm db:migrate && ./scripts/start-production.sh; fi"
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout

--- a/platform/frontend/src/app/_parts/maintenance-mode-overlay.tsx
+++ b/platform/frontend/src/app/_parts/maintenance-mode-overlay.tsx
@@ -30,7 +30,6 @@ export function MaintenanceModeOverlay() {
           Maintenance in Progress
         </h1>
         <p className="text-muted-foreground text-sm">{maintenanceMessage}</p>
-        <p className="text-xs text-muted-foreground">Please check back soon.</p>
       </div>
     </div>
   );

--- a/platform/frontend/src/app/knowledge/files/_parts/knowledge-file-viewer-dialog.test.tsx
+++ b/platform/frontend/src/app/knowledge/files/_parts/knowledge-file-viewer-dialog.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { KnowledgeFileViewerDialog } from "./knowledge-file-viewer-dialog";
+
+vi.mock("@/components/standard-dialog", () => ({
+  StandardDialog: ({
+    children,
+    description,
+    footer,
+    open,
+    title,
+  }: {
+    children: React.ReactNode;
+    description: React.ReactNode;
+    footer: React.ReactNode;
+    open: boolean;
+    title: string;
+  }) =>
+    open ? (
+      <div role="dialog" aria-label={title}>
+        {description}
+        {children}
+        {footer}
+      </div>
+    ) : null,
+}));
+
+describe("KnowledgeFileViewerDialog", () => {
+  it("embeds the content URL without iframe sandboxing", () => {
+    render(
+      <KnowledgeFileViewerDialog
+        file={{
+          id: "file-1",
+          originalName: "receipt.pdf",
+          fileSize: 1024,
+        }}
+        open
+        onOpenChange={() => {}}
+      />,
+    );
+
+    const frame = screen.getByTitle("receipt.pdf");
+    expect(frame).toHaveAttribute("src", "/api/knowledge-files/file-1/content");
+    expect(frame).not.toHaveAttribute("sandbox");
+  });
+});

--- a/platform/frontend/src/app/knowledge/files/_parts/knowledge-file-viewer-dialog.tsx
+++ b/platform/frontend/src/app/knowledge/files/_parts/knowledge-file-viewer-dialog.tsx
@@ -55,7 +55,6 @@ export function KnowledgeFileViewerDialog({
     >
       <iframe
         title={file.originalName}
-        sandbox=""
         src={getKnowledgeFileContentUrl(file.id)}
         className="min-h-0 flex-1 rounded-md border bg-background"
       />

--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -52,6 +52,19 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Maintenance mode can serve the frontend overlay and public config without
+database access. The chart can only detect this when the env var is set
+directly through archestra.env.
+*/}}
+{{- define "archestra-platform.maintenanceModeEnabled" -}}
+{{- if and (hasKey .Values.archestra.env "ARCHESTRA_MAINTENANCE_MODE_MESSAGE") (ne (toString (get .Values.archestra.env "ARCHESTRA_MAINTENANCE_MODE_MESSAGE")) "") -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end }}
+
+{{/*
 Environment variables for the Archestra Platform container
 */}}
 {{- define "archestra-platform.env" -}}

--- a/platform/helm/archestra/templates/archestra-platform.yaml
+++ b/platform/helm/archestra/templates/archestra-platform.yaml
@@ -102,8 +102,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "archestra-platform.serviceAccountName" . }}
+      {{- if ne (include "archestra-platform.maintenanceModeEnabled" .) "true" }}
       initContainers:
         {{- include "archestra-platform.initContainers" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ include "archestra-platform.image" . }}

--- a/platform/helm/archestra/templates/archestra-worker.yaml
+++ b/platform/helm/archestra/templates/archestra-worker.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.archestra.worker.enabled }}
+{{- if and .Values.archestra.worker.enabled (ne (include "archestra-platform.maintenanceModeEnabled" .) "true") }}
 {{- $workerPodAnnotations := mergeOverwrite (dict) (.Values.archestra.podAnnotations | default dict) (.Values.archestra.worker.podAnnotations | default dict) }}
 {{- if hasKey $workerPodAnnotations "prometheus.io/scrape" }}
 {{- $workerPodAnnotations = mergeOverwrite $workerPodAnnotations (dict "prometheus.io/port" "9000" "prometheus.io/path" "/metrics") }}

--- a/platform/helm/archestra/templates/migration-job.yaml
+++ b/platform/helm/archestra/templates/migration-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.archestra.migrationJob.enabled }}
+{{- if and .Values.archestra.migrationJob.enabled (ne (include "archestra-platform.maintenanceModeEnabled" .) "true") }}
 {{/*
 Database migration Job.
 

--- a/platform/helm/archestra/tests/archestra_migration_job_test.yaml
+++ b/platform/helm/archestra/tests/archestra_migration_job_test.yaml
@@ -127,6 +127,14 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: is omitted entirely when maintenance mode is enabled
+    set:
+      archestra.env:
+        ARCHESTRA_MAINTENANCE_MODE_MESSAGE: "Scheduled maintenance"
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: sources the database URL from Vault when vault secret injection is enabled
     set:
       archestra.initContainers.vaultSecrets.enabled: true

--- a/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
@@ -301,6 +301,15 @@ tests:
           path: spec.template.spec.initContainers[1].image
           value: registry.internal.example.com/platform/busybox:1.36
 
+  - it: should skip database init containers when maintenance mode is enabled
+    documentIndex: 1
+    set:
+      archestra.env:
+        ARCHESTRA_MAINTENANCE_MODE_MESSAGE: "Scheduled maintenance"
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+
   - it: should apply shared resources to chart-managed init containers
     documentIndex: 1
     set:

--- a/platform/helm/archestra/tests/archestra_worker_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_worker_deployment_test.yaml
@@ -4,6 +4,14 @@ templates:
 values:
   - ../ci/test-values.yaml
 tests:
+  - it: omits the worker deployment when maintenance mode is enabled
+    set:
+      archestra.env:
+        ARCHESTRA_MAINTENANCE_MODE_MESSAGE: "Scheduled maintenance"
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: worker deployment has default resources configured
     asserts:
       - equal:

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -23681,7 +23681,7 @@ export type GetHealthResponses = {
      */
     200: {
         name: string;
-        status: string;
+        status: 'ok';
         version: string;
     };
 };
@@ -23701,9 +23701,9 @@ export type GetReadyErrors = {
      */
     503: {
         name: string;
-        status: string;
+        status: 'degraded';
         version: string;
-        database: string;
+        database: 'disconnected';
     };
 };
 
@@ -23715,9 +23715,9 @@ export type GetReadyResponses = {
      */
     200: {
         name: string;
-        status: string;
+        status: 'ok' | 'maintenance';
         version: string;
-        database: string;
+        database: 'connected' | 'not_checked';
     };
 };
 


### PR DESCRIPTION
## Summary
- Fix knowledge file previews by allowing Chrome to render inline file content without iframe sandbox blocking.
- Make maintenance mode boot without database access and skip database-dependent Helm/Docker startup paths while active.
- Tighten health/readiness response schemas and regenerate OpenAPI/API client types.