### PR TITLE
fix(chat): fix hex hash false positives in secret scan, enable by default

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -48,7 +48,6 @@ archestra:
     ARCHESTRA_AGENTS_INCOMING_EMAIL_OUTLOOK_WEBHOOK_URL: "https://backend.archestra.dev/api/webhooks/incoming-email"
     ARCHESTRA_CHAT_DEFAULT_PROVIDER: "anthropic"
     ARCHESTRA_CHAT_DEFAULT_MODEL: "claude-opus-4-5-20251101"
-    ARCHESTRA_CHAT_SECRET_SCAN_ENABLED: "true"
 
   diagnostics:
     enabled: true

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -1050,8 +1050,9 @@ Enable polling compatibility only when your database endpoint cannot keep sessio
   - Set this when regular database traffic goes through PgBouncer transaction pooling but notifications can use a direct or session-pooled connection
 
 - **`ARCHESTRA_CHAT_SECRET_SCAN_ENABLED`** - Enables client-side pre-send scanning of chat messages for secrets and high-entropy tokens.
-  - Default: `false`
-  - When `true`, the chat composer intercepts sends and shows a confirmation dialog when the message appears to contain credentials (API keys, tokens, passwords, JWTs, PEM keys, or high-entropy strings).
+  - Default: `true`
+  - When enabled, the chat composer intercepts sends and shows a confirmation dialog when the message appears to contain credentials (API keys, tokens, passwords, JWTs, PEM keys, or high-entropy strings). Set to `false` to disable.
+  - This is a client-side convenience nudge, not a data-loss-prevention control: it runs in the browser and can be bypassed with "Send anyway".
   - Detection runs entirely in the browser — no message content is sent to the backend for scanning. The flag is read from the backend at runtime via `/api/config`, so toggling it does not require a frontend rebuild.
   - Values: `true`, `false`
 

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -292,6 +292,6 @@ ARCHESTRA_CODE_RUNTIME_ENABLED=false
 ARCHESTRA_QUICKSTART=false
 
 # Client-side pre-send scan for secrets in the chat composer (regex + entropy).
-# When "true", the composer asks for confirmation before sending messages
-# that look like they contain secrets. Default off.
-ARCHESTRA_CHAT_SECRET_SCAN_ENABLED=false
+# The composer asks for confirmation before sending messages that look like
+# they contain secrets. Default on; set to "false" to disable.
+ARCHESTRA_CHAT_SECRET_SCAN_ENABLED=true

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -1036,7 +1036,7 @@ const config = {
         process.env.ARCHESTRA_CHAT_ACTIVE_RUN_NOTIFY_DATABASE_URL?.trim() || "",
     },
     secretScanEnabled:
