### PR TITLE
chore(ci): scope main commit workflow

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -28,7 +28,6 @@ archestra:
   # instead of API keys for authentication
   env:
     ARCHESTRA_ANALYTICS: disabled
-    ARCHESTRA_AGENTS_ADVANCED_TOOL_FEATURES_ENABLED: "true"
     ARCHESTRA_AGENTS_SKILLS_ENABLED: "true"
     ARCHESTRA_ENTERPRISE_LICENSE_ACTIVATED: "true"
     ARCHESTRA_ENTERPRISE_LICENSE_FULL_WHITE_LABELING: "true"
@@ -120,4 +119,3 @@ archestra:
           - path: /
             port: 9000
             pathType: Prefix
-

--- a/.github/workflows/on-commits-to-main.yml
+++ b/.github/workflows/on-commits-to-main.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - ".github/**"
+      - "platform/**"
   # Allow manual triggering of the workflow
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

- Remove `ARCHESTRA_AGENTS_ADVANCED_TOOL_FEATURES_ENABLED` from staging Helm values.
- Limit `on-commits-to-main` push runs on `main` to changes under `.github/**` or `platform/**`.