### PR TITLE
chore(staging): add env-test environment namespace

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -63,6 +63,13 @@ archestra:
         # Enable SSRF protection for MCP server pods
         create: true
 
+      rbac:
+        # Namespaces backing deployment environments the platform may deploy
+        # MCP servers into. Each entry gets a namespace-scoped Role + RoleBinding
+        # and is surfaced to the app as ARCHESTRA_ORCHESTRATOR_ENVIRONMENT_NAMESPACES.
+        environmentNamespaces:
+          - env-test
+
       serviceAccount:
         # GKE Workload Identity binding to allow Vertex AI access via ADC
         # The GCP service account (archestra-vertex-ai@friendly-path-465518-r6.iam.gserviceaccount.com)
@@ -113,3 +120,4 @@ archestra:
           - path: /
             port: 9000
             pathType: Prefix
+


### PR DESCRIPTION
Adds `environmentNamespaces: [env-test]` under `orchestrator.kubernetes.rbac` in staging values, so the platform can deploy MCP servers into the `env-test` namespace.

Note: the `env-test` namespace must exist before `helm upgrade`.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>