### PR TITLE
fix(staging): cap database pool size

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -47,6 +47,7 @@ archestra:
     ARCHESTRA_AGENTS_INCOMING_EMAIL_OUTLOOK_WEBHOOK_URL: "https://backend.archestra.dev/api/webhooks/incoming-email"
     ARCHESTRA_CHAT_DEFAULT_PROVIDER: "anthropic"
     ARCHESTRA_CHAT_DEFAULT_MODEL: "claude-opus-4-5-20251101"
+    ARCHESTRA_DATABASE_POOL_MAX: "8"
 
   diagnostics:
     enabled: true


### PR DESCRIPTION
Summary
- Set ARCHESTRA_DATABASE_POOL_MAX to 8 in staging Helm values.
- Keeps total app-side database connections bounded across web and worker pods during rollouts.

Testing
- helm template archestra ./platform/helm/archestra -f .github/values-staging.yaml

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>