### PR TITLE
chore: guide chat models for load tools when needed

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -67775,6 +67775,13 @@
                               "agent"
                             ]
                           },
+                          "toolExposureMode": {
+                            "type": "string",
+                            "enum": [
+                              "full",
+                              "search_and_run_only"
+                            ]
+                          },
                           "llmApiKeyId": {
                             "nullable": true,
                             "type": "string"
@@ -67785,6 +67792,7 @@
                           "name",
                           "systemPrompt",
                           "agentType",
+                          "toolExposureMode",
                           "llmApiKeyId"
                         ],
                         "additionalProperties": false
@@ -68452,6 +68460,13 @@
                             "agent"
                           ]
                         },
+                        "toolExposureMode": {
+                          "type": "string",
+                          "enum": [
+                            "full",
+                            "search_and_run_only"
+                          ]
+                        },
                         "llmApiKeyId": {
                           "nullable": true,
                           "type": "string"
@@ -68462,6 +68477,7 @@
                         "name",
                         "systemPrompt",
                         "agentType",
+                        "toolExposureMode",
                         "llmApiKeyId"
                       ],
                       "additionalProperties": false
@@ -69106,6 +69122,13 @@
                             "agent"
                           ]
                         },
+                        "toolExposureMode": {
+                          "type": "string",
+                          "enum": [
+                            "full",
+                            "search_and_run_only"
+                          ]
+                        },
                         "llmApiKeyId": {
                           "nullable": true,
                           "type": "string"
@@ -69116,6 +69139,7 @@
                         "name",
                         "systemPrompt",
                         "agentType",
+                        "toolExposureMode",
                         "llmApiKeyId"
                       ],
                       "additionalProperties": false
@@ -69801,6 +69825,13 @@
                             "agent"
                           ]
                         },
+                        "toolExposureMode": {
+                          "type": "string",
+                          "enum": [
+                            "full",
+                            "search_and_run_only"
+                          ]
+                        },
                         "llmApiKeyId": {
                           "nullable": true,
                           "type": "string"
@@ -69811,6 +69842,7 @@
                         "name",
                         "systemPrompt",
                         "agentType",
+                        "toolExposureMode",
                         "llmApiKeyId"
                       ],
                       "additionalProperties": false
@@ -71333,6 +71365,13 @@
                             "agent"
                           ]
                         },
+                        "toolExposureMode": {
+                          "type": "string",
+                          "enum": [
+                            "full",
+                            "search_and_run_only"
+                          ]
+                        },
                         "llmApiKeyId": {
                           "nullable": true,
                           "type": "string"
@@ -71343,6 +71382,7 @@
                         "name",
                         "systemPrompt",
                         "agentType",
+                        "toolExposureMode",
                         "llmApiKeyId"
                       ],
                       "additionalProperties": false
@@ -72354,6 +72394,13 @@
                                 "agent"
                               ]
                             },
+                            "toolExposureMode": {
+                              "type": "string",
+                              "enum": [
+                                "full",
+                                "search_and_run_only"
+                              ]
+                            },
                             "llmApiKeyId": {
                               "nullable": true,
                               "type": "string"
@@ -72364,6 +72411,7 @@
                             "name",
                             "systemPrompt",
                             "agentType",
+                            "toolExposureMode",
                             "llmApiKeyId"
                           ],
                           "additionalProperties": false
@@ -73964,6 +74012,13 @@
                             "agent"
                           ]
                         },
+                        "toolExposureMode": {
+                          "type": "string",
+                          "enum": [
+                            "full",
+                            "search_and_run_only"
+                          ]
+                        },
                         "llmApiKeyId": {
                           "nullable": true,
                           "type": "string"
@@ -73974,6 +74029,7 @@
                         "name",
                         "systemPrompt",
                         "agentType",
+                        "toolExposureMode",
                         "llmApiKeyId"
                       ],
                       "additionalProperties": false
@@ -74642,6 +74698,13 @@
                             "agent"
                           ]
                         },
+                        "toolExposureMode": {
+                          "type": "string",
+                          "enum": [
+                            "full",
+                            "search_and_run_only"
+                          ]
+                        },
                         "llmApiKeyId": {
                           "nullable": true,
                           "type": "string"
@@ -74652,6 +74715,7 @@
                         "name",
                         "systemPrompt",
                         "agentType",
+                        "toolExposureMode",
                         "llmApiKeyId"
                       ],
                       "additionalProperties": false
