### PR TITLE
feat: improve usage limits visibility UX and DX (#4758)

### DIFF
--- a/platform/backend/src/models/limit.ts
+++ b/platform/backend/src/models/limit.ts
@@ -8,6 +8,7 @@ import type {
   LimitEntityType,
   LimitType,
   UpdateLimit,
+  ConstrainingLimitResult,
 } from "@/types";
 import AgentTeamModel from "./agent-team";
 import ModelModel from "./model";
@@ -903,29 +904,20 @@ export class LimitValidationService {
 <archestra-limit-remaining>${Math.max(0, limit.limitValue - totalTokens)}</archestra-limit-remaining>`;
 
           // For user message, use appropriate units based on limit type
-          let contentMessage: string;
-          if (limitDescription === "cost_dollars") {
-            contentMessage = `
-I cannot process this request because the ${entityType}-level token cost limit has been exceeded.
-
-Current usage: $${comparisonValue.toFixed(2)}
-Limit: $${limit.limitValue.toFixed(2)}
-Remaining: $${remaining.toFixed(2)}
-
-Please contact your administrator to increase the limit or wait for the usage to reset.`;
-          } else {
-            contentMessage = `
-I cannot process this request because the ${entityType}-level token cost limit has been exceeded.
-
-Current usage: ${totalTokens.toLocaleString()} tokens
-Limit: ${limit.limitValue.toLocaleString()} tokens
-Remaining: ${Math.max(0, limit.limitValue - totalTokens).toLocaleString()} tokens
-
-Please contact your administrator to increase the limit or wait for the usage to reset.`;
-          }
-
-          const refusalMessage = `${archestraMetadata}
-${contentMessage}`;
+          const limitInfo = {
+            lastCleanup: limit.lastCleanup,
+            cleanupInterval: limit.cleanupInterval,
+          };
+          const [refusalMessage, contentMessage] = buildLimitViolationResponse({
+            entityType,
+            entityId,
+            limitValue: limit.limitValue,
+            comparisonValue,
+            limitDescription,
+            totalTokensIn,
+            totalTokensOut,
+            limitInfo,
+          });
 
           return [refusalMessage, contentMessage];
         } else {
@@ -1000,12 +992,202 @@ ${contentMessage}`;
         limitDescription: "cost_dollars",
         totalTokensIn: usage.tokensIn,
         totalTokensOut: usage.tokensOut,
+        limitInfo: {
+          lastCleanup: null,
+          cleanupInterval: organization.defaultUserLimitCleanupInterval ?? "1w",
+        },
       });
     } catch (error) {
       logger.error(
         { error, params },
         "[LimitValidation] Error checking default user limit",
       );
+      return null;
+    }
+  }
+
+  /**
+   * Evaluates all applicable limits and returns the most constraining one (the one closest to its limit value).
+   * This logic maps identically to `checkLimitsBeforeRequest` but returns the full context of limits.
+   */
+  static async getMostConstrainingLimit(params: {
+    agentId: string;
+    userId?: string;
+    virtualKeyId?: string;
+  }): Promise<ConstrainingLimitResult | null> {
+    const { agentId, userId, virtualKeyId } = params;
+
+    let organizationId: string | null = null;
+    const agentTeamIds = await AgentTeamModel.getTeamsForAgent(agentId);
+
+    if (agentTeamIds.length > 0) {
+      const teams = await db
+        .select()
+        .from(schema.teamsTable)
+        .where(inArray(schema.teamsTable.id, agentTeamIds));
+      if (teams.length > 0 && teams[0].organizationId) {
+        organizationId = teams[0].organizationId;
+      }
+    } else {
+      const [agent] = await db
+        .select({ organizationId: schema.agentsTable.organizationId })
+        .from(schema.agentsTable)
+        .where(eq(schema.agentsTable.id, agentId))
+        .limit(1);
+      if (agent?.organizationId) {
+        organizationId = agent.organizationId;
+      }
+    }
+
+    const allLimits: ConstrainingLimitResult[] = [];
+
+    if (virtualKeyId) {
+      allLimits.push(
+        ...(await this.evaluateEntityLimits("virtual_key", virtualKeyId)),
+      );
+    }
+    if (userId) {
+      allLimits.push(...(await this.evaluateEntityLimits("user", userId)));
+      if (organizationId) {
+        const defaultUserLimit = await this.evaluateDefaultUserLimitForContext(
+          organizationId,
+          userId,
+        );
+        if (defaultUserLimit) allLimits.push(defaultUserLimit);
+      }
+    }
+    allLimits.push(...(await this.evaluateEntityLimits("agent", agentId)));
+    
+    if (agentTeamIds.length > 0) {
+      const teams = await db
+        .select()
+        .from(schema.teamsTable)
+        .where(inArray(schema.teamsTable.id, agentTeamIds));
+      for (const team of teams) {
+        allLimits.push(...(await this.evaluateEntityLimits("team", team.id)));
+      }
+      if (organizationId) {
+        allLimits.push(
+          ...(await this.evaluateEntityLimits("organization", organizationId)),
+        );
+      }
+    }
+
+    if (allLimits.length === 0) return null;
+
+    // Find the most constraining (highest usage ratio or smallest remaining / limit value)
+    return allLimits.reduce((mostConstraining, current) => {
+      const currentRatio = current.limitValue > 0 ? current.currentUsage / current.limitValue : Infinity;
+      const mostRatio = mostConstraining.limitValue > 0 ? mostConstraining.currentUsage / mostConstraining.limitValue : Infinity;
+      return currentRatio > mostRatio ? current : mostConstraining;
+    }, allLimits[0]);
+  }
+
+  private static async evaluateEntityLimits(
+    entityType: LimitEntityType,
+    entityId: string,
+  ): Promise<ConstrainingLimitResult[]> {
+    try {
+      const limits = await LimitModel.findLimitsForValidation(
+        entityType,
+        entityId,
+        "token_cost",
+      );
+      const results: ConstrainingLimitResult[] = [];
+
+      for (const limit of limits) {
+        let comparisonValue = 0;
+
+        if (limit.limitType === "token_cost") {
+          const modelUsages = await db
+            .select()
+            .from(schema.limitModelUsageTable)
+            .where(eq(schema.limitModelUsageTable.limitId, limit.id));
+
+          if (modelUsages.length > 0) {
+            const usageCosts = await calculateModelUsageCosts(modelUsages);
+            comparisonValue = usageCosts.cost;
+          }
+        }
+
+        let resetsAt: Date | null = null;
+        if (limit.lastCleanup && limit.cleanupInterval) {
+          const msMapping: Record<LimitCleanupInterval, number> = {
+            "1h": 60 * 60 * 1000,
+            "12h": 12 * 60 * 60 * 1000,
+            "24h": 24 * 60 * 60 * 1000,
+            "1w": 7 * 24 * 60 * 60 * 1000,
+            "1m": 30 * 24 * 60 * 60 * 1000,
+          };
+          resetsAt = new Date(
+            limit.lastCleanup.getTime() + (msMapping[limit.cleanupInterval] ?? 0),
+          );
+        }
+
+        results.push({
+          isDefaultUserLimit: false,
+          limitType: limit.limitType,
+          entityType: limit.entityType,
+          entityId: limit.entityId,
+          limitValue: limit.limitValue,
+          currentUsage: comparisonValue,
+          remainingUsage: Math.max(0, limit.limitValue - comparisonValue),
+          resetsAt,
+          models: limit.model,
+        });
+      }
+
+      return results;
+    } catch (error) {
+      logger.error(`[LimitValidation] Error evaluating entity limits: ${error}`);
+      return [];
+    }
+  }
+
+  private static async evaluateDefaultUserLimitForContext(
+    organizationId: string,
+    userId: string,
+  ): Promise<ConstrainingLimitResult | null> {
+    try {
+      const [organization] = await db
+        .select({
+          defaultUserLimitValue: schema.organizationsTable.defaultUserLimitValue,
+          defaultUserLimitModel: schema.organizationsTable.defaultUserLimitModel,
+          defaultUserLimitCleanupInterval: schema.organizationsTable.defaultUserLimitCleanupInterval,
+        })
+        .from(schema.organizationsTable)
+        .where(eq(schema.organizationsTable.id, organizationId))
+        .limit(1);
+
+      if (!organization?.defaultUserLimitValue) return null;
+
+      const customUserLimits = await LimitModel.findLimitsForValidation(
+        "user",
+        userId,
+        "token_cost",
+      );
+      if (customUserLimits.length > 0) return null;
+
+      const usage = await getDefaultUserLimitUsage({
+        organizationId,
+        userId,
+        models: normalizeLimitModels(organization.defaultUserLimitModel),
+        cleanupInterval: organization.defaultUserLimitCleanupInterval ?? "1w",
+      });
+
+      return {
+        isDefaultUserLimit: true,
+        limitType: "token_cost",
+        entityType: "user",
+        entityId: userId,
+        limitValue: organization.defaultUserLimitValue,
+        currentUsage: usage.cost,
+        remainingUsage: Math.max(0, organization.defaultUserLimitValue - usage.cost),
+        resetsAt: null,
+        models: normalizeLimitModels(organization.defaultUserLimitModel),
+      };
+    } catch (error) {
+      logger.error(`[LimitValidation] Error evaluating default user limit: ${error}`);
       return null;
     }
   }
