### PR TITLE
chore: bump default LLM models

### DIFF
--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_ADMIN_PASSWORD,
   DEFAULT_ADMIN_PASSWORD_ENV_VAR_NAME,
   DEFAULT_APP_NAME,
+  DEFAULT_MODELS,
   DEFAULT_VAULT_TOKEN,
   type SupportedProvider,
   SupportedProviders,
@@ -1001,7 +1002,7 @@ const config = {
       apiKey: process.env.ARCHESTRA_CHAT_AZURE_OPENAI_API_KEY || "",
     },
     defaultModel:
-      process.env.ARCHESTRA_CHAT_DEFAULT_MODEL || "claude-opus-4-1-20250805",
+      process.env.ARCHESTRA_CHAT_DEFAULT_MODEL || DEFAULT_MODELS.anthropic,
     defaultProvider: ((): SupportedProvider => {
       const provider = process.env.ARCHESTRA_CHAT_DEFAULT_PROVIDER;
       if (

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -132,6 +132,8 @@ export const PERPLEXITY_MODELS = [
  * @see https://platform.minimax.io/docs/guides/models-intro
  */
 export const MINIMAX_MODELS = [
+  { id: "MiniMax-M3", displayName: "MiniMax-M3" },
+  { id: "MiniMax-M3-highspeed", displayName: "MiniMax-M3-highspeed" },
   { id: "MiniMax-M2.7", displayName: "MiniMax-M2.7" },
   { id: "MiniMax-M2.7-highspeed", displayName: "MiniMax-M2.7-highspeed" },
   { id: "MiniMax-M2.5", displayName: "MiniMax-M2.5" },
@@ -190,7 +192,7 @@ export const OPENROUTER_LATEST_ALIAS_PREFIX = "~";
  * More specific patterns should come before general ones.
  */
 export const MODEL_MARKER_PATTERNS: Record<SupportedProvider, string[]> = {
-  anthropic: ["opus-4-7"],
+  anthropic: ["opus-4-8", "opus-4-7"],
   openai: ["gpt-5.5-pro", "gpt-5.5"],
   gemini: ["gemini-3.1-pro-preview", "gemini-2.5-pro"],
   cerebras: ["zai-glm-4.7"],
@@ -200,6 +202,7 @@ export const MODEL_MARKER_PATTERNS: Record<SupportedProvider, string[]> = {
   groq: ["openai/gpt-oss-120b"],
   xai: ["grok-4.3"],
   openrouter: [
+    "anthropic/claude-opus-4.8",
     "anthropic/claude-opus-4.7",
     "openai/gpt-5.5-pro",
     "openai/gpt-5.5",
@@ -211,9 +214,9 @@ export const MODEL_MARKER_PATTERNS: Record<SupportedProvider, string[]> = {
   vllm: ["gpt-oss-120b", "llama-4-maverick", "llama-4-scout", "qwen3-235b"],
   zhipuai: ["glm-5.1"],
   deepseek: ["deepseek-v4-pro"],
-  minimax: ["minimax-m2.7"],
+  minimax: ["minimax-m3", "minimax-m2.7"],
   azure: ["gpt-5.5"],
-  bedrock: ["anthropic.claude-opus-4-7"],
+  bedrock: ["anthropic.claude-opus-4-8", "anthropic.claude-opus-4-7"],
 };
 
 /**
@@ -221,10 +224,10 @@ export const MODEL_MARKER_PATTERNS: Record<SupportedProvider, string[]> = {
  * Using Record<SupportedProvider, string> ensures a compile-time error when a new provider is added.
  */
 export const DEFAULT_MODELS: Record<SupportedProvider, string> = {
-  anthropic: "claude-opus-4-7",
+  anthropic: "claude-opus-4-8",
   openai: "gpt-5.5",
   openrouter: "openrouter/auto",
-  gemini: "gemini-3.1-pro-preview",
+  gemini: "gemini-3.5-flash",
   cohere: "command-a-plus-05-2026",
   groq: "openai/gpt-oss-120b",
   xai: "grok-4.3",
@@ -235,8 +238,8 @@ export const DEFAULT_MODELS: Record<SupportedProvider, string> = {
   perplexity: "sonar-pro",
   zhipuai: "glm-5.1",
   deepseek: "deepseek-v4-pro",
-  bedrock: "anthropic.claude-opus-4-7",
-  minimax: "MiniMax-M2.7",
+  bedrock: "anthropic.claude-opus-4-8",
+  minimax: "MiniMax-M3",
   azure: "gpt-5.5",
 };
 /**


### PR DESCRIPTION
## Summary

Updates the app's default/fallback model identifiers, which had drifted behind the provider tables.

- **Chat fallback default** (`config.ts`): `claude-opus-4-1-20250805` → now sourced from `DEFAULT_MODELS.anthropic` so it tracks the shared table instead of drifting.
- **Anthropic → Opus 4.8**: `DEFAULT_MODELS.anthropic`/`bedrock` and marker patterns (`anthropic`, `openrouter`, `bedrock`). Previous `4-7` markers kept as fallback for deployments not yet synced to 4.8.
- **MiniMax → M3**: added `MiniMax-M3` + `-highspeed` to the source-of-truth list, set as default, marker prepended (`2.7` kept as fallback).
- **Gemini default → `gemini-3.5-flash`**: fallback default only. Marker patterns left on the pro tier intentionally, since those flag the highest-quality synced model.

Marker arrays keep the prior version as a fallback, so deployments that haven't synced the new model still resolve to the best one they have.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>