### PR TITLE
fix(chat): resume reconnect renders the streaming turn once, no render loop

### DIFF
--- a/platform/frontend/src/lib/chat/chat-session-utils.test.ts
+++ b/platform/frontend/src/lib/chat/chat-session-utils.test.ts
@@ -251,6 +251,46 @@ describe("restoreRenderableAssistantParts", () => {
       restoreRenderableAssistantParts({ previousMessages, nextMessages }),
     ).toBe(nextMessages);
   });
+
+  test("restores a mid-thread assistant that briefly empties even when a later assistant is renderable", () => {
+    // The placeholder guard must not suppress a genuine regression of an earlier
+    // turn: an empty assistant bounded by user turns is a real flicker to repair,
+    // not a reconnect duplicate.
+    const previousMessages = [
+      { id: "u1", role: "user", parts: [{ type: "text", text: "q1" }] },
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [{ type: "text", text: "answer 1" }],
+      },
+      { id: "u2", role: "user", parts: [{ type: "text", text: "q2" }] },
+      {
+        id: "a2",
+        role: "assistant",
+        parts: [{ type: "text", text: "answer 2" }],
+      },
+    ] as UIMessage[];
+
+    const nextMessages = [
+      previousMessages[0],
+      { id: "a1", role: "assistant", parts: [{ type: "text", text: "" }] },
+      previousMessages[2],
+      previousMessages[3],
+    ] as UIMessage[];
+
+    expect(
+      restoreRenderableAssistantParts({ previousMessages, nextMessages }),
+    ).toEqual([
+      previousMessages[0],
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [{ type: "text", text: "answer 1" }],
+      },
+      previousMessages[2],
+      previousMessages[3],
+    ]);
+  });
 });
 
 describe("pruneEmptyTrailingAssistantMessage", () => {

--- a/platform/frontend/src/lib/chat/chat-session-utils.test.ts
+++ b/platform/frontend/src/lib/chat/chat-session-utils.test.ts
@@ -215,6 +215,42 @@ describe("restoreRenderableAssistantParts", () => {
       restoreRenderableAssistantParts({ previousMessages, nextMessages }),
     ).toEqual(previousMessages);
   });
+
+  test("does not refill an empty assistant placeholder that precedes a live renderable assistant", () => {
+    // A stream-resume reconnect can briefly hold an empty assistant placeholder
+    // ahead of the live assistant carrying the turn. Refilling the placeholder
+    // would render the turn twice.
+    const previousMessages = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "call your tool" }],
+      },
+      {
+        id: "assistant-old",
+        role: "assistant",
+        parts: [{ type: "text", text: "I called the tool successfully." }],
+      },
+    ] as UIMessage[];
+
+    const nextMessages = [
+      previousMessages[0],
+      {
+        id: "assistant-placeholder",
+        role: "assistant",
+        parts: [{ type: "text", text: "" }],
+      },
+      {
+        id: "assistant-live",
+        role: "assistant",
+        parts: [{ type: "text", text: "I called the tool successfully." }],
+      },
+    ] as UIMessage[];
+
+    expect(
+      restoreRenderableAssistantParts({ previousMessages, nextMessages }),
+    ).toBe(nextMessages);
+  });
 });
 
 describe("pruneEmptyTrailingAssistantMessage", () => {

--- a/platform/frontend/src/lib/chat/chat-session-utils.ts
+++ b/platform/frontend/src/lib/chat/chat-session-utils.ts
@@ -25,10 +25,26 @@ export function restoreRenderableAssistantParts(params: {
     return restoredMessageTail;
   }
 
+  const lastRenderableAssistantIndex = nextMessages.reduce(
+    (last, message, index) =>
+      message.role === "assistant" && hasRenderableAssistantParts(message)
+        ? index
+        : last,
+    -1,
+  );
+
   let changed = false;
 
   const restoredMessages = nextMessages.map((message, index) => {
     if (message.role !== "assistant" || hasRenderableAssistantParts(message)) {
+      return message;
+    }
+
+    // A reconnect transiently holds an empty assistant placeholder ahead of the
+    // live assistant that carries the turn; refilling it would render the turn
+    // twice. Skip restoration when a later message is already a renderable
+    // assistant (the placeholder isn't the active tail).
+    if (index < lastRenderableAssistantIndex) {
       return message;
     }
 
@@ -52,7 +68,18 @@ export function restoreRenderableAssistantParts(params: {
     };
   });
 
-  return changed ? restoredMessages : nextMessages;
+  if (!changed) {
+    return nextMessages;
+  }
+
+  // Restoration rebuilds the assistant tail from `previousMessages` on every
+  // call, so a persistent empty assistant message (e.g. a reload into an
+  // interrupted resume) produces a fresh array each render. Reuse the prior
+  // reference when the result is renderably identical, so consumers keyed on
+  // array identity don't re-render in an infinite loop.
+  return hasSameRenderableMessages(restoredMessages, previousMessages)
+    ? previousMessages
+    : restoredMessages;
 }
 
 /**
@@ -156,4 +183,23 @@ function restoreTruncatedAssistantTail(params: {
 
 function sameMessageIdentity(a: UIMessage, b: UIMessage | undefined): boolean {
   return !!b && a.id === b.id && a.role === b.role;
+}
+
+function hasSameRenderableMessages(
+  candidate: UIMessage[],
+  previous: UIMessage[],
+): boolean {
+  if (candidate === previous) {
+    return true;
+  }
+  if (candidate.length !== previous.length) {
+    return false;
+  }
+  return candidate.every((message, index) => {
+    const previousMessage = previous[index];
+    return (
+      sameMessageIdentity(message, previousMessage) &&
+      message.parts === previousMessage?.parts
+    );
+  });
 }

--- a/platform/frontend/src/lib/chat/chat-session-utils.ts
+++ b/platform/frontend/src/lib/chat/chat-session-utils.ts
@@ -25,14 +25,6 @@ export function restoreRenderableAssistantParts(params: {
     return restoredMessageTail;
   }
 
-  const lastRenderableAssistantIndex = nextMessages.reduce(
-    (last, message, index) =>
-      message.role === "assistant" && hasRenderableAssistantParts(message)
-        ? index
-        : last,
-    -1,
-  );
-
   let changed = false;
 
   const restoredMessages = nextMessages.map((message, index) => {
@@ -40,11 +32,16 @@ export function restoreRenderableAssistantParts(params: {
       return message;
     }
 
-    // A reconnect transiently holds an empty assistant placeholder ahead of the
-    // live assistant that carries the turn; refilling it would render the turn
-    // twice. Skip restoration when a later message is already a renderable
-    // assistant (the placeholder isn't the active tail).
-    if (index < lastRenderableAssistantIndex) {
+    // A reconnect transiently holds an empty assistant placeholder directly
+    // next to the live assistant carrying the turn; refilling it would render
+    // the turn twice. Two adjacent assistant messages only occur in that split
+    // state (normal turns alternate user/assistant), so skip restoring an empty
+    // assistant adjacent to another assistant. A historical assistant that
+    // briefly empties is bounded by user turns and still restores.
+    if (
+      nextMessages[index - 1]?.role === "assistant" ||
+      nextMessages[index + 1]?.role === "assistant"
+    ) {
       return message;
     }
 
@@ -199,7 +196,8 @@ function hasSameRenderableMessages(
     const previousMessage = previous[index];
     return (
       sameMessageIdentity(message, previousMessage) &&
-      message.parts === previousMessage?.parts
+      message.parts === previousMessage?.parts &&
+      message.metadata === previousMessage?.metadata
     );
   });
 }


### PR DESCRIPTION
Reloading the chat page into an active streaming turn hit two bugs in `restoreRenderableAssistantParts`, the helper that keeps streamed assistant content from flickering when live session state briefly regresses.

1. The page could crash-loop with React error #185 ("Maximum update depth exceeded") and go blank. While an empty assistant message persisted (a reload into an interrupted resume), the helper rebuilt the message array into a fresh reference on every render, so an effect keyed on that array identity re-fired endlessly. It now returns the prior reference when the restored result is renderably identical.

2. The resumed turn rendered twice. Stream resume transiently holds an empty assistant placeholder ahead of the live assistant that carries the turn, and the helper refilled that placeholder with the turn's content — producing two identical bubbles. It now skips restoring an empty assistant that precedes a later renderable assistant (the placeholder isn't the active tail).

Net effect: reloading mid-stream resumes the assistant turn exactly once, without the render loop. This is the durable fix for the reconnect e2e (`chat.spec.ts:267`); it supersedes the `test.fixme` stopgap in #5261.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>