### PR TITLE
refactor(archestra-rs): align sandbox core with Rust/NAPI guidelines

### DIFF
--- a/platform/CLAUDE.md
+++ b/platform/CLAUDE.md
@@ -533,3 +533,93 @@ await page.waitForTimeout(1000); // Use auto-waiting instead
 Reference: https://playwright.dev/docs/locators#quick-guide
 
 - never amend commits
+
+## Rust / NAPI coding style
+
+Write Rust as a reusable library first. NAPI should be a thin adapter around the Rust core, not the place where product logic lives. The Rust part should be easy to move later into a companion app, CLI, daemon, desktop process, or IPC service.
+
+### Architecture
+
+- Keep core Rust logic independent from Node, JavaScript, and NAPI.
+- No `#[napi]`, `napi::Result`, JS types, or Node-specific assumptions in core Rust modules.
+- NAPI functions should only:
+  1. receive JS input,
+  2. validate and convert it into Rust domain types,
+  3. call the Rust core,
+  4. convert the result or error back to JS.
+- Minimize the JS ↔ Rust API surface. Prefer a few coarse operations over many tiny exported helpers.
+- Do not expose internal implementation details through the NAPI API.
+- Generated TypeScript definitions are part of the public API and should stay clean, stable, and intentional.
+- Keep observability in the core as `tracing` spans and events only. OTLP/exporter wiring belongs in a single feature-gated module, never scattered through the logic. Propagate trace context (W3C `traceparent`) explicitly across detached tasks and actor boundaries — it does not flow implicitly.
+
+### Types and data modeling
+
+- Prefer structs, enums, and newtypes over primitive-heavy signatures, tuples, raw strings, and boolean flags.
+- Use enums for closed sets of states or modes.
+- Use named structs for meaningful data instead of passing many positional arguments.
+- Make invalid states unrepresentable where practical.
+- Treat all JS input as untrusted. Validate it at the boundary and convert it immediately into Rust-native types.
+- Validate untrusted input at the public core entry points, not deep in the call graph. Data validated when first accepted (e.g. persisted or replayed history) is trusted on reuse — document that trust boundary wherever it is not obvious.
+- Keep NAPI-facing DTOs separate from richer internal domain types when that improves clarity.
+
+### Control flow and style
+
+- Prefer `match` for enums, variants, and meaningful branching.
+- Use `if` for simple boolean checks.
+- Prefer early returns for validation and error paths.
+- Avoid deeply nested control flow.
+- Prefer functional style where it improves readability.
+- Do not force iterator chains when a simple loop is clearer.
+- Prefer clear, boring, explicit code over clever abstractions.
+
+### Errors and safety
+
+- Use `Result<T, E>` consistently in core Rust.
+- Prefer domain-specific error enums over generic strings.
+- Convert Rust errors into JS/NAPI errors only at the boundary.
+- Preserve useful error context.
+- No `unwrap`, `expect`, or `panic!` in code reachable from the NAPI boundary.
+- Assume dependencies can still panic despite that rule. Wrap every future that enters the core from the NAPI boundary in `catch_unwind` and convert the payload into a domain error. The host process must never abort on a Rust panic.
+- No `unsafe` unless isolated, documented, and clearly justified.
+
+### Abstractions
+
+- Avoid speculative abstractions.
+- Avoid `dyn Trait` unless runtime polymorphism is clearly needed.
+- Prefer concrete types, enums, generics, or plain functions before trait objects.
+- Keep modules small and named around domain concepts, not patterns.
+- Do not add indirection unless it makes testing, ownership, or API boundaries meaningfully better.
+
+### Cleanliness
+
+- Zero dead code policy.
+- No commented-out code.
+- No unused exports.
+- No unused dependencies.
+- No placeholder modules “for later”.
+- Keep dependencies minimal and justified.
+- Avoid adding crates for trivial functionality.
+
+### Tests and checks
+
+- Test Rust core logic directly, not only through Node.
+- Add tests for validation, parsing, edge cases, and error handling.
+- Use JS/NAPI integration tests only for actual boundary behavior.
+- Keep every `cfg`/feature gate as narrow as its actual use. Code compiled only because a gate is wider than its callers is dead code and will trip `-D warnings`.
+- Run the checks under the default feature set AND the binding's feature set (`napi`, `telemetry`) — not only `--all-features`. Lints, dead code, and broken `cfg` paths hide in feature combinations you never build.
+- Required before merge:
+  - `cargo fmt`
+  - `cargo clippy -- -D warnings`
+  - `cargo test`
+
+### Design target
+
+The desired shape is:
+
+JS/Node → thin NAPI adapter → reusable Rust core
+
+Not:
+
+JS-flavored business logic written in Rust
+
+Deleting or replacing the NAPI layer should not delete or rewrite the product logic.

