### PR TITLE
fix(chat): stabilize per-render refs feeding chat-page effects

### DIFF
--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -41,6 +41,7 @@ import { ChatMessages } from "@/components/chat/chat-messages";
 import {
   collectBrowserToolCallIds,
   deriveCanvasesFromMessages,
+  type OptimisticToolCall,
 } from "@/components/chat/chat-messages.utils";
 import { ConversationArtifactPanel } from "@/components/chat/conversation-artifact";
 import { InitialAgentSelector } from "@/components/chat/initial-agent-selector";
@@ -159,6 +160,15 @@ import ArchestraPromptInput, {
 import { resolveSharedConversationForkState } from "./shared-conversation-fork";
 
 const BROWSER_OPEN_KEY = "archestra-chat-browser-open";
+
+// Stable empty defaults: falling back to a fresh `[]`/`{}` on every render gives
+// `useMemo` deps a new reference each time, which re-runs the canvas/browser
+// effects on every render and thrashes the chat page during an active stream.
+const EMPTY_OPTIMISTIC_TOOL_CALLS: OptimisticToolCall[] = [];
+const EMPTY_EARLY_TOOL_UI_STARTS: Record<
+  string,
+  { uiResourceUri?: string; toolName?: string }
+> = {};
 
 export function ChatPageContent({
   routeConversationId,
@@ -915,7 +925,7 @@ export function ChatPageContent({
     () =>
       deriveCanvasesFromMessages(
         messages,
-        chatSession?.earlyToolUiStarts ?? {},
+        chatSession?.earlyToolUiStarts ?? EMPTY_EARLY_TOOL_UI_STARTS,
       ),
     [messages, chatSession?.earlyToolUiStarts],
   );
@@ -930,7 +940,8 @@ export function ChatPageContent({
   const addToolResult = chatSession?.addToolResult;
   const addToolApprovalResponse = chatSession?.addToolApprovalResponse;
   const pendingCustomServerToolCall = chatSession?.pendingCustomServerToolCall;
-  const optimisticToolCalls = chatSession?.optimisticToolCalls ?? [];
+  const optimisticToolCalls =
+    chatSession?.optimisticToolCalls ?? EMPTY_OPTIMISTIC_TOOL_CALLS;
   const browserToolCallIds = useMemo(
     () =>
       collectBrowserToolCallIds({


### PR DESCRIPTION
## Summary

`chat.spec.ts:267` ("Chat active run reconnect → continues a streaming assistant turn after page reload") fails deterministically in the merge queue, blocking *all* merges. From the failing run's Playwright trace, the chat page throws **React error #185 (maximum update depth exceeded)** when it reloads into an active stream — an infinite render loop — so `chat-prompt-textarea` never mounts and `expectChatReady` times out.

This stabilizes two per-render references in the chat page: `optimisticToolCalls` and `earlyToolUiStarts` were falling back to a fresh `[]`/`{}` on every render, giving the `browserToolCallIds`/`mcpCanvases` `useMemo` deps a new reference each time and re-running the browser/canvas effects on every render — render thrash that the reload-into-active-stream path can drive into a loop. Module-level stable empties keep the deps referentially stable when the session has no optimistic tool calls / early UI starts.

The regression came in via #5228 ("share and browser pane"), which was merged bypassing the e2e gate. Local reproduction of the exact loop is in progress (the dev kind cluster was degraded); this lands the most likely fix and lets the `run-e2e` gate verify it in parallel.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>