### PR TITLE
fix(chat): auto-retry empty model responses, surface as structured error

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -67945,6 +67945,7 @@
                                     "content_filtered",
                                     "server_error",
                                     "network_error",
+                                    "empty_response",
                                     "unknown"
                                   ]
                                 },
@@ -68615,6 +68616,7 @@
                                   "content_filtered",
                                   "server_error",
                                   "network_error",
+                                  "empty_response",
                                   "unknown"
                                 ]
                               },
@@ -69262,6 +69264,7 @@
                                   "content_filtered",
                                   "server_error",
                                   "network_error",
+                                  "empty_response",
                                   "unknown"
                                 ]
                               },
@@ -69950,6 +69953,7 @@
                                   "content_filtered",
                                   "server_error",
                                   "network_error",
+                                  "empty_response",
                                   "unknown"
                                 ]
                               },
@@ -71475,6 +71479,7 @@
                                   "content_filtered",
                                   "server_error",
                                   "network_error",
+                                  "empty_response",
                                   "unknown"
                                 ]
                               },
@@ -72489,6 +72494,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -74092,6 +74098,7 @@
                                   "content_filtered",
                                   "server_error",
                                   "network_error",
+                                  "empty_response",
                                   "unknown"
                                 ]
                               },
@@ -74763,6 +74770,7 @@
                                   "content_filtered",
                                   "server_error",
                                   "network_error",
+                                  "empty_response",
                                   "unknown"
                                 ]
                               },
@@ -75426,6 +75434,7 @@
                                   "content_filtered",
                                   "server_error",
                                   "network_error",
+                                  "empty_response",
                                   "unknown"
                                 ]
                               },
@@ -76099,6 +76108,7 @@
                                   "content_filtered",
                                   "server_error",
                                   "network_error",
+                                  "empty_response",
                                   "unknown"
                                 ]
                               },
@@ -86150,6 +86160,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -86984,6 +86995,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -87520,6 +87532,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -87920,6 +87933,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -88331,6 +88345,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -90454,6 +90469,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -90865,6 +90881,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -91276,6 +91293,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -91687,6 +91705,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -92098,6 +92117,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -92509,6 +92529,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -92920,6 +92941,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -93331,6 +93353,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -93731,6 +93754,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -94131,6 +94155,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -94542,6 +94567,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -94953,6 +94979,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -95364,6 +95391,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -96001,6 +96029,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -96835,6 +96864,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -98722,6 +98752,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -99556,6 +99587,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -100092,6 +100124,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -100492,6 +100525,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -100903,6 +100937,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -103026,6 +103061,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -103437,6 +103473,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -103848,6 +103885,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -104259,6 +104297,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -104670,6 +104709,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -105081,6 +105121,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -105492,6 +105533,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -105903,6 +105945,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -106303,6 +106346,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -106703,6 +106747,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -107114,6 +107159,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -107525,6 +107571,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -107936,6 +107983,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -108573,6 +108621,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -109407,6 +109456,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -183475,6 +183525,7 @@
                                   "content_filtered",
                                   "server_error",
                                   "network_error",
+                                  "empty_response",
                                   "unknown"
                                 ]
                               },

--- a/platform/backend/src/routes/chat/errors.test.ts
+++ b/platform/backend/src/routes/chat/errors.test.ts
@@ -18,6 +18,7 @@ vi.mock("@sentry/node", () => ({
 }));
 
 import {
+  EmptyModelResponseError,
   mapProviderError,
   ProviderError,
   sanitizeChatErrorForFrontend,
@@ -1665,5 +1666,30 @@ describe("ProviderError", () => {
       traceId: "trace-123",
       spanId: "span-123",
     });
+  });
+});
+
+describe("mapProviderError - EmptyModelResponseError", () => {
+  it("maps a content-filter finish to the non-retryable ContentFiltered card", () => {
+    const result = mapProviderError(
+      new EmptyModelResponseError({
+        finishReason: "content-filter",
+        attempts: 1,
+      }),
+      "openai",
+    );
+
+    expect(result.code).toBe(ChatErrorCode.ContentFiltered);
+    expect(result.isRetryable).toBe(false);
+  });
+
+  it("maps an exhausted stop finish to the retryable EmptyResponse card", () => {
+    const result = mapProviderError(
+      new EmptyModelResponseError({ finishReason: "stop", attempts: 3 }),
+      "openai",
+    );
+
+    expect(result.code).toBe(ChatErrorCode.EmptyResponse);
+    expect(result.isRetryable).toBe(true);
   });
 });

--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -40,6 +40,25 @@ export class ProviderError extends Error {
   }
 }
 
+/**
+ * Thrown when the provider finishes a turn cleanly (finishReason stop/length)
+ * but produces no renderable content, after the empty-response auto-retries are
+ * exhausted. Carries the last finishReason for diagnostics. mapProviderError
+ * turns it into a structured EmptyResponse error so the frontend shows the same
+ * styled, retryable error card as any provider failure.
+ */
+export class EmptyModelResponseError extends Error {
+  public readonly finishReason: string;
+  public readonly attempts: number;
+
+  constructor(params: { finishReason: string; attempts: number }) {
+    super(`Model returned an empty response after ${params.attempts} attempts`);
+    this.name = "EmptyModelResponseError";
+    this.finishReason = params.finishReason;
+    this.attempts = params.attempts;
+  }
+}
+
 // =============================================================================
 // Safe Serialization
 // =============================================================================
@@ -1475,6 +1494,20 @@ export function mapProviderError(
           : undefined,
       };
     }
+  }
+
+  // Handle EmptyModelResponseError — the provider finished cleanly but gave no
+  // content, and the empty-response retries were exhausted. Surface it as a
+  // structured, retryable EmptyResponse error.
+  if (error instanceof EmptyModelResponseError) {
+    return createErrorResponse(
+      ChatErrorCode.EmptyResponse,
+      provider,
+      undefined,
+      ChatErrorMessages[ChatErrorCode.EmptyResponse],
+      "EmptyModelResponseError",
+      { finishReason: error.finishReason, attempts: error.attempts },
+    );
   }
 
   // Handle NoOutputGeneratedError — the provider failed before producing any

