### PR TITLE
chore(diag): pin which external-IdP validation branch fails the flaky JWKS gateway e2e

### DIFF
--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -250,6 +250,14 @@ jobs:
           echo "=== Archestra Platform Logs (main container) ==="
           kubectl logs -l app.kubernetes.io/name=archestra-platform -c archestra-platform --tail=200 2>/dev/null || true
 
+          # TEMPORARY [idp-diag] — the external-IdP validation branch logs fire
+          # mid-run (well before this dump), so --tail=200 misses them. Grep the
+          # full backend log for the marker to pin the flaky JWKS gateway e2e.
+          echo "=== [idp-diag] external IdP validation branch ==="
+          kubectl logs -l app.kubernetes.io/name=archestra-platform \
+            -c archestra-platform 2>/dev/null | grep -i '\[idp-diag\]' \
+            || echo "(no [idp-diag] line found)"
+
           echo "=== Platform Init Container: vault-secrets ==="
           kubectl logs -l app.kubernetes.io/name=archestra-platform -c vault-secrets --tail=200 2>/dev/null || true
 
@@ -385,6 +393,14 @@ jobs:
 
           echo "=== Archestra Platform Logs (main container) ==="
           kubectl logs -l app.kubernetes.io/name=archestra-platform -c archestra-platform --tail=200 2>/dev/null || true
+
+          # TEMPORARY [idp-diag] — the external-IdP validation branch logs fire
+          # mid-run (well before this dump), so --tail=200 misses them. Grep the
+          # full backend log for the marker to pin the flaky JWKS gateway e2e.
+          echo "=== [idp-diag] external IdP validation branch ==="
+          kubectl logs -l app.kubernetes.io/name=archestra-platform \
+            -c archestra-platform 2>/dev/null | grep -i '\[idp-diag\]' \
+            || echo "(no [idp-diag] line found)"
 
           echo "=== Platform Init Container: vault-secrets ==="
           kubectl logs -l app.kubernetes.io/name=archestra-platform -c vault-secrets --tail=200 2>/dev/null || true

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -255,7 +255,8 @@ jobs:
           # full backend log for the marker to pin the flaky JWKS gateway e2e.
           echo "=== [idp-diag] external IdP validation branch ==="
           kubectl logs -l app.kubernetes.io/name=archestra-platform \
-            -c archestra-platform 2>/dev/null | grep -i '\[idp-diag\]' \
+            -c archestra-platform 2>/dev/null \
+            | grep -iE '\[idp-diag\]|JWKS JWT validation failed' \
             || echo "(no [idp-diag] line found)"
 
           echo "=== Platform Init Container: vault-secrets ==="
@@ -399,7 +400,8 @@ jobs:
           # full backend log for the marker to pin the flaky JWKS gateway e2e.
           echo "=== [idp-diag] external IdP validation branch ==="
           kubectl logs -l app.kubernetes.io/name=archestra-platform \
