### PR TITLE
chore: extract project Claude skills

### DIFF
--- a/.claude/skills/archestra-dev-e2e/SKILL.md
+++ b/.claude/skills/archestra-dev-e2e/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: archestra-dev-e2e
+description: Use when writing, debugging, or running Archestra Playwright e2e tests, API/UI fixtures, WireMock-backed tests, local/CI e2e setup, or test selectors.
+---
+
+# Archestra E2E Testing
+
+Use this skill for files under `platform/e2e-tests/` and for frontend/backend changes that require Playwright coverage.
+
+Run commands from `platform/` unless specifically instructed otherwise.
+
+## Commands
+
+```bash
+pnpm test:e2e
+tilt trigger e2e-test-dependencies
+```
+
+`tilt trigger e2e-test-dependencies` starts WireMock and seeds test data to the database.
+
+In development, e2e tests use the development database. Local data can make e2e tests fail locally.
+
+Check WireMock health at `http://localhost:9092/__admin/health`.
+
+## WireMock environment variables
+
+Use port `9092` for the Tilt e2e dependency setup:
+
+```bash
+ARCHESTRA_OPENAI_BASE_URL=http://localhost:9092/v1
+ARCHESTRA_ANTHROPIC_BASE_URL=http://localhost:9092
+ARCHESTRA_GEMINI_BASE_URL=http://localhost:9092
+```
+
+Use port `9091` for the alternate local WireMock setup:
+
+```bash
+ARCHESTRA_OPENAI_BASE_URL=http://localhost:9091/v1
+ARCHESTRA_ANTHROPIC_BASE_URL=http://localhost:9091
+ARCHESTRA_GEMINI_BASE_URL=http://localhost:9091
+```
+
+## Local and CI setup
+
+- Local e2e uses docker-compose setup through `Tiltfile.test`.
+- CI uses a kind cluster and Helm deployment.
+- CI kind config is `.github/kind.yaml`.
+- CI Helm values are `.github/values-ci.yaml`.
+- CI NodePort services use frontend `3000`, backend `9000`, and metrics `9050`.
+- CI e2e checks include `drizzle-kit check`, codegen, and database migrations.
+
+## Fixtures
+
+- Use the Playwright fixtures pattern.
+- Import from `./fixtures` in API/UI test directories.
+- API fixtures include `makeApiRequest`, `createAgent`, `deleteAgent`, `createApiKey`, `deleteApiKey`, `createToolInvocationPolicy`, `deleteToolInvocationPolicy`, `createTrustedDataPolicy`, and `deleteTrustedDataPolicy`.
+- UI fixtures include `goToPage` and `makeRandomString`.
+
+Example:
+
+```typescript
+import { test } from "./fixtures";
+
+test("API example", async ({ request, createAgent, deleteAgent }) => {
+  const response = await createAgent(request, "Test Agent");
+  const agent = await response.json();
+  // test logic...
+  await deleteAgent(request, agent.id);
+});
+```
+
+## Locator best practices
+
+Prefer Playwright's recommended locators over raw `locator()` calls. In priority order:
+
+1. `page.getByRole()` - accessible elements by ARIA role, such as buttons, links, and headings.
+2. `page.getByText()` - text content.
+3. `page.getByLabel()` - form controls by label.
+4. `page.getByPlaceholder()` - input elements by placeholder.
+5. `page.getByTestId()` - custom test IDs using `E2eTestId` constants from `@shared`.
+
+Avoid raw CSS selectors, XPath selectors, and arbitrary timeouts. Use Playwright auto-waiting instead.
+
+```typescript
+// good
+await page.getByRole("button", { name: /Submit/i }).click();
+await page.getByLabel(/Email/i).fill("test@example.com");
+await page.getByTestId(E2eTestId.CreateAgentButton).click();
+
+// avoid
+await page.locator(".submit-btn").click();
+await page.locator("#email-input").fill("test@example.com");
+await page.waitForTimeout(1000); // use auto-waiting instead
+```
+
+Reference: https://playwright.dev/docs/locators#quick-guide

