### PR TITLE
chore: add Dependabot updates for Rust crates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,24 @@ updates:
     cooldown:
       default-days: 7
 
+  - package-ecosystem: cargo
+    directory: platform/archestra-rs
+    schedule:
+      interval: weekly
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+    commit-message:
+      prefix: deps
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: github-actions
     directory: /
     groups:


### PR DESCRIPTION
## Summary
- Add a Cargo Dependabot entry for `platform/archestra-rs`.
- Group minor and patch Rust dependency updates into weekly PRs.
- Match the existing dependency label, commit prefix, and cooldown settings.