### PR TITLE
fix(mcp-gateway): upstream Bearer forwarding

### DIFF
--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -4672,18 +4672,23 @@ describe("McpClient", () => {
           updatedAt: new Date(),
         });
 
-        const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-          new Response(
-            JSON.stringify({
-              access_token: "aggregate-downstream-access-token",
-              expires_in: 300,
-            }),
-            {
-              status: 200,
-              headers: { "Content-Type": "application/json" },
-            },
-          ),
-        );
+        const fetchMock = vi
+          .spyOn(globalThis, "fetch")
+          .mockImplementation(async (input) => {
+            const url = input instanceof Request ? input.url : input.toString();
+            expect(url).toBe("https://idp.example.com/oauth/token");
+
+            return new Response(
+              JSON.stringify({
+                access_token: "aggregate-downstream-access-token",
+                expires_in: 300,
+              }),
+              {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              },
+            );
+          });
         try {
           mockListResources.mockResolvedValueOnce({
             resources: [{ uri: "resource://exchange" }],
@@ -4709,6 +4714,7 @@ describe("McpClient", () => {
           expect(headers.get("Authorization")).toBe(
             "Bearer aggregate-downstream-access-token",
           );
+          expect(fetchMock).toHaveBeenCalledTimes(1);
         } finally {
           fetchMock.mockRestore();
         }

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -4684,32 +4684,34 @@ describe("McpClient", () => {
             },
           ),
         );
-        mockListResources.mockResolvedValueOnce({
-          resources: [{ uri: "resource://exchange" }],
-        });
+        try {
+          mockListResources.mockResolvedValueOnce({
+            resources: [{ uri: "resource://exchange" }],
+          });
 
-        const result = await mcpClient.listResources(agentId, {
-          tokenId: "session-token",
-          teamId: null,
-          isOrganizationToken: false,
-          userId: user.id,
-        });
+          const result = await mcpClient.listResources(agentId, {
+            tokenId: "session-token",
+            teamId: null,
+            isOrganizationToken: false,
+            userId: user.id,
+          });
 
-        expect(result.resources).toEqual([{ uri: "resource://exchange" }]);
-        const { StreamableHTTPClientTransport } = await import(
-          "@modelcontextprotocol/sdk/client/streamableHttp.js"
-        );
-        const [, options] =
-          vi.mocked(StreamableHTTPClientTransport).mock.calls.at(-1) ?? [];
-        const headers =
-          options?.requestInit?.headers instanceof Headers
-            ? options.requestInit.headers
-            : new Headers(options?.requestInit?.headers);
-        expect(headers.get("Authorization")).toBe(
-          "Bearer aggregate-downstream-access-token",
-        );
-
-        fetchMock.mockRestore();
+          expect(result.resources).toEqual([{ uri: "resource://exchange" }]);
+          const { StreamableHTTPClientTransport } = await import(
+            "@modelcontextprotocol/sdk/client/streamableHttp.js"
+          );
+          const [, options] =
+            vi.mocked(StreamableHTTPClientTransport).mock.calls.at(-1) ?? [];
+          const headers =
+            options?.requestInit?.headers instanceof Headers
+              ? options.requestInit.headers
+              : new Headers(options?.requestInit?.headers);
+          expect(headers.get("Authorization")).toBe(
+            "Bearer aggregate-downstream-access-token",
+          );
+        } finally {
+          fetchMock.mockRestore();
+        }
       });
     });
 

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -4507,6 +4507,51 @@ describe("McpClient", () => {
     });
 
     describe("MCP aggregate methods with OAuth headers", () => {
+      test("uses separate aggregate cached clients for external IdP users", async () => {
+        const tool = await ToolModel.createToolIfNotExists({
+          name: "github-mcp-server__external_idp_resources",
+          description: "External IdP resources",
+          parameters: {},
+          catalogId,
+        });
+        await AgentToolModel.create(agentId, tool.id, {
+          mcpServerId,
+          credentialResolutionMode: "static",
+        });
+
+        mockListResources
+          .mockResolvedValueOnce({
+            resources: [{ uri: "resource://external-a" }],
+          })
+          .mockResolvedValueOnce({
+            resources: [{ uri: "resource://external-b" }],
+          });
+
+        const firstResult = await mcpClient.listResources(agentId, {
+          tokenId: "external-token-a",
+          teamId: null,
+          isOrganizationToken: false,
+          isExternalIdp: true,
+          userId: "external-user-a",
+        });
+        const secondResult = await mcpClient.listResources(agentId, {
+          tokenId: "external-token-b",
+          teamId: null,
+          isOrganizationToken: false,
+          isExternalIdp: true,
+          userId: "external-user-b",
+        });
+
+        expect(firstResult.resources).toEqual([
+          { uri: "resource://external-a" },
+        ]);
+        expect(secondResult.resources).toEqual([
+          { uri: "resource://external-b" },
+        ]);
+        expect(mockConnect).toHaveBeenCalledTimes(2);
+        expect(mockClose).not.toHaveBeenCalled();
+      });
+
       const authCodeCases = [
         {
           label: "public authorization-code",
@@ -4601,7 +4646,7 @@ describe("McpClient", () => {
         });
       }
 
-      test("passes token-exchange Bearer token for resources/list", async ({
+      test("passes token-exchange Bearer token for resources/list and rebuilds after credential rotation", async ({
         makeIdentityProvider,
         makeOrganization,
         makeUser,
@@ -4672,15 +4717,22 @@ describe("McpClient", () => {
           updatedAt: new Date(),
         });
 
+        const downstreamTokens = [
+          "aggregate-downstream-access-token",
+          "aggregate-rotated-downstream-access-token",
+        ];
+        let tokenExchangeCount = 0;
         const fetchMock = vi
           .spyOn(globalThis, "fetch")
           .mockImplementation(async (input) => {
             const url = input instanceof Request ? input.url : input.toString();
             expect(url).toBe("https://idp.example.com/oauth/token");
+            const accessToken = downstreamTokens[tokenExchangeCount];
+            tokenExchangeCount += 1;
 
             return new Response(
               JSON.stringify({
-                access_token: "aggregate-downstream-access-token",
+                access_token: accessToken,
                 expires_in: 300,
               }),
               {
@@ -4690,31 +4742,55 @@ describe("McpClient", () => {
             );
           });
         try {
-          mockListResources.mockResolvedValueOnce({
-            resources: [{ uri: "resource://exchange" }],
-          });
+          mockListResources
+            .mockResolvedValueOnce({
+              resources: [{ uri: "resource://exchange" }],
+            })
+            .mockResolvedValueOnce({
+              resources: [{ uri: "resource://exchange-rotated" }],
+            });
 
           const result = await mcpClient.listResources(agentId, {
-            tokenId: "session-token",
+            tokenId: "session-token-a",
+            teamId: null,
+            isOrganizationToken: false,
+            userId: user.id,
+          });
+          const rotatedResult = await mcpClient.listResources(agentId, {
+            tokenId: "session-token-b",
             teamId: null,
             isOrganizationToken: false,
             userId: user.id,
           });
 
           expect(result.resources).toEqual([{ uri: "resource://exchange" }]);
+          expect(rotatedResult.resources).toEqual([
+            { uri: "resource://exchange-rotated" },
+          ]);
           const { StreamableHTTPClientTransport } = await import(
             "@modelcontextprotocol/sdk/client/streamableHttp.js"
           );
-          const [, options] =
-            vi.mocked(StreamableHTTPClientTransport).mock.calls.at(-1) ?? [];
-          const headers =
-            options?.requestInit?.headers instanceof Headers
-              ? options.requestInit.headers
-              : new Headers(options?.requestInit?.headers);
-          expect(headers.get("Authorization")).toBe(
+          const transportCalls = vi.mocked(StreamableHTTPClientTransport).mock
+            .calls;
+          const [, firstOptions] = transportCalls.at(-2) ?? [];
+          const firstHeaders =
+            firstOptions?.requestInit?.headers instanceof Headers
+              ? firstOptions.requestInit.headers
+              : new Headers(firstOptions?.requestInit?.headers);
+          expect(firstHeaders.get("Authorization")).toBe(
             "Bearer aggregate-downstream-access-token",
           );
-          expect(fetchMock).toHaveBeenCalledTimes(1);
+          const [, secondOptions] = transportCalls.at(-1) ?? [];
+          const secondHeaders =
+            secondOptions?.requestInit?.headers instanceof Headers
+              ? secondOptions.requestInit.headers
+              : new Headers(secondOptions?.requestInit?.headers);
+          expect(secondHeaders.get("Authorization")).toBe(
+            "Bearer aggregate-rotated-downstream-access-token",
+          );
+          expect(fetchMock).toHaveBeenCalledTimes(2);
+          expect(mockClose).toHaveBeenCalledTimes(1);
+          expect(mockConnect).toHaveBeenCalledTimes(2);
         } finally {
           fetchMock.mockRestore();
         }

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -4506,6 +4506,213 @@ describe("McpClient", () => {
       });
     });
 
+    describe("MCP aggregate methods with OAuth headers", () => {
+      const authCodeCases = [
+        {
+          label: "public authorization-code",
+          catalogName: "public-auth-code-mcp",
+          accessToken: "public-auth-code-access-token",
+        },
+        {
+          label: "confidential authorization-code",
+          catalogName: "confidential-auth-code-mcp",
+          accessToken: "confidential-auth-code-access-token",
+          clientSecret: "confidential-client-secret",
+        },
+      ];
+
+      for (const authCodeCase of authCodeCases) {
+        test(`passes Bearer token for ${authCodeCase.label} resources/list`, async ({
+          makeUser,
+        }) => {
+          const user = await makeUser({
+            email: `${authCodeCase.catalogName}@example.com`,
+          });
+          const secret = await secretManager().createSecret(
+            {
+              access_token: authCodeCase.accessToken,
+              refresh_token: `${authCodeCase.catalogName}-refresh-token`,
+              expires_at: Date.now() + 3_600_000,
+            },
+            `${authCodeCase.catalogName}-secret`,
+          );
+          const oauthCatalog = await InternalMcpCatalogModel.create({
+            name: authCodeCase.catalogName,
+            serverType: "remote",
+            serverUrl: `https://${authCodeCase.catalogName}.example.com/mcp/`,
+            oauthConfig: {
+              name: authCodeCase.catalogName,
+              server_url: `https://${authCodeCase.catalogName}.example.com/mcp/`,
+              grant_type: "authorization_code",
+              client_id: `${authCodeCase.catalogName}-client-id`,
+              ...(authCodeCase.clientSecret
+                ? { client_secret: authCodeCase.clientSecret }
+                : {}),
+              redirect_uris: ["http://localhost:3000/oauth-callback"],
+              scopes: ["read"],
+              default_scopes: ["read"],
+              supports_resource_metadata: false,
+              authorization_endpoint: `https://${authCodeCase.catalogName}.example.com/oauth/authorize`,
+              token_endpoint: `https://${authCodeCase.catalogName}.example.com/oauth/token`,
+            },
+          });
+          const oauthServer = await McpServerModel.create({
+            name: authCodeCase.catalogName,
+            catalogId: oauthCatalog.id,
+            secretId: secret.id,
+            serverType: "remote",
+            ownerId: user.id,
+          });
+          const tool = await ToolModel.createToolIfNotExists({
+            name: `${authCodeCase.catalogName}__list_resources`,
+            description: "List resources",
+            parameters: {},
+            catalogId: oauthCatalog.id,
+          });
+          await AgentToolModel.create(agentId, tool.id, {
+            mcpServerId: oauthServer.id,
+            credentialResolutionMode: "static",
+          });
+
+          mockListResources.mockResolvedValueOnce({
+            resources: [{ uri: "resource://example" }],
+          });
+
+          const result = await mcpClient.listResources(agentId, {
+            tokenId: "profile-token",
+            teamId: null,
+            isOrganizationToken: false,
+            userId: user.id,
+          });
+
+          expect(result.resources).toEqual([{ uri: "resource://example" }]);
+          const { StreamableHTTPClientTransport } = await import(
+            "@modelcontextprotocol/sdk/client/streamableHttp.js"
+          );
+          const [, options] =
+            vi.mocked(StreamableHTTPClientTransport).mock.calls.at(-1) ?? [];
+          const headers =
+            options?.requestInit?.headers instanceof Headers
+              ? options.requestInit.headers
+              : new Headers(options?.requestInit?.headers);
+          expect(headers.get("Authorization")).toBe(
+            `Bearer ${authCodeCase.accessToken}`,
+          );
+        });
+      }
+
+      test("passes token-exchange Bearer token for resources/list", async ({
+        makeIdentityProvider,
+        makeOrganization,
+        makeUser,
+      }) => {
+        const organization = await makeOrganization();
+        const user = await makeUser({
+          email: "aggregate-token-exchange@example.com",
+        });
+        const identityProvider = await makeIdentityProvider(organization.id, {
+          providerId: "aggregate-token-exchange-idp",
+          issuer: "https://idp.example.com",
+          oidcConfig: {
+            clientId: "aggregate-web-client",
+            tokenEndpoint: "https://idp.example.com/oauth/token",
+            enterpriseManagedCredentials: {
+              exchangeStrategy: "rfc8693",
+              clientId: "aggregate-agent-client",
+              clientSecret: "aggregate-agent-secret",
+              tokenEndpoint: "https://idp.example.com/oauth/token",
+              tokenEndpointAuthentication: "client_secret_post",
+              subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
+            },
+          },
+        });
+        await AgentModel.update(agentId, {
+          organizationId: organization.id,
+          identityProviderId: identityProvider.id,
+        });
+
+        const exchangeCatalog = await InternalMcpCatalogModel.create({
+          name: "aggregate-token-exchange-mcp",
+          serverType: "remote",
+          serverUrl: "https://aggregate-token-exchange.example.com/mcp/",
+          enterpriseManagedConfig: {
+            identityProviderId: identityProvider.id,
+            requestedCredentialType: "bearer_token",
+            resourceIdentifier: "api://aggregate-token-exchange",
+            tokenInjectionMode: "authorization_bearer",
+          },
+        });
+        const exchangeServer = await McpServerModel.create({
+          name: "aggregate-token-exchange-mcp",
+          catalogId: exchangeCatalog.id,
+          secretId: null,
+          serverType: "remote",
+          ownerId: user.id,
+        });
+        const tool = await ToolModel.createToolIfNotExists({
+          name: "aggregate-token-exchange-mcp__list_resources",
+          description: "List resources",
+          parameters: {},
+          catalogId: exchangeCatalog.id,
+        });
+        await AgentToolModel.create(agentId, tool.id, {
+          mcpServerId: exchangeServer.id,
+          credentialResolutionMode: "enterprise_managed",
+        });
+
+        await db.insert(schema.accountsTable).values({
+          id: randomUUID(),
+          accountId: "acct-aggregate-token-exchange",
+          providerId: identityProvider.providerId,
+          userId: user.id,
+          accessToken: "aggregate-login-access-token",
+          accessTokenExpiresAt: new Date(Date.now() + 300_000),
+          idToken: createJwt({ exp: futureExpSeconds() }),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        });
+
+        const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              access_token: "aggregate-downstream-access-token",
+              expires_in: 300,
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        );
+        mockListResources.mockResolvedValueOnce({
+          resources: [{ uri: "resource://exchange" }],
+        });
+
+        const result = await mcpClient.listResources(agentId, {
+          tokenId: "session-token",
+          teamId: null,
+          isOrganizationToken: false,
+          userId: user.id,
+        });
+
+        expect(result.resources).toEqual([{ uri: "resource://exchange" }]);
+        const { StreamableHTTPClientTransport } = await import(
+          "@modelcontextprotocol/sdk/client/streamableHttp.js"
+        );
+        const [, options] =
+          vi.mocked(StreamableHTTPClientTransport).mock.calls.at(-1) ?? [];
+        const headers =
+          options?.requestInit?.headers instanceof Headers
+            ? options.requestInit.headers
+            : new Headers(options?.requestInit?.headers);
+        expect(headers.get("Authorization")).toBe(
+          "Bearer aggregate-downstream-access-token",
+        );
+
+        fetchMock.mockRestore();
+      });
+    });
+
     describe("oauth client credentials", () => {
       test("exchanges stored client credentials for a bearer token on remote MCP calls", async ({
         makeUser,

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
@@ -201,6 +202,7 @@ type CachedResource = {
 
 type CachedServerState = {
   secretId: string | null;
+  credentialFingerprint: string | null;
 };
 
 class McpClient {
@@ -225,6 +227,7 @@ class McpClient {
       this.activeConnectionServerState.delete(key);
       this.toolNameCache.delete(key);
       this.pendingHttpSessionMetadata.delete(key);
+      this.pendingTransportCredentialFingerprints.delete(key);
       this.activeConnectionLastValidatedAt.delete(key);
     },
   });
@@ -255,6 +258,7 @@ class McpClient {
     string,
     { sessionEndpointUrl: string | null; sessionEndpointPodName: string | null }
   >();
+  private pendingTransportCredentialFingerprints = new Map<string, string>();
   // Cache for resource reads: key is `${agentId}:${uri}`, value is cached result with TTL.
   // Bounded to RESOURCE_CACHE_MAX_SIZE entries (LRU eviction) to prevent unbounded growth
   // in multi-tenant environments with many agents and resources.
@@ -453,6 +457,7 @@ class McpClient {
             catalogItem,
             targetMcpServerId,
             tokenAuth,
+            enterpriseTransportCredential,
             toolCatalogId: tool.catalogId,
             toolCatalogName: tool.catalogName,
             executeRetry: (nextGetTransport, secrets) =>
@@ -554,6 +559,7 @@ class McpClient {
             catalogItem,
             targetMcpServerId,
             tokenAuth,
+            enterpriseTransportCredential,
             toolCatalogId: tool.catalogId,
             toolCatalogName: tool.catalogName,
             executeRetry: (nextGetTransport, secrets) =>
@@ -718,6 +724,7 @@ class McpClient {
             catalogItem,
             targetMcpServerId,
             tokenAuth,
+            enterpriseTransportCredential,
             toolCatalogId: tool.catalogId,
             toolCatalogName: tool.catalogName,
             executeRetry: (getTransport, secrets) =>
@@ -888,6 +895,11 @@ class McpClient {
     targetMcpServerId: string,
     currentServerState: CachedServerState,
   ): Promise<Client> {
+    const effectiveServerState = this.withPendingCredentialFingerprint(
+      connectionKey,
+      currentServerState,
+    );
+
     // Check if we already have an active connection
     const existingClient = this.activeConnections.get(connectionKey);
     if (existingClient) {
@@ -895,16 +907,16 @@ class McpClient {
         this.activeConnectionServerState.get(connectionKey);
       if (
         !cachedServerState ||
-        !this.hasMatchingServerState(cachedServerState, currentServerState)
+        !this.hasMatchingServerState(cachedServerState, effectiveServerState)
       ) {
         logger.info(
           {
             connectionKey,
             targetMcpServerId,
             cachedSecretId: cachedServerState?.secretId ?? null,
-            currentSecretId: currentServerState.secretId,
+            currentSecretId: effectiveServerState.secretId,
           },
-          "Discarding cached MCP client after MCP server secret changed",
+          "Discarding cached MCP client after MCP server credentials changed",
         );
         try {
           await existingClient.close();
@@ -929,7 +941,10 @@ class McpClient {
         }
         logger.debug({ connectionKey }, "Reusing cached MCP client");
         this.activeConnections.set(connectionKey, reusableClient);
-        this.activeConnectionServerState.set(connectionKey, currentServerState);
+        this.activeConnectionServerState.set(
+          connectionKey,
+          effectiveServerState,
+        );
         return reusableClient;
       } catch (error) {
         // Connection is dead, invalidate cache and create fresh client
@@ -1018,7 +1033,7 @@ class McpClient {
     // This prevents a race where a second request creates a duplicate connection
     // while the upsert is in flight.
     this.activeConnections.set(connectionKey, client);
-    this.activeConnectionServerState.set(connectionKey, currentServerState);
+    this.activeConnectionServerState.set(connectionKey, effectiveServerState);
     this.activeConnectionLastValidatedAt.set(connectionKey, Date.now());
 
     // Persist the MCP session ID so other backend pods can reuse it.
@@ -1065,6 +1080,7 @@ class McpClient {
     this.activeConnectionServerState.delete(connectionKey);
     this.toolNameCache.delete(connectionKey);
     this.pendingHttpSessionMetadata.delete(connectionKey);
+    this.pendingTransportCredentialFingerprints.delete(connectionKey);
     this.activeConnectionLastValidatedAt.delete(connectionKey);
   }
 
@@ -1073,6 +1089,7 @@ class McpClient {
     this.activeConnectionServerState.clear();
     this.toolNameCache.clear();
     this.pendingHttpSessionMetadata.clear();
+    this.pendingTransportCredentialFingerprints.clear();
     this.activeConnectionLastValidatedAt.clear();
   }
 
@@ -1604,6 +1621,7 @@ class McpClient {
         }
 
         mergePassthroughHeaders(localHeaders, tokenAuth?.passthroughHeaders);
+        this.trackTransportCredentialFingerprint(connectionKey, localHeaders);
 
         return new StreamableHTTPClientTransport(new URL(endpointUrl), {
           sessionId,
@@ -1635,6 +1653,7 @@ class McpClient {
         }
 
         mergePassthroughHeaders(headers, tokenAuth?.passthroughHeaders);
+        this.trackTransportCredentialFingerprint(connectionKey, headers);
 
         return new StreamableHTTPClientTransport(
           new URL(catalogItem.serverUrl),
@@ -2017,6 +2036,7 @@ class McpClient {
     catalogItem: InternalMcpCatalog;
     targetMcpServerId: string;
     tokenAuth?: TokenAuthContext;
+    enterpriseTransportCredential?: ResolvedEnterpriseTransportCredential | null;
     toolCatalogId: string | null;
     toolCatalogName: string | null;
     executeRetry: (
@@ -2034,6 +2054,7 @@ class McpClient {
       catalogItem,
       targetMcpServerId,
       tokenAuth,
+      enterpriseTransportCredential,
       toolCatalogId,
       toolCatalogName,
       executeRetry,
@@ -2097,6 +2118,9 @@ class McpClient {
           targetMcpServerId,
           updatedSecret,
           secretId,
+          connectionKey,
+          tokenAuth,
+          enterpriseTransportCredential ?? undefined,
         );
 
       return await executeRetry(getUpdatedTransport, updatedSecret);
@@ -2929,45 +2953,81 @@ class McpClient {
    * Get connected MCP SDK clients for all upstream servers of an agent.
    * Returns one client per distinct catalog item (MCP server installation).
    */
-  private async getClientsForAgent(agentId: string): Promise<Client[]> {
+  private async getClientsForAgent(
+    agentId: string,
+    tokenAuth?: TokenAuthContext,
+  ): Promise<Client[]> {
     const tools = await ToolModel.getMcpToolsByAgent(agentId);
-
-    // Collect distinct catalog IDs (skip Archestra built-in tools which have no upstream server)
-    const catalogIds = [
-      ...new Set(
-        tools.map((t) => t.catalogId).filter((id): id is string => !!id),
-      ),
-    ];
+    const assignedTools = await ToolModel.getMcpToolsAssignedToAgent(
+      tools.map((tool) => tool.name),
+      agentId,
+    );
+    const toolsByCatalogId = new Map<string, McpToolAssignment>();
+    for (const tool of assignedTools) {
+      if (tool.catalogId && !toolsByCatalogId.has(tool.catalogId)) {
+        toolsByCatalogId.set(tool.catalogId, tool);
+      }
+    }
 
     const clients: Client[] = [];
 
-    for (const catalogId of catalogIds) {
+    for (const [catalogId, tool] of toolsByCatalogId) {
       try {
         const catalogItem = await InternalMcpCatalogModel.findById(catalogId);
         if (!catalogItem) continue;
 
-        const servers = await McpServerModel.findByCatalogId(catalogId);
-        const server = servers[0];
-        if (!server) continue;
+        const targetResult =
+          await this.determineTargetMcpServerIdForCatalogItem({
+            tool,
+            tokenAuth,
+            toolCall: {
+              id: "list-op",
+              name: tool.toolName,
+              arguments: {},
+            },
+            agentId,
+            catalogItem,
+          });
+        if ("error" in targetResult) continue;
+
+        const { targetMcpServerId } = targetResult;
+        const enterpriseTransportCredential =
+          tool.credentialResolutionMode === "enterprise_managed"
+            ? await this.resolveCachedEnterpriseTransportCredential({
+                agentId,
+                tokenAuth,
+                enterpriseManagedConfig:
+                  catalogItem.enterpriseManagedConfig ?? null,
+              })
+            : null;
+        if (
+          tool.credentialResolutionMode === "enterprise_managed" &&
+          !enterpriseTransportCredential
+        ) {
+          continue;
+        }
 
         const secretResult = await this.getSecretsForMcpServer({
-          targetMcpServerId: server.id,
-          toolCall: { id: "list-op", name: "list", arguments: {} },
+          targetMcpServerId,
+          toolCall: { id: "list-op", name: tool.toolName, arguments: {} },
           agentId,
         });
         if ("error" in secretResult) continue;
 
         const transport = await this.getTransport(
           catalogItem,
-          server.id,
+          targetMcpServerId,
           secretResult.secrets,
           secretResult.secretId,
+          `${catalogItem.id}:${targetMcpServerId}`,
+          tokenAuth,
+          enterpriseTransportCredential ?? undefined,
         );
-        const connectionKey = `${catalogItem.id}:${server.id}`;
+        const connectionKey = `${catalogItem.id}:${targetMcpServerId}`;
         const client = await this.getOrCreateClient(
           connectionKey,
           transport,
-          server.id,
+          targetMcpServerId,
           secretResult.serverState,
         );
         clients.push(client);
@@ -2987,8 +3047,9 @@ class McpClient {
    */
   async listResources(
     agentId: string,
+    tokenAuth?: TokenAuthContext,
   ): Promise<{ resources: Array<Record<string, unknown>> }> {
-    const clients = await this.getClientsForAgent(agentId);
+    const clients = await this.getClientsForAgent(agentId, tokenAuth);
     const allResources: Array<Record<string, unknown>> = [];
 
     await Promise.all(
@@ -3015,8 +3076,9 @@ class McpClient {
    */
   async listResourceTemplates(
     agentId: string,
+    tokenAuth?: TokenAuthContext,
   ): Promise<{ resourceTemplates: Array<Record<string, unknown>> }> {
-    const clients = await this.getClientsForAgent(agentId);
+    const clients = await this.getClientsForAgent(agentId, tokenAuth);
     const allTemplates: Array<Record<string, unknown>> = [];
 
     await Promise.all(
@@ -3045,8 +3107,9 @@ class McpClient {
    */
   async listPrompts(
     agentId: string,
+    tokenAuth?: TokenAuthContext,
   ): Promise<{ prompts: Array<Record<string, unknown>> }> {
-    const clients = await this.getClientsForAgent(agentId);
+    const clients = await this.getClientsForAgent(agentId, tokenAuth);
     const allPrompts: Array<Record<string, unknown>> = [];
 
     await Promise.all(
@@ -3137,7 +3200,10 @@ class McpClient {
     left: CachedServerState,
     right: CachedServerState,
   ): boolean {
-    return left.secretId === right.secretId;
+    return (
+      left.secretId === right.secretId &&
+      left.credentialFingerprint === right.credentialFingerprint
+    );
   }
 
   private toCachedServerState(
@@ -3145,6 +3211,32 @@ class McpClient {
   ): CachedServerState {
     return {
       secretId: mcpServer.secretId ?? null,
+      credentialFingerprint: null,
+    };
+  }
+
+  private trackTransportCredentialFingerprint(
+    connectionKey: string | undefined,
+    headers: Record<string, string>,
+  ): void {
+    if (!connectionKey) {
+      return;
+    }
+
+    this.pendingTransportCredentialFingerprints.set(
+      connectionKey,
+      fingerprintHeaders(headers),
+    );
+  }
+
+  private withPendingCredentialFingerprint(
+    connectionKey: string,
+    serverState: CachedServerState,
+  ): CachedServerState {
+    return {
+      ...serverState,
+      credentialFingerprint:
+        this.pendingTransportCredentialFingerprints.get(connectionKey) ?? null,
     };
   }
 }
@@ -3566,4 +3658,14 @@ function buildDefaultAuthorizationHeaders(
   }
 
   return headers;
+}
+
+function fingerprintHeaders(headers: Record<string, string>): string {
+  const canonicalHeaders = Object.entries(headers)
+    .map(([name, value]) => [name.toLowerCase(), value] as const)
+    .sort(([left], [right]) => left.localeCompare(right));
+
+  return createHash("sha256")
+    .update(JSON.stringify(canonicalHeaders))
+    .digest("base64url");
 }

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -227,7 +227,7 @@ class McpClient {
       this.activeConnectionServerState.delete(key);
       this.toolNameCache.delete(key);
       this.pendingHttpSessionMetadata.delete(key);
-      this.pendingTransportCredentialFingerprints.delete(key);
+      this.latestTransportCredentialFingerprints.delete(key);
       this.activeConnectionLastValidatedAt.delete(key);
     },
   });
@@ -258,10 +258,10 @@ class McpClient {
     string,
     { sessionEndpointUrl: string | null; sessionEndpointPodName: string | null }
   >();
-  // Populated while building an HTTP transport and consumed immediately by
-  // getOrCreateClient, so cached clients are invalidated when outbound
-  // credentials or required upstream headers change.
-  private pendingTransportCredentialFingerprints = new Map<string, string>();
+  // Latest outbound HTTP credential/header fingerprint per connection key.
+  // Retained until connection state is cleared so cached clients are
+  // invalidated when credentials or required upstream headers change.
+  private latestTransportCredentialFingerprints = new Map<string, string>();
   // Cache for resource reads: key is `${agentId}:${uri}`, value is cached result with TTL.
   // Bounded to RESOURCE_CACHE_MAX_SIZE entries (LRU eviction) to prevent unbounded growth
   // in multi-tenant environments with many agents and resources.
@@ -898,7 +898,7 @@ class McpClient {
     targetMcpServerId: string,
     currentServerState: CachedServerState,
   ): Promise<Client> {
-    const effectiveServerState = this.withPendingCredentialFingerprint(
+    const effectiveServerState = this.withLatestCredentialFingerprint(
       connectionKey,
       currentServerState,
     );
@@ -1083,7 +1083,7 @@ class McpClient {
     this.activeConnectionServerState.delete(connectionKey);
     this.toolNameCache.delete(connectionKey);
     this.pendingHttpSessionMetadata.delete(connectionKey);
-    this.pendingTransportCredentialFingerprints.delete(connectionKey);
+    this.latestTransportCredentialFingerprints.delete(connectionKey);
     this.activeConnectionLastValidatedAt.delete(connectionKey);
   }
 
@@ -1092,7 +1092,7 @@ class McpClient {
     this.activeConnectionServerState.clear();
     this.toolNameCache.clear();
     this.pendingHttpSessionMetadata.clear();
-    this.pendingTransportCredentialFingerprints.clear();
+    this.latestTransportCredentialFingerprints.clear();
     this.activeConnectionLastValidatedAt.clear();
   }
 
@@ -3226,20 +3226,20 @@ class McpClient {
       return;
     }
 
-    this.pendingTransportCredentialFingerprints.set(
+    this.latestTransportCredentialFingerprints.set(
       connectionKey,
       fingerprintHeaders(headers),
     );
   }
 
-  private withPendingCredentialFingerprint(
+  private withLatestCredentialFingerprint(
     connectionKey: string,
     serverState: CachedServerState,
   ): CachedServerState {
     return {
       ...serverState,
       credentialFingerprint:
-        this.pendingTransportCredentialFingerprints.get(connectionKey) ?? null,
+        this.latestTransportCredentialFingerprints.get(connectionKey) ?? null,
     };
   }
 }

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -3017,7 +3017,13 @@ class McpClient {
         });
         if ("error" in secretResult) continue;
 
-        const connectionKey = `${catalogItem.id}:${targetMcpServerId}`;
+        const externalIdpUserId = tokenAuth?.isExternalIdp
+          ? tokenAuth.userId
+          : undefined;
+        let connectionKey = `${catalogItem.id}:${targetMcpServerId}`;
+        if (externalIdpUserId) {
+          connectionKey = `${connectionKey}:ext:${externalIdpUserId}`;
+        }
         const transport = await this.getTransport(
           catalogItem,
           targetMcpServerId,

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -258,6 +258,9 @@ class McpClient {
     string,
     { sessionEndpointUrl: string | null; sessionEndpointPodName: string | null }
   >();
+  // Populated while building an HTTP transport and consumed immediately by
+  // getOrCreateClient, so cached clients are invalidated when outbound
+  // credentials or required upstream headers change.
   private pendingTransportCredentialFingerprints = new Map<string, string>();
   // Cache for resource reads: key is `${agentId}:${uri}`, value is cached result with TTL.
   // Bounded to RESOURCE_CACHE_MAX_SIZE entries (LRU eviction) to prevent unbounded growth
@@ -3014,16 +3017,16 @@ class McpClient {
         });
         if ("error" in secretResult) continue;
 
+        const connectionKey = `${catalogItem.id}:${targetMcpServerId}`;
         const transport = await this.getTransport(
           catalogItem,
           targetMcpServerId,
           secretResult.secrets,
           secretResult.secretId,
-          `${catalogItem.id}:${targetMcpServerId}`,
+          connectionKey,
           tokenAuth,
           enterpriseTransportCredential ?? undefined,
         );
-        const connectionKey = `${catalogItem.id}:${targetMcpServerId}`;
         const client = await this.getOrCreateClient(
           connectionKey,
           transport,

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -286,15 +286,15 @@ export async function createAgentServer(
   // SEP-1865: resources/list, resources/templates/list, prompts/list
   // Proxy to all upstream MCP servers connected to this agent and aggregate results.
   server.setRequestHandler(ListResourcesRequestSchema, async () => {
-    return mcpClient.listResources(agentId);
+    return mcpClient.listResources(agentId, tokenAuth);
   });
 
   server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
-    return mcpClient.listResourceTemplates(agentId);
+    return mcpClient.listResourceTemplates(agentId, tokenAuth);
   });
 
   server.setRequestHandler(ListPromptsRequestSchema, async () => {
-    return mcpClient.listPrompts(agentId);
+    return mcpClient.listPrompts(agentId, tokenAuth);
   });
 
   server.setRequestHandler(


### PR DESCRIPTION
## Summary

Fixes upstream MCP authentication for gateway requests that need OAuth or enterprise-managed credentials.

## Root cause

The gateway forwarded caller context for tool calls, but aggregate MCP methods such as `resources/list`, `resources/templates/list`, and `prompts/list` opened upstream MCP clients without the caller's token context. Those methods could also pick the first installed server for a catalog instead of using the same credential resolution path as tool calls.

Separately, cached downstream MCP clients only tracked the installed server secret ID. A client opened with one outbound credential context could be reused even after the effective upstream auth headers changed.

## Changes

- Pass gateway token context into upstream aggregate MCP methods.
- Resolve the upstream MCP server for aggregate methods through the same static, dynamic, and enterprise-managed credential resolution path used by tool calls.
- Track an outbound-header fingerprint in cached MCP client state so cached clients are rebuilt when credentials change.
- Preserve token context when retrying after OAuth refresh.
- Add backend coverage for public auth-code OAuth, confidential auth-code OAuth, and enterprise token-exchange Bearer header injection.