### PR TITLE
fix(k8s): tear down old namespace explicitly on env relocation

### DIFF
--- a/platform/backend/src/k8s/mcp-server-runtime/manager.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager.test.ts
@@ -551,6 +551,93 @@ describe("McpServerRuntimeManager", () => {
       mockMakeApiClient.mockRestore();
     });
 
+    test("getOrLoadDeployment with namespaceOverride bypasses the cache and builds in the override namespace", async () => {
+      const mockLoadFromDefault = vi
+        .spyOn(k8s.KubeConfig.prototype, "loadFromDefault")
+        .mockImplementation(() => {});
+      const mockK8sClient = {
+        getAPIResources: vi.fn().mockResolvedValue({ resources: [] }),
+      };
+      const mockMakeApiClient = vi
+        .spyOn(k8s.KubeConfig.prototype, "makeApiClient")
+        .mockReturnValue(mockK8sClient as unknown as k8s.CoreV1Api);
+
+      const McpServerModel = (await import("@/models/mcp-server")).default;
+      const InternalMcpCatalogModel = (
+        await import("@/models/internal-mcp-catalog")
+      ).default;
+      const staleServer = {
+        id: "stale-server",
+        name: "stale-server",
+        catalogId: "stale-catalog",
+      } as Awaited<ReturnType<typeof McpServerModel.findById>>;
+      // No environmentId → resolves to the manager's default namespace.
+      const staleCatalog = {
+        id: "stale-catalog",
+        serverType: "local",
+        environmentId: null,
+        localConfig: null,
+      } as unknown as Awaited<
+        ReturnType<typeof InternalMcpCatalogModel.findById>
+      >;
+      // Two loads (normal + override) look these up once each. Use *Once so the
+      // mock reverts to its default afterward and never leaks into other tests —
+      // the suite runs in a shuffled order.
+      vi.mocked(McpServerModel.findById)
+        .mockResolvedValueOnce(staleServer)
+        .mockResolvedValueOnce(staleServer);
+      vi.mocked(InternalMcpCatalogModel.findById)
+        .mockResolvedValueOnce(staleCatalog)
+        .mockResolvedValueOnce(staleCatalog);
+
+      const { McpServerRuntimeManager } = await import("./manager");
+      const manager = new McpServerRuntimeManager();
+      const managerAny = manager as unknown as {
+        k8sApi: unknown;
+        k8sAppsApi: unknown;
+        k8sNetworkingApi: unknown;
+        k8sCustomObjectsApi: unknown;
+        k8sAttach: unknown;
+        k8sLog: unknown;
+        k8sExec: unknown;
+      };
+      managerAny.k8sApi = mockK8sClient;
+      managerAny.k8sAppsApi = mockK8sClient;
+      managerAny.k8sNetworkingApi = mockK8sClient;
+      managerAny.k8sCustomObjectsApi = mockK8sClient;
+      managerAny.k8sAttach = {};
+      managerAny.k8sLog = {};
+      managerAny.k8sExec = {};
+
+      // A normal load caches the deployment against the manager's default namespace.
+      await manager.getOrLoadDeployment("stale-server");
+      const cachedNamespace =
+        mockK8sDeploymentInstances.at(-1)?.options.namespace;
+      const builtBeforeOverride = mockK8sDeploymentInstances.length;
+
+      // The override load must IGNORE that cached entry and build a fresh
+      // deployment pinned to the supplied namespace. This is the staleness
+      // bypass the relocation teardown relies on: a cached entry can point at a
+      // now-wrong namespace, so trusting it would delete the wrong namespace and
+      // orphan the old-namespace pod.
+      const overridden = await manager.getOrLoadDeployment("stale-server", {
+        namespaceOverride: "old-env-namespace",
+      });
+      const overrideNamespace =
+        mockK8sDeploymentInstances.at(-1)?.options.namespace;
+
+      expect(cachedNamespace).not.toBe("old-env-namespace");
+      expect(overrideNamespace).toBe("old-env-namespace");
+      // A NEW deployment object was constructed for the override (cache not reused)...
+      expect(mockK8sDeploymentInstances.length).toBe(builtBeforeOverride + 1);
+      expect(overridden).toBeDefined();
+      // ...and the override (teardown-only) path skips serving-endpoint resolution.
+      expect(mockResolveHttpEndpoint).toHaveBeenCalledTimes(1);
+
+      mockLoadFromDefault.mockRestore();
+      mockMakeApiClient.mockRestore();
+    });
+
     test("should call cleanup methods in correct order", async () => {
       const mockLoadFromDefault = vi
         .spyOn(k8s.KubeConfig.prototype, "loadFromDefault")

--- a/platform/backend/src/k8s/mcp-server-runtime/manager.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager.ts
@@ -675,11 +675,20 @@ export class McpServerRuntimeManager {
    */
   async getOrLoadDeployment(
     mcpServerId: string,
+    opts?: { namespaceOverride?: string },
   ): Promise<K8sDeployment | undefined> {
-    // First check if already in memory
-    const existing = this.mcpServerIdToDeploymentMap.get(mcpServerId);
-    if (existing) {
-      return existing;
+    // With an explicit namespace override (tearing down the OLD namespace during
+    // an environment relocation) the in-memory cache must be bypassed: a cached
+    // entry can hold a stale namespace, which is exactly the value we must not
+    // trust here. Build a fresh deployment pinned to the given namespace and do
+    // not read from or write to the cache.
+    const namespaceOverride = opts?.namespaceOverride;
+    if (!namespaceOverride) {
+      // First check if already in memory
+      const existing = this.mcpServerIdToDeploymentMap.get(mcpServerId);
+      if (existing) {
+        return existing;
+      }
     }
 
     // Not in memory - try to load from database
@@ -732,7 +741,9 @@ export class McpServerRuntimeManager {
         k8sCustomObjectsApi: this.k8sCustomObjectsApi,
         k8sAttach: this.k8sAttach,
         k8sLog: this.k8sLog,
-        namespace: await this.resolveNamespaceForCatalog(catalogItem),
+        namespace:
+          namespaceOverride ??
+          (await this.resolveNamespaceForCatalog(catalogItem)),
         catalogItem,
         effectiveNetworkPolicy: await this.resolveNetworkPolicyForDeployment({
           mcpServer,
@@ -743,6 +754,12 @@ export class McpServerRuntimeManager {
         ).networkPolicy,
         k8sExec: this.k8sExec,
       });
+
+      // Teardown path (explicit namespace): skip endpoint resolution and the
+      // cache so a torn-down deployment never overwrites a live cache entry.
+      if (namespaceOverride) {
+        return k8sDeployment;
+      }
 
       // Resolve HTTP endpoint URL (for streamable-http servers started by another replica)
       await k8sDeployment.resolveHttpEndpoint();
@@ -760,6 +777,45 @@ export class McpServerRuntimeManager {
       );
       return undefined;
     }
+  }
+
+  /**
+   * Tear down a local catalog's per-install deployments in the namespace
+   * resolved from the SUPPLIED catalog snapshot, bypassing the in-memory cache.
+   *
+   * During an environment reassignment, call this with the pre-update catalog
+   * item (which still holds the old environment) BEFORE recreating the
+   * deployment in the new namespace. Deriving the namespace from the snapshot —
+   * not the live row or a cached deployment — is what makes the teardown correct
+   * on a cache-cold or cache-stale replica, which would otherwise re-resolve the
+   * new namespace and orphan the old-namespace pod.
+   * @public — invoked from the internal-mcp-catalog PUT route
+   */
+  async tearDownOldNamespaceDeployments(
+    catalogSnapshot:
+      | Awaited<ReturnType<typeof InternalMcpCatalogModel.findById>>
+      | null
+      | undefined,
+  ): Promise<void> {
+    if (!this.isEnabled || !catalogSnapshot) {
+      return;
+    }
+    const namespace = await this.resolveNamespaceForCatalog(catalogSnapshot);
+    const installs = await McpServerModel.findByCatalogId(catalogSnapshot.id);
+    await Promise.all(
+      installs.map(async (mcpServer) => {
+        const deployment = await this.getOrLoadDeployment(mcpServer.id, {
+          namespaceOverride: namespace,
+        });
+        if (!deployment) {
+          return;
+        }
+        await deployment.removeDeployment();
+        // Drop any cached entry so the recreate path rebuilds against the new
+        // namespace instead of returning this torn-down, old-namespace object.
+        this.mcpServerIdToDeploymentMap.delete(mcpServer.id);
+      }),
+    );
   }
 
   /**

--- a/platform/backend/src/k8s/mcp-server-runtime/manager.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager.ts
@@ -677,11 +677,9 @@ export class McpServerRuntimeManager {
     mcpServerId: string,
     opts?: { namespaceOverride?: string },
   ): Promise<K8sDeployment | undefined> {
-    // With an explicit namespace override (tearing down the OLD namespace during
-    // an environment relocation) the in-memory cache must be bypassed: a cached
-    // entry can hold a stale namespace, which is exactly the value we must not
-    // trust here. Build a fresh deployment pinned to the given namespace and do
-    // not read from or write to the cache.
+    // An explicit namespace override (relocation teardown) bypasses the cache: a
+    // cached entry can hold a stale namespace, the one value we must not trust
+    // here. Build fresh, pinned to the given namespace; don't touch the cache.
     const namespaceOverride = opts?.namespaceOverride;
     if (!namespaceOverride) {
       // First check if already in memory

--- a/platform/backend/src/routes/internal-mcp-catalog.environment-relocation.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.environment-relocation.test.ts
@@ -230,6 +230,56 @@ describe("PUT /api/internal_mcp_catalog/:id — environment relocation", () => {
     expect(reinstallSpy).not.toHaveBeenCalled();
   });
 
+  test("single-tenant: combined environment + command change does NOT tear down (cascade defers recreate to manual reinstall)", async ({
+    makeMcpServer,
+  }) => {
+    const from = await createEnvironment({
+      organizationId,
+      data: { name: "Staging", restricted: false },
+    });
+    const to = await createEnvironment({
+      organizationId,
+      data: { name: "Prod", restricted: false },
+    });
+
+    const name = `st-combined-${crypto.randomUUID().slice(0, 8)}`;
+    const catalog = await InternalMcpCatalogModel.create(
+      {
+        name,
+        serverType: "local",
+        multitenant: false,
+        environmentId: from.id,
+        localConfig,
+        scope: "org",
+      },
+      { organizationId },
+    );
+    await makeMcpServer({ catalogId: catalog.id });
+
+    const response = await app.inject({
+      method: "PUT",
+      url: `/api/internal_mcp_catalog/${catalog.id}`,
+      payload: {
+        name,
+        serverType: "local" as const,
+        // Environment changes AND the command changes in the same edit →
+        // requiresNewUserInputForReinstall is true for single-tenant, so the
+        // cascade marks the install reinstall-required and does NOT recreate.
+        localConfig: { ...localConfig, command: "bun" },
+        environmentId: to.id,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().environmentId).toBe(to.id);
+    await drainCascade();
+    // Because the pod is NOT recreated (manual reinstall pending), the
+    // old-namespace deployment must NOT be torn down — doing so would leave the
+    // install with no running pod until the user reinstalls.
+    expect(tearDownSpy).not.toHaveBeenCalled();
+    expect(reinstallSpy).not.toHaveBeenCalled();
+  });
+
   test("multi-tenant: assigning from default (null) to an environment relocates the shared deployment", async ({
     makeMcpServer,
   }) => {

--- a/platform/backend/src/routes/internal-mcp-catalog.environment-relocation.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.environment-relocation.test.ts
@@ -10,12 +10,13 @@ vi.mock("@/auth", () => ({
 }));
 
 // Force the K8s runtime ON so the route's relocation branch is exercised, and
-// stub the cluster calls. restartServer/getOrLoadDeployment are no-ops here; we
-// only assert which relocation primitive the route picks.
+// stub the cluster calls. The teardown/recreate primitives are no-ops here; we
+// only assert which the route picks and what it's called with.
 vi.mock("@/k8s/mcp-server-runtime/manager", () => ({
   default: {
     isEnabled: true,
     getOrLoadDeployment: vi.fn().mockResolvedValue(undefined),
+    tearDownOldNamespaceDeployments: vi.fn().mockResolvedValue(undefined),
     reinstallSharedDeployment: vi.fn().mockResolvedValue(undefined),
     restartServer: vi.fn().mockResolvedValue(undefined),
     validateNamespace: vi.fn().mockResolvedValue(undefined),
@@ -28,7 +29,8 @@ import { createEnvironment } from "@/services/environments/environment";
 
 const mockHasPermission = hasPermission as Mock;
 const reinstallSpy = mcpServerRuntimeManager.reinstallSharedDeployment as Mock;
-const getOrLoadSpy = mcpServerRuntimeManager.getOrLoadDeployment as Mock;
+const tearDownSpy =
+  mcpServerRuntimeManager.tearDownOldNamespaceDeployments as Mock;
 
 // The cascade runs in `setImmediate` after the response; drain real ticks so it
 // settles before the app closes (its per-install tool sync errors harmlessly
@@ -126,12 +128,15 @@ describe("PUT /api/internal_mcp_catalog/:id — environment relocation", () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.json().environmentId).toBe(to.id);
-    // Shared deployment relocated via the catalog-level primitive...
+    // Shared deployment recreated in the new namespace via the catalog-level
+    // primitive...
     expect(reinstallSpy).toHaveBeenCalledWith(catalog.id);
-    // ...and pre-loaded while the row still held the old namespace, i.e. the
-    // pre-load runs BEFORE the relocation so teardown targets the old ns.
-    expect(getOrLoadSpy).toHaveBeenCalled();
-    expect(getOrLoadSpy.mock.invocationCallOrder[0]).toBeLessThan(
+    // ...and the OLD-namespace deployment was torn down first, using the
+    // pre-update snapshot (still carrying the old environment) so the teardown
+    // resolves the old namespace — and BEFORE the recreate.
+    expect(tearDownSpy).toHaveBeenCalled();
+    expect(tearDownSpy.mock.calls[0][0]?.environmentId).toBe(from.id);
+    expect(tearDownSpy.mock.invocationCallOrder[0]).toBeLessThan(
       reinstallSpy.mock.invocationCallOrder[0],
     );
   });
@@ -160,7 +165,7 @@ describe("PUT /api/internal_mcp_catalog/:id — environment relocation", () => {
       },
       { organizationId },
     );
-    const server = await makeMcpServer({ catalogId: catalog.id });
+    await makeMcpServer({ catalogId: catalog.id });
 
     const response = await app.inject({
       method: "PUT",
@@ -170,22 +175,20 @@ describe("PUT /api/internal_mcp_catalog/:id — environment relocation", () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.json().environmentId).toBe(to.id);
-    // The install's deployment is pre-loaded synchronously in the handler,
-    // while the catalog row still holds the OLD namespace — BEFORE the deferred
-    // cascade runs its per-install restartServer→stopServer teardown (which
-    // re-derives the namespace from the now-updated row). Asserting it here,
-    // before draining the cascade, proves the pre-load ran in-handler ahead of
-    // any teardown. Without it the teardown targets the new namespace and
-    // orphans the old-namespace pod on a cache-cold replica.
-    expect(getOrLoadSpy).toHaveBeenCalledWith(server.id);
+    // The OLD-namespace deployment is torn down explicitly, using the pre-update
+    // snapshot (still carrying the old environment) so the teardown resolves the
+    // OLD namespace — not the now-updated row, which a cache-stale replica would
+    // otherwise re-resolve to the new namespace, orphaning the old pod.
+    expect(tearDownSpy).toHaveBeenCalled();
+    expect(tearDownSpy.mock.calls[0][0]?.environmentId).toBe(from.id);
 
     await drainCascade();
-    // Single-tenant relocates via the cascade's per-install restart, never the
+    // Single-tenant recreates via the cascade's per-install restart, never the
     // shared-deployment primitive (that path no-ops on a shared deployment).
     expect(reinstallSpy).not.toHaveBeenCalled();
   });
 
-  test("single-tenant: reassignment back to default (null) still pre-loads the deployment", async ({
+  test("single-tenant: reassignment back to default (null) tears down the old env namespace", async ({
     makeMcpServer,
   }) => {
     const from = await createEnvironment({
@@ -205,7 +208,7 @@ describe("PUT /api/internal_mcp_catalog/:id — environment relocation", () => {
       },
       { organizationId },
     );
-    const server = await makeMcpServer({ catalogId: catalog.id });
+    await makeMcpServer({ catalogId: catalog.id });
 
     const response = await app.inject({
       method: "PUT",
@@ -216,10 +219,12 @@ describe("PUT /api/internal_mcp_catalog/:id — environment relocation", () => {
     expect(response.statusCode).toBe(200);
     expect(response.json().environmentId).toBeNull();
     // Prod→Default is the direction observed orphaning a pod in the previous
-    // environment's namespace. The pre-load must still run (in-handler, before
-    // the deferred cascade) so the teardown targets that namespace rather than
-    // the resolved default.
-    expect(getOrLoadSpy).toHaveBeenCalledWith(server.id);
+    // environment's namespace. The teardown must use the pre-update snapshot
+    // (environmentId = the Prod env) so it removes the pod from THAT namespace —
+    // not the default it's moving to. Passing the new (null) env here is exactly
+    // the bug: it would resolve to the default namespace and orphan the old pod.
+    expect(tearDownSpy).toHaveBeenCalled();
+    expect(tearDownSpy.mock.calls[0][0]?.environmentId).toBe(from.id);
 
     await drainCascade();
     expect(reinstallSpy).not.toHaveBeenCalled();

--- a/platform/backend/src/routes/internal-mcp-catalog.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.ts
@@ -1003,7 +1003,21 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
         throw new ApiError(404, "Catalog item not found");
       }
 
-      if (relocatingLocalDeployment) {
+      // Only tear down the old-namespace deployment when it will actually be
+      // recreated. A single-tenant edit that ALSO requires new user input (e.g.
+      // a command or prompted-env-var change in the same PUT) makes the cascade
+      // mark the install reinstall-required WITHOUT recreating the pod — so
+      // tearing it down here would leave the install with no running pod until a
+      // manual reinstall. Multi-tenant always recreates via
+      // reinstallSharedDeployment below, so it's always safe there.
+      const recreatingRelocatedDeployment =
+        relocatingLocalDeployment &&
+        (originalCatalogItem.multitenant === true ||
+          !requiresNewUserInputForReinstall(
+            originalCatalogItemForGate,
+            catalogItem,
+          ));
+      if (recreatingRelocatedDeployment) {
         // Remove the deployment(s) from the OLD namespace before recreating in
         // the new one. The old namespace is derived from `originalCatalogItem`
         // (captured before the update), so the teardown is correct even on a

--- a/platform/backend/src/routes/internal-mcp-catalog.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.ts
@@ -988,29 +988,13 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
         });
       }
 
-      // On an environment reassignment of a local catalog, the teardown must
-      // target the OLD namespace. Both teardown paths resolve the namespace
-      // from the catalog row — reinstallSharedDeployment (multi-tenant) and the
-      // cascade's per-install restartServer→stopServer→getOrLoadDeployment
-      // (single-tenant) — and the update below rewrites that row to the new
-      // environment. Pre-load the existing deployments now, while the row still
-      // holds the old namespace, so they are cached against the old-namespace
-      // pod and the teardown deletes it. Without this warm-up, a cache-cold
-      // replica (any of several) re-derives the new namespace at teardown and
-      // orphans the old-namespace pod.
+      // Detect an environment reassignment of a local catalog — it relocates
+      // the pod to a different namespace.
       const relocatingLocalDeployment =
         "environmentId" in restBody &&
         restBody.environmentId !== originalCatalogItem.environmentId &&
         originalCatalogItem.serverType === "local" &&
         mcpServerRuntimeManager.isEnabled;
-      if (relocatingLocalDeployment) {
-        const installs = await McpServerModel.findByCatalogId(id);
-        await Promise.all(
-          installs.map((s) =>
-            mcpServerRuntimeManager.getOrLoadDeployment(s.id),
-          ),
-        );
-      }
 
       // Update the catalog item
       const catalogItem = await InternalMcpCatalogModel.update(id, restBody);
@@ -1019,15 +1003,27 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
         throw new ApiError(404, "Catalog item not found");
       }
 
-      // A multi-tenant local catalog shares one K8s Deployment across all
-      // installs, and a per-install restart no-ops on it (the sibling guard in
-      // restartServer), so the shared Deployment must be relocated explicitly,
-      // mirroring the environment-namespace-edit route. Now that the row holds
-      // the new environment, recreate it in the new namespace — awaited before
-      // the cascade so its per-install tool sync runs against the relocated,
-      // ready pod rather than racing the recreate. Single-tenant installs
-      // relocate via the cascade's per-install restart below, using the
-      // deployments pre-loaded above.
+      if (relocatingLocalDeployment) {
+        // Remove the deployment(s) from the OLD namespace before recreating in
+        // the new one. The old namespace is derived from `originalCatalogItem`
+        // (captured before the update), so the teardown is correct even on a
+        // cache-cold or cache-stale replica — unlike the recreate paths below,
+        // which resolve the namespace from the now-updated row. Without this the
+        // old-namespace pod is orphaned: it keeps running in a namespace the
+        // catalog no longer points at, and the reconciler only scans the default
+        // namespace so it never reclaims it.
+        await mcpServerRuntimeManager.tearDownOldNamespaceDeployments(
+          originalCatalogItem,
+        );
+      }
+
+      // Recreate in the new namespace. A multi-tenant local catalog shares one
+      // K8s Deployment across all installs, and a per-install restart no-ops on
+      // it (the sibling guard in restartServer), so it must be recreated
+      // explicitly via reinstallSharedDeployment — awaited before the cascade so
+      // its per-install tool sync runs against the relocated, ready pod rather
+      // than racing the recreate. Single-tenant installs are recreated by the
+      // cascade's per-install restart below.
       if (
         relocatingLocalDeployment &&
         originalCatalogItem.multitenant === true


### PR DESCRIPTION
## Summary

PR #5236 tried to stop environment relocation from orphaning an MCP server's pod in its old namespace, but the fix was insufficient — the orphan still occurs on multi-replica deployments (reproduced on staging).

The pre-load approach relied on `getOrLoadDeployment`, which is **cache-first**: it returns a cached deployment object without re-checking its namespace. With multiple platform replicas, the replica handling a relocation can hold a **stale** namespace (the server's original location), so the teardown deleted the wrong namespace and left the old-namespace deployment running. The reconciler only scans the default namespace, so the orphan persisted indefinitely. The forward direction (Default → named env) happened to be safe because the default namespace is the universal fallback every stale/derived value collapses to; the reverse (named env → Default) was not.

This tears the old-namespace deployment down **explicitly**: the old namespace is derived from the **pre-update catalog snapshot** (authoritative, never stale) and the deployment is removed there before being recreated in the new namespace. `getOrLoadDeployment` gains a `namespaceOverride` that bypasses the cache and pins the built deployment to the supplied namespace.

Supersedes the pre-load mechanism added in #5236. The definitive multi-replica behavior is verified on staging after deploy (the single-replica/local path can't reproduce the cache-staleness race).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>