-            -c archestra-platform 2>/dev/null | grep -i '\[idp-diag\]' \
+            -c archestra-platform 2>/dev/null \
+            | grep -iE '\[idp-diag\]|JWKS JWT validation failed' \
             || echo "(no [idp-diag] line found)"
 
           echo "=== Platform Init Container: vault-secrets ==="

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -1087,8 +1087,9 @@ export async function validateExternalIdpToken(
     });
 
     if (!result) {
-      // TEMPORARY [idp-diag] — verify failed; the reason (expired / no-key /
-      // signature / issuer / audience) is on the "[idp-diag] jwks" line.
+      // TEMPORARY [idp-diag] — verify failed; the reason (no-matching-key /
+      // issuer / audience at warn; expired / signature at debug) is on the
+      // "JWKS JWT validation failed" line.
       logger.info(
         { profileId, issuer: idpProvider.issuer, jwksUrl },
         "[idp-diag] null: jwksValidator.validateJwt returned null",

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -1019,6 +1019,12 @@ export async function validateExternalIdpToken(
     // Look up the agent to check if it has an identity provider configured
     const agent = await AgentModel.findById(profileId);
     if (!agent?.identityProviderId) {
+      // TEMPORARY [idp-diag] — pin which branch fails the flaky JWKS gateway
+      // e2e (mcp-gateway-jwks/.jwt-propagation). Remove once root cause known.
+      logger.info(
+        { profileId, hasAgent: !!agent },
+        "[idp-diag] null: agent missing identityProviderId",
+      );
       return null;
     }
 
@@ -1036,9 +1042,10 @@ export async function validateExternalIdpToken(
 
     // Only OIDC providers support JWKS validation
     if (!idpProvider.oidcConfig) {
-      logger.debug(
+      // TEMPORARY [idp-diag] — promoted from debug so it's visible in CI.
+      logger.info(
         { profileId, identityProviderId: agent.identityProviderId },
-        "validateExternalIdpToken: Identity provider has no OIDC config",
+        "[idp-diag] null: identity provider has no OIDC config",
       );
       return null;
     }
@@ -1080,6 +1087,12 @@ export async function validateExternalIdpToken(
     });
 
     if (!result) {
+      // TEMPORARY [idp-diag] — verify failed; the reason (expired / no-key /
+      // signature / issuer / audience) is on the "[idp-diag] jwks" line.
+      logger.info(
+        { profileId, issuer: idpProvider.issuer, jwksUrl },
+        "[idp-diag] null: jwksValidator.validateJwt returned null",
+      );
       return null;
     }
 

--- a/platform/backend/src/services/jwks-validator.ts
+++ b/platform/backend/src/services/jwks-validator.ts
@@ -69,6 +69,13 @@ class JwksValidator {
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      // TEMPORARY [idp-diag] — surface the verify failure reason (expired /
+      // no-matching-key / signature / issuer / audience) at info so CI shows
+      // it. Remove once the flaky JWKS gateway e2e root cause is pinned.
+      logger.info(
+        { issuerUrl, jwksUrl, error: message },
+        "[idp-diag] jwks: JWT validation failed",
+      );
       // Expected validation failures (expired, bad signature) log at debug;
       // unexpected errors (network, malformed key) log at warn.
       const isExpected =

--- a/platform/backend/src/services/jwks-validator.ts
+++ b/platform/backend/src/services/jwks-validator.ts
@@ -69,15 +69,10 @@ class JwksValidator {
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      // TEMPORARY [idp-diag] — surface the verify failure reason (expired /
-      // no-matching-key / signature / issuer / audience) at info so CI shows
-      // it. Remove once the flaky JWKS gateway e2e root cause is pinned.
-      logger.info(
-        { issuerUrl, jwksUrl, error: message },
-        "[idp-diag] jwks: JWT validation failed",
-      );
       // Expected validation failures (expired, bad signature) log at debug;
-      // unexpected errors (network, malformed key) log at warn.
+      // unexpected errors (network, malformed key) log at warn. Include jwksUrl
+      // so a real auth failure shows which endpoint was used, not just the
+      // issuer.
       const isExpected =
         message.includes("expired") ||
         message.includes("signature") ||
@@ -85,7 +80,7 @@ class JwksValidator {
         message.includes("JWT");
       const level = isExpected ? "debug" : "warn";
       logger[level](
-        { issuerUrl, error: message },
+        { issuerUrl, jwksUrl, error: message },
         "JWKS JWT validation failed",
       );
       return null;


### PR DESCRIPTION
## Summary

Pins which branch of `validateExternalIdpToken` fails the flaky `mcp-gateway-jwks.ee` / `mcp-gateway-jwt-propagation.ee` e2e tests, where the gateway returns a per-profile `401 "Invalid token for this profile"` across the full ~161s readiness poll while the test-level retry's *fresh* profile validates fine. Deep-dive ruled out the JWKS-key/`createRemoteJWKSet` cooldown (sibling tests sharing the same realm/keyset pass in the same run), token expiry (realm `accessTokenLifespan` 3600s), the token-auth negative cache (already disabled), and a stale agent cache (`findById` reads fresh) — leaving one of the validator's null branches, several of which are silent or `debug`-level so CI logs don't reveal which.

The change is split by durability:

**Permanent** — the existing `"JWKS JWT validation failed"` log now includes `jwksUrl` alongside `issuerUrl`, so a real external-IdP auth failure shows *which* JWKS endpoint was used, not just the issuer. Useful for production debugging beyond this investigation.

**Temporary (`[idp-diag]`, removed once the branch is identified)** — `info` logs at the otherwise-silent/debug null-returns (missing `identityProviderId`, no OIDC config, `jwksValidator.validateJwt` returned null), plus a full-log grep in the e2e failure/flaky dump (these lines fire mid-run, which the existing `--tail=200` dump misses). The grep also catches the permanent `"JWKS JWT validation failed"` line so the verify reason (no-matching-key / issuer / audience at warn) is captured.

Logs only UUIDs, IdP URLs, and the jose error-class string — never the token, claims, OIDC clientId/secret, or signing keys (security-reviewed).