### PR TITLE
fix: respect model-scoped limits during validation

### DIFF
--- a/platform/backend/src/models/limit.test.ts
+++ b/platform/backend/src/models/limit.test.ts
@@ -2864,6 +2864,92 @@ describe("checkLimitsBeforeRequest cleanup integration", () => {
     expect(result).not.toBeNull();
   });
 
+  test("checkEntityLimits ignores stale usage rows outside a model-scoped limit", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent({ name: "Test Agent" });
+
+    const limit = await LimitModel.create({
+      entityType: "agent",
+      entityId: agent.id,
+      limitType: "token_cost",
+      limitValue: 1,
+      model: null,
+    });
+
+    await LimitModel.updateTokenLimitUsage(
+      "agent",
+      agent.id,
+      "claude-3-5-sonnet-20241022",
+      1_000_000_000,
+      1_000_000_000,
+    );
+
+    await LimitModel.patch(limit.id, {
+      model: ["gpt-4o"],
+      lastCleanup: new Date(),
+    });
+
+    const result = await LimitValidationService.checkLimitsBeforeRequest({
+      agentId: agent.id,
+      model: "gpt-4o",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("checkEntityLimits skips organization limits scoped to another request model", async ({
+    makeAgent,
+    makeMember,
+    makeOrganization,
+    makeTeam,
+    makeUser,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const team = await makeTeam(org.id, user.id);
+    const agent = await makeAgent({ name: "Test Agent" });
+    await makeMember(user.id, org.id, { role: "admin" });
+    await AgentTeamModel.assignTeamsToAgent(agent.id, [team.id]);
+
+    const orgLimit = await LimitModel.create({
+      entityType: "organization",
+      entityId: org.id,
+      limitType: "token_cost",
+      limitValue: 1,
+      model: ["gpt-4o"],
+    });
+
+    await LimitModel.updateTokenLimitUsage(
+      "organization",
+      org.id,
+      "gpt-4o",
+      1_000_000_000,
+      1_000_000_000,
+    );
+
+    await LimitModel.patch(orgLimit.id, { lastCleanup: new Date() });
+
+    const allowedResult = await LimitValidationService.checkLimitsBeforeRequest(
+      {
+        agentId: agent.id,
+        model: "claude-3-5-sonnet-20241022",
+      },
+    );
+
+    expect(allowedResult).toBeNull();
+
+    const blockedResult = await LimitValidationService.checkLimitsBeforeRequest(
+      {
+        agentId: agent.id,
+        model: "gpt-4o",
+      },
+    );
+
+    expect(blockedResult).not.toBeNull();
+    expect(blockedResult?.[1]).toContain("organization-level");
+  });
+
   test("checkEntityLimits allows request when usage is under limit value", async ({
     makeAgent,
   }) => {

--- a/platform/backend/src/models/limit.ts
+++ b/platform/backend/src/models/limit.ts
@@ -653,8 +653,9 @@ export class LimitValidationService {
     agentId: string;
     userId?: string;
     virtualKeyId?: string;
+    model?: string;
   }): Promise<null | [string, string]> {
-    const { agentId, userId, virtualKeyId } = params;
+    const { agentId, userId, virtualKeyId, model } = params;
 
     try {
       logger.info(
@@ -714,6 +715,7 @@ export class LimitValidationService {
         const vkLimitViolation = await LimitValidationService.checkEntityLimits(
           "virtual_key",
           virtualKeyId,
+          model,
         );
         if (vkLimitViolation) {
           logger.info(
@@ -731,7 +733,7 @@ export class LimitValidationService {
           `[LimitValidation] Checking user-level limits for: ${userId}`,
         );
         const userLimitViolation =
-          await LimitValidationService.checkEntityLimits("user", userId);
+          await LimitValidationService.checkEntityLimits("user", userId, model);
         if (userLimitViolation) {
           logger.info(
             `[LimitValidation] BLOCKED by user-level limit for: ${userId}`,
@@ -743,6 +745,7 @@ export class LimitValidationService {
             await LimitValidationService.checkDefaultUserLimit({
               organizationId,
               userId,
+              model,
             });
           if (defaultUserLimitViolation) {
             logger.info(
@@ -758,7 +761,7 @@ export class LimitValidationService {
         `[LimitValidation] Checking agent-level limits for: ${agentId}`,
       );
       const agentLimitViolation =
-        await LimitValidationService.checkEntityLimits("agent", agentId);
+        await LimitValidationService.checkEntityLimits("agent", agentId, model);
       if (agentLimitViolation) {
         logger.info(
           `[LimitValidation] BLOCKED by agent-level limit for: ${agentId}`,
@@ -785,7 +788,11 @@ export class LimitValidationService {
             `[LimitValidation] Checking team limit for team: ${team.id}`,
           );
           const teamLimitViolation =
-            await LimitValidationService.checkEntityLimits("team", team.id);
+            await LimitValidationService.checkEntityLimits(
+              "team",
+              team.id,
+              model,
+            );
           if (teamLimitViolation) {
             logger.info(
               `[LimitValidation] BLOCKED by team-level limit for team: ${team.id}`,
@@ -806,6 +813,7 @@ export class LimitValidationService {
             await LimitValidationService.checkEntityLimits(
               "organization",
               organizationId,
+              model,
             );
           if (orgLimitViolation) {
             logger.info(
@@ -838,6 +846,7 @@ export class LimitValidationService {
   private static async checkEntityLimits(
     entityType: LimitEntityType,
     entityId: string,
+    requestModel?: string,
   ): Promise<null | [string, string]> {
     try {
       logger.info(
@@ -861,6 +870,14 @@ export class LimitValidationService {
       }
 
       for (const limit of limits) {
+        const limitModels = normalizeLimitModels(limit.model);
+        if (!limitAppliesToRequestModel(limitModels, requestModel)) {
+          logger.info(
+            `[LimitValidation] Skipping limit ${limit.id} for ${entityType} ${entityId}: request model ${requestModel} is outside limit scope`,
+          );
+          continue;
+        }
+
         logger.info(
           `[LimitValidation] Checking limit ${limit.id} for ${entityType} ${entityId}`,
         );
@@ -873,11 +890,20 @@ export class LimitValidationService {
 
         if (limit.limitType === "token_cost") {
           try {
+            const modelUsageConditions: SQL[] = [
+              eq(schema.limitModelUsageTable.limitId, limit.id),
+            ];
+            if (limitModels) {
+              modelUsageConditions.push(
+                inArray(schema.limitModelUsageTable.model, limitModels) as SQL,
+              );
+            }
+
             // Get per-model usage from limit_model_usage table
             const modelUsages = await db
               .select()
               .from(schema.limitModelUsageTable)
-              .where(eq(schema.limitModelUsageTable.limitId, limit.id));
+              .where(and(...modelUsageConditions));
 
             if (modelUsages.length === 0) {
               logger.warn(
@@ -998,6 +1024,7 @@ ${contentMessage}`;
   private static async checkDefaultUserLimit(params: {
     organizationId: string;
     userId: string;
+    model?: string;
   }): Promise<null | [string, string]> {
     try {
       const [organization] = await db
@@ -1029,10 +1056,17 @@ ${contentMessage}`;
         return null;
       }
 
+      const limitModels = normalizeLimitModels(
+        organization.defaultUserLimitModel,
+      );
+      if (!limitAppliesToRequestModel(limitModels, params.model)) {
+        return null;
+      }
+
       const usage = await getDefaultUserLimitUsage({
         organizationId: params.organizationId,
         userId: params.userId,
-        models: normalizeLimitModels(organization.defaultUserLimitModel),
+        models: limitModels,
         cleanupInterval: organization.defaultUserLimitCleanupInterval ?? "1w",
       });
 
@@ -1239,6 +1273,17 @@ function normalizeLimitModels(models: string[] | null | undefined) {
   }
 
   return models;
+}
+
+function limitAppliesToRequestModel(
+  limitModels: string[] | null,
+  requestModel?: string,
+) {
+  if (!limitModels || !requestModel) {
+    return true;
+  }
+
+  return limitModels.includes(requestModel);
 }
 
 export default LimitModel;

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -461,6 +461,7 @@ export async function handleLLMProxy<
         agentId: resolvedAgentId,
         userId,
         virtualKeyId,
+        model: requestAdapter.getModel(),
       });
 
     if (limitViolation) {


### PR DESCRIPTION
## Summary

- Pass the request model into token-cost limit validation from the LLM proxy
- Skip model-scoped limits when the current request uses a different model
- Filter stale `limit_model_usage` rows to the models currently scoped by a limit
- Add regression coverage for stale usage rows and organization-level model-scoped limits

## Why

Fixes the model-scoping part of #4794. A model-specific org/user/agent/team/virtual-key limit should not block requests for unrelated models, and stale usage rows from a previously broader limit should not be counted after the limit is narrowed.

## Validation

- `pnpm exec biome check --write backend/src/models/limit.ts backend/src/models/limit.test.ts backend/src/routes/proxy/llm-proxy-handler.ts`
- `DATABASE_URL=postgresql://test:test@localhost:5432/test pnpm --filter @backend test src/models/limit.test.ts` (96 passed)
- `DATABASE_URL=postgresql://test:test@localhost:5432/test pnpm --filter @backend type-check`