### PR TITLE
fix: retry database transactions

### DIFF
--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -25,7 +25,7 @@ import { createAccessControl } from "better-auth/plugins/access";
 import { and, eq, ne } from "drizzle-orm";
 import { z } from "zod";
 import config from "@/config";
-import db, { schema } from "@/database";
+import db, { schema, withDbTransaction } from "@/database";
 import logger from "@/logging";
 import { LOG_LEVEL } from "@/logging/log-level";
 // Import directly from files to avoid circular dependency through barrel export
@@ -1553,7 +1553,7 @@ async function cleanupRejectedSsoLogin(params: {
   userId: string;
   sessionId: string;
 }) {
-  await db.transaction(async (tx) => {
+  await withDbTransaction(async (tx) => {
     await SessionModel.deleteById(params.sessionId, tx);
     await AccountModel.deleteByUserIdAndProviderId({
       userId: params.userId,

--- a/platform/backend/src/database/index.ts
+++ b/platform/backend/src/database/index.ts
@@ -3,7 +3,11 @@ import { drizzle } from "drizzle-orm/node-postgres";
 import pg from "pg";
 import config from "@/config";
 import logger from "@/logging";
-import { installDbErrorSafetyNet, wrapPoolWithRetry } from "./retry";
+import {
+  installDbErrorSafetyNet,
+  withTransactionRetry,
+  wrapPoolWithRetry,
+} from "./retry";
 import * as schema from "./schemas";
 import {
   DATABASE_URL_VAULT_REF_ENV,
@@ -82,6 +86,19 @@ export function getDb() {
     );
   }
   return db;
+}
+
+/**
+ * Run a database transaction with retry around the whole transaction.
+ *
+ * Pool-level retry only applies to standalone `pool.query()` calls. Drizzle
+ * transactions use a checked-out client, so transient connection failures must
+ * retry the entire transaction callback.
+ */
+export async function withDbTransaction<T>(
+  callback: (tx: Transaction) => Promise<T>,
+): Promise<T> {
+  return withTransactionRetry(() => getDb().transaction(callback));
 }
 
 /**

--- a/platform/backend/src/database/retry.test.ts
+++ b/platform/backend/src/database/retry.test.ts
@@ -5,6 +5,7 @@ import {
   installDbErrorSafetyNet,
   isTransientDbError,
   withDbRetry,
+  withTransactionRetry,
   wrapPoolWithRetry,
 } from "./retry";
 
@@ -240,6 +241,24 @@ describe("withDbRetry", () => {
     expect(fn).toHaveBeenCalledTimes(2);
 
     vi.useRealTimers();
+  });
+});
+
+describe("withTransactionRetry", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("retries the whole transaction operation on transient errors", async () => {
+    const runTransaction = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Connection terminated unexpectedly"))
+      .mockResolvedValue("committed");
+
+    const result = await withTransactionRetry(runTransaction);
+
+    expect(result).toBe("committed");
+    expect(runTransaction).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/platform/backend/src/database/retry.ts
+++ b/platform/backend/src/database/retry.ts
@@ -146,6 +146,19 @@ export async function withDbRetry<T>(
   throw new Error("withDbRetry: unreachable");
 }
 
+/**
+ * Retry a full database transaction callback on transient connection errors.
+ *
+ * Transaction retries must wrap the whole transaction because checked-out
+ * transaction clients are not covered by the pool.query() wrapper.
+ * @public — exported for testability and standalone Drizzle clients.
+ */
+export async function withTransactionRetry<T>(
+  runTransaction: () => Promise<T>,
+): Promise<T> {
+  return withDbRetry(runTransaction);
+}
+
 /** Symbol marker to prevent double-wrapping the same pool */
 const RETRY_WRAPPED = Symbol("retryWrapped");
 

--- a/platform/backend/src/database/seed.ts
+++ b/platform/backend/src/database/seed.ts
@@ -16,7 +16,7 @@ import {
 } from "@shared";
 import { and, eq, inArray, isNull } from "drizzle-orm";
 import config, { getProviderEnvApiKey } from "@/config";
-import db, { schema } from "@/database";
+import db, { schema, withDbTransaction } from "@/database";
 import logger from "@/logging";
 import {
   AgentModel,
@@ -504,7 +504,7 @@ async function migratePlaywrightToolsToDynamicCredential(): Promise<void> {
 }
 
 async function migrateSecretsToEncrypted(): Promise<void> {
-  await db.transaction(async (tx) => {
+  await withDbTransaction(async (tx) => {
     const rows = await tx.select().from(schema.secretsTable);
     let migrated = 0;
 

--- a/platform/backend/src/models/agent-label.ts
+++ b/platform/backend/src/models/agent-label.ts
@@ -1,5 +1,5 @@
 import { and, asc, eq, inArray, isNull } from "drizzle-orm";
-import db, { schema, type Transaction } from "@/database";
+import db, { schema, type Transaction, withDbTransaction } from "@/database";
 import type { AgentLabelGetResponse, AgentLabelWithDetails } from "@/types";
 
 class AgentLabelModel {
@@ -89,7 +89,7 @@ class AgentLabelModel {
     agentId: string,
     labels: AgentLabelWithDetails[],
   ): Promise<void> {
-    await db.transaction(async (tx) => {
+    await withDbTransaction(async (tx) => {
       // Delete all existing labels for this agent
       await tx
         .delete(schema.agentLabelsTable)
@@ -128,7 +128,7 @@ class AgentLabelModel {
     deletedKeys: number;
     deletedValues: number;
   }> {
-    return await db.transaction(async (tx) => {
+    return await withDbTransaction(async (tx) => {
       // Find orphaned keys (not referenced in agent_labels OR mcp_catalog_labels)
       const orphanedKeys = await tx
         .select({ id: schema.labelKeysTable.id })

--- a/platform/backend/src/models/agent-suggested-prompt.ts
+++ b/platform/backend/src/models/agent-suggested-prompt.ts
@@ -1,5 +1,5 @@
 import { asc, eq, inArray } from "drizzle-orm";
-import db, { schema } from "@/database";
+import db, { schema, withDbTransaction } from "@/database";
 import type { SuggestedPromptInput } from "@/types";
 
 class AgentSuggestedPromptModel {
@@ -11,7 +11,7 @@ class AgentSuggestedPromptModel {
     agentId: string,
     prompts: SuggestedPromptInput[],
   ): Promise<void> {
-    await db.transaction(async (tx) => {
+    await withDbTransaction(async (tx) => {
       await tx
         .delete(schema.agentSuggestedPromptsTable)
         .where(eq(schema.agentSuggestedPromptsTable.agentId, agentId));

--- a/platform/backend/src/models/agent-team.ts
+++ b/platform/backend/src/models/agent-team.ts
@@ -1,5 +1,5 @@
 import { and, eq, inArray, sql } from "drizzle-orm";
-import db, { schema } from "@/database";
+import db, { schema, withDbTransaction } from "@/database";
 import logger from "@/logging";
 import type { AgentAccessContext } from "@/types";
 import { findAgentAccessContextById } from "./agent-access-context";
@@ -212,7 +212,7 @@ class AgentTeamModel {
       { agentId, teamCount: teamIds.length },
       "AgentTeamModel.syncAgentTeams: syncing teams",
     );
-    await db.transaction(async (tx) => {
+    await withDbTransaction(async (tx) => {
       // Delete all existing team assignments
       await tx
         .delete(schema.agentTeamsTable)

--- a/platform/backend/src/models/chat-active-run.ts
+++ b/platform/backend/src/models/chat-active-run.ts
@@ -1,6 +1,6 @@
 import type { UIMessageChunk } from "ai";
 import { and, asc, desc, eq, gt, lt, sql } from "drizzle-orm";
-import db, { schema } from "@/database";
+import db, { schema, withDbTransaction } from "@/database";
 import type {
   ChatActiveRun,
   ChatActiveRunEvent,
@@ -34,7 +34,7 @@ class ActiveChatRunModel {
       return;
     }
 
-    await db.transaction(async (tx) => {
+    await withDbTransaction(async (tx) => {
       await tx.insert(schema.chatActiveRunEventsTable).values({
         runId: params.runId,
         seq: params.seq,

--- a/platform/backend/src/models/conversation-enabled-tool.ts
+++ b/platform/backend/src/models/conversation-enabled-tool.ts
@@ -1,5 +1,5 @@
 import { eq, inArray } from "drizzle-orm";
-import db, { schema } from "@/database";
+import db, { schema, withDbTransaction } from "@/database";
 import logger from "@/logging";
 
 class ConversationEnabledToolModel {
@@ -92,7 +92,7 @@ class ConversationEnabledToolModel {
       }
     }
 
-    await db.transaction(async (tx) => {
+    await withDbTransaction(async (tx) => {
       // Update the conversation to mark it as having custom tool selection
       await tx
         .update(schema.conversationsTable)
@@ -135,7 +135,7 @@ class ConversationEnabledToolModel {
       "ConversationEnabledToolModel.clearCustomSelection: clearing",
     );
 
-    await db.transaction(async (tx) => {
+    await withDbTransaction(async (tx) => {
       // Update the conversation to mark it as not having custom tool selection
       await tx
         .update(schema.conversationsTable)

--- a/platform/backend/src/models/conversation-share.ts
+++ b/platform/backend/src/models/conversation-share.ts
@@ -1,5 +1,5 @@
 import { and, eq } from "drizzle-orm";
-import db, { schema } from "@/database";
+import db, { schema, withDbTransaction } from "@/database";
 import type {
   Conversation,
   ConversationShare,
@@ -96,7 +96,7 @@ class ConversationShareModel {
     // Caller must verify the requesting user owns the conversation before
     // updating share state for it. This model only enforces org/conversation
     // identity, not conversation ownership.
-    const shareId = await db.transaction(async (tx) => {
+    const shareId = await withDbTransaction(async (tx) => {
       const [existing] = await tx
         .select()
         .from(schema.conversationSharesTable)

--- a/platform/backend/src/models/identity-provider.ee.ts
+++ b/platform/backend/src/models/identity-provider.ee.ts
@@ -14,7 +14,7 @@ import {
   extractGroupsFromClaims,
 } from "@/auth/idp-team-sync-cache.ee";
 import config from "@/config";
-import db, { schema } from "@/database";
+import db, { schema, withDbTransaction } from "@/database";
 import logger from "@/logging";
 import { evaluateRoleMappingTemplate } from "@/templating";
 import type {
@@ -813,7 +813,7 @@ class IdentityProviderModel {
     }
 
     // Wrap deletions in a transaction to ensure atomicity
-    await db.transaction(async (tx) => {
+    await withDbTransaction(async (tx) => {
       /**
        * Clean up associated SSO accounts to prevent orphaned records
        * This is important because orphaned accounts can cause issues with future IdP logins

--- a/platform/backend/src/models/kb-uploaded-file.ts
+++ b/platform/backend/src/models/kb-uploaded-file.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import type { ResourceVisibilityScope } from "@shared";
 import { and, count, desc, eq, ilike, inArray, or, sql } from "drizzle-orm";
-import db, { schema } from "@/database";
+import db, { schema, withDbTransaction } from "@/database";
 import type { UploadedFileProcessingStatus } from "@/types";
 import { escapeLikePattern } from "@/utils/sql-search";
 
@@ -266,7 +266,7 @@ class KbUploadedFileModel {
     fileId: string;
     connectorId: string;
   }): Promise<void> {
-    await db.transaction(async (tx) => {
+    await withDbTransaction(async (tx) => {
       await tx
         .delete(schema.kbDocumentsTable)
         .where(

--- a/platform/backend/src/models/limit.ts
+++ b/platform/backend/src/models/limit.ts
@@ -1,5 +1,5 @@
 import { and, eq, inArray, lt, or, type SQL, sql } from "drizzle-orm";
-import db, { schema } from "@/database";
+import db, { schema, withDbTransaction } from "@/database";
 import logger from "@/logging";
 import type {
   CreateLimit,
@@ -474,7 +474,7 @@ class LimitModel {
       return;
     }
 
-    await db.transaction(async (tx) => {
+    await withDbTransaction(async (tx) => {
       const limits = await tx
         .update(schema.limitsTable)
         .set({ lastCleanup: now, updatedAt: now })

--- a/platform/backend/src/models/llm-provider-api-key-model.ts
+++ b/platform/backend/src/models/llm-provider-api-key-model.ts
@@ -1,6 +1,6 @@
 import { MODEL_MARKER_PATTERNS, type SupportedProvider } from "@shared";
 import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
-import db, { schema } from "@/database";
+import db, { schema, withDbTransaction } from "@/database";
 import type { LlmProviderApiKey, Model } from "@/types";
 
 /**
@@ -98,7 +98,7 @@ class LlmProviderApiKeyModelLinkModel {
       new Map(models.map((model) => [model.id, model])).values(),
     );
 
-    await db.transaction(async (tx) => {
+    await withDbTransaction(async (tx) => {
       // Delete existing links for this API key
       await tx
         .delete(schema.llmProviderApiKeyModelsTable)

--- a/platform/backend/src/models/mcp-catalog-label.ts
+++ b/platform/backend/src/models/mcp-catalog-label.ts
@@ -1,6 +1,6 @@
 import { and, asc, eq, inArray, or } from "drizzle-orm";
 import { uniqBy } from "lodash-es";
-import db, { schema } from "@/database";
+import db, { schema, withDbTransaction } from "@/database";
 import type { AgentLabelGetResponse, AgentLabelWithDetails } from "@/types";
 import AgentLabelModel from "./agent-label";
 
@@ -122,7 +122,7 @@ class McpCatalogLabelModel {
     catalogId: string,
     labels: AgentLabelWithDetails[],
   ): Promise<void> {
-    const affectedPairs = await db.transaction(async (tx) => {
+    const affectedPairs = await withDbTransaction(async (tx) => {
       const previousLabels = await tx
         .select({
           keyId: schema.mcpCatalogLabelsTable.keyId,

--- a/platform/backend/src/models/mcp-catalog-team.ts
+++ b/platform/backend/src/models/mcp-catalog-team.ts
@@ -1,5 +1,5 @@
 import { and, eq, inArray, isNull, or, sql } from "drizzle-orm";
-import db, { schema } from "@/database";
+import db, { schema, withDbTransaction } from "@/database";
 import logger from "@/logging";
 
 class McpCatalogTeamModel {
@@ -119,7 +119,7 @@ class McpCatalogTeamModel {
       { catalogId, teamCount: teamIds.length },
       "McpCatalogTeamModel.syncCatalogTeams: syncing teams",
     );
-    await db.transaction(async (tx) => {
+    await withDbTransaction(async (tx) => {
       await tx
         .delete(schema.mcpCatalogTeamsTable)
         .where(eq(schema.mcpCatalogTeamsTable.catalogId, catalogId));

--- a/platform/backend/src/models/message.ts
+++ b/platform/backend/src/models/message.ts
@@ -1,5 +1,5 @@
 import { and, eq, gt, sql } from "drizzle-orm";
-import db, { schema } from "@/database";
+import db, { schema, withDbTransaction } from "@/database";
 import type { InsertMessage, Message } from "@/types";
 
 type DbExecutor =
@@ -247,7 +247,7 @@ class MessageModel {
 
     // when no outer transaction is provided, wrap so update + delete remain atomic
     if (executor === db) {
-      return await db.transaction(async (tx) => run(tx));
+      return await withDbTransaction(async (tx) => run(tx));
     }
     return await run(executor);
   }

--- a/platform/backend/src/models/model.ts
+++ b/platform/backend/src/models/model.ts
@@ -9,7 +9,7 @@ import {
   or,
   sql,
 } from "drizzle-orm";
-import db, { schema } from "@/database";
+import db, { schema, withDbTransaction } from "@/database";
 import logger from "@/logging";
 import type {
   CreateModel,
@@ -247,7 +247,7 @@ class ModelModel {
     );
 
     // Wrap all batches in a transaction to ensure atomicity
-    const results = await db.transaction(async (tx) => {
+    const results = await withDbTransaction(async (tx) => {
       const batchResults: Model[] = [];
 
       for (let i = 0; i < dataArray.length; i += BATCH_SIZE) {
@@ -314,7 +314,7 @@ class ModelModel {
       "Starting batched full model upsert",
     );
 
-    const results = await db.transaction(async (tx) => {
+    const results = await withDbTransaction(async (tx) => {
       const batchResults: Model[] = [];
 
       for (let i = 0; i < dataArray.length; i += BATCH_SIZE) {

--- a/platform/backend/src/models/skill-share-link.ts
+++ b/platform/backend/src/models/skill-share-link.ts
@@ -1,6 +1,6 @@
 import { createHash, randomBytes } from "node:crypto";
 import { and, desc, eq, gt, inArray, isNull, or, sql } from "drizzle-orm";
-import db, { schema } from "@/database";
+import db, { schema, withDbTransaction } from "@/database";
 import logger from "@/logging";
 import type {
   SkillShareLink,
@@ -51,7 +51,7 @@ class SkillShareLinkModel {
     const tokenHash = hashToken(rawToken);
     const tokenStart = rawToken.slice(0, TOKEN_START_LENGTH);
 
-    const link = await db.transaction(async (tx) => {
+    const link = await withDbTransaction(async (tx) => {
       const [created] = await tx
         .insert(schema.skillShareLinksTable)
         .values({

--- a/platform/backend/src/models/skill-team.ts
+++ b/platform/backend/src/models/skill-team.ts
@@ -1,5 +1,5 @@
 import { and, eq, inArray, sql } from "drizzle-orm";
-import db, { schema } from "@/database";
+import db, { schema, withDbTransaction } from "@/database";
 import type { ResourceVisibilityScope } from "@/types/visibility";
 
 /**
@@ -146,7 +146,7 @@ class SkillTeamModel {
     skillId: string,
     teamIds: string[],
   ): Promise<void> {
-    await db.transaction(async (tx) => {
+    await withDbTransaction(async (tx) => {
       await tx
         .delete(schema.skillTeamsTable)
         .where(eq(schema.skillTeamsTable.skillId, skillId));

--- a/platform/backend/src/models/skill.ts
+++ b/platform/backend/src/models/skill.ts
@@ -9,7 +9,7 @@ import {
   like,
   or,
 } from "drizzle-orm";
-import db, { schema } from "@/database";
+import db, { schema, withDbTransaction } from "@/database";
 import type { InsertSkill, InsertSkillFile, Skill, UpdateSkill } from "@/types";
 
 class SkillModel {
@@ -132,7 +132,7 @@ class SkillModel {
     files: Omit<InsertSkillFile, "skillId">[];
     teamIds?: string[];
   }): Promise<Skill | null> {
-    return await db.transaction(async (tx) => {
+    return await withDbTransaction(async (tx) => {
       const [skill] = await tx
         .insert(schema.skillsTable)
         .values(params.skill)
@@ -171,7 +171,7 @@ class SkillModel {
     skill: UpdateSkill;
     files?: Omit<InsertSkillFile, "skillId">[];
   }): Promise<Skill | null> {
-    return await db.transaction(async (tx) => {
+    return await withDbTransaction(async (tx) => {
       const [skill] = await tx
         .update(schema.skillsTable)
         .set(params.skill)

--- a/platform/backend/src/models/virtual-api-key.ts
+++ b/platform/backend/src/models/virtual-api-key.ts
@@ -5,7 +5,7 @@ import {
   type SupportedProvider,
 } from "@shared";
 import { and, count, eq, ilike, inArray, sql } from "drizzle-orm";
-import db, { schema } from "@/database";
+import db, { schema, withDbTransaction } from "@/database";
 import type { PaginatedResult } from "@/database/utils/pagination";
 import { createPaginatedResult } from "@/database/utils/pagination";
 import logger from "@/logging";
@@ -95,7 +95,7 @@ class VirtualApiKeyModel {
       FORCE_DB,
     );
 
-    const virtualKey = await db.transaction(async (tx) => {
+    const virtualKey = await withDbTransaction(async (tx) => {
       const [createdVirtualKey] = await tx
         .insert(schema.virtualApiKeysTable)
         .values({
@@ -161,7 +161,7 @@ class VirtualApiKeyModel {
     const { id, name, expiresAt, scope, authorId, teamIds, providerApiKeys } =
       params;
 
-    const updatedVirtualKey = await db.transaction(async (tx) => {
+    const updatedVirtualKey = await withDbTransaction(async (tx) => {
       const [updated] = await tx
         .update(schema.virtualApiKeysTable)
         .set({

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -37,7 +37,7 @@ import {
   isApiKeyRequired,
 } from "@/clients/llm-client";
 import config from "@/config";
-import db from "@/database";
+import { withDbTransaction } from "@/database";
 import { browserStreamFeature } from "@/features/browser-stream/services/browser-stream.feature";
 import { extractAndIngestDocuments } from "@/knowledge-base";
 import { fileUploadManager } from "@/knowledge-base/file-upload/file-upload-manager";
@@ -2118,7 +2118,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
       // run the message edit, optional subsequent-message deletion, and
       // compaction invalidation inside one transaction so a crash can't leave
       // stale compactions pointing at a now-edited or truncated history
-      await db.transaction(async (tx) => {
+      await withDbTransaction(async (tx) => {
         await MessageModel.updateTextPartAndDeleteSubsequent(
           message.id,
           partIndex,

--- a/platform/backend/src/services/identity-providers/linked-idp-auth.ts
+++ b/platform/backend/src/services/identity-providers/linked-idp-auth.ts
@@ -1,6 +1,6 @@
 import { LINKED_IDP_SSO_MODE } from "@shared";
 import { z } from "zod";
-import db, { type Transaction } from "@/database";
+import { type Transaction, withDbTransaction } from "@/database";
 import logger from "@/logging";
 import {
   AccountModel,
@@ -56,7 +56,7 @@ export async function completeLinkedIdentityProviderIntent(params: {
   currentUserId: string;
   currentSessionId: string;
 }) {
-  return await db.transaction(async (tx) => {
+  return await withDbTransaction(async (tx) => {
     const identifier = getLinkedIdentityProviderIntentIdentifier(
       params.intentId,
     );

--- a/platform/backend/src/standalone-scripts/hydrate-from.ts
+++ b/platform/backend/src/standalone-scripts/hydrate-from.ts
@@ -28,6 +28,7 @@
 import { and, eq, inArray, not, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import pg from "pg";
+import { withTransactionRetry } from "@/database/retry";
 import * as schema from "@/database/schemas";
 import logger from "@/logging";
 
@@ -159,140 +160,144 @@ try {
   let copiedKeys = 0;
   let copiedKeyModels = 0;
 
-  await target.transaction(async (tx) => {
-    if (secrets.length) {
-      // Re-hydrate after the source admin rotated a secret would otherwise
-      // skip the row (same PK) and leave target with the stale/revoked
-      // payload. Upsert the payload so rotations propagate.
-      const result = await tx
-        .insert(schema.secretsTable)
-        .values(secrets)
-        .onConflictDoUpdate({
-          target: schema.secretsTable.id,
-          set: {
-            secret: sql`excluded.secret`,
-            isVault: sql`excluded.is_vault`,
-            isByosVault: sql`excluded.is_byos_vault`,
-          },
-        })
-        .returning({ id: schema.secretsTable.id });
-      copiedSecrets = result.length;
-    }
-    if (models.length) {
-      // Models hit `models_provider_model_unique` when target already has the
-      // same (provider, modelId) under a different UUID. ON CONFLICT DO
-      // NOTHING would preserve target's row — including target's DEFAULT
-      // values for fields the source admin actually edited (custom prices,
-      // ignored flag). Upsert just those admin-editable columns from source
-      // so hydrating carries the admin's intent across. Catalog columns
-      // (externalId, contextLength, modalities, pricing-from-models.dev) are
-      // left as-is because target's models.dev sync may be fresher.
-      const result = await tx
-        .insert(schema.modelsTable)
-        .values(models)
-        .onConflictDoUpdate({
-          target: [schema.modelsTable.provider, schema.modelsTable.modelId],
-          set: {
-            customPricePerMillionInput: sql`excluded.custom_price_per_million_input`,
-            customPricePerMillionOutput: sql`excluded.custom_price_per_million_output`,
-            ignored: sql`excluded.ignored`,
-          },
-        })
-        .returning({ id: schema.modelsTable.id });
-      copiedModels = result.length;
-    }
-    if (rewrittenKeys.length) {
-      // Re-hydrate after the source admin renamed a key, swapped its
-      // secret, or tweaked the base URLs / extra headers would otherwise
-      // skip the row (same PK) and leave the stale config. Upsert the
-      // source-owned columns on PK conflict. Target-created keys (dev
-      // added by hand) have target-side UUIDs and never match this
-      // conflict target, so they're untouched. Ownership columns
-      // (organization_id / user_id / team_id / scope) and isSystem aren't
-      // re-set because they're always our chosen values. isPrimary uses
-      // `excluded.is_primary` so the demotion logic above applies on
-      // re-hydrate too.
-      const result = await tx
-        .insert(schema.llmProviderApiKeysTable)
-        .values(rewrittenKeys)
-        .onConflictDoUpdate({
-          target: schema.llmProviderApiKeysTable.id,
-          set: {
-            name: sql`excluded.name`,
-            secretId: sql`excluded.secret_id`,
-            baseUrl: sql`excluded.base_url`,
-            inferenceBaseUrl: sql`excluded.inference_base_url`,
-            extraHeaders: sql`excluded.extra_headers`,
-            isPrimary: sql`excluded.is_primary`,
-          },
-        })
-        .returning({ id: schema.llmProviderApiKeysTable.id });
-      copiedKeys = result.length;
-    }
-    if (apiKeyModels.length) {
-      // For keys we filter by what landed in target (a source key whose
-      // insert was skipped by a unique-index conflict has no target row to
-      // FK to). For models we have to REMAP — `models_provider_model_unique`
-      // means target may already have a logically-equivalent row under a
-      // different UUID, in which case the source row was skipped but the
-      // link should still resolve to target's existing UUID instead of
-      // being dropped.
-      const sourceProviders = Array.from(
-        new Set(models.map((m) => m.provider)),
-      );
-      const sourceModelIds = Array.from(new Set(models.map((m) => m.modelId)));
-      const [presentKeys, targetMatchingModels] = await Promise.all([
-        sourceKeyIds.length
-          ? tx
-              .select({ id: schema.llmProviderApiKeysTable.id })
-              .from(schema.llmProviderApiKeysTable)
-              .where(inArray(schema.llmProviderApiKeysTable.id, sourceKeyIds))
-          : Promise.resolve([] as { id: string }[]),
-        sourceProviders.length && sourceModelIds.length
-          ? tx
-              .select({
-                id: schema.modelsTable.id,
-                provider: schema.modelsTable.provider,
-                modelId: schema.modelsTable.modelId,
-              })
-              .from(schema.modelsTable)
-              .where(
-                and(
-                  inArray(schema.modelsTable.provider, sourceProviders),
-                  inArray(schema.modelsTable.modelId, sourceModelIds),
-                ),
-              )
-          : Promise.resolve(
-              [] as { id: string; provider: string; modelId: string }[],
-            ),
-      ]);
-      const presentKeyIds = new Set(presentKeys.map((r) => r.id));
-      const targetModelByCompound = new Map(
-        targetMatchingModels.map((t) => [`${t.provider}:${t.modelId}`, t.id]),
-      );
-      const sourceToTargetModelId = new Map<string, string>();
-      for (const sm of models) {
-        const tid = targetModelByCompound.get(`${sm.provider}:${sm.modelId}`);
-        if (tid) sourceToTargetModelId.set(sm.id, tid);
-      }
-      const linkable = apiKeyModels.flatMap((l) => {
-        if (!presentKeyIds.has(l.apiKeyId)) return [];
-        const remappedModelId = sourceToTargetModelId.get(l.modelId);
-        if (!remappedModelId) return [];
-        return [{ ...l, modelId: remappedModelId }];
-      });
-      if (linkable.length) {
+  await withTransactionRetry(() =>
+    target.transaction(async (tx) => {
+      if (secrets.length) {
+        // Re-hydrate after the source admin rotated a secret would otherwise
+        // skip the row (same PK) and leave target with the stale/revoked
+        // payload. Upsert the payload so rotations propagate.
         const result = await tx
-          .insert(schema.llmProviderApiKeyModelsTable)
-          .values(linkable)
-          .onConflictDoNothing()
-          .returning({
-            apiKeyId: schema.llmProviderApiKeyModelsTable.apiKeyId,
-          });
-        copiedKeyModels = result.length;
+          .insert(schema.secretsTable)
+          .values(secrets)
+          .onConflictDoUpdate({
+            target: schema.secretsTable.id,
+            set: {
+              secret: sql`excluded.secret`,
+              isVault: sql`excluded.is_vault`,
+              isByosVault: sql`excluded.is_byos_vault`,
+            },
+          })
+          .returning({ id: schema.secretsTable.id });
+        copiedSecrets = result.length;
       }
-    }
-  });
+      if (models.length) {
+        // Models hit `models_provider_model_unique` when target already has the
+        // same (provider, modelId) under a different UUID. ON CONFLICT DO
+        // NOTHING would preserve target's row — including target's DEFAULT
+        // values for fields the source admin actually edited (custom prices,
+        // ignored flag). Upsert just those admin-editable columns from source
+        // so hydrating carries the admin's intent across. Catalog columns
+        // (externalId, contextLength, modalities, pricing-from-models.dev) are
+        // left as-is because target's models.dev sync may be fresher.
+        const result = await tx
+          .insert(schema.modelsTable)
+          .values(models)
+          .onConflictDoUpdate({
+            target: [schema.modelsTable.provider, schema.modelsTable.modelId],
+            set: {
+              customPricePerMillionInput: sql`excluded.custom_price_per_million_input`,
+              customPricePerMillionOutput: sql`excluded.custom_price_per_million_output`,
+              ignored: sql`excluded.ignored`,
+            },
+          })
+          .returning({ id: schema.modelsTable.id });
+        copiedModels = result.length;
+      }
+      if (rewrittenKeys.length) {
+        // Re-hydrate after the source admin renamed a key, swapped its
+        // secret, or tweaked the base URLs / extra headers would otherwise
+        // skip the row (same PK) and leave the stale config. Upsert the
+        // source-owned columns on PK conflict. Target-created keys (dev
+        // added by hand) have target-side UUIDs and never match this
+        // conflict target, so they're untouched. Ownership columns
+        // (organization_id / user_id / team_id / scope) and isSystem aren't
+        // re-set because they're always our chosen values. isPrimary uses
+        // `excluded.is_primary` so the demotion logic above applies on
+        // re-hydrate too.
+        const result = await tx
+          .insert(schema.llmProviderApiKeysTable)
+          .values(rewrittenKeys)
+          .onConflictDoUpdate({
+            target: schema.llmProviderApiKeysTable.id,
+            set: {
+              name: sql`excluded.name`,
+              secretId: sql`excluded.secret_id`,
+              baseUrl: sql`excluded.base_url`,
+              inferenceBaseUrl: sql`excluded.inference_base_url`,
+              extraHeaders: sql`excluded.extra_headers`,
+              isPrimary: sql`excluded.is_primary`,
+            },
+          })
+          .returning({ id: schema.llmProviderApiKeysTable.id });
+        copiedKeys = result.length;
+      }
+      if (apiKeyModels.length) {
+        // For keys we filter by what landed in target (a source key whose
+        // insert was skipped by a unique-index conflict has no target row to
+        // FK to). For models we have to REMAP — `models_provider_model_unique`
+        // means target may already have a logically-equivalent row under a
+        // different UUID, in which case the source row was skipped but the
+        // link should still resolve to target's existing UUID instead of
+        // being dropped.
+        const sourceProviders = Array.from(
+          new Set(models.map((m) => m.provider)),
+        );
+        const sourceModelIds = Array.from(
+          new Set(models.map((m) => m.modelId)),
+        );
+        const [presentKeys, targetMatchingModels] = await Promise.all([
+          sourceKeyIds.length
+            ? tx
+                .select({ id: schema.llmProviderApiKeysTable.id })
+                .from(schema.llmProviderApiKeysTable)
+                .where(inArray(schema.llmProviderApiKeysTable.id, sourceKeyIds))
+            : Promise.resolve([] as { id: string }[]),
+          sourceProviders.length && sourceModelIds.length
+            ? tx
+                .select({
+                  id: schema.modelsTable.id,
+                  provider: schema.modelsTable.provider,
+                  modelId: schema.modelsTable.modelId,
+                })
+                .from(schema.modelsTable)
+                .where(
+                  and(
+                    inArray(schema.modelsTable.provider, sourceProviders),
+                    inArray(schema.modelsTable.modelId, sourceModelIds),
+                  ),
+                )
+            : Promise.resolve(
+                [] as { id: string; provider: string; modelId: string }[],
+              ),
+        ]);
+        const presentKeyIds = new Set(presentKeys.map((r) => r.id));
+        const targetModelByCompound = new Map(
+          targetMatchingModels.map((t) => [`${t.provider}:${t.modelId}`, t.id]),
+        );
+        const sourceToTargetModelId = new Map<string, string>();
+        for (const sm of models) {
+          const tid = targetModelByCompound.get(`${sm.provider}:${sm.modelId}`);
+          if (tid) sourceToTargetModelId.set(sm.id, tid);
+        }
+        const linkable = apiKeyModels.flatMap((l) => {
+          if (!presentKeyIds.has(l.apiKeyId)) return [];
+          const remappedModelId = sourceToTargetModelId.get(l.modelId);
+          if (!remappedModelId) return [];
+          return [{ ...l, modelId: remappedModelId }];
+        });
+        if (linkable.length) {
+          const result = await tx
+            .insert(schema.llmProviderApiKeyModelsTable)
+            .values(linkable)
+            .onConflictDoNothing()
+            .returning({
+              apiKeyId: schema.llmProviderApiKeyModelsTable.apiKeyId,
+            });
+          copiedKeyModels = result.length;
+        }
+      }
+    }),
+  );
 
   logger.info(
     `✅ Copied: ${copiedSecrets}/${secrets.length} secrets, ` +

--- a/platform/backend/src/standalone-scripts/migrate-byos-to-vault/migrate.ee.ts
+++ b/platform/backend/src/standalone-scripts/migrate-byos-to-vault/migrate.ee.ts
@@ -50,7 +50,7 @@ import { pathToFileURL } from "node:url";
 import { SecretsManagerType } from "@shared";
 import { eq, inArray, sql } from "drizzle-orm";
 import config from "@/config";
-import db, { initializeDatabase, schema } from "@/database";
+import db, { initializeDatabase, schema, withDbTransaction } from "@/database";
 import { getSecretsManagerTypeBasedOnEnvVars } from "@/secrets-manager";
 import { VaultClient } from "@/secrets-manager/vault-client.ee";
 import { getVaultConfigFromEnv } from "@/secrets-manager/vault-config";
@@ -1159,7 +1159,7 @@ async function phase2AtomicFlip(
     console.log(`        ${id}`);
   }
 
-  await db.transaction(async (tx) => {
+  await withDbTransaction(async (tx) => {
     for (const r of renames) {
       await tx
         .update(schema.secretsTable)
@@ -2487,7 +2487,7 @@ async function rollback(): Promise<void> {
   }
 
   let restoredCount = 0;
-  await db.transaction(async (tx) => {
+  await withDbTransaction(async (tx) => {
     const result = await tx.execute(
       sql.raw(`
       UPDATE secret AS s

--- a/platform/backend/src/task-queue/handlers/process-uploaded-files-handler.ts
+++ b/platform/backend/src/task-queue/handlers/process-uploaded-files-handler.ts
@@ -1,4 +1,4 @@
-import db, { schema } from "@/database";
+import { schema, withDbTransaction } from "@/database";
 import { knowledgeSourceAccessControlService } from "@/knowledge-base";
 import { chunkDocument } from "@/knowledge-base/chunker";
 import {
@@ -131,7 +131,7 @@ export async function handleProcessUploadedFiles(
         extractedFile.text,
       );
 
-      const txResult = await db.transaction(async (tx) => {
+      const txResult = await withDbTransaction(async (tx) => {
         const [doc] = await tx
           .insert(schema.kbDocumentsTable)
           .values({


### PR DESCRIPTION
## Summary
- Add a shared `withDbTransaction` helper that retries the full Drizzle transaction callback on transient database connection errors.
- Move existing transaction call sites to the helper so transaction-backed writes get the same resilience behavior as standalone pool queries.

## Root Cause
Pool-level retry only covered standalone `pool.query()` calls. Drizzle transactions use a checked-out client, so transient connection failures inside a transaction were not retried unless callers wrapped the entire transaction manually.