### PR TITLE
refactor: clean up dead sandbox and compaction TS

### DIFF
--- a/platform/backend/src/code-runtime/types.ts
+++ b/platform/backend/src/code-runtime/types.ts
@@ -2,7 +2,6 @@ export const CODE_RUNTIME_LIMITS = {
   maxCpuSeconds: 30,
   maxCodeBytes: 64 * 1024,
   maxMemoryBytes: 1024 * 1024 * 1024,
-  maxQueueLength: 50,
   maxRequirements: 20,
   maxRequirementBytes: 200,
 } as const;

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -1074,11 +1074,6 @@ const config = {
    */
   codeRuntime: {
     enabled: codeRuntimeEnabled,
-    /** runner host for the Dagger Engine (sets _EXPERIMENTAL_DAGGER_RUNNER_HOST). */
-    daggerRunnerHost: codeRuntimeDaggerRunnerHost,
-    /** path to a baked-in dagger CLI (sets _EXPERIMENTAL_DAGGER_CLI_BIN). */
-    daggerCliBin:
-      process.env.ARCHESTRA_CODE_RUNTIME_DAGGER_CLI_BIN || undefined,
     /** hard wall-clock cap per run, and the default when the caller omits one. */
     timeoutSeconds: parsePositiveInt(
       process.env.ARCHESTRA_CODE_RUNTIME_TIMEOUT_SECONDS,
@@ -1100,11 +1095,6 @@ const config = {
    */
   skillsSandbox: {
     enabled: skillsSandboxEnabled,
-    daggerRunnerHost: skillsSandboxDaggerRunnerHost,
-    daggerCliBin:
-      process.env.ARCHESTRA_SKILLS_SANDBOX_DAGGER_CLI_BIN ||
-      process.env.ARCHESTRA_CODE_RUNTIME_DAGGER_CLI_BIN ||
-      undefined,
     cpuLimit: parsePositiveInt(
       process.env.ARCHESTRA_SKILLS_SANDBOX_CPU_LIMIT_SECONDS,
       30,

--- a/platform/backend/src/routes/chat/context-compaction.ts
+++ b/platform/backend/src/routes/chat/context-compaction.ts
@@ -65,16 +65,6 @@ const ATTR_CONTEXT_COMPACTION_ORIGINAL_TOKEN_ESTIMATE =
 const ATTR_CONTEXT_COMPACTION_COMPACTED_TOKEN_ESTIMATE =
   "archestra.context_compaction.compacted_token_estimate";
 
-export const CONTEXT_COMPACTION_REASONS = [
-  "below_threshold",
-  "using_existing_summary",
-  "nothing_to_compact",
-  "missing_boundary_message_id",
-  "not_beneficial",
-  "aborted",
-  "summary_generation_failed",
-] as const;
-
 export type ContextCompactionStatus =
   | "created"
   | "existing"
@@ -82,7 +72,13 @@ export type ContextCompactionStatus =
   | "failed";
 
 export type ContextCompactionReason =
-  (typeof CONTEXT_COMPACTION_REASONS)[number];
+  | "below_threshold"
+  | "using_existing_summary"
+  | "nothing_to_compact"
+  | "missing_boundary_message_id"
+  | "not_beneficial"
+  | "aborted"
+  | "summary_generation_failed";
 
 export type ContextCompactionParams = {
   conversationId: string;

--- a/platform/backend/src/skills-sandbox/README.md
+++ b/platform/backend/src/skills-sandbox/README.md
@@ -41,14 +41,17 @@ would diverge. Live processes are not durable.
 
 ## Limits
 
-Defaults live in `types.ts` (`SKILL_SANDBOX_LIMITS`) and are surfaced through
-`config.skillsSandbox` so admins can tune them via env vars:
+Runtime resource defaults are surfaced through `config.skillsSandbox` so admins
+can tune them via env vars:
 
-- `maxCpuSeconds` — wall-clock cap per command (clamped against caller request)
-- `maxMemoryBytes` — container memory cap
-- `maxQueueLength` — concurrent runs queued behind the semaphore
-- `maxArtifactBytes` — cap on exported file size
-- `maxCommandBytes` — cap on stdout/stderr captured into the command log
+- `cpuLimit` — CPU cap per command
+- `memoryLimit` — container memory cap
+- `wallClockSeconds` — wall-clock cap per command (clamped against caller request)
+- `artifactBytesLimit` — cap on exported file size
+- `outputBytesLimit` — cap on stdout/stderr captured into the command log
+
+Fixed API limits live in `types.ts` (`SKILL_SANDBOX_LIMITS`), including command
+input length and the per-sandbox pending queue length.
 
 The sandbox always runs as the non-root user from `runtime-image.ts`, with no
 host mounts and no backend env exposed inside the container. Network access is

--- a/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
+++ b/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
@@ -433,13 +433,6 @@ function validateCommand(command: string): void {
 }
 
 /**
- * Synthesise one `uv pip install -r requirements.txt` per mounted skill that
- * ships a top-level requirements.txt. Primary skill first so its deps take
- * precedence on version conflicts; rest in deterministic alphabetical order.
- * Returns [] for skills without a requirements.txt — skill authors aren't
- * required to declare one.
- */
-/**
  * Order skill names primary-first, then the rest alphabetically — so the
  * primary skill's modules and requirements take precedence over same-named
  * ones in secondary skills.

--- a/platform/backend/src/skills-sandbox/types.ts
+++ b/platform/backend/src/skills-sandbox/types.ts
@@ -1,16 +1,11 @@
 import type { SandboxId } from "@/types";
 
 /**
- * Limits enforced by the skill sandbox runtime. These mirror the env-driven
- * defaults in `config.skillsSandbox` but are exposed as a frozen object so
- * tool-layer schemas can reference them.
+ * Fixed limits exposed to tool-layer schemas and per-sandbox queueing.
+ * Runtime resource limits are env-driven through `config.skillsSandbox`.
  */
 export const SKILL_SANDBOX_LIMITS = {
-  maxCpuSeconds: 30,
-  maxMemoryBytes: 1024 * 1024 * 1024,
-  maxQueueLength: 50,
   maxSandboxQueueLength: 10,
-  maxArtifactBytes: 16 * 1024 * 1024,
   maxCommandBytes: 16 * 1024,
 } as const;
 


### PR DESCRIPTION
## Summary
- remove stale code/skill sandbox config fields now centralized under the shared Dagger runtime
- drop unused sandbox limit constants and the dead compaction reason runtime array
- refresh the skill sandbox limits README to match the remaining config/constants

## Tests
- ./node_modules/.bin/tsgo --noEmit
- ./node_modules/.bin/vitest run src/skills-sandbox/skill-sandbox-runtime-service.test.ts src/code-runtime/code-runtime-service.test.ts src/routes/chat/context-compaction.test.ts src/routes/chat/context-compaction-attachments.test.ts
- ../node_modules/.bin/biome check src/config.ts src/code-runtime/types.ts src/skills-sandbox/types.ts src/skills-sandbox/skill-sandbox-runtime-service.ts src/routes/chat/context-compaction.ts src/skills-sandbox/README.md
- ./node_modules/.bin/knip

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>