### PR TITLE
fix: knowledge file chat attachment UI

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -1279,15 +1279,6 @@ These environment variables configure the [Knowledge Base](/docs/platform-knowle
   - Default: `true`
   - Set to `false` to use vector similarity search only.
 
-### Audit Log Configuration
-
-The audit log records administrative actions (mutations via `/api/*` and auth events) across your organization. Automatic retention is **disabled by default** - audit rows are kept indefinitely unless an org admin opts in by setting a positive retention window.
-
-- **`ARCHESTRA_AUDIT_LOG_RETENTION_DAYS`** - Number of days to retain audit log records before they are automatically deleted by the daily retention sweep.
-  - Default: `0` (disabled — audit rows are never auto-deleted).
-  - Set to a positive integer (e.g. `90`, `180`) to opt in to automatic purging after that many days.
-  - Must be a non-negative integer; invalid values fall back to the default (disabled).
-  - When enabled, the sweep runs once every 24 hours as a background task.
 #### Knowledge Files External Blob Storage
 
 Uploaded [Knowledge Files](/docs/platform-knowledge-bases#files) store file bytes in the database by default. Set the provider to `s3` to store file bytes externally while keeping metadata and indexing state in PostgreSQL.
@@ -1321,6 +1312,16 @@ Uploaded [Knowledge Files](/docs/platform-knowledge-bases#files) store file byte
 
 - **`ARCHESTRA_KNOWLEDGE_BASE_FILE_UPLOAD_S3_SECRET_ACCESS_KEY`** - Static S3 secret access key.
   - Used only when `ARCHESTRA_KNOWLEDGE_BASE_FILE_UPLOAD_S3_AUTH_METHOD=static`
+
+### Audit Log Configuration
+
+The audit log records administrative actions (mutations via `/api/*` and auth events) across your organization. Automatic retention is **disabled by default** - audit rows are kept indefinitely unless an org admin opts in by setting a positive retention window.
+
+- **`ARCHESTRA_AUDIT_LOG_RETENTION_DAYS`** - Number of days to retain audit log records before they are automatically deleted by the daily retention sweep.
+  - Default: `0` (disabled — audit rows are never auto-deleted).
+  - Set to a positive integer (e.g. `90`, `180`) to opt in to automatic purging after that many days.
+  - Must be a non-negative integer; invalid values fall back to the default (disabled).
+  - When enabled, the sweep runs once every 24 hours as a background task.
 
 ### Maintenance Mode
 

--- a/platform/frontend/src/app/knowledge/files/page.client.test.tsx
+++ b/platform/frontend/src/app/knowledge/files/page.client.test.tsx
@@ -56,6 +56,21 @@ vi.mock("@/lib/knowledge/knowledge-files.query", () => ({
           teamIds: [],
           assignedAgents: [
             { id: "agent-1", name: "Support", agentType: "agent" },
+            {
+              id: "gateway-1",
+              name: "My Gateway",
+              agentType: "mcp_gateway",
+            },
+            {
+              id: "agent-2",
+              name: "Hidden Assistant",
+              agentType: "agent",
+            },
+            {
+              id: "gateway-2",
+              name: "Hidden Gateway",
+              agentType: "mcp_gateway",
+            },
           ],
         },
       ],
@@ -108,6 +123,10 @@ describe("KnowledgeFilesPage", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("runbook.md")).toBeInTheDocument();
     expect(screen.getByText("Support")).toBeInTheDocument();
+    expect(screen.getByText("My Gateway")).toBeInTheDocument();
+    expect(screen.getByText("+2 more")).toBeInTheDocument();
+    expect(screen.queryByText("Hidden Assistant")).not.toBeInTheDocument();
+    expect(screen.queryByText("Hidden Gateway")).not.toBeInTheDocument();
     expect(screen.getByText("Indexed")).toBeInTheDocument();
     expect(screen.queryByText("42 B")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "View" })).toBeInTheDocument();

--- a/platform/frontend/src/app/knowledge/files/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/files/page.client.tsx
@@ -38,12 +38,6 @@ import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { TruncatedTooltip } from "@/components/ui/truncated-tooltip";
 import { DEFAULT_TABLE_LIMIT } from "@/consts";
 import {
@@ -555,29 +549,16 @@ function AssignedAgentsBadge({ file }: { file: KnowledgeFile }) {
   const hiddenAgents = file.assignedAgents.slice(2);
 
   return (
-    <TooltipProvider>
-      <div className="flex min-w-0 flex-wrap items-center gap-1">
-        {visibleAgents.map((agent) => (
-          <Badge key={agent.id} variant="outline" className="max-w-[140px]">
-            <span className="truncate">{agent.name}</span>
-          </Badge>
-        ))}
-        {hiddenAgents.length > 0 && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Badge variant="outline">+{hiddenAgents.length}</Badge>
-            </TooltipTrigger>
-            <TooltipContent>
-              <div className="space-y-1">
-                {hiddenAgents.map((agent) => (
-                  <div key={agent.id}>{agent.name}</div>
-                ))}
-              </div>
-            </TooltipContent>
-          </Tooltip>
-        )}
-      </div>
-    </TooltipProvider>
+    <div className="flex min-w-0 flex-wrap items-center gap-1">
+      {visibleAgents.map((agent) => (
+        <Badge key={agent.id} variant="outline" className="max-w-[140px]">
+          <span className="truncate">{agent.name}</span>
+        </Badge>
+      ))}
+      {hiddenAgents.length > 0 && (
+        <Badge variant="outline">+{hiddenAgents.length} more</Badge>
+      )}
+    </div>
   );
 }
 

--- a/platform/frontend/src/lib/chat/chat-utils.test.ts
+++ b/platform/frontend/src/lib/chat/chat-utils.test.ts
@@ -312,4 +312,48 @@ describe("mergePersistedMessageMetadata", () => {
       [PERSISTED_MESSAGE_ID_METADATA_KEY]: "db-user-1",
     });
   });