--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -43,9 +43,10 @@ export class ProviderError extends Error {
 /**
  * Thrown when the provider finishes a turn cleanly (finishReason stop/length)
  * but produces no renderable content, after the empty-response auto-retries are
- * exhausted. Carries the last finishReason for diagnostics. mapProviderError
- * turns it into a structured EmptyResponse error so the frontend shows the same
- * styled, retryable error card as any provider failure.
+ * exhausted (or immediately for a non-retryable finishReason). Carries the last
+ * finishReason for diagnostics. mapProviderError turns it into a structured
+ * error card: a content-filter finish becomes the non-retryable ContentFiltered
+ * card, everything else the retryable EmptyResponse card.
  */
 export class EmptyModelResponseError extends Error {
   public readonly finishReason: string;
@@ -1500,11 +1501,19 @@ export function mapProviderError(
   // content, and the empty-response retries were exhausted. Surface it as a
   // structured, retryable EmptyResponse error.
   if (error instanceof EmptyModelResponseError) {
+    // A content-filter finish is a deterministic block, not a transient empty
+    // turn — surface it as the non-retryable ContentFiltered card so the UI
+    // doesn't offer a pointless retry. Exhausted stop/length/unknown turns stay
+    // the retryable EmptyResponse.
+    const code =
+      error.finishReason === "content-filter"
+        ? ChatErrorCode.ContentFiltered
+        : ChatErrorCode.EmptyResponse;
     return createErrorResponse(
-      ChatErrorCode.EmptyResponse,
+      code,
       provider,
       undefined,
-      ChatErrorMessages[ChatErrorCode.EmptyResponse],
+      ChatErrorMessages[code],
       "EmptyModelResponseError",
       { finishReason: error.finishReason, attempts: error.attempts },
     );

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -105,10 +105,10 @@ import {
 } from "./context-compaction";
 import {
   parseMaxInputTokens,
-  shouldProbeTextStreamForContextTrimRetry,
   trimMessagesToTokenLimit,
 } from "./context-trimming";
 import {
+  EmptyModelResponseError,
   getActiveTraceContext,
   mapProviderError,
   ProviderError,
@@ -119,6 +119,10 @@ import { cloneAttachmentsForFork } from "./normalization/clone-attachments-for-f
 import { extractInlineAttachments } from "./normalization/extract-inline-attachments";
 import { materializeAttachments } from "./normalization/materialize-attachments";
 import { normalizeChatMessages } from "./normalization/normalize-chat-messages";
+import {
+  isRetryableEmptyFinishReason,
+  probeFirstRenderableEvent,
+} from "./stream-probe";
 
 const PromoteChatAttachmentResultSchema = z.object({
   filename: z.string(),
@@ -756,7 +760,10 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                     });
                   },
                   onFinish: async ({ usage, finishReason }) => {
-                    removeAbortListeners();
+                    // abort listeners are removed in the toUIMessageStream
+                    // onFinish, which fires only for the final merged result —
+                    // not for discarded empty-response retry attempts, whose
+                    // streams we also consume here.
                     logger.info(
                       {
                         conversationId,
@@ -781,28 +788,30 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   };
                 }
 
-                // Stream tokens to the client in real-time while also
-                // handling context-length errors from vLLM/LiteLLM.
-                //
-                // Context-length errors (400) are rejected by the provider
-                // before any tokens are emitted. We detect this by reading
-                // the first chunk from textStream — if the provider rejects,
-                // the iterator throws immediately. We then parse the error,
-                // trim messages, and retry with a new streamText call.
-                //
-                // For successful requests, the first chunk arrives quickly
-                // and we proceed to merge the full stream to the client.
+                // Probe each attempt's stream for its first renderable event
+                // before merging it to the client. This lets us, before anything
+                // reaches the user:
+                //   - trim + retry on a context-length rejection (vLLM/LiteLLM), and
+                //   - silently retry a clean-but-empty response (a stupid-model /
+                //     inference glitch), then surface a stream error if it persists.
+                // tee() buffers the stream, so consuming the probe prefix does not
+                // drop events from the toUIMessageStream merge below. Returning on
+                // the first *renderable* event (not first text) keeps Gemini's
+                // tool-call-before-text turns streaming the tool indicator promptly.
+                const MAX_EMPTY_RESPONSE_ATTEMPTS = 3;
                 let result = streamText(streamTextConfig);
 
-                // Try reading the first text chunk to detect immediate provider errors.
-                // Context-length errors fire before any tokens, so this catches them
-                // without blocking normal streaming (first token arrives in ~100-500ms).
-                if (shouldProbeTextStreamForContextTrimRetry(provider)) {
-                  try {
-                    const reader = result.textStream[Symbol.asyncIterator]();
-                    await reader.next();
-                  } catch (error) {
-                    const maxTokens = parseMaxInputTokens(error);
+                for (let attempt = 1; ; attempt++) {
+                  const probe = await probeFirstRenderableEvent(
+                    result.fullStream[Symbol.asyncIterator](),
+                  );
+
+                  if (probe.kind === "renderable" || probe.kind === "aborted") {
+                    break;
+                  }
+
+                  if (probe.kind === "error") {
+                    const maxTokens = parseMaxInputTokens(probe.error);
                     if (maxTokens !== null) {
                       const trimmed = trimMessagesToTokenLimit({
                         messages: modelMessages,
@@ -822,27 +831,53 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                         ...streamTextConfig,
                         messages: trimmed,
                       });
-                    } else {
-                      // Save messages before throwing — this error path runs before
-                      // writer.merge(), so onError/onFinish callbacks won't fire.
-                      if (!messagesPersisted && conversationId) {
-                        messagesPersisted = true;
-                        try {
-                          await persistNewMessages(
-                            conversationId,
-                            messages,
-                            "onExecuteError",
-                          );
-                        } catch (persistError) {
-                          logger.error(
-                            { persistError, conversationId },
-                            "Failed to persist messages during execute error",
-                          );
-                        }
-                      }
-                      throw error;
+                      continue;
+                    }
+                    // Any non-context error: fall through to the merge so the
+                    // existing toUIMessageStream onError surfaces it (preserving
+                    // e.g. unavailable-tool handling). tee() replays the error.
+                    break;
+                  }
+
+                  // probe.kind === "empty": the provider finished with no content.
+                  const canRetryEmptyResponse =
+                    isRetryableEmptyFinishReason(probe.finishReason) &&
+                    attempt < MAX_EMPTY_RESPONSE_ATTEMPTS;
+                  if (canRetryEmptyResponse) {
+                    logger.warn(
+                      {
+                        conversationId,
+                        finishReason: probe.finishReason,
+                        attempt,
+                      },
+                      "[EmptyResponse] model produced no content, retrying",
+                    );
+                    result = streamText(streamTextConfig);
+                    continue;
+                  }
+
+                  // Exhausted retries (or a non-retryable finishReason): treat the
+                  // empty turn as a stream error. Persist first — this runs before
+                  // writer.merge(), so the stream onError/onFinish won't fire.
+                  if (!messagesPersisted && conversationId) {
+                    messagesPersisted = true;
+                    try {
+                      await persistNewMessages(
+                        conversationId,
+                        messages,
+                        "onExecuteError",
+                      );
+                    } catch (persistError) {
+                      logger.error(
+                        { persistError, conversationId },
+                        "Failed to persist messages during empty-response error",
+                      );
                     }
                   }
+                  throw new EmptyModelResponseError({
+                    finishReason: probe.finishReason,
+                    attempts: attempt,
+                  });
                 }
 
                 // toUIMessageStream invokes onError twice for the same upstream

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -806,7 +806,11 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 const MAX_CONTEXT_TRIM_ATTEMPTS = 1;
                 let emptyResponseAttempts = 0;
                 let contextTrimAttempts = 0;
-                let result = streamText(streamTextConfig);
+                // the config the loop retries from; trim replaces its messages so
+                // a later empty-response retry reuses the trimmed payload instead
+                // of resending the original (too-large) one.
+                let currentConfig = streamTextConfig;
+                let result = streamText(currentConfig);
 
                 while (true) {
                   const probe = await probeFirstRenderableEvent(
@@ -838,10 +842,11 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                         },
                         "[ContextTrimming] retrying with trimmed messages",
                       );
-                      result = streamText({
-                        ...streamTextConfig,
+                      currentConfig = {
+                        ...currentConfig,
                         messages: trimmed,
-                      });
+                      };
+                      result = streamText(currentConfig);
                       continue;
                     }
                     // Non-context error, or context-trim retries exhausted: fall
@@ -865,7 +870,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                       },
                       "[EmptyResponse] model produced no content, retrying",
                     );
-                    result = streamText(streamTextConfig);
+                    result = streamText(currentConfig);
                     continue;
                   }
 

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -123,6 +123,7 @@ import {
   isRetryableEmptyFinishReason,
   probeFirstRenderableEvent,
 } from "./stream-probe";
+import { createToolUiStartTransform } from "./tool-ui-stream";
 
 const PromoteChatAttachmentResultSchema = z.object({
   filename: z.string(),
@@ -611,12 +612,13 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   }
                 }, 5000);
 
-                // Prefetch all UI resources eagerly before streaming starts
-                // so onChunk can write data-tool-ui-start synchronously.
-                // Even with LRU caching, .then() on a resolved promise runs
-                // as a microtask — the stream processes more chunks before
-                // the microtask fires, causing data-tool-ui-start to arrive
-                // after all tool deltas instead of right after tool-input-start.
+                // Prefetch all UI resources eagerly before streaming starts so
+                // the merge transform below can emit data-tool-ui-start
+                // synchronously right after each tool-input-start chunk. A
+                // .then() on a resolved promise runs as a microtask — the stream
+                // would process more chunks before it fires, landing
+                // data-tool-ui-start after all tool deltas instead of right
+                // after tool-input-start.
                 const MAX_SSE_HTML_BYTES = 1024 * 1024;
                 const prefetchedUiResources = new Map<
                   string,
@@ -662,31 +664,6 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                     ),
                   );
                 }
