### PR TITLE
fix(mcp-gateway): promote validateExternalIdpToken catch debug->warn

### DIFF
--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -250,15 +250,6 @@ jobs:
           echo "=== Archestra Platform Logs (main container) ==="
           kubectl logs -l app.kubernetes.io/name=archestra-platform -c archestra-platform --tail=200 2>/dev/null || true
 
-          # TEMPORARY [idp-diag] — the external-IdP validation branch logs fire
-          # mid-run (well before this dump), so --tail=200 misses them. Grep the
-          # full backend log for the marker to pin the flaky JWKS gateway e2e.
-          echo "=== [idp-diag] external IdP validation branch ==="
-          kubectl logs -l app.kubernetes.io/name=archestra-platform \
-            -c archestra-platform 2>/dev/null \
-            | grep -iE '\[idp-diag\]|validateExternalIdpToken|JWKS JWT validation failed' \
-            || echo "(no [idp-diag] line found)"
-
           echo "=== Platform Init Container: vault-secrets ==="
           kubectl logs -l app.kubernetes.io/name=archestra-platform -c vault-secrets --tail=200 2>/dev/null || true
 
@@ -394,15 +385,6 @@ jobs:
 
           echo "=== Archestra Platform Logs (main container) ==="
           kubectl logs -l app.kubernetes.io/name=archestra-platform -c archestra-platform --tail=200 2>/dev/null || true
-
-          # TEMPORARY [idp-diag] — the external-IdP validation branch logs fire
-          # mid-run (well before this dump), so --tail=200 misses them. Grep the
-          # full backend log for the marker to pin the flaky JWKS gateway e2e.
-          echo "=== [idp-diag] external IdP validation branch ==="
-          kubectl logs -l app.kubernetes.io/name=archestra-platform \
-            -c archestra-platform 2>/dev/null \
-            | grep -iE '\[idp-diag\]|validateExternalIdpToken|JWKS JWT validation failed' \
-            || echo "(no [idp-diag] line found)"
 
           echo "=== Platform Init Container: vault-secrets ==="
           kubectl logs -l app.kubernetes.io/name=archestra-platform -c vault-secrets --tail=200 2>/dev/null || true

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -1019,12 +1019,6 @@ export async function validateExternalIdpToken(
     // Look up the agent to check if it has an identity provider configured
     const agent = await AgentModel.findById(profileId);
     if (!agent?.identityProviderId) {
-      // TEMPORARY [idp-diag] — pin which branch fails the flaky JWKS gateway
-      // e2e (mcp-gateway-jwks/.jwt-propagation). Remove once root cause known.
-      logger.info(
-        { profileId, hasAgent: !!agent },
-        "[idp-diag] null: agent missing identityProviderId",
-      );
       return null;
     }
 
@@ -1040,20 +1034,15 @@ export async function validateExternalIdpToken(
       return null;
     }
 
-    // Only OIDC providers support JWKS validation
     if (!idpProvider.oidcConfig) {
-      // TEMPORARY [idp-diag] — promoted from debug so it's visible in CI.
-      logger.info(
+      logger.debug(
         { profileId, identityProviderId: agent.identityProviderId },
-        "[idp-diag] null: identity provider has no OIDC config",
+        "validateExternalIdpToken: identity provider has no OIDC config",
       );
       return null;
     }
 
     const oidcConfig = idpProvider.oidcConfig;
-    if (!oidcConfig) {
-      return null;
-    }
 
     if (!oidcConfig.clientId) {
       logger.warn(
@@ -1087,13 +1076,6 @@ export async function validateExternalIdpToken(
     });
 
     if (!result) {
-      // TEMPORARY [idp-diag] — verify failed; the reason (no-matching-key /
-      // issuer / audience at warn; expired / signature at debug) is on the
-      // "JWKS JWT validation failed" line.
-      logger.info(
-        { profileId, issuer: idpProvider.issuer, jwksUrl },
-        "[idp-diag] null: jwksValidator.validateJwt returned null",
-      );
       return null;
     }
 
@@ -1177,11 +1159,10 @@ export async function validateExternalIdpToken(
       rawToken: tokenValue,
     };
   } catch (error) {
-    logger.debug(
-      {
-        profileId,
-        error: error instanceof Error ? error.message : String(error),
-      },
+    const message = error instanceof Error ? error.message : String(error);
+    const stack = error instanceof Error ? error.stack : undefined;
+    logger.warn(
+      { profileId, error: message, stack },
       "validateExternalIdpToken: unexpected error",
     );
     return null;

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -1035,7 +1035,7 @@ export async function validateExternalIdpToken(
     }
 
     if (!idpProvider.oidcConfig) {
-      logger.debug(
+      logger.warn(
         { profileId, identityProviderId: agent.identityProviderId },
         "validateExternalIdpToken: identity provider has no OIDC config",
       );


### PR DESCRIPTION
## Summary

`validateExternalIdpToken` wraps its entire body in a `try`/`catch` and the catch logged at **`debug`** — below the backend's CI log level. Anything that threw inside the try (DB read, OIDC discovery fetch, downstream model call) was swallowed silently, the function returned `null`, and the MCP gateway responded `401 "Invalid token for this profile"` without any backend log naming the cause.

That was the diagnostic dead end behind the flaky JWKS-gateway e2e: #5125 added `[idp-diag]` info logs to every silent/debug null-return branch and #5128 broadened the CI dump grep to catch the warn branches too — and across multiple flaky MQ runs *none* of those patterns ever matched. For the failing profile, none of the labeled-null branches fire. The unlabeled catch was the only remaining path, and its debug-level log explained the silence.

Promote it to `warn` and include `error.stack` so the next throw names the call site (DB pool exhaustion, malformed `oidcConfig` JSON, fetch timeout — whatever it is). Also drops the now-redundant `[idp-diag]` temporary tags + the workflow grep step they fed, and deletes the unreachable `if (!oidcConfig)` (the preceding `!idpProvider.oidcConfig` guard already covers it).

The catch only sees errors from DB reads / fetch / parse — jose errors are caught internally by `jwksValidator`. Neither `tokenValue` nor `oidcConfig.clientSecret` is in scope at any throw path, so logging `error.message` + `error.stack` carries no token, signing-key, or secret material.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>