+
+  it("refreshes persisted user file URLs when the live message already has a persisted id", () => {
+    const liveMessages = [
+      {
+        id: "live-user-1",
+        role: "user",
+        metadata: {
+          [PERSISTED_MESSAGE_ID_METADATA_KEY]: "db-user-1",
+        },
+        parts: [
+          { type: "text", text: "read this" },
+          {
+            type: "file",
+            url: "data:application/pdf;base64,JVBERi0=",
+            mediaType: "application/pdf",
+            filename: "sample.pdf",
+          },
+        ],
+      },
+    ] as UIMessage[];
+    const persistedMessages = [
+      {
+        id: "db-user-1",
+        role: "user",
+        parts: [
+          { type: "text", text: "read this" },
+          {
+            type: "file",
+            url: "/api/chat/attachments/11111111-1111-1111-1111-111111111111/content",
+            mediaType: "application/pdf",
+            filename: "sample.pdf",
+          },
+        ],
+      },
+    ] as UIMessage[];
+
+    const mergedMessages = mergePersistedMessageMetadata({
+      liveMessages,
+      persistedMessages,
+    });
+
+    expect(mergedMessages).not.toBe(liveMessages);
+    expect(mergedMessages[0]?.parts).toBe(persistedMessages[0]?.parts);
+  });
 });

--- a/platform/frontend/src/lib/chat/chat-utils.ts
+++ b/platform/frontend/src/lib/chat/chat-utils.ts
@@ -107,17 +107,22 @@ export function mergePersistedMessageMetadata(params: {
 
   const mergedMessages = params.liveMessages.map((liveMessage) => {
     const liveMetadata = getObjectMetadata(liveMessage);
-    if (typeof liveMetadata[PERSISTED_MESSAGE_ID_METADATA_KEY] === "string") {
-      return liveMessage;
-    }
-
-    const persistedIndex = remainingPersistedMessages.findIndex(
-      (persistedMessage) =>
-        messagesHaveSameRenderableContent({
-          liveMessage,
-          persistedMessage,
-        }),
-    );
+    const persistedMessageId = liveMetadata[PERSISTED_MESSAGE_ID_METADATA_KEY];
+    const persistedIndexById =
+      typeof persistedMessageId === "string"
+        ? remainingPersistedMessages.findIndex(
+            (persistedMessage) => persistedMessage.id === persistedMessageId,
+          )
+        : -1;
+    const persistedIndex =
+      persistedIndexById === -1
+        ? remainingPersistedMessages.findIndex((persistedMessage) =>
+            messagesHaveSameRenderableContent({
+              liveMessage,
+              persistedMessage,
+            }),
+          )
+        : persistedIndexById;
 
     if (persistedIndex === -1) {
       return liveMessage;
@@ -127,14 +132,22 @@ export function mergePersistedMessageMetadata(params: {
       persistedIndex,
       1,
     );
+    if (!persistedMessage) {
+      return liveMessage;
+    }
 
-    changed = true;
+    const parts = mergePersistedUserFileParts({
+      liveMessage,
+      persistedMessage,
+    });
+
+    changed =
+      changed ||
+      parts !== liveMessage.parts ||
+      typeof persistedMessageId !== "string";
     return {
       ...liveMessage,
-      parts: mergePersistedUserFileParts({
-        liveMessage,
-        persistedMessage,
-      }),
+      parts,
       metadata: {
         ...getObjectMetadata(persistedMessage),
         ...liveMetadata,


### PR DESCRIPTION
## Summary
- refresh persisted chat attachment file URLs so supported uploads can show the Save to Knowledge action
- replace the Knowledge Files agent overflow tooltip with a compact `+N more` badge
- move Knowledge Files External Blob Storage under Knowledge Base Configuration in deployment docs