-
-                // Emit data-tool-ui-start synchronously in onChunk so it
-                // arrives right after tool-input-start, before any deltas.
-                const streamTextOnChunk: NonNullable<
-                  Parameters<typeof streamText>[0]["onChunk"]
-                > = ({ chunk }) => {
-                  if (chunk.type === "tool-input-start" && chunk.toolName) {
-                    const prefetched = prefetchedUiResources.get(
-                      chunk.toolName,
-                    );
-                    if (prefetched) {
-                      writer.write({
-                        type: "data-tool-ui-start",
-                        data: {
-                          toolCallId: chunk.id,
-                          toolName: chunk.toolName,
-                          uiResourceUri: toolUiResourceUris[chunk.toolName],
-                          html: prefetched.html,
-                          csp: prefetched.csp,
-                          permissions: prefetched.permissions,
-                        },
-                      });
-                    }
-                  }
-                };
 
                 let compactionStarted = false;
                 const compactionResult = await compactMessagesForChat({
@@ -745,7 +722,6 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   ...(supportsToolCalling && { tools: mcpTools }),
                   stopWhen: buildChatStopConditions(),
                   abortSignal: chatAbortController.signal,
-                  onChunk: streamTextOnChunk,
                   // Emit per-step usage so the context indicator tracks the
                   // prompt growing across tool round-trips, instead of jumping
                   // only once when the whole turn finishes.
@@ -910,161 +886,169 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 // (e.g. two unavailable tools in one step) independently.
                 const returnedChatErrorPayloads = new Set<string>();
 
-                writer.merge(
-                  result.toUIMessageStream({
-                    originalMessages: messages as UIMessage[],
-                    // Give the streamed assistant message a stable id. Without
-                    // generateMessageId the AI SDK leaves the response message
-                    // id empty, so the persisted assistant row can't be matched
-                    // when the approval resume re-sends the turn — the resolved
-                    // turn is appended as new rows while the original
-                    // approval-requested row is orphaned and re-renders a stale
-                    // prompt on reload (#4030).
-                    generateMessageId: generateId,
-                    onError: (error) => {
-                      const incomingErrorMessage =
-                        error instanceof Error ? error.message : String(error);
-                      if (returnedChatErrorPayloads.has(incomingErrorMessage)) {
-                        return incomingErrorMessage;
-                      }
+                const modelUiStream = result.toUIMessageStream({
+                  originalMessages: messages as UIMessage[],
+                  // Give the streamed assistant message a stable id. Without
+                  // generateMessageId the AI SDK leaves the response message
+                  // id empty, so the persisted assistant row can't be matched
+                  // when the approval resume re-sends the turn — the resolved
+                  // turn is appended as new rows while the original
+                  // approval-requested row is orphaned and re-renders a stale
+                  // prompt on reload (#4030).
+                  generateMessageId: generateId,
+                  onError: (error) => {
+                    const incomingErrorMessage =
+                      error instanceof Error ? error.message : String(error);
+                    if (returnedChatErrorPayloads.has(incomingErrorMessage)) {
+                      return incomingErrorMessage;
+                    }
 
-                      const unavailableToolError =
-                        getUnavailableToolErrorDetails(error);
-                      if (unavailableToolError) {
-                        const serializedToolError =
-                          formatUnavailableToolErrorDetails(
-                            unavailableToolError,
-                          );
-                        returnedChatErrorPayloads.add(serializedToolError);
-                        logger.info(
-                          {
-                            conversationId,
-                            unavailableToolError,
-                          },
-                          "Returning unavailable tool error as tool-level error",
-                        );
-                        return serializedToolError;
-                      }
-
-                      const traceContext = getActiveTraceContext();
-                      const correlationLogFields =
-                        getCorrelationLogFields(traceContext);
-
-                      // Use pre-built error from subagent if available (preserves correct provider),
-                      // otherwise map the error with the current provider
-                      const mappedError: ChatErrorResponse =
-                        error instanceof ProviderError
-                          ? error.chatErrorResponse
-                          : mapProviderError(error, provider);
-                      const fullError = { ...mappedError, ...traceContext };
-                      const errorForFrontend = slimChatErrorUi
-                        ? sanitizeChatErrorForFrontend(fullError)
-                        : fullError;
-
-                      // mapProviderError safely serializes raw errors, but add defensive try-catch
-                      let serializedChatError: string;
-                      try {
-                        serializedChatError = JSON.stringify(errorForFrontend);
-                      } catch (stringifyError) {
-                        logger.error(
-                          {
-                            stringifyError,
-                            errorCode: mappedError.code,
-                            ...correlationLogFields,
-                          },
-                          "Failed to stringify mapped error, returning minimal error",
-                        );
-                        serializedChatError = JSON.stringify(
-                          getMinimalFrontendError(errorForFrontend),
-                        );
-                      }
-                      returnedChatErrorPayloads.add(serializedChatError);
-
-                      activeRunError =
-                        error instanceof Error ? error.message : String(error);
-                      // Claim persistence before the async work below starts,
-                      // otherwise onFinish can race and also persist (duplicates).
-                      const shouldPersist =
-                        !messagesPersisted && !!conversationId;
-                      if (shouldPersist) {
-                        messagesPersisted = true;
-                      }
-
-                      (async () => {
-                        logger.error(
-                          {
-                            error,
-                            conversationId,
-                            agentId,
-                            ...correlationLogFields,
-                          },
-                          "Chat stream error occurred",
-                        );
-
-                        // Persist messages despite error so they have a valid ID for editing
-                        if (shouldPersist) {
-                          try {
-                            await persistNewMessages(
-                              conversationId,
-                              messages,
-                              "onError",
-                            );
-                          } catch (persistError) {
-                            // Log persistence error but don't prevent the error response
-                            logger.error(
-                              { persistError, conversationId },
-                              "Failed to persist messages during error handling",
-                            );
-                          }
-                        }
-                      })().catch((err) => {
-                        // Log any errors from the async IIFE but don't crash
-                        logger.error(
-                          { err },
-                          "Unexpected error in onError async handler",
-                        );
-                      });
-
-                      persistConversationChatError({
-                        conversationId,
-                        error: errorForFrontend,
-                      });
-
+                    const unavailableToolError =
+                      getUnavailableToolErrorDetails(error);
+                    if (unavailableToolError) {
+                      const serializedToolError =
+                        formatUnavailableToolErrorDetails(unavailableToolError);
+                      returnedChatErrorPayloads.add(serializedToolError);
                       logger.info(
                         {
-                          mappedError: fullError,
-                          originalErrorType:
-                            error instanceof Error ? error.name : typeof error,
-                          willBeSentToFrontend: true,
+                          conversationId,
+                          unavailableToolError,
+                        },
+                        "Returning unavailable tool error as tool-level error",
+                      );
+                      return serializedToolError;
+                    }
+
+                    const traceContext = getActiveTraceContext();
+                    const correlationLogFields =
+                      getCorrelationLogFields(traceContext);
+
+                    // Use pre-built error from subagent if available (preserves correct provider),
+                    // otherwise map the error with the current provider
+                    const mappedError: ChatErrorResponse =
+                      error instanceof ProviderError
+                        ? error.chatErrorResponse
+                        : mapProviderError(error, provider);
+                    const fullError = { ...mappedError, ...traceContext };
+                    const errorForFrontend = slimChatErrorUi
+                      ? sanitizeChatErrorForFrontend(fullError)
+                      : fullError;
+
+                    // mapProviderError safely serializes raw errors, but add defensive try-catch
+                    let serializedChatError: string;
+                    try {
+                      serializedChatError = JSON.stringify(errorForFrontend);
+                    } catch (stringifyError) {
+                      logger.error(
+                        {
+                          stringifyError,
+                          errorCode: mappedError.code,
                           ...correlationLogFields,
                         },
-                        "Returning mapped error to frontend via stream",
+                        "Failed to stringify mapped error, returning minimal error",
+                      );
+                      serializedChatError = JSON.stringify(
+                        getMinimalFrontendError(errorForFrontend),
+                      );
+                    }
+                    returnedChatErrorPayloads.add(serializedChatError);
+
+                    activeRunError =
+                      error instanceof Error ? error.message : String(error);
+                    // Claim persistence before the async work below starts,
+                    // otherwise onFinish can race and also persist (duplicates).
+                    const shouldPersist =
+                      !messagesPersisted && !!conversationId;
+                    if (shouldPersist) {
+                      messagesPersisted = true;
+                    }
+
+                    (async () => {
+                      logger.error(
+                        {
+                          error,
+                          conversationId,
+                          agentId,
+                          ...correlationLogFields,
+                        },
+                        "Chat stream error occurred",
                       );
 
-                      return serializedChatError;
-                    },
-                    onFinish: async ({ messages: finalMessages }) => {
-                      removeAbortListeners();
-                      stopActiveRunPolling();
-
-                      // Only persist if not already persisted by onError
-                      if (!messagesPersisted && conversationId) {
+                      // Persist messages despite error so they have a valid ID for editing
+                      if (shouldPersist) {
                         try {
                           await persistNewMessages(
                             conversationId,
-                            finalMessages,
-                            "onFinish",
+                            messages,
+                            "onError",
                           );
-                          messagesPersisted = true;
-                        } catch (error) {
+                        } catch (persistError) {
+                          // Log persistence error but don't prevent the error response
                           logger.error(
-                            { error, conversationId },
-                            "Failed to persist messages during onFinish",
+                            { persistError, conversationId },
+                            "Failed to persist messages during error handling",
                           );
                         }
                       }
-                    },
-                  }),
+                    })().catch((err) => {
+                      // Log any errors from the async IIFE but don't crash
+                      logger.error(
+                        { err },
+                        "Unexpected error in onError async handler",
+                      );
+                    });
+
+                    persistConversationChatError({
+                      conversationId,
+                      error: errorForFrontend,
+                    });
+
+                    logger.info(
+                      {
+                        mappedError: fullError,
+                        originalErrorType:
+                          error instanceof Error ? error.name : typeof error,
+                        willBeSentToFrontend: true,
+                        ...correlationLogFields,
+                      },
+                      "Returning mapped error to frontend via stream",
+                    );
+
+                    return serializedChatError;
+                  },
+                  onFinish: async ({ messages: finalMessages }) => {
+                    removeAbortListeners();
+                    stopActiveRunPolling();
+
+                    // Only persist if not already persisted by onError
+                    if (!messagesPersisted && conversationId) {
+                      try {
+                        await persistNewMessages(
+                          conversationId,
+                          finalMessages,
+                          "onFinish",
+                        );
+                        messagesPersisted = true;
+                      } catch (error) {
+                        logger.error(
+                          { error, conversationId },
+                          "Failed to persist messages during onFinish",
+                        );
+                      }
+                    }
+                  },
+                });
+
+                // Inject data-tool-ui-start right after each tool-input-start
+                // chunk (see createToolUiStartTransform — kept out of onChunk so
+                // the empty-response probe can't emit it before its own tool).
+                writer.merge(
+                  modelUiStream.pipeThrough(
+                    createToolUiStartTransform({
+                      prefetchedUiResources,
+                      toolUiResourceUris,
+                    }),
+                  ),
                 );
 
                 // Wait for the stream to complete and get usage data.

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -799,9 +799,16 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 // the first *renderable* event (not first text) keeps Gemini's
                 // tool-call-before-text turns streaming the tool indicator promptly.
                 const MAX_EMPTY_RESPONSE_ATTEMPTS = 3;
+                // a still-too-long trimmed payload reproduces the same context
+                // error (trim is deterministic from the unchanged messages), so
+                // cap trim retries to avoid an unbounded loop; on the cap we fall
+                // through to merge and let the existing onError surface it.
+                const MAX_CONTEXT_TRIM_ATTEMPTS = 1;
+                let emptyResponseAttempts = 0;
+                let contextTrimAttempts = 0;
                 let result = streamText(streamTextConfig);
 
-                for (let attempt = 1; ; attempt++) {
+                while (true) {
                   const probe = await probeFirstRenderableEvent(
                     result.fullStream[Symbol.asyncIterator](),
                   );
@@ -812,7 +819,11 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
 
                   if (probe.kind === "error") {
                     const maxTokens = parseMaxInputTokens(probe.error);
-                    if (maxTokens !== null) {
+                    if (
+                      maxTokens !== null &&
+                      contextTrimAttempts < MAX_CONTEXT_TRIM_ATTEMPTS
+                    ) {
+                      contextTrimAttempts++;
                       const trimmed = trimMessagesToTokenLimit({
                         messages: modelMessages,
                         maxTokens,
@@ -833,22 +844,24 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                       });
                       continue;
                     }
-                    // Any non-context error: fall through to the merge so the
-                    // existing toUIMessageStream onError surfaces it (preserving
-                    // e.g. unavailable-tool handling). tee() replays the error.
+                    // Non-context error, or context-trim retries exhausted: fall
+                    // through to the merge so the existing toUIMessageStream
+                    // onError surfaces it (preserving e.g. unavailable-tool
+                    // handling). tee() replays the error.
                     break;
                   }
 
                   // probe.kind === "empty": the provider finished with no content.
+                  emptyResponseAttempts++;
                   const canRetryEmptyResponse =
                     isRetryableEmptyFinishReason(probe.finishReason) &&
-                    attempt < MAX_EMPTY_RESPONSE_ATTEMPTS;
+                    emptyResponseAttempts < MAX_EMPTY_RESPONSE_ATTEMPTS;
                   if (canRetryEmptyResponse) {
                     logger.warn(
                       {
                         conversationId,
                         finishReason: probe.finishReason,
-                        attempt,
+                        attempt: emptyResponseAttempts,
                       },
                       "[EmptyResponse] model produced no content, retrying",
                     );
@@ -876,7 +889,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   }
                   throw new EmptyModelResponseError({
                     finishReason: probe.finishReason,
-                    attempts: attempt,
+                    attempts: emptyResponseAttempts,
                   });
                 }
 

--- a/platform/backend/src/routes/chat/stream-probe.test.ts
+++ b/platform/backend/src/routes/chat/stream-probe.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "vitest";
+import {
+  isRetryableEmptyFinishReason,
+  probeFirstRenderableEvent,
+  type StreamProbeEvent,
+} from "./stream-probe";
+
+// builds a real async iterator over the given events; `onReturn` records whether
+// the iterator was cancelled (which would cancel the underlying stream).
+function iteratorOf(
+  events: StreamProbeEvent[],
+  onReturn?: () => void,
+): AsyncIterator<StreamProbeEvent> {
+  let index = 0;
+  return {
+    next() {
+      if (index < events.length) {
+        return Promise.resolve({ value: events[index++], done: false });
+      }
+      return Promise.resolve({ value: undefined, done: true });
+    },
+    return() {
+      onReturn?.();
+      return Promise.resolve({ value: undefined, done: true });
+    },
+  };
+}
+
+describe("probeFirstRenderableEvent", () => {
+  test("returns renderable on the first text-delta", async () => {
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "start-step" },
+      { type: "text-start" },
+      { type: "text-delta" },
+      { type: "finish", finishReason: "stop" },
+    ];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "renderable",
+    });
+  });
+
+  test("treats a tool-only turn as renderable, not empty", async () => {
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "start-step" },
+      { type: "tool-input-start" },
+      { type: "tool-call" },
+      { type: "finish", finishReason: "tool-calls" },
+    ];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "renderable",
+    });
+  });
+
+  test("treats a reasoning-only opening as renderable", async () => {
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "reasoning-start" },
+    ];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "renderable",
+    });
+  });
+
+  test("reports empty with finishReason when the turn finishes with no content", async () => {
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "start-step" },
+      { type: "finish-step", finishReason: "stop" },
+      { type: "finish", finishReason: "stop" },
+    ];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "empty",
+      finishReason: "stop",
+    });
+  });
+
+  test("reports empty with unknown when the stream ends without a finish event", async () => {
+    const events: StreamProbeEvent[] = [{ type: "start" }];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "empty",
+      finishReason: "unknown",
+    });
+  });
+
+  test("surfaces an error event before any content", async () => {
+    const boom = new Error("provider exploded");
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "error", error: boom },
+    ];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "error",
+      error: boom,
+    });
+  });
+
+  test("surfaces a thrown error from the iterator", async () => {
+    const boom = new Error("context length exceeded");
+    const iterator: AsyncIterator<StreamProbeEvent> = {
+      next() {
+        return Promise.reject(boom);
+      },
+    };
+
+    expect(await probeFirstRenderableEvent(iterator)).toEqual({
+      kind: "error",
+      error: boom,
+    });
+  });
+
+  test("reports aborted when the stream is aborted before content", async () => {
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "abort", reason: "user stopped" } as StreamProbeEvent,
+    ];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "aborted",
+    });
+  });
+
+  test("does not cancel the iterator when it finds content (so the merge can replay)", async () => {
+    let returned = false;
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "text-delta" },
+      { type: "finish", finishReason: "stop" },
+    ];
+
+    await probeFirstRenderableEvent(
+      iteratorOf(events, () => {
+        returned = true;
+      }),
+    );
+
+    expect(returned).toBe(false);
+  });
+});
+
+describe("isRetryableEmptyFinishReason", () => {
+  test("retries on stop, length, and unknown", () => {
+    expect(isRetryableEmptyFinishReason("stop")).toBe(true);
+    expect(isRetryableEmptyFinishReason("length")).toBe(true);
+    expect(isRetryableEmptyFinishReason("unknown")).toBe(true);
+  });
+
+  test("does not retry on content-filter or other terminal reasons", () => {
+    expect(isRetryableEmptyFinishReason("content-filter")).toBe(false);
+    expect(isRetryableEmptyFinishReason("error")).toBe(false);
+    expect(isRetryableEmptyFinishReason("other")).toBe(false);
+  });
+});

