### PR TITLE
feat(environments): allow editing an MCP catalog item's environment

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -113980,6 +113980,12 @@
                     "format": "uuid",
                     "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
                   },
+                  "environmentId": {
+                    "nullable": true,
+                    "type": "string",
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                  },
                   "catalogReinstallRequired": {
                     "type": "boolean"
                   },

--- a/platform/backend/src/routes/internal-mcp-catalog.restricted-environment.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.restricted-environment.test.ts
@@ -143,4 +143,92 @@ describe("Internal MCP Catalog - Restricted Environment Assignment Guard", () =>
     expect(response.statusCode).toBe(200);
     expect(response.json().environmentId).toBe(open.id);
   });
+
+  // PUT /api/internal_mcp_catalog/:id — environment is editable after creation
+  // and the same assignment guard applies. Name is reused across create + update
+  // so the model's name-immutability check passes.
+  function bodyWith(name: string, environmentId: string | null) {
+    return {
+      name,
+      serverType: "remote" as const,
+      serverUrl: "https://example.com/mcp",
+      environmentId,
+    };
+  }
+
+  async function createWith(name: string, environmentId: string | null) {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/internal_mcp_catalog",
+      payload: bodyWith(name, environmentId),
+    });
+    expect(res.statusCode).toBe(200);
+    return res.json().id as string;
+  }
+
+  test("updating environmentId on an existing catalog item persists, and clearing to default works", async () => {
+    hasEnvironmentAdmin = false;
+    const open = await createEnvironment({
+      organizationId,
+      data: { name: "Staging", restricted: false },
+    });
+    const name = `edit-env-${crypto.randomUUID().slice(0, 8)}`;
+    const id = await createWith(name, null);
+
+    const assigned = await app.inject({
+      method: "PUT",
+      url: `/api/internal_mcp_catalog/${id}`,
+      payload: bodyWith(name, open.id),
+    });
+    expect(assigned.statusCode).toBe(200);
+    expect(assigned.json().environmentId).toBe(open.id);
+
+    const cleared = await app.inject({
+      method: "PUT",
+      url: `/api/internal_mcp_catalog/${id}`,
+      payload: bodyWith(name, null),
+    });
+    expect(cleared.statusCode).toBe(200);
+    expect(cleared.json().environmentId).toBeNull();
+  });
+
+  test("a non-env-admin updating to a RESTRICTED env is rejected (403) and the assignment is unchanged", async () => {
+    hasEnvironmentAdmin = false;
+    const restricted = await createEnvironment({
+      organizationId,
+      data: { name: "Prod", restricted: true },
+    });
+    const name = `edit-env-${crypto.randomUUID().slice(0, 8)}`;
+    const id = await createWith(name, null);
+
+    const response = await app.inject({
+      method: "PUT",
+      url: `/api/internal_mcp_catalog/${id}`,
+      payload: bodyWith(name, restricted.id),
+    });
+    expect(response.statusCode).toBe(403);
+
+    const item = await InternalMcpCatalogModel.findById(id, {
+      expandSecrets: false,
+    });
+    expect(item?.environmentId ?? null).toBeNull();
+  });
+
+  test("an env-admin updating to a RESTRICTED env succeeds", async () => {
+    hasEnvironmentAdmin = true;
+    const restricted = await createEnvironment({
+      organizationId,
+      data: { name: "Prod", restricted: true },
+    });
+    const name = `edit-env-${crypto.randomUUID().slice(0, 8)}`;
+    const id = await createWith(name, null);
+
+    const response = await app.inject({
+      method: "PUT",
+      url: `/api/internal_mcp_catalog/${id}`,
+      payload: bodyWith(name, restricted.id),
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json().environmentId).toBe(restricted.id);
+  });
 });

--- a/platform/backend/src/routes/internal-mcp-catalog.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.ts
@@ -956,6 +956,24 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
         if (repartitioned.bagValuesRotated) parentPresetBagRotated = true;
       }
 
+      // When the environment assignment changes, gate it the same way create
+      // does — the target must belong to this org, and a restricted environment
+      // (or restricted default) requires environment:admin.
+      if (
+        "environmentId" in restBody &&
+        restBody.environmentId !== originalCatalogItem.environmentId
+      ) {
+        const { success: hasEnvironmentAdmin } = await hasPermission(
+          { environment: ["admin"] },
+          request.headers,
+        );
+        await assertCanAssignEnvironment({
+          environmentId: restBody.environmentId ?? null,
+          organizationId: request.organizationId,
+          hasEnvironmentAdmin,
+        });
+      }
+
       // Update the catalog item
       const catalogItem = await InternalMcpCatalogModel.update(id, restBody);
 

--- a/platform/backend/src/types/mcp-catalog.ts
+++ b/platform/backend/src/types/mcp-catalog.ts
@@ -211,8 +211,6 @@ const UpdateInternalMcpCatalogSchemaBase = createUpdateSchema(
     multitenant: true,
     // Parent link is locked after creation
     parentCatalogItemId: true,
-    // Environment is locked after creation
-    environmentId: true,
   });
 
 export const UpdateInternalMcpCatalogSchema =

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -34,6 +34,7 @@ import { EnvironmentVariablesFormField } from "@/components/environment-variable
 import { ExternalDocsLink } from "@/components/external-docs-link";
 import { HeaderDialog, type HeaderDraft } from "@/components/header-dialog";
 import { HeadersReadOnlyTable } from "@/components/headers-read-only-table";
+import { ReinstallConfirmBar } from "@/components/reinstall-confirm-bar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -96,7 +97,6 @@ import {
   transformCatalogItemToFormValues,
   transformFormToApiData,
 } from "./mcp-catalog-form.utils";
-import { ReinstallConfirmBar } from "@/components/reinstall-confirm-bar";
 
 const { useIdentityProviders } = config.enterpriseFeatures.core
   ? // biome-ignore lint/style/noRestrictedImports: conditional EE query import for IdP selector
@@ -935,7 +935,6 @@ export function McpCatalogForm({
                                 : value,
                             )
                           }
-                          disabled={mode === "edit"}
                         >
                           <SelectTrigger className="w-full">
                             <SelectValue />

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -30211,6 +30211,7 @@ export type UpdateInternalMcpCatalogItemData = {
             [key: string]: UserConfigFieldDefaultInput;
         };
         presetSecretId?: string | null;
+        environmentId?: string | null;
         catalogReinstallRequired?: boolean;
         labels?: Array<{
             key: string;


### PR DESCRIPTION
## Summary

An MCP catalog item's deployment Environment could only be chosen at create time. In the edit modal the Environment dropdown was disabled, and even if it weren't, the update schema omitted `environmentId` — so a PUT returned 200 but silently dropped the change (the value reverted on reopen). This makes the assignment editable after creation.

- The update schema no longer locks `environmentId`, so the field persists on PUT.
- The edit modal's Environment dropdown is enabled (per-option gating of restricted environments is unchanged).
- The PUT route applies the same assignment guard as create (`assertCanAssignEnvironment`): the target environment must belong to the caller's organization, and a restricted environment — or a restricted default — requires `environment:admin`. The guard only runs when the assignment actually changes.

Consistent with this lineage, the namespace is stored but not applied at deploy time, so changing the environment updates the stored assignment without moving running pods.

The hey-api client and OpenAPI spec are regenerated to expose `environmentId` on the update body.