### PR TITLE
fix(frontend): derive chat MCP App canvases from messages; independent sidebar scroll

### DIFF
--- a/platform/frontend/src/app/_parts/app-shell.tsx
+++ b/platform/frontend/src/app/_parts/app-shell.tsx
@@ -18,6 +18,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { Version } from "@/components/version";
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import { useActiveSiteNotification } from "@/lib/site-notification.query";
+import { cn } from "@/lib/utils";
 import { MaintenanceModeOverlay } from "./maintenance-mode-overlay";
 import { AppSidebar } from "./sidebar";
 import { SiteNotificationBar } from "./site-notification-bar";
@@ -38,6 +39,12 @@ export function AppShell({ children }: AppShellProps) {
   const pathname = usePathname();
   const isBrowserPreview = pathname.startsWith("/chat/browser-preview/");
   const isAuthPage = pathname.startsWith("/auth/");
+  // The chat page is a viewport-locked, two-pane layout (conversation + right
+  // sidebar) that scrolls each pane independently. It needs its children slot
+  // bounded to the viewport (min-h-0) so its internal overflow containers take
+  // over. Other pages rely on natural body scroll, so we only bound the chain
+  // for chat to avoid clipping their content.
+  const isChat = pathname === "/chat" || pathname.startsWith("/chat/");
   const { data: shouldCollapse, isSuccess: permissionLoaded } =
     useHasPermissions(SIDEBAR_COLLAPSED_PERMISSION);
   const { data: canReadSiteNotification } = useHasPermissions(
@@ -109,7 +116,9 @@ export function AppShell({ children }: AppShellProps) {
             />
           </header>
           <div className="flex-1 min-h-0 min-w-0 flex flex-col">
-            <div className="flex-1 flex flex-col">{children}</div>
+            <div className={cn("flex-1 flex flex-col", isChat && "min-h-0")}>
+              {children}
+            </div>
             <Version />
           </div>
         </main>

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -38,6 +38,7 @@ import { ButtonWithTooltip } from "@/components/button-with-tooltip";
 import { BrowserPanel } from "@/components/chat/browser-panel";
 import { ChatLinkButton } from "@/components/chat/chat-help-link";
 import { ChatMessages } from "@/components/chat/chat-messages";
+import { deriveCanvasesFromMessages } from "@/components/chat/chat-messages.utils";
 import { ConversationArtifactPanel } from "@/components/chat/conversation-artifact";
 import { InitialAgentSelector } from "@/components/chat/initial-agent-selector";
 import { OnboardingWizardButton } from "@/components/chat/onboarding-wizard-button";
@@ -909,6 +910,18 @@ export function ChatPageContent({
           })
         : persistedConversationMessages,
     [chatSession?.messages, persistedConversationMessages],
+  );
+  // Derive the MCP App canvas list from the conversation itself so the sidebar
+  // selector is deterministic and survives transient section unmounts (the
+  // previous mount-effect registry could empty when a single canvas's section
+  // briefly unmounted).
+  const mcpCanvases = useMemo(
+    () =>
+      deriveCanvasesFromMessages(
+        messages,
+        chatSession?.earlyToolUiStarts ?? {},
+      ),
+    [messages, chatSession?.earlyToolUiStarts],
   );
   const sendMessage = chatSession?.sendMessage;
   const status = chatSession?.status ?? "ready";
@@ -1884,11 +1897,12 @@ export function ChatPageContent({
   return (
     <PinnedCanvasProvider
       conversationId={conversationId}
+      canvases={mcpCanvases}
       onShowInSidebar={() => openRightPanelTab("canvas" as RightPanelTab)}
     >
       <div className="flex h-full w-full min-h-0">
-        <div className="flex-1 flex flex-col min-w-0">
-          <div className="flex flex-col h-full">
+        <div className="flex-1 flex flex-col min-w-0 min-h-0">
+          <div className="flex flex-col h-full min-h-0">
             <StreamTimeoutWarning status={status} messages={messages} />
 
             <div
@@ -2359,7 +2373,7 @@ export function ChatPageContent({
         </div>
 
         {/* Right-side panel - desktop only */}
-        <div className="hidden md:flex">
+        <div className="hidden md:flex h-full min-h-0">
           <RightSidePanel
             isOpen={isRightPanelOpen}
             activeTab={activeRightTab}

--- a/platform/frontend/src/components/chat/chat-messages.utils.test.ts
+++ b/platform/frontend/src/components/chat/chat-messages.utils.test.ts
@@ -1,6 +1,7 @@
 import type { UIMessage } from "@ai-sdk/react";
 import { describe, expect, it } from "vitest";
 import {
+  deriveCanvasesFromMessages,
   extractFileAttachments,
   filterOptimisticToolCalls,
   hasTextPart,
@@ -183,6 +184,103 @@ describe("filterOptimisticToolCalls", () => {
     expect(filterOptimisticToolCalls(messages, optimisticToolCalls)).toEqual([
       optimisticToolCalls[1],
     ]);
+  });
+});
+
+describe("deriveCanvasesFromMessages", () => {
+  it("returns a canvas for a tool call whose output carries _meta.ui.resourceUri", () => {
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        metadata: { createdAt: "2026-05-29T18:13:52.000Z" },
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolName: "pm__show_board",
+            toolCallId: "call_1",
+            state: "output-available",
+            output: { _meta: { ui: { resourceUri: "ui://pm/board" } } },
+          },
+        ],
+      },
+    ] as never;
+
+    expect(deriveCanvasesFromMessages(messages, {})).toEqual([
+      {
+        toolCallId: "call_1",
+        label: "show_board",
+        serverName: "pm",
+        createdAt: Date.parse("2026-05-29T18:13:52.000Z"),
+      },
+    ]);
+  });
+
+  it("returns a canvas from early UI-start data before the result arrives", () => {
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolName: "pm__show_board",
+            toolCallId: "call_1",
+            state: "input-available",
+            input: {},
+          },
+        ],
+      },
+    ] as never;
+
+    expect(
+      deriveCanvasesFromMessages(messages, {
+        call_1: { uiResourceUri: "ui://pm/board", toolName: "pm__show_board" },
+      }),
+    ).toEqual([
+      {
+        toolCallId: "call_1",
+        label: "show_board",
+        serverName: "pm",
+        createdAt: 0,
+      },
+    ]);
+  });
+
+  it("ignores tool calls without a UI resource and de-dupes by toolCallId", () => {
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-google__search",
+            toolCallId: "call_plain",
+            state: "output-available",
+            output: { content: "no ui here" },
+          },
+          {
+            type: "tool-pm__show_board",
+            toolCallId: "call_1",
+            state: "input-available",
+            input: {},
+          },
+          {
+            type: "tool-pm__show_board",
+            toolCallId: "call_1",
+            state: "output-available",
+            output: { _meta: { ui: { resourceUri: "ui://pm/board" } } },
+          },
+        ],
+      },
+    ] as never;
+
+    const canvases = deriveCanvasesFromMessages(messages, {});
+    expect(canvases).toHaveLength(1);
+    expect(canvases[0]).toMatchObject({
+      toolCallId: "call_1",
+      label: "show_board",
+    });
   });
 });
 