--- a/platform/backend/src/routes/chat/stream-probe.test.ts
+++ b/platform/backend/src/routes/chat/stream-probe.test.ts
@@ -55,6 +55,31 @@ describe("probeFirstRenderableEvent", () => {
     });
   });
 
+  test("treats a resume turn opening with tool-output-denied as renderable", async () => {
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "start-step" },
+      { type: "tool-output-denied" },
+      { type: "finish", finishReason: "stop" },
+    ];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "renderable",
+    });
+  });
+
+  test("treats a tool-error opening as renderable", async () => {
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "tool-error" },
+      { type: "finish", finishReason: "stop" },
+    ];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "renderable",
+    });
+  });
+
   test("treats a reasoning-only opening as renderable", async () => {
     const events: StreamProbeEvent[] = [
       { type: "start" },

--- a/platform/backend/src/routes/chat/stream-probe.ts
+++ b/platform/backend/src/routes/chat/stream-probe.ts
@@ -1,0 +1,90 @@
+// Probes a streamText `fullStream` just far enough to decide whether the turn
+// will produce anything renderable, so the chat route can silently retry a
+// clean-but-empty response before committing the stream to the client.
+//
+// It pulls the stream iterator manually (never via `for await`) and returns
+// without calling `iterator.return()` — an early `for await` break would cancel
+// the underlying generation and break the subsequent `toUIMessageStream` merge.
+// This mirrors the existing context-trim first-chunk probe.
+
+export type StreamProbeEvent = {
+  type: string;
+  finishReason?: unknown;
+  error?: unknown;
+};
+
+export type StreamProbeOutcome =
+  | { kind: "renderable" }
+  | { kind: "empty"; finishReason: string }
+  | { kind: "aborted" }
+  | { kind: "error"; error: unknown };
+
+// fullStream event types that carry (or commit to) content the chat UI renders.
+// Seeing any of these means the turn is not empty and should stream normally.
+const RENDERABLE_EVENT_TYPES: ReadonlySet<string> = new Set([
+  "text-start",
+  "text-delta",
+  "reasoning-start",
+  "reasoning-delta",
+  "tool-input-start",
+  "tool-call",
+  "tool-result",
+  "source",
+  "file",
+]);
+
+// finishReasons where a content-free turn is plausibly a transient model/inference
+// glitch worth retrying. Excludes e.g. "content-filter" (deterministic block) and
+// "tool-calls" (which only finishes that way when tool calls — renderable — exist).
+const RETRYABLE_EMPTY_FINISH_REASONS: ReadonlySet<string> = new Set([
+  "stop",
+  "length",
+  "unknown",
+]);
+
+export function isRetryableEmptyFinishReason(finishReason: string): boolean {
+  return RETRYABLE_EMPTY_FINISH_REASONS.has(finishReason);
+}
+
+export async function probeFirstRenderableEvent(
+  iterator: AsyncIterator<StreamProbeEvent>,
+): Promise<StreamProbeOutcome> {
+  while (true) {
+    let result: IteratorResult<StreamProbeEvent>;
+    try {
+      result = await iterator.next();
+    } catch (error) {
+      return { kind: "error", error };
+    }
+
+    if (result.done) {
+      // stream ended without a terminal finish event — nothing renderable seen.
+      return { kind: "empty", finishReason: "unknown" };
+    }
+
+    const event = result.value;
+
+    if (RENDERABLE_EVENT_TYPES.has(event.type)) {
+      return { kind: "renderable" };
+    }
+
+    switch (event.type) {
+      case "error":
+        return { kind: "error", error: event.error };
+      case "abort":
+        return { kind: "aborted" };
+      case "finish":
+        return {
+          kind: "empty",
+          finishReason:
+            typeof event.finishReason === "string"
+              ? event.finishReason
+              : "unknown",
+        };
+      // control parts (start, start-step, finish-step, text-end, ...) carry no
+      // content on their own — keep pulling until content, finish, or error.
+      default:
+        break;
+    }
+  }
+}

--- a/platform/backend/src/routes/chat/stream-probe.ts
+++ b/platform/backend/src/routes/chat/stream-probe.ts
@@ -27,8 +27,16 @@ const RENDERABLE_EVENT_TYPES: ReadonlySet<string> = new Set([
   "reasoning-start",
   "reasoning-delta",
   "tool-input-start",
+  "tool-input-delta",
+  "tool-input-end",
   "tool-call",
   "tool-result",
+  // tool failure, denial, and approval-request parts are all UI-rendered turn
+  // state. A resume turn (input arrived in a prior turn) can open with one of
+  // these and no preceding tool-input-start, so they must count as renderable.
+  "tool-error",
+  "tool-output-denied",
+  "tool-approval-request",
   "source",
   "file",
 ]);

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -271,6 +271,24 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
             next: async () => ({ done: true, value: undefined }),
           }),
         },
