### PR TITLE
refactor(rbac): collapse environment permissions to admin + deploy-to-restricted

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -82372,7 +82372,7 @@
         "tags": [
           "Organization"
         ],
-        "description": "List org-level deployment environments with their assigned catalog counts, plus the count of catalog items with no environment (the default environment).\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`environment:read`: View deployment environments",
+        "description": "List org-level deployment environments with their assigned catalog counts, plus the count of catalog items with no environment (the default environment).\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\nNone (no additional RBAC permission required)",
         "responses": {
           "200": {
             "description": "Default Response",
@@ -82694,10 +82694,9 @@
           }
         },
         "x-required-permissions": {
-          "kind": "static",
-          "permissions": [
-            "environment:read"
-          ]
+          "kind": "none",
+          "note": "None (no additional RBAC permission required)",
+          "permissions": []
         }
       },
       "post": {
@@ -82705,7 +82704,7 @@
         "tags": [
           "Organization"
         ],
-        "description": "Create an org-level deployment environment.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`environment:create`: Create deployment environments",
+        "description": "Create an org-level deployment environment.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`environment:admin`: Create, edit, and delete deployment environments (everyone can view them)",
         "requestBody": {
           "required": true,
           "content": {
@@ -83046,7 +83045,7 @@
         "x-required-permissions": {
           "kind": "static",
           "permissions": [
-            "environment:create"
+            "environment:admin"
           ]
         }
       }
@@ -83057,7 +83056,7 @@
         "tags": [
           "Organization"
         ],
-        "description": "Update an environment's name, description, namespace, and restricted flag. When the namespace changes and the runtime is enabled, all MCP servers assigned to this environment are restarted in the new namespace.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`environment:update`: Modify deployment environment settings",
+        "description": "Update an environment's name, description, namespace, and restricted flag. When the namespace changes and the runtime is enabled, all MCP servers assigned to this environment are restarted in the new namespace.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`environment:admin`: Create, edit, and delete deployment environments (everyone can view them)",
         "requestBody": {
           "required": true,
           "content": {
@@ -83407,7 +83406,7 @@
         "x-required-permissions": {
           "kind": "static",
           "permissions": [
-            "environment:update"
+            "environment:admin"
           ]
         }
       },
@@ -83416,7 +83415,7 @@
         "tags": [
           "Organization"
         ],
-        "description": "Delete an org-level environment. Fails with 409 if any catalog items are still assigned to it.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`environment:delete`: Delete deployment environments",
+        "description": "Delete an org-level environment. Fails with 409 if any catalog items are still assigned to it.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`environment:admin`: Create, edit, and delete deployment environments (everyone can view them)",
         "parameters": [
           {
             "schema": {
@@ -83681,7 +83680,7 @@
         "x-required-permissions": {
           "kind": "static",
           "permissions": [
-            "environment:delete"
+            "environment:admin"
           ]
         }
       }
@@ -168659,7 +168658,8 @@
                                   "cancel",
                                   "enable",
                                   "query",
-                                  "execute"
+                                  "execute",
+                                  "deploy-to-restricted"
                                 ]
                               }
                             }
@@ -169015,7 +169015,8 @@
                           "cancel",
                           "enable",
                           "query",
-                          "execute"
+                          "execute",
+                          "deploy-to-restricted"
                         ]
                       }
                     }
@@ -169069,7 +169070,8 @@
                             "cancel",
                             "enable",
                             "query",
-                            "execute"
+                            "execute",
+                            "deploy-to-restricted"
                           ]
                         }
                       }
@@ -169412,7 +169414,8 @@
                             "cancel",
                             "enable",
                             "query",
-                            "execute"
+                            "execute",
+                            "deploy-to-restricted"
                           ]
                         }
                       }
@@ -169720,7 +169723,8 @@
                           "cancel",
                           "enable",
                           "query",
-                          "execute"
+                          "execute",
+                          "deploy-to-restricted"
                         ]
                       }
                     }
@@ -169795,7 +169799,8 @@
                             "cancel",
                             "enable",
                             "query",
-                            "execute"
+                            "execute",
+                            "deploy-to-restricted"
                           ]
                         }
                       }
@@ -177660,7 +177665,7 @@
         "tags": [
           "Organization"
         ],
-        "description": "Configure the implicit default environment (the deployment target referenced by internal_mcp_catalog.environment_id = null). Pass null for name to reset to the built-in 'Default' label, or null for namespace to unset it. Omitted fields are left unchanged.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`environment:update`: Modify deployment environment settings",
+        "description": "Configure the implicit default environment (the deployment target referenced by internal_mcp_catalog.environment_id = null). Pass null for name to reset to the built-in 'Default' label, or null for namespace to unset it. Omitted fields are left unchanged.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`environment:admin`: Create, edit, and delete deployment environments (everyone can view them)",
         "requestBody": {
           "required": true,
           "content": {
@@ -178405,7 +178410,7 @@
         "x-required-permissions": {
           "kind": "static",
           "permissions": [
-            "environment:update"
+            "environment:admin"
           ]
         }
       }
@@ -206177,7 +206182,8 @@
                         "cancel",
                         "enable",
                         "query",
-                        "execute"
+                        "execute",
+                        "deploy-to-restricted"
                       ]
                     }
                   }

