### PR TITLE
fix(sandbox): recover stale dagger sessions

### DIFF
--- a/platform/archestra-rs/sandbox-core/src/backend.rs
+++ b/platform/archestra-rs/sandbox-core/src/backend.rs
@@ -9,6 +9,7 @@ use crate::{ArtifactBytes, CommandExecution, Limits, ReplayCommand, Result, Snap
 
 /// a materialise-and-run request handed to a backend. validated at the public
 /// core entry points before it reaches here.
+#[derive(Clone)]
 pub(crate) struct RunRequest {
     pub snapshots: Vec<SnapshotFile>,
     pub replay_commands: Vec<ReplayCommand>,
@@ -24,6 +25,7 @@ pub(crate) struct RunRequest {
 }
 
 /// an artifact-read request. the backend replays history, then exports `path`.
+#[derive(Clone)]
 pub(crate) struct ArtifactRequest {
     pub snapshots: Vec<SnapshotFile>,
     pub replay_commands: Vec<ReplayCommand>,

--- a/platform/archestra-rs/sandbox-core/src/backends/dagger.rs
+++ b/platform/archestra-rs/sandbox-core/src/backends/dagger.rs
@@ -9,6 +9,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use base64::Engine;
+use dagger_sdk::core::gql_client::GraphQlExtension;
+use dagger_sdk::core::graphql_client::GraphQLError;
+use dagger_sdk::errors::DaggerError;
 use dagger_sdk::{
     Config, Container, ContainerWithExecOpts, ContainerWithNewFileOpts, DaggerConn, ReturnType,
     connect_opts,
@@ -25,7 +28,7 @@ use crate::validation::{
     SKILL_SANDBOX_HOME, SKILL_SANDBOX_ROOT, SKILL_SANDBOX_USER, format_artifact_error, shell_quote,
     skill_root_path, validate_artifact_path, validate_cwd, validate_snapshot_file_path,
 };
-use crate::{ArtifactBytes, CommandExecution, Result, SandboxError, SnapshotFile};
+use crate::{ArtifactBytes, CommandExecution, EngineFault, Result, SandboxError, SnapshotFile};
 
 /// debian + python + uv + node + npm + common cli, warmed once per process.
 /// override with `ARCHESTRA_DAGGER_RUNTIME_IMAGE` for a custom debian-based base.
@@ -52,6 +55,9 @@ const DEFAULT_VENV_PYTHON: &str = "/home/sandbox/.venv/bin/python";
 const DEFAULT_PYTHON_REQUIREMENTS: &[&str] = &["numpy", "pandas", "httpx"];
 
 const SESSION_READY_TIMEOUT: Duration = Duration::from_secs(60);
+/// the dagger SDK message emitted when the engine accepted `/query` but timed
+/// out waiting for this client's session attachables. see [`classify_engine_fault`].
+const SESSION_ATTACHABLES_WAIT_ERROR: &str = "waiting for client session attachables";
 
 const ARTIFACT_TOO_LARGE_EXIT_CODE: isize = 65;
 const ARTIFACT_NOT_FOUND_EXIT_CODE: isize = 66;
@@ -262,7 +268,12 @@ pub(crate) async fn spawn() -> Result<Arc<SessionHandle>> {
         if let Err(err) = result
             && let Some(tx) = fail_tx.take()
         {
-            let _ = tx.send(SandboxError::engine(err));
+            // a `ConnectError` is a connection/shutdown failure, never a
+            // per-session attachables timeout, so it is always plain unreachable.
+            let _ = tx.send(SandboxError::EngineUnreachable {
+                message: err.to_string(),
+                fault: EngineFault::Unreachable,
+            });
         }
     });
 
@@ -272,19 +283,22 @@ pub(crate) async fn spawn() -> Result<Arc<SessionHandle>> {
                 tracing::info!("dagger session ready");
                 Ok(Arc::new(SessionHandle::new(msg_tx)))
             }
-            Err(_) => Err(SandboxError::EngineUnreachable(
-                "the Dagger session task exited before reporting ready".to_string(),
-            )),
+            Err(_) => Err(SandboxError::EngineUnreachable {
+                message: "the Dagger session task exited before reporting ready".to_string(),
+                fault: EngineFault::Unreachable,
+            }),
         },
         failure = fail_rx => match failure {
             Ok(err) => Err(err),
-            Err(_) => Err(SandboxError::EngineUnreachable(
-                "the Dagger session failed without a diagnostic".to_string(),
-            )),
+            Err(_) => Err(SandboxError::EngineUnreachable {
+                message: "the Dagger session failed without a diagnostic".to_string(),
+                fault: EngineFault::Unreachable,
+            }),
         },
-        _ = tokio::time::sleep(SESSION_READY_TIMEOUT) => Err(SandboxError::EngineUnreachable(
-            format!("the Dagger session did not become ready within {}s", SESSION_READY_TIMEOUT.as_secs()),
-        )),
+        _ = tokio::time::sleep(SESSION_READY_TIMEOUT) => Err(SandboxError::EngineUnreachable {
+            message: format!("the Dagger session did not become ready within {}s", SESSION_READY_TIMEOUT.as_secs()),
+            fault: EngineFault::Unreachable,
+        }),
     }
 }
 