+        // the route probes fullStream for the first renderable event before
+        // merging; yield one so the probe proceeds to the merge these tests
+        // capture (errors are then injected via capturedInnerOnError).
+        fullStream: {
+          [Symbol.asyncIterator]: () => {
+            const events = [
+              { type: "text-delta", text: "" },
+              { type: "finish", finishReason: "stop" },
+            ];
+            let index = 0;
+            return {
+              next: async () =>
+                index < events.length
+                  ? { done: false, value: events[index++] }
+                  : { done: true, value: undefined },
+            };
+          },
+        },
         usage: Promise.resolve(null),
       }));
 
@@ -828,3 +846,176 @@ function toSseStream(stream: ReadableStream<unknown>): ReadableStream<string> {
 function delay(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+// streamText result whose fullStream yields the given events. Used to drive the
+// route's empty-response probe/retry loop without a live provider.
+function fakeStreamResult(events: Array<Record<string, unknown>>) {
+  return {
+    fullStream: {
+      [Symbol.asyncIterator]: () => {
+        let index = 0;
+        return {
+          next: async () =>
+            index < events.length
+              ? { done: false, value: events[index++] }
+              : { done: true, value: undefined },
+        };
+      },
+    },
+    toUIMessageStream: () =>
+      new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }),
+    usage: Promise.resolve(null),
+  };
+}
+
+const EMPTY_STREAM_EVENTS = [
+  { type: "start" },
+  { type: "finish", finishReason: "stop" },
+];
+const RENDERABLE_STREAM_EVENTS = [
+  { type: "text-delta", text: "hi" },
+  { type: "finish", finishReason: "stop" },
+];
+
+describe("POST /api/chat empty-response retry", () => {
+  let app: FastifyInstanceWithZod;
+  let user: User;
+  let organizationId: string;
+  let conversationId: string;
+  let executionPromise: Promise<void> | undefined;
+  let capturedOuterErrorPayload: string | undefined;
+
+  beforeEach(
+    async ({ makeAgent, makeConversation, makeOrganization, makeUser }) => {
+      executionPromise = undefined;
+      capturedOuterErrorPayload = undefined;
+
+      user = await makeUser();
+      const organization = await makeOrganization({ name: "Test Org" });
+      organizationId = organization.id;
+      const agent = await makeAgent({
+        organizationId,
+        name: "Router Agent",
+        systemPrompt: "",
+      });
+      const conversation = await makeConversation(agent.id, {
+        userId: user.id,
+        organizationId,
+      });
+      conversationId = conversation.id;
+
+      mockCreateLLMModelForAgent.mockResolvedValue({ model: "mock-model" });
+      mockGetChatMcpTools.mockResolvedValue({});
+      mockGetChatMcpToolUiResourceUris.mockResolvedValue({});
+      mockExtractAndIngestDocuments.mockResolvedValue(undefined);
+      mockCompactMessagesForChat.mockImplementation(
+        async ({ messages }: { messages: unknown[] }) => ({
+          messages,
+          status: "skipped",
+          compaction: null,
+          reason: "below_threshold",
+        }),
+      );
+      mockStartActiveChatSpan.mockImplementation(
+        async ({ callback }: { callback: () => Promise<Response> }) =>
+          callback(),
+      );
+      mockCreateUIMessageStream.mockImplementation(
+        ({
+          execute,
+          onError,
+        }: {
+          execute: (args: {
+            writer: {
+              write: (x: unknown) => void;
+              merge: (s: unknown) => void;
+            };
+          }) => Promise<void>;
+          onError: (error: unknown) => string;
+        }) => {
+          const writer = { write: vi.fn(), merge: vi.fn() };
+          // route the pre-merge throw (exhausted empty response) to onError,
+          // mirroring how createUIMessageStream surfaces an execute() rejection.
+          executionPromise = execute({ writer }).catch((error) => {
+            capturedOuterErrorPayload = onError(error);
+          });
+          return new ReadableStream({
+            start(controller) {
+              controller.close();
+            },
+          });
+        },
+      );
+      mockCreateUIMessageStreamResponse.mockImplementation(
+        ({ stream }: { stream: ReadableStream }) =>
+          new Response(stream, {
+            status: 200,
+            headers: { "content-type": "text/plain" },
+          }),
+      );
+
+      app = createFastifyInstance();
+      app.addHook("onRequest", async (request) => {
+        (request as typeof request & { user: User }).user = user;
+        (
+          request as typeof request & { organizationId: string }
+        ).organizationId = organizationId;
+      });
+      const { default: chatRoutes } = await import("./routes");
+      await app.register(chatRoutes);
+    },
+  );
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  async function postMessage() {
+    return app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: conversationId,
+        messages: [
+          { id: "msg-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        ],
+      },
+    });
+  }
+
+  test("retries a clean-but-empty response, then streams the renderable one", async ({
+    expect,
+  }) => {
+    mockStreamText
+      .mockImplementationOnce(() => fakeStreamResult(EMPTY_STREAM_EVENTS))
+      .mockImplementationOnce(() => fakeStreamResult(RENDERABLE_STREAM_EVENTS));
+
+    const response = await postMessage();
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    expect(mockStreamText).toHaveBeenCalledTimes(2);
+    expect(capturedOuterErrorPayload).toBeUndefined();
+  });
+
+  test("surfaces an EmptyResponse stream error after exhausting retries", async ({
+    expect,
+  }) => {
+    mockStreamText.mockImplementation(() =>
+      fakeStreamResult(EMPTY_STREAM_EVENTS),
+    );
+
+    const response = await postMessage();
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    expect(mockStreamText).toHaveBeenCalledTimes(3);
+    expect(capturedOuterErrorPayload).toBeDefined();
+    const payload = JSON.parse(capturedOuterErrorPayload ?? "{}");
+    expect(payload.code).toBe("empty_response");
+  });
+});

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -1040,6 +1040,43 @@ describe("POST /api/chat empty-response retry", () => {
     expect(payload.code).toBe("empty_response");
   });
 