@@ -75312,6 +75376,13 @@
                             "agent"
                           ]
                         },
+                        "toolExposureMode": {
+                          "type": "string",
+                          "enum": [
+                            "full",
+                            "search_and_run_only"
+                          ]
+                        },
                         "llmApiKeyId": {
                           "nullable": true,
                           "type": "string"
@@ -75322,6 +75393,7 @@
                         "name",
                         "systemPrompt",
                         "agentType",
+                        "toolExposureMode",
                         "llmApiKeyId"
                       ],
                       "additionalProperties": false
@@ -75992,6 +76064,13 @@
                             "agent"
                           ]
                         },
+                        "toolExposureMode": {
+                          "type": "string",
+                          "enum": [
+                            "full",
+                            "search_and_run_only"
+                          ]
+                        },
                         "llmApiKeyId": {
                           "nullable": true,
                           "type": "string"
@@ -76002,6 +76081,7 @@
                         "name",
                         "systemPrompt",
                         "agentType",
+                        "toolExposureMode",
                         "llmApiKeyId"
                       ],
                       "additionalProperties": false
@@ -188049,6 +188129,13 @@
                             "agent"
                           ]
                         },
+                        "toolExposureMode": {
+                          "type": "string",
+                          "enum": [
+                            "full",
+                            "search_and_run_only"
+                          ]
+                        },
                         "llmApiKeyId": {
                           "nullable": true,
                           "type": "string"
@@ -188059,6 +188146,7 @@
                         "name",
                         "systemPrompt",
                         "agentType",
+                        "toolExposureMode",
                         "llmApiKeyId"
                       ],
                       "additionalProperties": false

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -39,6 +39,7 @@ import type {
   AgentType,
   InsertAgent,
   SortingQuery,
+  ToolExposureMode,
   UpdateAgent,
 } from "@/types";
 import { isUniqueConstraintError } from "@/utils/db";
