### PR TITLE
fix: artifact table overflow

### DIFF
--- a/platform/frontend/src/components/ai-elements/response.tsx
+++ b/platform/frontend/src/components/ai-elements/response.tsx
@@ -65,6 +65,9 @@ export const Response = memo(
           "[&_pre]:bg-muted [&_pre]:p-3 [&_pre]:rounded [&_pre]:my-2 [&_pre]:overflow-x-auto",
           // Fix streamdown code blocks - remove padding from code elements inside them
           "[&_[data-streamdown='code-block']_code]:p-0 [&_[data-streamdown='code-block']_code]:bg-transparent",
+          // Keep large markdown tables readable without letting them dominate the chat scroll.
+          "[&_[data-streamdown='table-wrapper']>div:last-child]:max-h-[420px]",
+          "[&_[data-streamdown='table-header']]:sticky [&_[data-streamdown='table-header']]:top-0 [&_[data-streamdown='table-header']]:z-10",
           // Fix button link styling - use group variant to match parent's is-user/is-assistant class
           "group-[.is-user]:[&_[data-streamdown='link']]:text-primary-foreground",
           "group-[.is-assistant]:[&_[data-streamdown='link']]:text-secondary-foreground",

--- a/platform/frontend/src/components/chat/conversation-artifact.test.tsx
+++ b/platform/frontend/src/components/chat/conversation-artifact.test.tsx
@@ -68,22 +68,4 @@ describe("ConversationArtifactPanel", () => {
 
     expect(await screen.findByTestId("mermaid-diagram")).toBeInTheDocument();
   });
-
-  it("wraps markdown tables in a horizontal scroll container", () => {
-    render(
-      <ConversationArtifactPanel
-        artifact={[
-          "| Column A | Column B | Column C | Column D | Column E |",
-          "| --- | --- | --- | --- | --- |",
-          "| Alpha | Bravo | Charlie | Delta | Echo |",
-        ].join("\n")}
-        isOpen
-        onToggle={() => {}}
-      />,
-    );
-
-    const table = screen.getByRole("table");
-    expect(table).toHaveClass("min-w-max");
-    expect(table.parentElement).toHaveClass("overflow-x-auto");
-  });
 });

--- a/platform/frontend/src/components/chat/conversation-artifact.test.tsx
+++ b/platform/frontend/src/components/chat/conversation-artifact.test.tsx
@@ -68,4 +68,22 @@ describe("ConversationArtifactPanel", () => {
 
     expect(await screen.findByTestId("mermaid-diagram")).toBeInTheDocument();
   });
+
+  it("wraps markdown tables in a horizontal scroll container", () => {
+    render(
+      <ConversationArtifactPanel
+        artifact={[
+          "| Column A | Column B | Column C | Column D | Column E |",
+          "| --- | --- | --- | --- | --- |",
+          "| Alpha | Bravo | Charlie | Delta | Echo |",
+        ].join("\n")}
+        isOpen
+        onToggle={() => {}}
+      />,
+    );
+
+    const table = screen.getByRole("table");
+    expect(table).toHaveClass("min-w-max");
+    expect(table.parentElement).toHaveClass("overflow-x-auto");
+  });
 });