+  test("reuses the trimmed payload when a trimmed attempt then returns empty", async ({
+    expect,
+  }) => {
+    // messages large enough that trimMessagesToTokenLimit (400-char budget for the
+    // mocked 100-token limit) actually drops content, so the trimmed payload is
+    // observably different from the original.
+    const longContent = "x".repeat(300);
+    mockCompactMessagesForChat.mockImplementation(async () => ({
+      messages: [
+        { role: "user", content: longContent },
+        { role: "assistant", content: longContent },
+        { role: "user", content: longContent },
+      ],
+      status: "skipped",
+      compaction: null,
+      reason: "below_threshold",
+    }));
+    mockStreamText
+      .mockImplementationOnce(() => fakeContextLengthErrorResult())
+      .mockImplementationOnce(() => fakeStreamResult(EMPTY_STREAM_EVENTS))
+      .mockImplementationOnce(() => fakeStreamResult(RENDERABLE_STREAM_EVENTS));
+
+    const response = await postMessage();
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    expect(mockStreamText).toHaveBeenCalledTimes(3);
+    const originalMessages = mockStreamText.mock.calls[0][0].messages;
+    const trimmedMessages = mockStreamText.mock.calls[1][0].messages;
+    const emptyRetryMessages = mockStreamText.mock.calls[2][0].messages;
+    // the trim must have actually changed the payload, otherwise this test proves
+    // nothing about which payload the empty-retry resends.
+    expect(trimmedMessages).not.toEqual(originalMessages);
+    // the empty-response retry resends the trimmed payload, not the original.
+    expect(emptyRetryMessages).toEqual(trimmedMessages);
+  });
+
   test("bounds context-trim retries instead of looping on a repeated context-length error", async ({
     expect,
   }) => {

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -872,6 +872,27 @@ function fakeStreamResult(events: Array<Record<string, unknown>>) {
   };
 }
 
+// streamText result whose fullStream throws a context-length error on first read,
+// matching parseMaxInputTokens. Used to exercise the bounded context-trim retry.
+function fakeContextLengthErrorResult() {
+  return {
+    fullStream: {
+      [Symbol.asyncIterator]: () => ({
+        next: async () => {
+          throw new Error("maximum input length of 100 tokens");
+        },
+      }),
+    },
+    toUIMessageStream: () =>
+      new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }),
+    usage: Promise.resolve(null),
+  };
+}
+
 const EMPTY_STREAM_EVENTS = [
   { type: "start" },
   { type: "finish", finishReason: "stop" },
@@ -1017,5 +1038,28 @@ describe("POST /api/chat empty-response retry", () => {
     expect(capturedOuterErrorPayload).toBeDefined();
     const payload = JSON.parse(capturedOuterErrorPayload ?? "{}");
     expect(payload.code).toBe("empty_response");
+  });
+
+  test("bounds context-trim retries instead of looping on a repeated context-length error", async ({
+    expect,
+  }) => {
+    // content-shaped model messages so trimMessagesToTokenLimit runs cleanly and
+    // the cap (not a crash) is what bounds the loop.
+    mockCompactMessagesForChat.mockImplementation(async () => ({
+      messages: [{ role: "user", content: "hi" }],
+      status: "skipped",
+      compaction: null,
+      reason: "below_threshold",
+    }));
+    // every attempt rejects with the same max-token error; trimming is
+    // deterministic, so without a cap this would retry forever.
+    mockStreamText.mockImplementation(() => fakeContextLengthErrorResult());
+
+    const response = await postMessage();
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    // initial attempt + exactly one trim retry, then fall through to the merge.
+    expect(mockStreamText).toHaveBeenCalledTimes(2);
   });
 });

