### PR TITLE
chore: skill sandbox follow-ups

### DIFF
--- a/platform/archestra-rs/sandbox-rs/package.json
+++ b/platform/archestra-rs/sandbox-rs/package.json
@@ -9,7 +9,7 @@
     "build": "napi build --release --platform",
     "build:test-helpers": "napi build --release --platform --features test-helpers",
     "check:ci": "cargo fmt --check --all && cargo check --workspace --locked && cargo test --workspace --locked && pnpm build && pnpm smoke && pnpm build:test-helpers && pnpm smoke:panic && pnpm build",
-    "check:musl": "cargo check --workspace --locked && cargo test --workspace --locked && pnpm build && pnpm smoke && pnpm build:test-helpers && pnpm smoke:panic && pnpm build",
+    "check:musl": "cargo test --workspace --locked && pnpm build && pnpm smoke && pnpm build:test-helpers && pnpm smoke:panic",
     "lint": "cargo fmt --check --all",
     "smoke": "node smoke.test.cjs",
     "smoke:panic": "node panic-smoke.test.cjs",

--- a/platform/backend/src/archestra-mcp-server/skills.ts
+++ b/platform/backend/src/archestra-mcp-server/skills.ts
@@ -10,7 +10,6 @@ import {
   getSkillPermissionChecker,
   requireSkillModifyPermission,
 } from "@/auth/skill-permissions";