@@ -331,7 +345,7 @@ async fn build_warm_base(client: &DaggerConn) -> Result<Container> {
         .with_exec(vec!["sh".to_string(), "-c".to_string(), user_setup])
         .sync()
         .await
-        .map_err(SandboxError::engine)
+        .map_err(engine)
         .map(|id| client.load_container_from_id(id))
         .inspect(|_| tracing::info!("warm base image ready"))
         .inspect_err(|err| tracing::warn!(error = %err, "warm base image build failed"))
@@ -447,12 +461,62 @@ fn any_exit_opts<'a>() -> ContainerWithExecOpts<'a> {
 /// errors with an embedded `exit code: N` come from a container exec that
 /// returned non-zero (kill-by-signal counts here too); everything else is a
 /// real transport/engine failure.
-fn from_sdk(error: impl std::fmt::Display) -> SandboxError {
-    let message = error.to_string();
-    match parse_sdk_exit_code(&message) {
-        Some(exit_code) => SandboxError::CommandFailed { exit_code, message },
-        None => SandboxError::EngineUnreachable(message),
+/// categorise an error returned by the dagger SDK during exec evaluation. an
+/// exec that returned non-zero (kill-by-signal counts here too) becomes a
+/// `CommandFailed`; everything else is a real transport/engine failure, tagged
+/// with the specific fault so the session layer can pick a retry policy.
+fn from_sdk(err: DaggerError) -> SandboxError {
+    match exec_exit_code(&err) {
+        Some(exit_code) => SandboxError::CommandFailed {
+            exit_code,
+            message: err.to_string(),
+        },
+        None => SandboxError::EngineUnreachable {
+            fault: classify_engine_fault(&err),
+            message: err.to_string(),
+        },
     }
+}
+
+/// build an engine-unreachable error from a non-exec SDK failure (warm-base
+/// build), classifying the fault from the typed error.
+fn engine(err: DaggerError) -> SandboxError {
+    SandboxError::EngineUnreachable {
+        fault: classify_engine_fault(&err),
+        message: err.to_string(),
+    }
+}
+
+/// the engine reports a stale-attachables timeout as a GraphQL *domain* error:
+/// the query reached the engine but it gave up waiting for this client's
+/// attachables. dagger ships no machine-readable code for it, so the message
+/// substring is the only discriminator — but we consult it only on the typed
+/// domain-error path, never on transport/build/serialize errors.
+fn classify_engine_fault(err: &DaggerError) -> EngineFault {
+    match err {
+        DaggerError::Query(GraphQLError::DomainError { message, .. })
+            if message.contains(SESSION_ATTACHABLES_WAIT_ERROR) =>
+        {
+            EngineFault::StaleAttachables
+        }
+        _ => EngineFault::Unreachable,
+    }
+}
+
+/// pull a process exit code out of the engine's typed `EXEC_ERROR` extension.
+/// falls back to scraping the message because signal-killed execs (e.g. SIGXFSZ
+/// -> 153) can surface the code only in the message even under `ReturnType::Any`.
+fn exec_exit_code(err: &DaggerError) -> Option<i32> {
+    if let DaggerError::Query(GraphQLError::DomainError { fields, .. }) = err {
+        let typed = fields.iter().find_map(|field| match &field.extensions {
+            Some(GraphQlExtension::ExecError { exit_code, .. }) => Some(*exit_code),
+            _ => None,
+        });
+        if typed.is_some() {
+            return typed;
+        }
+    }
+    parse_sdk_exit_code(&err.to_string())
 }
 
 fn parse_sdk_exit_code(message: &str) -> Option<i32> {
@@ -468,17 +532,85 @@ fn parse_sdk_exit_code(message: &str) -> Option<i32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dagger_sdk::core::gql_client::GraphQLErrorMessage;
+
+    /// a GraphQL domain error carrying `message` and an optional typed extension.
+    fn domain_error(message: &str, extension: Option<GraphQlExtension>) -> DaggerError {
+        DaggerError::Query(GraphQLError::DomainError {
+            message: message.to_string(),
+            fields: extension
+                .map(|extension| GraphQLErrorMessage {
+                    message: message.to_string(),
+                    locations: None,
+                    extensions: Some(extension),
+                    path: None,
+                })
+                .into_iter()
+                .collect(),
+        })
+    }
+
+    fn exec_error(exit_code: i32, message: &str) -> DaggerError {
+        domain_error(
+            message,
+            Some(GraphQlExtension::ExecError {
+                cmd: Vec::new(),
+                exit_code,
+                stderr: String::new(),
+                stdout: String::new(),
+            }),
+        )
+    }
 
     #[test]
-    fn from_sdk_parses_exit_code_into_command_failed() {
-        let err =
-            from_sdk("process \"/.init bash -c …\" did not complete successfully: exit code: 153");
+    fn from_sdk_reads_exit_code_from_typed_extension() {
+        let err = exec_error(153, "process did not complete successfully");
         assert!(matches!(
-            err,
+            from_sdk(err),
             SandboxError::CommandFailed { exit_code: 153, .. }
         ));
-        // a plain transport error stays as EngineUnreachable
-        let err = from_sdk("connection refused");
-        assert!(matches!(err, SandboxError::EngineUnreachable(_)));
+    }
+
+    #[test]
+    fn from_sdk_falls_back_to_message_exit_code_without_extension() {
+        // signal-killed execs can omit the extension and only embed the code.
+        let err = domain_error(
+            "process \"/.init bash -c …\" did not complete successfully: exit code: 153",
+            None,
+        );
+        assert!(matches!(
+            from_sdk(err),
+            SandboxError::CommandFailed { exit_code: 153, .. }
+        ));
+    }
+
+    #[test]
+    fn from_sdk_keeps_transport_errors_as_generic_unreachable() {
+        let err = DaggerError::Query(GraphQLError::HttpError("connection refused".to_string()));
+        assert!(matches!(
+            from_sdk(err),
+            SandboxError::EngineUnreachable {
+                fault: EngineFault::Unreachable,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn classify_engine_fault_flags_stale_attachables_only_on_domain_errors() {
+        let stale = domain_error(
+            "waiting for client session attachables: context deadline exceeded",
+            None,
+        );
+        assert_eq!(classify_engine_fault(&stale), EngineFault::StaleAttachables);
+
+        // the same phrase in a non-domain error is never treated as attachables.
+        let http = DaggerError::Query(GraphQLError::HttpError(
+            "waiting for client session attachables".to_string(),
+        ));
+        assert_eq!(classify_engine_fault(&http), EngineFault::Unreachable);
+
+        let generic = domain_error("connection reset", None);
+        assert_eq!(classify_engine_fault(&generic), EngineFault::Unreachable);
     }
 }

--- a/platform/archestra-rs/sandbox-core/src/backends/dagger.rs
+++ b/platform/archestra-rs/sandbox-core/src/backends/dagger.rs
@@ -223,6 +223,7 @@ impl SandboxBackend for DaggerBackend {
         attach_trace(traceparent.as_deref());
         // ensure_warm covers the engine-reachable + base-image-buildable invariant.
         let _ = self.ensure_warm().await?;
+        self.client.version().await.map_err(from_sdk)?;
         Ok(())
     }
 

--- a/platform/archestra-rs/sandbox-core/src/lib.rs
+++ b/platform/archestra-rs/sandbox-core/src/lib.rs
@@ -185,7 +185,11 @@ pub async fn check_session(input: CheckSessionInput) -> Result<()> {
     let span = tracing::Span::current();
     tracing_ctx::attach_parent(&span, input.traceparent.as_deref());
     let traceparent = tracing_ctx::current_traceparent(&span).or(input.traceparent);
-    session::submit(move |reply| session::SessionMsg::CheckSession { traceparent, reply }).await
+    session::submit(move |reply| session::SessionMsg::CheckSession {
+        traceparent: traceparent.clone(),
+        reply,
+    })
+    .await
 }
 
 #[tracing::instrument(
@@ -203,17 +207,18 @@ pub async fn run_sandbox(input: RunSandboxInput) -> Result<CommandExecution> {
     if let Some(pp) = input.pythonpath.as_deref() {
         validate_pythonpath(pp)?;
     }
+    let req = backend::RunRequest {
+        snapshots: input.snapshots,
+        replay_commands: input.replay_commands,
+        limits: input.limits,
+        command: input.command,
+        cwd: input.cwd,
+        timeout_seconds: input.timeout_seconds,
+        traceparent,
+        pythonpath: input.pythonpath,
+    };
     session::submit(move |reply| session::SessionMsg::Run {
-        req: backend::RunRequest {
-            snapshots: input.snapshots,
-            replay_commands: input.replay_commands,
-            limits: input.limits,
-            command: input.command,
-            cwd: input.cwd,
-            timeout_seconds: input.timeout_seconds,
-            traceparent,
-            pythonpath: input.pythonpath,
-        },
+        req: req.clone(),
         reply,
     })
     .await
@@ -229,16 +234,17 @@ pub async fn read_artifact(input: ReadArtifactInput) -> Result<ArtifactBytes> {
     if let Some(pp) = input.pythonpath.as_deref() {
         validate_pythonpath(pp)?;
     }
+    let req = backend::ArtifactRequest {
+        snapshots: input.snapshots,
+        replay_commands: input.replay_commands,
+        limits: input.limits,
+        path: input.path,
+        default_cwd: input.default_cwd,
+        traceparent,
+        pythonpath: input.pythonpath,
+    };
     session::submit(move |reply| session::SessionMsg::ReadArtifact {
-        req: backend::ArtifactRequest {
-            snapshots: input.snapshots,
-            replay_commands: input.replay_commands,
-            limits: input.limits,
-            path: input.path,
-            default_cwd: input.default_cwd,
-            traceparent,
-            pythonpath: input.pythonpath,
-        },
+        req: req.clone(),
         reply,
     })
     .await

--- a/platform/archestra-rs/sandbox-core/src/lib.rs
+++ b/platform/archestra-rs/sandbox-core/src/lib.rs
@@ -18,7 +18,13 @@ pub type Result<T> = std::result::Result<T, SandboxError>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SandboxError {
-    EngineUnreachable(String),
+    /// an engine/transport-level failure. `fault` refines *how* the session
+    /// broke so the session layer can choose a retry policy without inspecting
+    /// the message text.
+    EngineUnreachable {
+        message: String,
+        fault: EngineFault,
+    },
     /// A command inside the materialised chain returned non-zero exit and the
     /// backend refused to honour "any exit code" (typical for signal-killed
     /// processes, e.g. SIGXFSZ → exit 153). Distinct from `EngineUnreachable`
@@ -39,20 +45,30 @@ pub enum SandboxError {
     Internal(String),
 }
 
+/// refines an [`SandboxError::EngineUnreachable`] with the specific way the
+/// engine session broke. backends classify the fault at their error boundary;
+/// the session layer matches on it instead of grepping the message.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EngineFault {
+    /// a generic transport/engine failure: unreachable, timed out, or an error
+    /// we can't refine further.
+    Unreachable,
+    /// the engine accepted `/query` but couldn't find this client's session
+    /// attachables. the query never ran, so a fresh session recovers it safely
+    /// even for command-executing operations.
+    StaleAttachables,
+}
+
 impl SandboxError {
     pub fn code(&self) -> &'static str {
         match self {
-            Self::EngineUnreachable(_) => "ARCHESTRA_ENGINE_UNREACHABLE",
+            Self::EngineUnreachable { .. } => "ARCHESTRA_ENGINE_UNREACHABLE",
             Self::CommandFailed { .. } => "ARCHESTRA_COMMAND_FAILED",
             Self::ArtifactTooLarge { .. } => "ARCHESTRA_ARTIFACT_TOO_LARGE",
             Self::ArtifactNotFound { .. } => "ARCHESTRA_ARTIFACT_NOT_FOUND",
             Self::InvalidInput(_) => "ARCHESTRA_INVALID_INPUT",
             Self::Internal(_) => "ARCHESTRA_INTERNAL",
         }
-    }
-
-    pub(crate) fn engine(error: impl fmt::Display) -> Self {
-        Self::EngineUnreachable(error.to_string())
     }
 
     pub(crate) fn internal(message: impl Into<String>) -> Self {
@@ -63,7 +79,7 @@ impl SandboxError {
 impl fmt::Display for SandboxError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::EngineUnreachable(message)
+            Self::EngineUnreachable { message, .. }
             | Self::CommandFailed { message, .. }
             | Self::ArtifactTooLarge { message, .. }
             | Self::ArtifactNotFound { message, .. }

--- a/platform/archestra-rs/sandbox-core/src/session.rs
+++ b/platform/archestra-rs/sandbox-core/src/session.rs
@@ -12,7 +12,7 @@ use futures_util::future::{BoxFuture, Shared};
 use tokio::sync::{Mutex, OnceCell, Semaphore, mpsc, oneshot};
 
 use crate::backend::{ArtifactRequest, Backend, RunRequest};
-use crate::{ArtifactBytes, CommandExecution, Result, SandboxError};
+use crate::{ArtifactBytes, CommandExecution, EngineFault, Result, SandboxError};
 
 pub(crate) const CHANNEL_CAPACITY: usize = 64;
 // Rust-side cap on concurrent backend handlers. Defense in depth — the TS
@@ -20,7 +20,6 @@ pub(crate) const CHANNEL_CAPACITY: usize = 64;
 // reaches the NAPI surface directly we still want the engine protected.
 const MAX_CONCURRENT_HANDLERS: usize = 32;
 const MAX_SUBMIT_ATTEMPTS: usize = 2;
-const SESSION_ATTACHABLES_WAIT_ERROR: &str = "waiting for client session attachables";
 
 pub(crate) enum SessionMsg {
     Run {
@@ -54,6 +53,22 @@ enum SessionOperation {
     CheckSession,
 }
 
+impl SessionOperation {
+    fn as_str(self) -> &'static str {
+        match self {
+            SessionOperation::Run => "run",
+            SessionOperation::ReadArtifact => "read_artifact",
+            SessionOperation::CheckSession => "check_session",
+        }
+    }
+}
+
+/// label for retry logs, covering the pre-send acquisition failure where the
+/// operation isn't known yet.
+fn operation_label(operation: Option<SessionOperation>) -> &'static str {
+    operation.map_or("unknown", SessionOperation::as_str)
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum RetryReason {
     SessionAcquisition,
@@ -83,9 +98,13 @@ impl SessionHandle {
     }
 
     async fn send(&self, msg: SessionMsg) -> Result<()> {
-        self.tx.send(msg).await.map_err(|_| {
-            SandboxError::EngineUnreachable("the sandbox session is not running".to_string())
-        })
+        self.tx
+            .send(msg)
+            .await
+            .map_err(|_| SandboxError::EngineUnreachable {
+                message: "the sandbox session is not running".to_string(),
+                fault: EngineFault::Unreachable,
+            })
     }
 
     fn is_open(&self) -> bool {
@@ -160,45 +179,106 @@ async fn submit_with_attempts<T, F>(mut build: F, max_attempts: usize) -> Result
 where
     F: FnMut(oneshot::Sender<Result<T>>) -> SessionMsg,
 {
-    let mut attempt = 1;
-    loop {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        let handle = match current().await {
-            Ok(handle) => handle,
-            Err(err) => {
-                if attempt < max_attempts && is_engine_unreachable(&err) {
-                    log_retry(attempt, max_attempts, RetryReason::SessionAcquisition, &err);
-                    attempt += 1;
-                    continue;
+    for attempt in 1..=max_attempts {
+        match attempt_once(&mut build).await {
+            Attempt::Done(result) => {
+                if attempt > 1 && result.is_ok() {
+                    tracing::info!(attempt, "sandbox request recovered on a fresh session");
                 }
+                return result;
+            }
+            // last attempt exhausted: surface the failure that triggered the retry.
+            Attempt::Retry {
+                reason,
+                err,
+                operation,
+            } if attempt == max_attempts => {
+                tracing::warn!(
+                    attempt,
+                    max_attempts,
+                    reason = reason.as_str(),
+                    operation = operation_label(operation),
+                    error_code = err.code(),
+                    error = %err,
+                    "sandbox request failed; retries exhausted"
+                );
                 return Err(err);
             }
+            Attempt::Retry {
+                reason,
+                err,
+                operation,
+            } => log_retry(attempt, max_attempts, reason, operation, &err),
+        }
+    }
+    unreachable!("max_attempts is at least 1, so the loop always returns")
+}
+
+/// the outcome of a single submit attempt: either a terminal result to return as
+/// is, or a retryable failure tagged with why a fresh session might recover it
+/// and which operation was in flight (absent before the request is built).
+enum Attempt<T> {
+    Done(Result<T>),
+    Retry {
+        reason: RetryReason,
+        err: SandboxError,
+        operation: Option<SessionOperation>,
+    },
+}
+
+/// run one acquire -> send -> await-reply cycle. each failure stage classifies
+/// itself as retryable or terminal; the caller owns the attempt bound and logging.
+async fn attempt_once<T, F>(build: &mut F) -> Attempt<T>
+where
+    F: FnMut(oneshot::Sender<Result<T>>) -> SessionMsg,
+{
+    let (reply_tx, reply_rx) = oneshot::channel();
+    let handle = match current().await {
+        Ok(handle) => handle,
+        // the request never left, so a fresh acquire is always side-effect-free.
+        Err(err) if is_engine_unreachable(&err) => {
+            return Attempt::Retry {
+                reason: RetryReason::SessionAcquisition,
+                err,
+                operation: None,
+            };
+        }
+        Err(err) => return Attempt::Done(Err(err)),
+    };
+
+    let msg = build(reply_tx);
+    let operation = msg.operation();
+    if let Err(err) = handle.send(msg).await {
+        // the actor closed before accepting the message: drop it and retry fresh.
+        invalidate_current(&handle, &err).await;
+        return Attempt::Retry {
+            reason: RetryReason::ClosedSession,
+            err,
+            operation: Some(operation),
         };
-        let msg = build(reply_tx);
-        let operation = msg.operation();
-        if let Err(err) = handle.send(msg).await {
-            invalidate_current(&handle, &err).await;
-            if attempt < max_attempts {
-                log_retry(attempt, max_attempts, RetryReason::ClosedSession, &err);
-                attempt += 1;
-                continue;
-            }
-            return Err(err);
+    }
+
+    let result = match reply_rx.await {
+        Ok(result) => result,
+        Err(_) => {
+            return Attempt::Done(Err(SandboxError::internal(
+                "the sandbox session dropped a request before replying",
+            )));
         }
-        let result = reply_rx.await.map_err(|_| {
-            SandboxError::internal("the sandbox session dropped a request before replying")
-        })?;
-        if let Err(err) = &result {
-            invalidate_current_on_engine_error(&handle, err).await;
-            if attempt < max_attempts
-                && let Some(reason) = retry_reason(operation, err)
-            {
-                log_retry(attempt, max_attempts, reason, err);
-                attempt += 1;
-                continue;
+    };
+    match result {
+        Ok(value) => Attempt::Done(Ok(value)),
+        Err(err) => {
+            invalidate_current_on_engine_error(&handle, &err).await;
+            match retry_reason(operation, &err) {
+                Some(reason) => Attempt::Retry {
+                    reason,
+                    err,
+                    operation: Some(operation),
+                },
+                None => Attempt::Done(Err(err)),
             }
         }
-        return result;
     }
 }
 
@@ -209,24 +289,32 @@ fn retry_reason(operation: SessionOperation, err: &SandboxError) -> Option<Retry
     match (operation, err) {
         (
             SessionOperation::ReadArtifact | SessionOperation::CheckSession,
-            SandboxError::EngineUnreachable(_),
+            SandboxError::EngineUnreachable { .. },
         ) => Some(RetryReason::ReadOnlyEngineError),
         _ => None,
     }
 }
 
-fn log_retry(attempt: usize, max_attempts: usize, reason: RetryReason, err: &SandboxError) {
+fn log_retry(
+    attempt: usize,
+    max_attempts: usize,
+    reason: RetryReason,
+    operation: Option<SessionOperation>,
+    err: &SandboxError,
+) {
     tracing::warn!(
         attempt,
         max_attempts,
         reason = reason.as_str(),
+        operation = operation_label(operation),
+        error_code = err.code(),
         error = %err,
-        "retrying sandbox request with a fresh session"
+        "retrying sandbox request on a fresh session"
     );
 }
 
 async fn invalidate_current_on_engine_error(handle: &Arc<SessionHandle>, err: &SandboxError) {
-    if let SandboxError::EngineUnreachable(_) = err {
+    if let SandboxError::EngineUnreachable { .. } = err {
         invalidate_current(handle, err).await;
     }
 }
@@ -237,7 +325,7 @@ async fn invalidate_current(handle: &Arc<SessionHandle>, err: &SandboxError) {
     };
     let mut guard = slot.lock().await;
     if clear_if_current(&mut guard, handle) {
-        tracing::warn!(error = %err, "dropping stale sandbox session");
+        tracing::warn!(error_code = err.code(), error = %err, "dropping stale sandbox session");
     }
 }
 
@@ -252,16 +340,17 @@ fn clear_if_current(slot: &mut Slot, handle: &Arc<SessionHandle>) -> bool {
 }
 
 fn is_stale_attachables_error(err: &SandboxError) -> bool {
-    match err {
-        SandboxError::EngineUnreachable(message) => {
-            message.contains(SESSION_ATTACHABLES_WAIT_ERROR)
+    matches!(
+        err,
+        SandboxError::EngineUnreachable {
+            fault: EngineFault::StaleAttachables,
+            ..
         }
-        _ => false,
-    }
+    )
 }
 
 fn is_engine_unreachable(err: &SandboxError) -> bool {
-    matches!(err, SandboxError::EngineUnreachable(_))
+    matches!(err, SandboxError::EngineUnreachable { .. })
 }
 
 /// drive the actor loop over `backend` until the request channel closes. called
@@ -374,17 +463,22 @@ mod tests {
         assert!(slot.handle.is_none());
     }
 
+    fn engine_error(fault: EngineFault) -> SandboxError {
+        SandboxError::EngineUnreachable {
+            message: "engine boom".to_string(),
+            fault,
+        }
+    }
+
     #[test]
-    fn is_stale_attachables_error_requires_attachables_wait() {
-        assert!(is_stale_attachables_error(
-            &SandboxError::EngineUnreachable(
-                "failed to query dagger engine: domain error: waiting for client session attachables: context deadline exceeded"
-                    .to_string(),
-            ),
-        ));
-        assert!(!is_stale_attachables_error(
-            &SandboxError::EngineUnreachable("connection refused".to_string()),
-        ));
+    fn is_stale_attachables_error_keys_off_the_fault() {
+        assert!(is_stale_attachables_error(&engine_error(
+            EngineFault::StaleAttachables
+        )));
+        assert!(!is_stale_attachables_error(&engine_error(
+            EngineFault::Unreachable
+        )));
+        // a non-engine error never qualifies, regardless of its message.
         assert!(!is_stale_attachables_error(&SandboxError::Internal(
             "waiting for client session attachables".to_string(),
         )));
@@ -392,7 +486,7 @@ mod tests {
 
     #[test]
     fn retry_reason_is_broad_for_read_only_operations_only() {
-        let err = SandboxError::EngineUnreachable("connection reset".to_string());
+        let err = engine_error(EngineFault::Unreachable);
 
         assert_eq!(
             retry_reason(SessionOperation::ReadArtifact, &err),
@@ -407,10 +501,7 @@ mod tests {
 
     #[test]
     fn stale_attachables_retry_applies_to_run_operations() {
-        let err = SandboxError::EngineUnreachable(
-            "failed to query dagger engine: domain error: waiting for client session attachables: context deadline exceeded"
-                .to_string(),
-        );
+        let err = engine_error(EngineFault::StaleAttachables);
 
         assert_eq!(
             retry_reason(SessionOperation::Run, &err),

--- a/platform/archestra-rs/sandbox-core/src/session.rs
+++ b/platform/archestra-rs/sandbox-core/src/session.rs
@@ -19,6 +19,8 @@ pub(crate) const CHANNEL_CAPACITY: usize = 64;
 // adapter caps its own queue at a smaller value, but if any other caller ever
 // reaches the NAPI surface directly we still want the engine protected.
 const MAX_CONCURRENT_HANDLERS: usize = 32;
+const MAX_SUBMIT_ATTEMPTS: usize = 2;
+const SESSION_ATTACHABLES_WAIT_ERROR: &str = "waiting for client session attachables";
 
 pub(crate) enum SessionMsg {
     Run {
@@ -33,6 +35,42 @@ pub(crate) enum SessionMsg {
         traceparent: Option<String>,
         reply: oneshot::Sender<Result<()>>,
     },
+}
+
+impl SessionMsg {
+    fn operation(&self) -> SessionOperation {
+        match self {
+            SessionMsg::Run { .. } => SessionOperation::Run,
+            SessionMsg::ReadArtifact { .. } => SessionOperation::ReadArtifact,
+            SessionMsg::CheckSession { .. } => SessionOperation::CheckSession,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SessionOperation {
+    Run,
+    ReadArtifact,
+    CheckSession,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RetryReason {
+    SessionAcquisition,
+    ClosedSession,
+    StaleAttachables,
+    ReadOnlyEngineError,
+}
+
+impl RetryReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            RetryReason::SessionAcquisition => "session_acquisition",
+            RetryReason::ClosedSession => "closed_session",
+            RetryReason::StaleAttachables => "stale_attachables",
+            RetryReason::ReadOnlyEngineError => "read_only_engine_error",
+        }
+    }
 }
 
 pub(crate) struct SessionHandle {
@@ -113,14 +151,117 @@ async fn current() -> Result<Arc<SessionHandle>> {
 /// submit a request and await the reply.
 pub(crate) async fn submit<T, F>(build: F) -> Result<T>
 where
-    F: FnOnce(oneshot::Sender<Result<T>>) -> SessionMsg,
+    F: FnMut(oneshot::Sender<Result<T>>) -> SessionMsg,
 {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    let handle = current().await?;
-    handle.send(build(reply_tx)).await?;
-    reply_rx.await.map_err(|_| {
-        SandboxError::internal("the sandbox session dropped a request before replying")
-    })?
+    submit_with_attempts(build, MAX_SUBMIT_ATTEMPTS).await
+}
+
+async fn submit_with_attempts<T, F>(mut build: F, max_attempts: usize) -> Result<T>
+where
+    F: FnMut(oneshot::Sender<Result<T>>) -> SessionMsg,
+{
+    let mut attempt = 1;
+    loop {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let handle = match current().await {
+            Ok(handle) => handle,
+            Err(err) => {
+                if attempt < max_attempts && is_engine_unreachable(&err) {
+                    log_retry(attempt, max_attempts, RetryReason::SessionAcquisition, &err);
+                    attempt += 1;
+                    continue;
+                }
+                return Err(err);
+            }
+        };
+        let msg = build(reply_tx);
+        let operation = msg.operation();
+        if let Err(err) = handle.send(msg).await {
+            invalidate_current(&handle, &err).await;
+            if attempt < max_attempts {
+                log_retry(attempt, max_attempts, RetryReason::ClosedSession, &err);
+                attempt += 1;
+                continue;
+            }
+            return Err(err);
+        }
+        let result = reply_rx.await.map_err(|_| {
+            SandboxError::internal("the sandbox session dropped a request before replying")
+        })?;
+        if let Err(err) = &result {
+            invalidate_current_on_engine_error(&handle, err).await;
+            if attempt < max_attempts
+                && let Some(reason) = retry_reason(operation, err)
+            {
+                log_retry(attempt, max_attempts, reason, err);
+                attempt += 1;
+                continue;
+            }
+        }
+        return result;
+    }
+}
+
+fn retry_reason(operation: SessionOperation, err: &SandboxError) -> Option<RetryReason> {
+    if is_stale_attachables_error(err) {
+        return Some(RetryReason::StaleAttachables);
+    }
+    match (operation, err) {
+        (
+            SessionOperation::ReadArtifact | SessionOperation::CheckSession,
+            SandboxError::EngineUnreachable(_),
+        ) => Some(RetryReason::ReadOnlyEngineError),
+        _ => None,
+    }
+}
+
+fn log_retry(attempt: usize, max_attempts: usize, reason: RetryReason, err: &SandboxError) {
+    tracing::warn!(
+        attempt,
+        max_attempts,
+        reason = reason.as_str(),
+        error = %err,
+        "retrying sandbox request with a fresh session"
+    );
+}
+
+async fn invalidate_current_on_engine_error(handle: &Arc<SessionHandle>, err: &SandboxError) {
+    if let SandboxError::EngineUnreachable(_) = err {
+        invalidate_current(handle, err).await;
+    }
+}
+
+async fn invalidate_current(handle: &Arc<SessionHandle>, err: &SandboxError) {
+    let Some(slot) = HANDLE_SLOT.get() else {
+        return;
+    };
+    let mut guard = slot.lock().await;
+    if clear_if_current(&mut guard, handle) {
+        tracing::warn!(error = %err, "dropping stale sandbox session");
+    }
+}
+
+fn clear_if_current(slot: &mut Slot, handle: &Arc<SessionHandle>) -> bool {
+    match slot.handle.as_ref() {
+        Some(current) if Arc::ptr_eq(current, handle) => {
+            slot.handle = None;
+            true
+        }
+        _ => false,
+    }
+}
+
+fn is_stale_attachables_error(err: &SandboxError) -> bool {
+    match err {
+        SandboxError::EngineUnreachable(message) => {
+            message.contains(SESSION_ATTACHABLES_WAIT_ERROR)
+        }
+        _ => false,
+    }
+}
+
+fn is_engine_unreachable(err: &SandboxError) -> bool {
+    matches!(err, SandboxError::EngineUnreachable(_))
 }
 
 /// drive the actor loop over `backend` until the request channel closes. called
@@ -205,4 +346,75 @@ fn panic_message(payload: &(dyn Any + Send)) -> &str {
         return s.as_str();
     }
     "unknown panic payload"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clear_if_current_only_removes_matching_handle() {
+        let (first_tx, _first_rx) = mpsc::channel(1);
+        let first = Arc::new(SessionHandle::new(first_tx));
+        let (second_tx, _second_rx) = mpsc::channel(1);
+        let second = Arc::new(SessionHandle::new(second_tx));
+        let mut slot = Slot {
+            handle: Some(first.clone()),
+            spawning: None,
+        };
+
+        assert!(!clear_if_current(&mut slot, &second));
+        assert!(
+            slot.handle
+                .as_ref()
+                .is_some_and(|handle| Arc::ptr_eq(handle, &first))
+        );
+
+        assert!(clear_if_current(&mut slot, &first));
+        assert!(slot.handle.is_none());
+    }
+
+    #[test]
+    fn is_stale_attachables_error_requires_attachables_wait() {
+        assert!(is_stale_attachables_error(
+            &SandboxError::EngineUnreachable(
+                "failed to query dagger engine: domain error: waiting for client session attachables: context deadline exceeded"
+                    .to_string(),
+            ),
+        ));
+        assert!(!is_stale_attachables_error(
+            &SandboxError::EngineUnreachable("connection refused".to_string()),
+        ));
+        assert!(!is_stale_attachables_error(&SandboxError::Internal(
+            "waiting for client session attachables".to_string(),
+        )));
+    }
+
+    #[test]
+    fn retry_reason_is_broad_for_read_only_operations_only() {
+        let err = SandboxError::EngineUnreachable("connection reset".to_string());
+
+        assert_eq!(
+            retry_reason(SessionOperation::ReadArtifact, &err),
+            Some(RetryReason::ReadOnlyEngineError),
+        );
+        assert_eq!(
+            retry_reason(SessionOperation::CheckSession, &err),
+            Some(RetryReason::ReadOnlyEngineError),
+        );
+        assert_eq!(retry_reason(SessionOperation::Run, &err), None);
+    }
+
+    #[test]
+    fn stale_attachables_retry_applies_to_run_operations() {
+        let err = SandboxError::EngineUnreachable(
+            "failed to query dagger engine: domain error: waiting for client session attachables: context deadline exceeded"
+                .to_string(),
+        );
+
+        assert_eq!(
+            retry_reason(SessionOperation::Run, &err),
+            Some(RetryReason::StaleAttachables),
+        );
+    }
 }

--- a/platform/archestra-rs/sandbox-core/src/session.rs
+++ b/platform/archestra-rs/sandbox-core/src/session.rs
@@ -119,6 +119,10 @@ struct Slot {
     /// the in-flight spawn future, shared so concurrent callers all await the
     /// same connect attempt instead of serially retrying after a 60s timeout.
     spawning: Option<SharedSpawn>,
+    /// session lineage counter, bumped on every invalidation. a spawn captures it
+    /// before awaiting and installs its result only if it is still current, so a
+    /// late waiter cannot resurrect a session another caller already retired.
+    generation: u64,
 }
 
 static HANDLE_SLOT: OnceCell<Mutex<Slot>> = OnceCell::const_new();
@@ -131,13 +135,16 @@ async fn current() -> Result<Arc<SessionHandle>> {
             Mutex::new(Slot {
                 handle: None,
                 spawning: None,
+                generation: 0,
             })
         })
         .await;
 
     // pick up either the live handle or a shared in-flight spawn; release the
     // lock before awaiting so concurrent callers don't block on each other.
-    let spawn_fut = {
+    // capture the generation so the post-await install can detect a concurrent
+    // invalidation that retired this spawn's lineage.
+    let (spawn_fut, generation) = {
         let mut guard = slot.lock().await;
         if let Some(handle) = guard.handle.as_ref() {
             if handle.is_open() {
@@ -145,7 +152,7 @@ async fn current() -> Result<Arc<SessionHandle>> {
             }
             guard.handle = None;
         }
-        if let Some(s) = guard.spawning.clone() {
+        let fut = if let Some(s) = guard.spawning.clone() {
             s
         } else {
             // the one hardcoded backend-selection point.
@@ -154,17 +161,28 @@ async fn current() -> Result<Arc<SessionHandle>> {
             let shared = fut.shared();
             guard.spawning = Some(shared.clone());
             shared
-        }
+        };
+        (fut, guard.generation)
     };
 
     let result = spawn_fut.await;
 
     let mut guard = slot.lock().await;
-    guard.spawning = None;
-    if let Ok(handle) = &result {
-        guard.handle = Some(handle.clone());
-    }
+    finish_spawn(&mut guard, generation, result.as_ref().ok());
     result
+}
+
+/// install a freshly spawned handle, unless a concurrent invalidation advanced
+/// the generation while we awaited — in that case the spawn belongs to a retired
+/// lineage, so its handle is dropped and the slot is left for the new lineage.
+fn finish_spawn(slot: &mut Slot, started_generation: u64, handle: Option<&Arc<SessionHandle>>) {
+    if slot.generation != started_generation {
+        return;
+    }
+    slot.spawning = None;
+    if let Some(handle) = handle {
+        slot.handle = Some(handle.clone());
+    }
 }
 
 /// submit a request and await the reply.
@@ -283,14 +301,19 @@ where
 }
 
 fn retry_reason(operation: SessionOperation, err: &SandboxError) -> Option<RetryReason> {
+    // stale attachables means the engine gave up before serving the query, so
+    // nothing ran — safe to retry for any operation, command execution included.
     if is_stale_attachables_error(err) {
         return Some(RetryReason::StaleAttachables);
     }
+    // a generic engine error is ambiguous about whether work executed. only
+    // check_session is side-effect-free; read_artifact replays the recorded
+    // command log before exporting, so a broad retry could re-run commands that
+    // may have already partially executed. run never gets a broad retry either.
     match (operation, err) {
-        (
-            SessionOperation::ReadArtifact | SessionOperation::CheckSession,
-            SandboxError::EngineUnreachable { .. },
-        ) => Some(RetryReason::ReadOnlyEngineError),
+        (SessionOperation::CheckSession, SandboxError::EngineUnreachable { .. }) => {
+            Some(RetryReason::ReadOnlyEngineError)
+        }
         _ => None,
     }
 }
@@ -333,6 +356,9 @@ fn clear_if_current(slot: &mut Slot, handle: &Arc<SessionHandle>) -> bool {
     match slot.handle.as_ref() {
         Some(current) if Arc::ptr_eq(current, handle) => {
             slot.handle = None;
+            // advance the lineage so an in-flight spawn waiter can't re-store this
+            // handle after we've retired it.
+            slot.generation = slot.generation.wrapping_add(1);
             true
         }
         _ => false,
@@ -441,18 +467,23 @@ fn panic_message(payload: &(dyn Any + Send)) -> &str {
 mod tests {
     use super::*;
 
+    fn make_handle() -> Arc<SessionHandle> {
+        let (tx, _rx) = mpsc::channel(1);
+        Arc::new(SessionHandle::new(tx))
+    }
+
     #[test]
     fn clear_if_current_only_removes_matching_handle() {
-        let (first_tx, _first_rx) = mpsc::channel(1);
-        let first = Arc::new(SessionHandle::new(first_tx));
-        let (second_tx, _second_rx) = mpsc::channel(1);
-        let second = Arc::new(SessionHandle::new(second_tx));
+        let first = make_handle();
+        let second = make_handle();
         let mut slot = Slot {
             handle: Some(first.clone()),
             spawning: None,
+            generation: 0,
         };
 
         assert!(!clear_if_current(&mut slot, &second));
+        assert_eq!(slot.generation, 0, "a no-op clear must not advance lineage");
         assert!(
             slot.handle
                 .as_ref()
@@ -461,6 +492,43 @@ mod tests {
 
         assert!(clear_if_current(&mut slot, &first));
         assert!(slot.handle.is_none());
+        assert_eq!(slot.generation, 1, "retiring a handle must advance lineage");
+    }
+
+    #[test]
+    fn finish_spawn_drops_handle_when_generation_advanced() {
+        let handle = make_handle();
+        let mut slot = Slot {
+            handle: None,
+            spawning: None,
+            generation: 0,
+        };
+        let started = slot.generation;
+        // a concurrent invalidation retired this lineage while we awaited the spawn.
+        slot.generation = slot.generation.wrapping_add(1);
+
+        finish_spawn(&mut slot, started, Some(&handle));
+        assert!(
+            slot.handle.is_none(),
+            "a retired spawn must not resurrect its handle"
+        );
+    }
+
+    #[test]
+    fn finish_spawn_installs_handle_for_current_generation() {
+        let handle = make_handle();
+        let mut slot = Slot {
+            handle: None,
+            spawning: None,
+            generation: 7,
+        };
+
+        finish_spawn(&mut slot, 7, Some(&handle));
+        assert!(
+            slot.handle
+                .as_ref()
+                .is_some_and(|installed| Arc::ptr_eq(installed, &handle))
+        );
     }
 
     fn engine_error(fault: EngineFault) -> SandboxError {
@@ -485,26 +553,34 @@ mod tests {
     }
 
     #[test]
-    fn retry_reason_is_broad_for_read_only_operations_only() {
+    fn generic_engine_retry_is_limited_to_check_session() {
         let err = engine_error(EngineFault::Unreachable);
 
-        assert_eq!(
-            retry_reason(SessionOperation::ReadArtifact, &err),
-            Some(RetryReason::ReadOnlyEngineError),
-        );
         assert_eq!(
             retry_reason(SessionOperation::CheckSession, &err),
             Some(RetryReason::ReadOnlyEngineError),
         );
+        // read_artifact replays the command log before exporting, so a generic
+        // engine error (which may have run some of that history) is not retried.
+        assert_eq!(retry_reason(SessionOperation::ReadArtifact, &err), None);
         assert_eq!(retry_reason(SessionOperation::Run, &err), None);
     }
 
     #[test]
-    fn stale_attachables_retry_applies_to_run_operations() {
+    fn stale_attachables_retry_applies_to_every_operation() {
         let err = engine_error(EngineFault::StaleAttachables);
 
+        // nothing executed, so the command-running and replay paths can retry too.
         assert_eq!(
             retry_reason(SessionOperation::Run, &err),
+            Some(RetryReason::StaleAttachables),
+        );
+        assert_eq!(
+            retry_reason(SessionOperation::ReadArtifact, &err),
+            Some(RetryReason::StaleAttachables),
+        );
+        assert_eq!(
+            retry_reason(SessionOperation::CheckSession, &err),
             Some(RetryReason::StaleAttachables),
         );
     }


### PR DESCRIPTION
## Summary
- drop the cached sandbox session after engine-unreachable failures so the next attempt creates a fresh Dagger session
- retry once for stale attachables, closed session channels, session acquisition failures, and read-only engine failures
- make check_session run a lightweight real Dagger query so cached warmup cannot mask a broken session

## Tests
- cargo fmt --manifest-path archestra-rs/Cargo.toml --all
- cargo check --manifest-path archestra-rs/Cargo.toml
- cargo test --manifest-path archestra-rs/Cargo.toml -p sandbox_core
- cargo clippy --manifest-path archestra-rs/Cargo.toml -- -D warnings

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>