### PR TITLE
feat(helm): grant platform ServiceAccount RBAC in MCP environment namespaces

### DIFF
--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -281,7 +281,7 @@ ServiceAccount name for the Archestra Platform
 {{/*
 RBAC rules granting the platform ServiceAccount the permissions it needs to
 manage MCP server workloads in a namespace. Shared by the release-namespace Role
-and the per-namespace Roles generated from rbac.additionalNamespaces, so both
+and the per-namespace Roles generated from rbac.environmentNamespace, so both
 grant exactly the same access (no drift).
 */}}
 {{- define "archestra-platform.mcpManagerRules" -}}

--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -279,6 +279,36 @@ ServiceAccount name for the Archestra Platform
 {{- end }}
 
 {{/*
+RBAC rules granting the platform ServiceAccount the permissions it needs to
+manage MCP server workloads in a namespace. Shared by the release-namespace Role
+and the per-namespace Roles generated from rbac.additionalNamespaces, so both
+grant exactly the same access (no drift).
+*/}}
+{{- define "archestra-platform.mcpManagerRules" -}}
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["get", "create"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods/attach"]
+  verbs: ["get", "create"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
+{{- end }}
+
+{{/*
 Worker selector labels
 */}}
 {{- define "archestra-platform.workerSelectorLabels" -}}

--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -281,7 +281,7 @@ ServiceAccount name for the Archestra Platform
 {{/*
 RBAC rules granting the platform ServiceAccount the permissions it needs to
 manage MCP server workloads in a namespace. Shared by the release-namespace Role
-and the per-namespace Roles generated from rbac.environmentNamespace, so both
+and the per-namespace Roles generated from rbac.environmentNamespaces, so both
 grant exactly the same access (no drift).
 */}}
 {{- define "archestra-platform.mcpManagerRules" -}}

--- a/platform/helm/archestra/templates/serviceaccount.yaml
+++ b/platform/helm/archestra/templates/serviceaccount.yaml
@@ -49,7 +49,7 @@ namespace-scoped Role + RoleBinding; the binding's subject points back at the SA
 the release namespace. The release namespace is skipped — its Role/RoleBinding is
 already created above, and re-emitting it would collide on name.
 */}}
-{{- range $ns := .Values.archestra.orchestrator.kubernetes.rbac.additionalNamespaces }}
+{{- range $ns := .Values.archestra.orchestrator.kubernetes.rbac.environmentNamespace }}
 {{- if ne $ns $.Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/platform/helm/archestra/templates/serviceaccount.yaml
+++ b/platform/helm/archestra/templates/serviceaccount.yaml
@@ -25,27 +25,7 @@ metadata:
   labels:
     {{- include "archestra-platform.labels" . | nindent 4 }}
 rules:
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
-- apiGroups: [""]
-  resources: ["pods/exec"]
-  verbs: ["get", "create"]
-- apiGroups: [""]
-  resources: ["pods/log"]
-  verbs: ["get", "list"]
-- apiGroups: [""]
-  resources: ["pods/attach"]
-  verbs: ["get", "create"]
-- apiGroups: [""]
-  resources: ["services"]
-  verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
-- apiGroups: ["apps"]
-  resources: ["deployments"]
-  verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
+{{ include "archestra-platform.mcpManagerRules" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -62,4 +42,41 @@ roleRef:
   kind: Role
   name: {{ include "archestra-platform.fullname" . }}-mcp-manager
   apiGroup: rbac.authorization.k8s.io
+{{- /*
+Grant the platform ServiceAccount the same MCP-manager permissions in additional
+namespaces (the K8s namespaces backing deployment environments). Each gets its own
+namespace-scoped Role + RoleBinding; the binding's subject points back at the SA in
+the release namespace. The release namespace is skipped — its Role/RoleBinding is
+already created above, and re-emitting it would collide on name.
+*/}}
+{{- range $ns := .Values.archestra.orchestrator.kubernetes.rbac.additionalNamespaces }}
+{{- if ne $ns $.Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "archestra-platform.fullname" $ }}-mcp-manager
+  namespace: {{ $ns }}
+  labels:
+    {{- include "archestra-platform.labels" $ | nindent 4 }}
+rules:
+{{ include "archestra-platform.mcpManagerRules" $ }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "archestra-platform.fullname" $ }}-mcp-manager
+  namespace: {{ $ns }}
+  labels:
+    {{- include "archestra-platform.labels" $ | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "archestra-platform.serviceAccountName" $ }}
+  namespace: {{ $.Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "archestra-platform.fullname" $ }}-mcp-manager
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}
 {{- end }}

--- a/platform/helm/archestra/templates/serviceaccount.yaml
+++ b/platform/helm/archestra/templates/serviceaccount.yaml
@@ -49,7 +49,7 @@ namespace-scoped Role + RoleBinding; the binding's subject points back at the SA
 the release namespace. The release namespace is skipped — its Role/RoleBinding is
 already created above, and re-emitting it would collide on name.
 */}}