--- a/platform/frontend/src/components/chat/conversation-artifact.tsx
+++ b/platform/frontend/src/components/chat/conversation-artifact.tsx
@@ -99,6 +99,54 @@ export function ConversationArtifactPanel({
     pre({ children }) {
       return <>{children}</>;
     },
+    table({ node, className, children, ...props }) {
+      return (
+        <div className="my-4 w-full overflow-x-auto rounded-md border border-border">
+          <table
+            className={cn(
+              "w-full min-w-max border-collapse text-sm",
+              className,
+            )}
+            {...props}
+          >
+            {children}
+          </table>
+        </div>
+      );
+    },
+    thead({ node, className, children, ...props }) {
+      return (
+        <thead className={cn("bg-muted", className)} {...props}>
+          {children}
+        </thead>
+      );
+    },
+    th({ node, className, children, ...props }) {
+      return (
+        <th
+          className={cn(
+            "border-r border-b border-border px-3 py-2 text-left font-semibold last:border-r-0",
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </th>
+      );
+    },
+    td({ node, className, children, ...props }) {
+      return (
+        <td
+          className={cn(
+            "border-r border-b border-border px-3 py-2 align-top last:border-r-0",
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </td>
+      );
+    },
     code({ node, className, children, ...props }) {
       const match = /language-(\w+)/.exec(className || "");
       const language = match ? match[1] : "";
@@ -422,7 +470,7 @@ export function ConversationArtifactPanel({
       <div className="flex-1 overflow-y-auto">
         <div ref={contentRef} className="px-6 py-4 max-w-none h-full">
           {artifact ? (
-            <div className="size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_ul]:list-inside [&_ul]:list-disc [&_ul]:ml-6 [&_ul]:my-2 [&_ol]:list-inside [&_ol]:list-decimal [&_ol]:ml-6 [&_ol]:my-2 [&_li]:my-1 [&_li>p]:inline [&_h1]:text-2xl [&_h1]:font-bold [&_h1]:my-4 [&_h2]:text-xl [&_h2]:font-bold [&_h2]:my-3 [&_h3]:text-lg [&_h3]:font-semibold [&_h3]:my-2 [&_p]:my-2 [&_code]:bg-muted [&_code]:text-foreground [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_pre]:bg-muted [&_pre]:p-3 [&_pre]:rounded [&_pre]:my-2 [&_pre]:overflow-x-auto [&_table]:border-collapse [&_table]:w-full [&_table]:my-4 [&_table]:border [&_table]:border-border [&_td]:border [&_td]:border-border [&_td]:px-3 [&_td]:py-2 [&_th]:border [&_th]:border-border [&_th]:px-3 [&_th]:py-2 [&_th]:bg-muted [&_th]:font-semibold [&_thead]:bg-muted">
+            <div className="size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_ul]:list-inside [&_ul]:list-disc [&_ul]:ml-6 [&_ul]:my-2 [&_ol]:list-inside [&_ol]:list-decimal [&_ol]:ml-6 [&_ol]:my-2 [&_li]:my-1 [&_li>p]:inline [&_h1]:text-2xl [&_h1]:font-bold [&_h1]:my-4 [&_h2]:text-xl [&_h2]:font-bold [&_h2]:my-3 [&_h3]:text-lg [&_h3]:font-semibold [&_h3]:my-2 [&_p]:my-2 [&_code]:bg-muted [&_code]:text-foreground [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_pre]:bg-muted [&_pre]:p-3 [&_pre]:rounded [&_pre]:my-2 [&_pre]:overflow-x-auto">
               <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
                 components={markdownComponents}

--- a/platform/frontend/src/components/chat/conversation-artifact.tsx
+++ b/platform/frontend/src/components/chat/conversation-artifact.tsx
@@ -101,7 +101,7 @@ export function ConversationArtifactPanel({
     },
     table({ node, className, children, ...props }) {
       return (
-        <div className="my-4 w-full overflow-x-auto rounded-md border border-border">
+        <div className="my-4 max-h-[420px] w-full overflow-auto rounded-md border border-border">
           <table
             className={cn(
               "w-full min-w-max border-collapse text-sm",
@@ -125,7 +125,7 @@ export function ConversationArtifactPanel({
       return (
         <th
           className={cn(
-            "border-r border-b border-border px-3 py-2 text-left font-semibold last:border-r-0",
+            "sticky top-0 z-10 border-r border-b border-border bg-muted px-3 py-2 text-left font-semibold last:border-r-0",
             className,
           )}
           {...props}


### PR DESCRIPTION
## Summary

- Wrap Markdown tables in chat artifacts with an artifact-local horizontal scroll container.
- Move table cell/header styling into explicit Markdown renderers so wide tables keep readable columns.