### PR TITLE
fix: usage limits and cleanup windows

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -67975,6 +67975,12 @@
                                 "spanId": {
                                   "type": "string"
                                 },
+                                "usageLimitExceeded": {
+                                  "type": "boolean"
+                                },
+                                "usageLimitEntityType": {
+                                  "type": "string"
+                                },
                                 "originalError": {
                                   "type": "object",
                                   "properties": {
@@ -68645,6 +68651,12 @@
                               "spanId": {
                                 "type": "string"
                               },
+                              "usageLimitExceeded": {
+                                "type": "boolean"
+                              },
+                              "usageLimitEntityType": {
+                                "type": "string"
+                              },
                               "originalError": {
                                 "type": "object",
                                 "properties": {
@@ -69290,6 +69302,12 @@
                                 "type": "string"
                               },
                               "spanId": {
+                                "type": "string"
+                              },
+                              "usageLimitExceeded": {
+                                "type": "boolean"
+                              },
+                              "usageLimitEntityType": {
                                 "type": "string"
                               },
                               "originalError": {
@@ -69978,6 +69996,12 @@
                                 "type": "string"
                               },
                               "spanId": {
+                                "type": "string"
+                              },
+                              "usageLimitExceeded": {
+                                "type": "boolean"
+                              },
+                              "usageLimitEntityType": {
                                 "type": "string"
                               },
                               "originalError": {
@@ -71505,6 +71529,12 @@
                               "spanId": {
                                 "type": "string"
                               },
+                              "usageLimitExceeded": {
+                                "type": "boolean"
+                              },
+                              "usageLimitEntityType": {
+                                "type": "string"
+                              },
                               "originalError": {
                                 "type": "object",
                                 "properties": {
@@ -72517,6 +72547,12 @@
                                     "type": "string"
                                   },
                                   "spanId": {
+                                    "type": "string"
+                                  },
+                                  "usageLimitExceeded": {
+                                    "type": "boolean"
+                                  },
+                                  "usageLimitEntityType": {
                                     "type": "string"
                                   },
                                   "originalError": {
@@ -74122,6 +74158,12 @@
                               "spanId": {
                                 "type": "string"
                               },
+                              "usageLimitExceeded": {
+                                "type": "boolean"
+                              },
+                              "usageLimitEntityType": {
+                                "type": "string"
+                              },
                               "originalError": {
                                 "type": "object",
                                 "properties": {
@@ -74793,6 +74835,12 @@
                               "spanId": {
                                 "type": "string"
                               },
+                              "usageLimitExceeded": {
+                                "type": "boolean"
+                              },
+                              "usageLimitEntityType": {
+                                "type": "string"
+                              },
                               "originalError": {
                                 "type": "object",
                                 "properties": {
@@ -75454,6 +75502,12 @@
                                 "type": "string"
                               },
                               "spanId": {
+                                "type": "string"
+                              },
+                              "usageLimitExceeded": {
+                                "type": "boolean"
+                              },
+                              "usageLimitEntityType": {
                                 "type": "string"
                               },
                               "originalError": {
@@ -76127,6 +76181,12 @@
                                 "type": "string"
                               },
                               "spanId": {
+                                "type": "string"
+                              },
+                              "usageLimitExceeded": {
+                                "type": "boolean"
+                              },
+                              "usageLimitEntityType": {
                                 "type": "string"
                               },
                               "originalError": {
@@ -87507,6 +87567,12 @@
                                         "spanId": {
                                           "type": "string"
                                         },
+                                        "usageLimitExceeded": {
+                                          "type": "boolean"
+                                        },
+                                        "usageLimitEntityType": {
+                                          "type": "string"
+                                        },
                                         "originalError": {
                                           "type": "object",
                                           "properties": {
@@ -88341,6 +88407,12 @@
                                         "spanId": {
                                           "type": "string"
                                         },
+                                        "usageLimitExceeded": {
+                                          "type": "boolean"
+                                        },
+                                        "usageLimitEntityType": {
+                                          "type": "string"
+                                        },
                                         "originalError": {
                                           "type": "object",
                                           "properties": {
@@ -88877,6 +88949,12 @@
                                         "spanId": {
                                           "type": "string"
                                         },
+                                        "usageLimitExceeded": {
+                                          "type": "boolean"
+                                        },
+                                        "usageLimitEntityType": {
+                                          "type": "string"
+                                        },
                                         "originalError": {
                                           "type": "object",
                                           "properties": {
@@ -89275,6 +89353,12 @@
                                           "type": "string"
                                         },
                                         "spanId": {
+                                          "type": "string"
+                                        },
+                                        "usageLimitExceeded": {
+                                          "type": "boolean"
+                                        },
+                                        "usageLimitEntityType": {
                                           "type": "string"
                                         },
                                         "originalError": {
@@ -89686,6 +89770,12 @@
                                           "type": "string"
                                         },
                                         "spanId": {
+                                          "type": "string"
+                                        },
+                                        "usageLimitExceeded": {
+                                          "type": "boolean"
+                                        },
+                                        "usageLimitEntityType": {
                                           "type": "string"
                                         },
                                         "originalError": {
@@ -91811,6 +91901,12 @@
                                         "spanId": {
                                           "type": "string"
                                         },
+                                        "usageLimitExceeded": {
+                                          "type": "boolean"
+                                        },
+                                        "usageLimitEntityType": {
+                                          "type": "string"
+                                        },
                                         "originalError": {
                                           "type": "object",
                                           "properties": {
@@ -92220,6 +92316,12 @@
                                           "type": "string"
                                         },
                                         "spanId": {
+                                          "type": "string"
+                                        },
+                                        "usageLimitExceeded": {
+                                          "type": "boolean"
+                                        },
+                                        "usageLimitEntityType": {
                                           "type": "string"
                                         },
                                         "originalError": {
@@ -92633,6 +92735,12 @@
                                         "spanId": {
                                           "type": "string"
                                         },
+                                        "usageLimitExceeded": {
+                                          "type": "boolean"
+                                        },
+                                        "usageLimitEntityType": {
+                                          "type": "string"
+                                        },
                                         "originalError": {
                                           "type": "object",
                                           "properties": {
@@ -93042,6 +93150,12 @@
                                           "type": "string"
                                         },
                                         "spanId": {
+                                          "type": "string"
+                                        },
+                                        "usageLimitExceeded": {
+                                          "type": "boolean"
+                                        },
+                                        "usageLimitEntityType": {
                                           "type": "string"
                                         },
                                         "originalError": {
@@ -93455,6 +93569,12 @@
                                         "spanId": {
                                           "type": "string"
                                         },
+                                        "usageLimitExceeded": {
+                                          "type": "boolean"
+                                        },
+                                        "usageLimitEntityType": {
+                                          "type": "string"
+                                        },
                                         "originalError": {
                                           "type": "object",
                                           "properties": {
@@ -93864,6 +93984,12 @@
                                           "type": "string"
                                         },
                                         "spanId": {
+                                          "type": "string"
+                                        },
+                                        "usageLimitExceeded": {
+                                          "type": "boolean"
+                                        },
+                                        "usageLimitEntityType": {
                                           "type": "string"
                                         },
                                         "originalError": {
@@ -94277,6 +94403,12 @@
                                         "spanId": {
                                           "type": "string"
                                         },
+                                        "usageLimitExceeded": {
+                                          "type": "boolean"
+                                        },
+                                        "usageLimitEntityType": {
+                                          "type": "string"
+                                        },
                                         "originalError": {
                                           "type": "object",
                                           "properties": {
@@ -94688,6 +94820,12 @@
                                         "spanId": {
                                           "type": "string"
                                         },
+                                        "usageLimitExceeded": {
+                                          "type": "boolean"
+                                        },
+                                        "usageLimitEntityType": {
+                                          "type": "string"
+                                        },
                                         "originalError": {
                                           "type": "object",
                                           "properties": {
@@ -95088,6 +95226,12 @@
                                         "spanId": {
                                           "type": "string"
                                         },
+                                        "usageLimitExceeded": {
+                                          "type": "boolean"
+                                        },
+                                        "usageLimitEntityType": {
+                                          "type": "string"
+                                        },
                                         "originalError": {
                                           "type": "object",
                                           "properties": {
@@ -95486,6 +95630,12 @@
                                           "type": "string"
                                         },
                                         "spanId": {
+                                          "type": "string"
+                                        },
+                                        "usageLimitExceeded": {
+                                          "type": "boolean"
+                                        },
+                                        "usageLimitEntityType": {
                                           "type": "string"
                                         },
                                         "originalError": {
@@ -95899,6 +96049,12 @@
                                         "spanId": {
                                           "type": "string"
                                         },
+                                        "usageLimitExceeded": {
+                                          "type": "boolean"
+                                        },
+                                        "usageLimitEntityType": {
+                                          "type": "string"
+                                        },
                                         "originalError": {
                                           "type": "object",
                                           "properties": {
@@ -96310,6 +96466,12 @@
                                         "spanId": {
                                           "type": "string"
                                         },
+                                        "usageLimitExceeded": {
+                                          "type": "boolean"
+                                        },
+                                        "usageLimitEntityType": {
+                                          "type": "string"
+                                        },
                                         "originalError": {
                                           "type": "object",
                                           "properties": {
@@ -96719,6 +96881,12 @@
                                           "type": "string"
                                         },
                                         "spanId": {
+                                          "type": "string"
+                                        },
+                                        "usageLimitExceeded": {
+                                          "type": "boolean"
+                                        },
+                                        "usageLimitEntityType": {
                                           "type": "string"
                                         },
                                         "originalError": {
@@ -97356,6 +97524,12 @@
                                           "type": "string"
                                         },
                                         "spanId": {
+                                          "type": "string"
+                                        },
+                                        "usageLimitExceeded": {
+                                          "type": "boolean"
+                                        },
+                                        "usageLimitEntityType": {
                                           "type": "string"
                                         },
                                         "originalError": {
@@ -98190,6 +98364,12 @@
                                           "type": "string"
                                         },
                                         "spanId": {
+                                          "type": "string"
+                                        },
+                                        "usageLimitExceeded": {
+                                          "type": "boolean"
+                                        },
+                                        "usageLimitEntityType": {
                                           "type": "string"
                                         },
                                         "originalError": {
@@ -100079,6 +100259,12 @@
                                   "spanId": {
                                     "type": "string"
                                   },
+                                  "usageLimitExceeded": {
+                                    "type": "boolean"
+                                  },
+                                  "usageLimitEntityType": {
+                                    "type": "string"
+                                  },
                                   "originalError": {
                                     "type": "object",
                                     "properties": {
@@ -100913,6 +101099,12 @@
                                   "spanId": {
                                     "type": "string"
                                   },
+                                  "usageLimitExceeded": {
+                                    "type": "boolean"
+                                  },
+                                  "usageLimitEntityType": {
+                                    "type": "string"
+                                  },
                                   "originalError": {
                                     "type": "object",
                                     "properties": {
@@ -101449,6 +101641,12 @@
                                   "spanId": {
                                     "type": "string"
                                   },
+                                  "usageLimitExceeded": {
+                                    "type": "boolean"
+                                  },
+                                  "usageLimitEntityType": {
+                                    "type": "string"
+                                  },
                                   "originalError": {
                                     "type": "object",
                                     "properties": {
@@ -101847,6 +102045,12 @@
                                     "type": "string"
                                   },
                                   "spanId": {
+                                    "type": "string"
+                                  },
+                                  "usageLimitExceeded": {
+                                    "type": "boolean"
+                                  },
+                                  "usageLimitEntityType": {
                                     "type": "string"
                                   },
                                   "originalError": {
@@ -102258,6 +102462,12 @@
                                     "type": "string"
                                   },
                                   "spanId": {
+                                    "type": "string"
+                                  },
+                                  "usageLimitExceeded": {
+                                    "type": "boolean"
+                                  },
+                                  "usageLimitEntityType": {
                                     "type": "string"
                                   },
                                   "originalError": {
@@ -104383,6 +104593,12 @@
                                   "spanId": {
                                     "type": "string"
                                   },
+                                  "usageLimitExceeded": {
+                                    "type": "boolean"
+                                  },
+                                  "usageLimitEntityType": {
+                                    "type": "string"
+                                  },
                                   "originalError": {
                                     "type": "object",
                                     "properties": {
@@ -104792,6 +105008,12 @@
                                     "type": "string"
                                   },
                                   "spanId": {
+                                    "type": "string"
+                                  },
+                                  "usageLimitExceeded": {
+                                    "type": "boolean"
+                                  },
+                                  "usageLimitEntityType": {
                                     "type": "string"
                                   },
                                   "originalError": {
@@ -105205,6 +105427,12 @@
                                   "spanId": {
                                     "type": "string"
                                   },
+                                  "usageLimitExceeded": {
+                                    "type": "boolean"
+                                  },
+                                  "usageLimitEntityType": {
+                                    "type": "string"
+                                  },
                                   "originalError": {
                                     "type": "object",
                                     "properties": {
@@ -105614,6 +105842,12 @@
                                     "type": "string"
                                   },
                                   "spanId": {
+                                    "type": "string"
+                                  },
+                                  "usageLimitExceeded": {
+                                    "type": "boolean"
+                                  },
+                                  "usageLimitEntityType": {
                                     "type": "string"
                                   },
                                   "originalError": {
@@ -106027,6 +106261,12 @@
                                   "spanId": {
                                     "type": "string"
                                   },
+                                  "usageLimitExceeded": {
+                                    "type": "boolean"
+                                  },
+                                  "usageLimitEntityType": {
+                                    "type": "string"
+                                  },
                                   "originalError": {
                                     "type": "object",
                                     "properties": {
@@ -106436,6 +106676,12 @@
                                     "type": "string"
                                   },
                                   "spanId": {
+                                    "type": "string"
+                                  },
+                                  "usageLimitExceeded": {
+                                    "type": "boolean"
+                                  },
+                                  "usageLimitEntityType": {
                                     "type": "string"
                                   },
                                   "originalError": {
@@ -106849,6 +107095,12 @@
                                   "spanId": {
                                     "type": "string"
                                   },
+                                  "usageLimitExceeded": {
+                                    "type": "boolean"
+                                  },
+                                  "usageLimitEntityType": {
+                                    "type": "string"
+                                  },
                                   "originalError": {
                                     "type": "object",
                                     "properties": {
@@ -107260,6 +107512,12 @@
                                   "spanId": {
                                     "type": "string"
                                   },
+                                  "usageLimitExceeded": {
+                                    "type": "boolean"
+                                  },
+                                  "usageLimitEntityType": {
+                                    "type": "string"
+                                  },
                                   "originalError": {
                                     "type": "object",
                                     "properties": {
@@ -107660,6 +107918,12 @@
                                   "spanId": {
                                     "type": "string"
                                   },
+                                  "usageLimitExceeded": {
+                                    "type": "boolean"
+                                  },
+                                  "usageLimitEntityType": {
+                                    "type": "string"
+                                  },
                                   "originalError": {
                                     "type": "object",
                                     "properties": {
@@ -108058,6 +108322,12 @@
                                     "type": "string"
                                   },
                                   "spanId": {
+                                    "type": "string"
+                                  },
+                                  "usageLimitExceeded": {
+                                    "type": "boolean"
+                                  },
+                                  "usageLimitEntityType": {
                                     "type": "string"
                                   },
                                   "originalError": {
@@ -108471,6 +108741,12 @@
                                   "spanId": {
                                     "type": "string"
                                   },
+                                  "usageLimitExceeded": {
+                                    "type": "boolean"
+                                  },
+                                  "usageLimitEntityType": {
+                                    "type": "string"
+                                  },
                                   "originalError": {
                                     "type": "object",
                                     "properties": {
@@ -108882,6 +109158,12 @@
                                   "spanId": {
                                     "type": "string"
                                   },
+                                  "usageLimitExceeded": {
+                                    "type": "boolean"
+                                  },
+                                  "usageLimitEntityType": {
+                                    "type": "string"
+                                  },
                                   "originalError": {
                                     "type": "object",
                                     "properties": {
@@ -109291,6 +109573,12 @@
                                     "type": "string"
                                   },
                                   "spanId": {
+                                    "type": "string"
+                                  },
+                                  "usageLimitExceeded": {
+                                    "type": "boolean"
+                                  },
+                                  "usageLimitEntityType": {
                                     "type": "string"
                                   },
                                   "originalError": {
@@ -109928,6 +110216,12 @@
                                     "type": "string"
                                   },
                                   "spanId": {
+                                    "type": "string"
+                                  },
+                                  "usageLimitExceeded": {
+                                    "type": "boolean"
+                                  },
+                                  "usageLimitEntityType": {
                                     "type": "string"
                                   },
                                   "originalError": {
@@ -110762,6 +111056,12 @@
                                     "type": "string"
                                   },
                                   "spanId": {
+                                    "type": "string"
+                                  },
+                                  "usageLimitExceeded": {
+                                    "type": "boolean"
+                                  },
+                                  "usageLimitEntityType": {
                                     "type": "string"
                                   },
                                   "originalError": {
@@ -136625,7 +136925,11 @@
                           "12h",
                           "24h",
                           "1w",
-                          "1m"
+                          "1m",
+                          "calendar_day",
+                          "calendar_week_sunday",
+                          "calendar_week_monday",
+                          "calendar_month"
                         ]
                       },
                       "lastCleanup": {
@@ -136986,7 +137290,11 @@
                       "12h",
                       "24h",
                       "1w",
-                      "1m"
+                      "1m",
+                      "calendar_day",
+                      "calendar_week_sunday",
+                      "calendar_week_monday",
+                      "calendar_month"
                     ]
                   },
                   "lastCleanup": {
@@ -137066,7 +137374,11 @@
                         "12h",
                         "24h",
                         "1w",
-                        "1m"
+                        "1m",
+                        "calendar_day",
+                        "calendar_week_sunday",
+                        "calendar_week_monday",
+                        "calendar_month"
                       ]
                     },
                     "lastCleanup": {
@@ -137419,7 +137731,11 @@
                         "12h",
                         "24h",
                         "1w",
-                        "1m"
+                        "1m",
+                        "calendar_day",
+                        "calendar_week_sunday",
+                        "calendar_week_monday",
+                        "calendar_month"
                       ]
                     },
                     "lastCleanup": {
@@ -137752,7 +138068,11 @@
                       "12h",
                       "24h",
                       "1w",
-                      "1m"
+                      "1m",
+                      "calendar_day",
+                      "calendar_week_sunday",
+                      "calendar_week_monday",
+                      "calendar_month"
                     ]
                   },
                   "lastCleanup": {
@@ -137838,7 +138158,11 @@
                         "12h",
                         "24h",
                         "1w",
-                        "1m"
+                        "1m",
+                        "calendar_day",
+                        "calendar_week_sunday",
+                        "calendar_week_monday",
+                        "calendar_month"
                       ]
                     },
                     "lastCleanup": {
@@ -170531,7 +170855,11 @@
                         "12h",
                         "24h",
                         "1w",
-                        "1m"
+                        "1m",
+                        "calendar_day",
+                        "calendar_week_sunday",
+                        "calendar_week_monday",
+                        "calendar_month"
                       ]
                     },
                     "defaultAgentId": {
@@ -171414,7 +171742,11 @@
                         "12h",
                         "24h",
                         "1w",
-                        "1m"
+                        "1m",
+                        "calendar_day",
+                        "calendar_week_sunday",
+                        "calendar_week_monday",
+                        "calendar_month"
                       ]
                     },
                     "defaultAgentId": {
@@ -172569,7 +172901,11 @@
                         "12h",
                         "24h",
                         "1w",
-                        "1m"
+                        "1m",
+                        "calendar_day",
+                        "calendar_week_sunday",
+                        "calendar_week_monday",
+                        "calendar_month"
                       ]
                     },
                     "defaultAgentId": {
@@ -173142,7 +173478,11 @@
                       "12h",
                       "24h",
                       "1w",
-                      "1m"
+                      "1m",
+                      "calendar_day",
+                      "calendar_week_sunday",
+                      "calendar_week_monday",
+                      "calendar_month"
                     ]
                   }
                 }
@@ -173334,7 +173674,11 @@
                         "12h",
                         "24h",
                         "1w",
-                        "1m"
+                        "1m",
+                        "calendar_day",
+                        "calendar_week_sunday",
+                        "calendar_week_monday",
+                        "calendar_month"
                       ]
                     },
                     "defaultAgentId": {
@@ -174086,7 +174430,11 @@
                         "12h",
                         "24h",
                         "1w",
-                        "1m"
+                        "1m",
+                        "calendar_day",
+                        "calendar_week_sunday",
+                        "calendar_week_monday",
+                        "calendar_month"
                       ]
                     },
                     "defaultAgentId": {
@@ -174900,7 +175248,11 @@
                         "12h",
                         "24h",
                         "1w",
-                        "1m"
+                        "1m",
+                        "calendar_day",
+                        "calendar_week_sunday",
+                        "calendar_week_monday",
+                        "calendar_month"
                       ]
                     },
                     "defaultAgentId": {
@@ -175647,7 +175999,11 @@
                         "12h",
                         "24h",
                         "1w",
-                        "1m"
+                        "1m",
+                        "calendar_day",
+                        "calendar_week_sunday",
+                        "calendar_week_monday",
+                        "calendar_month"
                       ]
                     },
                     "defaultAgentId": {
@@ -176387,7 +176743,11 @@
                         "12h",
                         "24h",
                         "1w",
-                        "1m"
+                        "1m",
+                        "calendar_day",
+                        "calendar_week_sunday",
+                        "calendar_week_monday",
+                        "calendar_month"
                       ]
                     },
                     "defaultAgentId": {
@@ -177126,7 +177486,11 @@
                         "12h",
                         "24h",
                         "1w",
-                        "1m"
+                        "1m",
+                        "calendar_day",
+                        "calendar_week_sunday",
+                        "calendar_week_monday",
+                        "calendar_month"
                       ]
                     },
                     "defaultAgentId": {
@@ -177882,7 +178246,11 @@
                         "12h",
                         "24h",
                         "1w",
-                        "1m"
+                        "1m",
+                        "calendar_day",
+                        "calendar_week_sunday",
+                        "calendar_week_monday",
+                        "calendar_month"
                       ]
                     },
                     "defaultAgentId": {
@@ -178621,7 +178989,11 @@
                         "12h",
                         "24h",
                         "1w",
-                        "1m"
+                        "1m",
+                        "calendar_day",
+                        "calendar_week_sunday",
+                        "calendar_week_monday",
+                        "calendar_month"
                       ]
                     },
                     "defaultAgentId": {
@@ -179373,7 +179745,11 @@
                         "12h",
                         "24h",
                         "1w",
-                        "1m"
+                        "1m",
+                        "calendar_day",
+                        "calendar_week_sunday",
+                        "calendar_week_monday",
+                        "calendar_month"
                       ]
                     },
                     "defaultAgentId": {
@@ -180092,7 +180468,11 @@
                         "12h",
                         "24h",
                         "1w",
-                        "1m"
+                        "1m",
+                        "calendar_day",
+                        "calendar_week_sunday",
+                        "calendar_week_monday",
+                        "calendar_month"
                       ]
                     },
                     "defaultAgentId": {
@@ -181124,7 +181504,11 @@
                         "12h",
                         "24h",
                         "1w",
-                        "1m"
+                        "1m",
+                        "calendar_day",
+                        "calendar_week_sunday",
+                        "calendar_week_monday",
+                        "calendar_month"
                       ]
                     },
                     "defaultAgentId": {
@@ -187678,6 +188062,12 @@
                                 "type": "string"
                               },
                               "spanId": {
+                                "type": "string"
+                              },
+                              "usageLimitExceeded": {
+                                "type": "boolean"
+                              },
+                              "usageLimitEntityType": {
                                 "type": "string"
                               },
                               "originalError": {

--- a/docs/pages/platform-archestra-mcp-server.md
+++ b/docs/pages/platform-archestra-mcp-server.md
@@ -641,7 +641,7 @@ Required RBAC permission: `llmLimit:create`
 | `limit_type` | `"token_cost" \| "mcp_server_calls" \| "tool_calls"` | Yes | The type of limit to apply. |
 | `limit_value` | `number` | Yes | The limit value (tokens or count depending on limit type). |
 | `model` | `string[] \| null` | No | Array of model names. Omit for all models. |
-| `cleanup_interval` | `"1h" \| "12h" \| "24h" \| "1w" \| "1m"` | No | Optional cleanup interval for this limit. Omit to use the weekly default. |
+| `cleanup_interval` | `"1h" \| "12h" \| "24h" \| "1w" \| "1m" \| "calendar_day" \| "calendar_week_sunday" \| "calendar_week_monday" \| "calendar_month"` | No | Optional cleanup interval for this limit. Omit to use the weekly default. |
 | `mcp_server_name` | `string` | No | MCP server name. Required for mcp_server_calls and tool_calls limits. |
 | `tool_name` | `string` | No | Tool name. Required for tool_calls limits. |
 
@@ -655,7 +655,7 @@ Required RBAC permission: `llmLimit:create`
 | `limit.entityId` | `string` | Yes | The limited entity ID. |
 | `limit.limitType` | `"token_cost" \| "mcp_server_calls" \| "tool_calls"` | Yes | The kind of limit. |
 | `limit.limitValue` | `number` | Yes | The configured limit value. |
-| `limit.cleanupInterval` | `"1h" \| "12h" \| "24h" \| "1w" \| "1m"` | Yes | How often this limit resets. |
+| `limit.cleanupInterval` | `"1h" \| "12h" \| "24h" \| "1w" \| "1m" \| "calendar_day" \| "calendar_week_sunday" \| "calendar_week_monday" \| "calendar_month"` | Yes | How often this limit resets. |
 | `limit.model` | `string[] \| null` | No | Models targeted by a token_cost limit. Null or empty array means all models. |
 | `limit.mcpServerName` | `string \| null` | No | MCP server name for MCP-specific limits, if any. |
 | `limit.toolName` | `string \| null` | No | Tool name for tool-specific limits, if any. |
@@ -681,7 +681,7 @@ Required RBAC permission: `llmLimit:read`
 | `limits[].entityId` | `string` | Yes | The limited entity ID. |
 | `limits[].limitType` | `"token_cost" \| "mcp_server_calls" \| "tool_calls"` | Yes | The kind of limit. |
 | `limits[].limitValue` | `number` | Yes | The configured limit value. |
-| `limits[].cleanupInterval` | `"1h" \| "12h" \| "24h" \| "1w" \| "1m"` | Yes | How often this limit resets. |
+| `limits[].cleanupInterval` | `"1h" \| "12h" \| "24h" \| "1w" \| "1m" \| "calendar_day" \| "calendar_week_sunday" \| "calendar_week_monday" \| "calendar_month"` | Yes | How often this limit resets. |
 | `limits[].model` | `string[] \| null` | No | Models targeted by a token_cost limit. Null or empty array means all models. |
 | `limits[].mcpServerName` | `string \| null` | No | MCP server name for MCP-specific limits, if any. |
 | `limits[].toolName` | `string \| null` | No | Tool name for tool-specific limits, if any. |
@@ -696,7 +696,7 @@ Required RBAC permission: `llmLimit:update`
 |-----------|------|----------|-------------|
 | `id` | `string` | Yes | The ID of the limit to update. |
 | `limit_value` | `number` | No | Optional new limit value. |
-| `cleanup_interval` | `"1h" \| "12h" \| "24h" \| "1w" \| "1m"` | No | Optional new cleanup interval for this limit. |
+| `cleanup_interval` | `"1h" \| "12h" \| "24h" \| "1w" \| "1m" \| "calendar_day" \| "calendar_week_sunday" \| "calendar_week_monday" \| "calendar_month"` | No | Optional new cleanup interval for this limit. |
 
 ##### Output
 
@@ -708,7 +708,7 @@ Required RBAC permission: `llmLimit:update`
 | `limit.entityId` | `string` | Yes | The limited entity ID. |
 | `limit.limitType` | `"token_cost" \| "mcp_server_calls" \| "tool_calls"` | Yes | The kind of limit. |
 | `limit.limitValue` | `number` | Yes | The configured limit value. |
-| `limit.cleanupInterval` | `"1h" \| "12h" \| "24h" \| "1w" \| "1m"` | Yes | How often this limit resets. |
+| `limit.cleanupInterval` | `"1h" \| "12h" \| "24h" \| "1w" \| "1m" \| "calendar_day" \| "calendar_week_sunday" \| "calendar_week_monday" \| "calendar_month"` | Yes | How often this limit resets. |
 | `limit.model` | `string[] \| null` | No | Models targeted by a token_cost limit. Null or empty array means all models. |
 | `limit.mcpServerName` | `string \| null` | No | MCP server name for MCP-specific limits, if any. |
 | `limit.toolName` | `string \| null` | No | Tool name for tool-specific limits, if any. |

--- a/docs/pages/platform-archestra-mcp-server.md
+++ b/docs/pages/platform-archestra-mcp-server.md
@@ -641,7 +641,7 @@ Required RBAC permission: `llmLimit:create`
 | `limit_type` | `"token_cost" \| "mcp_server_calls" \| "tool_calls"` | Yes | The type of limit to apply. |
 | `limit_value` | `number` | Yes | The limit value (tokens or count depending on limit type). |
 | `model` | `string[] \| null` | No | Array of model names. Omit for all models. |
-| `cleanup_interval` | `"1h" \| "12h" \| "24h" \| "1w" \| "1m" \| "calendar_day" \| "calendar_week_sunday" \| "calendar_week_monday" \| "calendar_month"` | No | Optional cleanup interval for this limit. Omit to use the weekly default. |
+| `cleanup_interval` | `"1h" \| "12h" \| "24h" \| "1w" \| "1m" \| "calendar_day" \| "calendar_week_sunday" \| "calendar_week_monday" \| "calendar_month"` | No | Optional cleanup interval for this limit. Omit to use the calendar-month default. |
 | `mcp_server_name` | `string` | No | MCP server name. Required for mcp_server_calls and tool_calls limits. |
 | `tool_name` | `string` | No | Tool name. Required for tool_calls limits. |
 

--- a/docs/pages/platform-costs-and-limits.md
+++ b/docs/pages/platform-costs-and-limits.md
@@ -46,7 +46,7 @@ A custom per-user limit overrides the default for that user. Use this when one u
 
 ## Limit Cleanup
 
-Limit usage is reset according to each limit's cleanup interval. Rolling intervals reset after the selected amount of time has elapsed since the previous reset. Calendar intervals reset at the next calendar boundary: day, week, or month. Calendar week limits can use either Sunday-Saturday or Monday-Sunday weeks. New limits default to calendar-month cleanup unless an admin chooses a different interval.
+Each limit has its own cleanup interval. Rolling intervals reset after elapsed time. Calendar intervals reset at the next day, week, or month boundary; weekly intervals can start on Sunday or Monday. New limits default to calendar-month cleanup. Changing a limit's cleanup interval resets its current usage.
 
 Default user limits use their own cleanup interval from LLM settings.
 

--- a/docs/pages/platform-costs-and-limits.md
+++ b/docs/pages/platform-costs-and-limits.md
@@ -2,7 +2,7 @@
 title: Costs & Limits
 category: LLM Proxy
 order: 4
-lastUpdated: 2026-05-14
+lastUpdated: 2026-06-02
 ---
 
 Archestra tracks LLM usage costs, enforces usage limits, and records savings from model optimization and tool-result compression. These controls work together: pricing defines cost, logs and statistics show what happened, limits stop or shape usage, and optimization reduces spend before a request reaches a model.
@@ -46,7 +46,7 @@ A custom per-user limit overrides the default for that user. Use this when one u
 
 ## Limit Cleanup
 
-Limit usage is reset according to each limit's cleanup interval. New limits default to weekly cleanup unless an admin chooses a different interval.
+Limit usage is reset according to each limit's cleanup interval. Intervals are rolling from the limit's last reset, not calendar boundaries. For example, a monthly limit resets one month after its previous reset, not automatically on the first day of the month. New limits default to weekly cleanup unless an admin chooses a different interval.
 
 Default user limits use their own cleanup interval from LLM settings.
 

--- a/docs/pages/platform-costs-and-limits.md
+++ b/docs/pages/platform-costs-and-limits.md
@@ -46,7 +46,7 @@ A custom per-user limit overrides the default for that user. Use this when one u
 
 ## Limit Cleanup
 
-Limit usage is reset according to each limit's cleanup interval. Intervals are rolling from the limit's last reset, not calendar boundaries. For example, a monthly limit resets one month after its previous reset, not automatically on the first day of the month. New limits default to weekly cleanup unless an admin chooses a different interval.
+Limit usage is reset according to each limit's cleanup interval. Rolling intervals reset after the selected amount of time has elapsed since the previous reset. Calendar intervals reset at the next calendar boundary: day, week, or month. Calendar week limits can use either Sunday-Saturday or Monday-Sunday weeks. New limits default to a rolling weekly cleanup unless an admin chooses a different interval.
 
 Default user limits use their own cleanup interval from LLM settings.
 

--- a/docs/pages/platform-costs-and-limits.md
+++ b/docs/pages/platform-costs-and-limits.md
@@ -46,7 +46,7 @@ A custom per-user limit overrides the default for that user. Use this when one u
 
 ## Limit Cleanup
 
-Limit usage is reset according to each limit's cleanup interval. Rolling intervals reset after the selected amount of time has elapsed since the previous reset. Calendar intervals reset at the next calendar boundary: day, week, or month. Calendar week limits can use either Sunday-Saturday or Monday-Sunday weeks. New limits default to a rolling weekly cleanup unless an admin chooses a different interval.
+Limit usage is reset according to each limit's cleanup interval. Rolling intervals reset after the selected amount of time has elapsed since the previous reset. Calendar intervals reset at the next calendar boundary: day, week, or month. Calendar week limits can use either Sunday-Saturday or Monday-Sunday weeks. New limits default to calendar-month cleanup unless an admin chooses a different interval.
 
 Default user limits use their own cleanup interval from LLM settings.
 

--- a/docs/pages/platform-costs-and-limits.md
+++ b/docs/pages/platform-costs-and-limits.md
@@ -46,7 +46,7 @@ A custom per-user limit overrides the default for that user. Use this when one u
 
 ## Limit Cleanup
 
-Each limit has its own cleanup interval. Rolling intervals reset after elapsed time. Calendar intervals reset at the next day, week, or month boundary; weekly intervals can start on Sunday or Monday. New limits default to calendar-month cleanup. Changing a limit's cleanup interval resets its current usage.
+Each limit has its own cleanup interval. Rolling intervals reset after elapsed time. Calendar intervals reset at the next day, week, or month boundary; weekly intervals can start on Sunday or Monday. Changing a limit's cleanup interval resets its current usage.
 
 Default user limits use their own cleanup interval from LLM settings.
 

--- a/platform/backend/src/archestra-mcp-server/limits.ts
+++ b/platform/backend/src/archestra-mcp-server/limits.ts
@@ -73,7 +73,7 @@ const CreateLimitToolArgsSchema = z
       .optional()
       .describe("Array of model names. Omit for all models."),
     cleanup_interval: LimitCleanupIntervalSchema.optional().describe(
-      "Optional cleanup interval for this limit. Omit to use the weekly default.",
+      "Optional cleanup interval for this limit. Omit to use the calendar-month default.",
     ),
     mcp_server_name: z
       .string()

--- a/platform/backend/src/models/interaction.ts
+++ b/platform/backend/src/models/interaction.ts
@@ -33,6 +33,7 @@ import type {
 } from "@/types";
 import { InteractionAuthMethodSchema } from "@/types";
 import { escapeLikePattern } from "@/utils/sql-search";
+import AgentModel from "./agent";
 import AgentTeamModel from "./agent-team";
 import ConversationChatErrorModel from "./conversation-chat-error";
 import LimitModel from "./limit";
@@ -711,20 +712,17 @@ class InteractionModel {
           `Profile ${interaction.profileId} has no team assignments for interaction ${interaction.id}`,
         );
 
-        // Even if agent has no teams, we should still try to update organization limits
-        // We'll use a default organization approach - get the first organization from existing limits
+        // Even if agent has no teams, update organization limits for its own org.
         try {
-          const existingOrgLimits = await db
-            .select({ entityId: schema.limitsTable.entityId })
-            .from(schema.limitsTable)
-            .where(eq(schema.limitsTable.entityType, "organization"))
-            .limit(1);
+          const organizationId = await AgentModel.findOrganizationId(
+            interaction.profileId,
+          );
 
-          if (existingOrgLimits.length > 0) {
+          if (organizationId) {
             updatePromises.push(
               LimitModel.updateTokenLimitUsage(
                 "organization",
-                existingOrgLimits[0].entityId,
+                organizationId,
                 model,
                 inputTokens,
                 outputTokens,

--- a/platform/backend/src/models/limit.test.ts
+++ b/platform/backend/src/models/limit.test.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import db, { schema } from "@/database";
 import { describe, expect, test, vi } from "@/test";
 import { CreateLimitSchema } from "@/types";
@@ -2194,6 +2194,31 @@ describe("cleanupLimitsIfNeeded", () => {
     );
     expect(dueUsage[0].currentUsageTokensIn).toBe(0);
     expect(currentMonthUsage[0].currentUsageTokensIn).toBe(500);
+  });
+
+  test("calendar Sunday week starts on the current Sunday", async () => {
+    const sunday = "2026-06-07 15:30:00";
+    const tuesday = "2026-06-09 15:30:00";
+
+    const result = await db.execute<{
+      sunday_period_start: string;
+      tuesday_period_start: string;
+    }>(sql`
+      select
+        to_char(
+          date_trunc('day', ${sunday}::timestamp)
+            - (extract(dow from ${sunday}::timestamp) * interval '1 day'),
+          'YYYY-MM-DD HH24:MI:SS'
+        ) as sunday_period_start,
+        to_char(
+          date_trunc('day', ${tuesday}::timestamp)
+            - (extract(dow from ${tuesday}::timestamp) * interval '1 day'),
+          'YYYY-MM-DD HH24:MI:SS'
+        ) as tuesday_period_start
+    `);
+
+    expect(result.rows[0].sunday_period_start).toBe("2026-06-07 00:00:00");
+    expect(result.rows[0].tuesday_period_start).toBe("2026-06-07 00:00:00");
   });
 
   test("default user limits do not create per-user limit rows", async ({

--- a/platform/backend/src/models/limit.test.ts
+++ b/platform/backend/src/models/limit.test.ts
@@ -2084,6 +2084,56 @@ describe("cleanupLimitsIfNeeded", () => {
     expect(monthlyUsage[0].currentUsageTokensIn).toBe(500);
   });
 
+  test("resets calendar monthly limits only after the month boundary", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+
+    const dueLimit = await LimitModel.create({
+      entityType: "organization",
+      entityId: org.id,
+      limitType: "token_cost",
+      limitValue: 1000000,
+      model: ["gpt-4o"],
+      cleanupInterval: "calendar_month",
+    });
+    const currentMonthLimit = await LimitModel.create({
+      entityType: "organization",
+      entityId: org.id,
+      limitType: "token_cost",
+      limitValue: 1000000,
+      model: ["gpt-4o"],
+      cleanupInterval: "calendar_month",
+    });
+
+    await LimitModel.updateTokenLimitUsage(
+      "organization",
+      org.id,
+      "gpt-4o",
+      500,
+      500,
+    );
+
+    const previousMonth = new Date();
+    previousMonth.setMonth(previousMonth.getMonth() - 1, 15);
+    const currentMonth = new Date();
+    currentMonth.setDate(1);
+    currentMonth.setHours(12, 0, 0, 0);
+    await LimitModel.patch(dueLimit.id, { lastCleanup: previousMonth });
+    await LimitModel.patch(currentMonthLimit.id, { lastCleanup: currentMonth });
+
+    await LimitModel.cleanupLimitsIfNeeded({
+      allForOrganizationId: org.id,
+    });
+
+    const dueUsage = await LimitModel.getRawModelUsage(dueLimit.id);
+    const currentMonthUsage = await LimitModel.getRawModelUsage(
+      currentMonthLimit.id,
+    );
+    expect(dueUsage[0].currentUsageTokensIn).toBe(0);
+    expect(currentMonthUsage[0].currentUsageTokensIn).toBe(500);
+  });
+
   test("default user limits do not create per-user limit rows", async ({
     makeOrganization,
     makeUser,

--- a/platform/backend/src/models/limit.test.ts
+++ b/platform/backend/src/models/limit.test.ts
@@ -477,6 +477,68 @@ describe("LimitModel", () => {
       expect(updated).toBeDefined();
       expect(updated?.model).toEqual(["gpt-4o"]);
     });
+
+    test("resets token usage when cleanup interval changes", async ({
+      makeAgent,
+    }) => {
+      const agent = await makeAgent({ name: "Interval Reset Agent" });
+      const limit = await LimitModel.create({
+        entityType: "agent",
+        entityId: agent.id,
+        limitType: "token_cost",
+        limitValue: 1000000,
+        model: ["gpt-4o"],
+        cleanupInterval: "1w",
+      });
+      await LimitModel.updateTokenLimitUsage(
+        "agent",
+        agent.id,
+        "gpt-4o",
+        500,
+        700,
+      );
+
+      const updated = await LimitModel.patch(limit.id, {
+        cleanupInterval: "calendar_month",
+      });
+
+      const usage = await LimitModel.getRawModelUsage(limit.id);
+      expect(updated?.cleanupInterval).toBe("calendar_month");
+      expect(updated?.lastCleanup).toBeInstanceOf(Date);
+      expect(usage[0].currentUsageTokensIn).toBe(0);
+      expect(usage[0].currentUsageTokensOut).toBe(0);
+    });
+
+    test("does not reset token usage when cleanup interval is unchanged", async ({
+      makeAgent,
+    }) => {
+      const agent = await makeAgent({ name: "Value Update Agent" });
+      const limit = await LimitModel.create({
+        entityType: "agent",
+        entityId: agent.id,
+        limitType: "token_cost",
+        limitValue: 1000000,
+        model: ["gpt-4o"],
+        cleanupInterval: "1w",
+      });
+      await LimitModel.updateTokenLimitUsage(
+        "agent",
+        agent.id,
+        "gpt-4o",
+        500,
+        700,
+      );
+
+      const updated = await LimitModel.patch(limit.id, {
+        limitValue: 2000000,
+        cleanupInterval: "1w",
+      });
+
+      const usage = await LimitModel.getRawModelUsage(limit.id);
+      expect(updated?.limitValue).toBe(2000000);
+      expect(usage[0].currentUsageTokensIn).toBe(500);
+      expect(usage[0].currentUsageTokensOut).toBe(700);
+    });
   });
 
   describe("delete", () => {

--- a/platform/backend/src/models/limit.ts
+++ b/platform/backend/src/models/limit.ts
@@ -49,6 +49,8 @@ type LimitViolationResponse = [
   },
 ];
 
+const DEFAULT_LIMIT_CLEANUP_INTERVAL: LimitCleanupInterval = "calendar_month";
+
 class LimitModel {
   // rollingCleanupIntervalSqlLiterals exists to compile-time check rolling literals.
   static readonly rollingCleanupIntervalSqlLiterals: Record<
@@ -67,7 +69,10 @@ class LimitModel {
   static async create(data: CreateLimit): Promise<Limit> {
     const [limit] = await db
       .insert(schema.limitsTable)
-      .values(data)
+      .values({
+        ...data,
+        cleanupInterval: data.cleanupInterval ?? DEFAULT_LIMIT_CLEANUP_INTERVAL,
+      })
       .returning();
 
     // For token_cost limits, initialize model usage records
@@ -218,11 +223,37 @@ class LimitModel {
       patchData.model = null;
     }
 
-    const [limit] = await db
-      .update(schema.limitsTable)
-      .set(patchData)
-      .where(eq(schema.limitsTable.id, id))
-      .returning();
+    const existingLimit = await LimitModel.findById(id);
+    if (!existingLimit) {
+      return null;
+    }
+
+    const shouldResetUsage =
+      patchData.cleanupInterval !== undefined &&
+      patchData.cleanupInterval !== existingLimit.cleanupInterval;
+    if (shouldResetUsage) {
+      patchData.lastCleanup = new Date();
+    }
+
+    const [limit] = await db.transaction(async (tx) => {
+      const updatedLimits = await tx
+        .update(schema.limitsTable)
+        .set(patchData)
+        .where(eq(schema.limitsTable.id, id))
+        .returning();
+
+      if (shouldResetUsage) {
+        await tx
+          .update(schema.limitModelUsageTable)
+          .set({
+            currentUsageTokensIn: 0,
+            currentUsageTokensOut: 0,
+          })
+          .where(eq(schema.limitModelUsageTable.limitId, id));
+      }
+
+      return updatedLimits;
+    });
 
     return limit || null;
   }
@@ -986,7 +1017,9 @@ ${contentMessage}`;
         organizationId: params.organizationId,
         userId: params.userId,
         models: normalizeLimitModels(organization.defaultUserLimitModel),
-        cleanupInterval: organization.defaultUserLimitCleanupInterval ?? "1w",
+        cleanupInterval:
+          organization.defaultUserLimitCleanupInterval ??
+          DEFAULT_LIMIT_CLEANUP_INTERVAL,
       });
 
       if (usage.cost < organization.defaultUserLimitValue) {

--- a/platform/backend/src/models/limit.ts
+++ b/platform/backend/src/models/limit.ts
@@ -760,27 +760,27 @@ export class LimitValidationService {
             `[LimitValidation] Team-level limits OK for team: ${team.id}`,
           );
         }
+      }
 
-        // Check organization-level limits
-        if (organizationId) {
-          logger.info(
-            `[LimitValidation] Checking organization-level limits for org: ${organizationId}`,
+      // Check organization-level limits for any agent with a resolvable org.
+      if (organizationId) {
+        logger.info(
+          `[LimitValidation] Checking organization-level limits for org: ${organizationId}`,
+        );
+        const orgLimitViolation =
+          await LimitValidationService.checkEntityLimits(
+            "organization",
+            organizationId,
           );
-          const orgLimitViolation =
-            await LimitValidationService.checkEntityLimits(
-              "organization",
-              organizationId,
-            );
-          if (orgLimitViolation) {
-            logger.info(
-              `[LimitValidation] BLOCKED by organization-level limit for org: ${organizationId}`,
-            );
-            return orgLimitViolation;
-          }
+        if (orgLimitViolation) {
           logger.info(
-            `[LimitValidation] Organization-level limits OK for org: ${organizationId}`,
+            `[LimitValidation] BLOCKED by organization-level limit for org: ${organizationId}`,
           );
+          return orgLimitViolation;
         }
+        logger.info(
+          `[LimitValidation] Organization-level limits OK for org: ${organizationId}`,
+        );
       }
 
       logger.info(

--- a/platform/backend/src/models/limit.ts
+++ b/platform/backend/src/models/limit.ts
@@ -223,22 +223,27 @@ class LimitModel {
       patchData.model = null;
     }
 
-    const existingLimit = await LimitModel.findById(id);
-    if (!existingLimit) {
-      return null;
-    }
-
-    const shouldResetUsage =
-      patchData.cleanupInterval !== undefined &&
-      patchData.cleanupInterval !== existingLimit.cleanupInterval;
-    if (shouldResetUsage) {
-      patchData.lastCleanup = new Date();
-    }
-
     const [limit] = await db.transaction(async (tx) => {
+      const [existingLimit] = await tx
+        .select()
+        .from(schema.limitsTable)
+        .where(eq(schema.limitsTable.id, id))
+        .limit(1);
+
+      if (!existingLimit) {
+        return [];
+      }
+
+      const shouldResetUsage =
+        patchData.cleanupInterval !== undefined &&
+        patchData.cleanupInterval !== existingLimit.cleanupInterval;
+      const limitPatchData = shouldResetUsage
+        ? { ...patchData, lastCleanup: new Date() }
+        : patchData;
+
       const updatedLimits = await tx
         .update(schema.limitsTable)
-        .set(patchData)
+        .set(limitPatchData)
         .where(eq(schema.limitsTable.id, id))
         .returning();
 
@@ -1052,6 +1057,8 @@ const calendarCleanupIntervals = [
   "calendar_month",
 ] as const satisfies readonly LimitCleanupInterval[];
 
+type CalendarLimitCleanupInterval = (typeof calendarCleanupIntervals)[number];
+
 function buildOrganizationLimitScopeCondition(organizationId: string): SQL {
   return or(
     and(
@@ -1133,10 +1140,16 @@ function buildUsagePeriodStartCondition(
     return sql`${schema.interactionsTable.createdAt} >= now() - ${rollingInterval}::interval`;
   }
 
-  return sql`${schema.interactionsTable.createdAt} >= ${getCalendarPeriodStartSql(cleanupInterval)}`;
+  if (isCalendarCleanupInterval(cleanupInterval)) {
+    return sql`${schema.interactionsTable.createdAt} >= ${getCalendarPeriodStartSql(cleanupInterval)}`;
+  }
+
+  throw new Error(`Unsupported cleanup interval: ${cleanupInterval}`);
 }
 
-function getCalendarPeriodStartSql(cleanupInterval: LimitCleanupInterval): SQL {
+function getCalendarPeriodStartSql(
+  cleanupInterval: CalendarLimitCleanupInterval,
+): SQL {
   switch (cleanupInterval) {
     case "calendar_day":
       return sql`date_trunc('day', now())`;
@@ -1146,11 +1159,15 @@ function getCalendarPeriodStartSql(cleanupInterval: LimitCleanupInterval): SQL {
       return sql`date_trunc('week', now())`;
     case "calendar_month":
       return sql`date_trunc('month', now())`;
-    default:
-      throw new Error(
-        `Unsupported calendar cleanup interval: ${cleanupInterval}`,
-      );
   }
+}
+
+function isCalendarCleanupInterval(
+  cleanupInterval: LimitCleanupInterval,
+): cleanupInterval is CalendarLimitCleanupInterval {
+  return calendarCleanupIntervals.includes(
+    cleanupInterval as CalendarLimitCleanupInterval,
+  );
 }
 
 async function calculateModelUsageCosts(modelUsages: LimitModelUsageRecord[]) {

--- a/platform/backend/src/models/limit.ts
+++ b/platform/backend/src/models/limit.ts
@@ -238,7 +238,7 @@ class LimitModel {
         patchData.cleanupInterval !== undefined &&
         patchData.cleanupInterval !== existingLimit.cleanupInterval;
       const limitPatchData = shouldResetUsage
-        ? { ...patchData, lastCleanup: new Date() }
+        ? { ...patchData, lastCleanup: sql`now()` }
         : patchData;
 
       const updatedLimits = await tx
@@ -1120,7 +1120,7 @@ function getCalendarPeriodStartSql(
     case "calendar_day":
       return sql`date_trunc('day', now())`;
     case "calendar_week_sunday":
-      return sql`date_trunc('week', now() + interval '1 day') - interval '1 day'`;
+      return sql`date_trunc('day', now()) - (extract(dow from now()) * interval '1 day')`;
     case "calendar_week_monday":
       return sql`date_trunc('week', now())`;
     case "calendar_month":

--- a/platform/backend/src/models/limit.ts
+++ b/platform/backend/src/models/limit.ts
@@ -40,6 +40,14 @@ type RollingLimitCleanupInterval = Extract<
 >;
 
 type LimitModelUsageRecord = typeof schema.limitModelUsageTable.$inferSelect;
+type LimitViolationResponse = [
+  refusalMessage: string,
+  contentMessage: string,
+  metadata?: {
+    entityType: LimitEntityType;
+    limitType: "token_cost";
+  },
+];
 
 class LimitModel {
   // rollingCleanupIntervalSqlLiterals exists to compile-time check rolling literals.
@@ -622,13 +630,13 @@ class LimitModel {
 export class LimitValidationService {
   /**
    * Check if current usage has already exceeded any token cost limits
-   * Returns null if allowed, or [refusalMessage, contentMessage] if blocked
+   * Returns null if allowed, or a refusal tuple if blocked.
    */
   static async checkLimitsBeforeRequest(params: {
     agentId: string;
     userId?: string;
     virtualKeyId?: string;
-  }): Promise<null | [string, string]> {
+  }): Promise<null | LimitViolationResponse> {
     const { agentId, userId, virtualKeyId } = params;
 
     try {
@@ -644,13 +652,14 @@ export class LimitValidationService {
 
       // Get organization ID to cleanup and check organization limits (either from teams or fallback)
       let organizationId: string | null = null;
+      let agentTeams: (typeof schema.teamsTable.$inferSelect)[] = [];
       if (agentTeamIds.length > 0) {
-        const teams = await db
+        agentTeams = await db
           .select()
           .from(schema.teamsTable)
           .where(inArray(schema.teamsTable.id, agentTeamIds));
-        if (teams.length > 0 && teams[0].organizationId) {
-          organizationId = teams[0].organizationId;
+        if (agentTeams.length > 0 && agentTeams[0].organizationId) {
+          organizationId = agentTeams[0].organizationId;
         }
       } else {
         organizationId = await AgentModel.findOrganizationId(agentId);
@@ -740,15 +749,11 @@ export class LimitValidationService {
         logger.info(
           `[LimitValidation] Checking team-level limits for agent: ${agentId}`,
         );
-        const teams = await db
-          .select()
-          .from(schema.teamsTable)
-          .where(inArray(schema.teamsTable.id, agentTeamIds));
         logger.info(
-          `[LimitValidation] Found ${teams.length} teams for agent ${agentId}: ${teams.map((t) => `${t.id}(org:${t.organizationId})`).join(", ")}`,
+          `[LimitValidation] Found ${agentTeams.length} teams for agent ${agentId}: ${agentTeams.map((t) => `${t.id}(org:${t.organizationId})`).join(", ")}`,
         );
 
-        for (const team of teams) {
+        for (const team of agentTeams) {
           logger.info(
             `[LimitValidation] Checking team limit for team: ${team.id}`,
           );
@@ -806,7 +811,7 @@ export class LimitValidationService {
   private static async checkEntityLimits(
     entityType: LimitEntityType,
     entityId: string,
-  ): Promise<null | [string, string]> {
+  ): Promise<null | LimitViolationResponse> {
     try {
       logger.info(
         `[LimitValidation] Querying limits for ${entityType} ${entityId}`,
@@ -919,7 +924,11 @@ Please contact your administrator to increase the limit or wait for the usage to
           const refusalMessage = `${archestraMetadata}
 ${contentMessage}`;
 
-          return [refusalMessage, contentMessage];
+          return [
+            refusalMessage,
+            contentMessage,
+            { entityType, limitType: "token_cost" },
+          ];
         } else {
           logger.info(
             `[LimitValidation] Limit OK for ${entityType} ${entityId}: ${comparisonValue} < ${limit.limitValue}`,
@@ -942,7 +951,7 @@ ${contentMessage}`;
   private static async checkDefaultUserLimit(params: {
     organizationId: string;
     userId: string;
-  }): Promise<null | [string, string]> {
+  }): Promise<null | LimitViolationResponse> {
     try {
       const [organization] = await db
         .select({
@@ -1229,7 +1238,7 @@ function buildLimitViolationResponse(params: {
   limitDescription: "tokens" | "cost_dollars";
   totalTokensIn: number;
   totalTokensOut: number;
-}): [string, string] {
+}): LimitViolationResponse {
   const totalTokens = params.totalTokensIn + params.totalTokensOut;
   const remaining = Math.max(0, params.limitValue - params.comparisonValue);
   const archestraMetadata = `
@@ -1259,7 +1268,11 @@ Remaining: ${Math.max(0, params.limitValue - totalTokens).toLocaleString()} toke
 
 Please contact your administrator to increase the limit or wait for the usage to reset.`;
 
-  return [`${archestraMetadata}\n${contentMessage}`, contentMessage];
+  return [
+    `${archestraMetadata}\n${contentMessage}`,
+    contentMessage,
+    { entityType: params.entityType, limitType: "token_cost" },
+  ];
 }
 
 function normalizeLimitModels(models: string[] | null | undefined) {

--- a/platform/backend/src/models/limit.ts
+++ b/platform/backend/src/models/limit.ts
@@ -1263,7 +1263,7 @@ function buildLimitViolationResponse(params: {
 <archestra-limit-entity-id>${params.entityId}</archestra-limit-entity-id>
 <archestra-limit-current-usage>${totalTokens}</archestra-limit-current-usage>
 <archestra-limit-value>${params.limitValue}</archestra-limit-value>
-<archestra-limit-remaining>${Math.max(0, params.limitValue - totalTokens)}</archestra-limit-remaining>`;
+<archestra-limit-remaining>${remaining}</archestra-limit-remaining>`;
 
   const contentMessage =
     params.limitDescription === "cost_dollars"

--- a/platform/backend/src/models/limit.ts
+++ b/platform/backend/src/models/limit.ts
@@ -34,13 +34,17 @@ type LimitsCleanupIntervalSqlLiteral =
   | "24 hours"
   | "1 week"
   | "1 month";
+type RollingLimitCleanupInterval = Extract<
+  LimitCleanupInterval,
+  "1h" | "12h" | "24h" | "1w" | "1m"
+>;
 
 type LimitModelUsageRecord = typeof schema.limitModelUsageTable.$inferSelect;
 
 class LimitModel {
-  // limitsCleanupIntervalSqlLiterals exists basically to compile-time check set of literals
-  static readonly limitsCleanupIntervalSqlLiterals: Record<
-    LimitCleanupInterval,
+  // rollingCleanupIntervalSqlLiterals exists to compile-time check rolling literals.
+  static readonly rollingCleanupIntervalSqlLiterals: Record<
+    RollingLimitCleanupInterval,
     LimitsCleanupIntervalSqlLiteral
   > = {
     "1h": "1 hour",
@@ -999,6 +1003,13 @@ ${contentMessage}`;
   }
 }
 
+const calendarCleanupIntervals = [
+  "calendar_day",
+  "calendar_week_sunday",
+  "calendar_week_monday",
+  "calendar_month",
+] as const satisfies readonly LimitCleanupInterval[];
+
 function buildOrganizationLimitScopeCondition(organizationId: string): SQL {
   return or(
     and(
@@ -1043,7 +1054,7 @@ function buildOrganizationLimitScopeCondition(organizationId: string): SQL {
 
 function buildCleanupDueCondition(): SQL {
   const intervalConditions = Object.entries(
-    LimitModel.limitsCleanupIntervalSqlLiterals,
+    LimitModel.rollingCleanupIntervalSqlLiterals,
   ).map(([cleanupInterval, sqlLiteral]) =>
     and(
       eq(
@@ -1054,7 +1065,50 @@ function buildCleanupDueCondition(): SQL {
     ),
   );
 
+  intervalConditions.push(
+    ...calendarCleanupIntervals.map((cleanupInterval) =>
+      and(
+        eq(schema.limitsTable.cleanupInterval, cleanupInterval),
+        lt(
+          schema.limitsTable.lastCleanup,
+          getCalendarPeriodStartSql(cleanupInterval),
+        ),
+      ),
+    ),
+  );
+
   return or(...intervalConditions) as SQL;
+}
+
+function buildUsagePeriodStartCondition(
+  cleanupInterval: LimitCleanupInterval,
+): SQL {
+  const rollingInterval =
+    LimitModel.rollingCleanupIntervalSqlLiterals[
+      cleanupInterval as RollingLimitCleanupInterval
+    ];
+  if (rollingInterval) {
+    return sql`${schema.interactionsTable.createdAt} >= now() - ${rollingInterval}::interval`;
+  }
+
+  return sql`${schema.interactionsTable.createdAt} >= ${getCalendarPeriodStartSql(cleanupInterval)}`;
+}
+
+function getCalendarPeriodStartSql(cleanupInterval: LimitCleanupInterval): SQL {
+  switch (cleanupInterval) {
+    case "calendar_day":
+      return sql`date_trunc('day', now())`;
+    case "calendar_week_sunday":
+      return sql`date_trunc('week', now() + interval '1 day') - interval '1 day'`;
+    case "calendar_week_monday":
+      return sql`date_trunc('week', now())`;
+    case "calendar_month":
+      return sql`date_trunc('month', now())`;
+    default:
+      throw new Error(
+        `Unsupported calendar cleanup interval: ${cleanupInterval}`,
+      );
+  }
 }
 
 async function calculateModelUsageCosts(modelUsages: LimitModelUsageRecord[]) {
@@ -1100,7 +1154,7 @@ async function getDefaultUserLimitUsage(params: {
     eq(schema.interactionsTable.userId, params.userId),
     eq(schema.agentsTable.organizationId, params.organizationId),
     notDeleted(schema.agentsTable),
-    sql`${schema.interactionsTable.createdAt} >= now() - ${LimitModel.limitsCleanupIntervalSqlLiterals[params.cleanupInterval]}::interval`,
+    buildUsagePeriodStartCondition(params.cleanupInterval),
   ];
 
   if (params.models && params.models.length > 0) {

--- a/platform/backend/src/models/limit.ts
+++ b/platform/backend/src/models/limit.ts
@@ -676,13 +676,13 @@ export class LimitValidationService {
     const { agentId, userId, virtualKeyId } = params;
 
     try {
-      logger.info(
+      logger.debug(
         `[LimitValidation] Starting limit check for agent: ${agentId}`,
       );
 
       // Get agent's teams to cleanup and check team and organization limits
       const agentTeamIds = await AgentTeamModel.getTeamsForAgent(agentId);
-      logger.info(
+      logger.debug(
         `[LimitValidation] Agent ${agentId} belongs to teams: ${agentTeamIds.join(", ")}`,
       );
 
@@ -717,11 +717,11 @@ export class LimitValidationService {
         entities.organization = organizationId;
       }
 
-      logger.info({ entities }, `[LimitValidation] Running limits cleanup`);
+      logger.debug({ entities }, `[LimitValidation] Running limits cleanup`);
       await LimitModel.cleanupLimitsIfNeeded({ entities });
 
       if (virtualKeyId) {
-        logger.info(
+        logger.debug(
           `[LimitValidation] Checking virtual-key-level limits for: ${virtualKeyId}`,
         );
         const vkLimitViolation = await LimitValidationService.checkEntityLimits(
@@ -734,13 +734,13 @@ export class LimitValidationService {
           );
           return vkLimitViolation;
         }
-        logger.info(
+        logger.debug(
           `[LimitValidation] Virtual-key-level limits OK for: ${virtualKeyId}`,
         );
       }
 
       if (userId) {
-        logger.info(
+        logger.debug(
           `[LimitValidation] Checking user-level limits for: ${userId}`,
         );
         const userLimitViolation =
@@ -764,10 +764,10 @@ export class LimitValidationService {
             return defaultUserLimitViolation;
           }
         }
-        logger.info(`[LimitValidation] User-level limits OK for: ${userId}`);
+        logger.debug(`[LimitValidation] User-level limits OK for: ${userId}`);
       }
 
-      logger.info(
+      logger.debug(
         `[LimitValidation] Checking agent-level limits for: ${agentId}`,
       );
       const agentLimitViolation =
@@ -778,19 +778,19 @@ export class LimitValidationService {
         );
         return agentLimitViolation;
       }
-      logger.info(`[LimitValidation] Agent-level limits OK for: ${agentId}`);
+      logger.debug(`[LimitValidation] Agent-level limits OK for: ${agentId}`);
 
       // Check team-level limits
       if (agentTeamIds.length > 0) {
-        logger.info(
+        logger.debug(
           `[LimitValidation] Checking team-level limits for agent: ${agentId}`,
         );
-        logger.info(
+        logger.debug(
           `[LimitValidation] Found ${agentTeams.length} teams for agent ${agentId}: ${agentTeams.map((t) => `${t.id}(org:${t.organizationId})`).join(", ")}`,
         );
 
         for (const team of agentTeams) {
-          logger.info(
+          logger.debug(
             `[LimitValidation] Checking team limit for team: ${team.id}`,
           );
           const teamLimitViolation =
@@ -801,7 +801,7 @@ export class LimitValidationService {
             );
             return teamLimitViolation;
           }
-          logger.info(
+          logger.debug(
             `[LimitValidation] Team-level limits OK for team: ${team.id}`,
           );
         }
@@ -809,7 +809,7 @@ export class LimitValidationService {
 
       // Check organization-level limits for any agent with a resolvable org.
       if (organizationId) {
-        logger.info(
+        logger.debug(
           `[LimitValidation] Checking organization-level limits for org: ${organizationId}`,
         );
         const orgLimitViolation =
@@ -823,7 +823,7 @@ export class LimitValidationService {
           );
           return orgLimitViolation;
         }
-        logger.info(
+        logger.debug(
           `[LimitValidation] Organization-level limits OK for org: ${organizationId}`,
         );
       }
@@ -849,7 +849,7 @@ export class LimitValidationService {
     entityId: string,
   ): Promise<null | LimitViolationResponse> {
     try {
-      logger.info(
+      logger.debug(
         `[LimitValidation] Querying limits for ${entityType} ${entityId}`,
       );
       const limits = await LimitModel.findLimitsForValidation(
@@ -858,25 +858,25 @@ export class LimitValidationService {
         "token_cost",
       );
 
-      logger.info(
+      logger.debug(
         `[LimitValidation] Found ${limits.length} token_cost limits for ${entityType} ${entityId}`,
       );
 
       if (limits.length === 0) {
-        logger.info(
+        logger.debug(
           `[LimitValidation] No token_cost limits found for ${entityType} ${entityId} - allowing`,
         );
         return null;
       }
 
       for (const limit of limits) {
-        logger.info(
+        logger.debug(
           `[LimitValidation] Checking limit ${limit.id} for ${entityType} ${entityId}`,
         );
 
         // For token_cost limits, convert tokens to actual cost using token prices
         let comparisonValue = 0;
-        let limitDescription = "tokens";
+        let limitDescription: "tokens" | "cost_dollars" = "tokens";
         let totalTokensIn = 0;
         let totalTokensOut = 0;
 
@@ -922,51 +922,17 @@ export class LimitValidationService {
             `[LimitValidation] LIMIT EXCEEDED for ${entityType} ${entityId}: ${comparisonValue} ${limitDescription} >= ${limit.limitValue}`,
           );
 
-          // Calculate remaining based on the comparison type (tokens vs dollars)
-          const remaining = Math.max(0, limit.limitValue - comparisonValue);
-          const totalTokens = totalTokensIn + totalTokensOut;
-
-          // For metadata, use token counts for programmatic access
-          const archestraMetadata = `
-<archestra-limit-type>token_cost</archestra-limit-type>
-<archestra-limit-entity-type>${entityType}</archestra-limit-entity-type>
-<archestra-limit-entity-id>${entityId}</archestra-limit-entity-id>
-<archestra-limit-current-usage>${totalTokens}</archestra-limit-current-usage>
-<archestra-limit-value>${limit.limitValue}</archestra-limit-value>
-<archestra-limit-remaining>${Math.max(0, limit.limitValue - totalTokens)}</archestra-limit-remaining>`;
-
-          // For user message, use appropriate units based on limit type
-          let contentMessage: string;
-          if (limitDescription === "cost_dollars") {
-            contentMessage = `
-I cannot process this request because the ${entityType}-level token cost limit has been exceeded.
-
-Current usage: $${comparisonValue.toFixed(2)}
-Limit: $${limit.limitValue.toFixed(2)}
-Remaining: $${remaining.toFixed(2)}
-
-Please contact your administrator to increase the limit or wait for the usage to reset.`;
-          } else {
-            contentMessage = `
-I cannot process this request because the ${entityType}-level token cost limit has been exceeded.
-
-Current usage: ${totalTokens.toLocaleString()} tokens
-Limit: ${limit.limitValue.toLocaleString()} tokens
-Remaining: ${Math.max(0, limit.limitValue - totalTokens).toLocaleString()} tokens
-
-Please contact your administrator to increase the limit or wait for the usage to reset.`;
-          }
-
-          const refusalMessage = `${archestraMetadata}
-${contentMessage}`;
-
-          return [
-            refusalMessage,
-            contentMessage,
-            { entityType, limitType: "token_cost" },
-          ];
+          return buildLimitViolationResponse({
+            entityType,
+            entityId,
+            limitValue: limit.limitValue,
+            comparisonValue,
+            limitDescription,
+            totalTokensIn,
+            totalTokensOut,
+          });
         } else {
-          logger.info(
+          logger.debug(
             `[LimitValidation] Limit OK for ${entityType} ${entityId}: ${comparisonValue} < ${limit.limitValue}`,
           );
         }

--- a/platform/backend/src/routes/chat/errors.test.ts
+++ b/platform/backend/src/routes/chat/errors.test.ts
@@ -182,6 +182,23 @@ describe("mapProviderError - OpenAI", () => {
       expect(result.code).toBe(ChatErrorCode.RateLimit);
       expect(result.isRetryable).toBe(true);
     });
+
+    it("marks usage-limit budget overages from the proxy", () => {
+      const error = createOpenAIError(
+        429,
+        OpenAIErrorTypes.RATE_LIMIT,
+        "I cannot process this request because the organization-level token cost limit has been exceeded.",
+        "token_cost_limit_exceeded",
+      );
+      const result = mapProviderError(error, "openai");
+
+      expect(result.code).toBe(ChatErrorCode.RateLimit);
+      expect(result.usageLimitExceeded).toBe(true);
+      expect(result.usageLimitEntityType).toBe("organization");
+      expect(result.message).toBe(
+        "The organization usage limit budget has been exceeded.",
+      );
+    });
   });
 
   describe("500 - server_error", () => {
@@ -1664,6 +1681,29 @@ describe("ProviderError", () => {
       sessionId: "session-123",
       traceId: "trace-123",
       spanId: "span-123",
+    });
+  });
+
+  it("preserves usage-limit metadata in the frontend error payload", () => {
+    expect(
+      sanitizeChatErrorForFrontend({
+        code: ChatErrorCode.RateLimit,
+        message: "The organization usage limit budget has been exceeded.",
+        isRetryable: true,
+        usageLimitExceeded: true,
+        usageLimitEntityType: "organization",
+        originalError: {
+          provider: "openai",
+          status: 429,
+          message: "Internal limit detail",
+        },
+      }),
+    ).toEqual({
+      code: ChatErrorCode.RateLimit,
+      message: "The organization usage limit budget has been exceeded.",
+      isRetryable: true,
+      usageLimitExceeded: true,
+      usageLimitEntityType: "organization",
     });
   });
 });

--- a/platform/backend/src/routes/chat/errors.test.ts
+++ b/platform/backend/src/routes/chat/errors.test.ts
@@ -41,6 +41,7 @@ describe("mapProviderError - OpenAI", () => {
     message: string,
     code?: string,
     internalCode?: string,
+    usageLimit?: { entity_type: string; limit_type: string },
   ) {
     return {
       name: "AI_APICallError",
@@ -51,6 +52,7 @@ describe("mapProviderError - OpenAI", () => {
           message,
           code,
           internal_code: internalCode,
+          usage_limit: usageLimit,
         },
       }),
       isRetryable: statusCode >= 500 || statusCode === 429,
@@ -189,6 +191,11 @@ describe("mapProviderError - OpenAI", () => {
         OpenAIErrorTypes.RATE_LIMIT,
         "I cannot process this request because the organization-level token cost limit has been exceeded.",
         "token_cost_limit_exceeded",
+        undefined,
+        {
+          entity_type: "organization",
+          limit_type: "token_cost",
+        },
       );
       const result = mapProviderError(error, "openai");
 

--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -187,6 +187,25 @@ function extractArchestraInternalCode(
   return undefined;
 }
 
+function extractUsageLimitError(
+  responseBody: string | undefined,
+): { entityType?: string } | null {
+  if (!responseBody) return null;
+  try {
+    const parsed = JSON.parse(responseBody);
+    if (parsed?.error?.code !== "token_cost_limit_exceeded") {
+      return null;
+    }
+    const message =
+      typeof parsed.error.message === "string" ? parsed.error.message : "";
+    return {
+      entityType: extractUsageLimitEntityType(message),
+    };
+  } catch {
+    return null;
+  }
+}
+
 // =============================================================================
 // Provider-Specific Error Parsers
 // =============================================================================
@@ -1413,10 +1432,13 @@ function createErrorResponse(
   originalMessage: string,
   errorType: string | undefined,
   rawError: unknown,
+  usageLimitError?: { entityType?: string } | null,
 ): ChatErrorResponse {
-  return {
+  const response: ChatErrorResponse = {
     code,
-    message: ChatErrorMessages[code],
+    message: usageLimitError
+      ? formatUsageLimitMessage(usageLimitError.entityType)
+      : ChatErrorMessages[code],
     isRetryable: RetryableErrorCodes.has(code),
     originalError: {
       provider,
@@ -1426,6 +1448,11 @@ function createErrorResponse(
       raw: safeSerialize(rawError),
     },
   };
+  if (usageLimitError) {
+    response.usageLimitExceeded = true;
+    response.usageLimitEntityType = usageLimitError.entityType;
+  }
+  return response;
 }
 
 /**
@@ -1542,6 +1569,7 @@ export function mapProviderError(
   if (normalizedCode === ArchestraInternalErrorCode.ContextLengthExceeded) {
     errorCode = ChatErrorCode.ContextTooLong;
   }
+  const usageLimitError = extractUsageLimitError(responseBody);
 
   // Extract the most meaningful error message
   const errorMessage = extractErrorMessage(parsedError, responseBody, error);
@@ -1596,6 +1624,7 @@ export function mapProviderError(
         ? (error as InstanceType<typeof APICallError>).isRetryable
         : undefined,
     },
+    usageLimitError,
   );
 }
 
@@ -1637,7 +1666,7 @@ export function getActiveTraceContext(): {
 export function sanitizeChatErrorForFrontend(
   error: ChatErrorResponse,
 ): ChatErrorResponse {
-  return {
+  const sanitized: ChatErrorResponse = {
     code: error.code,
     message: error.message,
     isRetryable: error.isRetryable,
@@ -1645,4 +1674,21 @@ export function sanitizeChatErrorForFrontend(
     traceId: error.traceId,
     spanId: error.spanId,
   };
+  if (error.usageLimitExceeded) {
+    sanitized.usageLimitExceeded = true;
+    sanitized.usageLimitEntityType = error.usageLimitEntityType;
+  }
+  return sanitized;
+}
+
+function extractUsageLimitEntityType(message: string): string | undefined {
+  const match = message.match(/\b([a-z_]+)-level token cost limit\b/i);
+  return match?.[1]?.toLowerCase();
+}
+
+function formatUsageLimitMessage(entityType: string | undefined): string {
+  if (!entityType) {
+    return "A usage limit budget has been exceeded.";
+  }
+  return `The ${entityType.replace(/_/g, " ")} usage limit budget has been exceeded.`;
 }

--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -196,10 +196,11 @@ function extractUsageLimitError(
     if (parsed?.error?.code !== "token_cost_limit_exceeded") {
       return null;
     }
-    const message =
-      typeof parsed.error.message === "string" ? parsed.error.message : "";
     return {
-      entityType: extractUsageLimitEntityType(message),
+      entityType:
+        typeof parsed.error.usage_limit?.entity_type === "string"
+          ? parsed.error.usage_limit.entity_type
+          : undefined,
     };
   } catch {
     return null;
@@ -1679,11 +1680,6 @@ export function sanitizeChatErrorForFrontend(
     sanitized.usageLimitEntityType = error.usageLimitEntityType;
   }
   return sanitized;
-}
-
-function extractUsageLimitEntityType(message: string): string | undefined {
-  const match = message.match(/\b([a-z_]+)-level token cost limit\b/i);
-  return match?.[1]?.toLowerCase();
 }
 
 function formatUsageLimitMessage(entityType: string | undefined): string {

--- a/platform/backend/src/routes/limits.test.ts
+++ b/platform/backend/src/routes/limits.test.ts
@@ -343,6 +343,25 @@ describe("limits routes", () => {
   });
 
   describe("POST /api/limits", () => {
+    test("defaults new limits to calendar-month cleanup", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/limits",
+        payload: {
+          entityType: "organization",
+          entityId: organizationId,
+          limitType: "token_cost",
+          limitValue: 1000,
+          model: ["gpt-4o"],
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        cleanupInterval: "calendar_month",
+      });
+    });
+
     test("creates a limit with a calendar-aligned cleanup interval", async () => {
       const response = await app.inject({
         method: "POST",
@@ -366,6 +385,90 @@ describe("limits routes", () => {
         cleanupInterval: "calendar_month",
         model: ["gpt-4o"],
       });
+    });
+  });
+
+  describe("PATCH /api/limits/:id", () => {
+    test("resets usage when cleanup interval changes", async ({
+      makeAgent,
+    }) => {
+      const agent = await makeAgent({
+        name: "Interval Reset Agent",
+        organizationId,
+      });
+      const limit = await LimitModel.create({
+        entityType: "agent",
+        entityId: agent.id,
+        limitType: "token_cost",
+        limitValue: 1000000,
+        model: ["gpt-4o"],
+        cleanupInterval: "1w",
+      });
+      await LimitModel.updateTokenLimitUsage(
+        "agent",
+        agent.id,
+        "gpt-4o",
+        500,
+        700,
+      );
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/api/limits/${limit.id}`,
+        payload: {
+          cleanupInterval: "calendar_month",
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        cleanupInterval: "calendar_month",
+      });
+      const usage = await LimitModel.getRawModelUsage(limit.id);
+      expect(usage[0].currentUsageTokensIn).toBe(0);
+      expect(usage[0].currentUsageTokensOut).toBe(0);
+    });
+
+    test("does not reset usage when cleanup interval is unchanged", async ({
+      makeAgent,
+    }) => {
+      const agent = await makeAgent({
+        name: "Value Update Agent",
+        organizationId,
+      });
+      const limit = await LimitModel.create({
+        entityType: "agent",
+        entityId: agent.id,
+        limitType: "token_cost",
+        limitValue: 1000000,
+        model: ["gpt-4o"],
+        cleanupInterval: "1w",
+      });
+      await LimitModel.updateTokenLimitUsage(
+        "agent",
+        agent.id,
+        "gpt-4o",
+        500,
+        700,
+      );
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/api/limits/${limit.id}`,
+        payload: {
+          limitValue: 2000000,
+          cleanupInterval: "1w",
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        limitValue: 2000000,
+        cleanupInterval: "1w",
+      });
+      const usage = await LimitModel.getRawModelUsage(limit.id);
+      expect(usage[0].currentUsageTokensIn).toBe(500);
+      expect(usage[0].currentUsageTokensOut).toBe(700);
     });
   });
 });

--- a/platform/backend/src/routes/limits.test.ts
+++ b/platform/backend/src/routes/limits.test.ts
@@ -341,4 +341,31 @@ describe("limits routes", () => {
       cleanupSpy.mockRestore();
     });
   });
+
+  describe("POST /api/limits", () => {
+    test("creates a limit with a calendar-aligned cleanup interval", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/limits",
+        payload: {
+          entityType: "organization",
+          entityId: organizationId,
+          limitType: "token_cost",
+          limitValue: 1000,
+          cleanupInterval: "calendar_month",
+          model: ["gpt-4o"],
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        entityType: "organization",
+        entityId: organizationId,
+        limitType: "token_cost",
+        limitValue: 1000,
+        cleanupInterval: "calendar_month",
+        model: ["gpt-4o"],
+      });
+    });
+  });
 });

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -469,6 +469,7 @@ export async function handleLLMProxy<
         { resolvedAgentId, reason: "token_cost_limit_exceeded" },
         `${providerName} request blocked due to token cost limit`,
       );
+      // Preserve the proxy-compatible error envelope so chat clients can read structured limit metadata.
       return reply.status(429).send({
         error: {
           message: contentMessage,

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -464,7 +464,7 @@ export async function handleLLMProxy<
       });
 
     if (limitViolation) {
-      const [_refusalMessage, contentMessage] = limitViolation;
+      const [_refusalMessage, contentMessage, limitMetadata] = limitViolation;
       logger.info(
         { resolvedAgentId, reason: "token_cost_limit_exceeded" },
         `${providerName} request blocked due to token cost limit`,
@@ -474,6 +474,12 @@ export async function handleLLMProxy<
           message: contentMessage,
           type: "rate_limit_exceeded",
           code: "token_cost_limit_exceeded",
+          usage_limit: limitMetadata
+            ? {
+                limit_type: limitMetadata.limitType,
+                entity_type: limitMetadata.entityType,
+              }
+            : undefined,
         },
       });
     }

--- a/platform/backend/src/routes/proxy/routes/limit-integration.test.ts
+++ b/platform/backend/src/routes/proxy/routes/limit-integration.test.ts
@@ -170,6 +170,10 @@ describe("LLM proxy limit enforcement (integration)", () => {
     expect(response.json()).toMatchObject({
       error: {
         code: "token_cost_limit_exceeded",
+        usage_limit: {
+          entity_type: "virtual_key",
+          limit_type: "token_cost",
+        },
       },
     });
   });
@@ -221,6 +225,10 @@ describe("LLM proxy limit enforcement (integration)", () => {
     expect(response.json()).toMatchObject({
       error: {
         code: "token_cost_limit_exceeded",
+        usage_limit: {
+          entity_type: "user",
+          limit_type: "token_cost",
+        },
       },
     });
   });
@@ -271,6 +279,10 @@ describe("LLM proxy limit enforcement (integration)", () => {
     expect(response.json()).toMatchObject({
       error: {
         code: "token_cost_limit_exceeded",
+        usage_limit: {
+          entity_type: "user",
+          limit_type: "token_cost",
+        },
       },
     });
     expect(response.json().error.message).toContain("user-level");
@@ -399,6 +411,10 @@ describe("LLM proxy limit enforcement (integration)", () => {
     expect(response.json()).toMatchObject({
       error: {
         code: "token_cost_limit_exceeded",
+        usage_limit: {
+          entity_type: "organization",
+          limit_type: "token_cost",
+        },
       },
     });
     expect(response.json().error.message).toContain("organization-level");

--- a/platform/backend/src/routes/proxy/routes/limit-integration.test.ts
+++ b/platform/backend/src/routes/proxy/routes/limit-integration.test.ts
@@ -357,6 +357,53 @@ describe("LLM proxy limit enforcement (integration)", () => {
     expect(response.statusCode).toBe(200);
   });
 
+  test("blocks org-scoped agent with 429 when organization limit is exceeded", async ({
+    makeAgent,
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+    const agent = await makeAgent({
+      organizationId: org.id,
+      name: "Org Limit Agent",
+      scope: "org",
+      teams: [],
+    });
+
+    await LimitModel.create({
+      entityType: "organization",
+      entityId: org.id,
+      limitType: "token_cost",
+      limitValue: 1,
+      model: null,
+      lastCleanup: new Date(),
+    });
+
+    await LimitModel.updateTokenLimitUsage(
+      "organization",
+      org.id,
+      "gpt-4o",
+      1_000_000,
+      1_000_000,
+    );
+
+    await setupRoute();
+
+    const response = await app.inject({
+      method: "POST",
+      url: OPENAI_ENDPOINT(agent.id),
+      headers: OPENAI_HEADERS(),
+      payload: SIMPLE_PAYLOAD(),
+    });
+
+    expect(response.statusCode).toBe(429);
+    expect(response.json()).toMatchObject({
+      error: {
+        code: "token_cost_limit_exceeded",
+      },
+    });
+    expect(response.json().error.message).toContain("organization-level");
+  });
+
   test("records usage in limit after successful request", async ({
     makeAgent,
   }) => {

--- a/platform/backend/src/types/limit.ts
+++ b/platform/backend/src/types/limit.ts
@@ -35,6 +35,10 @@ export const LimitCleanupIntervalSchema = z.enum([
   "24h",
   "1w",
   "1m",
+  "calendar_day",
+  "calendar_week_sunday",
+  "calendar_week_monday",
+  "calendar_month",
 ]);
 export type LimitCleanupInterval = z.infer<typeof LimitCleanupIntervalSchema>;
 

--- a/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import LimitsPage, { getLimitModels } from "./page";
 
 const mockSetCostsAction = vi.fn();
@@ -310,6 +310,10 @@ describe("LimitsPage", () => {
     });
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("shows a settings notice when a default user limit is configured", () => {
     render(<LimitsPage />);
 
@@ -368,7 +372,7 @@ describe("LimitsPage", () => {
     expect(modelsBadge).toHaveTextContent("All models");
   });
 
-  it("shows the next reset date for monthly limits", () => {
+  it("shows the next reset date for rolling monthly limits", () => {
     mockUseLimits.mockReturnValue({
       data: [
         {
@@ -393,8 +397,39 @@ describe("LimitsPage", () => {
     render(<LimitsPage />);
 
     const row = screen.getByTestId("data-table-row-limit-1");
-    expect(row).toHaveTextContent("Every month");
+    expect(row).toHaveTextContent("Rolling month");
     expect(row).toHaveTextContent("Resets Feb 15");
+  });
+
+  it("shows the next reset date for calendar monthly limits", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-15T12:00:00.000Z"));
+    mockUseLimits.mockReturnValue({
+      data: [
+        {
+          id: "limit-1",
+          entityType: "organization",
+          entityId: "org-1",
+          limitType: "token_cost",
+          limitValue: 1000,
+          model: null,
+          mcpServerName: null,
+          toolName: null,
+          cleanupInterval: "calendar_month",
+          lastCleanup: "2026-01-02T12:00:00.000Z",
+          createdAt: "2026-01-01",
+          updatedAt: "2026-01-01",
+          modelUsage: [],
+        },
+      ],
+      isPending: false,
+    });
+
+    render(<LimitsPage />);
+
+    const row = screen.getByTestId("data-table-row-limit-1");
+    expect(row).toHaveTextContent("Calendar month");
+    expect(row).toHaveTextContent("Resets Feb 1");
   });
 
   it("shows multiple model badges for limits with multiple models", () => {

--- a/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
@@ -353,17 +353,6 @@ describe("LimitsPage", () => {
     expect(mockUseAllVirtualApiKeys).toHaveBeenCalledWith({ limit: 100 });
   });
 
-  it("shows succinct cleanup interval help in the limit form", () => {
-    render(<LimitsPage />);
-
-    expect(
-      screen.getByText(/rolling resets after elapsed time/i),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/calendar resets at the next day, week, or month/i),
-    ).toBeInTheDocument();
-  });
-
   it("groups cleanup interval options with calendar windows first", () => {
     render(<LimitsPage />);
 

--- a/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
@@ -148,9 +148,16 @@ vi.mock("@/components/ui/select", () => ({
   SelectContent: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
+  SelectGroup: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
   SelectItem: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
+  SelectLabel: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectSeparator: () => <hr />,
 }));
 
 vi.mock("@/components/ui/searchable-select", () => ({
@@ -355,6 +362,15 @@ describe("LimitsPage", () => {
     expect(
       screen.getByText(/calendar resets at the next day, week, or month/i),
     ).toBeInTheDocument();
+  });
+
+  it("groups cleanup interval options with calendar windows first", () => {
+    render(<LimitsPage />);
+
+    const text = document.body.textContent ?? "";
+    expect(text.indexOf("Calendar month")).toBeLessThan(
+      text.indexOf("Rolling hour"),
+    );
   });
 
   it("shows 'All models' badge for limits with null model", () => {

--- a/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
@@ -368,6 +368,35 @@ describe("LimitsPage", () => {
     expect(modelsBadge).toHaveTextContent("All models");
   });
 
+  it("shows the next reset date for monthly limits", () => {
+    mockUseLimits.mockReturnValue({
+      data: [
+        {
+          id: "limit-1",
+          entityType: "organization",
+          entityId: "org-1",
+          limitType: "token_cost",
+          limitValue: 1000,
+          model: null,
+          mcpServerName: null,
+          toolName: null,
+          cleanupInterval: "1m",
+          lastCleanup: "2026-01-15T12:00:00.000Z",
+          createdAt: "2026-01-01",
+          updatedAt: "2026-01-01",
+          modelUsage: [],
+        },
+      ],
+      isPending: false,
+    });
+
+    render(<LimitsPage />);
+
+    const row = screen.getByTestId("data-table-row-limit-1");
+    expect(row).toHaveTextContent("Every month");
+    expect(row).toHaveTextContent("Resets Feb 15");
+  });
+
   it("shows multiple model badges for limits with multiple models", () => {
     const models = getLimitModels({
       id: "limit-1",

--- a/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
@@ -353,15 +353,6 @@ describe("LimitsPage", () => {
     expect(mockUseAllVirtualApiKeys).toHaveBeenCalledWith({ limit: 100 });
   });
 
-  it("groups cleanup interval options with calendar windows first", () => {
-    render(<LimitsPage />);
-
-    const text = document.body.textContent ?? "";
-    expect(text.indexOf("Calendar month")).toBeLessThan(
-      text.indexOf("Rolling hour"),
-    );
-  });
-
   it("shows 'All models' badge for limits with null model", () => {
     mockUseLimits.mockReturnValue({
       data: [

--- a/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
@@ -346,6 +346,17 @@ describe("LimitsPage", () => {
     expect(mockUseAllVirtualApiKeys).toHaveBeenCalledWith({ limit: 100 });
   });
 
+  it("shows succinct cleanup interval help in the limit form", () => {
+    render(<LimitsPage />);
+
+    expect(
+      screen.getByText(/rolling resets after elapsed time/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/calendar resets at the next day, week, or month/i),
+    ).toBeInTheDocument();
+  });
+
   it("shows 'All models' badge for limits with null model", () => {
     mockUseLimits.mockReturnValue({
       data: [

--- a/platform/frontend/src/app/llm/(costs)/limits/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.tsx
@@ -5,6 +5,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import {
   Building2,
   Edit,
+  Info,
   Key,
   Network,
   Plus,
@@ -887,7 +888,26 @@ export default function LimitsPage() {
             </div>
 
             <div className="space-y-2">
-              <Label>Cleanup interval</Label>
+              <div className="flex items-center gap-1.5">
+                <Label>Cleanup interval</Label>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      className="h-5 w-5 text-muted-foreground hover:text-foreground"
+                      aria-label="Cleanup interval help"
+                    >
+                      <Info className="h-3.5 w-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" align="start" className="max-w-72">
+                    Rolling resets after elapsed time. Calendar resets at the
+                    next day, week, or month boundary.
+                  </TooltipContent>
+                </Tooltip>
+              </div>
               <LimitCleanupIntervalSelect
                 value={formState.cleanupInterval}
                 onValueChange={(value) =>

--- a/platform/frontend/src/app/llm/(costs)/limits/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.tsx
@@ -943,6 +943,12 @@ function formatNextLimitReset(
   lastCleanup: LimitData["lastCleanup"],
   cleanupInterval: LimitCleanupInterval,
 ): string {
+  if (isCalendarCleanupInterval(cleanupInterval)) {
+    return formatResetDate(
+      getNextCalendarResetDate(new Date(), cleanupInterval),
+    );
+  }
+
   if (!lastCleanup) {
     return "Resets on next check";
   }
@@ -952,13 +958,15 @@ function formatNextLimitReset(
     return "Reset schedule unavailable";
   }
 
-  return `Resets ${nextReset.toLocaleDateString(undefined, {
+  return formatResetDate(nextReset);
+}
+
+function formatResetDate(date: Date): string {
+  return `Resets ${date.toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",
     year:
-      nextReset.getFullYear() === new Date().getFullYear()
-        ? undefined
-        : "numeric",
+      date.getFullYear() === new Date().getFullYear() ? undefined : "numeric",
   })}`;
 }
 
@@ -982,6 +990,56 @@ function addCleanupInterval(
       return next;
     case "1m":
       next.setMonth(next.getMonth() + 1);
+      return next;
+    case "calendar_day":
+    case "calendar_week_sunday":
+    case "calendar_week_monday":
+    case "calendar_month":
+      return getNextCalendarResetDate(next, cleanupInterval);
+  }
+}
+
+function isCalendarCleanupInterval(
+  cleanupInterval: LimitCleanupInterval,
+): cleanupInterval is Extract<
+  LimitCleanupInterval,
+  | "calendar_day"
+  | "calendar_week_sunday"
+  | "calendar_week_monday"
+  | "calendar_month"
+> {
+  return cleanupInterval.startsWith("calendar_");
+}
+
+function getNextCalendarResetDate(
+  date: Date,
+  cleanupInterval: Extract<
+    LimitCleanupInterval,
+    | "calendar_day"
+    | "calendar_week_sunday"
+    | "calendar_week_monday"
+    | "calendar_month"
+  >,
+): Date {
+  const next = new Date(date);
+  next.setHours(0, 0, 0, 0);
+
+  switch (cleanupInterval) {
+    case "calendar_day":
+      next.setDate(next.getDate() + 1);
+      return next;
+    case "calendar_week_sunday": {
+      const daysUntilSunday = (7 - next.getDay()) % 7 || 7;
+      next.setDate(next.getDate() + daysUntilSunday);
+      return next;
+    }
+    case "calendar_week_monday": {
+      const daysUntilMonday = (8 - next.getDay()) % 7 || 7;
+      next.setDate(next.getDate() + daysUntilMonday);
+      return next;
+    }
+    case "calendar_month":
+      next.setMonth(next.getMonth() + 1, 1);
       return next;
   }
 }

--- a/platform/frontend/src/app/llm/(costs)/limits/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.tsx
@@ -493,7 +493,17 @@ export default function LimitsPage() {
           const cleanupInterval =
             (row.original.cleanupInterval as LimitCleanupInterval | null) ??
             DEFAULT_LIMIT_CLEANUP_INTERVAL;
-          return CLEANUP_INTERVAL_LABELS[cleanupInterval];
+          return (
+            <div className="space-y-0.5">
+              <div>{CLEANUP_INTERVAL_LABELS[cleanupInterval]}</div>
+              <div className="text-xs text-muted-foreground">
+                {formatNextLimitReset(
+                  row.original.lastCleanup,
+                  cleanupInterval,
+                )}
+              </div>
+            </div>
+          );
         },
       },
       {
@@ -927,4 +937,51 @@ export function getLimitModels(limit: LimitData): string[] {
   return Array.isArray(limit.model)
     ? limit.model.filter((model): model is string => typeof model === "string")
     : [];
+}
+
+function formatNextLimitReset(
+  lastCleanup: LimitData["lastCleanup"],
+  cleanupInterval: LimitCleanupInterval,
+): string {
+  if (!lastCleanup) {
+    return "Resets on next check";
+  }
+
+  const nextReset = addCleanupInterval(new Date(lastCleanup), cleanupInterval);
+  if (Number.isNaN(nextReset.getTime())) {
+    return "Reset schedule unavailable";
+  }
+
+  return `Resets ${nextReset.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year:
+      nextReset.getFullYear() === new Date().getFullYear()
+        ? undefined
+        : "numeric",
+  })}`;
+}
+
+function addCleanupInterval(
+  date: Date,
+  cleanupInterval: LimitCleanupInterval,
+): Date {
+  const next = new Date(date);
+  switch (cleanupInterval) {
+    case "1h":
+      next.setHours(next.getHours() + 1);
+      return next;
+    case "12h":
+      next.setHours(next.getHours() + 12);
+      return next;
+    case "24h":
+      next.setDate(next.getDate() + 1);
+      return next;
+    case "1w":
+      next.setDate(next.getDate() + 7);
+      return next;
+    case "1m":
+      next.setMonth(next.getMonth() + 1);
+      return next;
+  }
 }

--- a/platform/frontend/src/components/chat/inline-chat-error.test.tsx
+++ b/platform/frontend/src/components/chat/inline-chat-error.test.tsx
@@ -37,13 +37,13 @@ describe("InlineChatError", () => {
             }),
           )
         }
-        supportMessage="Contact support@example.com and include these IDs."
+        supportMessage="Contact your administrator and include these IDs."
         slimChatErrorUi
       />,
     );
 
     expect(
-      screen.getByText("Contact support@example.com and include these IDs."),
+      screen.getByText("Contact your administrator and include these IDs."),
     ).toBeInTheDocument();
     expect(screen.getByText("session-12345678")).toBeInTheDocument();
     expect(screen.getByText("trace-12345678")).toBeInTheDocument();
@@ -88,6 +88,40 @@ describe("InlineChatError", () => {
     expect(
       screen.queryByText("secret provider detail"),
     ).not.toBeInTheDocument();
+  });
+
+  it("shows usage limit overages as a quiet slim notice below correlation IDs", () => {
+    render(
+      <InlineChatError
+        error={
+          new Error(
+            JSON.stringify({
+              code: "rate_limit",
+              message: "The organization usage limit budget has been exceeded.",
+              isRetryable: true,
+              sessionId: "session-12345678",
+              traceId: "trace-12345678",
+              spanId: "span-12345678",
+              usageLimitExceeded: true,
+              usageLimitEntityType: "organization",
+            }),
+          )
+        }
+        supportMessage="Contact support@example.com and include these IDs."
+        slimChatErrorUi
+      />,
+    );
+
+    expect(
+      screen.getByText("Contact support@example.com and include these IDs."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("session-12345678")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "The organization usage limit budget has been exceeded.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Error Details")).not.toBeInTheDocument();
   });
 
   it("still shows a copy button in slim mode when no IDs are available", () => {

--- a/platform/frontend/src/components/chat/inline-chat-error.test.tsx
+++ b/platform/frontend/src/components/chat/inline-chat-error.test.tsx
@@ -90,40 +90,6 @@ describe("InlineChatError", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows usage limit overages as a quiet slim notice below correlation IDs", () => {
-    render(
-      <InlineChatError
-        error={
-          new Error(
-            JSON.stringify({
-              code: "rate_limit",
-              message: "The organization usage limit budget has been exceeded.",
-              isRetryable: true,
-              sessionId: "session-12345678",
-              traceId: "trace-12345678",
-              spanId: "span-12345678",
-              usageLimitExceeded: true,
-              usageLimitEntityType: "organization",
-            }),
-          )
-        }
-        supportMessage="Contact support@example.com and include these IDs."
-        slimChatErrorUi
-      />,
-    );
-
-    expect(
-      screen.getByText("Contact support@example.com and include these IDs."),
-    ).toBeInTheDocument();
-    expect(screen.getByText("session-12345678")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "The organization usage limit budget has been exceeded.",
-      ),
-    ).toBeInTheDocument();
-    expect(screen.queryByText("Error Details")).not.toBeInTheDocument();
-  });
-
   it("still shows a copy button in slim mode when no IDs are available", () => {
     render(
       <InlineChatError error={new Error("Failed to fetch")} slimChatErrorUi />,

--- a/platform/frontend/src/components/chat/inline-chat-error.tsx
+++ b/platform/frontend/src/components/chat/inline-chat-error.tsx
@@ -5,6 +5,7 @@ import {
   ChevronDown,
   ChevronRight,
   Copy,
+  Gauge,
   RefreshCw,
 } from "lucide-react";
 import { useState } from "react";
@@ -48,6 +49,16 @@ export function InlineChatError({
     organizationSettings: ["read"],
   });
   const chatError = parseErrorResponse(error) ?? mapClientError(error);
+  const isUsageLimitExceeded = chatError.usageLimitExceeded === true;
+  const StatusIcon = isUsageLimitExceeded ? Gauge : AlertCircle;
+  const containerClassName = isUsageLimitExceeded
+    ? "bg-muted/30 border border-border rounded-lg"
+    : "bg-destructive/10 border border-destructive/20 rounded-lg";
+  const iconClassName = isUsageLimitExceeded
+    ? "text-muted-foreground"
+    : "text-destructive";
+  const usageLimitMessage =
+    isUsageLimitExceeded && supportMessage ? chatError.message : undefined;
   // Conversation IDs double as chat session IDs for the end-user chat flow.
   const sessionId = chatError.sessionId ?? conversationId;
 
@@ -90,9 +101,11 @@ export function InlineChatError({
   if (slimChatErrorUi) {
     return (
       <Message from="assistant">
-        <MessageContent className="bg-destructive/10 border border-destructive/20 rounded-lg">
-          <div className="flex items-start gap-2 text-destructive">
-            <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+        <MessageContent className={containerClassName}>
+          <div className="flex items-start gap-2">
+            <StatusIcon
+              className={`h-4 w-4 mt-0.5 flex-shrink-0 ${iconClassName}`}
+            />
             <div className="flex-1 space-y-2">
               <p className="text-sm text-foreground">
                 {supportMessage ? supportMessage : chatError.message}
@@ -119,6 +132,11 @@ export function InlineChatError({
                   <Copy className="h-3 w-3" />
                 </Button>
               </div>
+              {usageLimitMessage && (
+                <p className="text-xs text-muted-foreground">
+                  {usageLimitMessage}
+                </p>
+              )}
             </div>
           </div>
         </MessageContent>
@@ -128,9 +146,11 @@ export function InlineChatError({
 
   return (
     <Message from="assistant">
-      <MessageContent className="bg-destructive/10 border border-destructive/20 rounded-lg">
-        <div className="flex items-start gap-2 text-destructive">
-          <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+      <MessageContent className={containerClassName}>
+        <div className="flex items-start gap-2">
+          <StatusIcon
+            className={`h-4 w-4 mt-0.5 flex-shrink-0 ${iconClassName}`}
+          />
           <div className="flex-1 space-y-2">
             {supportMessage ? (
               <p className="text-sm text-foreground">{supportMessage}</p>
@@ -181,6 +201,11 @@ export function InlineChatError({
                 <Copy className="h-3 w-3" />
               </Button>
             </div>
+            {usageLimitMessage && (
+              <p className="text-xs text-muted-foreground">
+                {usageLimitMessage}
+              </p>
+            )}
 
             {isAdmin && (
               <Collapsible open={isDetailsOpen} onOpenChange={setIsDetailsOpen}>

--- a/platform/frontend/src/components/limit-cleanup-interval-select.tsx
+++ b/platform/frontend/src/components/limit-cleanup-interval-select.tsx
@@ -2,7 +2,10 @@ import type { archestraApiTypes } from "@shared";
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
+  SelectSeparator,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
@@ -13,19 +16,39 @@ export type LimitCleanupInterval = NonNullable<
   >["defaultUserLimitCleanupInterval"]
 >;
 
-export const DEFAULT_LIMIT_CLEANUP_INTERVAL: LimitCleanupInterval = "1w";
+export const DEFAULT_LIMIT_CLEANUP_INTERVAL: LimitCleanupInterval =
+  "calendar_month";
 
 export const CLEANUP_INTERVAL_LABELS: Record<LimitCleanupInterval, string> = {
+  calendar_day: "Calendar day",
+  calendar_week_sunday: "Calendar week (Sun-Sat)",
+  calendar_week_monday: "Calendar week (Mon-Sun)",
+  calendar_month: "Calendar month",
   "1h": "Rolling hour",
   "12h": "Rolling 12 hours",
   "24h": "Rolling day",
   "1w": "Rolling week",
   "1m": "Rolling month",
-  calendar_day: "Calendar day",
-  calendar_week_sunday: "Calendar week (Sun-Sat)",
-  calendar_week_monday: "Calendar week (Mon-Sun)",
-  calendar_month: "Calendar month",
 };
+
+const CLEANUP_INTERVAL_GROUPS: Array<{
+  label: string;
+  options: LimitCleanupInterval[];
+}> = [
+  {
+    label: "Calendar",
+    options: [
+      "calendar_day",
+      "calendar_week_sunday",
+      "calendar_week_monday",
+      "calendar_month",
+    ],
+  },
+  {
+    label: "Rolling",
+    options: ["1h", "12h", "24h", "1w", "1m"],
+  },
+];
 
 type LimitCleanupIntervalSelectProps = {
   value: LimitCleanupInterval;
@@ -44,10 +67,16 @@ export function LimitCleanupIntervalSelect({
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
-        {Object.entries(CLEANUP_INTERVAL_LABELS).map(([value, label]) => (
-          <SelectItem key={value} value={value}>
-            {label}
-          </SelectItem>
+        {CLEANUP_INTERVAL_GROUPS.map((group, index) => (
+          <SelectGroup key={group.label}>
+            <SelectLabel>{group.label}</SelectLabel>
+            {group.options.map((value) => (
+              <SelectItem key={value} value={value}>
+                {CLEANUP_INTERVAL_LABELS[value]}
+              </SelectItem>
+            ))}
+            {index < CLEANUP_INTERVAL_GROUPS.length - 1 && <SelectSeparator />}
+          </SelectGroup>
         ))}
       </SelectContent>
     </Select>

--- a/platform/frontend/src/components/limit-cleanup-interval-select.tsx
+++ b/platform/frontend/src/components/limit-cleanup-interval-select.tsx
@@ -16,11 +16,15 @@ export type LimitCleanupInterval = NonNullable<
 export const DEFAULT_LIMIT_CLEANUP_INTERVAL: LimitCleanupInterval = "1w";
 
 export const CLEANUP_INTERVAL_LABELS: Record<LimitCleanupInterval, string> = {
-  "1h": "Every hour",
-  "12h": "Every 12 hours",
-  "24h": "Every 24 hours",
-  "1w": "Every week",
-  "1m": "Every month",
+  "1h": "Rolling hour",
+  "12h": "Rolling 12 hours",
+  "24h": "Rolling day",
+  "1w": "Rolling week",
+  "1m": "Rolling month",
+  calendar_day: "Calendar day",
+  calendar_week_sunday: "Calendar week (Sun-Sat)",
+  calendar_week_monday: "Calendar week (Mon-Sun)",
+  calendar_month: "Calendar month",
 };
 
 type LimitCleanupIntervalSelectProps = {

--- a/platform/shared/chat-error.ts
+++ b/platform/shared/chat-error.ts
@@ -324,6 +324,10 @@ export interface ChatErrorResponse {
   traceId?: string;
   /** OpenTelemetry span ID for correlating with backend logs */
   spanId?: string;
+  /** True when the request was blocked by a configured usage-limit budget */
+  usageLimitExceeded?: boolean;
+  /** The usage-limit entity that blocked the request, when known */
+  usageLimitEntityType?: string;
   /** Original error details for debugging (provider-specific) */
   originalError?: {
     /** Provider name (anthropic, openai, gemini) */
@@ -346,6 +350,8 @@ export const ChatErrorResponseSchema: z.ZodType<ChatErrorResponse> = z.object({
   sessionId: z.string().optional(),
   traceId: z.string().optional(),
   spanId: z.string().optional(),
+  usageLimitExceeded: z.boolean().optional(),
+  usageLimitEntityType: z.string().optional(),
   originalError: z
     .object({
       provider: SupportedProvidersSchema.optional(),

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -19609,6 +19609,8 @@ export type GetChatConversationsResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -19758,6 +19760,8 @@ export type CreateChatConversationResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -19989,6 +19993,8 @@ export type GetChatConversationResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -20142,6 +20148,8 @@ export type UpdateChatConversationResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -20455,6 +20463,8 @@ export type ForkChatConversationResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -20705,6 +20715,8 @@ export type CompactChatConversationResponses = {
                     sessionId?: string;
                     traceId?: string;
                     spanId?: string;
+                    usageLimitExceeded?: boolean;
+                    usageLimitEntityType?: string;
                     originalError?: {
                         provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                         status?: number;
@@ -21125,6 +21137,8 @@ export type GetSharedConversationResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -21274,6 +21288,8 @@ export type ForkSharedConversationResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -21425,6 +21441,8 @@ export type GenerateChatConversationTitleResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -21575,6 +21593,8 @@ export type UpdateChatMessageResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -24979,6 +24999,8 @@ export type GetInteractionsResponses = {
                     sessionId?: string;
                     traceId?: string;
                     spanId?: string;
+                    usageLimitExceeded?: boolean;
+                    usageLimitEntityType?: string;
                     originalError?: {
                         provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                         status?: number;
@@ -25162,6 +25184,8 @@ export type GetInteractionsResponses = {
                     sessionId?: string;
                     traceId?: string;
                     spanId?: string;
+                    usageLimitExceeded?: boolean;
+                    usageLimitEntityType?: string;
                     originalError?: {
                         provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                         status?: number;
@@ -25251,6 +25275,8 @@ export type GetInteractionsResponses = {
                     sessionId?: string;
                     traceId?: string;
                     spanId?: string;
+                    usageLimitExceeded?: boolean;
+                    usageLimitEntityType?: string;
                     originalError?: {
                         provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                         status?: number;
@@ -25316,6 +25342,8 @@ export type GetInteractionsResponses = {
                     sessionId?: string;
                     traceId?: string;
                     spanId?: string;
+                    usageLimitExceeded?: boolean;
+                    usageLimitEntityType?: string;
                     originalError?: {
                         provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                         status?: number;
@@ -25383,6 +25411,8 @@ export type GetInteractionsResponses = {
                     sessionId?: string;
                     traceId?: string;
                     spanId?: string;
+                    usageLimitExceeded?: boolean;
+                    usageLimitEntityType?: string;
                     originalError?: {
                         provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                         status?: number;
@@ -25824,6 +25854,8 @@ export type GetInteractionsResponses = {
                     sessionId?: string;
                     traceId?: string;
                     spanId?: string;
+                    usageLimitExceeded?: boolean;
+                    usageLimitEntityType?: string;
                     originalError?: {
                         provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                         status?: number;
@@ -25891,6 +25923,8 @@ export type GetInteractionsResponses = {
                     sessionId?: string;
                     traceId?: string;
                     spanId?: string;
+                    usageLimitExceeded?: boolean;
+                    usageLimitEntityType?: string;
                     originalError?: {
                         provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                         status?: number;
@@ -25958,6 +25992,8 @@ export type GetInteractionsResponses = {
                     sessionId?: string;
                     traceId?: string;
                     spanId?: string;
+                    usageLimitExceeded?: boolean;
+                    usageLimitEntityType?: string;
                     originalError?: {
                         provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                         status?: number;
@@ -26025,6 +26061,8 @@ export type GetInteractionsResponses = {
                     sessionId?: string;
                     traceId?: string;
                     spanId?: string;
+                    usageLimitExceeded?: boolean;
+                    usageLimitEntityType?: string;
                     originalError?: {
                         provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                         status?: number;
@@ -26092,6 +26130,8 @@ export type GetInteractionsResponses = {
                     sessionId?: string;
                     traceId?: string;
                     spanId?: string;
+                    usageLimitExceeded?: boolean;
+                    usageLimitEntityType?: string;
                     originalError?: {
                         provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                         status?: number;
@@ -26159,6 +26199,8 @@ export type GetInteractionsResponses = {
                     sessionId?: string;
                     traceId?: string;
                     spanId?: string;
+                    usageLimitExceeded?: boolean;
+                    usageLimitEntityType?: string;
                     originalError?: {
                         provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                         status?: number;
@@ -26226,6 +26268,8 @@ export type GetInteractionsResponses = {
                     sessionId?: string;
                     traceId?: string;
                     spanId?: string;
+                    usageLimitExceeded?: boolean;
+                    usageLimitEntityType?: string;
                     originalError?: {
                         provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                         status?: number;
@@ -26293,6 +26337,8 @@ export type GetInteractionsResponses = {
                     sessionId?: string;
                     traceId?: string;
                     spanId?: string;
+                    usageLimitExceeded?: boolean;
+                    usageLimitEntityType?: string;
                     originalError?: {
                         provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                         status?: number;
@@ -26358,6 +26404,8 @@ export type GetInteractionsResponses = {
                     sessionId?: string;
                     traceId?: string;
                     spanId?: string;
+                    usageLimitExceeded?: boolean;
+                    usageLimitEntityType?: string;
                     originalError?: {
                         provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                         status?: number;
@@ -26423,6 +26471,8 @@ export type GetInteractionsResponses = {
                     sessionId?: string;
                     traceId?: string;
                     spanId?: string;
+                    usageLimitExceeded?: boolean;
+                    usageLimitEntityType?: string;
                     originalError?: {
                         provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                         status?: number;
@@ -26490,6 +26540,8 @@ export type GetInteractionsResponses = {
                     sessionId?: string;
                     traceId?: string;
                     spanId?: string;
+                    usageLimitExceeded?: boolean;
+                    usageLimitEntityType?: string;
                     originalError?: {
                         provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                         status?: number;
@@ -26557,6 +26609,8 @@ export type GetInteractionsResponses = {
                     sessionId?: string;
                     traceId?: string;
                     spanId?: string;
+                    usageLimitExceeded?: boolean;
+                    usageLimitEntityType?: string;
                     originalError?: {
                         provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                         status?: number;
@@ -26624,6 +26678,8 @@ export type GetInteractionsResponses = {
                     sessionId?: string;
                     traceId?: string;
                     spanId?: string;
+                    usageLimitExceeded?: boolean;
+                    usageLimitEntityType?: string;
                     originalError?: {
                         provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                         status?: number;
@@ -26758,6 +26814,8 @@ export type GetInteractionsResponses = {
                     sessionId?: string;
                     traceId?: string;
                     spanId?: string;
+                    usageLimitExceeded?: boolean;
+                    usageLimitEntityType?: string;
                     originalError?: {
                         provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                         status?: number;
@@ -26941,6 +26999,8 @@ export type GetInteractionsResponses = {
                     sessionId?: string;
                     traceId?: string;
                     spanId?: string;
+                    usageLimitExceeded?: boolean;
+                    usageLimitEntityType?: string;
                     originalError?: {
                         provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                         status?: number;
@@ -27422,6 +27482,8 @@ export type GetInteractionResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -27605,6 +27667,8 @@ export type GetInteractionResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -27694,6 +27758,8 @@ export type GetInteractionResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -27759,6 +27825,8 @@ export type GetInteractionResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -27826,6 +27894,8 @@ export type GetInteractionResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -28267,6 +28337,8 @@ export type GetInteractionResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -28334,6 +28406,8 @@ export type GetInteractionResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -28401,6 +28475,8 @@ export type GetInteractionResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -28468,6 +28544,8 @@ export type GetInteractionResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -28535,6 +28613,8 @@ export type GetInteractionResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -28602,6 +28682,8 @@ export type GetInteractionResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -28669,6 +28751,8 @@ export type GetInteractionResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -28736,6 +28820,8 @@ export type GetInteractionResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -28801,6 +28887,8 @@ export type GetInteractionResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -28866,6 +28954,8 @@ export type GetInteractionResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -28933,6 +29023,8 @@ export type GetInteractionResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -29000,6 +29092,8 @@ export type GetInteractionResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -29067,6 +29161,8 @@ export type GetInteractionResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -29201,6 +29297,8 @@ export type GetInteractionResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -29384,6 +29482,8 @@ export type GetInteractionResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;
@@ -35819,7 +35919,7 @@ export type GetLimitsResponses = {
         mcpServerName: string | null;
         toolName: string | null;
         model?: Array<string> | null;
-        cleanupInterval?: '1h' | '12h' | '24h' | '1w' | '1m';
+        cleanupInterval?: '1h' | '12h' | '24h' | '1w' | '1m' | 'calendar_day' | 'calendar_week_sunday' | 'calendar_week_monday' | 'calendar_month';
         lastCleanup: string | null;
         createdAt: string;
         updatedAt: string;
@@ -35843,7 +35943,7 @@ export type CreateLimitData = {
         mcpServerName?: string | null;
         toolName?: string | null;
         model?: Array<string> | null;
-        cleanupInterval?: '1h' | '12h' | '24h' | '1w' | '1m';
+        cleanupInterval?: '1h' | '12h' | '24h' | '1w' | '1m' | 'calendar_day' | 'calendar_week_sunday' | 'calendar_week_monday' | 'calendar_month';
         lastCleanup?: unknown;
     };
     path?: never;
@@ -35929,7 +36029,7 @@ export type CreateLimitResponses = {
         mcpServerName: string | null;
         toolName: string | null;
         model?: Array<string> | null;
-        cleanupInterval?: '1h' | '12h' | '24h' | '1w' | '1m';
+        cleanupInterval?: '1h' | '12h' | '24h' | '1w' | '1m' | 'calendar_day' | 'calendar_week_sunday' | 'calendar_week_monday' | 'calendar_month';
         lastCleanup: string | null;
         createdAt: string;
         updatedAt: string;
@@ -36110,7 +36210,7 @@ export type GetLimitResponses = {
         mcpServerName: string | null;
         toolName: string | null;
         model?: Array<string> | null;
-        cleanupInterval?: '1h' | '12h' | '24h' | '1w' | '1m';
+        cleanupInterval?: '1h' | '12h' | '24h' | '1w' | '1m' | 'calendar_day' | 'calendar_week_sunday' | 'calendar_week_monday' | 'calendar_month';
         lastCleanup: string | null;
         createdAt: string;
         updatedAt: string;
@@ -36128,7 +36228,7 @@ export type UpdateLimitData = {
         mcpServerName?: string | null;
         toolName?: string | null;
         model?: Array<string> | null;
-        cleanupInterval?: '1h' | '12h' | '24h' | '1w' | '1m';
+        cleanupInterval?: '1h' | '12h' | '24h' | '1w' | '1m' | 'calendar_day' | 'calendar_week_sunday' | 'calendar_week_monday' | 'calendar_month';
         lastCleanup?: unknown;
     };
     path: {
@@ -36216,7 +36316,7 @@ export type UpdateLimitResponses = {
         mcpServerName: string | null;
         toolName: string | null;
         model?: Array<string> | null;
-        cleanupInterval?: '1h' | '12h' | '24h' | '1w' | '1m';
+        cleanupInterval?: '1h' | '12h' | '24h' | '1w' | '1m' | 'calendar_day' | 'calendar_week_sunday' | 'calendar_week_monday' | 'calendar_month';
         lastCleanup: string | null;
         createdAt: string;
         updatedAt: string;
@@ -45149,7 +45249,7 @@ export type GetOrganizationResponses = {
         defaultLlmApiKeyId: string | null;
         defaultUserLimitValue: number | null;
         defaultUserLimitModel: Array<string> | null;
-        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m';
+        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m' | 'calendar_day' | 'calendar_week_sunday' | 'calendar_week_monday' | 'calendar_month';
         defaultAgentId: string | null;
         favicon: string | null;
         appName: string | null;
@@ -45435,7 +45535,7 @@ export type UpdateAppearanceSettingsResponses = {
         defaultLlmApiKeyId: string | null;
         defaultUserLimitValue: number | null;
         defaultUserLimitModel: Array<string> | null;
-        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m';
+        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m' | 'calendar_day' | 'calendar_week_sunday' | 'calendar_week_monday' | 'calendar_month';
         defaultAgentId: string | null;
         favicon: string | null;
         appName: string | null;
@@ -45592,7 +45692,7 @@ export type UpdateSecuritySettingsResponses = {
         defaultLlmApiKeyId: string | null;
         defaultUserLimitValue: number | null;
         defaultUserLimitModel: Array<string> | null;
-        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m';
+        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m' | 'calendar_day' | 'calendar_week_sunday' | 'calendar_week_monday' | 'calendar_month';
         defaultAgentId: string | null;
         favicon: string | null;
         appName: string | null;
@@ -45650,7 +45750,7 @@ export type UpdateLlmSettingsData = {
         compressionScope?: 'organization' | 'team';
         defaultUserLimitValue?: number | null;
         defaultUserLimitModel?: Array<string> | null;
-        defaultUserLimitCleanupInterval?: '1h' | '12h' | '24h' | '1w' | '1m';
+        defaultUserLimitCleanupInterval?: '1h' | '12h' | '24h' | '1w' | '1m' | 'calendar_day' | 'calendar_week_sunday' | 'calendar_week_monday' | 'calendar_month';
     };
     path?: never;
     query?: never;
@@ -45752,7 +45852,7 @@ export type UpdateLlmSettingsResponses = {
         defaultLlmApiKeyId: string | null;
         defaultUserLimitValue: number | null;
         defaultUserLimitModel: Array<string> | null;
-        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m';
+        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m' | 'calendar_day' | 'calendar_week_sunday' | 'calendar_week_monday' | 'calendar_month';
         defaultAgentId: string | null;
         favicon: string | null;
         appName: string | null;
@@ -45911,7 +46011,7 @@ export type UpdateAgentSettingsResponses = {
         defaultLlmApiKeyId: string | null;
         defaultUserLimitValue: number | null;
         defaultUserLimitModel: Array<string> | null;
-        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m';
+        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m' | 'calendar_day' | 'calendar_week_sunday' | 'calendar_week_monday' | 'calendar_month';
         defaultAgentId: string | null;
         favicon: string | null;
         appName: string | null;
@@ -46077,7 +46177,7 @@ export type UpdateConnectionSettingsResponses = {
         defaultLlmApiKeyId: string | null;
         defaultUserLimitValue: number | null;
         defaultUserLimitModel: Array<string> | null;
-        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m';
+        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m' | 'calendar_day' | 'calendar_week_sunday' | 'calendar_week_monday' | 'calendar_month';
         defaultAgentId: string | null;
         favicon: string | null;
         appName: string | null;
@@ -46234,7 +46334,7 @@ export type UpdatePresetEntityNameResponses = {
         defaultLlmApiKeyId: string | null;
         defaultUserLimitValue: number | null;
         defaultUserLimitModel: Array<string> | null;
-        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m';
+        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m' | 'calendar_day' | 'calendar_week_sunday' | 'calendar_week_monday' | 'calendar_month';
         defaultAgentId: string | null;
         favicon: string | null;
         appName: string | null;
@@ -46390,7 +46490,7 @@ export type UpdatePresetEntityDefaultLabelResponses = {
         defaultLlmApiKeyId: string | null;
         defaultUserLimitValue: number | null;
         defaultUserLimitModel: Array<string> | null;
-        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m';
+        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m' | 'calendar_day' | 'calendar_week_sunday' | 'calendar_week_monday' | 'calendar_month';
         defaultAgentId: string | null;
         favicon: string | null;
         appName: string | null;
@@ -46546,7 +46646,7 @@ export type UpdatePresetEntityDefaultValidationRegexResponses = {
         defaultLlmApiKeyId: string | null;
         defaultUserLimitValue: number | null;
         defaultUserLimitModel: Array<string> | null;
-        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m';
+        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m' | 'calendar_day' | 'calendar_week_sunday' | 'calendar_week_monday' | 'calendar_month';
         defaultAgentId: string | null;
         favicon: string | null;
         appName: string | null;
@@ -46706,7 +46806,7 @@ export type UpdateDefaultEnvironmentResponses = {
         defaultLlmApiKeyId: string | null;
         defaultUserLimitValue: number | null;
         defaultUserLimitModel: Array<string> | null;
-        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m';
+        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m' | 'calendar_day' | 'calendar_week_sunday' | 'calendar_week_monday' | 'calendar_month';
         defaultAgentId: string | null;
         favicon: string | null;
         appName: string | null;
@@ -46863,7 +46963,7 @@ export type UpdateAuthSettingsResponses = {
         defaultLlmApiKeyId: string | null;
         defaultUserLimitValue: number | null;
         defaultUserLimitModel: Array<string> | null;
-        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m';
+        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m' | 'calendar_day' | 'calendar_week_sunday' | 'calendar_week_monday' | 'calendar_month';
         defaultAgentId: string | null;
         favicon: string | null;
         appName: string | null;
@@ -47022,7 +47122,7 @@ export type UpdateKnowledgeSettingsResponses = {
         defaultLlmApiKeyId: string | null;
         defaultUserLimitValue: number | null;
         defaultUserLimitModel: Array<string> | null;
-        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m';
+        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m' | 'calendar_day' | 'calendar_week_sunday' | 'calendar_week_monday' | 'calendar_month';
         defaultAgentId: string | null;
         favicon: string | null;
         appName: string | null;
@@ -47176,7 +47276,7 @@ export type DropEmbeddingConfigResponses = {
         defaultLlmApiKeyId: string | null;
         defaultUserLimitValue: number | null;
         defaultUserLimitModel: Array<string> | null;
-        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m';
+        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m' | 'calendar_day' | 'calendar_week_sunday' | 'calendar_week_monday' | 'calendar_month';
         defaultAgentId: string | null;
         favicon: string | null;
         appName: string | null;
@@ -47419,7 +47519,7 @@ export type CompleteOnboardingResponses = {
         defaultLlmApiKeyId: string | null;
         defaultUserLimitValue: number | null;
         defaultUserLimitModel: Array<string> | null;
-        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m';
+        defaultUserLimitCleanupInterval: '1h' | '12h' | '24h' | '1w' | '1m' | 'calendar_day' | 'calendar_week_sunday' | 'calendar_week_monday' | 'calendar_month';
         defaultAgentId: string | null;
         favicon: string | null;
         appName: string | null;
@@ -49257,6 +49357,8 @@ export type CreateScheduleTriggerRunConversationResponses = {
                 sessionId?: string;
                 traceId?: string;
                 spanId?: string;
+                usageLimitExceeded?: boolean;
+                usageLimitEntityType?: string;
                 originalError?: {
                     provider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure';
                     status?: number;


### PR DESCRIPTION
## Summary
- Fix usage-limit enforcement and attribution for agents without team assignments.
- Preserve structured usage-limit overage metadata through chat errors and render overages as a quieter budget notice with correlation IDs.
- Add calendar-aligned cleanup intervals, grouped interval selection, calendar-month defaults, reset-date display, and cleanup interval help text.
- Reset current usage when a limit's cleanup interval changes and document the cleanup behavior concisely.