### PR TITLE
fix(chat): dedupe unavailable tool stream errors

### DIFF
--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -864,9 +864,18 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                     // prompt on reload (#4030).
                     generateMessageId: generateId,
                     onError: (error) => {
+                      if (chatErrorHandled) {
+                        return serializedChatError;
+                      }
+
                       const unavailableToolError =
                         getUnavailableToolErrorDetails(error);
                       if (unavailableToolError) {
+                        chatErrorHandled = true;
+                        serializedChatError =
+                          formatUnavailableToolErrorDetails(
+                            unavailableToolError,
+                          );
                         logger.info(
                           {
                             conversationId,
@@ -874,12 +883,6 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                           },
                           "Returning unavailable tool error as tool-level error",
                         );
-                        return formatUnavailableToolErrorDetails(
-                          unavailableToolError,
-                        );
-                      }
-
-                      if (chatErrorHandled) {
                         return serializedChatError;
                       }
                       chatErrorHandled = true;

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -846,11 +846,16 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 }
 
                 // toUIMessageStream invokes onError twice for the same upstream
-                // error (once when formatting the error chunk's errorText, once
-                // as a notification when the chunk is walked downstream). Guard
-                // so we don't persist or log the same error twice.
-                let chatErrorHandled = false;
-                let serializedChatError = "";
+                // error: first with the real error to build the chunk's
+                // errorText, then again as the chunk is walked downstream — but
+                // that second call wraps the previous return value in a fresh
+                // `new Error(errorText)` (process-ui-message-stream.ts), so the
+                // two share no object identity. We dedupe by signature instead:
+                // track every payload we've returned and replay it when an
+                // incoming error's message matches one. This collapses the
+                // duplicate notification while still handling distinct errors
+                // (e.g. two unavailable tools in one step) independently.
+                const returnedChatErrorPayloads = new Set<string>();
 
                 writer.merge(
                   result.toUIMessageStream({
@@ -864,18 +869,20 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                     // prompt on reload (#4030).
                     generateMessageId: generateId,
                     onError: (error) => {
-                      if (chatErrorHandled) {
-                        return serializedChatError;
+                      const incomingErrorMessage =
+                        error instanceof Error ? error.message : String(error);
+                      if (returnedChatErrorPayloads.has(incomingErrorMessage)) {
+                        return incomingErrorMessage;
                       }
 
                       const unavailableToolError =
                         getUnavailableToolErrorDetails(error);
                       if (unavailableToolError) {
-                        chatErrorHandled = true;
-                        serializedChatError =
+                        const serializedToolError =
                           formatUnavailableToolErrorDetails(
                             unavailableToolError,
                           );
+                        returnedChatErrorPayloads.add(serializedToolError);
                         logger.info(
                           {
                             conversationId,
@@ -883,9 +890,8 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                           },
                           "Returning unavailable tool error as tool-level error",
                         );
-                        return serializedChatError;
+                        return serializedToolError;
                       }
-                      chatErrorHandled = true;
 
                       const traceContext = getActiveTraceContext();
                       const correlationLogFields =
@@ -903,6 +909,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                         : fullError;
 
                       // mapProviderError safely serializes raw errors, but add defensive try-catch
+                      let serializedChatError: string;
                       try {
                         serializedChatError = JSON.stringify(errorForFrontend);
                       } catch (stringifyError) {
@@ -918,6 +925,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                           getMinimalFrontendError(errorForFrontend),
                         );
                       }
+                      returnedChatErrorPayloads.add(serializedChatError);
 
                       activeRunError =
                         error instanceof Error ? error.message : String(error);

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -409,7 +409,9 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
       availableTools: ["known_tool"],
     });
     const payload1 = capturedInnerOnError?.(unavailableToolError);
-    const payload2 = capturedInnerOnError?.(unavailableToolError.message);
+    // the AI SDK re-invokes onError downstream with `new Error(errorText)`,
+    // wrapping the first return value — that duplicate must replay the payload.
+    const payload2 = capturedInnerOnError?.(new Error(payload1));
 
     expect(payload1).toBe(payload2);
     expect(payload1).toContain(
@@ -424,6 +426,54 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
     const persistedErrors =
       await ConversationChatErrorModel.findByConversation(conversationId);
     expect(persistedErrors).toHaveLength(0);
+  });
+
+  test("formats each distinct unavailable tool error independently within one stream", async ({
+    expect,
+  }) => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: conversationId,
+        messages: [
+          {
+            id: "msg-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+    expect(capturedInnerOnError).toBeDefined();
+
+    const firstToolError = new NoSuchToolError({
+      toolName: "first_missing_tool",
+      availableTools: ["known_tool"],
+    });
+    const secondToolError = new NoSuchToolError({
+      toolName: "second_missing_tool",
+      availableTools: ["known_tool"],
+    });
+
+    const firstPayload = capturedInnerOnError?.(firstToolError);
+    const secondPayload = capturedInnerOnError?.(secondToolError);
+
+    expect(firstPayload).toContain('"requestedToolName": "first_missing_tool"');
+    expect(secondPayload).toContain(
+      '"requestedToolName": "second_missing_tool"',
+    );
+    expect(secondPayload).not.toBe(firstPayload);
+
+    // each payload is replayed (not reprocessed) on the downstream
+    // re-invocation the AI SDK fires as `new Error(errorText)`.
+    expect(capturedInnerOnError?.(new Error(firstPayload))).toBe(firstPayload);
+    expect(capturedInnerOnError?.(new Error(secondPayload))).toBe(
+      secondPayload,
+    );
   });
 
   test("persists user message with new DB id on provider error and allows subsequent PATCH", async ({

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -409,7 +409,7 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
       availableTools: ["known_tool"],
     });
     const payload1 = capturedInnerOnError?.(unavailableToolError);
-    const payload2 = capturedInnerOnError?.(unavailableToolError);
+    const payload2 = capturedInnerOnError?.(unavailableToolError.message);
 
     expect(payload1).toBe(payload2);
     expect(payload1).toContain(


### PR DESCRIPTION
Summary:
- Dedupe chat stream `onError` callbacks by the returned payload signature instead of a single stream-wide flag.
- The AI SDK invokes `onError` twice per error: first with the real error to build the chunk's `errorText`, then downstream as a fresh `new Error(errorText)` that shares no object identity. The old boolean collapsed *all* errors in a stream onto the first one's payload, so a step with multiple unavailable tools reported the first tool's name (and available-tools list) for every error.
- Track every payload we return and replay it only when an incoming error's message matches one. Distinct errors (e.g. two unavailable tools in one step) are now formatted independently, while the genuine duplicate notification is still collapsed and not re-persisted as a hard chat error.

Tests:
- ARCHESTRA_DATABASE_URL=postgresql://test:test@localhost:5432/test pnpm --filter @backend test src/routes/chat/stream-route.test.ts
- ARCHESTRA_DATABASE_URL=postgresql://test:test@localhost:5432/test pnpm --filter @backend type-check
- pnpm --filter @backend exec biome check src/routes/chat/routes.ts src/routes/chat/stream-route.test.ts

Test coverage:
- Updated the unavailable-tool dedupe test to model the real downstream re-invocation (`new Error(payload)`) rather than a raw string.
- Added a regression test asserting two distinct `NoSuchToolError`s in one stream each report their own `requestedToolName`.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
