### PR TITLE
chore: add pre-push hook running codegen drift check

### DIFF
--- a/platform/.husky/pre-push
+++ b/platform/.husky/pre-push
@@ -1,0 +1,18 @@
+cd platform
+if ! pnpm codegen; then
+  echo ""
+  echo "❌ pre-push: 'pnpm codegen' failed. Fix the errors above before pushing."
+  echo ""
+  exit 1
+fi
+
+if ! git diff --quiet HEAD; then
+  echo ""
+  echo "❌ pre-push: generated code is out of date. 'pnpm codegen' produced changes:"
+  echo ""
+  git diff --stat HEAD
+  echo ""
+  echo "💡 Commit the regenerated files, then push again."
+  echo ""
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Generated artifacts in this repo — the hey-api API clients, `docs/openapi.json`, `frontend/src/app/themes.css`, and the Grafana pg-dashboard variants — are committed but derived from source. When source changes without re-running `pnpm codegen`, the committed generated code silently drifts, and reviewers/CI consume stale clients and schemas.

This adds a Husky `pre-push` hook that runs `pnpm codegen` and **aborts the push** if the working tree is dirty afterward, with a message telling the developer to commit the regenerated files. The observable effect: you can no longer push a branch whose committed generated code is out of sync with its source.

The hook lives at `platform/.husky/pre-push` and follows the existing `pre-commit` convention (`cd platform` first, since the git root is one level above the package).

## Activation caveat

The hook only fires after `pnpm prepare` has wired Husky. Because `pnpm-workspace.yaml` sets `ignoreScripts: true` (supply-chain hardening), a plain `pnpm install` does **not** run the `prepare` lifecycle script, so hooks are not auto-installed on clone — `pnpm prepare` must be run once. This is intentional: re-enabling install scripts to auto-wire Husky would reopen install-script execution for every transitive dependency.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>