--- a/platform/backend/src/routes/chat/tool-ui-stream.test.ts
+++ b/platform/backend/src/routes/chat/tool-ui-stream.test.ts
@@ -1,0 +1,105 @@
+import type { UIMessageChunk } from "ai";
+import { describe, expect, test } from "vitest";
+import type { ToolUiResourceData } from "@/clients/chat-mcp-client";
+import { createToolUiStartTransform } from "./tool-ui-stream";
+
+async function pipeThroughTransform(
+  chunks: UIMessageChunk[],
+  transform: TransformStream<UIMessageChunk, UIMessageChunk>,
+): Promise<UIMessageChunk[]> {
+  const source = new ReadableStream<UIMessageChunk>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+
+  const out: UIMessageChunk[] = [];
+  const reader = source.pipeThrough(transform).getReader();
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    out.push(value);
+  }
+  return out;
+}
+
+describe("createToolUiStartTransform", () => {
+  test("injects data-tool-ui-start immediately after its tool-input-start", async () => {
+    const prefetched = new Map<string, ToolUiResourceData>([
+      ["search", { html: "<div>app</div>" }],
+    ]);
+    const transform = createToolUiStartTransform({
+      prefetchedUiResources: prefetched,
+      toolUiResourceUris: { search: "ui://search" },
+    });
+
+    const out = await pipeThroughTransform(
+      [
+        { type: "text-start", id: "t0" },
+        { type: "tool-input-start", toolCallId: "call-1", toolName: "search" },
+        { type: "tool-input-delta", toolCallId: "call-1", inputTextDelta: "{" },
+      ],
+      transform,
+    );
+
+    const types = out.map((c) => c.type);
+    const startIdx = types.indexOf("tool-input-start");
+    expect(types[startIdx + 1]).toBe("data-tool-ui-start");
+    // arrives before any tool input delta
+    expect(startIdx + 1).toBeLessThan(types.indexOf("tool-input-delta"));
+
+    const uiStart = out[startIdx + 1] as unknown as {
+      data: { toolCallId: string; uiResourceUri: string; html: string };
+    };
+    expect(uiStart.data).toMatchObject({
+      toolCallId: "call-1",
+      uiResourceUri: "ui://search",
+      html: "<div>app</div>",
+    });
+  });
+
+  test("leaves a tool without a prefetched resource untouched", async () => {
+    const transform = createToolUiStartTransform({
+      prefetchedUiResources: new Map(),
+      toolUiResourceUris: {},
+    });
+
+    const input: UIMessageChunk[] = [
+      { type: "tool-input-start", toolCallId: "call-1", toolName: "plain" },
+      { type: "tool-input-delta", toolCallId: "call-1", inputTextDelta: "{}" },
+    ];
+    const out = await pipeThroughTransform(input, transform);
+
+    expect(out.map((c) => c.type)).toEqual([
+      "tool-input-start",
+      "tool-input-delta",
+    ]);
+  });
+
+  test("injects once per tool when several tools open in one turn", async () => {
+    const prefetched = new Map<string, ToolUiResourceData>([
+      ["search", { html: "<a/>" }],
+      ["browse", { html: "<b/>" }],
+    ]);
+    const transform = createToolUiStartTransform({
+      prefetchedUiResources: prefetched,
+      toolUiResourceUris: { search: "ui://search", browse: "ui://browse" },
+    });
+
+    const out = await pipeThroughTransform(
+      [
+        { type: "tool-input-start", toolCallId: "c1", toolName: "search" },
+        { type: "tool-input-start", toolCallId: "c2", toolName: "browse" },
+      ],
+      transform,
+    );
+
+    expect(out.map((c) => c.type)).toEqual([
+      "tool-input-start",
+      "data-tool-ui-start",
+      "tool-input-start",
+      "data-tool-ui-start",
+    ]);
+  });
+});

