### PR TITLE
fix: use backend proxy URL for local connection hints

### DIFF
--- a/platform/frontend/src/lib/config/config.test.ts
+++ b/platform/frontend/src/lib/config/config.test.ts
@@ -131,6 +131,34 @@ describe("getExternalProxyUrls", () => {
     expect(result).toEqual(["https://gateway.example.com/v1"]);
   });
 
+  it("should use the backend proxy URL for local browser origins", () => {
+    delete process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL;
+    delete process.env.NEXT_PUBLIC_ARCHESTRA_INTERNAL_API_BASE_URL;
+    delete process.env.ARCHESTRA_INTERNAL_API_BASE_URL;
+    Object.defineProperty(window, "location", {
+      value: { origin: "http://localhost:3000" },
+      writable: true,
+    });
+
+    const result = getExternalProxyUrls();
+
+    expect(result).toEqual(["http://localhost:9000/v1"]);
+  });
+
+  it("should honor the configured backend proxy URL for local browser origins", () => {
+    delete process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL;
+    process.env.NEXT_PUBLIC_ARCHESTRA_INTERNAL_API_BASE_URL =
+      "http://localhost:9500";
+    Object.defineProperty(window, "location", {
+      value: { origin: "http://127.0.0.1:3000" },
+      writable: true,
+    });
+
+    const result = getExternalProxyUrls();
+
+    expect(result).toEqual(["http://localhost:9500/v1"]);
+  });
+
   it("should return single URL with /v1 suffix when one URL is set", () => {
     process.env.NEXT_PUBLIC_ARCHESTRA_API_BASE_URL =
       "https://api.archestra.com";

--- a/platform/frontend/src/lib/config/config.ts
+++ b/platform/frontend/src/lib/config/config.ts
@@ -64,6 +64,15 @@ const appendProxySuffix = (baseUrl: string): string => {
   return `${baseUrl}${proxyUrlSuffix}`;
 };
 
+const isLocalBrowserOrigin = (origin: string): boolean => {
+  try {
+    const { hostname } = new URL(origin);
+    return hostname === "localhost" || hostname === "127.0.0.1";
+  } catch {
+    return false;
+  }
+};
+
 /**
  * Get all configured external proxy URLs (with /v1 suffix).
  * Supports comma-separated list in NEXT_PUBLIC_ARCHESTRA_API_BASE_URL.
@@ -72,9 +81,13 @@ const appendProxySuffix = (baseUrl: string): string => {
 export const getExternalProxyUrls = (): string[] => {
   const externalUrl = env("NEXT_PUBLIC_ARCHESTRA_API_BASE_URL");
   if (!externalUrl) {
-    return typeof window !== "undefined"
-      ? [appendProxySuffix(window.location.origin)]
-      : [];
+    if (typeof window === "undefined") return [];
+    const origin = window.location.origin;
+    return [
+      isLocalBrowserOrigin(origin)
+        ? getInternalProxyUrl()
+        : appendProxySuffix(origin),
+    ];
   }
   return externalUrl
     .split(",")


### PR DESCRIPTION
## Summary
- use the backend proxy URL for local browser origins when no external proxy URL is configured
- keep explicit `NEXT_PUBLIC_ARCHESTRA_API_BASE_URL` and non-local browser origins on the existing external URL path
- add coverage for default local and configured-backend local hints

## Why
For local deployments, the connection page can currently suggest `localhost:3000/v1`, which is the frontend origin. Claude Code should be pointed at the backend proxy URL, e.g. `localhost:9000/v1`, unless an explicit external proxy URL is configured.

Fixes #4431.

## Tests
- `pnpm --filter @frontend test src/lib/config/config.test.ts`
- `pnpm exec biome check --write frontend/src/lib/config/config.ts frontend/src/lib/config/config.test.ts`
- `pnpm --filter @frontend type-check`