@@ -1185,6 +1367,10 @@ function buildLimitViolationResponse(params: {
   limitDescription: "tokens" | "cost_dollars";
   totalTokensIn: number;
   totalTokensOut: number;
+  limitInfo?: {
+    lastCleanup: Date | null;
+    cleanupInterval: string | null;
+  };
 }): [string, string] {
   const totalTokens = params.totalTokensIn + params.totalTokensOut;
   const remaining = Math.max(0, params.limitValue - params.comparisonValue);
@@ -1195,6 +1381,38 @@ function buildLimitViolationResponse(params: {
 <archestra-limit-current-usage>${totalTokens}</archestra-limit-current-usage>
 <archestra-limit-value>${params.limitValue}</archestra-limit-value>
 <archestra-limit-remaining>${Math.max(0, params.limitValue - totalTokens)}</archestra-limit-remaining>`;
+
+  let waitString = "for limit resets";
+  if (params.limitInfo?.lastCleanup && params.limitInfo?.cleanupInterval) {
+    const last = params.limitInfo.lastCleanup.getTime();
+    let ms = 0;
+    switch (params.limitInfo.cleanupInterval) {
+      case "1h": ms = 60 * 60 * 1000; break;
+      case "12h": ms = 12 * 60 * 60 * 1000; break;
+      case "24h": ms = 24 * 60 * 60 * 1000; break;
+      case "1w": ms = 7 * 24 * 60 * 60 * 1000; break;
+      case "1m": ms = 30 * 24 * 60 * 60 * 1000; break;
+    }
+    if (ms) {
+      const nextReset = last + ms;
+      const now = Date.now();
+      if (nextReset <= now) {
+        waitString = "soon";
+      } else {
+        const diffMs = nextReset - now;
+        const diffDays = Math.floor(diffMs / (24 * 60 * 60 * 1000));
+        if (diffDays > 0) waitString = `${diffDays}d`;
+        else {
+          const diffHours = Math.floor(diffMs / (60 * 60 * 1000));
+          if (diffHours > 0) waitString = `${diffHours}h`;
+          else {
+            const diffMins = Math.floor(diffMs / (60 * 1000));
+            waitString = `${diffMins}m`;
+          }
+        }
+      }
+    }
+  }
 
   const contentMessage =
     params.limitDescription === "cost_dollars"

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -482,6 +482,29 @@ export async function handleLLMProxy<
       `[${providerName}Proxy] Limit check passed`,
     );
 
+    const constrainingLimit = await LimitValidationService.getMostConstrainingLimit({
+      agentId: resolvedAgentId,
+      userId,
+      virtualKeyId,
+    });
+    
+    const limitHeaders: Record<string, string> = {};
+    if (constrainingLimit) {
+      if (constrainingLimit.models) {
+        limitHeaders["X-Archestra-Limit-Models"] = JSON.stringify(constrainingLimit.models);
+      }
+      limitHeaders["X-Archestra-Limit-Scope"] = constrainingLimit.entityType;
+      limitHeaders["X-Archestra-Limit-Value"] = constrainingLimit.limitValue.toString();
+      limitHeaders["X-Archestra-Limit-Remaining"] = constrainingLimit.remainingUsage.toString();
+      if (constrainingLimit.resetsAt) {
+        limitHeaders["X-Archestra-Limit-Resets-At"] = constrainingLimit.resetsAt.toISOString();
+      }
+    }
+    
+    if (!requestAdapter.isStreaming()) {
+      reply.headers(limitHeaders);
+    }
+
     // Persist tools declared by client (only for llm_proxy agents)
     if (resolvedAgent.agentType === "llm_proxy") {
       const tools = requestAdapter.getTools();
@@ -553,6 +576,7 @@ export async function handleLLMProxy<
         `[${providerName}Proxy] Preparing streaming response headers (lazy commit)`,
       );
       sseHeaders = streamAdapter.getSSEHeaders();
+      Object.assign(sseHeaders, limitHeaders);
     }
 
     // Helper to commit SSE headers before the first write.

--- a/platform/backend/src/types/limit.ts
+++ b/platform/backend/src/types/limit.ts
@@ -157,3 +157,15 @@ export const LimitWithUsageSchema = SelectLimitSchema.extend({
 });
 
 export type LimitWithUsage = z.infer<typeof LimitWithUsageSchema>;
+
+export interface ConstrainingLimitResult {
+  isDefaultUserLimit: boolean;
+  limitType: LimitType;
+  entityType: LimitEntityType;
+  entityId: string;
+  limitValue: number;
+  currentUsage: number;
+  remainingUsage: number;
+  resetsAt: Date | null;
+  models: string[] | null;
+}

--- a/platform/frontend/src/app/agents/page.client.tsx
+++ b/platform/frontend/src/app/agents/page.client.tsx
@@ -43,6 +43,7 @@ import { useAppName } from "@/lib/hooks/use-app-name";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
 import { useTeams } from "@/lib/teams/team.query";
 import { AgentActions } from "./agent-actions";
+import { LimitUsageDisplay } from "@/components/limits/limit-usage-display";
 
 type AgentsInitialData = {
   agents: archestraApiTypes.GetAgentsResponses["200"] | null;
@@ -398,6 +399,16 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
         ).length;
         return <div>{subagentsCount}</div>;
       },
+    },
+    {
+      id: "usage",
+      header: "Usage",
+      cell: ({ row }) => (
+        <LimitUsageDisplay
+          entityType="agent"
+          entityId={row.original.id}
+        />
+      ),
     },
     ...(isAgentAdmin
       ? [

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -2231,6 +2231,7 @@ export function ChatPageContent({
                           onResetModelOverride={
                             handleConversationResetModelOverride
                           }
+                          limitContext={chatSession?.limitContext}
                         />
                         <div className="text-center">
                           <Version inline />

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -46,6 +46,63 @@ import {
   parseSkillCommand,
   type SkillCommand,
 } from "./skill-commands";
+import { Progress } from "@/components/ui/progress";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+function formatCurrencyWhole(value: number) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function LimitProgressBar({
+  limitContext,
+}: {
+  limitContext: ArchestraPromptInputProps["limitContext"];
+}) {
+  if (!limitContext) return null;
+
+  const actualUsage = limitContext.limitValue - limitContext.remainingUsage;
+  const percentage = Math.min((actualUsage / limitContext.limitValue) * 100, 100);
+  const status =
+    percentage >= 90 ? "danger" : percentage >= 75 ? "warning" : "safe";
+
+  return (
+    <div className="absolute top-0 inset-x-0 -mt-1 px-4 z-10 opacity-70 hover:opacity-100 transition-opacity">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="w-full cursor-default py-1">
+            <Progress
+              value={percentage}
+              className={cn(
+                "h-1 rounded-sm",
+                status === "danger"
+                  ? "bg-red-100 [&>div]:bg-red-500"
+                  : status === "warning"
+                    ? "bg-orange-100 [&>div]:bg-orange-500"
+                    : undefined
+              )}
+            />
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          <p className="text-xs">
+            Usage: {formatCurrencyWhole(actualUsage)} /{" "}
+            {formatCurrencyWhole(limitContext.limitValue)} ({percentage.toFixed(1)}%)
+            <br />
+            Scope: {limitContext.entityType}
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}
 
 const CHAT_ATTACHMENT_MAX_BYTES = 50 * 1024 * 1024;
 const CHAT_ATTACHMENT_MAX_MB = CHAT_ATTACHMENT_MAX_BYTES / (1024 * 1024);
@@ -70,6 +127,13 @@ export interface ArchestraPromptInputProps
   onCompactConversation?: () => Promise<void> | void;
   /** Whether Playwright setup overlay is visible (for showing Playwright install dialog) */
   isPlaywrightSetupVisible: boolean;
+  limitContext?: {
+    limitValue: number;
+    remainingUsage: number;
+    entityType: string;
+    models: string[] | null;
+    resetsAt: string | null;
+  } | null;
 }
 
 type SlashCommand = {
@@ -115,6 +179,7 @@ const PromptInputContent = ({
   onAgentChange,
   modelSource,
   onResetModelOverride,
+  limitContext,
 }: Omit<ArchestraPromptInputProps, "onSubmit"> & {
   onSubmit: ArchestraPromptInputProps["onSubmit"];
 }) => {
@@ -497,6 +562,7 @@ const PromptInputContent = ({
         maxFileSize={CHAT_ATTACHMENT_MAX_BYTES}
         onError={handleFileError}
       >
+        <LimitProgressBar limitContext={limitContext} />
         {/* File attachments display - shown inline above textarea */}
         <PromptInputAttachments className="px-3 pt-2 pb-0">
           {(attachment) => <PromptInputAttachment data={attachment} />}
@@ -599,6 +665,7 @@ const ArchestraPromptInput = ({
   onAgentChange,
   modelSource,
   onResetModelOverride,
+  limitContext,
 }: ArchestraPromptInputProps) => {
   const handleProviderFileError = useCallback(
     (err: {
@@ -650,6 +717,7 @@ const ArchestraPromptInput = ({
           onAgentChange={onAgentChange}
           modelSource={modelSource}
           onResetModelOverride={onResetModelOverride}
+          limitContext={limitContext}
         />
       </PromptInputProvider>
     </div>

--- a/platform/frontend/src/app/llm/(costs)/limits/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.tsx
@@ -4,6 +4,7 @@ import type { archestraApiTypes } from "@shared";
 import type { ColumnDef } from "@tanstack/react-table";
 import {
   Building2,
+  Clock,
   Edit,
   Key,
   Network,
@@ -156,6 +157,31 @@ function formatCurrencyWhole(value: number) {
 function formatNumericInput(value: string) {
   if (!value) return "";
   return Number(value).toLocaleString("en-US");
+}
+
+function getResetsInText(limit: LimitData) {
+  if (!limit.lastCleanup || !limit.cleanupInterval) return null;
+  const last = new Date(limit.lastCleanup as string).getTime();
+  let ms = 0;
+  switch (limit.cleanupInterval) {
+    case "1h": ms = 60 * 60 * 1000; break;
+    case "12h": ms = 12 * 60 * 60 * 1000; break;
+    case "24h": ms = 24 * 60 * 60 * 1000; break;
+    case "1w": ms = 7 * 24 * 60 * 60 * 1000; break;
+    case "1m": ms = 30 * 24 * 60 * 60 * 1000; break;
+  }
+  if (!ms) return null;
+  const nextReset = last + ms;
+  const now = Date.now();
+  if (nextReset <= now) return "soon";
+  
+  const diffMs = nextReset - now;
+  const diffDays = Math.floor(diffMs / (24 * 60 * 60 * 1000));
+  if (diffDays > 0) return `${diffDays}d`;
+  const diffHours = Math.floor(diffMs / (60 * 60 * 1000));
+  if (diffHours > 0) return `${diffHours}h`;
+  const diffMins = Math.floor(diffMs / (60 * 1000));
+  return `${diffMins}m`;
 }
 
 export default function LimitsPage() {
@@ -503,8 +529,27 @@ export default function LimitsPage() {
         minSize: 160,
         cell: ({ row }) => {
           const usage = getUsageStatus(row.original);
+          const resetsInText = getResetsInText(row.original);
           return (
             <div className="w-[180px]">
+              <div className="mb-1 flex items-center justify-between">
+                <span className="text-xs text-muted-foreground">
+                  {`${formatCurrencyWhole(usage.actualUsage)} / ${formatCurrencyWhole(usage.actualLimit)}`}
+                </span>
+                {resetsInText && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Badge variant="outline" className="text-[10px] h-5 px-1 py-0 font-normal cursor-default flex items-center gap-1">
+                        <Clock className="h-3 w-3" />
+                        {resetsInText}
+                      </Badge>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Resets in {resetsInText}
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+              </div>
               <Progress
                 value={Math.min(usage.percentage, 100)}
                 className={
@@ -515,9 +560,6 @@ export default function LimitsPage() {
                       : undefined
                 }
               />
-              <p className="mt-1 text-left text-xs text-muted-foreground">
-                {`${formatCurrencyWhole(usage.actualUsage)} / ${formatCurrencyWhole(usage.actualLimit)} (${usage.percentage.toFixed(1)}%)`}
-              </p>
             </div>
           );
         },

--- a/platform/frontend/src/app/llm/credentials/virtual-keys/page.tsx
+++ b/platform/frontend/src/app/llm/credentials/virtual-keys/page.tsx
@@ -60,6 +60,18 @@ import {
   useUpdateVirtualApiKey,
 } from "@/lib/virtual-api-keys.query";
 import { useSetCredentialsAction } from "../layout";
+import { LimitUsageDisplay } from "@/components/limits/limit-usage-display";
+import {
+  LimitFormSection,
+  useEntityLimitFormState,
+  saveEntityLimit,
+  type LimitFormValues,
+} from "@/components/limits/limit-form-section";
+import {
+  useCreateLimit,
+  useUpdateLimit,
+  useDeleteLimit,
+} from "@/lib/limits.query";
 
 type VirtualKeyWithParent =
   archestraApiTypes.GetAllVirtualApiKeysResponses["200"]["data"][number];
@@ -154,6 +166,16 @@ export default function VirtualKeysPage() {
           <span className="text-sm text-muted-foreground">
             {formatProviderKeySummary(row.original.providerApiKeys)}
           </span>
+        ),
+      },
+      {
+        id: "usage",
+        header: "Usage",
+        cell: ({ row }) => (
+          <LimitUsageDisplay
+            entityType="virtual_key"
+            entityId={row.original.id}
+          />
         ),
       },
       {
@@ -348,6 +370,9 @@ function CreateVirtualKeyDialog({
   canReadTeams: boolean;
 }) {
   const createMutation = useCreateVirtualApiKey();
+  const createLimit = useCreateLimit();
+  const updateLimit = useUpdateLimit();
+  const deleteLimit = useDeleteLimit();
 
   const [newKeyName, setNewKeyName] = useState("");
   const [expiresAt, setExpiresAt] = useState<Date | null>(null);
@@ -362,6 +387,13 @@ function CreateVirtualKeyDialog({
   const [createdKeyExpiresAt, setCreatedKeyExpiresAt] = useState<Date | null>(
     null,
   );
+  const [limitValues, setLimitValues] = useState<LimitFormValues>({
+    enabled: false,
+    limitValue: "",
+    cleanupInterval: "24h",
+    isAllModels: true,
+    models: [],
+  });
 
   const prevOpenRef = useRef(open);
 
@@ -376,6 +408,13 @@ function CreateVirtualKeyDialog({
       setScope(getDefaultVirtualKeyScope(visibilityOptions));
       setTeamIds([]);
       setProviderApiKeyIds({});
+      setLimitValues({
+        enabled: false,
+        limitValue: "",
+        cleanupInterval: "24h",
+        isAllModels: true,
+        models: [],
+      });
     }
   }, [open, defaultExpirationSeconds, visibilityOptions]);
 
@@ -393,6 +432,16 @@ function CreateVirtualKeyDialog({
           providerApiKeys,
         },
       });
+      if (result?.id) {
+        await saveEntityLimit({
+          entityId: result.id,
+          entityType: "virtual_key",
+          limitValues,
+          createLimit,
+          updateLimit,
+          deleteLimit,
+        });
+      }
       setNewKeyName("");
       if (result?.value) {
         setCreatedKeyValue(result.value);
@@ -408,6 +457,10 @@ function CreateVirtualKeyDialog({
     newKeyName,
     scope,
     teamIds,
+    limitValues,
+    createLimit,
+    updateLimit,
+    deleteLimit,
   ]);
 
   return (
@@ -484,6 +537,12 @@ function CreateVirtualKeyDialog({
                 onProviderApiKeyIdsChange={setProviderApiKeyIds}
                 providerApiKeys={parentableKeys}
               />
+
+              <LimitFormSection
+                values={limitValues}
+                onChange={setLimitValues}
+                entityTypeName="virtual key"
+              />
             </>
           )}
         </DialogBody>
@@ -535,6 +594,10 @@ function EditVirtualKeyDialog({
   canReadTeams: boolean;
 }) {
   const updateMutation = useUpdateVirtualApiKey();
+  const createLimit = useCreateLimit();
+  const updateLimit = useUpdateLimit();
+  const deleteLimit = useDeleteLimit();
+
   const [name, setName] = useState("");
   const [expiresAt, setExpiresAt] = useState<Date | null>(null);
   const [scope, setScope] = useState<VirtualKeyScope>(
@@ -544,6 +607,15 @@ function EditVirtualKeyDialog({
   const [providerApiKeyIds, setProviderApiKeyIds] = useState<ProviderApiKeyMap>(
     {},
   );
+  const [limitValues, setLimitValues] = useState<LimitFormValues>({
+    enabled: false,
+    limitValue: "",
+    cleanupInterval: "24h",
+    isAllModels: true,
+    models: [],
+  });
+
+  useEntityLimitFormState("virtual_key", virtualKey?.id, setLimitValues);
 
   useEffect(() => {
     if (!open || !virtualKey) {
@@ -586,6 +658,14 @@ function EditVirtualKeyDialog({
       });
 
       if (result) {
+        await saveEntityLimit({
+          entityId: virtualKey.id,
+          entityType: "virtual_key",
+          limitValues,
+          createLimit,
+          updateLimit,
+          deleteLimit,
+        });
         onOpenChange(false);
       }
     } catch {
@@ -600,6 +680,10 @@ function EditVirtualKeyDialog({
     teamIds,
     updateMutation,
     virtualKey,
+    limitValues,
+    createLimit,
+    updateLimit,
+    deleteLimit,
   ]);
 
   if (!virtualKey) {
@@ -654,6 +738,12 @@ function EditVirtualKeyDialog({
             providerApiKeyIds={providerApiKeyIds}
             onProviderApiKeyIdsChange={setProviderApiKeyIds}
             providerApiKeys={providerApiKeys}
+          />
+
+          <LimitFormSection
+            values={limitValues}
+            onChange={setLimitValues}
+            entityTypeName="virtual key"
           />
         </DialogBody>
         <DialogStickyFooter className="mt-0">

--- a/platform/frontend/src/app/llm/proxies/page.client.tsx
+++ b/platform/frontend/src/app/llm/proxies/page.client.tsx
@@ -38,6 +38,7 @@ import { getFrontendDocsUrl } from "@/lib/docs/docs";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
 import { useTeams } from "@/lib/teams/team.query";
 import { LlmProxyActions } from "./llm-proxy-actions";
+import { LimitUsageDisplay } from "@/components/limits/limit-usage-display";
 
 type LlmProxiesInitialData = {
   agents: archestraApiTypes.GetAgentsResponses["200"] | null;
@@ -273,6 +274,16 @@ function LlmProxies({ initialData }: { initialData?: LlmProxiesInitialData }) {
           />
         );
       },
+    },
+    {
+      id: "usage",
+      header: "Usage",
+      cell: ({ row }) => (
+        <LimitUsageDisplay
+          entityType="agent"
+          entityId={row.original.id}
+        />
+      ),
     },
     ...(isAdmin
       ? [

--- a/platform/frontend/src/app/settings/account/page.tsx
+++ b/platform/frontend/src/app/settings/account/page.tsx
@@ -10,6 +10,7 @@ import { useSetSettingsAction } from "@/app/settings/layout";
 import { LoadingSpinner } from "@/components/loading";
 import { PersonalTokenCard } from "@/components/settings/personal-token-card";
 import { RolePermissionsCard } from "@/components/settings/role-permissions-card";
+import { UserLimitsCard } from "@/components/settings/user-limits-card";
 import { SettingsSectionStack } from "@/components/settings/settings-block";
 import { Button } from "@/components/ui/button";
 import { usePublicConfig } from "@/lib/config/config.query";
@@ -51,6 +52,7 @@ function AccountSettingsContent() {
     <>
       <SettingsSectionStack>
         <RolePermissionsCard />
+        <UserLimitsCard />
         <PersonalTokenCard />
         {organization?.showTwoFactor && (
           <TwoFactorCard classNames={{ base: "w-full" }} />

--- a/platform/frontend/src/app/settings/users/page.client.tsx
+++ b/platform/frontend/src/app/settings/users/page.client.tsx
@@ -20,6 +20,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
+import { Label } from "@/components/ui/label";
 import { DialogBody, DialogStickyFooter } from "@/components/ui/dialog";
 import { PermissionButton } from "@/components/ui/permission-button";
 import { RoleSelect } from "@/components/ui/role-select";
@@ -56,6 +57,18 @@ import {
 import { useRoles } from "@/lib/role.query";
 import { cn } from "@/lib/utils";
 import { useSetSettingsAction } from "../layout";
+import { LimitUsageDisplay } from "@/components/limits/limit-usage-display";
+import {
+  LimitFormSection,
+  useEntityLimitFormState,
+  saveEntityLimit,
+  type LimitFormValues,
+} from "@/components/limits/limit-form-section";
+import {
+  useCreateLimit,
+  useUpdateLimit,
+  useDeleteLimit,
+} from "@/lib/limits.query";
 
 export default function UsersPageClient() {
   return (
@@ -213,6 +226,9 @@ function MembersTab({
   });
 
   const updateMemberRole = useUpdateMemberRole();
+  const createLimit = useCreateLimit();
+  const updateLimit = useUpdateLimit();
+  const deleteLimit = useDeleteLimit();
   const removeMember = useRemoveMember();
   const { data: signupStatus } = useMemberSignupStatus();
   const pendingSignupMembers = signupStatus?.pendingSignupMembers ?? [];
@@ -312,6 +328,22 @@ function MembersTab({
           {row.original.role}
         </Badge>
       ),
+    },
+    {
+      id: "usage",
+      header: "Usage",
+      cell: ({ row }) => {
+        const member = row.original;
+        if ("provider" in member) {
+          return <span className="text-xs text-muted-foreground">—</span>;
+        }
+        return (
+          <LimitUsageDisplay
+            entityType="user"
+            entityId={member.userId}
+          />
+        );
+      },
     },
     {
       id: "joined",
@@ -449,16 +481,25 @@ function MembersTab({
         />
       </LoadingWrapper>
 
-      {/* Change Role Dialog */}
       {changingRole && (
         <ChangeRoleDialog
           member={changingRole.member}
           open={!!changingRole}
           onOpenChange={(open) => !open && setChangingRole(null)}
-          onConfirm={async (newRole) => {
-            await updateMemberRole.mutateAsync({
-              memberId: changingRole.member.id,
-              role: newRole,
+          onConfirm={async (newRole, limitValues) => {
+            if (newRole !== changingRole.member.role) {
+              await updateMemberRole.mutateAsync({
+                memberId: changingRole.member.id,
+                role: newRole,
+              });
+            }
+            await saveEntityLimit({
+              entityId: changingRole.member.userId,
+              entityType: "user",
+              limitValues,
+              createLimit,
+              updateLimit,
+              deleteLimit,
             });
             setChangingRole(null);
           }}
@@ -546,10 +587,19 @@ function ChangeRoleDialog({
   member: Member;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onConfirm: (role: string) => void;
+  onConfirm: (role: string, limitValues: LimitFormValues) => void;
   isPending: boolean;
 }) {
   const [selectedRole, setSelectedRole] = useState(member.role);
+  const [limitValues, setLimitValues] = useState<LimitFormValues>({
+    enabled: false,
+    limitValue: "",
+    cleanupInterval: "24h",
+    isAllModels: true,
+    models: [],
+  });
+
+  useEntityLimitFormState("user", member.userId, setLimitValues);
 
   useEffect(() => {
     setSelectedRole(member.role);
@@ -559,22 +609,30 @@ function ChangeRoleDialog({
     <FormDialog
       open={open}
       onOpenChange={onOpenChange}
-      title="Change Role"
+      title="Edit User & Role"
       description={
         <>
-          Update the role for{" "}
+          Update settings for{" "}
           <span className="font-medium text-foreground">
             {member.name || member.email}
           </span>
         </>
       }
-      size="small"
+      size="medium"
     >
       <DialogBody className="space-y-4">
-        <RoleSelect
-          value={selectedRole}
-          onValueChange={setSelectedRole}
-          className="w-full"
+        <div className="space-y-2">
+          <Label>Role</Label>
+          <RoleSelect
+            value={selectedRole}
+            onValueChange={setSelectedRole}
+            className="w-full"
+          />
+        </div>
+        <LimitFormSection
+          values={limitValues}
+          onChange={setLimitValues}
+          entityTypeName="user"
         />
       </DialogBody>
       <DialogStickyFooter>
@@ -582,10 +640,10 @@ function ChangeRoleDialog({
           Cancel
         </Button>
         <Button
-          onClick={() => onConfirm(selectedRole)}
-          disabled={isPending || selectedRole === member.role}
+          onClick={() => onConfirm(selectedRole, limitValues)}
+          disabled={isPending}
         >
-          {isPending ? "Updating..." : "Update Role"}
+          {isPending ? "Saving..." : "Save Changes"}
         </Button>
       </DialogStickyFooter>
     </FormDialog>

--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -140,6 +140,17 @@ import { useAvailableLlmProviderApiKeys } from "@/lib/llm-provider-api-keys.quer
 import { useTeams } from "@/lib/teams/team.query";
 import { cn } from "@/lib/utils";
 import {
+  LimitFormSection,
+  useEntityLimitFormState,
+  saveEntityLimit,
+  type LimitFormValues,
+} from "@/components/limits/limit-form-section";
+import {
+  useCreateLimit,
+  useUpdateLimit,
+  useDeleteLimit,
+} from "@/lib/limits.query";
+import {
   getDescriptionPlaceholder,
   getNamePlaceholder,
   normalizeSuggestedPrompts,
@@ -665,6 +676,19 @@ export function AgentDialog({
     useState<ToolExposureMode>("full");
   const [isSaving, setIsSaving] = useState(false);
 
+  const createLimit = useCreateLimit();
+  const updateLimit = useUpdateLimit();
+  const deleteLimit = useDeleteLimit();
+  const [limitValues, setLimitValues] = useState<LimitFormValues>({
+    enabled: false,
+    limitValue: "",
+    cleanupInterval: "24h",
+    isAllModels: true,
+    models: [],
+  });
+
+  useEntityLimitFormState("agent", agent?.id, setLimitValues);
+
   // Determine type-specific visibility based on agentType prop
   const isInternalAgent = agentType === "agent";
   const isBuiltIn = !!agent?.builtIn;
@@ -776,6 +800,13 @@ export function AgentDialog({
         setToolExposureMode("full");
         setAutoConfigureOnToolDiscovery(false);
         setDualLlmMaxRounds("5");
+        setLimitValues({
+          enabled: false,
+          limitValue: "",
+          cleanupInterval: "24h",
+          isAllModels: true,
+          models: [],
+        });
       }
       // Reset counts when dialog opens
       setSelectedToolsCount(0);
@@ -1082,6 +1113,17 @@ export function AgentDialog({
         });
       }
 
+      if (savedAgentId && !isBuiltIn) {
+        await saveEntityLimit({
+          entityId: savedAgentId,
+          entityType: "agent",
+          limitValues,
+          createLimit,
+          updateLimit,
+          deleteLimit,
+        });
+      }
+
       // Close dialog on success
       onOpenChange(false);
     } catch (_error) {
@@ -1129,6 +1171,10 @@ export function AgentDialog({
     supportsAutomaticToolAssignment,
     deleteAgent,
     toolExposureMode,
+    limitValues,
+    createLimit,
+    updateLimit,
+    deleteLimit,
   ]);
 
   const handleClose = useCallback(() => {
@@ -1883,6 +1929,14 @@ export function AgentDialog({
                         </>
                       )}
                     </div>
+                  )}
+
+                  {!isBuiltIn && (
+                    <LimitFormSection
+                      values={limitValues}
+                      onChange={setLimitValues}
+                      entityTypeName={agentType === "llm_proxy" ? "LLM proxy" : "agent"}
+                    />
                   )}
                 </div>
               )}

--- a/platform/frontend/src/components/chat/chat-error.utils.ts
+++ b/platform/frontend/src/components/chat/chat-error.utils.ts
@@ -130,6 +130,7 @@ const BACKEND_ERROR_TYPE_TO_CODE: Record<string, ChatErrorCode> = {
   api_authorization_error: ChatErrorCode.PermissionDenied,
   api_not_found_error: ChatErrorCode.NotFound,
   api_internal_server_error: ChatErrorCode.ServerError,
+  rate_limit_exceeded: ChatErrorCode.RateLimit,
 };
 
 /**

--- a/platform/frontend/src/components/limits/limit-form-section.tsx
+++ b/platform/frontend/src/components/limits/limit-form-section.tsx
@@ -1,0 +1,191 @@
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { LimitCleanupIntervalSelect } from "@/components/limit-cleanup-interval-select";
+import { LlmModelPicker } from "@/components/llm-model-picker";
+import { useModelsWithApiKeys } from "@/lib/llm-models.query";
+import { useLimits } from "@/lib/limits.query";
+import { useMemo, useEffect } from "react";
+
+export type LimitFormValues = {
+  enabled: boolean;
+  limitValue: string;
+  cleanupInterval: string;
+  isAllModels: boolean;
+  models: string[];
+  limitId?: string;
+};
+
+export function useEntityLimitFormState(
+  entityType: string,
+  entityId: string | null | undefined,
+  setLimitValues: (values: LimitFormValues) => void
+) {
+  const { data: limits = [] } = useLimits();
+
+  useEffect(() => {
+    if (!entityId) {
+      setLimitValues({
+        enabled: false,
+        limitValue: "",
+        cleanupInterval: "24h",
+        isAllModels: true,
+        models: [],
+      });
+      return;
+    }
+
+    const entityLimit = limits.find(
+      (l) => l.entityType === entityType && l.entityId === entityId
+    );
+
+    if (entityLimit) {
+      setLimitValues({
+        enabled: true,
+        limitValue: String(entityLimit.limitValue),
+        cleanupInterval: entityLimit.cleanupInterval ?? "24h",
+        isAllModels: !entityLimit.model || entityLimit.model.length === 0,
+        models: entityLimit.model ?? [],
+        limitId: entityLimit.id,
+      });
+    } else {
+      setLimitValues({
+        enabled: false,
+        limitValue: "",
+        cleanupInterval: "24h",
+        isAllModels: true,
+        models: [],
+      });
+    }
+  }, [limits, entityType, entityId, setLimitValues]);
+}
+
+export async function saveEntityLimit({
+  entityId,
+  entityType,
+  limitValues,
+  createLimit,
+  updateLimit,
+  deleteLimit,
+}: {
+  entityId: string;
+  entityType: string;
+  limitValues: LimitFormValues;
+  createLimit: any;
+  updateLimit: any;
+  deleteLimit: any;
+}) {
+  if (limitValues.enabled) {
+    const body = {
+      entityType,
+      entityId,
+      limitType: "token_cost" as const,
+      limitValue: Number(limitValues.limitValue),
+      cleanupInterval: limitValues.cleanupInterval as any,
+      model: limitValues.isAllModels ? null : limitValues.models,
+    };
+
+    if (limitValues.limitId) {
+      await updateLimit.mutateAsync({
+        id: limitValues.limitId,
+        ...body,
+      });
+    } else {
+      await createLimit.mutateAsync(body);
+    }
+  } else if (limitValues.limitId) {
+    await deleteLimit.mutateAsync({ id: limitValues.limitId });
+  }
+}
+
+export function LimitFormSection({
+  values,
+  onChange,
+  entityTypeName,
+}: {
+  values: LimitFormValues;
+  onChange: (values: LimitFormValues) => void;
+  entityTypeName: string;
+}) {
+  const { data: modelsWithApiKeys = [] } = useModelsWithApiKeys();
+
+  const modelOptions = useMemo(
+    () =>
+      modelsWithApiKeys.map((model) => ({
+        value: model.modelId,
+        model: model.modelId,
+        provider: model.provider,
+        pricePerMillionInput: model.pricePerMillionInput ?? "0",
+        pricePerMillionOutput: model.pricePerMillionOutput ?? "0",
+      })),
+    [modelsWithApiKeys]
+  );
+
+  return (
+    <div className="space-y-4 pt-4 border-t border-border mt-4">
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id="enable-usage-limit"
+          checked={values.enabled}
+          onCheckedChange={(checked) =>
+            onChange({ ...values, enabled: !!checked })
+          }
+        />
+        <Label htmlFor="enable-usage-limit" className="font-medium cursor-pointer">
+          Enable usage limit for this {entityTypeName}
+        </Label>
+      </div>
+
+      {values.enabled && (
+        <div className="space-y-4 pl-6 border-l-2 border-primary/20 animate-in fade-in-50 duration-200">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="limit-value">Limit value ($)</Label>
+              <Input
+                id="limit-value"
+                type="number"
+                min="0"
+                step="any"
+                value={values.limitValue}
+                onChange={(e) =>
+                  onChange({ ...values, limitValue: e.target.value })
+                }
+                placeholder="100"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Reset interval</Label>
+              <LimitCleanupIntervalSelect
+                value={values.cleanupInterval as any}
+                onValueChange={(val) =>
+                  onChange({ ...values, cleanupInterval: val })
+                }
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Apply to models</Label>
+            <LlmModelPicker
+              multiple
+              sortDirection="desc"
+              value={values.isAllModels ? ["all"] : values.models}
+              onValueChange={(vals) => {
+                const isAllModels = vals.includes("all");
+                onChange({
+                  ...values,
+                  models: isAllModels ? [] : vals,
+                  isAllModels,
+                });
+              }}
+              models={modelOptions}
+              editable
+              includeAllOption
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/platform/frontend/src/components/limits/limit-usage-display.tsx
+++ b/platform/frontend/src/components/limits/limit-usage-display.tsx
@@ -1,0 +1,126 @@
+import { useLimits } from "@/lib/limits.query";
+import { Progress } from "@/components/ui/progress";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Badge } from "@/components/ui/badge";
+import { Clock } from "lucide-react";
+import Link from "next/link";
+import { useMemo } from "react";
+
+function formatCurrencyWhole(value: number) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function getResetsInText(limit: any) {
+  if (!limit.lastCleanup || !limit.cleanupInterval) return null;
+  const last = new Date(limit.lastCleanup as string).getTime();
+  let ms = 0;
+  switch (limit.cleanupInterval) {
+    case "1h": ms = 60 * 60 * 1000; break;
+    case "12h": ms = 12 * 60 * 60 * 1000; break;
+    case "24h": ms = 24 * 60 * 60 * 1000; break;
+    case "1w": ms = 7 * 24 * 60 * 60 * 1000; break;
+    case "1m": ms = 30 * 24 * 60 * 60 * 1000; break;
+  }
+  if (!ms) return null;
+  const nextReset = last + ms;
+  const now = Date.now();
+  if (nextReset <= now) return "soon";
+  
+  const diffMs = nextReset - now;
+  const diffDays = Math.floor(diffMs / (24 * 60 * 60 * 1000));
+  if (diffDays > 0) return `${diffDays}d`;
+  const diffHours = Math.floor(diffMs / (60 * 60 * 1000));
+  if (diffHours > 0) return `${diffHours}h`;
+  const diffMins = Math.floor(diffMs / (60 * 1000));
+  return `${diffMins}m`;
+}
+
+export function LimitUsageDisplay({
+  entityType,
+  entityId,
+}: {
+  entityType: string;
+  entityId: string;
+}) {
+  const { data: limits = [] } = useLimits();
+
+  const entityLimits = useMemo(() => {
+    return limits.filter(
+      (l) => l.entityType === entityType && l.entityId === entityId
+    );
+  }, [limits, entityType, entityId]);
+
+  if (entityLimits.length === 0) {
+    return <span className="text-xs text-muted-foreground">—</span>;
+  }
+
+  // Find the limit with the least remaining usage percentage (most constraining)
+  const mostConstrainingLimit = entityLimits.reduce((prev, curr) => {
+    const prevUsage = (prev.modelUsage ?? []).reduce((sum: number, u: any) => sum + u.cost, 0);
+    const currUsage = (curr.modelUsage ?? []).reduce((sum: number, u: any) => sum + u.cost, 0);
+    const prevRatio = prev.limitValue > 0 ? prevUsage / prev.limitValue : 0;
+    const currRatio = curr.limitValue > 0 ? currUsage / curr.limitValue : 0;
+    return currRatio > prevRatio ? curr : prev;
+  }, entityLimits[0]);
+
+  const actualUsage = (mostConstrainingLimit.modelUsage ?? []).reduce(
+    (sum: number, u: any) => sum + u.cost,
+    0
+  );
+  const actualLimit = mostConstrainingLimit.limitValue;
+  const percentage = actualLimit > 0 ? (actualUsage / actualLimit) * 100 : 0;
+  const status = percentage >= 90 ? "danger" : percentage >= 75 ? "warning" : "safe";
+  const resetsInText = getResetsInText(mostConstrainingLimit);
+
+  return (
+    <div className="flex flex-col gap-1 w-[160px]">
+      <div className="flex items-center justify-between text-[11px]">
+        <span className="text-muted-foreground font-mono">
+          {formatCurrencyWhole(actualUsage)} / {formatCurrencyWhole(actualLimit)}
+        </span>
+        {resetsInText && (
+          <Badge variant="outline" className="text-[9px] h-4 px-1 py-0 font-normal flex items-center gap-0.5">
+            <Clock className="h-2.5 w-2.5" />
+            {resetsInText}
+          </Badge>
+        )}
+      </div>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="w-full">
+            <Progress
+              value={Math.min(percentage, 100)}
+              className={
+                status === "danger"
+                  ? "bg-red-100 [&>div]:bg-red-500 h-1.5"
+                  : status === "warning"
+                    ? "bg-orange-100 [&>div]:bg-orange-500 h-1.5"
+                    : "h-1.5"
+              }
+            />
+          </div>
+        </TooltipTrigger>
+        <TooltipContent className="text-xs">
+          <p>
+            Usage: {formatCurrencyWhole(actualUsage)} / {formatCurrencyWhole(actualLimit)} ({percentage.toFixed(1)}%)
+          </p>
+          {entityLimits.length > 1 && (
+            <div className="mt-1.5 pt-1.5 border-t border-border flex flex-col gap-1">
+              <span className="font-semibold">{entityLimits.length} limits active</span>
+              <Link
+                href={`/llm/limits?appliedTo=${entityType}`}
+                className="text-primary hover:underline font-medium block"
+              >
+                View all limits
+              </Link>
+            </div>
+          )}
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}

--- a/platform/frontend/src/components/settings/user-limits-card.tsx
+++ b/platform/frontend/src/components/settings/user-limits-card.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useLimits } from "@/lib/limits.query";
+import { useSession } from "@/lib/auth/auth.query";
+import { useOrganization } from "@/lib/organization.query";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Clock, Coins, Info, ShieldCheck, Zap } from "lucide-react";
+import { useMemo } from "react";
+
+function formatCurrencyWhole(value: number) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function getFriendlyInterval(interval: string | null | undefined) {
+  if (!interval) return "";
+  switch (interval) {
+    case "1h": return "hourly";
+    case "12h": return "every 12 hours";
+    case "24h": return "daily";
+    case "1w": return "weekly";
+    case "1m": return "monthly";
+    default: return `every ${interval}`;
+  }
+}
+
+function getResetsInText(limit: any) {
+  if (!limit.lastCleanup || !limit.cleanupInterval) return null;
+  const last = new Date(limit.lastCleanup as string).getTime();
+  let ms = 0;
+  switch (limit.cleanupInterval) {
+    case "1h": ms = 60 * 60 * 1000; break;
+    case "12h": ms = 12 * 60 * 60 * 1000; break;
+    case "24h": ms = 24 * 60 * 60 * 1000; break;
+    case "1w": ms = 7 * 24 * 60 * 60 * 1000; break;
+    case "1m": ms = 30 * 24 * 60 * 60 * 1000; break;
+  }
+  if (!ms) return null;
+  const nextReset = last + ms;
+  const now = Date.now();
+  if (nextReset <= now) return "soon";
+  
+  const diffMs = nextReset - now;
+  const diffDays = Math.floor(diffMs / (24 * 60 * 60 * 1000));
+  if (diffDays > 0) return `${diffDays}d`;
+  const diffHours = Math.floor(diffMs / (60 * 60 * 1000));
+  if (diffHours > 0) return `${diffHours}h`;
+  const diffMins = Math.floor(diffMs / (60 * 1000));
+  return `${diffMins}m`;
+}
+
+export function UserLimitsCard() {
+  const { data: session } = useSession();
+  const { data: organization } = useOrganization();
+  const userId = session?.user?.id;
+
+  const { data: limits = [], isLoading: isLimitsLoading } = useLimits(
+    userId ? { entityType: "user", entityId: userId } : undefined
+  );
+
+  const userLimits = useMemo(() => {
+    if (!userId) return [];
+    return limits.filter(
+      (l) => l.entityType === "user" && l.entityId === userId
+    );
+  }, [limits, userId]);
+
+  const isLoading = isLimitsLoading;
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Usage Limits</CardTitle>
+          <CardDescription>Your current spending limits and API usage.</CardDescription>
+        </CardHeader>
+        <CardContent className="h-24 flex items-center justify-center">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Clock className="h-4 w-4 animate-spin" />
+            Loading limits...
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Case 1: Direct custom user-level limits configured
+  if (userLimits.length > 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Coins className="h-5 w-5 text-primary" />
+            Personal Usage Limits
+          </CardTitle>
+          <CardDescription>
+            You have custom spending limits configured for your account.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {userLimits.map((limit) => {
+            const actualUsage = (limit.modelUsage ?? []).reduce(
+              (sum: number, u: any) => sum + u.cost,
+              0
+            );
+            const actualLimit = limit.limitValue;
+            const percentage = actualLimit > 0 ? (actualUsage / actualLimit) * 100 : 0;
+            const resetsIn = getResetsInText(limit);
+            const status = percentage >= 90 ? "danger" : percentage >= 75 ? "warning" : "safe";
+
+            return (
+              <div key={limit.id} className="space-y-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="space-y-0.5">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium">
+                        Token Spending Limit
+                      </span>
+                      {limit.model && limit.model.length > 0 ? (
+                        <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+                          {limit.model.length} model{limit.model.length > 1 ? "s" : ""}
+                        </Badge>
+                      ) : (
+                        <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+                          All models
+                        </Badge>
+                      )}
+                    </div>
+                    {limit.model && limit.model.length > 0 && (
+                      <p className="text-xs text-muted-foreground truncate max-w-md">
+                        Applies to: {limit.model.join(", ")}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {resetsIn && (
+                      <Badge variant="outline" className="text-xs font-normal flex items-center gap-1">
+                        <Clock className="h-3.5 w-3.5 text-muted-foreground" />
+                        resets in {resetsIn}
+                      </Badge>
+                    )}
+                    <span className="text-xs text-muted-foreground">
+                      Resets {getFriendlyInterval(limit.cleanupInterval)}
+                    </span>
+                  </div>
+                </div>
+
+                <div className="space-y-1.5">
+                  <div className="flex items-center justify-between text-xs font-mono">
+                    <span className="font-semibold text-foreground">
+                      {formatCurrencyWhole(actualUsage)}
+                    </span>
+                    <span className="text-muted-foreground">
+                      of {formatCurrencyWhole(actualLimit)}
+                    </span>
+                  </div>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="w-full cursor-help">
+                        <Progress
+                          value={Math.min(percentage, 100)}
+                          className={
+                            status === "danger"
+                              ? "bg-red-100 dark:bg-red-950/20 [&>div]:bg-red-500 h-2"
+                              : status === "warning"
+                                ? "bg-orange-100 dark:bg-orange-950/20 [&>div]:bg-orange-500 h-2"
+                                : "h-2"
+                          }
+                        />
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent className="text-xs">
+                      <p>
+                        Spending progress: {percentage.toFixed(1)}%
+                      </p>
+                      {limit.modelUsage && limit.modelUsage.length > 0 && (
+                        <div className="mt-2 pt-2 border-t border-border space-y-1">
+                          <p className="font-semibold">Usage by Model:</p>
+                          {limit.modelUsage.map((u: any) => (
+                            <div key={u.model} className="flex justify-between gap-4 font-mono text-[10px]">
+                              <span>{u.model}:</span>
+                              <span>{formatCurrencyWhole(u.cost)}</span>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+              </div>
+            );
+          })}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Case 2: No custom limits, but organization has default user limit configured
+  if (organization?.defaultUserLimitValue) {
+    const defaultLimitVal = organization.defaultUserLimitValue;
+    const defaultInterval = getFriendlyInterval(organization.defaultUserLimitCleanupInterval);
+    const defaultModels = organization.defaultUserLimitModel;
+
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <ShieldCheck className="h-5 w-5 text-emerald-500" />
+            Organization Default Limit
+          </CardTitle>
+          <CardDescription>
+            Your account is governed by the organization's default user limit settings.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="rounded-lg border border-border bg-muted/40 p-4">
+            <div className="flex items-start gap-3">
+              <Zap className="mt-0.5 h-5 w-5 text-amber-500 shrink-0" />
+              <div className="space-y-1 min-w-0 flex-1">
+                <p className="text-sm font-semibold leading-none">
+                  Default User Spending Cap
+                </p>
+                <div className="text-2xl font-bold font-mono tracking-tight mt-1.5">
+                  {formatCurrencyWhole(defaultLimitVal)}
+                  <span className="text-xs font-normal text-muted-foreground font-sans ml-1">
+                    {defaultInterval}
+                  </span>
+                </div>
+                {defaultModels && defaultModels.length > 0 ? (
+                  <p className="text-xs text-muted-foreground mt-2 truncate">
+                    Applies to: {defaultModels.join(", ")}
+                  </p>
+                ) : (
+                  <p className="text-xs text-muted-foreground mt-2">
+                    Applies to all LLM requests
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Info className="h-4 w-4 shrink-0 text-primary" />
+            <span>
+              If you require a higher spending limit, please contact your workspace administrator to request a custom limit override.
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Case 3: Neither custom nor default user limits are configured
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <ShieldCheck className="h-5 w-5 text-emerald-500" />
+          Usage Limits
+        </CardTitle>
+        <CardDescription>
+          No spending limits are configured for your account.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-4">
+          <div className="flex items-start gap-3">
+            <ShieldCheck className="mt-0.5 h-5 w-5 text-emerald-500 shrink-0" />
+            <div className="space-y-1">
+              <p className="text-sm font-semibold leading-none text-emerald-800 dark:text-emerald-300">
+                Unlimited Access Enabled
+              </p>
+              <p className="text-xs text-emerald-700/80 dark:text-emerald-400/80 mt-1.5">
+                You can make LLM proxy calls without any spending limits or token caps.
+              </p>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/platform/frontend/src/components/teams/teams-list.tsx
+++ b/platform/frontend/src/components/teams/teams-list.tsx
@@ -27,6 +27,17 @@ import { useTeams } from "@/lib/teams/team.query";
 import { type TeamToken, useTokens } from "@/lib/teams/team-token.query";
 import { formatRelativeTimeFromNow } from "@/lib/utils/date-time";
 import { TeamMembersDialog } from "./team-members-dialog";
+import { LimitUsageDisplay } from "@/components/limits/limit-usage-display";
+import {
+  LimitFormSection,
+  saveEntityLimit,
+  type LimitFormValues,
+} from "@/components/limits/limit-form-section";
+import {
+  useCreateLimit,
+  useUpdateLimit,
+  useDeleteLimit,
+} from "@/lib/limits.query";
 import { TokenManagerDialog } from "./token-manager-dialog";
 
 const TeamVaultFolderDialog = lazy(
@@ -74,18 +85,52 @@ export function TeamsList() {
 
   const { data: teams, isLoading } = useTeams();
 
+  const createLimit = useCreateLimit();
+  const updateLimit = useUpdateLimit();
+  const deleteLimit = useDeleteLimit();
+  const [limitValues, setLimitValues] = useState<LimitFormValues>({
+    enabled: false,
+    limitValue: "",
+    cleanupInterval: "24h",
+    isAllModels: true,
+    models: [],
+  });
+
   const createMutation = useMutation({
     mutationFn: async (data: { name: string; description?: string }) => {
-      return await archestraApiSdk.createTeam({
+      const response = await archestraApiSdk.createTeam({
         body: data,
       });
+      if (response.error) {
+        throw new Error(
+          (response.error as any)?.error?.message || "Failed to create team",
+        );
+      }
+      return response.data;
     },
-    onSuccess: () => {
+    onSuccess: async (teamData) => {
+      if (teamData?.id) {
+        await saveEntityLimit({
+          entityId: teamData.id,
+          entityType: "team",
+          limitValues,
+          createLimit,
+          updateLimit,
+          deleteLimit,
+        });
+      }
       queryClient.invalidateQueries({ queryKey: ["teams"] });
       queryClient.invalidateQueries({ queryKey: ["tokens"] });
       setCreateDialogOpen(false);
       setTeamName("");
       setTeamDescription("");
+      setLimitValues({
+        enabled: false,
+        limitValue: "",
+        cleanupInterval: "24h",
+        isAllModels: true,
+        models: [],
+      });
       toast.success("Team created successfully");
     },
     onError: (error: Error) => {
@@ -142,7 +187,16 @@ export function TeamsList() {
     setActionButton(
       <PermissionButton
         permissions={{ team: ["create"] }}
-        onClick={() => setCreateDialogOpen(true)}
+        onClick={() => {
+          setLimitValues({
+            enabled: false,
+            limitValue: "",
+            cleanupInterval: "24h",
+            isAllModels: true,
+            models: [],
+          });
+          setCreateDialogOpen(true);
+        }}
       >
         <Plus className="h-4 w-4" />
         Create Team
@@ -184,6 +238,17 @@ export function TeamsList() {
           </div>
         );
       },
+    },
+    {
+      id: "usage",
+      header: "Usage",
+      enableSorting: false,
+      cell: ({ row }) => (
+        <LimitUsageDisplay
+          entityType="team"
+          entityId={row.original.id}
+        />
+      ),
     },
     {
       id: "createdAt",
@@ -327,6 +392,12 @@ export function TeamsList() {
                 onChange={(e) => setTeamDescription(e.target.value)}
               />
             </div>
+
+            <LimitFormSection
+              values={limitValues}
+              onChange={setLimitValues}
+              entityTypeName="team"
+            />
           </div>
           <DialogStickyFooter>
             <Button

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -136,6 +136,13 @@ interface ChatSession {
   contextTokensUsed: number | null;
   contextCompaction: ContextCompactionState;
   recordContextCompaction: (compaction: ContextCompactionRecord) => void;
+  limitContext: {
+    limitValue: number;
+    remainingUsage: number;
+    entityType: string;
+    models: string[] | null;
+    resetsAt: string | null;
+  } | null;
   /** Early UI data from data-tool-ui-start events (toolCallId → resource data incl. pre-fetched HTML) */
   earlyToolUiStarts: Record<
     string,
@@ -416,6 +423,38 @@ function ChatSessionHook({
       trigger: null,
       lastCompaction: null,
     });
+  const [limitContext, setLimitContext] = useState<ChatSession["limitContext"]>(null);
+
+  const lastToastThresholdRef = useRef<number>(0);
+  useEffect(() => {
+    if (!limitContext) return;
+    const actualUsage = limitContext.limitValue - limitContext.remainingUsage;
+    const percentage = limitContext.limitValue > 0 ? (actualUsage / limitContext.limitValue) * 100 : 0;
+
+    let currentThreshold = 0;
+    if (percentage >= 100) {
+      currentThreshold = 100;
+    } else if (percentage >= 90) {
+      currentThreshold = 90;
+    } else if (percentage >= 75) {
+      currentThreshold = 75;
+    }
+
+    if (currentThreshold !== lastToastThresholdRef.current) {
+      const scopeName = limitContext.entityType.charAt(0).toUpperCase() + limitContext.entityType.slice(1);
+      if (currentThreshold === 100) {
+        toast.error(`Limit Exceeded: You have used 100% of your ${scopeName} limit.`);
+      } else if (currentThreshold === 90) {
+        toast.warning(`Limit Warning: You have used ${percentage.toFixed(0)}% of your ${scopeName} limit.`, {
+          description: "Approaching hard limit. Please wait for a reset or request an upgrade.",
+        });
+      } else if (currentThreshold === 75) {
+        toast.warning(`Limit Warning: You have used ${percentage.toFixed(0)}% of your ${scopeName} limit.`);
+      }
+      lastToastThresholdRef.current = currentThreshold;
+    }
+  }, [limitContext]);
+
   const generateTitleMutation = useGenerateConversationTitle();
   // Track if title generation has been attempted for this conversation
   const titleGenerationAttemptedRef = useRef(false);
@@ -498,6 +537,23 @@ function ChatSessionHook({
 
     experimental_throttle: 100,
     id: conversationId,
+    onResponse: (response: Response) => {
+      const limitValueStr = response.headers.get("X-Archestra-Limit-Value");
+      const limitRemainingStr = response.headers.get("X-Archestra-Limit-Remaining");
+      const limitScopeStr = response.headers.get("X-Archestra-Limit-Scope");
+      const limitModelsStr = response.headers.get("X-Archestra-Limit-Models");
+      const limitResetsAtStr = response.headers.get("X-Archestra-Limit-Resets-At");
+
+      if (limitValueStr && limitRemainingStr && limitScopeStr) {
+        setLimitContext({
+          limitValue: parseFloat(limitValueStr),
+          remainingUsage: parseFloat(limitRemainingStr),
+          entityType: limitScopeStr,
+          models: limitModelsStr ? JSON.parse(limitModelsStr) : null,
+          resetsAt: limitResetsAtStr,
+        });
+      }
+    },
     onFinish: async ({ message, isAbort }) => {
       setOptimisticToolCalls([]);
       clearActiveContextCompaction();
@@ -835,6 +891,7 @@ function ChatSessionHook({
     contextTokensUsed,
     contextCompaction,
     recordContextCompaction,
+    limitContext,
     earlyToolUiStarts,
   };
 
@@ -861,6 +918,7 @@ function ChatSessionHook({
     contextTokensUsed,
     contextCompaction,
     recordContextCompaction,
+    limitContext,
     earlyToolUiStarts,
     sessionsRef,
     notifySessionUpdate,


### PR DESCRIPTION
## Summary
Implements complete usage limits visibility enhancements for both UX and DX, resolving issue #4758 ($150 bounty).

### 1. Backend Proxy Headers & Error Refinement
*   **Most Constraining Limit Resolver**: Added `LimitValidationService.getMostConstrainingLimit` in `limit.ts` to evaluate all active limits (User, Agent, Virtual Key, Team, Organization) and resolve the one closest to its threshold.
*   **Custom Proxy Response Headers**: Updated `llm-proxy-handler.ts` to inject usage-limit metrics:
    *   `X-Archestra-Limit-Value`
    *   `X-Archestra-Limit-Remaining`
    *   `X-Archestra-Limit-Scope`
    *   `X-Archestra-Limit-Models`
    *   `X-Archestra-Limit-Resets-At`
*   **Wait Duration in Block Message**: Updated the database limit violation formatter in `LimitModel` to compute and include relative resetting durations (e.g. `Wait 6d for limit resets`) in 429 error payloads.

### 2. Global Chat UI Enhancements
*   **Dynamic Limit Cache**: Intercepted the new proxy headers inside `global-chat.context.tsx` to cache and update limit contexts dynamically.
*   **Visual Progress Indicator**: Added an inline, hoverable `LimitProgressBar` above the chat input in `prompt-input.tsx` that colors to orange (warning) at 75% usage and red (danger) at 90% usage, with detailed breakdown tooltips.
*   **Toast Notifications**: Integrated `sonner` warnings in `global-chat.context.tsx` that trigger immediately when a user's usage reaches 75%, 90%, and 100% of their limit.
*   **Inline 429 Cards**: Standardized `chat-error.utils.ts` and `inline-chat-error.tsx` to identify rate limit errors and render detailed descriptions including relative reset times.

### 3. Reusable UI Components
*   **Usage Columns**: Created `limit-usage-display.tsx` to render progress bars, remaining value tooltips, and relative reset-intervals within management tables.
*   **Form Sections**: Created `limit-form-section.tsx` to handle limit creation, editing, syncing, and deletion.

### 4. Admin Management Tables & Forms
Integrated the new limit visualization and form configurations into:
*   **Virtual Keys**: `virtual-keys/page.tsx`
*   **Users / Org Members**: `users/page.client.tsx`
*   **Agents**: `agents/page.client.tsx` & `agent-dialog.tsx`
*   **LLM Proxies**: `proxies/page.client.tsx`
*   **Teams**: `teams-list.tsx`

### 5. Account Settings Display
*   **Limits Card**: Created `user-limits-card.tsx` and mounted it in `account/page.tsx`. It displays:
    *   Spending progress bar with active resets countdown for users with custom limits.
    *   Organization's default cap and active reset intervals for default users.
    *   A themed check card stating unlimited access if no limits are configured.

---

## Verification
*   **Automated Tests**: All backend unit tests pass:
    ```bash
    ARCHESTRA_DATABASE_URL=postgres://dummy/db NODE_OPTIONS="--experimental-require-module" npx vitest run limit
    # Result: 131 passed
    ```
*   **TypeScript Checks**: Next.js frontend compiles with zero type errors:
    ```bash
    npx tsgo --noEmit
    # Result: Command completed successfully with zero errors
    ```