--- a/docs/pages/platform-access-control.md
+++ b/docs/pages/platform-access-control.md
@@ -3,7 +3,7 @@ title: "Access Control"
 category: Administration
 description: "Role-based access control (RBAC) system for managing user permissions in Archestra"
 order: 1
-lastUpdated: 2026-06-01
+lastUpdated: 2026-06-02
 ---
 <!--
 Check ../docs_writer_prompt.md before changing this file.
@@ -53,7 +53,7 @@ Full access to core resources and settings, but cannot manage users, roles, or i
 | MCP Registry | `read`, `create`, `update`, `delete` |
 | MCP Server Installations | `read`, `create`, `update`, `delete` |
 | MCP Server Installation Requests | `read`, `create`, `update`, `delete` |
-| Environments | `read`, `create`, `update`, `delete` |
+| Environments | `admin` |
 | Network Policies | `read`, `create`, `update`, `delete` |
 | Knowledge Files | `read`, `create`, `update`, `delete` |
 | Knowledge Sources | `read`, `create`, `update`, `delete`, `query` |
@@ -93,7 +93,6 @@ Can manage agents, tools, and chat, with read-only access to most other resource
 | MCP Registry | `read` |
 | MCP Server Installations | `read`, `create`, `delete` |
 | MCP Server Installation Requests | `read`, `create`, `update` |
-| Environments | `read` |
 | Network Policies | `read` |
 | Knowledge Files | `read` |
 | Knowledge Sources | `read`, `query` |
@@ -144,11 +143,8 @@ The following table lists all available permissions that can be assigned to cust
 | `chatAgentPicker:enable` | Show agent picker in chat |
 | `chatExpandToolCalls:enable` | Allow expanding tool call details in chat |
 | `chatProviderSettings:enable` | Show model and API key selectors in chat |
-| `environment:read` | View deployment environments |
-| `environment:create` | Create deployment environments |
-| `environment:update` | Modify deployment environment settings |
-| `environment:delete` | Delete deployment environments |
-| `environment:admin` | Assign catalog items to restricted environments |
+| `environment:admin` | Create, edit, and delete deployment environments (everyone can view them) |
+| `environment:deploy-to-restricted` | Deploy catalog items to restricted environments |
 | `identityProvider:read` | View identity provider configurations (SSO) |
 | `identityProvider:create` | Set up new identity providers |
 | `identityProvider:update` | Modify identity provider settings |

--- a/docs/pages/platform-private-registry.md
+++ b/docs/pages/platform-private-registry.md
@@ -80,9 +80,9 @@ For example, every catalog entry tagged `department: finance` is automatically w
 
 ## Environments
 
-An environment is an organization-level deployment target — for example `sandbox`, `staging`, or `production`. Admins manage the list of environments, and each carries a name, an optional Kubernetes namespace, and an optional default network policy.
+An environment is an organization-level deployment target — for example `sandbox`, `staging`, or `production`. Any member can view the list of environments; creating, editing, and deleting them requires the `environment:admin` permission. Each environment carries a name, an optional Kubernetes namespace, and an optional default network policy.
 
-An environment can be marked **restricted**. Only members with the `environment:admin` permission can assign catalog entries to a restricted environment. Unrestricted environments and Default stay open to anyone who can create MCP registry catalog entries.
+An environment can be marked **restricted**. Only members with the `environment:deploy-to-restricted` permission (or `environment:admin`, which implies it) can assign catalog entries to a restricted environment. Unrestricted environments and Default stay open to anyone who can create MCP registry catalog entries.
 
 ### Network Policies
 

