### PR TITLE
feat: Add embeddingErrorCode to show descriptive error messages on file upload failure

### DIFF
--- a/platform/backend/src/database/migrations/0255_add_kb_documents_embedding_error_code.sql
+++ b/platform/backend/src/database/migrations/0255_add_kb_documents_embedding_error_code.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "kb_documents" ADD COLUMN "embedding_error_code" text;

--- a/platform/backend/src/database/migrations/meta/0255_snapshot.json
+++ b/platform/backend/src/database/migrations/meta/0255_snapshot.json
@@ -1,0 +1,5 @@
+{
+  "id": "0255_add_kb_documents_embedding_error_code",
+  "description": "Add embedding_error_code column to kb_documents",
+  "migration": "ALTER TABLE \"kb_documents\" ADD COLUMN \"embedding_error_code\" text;"
+}

--- a/platform/backend/src/database/schemas/kb-document.ts
+++ b/platform/backend/src/database/schemas/kb-document.ts
@@ -8,7 +8,7 @@ import {
   uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
-import type { EmbeddingStatus, KbDocumentMetadata } from "@/types/kb-document";
+import type { EmbeddingErrorCode, EmbeddingStatus, KbDocumentMetadata } from "@/types/kb-document";
 import knowledgeBaseConnectorsTable from "./knowledge-base-connector";
 
 const kbDocumentsTable = pgTable(
@@ -32,6 +32,7 @@ const kbDocumentsTable = pgTable(
       .$type<EmbeddingStatus>()
       .notNull()
       .default("pending"),
+    embeddingErrorCode: text("embedding_error_code").$type<EmbeddingErrorCode>(),
     chunkCount: integer("chunk_count").notNull().default(0),
     createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })

--- a/platform/backend/src/knowledge-base/embedder.ts
+++ b/platform/backend/src/knowledge-base/embedder.ts
@@ -3,6 +3,7 @@ import logger from "@/logging";
 import { KbChunkModel, KbDocumentModel } from "@/models";
 import {
   callEmbedding,
+  categorizeEmbeddingError,
   type EmbeddingApiResponse,
   type EmbeddingInput,
   getEmbeddingDiscriminator,
@@ -91,6 +92,7 @@ class EmbeddingService {
     } catch (error) {
       await KbDocumentModel.update(documentId, {
         embeddingStatus: "failed",
+        embeddingErrorCode: categorizeEmbeddingError(error),
       });
       logger.error(
         {
@@ -240,6 +242,7 @@ class EmbeddingService {
       if (anyFailed) {
         await KbDocumentModel.update(documentId, {
           embeddingStatus: "failed",
+          embeddingErrorCode: "unknown",
         });
         logger.error(
           { documentId, runId: connectorRunId },

--- a/platform/backend/src/knowledge-base/embedding-clients/index.ts
+++ b/platform/backend/src/knowledge-base/embedding-clients/index.ts
@@ -1,4 +1,5 @@
 import type {
+  EmbeddingErrorCode,
   SupportedProvider,
   SupportedProviderDiscriminator,
 } from "@shared";
@@ -93,4 +94,28 @@ export function getEmbeddingRetryDelayMs(
   }
 
   return fallbackDelayMs;
+}
+
+/**
+ * Categorizes an embedding error into a structured error code.
+ * Maps API errors to an EmbeddingErrorCode enum value for persisting in the DB
+ * and displaying human-readable messages on the frontend.
+ */
+export function categorizeEmbeddingError(error: unknown): EmbeddingErrorCode {
+  if (
+    error instanceof AzureEmbeddingError ||
+    error instanceof GeminiEmbeddingError ||
+    error instanceof OpenAIEmbeddingError
+  ) {
+    const status = error.status;
+    const message = error.message.toLowerCase();
+
+    if (status === 429 || message.includes("rate limit")) return "rate_limit";
+    if (status === 401 || status === 403 || message.includes("api key") || message.includes("unauthorized") || message.includes("forbidden")) return "auth_error";
+    if (status >= 500) return "server_error";
+    if (message.includes("dimension") || message.includes("dimensionality")) return "dimensions_mismatch";
+    if ((message.includes("model") && (message.includes("not found") || message.includes("does not exist") || message.includes("not supported"))) || status === 404) return "model_not_found";
+    return "unknown";
+  }
+  return "unknown";
 }

--- a/platform/backend/src/knowledge-base/embedding-clients/index.ts
+++ b/platform/backend/src/knowledge-base/embedding-clients/index.ts
@@ -1,5 +1,5 @@
+import type { EmbeddingErrorCode } from "@/types/kb-document";
 import type {
-  EmbeddingErrorCode,
   SupportedProvider,
   SupportedProviderDiscriminator,
 } from "@shared";

--- a/platform/backend/src/routes/knowledge-base.ts
+++ b/platform/backend/src/routes/knowledge-base.ts
@@ -41,6 +41,7 @@ import {
   ConnectorTypeSchema,
   constructResponseSchema,
   DeleteObjectResponseSchema,
+  EmbeddingErrorCodeSchema,
   EmbeddingStatusSchema,
   KnowledgeSourceVisibilitySchema,
   SelectConnectorRunListSchema,
@@ -1063,6 +1064,7 @@ const knowledgeBaseRoutes: FastifyPluginAsyncZod = async (fastify) => {
     processingStatus: z.string(),
     processingError: z.string().nullable(),
     embeddingStatus: EmbeddingStatusSchema,
+    embeddingErrorCode: EmbeddingErrorCodeSchema.nullable(),
   });
 
   fastify.post(
@@ -1322,6 +1324,7 @@ const knowledgeBaseRoutes: FastifyPluginAsyncZod = async (fastify) => {
           processingStatus: file.processingStatus,
           processingError: file.processingError ?? null,
           embeddingStatus: doc?.embeddingStatus ?? "pending",
+          embeddingErrorCode: doc?.embeddingErrorCode ?? null,
         };
       });
 
@@ -1367,6 +1370,7 @@ const knowledgeBaseRoutes: FastifyPluginAsyncZod = async (fastify) => {
         processingStatus: file.processingStatus,
         processingError: file.processingError ?? null,
         embeddingStatus: doc?.embeddingStatus ?? "pending",
+        embeddingErrorCode: doc?.embeddingErrorCode ?? null,
       });
     },
   );

--- a/platform/backend/src/types/kb-document.ts
+++ b/platform/backend/src/types/kb-document.ts
@@ -31,12 +31,23 @@ export const EmbeddingStatusSchema = z.enum([
 ]);
 export type EmbeddingStatus = z.infer<typeof EmbeddingStatusSchema>;
 
+export const EmbeddingErrorCodeSchema = z.enum([
+  "rate_limit",
+  "auth_error",
+  "model_not_found",
+  "server_error",
+  "dimensions_mismatch",
+  "unknown",
+]);
+export type EmbeddingErrorCode = z.infer<typeof EmbeddingErrorCodeSchema>;
+
 export const KbDocumentMetadataSchema = z.record(z.string(), z.unknown());
 export type KbDocumentMetadata = z.infer<typeof KbDocumentMetadataSchema>;
 
 // Shared field overrides for drizzle-zod schema generation
 const extendedFields = {
   embeddingStatus: EmbeddingStatusSchema,
+  embeddingErrorCode: EmbeddingErrorCodeSchema.nullable(),
   acl: z.array(AclEntrySchema),
   metadata: KbDocumentMetadataSchema.nullable(),
 };
@@ -50,6 +61,7 @@ export const InsertKbDocumentSchema = createInsertSchema(
   {
     ...extendedFields,
     embeddingStatus: EmbeddingStatusSchema.optional(),
+    embeddingErrorCode: EmbeddingErrorCodeSchema.nullable().optional(),
     acl: z.array(AclEntrySchema).optional(),
     metadata: KbDocumentMetadataSchema.optional(),
   },
@@ -58,6 +70,7 @@ export const UpdateKbDocumentSchema = createUpdateSchema(
   schema.kbDocumentsTable,
   {
     embeddingStatus: EmbeddingStatusSchema.optional(),
+    embeddingErrorCode: EmbeddingErrorCodeSchema.nullable().optional(),
     acl: z.array(AclEntrySchema).optional(),
     metadata: KbDocumentMetadataSchema.optional(),
   },
@@ -69,6 +82,7 @@ export const UpdateKbDocumentSchema = createUpdateSchema(
   acl: true,
   metadata: true,
   embeddingStatus: true,
+  embeddingErrorCode: true,
   chunkCount: true,
 });
 

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-files-section.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-files-section.tsx
@@ -33,14 +33,25 @@ const ACCEPTED_EXTENSIONS =
   ".txt,.md,.csv,.json,.xml,.html,.htm,.pdf,.doc,.docx,.zip";
 const MAX_FILE_SIZE_MB = 10;
 
+const EMBEDDING_ERROR_LABELS: Record<string, string> = {
+  rate_limit: "Rate limit exceeded - the embedding API is being throttled. Try again later.",
+  auth_error: "Authentication failed - check your embedding API key.",
+  model_not_found: "Embedding model not found - check the model name in your configuration.",
+  server_error: "Embedding server error - the API returned a server error. Try again later.",
+  dimensions_mismatch: "Dimension mismatch - the configured embedding dimensions are not supported by this model.",
+  unknown: "An unknown error occurred during embedding. Check the logs for more details.",
+};
+
 function FileStatusBadge({
   processingStatus,
   embeddingStatus,
   processingError,
+  embeddingErrorCode,
 }: {
   processingStatus?: string;
   embeddingStatus: string;
   processingError?: string | null;
+  embeddingErrorCode?: string | null;
 }) {
   if (processingStatus && processingStatus !== "completed") {
     const variants = {
@@ -81,31 +92,56 @@ function FileStatusBadge({
     );
   }
 
-  const variants = {
+  const embeddingVariants = {
     completed: "default",
     pending: "secondary",
     processing: "secondary",
     failed: "destructive",
   } as const;
 
-  const labels = {
+  const embeddingLabels = {
     completed: "Indexed",
     pending: "Pending",
     processing: "Indexing…",
     failed: "Failed",
   };
 
+  const variant =
+    embeddingVariants[embeddingStatus as keyof typeof embeddingVariants] ??
+    "secondary";
+  const label =
+    embeddingLabels[embeddingStatus as keyof typeof embeddingLabels] ??
+    embeddingStatus;
+
+  if (embeddingStatus === "failed") {
+    const errorMessage = embeddingErrorCode
+      ? EMBEDDING_ERROR_LABELS[embeddingErrorCode] ?? embeddingErrorCode
+      : "An unknown error occurred during embedding.";
+
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Badge
+            variant={variant}
+            className="capitalize text-xs cursor-help"
+          >
+            {embeddingStatus === "processing" && (
+              <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+            )}
+            {label}
+          </Badge>
+        </TooltipTrigger>
+        <TooltipContent>{errorMessage}</TooltipContent>
+      </Tooltip>
+    );
+  }
+
   return (
-    <Badge
-      variant={
-        variants[embeddingStatus as keyof typeof variants] ?? "secondary"
-      }
-      className="capitalize text-xs"
-    >
+    <Badge variant={variant} className="capitalize text-xs">
       {embeddingStatus === "processing" && (
         <Loader2 className="h-3 w-3 mr-1 animate-spin" />
       )}
-      {labels[embeddingStatus as keyof typeof labels] ?? embeddingStatus}
+      {label}
     </Badge>
   );
 }
@@ -125,6 +161,7 @@ function FileStatusCell({
       processingStatus={current.processingStatus}
       embeddingStatus={current.embeddingStatus}
       processingError={current.processingError}
+      embeddingErrorCode={current.embeddingErrorCode}
     />
   );
 }

--- a/platform/frontend/src/lib/knowledge/connector-files.query.ts
+++ b/platform/frontend/src/lib/knowledge/connector-files.query.ts
@@ -161,7 +161,7 @@ export function useUploadConnectorFiles(connectorId: string) {
       }
       if (extractionFailed > 0) {
         toast.error(
-          `${extractionFailed} file${extractionFailed > 1 ? "s" : ""} failed to extract text — the file may be corrupted or use unsupported formatting`,
+          `${extractionFailed} file${extractionFailed > 1 ? "s" : ""} failed to extract text - the file may be corrupted or use unsupported formatting`,
         );
       }
     },


### PR DESCRIPTION
/claim #5033

## Summary

When file embedding fails (e.g., rate limits, auth errors, dimension mismatches), users previously saw only a red "Failed" badge with no explanation. This PR persists a categorized error code to the database and displays a human-readable tooltip on the frontend, matching the existing `processingError` pattern.

## Changes

### Backend
- **`backend/src/types/kb-document.ts`**: Added `EmbeddingErrorCode` zod enum (`rate_limit`, `auth_error`, `model_not_found`, `server_error`, `dimensions_mismatch`, `unknown`) and wired it into drizzle-zod schemas
- **`backend/src/database/schemas/kb-document.ts`**: Added nullable `embedding_error_code` column to `kb_documents` table
- **`backend/src/database/migrations/0255_add_kb_documents_embedding_error_code.sql`**: Drizzle migration for the new column
- **`backend/src/knowledge-base/embedding-clients/index.ts`**: Added `categorizeEmbeddingError()` function that maps API errors to error codes based on HTTP status and message content
- **`backend/src/knowledge-base/embedder.ts`**: Persist `embeddingErrorCode` on embedding failure in both `processDocument` and `processDocuments`
- **`backend/src/routes/knowledge-base.ts`**: Expose `embeddingErrorCode` in the file list and single-file API responses

### Frontend
- **`frontend/src/lib/knowledge/connector-files.query.ts`**: `UploadedFile` type now includes `embeddingErrorCode` from the auto-generated API types
- **`frontend/src/app/knowledge/connectors/_parts/connector-files-section.tsx`**: Added `EMBEDDING_ERROR_LABELS` map with descriptive messages, wrapped the "Failed" badge in a `<Tooltip>` showing the error reason

## Implementation Details

- Error categorization checks HTTP status codes first (429 = rate_limit, 401/403 = auth_error, 500+ = server_error, 404 = model_not_found), then falls back to message content matching for providers that may not return standard status codes
- Legacy records with `embeddingStatus: "failed"` but no `embeddingErrorCode` show "An unknown error occurred during embedding." in the tooltip
- The migration is a simple nullable column addition - no data backfill needed

## Testing

- The `categorizeEmbeddingError` function handles all three embedding error classes (OpenAI, Azure, Gemini)
- Frontend gracefully handles null/missing `embeddingErrorCode`
- Pre-migration records with null `embeddingErrorCode` show the fallback text