--- a/platform/backend/src/routes/chat/tool-ui-stream.ts
+++ b/platform/backend/src/routes/chat/tool-ui-stream.ts
@@ -1,0 +1,36 @@
+import type { UIMessageChunk } from "ai";
+import type { ToolUiResourceData } from "@/clients/chat-mcp-client";
+
+// Injects a `data-tool-ui-start` chunk right after each `tool-input-start` chunk
+// that has a prefetched UI resource, so the frontend renders the MCP App iframe
+// as soon as the tool call opens. This deliberately lives in a transform over
+// the merged UI message stream rather than in streamText's `onChunk`: `onChunk`
+// runs upstream of the SDK's internal stream tee, so the empty-response probe
+// (which pulls the first renderable chunk ahead of the merge) would fire it and
+// emit `data-tool-ui-start` before its own `tool-input-start` ever reaches the
+// client. Emitting in stream order keeps the UI-start right after its tool.
+export function createToolUiStartTransform(params: {
+  prefetchedUiResources: ReadonlyMap<string, ToolUiResourceData>;
+  toolUiResourceUris: Record<string, string>;
+}): TransformStream<UIMessageChunk, UIMessageChunk> {
+  const { prefetchedUiResources, toolUiResourceUris } = params;
+  return new TransformStream({
+    transform(chunk, controller) {
+      controller.enqueue(chunk);
+      if (chunk.type !== "tool-input-start") return;
+      const prefetched = prefetchedUiResources.get(chunk.toolName);
+      if (!prefetched) return;
+      controller.enqueue({
+        type: "data-tool-ui-start",
+        data: {
+          toolCallId: chunk.toolCallId,
+          toolName: chunk.toolName,
+          uiResourceUri: toolUiResourceUris[chunk.toolName],
+          html: prefetched.html,
+          csp: prefetched.csp,
+          permissions: prefetched.permissions,
+        },
+      });
+    },
+  });
+}

--- a/platform/shared/chat-error.ts
+++ b/platform/shared/chat-error.ts
@@ -270,6 +270,8 @@ export enum ChatErrorCode {
   ServerError = "server_error",
   /** Network/connection issues - retryable */
   NetworkError = "network_error",
+  /** Provider finished cleanly but produced no content - retryable */
+  EmptyResponse = "empty_response",
   /** Catch-all for unrecognized errors */
   Unknown = "unknown",
 }
@@ -295,6 +297,8 @@ export const ChatErrorMessages: Record<ChatErrorCode, string> = {
   [ChatErrorCode.ServerError]: "The AI provider is experiencing issues.",
   [ChatErrorCode.NetworkError]:
     "Connection error. Please check your network and try again.",
+  [ChatErrorCode.EmptyResponse]:
+    "The model returned an empty response. Please try again.",
   [ChatErrorCode.Unknown]: "An unexpected error occurred. Please try again.",
 };
 
@@ -305,6 +309,7 @@ export const RetryableErrorCodes: Set<ChatErrorCode> = new Set([
   ChatErrorCode.RateLimit,
   ChatErrorCode.ServerError,
   ChatErrorCode.NetworkError,
+  ChatErrorCode.EmptyResponse,
 ]);
 
 /**

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -19603,7 +19603,7 @@ export type GetChatConversationsResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -19752,7 +19752,7 @@ export type CreateChatConversationResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -19983,7 +19983,7 @@ export type GetChatConversationResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -20136,7 +20136,7 @@ export type UpdateChatConversationResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -20449,7 +20449,7 @@ export type ForkChatConversationResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -20699,7 +20699,7 @@ export type CompactChatConversationResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -21119,7 +21119,7 @@ export type GetSharedConversationResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -21268,7 +21268,7 @@ export type ForkSharedConversationResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -21419,7 +21419,7 @@ export type GenerateChatConversationTitleResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -21569,7 +21569,7 @@ export type UpdateChatMessageResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -24593,7 +24593,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -24776,7 +24776,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -24865,7 +24865,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -24930,7 +24930,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -24997,7 +24997,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -25438,7 +25438,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -25505,7 +25505,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -25572,7 +25572,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -25639,7 +25639,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -25706,7 +25706,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -25773,7 +25773,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -25840,7 +25840,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -25907,7 +25907,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -25972,7 +25972,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -26037,7 +26037,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -26104,7 +26104,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -26171,7 +26171,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -26238,7 +26238,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -26372,7 +26372,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -26555,7 +26555,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -27036,7 +27036,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -27219,7 +27219,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -27308,7 +27308,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -27373,7 +27373,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -27440,7 +27440,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -27881,7 +27881,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -27948,7 +27948,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -28015,7 +28015,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -28082,7 +28082,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -28149,7 +28149,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -28216,7 +28216,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -28283,7 +28283,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -28350,7 +28350,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -28415,7 +28415,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -28480,7 +28480,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -28547,7 +28547,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -28614,7 +28614,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -28681,7 +28681,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -28815,7 +28815,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -28998,7 +28998,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -48164,7 +48164,7 @@ export type CreateScheduleTriggerRunConversationResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;


### PR DESCRIPTION
## Summary

Auto-retry clean-but-empty model responses in chat, then surface a structured error card when retries are exhausted — instead of silently rendering a blank assistant turn.

## Changes

- **Empty-response detection** — primitives to recognize a clean-but-empty model turn (no renderable text/tool parts despite a normal finishReason).
- **Auto-retry probe loop** — `streamText`'s `fullStream` is probed for the first renderable event; empty turns retry (up to 3, for retryable finishReasons stop/length/unknown). On a context-window error the payload is trimmed once and retried. Exhausted attempts throw `EmptyModelResponseError`, routed through `onError` → a structured error card.
- **Bounded context-trim retries** — the trim path is capped at one attempt so it can't loop.
- **Preserve trimmed payload** on retry, and treat tool-failure parts as renderable so a turn that only errors a tool isn't misread as empty.
- **`data-tool-ui-start` ordering** — moved its emission out of `streamText`'s `onChunk` (which runs upstream of the SDK's stream tee, so the probe could fire it before the matching `tool-input-start` reached the client) into a transform over the merged UI message stream. Now the UI-start always follows its tool-input-start.
- **Content-filter empties are non-retryable** — `mapProviderError` previously mapped every `EmptyModelResponseError` to the retryable `EmptyResponse` card; a content-filter block now maps to the non-retryable `ContentFiltered` card, while stop/length/unknown stay retryable.

## Tests

Unit tests for the probe loop, the tool-ui-start transform (real streams), and the error-mapping branches. Backend type-check and the full chat-route suite pass.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>