### PR TITLE
feat(mcp-registry): retire Presets field scope option and sidebar section

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-settings-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-settings-dialog.tsx
@@ -38,13 +38,11 @@ import {
   PresetSelector,
 } from "./mcp-logs-dialog";
 import type { CatalogItem } from "./mcp-server-card";
-import { PresetsSection } from "./presets-section";
 import { YamlConfigContent } from "./yaml-config-dialog";
 
 type SettingsPage =
   | "configuration"
   | "connections"
-  | "presets"
   | "debug-logs"
   | "debug-inspector"
   | "debug-shell"
@@ -105,7 +103,6 @@ const DEBUG_TAB_MAP: Record<string, McpLogsTab> = {
 const PAGE_TITLES: Record<SettingsPage, string> = {
   configuration: "Configuration",
   connections: "Credentials",
-  presets: "Presets",
   "debug-logs": "Logs",
   "debug-inspector": "Inspector",
   "debug-shell": "Shell",
@@ -152,17 +149,10 @@ export function McpServerSettingsDialog({
   const { data: presets = [] } = useCatalogPresets(
     isBuiltin || !presetEntityName.configured ? null : item.id,
   );
-  const showPresets = !isBuiltin && presetEntityName.configured;
 
   const navItems: NavItemDef[] = [];
   if (!isBuiltin) {
     navItems.push({ id: "configuration", label: "Configuration" });
-  }
-  if (showPresets) {
-    navItems.push({
-      id: "presets",
-      label: presetEntityName.plural,
-    });
   }
   if (showConnections) {
     navItems.push({
@@ -201,11 +191,6 @@ export function McpServerSettingsDialog({
     : (navItems[0]?.id ?? "configuration");
 
   const isDebugPage = validPage.startsWith("debug-");
-
-  const pageTitles: Record<SettingsPage, string> = {
-    ...PAGE_TITLES,
-    presets: presetEntityName.plural,
-  };
 
   // Preset filter shown in the slim page header on Logs/Inspector/Shell and
   // Credentials. Drives both McpLogsContent (filters the pod selector) and
@@ -421,7 +406,9 @@ export function McpServerSettingsDialog({
           <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
             {/* Content header */}
             <div className="flex min-h-[72px] shrink-0 items-center justify-between border-b px-4 py-4">
-              <h2 className="text-lg font-semibold">{pageTitles[validPage]}</h2>
+              <h2 className="text-lg font-semibold">
+                {PAGE_TITLES[validPage]}
+              </h2>
               <div className="flex items-center gap-2">
                 {presetSelectorVisible && (
                   <PresetSelector
@@ -459,15 +446,6 @@ export function McpServerSettingsDialog({
                   onDirtyChange={setIsConfigDirty}
                   submitRef={configSubmitRef}
                 />
-              )}
-
-              {validPage === "presets" && showPresets && (
-                <div className="flex-1 overflow-y-auto p-6">
-                  <PresetsSection
-                    cat={item}
-                    onGoToConfiguration={() => navigateTo("configuration")}
-                  />
-                </div>
               )}
 
               {validPage === "connections" && showConnections && (
@@ -558,7 +536,7 @@ export function McpServerSettingsDialog({
                       </EmptyMedia>
                       <EmptyDescription>
                         Install this server to open the{" "}
-                        {pageTitles[validPage].toLowerCase()}.
+                        {PAGE_TITLES[validPage].toLowerCase()}.
                       </EmptyDescription>
                     </EmptyHeader>
                     {onConnect && (

--- a/platform/frontend/src/components/field-scope-select.tsx
+++ b/platform/frontend/src/components/field-scope-select.tsx
@@ -20,8 +20,6 @@ export type FieldScopeValue = "installation" | "preset" | "static";
 interface FieldScopeSelectProps {
   value: FieldScopeValue;
   onChange: (next: FieldScopeValue) => void;
-  /** When false, the "preset" option is hidden (caller doesn't model preset-scoped values). */
-  allowPresetScope?: boolean;
   /** When true, "installation" is forbidden (e.g. multi-tenant servers). */
   disableInstallation?: boolean;
   /** Tooltip copy shown when the disabled "Installation" option is hovered. */
@@ -31,12 +29,14 @@ interface FieldScopeSelectProps {
 export function FieldScopeSelect({
   value,
   onChange,
-  allowPresetScope = true,
   disableInstallation = false,
   disabledReason,
 }: FieldScopeSelectProps) {
-  const { singular, configured } = usePresetEntityName();
-  const showPresetScope = allowPresetScope && configured;
+  const { singular } = usePresetEntityName();
+  // "preset" is deprecated as a selectable scope: it is no longer offered when
+  // adding a field, but a field that already has preset scope keeps rendering
+  // the option so its value still displays and existing config isn't dropped.
+  const showPresetScope = value === "preset";
   const installationItem = (
     <SelectItem
       value="installation"


### PR DESCRIPTION
## What

Removes "Presets" as a **new** field-scope option and removes the **Presets** sidebar section from the MCP server settings dialog. Existing preset-scoped fields keep working — they just can't be created anew.

## Why

"Presets" is being retired as a field scope. Keeping existing preset-scoped fields renderable avoids silently dropping config that's already in use.
---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>