### PR TITLE
fix(chats-ui): limit maximum number of tokens to generate chat title

### DIFF
--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -2484,6 +2484,11 @@ export async function generateConversationTitle(
       model,
       system: systemPrompt,
       prompt: titlePrompt,
+      // The Anthropic SDK throws "Streaming is required for operations that may take longer than 10 minutes"
+      // when new large models default to 32k on non-streaming requests
+      // so we limit maxOutputTokens to 20, since the prompt requests "3-6 words" (~10 tokens)
+      // https://platform.claude.com/docs/en/api/sdks/typescript#long-requests
+      maxOutputTokens: 20,
     });
 
     logger.debug(


### PR DESCRIPTION
## Summary
Set `maxOutputTokens: 20` in `generateText` to stay under Anthropic's non-streaming output token limit for larger models.

https://platform.claude.com/docs/en/api/sdks/typescript#long-requests

## Detailed
Title generation stopped working with Anthropic models on my machine, I found this error in the log:
`Streaming is required for operations that may take longer than 10 minutes. See https://github.com/anthropics/anthropic-sdk-typescript#long-requests for more details`

Root cause (best guess): `@ai-sdk/anthropic` added support for the new Opus model ~3 days ago. Since `backend/package.json` has `"@ai-sdk/anthropic": "^3.0.58"`, the update was pulled in automatically. The new model is slower, causing title generation requests to exceed the limit and fail.

<details>
<summary>Full log</summary>

```
{
      "name": "AI_APICallError",
      "url": "http://localhost:9000/v1/anthropic/58a0a335-c47c-4eca-af8c-68756344be30/v1/messages",
      "requestBodyValues": {
        "model": "claude-opus-4-7",
        "max_tokens": 32000,
        "system": [
          {
            "type": "text",
            "text": "You generate short chat titles.\n\nReturn only a concise 3-6 word title. Do not wrap the title in quotes. Do not include explanations, markdown, or punctuation unless it is part of the topic."
          }
        ],
        "messages": [
          {
            "role": "user",
            "content": [
              {
                "type": "text",
                "text": "Chat conversation messages:\n\nUser: i love racoons\n\nAssistant: Ha, raccoons are awesome! 🦝 They're clever, curious, and those little masked faces are adorable. Plus, their tiny hands are ridiculously cute – they look like they're always up to something mischievous (and they usually are!).\n\nIs there something raccoon-related I can help you with? Fun facts, pictures to draw, a raccoon-themed project, or just here to share the raccoon appreciation? 😄"
              }
            ]
          }
        ]
      },
      "statusCode": 500,
      "responseHeaders": {
        "access-control-allow-credentials": "true",
        "access-control-expose-headers": "Set-Cookie",
        "connection": "keep-alive",
        "content-length": "223",
        "content-type": "application/json; charset=utf-8",
        "date": "Sun, 31 May 2026 14:57:54 GMT",
        "keep-alive": "timeout=72",
        "vary": "Origin"
      },
      "responseBody": "{\"error\":{\"message\":\"Streaming is required for operations that may take longer than 10 minutes. See https://github.com/anthropics/anthropic-sdk-typescript#long-requests for more details\",\"type\":\"api_internal_server_error\"}}",
      "isRetryable": true
    }
    
    
```

</details>

## Potential improvements
- **Use conversation model for title generation** -- `titleLlm` at `platform/backend/src/routes/chat/routes.ts:2082` always resolves to the provider's default model (Opus for Anthropic), ignoring the user's actual model choice. It should inherit the current conversation model so users on Haiku aren't silently billed for Opus for title generation.
- **Better context window for title generation** -- `generateConversationTitle` only uses the first user+assistant messages, so titles never reflect how the conversation evolved. Passing last N, or first N + last M chars would give the model both the original intent and the current topic.

Wdyt? Shall I implement these two as well?