--- a/.claude/skills/archestra-dev-frontend/SKILL.md
+++ b/.claude/skills/archestra-dev-frontend/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: archestra-dev-frontend
+description: Use when modifying Archestra frontend Next.js/React code, UI components, forms, TanStack Query hooks, generated API client usage, frontend copy, or documentation links.
+---
+
+# Archestra Frontend Development
+
+Use this skill before changing files under `platform/frontend/` or frontend-facing shared code.
+
+## Commands
+
+Run commands from `platform/` unless specifically instructed otherwise.
+
+```bash
+pnpm codegen:api-client
+pnpm type-check
+pnpm lint
+pnpm test
+```
+
+## Data fetching
+
+- Use TanStack Query for data fetching.
+- Prefer `useQuery` over `useSuspenseQuery` with explicit loading states.
+- Prefer TanStack Query over prop drilling when a component can fetch data by identifier itself.
+- Only pass minimal identifiers, such as `catalogId`, needed for child components to fetch or filter their own data.
+- TanStack Query caching prevents duplicate requests when multiple components use the same query.
+
+## API clients
+
+- Frontend `.query.ts` files should never use `fetch()` directly.
+- Run `pnpm codegen:api-client` first to ensure the generated SDK is up to date.
+- Use generated SDK methods instead of manual API calls for type safety and consistency.
+- Reuse API types from `@shared`, especially `archestraApiTypes` types such as `archestraApiTypes.CreateXxxData["body"]` and `archestraApiTypes.GetXxxResponses["200"]`.
+- Do not define duplicate frontend API types when generated/shared types already exist.
+
+## Query error handling
+
+- Handle toasts in `.query.ts` files, not in components.
+- Define mutation success/error toasts in `onSuccess` and `onError` callbacks.
+- Never throw on HTTP errors in query or mutation functions.
+- Use `handleApiError(error)` for user notification and return an appropriate default such as `null`, `[]`, or `{}`.
+- Components should not use `try`/`catch` for API calls; API error handling belongs in `.query.ts` files.
+
+## UI components
+
+- Use shadcn/ui components only.
+- Add shadcn/ui components with `npx shadcn@latest add <component>`.
+- Prefer components from `frontend/src/components/ui` over plain HTML elements when a component exists.
+- Use `Button` over raw `<button>`, `Input` over raw `<input>`, and the matching UI component for selects and other controls.
+- Keep components small and focused, with extracted business logic where it improves clarity.
+- Keep frontend files flat where practical and avoid barrel files.
+- Only export what is needed externally.
+
+## Forms
+
+- Prefer `useForm` from `react-hook-form` over multiple `useState` hooks for form state.
+- Pass form objects to child components as `form: UseFormReturn<FormValues>` rather than passing individual setters.
+- Parent components should handle mutations and submission.
+- Form components should focus on rendering and validation UI.
+
+## Copy and documentation links
+
+- Do not hardcode `Archestra` in frontend UI copy.
+- Use `const appName = useAppName();` and interpolate the app name so white-labeled deployments render correctly.
+- Always use `getDocsUrl(DocsPage.PageName, "optional-anchor")` from `@shared` for documentation links.
+- Never hardcode documentation URLs.

--- a/.claude/skills/archestra-dev-migrations/SKILL.md
+++ b/.claude/skills/archestra-dev-migrations/SKILL.md
@@ -1,13 +1,19 @@
 ---
 name: archestra-dev-migrations
-description: Use when changing Drizzle schemas, generating migrations, editing migration SQL, creating data-only migrations, or diagnosing drizzle-kit check failures that are not merge/rebase conflicts.
+description: Use when changing Drizzle schemas, generating migrations, editing migration SQL, creating data-only migrations, diagnosing drizzle-kit check failures, or resolving migration/generated-client conflicts.
 ---
 
 # Archestra Database Migrations
 
-Use this skill for normal migration work. Use `archestra-dev-resolve-conflicts` instead when git reports merge/rebase conflicts in Drizzle migration metadata or generated clients.
+Use this skill for migration work.
 
 Run commands from `platform/` unless specifically instructed otherwise.
+
+## Merge/rebase conflicts
+
+When git reports merge/rebase conflicts in Drizzle migration metadata or generated clients, follow `resolve-conflicts.md` instead of the normal migration flow.
+
+That subpage overrides the default working directory rule and runs its procedure from the repo root where needed.
 
 ## Common commands
 

--- a/.claude/skills/archestra-dev-migrations/SKILL.md
+++ b/.claude/skills/archestra-dev-migrations/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: archestra-dev-migrations
+description: Use when changing Drizzle schemas, generating migrations, editing migration SQL, creating data-only migrations, or diagnosing drizzle-kit check failures that are not merge/rebase conflicts.
+---
+
+# Archestra Database Migrations
+
+Use this skill for normal migration work. Use `archestra-dev-resolve-conflicts` instead when git reports merge/rebase conflicts in Drizzle migration metadata or generated clients.
+
+Run commands from `platform/` unless specifically instructed otherwise.
+
+## Common commands
+
+```bash
+pnpm db:generate
+pnpm exec drizzle-kit check
+pnpm db:migrate
+pnpm db:studio
+```
+
+Ask before applying migrations locally if the command will modify database state. Generating migrations and checking consistency are safe.
+
+## Schema migrations
+
+When creating migrations that include schema changes and data migration logic:
+
+1. Update the Drizzle schema files with the schema changes.
+2. Run `pnpm db:generate`.
+3. Add the data migration SQL to the generated file.
+4. Run `pnpm exec drizzle-kit check` to verify consistency.
+
+Drizzle creates a migration with a generated name such as `0119_military_alice.sql`. Use that generated filename. Never create manually named migration files because Drizzle tracks migrations through `backend/src/database/migrations/meta/_journal.json`, which references generated file names.
+
+## Data migration SQL
+
+Data migration SQL can include statements such as `INSERT`, `UPDATE`, and other data-changing statements inside the generated migration file.
+
+Keep schema DDL before data migration statements when the data migration references newly created tables or columns.
+
+Always verify with `pnpm exec drizzle-kit check` after editing generated SQL.
+
+## Custom data-only migrations
+
+For pure data migrations with no schema changes, create an empty custom migration tracked by Drizzle:
+
+```bash
+pnpm --dir backend exec drizzle-kit generate --custom --name=<descriptive-name>
+```
+
+Then add the SQL to the generated file and run:
+
+```bash
+pnpm exec drizzle-kit check
+```
+
+## Database connection
+
+PostgreSQL runs in Kubernetes when managed by Tilt.
+
+```bash
+kubectl exec -n archestra-dev postgresql-0 -- env PGPASSWORD=archestra_dev_password psql -U archestra -d archestra_dev
+```
+
+Useful read-only inspection commands inside `psql` include `\dt`, `\d table_name`, and `SELECT COUNT(*) FROM drizzle.__drizzle_migrations;`.

