### PR TITLE
fix(teams): reject oversized team names and surface API errors in UI

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -195690,10 +195690,12 @@
                 "properties": {
                   "name": {
                     "type": "string",
-                    "minLength": 1
+                    "minLength": 1,
+                    "maxLength": 256
                   },
                   "description": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 500
                   }
                 },
                 "required": [
@@ -196382,10 +196384,12 @@
                 "properties": {
                   "name": {
                     "type": "string",
-                    "minLength": 1
+                    "minLength": 1,
+                    "maxLength": 256
                   },
                   "description": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 500
                   },
                   "convertToolResultsToToon": {
                     "type": "boolean"
@@ -197326,11 +197330,15 @@
                 "type": "object",
                 "properties": {
                   "userId": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 256
                   },
                   "role": {
                     "default": "member",
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 256
                   }
                 },
                 "required": [
@@ -198214,7 +198222,8 @@
                 "properties": {
                   "groupIdentifier": {
                     "type": "string",
-                    "minLength": 1
+                    "minLength": 1,
+                    "maxLength": 256
                   }
                 },
                 "required": [
@@ -210520,7 +210529,8 @@
                 "properties": {
                   "vaultPath": {
                     "type": "string",
-                    "minLength": 1
+                    "minLength": 1,
+                    "maxLength": 1024
                   }
                 },
                 "required": [

--- a/platform/backend/src/types/team.ts
+++ b/platform/backend/src/types/team.ts
@@ -23,19 +23,19 @@ export const InsertTeamSchema = createInsertSchema(schema.teamsTable);
 export const UpdateTeamSchema = createUpdateSchema(schema.teamsTable);
 
 export const CreateTeamBodySchema = z.object({
-  name: z.string().min(1, "Team name is required"),
-  description: z.string().optional(),
+  name: z.string().trim().min(1, "Team name is required").max(256),
+  description: z.string().trim().max(500).optional(),
 });
 
 export const UpdateTeamBodySchema = z.object({
-  name: z.string().min(1).optional(),
-  description: z.string().optional(),
+  name: z.string().trim().min(1).max(256).optional(),
+  description: z.string().trim().max(500).optional(),
   convertToolResultsToToon: z.boolean().optional(),
 });
 
 export const AddTeamMemberBodySchema = z.object({
-  userId: z.string(),
-  role: z.string().default(MEMBER_ROLE_NAME),
+  userId: z.string().trim().min(1).max(256),
+  role: z.string().trim().min(1).max(256).default(MEMBER_ROLE_NAME),
 });
 
 // Team External Group schemas for SSO team sync
@@ -47,7 +47,11 @@ export const InsertTeamExternalGroupSchema = createInsertSchema(
 );
 
 export const AddTeamExternalGroupBodySchema = z.object({
-  groupIdentifier: z.string().min(1, "Group identifier is required"),
+  groupIdentifier: z
+    .string()
+    .trim()
+    .min(1, "Group identifier is required")
+    .max(256),
 });
 
 export type Team = z.infer<typeof SelectTeamSchema>;
@@ -78,7 +82,7 @@ export const UpdateTeamVaultFolderSchema = createUpdateSchema(
 );
 
 export const SetTeamVaultFolderBodySchema = z.object({
-  vaultPath: z.string().min(1, "Vault path is required"),
+  vaultPath: z.string().trim().min(1, "Vault path is required").max(1024),
 });
 
 export type TeamVaultFolder = z.infer<typeof SelectTeamVaultFolderSchema>;

--- a/platform/frontend/src/components/teams/teams-list.tsx
+++ b/platform/frontend/src/components/teams/teams-list.tsx
@@ -1,6 +1,5 @@
 "use client";
-import { archestraApiSdk, type archestraApiTypes, E2eTestId } from "@shared";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { type archestraApiTypes, E2eTestId } from "@shared";
 import type { ColumnDef } from "@tanstack/react-table";
 import { Key, Link2, Plus, Trash2, Users, Vault } from "lucide-react";
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
@@ -23,7 +22,11 @@ import { Textarea } from "@/components/ui/textarea";
 import config from "@/lib/config/config";
 import { useFeature } from "@/lib/config/config.query";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
-import { useTeams } from "@/lib/teams/team.query";
+import {
+  useCreateTeam,
+  useDeleteTeam,
+  useTeams,
+} from "@/lib/teams/team.query";
 import { type TeamToken, useTokens } from "@/lib/teams/team-token.query";
 import { formatRelativeTimeFromNow } from "@/lib/utils/date-time";
 import { TeamMembersDialog } from "./team-members-dialog";
@@ -47,7 +50,6 @@ const { TeamExternalGroupsDialog } = config.enterpriseFeatures.core
 export function TeamsList() {
   const { searchParams, updateQueryParams } = useDataTableQueryParams();
   const setActionButton = useSetSettingsAction();
-  const queryClient = useQueryClient();
   const byosEnabled = useFeature("byosEnabled");
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
@@ -73,43 +75,8 @@ export function TeamsList() {
   const tokens = tokensData?.tokens;
 
   const { data: teams, isLoading } = useTeams();
-
-  const createMutation = useMutation({
-    mutationFn: async (data: { name: string; description?: string }) => {
-      return await archestraApiSdk.createTeam({
-        body: data,
-      });
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["teams"] });
-      queryClient.invalidateQueries({ queryKey: ["tokens"] });
-      setCreateDialogOpen(false);
-      setTeamName("");
-      setTeamDescription("");
-      toast.success("Team created successfully");
-    },
-    onError: (error: Error) => {
-      toast.error(error.message || "Failed to create team");
-    },
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: async (teamId: string) => {
-      return await archestraApiSdk.deleteTeam({
-        path: { id: teamId },
-      });
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["teams"] });
-      queryClient.invalidateQueries({ queryKey: ["tokens"] });
-      setDeleteDialogOpen(false);
-      setTeamToDelete(null);
-      toast.success("Team deleted successfully");
-    },
-    onError: (error: Error) => {
-      toast.error(error.message || "Failed to delete team");
-    },
-  });
+  const createMutation = useCreateTeam();
+  const deleteMutation = useDeleteTeam();
 
   const handleCreateTeam = () => {
     if (!teamName.trim()) {
@@ -117,16 +84,31 @@ export function TeamsList() {
       return;
     }
 
-    createMutation.mutate({
-      name: teamName,
-      description: teamDescription || undefined,
-    });
+    createMutation.mutate(
+      {
+        name: teamName,
+        description: teamDescription || undefined,
+      },
+      {
+        onSuccess: (data) => {
+          if (!data) return;
+          setCreateDialogOpen(false);
+          setTeamName("");
+          setTeamDescription("");
+        },
+      },
+    );
   };
 
   const handleDeleteTeam = () => {
-    if (teamToDelete) {
-      deleteMutation.mutate(teamToDelete.id);
-    }
+    if (!teamToDelete) return;
+    deleteMutation.mutate(teamToDelete.id, {
+      onSuccess: (data) => {
+        if (!data) return;
+        setDeleteDialogOpen(false);
+        setTeamToDelete(null);
+      },
+    });
   };
 
   const filteredTeams = useMemo(

--- a/platform/frontend/src/components/teams/teams-list.tsx
+++ b/platform/frontend/src/components/teams/teams-list.tsx
@@ -22,11 +22,7 @@ import { Textarea } from "@/components/ui/textarea";
 import config from "@/lib/config/config";
 import { useFeature } from "@/lib/config/config.query";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
-import {
-  useCreateTeam,
-  useDeleteTeam,
-  useTeams,
-} from "@/lib/teams/team.query";
+import { useCreateTeam, useDeleteTeam, useTeams } from "@/lib/teams/team.query";
 import { type TeamToken, useTokens } from "@/lib/teams/team-token.query";
 import { formatRelativeTimeFromNow } from "@/lib/utils/date-time";
 import { TeamMembersDialog } from "./team-members-dialog";

--- a/platform/frontend/src/lib/teams/team.query.ts
+++ b/platform/frontend/src/lib/teams/team.query.ts
@@ -1,8 +1,16 @@
 import { archestraApiSdk, type archestraApiTypes } from "@shared";
-import { useQueries, useQuery } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { toast } from "sonner";
 import { useFeature } from "@/lib/config/config.query";
+import { handleApiError, toApiError } from "@/lib/utils";
 
-const { getTeams, getTeamVaultFolder } = archestraApiSdk;
+const { createTeam, deleteTeam, getTeams, getTeamVaultFolder } =
+  archestraApiSdk;
 
 type TeamsResponse = archestraApiTypes.GetTeamsResponses["200"];
 export type Team = TeamsResponse["data"][number];
@@ -84,4 +92,48 @@ export function useTeamsWithVaultFolders() {
     data: teamsWithVaultPaths,
     isLoading,
   };
+}
+
+export function useCreateTeam() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (body: archestraApiTypes.CreateTeamData["body"]) => {
+      const { data, error } = await createTeam({ body });
+      if (error) {
+        handleApiError(error);
+        throw toApiError(error);
+      }
+
+      return data;
+    },
+    onSuccess: (data) => {
+      if (!data) return;
+      toast.success("Team created successfully");
+      queryClient.invalidateQueries({ queryKey: ["teams"] });
+      queryClient.invalidateQueries({ queryKey: ["tokens"] });
+    },
+  });
+}
+
+export function useDeleteTeam() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const { data, error } = await deleteTeam({ path: { id } });
+      if (error) {
+        handleApiError(error);
+        throw toApiError(error);
+      }
+
+      return data;
+    },
+    onSuccess: (data) => {
+      if (!data) return;
+      toast.success("Team deleted successfully");
+      queryClient.invalidateQueries({ queryKey: ["teams"] });
+      queryClient.invalidateQueries({ queryKey: ["tokens"] });
+    },
+  });
 }


### PR DESCRIPTION
When you create a team in **Settings -> Teams**, the form accepts a name of any length and tells you it was created successfully - even when the name is huge enough to break the page.

## Steps to reproduce

1. Open **Settings -> Teams** as an admin.
2. Click **Create Team**.
3. Paste a long string into the **Name** field. Easy way on Windows:
   ```powershell
   ("A" * 300000) | Set-Clipboard
   ```
   then `Ctrl+V` into the input.
4. Click **Create Team**.

## Actual result

- Green toast: "Team created successfully".
- Row is saved (`SELECT length(name) FROM team` returns `300000`).
- The service is stucked
<img width="2559" height="1432" alt="Screenshot 2026-06-01 151443" src="https://github.com/user-attachments/assets/68a65529-ea62-4774-af9a-e2c70d4d1df0" />

## Expected result

- Red toast shows that message ("Too big: expected string to have at most 256 characters" or similar).
- Dialog stays open with the input still filled, so the user can fix it.
- Nothing is written to the database.

## Note

The same unbounded-string pattern exists in `Agent`, `McpServer`, `OrganizationRole`, `OptimizationRule`, and `ScheduleTrigger.messageTemplate`. I kept this PR focused on Teams 