--- a/platform/frontend/src/components/chat/chat-messages.utils.ts
+++ b/platform/frontend/src/components/chat/chat-messages.utils.ts
@@ -1,11 +1,12 @@
 import type { UIMessage } from "@ai-sdk/react";
-import type { ArchestraToolShortName } from "@shared";
+import { type ArchestraToolShortName, parseFullToolName } from "@shared";
 import type { DynamicToolUIPart, ToolUIPart } from "ai";
 import {
   getToolErrorText,
   isCompactEligible,
 } from "@/lib/chat/chat-tools-display.utils";
 import type { FileAttachment } from "./editable-user-message";
+import type { CanvasInfo } from "./pinned-canvas-context";
 
 export type OptimisticToolCall = {
   toolCallId: string;
@@ -53,6 +54,70 @@ export function extractFileAttachments(
  */
 export function hasTextPart(parts: UIMessage["parts"] | undefined): boolean {
   return parts?.some((p) => p.type === "text") ?? false;
+}
+
+/**
+ * Derive the list of MCP App canvases for a conversation directly from its
+ * messages (plus any early UI-start data from the active stream).
+ *
+ * A tool call is a canvas when its output carries `_meta.ui.resourceUri`, or
+ * when the backend announced it via a `data-tool-ui-start` event (tracked in
+ * `earlyToolUiStarts`) before the result arrived. Deriving the registry from
+ * the conversation — rather than from `McpAppSection` mount/unmount effects —
+ * makes the sidebar selector deterministic: it matches what a page refresh
+ * reconstructs and never empties because a single section briefly unmounts.
+ */
+export function deriveCanvasesFromMessages(
+  messages: UIMessage[],
+  earlyToolUiStarts: Record<
+    string,
+    { uiResourceUri?: string; toolName?: string }
+  >,
+): CanvasInfo[] {
+  const canvases: CanvasInfo[] = [];
+  const seen = new Set<string>();
+
+  for (const message of messages) {
+    const createdAt = getMessageCreatedAt(message);
+    for (const part of message.parts ?? []) {
+      if (!isToolPart(part)) continue;
+      const toolCallId = part.toolCallId;
+      if (!toolCallId || seen.has(toolCallId)) continue;
+
+      const early = earlyToolUiStarts[toolCallId];
+      const hasUiResource =
+        // biome-ignore lint/suspicious/noExplicitAny: checking nested _meta shape on unknown output
+        Boolean((part.output as any)?._meta?.ui?.resourceUri) ||
+        Boolean(early?.uiResourceUri);
+      if (!hasUiResource) continue;
+
+      seen.add(toolCallId);
+      const fullToolName = getToolName(part) ?? early?.toolName ?? "";
+      const parsed = parseFullToolName(fullToolName);
+      canvases.push({
+        toolCallId,
+        label: parsed.toolName || fullToolName,
+        serverName: parsed.serverName,
+        createdAt: createdAt ?? 0,
+      });
+    }
+  }
+
+  return canvases;
+}
+
+function getMessageCreatedAt(message: UIMessage): number | null {
+  const metadata = message.metadata;
+  if (
+    typeof metadata === "object" &&
+    metadata !== null &&
+    "createdAt" in metadata &&
+    typeof metadata.createdAt === "string"
+  ) {
+    const createdAt = Date.parse(metadata.createdAt);
+    return Number.isNaN(createdAt) ? null : createdAt;
+  }
+  return null;
 }
 
 export function filterOptimisticToolCalls(

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -290,37 +290,17 @@ export function McpAppSection({
     null,
   );
 
-  const {
-    selectedCanvasId,
-    select,
-    showInSidebar,
-    register,
-    unregister,
-    portalTarget,
-  } = usePinnedCanvas();
+  const { selectedCanvasId, select, showInSidebar, portalTarget } =
+    usePinnedCanvas();
 
   const parsedToolName = parseFullToolName(toolName);
   const shortToolName = parsedToolName.toolName ?? toolName;
-  const serverName = parsedToolName.serverName;
   const isSelected = !!toolCallId && selectedCanvasId === toolCallId;
   const sidebarHostingActive = portalTarget !== null;
   // When the sidebar canvas tab is open, every inline canvas is replaced by a
   // placeholder; only the *selected* canvas's iframe lives in the sidebar.
   const renderInSidebar = sidebarHostingActive && isSelected;
   const renderPlaceholder = sidebarHostingActive;
-
-  // Register the canvas with the conversation-level registry so the sidebar
-  // selector can list it.
-  useEffect(() => {
-    if (!toolCallId) return;
-    register({
-      toolCallId,
-      label: shortToolName,
-      serverName,
-      createdAt: Date.now(),
-    });
-    return () => unregister(toolCallId);
-  }, [toolCallId, shortToolName, serverName, register, unregister]);
 
   // Reconstruct McpCallToolResult for AppFrame
   const toolResult = useMemo((): McpCallToolResult | undefined => {

--- a/platform/frontend/src/components/chat/pinned-canvas-context.tsx
+++ b/platform/frontend/src/components/chat/pinned-canvas-context.tsx
@@ -32,10 +32,6 @@ interface PinnedCanvasContextValue {
   setPinned: (toolCallId: string | null) => void;
   /** Update which canvas the sidebar displays. */
   select: (toolCallId: string) => void;
-  /** Register a canvas when its McpAppSection mounts. */
-  register: (info: CanvasInfo) => void;
-  /** Unregister a canvas when its McpAppSection unmounts. */
-  unregister: (toolCallId: string) => void;
   /** DOM node where the selected canvas should portal its content; null when sidebar is not on the MCP App tab. */
   portalTarget: HTMLElement | null;
   setPortalTarget: (el: HTMLElement | null) => void;
@@ -53,8 +49,6 @@ const NOOP_VALUE: PinnedCanvasContextValue = {
   selectedCanvasId: null,
   setPinned: () => {},
   select: () => {},
-  register: () => {},
-  unregister: () => {},
   portalTarget: null,
   setPortalTarget: () => {},
   showInSidebar: () => {},
@@ -62,24 +56,23 @@ const NOOP_VALUE: PinnedCanvasContextValue = {
 
 export function PinnedCanvasProvider({
   conversationId,
+  canvases,
   onShowInSidebar,
   children,
 }: {
   conversationId: string | undefined;
+  /** Canvases for this conversation, derived from its messages by the caller. */
+  canvases: CanvasInfo[];
   /** Called when a canvas requests to be shown in the sidebar — wire this to open the panel and switch to the canvas tab. */
   onShowInSidebar?: (toolCallId: string) => void;
   children: ReactNode;
 }) {
-  const [canvases, setCanvases] = useState<CanvasInfo[]>([]);
   const [pinnedCanvasId, setPinnedCanvasId] = useState<string | null>(null);
   const [selectedCanvasId, setSelectedCanvasId] = useState<string | null>(null);
   const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
 
   // Hydrate the pinned canvas id from localStorage when the conversation
-  // changes. Don't wipe `canvases` here — child McpAppSections unmount/remount
-  // with the conversation switch and manage the registry themselves. (Wiping
-  // here in a parent effect would race with child mount effects and overwrite
-  // freshly-registered canvases.)
+  // changes.
   useEffect(() => {
     if (!conversationId || typeof window === "undefined") {
       setPinnedCanvasId(null);
@@ -135,31 +128,6 @@ export function PinnedCanvasProvider({
     [onShowInSidebar],
   );
 
-  const register = useCallback((info: CanvasInfo) => {
-    setCanvases((prev) => {
-      const existing = prev.findIndex((c) => c.toolCallId === info.toolCallId);
-      if (existing !== -1) {
-        const current = prev[existing];
-        // Preserve the original createdAt across remounts.
-        const merged: CanvasInfo = { ...info, createdAt: current.createdAt };
-        if (
-          current.label === merged.label &&
-          current.serverName === merged.serverName
-        ) {
-          return prev;
-        }
-        const next = [...prev];
-        next[existing] = merged;
-        return next;
-      }
-      return [...prev, info];
-    });
-  }, []);
-
-  const unregister = useCallback((toolCallId: string) => {
-    setCanvases((prev) => prev.filter((c) => c.toolCallId !== toolCallId));
-  }, []);
-
   const value = useMemo<PinnedCanvasContextValue>(
     () => ({
       canvases,
@@ -167,8 +135,6 @@ export function PinnedCanvasProvider({
       selectedCanvasId,
       setPinned,
       select,
-      register,
-      unregister,
       portalTarget,
       setPortalTarget,
       showInSidebar,
@@ -179,8 +145,6 @@ export function PinnedCanvasProvider({
       selectedCanvasId,
       setPinned,
       select,
-      register,
-      unregister,
       portalTarget,
       showInSidebar,
     ],

--- a/platform/frontend/src/components/chat/right-side-panel.tsx
+++ b/platform/frontend/src/components/chat/right-side-panel.tsx
@@ -3,6 +3,7 @@
 import { format } from "date-fns";
 import { FileText, Globe, GripVertical, Pin, PinOff, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { BrowserPanel } from "@/components/chat/browser-panel";
 import { ConversationArtifactPanel } from "@/components/chat/conversation-artifact";
 import { usePinnedCanvas } from "@/components/chat/pinned-canvas-context";
@@ -191,6 +192,20 @@ export function RightSidePanel({
           <GripVertical className="h-4 w-4 text-muted-foreground" />
         </div>
       </div>
+
+      {/* While dragging, a transparent full-viewport overlay sits above any
+          iframes (MCP App / Browser tabs) so they don't swallow the mouse
+          events that drive the resize — without it, the resize freezes the
+          moment the cursor crosses an iframe. */}
+      {isResizing &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <div
+            className="fixed inset-0 z-[9999] cursor-col-resize"
+            aria-hidden
+          />,
+          document.body,
+        )}
 
       <Tabs
         value={resolvedTab}

--- a/platform/frontend/src/components/chat/right-side-panel.tsx
+++ b/platform/frontend/src/components/chat/right-side-panel.tsx
@@ -20,6 +20,11 @@ import { cn } from "@/lib/utils";
 
 export type RightPanelTab = "artifact" | "browser" | "canvas";
 
+/** Smallest the panel itself may shrink to. */
+const MIN_PANEL_WIDTH = 300;
+/** Width the conversation column must always keep so it never squashes. */
+const MIN_CHAT_WIDTH = 400;
+
 interface RightSidePanelProps {
   isOpen: boolean;
   activeTab: RightPanelTab;
@@ -71,6 +76,19 @@ export function RightSidePanel({
   const [isResizing, setIsResizing] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
 
+  // Largest the panel may grow to: the width of the chat layout row (chat
+  // column + this panel) minus the minimum chat column width. The panel's
+  // direct parent is a tight flex wrapper whose width equals the panel, so we
+  // measure its parent — the row — which spans the whole chat area (everything
+  // right of the left nav). Falls back to the viewport before layout exists.
+  const getMaxWidth = useCallback(() => {
+    const row = panelRef.current?.parentElement?.parentElement;
+    const available =
+      row?.getBoundingClientRect().width ??
+      (typeof window !== "undefined" ? window.innerWidth : 0);
+    return Math.max(MIN_PANEL_WIDTH, available - MIN_CHAT_WIDTH);
+  }, []);
+
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
     setIsResizing(true);
@@ -79,8 +97,7 @@ export function RightSidePanel({
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       const step = e.shiftKey ? 50 : 10; // Larger step with shift key
-      const minWidth = 300;
-      const maxWidth = window.innerWidth * 0.7;
+      const maxWidth = getMaxWidth();
 
       if (e.key === "ArrowLeft") {
         e.preventDefault();
@@ -92,7 +109,7 @@ export function RightSidePanel({
         );
       } else if (e.key === "ArrowRight") {
         e.preventDefault();
-        const newWidth = Math.max(minWidth, width - step);
+        const newWidth = Math.max(MIN_PANEL_WIDTH, width - step);
         setWidth(newWidth);
         localStorage.setItem(
           "archestra-right-panel-width",
@@ -100,7 +117,7 @@ export function RightSidePanel({
         );
       }
     },
-    [width],
+    [width, getMaxWidth],
   );
 
   useEffect(() => {
@@ -108,10 +125,10 @@ export function RightSidePanel({
       if (!isResizing) return;
 
       const newWidth = window.innerWidth - e.clientX;
-      const minWidth = 300;
-      const maxWidth = window.innerWidth * 0.7;
-
-      const clampedWidth = Math.max(minWidth, Math.min(maxWidth, newWidth));
+      const clampedWidth = Math.max(
+        MIN_PANEL_WIDTH,
+        Math.min(getMaxWidth(), newWidth),
+      );
       setWidth(clampedWidth);
       localStorage.setItem(
         "archestra-right-panel-width",
@@ -136,7 +153,20 @@ export function RightSidePanel({
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
     };
-  }, [isResizing]);
+  }, [isResizing, getMaxWidth]);
+
+  // Keep the panel within bounds when the window resizes (or on first mount),
+  // so a previously-saved width never squashes the chat column.
+  useEffect(() => {
+    const clamp = () => {
+      setWidth((prev) =>
+        Math.max(MIN_PANEL_WIDTH, Math.min(getMaxWidth(), prev)),
+      );
+    };
+    clamp();
+    window.addEventListener("resize", clamp);
+    return () => window.removeEventListener("resize", clamp);
+  }, [getMaxWidth]);
 
   const {
     canvases,
@@ -182,10 +212,8 @@ export function RightSidePanel({
         aria-orientation="vertical"
         aria-label="Resize panel. Use arrow keys to resize, hold shift for larger steps."
         aria-valuenow={width}
-        aria-valuemin={300}
-        aria-valuemax={
-          typeof window !== "undefined" ? window.innerWidth * 0.7 : 1000
-        }
+        aria-valuemin={MIN_PANEL_WIDTH}
+        aria-valuemax={getMaxWidth()}
         tabIndex={0}
       >
         <div className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-1/2 opacity-0 hover:opacity-100 transition-opacity">

--- a/platform/frontend/src/components/chat/right-side-panel.tsx
+++ b/platform/frontend/src/components/chat/right-side-panel.tsx
@@ -240,23 +240,28 @@ export function RightSidePanel({
         onValueChange={(value) => onTabChange(value as RightPanelTab)}
         className="flex-1 min-h-0 flex flex-col gap-0"
       >
-        <div className="flex items-center justify-between gap-2 border-b px-2 py-2">
-          <TabsList className="h-8">
-            <TabsTrigger value="artifact" className="text-xs px-3">
-              <FileText className="h-3 w-3" />
-              Artifact
-            </TabsTrigger>
-            {canShowBrowser && (
-              <TabsTrigger value="browser" className="text-xs px-3">
-                <Globe className="h-3 w-3" />
-                Browser
+        <div className="flex items-center gap-2 border-b px-2 py-2">
+          {/* Tabs take the remaining space and scroll horizontally when the
+              panel is too narrow, so the action buttons on the right are never
+              clipped. */}
+          <div className="min-w-0 flex-1 overflow-x-auto">
+            <TabsList className="h-8 w-max">
+              <TabsTrigger value="artifact" className="text-xs px-3">
+                <FileText className="h-3 w-3" />
+                Artifact
               </TabsTrigger>
-            )}
-            <TabsTrigger value="canvas" className="text-xs px-3">
-              MCP App
-            </TabsTrigger>
-          </TabsList>
-          <div className="flex items-center gap-1">
+              {canShowBrowser && (
+                <TabsTrigger value="browser" className="text-xs px-3">
+                  <Globe className="h-3 w-3" />
+                  Browser
+                </TabsTrigger>
+              )}
+              <TabsTrigger value="canvas" className="text-xs px-3">
+                MCP App
+              </TabsTrigger>
+            </TabsList>
+          </div>
+          <div className="flex items-center gap-1 shrink-0">
             {headerActions}
             <Button
               variant="ghost"


### PR DESCRIPTION
Fixes the chat MCP App sidebar so the canvas selector is derived from the conversation (no longer empties for a single app), the right panel scrolls independently, keeps resizing over MCP App/Browser iframes, and can't be dragged small enough to squash the conversation column.