@@ -1373,6 +1374,18 @@ class AgentModel {
     AgentModel.filterUnavailableKnowledgeTools([result]);
 
     return result;
+  }
+
+  static async getToolExposureMode(
+    id: string,
+  ): Promise<ToolExposureMode | null> {
+    const [row] = await db
+      .select({ toolExposureMode: schema.agentsTable.toolExposureMode })
+      .from(schema.agentsTable)
+      .where(and(eq(schema.agentsTable.id, id), notDeleted(schema.agentsTable)))
+      .limit(1);
+
+    return row?.toolExposureMode ?? null;
   }
 
   static async findDeletedByIdForOrganization(

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -39,7 +39,6 @@ import type {
   AgentType,
   InsertAgent,
   SortingQuery,
-  ToolExposureMode,
   UpdateAgent,
 } from "@/types";
 import { isUniqueConstraintError } from "@/utils/db";
@@ -1374,18 +1373,6 @@ class AgentModel {
     AgentModel.filterUnavailableKnowledgeTools([result]);
 
     return result;
-  }
-
-  static async getToolExposureMode(
-    id: string,
-  ): Promise<ToolExposureMode | null> {
-    const [row] = await db
-      .select({ toolExposureMode: schema.agentsTable.toolExposureMode })
-      .from(schema.agentsTable)
-      .where(and(eq(schema.agentsTable.id, id), notDeleted(schema.agentsTable)))
-      .limit(1);
-
-    return row?.toolExposureMode ?? null;
   }
 
   static async findDeletedByIdForOrganization(

--- a/platform/backend/src/models/conversation.ts
+++ b/platform/backend/src/models/conversation.ts
@@ -13,6 +13,7 @@ import db, { schema } from "@/database";
 import type {
   Conversation,
   InsertConversation,
+  ToolExposureMode,
   UpdateConversation,
 } from "@/types";
 import { escapeLikePattern } from "@/utils/sql-search";
@@ -126,6 +127,7 @@ class ConversationModel {
             name: schema.agentsTable.name,
             systemPrompt: schema.agentsTable.systemPrompt,
             agentType: schema.agentsTable.agentType,
+            toolExposureMode: schema.agentsTable.toolExposureMode,
             llmApiKeyId: schema.agentsTable.llmApiKeyId,
             deletedAt: schema.agentsTable.deletedAt,
           },
@@ -227,6 +229,7 @@ class ConversationModel {
             name: schema.agentsTable.name,
             systemPrompt: schema.agentsTable.systemPrompt,
             agentType: schema.agentsTable.agentType,
+            toolExposureMode: schema.agentsTable.toolExposureMode,
             llmApiKeyId: schema.agentsTable.llmApiKeyId,
             deletedAt: schema.agentsTable.deletedAt,
           },
@@ -278,6 +281,7 @@ class ConversationModel {
           name: schema.agentsTable.name,
           systemPrompt: schema.agentsTable.systemPrompt,
           agentType: schema.agentsTable.agentType,
+          toolExposureMode: schema.agentsTable.toolExposureMode,
           llmApiKeyId: schema.agentsTable.llmApiKeyId,
           deletedAt: schema.agentsTable.deletedAt,
         },
@@ -384,6 +388,7 @@ class ConversationModel {
           name: schema.agentsTable.name,
           systemPrompt: schema.agentsTable.systemPrompt,
           agentType: schema.agentsTable.agentType,
+          toolExposureMode: schema.agentsTable.toolExposureMode,
           llmApiKeyId: schema.agentsTable.llmApiKeyId,
           deletedAt: schema.agentsTable.deletedAt,
         },
@@ -579,6 +584,7 @@ type JoinedConversationAgent = {
   name: string | null;
   systemPrompt: string | null;
   agentType: "profile" | "mcp_gateway" | "llm_proxy" | "agent" | null;
+  toolExposureMode: ToolExposureMode | null;
   llmApiKeyId: string | null;
   deletedAt: Date | null;
 } | null;
@@ -604,6 +610,7 @@ function withVisibleAgent(
       name: agent.name ?? "",
       systemPrompt: agent.systemPrompt,
       agentType: agent.agentType ?? "agent",
+      toolExposureMode: agent.toolExposureMode ?? "full",
       llmApiKeyId: agent.llmApiKeyId,
     },
   };

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -10,6 +10,8 @@ import {
   RouteId,
   type SupportedProvider,
   TimeInMs,
+  TOOL_RUN_TOOL_SHORT_NAME,
+  TOOL_SEARCH_TOOLS_SHORT_NAME,
   type TokenUsage,
 } from "@shared";
 import {
@@ -165,6 +167,8 @@ function getMinimalFrontendError(errorForFrontend: ChatErrorResponse) {
 
 const UNAVAILABLE_TOOL_ERROR_MESSAGE =
   "The requested tool is not available in this chat. Available tools are listed in the details below; use an exact available tool name for the next tool call.";
+
+const LOAD_TOOLS_WHEN_NEEDED_SYSTEM_PROMPT = `Some available tools are not listed upfront. If the visible tools do not fit the task, use \`${TOOL_SEARCH_TOOLS_SHORT_NAME}\` to find relevant tools, then call \`${TOOL_RUN_TOOL_SHORT_NAME}\` with the selected tool name and arguments. Do not guess hidden tool names without searching unless the exact tool name is already known from the conversation.`;
 
 type UnavailableToolErrorDetails = {
   type: "unavailable_tool";
@@ -323,6 +327,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
 
       try {
         const { agentId, agent } = conversation;
+        const toolExposureMode = await AgentModel.getToolExposureMode(agentId);
 
         // Extract and ingest documents to agent's knowledge base (fire and forget)
         // This runs asynchronously to avoid blocking the chat response
@@ -401,8 +406,18 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
         const toolDenialInstruction =
           "When a tool execution is not approved by the user, do not retry it. Explain what happened and ask the user what they'd like to do instead.";
 
+        const toolLoadingInstructions =
+          toolExposureMode === "search_and_run_only"
+            ? LOAD_TOOLS_WHEN_NEEDED_SYSTEM_PROMPT
+            : "";
+
         systemPrompt =
-          [renderedPrompt, toolDenialInstruction, toolResultInstructions]
+          [
+            toolLoadingInstructions,
+            renderedPrompt,
+            toolDenialInstruction,
+            toolResultInstructions,
+          ]
             .filter(Boolean)
             .join("\n\n") || undefined;
 

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -339,7 +339,6 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
 
       try {
         const { agentId, agent } = conversation;
-        const toolExposureMode = await AgentModel.getToolExposureMode(agentId);
 
         // Extract and ingest documents to agent's knowledge base (fire and forget)
         // This runs asynchronously to avoid blocking the chat response
@@ -419,7 +418,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
           "When a tool execution is not approved by the user, do not retry it. Explain what happened and ask the user what they'd like to do instead.";
 
         const toolLoadingInstructions =
-          toolExposureMode === "search_and_run_only"
+          agent.toolExposureMode === "search_and_run_only"
             ? buildLoadToolsWhenNeededSystemPrompt()
             : "";
 

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -165,10 +165,19 @@ function getMinimalFrontendError(errorForFrontend: ChatErrorResponse) {
   };
 }
 
+function buildLoadToolsWhenNeededSystemPrompt(): string {
+  const searchToolsName = archestraMcpBranding.getToolName(
+    TOOL_SEARCH_TOOLS_SHORT_NAME,
+  );
+  const runToolName = archestraMcpBranding.getToolName(
+    TOOL_RUN_TOOL_SHORT_NAME,
+  );
+
+  return `Some available tools are not listed upfront. If the visible tools do not fit the task, use \`${searchToolsName}\` to find relevant tools, then call \`${runToolName}\` with the selected tool name and arguments. Do not guess hidden tool names without searching unless the exact tool name is already known from the conversation.`;
+}
+
 const UNAVAILABLE_TOOL_ERROR_MESSAGE =
   "The requested tool is not available in this chat. Available tools are listed in the details below; use an exact available tool name for the next tool call.";
-
-const LOAD_TOOLS_WHEN_NEEDED_SYSTEM_PROMPT = `Some available tools are not listed upfront. If the visible tools do not fit the task, use \`${TOOL_SEARCH_TOOLS_SHORT_NAME}\` to find relevant tools, then call \`${TOOL_RUN_TOOL_SHORT_NAME}\` with the selected tool name and arguments. Do not guess hidden tool names without searching unless the exact tool name is already known from the conversation.`;
 
 type UnavailableToolErrorDetails = {
   type: "unavailable_tool";
@@ -408,7 +417,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
 
         const toolLoadingInstructions =
           toolExposureMode === "search_and_run_only"
-            ? LOAD_TOOLS_WHEN_NEEDED_SYSTEM_PROMPT
+            ? buildLoadToolsWhenNeededSystemPrompt()
             : "";
 
         systemPrompt =

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -1,5 +1,10 @@
+import {
+  TOOL_RUN_TOOL_SHORT_NAME,
+  TOOL_SEARCH_TOOLS_SHORT_NAME,
+} from "@shared";
 import { NoSuchToolError } from "ai";
 import { vi } from "vitest";
+import { archestraMcpBranding } from "@/archestra-mcp-server";
 import { MessageModel } from "@/models";
 import ActiveChatRunModel from "@/models/chat-active-run";
 import type { FastifyInstanceWithZod } from "@/server";
@@ -342,6 +347,7 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
   );
 
   afterEach(async () => {
+    archestraMcpBranding.syncFromOrganization(null);
     await app.close();
   });
 
@@ -624,8 +630,12 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
     expect(systemPrompt).toContain(
       "Some available tools are not listed upfront",
     );
-    expect(systemPrompt).toContain("use `search_tools` to find relevant tools");
-    expect(systemPrompt).toContain("then call `run_tool`");
+    expect(systemPrompt).toContain(
+      `use \`${archestraMcpBranding.getToolName(TOOL_SEARCH_TOOLS_SHORT_NAME)}\` to find relevant tools`,
+    );
+    expect(systemPrompt).toContain(
+      `then call \`${archestraMcpBranding.getToolName(TOOL_RUN_TOOL_SHORT_NAME)}\``,
+    );
     expect(systemPrompt).toContain("You are a careful analyst.");
     expect(systemPrompt?.indexOf("Some available tools")).toBeLessThan(
       systemPrompt?.indexOf("You are a careful analyst.") ?? -1,
@@ -662,8 +672,51 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
     expect(systemPrompt).toContain(
       "Some available tools are not listed upfront",
     );
-    expect(systemPrompt).toContain("use `search_tools` to find relevant tools");
-    expect(systemPrompt).toContain("then call `run_tool`");
+    expect(systemPrompt).toContain(
+      `use \`${archestraMcpBranding.getToolName(TOOL_SEARCH_TOOLS_SHORT_NAME)}\` to find relevant tools`,
+    );
+    expect(systemPrompt).toContain(
+      `then call \`${archestraMcpBranding.getToolName(TOOL_RUN_TOOL_SHORT_NAME)}\``,
+    );
+  });
+
+  test("uses branded full tool names in load-tools guidance", async () => {
+    archestraMcpBranding.syncFromOrganization({
+      appName: "Custom Ops",
+      iconLogo: null,
+    });
+    const { AgentModel } = await import("@/models");
+    await AgentModel.update(agentId, {
+      toolExposureMode: "search_and_run_only",
+      systemPrompt: null,
+    });
+    mockStreamText.mockClear();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: conversationId,
+        messages: [
+          {
+            id: "msg-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    const systemPrompt = mockStreamText.mock.calls[0]?.[0].system;
+    expect(systemPrompt).toContain(
+      "use `custom_ops__search_tools` to find relevant tools",
+    );
+    expect(systemPrompt).toContain("then call `custom_ops__run_tool`");
+    expect(systemPrompt).not.toContain("use `search_tools`");
+    expect(systemPrompt).not.toContain("then call `run_tool`");
   });
 
   test("does not add load-tools guidance for fully exposed tools", async () => {

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -206,6 +206,7 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
   let app: FastifyInstanceWithZod;
   let user: User;
   let organizationId: string;
+  let agentId: string;
   let conversationId: string;
   let capturedInnerOnError: ((err: unknown) => string) | undefined;
   let capturedInnerOnFinish:
@@ -230,6 +231,7 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
         name: "Router Agent",
         systemPrompt: "",
       });
+      agentId = agent.id;
       const conversation = await makeConversation(agent.id, {
         userId: user.id,
         organizationId,
@@ -589,6 +591,111 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
     expect(mockStreamText).toHaveBeenCalledTimes(1);
     expect(mockStreamText.mock.calls[0]?.[0].messages).toEqual(
       compactedMessages,
+    );
+  });
+
+  test("prepends load-tools guidance when the agent loads tools when needed", async () => {
+    const { AgentModel } = await import("@/models");
+    await AgentModel.update(agentId, {
+      toolExposureMode: "search_and_run_only",
+      systemPrompt: "You are a careful analyst.",
+    });
+    mockStreamText.mockClear();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: conversationId,
+        messages: [
+          {
+            id: "msg-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    const systemPrompt = mockStreamText.mock.calls[0]?.[0].system;
+    expect(systemPrompt).toContain(
+      "Some available tools are not listed upfront",
+    );
+    expect(systemPrompt).toContain("use `search_tools` to find relevant tools");
+    expect(systemPrompt).toContain("then call `run_tool`");
+    expect(systemPrompt).toContain("You are a careful analyst.");
+    expect(systemPrompt?.indexOf("Some available tools")).toBeLessThan(
+      systemPrompt?.indexOf("You are a careful analyst.") ?? -1,
+    );
+  });
+
+  test("adds load-tools guidance when the agent has no authored prompt", async () => {
+    const { AgentModel } = await import("@/models");
+    await AgentModel.update(agentId, {
+      toolExposureMode: "search_and_run_only",
+      systemPrompt: null,
+    });
+    mockStreamText.mockClear();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: conversationId,
+        messages: [
+          {
+            id: "msg-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    const systemPrompt = mockStreamText.mock.calls[0]?.[0].system;
+    expect(systemPrompt).toContain(
+      "Some available tools are not listed upfront",
+    );
+    expect(systemPrompt).toContain("use `search_tools` to find relevant tools");
+    expect(systemPrompt).toContain("then call `run_tool`");
+  });
+
+  test("does not add load-tools guidance for fully exposed tools", async () => {
+    const { AgentModel } = await import("@/models");
+    await AgentModel.update(agentId, {
+      toolExposureMode: "full",
+      systemPrompt: "Use the normal tools.",
+    });
+    mockStreamText.mockClear();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: conversationId,
+        messages: [
+          {
+            id: "msg-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    const systemPrompt = mockStreamText.mock.calls[0]?.[0].system;
+    expect(systemPrompt).toContain("Use the normal tools.");
+    expect(systemPrompt).not.toContain(
+      "Some available tools are not listed upfront",
     );
   });
 

--- a/platform/backend/src/types/conversation.ts
+++ b/platform/backend/src/types/conversation.ts
@@ -6,6 +6,7 @@ import {
 } from "drizzle-zod";
 import { z } from "zod";
 import { schema } from "@/database";
+import { ToolExposureModeSchema } from "./agent";
 import { SelectConversationChatErrorSchema } from "./conversation-chat-error";
 import { SelectConversationCompactionSchema } from "./conversation-compaction";
 import { ConversationShareVisibilitySchema } from "./conversation-share";
@@ -38,6 +39,7 @@ export const SelectConversationSchema = createSelectSchema(
       name: z.string(),
       systemPrompt: z.string().nullable(),
       agentType: z.enum(["profile", "mcp_gateway", "llm_proxy", "agent"]),
+      toolExposureMode: ToolExposureModeSchema,
       llmApiKeyId: z.string().nullable(),
     })
     .nullable(),

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -19578,6 +19578,7 @@ export type GetChatConversationsResponses = {
             name: string;
             systemPrompt: string | null;
             agentType: 'profile' | 'mcp_gateway' | 'llm_proxy' | 'agent';
+            toolExposureMode: 'full' | 'search_and_run_only';
             llmApiKeyId: string | null;
         } | null;
         share: {
@@ -19729,6 +19730,7 @@ export type CreateChatConversationResponses = {
             name: string;
             systemPrompt: string | null;
             agentType: 'profile' | 'mcp_gateway' | 'llm_proxy' | 'agent';
+            toolExposureMode: 'full' | 'search_and_run_only';
             llmApiKeyId: string | null;
         } | null;
         share: {
@@ -19962,6 +19964,7 @@ export type GetChatConversationResponses = {
             name: string;
             systemPrompt: string | null;
             agentType: 'profile' | 'mcp_gateway' | 'llm_proxy' | 'agent';
+            toolExposureMode: 'full' | 'search_and_run_only';
             llmApiKeyId: string | null;
         } | null;
         share: {
@@ -20117,6 +20120,7 @@ export type UpdateChatConversationResponses = {
             name: string;
             systemPrompt: string | null;
             agentType: 'profile' | 'mcp_gateway' | 'llm_proxy' | 'agent';
+            toolExposureMode: 'full' | 'search_and_run_only';
             llmApiKeyId: string | null;
         } | null;
         share: {
@@ -20432,6 +20436,7 @@ export type ForkChatConversationResponses = {
             name: string;
             systemPrompt: string | null;
             agentType: 'profile' | 'mcp_gateway' | 'llm_proxy' | 'agent';
+            toolExposureMode: 'full' | 'search_and_run_only';
             llmApiKeyId: string | null;
         } | null;
         share: {
@@ -20684,6 +20689,7 @@ export type CompactChatConversationResponses = {
                 name: string;
                 systemPrompt: string | null;
                 agentType: 'profile' | 'mcp_gateway' | 'llm_proxy' | 'agent';
+                toolExposureMode: 'full' | 'search_and_run_only';
                 llmApiKeyId: string | null;
             } | null;
             share: {
@@ -21106,6 +21112,7 @@ export type GetSharedConversationResponses = {
             name: string;
             systemPrompt: string | null;
             agentType: 'profile' | 'mcp_gateway' | 'llm_proxy' | 'agent';
+            toolExposureMode: 'full' | 'search_and_run_only';
             llmApiKeyId: string | null;
         } | null;
         share: {
@@ -21257,6 +21264,7 @@ export type ForkSharedConversationResponses = {
             name: string;
             systemPrompt: string | null;
             agentType: 'profile' | 'mcp_gateway' | 'llm_proxy' | 'agent';
+            toolExposureMode: 'full' | 'search_and_run_only';
             llmApiKeyId: string | null;
         } | null;
         share: {
@@ -21410,6 +21418,7 @@ export type GenerateChatConversationTitleResponses = {
             name: string;
             systemPrompt: string | null;
             agentType: 'profile' | 'mcp_gateway' | 'llm_proxy' | 'agent';
+            toolExposureMode: 'full' | 'search_and_run_only';
             llmApiKeyId: string | null;
         } | null;
         share: {
@@ -21562,6 +21571,7 @@ export type UpdateChatMessageResponses = {
             name: string;
             systemPrompt: string | null;
             agentType: 'profile' | 'mcp_gateway' | 'llm_proxy' | 'agent';
+            toolExposureMode: 'full' | 'search_and_run_only';
             llmApiKeyId: string | null;
         } | null;
         share: {
@@ -49340,6 +49350,7 @@ export type CreateScheduleTriggerRunConversationResponses = {
             name: string;
             systemPrompt: string | null;
             agentType: 'profile' | 'mcp_gateway' | 'llm_proxy' | 'agent';
+            toolExposureMode: 'full' | 'search_and_run_only';
             llmApiKeyId: string | null;
         } | null;
         share: {


### PR DESCRIPTION
## What changed

Adds a small chat system-prompt supplement when an agent uses **Load tools when needed**. The supplement tells the model to use the full branded search tool name when visible tools do not fit, then call the full branded run tool name with the selected tool and args. Keeps full tool exposure mode unchanged.
