### PR TITLE
chore(gitignore): ignore local *.kubeconfig files

### DIFF
--- a/platform/.gitignore
+++ b/platform/.gitignore
@@ -89,3 +89,6 @@ specs/
 
 # project-local binaries bootstrapped by dev scripts (e.g., dagger CLI)
 dev/bin/
+
+# local kubeconfigs (may embed live ServiceAccount tokens) — never commit
+*.kubeconfig


### PR DESCRIPTION
## Summary

Local development sometimes involves a kubeconfig that embeds a live Kubernetes ServiceAccount bearer token — for example, a restricted-SA kubeconfig used to reproduce how the platform behaves when it lacks RBAC in a namespace. Such a file landing in the working tree is one `git add .` away from committing a real cluster credential into history.

Ignoring `*.kubeconfig` under `platform/` removes that footgun. No tracked files use the extension, so nothing currently committed is affected.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>