--- a/platform/archestra-rs/sandbox-core/src/lib.rs
+++ b/platform/archestra-rs/sandbox-core/src/lib.rs
@@ -301,12 +301,20 @@ pub(crate) fn supervised_argv(command: &str, timeout_seconds: u32, limits: &Limi
 }
 
 pub(crate) fn validate_snapshot_file_path(path: &str) -> Result<()> {
-    match path {
-        _ if path.starts_with('/') || path.split('/').any(|segment| segment == "..") => Err(
-            SandboxError::InvalidInput(format!("invalid snapshot file path: {path:?}")),
-        ),
-        _ => Ok(()),
+    if path.starts_with('/') || path.split('/').any(|segment| segment == "..") {
+        return Err(SandboxError::InvalidInput(format!(
+            "invalid snapshot file path: {path:?}"
+        )));
     }
+    Ok(())
+}
+
+/// true when `path` is exactly one of the sandbox roots or nested beneath it.
+/// the single source of truth for the artifact/cwd/pythonpath allowlist checks.
+fn within_sandbox_roots(path: &str) -> bool {
+    [SKILL_SANDBOX_ROOT, SKILL_SANDBOX_HOME]
+        .iter()
+        .any(|root| path == *root || path.strip_prefix(root).is_some_and(|r| r.starts_with('/')))
 }
 
 pub(crate) fn validate_artifact_path(path: &str) -> Result<()> {
@@ -323,15 +331,10 @@ pub(crate) fn validate_artifact_path(path: &str) -> Result<()> {
             "invalid artifact path: {path:?}"
         )));
     }
-    if path.starts_with('/') {
-        let allowed = [SKILL_SANDBOX_ROOT, SKILL_SANDBOX_HOME]
-            .iter()
-            .any(|root| path == *root || path.starts_with(&format!("{root}/")));
-        if !allowed {
-            return Err(SandboxError::InvalidInput(format!(
-                "artifact path must be under {SKILL_SANDBOX_ROOT} or {SKILL_SANDBOX_HOME}: {path:?}"
-            )));
-        }
+    if path.starts_with('/') && !within_sandbox_roots(path) {
+        return Err(SandboxError::InvalidInput(format!(
+            "artifact path must be under {SKILL_SANDBOX_ROOT} or {SKILL_SANDBOX_HOME}: {path:?}"
+        )));
     }
     Ok(())
 }
@@ -359,10 +362,7 @@ pub(crate) fn validate_pythonpath(pythonpath: &str) -> Result<()> {
                 "pythonpath entries must be absolute: {entry:?}"
             )));
         }
-        let allowed = [SKILL_SANDBOX_ROOT, SKILL_SANDBOX_HOME]
-            .iter()
-            .any(|root| entry == *root || entry.starts_with(&format!("{root}/")));
-        if !allowed {
+        if !within_sandbox_roots(entry) {
             return Err(SandboxError::InvalidInput(format!(
                 "pythonpath entries must be under {SKILL_SANDBOX_ROOT} or {SKILL_SANDBOX_HOME}: {entry:?}"
             )));
@@ -380,10 +380,7 @@ pub(crate) fn validate_cwd(cwd: &str) -> Result<()> {
             "cwd must be an absolute path: {cwd:?}"
         )));
     }
