### PR TITLE
feat(idp): warn when deleting a provider detaches bound agents

### DIFF
--- a/platform/backend/src/models/identity-provider.ee.ts
+++ b/platform/backend/src/models/identity-provider.ee.ts
@@ -15,6 +15,7 @@ import {
 } from "@/auth/idp-team-sync-cache.ee";
 import config from "@/config";
 import db, { schema, withDbTransaction } from "@/database";
+import { notDeleted } from "@/database/schemas/soft-deletable-table";
 import logger from "@/logging";
 import { evaluateRoleMappingTemplate } from "@/templating";
 import type {
@@ -810,6 +811,31 @@ class IdentityProviderModel {
     );
     if (!existingProvider) {
       return false;
+    }
+
+    // agents.identity_provider_id is ON DELETE SET NULL, so deleting a provider
+    // detaches every agent bound to it (MCP gateways and LLM proxies that
+    // validate caller JWTs against this IdP's JWKS) with no other trace — their
+    // external-JWT auth then fails (401) until they are rebound. Surface that
+    // here so an operator isn't left guessing.
+    const boundAgents = await db
+      .select({ id: schema.agentsTable.id })
+      .from(schema.agentsTable)
+      .where(
+        and(
+          eq(schema.agentsTable.identityProviderId, id),
+          notDeleted(schema.agentsTable),
+        ),
+      );
+    if (boundAgents.length > 0) {
+      logger.warn(
+        {
+          identityProviderId: id,
+          organizationId,
+          boundAgentCount: boundAgents.length,
+        },
+        "Deleting identity provider detaches agents bound to it for external-JWT (JWKS) auth; those agents will reject JWTs until rebound to a provider",
+      );
     }
 
     // Wrap deletions in a transaction to ensure atomicity


### PR DESCRIPTION
## Summary

`agents.identity_provider_id` is a foreign key with `ON DELETE SET NULL`. Deleting an identity provider therefore **silently nulls the binding** on every agent that uses it — MCP gateways and LLM proxies that validate caller JWTs against the provider's JWKS. Those agents immediately start rejecting external JWTs with an opaque `401 "Invalid token for this profile"` and **no log explaining why**: the cascade happens in Postgres, so the auth path (`validateExternalIdpToken`) just sees a profile with no provider and returns null on its only unlogged branch.

This emits a warning at delete time naming the provider and how many agents will be detached, so an operator who later sees the 401s can connect them to the deletion instead of guessing. Read-only and advisory — it does not change delete behavior. (It also surfaced a real, days-long flaky-CI investigation where this exact silent cascade — an unrelated test deleting a provider mid-run — was nulling a gateway agent's binding.)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>