--- a/platform/backend/src/archestra-mcp-server/mcp-servers.ts
+++ b/platform/backend/src/archestra-mcp-server/mcp-servers.ts
@@ -897,16 +897,26 @@ async function handleCreateMcpServer(
     }
 
     try {
-      const hasEnvironmentAdmin = await userHasPermission(
-        context.userId,
-        organizationId,
-        "environment",
-        "admin",
-      );
+      // Deploying to a restricted environment requires
+      // environment:deploy-to-restricted (environment:admin implies it).
+      const [hasAdmin, hasDeploy] = await Promise.all([
+        userHasPermission(
+          context.userId,
+          organizationId,
+          "environment",
+          "admin",
+        ),
+        userHasPermission(
+          context.userId,
+          organizationId,
+          "environment",
+          "deploy-to-restricted",
+        ),
+      ]);
       await assertCanAssignEnvironment({
         environmentId: args.environmentId ?? null,
         organizationId,
-        hasEnvironmentAdmin,
+        canDeployToRestricted: hasAdmin || hasDeploy,
       });
     } catch (error) {
       return errorResult(

--- a/platform/backend/src/routes/environment.test.ts
+++ b/platform/backend/src/routes/environment.test.ts
@@ -229,7 +229,7 @@ describe("environment routes", () => {
     expect(response.json().error.message).toBe("Network policy not found");
   });
 
-  test("member without environment:create is forbidden", async ({
+  test("member without environment:admin is forbidden from creating", async ({
     makeUser,
     makeOrganization,
   }) => {

--- a/platform/backend/src/routes/internal-mcp-catalog.restricted-environment.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.restricted-environment.test.ts
@@ -17,33 +17,35 @@ const mockHasPermission = hasPermission as Mock;
 
 /**
  * POST /api/internal_mcp_catalog must refuse to assign a *restricted*
- * environment unless the caller holds `environment:admin`. The route computes
- * `hasEnvironmentAdmin` via `hasPermission({ environment: ["admin"] }, ...)`
- * and feeds it into `assertCanAssignEnvironment`, which throws 403 for a
- * restricted env the caller can't touch.
+ * environment unless the caller can deploy to restricted environments — i.e.
+ * holds `environment:deploy-to-restricted` (or `environment:admin`, which
+ * implies it). The route ORs both probes into `canDeployToRestricted` and feeds
+ * it into `assertCanAssignEnvironment`, which throws 403 for a restricted env
+ * the caller can't touch.
  *
  * The harness mirrors internal-mcp-catalog.headers.test.ts (real PGlite via
  * `@/test`, identity injected on the onRequest hook, mocked `hasPermission`),
- * but the mock here is *resource-aware*: it answers the `environment:["admin"]`
- * probe from a per-test flag so we can model an env-admin (built-in Admin) vs.
- * a plain member without env-admin. Every other permission probe (e.g. the
- * `mcpServerInstallation:["admin"]` scope check) stays `success: true` so the
- * test isolates the environment gate.
+ * but the mock here is *resource-aware*: it answers any `environment` probe
+ * (admin or deploy-to-restricted) from a per-test flag so we can model a caller
+ * who can deploy to restricted envs vs. one who can't. Every other permission
+ * probe (e.g. the `mcpServerInstallation:["admin"]` scope check) stays
+ * `success: true` so the test isolates the environment gate.
  */
 describe("Internal MCP Catalog - Restricted Environment Assignment Guard", () => {
   let app: FastifyInstanceWithZod;
   let user: User;
   let organizationId: string;
-  // Toggles the answer to the `environment:["admin"]` permission probe.
-  let hasEnvironmentAdmin: boolean;
+  // Toggles the answer to the environment permission probes (admin / deploy).
+  let canDeployToRestricted: boolean;
 
   beforeEach(async ({ makeOrganization, makeUser }) => {
     vi.clearAllMocks();
-    hasEnvironmentAdmin = false;
+    canDeployToRestricted = false;
     mockHasPermission.mockImplementation(async (permissions: Permissions) => {
       // The environment gate is the only probe whose answer varies per test.
-      if (permissions.environment?.includes("admin")) {
-        return { success: hasEnvironmentAdmin, error: null };
+      // Both the `admin` and `deploy-to-restricted` probes resolve to the flag.
+      if (permissions.environment?.length) {
+        return { success: canDeployToRestricted, error: null };
       }
       // Everything else (scope check, etc.) is granted so this suite isolates
       // the environment guard.
@@ -80,7 +82,7 @@ describe("Internal MCP Catalog - Restricted Environment Assignment Guard", () =>
   }
 
   test("a non-env-admin member assigning a RESTRICTED env is rejected (403) and nothing is created", async () => {
-    hasEnvironmentAdmin = false;
+    canDeployToRestricted = false;
     const restricted = await createEnvironment({
       organizationId,
       data: { name: "Prod", restricted: true },
@@ -111,7 +113,7 @@ describe("Internal MCP Catalog - Restricted Environment Assignment Guard", () =>
   });
 
   test("an env-admin (built-in Admin holds environment:admin) assigning a RESTRICTED env succeeds", async () => {
-    hasEnvironmentAdmin = true;
+    canDeployToRestricted = true;
     const restricted = await createEnvironment({
       organizationId,
       data: { name: "Prod", restricted: true },
@@ -128,7 +130,7 @@ describe("Internal MCP Catalog - Restricted Environment Assignment Guard", () =>
   });
 
   test("a non-env-admin member assigning an UNRESTRICTED env succeeds", async () => {
-    hasEnvironmentAdmin = false;
+    canDeployToRestricted = false;
     const open = await createEnvironment({
       organizationId,
       data: { name: "Staging", restricted: false },
@@ -167,7 +169,7 @@ describe("Internal MCP Catalog - Restricted Environment Assignment Guard", () =>
   }
 
   test("updating environmentId on an existing catalog item persists, and clearing to default works", async () => {
-    hasEnvironmentAdmin = false;
+    canDeployToRestricted = false;
     const open = await createEnvironment({
       organizationId,
       data: { name: "Staging", restricted: false },
@@ -193,7 +195,7 @@ describe("Internal MCP Catalog - Restricted Environment Assignment Guard", () =>
   });
 
   test("a non-env-admin updating to a RESTRICTED env is rejected (403) and the assignment is unchanged", async () => {
-    hasEnvironmentAdmin = false;
+    canDeployToRestricted = false;
     const restricted = await createEnvironment({
       organizationId,
       data: { name: "Prod", restricted: true },
@@ -215,7 +217,7 @@ describe("Internal MCP Catalog - Restricted Environment Assignment Guard", () =>
   });
 
   test("an env-admin updating to a RESTRICTED env succeeds", async () => {
-    hasEnvironmentAdmin = true;
+    canDeployToRestricted = true;
     const restricted = await createEnvironment({
       organizationId,
       data: { name: "Prod", restricted: true },

--- a/platform/backend/src/routes/internal-mcp-catalog.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.ts
@@ -191,17 +191,15 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
         delete restBody.teams;
       }
 
-      // Gate assigning a restricted environment. Built-in Admin holds
-      // environment:admin via ...allAvailableActions; custom roles can be
-      // granted it. Unrestricted and default (null) environments are open.
-      const { success: hasEnvironmentAdmin } = await hasPermission(
-        { environment: ["admin"] },
-        request.headers,
-      );
+      // Gate assigning a restricted environment. Requires
+      // environment:deploy-to-restricted (environment:admin implies it).
+      // Unrestricted and default (null) environments are open.
       await assertCanAssignEnvironment({
         environmentId: restBody.environmentId ?? null,
         organizationId: request.organizationId,
-        hasEnvironmentAdmin,
+        canDeployToRestricted: await callerCanDeployToRestricted(
+          request.headers,
+        ),
       });
 
       let clientSecretId: string | undefined;
@@ -975,19 +973,18 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
 
       // When the environment assignment changes, gate it the same way create
       // does — the target must belong to this org, and a restricted environment
-      // (or restricted default) requires environment:admin.
+      // (or restricted default) requires environment:deploy-to-restricted
+      // (environment:admin implies it).
       if (
         "environmentId" in restBody &&
         restBody.environmentId !== originalCatalogItem.environmentId
       ) {
-        const { success: hasEnvironmentAdmin } = await hasPermission(
-          { environment: ["admin"] },
-          request.headers,
-        );
         await assertCanAssignEnvironment({
           environmentId: restBody.environmentId ?? null,
           organizationId: request.organizationId,
-          hasEnvironmentAdmin,
+          canDeployToRestricted: await callerCanDeployToRestricted(
+            request.headers,
+          ),
         });
       }
 
@@ -1784,6 +1781,21 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
  * Mirror catalog item permissions - preset scoped fields could be added or
  * edited by same person who can edit catalog item.
  */
+/**
+ * Whether the caller may deploy catalog items to restricted environments.
+ * Holding `environment:admin` (full environment management) implies the
+ * `environment:deploy-to-restricted` capability.
+ */
+async function callerCanDeployToRestricted(
+  headers: FastifyRequest["headers"],
+): Promise<boolean> {
+  const [{ success: hasAdmin }, { success: hasDeploy }] = await Promise.all([
+    hasPermission({ environment: ["admin"] }, headers),
+    hasPermission({ environment: ["deploy-to-restricted"] }, headers),
+  ]);
+  return hasAdmin || hasDeploy;
+}
+
 async function assertCanEditCatalogPresets(
   parent: InternalMcpCatalog,
   request: FastifyRequest,

--- a/platform/backend/src/services/environments/environment.test.ts
+++ b/platform/backend/src/services/environments/environment.test.ts
@@ -172,7 +172,7 @@ describe("EnvironmentService", () => {
       assertCanAssignEnvironment({
         environmentId: null,
         organizationId: org.id,
-        hasEnvironmentAdmin: false,
+        canDeployToRestricted: false,
       }),
     ).resolves.toBeUndefined();
   });
@@ -188,7 +188,7 @@ describe("EnvironmentService", () => {
       assertCanAssignEnvironment({
         environmentId: null,
         organizationId: org.id,
-        hasEnvironmentAdmin: false,
+        canDeployToRestricted: false,
       }),
     ).rejects.toMatchObject({ statusCode: 403 });
   });
@@ -204,7 +204,7 @@ describe("EnvironmentService", () => {
       assertCanAssignEnvironment({
         environmentId: null,
         organizationId: org.id,
-        hasEnvironmentAdmin: true,
+        canDeployToRestricted: true,
       }),
     ).resolves.toBeUndefined();
   });
@@ -221,7 +221,7 @@ describe("EnvironmentService", () => {
       assertCanAssignEnvironment({
         environmentId: env.id,
         organizationId: org.id,
-        hasEnvironmentAdmin: false,
+        canDeployToRestricted: false,
       }),
     ).resolves.toBeUndefined();
   });
@@ -238,7 +238,7 @@ describe("EnvironmentService", () => {
       assertCanAssignEnvironment({
         environmentId: env.id,
         organizationId: org.id,
-        hasEnvironmentAdmin: false,
+        canDeployToRestricted: false,
       }),
     ).rejects.toMatchObject({ statusCode: 403 });
   });
@@ -255,7 +255,7 @@ describe("EnvironmentService", () => {
       assertCanAssignEnvironment({
         environmentId: env.id,
         organizationId: org.id,
-        hasEnvironmentAdmin: true,
+        canDeployToRestricted: true,
       }),
     ).resolves.toBeUndefined();
   });
@@ -268,7 +268,7 @@ describe("EnvironmentService", () => {
       assertCanAssignEnvironment({
         environmentId: MISSING_ID,
         organizationId: org.id,
-        hasEnvironmentAdmin: true,
+        canDeployToRestricted: true,
       }),
     ).rejects.toMatchObject({ statusCode: 404 });
   });

--- a/platform/backend/src/services/environments/environment.ts
+++ b/platform/backend/src/services/environments/environment.ts
@@ -81,22 +81,23 @@ export async function updateEnvironment(params: {
 /**
  * Gate assigning a catalog item to an environment. Unrestricted environments
  * are open; a `restricted` environment requires the caller to hold
- * `environment:admin`. The default (null) environment is open unless the org
- * has marked its default environment restricted, in which case it is gated the
- * same way. Callers compute `hasEnvironmentAdmin` with their own auth primitive
- * (route headers vs. MCP user context) and pass the result in, so this stays
- * free of HTTP concerns.
+ * `environment:deploy-to-restricted` (or `environment:admin`, which implies it).
+ * The default (null) environment is open unless the org has marked its default
+ * environment restricted, in which case it is gated the same way. Callers
+ * compute `canDeployToRestricted` with their own auth primitive (route headers
+ * vs. MCP user context) and pass the result in, so this stays free of HTTP
+ * concerns.
  */
 export async function assertCanAssignEnvironment(params: {
   environmentId: string | null | undefined;
   organizationId: string;
-  hasEnvironmentAdmin: boolean;
+  canDeployToRestricted: boolean;
 }): Promise<void> {
-  const { environmentId, organizationId, hasEnvironmentAdmin } = params;
+  const { environmentId, organizationId, canDeployToRestricted } = params;
 
   if (!environmentId) {
     const organization = await OrganizationModel.getById(organizationId);
-    if (organization?.defaultEnvironmentRestricted && !hasEnvironmentAdmin) {
+    if (organization?.defaultEnvironmentRestricted && !canDeployToRestricted) {
       throw new ApiError(
         403,
         "You do not have permission to assign catalog items to the default environment.",
@@ -112,7 +113,7 @@ export async function assertCanAssignEnvironment(params: {
   if (!environment) {
     throw new ApiError(404, "Environment not found");
   }
-  if (environment.restricted && !hasEnvironmentAdmin) {
+  if (environment.restricted && !canDeployToRestricted) {
     throw new ApiError(
       403,
       "You do not have permission to assign catalog items to this restricted environment.",

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -529,14 +529,19 @@ export function McpCatalogForm({
   const { data: teams } = useTeams();
   const { data: environmentList } = useEnvironments();
   const environments = environmentList?.environments;
-  const { data: canDeployRestricted } = useHasPermissions({
-    environment: ["admin"],
+  // Deploying to a restricted environment needs environment:deploy-to-restricted;
+  // environment:admin (full environment management) implies it.
+  const { data: hasEnvAdmin } = useHasPermissions({ environment: ["admin"] });
+  const { data: hasDeployToRestricted } = useHasPermissions({
+    environment: ["deploy-to-restricted"],
   });
+  const canDeployRestricted =
+    (hasEnvAdmin ?? false) || (hasDeployToRestricted ?? false);
   const defaultEnvironment = useDefaultEnvironment();
-  // Environments the user can deploy to. Restricted environments the user lacks
-  // environment:admin for are hidden entirely. The default is always available,
-  // so with no accessible custom environments there's only one option and the
-  // selector is hidden.
+  // Environments the user can deploy to. Restricted environments the user can't
+  // deploy to are hidden entirely. The default is always available, so with no
+  // accessible custom environments there's only one option and the selector is
+  // hidden.
   const accessibleEnvironments = (environments ?? []).filter(
     (e) => !e.restricted || canDeployRestricted,
   );

--- a/platform/frontend/src/app/mcp/registry/environments/page.client.tsx
+++ b/platform/frontend/src/app/mcp/registry/environments/page.client.tsx
@@ -5,7 +5,7 @@ import { EnvironmentsSection } from "../_parts/environments-section";
 
 export default function EnvironmentsPageClient() {
   const { data: canEdit } = useHasPermissions({
-    environment: ["create", "update", "delete"],
+    environment: ["admin"],
   });
   const { data: canReadNetworkPolicies } = useHasPermissions({
     networkPolicy: ["read"],

--- a/platform/frontend/src/app/mcp/registry/layout.tsx
+++ b/platform/frontend/src/app/mcp/registry/layout.tsx
@@ -27,8 +27,8 @@ export default function McpCatalogLayout({
   const pathname = usePathname();
   const isRegistryPage = pathname === "/mcp/registry";
   const [pageActionButton, setActionButton] = useState<React.ReactNode>(null);
-  const { data: canReadEnvironments } = useHasPermissions({
-    environment: ["read"],
+  const { data: canManageEnvironments } = useHasPermissions({
+    environment: ["admin"],
   });
   const { data: canReadNetworkPolicies } = useHasPermissions({
     networkPolicy: ["read"],
@@ -36,7 +36,10 @@ export default function McpCatalogLayout({
 
   const tabs = [
     { label: "Catalog", href: "/mcp/registry" },
-    ...(canReadEnvironments
+    // The Environments tab leads to environment management — gate it on
+    // environment:admin. (Listing environments via the API stays ungated so the
+    // catalog deploy-selector works for everyone.)
+    ...(canManageEnvironments
       ? [{ label: "Environments", href: "/mcp/registry/environments" }]
       : []),
     ...(canReadNetworkPolicies

--- a/platform/frontend/src/components/roles/role-permission-builder.ee.tsx
+++ b/platform/frontend/src/components/roles/role-permission-builder.ee.tsx
@@ -42,6 +42,7 @@ const actionLabels: Record<Action, string> = {
   enable: "Enable",
   query: "Query",
   execute: "Execute",
+  "deploy-to-restricted": "Deploy to Restricted",
 };
 
 const UNGRANTABLE_PERMISSION_TOOLTIP =

--- a/platform/frontend/src/components/settings/role-permissions-card.tsx
+++ b/platform/frontend/src/components/settings/role-permissions-card.tsx
@@ -62,6 +62,7 @@ const actionLabels: Record<Action, string> = {
   enable: "Enable",
   query: "Query",
   execute: "Execute",
+  "deploy-to-restricted": "Deploy to Restricted",
 };
 
 export function RolePermissionsCard() {

--- a/platform/frontend/src/mocks/data/auth.ts
+++ b/platform/frontend/src/mocks/data/auth.ts
@@ -73,7 +73,7 @@ export function makeUserPermissions(
     mcpServerInstallation: [...ALL],
     mcpServerInstallationRequest: [...ALL],
     mcpGateway: [...ALL],
-    environment: [...ALL],
+    environment: ["admin", "deploy-to-restricted"],
     networkPolicy: [...ALL],
     agent: [...ALL, "team-admin"],
     agentTrigger: [...ALL],

--- a/platform/shared/access-control.ts
+++ b/platform/shared/access-control.ts
@@ -992,9 +992,6 @@ export const requiredEndpointPermissionsMap: Partial<
   [RouteId.UpdateDefaultEnvironment]: {
     environment: ["admin"],
   },
-  [RouteId.ValidateEnvironmentNamespace]: {
-    environment: ["admin"],
-  },
   [RouteId.GetK8sCapabilities]: {
     networkPolicy: ["read"],
   },

--- a/platform/shared/access-control.ts
+++ b/platform/shared/access-control.ts
@@ -54,7 +54,7 @@ export const allAvailableActions: Record<Resource, Action[]> = {
   mcpRegistry: ["read", "create", "update", "delete"],
   mcpServerInstallation: ["read", "create", "update", "delete", "admin"],
   mcpServerInstallationRequest: ["read", "create", "update", "delete", "admin"],
-  environment: ["read", "create", "update", "delete", "admin"],
+  environment: ["admin", "deploy-to-restricted"],
   networkPolicy: ["read", "create", "update", "delete"],
 
   // Knowledge
@@ -116,7 +116,7 @@ export const editorPermissions: Record<Resource, Action[]> = {
   mcpRegistry: ["read", "create", "update", "delete"],
   mcpServerInstallation: ["read", "create", "update", "delete"],
   mcpServerInstallationRequest: ["read", "create", "update", "delete"],
-  environment: ["read", "create", "update", "delete"],
+  environment: ["admin"],
   networkPolicy: ["read", "create", "update", "delete"],
 
   // Knowledge
@@ -178,7 +178,7 @@ export const memberPermissions: Record<Resource, Action[]> = {
   mcpRegistry: ["read"],
   mcpServerInstallation: ["read", "create", "delete"],
   mcpServerInstallationRequest: ["read", "create", "update"],
-  environment: ["read"],
+  environment: [],
   networkPolicy: ["read"],
 
   // Knowledge
@@ -297,11 +297,10 @@ export const permissionDescriptions: Record<string, string> = {
   "mcpServerInstallationRequest:delete": "Delete installation requests",
   "mcpServerInstallationRequest:admin":
     "Approve or decline installation requests",
-  "environment:read": "View deployment environments",
-  "environment:create": "Create deployment environments",
-  "environment:update": "Modify deployment environment settings",
-  "environment:delete": "Delete deployment environments",
-  "environment:admin": "Assign catalog items to restricted environments",
+  "environment:admin":
+    "Create, edit, and delete deployment environments (everyone can view them)",
+  "environment:deploy-to-restricted":
+    "Deploy catalog items to restricted environments",
   "networkPolicy:read": "View network policies",
   "networkPolicy:create": "Create network policies",
   "networkPolicy:update": "Modify network policies",
@@ -979,23 +978,22 @@ export const requiredEndpointPermissionsMap: Partial<
   [RouteId.DeleteMcpPresetEntry]: {
     mcpServerInstallation: ["admin"],
   },
-  [RouteId.ListEnvironments]: {
-    environment: ["read"],
-  },
+  // Listing environments is available to any authenticated user (read is ungated).
+  [RouteId.ListEnvironments]: {},
   [RouteId.CreateEnvironment]: {
-    environment: ["create"],
+    environment: ["admin"],
   },
   [RouteId.UpdateEnvironment]: {
-    environment: ["update"],
+    environment: ["admin"],
   },
   [RouteId.DeleteEnvironment]: {
-    environment: ["delete"],
+    environment: ["admin"],
   },
   [RouteId.UpdateDefaultEnvironment]: {
-    environment: ["update"],
+    environment: ["admin"],
   },
   [RouteId.ValidateEnvironmentNamespace]: {
-    environment: ["read"],
+    environment: ["admin"],
   },
   [RouteId.GetK8sCapabilities]: {
     networkPolicy: ["read"],

--- a/platform/shared/hey-api/clients/api/sdk.gen.ts
+++ b/platform/shared/hey-api/clients/api/sdk.gen.ts
@@ -1783,7 +1783,7 @@ export const deepseekChatCompletionsWithAgent = <ThrowOnError extends boolean = 
  *
  * Authorization:
  *
- * `environment:read`: View deployment environments
+ * None (no additional RBAC permission required)
  */
 export const listEnvironments = <ThrowOnError extends boolean = false>(options?: Options<ListEnvironmentsData, ThrowOnError>) => (options?.client ?? client).get<ListEnvironmentsResponses, ListEnvironmentsErrors, ThrowOnError>({ url: '/api/organization/environments', ...options });
 
@@ -1796,7 +1796,7 @@ export const listEnvironments = <ThrowOnError extends boolean = false>(options?:
  *
  * Authorization:
  *
- * `environment:create`: Create deployment environments
+ * `environment:admin`: Create, edit, and delete deployment environments (everyone can view them)
  */
 export const createEnvironment = <ThrowOnError extends boolean = false>(options: Options<CreateEnvironmentData, ThrowOnError>) => (options.client ?? client).post<CreateEnvironmentResponses, CreateEnvironmentErrors, ThrowOnError>({
     url: '/api/organization/environments',
@@ -1816,7 +1816,7 @@ export const createEnvironment = <ThrowOnError extends boolean = false>(options:
  *
  * Authorization:
  *
- * `environment:delete`: Delete deployment environments
+ * `environment:admin`: Create, edit, and delete deployment environments (everyone can view them)
  */
 export const deleteEnvironment = <ThrowOnError extends boolean = false>(options: Options<DeleteEnvironmentData, ThrowOnError>) => (options.client ?? client).delete<DeleteEnvironmentResponses, DeleteEnvironmentErrors, ThrowOnError>({ url: '/api/organization/environments/{id}', ...options });
 
@@ -1829,7 +1829,7 @@ export const deleteEnvironment = <ThrowOnError extends boolean = false>(options:
  *
  * Authorization:
  *
- * `environment:update`: Modify deployment environment settings
+ * `environment:admin`: Create, edit, and delete deployment environments (everyone can view them)
  */
 export const updateEnvironment = <ThrowOnError extends boolean = false>(options: Options<UpdateEnvironmentData, ThrowOnError>) => (options.client ?? client).patch<UpdateEnvironmentResponses, UpdateEnvironmentErrors, ThrowOnError>({
     url: '/api/organization/environments/{id}',
@@ -4335,7 +4335,7 @@ export const updatePresetEntityDefaultValidationRegex = <ThrowOnError extends bo
  *
  * Authorization:
  *
- * `environment:update`: Modify deployment environment settings
+ * `environment:admin`: Create, edit, and delete deployment environments (everyone can view them)
  */
 export const updateDefaultEnvironment = <ThrowOnError extends boolean = false>(options: Options<UpdateDefaultEnvironmentData, ThrowOnError>) => (options.client ?? client).patch<UpdateDefaultEnvironmentResponses, UpdateDefaultEnvironmentErrors, ThrowOnError>({
     url: '/api/organization/default-environment',

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -44639,7 +44639,7 @@ export type GetRolesResponses = {
             name: string;
             description: string | null;
             permission: {
-                [key: string]: Array<'create' | 'read' | 'update' | 'delete' | 'team-admin' | 'admin' | 'cancel' | 'enable' | 'query' | 'execute'>;
+                [key: string]: Array<'create' | 'read' | 'update' | 'delete' | 'team-admin' | 'admin' | 'cancel' | 'enable' | 'query' | 'execute' | 'deploy-to-restricted'>;
             };
             createdAt: string;
             updatedAt: string | null;
@@ -44663,7 +44663,7 @@ export type CreateRoleData = {
         name: string;
         description?: string;
         permission: {
-            [key: string]: Array<'create' | 'read' | 'update' | 'delete' | 'team-admin' | 'admin' | 'cancel' | 'enable' | 'query' | 'execute'>;
+            [key: string]: Array<'create' | 'read' | 'update' | 'delete' | 'team-admin' | 'admin' | 'cancel' | 'enable' | 'query' | 'execute' | 'deploy-to-restricted'>;
         };
     };
     path?: never;
@@ -44747,7 +44747,7 @@ export type CreateRoleResponses = {
         name: string;
         description: string | null;
         permission: {
-            [key: string]: Array<'create' | 'read' | 'update' | 'delete' | 'team-admin' | 'admin' | 'cancel' | 'enable' | 'query' | 'execute'>;
+            [key: string]: Array<'create' | 'read' | 'update' | 'delete' | 'team-admin' | 'admin' | 'cancel' | 'enable' | 'query' | 'execute' | 'deploy-to-restricted'>;
         };
         createdAt: string;
         updatedAt: string | null;
@@ -44933,7 +44933,7 @@ export type GetRoleResponses = {
         name: string;
         description: string | null;
         permission: {
-            [key: string]: Array<'create' | 'read' | 'update' | 'delete' | 'team-admin' | 'admin' | 'cancel' | 'enable' | 'query' | 'execute'>;
+            [key: string]: Array<'create' | 'read' | 'update' | 'delete' | 'team-admin' | 'admin' | 'cancel' | 'enable' | 'query' | 'execute' | 'deploy-to-restricted'>;
         };
         createdAt: string;
         updatedAt: string | null;
@@ -44948,7 +44948,7 @@ export type UpdateRoleData = {
         name?: string;
         description?: string;
         permission?: {
-            [key: string]: Array<'create' | 'read' | 'update' | 'delete' | 'team-admin' | 'admin' | 'cancel' | 'enable' | 'query' | 'execute'>;
+            [key: string]: Array<'create' | 'read' | 'update' | 'delete' | 'team-admin' | 'admin' | 'cancel' | 'enable' | 'query' | 'execute' | 'deploy-to-restricted'>;
         };
     };
     path: {
@@ -45037,7 +45037,7 @@ export type UpdateRoleResponses = {
         name: string;
         description: string | null;
         permission: {
-            [key: string]: Array<'create' | 'read' | 'update' | 'delete' | 'team-admin' | 'admin' | 'cancel' | 'enable' | 'query' | 'execute'>;
+            [key: string]: Array<'create' | 'read' | 'update' | 'delete' | 'team-admin' | 'admin' | 'cancel' | 'enable' | 'query' | 'execute' | 'deploy-to-restricted'>;
         };
         createdAt: string;
         updatedAt: string | null;
@@ -54559,7 +54559,7 @@ export type GetUserPermissionsResponses = {
      * Default Response
      */
     200: {
-        [key: string]: Array<'create' | 'read' | 'update' | 'delete' | 'team-admin' | 'admin' | 'cancel' | 'enable' | 'query' | 'execute'>;
+        [key: string]: Array<'create' | 'read' | 'update' | 'delete' | 'team-admin' | 'admin' | 'cancel' | 'enable' | 'query' | 'execute' | 'deploy-to-restricted'>;
     };
 };
 

--- a/platform/shared/permission.types.ts
+++ b/platform/shared/permission.types.ts
@@ -20,6 +20,7 @@ export const actions = [
   "enable",
   "query",
   "execute",
+  "deploy-to-restricted",
 ] as const;
 
 export const resources = [

--- a/platform/shared/routes.ts
+++ b/platform/shared/routes.ts
@@ -393,7 +393,6 @@ export const RouteId = {
   UpdateEnvironment: "updateEnvironment",
   DeleteEnvironment: "deleteEnvironment",
   UpdateDefaultEnvironment: "updateDefaultEnvironment",
-  ValidateEnvironmentNamespace: "validateEnvironmentNamespace",
   GetK8sCapabilities: "getK8sCapabilities",
   ListNetworkPolicies: "listNetworkPolicies",
   CreateNetworkPolicy: "createNetworkPolicy",


### PR DESCRIPTION
## What

Collapses the `environment` RBAC resource from five actions to two:

| Permission | Gates |
|---|---|
| `environment:admin` | Full environment CRUD (create / edit / delete). Keeps the 409 rule blocking deletion of an environment that still has catalog items assigned. |
| `environment:deploy-to-restricted` | Assigning / deploying catalog items to a **restricted** environment. `environment:admin` implies it. |

- **Read is ungated** — any authenticated user can list environments via the API (so the catalog deploy-selector can populate for everyone).
- The **Environments management tab** is shown only to `environment:admin` holders.



## Verification

- Type-check clean (shared / backend / frontend); biome clean; `pnpm codegen` idempotent.
- Tests pass: env service (27), MCP server tools (26), shared access-control (7), frontend catalog form (65).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>