### PR TITLE
perf: address backend query performance issues

### DIFF
--- a/platform/backend/src/models/chat-active-run.test.ts
+++ b/platform/backend/src/models/chat-active-run.test.ts
@@ -84,6 +84,50 @@ test("appends and reads ordered active chat run events", async ({
   ]);
 });
 
+test("appends active chat run events without touching the run every time", async ({
+  makeAgent,
+  makeConversation,
+  makeOrganization,
+  makeUser,
+}) => {
+  const user = await makeUser();
+  const organization = await makeOrganization();
+  const agent = await makeAgent({ organizationId: organization.id });
+  const conversation = await makeConversation(agent.id, {
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const run = await ActiveChatRunModel.create({
+    conversationId: conversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const oldUpdatedAt = new Date(Date.now() - 60 * 60 * 1000);
+  await db
+    .update(schema.chatActiveRunsTable)
+    .set({ updatedAt: oldUpdatedAt })
+    .where(eq(schema.chatActiveRunsTable.id, run?.id ?? ""));
+
+  await ActiveChatRunModel.appendEvents({
+    runId: run?.id ?? "",
+    seq: 1,
+    payloads: [{ type: "start" }],
+  });
+  const untouchedRun = await ActiveChatRunModel.findById(run?.id ?? "");
+  expect(untouchedRun?.updatedAt.getTime()).toBe(oldUpdatedAt.getTime());
+
+  await ActiveChatRunModel.appendEvents({
+    runId: run?.id ?? "",
+    seq: 2,
+    payloads: [{ type: "finish", finishReason: "stop" }],
+    touchRun: true,
+  });
+  const touchedRun = await ActiveChatRunModel.findById(run?.id ?? "");
+  expect(touchedRun?.updatedAt.getTime()).toBeGreaterThan(
+    oldUpdatedAt.getTime(),
+  );
+});
+
 test("updates stopRequestedAt on the running active chat run", async ({
   makeAgent,
   makeConversation,

--- a/platform/backend/src/models/chat-active-run.ts
+++ b/platform/backend/src/models/chat-active-run.ts
@@ -29,8 +29,18 @@ class ActiveChatRunModel {
     runId: string;
     seq: number;
     payloads: UIMessageChunk[];
+    touchRun?: boolean;
   }): Promise<void> {
     if (params.payloads.length === 0) {
+      return;
+    }
+
+    if (!params.touchRun) {
+      await db.insert(schema.chatActiveRunEventsTable).values({
+        runId: params.runId,
+        seq: params.seq,
+        payloads: params.payloads,
+      });
       return;
     }
 
@@ -40,7 +50,6 @@ class ActiveChatRunModel {
         seq: params.seq,
         payloads: params.payloads,
       });
-
       await tx
         .update(schema.chatActiveRunsTable)
         .set({ updatedAt: new Date() })

--- a/platform/backend/src/models/limit.test.ts
+++ b/platform/backend/src/models/limit.test.ts
@@ -1,9 +1,10 @@
 import { eq } from "drizzle-orm";
 import db, { schema } from "@/database";
-import { describe, expect, test } from "@/test";
+import { describe, expect, test, vi } from "@/test";
 import { CreateLimitSchema } from "@/types";
 import AgentTeamModel from "./agent-team";
 import LimitModel, { LimitValidationService } from "./limit";
+import ModelModel from "./model";
 import OrganizationModel from "./organization";
 
 describe("CreateLimitSchema", () => {
@@ -929,6 +930,45 @@ describe("LimitModel", () => {
       // Total cost should be sum of both
       const totalCost = breakdown.reduce((sum, b) => sum + b.cost, 0);
       expect(totalCost).toBeGreaterThanOrEqual(0);
+    });
+
+    test("loads pricing records in one batch", async ({ makeAgent }) => {
+      const agent = await makeAgent({ name: "Test Agent" });
+      const limit = await LimitModel.create({
+        entityType: "agent",
+        entityId: agent.id,
+        limitType: "token_cost",
+        limitValue: 1000000,
+        model: ["batch-model-a", "batch-model-b", "batch-model-c"],
+      });
+      await LimitModel.updateTokenLimitUsage(
+        "agent",
+        agent.id,
+        "batch-model-a",
+        100,
+        50,
+      );
+      await LimitModel.updateTokenLimitUsage(
+        "agent",
+        agent.id,
+        "batch-model-b",
+        200,
+        100,
+      );
+      await LimitModel.updateTokenLimitUsage(
+        "agent",
+        agent.id,
+        "batch-model-c",
+        300,
+        150,
+      );
+      const findByModelIdsOnlySpy = vi.spyOn(ModelModel, "findByModelIdsOnly");
+      const findByModelIdOnlySpy = vi.spyOn(ModelModel, "findByModelIdOnly");
+
+      await LimitModel.getModelUsageBreakdown(limit.id);
+
+      expect(findByModelIdsOnlySpy).toHaveBeenCalledTimes(1);
+      expect(findByModelIdOnlySpy).not.toHaveBeenCalled();
     });
   });
 

--- a/platform/backend/src/models/limit.ts
+++ b/platform/backend/src/models/limit.ts
@@ -33,6 +33,8 @@ type LimitsCleanupIntervalSqlLiteral =
   | "1 week"
   | "1 month";
 
+type LimitModelUsageRecord = typeof schema.limitModelUsageTable.$inferSelect;
+
 class LimitModel {
   // limitsCleanupIntervalSqlLiterals exists basically to compile-time check set of literals
   static readonly limitsCleanupIntervalSqlLiterals: Record<
@@ -141,38 +143,12 @@ class LimitModel {
   ): Promise<
     Array<{ model: string; tokensIn: number; tokensOut: number; cost: number }>
   > {
-    // Get the model usage records
     const modelUsages = await db
       .select()
       .from(schema.limitModelUsageTable)
       .where(eq(schema.limitModelUsageTable.limitId, limitId));
 
-    // Calculate cost for each model
-    const breakdown = await Promise.all(
-      modelUsages.map(async (usage) => {
-        // Look up model by modelId only — limit usage records don't store provider
-        const modelEntry = await ModelModel.findByModelIdOnly(usage.model);
-        const pricing = ModelModel.getEffectivePricing(modelEntry, usage.model);
-
-        const inputCost =
-          (usage.currentUsageTokensIn *
-            parseFloat(pricing.pricePerMillionInput)) /
-          1_000_000;
-        const outputCost =
-          (usage.currentUsageTokensOut *
-            parseFloat(pricing.pricePerMillionOutput)) /
-          1_000_000;
-
-        return {
-          model: usage.model,
-          tokensIn: usage.currentUsageTokensIn,
-          tokensOut: usage.currentUsageTokensOut,
-          cost: inputCost + outputCost,
-        };
-      }),
-    );
-
-    return breakdown;
+    return (await calculateModelUsageCosts(modelUsages)).breakdown;
   }
 
   /**
@@ -885,44 +861,20 @@ export class LimitValidationService {
               );
               comparisonValue = 0;
             } else {
-              let totalCost = 0;
-
-              for (const usage of modelUsages) {
-                // Track total tokens for metadata
-                totalTokensIn += usage.currentUsageTokensIn;
-                totalTokensOut += usage.currentUsageTokensOut;
-
-                // Look up model by modelId only — limit usage records don't store provider
-                const modelEntry = await ModelModel.findByModelIdOnly(
-                  usage.model,
-                );
-                const pricing = ModelModel.getEffectivePricing(
-                  modelEntry,
-                  usage.model,
-                );
-
-                const inputCost =
-                  (usage.currentUsageTokensIn *
-                    parseFloat(pricing.pricePerMillionInput)) /
-                  1000000;
-                const outputCost =
-                  (usage.currentUsageTokensOut *
-                    parseFloat(pricing.pricePerMillionOutput)) /
-                  1000000;
-                const modelCost = inputCost + outputCost;
-
-                totalCost += modelCost;
-
+              const usageCosts = await calculateModelUsageCosts(modelUsages);
+              for (const usage of usageCosts.breakdown) {
                 logger.debug(
-                  `[LimitValidation] Model ${usage.model}: ${usage.currentUsageTokensIn} in + ${usage.currentUsageTokensOut} out = $${modelCost.toFixed(2)}`,
+                  `[LimitValidation] Model ${usage.model}: ${usage.tokensIn} in + ${usage.tokensOut} out = $${usage.cost.toFixed(2)}`,
                 );
               }
 
-              comparisonValue = totalCost;
+              totalTokensIn = usageCosts.tokensIn;
+              totalTokensOut = usageCosts.tokensOut;
+              comparisonValue = usageCosts.cost;
               limitDescription = "cost_dollars";
 
               logger.debug(
-                `[LimitValidation] Total cost for limit ${limit.id}: $${totalCost.toFixed(2)} across ${modelUsages.length} models`,
+                `[LimitValidation] Total cost for limit ${limit.id}: $${usageCosts.cost.toFixed(2)} across ${modelUsages.length} models`,
               );
             }
           } catch (error) {
@@ -1114,6 +1066,39 @@ function buildCleanupDueCondition(): SQL {
   );
 
   return or(...intervalConditions) as SQL;
+}
+
+async function calculateModelUsageCosts(modelUsages: LimitModelUsageRecord[]) {
+  const modelEntriesByModelId = await ModelModel.findByModelIdsOnly(
+    Array.from(new Set(modelUsages.map((usage) => usage.model))),
+  );
+
+  let cost = 0;
+  let tokensIn = 0;
+  let tokensOut = 0;
+  const breakdown = modelUsages.map((usage) => {
+    tokensIn += usage.currentUsageTokensIn;
+    tokensOut += usage.currentUsageTokensOut;
+
+    const modelEntry = modelEntriesByModelId.get(usage.model) ?? null;
+    const pricing = ModelModel.getEffectivePricing(modelEntry, usage.model);
+    const modelCost =
+      (usage.currentUsageTokensIn * parseFloat(pricing.pricePerMillionInput)) /
+        1_000_000 +
+      (usage.currentUsageTokensOut *
+        parseFloat(pricing.pricePerMillionOutput)) /
+        1_000_000;
+    cost += modelCost;
+
+    return {
+      model: usage.model,
+      tokensIn: usage.currentUsageTokensIn,
+      tokensOut: usage.currentUsageTokensOut,
+      cost: modelCost,
+    };
+  });
+
+  return { breakdown, cost, tokensIn, tokensOut };
 }
 
 async function getDefaultUserLimitUsage(params: {

--- a/platform/backend/src/services/active-chat-run.ts
+++ b/platform/backend/src/services/active-chat-run.ts
@@ -7,8 +7,9 @@ import {
   createActiveChatRunNotifier,
 } from "@/services/active-chat-run-notifier";
 
-const EVENT_FLUSH_INTERVAL_MS = 100;
-const EVENT_BATCH_SIZE = 16;
+const EVENT_FLUSH_INTERVAL_MS = 500;
+const EVENT_BATCH_SIZE = 256;
+const RUN_TOUCH_INTERVAL_MS = 30 * 1000;
 const STALE_RUNNING_MS = 10 * 60 * 1000;
 const TERMINAL_CLEANUP_INTERVAL_MS = 60 * 1000;
 const ACTIVE_CHAT_RUN_TERMINAL_RETENTION_MS = 60 * 60 * 1000;
@@ -273,6 +274,7 @@ class ActiveChatRunEventBatcher {
   private pending: UIMessageChunk[] = [];
   private flushTimer: NodeJS.Timeout | null = null;
   private flushPromise: Promise<void> = Promise.resolve();
+  private lastRunTouchAt = 0;
 
   constructor(
     private readonly runId: string,
@@ -307,6 +309,7 @@ class ActiveChatRunEventBatcher {
 
     const payloads = compactReplayPayloads(this.pending);
     const seq = this.nextSeq;
+    const touchRun = this.shouldTouchRun();
     this.pending = [];
     this.nextSeq += 1;
 
@@ -315,10 +318,24 @@ class ActiveChatRunEventBatcher {
         runId: this.runId,
         seq,
         payloads,
+        touchRun,
       }).then(() => this.onFlush()),
     );
 
     await this.flushPromise;
+  }
+
+  private shouldTouchRun(): boolean {
+    const now = Date.now();
+    if (
+      this.lastRunTouchAt &&
+      now - this.lastRunTouchAt < RUN_TOUCH_INTERVAL_MS
+    ) {
+      return false;
+    }
+
+    this.lastRunTouchAt = now;
+    return true;
   }
 }
 


### PR DESCRIPTION
## Summary

- batch active chat stream event persistence more aggressively
- avoid touching active chat run rows on every event insert
- bulk-load model pricing records while calculating token-cost limit usage

## Impact

This reduces repeated database writes during streamed chat responses and removes per-model pricing lookups in token-cost limit calculations.