### PR TITLE
test(e2e): probe IdP server-state when JWT gateway readiness gives up

### DIFF
--- a/platform/e2e-tests/tests/mcp-gateway-jwks.ee.spec.ts
+++ b/platform/e2e-tests/tests/mcp-gateway-jwks.ee.spec.ts
@@ -86,6 +86,7 @@ test.describe("MCP Gateway - External IdP JWKS Authentication", () => {
         request,
         profileId: pid,
         token: jwt,
+        identityProviderId,
       });
       expect(tools.length).toBeGreaterThan(0);
 

--- a/platform/e2e-tests/tests/mcp-gateway-jwt-propagation.ee.spec.ts
+++ b/platform/e2e-tests/tests/mcp-gateway-jwt-propagation.ee.spec.ts
@@ -156,6 +156,7 @@ test.describe("MCP Gateway - JWT Propagation to Upstream MCP Server", () => {
         profileId: pid,
         token: jwt,
         expectedToolName: getServerInfoToolName,
+        identityProviderId,
       });
       const toolNames = tools.map((t) => t.name);
       expect(toolNames).toContain(getServerInfoToolName);
@@ -505,6 +506,7 @@ test.describe("MCP Gateway - JWT Propagation to Upstream MCP Server", () => {
         profileId: pid,
         token: jwt,
         expectedToolName: getServerInfoToolName,
+        identityProviderId,
       });
       const toolNames = tools.map((t) => t.name);
       expect(toolNames).toContain(getServerInfoToolName);

