### PR TITLE
fix(dev): use --webpack for int-tests frontend to avoid turbopack idle CPU

### DIFF
--- a/platform/dev/Tiltfile.dev
+++ b/platform/dev/Tiltfile.dev
@@ -127,8 +127,11 @@ else:
   # silently hitting the real backend.
   local_resource(
     dev_resource_name + '-frontend-int-tests',
-    serve_cmd='trap "pkill -TERM -P $$" EXIT INT TERM; cd ../frontend && pnpm exec next dev -H 127.0.0.1 -p ' + frontend_int_tests_port + ' & wait $!',
-    serve_cmd_bat='cd ..\\frontend && pnpm exec next dev -H 127.0.0.1 -p ' + frontend_int_tests_port,
+    # --webpack mirrors the main frontend workaround for the next@16.2.6 turbopack
+    # idle-CPU bug (vercel/next.js#92055); see the "//dev" comment in frontend/package.json.
+    # `pnpm exec next dev` bypasses that package.json script, so the flag must be set here too.
+    serve_cmd='trap "pkill -TERM -P $$" EXIT INT TERM; cd ../frontend && pnpm exec next dev --webpack -H 127.0.0.1 -p ' + frontend_int_tests_port + ' & wait $!',
+    serve_cmd_bat='cd ..\\frontend && pnpm exec next dev --webpack -H 127.0.0.1 -p ' + frontend_int_tests_port,
     labels=['dev'],
     deps=['../.env'],
     serve_env={


### PR DESCRIPTION
## Problem

The `pnpm-dev-frontend-int-tests` Tilt resource (second Next.js dev server on :3010 for Playwright integration tests) pegs ~540% CPU even when idle on macOS arm64, dominating the dev stack's CPU usage.

## Root cause

The team already worked around the [next@16.2.6 turbopack idle-CPU bug](https://github.com/vercel/next.js/issues/92055) for the main frontend by reverting `--turbopack` → `--webpack` in `frontend/package.json`'s `dev` script.

The int-tests resource bypasses that workaround: its `serve_cmd` calls `pnpm exec next dev` directly (not the package.json `dev` script), so it never gets `--webpack` and defaults to turbopack.

The main frontend (`pnpm-dev-frontend`, :3000) runs `pnpm dev --filter @frontend` → routes through the patched script → gets `--webpack` → idles at ~0% CPU.

## Fix

Add `--webpack` to both `serve_cmd` (Unix) and `serve_cmd_bat` (Windows) of `pnpm-dev-frontend-int-tests`, mirroring the main frontend workaround. The second dev server now idles near 0% CPU.

Restore `--turbopack` here and in `frontend/package.json` once a fixed `next` ships.

## Testing

Local: `tilt enable pnpm-dev-frontend-int-tests` (or `tilt trigger`) → :3010 idles near 0% CPU instead of ~540%.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>