### PR TITLE
feat: add sorting hat MCP server and patronus authorization

### DIFF
--- a/docs/pages/sorting-your-mcp-tools.md
+++ b/docs/pages/sorting-your-mcp-tools.md
@@ -1,0 +1,24 @@
+# Sorting your MCP tools
+
+Sorting Hat MCP adds a first-party authorization step for MCP tool calls. It sorts each tool into a house from the tool name and description, casts the user's Patronus, and only forwards the call when the house-specific authorization rules pass.
+
+## Sorting prompt
+
+The Sorting Hat stream should speak in short partial events so the chat UI can render the monologue token by token:
+
+```text
+A thread of intent, a glimmer of might,
+I weigh {tool_name} by risk and light,
+Where purpose and peril both start to sing,
+I name {house} for this tool-call thing.
+```
+
+Clients can pass the `please_not_slytherin` request header when the user whispers a house preference. The server still evaluates risk first, then shifts a Slytherin result to Ravenclaw with reduced confidence.
+
+## Authorization
+
+- `sorting_hat.sort(tool_name, tool_description)` returns `{ house, confidence }`.
+- `patronus.cast(user_id, "expecto_patronum")` returns a stable `{ form, corporeal }` result for the same user id.
+- Slytherin-sorted tools require a corporeal Patronus.
+- Gryffindor-sorted tools can use the Golden Snitch loader by subscribing to `quidditch.stream(tool_call_id)`.
+- Successful tool calls can use `floo.travel(from_server, to_server, payload)` to carry green flame particle metadata alongside the proxied payload.

