### PR TITLE
ci(e2e): restore full-log grep for external-IdP validation in dump step

### DIFF
--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -250,6 +250,17 @@ jobs:
           echo "=== Archestra Platform Logs (main container) ==="
           kubectl logs -l app.kubernetes.io/name=archestra-platform -c archestra-platform --tail=200 2>/dev/null || true
 
+          # The external-IdP validation logs (validateExternalIdpToken /
+          # "JWKS JWT validation failed") fire mid-run, well before this dump,
+          # so --tail=200 above misses them. Grep the full backend log so a
+          # flaky JWKS-gateway 401 can be traced to the branch that rejected
+          # the token.
+          echo "=== External IdP validation (full-log grep) ==="
+          kubectl logs -l app.kubernetes.io/name=archestra-platform \
+            -c archestra-platform 2>/dev/null \
+            | grep -iE 'validateExternalIdpToken|JWKS JWT validation failed|Invalid token for this profile' \
+            || echo "(no external-IdP validation log found)"
+
           echo "=== Platform Init Container: vault-secrets ==="
           kubectl logs -l app.kubernetes.io/name=archestra-platform -c vault-secrets --tail=200 2>/dev/null || true
 
@@ -385,6 +396,17 @@ jobs:
 
           echo "=== Archestra Platform Logs (main container) ==="
           kubectl logs -l app.kubernetes.io/name=archestra-platform -c archestra-platform --tail=200 2>/dev/null || true
+
+          # The external-IdP validation logs (validateExternalIdpToken /
+          # "JWKS JWT validation failed") fire mid-run, well before this dump,
+          # so --tail=200 above misses them. Grep the full backend log so a
+          # flaky JWKS-gateway 401 can be traced to the branch that rejected
+          # the token.
+          echo "=== External IdP validation (full-log grep) ==="
+          kubectl logs -l app.kubernetes.io/name=archestra-platform \
+            -c archestra-platform 2>/dev/null \
+            | grep -iE 'validateExternalIdpToken|JWKS JWT validation failed|Invalid token for this profile' \
+            || echo "(no external-IdP validation log found)"
 
           echo "=== Platform Init Container: vault-secrets ==="
           kubectl logs -l app.kubernetes.io/name=archestra-platform -c vault-secrets --tail=200 2>/dev/null || true


### PR DESCRIPTION
## Summary

#5193 promoted the silent/`debug` null-return branches in `validateExternalIdpToken` to `warn` so a flaky JWKS-gateway `401 "Invalid token for this profile"` would finally name the branch that rejected the token. But that visibility is moot if CI never captures the line: the e2e dump step ("Show logs on failure or flaky tests") only does `kubectl logs --tail=200`, and these validation logs fire ~162s mid-run — long scrolled past the 200-line tail by dump time.

This re-adds a targeted full-backend-log grep (it existed as part of the `[idp-diag]` instrumentation and was removed alongside it in #5193) so the next flaky run records which branch rejected the token. The grep lives in the same `always()` dump step and its non-zero exit on no-match is swallowed by `|| echo`, so it cannot affect the job outcome. Markers are the durable lines that survive #5193: `validateExternalIdpToken` / `JWKS JWT validation failed` / `Invalid token for this profile`.

The `mcp-gateway-jwks.ee` test flakes on nearly every run, so the grep should produce a conclusive branch attribution within a run or two.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>