### PR TITLE
fix(docker): cache cargo/turbo/next artifacts in builder pnpm build

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -192,7 +192,17 @@ FROM builder-base AS builder
 #
 # https://docs.docker.com/build/building/secrets/#using-build-secrets
 # https://docs.docker.com/build/building/secrets/#target
-RUN --mount=type=secret,id=turbo_team,env=TURBO_TEAM \
+# Cache cargo registry/git, the Rust workspace target dir, turbo's local cache,
+# and Next.js's build cache so a cold `pnpm build` (which recompiles the Rust
+# N-API addon and builds the frontend) reuses prior work on subsequent builds.
+# The cargo targets match the sandbox-rs-musl-smoke stage above, so that stage
+# warms the registry for this one; cargo isolates artifacts by target triple.
+RUN --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/root/.cargo/git \
+    --mount=type=cache,target=/app/archestra-rs/target \
+    --mount=type=cache,target=/app/.turbo \
+    --mount=type=cache,target=/app/frontend/.next/cache \
+    --mount=type=secret,id=turbo_team,env=TURBO_TEAM \
     --mount=type=secret,id=turbo_token,env=TURBO_TOKEN \
     --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN \
     SENTRY_URL=https://de.sentry.io/ \


### PR DESCRIPTION
## Summary

A cold `docker build` of the platform image recompiles the Rust N-API skill-sandbox addon (`@archestra/sandbox-rs`) and its full `dagger-sdk` dependency graph (tokio, hyper, tonic, …) and rebuilds the Next.js frontend from scratch on every build, because the `builder` stage's `pnpm build` step had no BuildKit cache mounts. On a developer machine this is the dominant cost of an image build — the Rust compile alone runs for the better part of an hour.

This adds cache mounts for the cargo registry/git directories, the Rust workspace `target/`, turbo's local cache, and the Next.js build cache to that `pnpm build` step, so subsequent builds reuse compiled crate artifacts and incremental frontend output instead of starting cold. The cargo mounts reuse the same targets already declared on the `sandbox-rs-musl-smoke` stage, so that stage warms the crate registry for the real build; cargo isolates compiled artifacts per target triple, so the musl smoke build and the glibc builder build share the mount without colliding.

The cache mounts are excluded from the image layers, so the produced image is byte-for-byte unaffected — only build wall-time changes. The benefit is realized on any builder that persists BuildKit state across runs (local iterative builds, self-hosted or cached CI runners).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>