### PR TITLE
refactor: genericize sandbox runtime wrapper (no behavior change)

### DIFF
--- a/platform/backend/src/code-runtime/code-runtime-service.ts
+++ b/platform/backend/src/code-runtime/code-runtime-service.ts
@@ -1,10 +1,10 @@
 import config from "@/config";
-import {
-  DaggerRuntimeError,
-  daggerRuntimeService,
-} from "@/dagger-runtime/dagger-runtime-service";
 import logger from "@/logging";
 import * as metrics from "@/observability/metrics";
+import {
+  SandboxRuntimeError,
+  sandboxRuntimeService,
+} from "@/sandbox-runtime/sandbox-runtime-service";
 import {
   CODE_RUNTIME_LIMITS,
   CodeRuntimeError,
@@ -19,26 +19,26 @@ const SKILL_DIR = `/skills/${SKILL_NAME}`;
 const VENV_PYTHON = "/home/sandbox/.venv/bin/python";
 
 /**
- * Thin adapter over the unified `daggerRuntimeService`. Takes a Python script
+ * Thin adapter over the unified `sandboxRuntimeService`. Takes a Python script
  * (and optional pip requirements), snapshots it into the shared warm sandbox,
  * and runs it. The native side owns the Dagger session + warm venv.
  */
 class CodeRuntimeService {
   get isEnabled(): boolean {
-    return config.codeRuntime.enabled && daggerRuntimeService.isEnabled;
+    return config.codeRuntime.enabled && sandboxRuntimeService.isEnabled;
   }
 
   get isReady(): boolean {
-    return daggerRuntimeService.isReady;
+    return sandboxRuntimeService.isReady;
   }
 
   async init(): Promise<void> {
     if (!config.codeRuntime.enabled) return;
-    await daggerRuntimeService.attach(CONSUMER_ID);
+    await sandboxRuntimeService.attach(CONSUMER_ID);
   }
 
   async shutdown(): Promise<void> {
-    await daggerRuntimeService.detach(CONSUMER_ID);
+    await sandboxRuntimeService.detach(CONSUMER_ID);
   }
 
   async run(params: RunCodeParams): Promise<RunCodeResult> {
@@ -50,7 +50,7 @@ class CodeRuntimeService {
 
     const startedAt = Date.now();
     try {
-      const executed = await daggerRuntimeService.runCommand({
+      const executed = await sandboxRuntimeService.runCommand({
         command: buildPythonCommand(validated.requirements),
         cwd: SKILL_DIR,
         timeoutSeconds,
@@ -116,11 +116,11 @@ export const codeRuntimeService = new CodeRuntimeService();
  */
 function toCodeRuntimeError(error: unknown): CodeRuntimeError {
   if (error instanceof CodeRuntimeError) return error;
-  if (error instanceof DaggerRuntimeError) {
+  if (error instanceof SandboxRuntimeError) {
     switch (error.code) {
       case "ARCHESTRA_INVALID_INPUT":
-        // INVALID_INPUT messages from the runtime layer mention "Dagger"; the
-        // user-facing shape should match skill-sandbox's "not enabled" path.
+        // INVALID_INPUT from the runtime layer means it is not enabled; keep
+        // the user-facing shape aligned with skill-sandbox's "not enabled" path.
         return new CodeRuntimeError("the code runtime is not enabled");
       case "ARCHESTRA_COMMAND_FAILED":
         logger.error({ err: error }, "[CodeRuntime] script command failed");

--- a/platform/backend/src/sandbox-runtime/sandbox-runtime-service.ts
+++ b/platform/backend/src/sandbox-runtime/sandbox-runtime-service.ts
@@ -16,21 +16,21 @@ function loadNative(): Promise<NativeBindings> {
   return nativeBindings;
 }
 
-type DaggerRuntimeStatus =
+type SandboxRuntimeStatus =
   | "disabled"
   | "initializing"
   | "ready"
   | "error"
   | "stopped";
 
-export class DaggerRuntimeError extends Error {
+export class SandboxRuntimeError extends Error {
   readonly code: NativeSandboxErrorCode;
   constructor(
     message: string,
     code: NativeSandboxErrorCode = "ARCHESTRA_INTERNAL",
   ) {
     super(message);
-    this.name = "DaggerRuntimeError";
+    this.name = "SandboxRuntimeError";
     this.code = code;
   }
 }
@@ -89,18 +89,19 @@ interface ReadArtifactResult {
 }
 
 /**
- * Process-singleton Dagger runtime — every shell command (skill sandbox or
+ * Process-singleton sandbox runtime — every shell command (skill sandbox or
  * python script) flows through this service. The native side keeps one
- * long-lived Dagger session with a pre-warmed base container, so per-call
- * overhead is dominated by the command itself rather than session/image setup.
+ * long-lived session with a pre-warmed base container, so per-call overhead is
+ * dominated by the command itself rather than session/image setup. The backend
+ * is currently Dagger; this wrapper is the seam where another could slot in.
  */
 interface Waiter {
   resolve: () => void;
-  reject: (err: DaggerRuntimeError) => void;
+  reject: (err: SandboxRuntimeError) => void;
 }
 
-class DaggerRuntimeService {
-  private status: DaggerRuntimeStatus = "disabled";
+class SandboxRuntimeService {
+  private status: SandboxRuntimeStatus = "disabled";
   private initPromise: Promise<void> | null = null;
   private lastInitAttemptAt = 0;
   private activeRuns = 0;
@@ -209,8 +210,8 @@ class DaggerRuntimeService {
     if (this.status === "disabled") return;
     this.status = "stopped";
     this.drainWaiters(
-      new DaggerRuntimeError(
-        "the Dagger runtime is shutting down",
+      new SandboxRuntimeError(
+        "the sandbox runtime is shutting down",
         "ARCHESTRA_ENGINE_UNREACHABLE",
       ),
     );
@@ -232,23 +233,23 @@ class DaggerRuntimeService {
 
   private async ensureReady(): Promise<void> {
     if (!config.daggerRuntime.enabled) {
-      throw new DaggerRuntimeError(
-        "the Dagger runtime is not enabled",
+      throw new SandboxRuntimeError(
+        "the sandbox runtime is not enabled",
         "ARCHESTRA_INVALID_INPUT",
       );
     }
     await this.init();
     switch (this.status) {
       case "stopped":
-        throw new DaggerRuntimeError(
-          "the Dagger runtime has been stopped",
+        throw new SandboxRuntimeError(
+          "the sandbox runtime has been stopped",
           "ARCHESTRA_ENGINE_UNREACHABLE",
         );
       case "ready":
         return;
       default:
-        throw new DaggerRuntimeError(
-          "the Dagger runtime is not available (engine unreachable)",
+        throw new SandboxRuntimeError(
+          "the sandbox runtime is not available (engine unreachable)",
           "ARCHESTRA_ENGINE_UNREACHABLE",
         );
     }
@@ -268,16 +269,16 @@ class DaggerRuntimeService {
       await checkSession({ traceparent: getTraceparent() });
       // shutdown() may have fired while we were awaiting; don't revive it.
       // re-read status as the union type since TS narrows past the await.
-      if ((this.status as DaggerRuntimeStatus) === "stopped") return;
+      if ((this.status as SandboxRuntimeStatus) === "stopped") return;
       this.status = "ready";
-      logger.info("[DaggerRuntime] ready — shared session + warm base online");
+      logger.info("[SandboxRuntime] ready — shared session + warm base online");
     } catch (error) {
-      if ((this.status as DaggerRuntimeStatus) !== "stopped") {
+      if ((this.status as SandboxRuntimeStatus) !== "stopped") {
         this.status = "error";
       }
       logger.error(
         { err: error },
-        "[DaggerRuntime] failed to initialize — sandbox execution unavailable",
+        "[SandboxRuntime] failed to initialize — sandbox execution unavailable",
       );
       throw error;
     }
@@ -311,8 +312,8 @@ class DaggerRuntimeService {
       return;
     }
     if (this.waiters.length >= config.daggerRuntime.maxQueueLength) {
-      throw new DaggerRuntimeError(
-        "the Dagger runtime is at capacity — too many runs are already queued",
+      throw new SandboxRuntimeError(
+        "the sandbox runtime is at capacity — too many runs are already queued",
         "ARCHESTRA_ENGINE_UNREACHABLE",
       );
     }
@@ -330,7 +331,7 @@ class DaggerRuntimeService {
     }
   }
 
-  private drainWaiters(err: DaggerRuntimeError): void {
+  private drainWaiters(err: SandboxRuntimeError): void {
     while (this.waiters.length > 0) {
       const w = this.waiters.shift();
       w?.reject(err);
@@ -354,11 +355,11 @@ class DaggerRuntimeService {
           if (this.status !== "stopped") this.status = "error";
           logger.error(
             { totalMs },
-            "[DaggerRuntime] native call exceeded backstop — engine assumed wedged",
+            "[SandboxRuntime] native call exceeded backstop — engine assumed wedged",
           );
           reject(
-            new DaggerRuntimeError(
-              "the Dagger runtime native call did not return within the backstop window",
+            new SandboxRuntimeError(
+              "the sandbox runtime native call did not return within the backstop window",
               "ARCHESTRA_ENGINE_UNREACHABLE",
             ),
           );
@@ -370,15 +371,15 @@ class DaggerRuntimeService {
     }
   }
 
-  private normalizeError(error: unknown): DaggerRuntimeError {
-    if (error instanceof DaggerRuntimeError) return error;
+  private normalizeError(error: unknown): SandboxRuntimeError {
+    if (error instanceof SandboxRuntimeError) return error;
     const native = getNativeSandboxError(error);
     switch (native.code) {
       case "ARCHESTRA_ARTIFACT_NOT_FOUND":
       case "ARCHESTRA_ARTIFACT_TOO_LARGE":
       case "ARCHESTRA_COMMAND_FAILED":
       case "ARCHESTRA_INVALID_INPUT":
-        return new DaggerRuntimeError(native.message, native.code);
+        return new SandboxRuntimeError(native.message, native.code);
       case "ARCHESTRA_ENGINE_UNREACHABLE":
         // genuine engine outage — flip status so the cooldown gate kicks in.
         // never overwrite 'stopped': shutdown is the terminal state and
@@ -386,10 +387,10 @@ class DaggerRuntimeService {
         if (this.status !== "stopped") this.status = "error";
         logger.error(
           { err: error, code: native.code },
-          "[DaggerRuntime] engine unreachable",
+          "[SandboxRuntime] engine unreachable",
         );
-        return new DaggerRuntimeError(
-          "the Dagger runtime is not available (engine unreachable)",
+        return new SandboxRuntimeError(
+          "the sandbox runtime is not available (engine unreachable)",
           "ARCHESTRA_ENGINE_UNREACHABLE",
         );
       case "ARCHESTRA_INTERNAL":
@@ -398,17 +399,17 @@ class DaggerRuntimeService {
         // surface the original message and leave runtime status untouched.
         logger.warn(
           { err: error, code: native.code },
-          "[DaggerRuntime] execution failed",
+          "[SandboxRuntime] execution failed",
         );
-        return new DaggerRuntimeError(
-          native.message || "the Dagger runtime call failed",
+        return new SandboxRuntimeError(
+          native.message || "the sandbox runtime call failed",
           "ARCHESTRA_INTERNAL",
         );
     }
   }
 }
 
-export const daggerRuntimeService = new DaggerRuntimeService();
+export const sandboxRuntimeService = new SandboxRuntimeService();
 
 const INIT_RETRY_COOLDOWN_MS = 10_000;
 // artifact reads have no per-call timeout; cap their backstop budget here.

--- a/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
+++ b/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
@@ -1,9 +1,5 @@
 import type { ReplayCommand, SnapshotFile } from "@archestra/sandbox-rs";
 import config from "@/config";
-import {
-  DaggerRuntimeError,
-  daggerRuntimeService,
-} from "@/dagger-runtime/dagger-runtime-service";
 import logger from "@/logging";
 import {
   SkillSandboxArtifactModel,
@@ -11,6 +7,10 @@ import {
   SkillSandboxFileSnapshotModel,
   SkillSandboxModel,
 } from "@/models";
+import {
+  SandboxRuntimeError,
+  sandboxRuntimeService,
+} from "@/sandbox-runtime/sandbox-runtime-service";
 import type { SkillSandbox, SkillSandboxFileSnapshot } from "@/types";
 import { asSandboxId, type SandboxId } from "@/types";
 import { resolveArtifactMime } from "./mime-sniff";
@@ -44,7 +44,7 @@ const REQUIREMENTS_INSTALL_TIMEOUT_SECONDS = 180;
 
 /**
  * Orchestrates DB-backed skill sandboxes: loads snapshots + replay log,
- * delegates execution to the unified `daggerRuntimeService`, appends the
+ * delegates execution to the unified `sandboxRuntimeService`, appends the
  * result to the command log.
  *
  * Per-sandbox serialization is enforced here (not in the runtime service) so
@@ -58,20 +58,20 @@ class SkillSandboxRuntimeService {
   private readonly sandboxPendingCounts = new Map<string, number>();
 
   get isEnabled(): boolean {
-    return config.skillsSandbox.enabled && daggerRuntimeService.isEnabled;
+    return config.skillsSandbox.enabled && sandboxRuntimeService.isEnabled;
   }
 
   get isReady(): boolean {
-    return daggerRuntimeService.isReady;
+    return sandboxRuntimeService.isReady;
   }
 
   async init(): Promise<void> {
     if (!config.skillsSandbox.enabled) return;
-    await daggerRuntimeService.attach(CONSUMER_ID);
+    await sandboxRuntimeService.attach(CONSUMER_ID);
   }
 
   async shutdown(): Promise<void> {
-    await daggerRuntimeService.detach(CONSUMER_ID);
+    await sandboxRuntimeService.detach(CONSUMER_ID);
   }
 
   async runCommand(params: RunCommandParams): Promise<CommandResult> {
@@ -85,9 +85,11 @@ class SkillSandboxRuntimeService {
       const { snapshots, replayCommands, pythonpath } =
         await this.buildContext(sandbox);
 
-      let executed: Awaited<ReturnType<typeof daggerRuntimeService.runCommand>>;
+      let executed: Awaited<
+        ReturnType<typeof sandboxRuntimeService.runCommand>
+      >;
       try {
-        executed = await daggerRuntimeService.runCommand({
+        executed = await sandboxRuntimeService.runCommand({
           command: params.command,
           cwd,
           timeoutSeconds,
@@ -163,10 +165,10 @@ class SkillSandboxRuntimeService {
         await this.buildContext(sandbox);
 
       let artifact: Awaited<
-        ReturnType<typeof daggerRuntimeService.readArtifact>
+        ReturnType<typeof sandboxRuntimeService.readArtifact>
       >;
       try {
-        artifact = await daggerRuntimeService.readArtifact({
+        artifact = await sandboxRuntimeService.readArtifact({
           snapshots,
           replayCommands,
           path: resolvedPath,
@@ -321,7 +323,7 @@ class SkillSandboxRuntimeService {
 
   private toSkillError(error: unknown): SkillSandboxError {
     if (error instanceof SkillSandboxError) return error;
-    if (error instanceof DaggerRuntimeError) {
+    if (error instanceof SandboxRuntimeError) {
       switch (error.code) {
         case "ARCHESTRA_ARTIFACT_NOT_FOUND":
         case "ARCHESTRA_ARTIFACT_TOO_LARGE":
@@ -335,7 +337,7 @@ class SkillSandboxRuntimeService {
             `a setup or replay command in this sandbox failed: ${error.message}`,
           );
         case "ARCHESTRA_INVALID_INPUT":
-          // INVALID_INPUT from the runtime layer says "the Dagger runtime is
+          // INVALID_INPUT from the runtime layer says "the sandbox runtime is
           // not enabled"; replace with adapter-specific wording so we never
           // leak the underlying implementation to the model/user.
           return new SkillSandboxError(
@@ -410,7 +412,7 @@ export const skillSandboxRuntimeService = new SkillSandboxRuntimeService();
 // === internal helpers ===
 
 function shouldRecordOnFailure(error: unknown): boolean {
-  if (!(error instanceof DaggerRuntimeError)) return false;
+  if (!(error instanceof SandboxRuntimeError)) return false;
   // ARCHESTRA_ENGINE_UNREACHABLE is also raised by the JS-side backstop timer
   // alone (no native attempt). Persisting a synthetic row there would re-run
   // the user's command on every subsequent replay forever, including the


### PR DESCRIPTION
## What

No-behavior-change refactor that genericizes the TypeScript sandbox-runtime wrapper so additional sandbox backends (beyond Dagger) can slot in later. Dagger stays the only backend today and remains the implementation detail it already is inside the Rust crate.

## Changes

- **Move + rename the wrapper**
  - `backend/src/dagger-runtime/` → `backend/src/sandbox-runtime/`
  - `dagger-runtime-service.ts` → `sandbox-runtime-service.ts`
- **Symbol renames** (the tiny wrapper stays tiny — no new abstraction layer):
  - `DaggerRuntimeError` → `SandboxRuntimeError` (user-facing error type)
  - `DaggerRuntimeService` → `SandboxRuntimeService`, `daggerRuntimeService` → `sandboxRuntimeService`
  - `DaggerRuntimeStatus` → `SandboxRuntimeStatus`, log tag `[DaggerRuntime]` → `[SandboxRuntime]`, message wording "the Dagger runtime …" → "the sandbox runtime …"
- **Consumers updated** to depend on the generic wrapper:
  - `backend/src/code-runtime/code-runtime-service.ts`
  - `backend/src/skills-sandbox/skill-sandbox-runtime-service.ts`

## Intentionally kept Dagger-named (env/config contract preserved)

- `config.daggerRuntime.*`, `applyDaggerEnv()`, the `_EXPERIMENTAL_DAGGER_*` env vars, and all `ARCHESTRA_*_DAGGER_*` config/env keys — renaming these would change the deployment contract. To be genericized in a follow-up if/when a second backend lands.
- Runtime DTO imports from `@archestra/sandbox-rs` and the lazy native loader are unchanged.
- Rust crates (`sandbox-core`, `sandbox-rs`) untouched — Dagger naming stays internal there.

## Verification

- `pnpm type-check` — clean
- `pnpm lint` — clean
- `vitest run` on code-runtime, skills-sandbox, archestra-mcp-server/skill-sandbox, config suites — **262 passed**
- Adversarial review (Codex) found nothing behavior-changing
- Remaining `dagger-runtime` string matches are the intentional K8s hostname (`dagger-runtime.dagger.svc.cluster.local`) and `ARCHESTRA_*_DAGGER_*` keys in tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>