### PR TITLE
feat(audit): add audit_write_failures_total metric

### DIFF
--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -36,6 +36,7 @@ import InvitationModel from "@/models/invitation";
 import MemberModel from "@/models/member";
 import SessionModel from "@/models/session";
 import UserModel from "@/models/user";
+import { reportAuditWriteFailure } from "@/observability/metrics/audit";
 import type { AuditEventName } from "@/types/audit-log";
 import { linkedIdentityProviderPlugin } from "./linked-idp";
 
@@ -958,6 +959,10 @@ export async function handleAfterHook(ctx: HookEndpointContext) {
             { err },
             "[auth:audit] failed to write cancel-invitation audit row",
           );
+          reportAuditWriteFailure({
+            source: "auth",
+            resourceType: "invitation",
+          });
         }
       }
     }
@@ -1015,6 +1020,7 @@ export async function handleAfterHook(ctx: HookEndpointContext) {
           { err },
           "[auth:audit] failed to write invite-member audit row",
         );
+        reportAuditWriteFailure({ source: "auth", resourceType: "invitation" });
       }
     }
   }
@@ -1065,6 +1071,7 @@ export async function handleAfterHook(ctx: HookEndpointContext) {
           { err },
           "[auth:audit] failed to write accept-invitation audit row",
         );
+        reportAuditWriteFailure({ source: "auth", resourceType: "member" });
       }
     }
   }
@@ -1116,6 +1123,7 @@ export async function handleAfterHook(ctx: HookEndpointContext) {
           { err },
           "[auth:audit] failed to write member role update audit row",
         );
+        reportAuditWriteFailure({ source: "auth", resourceType: "member" });
       }
     }
   }
@@ -1160,6 +1168,7 @@ export async function handleAfterHook(ctx: HookEndpointContext) {
           { err },
           "[auth:audit] failed to write remove-member audit row",
         );
+        reportAuditWriteFailure({ source: "auth", resourceType: "member" });
       }
     }
   }