--- a/platform/e2e-tests/utils/mcp-gateway.ts
+++ b/platform/e2e-tests/utils/mcp-gateway.ts
@@ -321,6 +321,9 @@ export async function waitForMcpGatewayJwtReady(params: {
   token: string;
   expectedToolName?: string;
   requireToolsListed?: boolean;
+  /** IdP the profile was bound to; lets the give-up probe report whether that
+   *  provider row still exists (404 = deleted, which FK-nulls the binding). */
+  identityProviderId?: string;
 }): Promise<McpTool[]> {
   const requireToolsListed = params.requireToolsListed !== false;
   const delaysMs = [
@@ -390,6 +393,7 @@ export async function waitForMcpGatewayJwtReady(params: {
   const serverState = await probeIdpServerState(
     params.request,
     params.profileId,
+    params.identityProviderId,
   );
 
   const lastMsg = lastError instanceof Error ? lastError.message : "";
@@ -401,6 +405,7 @@ export async function waitForMcpGatewayJwtReady(params: {
 async function probeIdpServerState(
   request: APIRequestContext,
   profileId: string,
+  expectedIdpId?: string,
 ): Promise<string> {
   try {
     const agentResp = await makeApiRequest({
@@ -415,17 +420,24 @@ async function probeIdpServerState(
     };
     const idpId = agent.identityProviderId;
     let state = `[agent GET=${agentResp.status()} identityProviderId=${idpId ? "set" : "MISSING"} agentType=${agent.agentType ?? "?"}`;
-    if (idpId) {
+    // Resolve which provider to probe: the one still on the agent, or — if the
+    // binding is gone — the one the profile was created with. A 404 on the
+    // latter proves the provider row was deleted (FK ON DELETE SET NULL nulled
+    // the binding); a 200 means the binding vanished without the row being
+    // deleted.
+    const probeIdpId = idpId ?? expectedIdpId;
+    if (probeIdpId) {
       const idpResp = await makeApiRequest({
         request,
         method: "get",
-        urlSuffix: `/api/identity-providers/${idpId}`,
+        urlSuffix: `/api/identity-providers/${probeIdpId}`,
         ignoreStatusCheck: true,
       });
       const idp = (await idpResp.json().catch(() => ({}))) as {
         oidcConfig?: { clientId?: string; jwksEndpoint?: string } | null;
       };
-      state += `; idp GET=${idpResp.status()} hasOidcConfig=${!!idp.oidcConfig} hasJwksEndpoint=${!!idp.oidcConfig?.jwksEndpoint} hasClientId=${!!idp.oidcConfig?.clientId}]`;
+      const which = idpId ? "idp" : "expectedIdp";
+      state += `; ${which} GET=${idpResp.status()} hasOidcConfig=${!!idp.oidcConfig} hasJwksEndpoint=${!!idp.oidcConfig?.jwksEndpoint} hasClientId=${!!idp.oidcConfig?.clientId}]`;
     } else {
       state += "]";
     }

--- a/platform/e2e-tests/utils/mcp-gateway.ts
+++ b/platform/e2e-tests/utils/mcp-gateway.ts
@@ -383,10 +383,56 @@ export async function waitForMcpGatewayJwtReady(params: {
     ? `Tool ${params.expectedToolName} was not available via JWT auth`
     : "MCP Gateway did not become ready for external JWT auth";
 
+  // The 401 collapses many silent validateExternalIdpToken null branches into
+  // one opaque error, and backend logs rotate out before the CI dump. Fold the
+  // deciding state (IdP binding present? OIDC config resolvable?) into the
+  // failure message — booleans/status only, never secret config.
+  const serverState = await probeIdpServerState(
+    params.request,
+    params.profileId,
+  );
+
   const lastMsg = lastError instanceof Error ? lastError.message : "";
   throw new Error(
-    `${headline} — ${delaysMs.length} attempts over ~${Math.round(delaysMs.reduce((a, b) => a + b, 0) / 1000)}s. ${errorSummary || "(no failure signal captured)"}${lastMsg && !errorSummary.includes(lastMsg) ? ` Last: ${lastMsg}` : ""}`,
+    `${headline} — ${delaysMs.length} attempts over ~${Math.round(delaysMs.reduce((a, b) => a + b, 0) / 1000)}s. ${errorSummary || "(no failure signal captured)"}${lastMsg && !errorSummary.includes(lastMsg) ? ` Last: ${lastMsg}` : ""} ${serverState}`,
   );
+}
+
+async function probeIdpServerState(
+  request: APIRequestContext,
+  profileId: string,
+): Promise<string> {
+  try {
+    const agentResp = await makeApiRequest({
+      request,
+      method: "get",
+      urlSuffix: `/api/agents/${profileId}`,
+      ignoreStatusCheck: true,
+    });
+    const agent = (await agentResp.json().catch(() => ({}))) as {
+      identityProviderId?: string | null;
+      agentType?: string;
+    };
+    const idpId = agent.identityProviderId;
+    let state = `[agent GET=${agentResp.status()} identityProviderId=${idpId ? "set" : "MISSING"} agentType=${agent.agentType ?? "?"}`;
+    if (idpId) {
+      const idpResp = await makeApiRequest({
+        request,
+        method: "get",
+        urlSuffix: `/api/identity-providers/${idpId}`,
+        ignoreStatusCheck: true,
+      });
+      const idp = (await idpResp.json().catch(() => ({}))) as {
+        oidcConfig?: { clientId?: string; jwksEndpoint?: string } | null;
+      };
+      state += `; idp GET=${idpResp.status()} hasOidcConfig=${!!idp.oidcConfig} hasJwksEndpoint=${!!idp.oidcConfig?.jwksEndpoint} hasClientId=${!!idp.oidcConfig?.clientId}]`;
+    } else {
+      state += "]";
+    }
+    return state;
+  } catch (error) {
+    return `[server-state probe failed: ${error instanceof Error ? error.message : String(error)}]`;
+  }
 }
 
 export async function listMcpTools(


### PR DESCRIPTION
## Summary

The flaky `mcp-gateway-jwks` / `jwt-propagation` e2e tests fail when the MCP gateway returns `401 "Invalid token for this profile"` for the full ~162s readiness window — meaning `validateExternalIdpToken` returned `null`. Pinning *which* of its null branches has been the blocker: most are silent or log at a level that scrolls out of the backend container log before the CI dump reads it, so successive rounds of backend-log instrumentation kept coming back empty even after the dump was fixed to read the whole log.

This sidesteps backend-log rotation entirely. When `waitForMcpGatewayJwtReady` exhausts its retries, it now GETs the agent and its identity provider and folds the deciding facts into the thrown error — which lands in the always-uploaded Playwright report:

- `identityProviderId=set|MISSING` — is the IdP binding still on the agent? (distinguishes a regressed/never-persisted binding — the silent branch-1 path — from everything else)
- `hasOidcConfig` / `hasJwksEndpoint` / `hasClientId` — is the provider's OIDC config resolvable?

One failing run now tells us whether the binding regressed or the JWT validation itself is failing. The probe is diagnostic-only: it never throws (all calls guarded; returns a string on any error) and emits booleans / HTTP status codes only — never the `clientId`, `jwksEndpoint`, `clientSecret`, or token values.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>