### PR TITLE
fix(audit): show only the occurred time in event detail

### DIFF
--- a/platform/frontend/src/app/audit/logs/_components/audit-log-detail-dialog.test.tsx
+++ b/platform/frontend/src/app/audit/logs/_components/audit-log-detail-dialog.test.tsx
@@ -105,23 +105,14 @@ describe("AuditLogDetailDialog", () => {
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith("req-copy-me");
   });
 
-  it("shows 'same as occurred' hint when occurredAt equals createdAt", () => {
-    const ts = new Date("2026-05-13T10:00:00Z").toISOString();
-    renderDialog(makeEvent({ occurredAt: ts, createdAt: ts }));
-    expect(screen.getByText(/same as occurred/i)).toBeInTheDocument();
-  });
-
-  it("shows both timestamps when occurredAt differs from createdAt", () => {
+  it("shows only the occurred timestamp, never a separate recorded one", () => {
     renderDialog(
       makeEvent({
         occurredAt: new Date("2026-05-13T10:00:00Z").toISOString(),
         createdAt: new Date("2026-05-13T10:00:05Z").toISOString(),
       }),
     );
-    // Both "Occurred" and "Recorded" labels should appear.
-    expect(screen.getByText("Occurred")).toBeInTheDocument();
-    expect(screen.getByText("Recorded")).toBeInTheDocument();
-    // The "same as occurred" hint must NOT appear.
+    expect(screen.queryByText("Recorded")).not.toBeInTheDocument();
     expect(screen.queryByText(/same as occurred/i)).not.toBeInTheDocument();
   });
 

--- a/platform/frontend/src/app/audit/logs/_components/audit-log-detail-dialog.tsx
+++ b/platform/frontend/src/app/audit/logs/_components/audit-log-detail-dialog.tsx
@@ -140,36 +140,13 @@ function DetailRow({
 }
 
 function WhenBlock({ event }: { event: AuditLog }) {
-  const occurredTs = new Date(event.occurredAt).getTime();
-  const createdTs = new Date(event.createdAt).getTime();
-  const isSame = occurredTs === createdTs;
-
   return (
-    <div className="space-y-2">
-      <div>
-        <div className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">
-          Occurred
-        </div>
-        <div className="font-mono text-xs">
-          {formatDate({ date: event.occurredAt })}
-        </div>
-        <div className="text-xs text-muted-foreground">
-          {formatRelativeTimeFromNow(event.occurredAt)}
-        </div>
+    <div>
+      <div className="font-mono text-xs">
+        {formatDate({ date: event.occurredAt })}
       </div>
-      <div>
-        <div className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">
-          Recorded
-        </div>
-        {isSame ? (
-          <div className="text-xs text-muted-foreground italic">
-            same as occurred
-          </div>
-        ) : (
-          <div className="font-mono text-xs">
-            {formatDate({ date: event.createdAt })}
-          </div>
-        )}
+      <div className="text-xs text-muted-foreground">
+        {formatRelativeTimeFromNow(event.occurredAt)}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

The audit event detail dialog's **When** section rendered two timestamps — **Occurred** (`occurred_at`) and **Recorded** (`created_at`). On the synchronous write path the two are effectively identical, so **Recorded** only ever repeated **Occurred** or displayed "same as occurred" — visual noise with no added information.

This collapses the block to the single `occurred_at` timestamp (formatted time + relative "x ago"). `created_at` is still persisted; it's just no longer surfaced as a redundant second line in the detail view.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>