-      process.env.ARCHESTRA_CHAT_SECRET_SCAN_ENABLED === "true",
+      process.env.ARCHESTRA_CHAT_SECRET_SCAN_ENABLED !== "false",
   },
   enterpriseFeatures: {
     core: process.env.ARCHESTRA_ENTERPRISE_LICENSE_ACTIVATED === "true",

--- a/platform/backend/src/routes/config.test.ts
+++ b/platform/backend/src/routes/config.test.ts
@@ -79,6 +79,7 @@ describe("config routes", () => {
       isQuickstart: expect.any(Boolean),
       ngrokDomain: expect.any(String),
       virtualKeyDefaultExpirationSeconds: expect.any(Number),
+      chatSecretScanEnabled: true,
     });
     expect(["permissive", "restrictive"]).toContain(
       payload.features.globalToolPolicy,

--- a/platform/frontend/src/lib/sensitive-data/entropy-detector.test.ts
+++ b/platform/frontend/src/lib/sensitive-data/entropy-detector.test.ts
@@ -61,12 +61,24 @@ describe("entropyDetector", () => {
     expect(found[0].endIndex).toBe("prefix ".length + token.length);
   });
 
-  it("flags a hex-like SHA-style digest", () => {
+  // content hashes are entropy-identical to hex secrets, so an entropy
+  // threshold cannot tell them apart. scoring against the base64-sized
+  // reference alphabet keeps single-alphabet hex below the bar — these are
+  // routinely pasted by developers and should not trigger the dialog.
+  it("does not flag a sha256 digest", () => {
     const sha =
       "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
-    const found = scan(`digest: ${sha}`);
-    expect(found).toHaveLength(1);
-    expect(found[0].internalLabel).toBe("high-entropy-token");
+    expect(scan(`digest: ${sha}`)).toEqual([]);
+  });
+
+  it("does not flag a 40-char git commit SHA", () => {
+    const sha = "9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1f0a";
+    expect(scan(`see commit ${sha} for the fix`)).toEqual([]);
+  });
+
+  it("does not flag an md5 digest", () => {
+    const md5 = "9e107d9d372bb6826bd81d3542a419d6";
+    expect(scan(`checksum ${md5}`)).toEqual([]);
   });
 
   it("does not flag a long low-entropy token", () => {

--- a/platform/frontend/src/lib/sensitive-data/entropy-detector.ts
+++ b/platform/frontend/src/lib/sensitive-data/entropy-detector.ts
@@ -9,7 +9,6 @@ const ENTROPY_DETECTOR_ID = detectorId("entropy");
 const INTERNAL_LABEL = "high-entropy-token";
 
 const CANDIDATE_PATTERN = /\S{20,}/g;
-const HEX_ONLY_PATTERN = /^[0-9a-fA-F]+$/;
 // matches RFC 3986 scheme followed by "://" — skip these to avoid false
 // positives on URLs (e.g. Google Docs URLs contain high-entropy document IDs).
 const URL_LIKE_PATTERN = /^[a-z][a-z0-9+.-]*:\/\//i;
@@ -19,8 +18,13 @@ const URL_LIKE_PATTERN = /^[a-z][a-z0-9+.-]*:\/\//i;
 // max entropy is capped by log2(min(len, alphabet)). a ratio works uniformly
 // across lengths.
 const ENTROPY_RATIO_THRESHOLD = 0.85;
-const HEX_ALPHABET_SIZE = 16;
-const NON_HEX_ALPHABET_SIZE = 64;
+// every token is scored against this single reference alphabet (base64-sized).
+// scoring hex against a 16-symbol alphabet would make any uniform hex string
+// (git SHAs, sha256/md5 digests) reach ratio ~1.0 and flag — but a hash and a
+// hex secret are entropy-identical, so that branch only ever produced false
+// positives on content hashes. against the 64-symbol alphabet hex under-fills
+// and falls below threshold, while genuine base64/base62 keys still clear it.
+const REFERENCE_ALPHABET_SIZE = 64;
 
 export function shannonEntropy(s: string): number {
   if (s.length === 0) return 0;
@@ -80,10 +84,7 @@ export const entropyDetector: Detector = {
 };
 
 function isHighEntropy(token: string): boolean {
-  const alphabetSize = HEX_ONLY_PATTERN.test(token)
-    ? HEX_ALPHABET_SIZE
-    : NON_HEX_ALPHABET_SIZE;
-  const maxEntropy = Math.log2(Math.min(token.length, alphabetSize));
+  const maxEntropy = Math.log2(Math.min(token.length, REFERENCE_ALPHABET_SIZE));
   if (maxEntropy === 0) return false;
   return shannonEntropy(token) / maxEntropy >= ENTROPY_RATIO_THRESHOLD;
 }

--- a/platform/frontend/src/mocks/data/config.ts
+++ b/platform/frontend/src/mocks/data/config.ts
@@ -34,7 +34,7 @@ export function makeConfig(
       ngrokDomain: "",
       virtualKeyDefaultExpirationSeconds: 3600,
       mcpSandboxDomain: null,
-      chatSecretScanEnabled: false,
+      chatSecretScanEnabled: true,
       ...overrides.features,
       maintenanceMode: overrides.features?.maintenanceMode ?? null,
     },


### PR DESCRIPTION
## Summary

Follow-up to the chat pre-send secret scan (#5024, #5028, #5030). Fixes the dominant false-positive source in the entropy detector and flips the feature on by default.

**The bug.** The entropy detector scored hex tokens against a 16-symbol alphabet (`HEX_ALPHABET_SIZE`), so `maxEntropy = log2(16) = 4`. A uniform hex string has Shannon entropy ≈ 4, so the ratio was ≈ 1.0 and *always* cleared the 0.85 threshold. Result: every git SHA, sha256/md5 digest, and integrity hash tripped the "sensitive data" dialog — strings developers paste constantly.

**Why it can't be threshold-tuned.** A content hash and a hex secret are entropy-identical (same bytes), so no entropy threshold separates them. The hex branch was structurally guaranteed to false-positive on hashes.

**The fix.** Score every token against the single 64-symbol reference alphabet. Hex under-fills a base64-sized alphabet, so its ratio drops below threshold, while genuine base64/base62 keys (which fill it) still clear it. No real detection capability is lost — known hex-ish secret *formats* with prefixes remain covered by the regex layer.

Verified empirically:

| Input | Before | After |
|---|---|---|
| git SHA / sha256 / md5 / 24-char hex | 🚩 flag | ✅ ok |
| AWS secret key (base64) | 🚩 flag | 🚩 flag |
| random base64/base62 token | 🚩 flag | 🚩 flag |
| existing high-entropy fixtures | 🚩 flag | 🚩 flag |

**Default on.** With the noise gone, `ARCHESTRA_CHAT_SECRET_SCAN_ENABLED` now defaults to `true` (set `"false"` to disable). The now-redundant staging override is removed.

## Scope note

This is a client-side convenience nudge, not DLP — it runs in the browser and is bypassable via "Send anyway". Documented as such. Known limitations left as-is for now: file attachments aren't scanned, and connection-string passwords (`postgres://user:pass@…`) / generic `api_key=`/`secret=` assignments aren't matched by the regex layer.

## Test plan

- [x] `pnpm vitest run src/lib/sensitive-data` — inverted the sha256 assertion, added git-SHA and md5 regression cases (71 passing)
- [x] `prompt-input` flow tests pass
- [x] biome + tsc clean
- [ ] On staging: paste a git SHA / sha256 → no dialog; paste a fake `ghp_…`/AWS key → dialog still appears

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>