### PR TITLE
chore(e2e): remove auth rate-limit diagnostics; honor x-retry-after in setup sign-in

### DIFF
--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -221,23 +221,6 @@ jobs:
           platform-context: ./platform
           mcp-server-base-image-tag: ${{ steps.load-mcp-server-base-image.outputs.image-tag }}
 
-      # TEMPORARY — remove with the [auth-diagnostic] startup log once the
-      # setup-teams 429 flake is resolved. Surfaces the runtime auth
-      # rate-limit config: the [auth-diagnostic] startup log only reaches the
-      # failure/flaky dump via --tail=200, which misses startup, so read it
-      # directly here on every run.
-      - name: Diagnose auth rate-limit config (temporary)
-        run: |
-          POD=$(kubectl get pod -l app.kubernetes.io/name=archestra-platform \
-            -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
-          echo "=== ARCHESTRA_AUTH_RATE_LIMIT_DISABLED in pod env ==="
-          kubectl exec "$POD" -c archestra-platform -- \
-            printenv ARCHESTRA_AUTH_RATE_LIMIT_DISABLED || echo "(printenv failed / not set)"
-          echo "=== [auth-diagnostic] startup log (full backend log) ==="
-          kubectl logs -l app.kubernetes.io/name=archestra-platform \
-            -c archestra-platform 2>/dev/null | grep -i 'auth-diagnostic' \
-            || echo "(no [auth-diagnostic] line found)"
-
       - name: Run all non-quickstart E2E tests
         id: e2e
         continue-on-error: true

--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -410,21 +410,6 @@ export const auth = betterAuth({
   },
 });
 
-// TEMPORARY DIAGNOSTIC — remove once the setup-teams 429 flake is resolved.
-// The e2e env sets ARCHESTRA_AUTH_RATE_LIMIT_DISABLED=true and the chart
-// renders it into the pod, yet better-auth's limiter still 429s sign-in under
-// CI parallelism. Log the runtime-effective flag so a CI pod log reveals
-// whether the disable actually takes effect at construction time, instead of
-// us deducing it from source. (better-auth derives rateLimit.enabled directly
-// from this, so the parsed flag is the decisive value.)
-logger.info(
-  {
-    rawEnv: process.env.ARCHESTRA_AUTH_RATE_LIMIT_DISABLED ?? null,
-    authRateLimitDisabled: config.authRateLimitDisabled,
-  },
-  "[auth-diagnostic] startup rate-limit config",
-);
-
 /**
  * Per-request stashes used to ferry data from the `before` hook to the
  * `after` hook (prior member role, removed-member identity, sign-out session).

--- a/platform/e2e-tests/auth.teams.setup.ts
+++ b/platform/e2e-tests/auth.teams.setup.ts
@@ -287,7 +287,20 @@ async function withRetries(
       attempt < maxRetries &&
       params.retryStatuses.includes(response.status())
     ) {
-      await sleep(delay);
+      // better-auth's 429 carries x-retry-after (seconds until its rate-limit
+      // window clears). Honor it so a transient rate-limit recovers within
+      // this setup attempt instead of forcing a full test-level retry — the
+      // default exponential backoff never sleeps longer than the ~10s window,
+      // and retrying inside the window keeps the limiter's bucket full.
+      const headers = response.headers();
+      const retryAfterSec = Number.parseInt(
+        headers["x-retry-after"] ?? headers["retry-after"] ?? "",
+        10,
+      );
+      const waitMs = Number.isFinite(retryAfterSec)
+        ? Math.min(retryAfterSec * 1000 + 500, 20_000)
+        : delay;
+      await sleep(waitMs);
       delay *= 2;
       continue;
     }


### PR DESCRIPTION
## Summary

The temporary diagnostics (#5098 startup log + #5099 e2e workflow step) answered their question and are removed here per their own "remove once resolved" markers. Across multiple merge-queue runs, the `[auth-diagnostic]` log read `{"rawEnv":"true","authRateLimitDisabled":true}` on every backend instance, and `printenv` confirmed the flag is present in the live pod. So better-auth's limiter is genuinely disabled in CI, and the earlier `setup-teams` 429 was a rare, non-reproducing transient — not the wiring failure I initially suspected.

As cheap insurance against a recurrence, the team-setup sign-in retry now honors better-auth's `x-retry-after` header on a 429. The previous exponential backoff (~1s/2s/4s) never sleeps longer than better-auth's ~10s rate-limit window, and retrying *inside* the window keeps the limiter's bucket full — so a transient rate-limit could never recover within the setup attempt and instead forced a full test-level retry. Waiting the header's advertised seconds clears the window deterministically (capped at 20s; falls back to exponential backoff when the header is absent or non-numeric).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>