### PR TITLE
fix: show Mermaid render errors without leaking DOM

### DIFF
--- a/platform/frontend/src/components/mermaid-diagram.test.tsx
+++ b/platform/frontend/src/components/mermaid-diagram.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MermaidDiagram } from "./mermaid-diagram";
+
+const { mockInitialize, mockRender, mockUseTheme } = vi.hoisted(() => ({
+  mockInitialize: vi.fn(),
+  mockRender: vi.fn(),
+  mockUseTheme: vi.fn(),
+}));
+
+vi.mock("mermaid", () => ({
+  default: {
+    initialize: mockInitialize,
+    render: mockRender,
+  },
+}));
+
+vi.mock("next-themes", () => ({
+  useTheme: () => mockUseTheme(),
+}));
+
+describe("MermaidDiagram", () => {
+  beforeEach(() => {
+    mockUseTheme.mockReturnValue({ theme: "light" });
+    vi.spyOn(Date, "now").mockReturnValue(1234);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockInitialize.mockReset();
+    mockRender.mockReset();
+    mockUseTheme.mockReset();
+    document.body.replaceChildren();
+  });
+
+  it("renders a Mermaid SVG when the diagram is valid", async () => {
+    mockRender.mockResolvedValueOnce({
+      svg: '<svg viewBox="0 0 100 50"><text>Rendered diagram</text></svg>',
+    });
+
+    const { container } = render(
+      <MermaidDiagram chart="graph TD; A-->B;" id="test-mermaid" />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector("svg")).not.toBeNull();
+    });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(mockRender).toHaveBeenCalledWith(
+      "test-mermaid-1234",
+      "graph TD; A-->B;",
+    );
+  });
+
+  it("displays the parse error and removes Mermaid scratch DOM on invalid diagrams", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    mockRender.mockImplementationOnce(async (uniqueId: string) => {
+      const scratch = document.createElement("div");
+      scratch.id = uniqueId;
+      scratch.textContent = "leaked scratch element";
+      document.body.appendChild(scratch);
+      throw new Error("Parse error on line 2");
+    });
+
+    render(<MermaidDiagram chart="graph TD; A-->" id="broken-mermaid" />);
+
+    const alert = await screen.findByRole("alert");
+
+    expect(alert).toHaveTextContent("Unable to render Mermaid diagram");
+    expect(alert).toHaveTextContent("Parse error on line 2");
+    expect(document.getElementById("broken-mermaid-1234")).toBeNull();
+    expect(screen.queryByText("graph TD; A-->")).not.toBeInTheDocument();
+    expect(consoleError).toHaveBeenCalledWith(
+      "Error rendering mermaid diagram:",
+      expect.any(Error),
+    );
+  });
+});

--- a/platform/frontend/src/components/mermaid-diagram.tsx
+++ b/platform/frontend/src/components/mermaid-diagram.tsx
@@ -9,6 +9,18 @@ interface MermaidDiagramProps {
   id?: string;
 }
 
+function formatMermaidRenderError(error: unknown) {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  if (typeof error === "string" && error.trim()) {
+    return error;
+  }
+
+  return "The Mermaid diagram could not be rendered.";
+}
+
 export function MermaidDiagram({
   chart,
   id = "mermaid-diagram",
@@ -16,9 +28,11 @@ export function MermaidDiagram({
   const ref = useRef<HTMLDivElement>(null);
   const { theme } = useTheme();
   const [isLoaded, setIsLoaded] = useState(false);
+  const [renderError, setRenderError] = useState<string | null>(null);
 
   useEffect(() => {
     setIsLoaded(false);
+    setRenderError(null);
     const isDark = theme === "dark";
 
     mermaid.initialize({
@@ -54,9 +68,10 @@ export function MermaidDiagram({
     const renderDiagram = async () => {
       if (ref.current) {
         ref.current.replaceChildren();
+        let uniqueId: string | null = null;
         try {
           // Generate a unique ID to avoid conflicts
-          const uniqueId = `${id}-${Date.now()}`;
+          uniqueId = `${id}-${Date.now()}`;
           const { svg } = await mermaid.render(uniqueId, chart);
           if (ref.current) {
             // Parse SVG string via DOMParser to avoid innerHTML
@@ -67,10 +82,12 @@ export function MermaidDiagram({
           }
         } catch (error) {
           console.error("Error rendering mermaid diagram:", error);
+          if (uniqueId) {
+            document.getElementById(uniqueId)?.remove();
+          }
           if (ref.current) {
-            const pre = document.createElement("pre");
-            pre.textContent = chart;
-            ref.current.replaceChildren(pre);
+            ref.current.replaceChildren();
+            setRenderError(formatMermaidRenderError(error));
             setIsLoaded(true);
           }
         }
@@ -86,6 +103,18 @@ export function MermaidDiagram({
       className={`flex justify-center w-full [&_svg]:!max-w-full [&_svg]:!h-auto transition-opacity duration-300 motion-reduce:transition-none ${
         isLoaded ? "opacity-100" : "opacity-0"
       }`}
-    />
+    >
+      {renderError ? (
+        <div
+          className="w-full rounded-md border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-700 dark:text-red-300"
+          role="alert"
+        >
+          <p className="font-medium">Unable to render Mermaid diagram</p>
+          <pre className="mt-2 whitespace-pre-wrap break-words font-mono text-xs">
+            {renderError}
+          </pre>
+        </div>
+      ) : null}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- Clean up Mermaid's temporary render element when invalid diagram syntax throws.
- Show a focused render error panel instead of echoing the raw chart text.
- Add component coverage for successful rendering and invalid-diagram cleanup.

Fixes #3511.

## Validation

- `pnpm exec biome check --write frontend/src/components/mermaid-diagram.tsx frontend/src/components/mermaid-diagram.test.tsx`
- `pnpm --filter @frontend test src/components/mermaid-diagram.test.tsx`
- `pnpm --filter @frontend type-check`