### PR TITLE
fix(chat): update context indicator after compaction

### DIFF
--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -193,7 +193,7 @@ describe("ChatProvider retries", () => {
     });
   });
 
-  it("does not overwrite live context tokens from auto compaction estimates", async () => {
+  it("updates live context tokens from auto compaction estimates", async () => {
     const latestSessionRef: { current: ChatSessionSnapshot } = {
       current: undefined,
     };
@@ -248,7 +248,7 @@ describe("ChatProvider retries", () => {
         compactedTokenEstimate: 794_797,
       }),
     );
-    expect(latestSessionRef.current?.contextTokensUsed).toBe(120);
+    expect(latestSessionRef.current?.contextTokensUsed).toBe(794_797);
   });
 
   it("configures active-run reconnect URL and resumes when the last persisted message is from the user", async () => {

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -630,10 +630,7 @@ function ChatSessionHook({
           originalTokenEstimate?: number;
           compactedTokenEstimate?: number;
         };
-        recordContextCompaction({
-          ...data,
-          updateContextTokens: data.trigger !== "auto",
-        });
+        recordContextCompaction(data);
         queryClient.invalidateQueries({
           queryKey: ["conversation", conversationId],
         });


### PR DESCRIPTION
## Summary
- update live context token usage when auto-compaction finishes
- keep compaction metadata recording unchanged while applying the compacted estimate immediately
- update the regression test to cover auto-compaction indicator refresh

## Root cause
The backend already streamed compactedTokenEstimate in data-context-compaction-finish, but the frontend passed updateContextTokens: false for trigger: auto. That left the context indicator on the pre-compaction token usage until the next assistant turn emitted fresh usage.

## Test plan
- pnpm --dir platform/frontend test src/lib/chat/global-chat.context.test.tsx --run
- pnpm --dir platform/frontend type-check

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>