-import config from "@/config";
 import logger from "@/logging";
 import {
   SkillFileModel,
@@ -32,8 +31,8 @@ import {
   escapeXmlAttr,
   escapeXmlText,
   formatSkillActivation,
-  skillSandboxAvailable,
 } from "@/skills/skill-activation";
+import { isSkillSandboxAvailableForAgent } from "@/skills/skill-sandbox-availability";
 import { ApiError, type Skill, SkillFileEncodingSchema } from "@/types";
 import { isUniqueConstraintError } from "@/utils/db";
 import {
@@ -166,25 +165,22 @@ const registry = defineArchestraTools([
         return errorResult("This tool requires an organization context.");
       }
 
-      return listSkillCatalog(ctx);
+      return listSkillCatalog(ctx, context.agent.id);
     },
   }),
   defineArchestraTool({
     shortName: TOOL_ACTIVATE_SKILL_SHORT_NAME,
     title: "Activate Skill",
-    // the sandbox sentence is appended only when the feature is enabled on
-    // this deployment — getArchestraMcpTools() also drops the sandbox tools
-    // from tools/list in that case, so we never name tools that aren't there.
+    // a static tool description can't know whether the sandbox tools are
+    // enabled, permitted, and assigned to the calling agent, so it does not
+    // mention them. The activate_skill *result* adds an agent-aware sandbox
+    // hint (see formatSkillActivation) only when they are genuinely available.
     description:
       "Load a specialized Agent Skill — a reusable SKILL.md instruction set. " +
       "Call list_skills first to discover what is available, then call this " +
       "with a skill name to load its full instructions. Activate a skill " +
       "before attempting the task it covers. To inspect bundled resources " +
-      "use read_skill_file." +
-      (config.skillsSandbox.enabled
-        ? " To execute scripts or shell commands use create_skill_sandbox + " +
-          "run_skill_command."
-        : ""),
+      "use read_skill_file.",
     schema: ActivateSkillSchema,
     async handler({ args, context }) {
       const ctx = requireOrgContext(context);
@@ -213,7 +209,7 @@ const registry = defineArchestraTools([
         formatSkillActivation({
           skill,
           files,
-          canRunSandbox: await canRunSkillSandbox(ctx),
+          canRunSandbox: await canRunSkillSandbox(ctx, context.agent.id),
         }),
       );
     },
@@ -405,22 +401,24 @@ function requireOrgContext(context: ArchestraContext): SkillReadContext | null {
   return { organizationId: context.organizationId, userId: context.userId };
 }
 
+/** `isSkillSandboxAvailableForAgent` for callers that only hold a read context. */
+async function canRunSkillSandbox(
+  ctx: SkillReadContext,
+  agentId: string | undefined,
+): Promise<boolean> {
+  if (ctx.userId === undefined) return false;
+  const checker = await getSkillPermissionChecker({
+    userId: ctx.userId,
+    organizationId: ctx.organizationId,
+  });
+  return isSkillSandboxAvailableForAgent({ checker, agentId });
+}
+
 /**
  * Look up a skill by name and return it only if the caller can access it under
  * the skill's scope. Returns null otherwise — callers surface a generic
  * "no skill named …" so an inaccessible skill's existence is not leaked.
  */
-/** `skillSandboxAvailable` for callers that only hold a read context. */
-async function canRunSkillSandbox(ctx: SkillReadContext): Promise<boolean> {
-  if (ctx.userId === undefined) return false;
-  return skillSandboxAvailable(
-    await getSkillPermissionChecker({
-      userId: ctx.userId,
-      organizationId: ctx.organizationId,
-    }),
-  );
-}
-
 async function findAccessibleSkill(ctx: SkillReadContext, name: string) {
   const skill = await SkillModel.findByName(ctx.organizationId, name);
   if (!skill) return null;
@@ -493,7 +491,10 @@ function toSkillFiles(
   }));
 }
 
-async function listSkillCatalog(ctx: SkillReadContext) {
+async function listSkillCatalog(
+  ctx: SkillReadContext,
+  agentId: string | undefined,
+) {
   const checker =
     ctx.userId !== undefined
       ? await getSkillPermissionChecker({
@@ -529,8 +530,12 @@ async function listSkillCatalog(ctx: SkillReadContext) {
     .join("\n");
 
   // only advertise the sandbox path when it would actually work: the feature
-  // is enabled on this deployment and the caller can execute skills.
-  const instructions = skillSandboxAvailable(checker)
+  // is enabled, the caller can execute skills, and the sandbox tools are
+  // assigned to this agent (so they appear in its tools/list).
+  const instructions = (await isSkillSandboxAvailableForAgent({
+    checker,
+    agentId,
+  }))
     ? "Call activate_skill with one of these names to load its instructions. " +
       "To run a skill's scripts or shell commands, create_skill_sandbox with " +
       "the skill name, then run_skill_command."

--- a/platform/backend/src/archestra-mcp-server/skills.ts
+++ b/platform/backend/src/archestra-mcp-server/skills.ts
@@ -10,6 +10,7 @@ import {
   getSkillPermissionChecker,
   requireSkillModifyPermission,
 } from "@/auth/skill-permissions";
+import config from "@/config";
 import logger from "@/logging";
 import {
   SkillFileModel,
@@ -171,13 +172,19 @@ const registry = defineArchestraTools([
   defineArchestraTool({
     shortName: TOOL_ACTIVATE_SKILL_SHORT_NAME,
     title: "Activate Skill",
+    // the sandbox sentence is appended only when the feature is enabled on
+    // this deployment — getArchestraMcpTools() also drops the sandbox tools
+    // from tools/list in that case, so we never name tools that aren't there.
     description:
       "Load a specialized Agent Skill — a reusable SKILL.md instruction set. " +
       "Call list_skills first to discover what is available, then call this " +
       "with a skill name to load its full instructions. Activate a skill " +
       "before attempting the task it covers. To inspect bundled resources " +
-      "use read_skill_file; to execute scripts or shell commands use " +
-      "create_skill_sandbox + run_skill_command.",
+      "use read_skill_file." +
+      (config.skillsSandbox.enabled
+        ? " To execute scripts or shell commands use create_skill_sandbox + " +
+          "run_skill_command."
+        : ""),
     schema: ActivateSkillSchema,
     async handler({ args, context }) {
       const ctx = requireOrgContext(context);

--- a/platform/backend/src/archestra-mcp-server/skills.ts
+++ b/platform/backend/src/archestra-mcp-server/skills.ts
@@ -31,6 +31,7 @@ import {
   escapeXmlAttr,
   escapeXmlText,
   formatSkillActivation,
+  skillSandboxAvailable,
 } from "@/skills/skill-activation";
 import { ApiError, type Skill, SkillFileEncodingSchema } from "@/types";
 import { isUniqueConstraintError } from "@/utils/db";
@@ -201,7 +202,13 @@ const registry = defineArchestraTools([
         "[Skills] Skill activated",
       );
 
-      return successResult(formatSkillActivation({ skill, files }));
+      return successResult(
+        formatSkillActivation({
+          skill,
+          files,
+          canRunSandbox: await canRunSkillSandbox(ctx),
+        }),
+      );
     },
   }),
   defineArchestraTool({
@@ -396,6 +403,17 @@ function requireOrgContext(context: ArchestraContext): SkillReadContext | null {
  * the skill's scope. Returns null otherwise — callers surface a generic
  * "no skill named …" so an inaccessible skill's existence is not leaked.
  */
+/** `skillSandboxAvailable` for callers that only hold a read context. */
+async function canRunSkillSandbox(ctx: SkillReadContext): Promise<boolean> {
+  if (ctx.userId === undefined) return false;
+  return skillSandboxAvailable(
+    await getSkillPermissionChecker({
+      userId: ctx.userId,
+      organizationId: ctx.organizationId,
+    }),
+  );
+}
+
 async function findAccessibleSkill(ctx: SkillReadContext, name: string) {
   const skill = await SkillModel.findByName(ctx.organizationId, name);
   if (!skill) return null;
@@ -469,14 +487,14 @@ function toSkillFiles(
 }
 
 async function listSkillCatalog(ctx: SkillReadContext) {
-  const isSkillAdmin =
-    ctx.userId !== undefined &&
-    (
-      await getSkillPermissionChecker({
-        userId: ctx.userId,
-        organizationId: ctx.organizationId,
-      })
-    ).isAdmin;
+  const checker =
+    ctx.userId !== undefined
+      ? await getSkillPermissionChecker({
+          userId: ctx.userId,
+          organizationId: ctx.organizationId,
+        })
+      : null;
+  const isSkillAdmin = checker?.isAdmin ?? false;
   const accessibleSkillIds = isSkillAdmin
     ? undefined
     : await SkillTeamModel.getUserAccessibleSkillIds({
@@ -503,9 +521,16 @@ async function listSkillCatalog(ctx: SkillReadContext) {
     )
     .join("\n");
 
+  // only advertise the sandbox path when it would actually work: the feature
+  // is enabled on this deployment and the caller can execute skills.
+  const instructions = skillSandboxAvailable(checker)
+    ? "Call activate_skill with one of these names to load its instructions. " +
+      "To run a skill's scripts or shell commands, create_skill_sandbox with " +
+      "the skill name, then run_skill_command."
+    : "Call activate_skill with one of these names to load its instructions.";
+
   return successResult(
-    `<available_skills>\n${catalog}\n</available_skills>\n` +
-      "Call activate_skill with one of these names to load its instructions.",
+    `<available_skills>\n${catalog}\n</available_skills>\n${instructions}`,
   );
 }
 

--- a/platform/backend/src/routes/chat/inject-skill-activation.test.ts
+++ b/platform/backend/src/routes/chat/inject-skill-activation.test.ts
@@ -52,6 +52,7 @@ test("prepends the skill activation block to the last user message", async ({
     messages,
     organizationId: org.id,
     userId: user.id,
+    agentId: undefined,
   });
 
   const text = result[0].parts?.[0]?.text ?? "";
@@ -83,6 +84,7 @@ test("ignores a skill that belongs to another organization", async ({
     messages,
     organizationId: org.id,
     userId: user.id,
+    agentId: undefined,
   });
 
   expect(result[0].parts?.[0]?.text).toBe("hello");
@@ -112,6 +114,7 @@ test("ignores a skill the user cannot access under its scope", async ({
     messages,
     organizationId: org.id,
     userId: otherUser.id,
+    agentId: undefined,
   });
 
   expect(result[0].parts?.[0]?.text).toBe("hello");
@@ -145,6 +148,7 @@ test("ignores a slash-command skill when the user lacks skill:read", async ({
     messages,
     organizationId: org.id,
     userId: user.id,
+    agentId: undefined,
   });
 
   expect(result[0].parts?.[0]?.text).toBe("hello");
@@ -165,6 +169,7 @@ test("returns the messages unchanged when no skill metadata is present", async (
     messages,
     organizationId: org.id,
     userId: user.id,
+    agentId: undefined,
   });
 
   expect(result).toBe(messages);

--- a/platform/backend/src/routes/chat/inject-skill-activation.ts
+++ b/platform/backend/src/routes/chat/inject-skill-activation.ts
@@ -6,10 +6,8 @@ import {
 import { getSkillPermissionChecker } from "@/auth/skill-permissions";
 import logger from "@/logging";
 import { SkillFileModel, SkillModel, SkillTeamModel } from "@/models";
-import {
-  formatSkillActivation,
-  skillSandboxAvailable,
-} from "@/skills/skill-activation";
+import { formatSkillActivation } from "@/skills/skill-activation";
+import { isSkillSandboxAvailableForAgent } from "@/skills/skill-sandbox-availability";
 
 /**
  * When the last user message was sent via a skill slash command, prepend the
@@ -26,10 +24,13 @@ export async function injectSkillActivation({
   messages,
   organizationId,
   userId,
+  agentId,
 }: {
   messages: ChatMessage[];
   organizationId: string;
   userId: string;
+  /** The conversation's agent — gates the sandbox hint on tool assignment. */
+  agentId: string | undefined;
 }): Promise<ChatMessage[]> {
   const lastUserIndex = messages.findLastIndex(
     (message) => message.role === "user",
@@ -92,7 +93,10 @@ export async function injectSkillActivation({
     formatSkillActivation({
       skill,
       files,
-      canRunSandbox: skillSandboxAvailable(checker),
+      canRunSandbox: await isSkillSandboxAvailableForAgent({
+        checker,
+        agentId,
+      }),
     }),
   );
   return next;

--- a/platform/backend/src/routes/chat/inject-skill-activation.ts
+++ b/platform/backend/src/routes/chat/inject-skill-activation.ts
@@ -6,7 +6,10 @@ import {
 import { getSkillPermissionChecker } from "@/auth/skill-permissions";
 import logger from "@/logging";
 import { SkillFileModel, SkillModel, SkillTeamModel } from "@/models";
-import { formatSkillActivation } from "@/skills/skill-activation";
+import {
+  formatSkillActivation,
+  skillSandboxAvailable,
+} from "@/skills/skill-activation";
 
 /**
  * When the last user message was sent via a skill slash command, prepend the
@@ -86,7 +89,11 @@ export async function injectSkillActivation({
   const next = [...messages];
   next[lastUserIndex] = prependText(
     userMessage,
-    formatSkillActivation({ skill, files }),
+    formatSkillActivation({
+      skill,
+      files,
+      canRunSandbox: skillSandboxAvailable(checker),
+    }),
   );
   return next;
 }

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -444,6 +444,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   messages: messages as ChatMessage[],
                   organizationId,
                   userId: user.id,
+                  agentId: conversation.agentId ?? undefined,
                 })
               : (messages as ChatMessage[]);
 

--- a/platform/backend/src/skills/skill-activation.test.ts
+++ b/platform/backend/src/skills/skill-activation.test.ts
@@ -6,6 +6,7 @@ describe("formatSkillActivation", () => {
     const result = formatSkillActivation({
       skill: { name: "Research", content: "Do research.", compatibility: null },
       files: [],
+      canRunSandbox: true,
     });
 
     expect(result).toBe(
@@ -20,6 +21,7 @@ describe("formatSkillActivation", () => {
         { path: "references/REF.md", kind: "reference" },
         { path: "scripts/run.py", kind: "script" },
       ],
+      canRunSandbox: true,
     });
 
     expect(result).toContain(
@@ -33,6 +35,7 @@ describe("formatSkillActivation", () => {
     const result = formatSkillActivation({
       skill: { name: "Research", content: "Body", compatibility: null },
       files: [{ path: "scripts/run.py", kind: "script" }],
+      canRunSandbox: true,
     });
 
     expect(result).toContain("read_skill_file");
@@ -42,10 +45,24 @@ describe("formatSkillActivation", () => {
     expect(result).not.toMatch(/not executed/i);
   });
 
+  test("mentions read_skill_file but omits sandbox tools when unavailable", () => {
+    const result = formatSkillActivation({
+      skill: { name: "Research", content: "Body", compatibility: null },
+      files: [{ path: "scripts/run.py", kind: "script" }],
+      canRunSandbox: false,
+    });
+
+    expect(result).toContain("read_skill_file");
+    expect(result).not.toContain("create_skill_sandbox");
+    expect(result).not.toContain("run_skill_command");
+    expect(result).not.toContain("get_skill_sandbox_artifact");
+  });
+
   test("omits sandbox guidance when the skill has no resource files", () => {
     const result = formatSkillActivation({
       skill: { name: "Research", content: "Body", compatibility: null },
       files: [],
+      canRunSandbox: true,
     });
 
     expect(result).not.toContain("read_skill_file");
@@ -56,6 +73,7 @@ describe("formatSkillActivation", () => {
     const result = formatSkillActivation({
       skill: { name: "A & B <c>", content: "x", compatibility: null },
       files: [{ path: "refs/<a>.md", kind: "reference" }],
+      canRunSandbox: true,
     });
 
     expect(result).toContain('name="A &amp; B &lt;c&gt;"');

--- a/platform/backend/src/skills/skill-activation.ts
+++ b/platform/backend/src/skills/skill-activation.ts
@@ -1,18 +1,4 @@
-import type { SkillPermissionChecker } from "@/auth/skill-permissions";
-import config from "@/config";
 import type { Skill, SkillFile } from "@/types";
-
-/**
- * Whether the caller can actually use the skill sandbox tools: the feature is
- * enabled on this deployment and the caller holds `skill:execute`. Gates the
- * sandbox hint in activation/catalog output so the model is never pointed at
- * tools that would just refuse. Fail-closed for org-token sessions (no checker).
- */
-export function skillSandboxAvailable(
-  checker: SkillPermissionChecker | null,
-): boolean {
-  return config.skillsSandbox.enabled && (checker?.canExecute ?? false);
-}
 
 /**
  * Render a skill's SKILL.md body, compatibility note, and resource listing into

--- a/platform/backend/src/skills/skill-activation.ts
+++ b/platform/backend/src/skills/skill-activation.ts
@@ -1,4 +1,18 @@
+import type { SkillPermissionChecker } from "@/auth/skill-permissions";
+import config from "@/config";
 import type { Skill, SkillFile } from "@/types";
+
+/**
+ * Whether the caller can actually use the skill sandbox tools: the feature is
+ * enabled on this deployment and the caller holds `skill:execute`. Gates the
+ * sandbox hint in activation/catalog output so the model is never pointed at
+ * tools that would just refuse. Fail-closed for org-token sessions (no checker).
+ */
+export function skillSandboxAvailable(
+  checker: SkillPermissionChecker | null,
+): boolean {
+  return config.skillsSandbox.enabled && (checker?.canExecute ?? false);
+}
 
 /**
  * Render a skill's SKILL.md body, compatibility note, and resource listing into
@@ -14,20 +28,31 @@ import type { Skill, SkillFile } from "@/types";
 export function formatSkillActivation({
   skill,
   files,
+  canRunSandbox,
 }: {
   skill: Pick<Skill, "name" | "content" | "compatibility">;
   files: Pick<SkillFile, "path" | "kind">[];
+  /**
+   * Whether the sandbox tools are usable for this caller (feature enabled +
+   * `skill:execute`). When false, omit the sandbox hint so we never point the
+   * model at tools that would just refuse.
+   */
+  canRunSandbox: boolean;
 }): string {
+  const sandboxHint = canRunSandbox
+    ? " To execute a script or shell command from this skill, call " +
+      "create_skill_sandbox with this skill's name, then run_skill_command — " +
+      "commands run from the skill root so relative paths from the spec " +
+      "resolve correctly. Use get_skill_sandbox_artifact to retrieve " +
+      "generated files."
+    : "";
   const resources =
     files.length > 0
       ? `\n<skill_resources>\n${files
           .map((file) => `${escapeXmlText(file.path)} (${file.kind})`)
           .join("\n")}\n</skill_resources>\n` +
-        "Inspect any resource with read_skill_file. To execute a script or " +
-        "shell command from this skill, call create_skill_sandbox with this " +
-        "skill's name, then run_skill_command — commands run from the skill " +
-        "root so relative paths from the spec resolve correctly. Use " +
-        "get_skill_sandbox_artifact to retrieve generated files."
+        "Inspect any resource with read_skill_file." +
+        sandboxHint
       : "";
 
   const compatibility = skill.compatibility

--- a/platform/backend/src/skills/skill-sandbox-availability.test.ts
+++ b/platform/backend/src/skills/skill-sandbox-availability.test.ts
@@ -1,0 +1,100 @@
+import type { SkillPermissionChecker } from "@/auth/skill-permissions";
+import config from "@/config";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import { isSkillSandboxAvailableForAgent } from "./skill-sandbox-availability";
+
+const executor: SkillPermissionChecker = {
+  canRead: true,
+  canExecute: true,
+  isAdmin: false,
+  isTeamAdmin: false,
+};
+
+describe("isSkillSandboxAvailableForAgent", () => {
+  let originalEnabled: boolean;
+
+  beforeEach(() => {
+    originalEnabled = config.skillsSandbox.enabled;
+    (config.skillsSandbox as { enabled: boolean }).enabled = true;
+  });
+
+  afterEach(() => {
+    (config.skillsSandbox as { enabled: boolean }).enabled = originalEnabled;
+  });
+
+  test("true when feature on, caller can execute, and tools are assigned", async ({
+    makeAgent,
+    seedAndAssignArchestraTools,
+  }) => {
+    const agent = await makeAgent({ name: "Sandbox Agent" });
+    // seeding pulls from getArchestraMcpTools(), which only includes the
+    // sandbox tools while the feature is enabled — hence the flag is set first.
+    await seedAndAssignArchestraTools(agent.id);
+
+    expect(
+      await isSkillSandboxAvailableForAgent({
+        checker: executor,
+        agentId: agent.id,
+      }),
+    ).toBe(true);
+  });
+
+  test("false when the sandbox tools are not assigned to the agent", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent({ name: "Bare Agent" });
+
+    expect(
+      await isSkillSandboxAvailableForAgent({
+        checker: executor,
+        agentId: agent.id,
+      }),
+    ).toBe(false);
+  });
+
+  test("false when the feature is disabled, even with tools assigned", async ({
+    makeAgent,
+    seedAndAssignArchestraTools,
+  }) => {
+    const agent = await makeAgent({ name: "Sandbox Agent" });
+    await seedAndAssignArchestraTools(agent.id);
+    (config.skillsSandbox as { enabled: boolean }).enabled = false;
+
+    expect(
+      await isSkillSandboxAvailableForAgent({
+        checker: executor,
+        agentId: agent.id,
+      }),
+    ).toBe(false);
+  });
+
+  test("false without skill:execute", async ({
+    makeAgent,
+    seedAndAssignArchestraTools,
+  }) => {
+    const agent = await makeAgent({ name: "Sandbox Agent" });
+    await seedAndAssignArchestraTools(agent.id);
+
+    expect(
+      await isSkillSandboxAvailableForAgent({
+        checker: { ...executor, canExecute: false },
+        agentId: agent.id,
+      }),
+    ).toBe(false);
+    expect(
+      await isSkillSandboxAvailableForAgent({
+        checker: null,
+        agentId: agent.id,
+      }),
+    ).toBe(false);
+  });
+
+  test("false when no agent context is available", async () => {
+    expect(
+      await isSkillSandboxAvailableForAgent({
+        checker: executor,
+        agentId: undefined,
+      }),
+    ).toBe(false);
+  });
+});

--- a/platform/backend/src/skills/skill-sandbox-availability.ts
+++ b/platform/backend/src/skills/skill-sandbox-availability.ts
@@ -1,6 +1,7 @@
 import {
   type ArchestraToolShortName,
   TOOL_CREATE_SKILL_SANDBOX_SHORT_NAME,
+  TOOL_GET_SKILL_SANDBOX_ARTIFACT_SHORT_NAME,
   TOOL_RUN_SKILL_COMMAND_SHORT_NAME,
 } from "@shared";
 import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
@@ -12,7 +13,11 @@ import { ToolModel } from "@/models";
  * Whether the skill sandbox tools are genuinely usable for a given agent:
  *   1. the feature is enabled on this deployment,
  *   2. the caller holds `skill:execute`, and
- *   3. both sandbox tools are assigned to the agent.
+ *   3. all three sandbox tools are assigned to the agent.
+ *
+ * All three are required because the activation hint names each of them
+ * (create → run → get artifact); a subset would point the model at a tool the
+ * agent cannot call.
  *
  * The assignment check mirrors what `tools/list` exposes (it reads the same
  * `getMcpToolsByAgent` source), so we never advertise the sandbox path to a
@@ -35,6 +40,7 @@ export async function isSkillSandboxAvailableForAgent(params: {
   const required: ArchestraToolShortName[] = [
     TOOL_CREATE_SKILL_SANDBOX_SHORT_NAME,
     TOOL_RUN_SKILL_COMMAND_SHORT_NAME,
+    TOOL_GET_SKILL_SANDBOX_ARTIFACT_SHORT_NAME,
   ];
   return required.every((shortName) =>
     assigned.has(archestraMcpBranding.getToolName(shortName)),

--- a/platform/backend/src/skills/skill-sandbox-availability.ts
+++ b/platform/backend/src/skills/skill-sandbox-availability.ts
@@ -1,0 +1,42 @@
+import {
+  type ArchestraToolShortName,
+  TOOL_CREATE_SKILL_SANDBOX_SHORT_NAME,
+  TOOL_RUN_SKILL_COMMAND_SHORT_NAME,
+} from "@shared";
+import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
+import type { SkillPermissionChecker } from "@/auth/skill-permissions";
+import config from "@/config";
+import { ToolModel } from "@/models";
+
+/**
+ * Whether the skill sandbox tools are genuinely usable for a given agent:
+ *   1. the feature is enabled on this deployment,
+ *   2. the caller holds `skill:execute`, and
+ *   3. both sandbox tools are assigned to the agent.
+ *
+ * The assignment check mirrors what `tools/list` exposes (it reads the same
+ * `getMcpToolsByAgent` source), so we never advertise the sandbox path to a
+ * model whose agent cannot call those tools. Assignment is the right signal in
+ * both exposure modes: `search_and_run_only` hides assigned tools from
+ * `tools/list` but still runs them through `run_tool`. Fail-closed when any
+ * input is missing.
+ */
+export async function isSkillSandboxAvailableForAgent(params: {
+  checker: SkillPermissionChecker | null;
+  agentId: string | undefined;
+}): Promise<boolean> {
+  if (!config.skillsSandbox.enabled) return false;
+  if (!(params.checker?.canExecute ?? false)) return false;
+  if (!params.agentId) return false;
+
+  const assigned = new Set(
+    (await ToolModel.getMcpToolsByAgent(params.agentId)).map((t) => t.name),
+  );
+  const required: ArchestraToolShortName[] = [
+    TOOL_CREATE_SKILL_SANDBOX_SHORT_NAME,
+    TOOL_RUN_SKILL_COMMAND_SHORT_NAME,
+  ];
+  return required.every((shortName) =>
+    assigned.has(archestraMcpBranding.getToolName(shortName)),
+  );
+}


### PR DESCRIPTION
Follow-ups to #5058 (skill sandbox runtime). Small, low-risk cleanups that didn't make the merge window; more may be added to this branch.

## Changes

### CI: slim `sandbox-rs` `check:musl`
The Docker smoke stage runs `check:musl`, which did ~5 full Rust recompiles in different profiles. Two were redundant:
- **`cargo check`** — `cargo test` (next in the chain) compiles the same crates plus the tests, so it's subsumed.
- **trailing `pnpm build`** — re-builds the production `.node` only to overwrite the test-helpers variant from the prior step; the smoke stage discards the artifact, so it's pure waste in CI.

```diff
-"check:musl": "cargo check --workspace --locked && cargo test --workspace --locked && pnpm build && pnpm smoke && pnpm build:test-helpers && pnpm smoke:panic && pnpm build",
+"check:musl": "cargo test --workspace --locked && pnpm build && pnpm smoke && pnpm build:test-helpers && pnpm smoke:panic",
```

Coverage is unchanged — Rust unit tests, the release-build smoke, and the panic smoke all stay. Pairs with the arm64-drop + cargo-cache-mount changes already merged in #5058 to keep the musl smoke build fast.

## Test plan
- [x] `pnpm --filter @archestra/sandbox-rs check:musl` passes locally (exit 0: cargo test 7 passed → build → smoke → build:test-helpers → panic smoke)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>