### PR TITLE
fix(chat): drop empty assistant messages after normalization

### DIFF
--- a/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
+++ b/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest";
-import { normalizeChatMessages } from "./normalize-chat-messages";
+import {
+  dropEmptyAssistantMessages,
+  normalizeChatMessages,
+} from "./normalize-chat-messages";
 
 describe("normalizeChatMessages", () => {
   test("dedupes duplicate tool parts with the same toolCallId", () => {
@@ -98,5 +101,70 @@ describe("normalizeChatMessages", () => {
     const result = normalizeChatMessages(messages);
 
     expect(result[0].parts).toHaveLength(2);
+  });
+});
+
+describe("dropEmptyAssistantMessages", () => {
+  test("drops an assistant turn left empty after a dangling tool call is stripped", () => {
+    // a stopped/interrupted turn whose only part is an unresolved tool call
+    const messages = [
+      {
+        id: "user1",
+        role: "user" as const,
+        parts: [{ type: "text", text: "go" }],
+      },
+      {
+        id: "assistant1",
+        role: "assistant" as const,
+        parts: [
+          {
+            type: "tool-archestra__create_agent",
+            toolCallId: "call_interrupted",
+            state: "input-available",
+            input: {},
+          },
+        ],
+      },
+    ];
+
+    const normalized = normalizeChatMessages(messages);
+    const result = dropEmptyAssistantMessages(normalized);
+
+    expect(result.map((m) => m.id)).toEqual(["user1"]);
+  });
+
+  test("keeps assistant turns that still render text or a completed tool result", () => {
+    const messages = [
+      {
+        id: "with-text",
+        role: "assistant" as const,
+        parts: [{ type: "text", text: "done" }],
+      },
+      {
+        id: "with-result",
+        role: "assistant" as const,
+        parts: [
+          {
+            type: "tool-archestra__create_agent",
+            toolCallId: "call_ok",
+            state: "output-available",
+            output: "created",
+          },
+        ],
+      },
+    ];
+
+    const result = dropEmptyAssistantMessages(messages);
+
+    expect(result.map((m) => m.id)).toEqual(["with-text", "with-result"]);
+  });
+
+  test("leaves non-assistant messages untouched even when empty", () => {
+    const messages = [
+      { id: "u", role: "user" as const, parts: [] },
+      { id: "s", role: "system" as const, parts: [] },
+    ];
+
+    expect(dropEmptyAssistantMessages(messages)).toEqual(messages);
   });
 });

--- a/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
+++ b/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, test } from "vitest";
-import {
-  dropEmptyAssistantMessages,
-  normalizeChatMessages,
-} from "./normalize-chat-messages";
+import { normalizeChatMessages } from "./normalize-chat-messages";
 
 describe("normalizeChatMessages", () => {
   test("dedupes duplicate tool parts with the same toolCallId", () => {
@@ -104,7 +101,7 @@ describe("normalizeChatMessages", () => {
   });
 });
 
-describe("dropEmptyAssistantMessages", () => {
+describe("normalizeChatMessages empty-assistant dropping", () => {
   test("drops an assistant turn left empty after a dangling tool call is stripped", () => {
     // a stopped/interrupted turn whose only part is an unresolved tool call
     const messages = [
@@ -127,8 +124,7 @@ describe("dropEmptyAssistantMessages", () => {
       },
     ];
 
-    const normalized = normalizeChatMessages(messages);
-    const result = dropEmptyAssistantMessages(normalized);
+    const result = normalizeChatMessages(messages);
 
     expect(result.map((m) => m.id)).toEqual(["user1"]);
   });
@@ -154,7 +150,7 @@ describe("dropEmptyAssistantMessages", () => {
       },
     ];
 
-    const result = dropEmptyAssistantMessages(messages);
+    const result = normalizeChatMessages(messages);
 
     expect(result.map((m) => m.id)).toEqual(["with-text", "with-result"]);
   });
@@ -165,6 +161,6 @@ describe("dropEmptyAssistantMessages", () => {
       { id: "s", role: "system" as const, parts: [] },
     ];
 
-    expect(dropEmptyAssistantMessages(messages)).toEqual(messages);
+    expect(normalizeChatMessages(messages)).toEqual(messages);
   });
 });

--- a/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
+++ b/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
@@ -204,6 +204,40 @@ describe("normalizeChatMessages empty-assistant dropping", () => {
     ]);
   });
 
+  test("keeps an MCP-app turn whose tool call completed as a dynamic-tool", () => {
+    // MCP tools deserialize to `dynamic-tool`, not `tool-<name>`; the marker must
+    // still count as live so it survives persistence and renders as an MCP app.
+    const messages = [
+      {
+        id: "assistant1",
+        role: "assistant" as const,
+        parts: [
+          { type: "step-start" },
+          {
+            type: "data-tool-ui-start",
+            data: { toolCallId: "call_ok", toolName: "render_chart" },
+          },
+          {
+            type: "dynamic-tool",
+            toolName: "render_chart",
+            toolCallId: "call_ok",
+            state: "output-available",
+            output: "rendered",
+          },
+        ],
+      },
+    ];
+
+    const result = normalizeChatMessages(messages);
+
+    expect(result.map((m) => m.id)).toEqual(["assistant1"]);
+    expect(result[0].parts?.map((p) => p.type)).toEqual([
+      "step-start",
+      "data-tool-ui-start",
+      "dynamic-tool",
+    ]);
+  });
+
   test("drops a stopped MCP-app turn left with an orphaned tool-ui-start", () => {
     // abort after the MCP app started but before its tool call resolved:
     // stripDanglingToolCalls removes the input-streaming tool, leaving the

--- a/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
+++ b/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
@@ -178,14 +178,23 @@ describe("normalizeChatMessages empty-assistant dropping", () => {
     expect(normalizeChatMessages(messages)).toEqual([]);
   });
 
-  test("keeps an assistant turn whose only non-text part renders an MCP app", () => {
+  test("keeps an MCP-app turn whose tool call completed", () => {
     const messages = [
       {
         id: "assistant1",
         role: "assistant" as const,
         parts: [
           { type: "step-start" },
-          { type: "data-tool-ui-start", data: { toolCallId: "call_ok" } },
+          {
+            type: "data-tool-ui-start",
+            data: { toolCallId: "call_ok", toolName: "render_chart" },
+          },
+          {
+            type: "tool-render_chart",
+            toolCallId: "call_ok",
+            state: "output-available",
+            output: "rendered",
+          },
         ],
       },
     ];
@@ -193,6 +202,33 @@ describe("normalizeChatMessages empty-assistant dropping", () => {
     expect(normalizeChatMessages(messages).map((m) => m.id)).toEqual([
       "assistant1",
     ]);
+  });
+
+  test("drops a stopped MCP-app turn left with an orphaned tool-ui-start", () => {
+    // abort after the MCP app started but before its tool call resolved:
+    // stripDanglingToolCalls removes the input-streaming tool, leaving the
+    // marker orphaned — the renderer would otherwise show a stuck running tool.
+    const messages = [
+      {
+        id: "assistant1",
+        role: "assistant" as const,
+        parts: [
+          { type: "step-start" },
+          {
+            type: "data-tool-ui-start",
+            data: { toolCallId: "call_interrupted", toolName: "render_chart" },
+          },
+          {
+            type: "tool-render_chart",
+            toolCallId: "call_interrupted",
+            state: "input-streaming",
+            input: {},
+          },
+        ],
+      },
+    ];
+
+    expect(normalizeChatMessages(messages)).toEqual([]);
   });
 
   test("leaves non-assistant messages untouched even when empty", () => {

--- a/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
+++ b/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
@@ -155,6 +155,46 @@ describe("normalizeChatMessages empty-assistant dropping", () => {
     expect(result.map((m) => m.id)).toEqual(["with-text", "with-result"]);
   });
 
+  test("drops an assistant turn left with only a step-start after a dangling tool call is stripped", () => {
+    // AI SDK assistant messages open with step-start; an aborted turn that
+    // emitted only a tool call leaves [step-start] once the call is stripped.
+    const messages = [
+      {
+        id: "assistant1",
+        role: "assistant" as const,
+        parts: [
+          { type: "step-start" },
+          { type: "data-token-usage", data: { totalTokens: 10 } },
+          {
+            type: "tool-archestra__create_agent",
+            toolCallId: "call_interrupted",
+            state: "input-available",
+            input: {},
+          },
+        ],
+      },
+    ];
+
+    expect(normalizeChatMessages(messages)).toEqual([]);
+  });
+
+  test("keeps an assistant turn whose only non-text part renders an MCP app", () => {
+    const messages = [
+      {
+        id: "assistant1",
+        role: "assistant" as const,
+        parts: [
+          { type: "step-start" },
+          { type: "data-tool-ui-start", data: { toolCallId: "call_ok" } },
+        ],
+      },
+    ];
+
+    expect(normalizeChatMessages(messages).map((m) => m.id)).toEqual([
+      "assistant1",
+    ]);
+  });
+
   test("leaves non-assistant messages untouched even when empty", () => {
     const messages = [
       { id: "u", role: "user" as const, parts: [] },

--- a/platform/backend/src/routes/chat/normalization/normalize-chat-messages.ts
+++ b/platform/backend/src/routes/chat/normalization/normalize-chat-messages.ts
@@ -4,24 +4,10 @@ import type { ChatMessage, ChatMessagePart } from "@/types";
 import { stripImagesFromMessages } from "./strip-images-from-messages";
 
 export function normalizeChatMessages(messages: ChatMessage[]): ChatMessage[] {
-  return stripImagesFromMessages(
-    stripDanglingToolCallsFromMessages(dedupeToolPartsFromMessages(messages)),
-  );
-}
-
-/**
- * Drops assistant messages that normalization emptied of renderable content —
- * e.g. a turn whose only parts were dangling tool calls that `stripDanglingTool-
- * Calls` removed. Run after `normalizeChatMessages` and before persisting so the
- * DB never holds a stuck-looking empty assistant row. Non-assistant messages are
- * left untouched.
- */
-export function dropEmptyAssistantMessages(
-  messages: ChatMessage[],
-): ChatMessage[] {
-  return messages.filter(
-    (message) =>
-      message.role !== "assistant" || hasRenderableAssistantContent(message),
+  return dropEmptyAssistantMessages(
+    stripImagesFromMessages(
+      stripDanglingToolCallsFromMessages(dedupeToolPartsFromMessages(messages)),
+    ),
   );
 }
 
@@ -99,6 +85,17 @@ function stripDanglingToolCallsFromMessages(messages: ChatMessage[]) {
 
     return message;
   });
+}
+
+// drops assistant turns left with no renderable content — e.g. a turn whose only
+// parts were dangling tool calls that stripDanglingToolCalls removed. An empty
+// assistant response is never valid, so neither the model nor the DB should see
+// one. Non-assistant messages are left untouched.
+function dropEmptyAssistantMessages(messages: ChatMessage[]): ChatMessage[] {
+  return messages.filter(
+    (message) =>
+      message.role !== "assistant" || hasRenderableAssistantContent(message),
+  );
 }
 
 function getToolPartSignature(part: NonNullable<ChatMessage["parts"]>[number]) {

--- a/platform/backend/src/routes/chat/normalization/normalize-chat-messages.ts
+++ b/platform/backend/src/routes/chat/normalization/normalize-chat-messages.ts
@@ -150,8 +150,12 @@ function dropEmptyAssistantMessages(messages: ChatMessage[]): ChatMessage[] {
   );
 }
 
+// matches both statically-typed `tool-<name>` parts and the `dynamic-tool`
+// shape MCP tools deserialize to — the frontend renderer and shared dangling-call
+// normalization both treat `dynamic-tool` as a real tool part, so a `data-tool-ui-start`
+// can legitimately pair with one and its toolCallId must count as live.
 function isToolPart(part: ChatMessagePart): boolean {
-  return part.type.startsWith("tool-");
+  return part.type.startsWith("tool-") || part.type === "dynamic-tool";
 }
 
 function isToolUiStartPart(part: ChatMessagePart): boolean {

--- a/platform/backend/src/routes/chat/normalization/normalize-chat-messages.ts
+++ b/platform/backend/src/routes/chat/normalization/normalize-chat-messages.ts
@@ -5,8 +5,12 @@ import { stripImagesFromMessages } from "./strip-images-from-messages";
 
 export function normalizeChatMessages(messages: ChatMessage[]): ChatMessage[] {
   return dropEmptyAssistantMessages(
-    stripImagesFromMessages(
-      stripDanglingToolCallsFromMessages(dedupeToolPartsFromMessages(messages)),
+    stripOrphanedToolUiStartsFromMessages(
+      stripImagesFromMessages(
+        stripDanglingToolCallsFromMessages(
+          dedupeToolPartsFromMessages(messages),
+        ),
+      ),
     ),
   );
 }
@@ -87,6 +91,54 @@ function stripDanglingToolCallsFromMessages(messages: ChatMessage[]) {
   });
 }
 
+// drops `data-tool-ui-start` markers whose tool call no longer survives — e.g. an
+// aborted MCP-app turn whose dangling `tool-*` part was just stripped. The chat
+// renderer treats such a marker as canonical and synthesizes an `input-streaming`
+// tool from it, so an orphaned marker reloads as a perpetually running tool. Runs
+// after dangling-call stripping so "surviving" reflects the cleaned-up parts.
+function stripOrphanedToolUiStartsFromMessages(
+  messages: ChatMessage[],
+): ChatMessage[] {
+  return messages.map((message) => {
+    const parts = message.parts;
+    if (!parts?.length) {
+      return message;
+    }
+
+    const liveToolCallIds = new Set<string>();
+    for (const part of parts) {
+      if (isToolPart(part) && typeof part.toolCallId === "string") {
+        liveToolCallIds.add(part.toolCallId);
+      }
+    }
+
+    const keptParts = parts.filter((part) => {
+      if (!isToolUiStartPart(part)) {
+        return true;
+      }
+
+      const toolCallId = getToolUiStartToolCallId(part);
+      return toolCallId !== null && liveToolCallIds.has(toolCallId);
+    });
+
+    if (keptParts.length === parts.length) {
+      return message;
+    }
+
+    logger.warn(
+      {
+        messageId: message.id,
+        role: message.role,
+        originalCount: parts.length,
+        keptCount: keptParts.length,
+      },
+      "[normalizeChatMessages] Removed orphaned tool-ui-start parts from message",
+    );
+
+    return { ...message, parts: keptParts };
+  });
+}
+
 // drops assistant turns left with no renderable content — e.g. a turn whose only
 // parts were dangling tool calls that stripDanglingToolCalls removed. An empty
 // assistant response is never valid, so neither the model nor the DB should see
@@ -96,6 +148,24 @@ function dropEmptyAssistantMessages(messages: ChatMessage[]): ChatMessage[] {
     (message) =>
       message.role !== "assistant" || hasRenderableAssistantContent(message),
   );
+}
+
+function isToolPart(part: ChatMessagePart): boolean {
+  return part.type.startsWith("tool-");
+}
+
+function isToolUiStartPart(part: ChatMessagePart): boolean {
+  return part.type.startsWith("data-tool-ui-start");
+}
+
+function getToolUiStartToolCallId(part: ChatMessagePart): string | null {
+  const data = part.data;
+  if (typeof data !== "object" || data === null || !("toolCallId" in data)) {
+    return null;
+  }
+
+  const toolCallId = (data as { toolCallId?: unknown }).toolCallId;
+  return typeof toolCallId === "string" ? toolCallId : null;
 }
 
 function getToolPartSignature(part: NonNullable<ChatMessage["parts"]>[number]) {

--- a/platform/backend/src/routes/chat/normalization/normalize-chat-messages.ts
+++ b/platform/backend/src/routes/chat/normalization/normalize-chat-messages.ts
@@ -1,4 +1,4 @@
-import { stripDanglingToolCalls } from "@shared";
+import { hasRenderableAssistantContent, stripDanglingToolCalls } from "@shared";
 import logger from "@/logging";
 import type { ChatMessage, ChatMessagePart } from "@/types";
 import { stripImagesFromMessages } from "./strip-images-from-messages";
@@ -6,6 +6,22 @@ import { stripImagesFromMessages } from "./strip-images-from-messages";
 export function normalizeChatMessages(messages: ChatMessage[]): ChatMessage[] {
   return stripImagesFromMessages(
     stripDanglingToolCallsFromMessages(dedupeToolPartsFromMessages(messages)),
+  );
+}
+
+/**
+ * Drops assistant messages that normalization emptied of renderable content —
+ * e.g. a turn whose only parts were dangling tool calls that `stripDanglingTool-
+ * Calls` removed. Run after `normalizeChatMessages` and before persisting so the
+ * DB never holds a stuck-looking empty assistant row. Non-assistant messages are
+ * left untouched.
+ */
+export function dropEmptyAssistantMessages(
+  messages: ChatMessage[],
+): ChatMessage[] {
+  return messages.filter(
+    (message) =>
+      message.role !== "assistant" || hasRenderableAssistantContent(message),
   );
 }
 

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -118,10 +118,7 @@ import { injectSkillActivation } from "./inject-skill-activation";
 import { cloneAttachmentsForFork } from "./normalization/clone-attachments-for-fork";
 import { extractInlineAttachments } from "./normalization/extract-inline-attachments";
 import { materializeAttachments } from "./normalization/materialize-attachments";
-import {
-  dropEmptyAssistantMessages,
-  normalizeChatMessages,
-} from "./normalization/normalize-chat-messages";
+import { normalizeChatMessages } from "./normalization/normalize-chat-messages";
 
 const PromoteChatAttachmentResultSchema = z.object({
   filename: z.string(),
@@ -2595,13 +2592,10 @@ async function persistNewMessages(
       }
 
       if (messagesToSave.length > 0) {
-        // Strip base64 images and large browser tool results, then drop any
-        // assistant message left non-renderable — normalization can empty a turn
-        // whose only parts were dangling tool calls, and persisting that yields a
-        // stuck-looking empty assistant bubble on reload.
-        const messagesToStore = dropEmptyAssistantMessages(
-          normalizeChatMessages(messagesToSave),
-        );
+        // Strip base64 images / large tool results and drop assistant turns left
+        // non-renderable (e.g. only a dangling tool call) — persisting one of
+        // those yields a stuck-looking empty bubble on reload.
+        const messagesToStore = normalizeChatMessages(messagesToSave);
 
         if (context === "onFinish") {
           // Log size reduction only for onFinish (where we have complete messages)

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -118,7 +118,10 @@ import { injectSkillActivation } from "./inject-skill-activation";
 import { cloneAttachmentsForFork } from "./normalization/clone-attachments-for-fork";
 import { extractInlineAttachments } from "./normalization/extract-inline-attachments";
 import { materializeAttachments } from "./normalization/materialize-attachments";
-import { normalizeChatMessages } from "./normalization/normalize-chat-messages";
+import {
+  dropEmptyAssistantMessages,
+  normalizeChatMessages,
+} from "./normalization/normalize-chat-messages";
 
 const PromoteChatAttachmentResultSchema = z.object({
   filename: z.string(),
@@ -2592,18 +2595,22 @@ async function persistNewMessages(
       }
 
       if (messagesToSave.length > 0) {
-        let messagesToStore: ChatMessage[];
+        // Strip base64 images and large browser tool results, then drop any
+        // assistant message left non-renderable — normalization can empty a turn
+        // whose only parts were dangling tool calls, and persisting that yields a
+        // stuck-looking empty assistant bubble on reload.
+        const messagesToStore = dropEmptyAssistantMessages(
+          normalizeChatMessages(messagesToSave),
+        );
 
-        // Strip base64 images and large browser tool results before storing
         if (context === "onFinish") {
           // Log size reduction only for onFinish (where we have complete messages)
           const beforeSize = estimateMessagesSize(messagesToSave);
-          messagesToStore = normalizeChatMessages(messagesToSave);
           const afterSize = estimateMessagesSize(messagesToStore);
 
           logger.info(
             {
-              messageCount: messagesToSave.length,
+              messageCount: messagesToStore.length,
               beforeSizeKB: Math.round(beforeSize.length / 1024),
               afterSizeKB: Math.round(afterSize.length / 1024),
               savedKB: Math.round(
@@ -2614,25 +2621,24 @@ async function persistNewMessages(
             },
             "[Chat] Stripped messages before saving to DB",
           );
-        } else {
-          // For onError, just strip without detailed logging
-          messagesToStore = normalizeChatMessages(messagesToSave);
         }
 
-        const now = Date.now();
-        const messageData = messagesToStore.map((msg, index) => ({
-          conversationId,
-          role: msg.role ?? "assistant",
-          content: msg,
-          createdAt: new Date(now + index),
-        }));
+        if (messagesToStore.length > 0) {
+          const now = Date.now();
+          const messageData = messagesToStore.map((msg, index) => ({
+            conversationId,
+            role: msg.role ?? "assistant",
+            content: msg,
+            createdAt: new Date(now + index),
+          }));
 
-        await MessageModel.bulkCreate(messageData);
-        persistedCount += messagesToSave.length;
+          await MessageModel.bulkCreate(messageData);
+          persistedCount += messagesToStore.length;
 
-        logger.info(
-          `Appended ${messagesToSave.length} new messages to conversation ${conversationId} (${context})`,
-        );
+          logger.info(
+            `Appended ${messagesToStore.length} new messages to conversation ${conversationId} (${context})`,
+          );
+        }
       }
     }
 

--- a/platform/frontend/src/lib/chat/chat-session-utils.test.ts
+++ b/platform/frontend/src/lib/chat/chat-session-utils.test.ts
@@ -250,3 +250,50 @@ describe("pruneEmptyTrailingAssistantMessage", () => {
     expect(pruneEmptyTrailingAssistantMessage(messages)).toEqual(messages);
   });
 });
+
+describe("restoreTruncatedAssistantTail renderability gating", () => {
+  test("does not restore a truncated tail that is a telemetry-only assistant", () => {
+    const previousMessages = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "go" }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          { type: "step-start" },
+          { type: "data-token-usage", data: { totalTokens: 10 } },
+        ],
+      },
+    ] as UIMessage[];
+
+    const nextMessages = [previousMessages[0]] as UIMessage[];
+
+    expect(
+      restoreRenderableAssistantParts({ previousMessages, nextMessages }),
+    ).toEqual(nextMessages);
+  });
+
+  test("does not restore when the live session clears to a non-renderable assistant tail", () => {
+    const previousMessages = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "go" }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "step-start" }],
+      },
+    ] as UIMessage[];
+
+    const nextMessages = [] as UIMessage[];
+
+    expect(
+      restoreRenderableAssistantParts({ previousMessages, nextMessages }),
+    ).toEqual(nextMessages);
+  });
+});

--- a/platform/frontend/src/lib/chat/chat-session-utils.test.ts
+++ b/platform/frontend/src/lib/chat/chat-session-utils.test.ts
@@ -1,6 +1,9 @@
 import type { UIMessage } from "@ai-sdk/react";
 import { describe, expect, test } from "vitest";
-import { restoreRenderableAssistantParts } from "./chat-session-utils";
+import {
+  pruneEmptyTrailingAssistantMessage,
+  restoreRenderableAssistantParts,
+} from "./chat-session-utils";
 
 describe("restoreRenderableAssistantParts", () => {
   test("preserves previous assistant parts when the same assistant message becomes empty", () => {
@@ -211,5 +214,39 @@ describe("restoreRenderableAssistantParts", () => {
     expect(
       restoreRenderableAssistantParts({ previousMessages, nextMessages }),
     ).toEqual(previousMessages);
+  });
+});
+
+describe("pruneEmptyTrailingAssistantMessage", () => {
+  test("drops a trailing assistant left with only step-start/telemetry after dangling-tool stripping", () => {
+    const messages = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "go" }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          { type: "step-start" },
+          { type: "data-token-usage", data: { totalTokens: 10 } },
+        ],
+      },
+    ] as UIMessage[];
+
+    expect(pruneEmptyTrailingAssistantMessage(messages)).toEqual([messages[0]]);
+  });
+
+  test("keeps a trailing assistant that still renders text", () => {
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "step-start" }, { type: "text", text: "done" }],
+      },
+    ] as UIMessage[];
+
+    expect(pruneEmptyTrailingAssistantMessage(messages)).toEqual(messages);
   });
 });

--- a/platform/frontend/src/lib/chat/chat-session-utils.ts
+++ b/platform/frontend/src/lib/chat/chat-session-utils.ts
@@ -56,10 +56,10 @@ export function restoreRenderableAssistantParts(params: {
 }
 
 /**
- * Drops a trailing assistant message left with no parts. Mirrors the backend's
- * persist behavior (an empty last message is not stored), keeping the live view
- * consistent with what a reload would show — used after stripping dangling tool
- * parts from a stopped turn.
+ * Drops a trailing assistant message left with no renderable content. Mirrors the
+ * backend's persist behavior (an empty last message is not stored), keeping the live
+ * view consistent with what a reload would show — used after stripping dangling tool
+ * parts from a stopped turn, which can leave only `step-start`/telemetry parts behind.
  */
 export function pruneEmptyTrailingAssistantMessage(
   messages: UIMessage[],
@@ -67,7 +67,7 @@ export function pruneEmptyTrailingAssistantMessage(
   const lastMessage = messages.at(-1);
   if (
     lastMessage?.role === "assistant" &&
-    (lastMessage.parts?.length ?? 0) === 0
+    !hasRenderableAssistantContent(lastMessage)
   ) {
     return messages.slice(0, -1);
   }

--- a/platform/frontend/src/lib/chat/chat-session-utils.ts
+++ b/platform/frontend/src/lib/chat/chat-session-utils.ts
@@ -120,9 +120,11 @@ function restoreTruncatedAssistantTail(params: {
     return nextMessages;
   }
 
+  const lastPreviousMessage = previousMessages.at(-1);
   if (
     nextMessages.length === 0 &&
-    previousMessages.at(-1)?.role === "assistant"
+    lastPreviousMessage?.role === "assistant" &&
+    hasRenderableAssistantContent(lastPreviousMessage)
   ) {
     return previousMessages;
   }
@@ -134,11 +136,17 @@ function restoreTruncatedAssistantTail(params: {
   const hasStablePrefix = nextMessages.every((message, index) =>
     sameMessageIdentity(message, previousMessages[index]),
   );
+  // only restore a tail that carries content worth keeping — restoring a
+  // non-renderable assistant (e.g. step-start/telemetry after a stopped turn)
+  // would resurrect the empty bubble the persist path just pruned away.
   const truncatedTail = previousMessages.slice(nextMessages.length);
   if (
     hasStablePrefix &&
     truncatedTail.length > 0 &&
-    truncatedTail.every((message) => message.role === "assistant")
+    truncatedTail.every(
+      (message) =>
+        message.role === "assistant" && hasRenderableAssistantContent(message),
+    )
   ) {
     return previousMessages;
   }

--- a/platform/frontend/src/lib/chat/chat-session-utils.ts
+++ b/platform/frontend/src/lib/chat/chat-session-utils.ts
@@ -1,4 +1,5 @@
 import type { UIMessage } from "@ai-sdk/react";
+import { hasRenderableAssistantContent } from "@shared";
 
 /**
  * Preserves the last renderable assistant content when a live session update
@@ -73,18 +74,10 @@ export function pruneEmptyTrailingAssistantMessage(
   return messages;
 }
 
-/**
- * Returns true when an assistant message still has content the chat UI can
- * actually render. Empty text parts do not count, but any non-text part does.
- */
+// shared with the backend persist path so the live view and what a reload shows
+// agree on what counts as renderable.
 function hasRenderableAssistantParts(message: UIMessage): boolean {
-  return (message.parts ?? []).some((part) => {
-    if (part.type === "text") {
-      return Boolean(part.text);
-    }
-
-    return true;
-  });
+  return hasRenderableAssistantContent(message);
 }
 
 function findPreviousRenderableAssistantMessage(params: {

--- a/platform/shared/chat.ts
+++ b/platform/shared/chat.ts
@@ -50,20 +50,40 @@ export type ChatMessage = {
   metadata?: unknown;
 };
 
+// Control/telemetry parts the chat UI skips and providers never see. An
+// assistant turn left with only these (e.g. a `step-start` after a dangling
+// tool call is stripped) renders nothing, so it must not count as content.
+// `data-tool-ui-start` is deliberately absent — the UI renders it as an MCP app.
+const NON_RENDERABLE_ASSISTANT_PART_TYPES: ReadonlySet<string> = new Set([
+  "step-start",
+  "data-token-usage",
+  "data-heartbeat",
+  "data-context-window-estimate",
+  "data-context-compaction-start",
+  "data-context-compaction-finish",
+]);
+
 /**
  * True when an assistant message still carries something the chat UI can
- * render: a non-empty text part, or any non-text part (completed tool result,
- * reasoning, file, ...). An assistant turn left with no parts — or only empty
- * text — after normalization is not renderable and must not be persisted or
- * shown. Structurally typed so both backend `ChatMessagePart`s and the
- * frontend's AI SDK `UIMessage` parts satisfy it.
+ * render: a non-empty text part, or any non-text part that is not a known
+ * non-renderable control/telemetry marker (so completed tool results,
+ * reasoning, files, MCP-app parts all count). An assistant turn left with no
+ * parts — or only empty text / control parts — after normalization is not
+ * renderable and must not be persisted or shown. Fails safe toward keeping:
+ * an unrecognized part type counts as content. Structurally typed so both
+ * backend `ChatMessagePart`s and the frontend's AI SDK `UIMessage` parts
+ * satisfy it.
  */
 export function hasRenderableAssistantContent(message: {
   parts?: ReadonlyArray<{ type: string; text?: unknown }>;
 }): boolean {
-  return (message.parts ?? []).some((part) =>
-    part.type === "text" ? Boolean(part.text) : true,
-  );
+  return (message.parts ?? []).some((part) => {
+    if (part.type === "text") {
+      return Boolean(part.text);
+    }
+
+    return !NON_RENDERABLE_ASSISTANT_PART_TYPES.has(part.type);
+  });
 }
 
 /**

--- a/platform/shared/chat.ts
+++ b/platform/shared/chat.ts
@@ -51,6 +51,22 @@ export type ChatMessage = {
 };
 
 /**
+ * True when an assistant message still carries something the chat UI can
+ * render: a non-empty text part, or any non-text part (completed tool result,
+ * reasoning, file, ...). An assistant turn left with no parts — or only empty
+ * text — after normalization is not renderable and must not be persisted or
+ * shown. Structurally typed so both backend `ChatMessagePart`s and the
+ * frontend's AI SDK `UIMessage` parts satisfy it.
+ */
+export function hasRenderableAssistantContent(message: {
+  parts?: ReadonlyArray<{ type: string; text?: unknown }>;
+}): boolean {
+  return (message.parts ?? []).some((part) =>
+    part.type === "text" ? Boolean(part.text) : true,
+  );
+}
+
+/**
  * The skill a user explicitly invoked via slash command, carried on the user
  * message's metadata. The backend uses it to inject the skill's activation
  * block; the chat UI uses it to badge the message.


### PR DESCRIPTION
## Problem

A finished chat turn could show an empty assistant bubble — no text, no tool result — that looked stuck even though the backend considered the turn complete and persisted it.

## Root cause

An interrupted turn (stream errored / stopped / finished before a tool produced a result) yields an assistant message whose only part is a dangling tool call. The persist path's emptiness guard ran *before* normalization, so it passed; normalization then stripped the unresolved tool call, leaving `parts: []`, which got persisted as an empty assistant row and rendered as a stuck bubble on reload.

## Approach

An empty assistant response is never valid, so neither the model nor the DB should ever see one. The drop is folded into `normalizeChatMessages` as its final step, so it applies everywhere normalization runs: persistence, LLM-prep, and compaction. A message is dropped only when it has no renderable content (no parts, or only empty text); anything with a non-text part — completed tool result, reasoning, approval-requested tool call — is kept.

## Changes

- `shared/chat.ts`: add `hasRenderableAssistantContent()` — single source of truth, structurally typed so both backend `ChatMessagePart`s and frontend `UIMessage` parts satisfy it.
- `normalize-chat-messages.ts`: `normalizeChatMessages` now drops empty assistant turns as its final step.
- `chat-session-utils.ts`: frontend live-view prune delegates to the shared predicate so live and reloaded views agree.
- The tool-approval `changedMessages` path is unaffected — those always carry a terminal tool-state part, so they stay renderable.

## Tests

Backend cases for drop-after-strip, keep-text/keep-completed-result, and leave-non-assistant-untouched. Full chat route suite (365 tests) green.
