### PR TITLE
feat(mcp-registry): shareable catalog edit deep-link + environment label

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/catalog-edit-link.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/catalog-edit-link.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  clearCatalogEditParam,
+  setCatalogEditParam,
+} from "./catalog-edit-link";
+
+describe("setCatalogEditParam", () => {
+  it("adds the edit param to an empty search", () => {
+    expect(setCatalogEditParam("", "cat-1")).toBe("edit=cat-1");
+  });
+
+  it("preserves existing params", () => {
+    const result = new URLSearchParams(
+      setCatalogEditParam("search=foo&labels=x", "cat-1"),
+    );
+    expect(result.get("search")).toBe("foo");
+    expect(result.get("labels")).toBe("x");
+    expect(result.get("edit")).toBe("cat-1");
+  });
+
+  it("overwrites an existing edit param", () => {
+    expect(setCatalogEditParam("edit=old", "new")).toBe("edit=new");
+  });
+});
+
+describe("clearCatalogEditParam", () => {
+  it("removes the edit param", () => {
+    expect(clearCatalogEditParam("edit=cat-1")).toBe("");
+  });
+
+  it("preserves other params", () => {
+    const result = new URLSearchParams(
+      clearCatalogEditParam("search=foo&edit=cat-1"),
+    );
+    expect(result.get("search")).toBe("foo");
+    expect(result.has("edit")).toBe(false);
+  });
+
+  it("is a no-op when there is no edit param", () => {
+    expect(clearCatalogEditParam("search=foo")).toBe("search=foo");
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/_parts/catalog-edit-link.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/catalog-edit-link.ts
@@ -1,0 +1,21 @@
+import { MCP_CATALOG_EDIT_QUERY_PARAM } from "@shared";
+
+/**
+ * Search string (without leading `?`) with `?edit=<id>` set, preserving all
+ * other params. Used to make an open editor shareable via the address bar.
+ */
+export function setCatalogEditParam(currentSearch: string, id: string): string {
+  const params = new URLSearchParams(currentSearch);
+  params.set(MCP_CATALOG_EDIT_QUERY_PARAM, id);
+  return params.toString();
+}
+
+/**
+ * Search string (without leading `?`) with `?edit` removed, preserving all
+ * other params. Used when the editor closes or an unknown id is ignored.
+ */
+export function clearCatalogEditParam(currentSearch: string): string {
+  const params = new URLSearchParams(currentSearch);
+  params.delete(MCP_CATALOG_EDIT_QUERY_PARAM);
+  return params.toString();
+}

--- a/platform/frontend/src/app/mcp/registry/_parts/catalog-environment-label.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/catalog-environment-label.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { resolveCatalogEnvironmentLabel } from "./catalog-environment-label";
+
+const envs = [
+  { id: "prod", name: "Production" },
+  { id: "staging", name: "Staging" },
+];
+
+describe("resolveCatalogEnvironmentLabel", () => {
+  it("hides the label when there are no real environments (only Default)", () => {
+    expect(
+      resolveCatalogEnvironmentLabel({
+        environmentId: "prod",
+        environments: [],
+        defaultEnvironmentName: "Default",
+      }),
+    ).toBeNull();
+    expect(
+      resolveCatalogEnvironmentLabel({
+        environmentId: null,
+        environments: [],
+        defaultEnvironmentName: "Renamed",
+      }),
+    ).toBeNull();
+  });
+
+  it("shows the assigned real environment's name", () => {
+    expect(
+      resolveCatalogEnvironmentLabel({
+        environmentId: "staging",
+        environments: envs,
+        defaultEnvironmentName: "Default",
+      }),
+    ).toBe("Staging");
+  });
+
+  it("returns null for a Default-assigned item when Default is unnamed", () => {
+    expect(
+      resolveCatalogEnvironmentLabel({
+        environmentId: null,
+        environments: envs,
+        defaultEnvironmentName: "Default",
+      }),
+    ).toBeNull();
+  });
+
+  it("shows the Default name only when it has been customized", () => {
+    expect(
+      resolveCatalogEnvironmentLabel({
+        environmentId: null,
+        environments: envs,
+        defaultEnvironmentName: "Sandbox",
+      }),
+    ).toBe("Sandbox");
+  });
+
+  it("returns null when the assigned environment is no longer in the list", () => {
+    expect(
+      resolveCatalogEnvironmentLabel({
+        environmentId: "deleted",
+        environments: envs,
+        defaultEnvironmentName: "Default",
+      }),
+    ).toBeNull();
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/_parts/catalog-environment-label.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/catalog-environment-label.ts
@@ -1,0 +1,36 @@
+// Fallback name `useDefaultEnvironment()` returns when the org hasn't given the
+// implicit Default environment a custom name. Mirrors the check in
+// environments-section.tsx, where the "Default" badge is also keyed off it.
+export const DEFAULT_ENVIRONMENT_NAME = "Default";
+
+/**
+ * Decides which environment name (if any) to surface on a catalog card.
+ *
+ * - Hidden entirely unless the org has more than the single implicit Default
+ *   environment — i.e. at least one real environment exists. With only Default
+ *   around, the label carries no information.
+ * - Items assigned to a real environment show that environment's name.
+ * - Items on the Default environment (null `environmentId`) only show a label
+ *   when Default has been renamed; the bare "Default" is noise.
+ *
+ * Returns null when nothing should be rendered.
+ */
+export function resolveCatalogEnvironmentLabel({
+  environmentId,
+  environments,
+  defaultEnvironmentName,
+}: {
+  environmentId: string | null;
+  environments: Array<{ id: string; name: string }>;
+  defaultEnvironmentName: string;
+}): string | null {
+  if (environments.length === 0) return null;
+
+  if (environmentId === null) {
+    return defaultEnvironmentName === DEFAULT_ENVIRONMENT_NAME
+      ? null
+      : defaultEnvironmentName;
+  }
+
+  return environments.find((env) => env.id === environmentId)?.name ?? null;
+}

--- a/platform/frontend/src/app/mcp/registry/_parts/edit-catalog-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/edit-catalog-dialog.tsx
@@ -1,4 +1,5 @@
 import type { archestraApiTypes } from "@shared";
+import { Loader2, ShieldX } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -14,6 +15,7 @@ import { useMcpServers } from "@/lib/mcp/mcp-server.query";
 import { McpCatalogForm } from "./mcp-catalog-form";
 import type { McpCatalogFormValues } from "./mcp-catalog-form.types";
 import { transformFormToApiData } from "./mcp-catalog-form.utils";
+import { useCanEditCatalogPresets } from "./preset-helpers";
 
 interface EditCatalogDialogProps {
   item: archestraApiTypes.GetInternalMcpCatalogResponses["200"][number] | null;
@@ -27,6 +29,32 @@ export function EditCatalogDialog({ item, onClose }: EditCatalogDialogProps) {
         {item && <EditCatalogContent item={item} onClose={onClose} />}
       </DialogContent>
     </Dialog>
+  );
+}
+
+/** Centered spinner while the edit-permission check resolves. */
+function CatalogEditLoading() {
+  return (
+    <div className="flex flex-1 items-center justify-center">
+      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+    </div>
+  );
+}
+
+/**
+ * Access-denied body shown in place of the edit form. Plain content (no
+ * DialogHeader) so it can be dropped inside any dialog that already provides a
+ * title — the settings dialog's Configuration page, or the standalone
+ * deep-link dialog on the catalog card.
+ */
+export function CatalogEditNoAccess() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center text-muted-foreground">
+      <ShieldX className="h-10 w-10" />
+      <p className="text-sm">
+        You don't have access to edit this catalog item.
+      </p>
+    </div>
   );
 }
 
@@ -48,6 +76,11 @@ export function EditCatalogContent({
   onDirtyChange,
   submitRef,
 }: EditCatalogContentProps) {
+  // Authorization gate for the edit form itself — covers every entry point
+  // (the settings dialog's Configuration page, a shared `?edit=<id>` deep link,
+  // or the legacy EditCatalogDialog). Mirrors the backend
+  // `assertCanEditCatalogPresets`: an admin, or the author of a personal item.
+  const { canEdit, isLoading: canEditLoading } = useCanEditCatalogPresets(item);
   const updateMutation = useUpdateInternalMcpCatalogItem();
 
   const { data: presets = [] } = useCatalogPresets(item.id);
@@ -70,6 +103,13 @@ export function EditCatalogContent({
       onClose();
     }
   };
+
+  if (canEditLoading) {
+    return <CatalogEditLoading />;
+  }
+  if (!canEdit) {
+    return <CatalogEditNoAccess />;
+  }
 
   return (
     <McpCatalogForm

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -296,13 +296,19 @@ export function McpServerCard({
   };
 
   const openEditorConfiguration = () => {
+    // Opening via the pencil writes `?edit=<id>`, which would otherwise wake
+    // the auto-open effect below. Mark the deep-link as already handled so the
+    // manual and shared-link paths don't both fire.
+    deepLinkHandledRef.current = true;
     writeEditParam();
     openSettingsPage("configuration");
   };
 
-  // Auto-open on a shared link. Runs once (ref-guarded), and only after the
-  // edit-permission check resolves so non-editors aren't briefly shown the
-  // form. Builtin items aren't editable, so canEditPresets is false for them.
+  // Auto-open on a shared link. One-shot per mount (ref-guarded): a shared link
+  // is resolved at most once, so a client-side change of `?edit` to a different
+  // id without a remount won't re-trigger it. Runs only after the edit-
+  // permission check resolves so non-editors aren't briefly shown the form.
+  // Builtin items aren't editable, so canEditPresets is false for them.
   useEffect(() => {
     if (deepLinkHandledRef.current) return;
     if (canEditPresetsLoading) return;

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -4,6 +4,7 @@ import {
   type archestraApiTypes,
   E2eTestId,
   getManageCredentialsButtonTestId,
+  MCP_CATALOG_EDIT_QUERY_PARAM,
   type McpDeploymentStatusEntry,
 } from "@shared";
 import {
@@ -16,7 +17,8 @@ import {
   User,
   Wrench,
 } from "lucide-react";
-import { useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
@@ -28,8 +30,16 @@ import {
   AvatarGroupCount,
 } from "@/components/ui/avatar";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { PermissionButton } from "@/components/ui/permission-button";
 import {
   Tooltip,
@@ -49,12 +59,22 @@ import {
   useReinstallInternalMcpCatalogItem,
 } from "@/lib/mcp/internal-mcp-catalog.query";
 import { useMcpServers } from "@/lib/mcp/mcp-server.query";
-import { usePresetEntityName } from "@/lib/organization.query";
+import { useEnvironments } from "@/lib/organization/environment.query";
+import {
+  useDefaultEnvironment,
+  usePresetEntityName,
+} from "@/lib/organization.query";
 import { useTeams } from "@/lib/teams/team.query";
+import {
+  clearCatalogEditParam,
+  setCatalogEditParam,
+} from "./catalog-edit-link";
+import { resolveCatalogEnvironmentLabel } from "./catalog-environment-label";
 import {
   computeDeploymentStatusSummary,
   DeploymentStatusDot,
 } from "./deployment-status";
+import { CatalogEditNoAccess } from "./edit-catalog-dialog";
 import { InstallationProgress } from "./installation-progress";
 import {
   McpServerSettingsDialog,
@@ -173,14 +193,29 @@ export function McpServerCard({
   });
   const isLocalMcpEnabled = useFeature("orchestratorK8sRuntime");
 
+  // Environment label shown next to the title. Only surfaced once the org has
+  // more than the single implicit Default environment; Default-assigned items
+  // only show it when Default has been renamed. Built-in (Playwright) servers
+  // aren't environment-scoped, so skip them. Both queries are shared/cached, so
+  // calling them per card doesn't fan out requests.
+  const { data: environmentList } = useEnvironments();
+  const defaultEnvironment = useDefaultEnvironment();
+  const environmentLabel =
+    variant === "builtin"
+      ? null
+      : resolveCatalogEnvironmentLabel({
+          environmentId: item.environmentId,
+          environments: environmentList?.environments ?? [],
+          defaultEnvironmentName: defaultEnvironment.name,
+        });
+
   // Gate the Install button when the default preset (the parent catalog
   // itself) has unfilled preset-scoped fields and the current user cannot
   // edit them — clicking Install would land on Step 1 and 403 on save.
   const { singular: presetSingular, defaultLabel } = usePresetEntityName();
   const presetSingularLower = presetSingular.toLowerCase();
-  const { canEdit: canEditPresets } = useCanEditCatalogPresets(
-    variant !== "builtin" ? item : null,
-  );
+  const { canEdit: canEditPresets, isLoading: canEditPresetsLoading } =
+    useCanEditCatalogPresets(variant !== "builtin" ? item : null);
   const defaultPresetNeedsFill =
     variant !== "builtin" && presetHasUnfilledFields(item, item);
   const installBlockedByPresetFill = defaultPresetNeedsFill && !canEditPresets;
@@ -230,11 +265,56 @@ export function McpServerCard({
     null,
   );
   const [uninstallDialogOpen, setUninstallDialogOpen] = useState(false);
+  // Shown when a shared `?edit=<id>` link targets this item but the current
+  // user can't edit it.
+  const [editNoAccessOpen, setEditNoAccessOpen] = useState(false);
 
   const openSettingsPage = (page: SettingsPage) => {
     setSettingsInitialPage(page);
     setSettingsDialogOpen(true);
   };
+
+  // ── Shareable edit deep-link (`?edit=<catalogId>`) ──────────────────────
+  // The pencil opens the Configuration page and writes `?edit=<id>` so the
+  // address bar can be copied and shared. Opening a shared link auto-opens the
+  // editor for users who can edit, or a "no access" dialog for everyone else.
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const editParam = searchParams.get(MCP_CATALOG_EDIT_QUERY_PARAM);
+  const deepLinkHandledRef = useRef(false);
+
+  const writeEditParam = () => {
+    const qs = setCatalogEditParam(searchParams.toString(), item.id);
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  };
+
+  const clearEditParam = () => {
+    if (!searchParams.get(MCP_CATALOG_EDIT_QUERY_PARAM)) return;
+    const qs = clearCatalogEditParam(searchParams.toString());
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  };
+
+  const openEditorConfiguration = () => {
+    writeEditParam();
+    openSettingsPage("configuration");
+  };
+
+  // Auto-open on a shared link. Runs once (ref-guarded), and only after the
+  // edit-permission check resolves so non-editors aren't briefly shown the
+  // form. Builtin items aren't editable, so canEditPresets is false for them.
+  useEffect(() => {
+    if (deepLinkHandledRef.current) return;
+    if (canEditPresetsLoading) return;
+    if (editParam !== item.id) return;
+    deepLinkHandledRef.current = true;
+    if (canEditPresets) {
+      setSettingsInitialPage("configuration");
+      setSettingsDialogOpen(true);
+    } else {
+      setEditNoAccessOpen(true);
+    }
+  }, [editParam, item.id, canEditPresets, canEditPresetsLoading]);
 
   const handleChatWithMcpServer = async () => {
     setIsChatCreating(true);
@@ -574,7 +654,7 @@ export function McpServerCard({
       size="icon"
       className="h-8 w-8"
       data-testid={`${E2eTestId.McpServerSettingsButton}-${item.name}`}
-      onClick={() => openSettingsPage("configuration")}
+      onClick={openEditorConfiguration}
     >
       <Pencil className="h-4 w-4" />
     </Button>
@@ -948,6 +1028,8 @@ export function McpServerCard({
           if (!open) {
             setLogsInitialServerId(null);
             setSettingsInitialPage(undefined);
+            // Drop the shareable `?edit` param when the editor closes.
+            clearEditParam();
           }
         }}
         initialPage={settingsInitialPage}
@@ -980,6 +1062,24 @@ export function McpServerCard({
         }
       />
 
+      <Dialog
+        open={editNoAccessOpen}
+        onOpenChange={(open) => {
+          setEditNoAccessOpen(open);
+          if (!open) clearEditParam();
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader className="sr-only">
+            <DialogTitle>No access</DialogTitle>
+            <DialogDescription>
+              You don't have access to edit this catalog item.
+            </DialogDescription>
+          </DialogHeader>
+          <CatalogEditNoAccess />
+        </DialogContent>
+      </Dialog>
+
       <UninstallServerDialog
         open={uninstallDialogOpen}
         onClose={() => setUninstallDialogOpen(false)}
@@ -1005,6 +1105,14 @@ export function McpServerCard({
                   {item.name}
                 </span>
               </TruncatedTooltip>
+              {environmentLabel && (
+                <Badge
+                  variant="outline"
+                  className="shrink-0 text-muted-foreground"
+                >
+                  <span className="max-w-32 truncate">{environmentLabel}</span>
+                </Badge>
+              )}
             </div>
             {item.description && (
               <p className="text-xs text-muted-foreground line-clamp-2">

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-settings-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-settings-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { E2eTestId, type McpDeploymentStatusEntry } from "@shared";
-import { AlertCircle, Copy, PlugZap, RefreshCw, XIcon } from "lucide-react";
+import { AlertCircle, PlugZap, RefreshCw, XIcon } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
 import { Button } from "@/components/ui/button";
@@ -365,7 +365,7 @@ export function McpServerSettingsDialog({
             <div className="px-2 pb-3 flex flex-col gap-1.5">
               {!hasPersonalConnection && onConnect && (
                 <Button
-                  variant="outline"
+                  variant="ghost"
                   size="sm"
                   className="w-full justify-start"
                   onClick={() =>
@@ -392,13 +392,12 @@ export function McpServerSettingsDialog({
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="w-full justify-start gap-2"
+                  className="w-full justify-start"
                   onClick={() => {
                     handleClose();
                     onClone();
                   }}
                 >
-                  <Copy className="h-4 w-4" />
                   Clone
                 </Button>
               )}

--- a/platform/shared/oauth.ts
+++ b/platform/shared/oauth.ts
@@ -69,3 +69,12 @@ export const MCP_CATALOG_INSTALL_QUERY_PARAM = "install";
  */
 export const MCP_CATALOG_REAUTH_QUERY_PARAM = "reauth";
 export const MCP_CATALOG_SERVER_QUERY_PARAM = "server";
+
+/**
+ * Query param for deep-linking to a catalog item's edit dialog.
+ * Append `?edit={catalogId}` to auto-open the editor. Unlike the install/reauth
+ * params, this one persists while the dialog is open so the URL stays
+ * shareable. Only users who can edit the item see the editor; others get an
+ * access-denied message, and unknown/invisible ids are silently ignored.
+ */
+export const MCP_CATALOG_EDIT_QUERY_PARAM = "edit";


### PR DESCRIPTION
Two changes to the MCP registry catalog cards:

1. Shareable catalog edit deep-link (`?edit=<catalogId>`)
2. Environment label - Catalog item titles show their environment label

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>