### PR TITLE
fix: use 127.0.0.1 instead of localhost in HEALTHCHECK to fix IPv6 issue

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -283,6 +283,6 @@ EXPOSE 5432 9000 9050 3000
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:3000/ || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:3000/ || exit 1
 
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
## Problem
On Ubuntu 24.04, the Docker health check fails immediately after 
container start because `localhost` resolves to `::1` (IPv6) by 
default. However, the Next.js frontend only listens on `127.0.0.1` 
(IPv4). This causes the container to show as `(unhealthy)` and 
the platform becomes unreachable.

This can cause serious problems in production:
- Docker automatically restarts the container
- Kubernetes stops routing traffic to it
- CI/CD deployments fail

## Root cause
Health check command:
wget --spider http://localhost:3000/
On Ubuntu 24.04, `localhost` → `::1` but Next.js listens on `127.0.0.1`. Connection refused.

## Fix
wget --spider http://127.0.0.1:3000/
Bypasses DNS resolution entirely. Connects directly to IPv4 where Next.js is listening.

## Demo
https://www.loom.com/share/8479cf5e74d14b2db3ade255b105e0ca

## Tested on
- Ubuntu 24.04 LTS
- Docker 27.3.1
- Archestra v1.2.50
Fixes #4917