### PR TITLE
docs: knowledge bases docs sidebar grouping

### DIFF
--- a/docs/pages/platform-knowledge-bases.md
+++ b/docs/pages/platform-knowledge-bases.md
@@ -3,7 +3,7 @@ title: Overview
 category: Knowledge
 order: 1
 description: Built-in RAG Knowledge Base to give your agents access to your data.
-lastUpdated: 2026-04-30
+lastUpdated: 2026-06-01
 ---
 
 <!--
@@ -41,11 +41,11 @@ Pick the LLM that scores and reorders search results by relevance.
 - **Key** — any LLM provider key.
 - **Model** — any chat model from that provider.
 
-### Creating a Knowledge Base
+## Creating a Knowledge Base
 
 A Knowledge Base is a set of connectors. Create one from the **Knowledge** page and assign connectors to get data from. The same Knowledge Base can be reused across multiple agents and MCP Gateways.
 
-### Files
+## Files
 
 Files are static documents uploaded from **Knowledge > Files** and assigned directly to agents or MCP Gateways. Use files when you want reusable retrieval from `.txt`, `.md`, `.csv`, `.json`, `.xml`, or `.pdf` documents without setting up an external connector.
 
@@ -59,11 +59,11 @@ Chat attachments stay with one conversation unless they are saved to **Knowledge
 
 For production deployments, file bytes are stored in PostgreSQL by default. To store bytes in S3, configure external blob storage in [Knowledge Base Configuration](/docs/platform-deployment#knowledge-files-external-blob-storage).
 
-### Creating a Connector
+## Creating a Connector
 
 Connectors pull data from external tools (Jira, Confluence, GitHub, etc.) and feed it into one or more Knowledge Bases. Each connector has a visibility setting that controls who can query its data — see [Connector Visibility](/docs/platform-knowledge-connectors#visibility). For supported types and configuration, see [Connectors](/docs/platform-knowledge-connectors).
 
-### Assigning to an Agent
+## Assigning to an Agent
 
 1. Go to **Agents** in the left sidebar and click the agent you want to attach knowledge to (or create a new one).
 2. In the **Edit Agent** dialog, scroll to **Knowledge Sources**.


### PR DESCRIPTION
## Summary

- Promote Knowledge Bases workflow sections to top-level headings so the docs right sidebar no longer nests them under Configuration.
- Update the page metadata date for the docs change.