-{{- range $ns := .Values.archestra.orchestrator.kubernetes.rbac.environmentNamespace }}
+{{- range $ns := .Values.archestra.orchestrator.kubernetes.rbac.environmentNamespaces }}
 {{- if ne $ns $.Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/platform/helm/archestra/tests/archestra_platform_service_account_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_service_account_test.yaml
@@ -267,17 +267,17 @@ tests:
           path: subjects[0].name
           value: "custom-archestra-sa"
 
-  # environmentNamespace tests
+  # environmentNamespaces tests
   # Default rendering is 3 docs (SA, Role, RoleBinding). Each additional namespace
   # appends a Role then a RoleBinding, so [staging, prod-ns] => indexes 3..6.
-  - it: should not create extra RBAC for environmentNamespace by default
+  - it: should not create extra RBAC for environmentNamespaces by default
     asserts:
       - hasDocuments:
           count: 3
 
   - it: should create a Role and RoleBinding per additional namespace
     set:
-      archestra.orchestrator.kubernetes.rbac.environmentNamespace:
+      archestra.orchestrator.kubernetes.rbac.environmentNamespaces:
         - staging
         - prod-ns
     asserts:
@@ -286,7 +286,7 @@ tests:
 
   - it: additional namespace Role targets that namespace
     set:
-      archestra.orchestrator.kubernetes.rbac.environmentNamespace:
+      archestra.orchestrator.kubernetes.rbac.environmentNamespaces:
         - staging
         - prod-ns
     documentIndex: 3
@@ -302,7 +302,7 @@ tests:
 
   - it: additional namespace RoleBinding targets that namespace and binds the release-namespace SA
     set:
-      archestra.orchestrator.kubernetes.rbac.environmentNamespace:
+      archestra.orchestrator.kubernetes.rbac.environmentNamespaces:
         - staging
         - prod-ns
     documentIndex: 4
@@ -331,7 +331,7 @@ tests:
 
   - it: second additional namespace also renders Role and RoleBinding
     set:
-      archestra.orchestrator.kubernetes.rbac.environmentNamespace:
+      archestra.orchestrator.kubernetes.rbac.environmentNamespaces:
         - staging
         - prod-ns
     documentIndex: 5
@@ -344,7 +344,7 @@ tests:
 
   - it: additional namespace Role grants the same MCP-manager rules (no drift)
     set:
-      archestra.orchestrator.kubernetes.rbac.environmentNamespace:
+      archestra.orchestrator.kubernetes.rbac.environmentNamespaces:
         - staging
     documentIndex: 3
     asserts:
@@ -364,7 +364,7 @@ tests:
   - it: should not create additional-namespace RBAC when rbac.create is false
     set:
       archestra.orchestrator.kubernetes.rbac.create: false
-      archestra.orchestrator.kubernetes.rbac.environmentNamespace:
+      archestra.orchestrator.kubernetes.rbac.environmentNamespaces:
         - staging
         - prod-ns
     asserts:
@@ -373,7 +373,7 @@ tests:
 
   - it: should skip an additional namespace equal to the release namespace
     set:
-      archestra.orchestrator.kubernetes.rbac.environmentNamespace:
+      archestra.orchestrator.kubernetes.rbac.environmentNamespaces:
         - NAMESPACE
     asserts:
       - hasDocuments:
@@ -381,7 +381,7 @@ tests:
 
   - it: should skip only the release namespace from a mixed list
     set:
-      archestra.orchestrator.kubernetes.rbac.environmentNamespace:
+      archestra.orchestrator.kubernetes.rbac.environmentNamespaces:
         - NAMESPACE
         - staging
     asserts:
@@ -391,7 +391,7 @@ tests:
   - it: additional namespace RoleBinding honors a custom ServiceAccount name
     set:
       archestra.orchestrator.kubernetes.serviceAccount.name: "custom-sa-name"
-      archestra.orchestrator.kubernetes.rbac.environmentNamespace:
+      archestra.orchestrator.kubernetes.rbac.environmentNamespaces:
         - staging
     documentIndex: 4
     asserts:

--- a/platform/helm/archestra/tests/archestra_platform_service_account_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_service_account_test.yaml
@@ -267,17 +267,17 @@ tests:
           path: subjects[0].name
           value: "custom-archestra-sa"
 
-  # additionalNamespaces tests
+  # environmentNamespace tests
   # Default rendering is 3 docs (SA, Role, RoleBinding). Each additional namespace
   # appends a Role then a RoleBinding, so [staging, prod-ns] => indexes 3..6.
-  - it: should not create extra RBAC for additionalNamespaces by default
+  - it: should not create extra RBAC for environmentNamespace by default
     asserts:
       - hasDocuments:
           count: 3
 
   - it: should create a Role and RoleBinding per additional namespace
     set:
-      archestra.orchestrator.kubernetes.rbac.additionalNamespaces:
+      archestra.orchestrator.kubernetes.rbac.environmentNamespace:
         - staging
         - prod-ns
     asserts:
@@ -286,7 +286,7 @@ tests:
 
   - it: additional namespace Role targets that namespace
     set:
-      archestra.orchestrator.kubernetes.rbac.additionalNamespaces:
+      archestra.orchestrator.kubernetes.rbac.environmentNamespace:
         - staging
         - prod-ns
     documentIndex: 3
@@ -302,7 +302,7 @@ tests:
 
   - it: additional namespace RoleBinding targets that namespace and binds the release-namespace SA
     set:
-      archestra.orchestrator.kubernetes.rbac.additionalNamespaces:
+      archestra.orchestrator.kubernetes.rbac.environmentNamespace:
         - staging
         - prod-ns
     documentIndex: 4
@@ -331,7 +331,7 @@ tests:
 
   - it: second additional namespace also renders Role and RoleBinding
     set:
-      archestra.orchestrator.kubernetes.rbac.additionalNamespaces:
+      archestra.orchestrator.kubernetes.rbac.environmentNamespace:
         - staging
         - prod-ns
     documentIndex: 5
@@ -344,7 +344,7 @@ tests:
 
   - it: additional namespace Role grants the same MCP-manager rules (no drift)
     set:
-      archestra.orchestrator.kubernetes.rbac.additionalNamespaces:
+      archestra.orchestrator.kubernetes.rbac.environmentNamespace:
         - staging
     documentIndex: 3
     asserts:
@@ -364,7 +364,7 @@ tests:
   - it: should not create additional-namespace RBAC when rbac.create is false
     set:
       archestra.orchestrator.kubernetes.rbac.create: false
-      archestra.orchestrator.kubernetes.rbac.additionalNamespaces:
+      archestra.orchestrator.kubernetes.rbac.environmentNamespace:
         - staging
         - prod-ns
     asserts:
@@ -373,7 +373,7 @@ tests:
 
   - it: should skip an additional namespace equal to the release namespace
     set:
-      archestra.orchestrator.kubernetes.rbac.additionalNamespaces:
+      archestra.orchestrator.kubernetes.rbac.environmentNamespace:
         - NAMESPACE
     asserts:
       - hasDocuments:
@@ -381,7 +381,7 @@ tests:
 
   - it: should skip only the release namespace from a mixed list
     set:
-      archestra.orchestrator.kubernetes.rbac.additionalNamespaces:
+      archestra.orchestrator.kubernetes.rbac.environmentNamespace:
         - NAMESPACE
         - staging
     asserts:
@@ -391,7 +391,7 @@ tests:
   - it: additional namespace RoleBinding honors a custom ServiceAccount name
     set:
       archestra.orchestrator.kubernetes.serviceAccount.name: "custom-sa-name"
-      archestra.orchestrator.kubernetes.rbac.additionalNamespaces:
+      archestra.orchestrator.kubernetes.rbac.environmentNamespace:
         - staging
     documentIndex: 4
     asserts:

--- a/platform/helm/archestra/tests/archestra_platform_service_account_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_service_account_test.yaml
@@ -267,3 +267,135 @@ tests:
           path: subjects[0].name
           value: "custom-archestra-sa"
 
+  # additionalNamespaces tests
+  # Default rendering is 3 docs (SA, Role, RoleBinding). Each additional namespace
+  # appends a Role then a RoleBinding, so [staging, prod-ns] => indexes 3..6.
+  - it: should not create extra RBAC for additionalNamespaces by default
+    asserts:
+      - hasDocuments:
+          count: 3
+
+  - it: should create a Role and RoleBinding per additional namespace
+    set:
+      archestra.orchestrator.kubernetes.rbac.additionalNamespaces:
+        - staging
+        - prod-ns
+    asserts:
+      - hasDocuments:
+          count: 7  # SA + release Role/RoleBinding + 2 namespaces * (Role + RoleBinding)
+
+  - it: additional namespace Role targets that namespace
+    set:
+      archestra.orchestrator.kubernetes.rbac.additionalNamespaces:
+        - staging
+        - prod-ns
+    documentIndex: 3
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.namespace
+          value: staging
+      - matchRegex:
+          path: metadata.name
+          pattern: -archestra-platform-mcp-manager$
+
+  - it: additional namespace RoleBinding targets that namespace and binds the release-namespace SA
+    set:
+      archestra.orchestrator.kubernetes.rbac.additionalNamespaces:
+        - staging
+        - prod-ns
+    documentIndex: 4
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: metadata.namespace
+          value: staging
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - matchRegex:
+          path: subjects[0].name
+          pattern: -archestra-platform$
+      # Subject SA lives in the release namespace, not the target namespace.
+      - equal:
+          path: subjects[0].namespace
+          value: NAMESPACE
+      - equal:
+          path: roleRef.kind
+          value: Role
+      - matchRegex:
+          path: roleRef.name
+          pattern: -archestra-platform-mcp-manager$
+
+  - it: second additional namespace also renders Role and RoleBinding
+    set:
+      archestra.orchestrator.kubernetes.rbac.additionalNamespaces:
+        - staging
+        - prod-ns
+    documentIndex: 5
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.namespace
+          value: prod-ns
+
+  - it: additional namespace Role grants the same MCP-manager rules (no drift)
+    set:
+      archestra.orchestrator.kubernetes.rbac.additionalNamespaces:
+        - staging
+    documentIndex: 3
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["apps"]
+            resources: ["deployments"]
+            verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["secrets"]
+            verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
+
+  - it: should not create additional-namespace RBAC when rbac.create is false
+    set:
+      archestra.orchestrator.kubernetes.rbac.create: false
+      archestra.orchestrator.kubernetes.rbac.additionalNamespaces:
+        - staging
+        - prod-ns
+    asserts:
+      - hasDocuments:
+          count: 1  # Only the ServiceAccount
+
+  - it: should skip an additional namespace equal to the release namespace
+    set:
+      archestra.orchestrator.kubernetes.rbac.additionalNamespaces:
+        - NAMESPACE
+    asserts:
+      - hasDocuments:
+          count: 3  # No duplicate Role/RoleBinding for the release namespace
+
+  - it: should skip only the release namespace from a mixed list
+    set:
+      archestra.orchestrator.kubernetes.rbac.additionalNamespaces:
+        - NAMESPACE
+        - staging
+    asserts:
+      - hasDocuments:
+          count: 5  # SA + release Role/RoleBinding + staging Role/RoleBinding
+
+  - it: additional namespace RoleBinding honors a custom ServiceAccount name
+    set:
+      archestra.orchestrator.kubernetes.serviceAccount.name: "custom-sa-name"
+      archestra.orchestrator.kubernetes.rbac.additionalNamespaces:
+        - staging
+    documentIndex: 4
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: "custom-sa-name"
+

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -453,6 +453,27 @@ archestra:
         # Specifies whether RBAC resources should be created
         create: true
 
+        # Additional namespaces the platform may deploy MCP servers into (the
+        # Kubernetes namespaces backing deployment environments). The platform
+        # ServiceAccount only gets MCP-manager permissions in the release
+        # namespace by default, so an environment pointing at any other namespace
+        # fails with a 403 until that namespace is listed here.
+        #
+        # For each entry the chart creates a namespace-scoped Role + RoleBinding
+        # granting the platform ServiceAccount the same MCP-manager permissions it
+        # has in the release namespace. The namespaces MUST already exist before
+        # `helm upgrade` (a RoleBinding cannot be created in a missing namespace).
+        # An entry equal to the release namespace is ignored (already covered above).
+        #
+        # Note: unlike mcpServerRbac.additionalRoleBindings (which only creates a
+        # binding to an externally-managed Role), this creates the Role too.
+        #
+        # Example:
+        #   additionalNamespaces:
+        #     - staging
+        #     - prod-eu
+        additionalNamespaces: []
+
       # NetworkPolicy configuration for MCP server pods (SSRF protection)
       # When enabled, creates a Kubernetes NetworkPolicy that prevents MCP server pods from
       # accessing private/internal IP ranges, blocking SSRF attacks against cluster services,

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -471,7 +471,7 @@ archestra:
         # Example:
         #   environmentNamespaces:
         #     - staging
-        #     - prod-eu
+        #     - production
         environmentNamespaces: []
 
       # NetworkPolicy configuration for MCP server pods (SSRF protection)

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -453,11 +453,11 @@ archestra:
         # Specifies whether RBAC resources should be created
         create: true
 
-        # Additional namespaces the platform may deploy MCP servers into (the
-        # Kubernetes namespaces backing deployment environments). The platform
-        # ServiceAccount only gets MCP-manager permissions in the release
-        # namespace by default, so an environment pointing at any other namespace
-        # fails with a 403 until that namespace is listed here.
+        # Kubernetes namespaces backing deployment environments that the platform
+        # may deploy MCP servers into. The platform ServiceAccount only gets
+        # MCP-manager permissions in the release namespace by default, so an
+        # environment pointing at any other namespace fails with a 403 until that
+        # namespace is listed here.
         #
         # For each entry the chart creates a namespace-scoped Role + RoleBinding
         # granting the platform ServiceAccount the same MCP-manager permissions it
@@ -469,10 +469,10 @@ archestra:
         # binding to an externally-managed Role), this creates the Role too.
         #
         # Example:
-        #   additionalNamespaces:
+        #   environmentNamespace:
         #     - staging
         #     - prod-eu
-        additionalNamespaces: []
+        environmentNamespace: []
 
       # NetworkPolicy configuration for MCP server pods (SSRF protection)
       # When enabled, creates a Kubernetes NetworkPolicy that prevents MCP server pods from

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -469,10 +469,10 @@ archestra:
         # binding to an externally-managed Role), this creates the Role too.
         #
         # Example:
-        #   environmentNamespace:
+        #   environmentNamespaces:
         #     - staging
         #     - prod-eu
-        environmentNamespace: []
+        environmentNamespaces: []
 
       # NetworkPolicy configuration for MCP server pods (SSRF protection)
       # When enabled, creates a Kubernetes NetworkPolicy that prevents MCP server pods from


### PR DESCRIPTION
## Summary

Deployment environments let an MCP catalog item target an arbitrary Kubernetes namespace. The platform ServiceAccount, however, is only granted MCP-manager permissions (pods / services / secrets / deployments, plus `pods/exec` and `pods/attach`) in the Helm **release** namespace. So in production, assigning a catalog item to any other namespace makes the backend's deploy fail with a 403 — `cannot create resource "deployments" … in the namespace "<env-ns>"`. Local Tilt never reproduces this because the dev kubeconfig has broad permissions.

This adds `archestra.orchestrator.kubernetes.rbac.additionalNamespaces`. For each listed namespace the chart renders a namespace-scoped **Role + RoleBinding** granting the platform ServiceAccount the same MCP-manager permissions, with the RoleBinding subject pinned to the ServiceAccount in the release namespace. Operators grant access to environment namespaces entirely through the chart — no externally-managed Role required.

The grant is intentionally a namespace-scoped `Role` (not a `ClusterRole`): the blast radius is limited to exactly the namespaces an operator opts into, and the default (`[]`) changes nothing. The namespaces must already exist at `helm upgrade` time, and an entry equal to the release namespace is ignored (its Role/RoleBinding already exists). The shared `mcpManagerRules` helper keeps the release-namespace Role and the per-namespace Roles from drifting.

This differs from the existing `mcpServerRbac.additionalRoleBindings` (which binds to an externally-created Role on the read-only operator SA): here the chart creates the Role too, for the pod-managing platform SA.

## Out of scope

Keeping `additionalNamespaces` in sync with the deployment environments configured in-app remains a manual, operator-owned step; surfacing missing-grant state in the UI is handled separately.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>