### PR TITLE
fix(chat): drive context indicator from live estimate and per-step usage

### DIFF
--- a/platform/backend/src/routes/chat/context-compaction.ts
+++ b/platform/backend/src/routes/chat/context-compaction.ts
@@ -107,6 +107,11 @@ export type ContextCompactionResult = {
   status: ContextCompactionStatus;
   compaction: ConversationCompaction | null;
   reason?: ContextCompactionReason;
+  // estimated tokens of `messages` (what is actually sent to the model this
+  // turn), on the same yardstick as the auto-compaction threshold. Drives the
+  // live context indicator. Reuses the estimate already computed for the
+  // threshold check, so it adds no extra tokenization on the hot path.
+  inputTokenEstimate?: number;
 };
 
 export type ContextCompactionStreamData = {
@@ -183,14 +188,20 @@ async function runCompactMessagesForChat(
     );
   }
 
-  const shouldCreate =
-    !policy.requireAutoThreshold ||
-    (await shouldAutoCompact({
+  // estimate of the messages we would send without creating a new summary;
+  // reused both for the threshold decision and to seed the context indicator.
+  let messagesTokenEstimate: number | undefined;
+  let shouldCreate = !policy.requireAutoThreshold;
+  if (!shouldCreate) {
+    const decision = await shouldAutoCompact({
       provider: params.provider,
       selectedModel: params.selectedModel,
       systemPrompt: params.systemPrompt,
       messages: existingMessages,
-    }));
+    });
+    messagesTokenEstimate = decision.estimatedTokens;
+    shouldCreate = decision.shouldCompact;
+  }
 
   if (!shouldCreate) {
     return {
@@ -200,6 +211,7 @@ async function runCompactMessagesForChat(
       reason: usableLatestCompaction
         ? "using_existing_summary"
         : "below_threshold",
+      inputTokenEstimate: messagesTokenEstimate,
     };
   }
 
@@ -292,6 +304,7 @@ async function runCompactMessagesForChat(
       messages: compactedMessages,
       status: "created",
       compaction,
+      inputTokenEstimate: compaction.compactedTokenEstimate,
     };
   } catch (error) {
     if (params.abortSignal?.aborted) {
@@ -508,19 +521,22 @@ async function shouldAutoCompact(params: {
   selectedModel: string;
   systemPrompt?: string;
   messages: ChatMessage[];
-}): Promise<boolean> {
+}): Promise<{ shouldCompact: boolean; estimatedTokens: number }> {
+  const estimatedTokens = estimateChatMessagesTokens(params);
   const model = await ModelModel.findByProviderAndModelId(
     params.provider,
     params.selectedModel,
   );
   if (!model?.contextLength) {
-    return false;
+    return { shouldCompact: false, estimatedTokens };
   }
 
-  const estimatedTokens = estimateChatMessagesTokens(params);
-  return (
-    estimatedTokens >= model.contextLength * CONTEXT_COMPACTION_AUTO_THRESHOLD
-  );
+  return {
+    shouldCompact:
+      estimatedTokens >=
+      model.contextLength * CONTEXT_COMPACTION_AUTO_THRESHOLD,
+    estimatedTokens,
+  };
 }
 
 async function createConversationCompaction(params: {

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import {
   buildUserSystemPromptContext,
   type ChatErrorResponse,
+  type ContextWindowEstimate,
   isModelSelectionComplete,
   ResourceVisibilityScopeSchema,
   RouteId,
@@ -715,6 +716,19 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   });
                 }
 
+                // Seed the context indicator with the size of what we are about
+                // to send, on the same yardstick that triggers auto-compaction,
+                // so the bar is correct before the first token (and reflects a
+                // compaction drop immediately). Per-step usage refines it below.
+                if (compactionResult.inputTokenEstimate !== undefined) {
+                  writer.write({
+                    type: "data-context-window-estimate",
+                    data: {
+                      estimatedTokens: compactionResult.inputTokenEstimate,
+                    } satisfies ContextWindowEstimate,
+                  });
+                }
+
                 const modelMessages = await buildModelMessagesForProvider({
                   messages: compactionResult.messages,
                   provider,
@@ -727,6 +741,19 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   stopWhen: buildChatStopConditions(),
                   abortSignal: chatAbortController.signal,
                   onChunk: streamTextOnChunk,
+                  // Emit per-step usage so the context indicator tracks the
+                  // prompt growing across tool round-trips, instead of jumping
+                  // only once when the whole turn finishes.
+                  onStepFinish: ({ usage }) => {
+                    writer.write({
+                      type: "data-token-usage",
+                      data: {
+                        inputTokens: usage.inputTokens,
+                        outputTokens: usage.outputTokens,
+                        totalTokens: usage.totalTokens,
+                      } satisfies TokenUsage,
+                    });
+                  },
                   onFinish: async ({ usage, finishReason }) => {
                     removeAbortListeners();
                     logger.info(

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -168,8 +168,9 @@ describe("ChatProvider retries", () => {
       });
     });
 
+    // the indicator tracks prompt (input) occupancy, not input+output total
     await waitFor(() =>
-      expect(latestSessionRef.current?.contextTokensUsed).toBe(120),
+      expect(latestSessionRef.current?.contextTokensUsed).toBe(100),
     );
 
     act(() => {
@@ -222,8 +223,9 @@ describe("ChatProvider retries", () => {
       });
     });
 
+    // the indicator tracks prompt (input) occupancy, not input+output total
     await waitFor(() =>
-      expect(latestSessionRef.current?.contextTokensUsed).toBe(120),
+      expect(latestSessionRef.current?.contextTokensUsed).toBe(100),
     );
 
     act(() => {
@@ -249,6 +251,50 @@ describe("ChatProvider retries", () => {
       }),
     );
     expect(latestSessionRef.current?.contextTokensUsed).toBe(794_797);
+  });
+
+  it("seeds context tokens from the turn-start window estimate, then refines from per-step usage", async () => {
+    const latestSessionRef: { current: ChatSessionSnapshot } = {
+      current: undefined,
+    };
+
+    render(
+      <ChatProvider>
+        <RegisterChatSession />
+        <CaptureChatSession
+          onSession={(session) => {
+            latestSessionRef.current = session;
+          }}
+        />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(latestSessionRef.current).toBeDefined());
+
+    // turn-start estimate seeds the indicator before the model responds
+    act(() => {
+      chatOptions?.onData?.({
+        type: "data-context-window-estimate",
+        data: { estimatedTokens: 542_000 },
+      });
+    });
+
+    await waitFor(() =>
+      expect(latestSessionRef.current?.contextTokensUsed).toBe(542_000),
+    );
+
+    // a per-step usage event then refines the seed with the provider's real
+    // prompt size (input tokens), e.g. right after an auto-compaction drop
+    act(() => {
+      chatOptions?.onData?.({
+        type: "data-token-usage",
+        data: { inputTokens: 7_199, outputTokens: 86, totalTokens: 7_285 },
+      });
+    });
+
+    await waitFor(() =>
+      expect(latestSessionRef.current?.contextTokensUsed).toBe(7_199),
+    );
   });
 
   it("configures active-run reconnect URL and resumes when the last persisted message is from the user", async () => {

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -3,6 +3,7 @@
 import { type UIMessage, useChat } from "@ai-sdk/react";
 import {
   type ArchestraToolShortName,
+  type ContextWindowEstimate,
   EXTERNAL_AGENT_ID_HEADER,
   getArchestraToolShortName,
   makeSwapAgentPokeText,
@@ -621,8 +622,22 @@ function ChatSessionHook({
       if (dataPart.type === "data-token-usage") {
         const usage = dataPart.data as TokenUsage;
         setTokenUsage(usage);
-        if (typeof usage.totalTokens === "number") {
-          setContextTokensUsed(usage.totalTokens);
+        // The indicator tracks context-window occupancy, which is the prompt
+        // (input) size; totalTokens additionally folds in output and would
+        // overstate how full the window is.
+        const occupancy = usage.inputTokens ?? usage.totalTokens;
+        if (typeof occupancy === "number") {
+          setContextTokensUsed(occupancy);
+        }
+      }
+
+      // Seed the indicator at turn start with the backend's estimate of the
+      // outgoing prompt, on the same yardstick as auto-compaction. Per-step
+      // data-token-usage events then refine it with the provider's real count.
+      if (dataPart.type === "data-context-window-estimate") {
+        const data = dataPart.data as ContextWindowEstimate;
+        if (typeof data.estimatedTokens === "number") {
+          setContextTokensUsed(data.estimatedTokens);
         }
       }
 

--- a/platform/shared/chat.ts
+++ b/platform/shared/chat.ts
@@ -14,6 +14,16 @@ export interface TokenUsage {
   totalTokens: number | undefined;
 }
 
+/**
+ * Estimated context-window occupancy streamed at the start of a turn, on the
+ * same token yardstick that drives auto-compaction. Seeds the context
+ * indicator before the model responds; per-step `TokenUsage` then refines it
+ * with the provider's actual prompt size.
+ */
+export interface ContextWindowEstimate {
+  estimatedTokens: number;
+}
+
 // ============================================================================
 // Chat Message Part Types
 // ============================================================================


### PR DESCRIPTION
## Summary
- emit a turn-start `data-context-window-estimate` so the context indicator is correct before the first token, on the **same token yardstick that triggers auto-compaction**
- emit per-step usage via `onStepFinish` so the bar tracks the prompt growing across tool round-trips, instead of jumping only once when the whole turn finishes
- drive the indicator from input (prompt) tokens — the real context-window occupancy — instead of input+output total

## Root cause
The indicator was refreshed once per turn, from the final step's provider `usage.totalTokens`. Two gaps:
1. During long tool-heavy turns it lagged the true prompt size (only updated at turn end).
2. On turns where auto-compaction did **not** run, there was no fresh signal at all, so the bar could sit on stale pre-compaction usage — and its number never matched the estimate that actually decides compaction.

## What changed
- `shouldAutoCompact` returns `{ shouldCompact, estimatedTokens }`, so the estimate it already computes for the threshold check is **reused** as the indicator seed — no second tokenization of the full history on the hot path.
- `ContextCompactionResult.inputTokenEstimate` carries the estimate of what is actually sent (reused estimate for below-threshold/existing; `compactedTokenEstimate` for created).
- New typed `ContextWindowEstimate` stream event, emitted every turn (independent of the compaction-record event, so no `lastCompaction`/query-invalidation churn).
- Frontend seeds `contextTokensUsed` from the estimate and reads `inputTokens ?? totalTokens` from per-step/last usage.

Net per-turn progression: **estimate seed → real per-step input → real last-step**.

## Test plan
- `pnpm --filter @frontend test src/lib/chat/global-chat.context.test.tsx --run` (updated the two `data-token-usage` assertions to input-token semantics; added a test for estimate-seed → per-step-refine)
- `pnpm --filter @backend test src/routes/chat/context-compaction.test.ts src/routes/chat/routes.test.ts --run`
- `pnpm --filter @backend type-check` / `pnpm --filter @frontend type-check`

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>