### PR TITLE
fix(chat): drop empty assistant turns from persist, read, and model prep

### DIFF
--- a/platform/backend/src/models/conversation.test.ts
+++ b/platform/backend/src/models/conversation.test.ts
@@ -717,6 +717,86 @@ describe("ConversationModel", () => {
     expect(found?.messages[0].id).not.toBe("temp-ai-sdk-id");
   });
 
+  test("findById filters already-persisted empty assistant rows", async ({
+    makeUser,
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const user = await makeUser();
+    const org = await makeOrganization();
+    const agent = await makeAgent({ name: "Empty Bubble Agent", teams: [] });
+
+    const conversation = await ConversationModel.create({
+      userId: user.id,
+      organizationId: org.id,
+      agentId: agent.id,
+      title: "Empty Bubble Test",
+    });
+
+    // a healthy turn: user prompt + assistant answer.
+    await MessageModel.create({
+      conversationId: conversation.id,
+      role: "user",
+      content: { role: "user", parts: [{ type: "text", text: "hello" }] },
+    });
+    await MessageModel.create({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: { role: "assistant", parts: [{ type: "text", text: "hi" }] },
+    });
+
+    // historical bad assistant rows that must not render after refresh.
+    await MessageModel.create({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: { role: "assistant", parts: [] },
+    });
+    await MessageModel.create({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: { role: "assistant" },
+    });
+    await MessageModel.create({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "",
+    });
+    await MessageModel.create({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: {
+        role: "assistant",
+        parts: [
+          { type: "step-start" },
+          { type: "data-token-usage", data: { totalTokens: 5 } },
+        ],
+      },
+    });
+    await MessageModel.create({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: {
+        role: "assistant",
+        parts: [
+          {
+            type: "data-tool-ui-start",
+            data: { toolCallId: "call_orphan", toolName: "render_chart" },
+          },
+        ],
+      },
+    });
+
+    const found = await ConversationModel.findById({
+      id: conversation.id,
+      userId: user.id,
+      organizationId: org.id,
+    });
+
+    expect(found?.messages).toHaveLength(2);
+    expect(found?.messages.map((m) => m.role)).toEqual(["user", "assistant"]);
+    expect(found?.messages[1].parts).toEqual([{ type: "text", text: "hi" }]);
+  });
+
   test("findById merges database UUIDs into multiple messages", async ({
     makeUser,
     makeOrganization,

--- a/platform/backend/src/models/conversation.ts
+++ b/platform/backend/src/models/conversation.ts
@@ -1,3 +1,4 @@
+import { hasPersistableAssistantContent } from "@shared";
 import {
   and,
   desc,
@@ -192,7 +193,11 @@ class ConversationModel {
         }
 
         const conversation = conversationMap.get(conversationId);
-        if (conversation && row?.message?.content) {
+        if (
+          conversation &&
+          row?.message?.content &&
+          shouldReturnPersistedMessageRow(row.message)
+        ) {
           // Limit messages per conversation for preview
           if (
             conversation.messages.length <
@@ -314,7 +319,10 @@ class ConversationModel {
     const messages = [];
 
     for (const row of rows) {
-      if (row.message?.content) {
+      if (
+        row.message?.content &&
+        shouldReturnPersistedMessageRow(row.message)
+      ) {
         // Merge database UUID into message content (overrides AI SDK's temporary ID)
         messages.push(addMessagePersistenceMetadata(row.message));
       }
@@ -416,7 +424,10 @@ class ConversationModel {
     const messages = [];
 
     for (const row of rows) {
-      if (row.message?.content) {
+      if (
+        row.message?.content &&
+        shouldReturnPersistedMessageRow(row.message)
+      ) {
         messages.push(addMessagePersistenceMetadata(row.message));
       }
     }
@@ -517,6 +528,25 @@ class ConversationModel {
 }
 
 export default ConversationModel;
+
+// Read-side guard for assistant rows that were persisted before the strict
+// persist normalization (or by an older client) and would otherwise reload as
+// an empty bubble. The DB `role` column is authoritative — a `content: ""` row
+// has no role inside its content. Read-only: bad rows are hidden, never deleted.
+function shouldReturnPersistedMessageRow(message: {
+  role: string;
+  content: unknown;
+}): boolean {
+  if (message.role !== "assistant") {
+    return true;
+  }
+  if (typeof message.content !== "object" || message.content === null) {
+    return false;
+  }
+  return hasPersistableAssistantContent(
+    message.content as { parts?: ReadonlyArray<{ type: string }> },
+  );
+}
 
 function addMessagePersistenceMetadata(message: {
   id: string;

--- a/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
+++ b/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest";
-import { normalizeChatMessages } from "./normalize-chat-messages";
+import {
+  normalizeChatMessages,
+  normalizeChatMessagesForPersistence,
+} from "./normalize-chat-messages";
 
 describe("normalizeChatMessages", () => {
   test("dedupes duplicate tool parts with the same toolCallId", () => {
@@ -272,5 +275,210 @@ describe("normalizeChatMessages empty-assistant dropping", () => {
     ];
 
     expect(normalizeChatMessages(messages)).toEqual(messages);
+  });
+});
+
+describe("normalizeChatMessagesForPersistence", () => {
+  const keep = (id: string) => ({
+    id,
+    role: "user" as const,
+    parts: [{ type: "text", text: "anchor" }],
+  });
+
+  test("drops an assistant turn with an empty parts array", () => {
+    const messages = [
+      keep("user1"),
+      { id: "assistant1", role: "assistant" as const, parts: [] },
+    ];
+
+    expect(
+      normalizeChatMessagesForPersistence(messages).map((m) => m.id),
+    ).toEqual(["user1"]);
+  });
+
+  test("drops an assistant turn with missing parts", () => {
+    const messages = [
+      keep("user1"),
+      { id: "assistant1", role: "assistant" as const },
+    ];
+
+    expect(
+      normalizeChatMessagesForPersistence(messages).map((m) => m.id),
+    ).toEqual(["user1"]);
+  });
+
+  test("drops an assistant turn with only empty/whitespace text", () => {
+    const messages = [
+      keep("user1"),
+      {
+        id: "assistant1",
+        role: "assistant" as const,
+        parts: [{ type: "text", text: "   " }],
+      },
+    ];
+
+    expect(
+      normalizeChatMessagesForPersistence(messages).map((m) => m.id),
+    ).toEqual(["user1"]);
+  });
+
+  test("drops an assistant turn with only step-start/telemetry parts", () => {
+    const messages = [
+      keep("user1"),
+      {
+        id: "assistant1",
+        role: "assistant" as const,
+        parts: [
+          { type: "step-start" },
+          { type: "data-token-usage", data: { totalTokens: 10 } },
+        ],
+      },
+    ];
+
+    expect(
+      normalizeChatMessagesForPersistence(messages).map((m) => m.id),
+    ).toEqual(["user1"]);
+  });
+
+  test("drops an assistant turn left with an orphaned data-tool-ui-start", () => {
+    // the marker's tool call never resolved — the looser normalize keeps the
+    // turn for live view, but it must not be persisted as an empty bubble.
+    const messages = [
+      keep("user1"),
+      {
+        id: "assistant1",
+        role: "assistant" as const,
+        parts: [
+          { type: "step-start" },
+          {
+            type: "data-tool-ui-start",
+            data: { toolCallId: "call_interrupted", toolName: "render_chart" },
+          },
+          {
+            type: "tool-render_chart",
+            toolCallId: "call_interrupted",
+            state: "input-streaming",
+            input: {},
+          },
+        ],
+      },
+    ];
+
+    expect(
+      normalizeChatMessagesForPersistence(messages).map((m) => m.id),
+    ).toEqual(["user1"]);
+  });
+
+  test("keeps an assistant turn with a completed tool result", () => {
+    const messages = [
+      keep("user1"),
+      {
+        id: "assistant1",
+        role: "assistant" as const,
+        parts: [
+          {
+            type: "tool-archestra__create_agent",
+            toolCallId: "call_ok",
+            state: "output-available",
+            output: "created",
+          },
+        ],
+      },
+    ];
+
+    expect(
+      normalizeChatMessagesForPersistence(messages).map((m) => m.id),
+    ).toEqual(["user1", "assistant1"]);
+  });
+
+  test("keeps an MCP-app marker only when paired with a completed tool part", () => {
+    const paired = {
+      id: "paired",
+      role: "assistant" as const,
+      parts: [
+        { type: "step-start" },
+        {
+          type: "data-tool-ui-start",
+          data: { toolCallId: "call_ok", toolName: "render_chart" },
+        },
+        {
+          type: "tool-render_chart",
+          toolCallId: "call_ok",
+          state: "output-available",
+          output: "rendered",
+        },
+      ],
+    };
+    // an MCP-app marker whose paired tool part never reached a terminal state
+    // (here it is only input-available, which normalize strips as dangling).
+    const unpaired = {
+      id: "unpaired",
+      role: "assistant" as const,
+      parts: [
+        { type: "step-start" },
+        {
+          type: "data-tool-ui-start",
+          data: { toolCallId: "call_pending", toolName: "render_chart" },
+        },
+        {
+          type: "tool-render_chart",
+          toolCallId: "call_pending",
+          state: "input-available",
+          input: {},
+        },
+      ],
+    };
+
+    const result = normalizeChatMessagesForPersistence([
+      keep("user1"),
+      paired,
+      unpaired,
+    ]);
+
+    expect(result.map((m) => m.id)).toEqual(["user1", "paired"]);
+  });
+
+  test("keeps an assistant turn whose only content is a generated image", () => {
+    // model-generated images (e.g. Gemini) are preserved for multi-turn image
+    // editing and must survive persistence.
+    const messages = [
+      keep("user1"),
+      {
+        id: "assistant1",
+        role: "assistant" as const,
+        parts: [
+          { type: "step-start" },
+          { type: "image", image: "data:image/png;base64,iVBOR..." },
+        ],
+      },
+    ];
+
+    expect(
+      normalizeChatMessagesForPersistence(messages).map((m) => m.id),
+    ).toEqual(["user1", "assistant1"]);
+  });
+
+  test("keeps an assistant turn that is still in approval-requested state", () => {
+    // a paused tool approval renders a prompt the user must answer — it is real
+    // content and must survive persistence (#4030).
+    const messages = [
+      keep("user1"),
+      {
+        id: "assistant1",
+        role: "assistant" as const,
+        parts: [
+          {
+            type: "tool-print_test",
+            toolCallId: "call_wait",
+            state: "approval-requested",
+            input: {},
+          },
+        ],
+      },
+    ];
+
+    expect(
+      normalizeChatMessagesForPersistence(messages).map((m) => m.id),
+    ).toEqual(["user1", "assistant1"]);
   });
 });

--- a/platform/backend/src/routes/chat/normalization/normalize-chat-messages.ts
+++ b/platform/backend/src/routes/chat/normalization/normalize-chat-messages.ts
@@ -1,4 +1,8 @@
-import { hasRenderableAssistantContent, stripDanglingToolCalls } from "@shared";
+import {
+  hasPersistableAssistantContent,
+  hasRenderableAssistantContent,
+  stripDanglingToolCalls,
+} from "@shared";
 import logger from "@/logging";
 import type { ChatMessage, ChatMessagePart } from "@/types";
 import { stripImagesFromMessages } from "./strip-images-from-messages";
@@ -13,6 +17,16 @@ export function normalizeChatMessages(messages: ChatMessage[]): ChatMessage[] {
       ),
     ),
   );
+}
+
+// Stricter normalization for the persist path: after the shared cleanup, drop
+// assistant turns that would reload as an empty bubble. The replay/model path
+// uses the looser `normalizeChatMessages` so live-streamed turns aren't blanked,
+// but only durably-renderable assistant turns should ever reach the DB.
+export function normalizeChatMessagesForPersistence(
+  messages: ChatMessage[],
+): ChatMessage[] {
+  return dropNonPersistableAssistantMessages(normalizeChatMessages(messages));
 }
 
 function dedupeToolPartsFromMessages(messages: ChatMessage[]): ChatMessage[] {
@@ -148,6 +162,33 @@ function dropEmptyAssistantMessages(messages: ChatMessage[]): ChatMessage[] {
     (message) =>
       message.role !== "assistant" || hasRenderableAssistantContent(message),
   );
+}
+
+// drops assistant turns that survive UI-renderability but would reload as an
+// empty bubble — e.g. a turn left with only a `data-tool-ui-start` whose tool
+// call never resolved, an unrecognized telemetry `data-*`, or `content: ""`.
+function dropNonPersistableAssistantMessages(
+  messages: ChatMessage[],
+): ChatMessage[] {
+  return messages.filter((message) => {
+    if (message.role !== "assistant") {
+      return true;
+    }
+
+    if (hasPersistableAssistantContent(message)) {
+      return true;
+    }
+
+    logger.warn(
+      {
+        messageId: message.id,
+        role: message.role,
+        partCount: message.parts?.length ?? 0,
+      },
+      "[normalizeChatMessages] Dropped non-persistable empty assistant message",
+    );
+    return false;
+  });
 }
 
 // matches both statically-typed `tool-<name>` parts and the `dynamic-tool`

--- a/platform/backend/src/routes/chat/routes.test.ts
+++ b/platform/backend/src/routes/chat/routes.test.ts
@@ -380,6 +380,72 @@ describe("prepareMessagesForProvider", () => {
   });
 });
 
+describe("buildModelMessagesForProvider", () => {
+  // ref-free messages never hit the attachment table, so these run without DB.
+  const conversationId = "conv-model-prep";
+
+  it("drops an assistant turn that converts to empty model content", async () => {
+    const modelMessages = await __test.buildModelMessagesForProvider({
+      provider: "openai",
+      conversationId,
+      messages: [
+        { role: "user", parts: [{ type: "text", text: "hi" }] },
+        {
+          // only provider-invisible parts — convertToModelMessages yields an
+          // assistant message with empty content here.
+          role: "assistant",
+          parts: [
+            { type: "step-start" },
+            {
+              type: "data-tool-ui-start",
+              data: { toolCallId: "call_x", toolName: "render_chart" },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(modelMessages.map((message) => message.role)).toEqual(["user"]);
+  });
+
+  it("keeps normal text and tool assistant turns", async () => {
+    const modelMessages = await __test.buildModelMessagesForProvider({
+      provider: "openai",
+      conversationId,
+      messages: [
+        { role: "user", parts: [{ type: "text", text: "search please" }] },
+        {
+          role: "assistant",
+          parts: [
+            { type: "step-start" },
+            {
+              type: "tool-search",
+              toolCallId: "call_ok",
+              toolName: "search",
+              state: "output-available",
+              input: { q: "query" },
+              output: { hits: [] },
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          parts: [{ type: "text", text: "Here are the results." }],
+        },
+      ],
+    });
+
+    const assistantMessages = modelMessages.filter(
+      (message) => message.role === "assistant",
+    );
+    // the tool-call turn and the text turn both survive.
+    expect(assistantMessages.length).toBeGreaterThanOrEqual(2);
+    expect(assistantMessages.at(-1)?.content).toContainEqual(
+      expect.objectContaining({ type: "text", text: "Here are the results." }),
+    );
+  });
+});
+
 describe("getMessagesNotYetPersisted", () => {
   it("keeps new messages even when the incoming thread is shorter than the persisted thread", () => {
     const newMessages = __test.getMessagesNotYetPersisted({

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -118,7 +118,10 @@ import { injectSkillActivation } from "./inject-skill-activation";
 import { cloneAttachmentsForFork } from "./normalization/clone-attachments-for-fork";
 import { extractInlineAttachments } from "./normalization/extract-inline-attachments";
 import { materializeAttachments } from "./normalization/materialize-attachments";
-import { normalizeChatMessages } from "./normalization/normalize-chat-messages";
+import {
+  normalizeChatMessages,
+  normalizeChatMessagesForPersistence,
+} from "./normalization/normalize-chat-messages";
 import {
   isRetryableEmptyFinishReason,
   probeFirstRenderableEvent,
@@ -2630,9 +2633,11 @@ async function persistNewMessages(
 
       if (messagesToSave.length > 0) {
         // Strip base64 images / large tool results and drop assistant turns left
-        // non-renderable (e.g. only a dangling tool call) — persisting one of
-        // those yields a stuck-looking empty bubble on reload.
-        const messagesToStore = normalizeChatMessages(messagesToSave);
+        // non-renderable (e.g. only a dangling tool call, an unpaired MCP-app
+        // marker, or empty/telemetry-only parts) — persisting one of those
+        // yields a stuck-looking empty bubble on reload.
+        const messagesToStore =
+          normalizeChatMessagesForPersistence(messagesToSave);
 
         if (context === "onFinish") {
           // Log size reduction only for onFinish (where we have complete messages)
@@ -2970,9 +2975,47 @@ async function buildModelMessagesForProvider(params: {
   });
 
   // Cast to UIMessage[] - ChatMessage is structurally compatible at runtime.
-  return await convertToModelMessages(
+  const modelMessages = await convertToModelMessages(
     providerPreparedMessages as unknown as Omit<UIMessage, "id">[],
   );
+
+  // convertToModelMessages can split an assistant turn at `step-start` and drop
+  // provider-invisible parts (data-*, tool-ui-start), yielding an assistant
+  // message with empty content that some providers reject. Drop those here —
+  // after Bedrock's `(no content)` padding above, so its intentional
+  // placeholders survive while other providers never see an empty turn. An
+  // empty assistant message has no tool-call block, so removing it cannot
+  // orphan a tool result.
+  return modelMessages.filter(
+    (message) => !isEmptyAssistantModelMessage(message),
+  );
+}
+
+function isEmptyAssistantModelMessage(message: {
+  role: string;
+  content: unknown;
+}): boolean {
+  if (message.role !== "assistant") {
+    return false;
+  }
+
+  const { content } = message;
+  if (typeof content === "string") {
+    return content.trim().length === 0;
+  }
+
+  if (Array.isArray(content)) {
+    // empty, or only blank text parts — any tool-call/file/reasoning part is
+    // real provider-visible content and keeps the message.
+    return content.every(
+      (part) =>
+        part?.type === "text" &&
+        (typeof part.text !== "string" || part.text.trim().length === 0),
+    );
+  }
+
+  // unknown content shape: keep, to avoid dropping something the provider needs.
+  return false;
 }
 
 function normalizeAnthropicMessageFileParts(message: ChatMessage): ChatMessage {
@@ -3409,6 +3452,7 @@ async function validateChatApiKeyAccess(
 }
 
 export const __test = {
+  buildModelMessagesForProvider,
   getMessagesNotYetPersisted,
   getMessagesWithChangedContent,
   persistNewMessages,

--- a/platform/shared/chat.test.ts
+++ b/platform/shared/chat.test.ts
@@ -3,6 +3,7 @@ import {
   getAcceptedFileTypes,
   getMediaType,
   getSupportedFileTypesDescription,
+  hasPersistableAssistantContent,
   INPUT_MODALITY_OPTIONS,
   OUTPUT_MODALITY_OPTIONS,
   supportsFileUploads,
@@ -89,5 +90,42 @@ describe("chat file upload helpers", () => {
       "image",
       "audio",
     ]);
+  });
+});
+
+describe("hasPersistableAssistantContent", () => {
+  test("keeps assistant turns carrying renderable content", () => {
+    expect(
+      hasPersistableAssistantContent({
+        parts: [{ type: "text", text: "hello" }],
+      }),
+    ).toBe(true);
+  });
+
+  test("drops empty turns", () => {
+    expect(hasPersistableAssistantContent({})).toBe(false);
+    expect(hasPersistableAssistantContent({ parts: [] })).toBe(false);
+    expect(
+      hasPersistableAssistantContent({ parts: [{ type: "text", text: "  " }] }),
+    ).toBe(false);
+  });
+
+  // read-path callers pass historical JSON that is only cast, so malformed
+  // rows must be treated as empty rather than throwing and failing the load.
+  test("tolerates malformed persisted parts without throwing", () => {
+    const malformed = [
+      { parts: {} },
+      { parts: [{}] },
+      { parts: [null] },
+      { parts: [{ type: 42 }] },
+      { parts: "not-an-array" },
+    ];
+    for (const message of malformed) {
+      expect(
+        hasPersistableAssistantContent(
+          message as Parameters<typeof hasPersistableAssistantContent>[0],
+        ),
+      ).toBe(false);
+    }
   });
 });

--- a/platform/shared/chat.ts
+++ b/platform/shared/chat.ts
@@ -124,7 +124,9 @@ export function hasPersistableAssistantContent(message: {
   parts?: ReadonlyArray<AssistantContentPart>;
 }): boolean {
   const parts = message.parts;
-  if (!parts || parts.length === 0) {
+  // read-path callers pass historical JSON that is only cast, so reject any
+  // shape that is not an array of `type`-tagged parts before inspecting it.
+  if (!Array.isArray(parts) || parts.length === 0) {
     return false;
   }
 
@@ -136,6 +138,10 @@ export function hasPersistableAssistantContent(message: {
   }
 
   return parts.some((part) => {
+    if (typeof part?.type !== "string") {
+      return false;
+    }
+
     if (part.type === "text" || part.type === "reasoning") {
       return typeof part.text === "string" && part.text.trim().length > 0;
     }
@@ -175,6 +181,9 @@ export function hasPersistableAssistantContent(message: {
 }
 
 function isTerminalToolPart(part: AssistantContentPart): boolean {
+  if (typeof part?.type !== "string") {
+    return false;
+  }
   if (part.type === "tool-result") {
     return true;
   }

--- a/platform/shared/chat.ts
+++ b/platform/shared/chat.ts
@@ -86,6 +86,107 @@ export function hasRenderableAssistantContent(message: {
   });
 }
 
+// Tool states that survive normalization and render durably: a result, an
+// error, a denial, or an approval prompt/answer. A tool part in any of these
+// is real assistant content. Excludes `input-streaming`/`input-available` and
+// bare `tool-call` parts — those are pending/dangling and get stripped before
+// persistence.
+const TERMINAL_TOOL_PART_STATES: ReadonlySet<string> = new Set([
+  "output-available",
+  "output-error",
+  "output-denied",
+  "approval-requested",
+  "approval-responded",
+]);
+
+type AssistantContentPart = {
+  type: string;
+  text?: unknown;
+  state?: unknown;
+  toolCallId?: unknown;
+  data?: unknown;
+};
+
+/**
+ * Strict counterpart to {@link hasRenderableAssistantContent} for the persist
+ * and read paths. Unlike the UI predicate (which keeps any unknown non-text
+ * part so live streaming never blanks out), this fails safe toward *dropping*:
+ * an assistant message is persistable only when it carries content that still
+ * renders after a reload — non-empty text, reasoning, a file/image/source, a terminal
+ * tool part, or a `data-tool-ui-start` MCP-app marker paired with a terminal
+ * tool part in the same message. Everything else (no parts, `parts: []`,
+ * `content: ""`, whitespace-only text, only `step-start`/telemetry `data-*`, or
+ * an unpaired marker) is an empty bubble and must not be stored or shown.
+ * Structurally typed so backend `ChatMessagePart`s and the frontend's AI SDK
+ * `UIMessage` parts both satisfy it.
+ */
+export function hasPersistableAssistantContent(message: {
+  parts?: ReadonlyArray<AssistantContentPart>;
+}): boolean {
+  const parts = message.parts;
+  if (!parts || parts.length === 0) {
+    return false;
+  }
+
+  const terminalToolCallIds = new Set<string>();
+  for (const part of parts) {
+    if (isTerminalToolPart(part) && typeof part.toolCallId === "string") {
+      terminalToolCallIds.add(part.toolCallId);
+    }
+  }
+
+  return parts.some((part) => {
+    if (part.type === "text" || part.type === "reasoning") {
+      return typeof part.text === "string" && part.text.trim().length > 0;
+    }
+
+    // `image` covers model-generated images (e.g. Gemini image generation),
+    // which the image-stripping normalizer deliberately preserves on assistant
+    // turns for multi-turn image editing.
+    if (
+      part.type === "file" ||
+      part.type === "image" ||
+      part.type.startsWith("source")
+    ) {
+      return true;
+    }
+
+    if (isTerminalToolPart(part)) {
+      return true;
+    }
+
+    // an MCP-app marker only counts when its tool call actually resolved —
+    // an orphaned marker reloads as a perpetually running tool, i.e. an empty
+    // bubble.
+    if (part.type.startsWith("data-tool-ui-start")) {
+      const toolCallId =
+        typeof part.data === "object" &&
+        part.data !== null &&
+        "toolCallId" in part.data
+          ? (part.data as { toolCallId?: unknown }).toolCallId
+          : undefined;
+      return (
+        typeof toolCallId === "string" && terminalToolCallIds.has(toolCallId)
+      );
+    }
+
+    return false;
+  });
+}
+
+function isTerminalToolPart(part: AssistantContentPart): boolean {
+  if (part.type === "tool-result") {
+    return true;
+  }
+  const isToolPart =
+    part.type.startsWith("tool-") || part.type === "dynamic-tool";
+  return (
+    isToolPart &&
+    typeof part.state === "string" &&
+    TERMINAL_TOOL_PART_STATES.has(part.state)
+  );
+}
+
 /**
  * The skill a user explicitly invoked via slash command, carried on the user
  * message's metadata. The backend uses it to inject the skill's activation


### PR DESCRIPTION
## Problem

Empty assistant bubbles were being persisted and kept rendering after refresh. The existing UI renderability predicate fails safe toward *keeping* (any unknown non-text part counts as content), so assistant turns with no durable content — `parts: []`, missing parts, `content: ""`, whitespace-only text, telemetry-only `data-*`, or an unpaired `data-tool-ui-start` MCP-app marker — slipped into the DB. `convertToModelMessages()` could also emit `content: []` assistant messages for the provider.

## Changes

- **Strict predicate** (`shared/chat.ts`): new `hasPersistableAssistantContent()`, a sibling of the UI predicate that fails safe toward *dropping*. Keeps only durable content — non-empty text, reasoning, file/image/source, a terminal tool part (`output-*`/`approval-*`/`tool-result`), or a `data-tool-ui-start` paired with a terminal tool part. Model-generated images and `approval-requested` turns are preserved.
- **Persist path**: `normalizeChatMessagesForPersistence()` drops non-renderable assistant turns before they reach the DB; used by `persistNewMessages()`.
- **Read path** (`models/conversation.ts`): filters already-persisted empty assistant rows on read in `findById`/`findByIdInOrganization`/search. Read-only — no DB rows deleted.
- **Model prep**: drops empty/whitespace-only assistant messages after `convertToModelMessages()`, after Bedrock's `(no content)` padding so its placeholders survive.

## Tests

- Persist normalization: drops `parts: []` / missing parts / empty text / telemetry-only / orphaned marker; keeps tool result, paired-marker-only, approval-requested, generated-image.
- Conversation read path filters persisted empty assistant rows.
- Model prep drops empty-converting turns and keeps normal text/tool turns.

The UI live-view predicate is intentionally left unchanged so streaming never blanks out.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>