### PR TITLE
ci(e2e): force --tail=-1 on the external-IdP validation grep

### DIFF
--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -252,12 +252,13 @@ jobs:
 
           # The external-IdP validation logs (validateExternalIdpToken /
           # "JWKS JWT validation failed") fire mid-run, well before this dump,
-          # so --tail=200 above misses them. Grep the full backend log so a
+          # so the --tail=200 above misses them. Grep the full backend log so a
           # flaky JWKS-gateway 401 can be traced to the branch that rejected
-          # the token.
+          # the token. --tail=-1 is required: with a label selector, kubectl
+          # logs otherwise caps output at the last 10 lines.
           echo "=== External IdP validation (full-log grep) ==="
           kubectl logs -l app.kubernetes.io/name=archestra-platform \
-            -c archestra-platform 2>/dev/null \
+            -c archestra-platform --tail=-1 2>/dev/null \
             | grep -iE 'validateExternalIdpToken|JWKS JWT validation failed|Invalid token for this profile' \
             || echo "(no external-IdP validation log found)"
 
@@ -399,12 +400,13 @@ jobs:
 
           # The external-IdP validation logs (validateExternalIdpToken /
           # "JWKS JWT validation failed") fire mid-run, well before this dump,
-          # so --tail=200 above misses them. Grep the full backend log so a
+          # so the --tail=200 above misses them. Grep the full backend log so a
           # flaky JWKS-gateway 401 can be traced to the branch that rejected
-          # the token.
+          # the token. --tail=-1 is required: with a label selector, kubectl
+          # logs otherwise caps output at the last 10 lines.
           echo "=== External IdP validation (full-log grep) ==="
           kubectl logs -l app.kubernetes.io/name=archestra-platform \
-            -c archestra-platform 2>/dev/null \
+            -c archestra-platform --tail=-1 2>/dev/null \
             | grep -iE 'validateExternalIdpToken|JWKS JWT validation failed|Invalid token for this profile' \
             || echo "(no external-IdP validation log found)"
 


### PR DESCRIPTION
## Summary

#5202 added a full-backend-log grep to the e2e dump step so a flaky JWKS-gateway `401` would surface the `validateExternalIdpToken` branch that rejected the token. But it omitted `--tail`, and `kubectl logs -l <selector>` defaults to `--tail=10` — so the grep only ever scanned the last 10 lines of the backend log (postgres/shutdown noise by dump time) and reliably printed `(no external-IdP validation log found)`, even on a run where the `validateExternalIdpToken: JWT validated` line sat inside the sibling `--tail=200` dump directly above it.

Passing `--tail=-1` reads the whole retained backend log, so the next flaky `mcp-gateway-jwks` run records which branch returned null. The grep stays in the `always()` dump step with its no-match exit swallowed by `|| echo`, so it cannot affect the job outcome.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>