--- a/.claude/skills/archestra-dev-migrations/resolve-conflicts.md
+++ b/.claude/skills/archestra-dev-migrations/resolve-conflicts.md
@@ -1,8 +1,3 @@
----
-name: archestra-dev-resolve-conflicts
-description: Resolve merge/rebase conflicts in this repo — Drizzle migration number collisions (platform/backend/src/database/migrations/meta/_journal.json, meta/<NNNN>_snapshot.json), preserving any hand-written data-migration tail (UPDATE/INSERT/DO $$). Use when git reports a conflict in those files, when `drizzle-kit check` fails after a merge, or when conflicted generated clients under platform/shared/hey-api/** need to be reconciled.
----
-
 # Resolving Drizzle migration merge conflicts
 
 When main has landed migrations that collide with your branch's migration

--- a/.claude/skills/archestra-dev-observability/SKILL.md
+++ b/.claude/skills/archestra-dev-observability/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: archestra-dev-observability
+description: Use when changing Archestra tracing, metrics, OpenTelemetry, Tempo, Grafana, Prometheus, LLM/MCP spans, observability labels, or local observability setup.
+---
+
+# Archestra Observability
+
+Use this skill before changing tracing, metrics, span naming, metric labels, or local observability setup.
+
+Run commands from `platform/` unless specifically instructed otherwise.
+
+## Local setup
+
+```bash
+tilt trigger observability
+docker compose -f dev/docker-compose.observability.yml up -d
+```
+
+`tilt trigger observability` starts the full observability stack: Tempo, OTEL Collector, Prometheus, and Grafana.
+
+The docker-compose command is an alternative local setup with pre-configured datasources.
+
+## Local URLs
+
+- Tempo API: `http://localhost:3200/`.
+- Grafana: `http://localhost:3002/`.
+- Prometheus: `http://localhost:9090/`.
+- Backend metrics: `http://localhost:9050/metrics`.
+
+## Tracing
+
+- Follow OTEL GenAI Semantic Conventions: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/.
+- LLM spans use `gen_ai.agent.id`, `gen_ai.agent.name`, `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.operation.name`, and `archestra.label.<key>` for dynamic labels.
+- MCP spans use `gen_ai.tool.name` and `mcp.server.name`.
+- Session tracking uses `gen_ai.conversation.id` from the `X-Archestra-Session-Id` header.
+- Span names are `chat {model}`, `generate_content {model}`, and `execute_tool {tool_name}`.
+- Agent label keys are fetched from the database on startup and included as resource attributes.
+- Traces are stored in Grafana Tempo.
+- User identity is tracked with `archestra.user.id`, `archestra.user.email`, and `archestra.user.name` when available.
+- LLM spans include `archestra.cost` in USD and `gen_ai.usage.total_tokens`.
+
+## Metrics
+
+- Prometheus metrics `llm_request_duration_seconds` and `llm_tokens_total` include `agent_id`, `agent_name`, `agent_type`, `external_agent_id`, and dynamic agent labels as dimensions.
+- `agent_id` is internal.
+- `external_agent_id` comes from the client-provided header and is used for agent execution metrics.
+- MCP metrics include `agent_id`, `agent_name`, and `agent_type`.
+- Metrics are reinitialized on startup with current label keys from the database.

--- a/.claude/skills/archestra-dev-resolve-conflicts/SKILL.md
+++ b/.claude/skills/archestra-dev-resolve-conflicts/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: resolve-conflicts
+name: archestra-dev-resolve-conflicts
 description: Resolve merge/rebase conflicts in this repo — Drizzle migration number collisions (platform/backend/src/database/migrations/meta/_journal.json, meta/<NNNN>_snapshot.json), preserving any hand-written data-migration tail (UPDATE/INSERT/DO $$). Use when git reports a conflict in those files, when `drizzle-kit check` fails after a merge, or when conflicted generated clients under platform/shared/hey-api/** need to be reconciled.
 ---
 

--- a/.claude/skills/archestra-dev-rust-napi/SKILL.md
+++ b/.claude/skills/archestra-dev-rust-napi/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: archestra-dev-rust-napi
+description: Use when editing Rust core code, NAPI bindings, generated TypeScript bindings, Rust telemetry, Rust validation/errors, or Rust build/test checks.
+---
+
+# Archestra Rust / NAPI Coding Style
+
+Write Rust as a reusable library first. NAPI should be a thin adapter around the Rust core, not the place where product logic lives. The Rust part should be easy to move later into a companion app, CLI, daemon, desktop process, or IPC service.
+
+## Architecture
+
+- Keep core Rust logic independent from Node, JavaScript, and NAPI.
+- No `#[napi]`, `napi::Result`, JS types, or Node-specific assumptions in core Rust modules.
+- NAPI functions should only receive JS input, validate and convert it into Rust domain types, call the Rust core, and convert the result or error back to JS.
+- Minimize the JS-to-Rust API surface. Prefer a few coarse operations over many tiny exported helpers.
+- Do not expose internal implementation details through the NAPI API.
+- Generated TypeScript definitions are part of the public API and should stay clean, stable, and intentional.
+- Keep observability in the core as `tracing` spans and events only.
+- OTLP/exporter wiring belongs in a single feature-gated module, never scattered through the logic.
+- Propagate trace context, such as W3C `traceparent`, explicitly across detached tasks and actor boundaries. It does not flow implicitly.
+
+## Types and data modeling
+
+- Prefer structs, enums, and newtypes over primitive-heavy signatures, tuples, raw strings, and boolean flags.
+- Use enums for closed sets of states or modes.
+- Use named structs for meaningful data instead of passing many positional arguments.
+- Make invalid states unrepresentable where practical.
+- Treat all JS input as untrusted.
+- Validate JS input at the boundary and convert it immediately into Rust-native types.
+- Validate untrusted input at the public core entry points, not deep in the call graph.
+- Data validated when first accepted, such as persisted or replayed history, is trusted on reuse. Document that trust boundary wherever it is not obvious.
+- Keep NAPI-facing DTOs separate from richer internal domain types when that improves clarity.
+
+## Control flow and style
+
+- Prefer `match` for enums, variants, and meaningful branching.
+- Use `if` for simple boolean checks.
+- Prefer early returns for validation and error paths.
+- Avoid deeply nested control flow.
+- Prefer functional style where it improves readability.
+- Do not force iterator chains when a simple loop is clearer.
+- Prefer clear, boring, explicit code over clever abstractions.
+
+## Errors and safety
+
+- Use `Result<T, E>` consistently in core Rust.
+- Prefer domain-specific error enums over generic strings.
+- Convert Rust errors into JS/NAPI errors only at the boundary.
+- Preserve useful error context.
+- No `unwrap`, `expect`, or `panic!` in code reachable from the NAPI boundary.
+- Assume dependencies can still panic despite that rule.
+- Wrap every future that enters the core from the NAPI boundary in `catch_unwind` and convert the payload into a domain error.
+- The host process must never abort on a Rust panic.
+- No `unsafe` unless isolated, documented, and clearly justified.
+
+## Abstractions
+
+- Avoid speculative abstractions.
+- Avoid `dyn Trait` unless runtime polymorphism is clearly needed.
+- Prefer concrete types, enums, generics, or plain functions before trait objects.
+- Keep modules small and named around domain concepts, not patterns.
+- Do not add indirection unless it makes testing, ownership, or API boundaries meaningfully better.
+
+## Cleanliness
+
+- Zero dead code policy.
+- No commented-out code.
+- No unused exports.
+- No unused dependencies.
+- No placeholder modules for later.
+- Keep dependencies minimal and justified.
+- Avoid adding crates for trivial functionality.
+
+## Tests and checks
+
+- Test Rust core logic directly, not only through Node.
+- Add tests for validation, parsing, edge cases, and error handling.
+- Use JS/NAPI integration tests only for actual boundary behavior.
+- Keep every `cfg` or feature gate as narrow as its actual use.
+- Code compiled only because a gate is wider than its callers is dead code and will trip `-D warnings`.
+- Run checks under the default feature set and the binding's feature set, such as `napi` and `telemetry`, not only `--all-features`.
+- Always run `cargo check` after finishing Rust work.
+- Required before merge: `cargo fmt`, `cargo check`, `cargo clippy -- -D warnings`, and `cargo test`.
+
+## Design target
+
+The desired shape is:
+
+```text
+JS/Node -> thin NAPI adapter -> reusable Rust core
+```
+
+Not:
+
+```text
+JS-flavored business logic written in Rust
+```
+
+Deleting or replacing the NAPI layer should not delete or rewrite the product logic.

--- a/platform/CLAUDE.md
+++ b/platform/CLAUDE.md
@@ -28,11 +28,10 @@ Check ./docs/docs_writer_prompt.md before changing docs files.
 Load these project skills when the task matches their domain:
 
 - `archestra-dev-frontend` - use for frontend Next.js/React work, UI components, forms, TanStack Query hooks, generated API clients, white-label copy, and docs links.
-- `archestra-dev-migrations` - use for Drizzle schema changes, generated migrations, data migrations, custom migrations, or `drizzle-kit check` failures not caused by merge conflicts.
+- `archestra-dev-migrations` - use for Drizzle schema changes, generated migrations, data migrations, custom migrations, `drizzle-kit check` failures, or migration conflict resolution via its `resolve-conflicts.md` subpage.
 - `archestra-dev-e2e` - use for Playwright e2e tests, API/UI fixtures, WireMock setup, local/CI e2e behavior, and locator guidance.
 - `archestra-dev-observability` - use for tracing, metrics, OpenTelemetry, Tempo, Grafana, Prometheus, LLM/MCP spans, or observability label changes.
 - `archestra-dev-rust-napi` - use for Rust core code, NAPI bindings, generated TypeScript bindings, Rust telemetry, and Rust checks.
-- `archestra-dev-resolve-conflicts` - use specifically for merge/rebase conflicts in Drizzle migrations or generated API clients.
 
 ## Key URLs
 

--- a/platform/CLAUDE.md
+++ b/platform/CLAUDE.md
@@ -10,7 +10,6 @@
 
 1. **Use pnpm** for package management
 2. **Use Tilt for development** - `tilt up` to start the full environment
-3. **Use shadcn/ui components** - Add with `npx shadcn@latest add <component>`
 4. **Documentation Updates** - For any feature or system changes, audit `../docs/pages` to determine if existing content needs modification/updates or if new documentation should be added. Follow the writing guidelines in `../docs/docs_writer_prompt.md`
 5. **Always Add Tests** - When working on any feature, ALWAYS add or modify appropriate test cases (unit tests, integration tests, or e2e tests under `platform/e2e-tests/tests`)
 6. **Enterprise Edition Imports** - NEVER directly import from `.ee.ts` files unless the importing file is itself an `.ee.ts` file. Use runtime conditional logic with `config.enterpriseFeatures.core` checks instead to avoid bundling enterprise code into free builds
@@ -23,6 +22,17 @@
 
 Docs are stored at ./docs
 Check ./docs/docs_writer_prompt.md before changing docs files.
+
+## Project Skills
+
+Load these project skills when the task matches their domain:
+
+- `archestra-dev-frontend` - use for frontend Next.js/React work, UI components, forms, TanStack Query hooks, generated API clients, white-label copy, and docs links.
+- `archestra-dev-migrations` - use for Drizzle schema changes, generated migrations, data migrations, custom migrations, or `drizzle-kit check` failures not caused by merge conflicts.
+- `archestra-dev-e2e` - use for Playwright e2e tests, API/UI fixtures, WireMock setup, local/CI e2e behavior, and locator guidance.
+- `archestra-dev-observability` - use for tracing, metrics, OpenTelemetry, Tempo, Grafana, Prometheus, LLM/MCP spans, or observability label changes.
+- `archestra-dev-rust-napi` - use for Rust core code, NAPI bindings, generated TypeScript bindings, Rust telemetry, and Rust checks.
+- `archestra-dev-resolve-conflicts` - use specifically for merge/rebase conflicts in Drizzle migrations or generated API clients.
 
 ## Key URLs
 
@@ -77,22 +87,6 @@ pnpm db:studio       # Open Drizzle Studio
 pnpm db:generate     # Generate new migrations (CI checks for uncommitted migrations)
 drizzle-kit check    # Check consistency of generated SQL migrations history
 
-# Manual Migrations with Data Migration Logic
-# When creating migrations that include data migration (INSERT/UPDATE statements),
-# you must use the Drizzle-generated migration file name to ensure proper tracking:
-# 1. First, update the Drizzle schema files with your schema changes
-# 2. Run `pnpm db:generate` - this creates a migration with a random name (e.g., 0119_military_alice.sql)
-# 3. Add your data migration SQL to the generated file (INSERT, UPDATE statements, etc.)
-# 4. Run `drizzle-kit check` to verify consistency
-# IMPORTANT: Never create manually-named migration files - Drizzle tracks migrations
-# via the meta/_journal.json file which references the generated file names.
-
-# Custom Data-Only Migrations (no schema changes)
-# For pure data migrations (UPDATE, INSERT) with no schema changes, use:
-#   cd backend && npx drizzle-kit generate --custom --name=<descriptive-name>
-# This creates an empty SQL file tracked by Drizzle's journal. Add your SQL, then run:
-#   npx drizzle-kit check
-
 # Database Connection
 # PostgreSQL is running in Kubernetes (managed by Tilt)
 # Connect to database:
@@ -104,34 +98,6 @@ kubectl exec -n archestra-dev postgresql-0 -- env PGPASSWORD=archestra_dev_passw
 tilt logs pnpm-dev-backend           # Get backend logs
 tilt logs pnpm-dev-frontend          # Get frontend logs
 tilt trigger <pnpm-dev-backend|pnpm-dev-frontend|wiremock|etc> # Trigger an update for the specified resource
-
-# E2E setup
-Runs wiremock and seeds test data to database. Note that in development e2e use your development database. This means some of your local data may cause e2e to fail locally.
-tilt trigger e2e-test-dependencies   # Start e2e WireMock
-
-Check wiremock health at:
-http://localhost:9092/__admin/health
-
-ARCHESTRA_OPENAI_BASE_URL=http://localhost:9092/v1
-ARCHESTRA_ANTHROPIC_BASE_URL=http://localhost:9092
-ARCHESTRA_GEMINI_BASE_URL=http://localhost:9092
-
-ARCHESTRA_OPENAI_BASE_URL=http://localhost:9091/v1
-ARCHESTRA_ANTHROPIC_BASE_URL=http://localhost:9091
-ARCHESTRA_GEMINI_BASE_URL=http://localhost:9091
-
-# E2E Testing
-pnpm test:e2e                        # Run Playwright tests
-# Local: docker-compose setup (Tiltfile.test)
-# CI: kind cluster + helm deployment
-#   - kind config: .github/kind.yaml
-#   - helm values: .github/values-ci.yaml
-#   - NodePort services: frontend:3000, backend:9000, metrics:9050
-#   - CI checks in e2e job: drizzle-kit check, codegen, db migrations
-
-# Observability
-tilt trigger observability           # Start full observability stack (Tempo, OTEL Collector, Prometheus, Grafana)
-docker compose -f dev/docker-compose.observability.yml up -d  # Alternative: Start via docker-compose
 ```
 
 ## Environment Variables
@@ -178,14 +144,6 @@ Tool invocation policies and trusted data policies are still enforced by the pro
 - **Route Permissions**: Configure in `shared/access-control.ts`
 - **Request Context**: `request.user` and `request.organizationId`
 - **Schema Files**: Auth schemas in separate files: `account`, `api-key`, `invitation`, `member`, `session`, `two-factor`, `verification`
-
-## Observability
-
-**Tracing**: Follows [OTEL GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/). LLM spans use `gen_ai.agent.id`, `gen_ai.agent.name`, `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.operation.name`, and `archestra.label.<key>` for dynamic labels. MCP spans use `gen_ai.tool.name`, `mcp.server.name`. Session tracking via `gen_ai.conversation.id` (from `X-Archestra-Session-Id` header). Span names: `chat {model}`, `generate_content {model}`, `execute_tool {tool_name}`. Agent label keys fetched from database on startup and included as resource attributes. Traces stored in Grafana Tempo. User identity tracked via `archestra.user.id`, `archestra.user.email`, `archestra.user.name` (when available). LLM spans include `archestra.cost` (USD) and `gen_ai.usage.total_tokens`.
-
-**Metrics**: Prometheus metrics (`llm_request_duration_seconds`, `llm_tokens_total`) include `agent_id` (internal), `agent_name`, `agent_type`, `external_agent_id` (from header), and dynamic agent labels as dimensions. MCP metrics include `agent_id`, `agent_name`, `agent_type`. Agent execution metrics use `external_agent_id` for the client-provided ID. Metrics are reinitialized on startup with current label keys from database.
-
-**Local Setup**: Use `tilt trigger observability` or `docker compose -f dev/docker-compose.observability.yml up` to start Tempo, Prometheus, and Grafana with pre-configured datasources.
 
 ## Dependency Security
 
@@ -303,20 +261,7 @@ pnpm rebuild <package-name>  # Enable scripts for specific package
 
 **Frontend**:
 
-- Use TanStack Query for data fetching (prefer `useQuery` over `useSuspenseQuery` with explicit loading states)
-- Use shadcn/ui components only
-- **Use components from `frontend/src/components/ui` over plain HTML elements**: Never use raw `<button>`, `<input>`, `<select>`, etc. when a component exists in `frontend/src/components/ui` (Button over button, Input over input, etc.)
-- **Do not hardcode `Archestra` in frontend UI copy**: Use `const appName = useAppName();` and interpolate the app name so white-labeled deployments render correctly
-- **Handle toasts in .query.ts files, not in components**: Toast notifications for mutations (success/error) should be defined in the mutation's `onSuccess`/`onError` callbacks within `.query.ts` files, not in components
-- **Never throw on HTTP errors**: In query/mutation functions, never throw errors on HTTP failures. Use `handleApiError(error)` for user notification and return appropriate default values (`null`, `[]`, `{}`). Components should not have try/catch for API calls - all error handling belongs in `.query.ts` files.
-- Small focused components with extracted business logic
-- Flat file structure, avoid barrel files
-- Only export what's needed externally
-- **API Client Guidelines**: Frontend `.query.ts` files should NEVER use `fetch()` directly - always run `pnpm codegen:api-client` first to ensure SDK is up-to-date, then use the generated SDK methods instead of manual API calls for type safety and consistency
-- **Prefer TanStack Query over prop drilling**: When a component needs data that's available via a TanStack Query hook, use the hook directly in that component rather than fetching in a parent and passing via props. TanStack Query's built-in caching ensures no duplicate requests. Only pass minimal identifiers (like `catalogId`) needed for the component to fetch/filter its own data.
-- **Use react-hook-form for forms**: Prefer `useForm` over multiple `useState` hooks for form state management. Pass form objects to child components via `form: UseFormReturn<FormValues>` prop rather than individual state setters. Parent components handle mutations and submission, form components focus on rendering.
-- **Reuse API types from @shared**: Use types from `archestraApiTypes` (e.g., `archestraApiTypes.CreateXxxData["body"]`, `archestraApiTypes.GetXxxResponses["200"]`) instead of defining duplicate types. Import from `@shared`.
-- **Documentation URLs**: Always use `getDocsUrl(DocsPage.PageName, "optional-anchor")` from `@shared` to construct docs links. Never hardcode docs URLs.
+- For frontend work, load the `archestra-dev-frontend` skill before editing React/Next.js UI, forms, query hooks, generated API client usage, copy, or docs links.
 
 **Backend**:
 
@@ -468,10 +413,7 @@ pnpm rebuild <package-name>  # Enable scripts for specific package
 
 - **Backend**: Vitest with PGLite for in-memory PostgreSQL testing - never mock database interfaces, use real database operations via models for comprehensive integration testing
 - **Test What Matters**: Prefer behavior-focused tests over implementation-detail tests. Do not add tests that only assert class names, prop plumbing, or incidental markup unless that detail is itself the contract.
-- **E2E Tests**: Playwright with test fixtures pattern - import from `./fixtures` in API/UI test directories
-- **E2E Test Fixtures**:
-  - API fixtures: `makeApiRequest`, `createAgent`, `deleteAgent`, `createApiKey`, `deleteApiKey`, `createToolInvocationPolicy`, `deleteToolInvocationPolicy`, `createTrustedDataPolicy`, `deleteTrustedDataPolicy`
-  - UI fixtures: `goToPage`, `makeRandomString`
+- **E2E Tests**: Load the `archestra-dev-e2e` skill for Playwright tests, fixtures, WireMock setup, local/CI behavior, and locator guidance.
 - **Backend Test Fixtures**: Import from `@/test` to access Vitest context with fixture functions. Available fixtures: `makeUser`, `makeAdmin`, `makeOrganization`, `makeTeam`, `makeAgent`, `makeTool`, `makeAgentTool`, `makeToolPolicy`, `makeTrustedDataPolicy`, `makeCustomRole`, `makeMember`, `makeMcpServer`, `makeInternalMcpCatalog`, `makeInvitation`, `seedAndAssignArchestraTools`
 
 **Backend Test Fixtures Usage**:
@@ -487,139 +429,4 @@ test("example test", async ({ makeUser, makeOrganization, makeTeam }) => {
 });
 ```
 
-**E2E Test Fixtures Usage**:
-
-```typescript
-import { test } from "./fixtures";
-
-test("API example", async ({ request, createAgent, deleteAgent }) => {
-  const response = await createAgent(request, "Test Agent");
-  const agent = await response.json();
-  // test logic...
-  await deleteAgent(request, agent.id);
-});
-```
-
-**Playwright Locator Best Practices**:
-
-Prefer Playwright's recommended locators over raw `locator()` calls. In priority order:
-
-1. `page.getByRole()` - Accessible elements by ARIA role (buttons, links, headings, etc.)
-2. `page.getByText()` - Find by text content
-3. `page.getByLabel()` - Form controls by label
-4. `page.getByPlaceholder()` - Input elements by placeholder
-5. `page.getByTestId()` - Custom test IDs (use `E2eTestId` constants from `@shared`)
-
-Avoid:
-
-- Raw CSS selectors: `page.locator('.my-class')` or `page.locator('#my-id')`
-- XPath selectors
-- Arbitrary timeouts - use Playwright's auto-waiting instead
-
-Example:
-
-```typescript
-// Good
-await page.getByRole("button", { name: /Submit/i }).click();
-await page.getByLabel(/Email/i).fill("test@example.com");
-await page.getByTestId(E2eTestId.CreateAgentButton).click();
-
-// Avoid
-await page.locator(".submit-btn").click();
-await page.locator("#email-input").fill("test@example.com");
-await page.waitForTimeout(1000); // Use auto-waiting instead
-```
-
-Reference: https://playwright.dev/docs/locators#quick-guide
-
 - never amend commits
-
-## Rust / NAPI coding style
-
-Write Rust as a reusable library first. NAPI should be a thin adapter around the Rust core, not the place where product logic lives. The Rust part should be easy to move later into a companion app, CLI, daemon, desktop process, or IPC service.
-
-### Architecture
-
-- Keep core Rust logic independent from Node, JavaScript, and NAPI.
-- No `#[napi]`, `napi::Result`, JS types, or Node-specific assumptions in core Rust modules.
-- NAPI functions should only:
-  1. receive JS input,
-  2. validate and convert it into Rust domain types,
-  3. call the Rust core,
-  4. convert the result or error back to JS.
-- Minimize the JS ↔ Rust API surface. Prefer a few coarse operations over many tiny exported helpers.
-- Do not expose internal implementation details through the NAPI API.
-- Generated TypeScript definitions are part of the public API and should stay clean, stable, and intentional.
-- Keep observability in the core as `tracing` spans and events only. OTLP/exporter wiring belongs in a single feature-gated module, never scattered through the logic. Propagate trace context (W3C `traceparent`) explicitly across detached tasks and actor boundaries — it does not flow implicitly.
-
-### Types and data modeling
-
-- Prefer structs, enums, and newtypes over primitive-heavy signatures, tuples, raw strings, and boolean flags.
-- Use enums for closed sets of states or modes.
-- Use named structs for meaningful data instead of passing many positional arguments.
-- Make invalid states unrepresentable where practical.
-- Treat all JS input as untrusted. Validate it at the boundary and convert it immediately into Rust-native types.
-- Validate untrusted input at the public core entry points, not deep in the call graph. Data validated when first accepted (e.g. persisted or replayed history) is trusted on reuse — document that trust boundary wherever it is not obvious.
-- Keep NAPI-facing DTOs separate from richer internal domain types when that improves clarity.
-
-### Control flow and style
-
-- Prefer `match` for enums, variants, and meaningful branching.
-- Use `if` for simple boolean checks.
-- Prefer early returns for validation and error paths.
-- Avoid deeply nested control flow.
-- Prefer functional style where it improves readability.
-- Do not force iterator chains when a simple loop is clearer.
-- Prefer clear, boring, explicit code over clever abstractions.
-
-### Errors and safety
-
-- Use `Result<T, E>` consistently in core Rust.
-- Prefer domain-specific error enums over generic strings.
-- Convert Rust errors into JS/NAPI errors only at the boundary.
-- Preserve useful error context.
-- No `unwrap`, `expect`, or `panic!` in code reachable from the NAPI boundary.
-- Assume dependencies can still panic despite that rule. Wrap every future that enters the core from the NAPI boundary in `catch_unwind` and convert the payload into a domain error. The host process must never abort on a Rust panic.
-- No `unsafe` unless isolated, documented, and clearly justified.
-
-### Abstractions
-
-- Avoid speculative abstractions.
-- Avoid `dyn Trait` unless runtime polymorphism is clearly needed.
-- Prefer concrete types, enums, generics, or plain functions before trait objects.
-- Keep modules small and named around domain concepts, not patterns.
-- Do not add indirection unless it makes testing, ownership, or API boundaries meaningfully better.
-
-### Cleanliness
-
-- Zero dead code policy.
-- No commented-out code.
-- No unused exports.
-- No unused dependencies.
-- No placeholder modules “for later”.
-- Keep dependencies minimal and justified.
-- Avoid adding crates for trivial functionality.
-
-### Tests and checks
-
-- Test Rust core logic directly, not only through Node.
-- Add tests for validation, parsing, edge cases, and error handling.
-- Use JS/NAPI integration tests only for actual boundary behavior.
-- Keep every `cfg`/feature gate as narrow as its actual use. Code compiled only because a gate is wider than its callers is dead code and will trip `-D warnings`.
-- Run the checks under the default feature set AND the binding's feature set (`napi`, `telemetry`) — not only `--all-features`. Lints, dead code, and broken `cfg` paths hide in feature combinations you never build.
-- Required before merge:
-  - `cargo fmt`
-  - `cargo clippy -- -D warnings`
-  - `cargo test`
-
-### Design target
-
-The desired shape is:
-
-JS/Node → thin NAPI adapter → reusable Rust core
-
-Not:
-
-JS-flavored business logic written in Rust
-
-Deleting or replacing the NAPI layer should not delete or rewrite the product logic.


### PR DESCRIPTION
Summary:
- Split detailed platform guidance into project skills for frontend, migrations, e2e, observability, Rust/NAPI, and conflict handling.
- Added main instruction references so agents load only relevant skills.
- Kept conflict handling separate from normal migration guidance and renamed it with the project prefix.

Validation:
- git diff --check

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>