### PR TITLE
docs: update supported LLM providers page

### DIFF
--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -22,10 +22,12 @@ The model router exposes one OpenAI-compatible interface for models across confi
 
 ### Supported Model Router APIs
 
-- **Responses API** (`/responses`) - ✅ Supported for text requests across model-router-compatible providers
-- **Chat Completions API** (`/chat/completions`) - ✅ Supported for text chat requests across model-router-compatible providers
-- **Embeddings API** (`/embeddings`) - ✅ Supported for OpenAI embedding models
-- **Models API** (`/models`) - ✅ Returns provider-qualified chat and embedding model IDs
+- **Responses API** (`/responses`) for text requests across model-router-compatible providers
+- **Chat Completions API** (`/chat/completions`) for text chat requests across model-router-compatible providers
+- **Models API** (`/models`) for provider-qualified chat and embedding model IDs
+- **Embeddings API** (`/embeddings`) for OpenAI embedding models only
+
+> ⚠️ Embeddings support for other providers is tracked in [GitHub Issue #5174](https://github.com/archestra-ai/archestra/issues/5174).
 
 ### Model Router Connection Details
 
@@ -46,17 +48,13 @@ The `/models` response includes model-router-compatible text models for the prov
 
 Model Router translation is text-first. Anthropic, Gemini, and Cohere routes currently drop non-text content parts such as OpenAI `image_url` message parts; Bedrock supports base64 data URL images.
 
-### Model Router Embeddings
-
-Call `POST /v1/model-router/{llm-proxy-id}/embeddings` with an OpenAI-compatible embedding request. Use the provider-qualified embedding model ID from `/models`, for example `openai:text-embedding-3-small`. Embedding requests currently route to OpenAI embedding models.
-
 ## OpenAI
 
 ### Supported OpenAI APIs
 
-- **Chat Completions API** (`/chat/completions`) - ✅ Fully supported
-- **Responses API** (`/responses`) - ✅ Fully supported
-- **Embeddings API** (`/embeddings`) - ✅ Fully supported
+- **Chat Completions API** (`/chat/completions`)
+- **Responses API** (`/responses`)
+- **Embeddings API** (`/embeddings`)
 
 ### OpenAI Connection Details
 
@@ -72,7 +70,7 @@ Call `POST /v1/model-router/{llm-proxy-id}/embeddings` with an OpenAI-compatible
 
 ### Supported Anthropic APIs
 
-- **Messages API** (`/messages`) - ✅ Fully supported
+- **Messages API** (`/messages`)
 
 ### Anthropic Connection Details
 
@@ -96,8 +94,8 @@ Archestra supports both the [Google AI Studio](https://ai.google.dev/) (Gemini D
 
 ### Supported Gemini APIs
 
-- **Generate Content API** (`:generateContent`) - ✅ Fully supported
-- **Stream Generate Content API** (`:streamGenerateContent`) - ✅ Fully supported
+- **Generate Content API** (`:generateContent`)
+- **Stream Generate Content API** (`:streamGenerateContent`)
 
 ### Gemini Connection Details
 
@@ -179,16 +177,12 @@ See the [Vertex AI authentication guide](https://cloud.google.com/vertex-ai/docs
 
 ### Supported Cerebras APIs
 
-- **Chat Completions API** (`/chat/completions`) - ✅ Fully supported
+- **Chat Completions API** (`/chat/completions`)
 
 ### Cerebras Connection Details
 
 - **Base URL**: `http://localhost:9000/v1/cerebras/{agent-id}`
 - **Authentication**: Pass your Cerebras API key in the `Authorization` header as `Bearer <your-api-key>`
-
-### Important Notes
-
-- Usage of the llama models in the chat ⚠️ Not yet supported ([GitHub Issue #2058](https://github.com/archestra-ai/archestra/issues/2058)) 
 
 ## Cohere
 
@@ -196,8 +190,8 @@ See the [Vertex AI authentication guide](https://cloud.google.com/vertex-ai/docs
 
 ### Supported Cohere APIs
 
-- **Chat API** (`/chat`) - ✅ Fully supported
-- **Streaming**: ✅ Fully supported
+- **Chat API** (`/chat`)
+- **Streaming**
 
 ### Cohere Connection Details
 
@@ -221,7 +215,7 @@ See the [Vertex AI authentication guide](https://cloud.google.com/vertex-ai/docs
 
 ### Supported Groq APIs
 
-- **Chat Completions API** (`/chat/completions`) - ✅ Fully supported (OpenAI-compatible)
+- **Chat Completions API** (`/chat/completions`) - OpenAI-compatible
 
 ### Groq Connection Details
 
@@ -256,8 +250,8 @@ You can generate an API key from the [Groq Console](https://console.groq.com/key
 
 ### Supported OpenRouter APIs
 
-- **Chat Completions API** (`/chat/completions`) - ✅ Fully supported (OpenAI-compatible)
-- **Embeddings API** (`/embeddings`) - ✅ Supported for Knowledge Base embeddings
+- **Chat Completions API** (`/chat/completions`) - OpenAI-compatible
+- **Embeddings API** (`/embeddings`) for Knowledge Base embeddings
 
 ### OpenRouter Connection Details
 
@@ -300,7 +294,7 @@ Dynamic-pricing routers (`openrouter/auto`) report no fixed per-token price, so 
 
 ### Supported Mistral APIs
 
-- **Chat Completions API** (`/chat/completions`) - ✅ Fully supported
+- **Chat Completions API** (`/chat/completions`)
 
 ### Mistral Connection Details
 
@@ -317,7 +311,7 @@ You can get an API key from the [Mistral AI Console](https://console.mistral.ai/
 
 ### Supported Perplexity APIs
 
-- **Chat Completions API** (`/chat/completions`) - ✅ Fully supported
+- **Chat Completions API** (`/chat/completions`)
 
 ### Perplexity Connection Details
 
@@ -347,7 +341,7 @@ You can get an API key from the [Perplexity Settings](https://www.perplexity.ai/
 
 ### Supported vLLM APIs
 
-- **Chat Completions API** (`/chat/completions`) - ✅ Fully supported (OpenAI-compatible)
+- **Chat Completions API** (`/chat/completions`) - OpenAI-compatible
 
 ### vLLM Connection Details
 
@@ -380,7 +374,7 @@ The base URL can also be set globally via the `ARCHESTRA_VLLM_BASE_URL` environm
 
 ### Supported Ollama APIs
 
-- **Chat Completions API** (`/chat/completions`) - ✅ Fully supported (OpenAI-compatible)
+- **Chat Completions API** (`/chat/completions`) - OpenAI-compatible
 
 ### Ollama Connection Details
 
@@ -414,7 +408,7 @@ The default base URL is `http://localhost:11434/v1`. Override it per-key in the 
 
 ### Supported Zhipu AI APIs
 
-- **Chat Completions API** (`/chat/completions`) - ✅ Fully supported (OpenAI-compatible)
+- **Chat Completions API** (`/chat/completions`) - OpenAI-compatible
 
 ### Zhipu AI Connection Details
 
@@ -449,7 +443,7 @@ The default base URL is `http://localhost:11434/v1`. Override it per-key in the 
 
 ### Supported xAI APIs
 
-- **Chat Completions API** (`/chat/completions`) - ✅ Fully supported (OpenAI-compatible)
+- **Chat Completions API** (`/chat/completions`) - OpenAI-compatible
 
 ### xAI Connection Details
 
@@ -486,7 +480,7 @@ You can generate an API key from the [xAI Console](https://console.x.ai/).
 
 ### Supported MiniMax APIs
 
-- **Chat Completions API** (`/chat/completions`) - ✅ Fully supported (OpenAI-compatible)
+- **Chat Completions API** (`/chat/completions`) - OpenAI-compatible
 
 ### MiniMax Connection Details
 
@@ -520,10 +514,10 @@ You can generate an API key from the [xAI Console](https://console.x.ai/).
 
 ### Supported Bedrock APIs
 
-- **Converse API** (`/converse`) - ✅ Fully supported ([AWS Docs](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html))
-- **Converse Stream API** (`/converse-stream`) - ✅ Fully supported ([AWS Docs](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html))
-- **InvokeModel API** (`/invoke`) -  ⚠️ Not yet supported  ([AWS Docs](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeModel.html))
-- **OpenAI-compatible API (Mantle)** -  ⚠️ Not yet supported ([AWS Docs](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html))
+- **Converse API** (`/converse`) ([AWS Docs](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html))
+- **Converse Stream API** (`/converse-stream`) ([AWS Docs](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html))
+- **InvokeModel API** (`/invoke`) - ⚠️ Not yet supported ([AWS Docs](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeModel.html))
+- **OpenAI-compatible API (Mantle)** - ⚠️ Not yet supported ([AWS Docs](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html))
 
 ### Bedrock Connection Details
 


### PR DESCRIPTION
## Summary

- Remove emoji status markers from supported API rows while keeping warning emoji only for "Not yet supported" entries.
- Replace repeated "Fully supported" wording with shorter supported API inventories.
- Remove the obsolete Cerebras Llama chat limitation note now that issue 2058 is closed as completed.
- Clarify that model-router embeddings currently support OpenAI embedding models only and link to #5174 for non-OpenAI provider support.