### PR TITLE
feat(audit): record created skills in the skill.imported audit row

### DIFF
--- a/platform/backend/src/middleware/audit-log-hook.test.ts
+++ b/platform/backend/src/middleware/audit-log-hook.test.ts
@@ -99,6 +99,12 @@ vi.mock("./audit-log-registry", async () => {
       action: "userToken.rotated",
       resourceIdSource: "currentUserPersonalToken" as const,
     },
+    // Bulk import — no fetchById/resourceIdSource; the handler supplies the
+    // post-state via request.auditAfter and resourceId stays null.
+    "/api/bulk-imports": {
+      resourceType: "skill",
+      action: "skill.imported",
+    },
   };
 
   function resolveAuditableRouteConfig(routePattern: string | undefined) {
@@ -277,6 +283,15 @@ describe("registerAuditLogHook", () => {
     // Token rotation route.
     app.post("/api/user-tokens/me/rotate", async () => ({ ok: true }));
 
+    // Bulk import route — handler supplies the audit post-state directly.
+    app.post("/api/bulk-imports", async (request, reply) => {
+      request.auditAfter = {
+        created: [{ id: "skill-1", name: "Skill One" }],
+        skipped: ["repo/bad-skill"],
+      };
+      return reply.send({ ok: true });
+    });
+
     // Non-mutating verbs
     app.route({
       method: "HEAD",
@@ -351,6 +366,28 @@ describe("registerAuditLogHook", () => {
       });
 
       await envelopeApp.close();
+    });
+  });
+
+  describe("handler-supplied after (request.auditAfter)", () => {
+    test("uses request.auditAfter verbatim and leaves resourceId null", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/bulk-imports",
+      });
+      expect(res.statusCode).toBe(200);
+      await settle();
+
+      const rows = await getRows();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].action).toBe("skill.imported");
+      expect(rows[0].outcome).toBe("success");
+      expect(rows[0].resourceId).toBeNull();
+      expect(rows[0].before).toBeNull();
+      expect(rows[0].after).toEqual({
+        created: [{ id: "skill-1", name: "Skill One" }],
+        skipped: ["repo/bad-skill"],
+      });
     });
   });
 

--- a/platform/backend/src/middleware/audit-log-hook.ts
+++ b/platform/backend/src/middleware/audit-log-hook.ts
@@ -88,16 +88,22 @@ export function registerAuditLogHook(fastify: FastifyInstanceWithZod): void {
       request.auditResponseBodyId ??
       null;
 
+    // A handler may supply the post-state directly (e.g. bulk creates whose
+    // result can't be represented by a single fetchById); prefer it.
     const after =
-      outcome === "success"
-        ? await resolveAfterState({
-            method: request.method,
-            id,
-            organizationId: request.organizationId,
-            cfg,
-            routeParams: request.params as Record<string, unknown> | undefined,
-          })
-        : null;
+      outcome !== "success"
+        ? null
+        : request.auditAfter !== undefined
+          ? request.auditAfter
+          : await resolveAfterState({
+              method: request.method,
+              id,
+              organizationId: request.organizationId,
+              cfg,
+              routeParams: request.params as
+                | Record<string, unknown>
+                | undefined,
+            });
 
     const sourceIp = extractIp(request);
     const userAgent =

--- a/platform/backend/src/middleware/audit-log-registry.ts
+++ b/platform/backend/src/middleware/audit-log-registry.ts
@@ -291,12 +291,12 @@ export const AUDITABLE_ROUTES: Record<string, AuditableRouteConfig> = {
     resourceIdSource: "organizationContext",
     fetchById: (id, _orgId) => OrganizationModel.findByIdForAudit(id, _orgId),
   },
-  // GitHub import has distinct semantics from a plain create.
+  // Bulk import creates multiple skills, so there is no single resourceId and
+  // fetchById can't represent the result. The route handler sets
+  // `request.auditAfter` with the created list; resourceId stays null.
   "/api/skills/github/import": {
     resourceType: "skill",
     action: "skill.imported",
-    resourceIdSource: "organizationContext",
-    fetchById: (id, orgId) => SkillModel.findByIdForAudit(id, orgId),
   },
 
   // Scheduled agent triggers (sub-routes resolve via `resolveAuditableRouteConfig`)

--- a/platform/backend/src/routes/skill.ts
+++ b/platform/backend/src/routes/skill.ts
@@ -604,7 +604,8 @@ const skillRoutes: FastifyPluginAsyncZod = async (fastify) => {
         ),
       },
     },
-    async ({ body, organizationId, user }, reply) => {
+    async (request, reply) => {
+      const { body, organizationId, user } = request;
       // Imported skills carry an explicit scope, authorized like manual create;
       // when omitted they default to `personal` so a bulk import is never
       // silently published org-wide.
@@ -671,6 +672,13 @@ const skillRoutes: FastifyPluginAsyncZod = async (fastify) => {
         { organizationId, created: created.length, skipped: skipped.length },
         "[Skills] GitHub import complete",
       );
+
+      // Supply the audit post-state: a bulk import has no single resourceId,
+      // so record the created skills (id + name) for traceability.
+      request.auditAfter = {
+        created: created.map((s) => ({ id: s.id, name: s.name })),
+        skipped,
+      };
 
       return reply.send({ created, skipped });
     },

--- a/platform/backend/src/types/fastify.d.ts
+++ b/platform/backend/src/types/fastify.d.ts
@@ -8,6 +8,13 @@ declare module "fastify" {
     authMethod?: "session" | "api_key";
     /** Snapshot of the resource before the mutation; set by the audit preHandler hook. */
     auditBefore?: Record<string, unknown> | null;
+    /**
+     * Post-state supplied by a route handler for the audit `after` snapshot,
+     * used when the generic `fetchById` snapshot can't represent the result —
+     * e.g. a bulk create that yields multiple ids. When set, the onResponse
+     * hook uses this verbatim instead of calling `fetchById`.
+     */
+    auditAfter?: Record<string, unknown> | null;
     /** Timestamp captured at the start of preHandler, before the route handler executes. */
     auditOccurredAt?: Date;
     /** ID extracted from the POST response body; set by the audit onSend hook. */


### PR DESCRIPTION
## Summary

A github skill import (`POST /api/skills/github/import`) bulk-creates multiple skills, but the audit log recorded the row against the **organization id** with a `null` `after` snapshot — so the skills an admin imported were untraceable from the audit trail. The generic snapshot hook can't represent a multi-create result: there's no single `resourceId`, and `fetchById` runs without knowledge of what was just created.

This adds a `request.auditAfter` decorator that a route handler can set to supply the audit `after` snapshot directly; the `onResponse` hook uses it verbatim (still passing through `sanitizeAuditSnapshot`) when present. The import handler populates it with the created skills (`id` + `name`) and the skipped paths. The registry entry drops `resourceIdSource`/`fetchById`, so `resourceId` is correctly `null` for the bulk operation.

After: a `skill.imported` row carries `after: { created: [{ id, name }, …], skipped: [...] }` — the imported skills are now traceable by id.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>