@@ -1623,29 +1632,34 @@ async function writeAuthAuditLog(params: {
     after = { sessionId: session.id, userId: user.id };
   }
 
-  await AuditLogModel.create({
-    organizationId,
-    actorId: user.id,
-    actorType,
-    actorName: user.name ?? null,
-    actorEmail: user.email,
-    action,
-    outcome: "success",
-    resourceType: "auth",
-    resourceId: user.id,
-    before: null,
-    after,
-    httpMethod: "POST",
-    httpPath: path,
-    httpRoute: null,
-    httpStatus: null,
-    // better-auth operates on Web Request objects; Fastify's request.id is not
-    // accessible here. requestId is null for all auth-surface audit rows.
-    requestId: null,
-    sourceIp,
-    userAgent,
-    occurredAt: new Date(),
-  });
+  try {
+    await AuditLogModel.create({
+      organizationId,
+      actorId: user.id,
+      actorType,
+      actorName: user.name ?? null,
+      actorEmail: user.email,
+      action,
+      outcome: "success",
+      resourceType: "auth",
+      resourceId: user.id,
+      before: null,
+      after,
+      httpMethod: "POST",
+      httpPath: path,
+      httpRoute: null,
+      httpStatus: null,
+      // better-auth operates on Web Request objects; Fastify's request.id is not
+      // accessible here. requestId is null for all auth-surface audit rows.
+      requestId: null,
+      sourceIp,
+      userAgent,
+      occurredAt: new Date(),
+    });
+  } catch (err) {
+    reportAuditWriteFailure({ source: "auth", resourceType: "auth" });
+    throw err;
+  }
 }
 
 /**

--- a/platform/backend/src/middleware/audit-log-hook.ts
+++ b/platform/backend/src/middleware/audit-log-hook.ts
@@ -1,6 +1,7 @@
 import logger from "@/logging";
 import AuditLogModel from "@/models/audit-log";
 import UserTokenModel from "@/models/user-token";
+import { reportAuditWriteFailure } from "@/observability/metrics/audit";
 import type { FastifyInstanceWithZod } from "@/server";
 import type { AuditActorType, AuditEventName, AuditOutcome } from "@/types";
 import {
@@ -130,6 +131,10 @@ export function registerAuditLogHook(fastify: FastifyInstanceWithZod): void {
 
     void AuditLogModel.create(payload).catch((err) => {
       logger.error({ err }, "audit: failed to write audit log row");
+      reportAuditWriteFailure({
+        source: "http",
+        resourceType: payload.resourceType,
+      });
     });
   });
 }

--- a/platform/backend/src/observability/index.ts
+++ b/platform/backend/src/observability/index.ts
@@ -23,6 +23,7 @@ export async function initializeObservabilityMetrics(params?: {
   metrics.scheduleTrigger.initializeScheduleTriggerMetrics();
   metrics.taskQueue.initializeTaskQueueMetrics();
   metrics.codeRuntime.initializeCodeRuntimeMetrics();
+  metrics.audit.initializeAuditMetrics();
 
   return labelKeys;
 }

--- a/platform/backend/src/observability/metrics/audit.test.ts
+++ b/platform/backend/src/observability/metrics/audit.test.ts
@@ -1,0 +1,52 @@
+import { vi } from "vitest";
+import { beforeEach, describe, expect, test } from "@/test";
+
+const counterInc = vi.fn();
+
+vi.mock("prom-client", () => {
+  return {
+    default: {
+      Counter: class {
+        inc(...args: unknown[]) {
+          return counterInc(...args);
+        }
+      },
+    },
+  };
+});
+
+import { initializeAuditMetrics, reportAuditWriteFailure } from "./audit";
+
+describe("audit metrics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    initializeAuditMetrics();
+  });
+
+  test("reports an http write failure with resource type", () => {
+    reportAuditWriteFailure({ source: "http", resourceType: "agent" });
+
+    expect(counterInc).toHaveBeenCalledWith({
+      source: "http",
+      resource_type: "agent",
+    });
+  });
+
+  test("reports an auth write failure", () => {
+    reportAuditWriteFailure({ source: "auth", resourceType: "auth" });
+
+    expect(counterInc).toHaveBeenCalledWith({
+      source: "auth",
+      resource_type: "auth",
+    });
+  });
+
+  test("falls back to 'unknown' when resource type is null", () => {
+    reportAuditWriteFailure({ source: "http", resourceType: null });
+
+    expect(counterInc).toHaveBeenCalledWith({
+      source: "http",
+      resource_type: "unknown",
+    });
+  });
+});

--- a/platform/backend/src/observability/metrics/audit.ts
+++ b/platform/backend/src/observability/metrics/audit.ts
@@ -1,0 +1,41 @@
+/**
+ * Prometheus metrics for the audit log write path.
+ *
+ * Audit rows are written best-effort (fire-and-forget on the HTTP hook, and
+ * `void`-dispatched on the auth surface), so a failed insert is otherwise only
+ * a log line. This counter makes that loss alertable.
+ *
+ * Failed writes in the last 5m, by source:
+ * sum by (source) (rate(audit_write_failures_total[5m]))
+ */
+
+import client from "prom-client";
+import logger from "@/logging";
+
+let auditWriteFailuresTotal: client.Counter<string>;
+
+let initialized = false;
+
+export function initializeAuditMetrics(): void {
+  if (initialized) return;
+  initialized = true;
+
+  auditWriteFailuresTotal = new client.Counter({
+    name: "audit_write_failures_total",
+    help: "Total audit log rows that failed to persist, by source and resource type",
+    labelNames: ["source", "resource_type"],
+  });
+
+  logger.info("Audit metrics initialized");
+}
+
+export function reportAuditWriteFailure(params: {
+  source: "http" | "auth";
+  resourceType: string | null;
+}): void {
+  if (!auditWriteFailuresTotal) return;
+  auditWriteFailuresTotal.inc({
+    source: params.source,
+    resource_type: params.resourceType ?? "unknown",
+  });
+}

--- a/platform/backend/src/observability/metrics/index.ts
+++ b/platform/backend/src/observability/metrics/index.ts
@@ -1,4 +1,5 @@
 export * as agentExecution from "./agent-execution";
+export * as audit from "./audit";
 export * as codeRuntime from "./code-runtime";
 export * as llm from "./llm";
 export * as mcp from "./mcp";


### PR DESCRIPTION
## Summary

Audit rows are written best-effort: the HTTP hook dispatches the insert fire-and-forget (`void AuditLogModel.create(...).catch(...)`), and the better-auth surface does the same. A failed insert is therefore only a log line — silent audit loss is otherwise invisible, which is exactly the failure mode you most want to know about for an audit log.

This adds a Prometheus counter `audit_write_failures_total`, incremented in every audit-write failure path:
- the HTTP `onResponse` hook (`source="http"`, `resource_type` from the route registry)
- the central `writeAuthAuditLog` writer and the inline invitation/member audit writes in better-auth (`source="auth"`)

Labels are low-cardinality and server-controlled (`source` is a closed union; `resource_type` comes from the auditable-route registry / hardcoded literals — never user input), so there's no cardinality or label-injection concern.

```promql
sum by (source) (rate(audit_write_failures_total[5m]))
```

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>