### PR TITLE
test(e2e): skip flaky Chat-UI-cohere chat test

### DIFF
--- a/platform/e2e-tests/tests/chat.spec.ts
+++ b/platform/e2e-tests/tests/chat.spec.ts
@@ -183,7 +183,9 @@ const testConfigs: ChatProviderTestConfig[] = [
 
 // cerebras: model selector intermittently never renders in CI (15s timeout).
 // Tracked alongside MQ flakiness from https://github.com/archestra-ai/archestra/actions/runs/26282803981.
-const skippedProviders = new Set<string>(["cerebras"]);
+// cohere: mocked streaming response intermittently never becomes visible in CI (90s timeout),
+// failing all retries. Tracked from https://github.com/archestra-ai/archestra/actions/runs/26950850016.
+const skippedProviders = new Set<string>(["cerebras", "cohere"]);
 
 for (const config of testConfigs) {
   test.describe(`Chat-UI-${config.providerName}`, () => {


### PR DESCRIPTION
The `Chat-UI-cohere` case of the parametrized `chat.spec.ts` suite intermittently times out (90s) waiting for the mocked WireMock streaming response to become visible, failing on the initial run and both retries and blocking the merge queue ([example run](https://github.com/archestra-ai/archestra/actions/runs/26950850016/job/79516194132)). The same parametrized assertion flakes-then-passes for other providers (e.g. `Chat-UI-openai`) in the same run, pointing at a CI streaming-visibility race rather than a Cohere-specific defect.

Adds `"cohere"` to the existing `skippedProviders` set (alongside `"cerebras"`) so the unstable case stops gating merges. The skip is commented with the symptom and a tracking link so it can be removed once the streaming wait is stabilized.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>