### PR TITLE
fix: handle unavailable chat tool calls

### DIFF
--- a/platform/backend/src/archestra-mcp-server/index.test.ts
+++ b/platform/backend/src/archestra-mcp-server/index.test.ts
@@ -5,7 +5,13 @@ import {
 } from "@shared";
 import { beforeEach, describe, expect, test } from "@/test";
 import type { Agent } from "@/types";
-import { __test, type ArchestraContext, executeArchestraTool } from ".";
+import {
+  __test,
+  type ArchestraContext,
+  archestraMcpBranding,
+  executeArchestraTool,
+  getArchestraMcpTools,
+} from ".";
 
 describe("executeArchestraTool", () => {
   let testAgent: Agent;
@@ -137,5 +143,27 @@ describe("executeArchestraTool", () => {
         );
       }
     });
+  });
+});
+
+describe("getArchestraMcpTools", () => {
+  test("rewrites built-in tool references in descriptions when branded", () => {
+    archestraMcpBranding.syncFromOrganization({
+      appName: "Acme Control Plane",
+      iconLogo: null,
+    });
+
+    const tools = getArchestraMcpTools();
+    const activateSkill = tools.find((tool) =>
+      tool.name.endsWith("__activate_skill"),
+    );
+
+    expect(activateSkill?.name).toBe("acme_control_plane__activate_skill");
+    expect(activateSkill?.description).toContain(
+      "acme_control_plane__list_skills",
+    );
+    expect(activateSkill?.description).not.toContain("Call list_skills");
+
+    archestraMcpBranding.syncFromOrganization(null);
   });
 });

--- a/platform/backend/src/archestra-mcp-server/index.ts
+++ b/platform/backend/src/archestra-mcp-server/index.ts
@@ -1,7 +1,9 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import {
   ARCHESTRA_TOOL_PREFIX,
+  ARCHESTRA_TOOL_SHORT_NAMES,
   type ArchestraToolFullName,
+  type ArchestraToolShortName,
   getArchestraToolFullName,
   getArchestraToolShortName,
   isAgentTool,
@@ -124,6 +126,7 @@ export function getArchestraMcpTools() {
     return {
       ...tool,
       name: archestraMcpBranding.getToolName(shortName),
+      description: rewriteBuiltInToolDescription(tool.description),
     };
   });
 }
@@ -207,6 +210,24 @@ function resolveArchestraToolName(toolName: string): string | null {
   }
 
   return getArchestraToolFullName(shortName);
+}
+
+function rewriteBuiltInToolDescription(
+  description: string | undefined,
+): string | undefined {
+  if (!description) {
+    return description;
+  }
+
+  let rewritten = description;
+  for (const shortName of ARCHESTRA_TOOL_SHORT_NAMES) {
+    rewritten = rewritten.replace(
+      new RegExp(`\\b${shortName}\\b`, "g"),
+      archestraMcpBranding.getToolName(shortName as ArchestraToolShortName),
+    );
+  }
+
+  return rewritten;
 }
 
 function validateToolResult(

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -2518,16 +2518,51 @@ export async function generateConversationTitle(
 function getUnavailableToolErrorDetails(
   error: unknown,
 ): UnavailableToolErrorDetails | null {
-  if (!NoSuchToolError.isInstance(error)) {
+  if (NoSuchToolError.isInstance(error)) {
+    return {
+      type: "unavailable_tool",
+      message: UNAVAILABLE_TOOL_ERROR_MESSAGE,
+      requestedToolName: error.toolName,
+      availableToolNames: error.availableTools ?? [],
+      originalErrorMessage: error.message,
+    };
+  }
+
+  const parsedError = parseUnavailableToolErrorMessage(error);
+  if (!parsedError) {
     return null;
   }
 
   return {
     type: "unavailable_tool",
     message: UNAVAILABLE_TOOL_ERROR_MESSAGE,
-    requestedToolName: error.toolName,
-    availableToolNames: error.availableTools ?? [],
-    originalErrorMessage: error.message,
+    requestedToolName: parsedError.requestedToolName,
+    availableToolNames: parsedError.availableToolNames,
+    originalErrorMessage: parsedError.originalErrorMessage,
+  };
+}
+
+function parseUnavailableToolErrorMessage(error: unknown): {
+  requestedToolName: string;
+  availableToolNames: string[];
+  originalErrorMessage: string;
+} | null {
+  const message = error instanceof Error ? error.message : String(error);
+  const match = message.match(
+    /^Model tried to call unavailable tool '([^']+)'\. Available tools: (.*)\.$/s,
+  );
+
+  if (!match) {
+    return null;
+  }
+
+  return {
+    requestedToolName: match[1],
+    availableToolNames: match[2]
+      .split(",")
+      .map((toolName) => toolName.trim())
+      .filter(Boolean),
+    originalErrorMessage: message,
   };
 }
 

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -428,6 +428,51 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
     expect(persistedErrors).toHaveLength(0);
   });
 
+  test("formats provider-wrapped unavailable tool messages as tool-level errors", async ({
+    expect,
+  }) => {
+    const { default: ConversationChatErrorModel } = await import(
+      "@/models/conversation-chat-error"
+    );
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: conversationId,
+        messages: [
+          {
+            id: "msg-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+    expect(capturedInnerOnError).toBeDefined();
+
+    const payload = capturedInnerOnError?.(
+      new Error(
+        "Model tried to call unavailable tool 'list_skills'. Available tools: branded__list_skills, branded__activate_skill.",
+      ),
+    );
+
+    expect(payload).toContain(
+      "The requested tool is not available in this chat.",
+    );
+    expect(payload).toContain('"requestedToolName": "list_skills"');
+    expect(payload).toContain("branded__list_skills");
+    expect(payload).toContain("branded__activate_skill");
+
+    await new Promise((resolve) => setImmediate(resolve));
+    const persistedErrors =
+      await ConversationChatErrorModel.findByConversation(conversationId);
+    expect(persistedErrors).toHaveLength(0);
+  });
+
   test("formats each distinct unavailable tool error independently within one stream", async ({
     expect,
   }) => {


### PR DESCRIPTION
## Summary

Handle unavailable tool-call errors as recoverable chat tool errors even when they arrive as provider-wrapped messages, and make branded built-in tool descriptions reference the exact callable tool names.

## Why

Some providers surface missing tool calls as plain error messages instead of preserving the SDK error class. Those errors should remain in the tool-result path so the model can recover, rather than being treated as generic provider failures.

## Validation

- `pnpm --dir backend exec vitest run src/routes/chat/stream-route.test.ts src/archestra-mcp-server/index.test.ts`
- `pnpm --filter @backend lint -- src/routes/chat/routes.ts src/routes/chat/stream-route.test.ts src/archestra-mcp-server/index.ts src/archestra-mcp-server/index.test.ts`
- `pnpm --filter @backend type-check`

Docs were audited; no docs changes were needed because this is internal error handling and tool metadata hygiene.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>