### PR TITLE
chore(diag): broaden [idp-diag] dump grep to catch all validator branches

### DIFF
--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -256,7 +256,7 @@ jobs:
           echo "=== [idp-diag] external IdP validation branch ==="
           kubectl logs -l app.kubernetes.io/name=archestra-platform \
             -c archestra-platform 2>/dev/null \
-            | grep -iE '\[idp-diag\]|JWKS JWT validation failed' \
+            | grep -iE '\[idp-diag\]|validateExternalIdpToken|JWKS JWT validation failed' \
             || echo "(no [idp-diag] line found)"
 
           echo "=== Platform Init Container: vault-secrets ==="
@@ -401,7 +401,7 @@ jobs:
           echo "=== [idp-diag] external IdP validation branch ==="
           kubectl logs -l app.kubernetes.io/name=archestra-platform \
             -c archestra-platform 2>/dev/null \
-            | grep -iE '\[idp-diag\]|JWKS JWT validation failed' \
+            | grep -iE '\[idp-diag\]|validateExternalIdpToken|JWKS JWT validation failed' \
             || echo "(no [idp-diag] line found)"
 
           echo "=== Platform Init Container: vault-secrets ==="


### PR DESCRIPTION
## Summary

Follow-up to the `[idp-diag]` diagnostic (#5125). The first flaky run carrying it ruled out the silent/debug branches (`[idp-diag]` never logged) and any JWKS verify failure (`"JWKS JWT validation failed"` never logged) — so the 401 comes from a branch that *already* logs at `warn` with a `validateExternalIdpToken:` prefix (IdP-not-found / no clientId / no jwksUrl / user-member-team). That warn is in the backend log but the dump grep only matched `[idp-diag]` + the JWKS line, so it went uncaptured.

This adds `validateExternalIdpToken` to the grep alternation in the failure/flaky dump so the next flaky run surfaces the exact branch. CI-only, temporary; removed with the rest of the `[idp-diag]` diagnostic once the branch is pinned.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>