--- a/platform/frontend/src/app/settings/account/_components/patronus-picker.tsx
+++ b/platform/frontend/src/app/settings/account/_components/patronus-picker.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { SettingsCardHeader } from "@/components/settings/settings-block";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+const PATRONUS_STORAGE_KEY = "archestra-patronus-form";
+const PATRONUS_FORMS = ["otter", "stag", "doe", "hare", "lynx", "swan"];
+
+export function PatronusPicker() {
+  const [selectedForm, setSelectedForm] = useState(PATRONUS_FORMS[0]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(PATRONUS_STORAGE_KEY);
+    if (stored && PATRONUS_FORMS.includes(stored)) {
+      setSelectedForm(stored);
+    }
+  }, []);
+
+  const path = useMemo(() => getPatronusPath(selectedForm), [selectedForm]);
+
+  const handleSelect = (form: string) => {
+    setSelectedForm(form);
+    localStorage.setItem(PATRONUS_STORAGE_KEY, form);
+  };
+
+  return (
+    <Card>
+      <SettingsCardHeader
+        title="Patronus"
+        description="Choose the Patronus form shown during governed MCP tool authorization."
+      />
+      <CardContent className="space-y-4">
+        <div className="flex items-center gap-4">
+          <div className="relative grid size-20 shrink-0 place-items-center overflow-hidden rounded-md border bg-muted/40">
+            <div className="absolute h-12 w-12 animate-ping rounded-full bg-primary/15" />
+            <svg
+              aria-label={`${selectedForm} Patronus animation`}
+              className="relative h-12 w-12 text-primary drop-shadow"
+              viewBox="0 0 64 64"
+            >
+              <path d={path} fill="currentColor" opacity="0.9" />
+            </svg>
+          </div>
+          <div className="grid flex-1 grid-cols-2 gap-2 sm:grid-cols-3">
+            {PATRONUS_FORMS.map((form) => (
+              <Button
+                key={form}
+                type="button"
+                variant={selectedForm === form ? "default" : "outline"}
+                className={cn("justify-center capitalize")}
+                onClick={() => handleSelect(form)}
+              >
+                {form}
+              </Button>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function getPatronusPath(form: string): string {
+  switch (form) {
+    case "stag":
+      return "M11 42c8-18 15-21 25-15l9-12 2 14 10-1-8 8c3 9-1 16-10 17-8 1-14-3-18-11l-8 7-2-7Z";
+    case "doe":
+      return "M10 43c7-16 17-21 30-13l8-8 1 11 8 1-8 6c0 9-6 14-15 14-8 0-13-4-16-12l-6 6-2-5Z";
+    case "hare":
+      return "M9 43c6-10 15-12 24-8l11-24 1 25 12-7-8 15c-5 9-16 11-26 7l-9 6-5-14Z";
+    case "lynx":
+      return "M10 42c8-13 19-17 31-11l4-13 5 12 8-2-6 10c3 12-7 20-22 18-10-2-16-6-20-14Z";
+    case "swan":
+      return "M8 43c12 7 25 5 34-6 5-6 1-14-5-11-4 2-4 8 1 11-12 2-20-2-24-10 4 2 8 3 12 1-5 9-11 14-18 15Z";
+    default:
+      return "M9 42c7-15 18-20 31-12l8-9 1 12 8 2-8 6c0 10-8 15-20 14-9-1-16-5-20-13Z";
+  }
+}

--- a/platform/frontend/src/app/settings/account/page.tsx
+++ b/platform/frontend/src/app/settings/account/page.tsx
@@ -6,6 +6,7 @@ import { Suspense, useEffect, useMemo, useState } from "react";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
 import { ChangePasswordDialog } from "@/app/settings/account/_components/change-password-dialog";
 import { LightDarkToggle } from "@/app/settings/account/_components/light-dark-toggle";
+import { PatronusPicker } from "@/app/settings/account/_components/patronus-picker";
 import { useSetSettingsAction } from "@/app/settings/layout";
 import { LoadingSpinner } from "@/components/loading";
 import { PersonalTokenCard } from "@/components/settings/personal-token-card";
@@ -52,6 +53,7 @@ function AccountSettingsContent() {
       <SettingsSectionStack>
         <RolePermissionsCard />
         <PersonalTokenCard />
+        <PatronusPicker />
         {organization?.showTwoFactor && (
           <TwoFactorCard classNames={{ base: "w-full" }} />
         )}

--- a/platform/frontend/src/app/themes.css
+++ b/platform/frontend/src/app/themes.css
@@ -2415,3 +2415,88 @@ html.dark.theme-moonlight-dark {
   --shadow-2xl: 0 2px 4px 0px hsl(0 0% 0% / 0.40);
   --tracking-normal: 0em;
 }
+
+/* Forbidden Forest */
+html.theme-forbidden-forest {
+  --background: oklch(0.97 0.018 145);
+  --foreground: oklch(0.24 0.035 145);
+  --card: oklch(0.99 0.012 145);
+  --card-foreground: oklch(0.24 0.035 145);
+  --popover: oklch(0.99 0.012 145);
+  --popover-foreground: oklch(0.24 0.035 145);
+  --primary: oklch(0.43 0.13 145);
+  --primary-foreground: oklch(0.98 0.015 145);
+  --secondary: oklch(0.91 0.035 140);
+  --secondary-foreground: oklch(0.25 0.04 145);
+  --muted: oklch(0.92 0.025 145);
+  --muted-foreground: oklch(0.45 0.035 145);
+  --accent: oklch(0.86 0.055 120);
+  --accent-foreground: oklch(0.25 0.04 145);
+  --destructive: oklch(0.58 0.2 28);
+  --destructive-foreground: oklch(0.98 0.015 145);
+  --border: oklch(0.82 0.035 145);
+  --input: oklch(0.86 0.03 145);
+  --ring: oklch(0.5 0.13 145);
+  --chart-1: oklch(0.45 0.13 145);
+  --chart-2: oklch(0.58 0.12 115);
+  --chart-3: oklch(0.52 0.1 185);
+  --chart-4: oklch(0.64 0.14 75);
+  --chart-5: oklch(0.5 0.12 35);
+  --radius: 0.5rem;
+  --sidebar: oklch(0.93 0.025 145);
+  --sidebar-foreground: oklch(0.24 0.035 145);
+  --sidebar-primary: oklch(0.43 0.13 145);
+  --sidebar-primary-foreground: oklch(0.98 0.015 145);
+  --sidebar-accent: oklch(0.86 0.055 120);
+  --sidebar-accent-foreground: oklch(0.25 0.04 145);
+  --sidebar-border: oklch(0.82 0.035 145);
+  --sidebar-ring: oklch(0.5 0.13 145);
+  --font-sans: var(--font-inter);
+  --font-serif: Merriweather, serif;
+  --font-mono: var(--font-jetbrains-mono);
+  --letter-spacing: 0em;
+  --spacing: 0.25rem;
+  --tracking-normal: 0em;
+}
+
+html.dark.theme-forbidden-forest {
+  --background: oklch(0.18 0.028 145);
+  --foreground: oklch(0.9 0.035 125);
+  --card: oklch(0.21 0.03 145);
+  --card-foreground: oklch(0.9 0.035 125);
+  --popover: oklch(0.2 0.03 145);
+  --popover-foreground: oklch(0.92 0.035 125);
+  --primary: oklch(0.72 0.14 130);
+  --primary-foreground: oklch(0.16 0.03 145);
+  --secondary: oklch(0.29 0.04 145);
+  --secondary-foreground: oklch(0.88 0.03 125);
+  --muted: oklch(0.27 0.032 145);
+  --muted-foreground: oklch(0.72 0.03 125);
+  --accent: oklch(0.35 0.07 125);
+  --accent-foreground: oklch(0.94 0.03 125);
+  --destructive: oklch(0.62 0.22 28);
+  --destructive-foreground: oklch(0.98 0.015 145);
+  --border: oklch(0.34 0.035 145);
+  --input: oklch(0.32 0.035 145);
+  --ring: oklch(0.72 0.14 130);
+  --chart-1: oklch(0.72 0.14 130);
+  --chart-2: oklch(0.58 0.12 175);
+  --chart-3: oklch(0.78 0.12 85);
+  --chart-4: oklch(0.66 0.13 45);
+  --chart-5: oklch(0.7 0.11 210);
+  --radius: 0.5rem;
+  --sidebar: oklch(0.16 0.028 145);
+  --sidebar-foreground: oklch(0.9 0.035 125);
+  --sidebar-primary: oklch(0.72 0.14 130);
+  --sidebar-primary-foreground: oklch(0.16 0.03 145);
+  --sidebar-accent: oklch(0.29 0.04 145);
+  --sidebar-accent-foreground: oklch(0.9 0.035 125);
+  --sidebar-border: oklch(0.32 0.035 145);
+  --sidebar-ring: oklch(0.72 0.14 130);
+  --font-sans: var(--font-inter);
+  --font-serif: Merriweather, serif;
+  --font-mono: var(--font-jetbrains-mono);
+  --letter-spacing: 0em;
+  --spacing: 0.25rem;
+  --tracking-normal: 0em;
+}

--- a/platform/frontend/src/components/ai-elements/golden-snitch-loader.tsx
+++ b/platform/frontend/src/components/ai-elements/golden-snitch-loader.tsx
@@ -1,0 +1,50 @@
+import type { HTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+
+export type GoldenSnitchLoaderProps = HTMLAttributes<HTMLDivElement> & {
+  size?: number;
+};
+
+export function GoldenSnitchLoader({
+  className,
+  size = 18,
+  ...props
+}: GoldenSnitchLoaderProps) {
+  return (
+    <div
+      className={cn(
+        "relative inline-flex items-center justify-center text-amber-500",
+        className,
+      )}
+      style={{ width: size, height: size }}
+      aria-label="Golden Snitch loader"
+      {...props}
+    >
+      <span className="absolute h-1.5 w-5 animate-pulse rounded-full bg-current opacity-30" />
+      <svg
+        aria-hidden="true"
+        className="relative animate-spin"
+        height={size}
+        viewBox="0 0 24 24"
+        width={size}
+      >
+        <path
+          d="M9 12c-2.6-2.4-5.1-3.3-7.5-2.7 2.1 1.4 3.8 3 5.1 4.9"
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeWidth="1.7"
+        />
+        <path
+          d="M15 12c2.6-2.4 5.1-3.3 7.5-2.7-2.1 1.4-3.8 3-5.1 4.9"
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeWidth="1.7"
+        />
+        <circle cx="12" cy="12" fill="currentColor" r="3.2" />
+        <circle cx="11" cy="10.8" fill="white" opacity="0.55" r="0.8" />
+      </svg>
+    </div>
+  );
+}

--- a/platform/frontend/src/components/ai-elements/tool.tsx
+++ b/platform/frontend/src/components/ai-elements/tool.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import { CodeBlock } from "./code-block";
+import { GoldenSnitchLoader } from "./golden-snitch-loader";
 
 export type ToolProps = ComponentProps<typeof Collapsible>;
 
@@ -63,6 +64,7 @@ export type ToolHeaderProps = {
   state: ToolUIPart["state"] | "output-available-dual-llm" | "output-denied";
   className?: string;
   icon?: React.ReactNode;
+  sortingHouse?: "gryffindor" | "slytherin" | "ravenclaw" | "hufflepuff" | null;
   isCollapsible?: boolean;
   /** Optional action button to display in the header (e.g., View Logs) */
   actionButton?: React.ReactNode;
@@ -70,6 +72,7 @@ export type ToolHeaderProps = {
 
 const getStatusBadge = (
   status: ToolUIPart["state"] | "output-available-dual-llm" | "output-denied",
+  sortingHouse?: ToolHeaderProps["sortingHouse"],
 ) => {
   const labels = {
     "input-streaming": "Pending",
@@ -84,7 +87,12 @@ const getStatusBadge = (
 
   const icons = {
     "input-streaming": <CircleIcon className="size-4" />,
-    "input-available": <ClockIcon className="size-4 animate-pulse" />,
+    "input-available":
+      sortingHouse === "gryffindor" ? (
+        <GoldenSnitchLoader size={16} />
+      ) : (
+        <ClockIcon className="size-4 animate-pulse" />
+      ),
     "approval-requested": <ClockIcon className="size-4 text-yellow-600" />,
     "approval-responded": <CheckCircleIcon className="size-4 text-blue-600" />,
     "output-available": <CheckCircleIcon className="size-4 text-green-600" />,
@@ -109,6 +117,7 @@ export const ToolHeader = ({
   type,
   state,
   icon,
+  sortingHouse,
   isCollapsible = true,
   actionButton,
   ...props
@@ -127,7 +136,7 @@ export const ToolHeader = ({
         <span className="font-medium text-sm">
           {title ?? type.split("-").slice(1).join("-")}
         </span>
-        {getStatusBadge(state)}
+        {getStatusBadge(state, sortingHouse)}
       </div>
     </div>
     {actionButton && (

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -73,6 +73,7 @@ import {
   getToolHeaderState,
   getToolNameFromPart,
 } from "@/lib/chat/chat-tools-display.utils";
+import { getSortingHatHouse } from "@/lib/chat/sorting-hat";
 import { PERSISTED_MESSAGE_ID_METADATA_KEY } from "@/lib/chat/chat-utils";
 import { useGlobalChat } from "@/lib/chat/global-chat.context";
 import {
@@ -1668,6 +1669,7 @@ const MessageTool = memo(
     // Use the text content string when available; fall back to the raw output for non-MCP tools.
     const output = mcpOutput?.content ?? rawOutput;
     const errorText = getToolErrorText({ part, toolResultPart });
+    const sortingHouse = getSortingHatHouse(rawOutput);
 
     const isApprovalRequested = part.state === "approval-requested";
     const isToolDenied = part.state === "output-denied";
@@ -1867,6 +1869,7 @@ const MessageTool = memo(
                     toolResultPart,
                     errorText,
                   })}
+                  sortingHouse={sortingHouse}
                   isCollapsible={!!hasInput}
                 />
                 <ToolContent>
@@ -1924,6 +1927,7 @@ const MessageTool = memo(
             toolResultPart,
             errorText,
           })}
+          sortingHouse={sortingHouse}
           isCollapsible={isExpandable}
           actionButton={logsButton}
         />

--- a/platform/frontend/src/components/chat/compact-tool-call.tsx
+++ b/platform/frontend/src/components/chat/compact-tool-call.tsx
@@ -4,6 +4,7 @@ import { ARCHESTRA_MCP_CATALOG_ID, parseFullToolName } from "@shared";
 import type { DynamicToolUIPart, ToolUIPart } from "ai";
 import { BotIcon, CheckCircleIcon, ClockIcon } from "lucide-react";
 import { useState } from "react";
+import { GoldenSnitchLoader } from "@/components/ai-elements/golden-snitch-loader";
 import {
   Tool,
   ToolContent,
@@ -23,6 +24,10 @@ import {
   getCompactToolState,
   getToolHeaderState,
 } from "@/lib/chat/chat-tools-display.utils";
+import {
+  getSortingHatHouse,
+  type SortingHatHouse,
+} from "@/lib/chat/sorting-hat";
 import { useArchestraMcpIdentity } from "@/lib/mcp/archestra-mcp-server";
 import { cn } from "@/lib/utils";
 import {
@@ -49,6 +54,7 @@ function CompactCircle({
   onClick,
   icon,
   catalogId,
+  sortingHouse,
 }: {
   toolName: string;
   state: "running" | "completed" | "error";
@@ -57,7 +63,10 @@ function CompactCircle({
   onClick: () => void;
   icon?: string | null;
   catalogId?: string;
+  sortingHouse?: SortingHatHouse | null;
 }) {
+  const showSnitch = state === "running" && sortingHouse === "gryffindor";
+
   return (
     <TooltipProvider delayDuration={200}>
       <Tooltip>
@@ -81,14 +90,21 @@ function CompactCircle({
             ) : (
               <BotIcon className="size-3.5 text-muted-foreground" />
             )}
-            <span
-              className={cn(
-                "absolute -bottom-0.5 -right-0.5 size-2.5 rounded-full border-2 border-background",
-                state === "completed" && "bg-green-500",
-                state === "running" && "bg-blue-500 animate-pulse",
-                state === "error" && "bg-destructive",
-              )}
-            />
+            {showSnitch ? (
+              <GoldenSnitchLoader
+                className="absolute -bottom-1 -right-1"
+                size={14}
+              />
+            ) : (
+              <span
+                className={cn(
+                  "absolute -bottom-0.5 -right-0.5 size-2.5 rounded-full border-2 border-background",
+                  state === "completed" && "bg-green-500",
+                  state === "running" && "bg-blue-500 animate-pulse",
+                  state === "error" && "bg-destructive",
+                )}
+              />
+            )}
           </button>
         </TooltipTrigger>
         <TooltipContent side="top" className="text-xs">
@@ -142,6 +158,9 @@ export function CompactToolGroup({
           const fallbackCatalogId =
             iconInfo?.catalogId ??
             (isToolName(tool.toolName) ? ARCHESTRA_MCP_CATALOG_ID : undefined);
+          const sortingHouse = getSortingHatHouse(
+            tool.toolResultPart?.output ?? tool.part.output,
+          );
           return (
             <CompactCircle
               key={tool.key}
@@ -155,6 +174,7 @@ export function CompactToolGroup({
               onClick={() => handleToggle(tool.key)}
               icon={iconInfo?.icon}
               catalogId={fallbackCatalogId}
+              sortingHouse={sortingHouse}
             />
           );
         })}
@@ -202,12 +222,14 @@ function ExpandedToolCard({
     toolResultPart,
     errorText,
   });
+  const sortingHouse = getSortingHatHouse(toolResultPart?.output ?? part.output);
 
   return (
     <Tool defaultOpen={true}>
       <ToolHeader
         type={`tool-${toolName}`}
         state={headerState}
+        sortingHouse={sortingHouse}
         isCollapsible={hasContent}
         actionButton={logsButton}
       />

--- a/platform/frontend/src/lib/chat/sorting-hat.test.ts
+++ b/platform/frontend/src/lib/chat/sorting-hat.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { getSortingHatHouse } from "./sorting-hat";
+
+describe("getSortingHatHouse", () => {
+  it("reads Sorting Hat house from MCP metadata", () => {
+    expect(
+      getSortingHatHouse({
+        _meta: {
+          sortingHat: {
+            house: "gryffindor",
+          },
+        },
+      }),
+    ).toBe("gryffindor");
+  });
+
+  it("reads snake_case Sorting Hat metadata", () => {
+    expect(
+      getSortingHatHouse({
+        structuredContent: {
+          sorting_hat: {
+            house: "Slytherin",
+          },
+        },
+      }),
+    ).toBe("slytherin");
+  });
+
+  it("ignores unknown houses", () => {
+    expect(getSortingHatHouse({ house: "ministry" })).toBeNull();
+  });
+});

--- a/platform/frontend/src/lib/chat/sorting-hat.ts
+++ b/platform/frontend/src/lib/chat/sorting-hat.ts
@@ -1,0 +1,46 @@
+export type SortingHatHouse =
+  | "gryffindor"
+  | "slytherin"
+  | "ravenclaw"
+  | "hufflepuff";
+
+const HOUSES = new Set<SortingHatHouse>([
+  "gryffindor",
+  "slytherin",
+  "ravenclaw",
+  "hufflepuff",
+]);
+
+export function getSortingHatHouse(value: unknown): SortingHatHouse | null {
+  const candidates = [
+    readPath(value, ["_meta", "sortingHat", "house"]),
+    readPath(value, ["_meta", "sorting_hat", "house"]),
+    readPath(value, ["structuredContent", "sortingHat", "house"]),
+    readPath(value, ["structuredContent", "sorting_hat", "house"]),
+    readPath(value, ["sortingHat", "house"]),
+    readPath(value, ["sorting_hat", "house"]),
+    readPath(value, ["house"]),
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === "string") {
+      const normalized = candidate.toLowerCase();
+      if (HOUSES.has(normalized as SortingHatHouse)) {
+        return normalized as SortingHatHouse;
+      }
+    }
+  }
+
+  return null;
+}
+
+function readPath(value: unknown, path: string[]): unknown {
+  let current = value;
+  for (const key of path) {
+    if (!current || typeof current !== "object" || !(key in current)) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}

--- a/platform/pnpm-workspace.yaml
+++ b/platform/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - "backend"
   - "frontend"
   - "shared"
+  - "sorting-hat-mcp"
   - "archestra-rs/sandbox-rs"
   - "e2e-tests"
 

--- a/platform/shared/themes/theme-config.ts
+++ b/platform/shared/themes/theme-config.ts
@@ -31,6 +31,7 @@ export const SUPPORTED_THEMES = [
   "dracula-dark",
   "monokai-dark",
   "moonlight-dark",
+  "forbidden-forest",
 ] as const;
 
 /**

--- a/platform/shared/themes/tweakcn-themes.json
+++ b/platform/shared/themes/tweakcn-themes.json
@@ -5642,6 +5642,110 @@
           "tracking-normal": "0em"
         }
       }
+    },
+    {
+      "name": "forbidden-forest",
+      "type": "registry:style",
+      "title": "Forbidden Forest",
+      "description": "A dark green theme variant for Sorting Hat governed tool calls.",
+      "css": {
+        "@layer base": {
+          "body": {
+            "letter-spacing": "var(--tracking-normal)"
+          }
+        }
+      },
+      "cssVars": {
+        "theme": {
+          "font-sans": "Inter, sans-serif",
+          "font-mono": "JetBrains Mono, monospace",
+          "font-serif": "Merriweather, serif",
+          "radius": "0.5rem",
+          "tracking-normal": "0em"
+        },
+        "light": {
+          "background": "oklch(0.97 0.018 145)",
+          "foreground": "oklch(0.24 0.035 145)",
+          "card": "oklch(0.99 0.012 145)",
+          "card-foreground": "oklch(0.24 0.035 145)",
+          "popover": "oklch(0.99 0.012 145)",
+          "popover-foreground": "oklch(0.24 0.035 145)",
+          "primary": "oklch(0.43 0.13 145)",
+          "primary-foreground": "oklch(0.98 0.015 145)",
+          "secondary": "oklch(0.91 0.035 140)",
+          "secondary-foreground": "oklch(0.25 0.04 145)",
+          "muted": "oklch(0.92 0.025 145)",
+          "muted-foreground": "oklch(0.45 0.035 145)",
+          "accent": "oklch(0.86 0.055 120)",
+          "accent-foreground": "oklch(0.25 0.04 145)",
+          "destructive": "oklch(0.58 0.2 28)",
+          "destructive-foreground": "oklch(0.98 0.015 145)",
+          "border": "oklch(0.82 0.035 145)",
+          "input": "oklch(0.86 0.03 145)",
+          "ring": "oklch(0.5 0.13 145)",
+          "chart-1": "oklch(0.45 0.13 145)",
+          "chart-2": "oklch(0.58 0.12 115)",
+          "chart-3": "oklch(0.52 0.1 185)",
+          "chart-4": "oklch(0.64 0.14 75)",
+          "chart-5": "oklch(0.5 0.12 35)",
+          "radius": "0.5rem",
+          "sidebar": "oklch(0.93 0.025 145)",
+          "sidebar-foreground": "oklch(0.24 0.035 145)",
+          "sidebar-primary": "oklch(0.43 0.13 145)",
+          "sidebar-primary-foreground": "oklch(0.98 0.015 145)",
+          "sidebar-accent": "oklch(0.86 0.055 120)",
+          "sidebar-accent-foreground": "oklch(0.25 0.04 145)",
+          "sidebar-border": "oklch(0.82 0.035 145)",
+          "sidebar-ring": "oklch(0.5 0.13 145)",
+          "font-sans": "Inter, sans-serif",
+          "font-serif": "Merriweather, serif",
+          "font-mono": "JetBrains Mono, monospace",
+          "letter-spacing": "0em",
+          "spacing": "0.25rem",
+          "tracking-normal": "0em"
+        },
+        "dark": {
+          "background": "oklch(0.18 0.028 145)",
+          "foreground": "oklch(0.9 0.035 125)",
+          "card": "oklch(0.21 0.03 145)",
+          "card-foreground": "oklch(0.9 0.035 125)",
+          "popover": "oklch(0.2 0.03 145)",
+          "popover-foreground": "oklch(0.92 0.035 125)",
+          "primary": "oklch(0.72 0.14 130)",
+          "primary-foreground": "oklch(0.16 0.03 145)",
+          "secondary": "oklch(0.29 0.04 145)",
+          "secondary-foreground": "oklch(0.88 0.03 125)",
+          "muted": "oklch(0.27 0.032 145)",
+          "muted-foreground": "oklch(0.72 0.03 125)",
+          "accent": "oklch(0.35 0.07 125)",
+          "accent-foreground": "oklch(0.94 0.03 125)",
+          "destructive": "oklch(0.62 0.22 28)",
+          "destructive-foreground": "oklch(0.98 0.015 145)",
+          "border": "oklch(0.34 0.035 145)",
+          "input": "oklch(0.32 0.035 145)",
+          "ring": "oklch(0.72 0.14 130)",
+          "chart-1": "oklch(0.72 0.14 130)",
+          "chart-2": "oklch(0.58 0.12 175)",
+          "chart-3": "oklch(0.78 0.12 85)",
+          "chart-4": "oklch(0.66 0.13 45)",
+          "chart-5": "oklch(0.7 0.11 210)",
+          "radius": "0.5rem",
+          "sidebar": "oklch(0.16 0.028 145)",
+          "sidebar-foreground": "oklch(0.9 0.035 125)",
+          "sidebar-primary": "oklch(0.72 0.14 130)",
+          "sidebar-primary-foreground": "oklch(0.16 0.03 145)",
+          "sidebar-accent": "oklch(0.29 0.04 145)",
+          "sidebar-accent-foreground": "oklch(0.9 0.035 125)",
+          "sidebar-border": "oklch(0.32 0.035 145)",
+          "sidebar-ring": "oklch(0.72 0.14 130)",
+          "font-sans": "Inter, sans-serif",
+          "font-serif": "Merriweather, serif",
+          "font-mono": "JetBrains Mono, monospace",
+          "letter-spacing": "0em",
+          "spacing": "0.25rem",
+          "tracking-normal": "0em"
+        }
+      }
     }
   ]
 }

--- a/platform/sorting-hat-mcp/README.md
+++ b/platform/sorting-hat-mcp/README.md
@@ -1,0 +1,32 @@
+# Sorting Hat MCP
+
+Sorting Hat MCP is a first-party MCP authorization shim for tool calls that need a lightweight governance step before they are proxied to an upstream server.
+
+## Tools
+
+- `sorting_hat.sort` classifies a tool into `gryffindor`, `slytherin`, `ravenclaw`, or `hufflepuff` from its name and description. Passing the `please_not_slytherin` header shifts Slytherin results to Ravenclaw with lower confidence.
+- `patronus.cast` returns a deterministic Patronus form for a `userId` when the charm is `expecto_patronum`.
+- `floo.travel` returns the route payload plus green flame particle metadata for the streaming UI.
+- `quidditch.stream` returns Golden Snitch progress events at 60fps for an active tool call.
+
+## Authorization
+
+Use `authorizeToolCall` before proxying to an upstream MCP server. Slytherin-sorted tools require a corporeal Patronus; all other houses are allowed once the Patronus charm is valid.
+
+```js
+import { authorizeToolCall, flooTravel } from "@archestra/sorting-hat-mcp";
+
+const authorization = authorizeToolCall({
+  userId: "user-123",
+  charm: "expecto_patronum",
+  toolName: "delete_database",
+});
+
+if (authorization.authorized) {
+  flooTravel({
+    fromServer: "sorting-hat-mcp",
+    toServer: "postgres",
+    payload: { name: "delete_database", arguments: {} },
+  });
+}
+```

--- a/platform/sorting-hat-mcp/package.json
+++ b/platform/sorting-hat-mcp/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@archestra/sorting-hat-mcp",
+  "version": "1.2.54",
+  "description": "First-party MCP authorization shim for Sorting Hat and Patronus governed tool calls",
+  "type": "module",
+  "private": true,
+  "bin": {
+    "sorting-hat-mcp": "./src/server.js"
+  },
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "scripts": {
+    "start": "node ./src/server.js",
+    "test": "node ./src/index.test.js"
+  },
+  "engines": {
+    "node": ">=18.0.0 <25.0.0"
+  },
+  "license": "UNLICENSED"
+}

--- a/platform/sorting-hat-mcp/src/index.js
+++ b/platform/sorting-hat-mcp/src/index.js
@@ -1,0 +1,232 @@
+import { createHash } from "node:crypto";
+
+export const HOUSES = ["gryffindor", "slytherin", "ravenclaw", "hufflepuff"];
+export const SORTING_HAT_HEADER = "please_not_slytherin";
+export const REQUIRED_CHARM = "expecto_patronum";
+
+const HOUSE_RULES = [
+  {
+    house: "slytherin",
+    confidence: 0.94,
+    patterns: [
+      /delete|destroy|drop|truncate|wipe|revoke|rotate|write|update|execute|shell|admin|secret|token|credential|database/i,
+    ],
+  },
+  {
+    house: "ravenclaw",
+    confidence: 0.86,
+    patterns: [/analy[sz]e|search|query|inspect|debug|explain|summari[sz]e|report|calculate|schema/i],
+  },
+  {
+    house: "gryffindor",
+    confidence: 0.82,
+    patterns: [/deploy|restart|incident|rollback|rescue|repair|migrate|approve|critical|urgent/i],
+  },
+  {
+    house: "hufflepuff",
+    confidence: 0.78,
+    patterns: [/read|list|get|docs|status|health|fetch|view|describe|help/i],
+  },
+];
+
+const PATRONUS_FORMS = [
+  "otter",
+  "stag",
+  "doe",
+  "hare",
+  "lynx",
+  "terrier",
+  "swan",
+  "falcon",
+  "fox",
+  "horse",
+  "cat",
+  "badger",
+];
+
+export function sortTool({ toolName, toolDescription = "", headers = {} }) {
+  const text = `${toolName ?? ""} ${toolDescription}`.trim();
+  const requestedHouseAvoidance = headers[SORTING_HAT_HEADER] ?? headers[SORTING_HAT_HEADER.toLowerCase()];
+  const ranked = HOUSE_RULES.find((rule) => rule.patterns.some((pattern) => pattern.test(text)));
+  const result = ranked ?? {
+    house: stableHouse(text),
+    confidence: 0.64,
+  };
+
+  if (result.house === "slytherin" && requestedHouseAvoidance) {
+    return {
+      house: "ravenclaw",
+      confidence: Math.max(0.51, result.confidence - 0.18),
+    };
+  }
+
+  return {
+    house: result.house,
+    confidence: result.confidence,
+  };
+}
+
+export function createSortingHatStream({ toolName, toolDescription = "", headers = {} }) {
+  const sorted = sortTool({ toolName, toolDescription, headers });
+  const lines = [
+    "A thread of intent, a glimmer of might,",
+    `I weigh ${toolName} by risk and light,`,
+    "Where purpose and peril both start to sing,",
+    `I name ${sorted.house} for this tool-call thing.`,
+  ];
+
+  return lines.map((message, index) => ({
+    event: "sorting_hat.token",
+    data: {
+      index,
+      message,
+      house: sorted.house,
+      confidence: sorted.confidence,
+      done: index === lines.length - 1,
+    },
+  }));
+}
+
+export function castPatronus({ userId, charm }) {
+  if (charm !== REQUIRED_CHARM) {
+    throw new Error("Patronus casting requires expecto_patronum");
+  }
+
+  const digest = hash(userId);
+  const form = PATRONUS_FORMS[Number.parseInt(digest.slice(0, 8), 16) % PATRONUS_FORMS.length];
+  const corporeal = Number.parseInt(digest.slice(8, 16), 16) % 5 !== 0;
+
+  return { form, corporeal };
+}
+
+export function authorizeToolCall({ userId, charm, toolName, toolDescription = "", headers = {} }) {
+  const sorting = sortTool({ toolName, toolDescription, headers });
+  const patronus = castPatronus({ userId, charm });
+  const authorized = sorting.house !== "slytherin" || patronus.corporeal;
+
+  return {
+    authorized,
+    sorting,
+    patronus,
+    reason: authorized
+      ? "authorized"
+      : "non_corporeal_patronus_cannot_authorize_slytherin_tool",
+  };
+}
+
+export function flooTravel({ fromServer, toServer, payload }) {
+  return {
+    fromServer,
+    toServer,
+    payload,
+    particles: createFlooParticles({ fromServer, toServer }),
+  };
+}
+
+export function createQuidditchStream({ toolCallId, frames = 60 }) {
+  const safeFrames = Math.max(1, Math.min(frames, 300));
+
+  return Array.from({ length: safeFrames }, (_, frame) => ({
+    event: "quidditch.snitch",
+    data: {
+      toolCallId,
+      frame,
+      fps: 60,
+      x: Number(((frame % 60) / 59).toFixed(4)),
+      y: Number((0.5 + Math.sin(frame / 6) * 0.25).toFixed(4)),
+      shape: "golden-snitch",
+      done: frame === safeFrames - 1,
+    },
+  }));
+}
+
+export const tools = [
+  {
+    name: "sorting_hat.sort",
+    description: "Sort an MCP tool into a risk house with optional Hat monologue stream events.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        toolName: { type: "string" },
+        toolDescription: { type: "string" },
+        headers: { type: "object", additionalProperties: true },
+        stream: { type: "boolean" },
+      },
+      required: ["toolName"],
+    },
+  },
+  {
+    name: "patronus.cast",
+    description: "Cast a deterministic Patronus for a user.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        userId: { type: "string" },
+        charm: { type: "string", enum: [REQUIRED_CHARM] },
+      },
+      required: ["userId", "charm"],
+    },
+  },
+  {
+    name: "floo.travel",
+    description: "Route an authorized tool payload and emit green flame particle metadata.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        fromServer: { type: "string" },
+        toServer: { type: "string" },
+        payload: {},
+      },
+      required: ["fromServer", "toServer", "payload"],
+    },
+  },
+  {
+    name: "quidditch.stream",
+    description: "Create 60fps Golden Snitch progress events for an in-flight tool call.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        toolCallId: { type: "string" },
+        frames: { type: "number" },
+      },
+      required: ["toolCallId"],
+    },
+  },
+];
+
+export function callTool(name, args = {}) {
+  switch (name) {
+    case "sorting_hat.sort": {
+      const result = sortTool(args);
+      return args.stream ? { ...result, stream: createSortingHatStream(args) } : result;
+    }
+    case "patronus.cast":
+      return castPatronus(args);
+    case "floo.travel":
+      return flooTravel(args);
+    case "quidditch.stream":
+      return createQuidditchStream(args);
+    default:
+      throw new Error(`Unknown Sorting Hat MCP tool: ${name}`);
+  }
+}
+
+function stableHouse(value) {
+  const index = Number.parseInt(hash(value).slice(0, 8), 16) % HOUSES.length;
+  return HOUSES[index];
+}
+
+function createFlooParticles({ fromServer, toServer }) {
+  const seed = Number.parseInt(hash(`${fromServer}:${toServer}`).slice(0, 8), 16);
+
+  return Array.from({ length: 12 }, (_, index) => ({
+    color: "green",
+    size: 2 + ((seed + index) % 5),
+    delayMs: index * 16,
+    opacity: Number((0.35 + ((seed + index * 7) % 60) / 100).toFixed(2)),
+  }));
+}
+
+function hash(value) {
+  return createHash("sha256").update(String(value ?? "")).digest("hex");
+}

--- a/platform/sorting-hat-mcp/src/index.test.js
+++ b/platform/sorting-hat-mcp/src/index.test.js
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  authorizeToolCall,
+  callTool,
+  castPatronus,
+  createQuidditchStream,
+  createSortingHatStream,
+  flooTravel,
+  sortTool,
+} from "./index.js";
+
+test("sorts risky tools into slytherin", () => {
+  assert.deepEqual(sortTool({ toolName: "delete_database" }), {
+    house: "slytherin",
+    confidence: 0.94,
+  });
+});
+
+test("respects please_not_slytherin header", () => {
+  assert.deepEqual(
+    sortTool({
+      toolName: "delete_database",
+      headers: { please_not_slytherin: "please" },
+    }),
+    {
+      house: "ravenclaw",
+      confidence: 0.76,
+    },
+  );
+});
+
+test("streams a rhyming sorting monologue with final house", () => {
+  const stream = createSortingHatStream({
+    toolName: "read_docs",
+    toolDescription: "Read public docs",
+  });
+
+  assert.equal(stream.length, 4);
+  assert.equal(stream.at(-1).data.house, "hufflepuff");
+  assert.equal(stream.at(-1).data.done, true);
+});
+
+test("casts a deterministic Patronus snapshot", () => {
+  assert.deepEqual(castPatronus({ userId: "user-123", charm: "expecto_patronum" }), {
+    form: "falcon",
+    corporeal: true,
+  });
+});
+
+test("blocks non-corporeal Patronus for slytherin tools", () => {
+  assert.deepEqual(
+    authorizeToolCall({
+      userId: "user-6",
+      charm: "expecto_patronum",
+      toolName: "delete_database",
+    }),
+    {
+      authorized: false,
+      sorting: { house: "slytherin", confidence: 0.94 },
+      patronus: { form: "lynx", corporeal: false },
+      reason: "non_corporeal_patronus_cannot_authorize_slytherin_tool",
+    },
+  );
+});
+
+test("routes floo travel with green flame particle metadata", () => {
+  const result = flooTravel({
+    fromServer: "sorting-hat-mcp",
+    toServer: "github",
+    payload: { method: "tools/call" },
+  });
+
+  assert.equal(result.particles.length, 12);
+  assert.equal(result.particles.every((particle) => particle.color === "green"), true);
+});
+
+test("creates 60fps snitch progress events", () => {
+  const stream = createQuidditchStream({ toolCallId: "call-1", frames: 3 });
+
+  assert.deepEqual(
+    stream.map((event) => [event.event, event.data.fps, event.data.shape, event.data.done]),
+    [
+      ["quidditch.snitch", 60, "golden-snitch", false],
+      ["quidditch.snitch", 60, "golden-snitch", false],
+      ["quidditch.snitch", 60, "golden-snitch", true],
+    ],
+  );
+});
+
+test("exposes all four MCP tools through callTool", () => {
+  assert.equal(callTool("sorting_hat.sort", { toolName: "read_docs" }).house, "hufflepuff");
+  assert.equal(callTool("patronus.cast", { userId: "user-123", charm: "expecto_patronum" }).form, "falcon");
+  assert.equal(callTool("floo.travel", { fromServer: "a", toServer: "b", payload: {} }).particles.length, 12);
+  assert.equal(callTool("quidditch.stream", { toolCallId: "call-1", frames: 1 }).length, 1);
+});

--- a/platform/sorting-hat-mcp/src/server.js
+++ b/platform/sorting-hat-mcp/src/server.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+import { callTool, tools } from "./index.js";
+
+const decoder = new TextDecoder();
+let buffer = "";
+
+process.stdin.on("data", (chunk) => {
+  buffer += decoder.decode(chunk, { stream: true });
+  drainBuffer();
+});
+
+function drainBuffer() {
+  while (buffer.length > 0) {
+    const message = readMessage();
+    if (!message) return;
+    handleMessage(message);
+  }
+}
+
+function readMessage() {
+  const headerEnd = buffer.indexOf("\r\n\r\n");
+  if (headerEnd === -1) {
+    const newlineEnd = buffer.indexOf("\n");
+    if (newlineEnd === -1) return null;
+
+    const line = buffer.slice(0, newlineEnd).trim();
+    buffer = buffer.slice(newlineEnd + 1);
+    return line ? JSON.parse(line) : null;
+  }
+
+  const header = buffer.slice(0, headerEnd);
+  const match = /content-length:\s*(\d+)/i.exec(header);
+  if (!match) {
+    throw new Error("Missing Content-Length header");
+  }
+
+  const bodyStart = headerEnd + 4;
+  const bodyLength = Number.parseInt(match[1], 10);
+  const bodyEnd = bodyStart + bodyLength;
+  if (buffer.length < bodyEnd) return null;
+
+  const body = buffer.slice(bodyStart, bodyEnd);
+  buffer = buffer.slice(bodyEnd);
+  return JSON.parse(body);
+}
+
+function handleMessage(message) {
+  try {
+    if (message.method === "initialize") {
+      writeResponse(message.id, {
+        protocolVersion: "2024-11-05",
+        capabilities: { tools: {} },
+        serverInfo: {
+          name: "sorting-hat-mcp",
+          version: "1.2.54",
+        },
+      });
+      return;
+    }
+
+    if (message.method === "tools/list") {
+      writeResponse(message.id, { tools });
+      return;
+    }
+
+    if (message.method === "tools/call") {
+      const result = callTool(message.params?.name, message.params?.arguments ?? {});
+      writeResponse(message.id, {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result),
+          },
+        ],
+      });
+      return;
+    }
+
+    if (message.id !== undefined) {
+      writeError(message.id, -32601, `Unsupported method: ${message.method}`);
+    }
+  } catch (error) {
+    writeError(message.id, -32000, error instanceof Error ? error.message : String(error));
+  }
+}
+
+function writeResponse(id, result) {
+  writeMessage({ jsonrpc: "2.0", id, result });
+}
+
+function writeError(id, code, message) {
+  writeMessage({
+    jsonrpc: "2.0",
+    id,
+    error: { code, message },
+  });
+}
+
+function writeMessage(message) {
+  const body = JSON.stringify(message);
+  process.stdout.write(`Content-Length: ${Buffer.byteLength(body, "utf8")}\r\n\r\n${body}`);
+}


### PR DESCRIPTION
## Summary
- Add `platform/sorting-hat-mcp` first-party MCP package with Sorting Hat, Patronus, Floo, and Quidditch tools
- Implement deterministic Patronus casting and Slytherin authorization blocking for non-corporeal Patronuses
- Add Golden Snitch loader support for Gryffindor-sorted tool calls
- Add Patronus picker in account settings
- Add Forbidden Forest theme variant
- Add docs page: "Sorting your MCP tools"

## Tests
- `npm test` in `platform/sorting-hat-mcp`
- Theme JSON parse check
- `git diff --check`

## Notes
Frontend dependency checks were not run because `node_modules` is not installed in this checkout.