-    let allowed = [SKILL_SANDBOX_ROOT, SKILL_SANDBOX_HOME]
-        .iter()
-        .any(|root| cwd == *root || cwd.starts_with(&format!("{root}/")));
-    if !allowed {
+    if !within_sandbox_roots(cwd) {
         return Err(SandboxError::InvalidInput(format!(
             "cwd must be under {SKILL_SANDBOX_ROOT} or {SKILL_SANDBOX_HOME}: {cwd:?}"
         )));
@@ -399,12 +396,12 @@ pub(crate) fn format_artifact_error(prefix: &str, path: &str, stderr: &str) -> S
 }
 
 pub(crate) fn skill_root_path(skill_name: &str) -> Result<String> {
-    match skill_name {
-        _ if skill_name.contains('/') || skill_name.contains("..") => Err(
-            SandboxError::InvalidInput(format!("invalid skill name: {skill_name:?}")),
-        ),
-        _ => Ok(format!("{SKILL_SANDBOX_ROOT}/{skill_name}")),
+    if skill_name.contains('/') || skill_name.contains("..") {
+        return Err(SandboxError::InvalidInput(format!(
+            "invalid skill name: {skill_name:?}"
+        )));
     }
+    Ok(format!("{SKILL_SANDBOX_ROOT}/{skill_name}"))
 }
 
 pub(crate) fn shell_quote(value: &str) -> String {

--- a/platform/archestra-rs/sandbox-core/src/runtime.rs
+++ b/platform/archestra-rs/sandbox-core/src/runtime.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use base64::Engine;
-use dagger_sdk::{Container, ContainerWithExecOpts, DaggerConn, ReturnType};
+use dagger_sdk::{Container, ContainerWithExecOpts, ReturnType};
 use serde::Deserialize;
 use tracing::Span;
 
@@ -55,7 +55,7 @@ pub(crate) async fn execute_run(
     validate_cwd(&req.cwd)?;
 
     let warm = session.ensure_warm().await?;
-    let materialized = materialize(session.client(), warm, &req).await?;
+    let materialized = materialize(warm, &req).await?;
 
     let argv = supervised_argv(&req.command, req.timeout_seconds, &req.limits);
     let executed = materialized
@@ -120,7 +120,7 @@ pub(crate) async fn execute_read_artifact(
         traceparent: None,
         pythonpath: req.pythonpath,
     };
-    let materialized = materialize(session.client(), warm, &run).await?;
+    let materialized = materialize(warm, &run).await?;
     let bytes_limit = u64::from(req.limits.file_size_limit_bytes);
     let command = format!(
         "[ -e {path} ] || {{ echo 'artifact not found: {path}' >&2; exit {not_found}; }}; _s=$(stat -c '%s' {path}) && [ \"$_s\" -le {limit} ] || {{ echo 'artifact is too large' >&2; exit {too_large}; }}; base64 -w0 {path}",
@@ -197,7 +197,7 @@ pub(crate) async fn execute_check_session(
     skip_all,
     fields(snapshots = req.snapshots.len(), replay.len = req.replay_commands.len())
 )]
-async fn materialize(client: &DaggerConn, warm: Container, req: &RunRequest) -> Result<Container> {
+async fn materialize(warm: Container, req: &RunRequest) -> Result<Container> {
     let mut container = warm;
 
     if !req.snapshots.is_empty() {
@@ -244,7 +244,6 @@ async fn materialize(client: &DaggerConn, warm: Container, req: &RunRequest) -> 
             .with_exec_opts(argv, any_exit_opts());
     }
 
-    let _ = client; // reserved for future host()-based bulk uploads
     Ok(container)
 }
 

--- a/platform/archestra-rs/sandbox-core/src/session.rs
+++ b/platform/archestra-rs/sandbox-core/src/session.rs
@@ -184,10 +184,10 @@ async fn spawn() -> Result<Arc<SessionHandle>> {
             Ok(())
         })
         .await;
-        if let Err(err) = result {
-            if let Some(tx) = fail_tx.take() {
-                let _ = tx.send(SandboxError::engine(err));
-            }
+        if let Err(err) = result
+            && let Some(tx) = fail_tx.take()
+        {
+            let _ = tx.send(SandboxError::engine(err));
         }
     });
 
@@ -241,11 +241,13 @@ async fn run_loop(client: DaggerConn, mut rx: mpsc::Receiver<SessionMsg>) {
                     max = MAX_CONCURRENT_HANDLERS,
                     "dagger handler pool saturated; waiting for a permit"
                 );
-                permits
-                    .clone()
-                    .acquire_owned()
-                    .await
-                    .expect("session semaphore was closed")
+                match permits.clone().acquire_owned().await {
+                    Ok(permit) => permit,
+                    // the semaphore lives as long as this loop and is never
+                    // closed; an error means it was dropped out from under us,
+                    // so stop accepting work and let the session tear down.
+                    Err(_) => break,
+                }
             }
         };
         let session = session.clone();
@@ -262,10 +264,6 @@ pub(crate) struct Session {
 }
 
 impl Session {
-    pub(crate) fn client(&self) -> &DaggerConn {
-        &self.client
-    }
-
     pub(crate) async fn ensure_warm(&self) -> Result<Container> {
         let container = self
             .warm

--- a/platform/archestra-rs/sandbox-core/src/telemetry.rs
+++ b/platform/archestra-rs/sandbox-core/src/telemetry.rs
@@ -27,7 +27,7 @@ pub fn flush() {
 
 /// matches the node SDK default; the per-signal `/v1/...` path is appended
 /// explicitly because the http exporter uses a provided endpoint verbatim.
-#[cfg(any(feature = "telemetry", test))]
+#[cfg(feature = "telemetry")]
 const DEFAULT_ENDPOINT: &str = "http://localhost:4318";
 
 /// reduce the shared endpoint env var to a bare base. it may hold either a


### PR DESCRIPTION
## Summary

First pass at codifying Rust/NAPI coding guidelines and bringing `archestra-rs` in line with them. No behavior change — refactor + docs only.

## Code changes (`sandbox-core`)

- **Boundary safety**: removed a `.expect("session semaphore was closed")` reachable from the NAPI boundary; the run loop now handles a closed semaphore gracefully and tears the session down instead of panicking.
- **Dead code**: dropped the unused `client` param on `materialize` (it was held only by a `let _ = client; // reserved for future` placeholder) and the now-unused `Session::client()` accessor.
- **Lints**: collapsed a nested `if let` into a let-chain and narrowed the `DEFAULT_ENDPOINT` `cfg` gate so it isn't compiled-but-unused in the default feature build — both tripped `clippy -D warnings` off the `--all-features` path.
- **Consistency/reuse**: unified the path validators on early-return guard style (two were awkward `match`-with-only-guards) and deduped the triplicated sandbox-root allowlist check into one `within_sandbox_roots` helper.

## Docs

- Added a **Rust / NAPI coding style** section to `platform/CLAUDE.md`: core stays independent of Node with NAPI as a thin adapter, domain error enums, validate-at-the-boundary, panic isolation via `catch_unwind`, observability as `tracing`-only in core, feature-gate hygiene + feature-matrix checks, and the `fmt`/`clippy -D warnings`/`test` gate.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all pass under both the default and `--all-features` feature sets.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>