### PR TITLE
[codex] fix k8s fqdn policy rbac detection

### DIFF
--- a/platform/backend/src/k8s/capabilities.test.ts
+++ b/platform/backend/src/k8s/capabilities.test.ts
@@ -10,21 +10,32 @@ describe("Kubernetes capability inspection", () => {
     clearK8sCapabilitiesCache();
   });
 
-  test("reports Cilium FQDN support when the CiliumNetworkPolicy CRD exists", async () => {
+  test("reports Cilium FQDN support when the CiliumNetworkPolicy CRD exists and can be managed", async () => {
     const customObjectsApi = {
       getAPIResources: vi.fn(async ({ group }: { group: string }) => ({
         resources:
           group === "cilium.io" ? [{ name: "ciliumnetworkpolicies" }] : [],
       })),
     };
+    const authApi = createAuthApi();
 
-    const capabilities = await getK8sCapabilitiesFromApi(
-      customObjectsApi as never,
-    );
+    const capabilities = await getCapabilities(customObjectsApi, authApi);
 
     expect(customObjectsApi.getAPIResources).toHaveBeenCalledWith({
       group: "cilium.io",
       version: "v2",
+    });
+    expect(authApi.createSelfSubjectAccessReview).toHaveBeenCalledWith({
+      body: {
+        spec: {
+          resourceAttributes: {
+            namespace: "test-ns",
+            verb: "delete",
+            group: "cilium.io",
+            resource: "ciliumnetworkpolicies",
+          },
+        },
+      },
     });
     expect(capabilities.networkPolicy).toMatchObject({
       kubernetesNetworkPolicy: true,
@@ -37,14 +48,35 @@ describe("Kubernetes capability inspection", () => {
     });
   });
 
+  test("falls back to Kubernetes NetworkPolicy when Cilium delete access is denied", async () => {
+    const customObjectsApi = {
+      getAPIResources: vi.fn(async ({ group }: { group: string }) => ({
+        resources:
+          group === "cilium.io" ? [{ name: "ciliumnetworkpolicies" }] : [],
+      })),
+    };
+    const authApi = createAuthApi(({ verb }) => verb !== "delete");
+
+    const capabilities = await getCapabilities(customObjectsApi, authApi);
+
+    expect(capabilities.networkPolicy).toMatchObject({
+      kubernetesNetworkPolicy: true,
+      ciliumNetworkPolicy: false,
+      gkeFqdnNetworkPolicy: false,
+      awsApplicationNetworkPolicy: false,
+      provider: "kubernetes",
+      supportsFqdn: false,
+      supportsHttpMethods: false,
+    });
+  });
+
   test("falls back to Kubernetes NetworkPolicy when the Cilium CRD is absent", async () => {
     const customObjectsApi = {
       getAPIResources: vi.fn().mockRejectedValue({ statusCode: 404 }),
     };
+    const authApi = createAuthApi();
 
-    const capabilities = await getK8sCapabilitiesFromApi(
-      customObjectsApi as never,
-    );
+    const capabilities = await getCapabilities(customObjectsApi, authApi);
 
     expect(capabilities.networkPolicy).toMatchObject({
       kubernetesNetworkPolicy: true,
@@ -66,10 +98,9 @@ describe("Kubernetes capability inspection", () => {
             : [],
       })),
     };
+    const authApi = createAuthApi();
 
-    const capabilities = await getK8sCapabilitiesFromApi(
-      customObjectsApi as never,
-    );
+    const capabilities = await getCapabilities(customObjectsApi, authApi);
 
     expect(capabilities.networkPolicy).toMatchObject({
       kubernetesNetworkPolicy: true,
@@ -91,10 +122,9 @@ describe("Kubernetes capability inspection", () => {
             : [],
       })),
     };
+    const authApi = createAuthApi();
 
-    const capabilities = await getK8sCapabilitiesFromApi(
-      customObjectsApi as never,
-    );
+    const capabilities = await getCapabilities(customObjectsApi, authApi);
 
     expect(capabilities.networkPolicy).toMatchObject({
       kubernetesNetworkPolicy: true,
@@ -111,11 +141,24 @@ describe("Kubernetes capability inspection", () => {
     const customObjectsApi = {
       getAPIResources: vi.fn(async () => ({ resources: [] })),
     };
+    const authApi = createAuthApi();
 
-    await getK8sCapabilitiesFromApi(customObjectsApi as never);
-    await getK8sCapabilitiesFromApi(customObjectsApi as never);
+    await getCapabilities(customObjectsApi, authApi);
+    await getCapabilities(customObjectsApi, authApi);
 
     expect(customObjectsApi.getAPIResources).toHaveBeenCalledTimes(3);
+  });
+
+  test("caches CRD inspection separately per namespace", async () => {
+    const customObjectsApi = {
+      getAPIResources: vi.fn(async () => ({ resources: [] })),
+    };
+    const authApi = createAuthApi();
+
+    await getCapabilities(customObjectsApi, authApi, "first-ns");
+    await getCapabilities(customObjectsApi, authApi, "second-ns");
+
+    expect(customObjectsApi.getAPIResources).toHaveBeenCalledTimes(6);
   });
 
   test("reprobes after the capability cache TTL expires", async () => {
@@ -124,11 +167,54 @@ describe("Kubernetes capability inspection", () => {
     const customObjectsApi = {
       getAPIResources: vi.fn(async () => ({ resources: [] })),
     };
+    const authApi = createAuthApi();
 
-    await getK8sCapabilitiesFromApi(customObjectsApi as never);
+    await getCapabilities(customObjectsApi, authApi);
     vi.advanceTimersByTime(5 * 60 * 1000 + 1);
-    await getK8sCapabilitiesFromApi(customObjectsApi as never);
+    await getCapabilities(customObjectsApi, authApi);
 
     expect(customObjectsApi.getAPIResources).toHaveBeenCalledTimes(6);
   });
 });
+
+function createAuthApi(
+  isAllowed: (attributes: {
+    namespace: string;
+    verb: string;
+    group: string;
+    resource: string;
+  }) => boolean = () => true,
+) {
+  return {
+    createSelfSubjectAccessReview: vi.fn(
+      async (params: {
+        body: {
+          spec: {
+            resourceAttributes: {
+              namespace: string;
+              verb: string;
+              group: string;
+              resource: string;
+            };
+          };
+        };
+      }) => ({
+        status: {
+          allowed: isAllowed(params.body.spec.resourceAttributes),
+        },
+      }),
+    ),
+  };
+}
+
+function getCapabilities(
+  customObjectsApi: unknown,
+  authApi: unknown,
+  namespace = "test-ns",
+) {
+  return getK8sCapabilitiesFromApi({
+    customObjectsApi: customObjectsApi as never,
+    authApi: authApi as never,
+    namespace,
+  });
+}

--- a/platform/backend/src/k8s/capabilities.ts
+++ b/platform/backend/src/k8s/capabilities.ts
@@ -12,9 +12,11 @@ export async function getK8sCapabilities(): Promise<K8sCapabilities> {
   try {
     const { kubeConfig, namespace } = loadKubeConfig();
     const clients = createK8sClients(kubeConfig, namespace);
-    const capabilities = await getK8sCapabilitiesFromApi(
-      clients.customObjectsApi,
-    );
+    const capabilities = await getK8sCapabilitiesFromApi({
+      customObjectsApi: clients.customObjectsApi,
+      authApi: clients.authApi,
+      namespace,
+    });
     globalCapabilitiesCache = createCacheEntry(capabilities);
     return capabilities;
   } catch (error) {
@@ -23,10 +25,14 @@ export async function getK8sCapabilities(): Promise<K8sCapabilities> {
   }
 }
 
-export async function getK8sCapabilitiesFromApi(
-  customObjectsApi: k8s.CustomObjectsApi,
-): Promise<K8sCapabilities> {
-  const cached = getValidCacheEntry(apiCapabilitiesCache.get(customObjectsApi));
+export async function getK8sCapabilitiesFromApi(params: {
+  customObjectsApi: k8s.CustomObjectsApi;
+  authApi: k8s.AuthorizationV1Api;
+  namespace: string;
+}): Promise<K8sCapabilities> {
+  const cached = getValidCacheEntry(
+    apiCapabilitiesCache.get(params.customObjectsApi)?.get(params.namespace),
+  );
   if (cached) return cached;
 
   const [
@@ -34,9 +40,33 @@ export async function getK8sCapabilitiesFromApi(
     gkeFqdnNetworkPolicy,
     awsApplicationNetworkPolicy,
   ] = await Promise.all([
-    hasCiliumNetworkPolicyResource(customObjectsApi),
-    hasGkeFqdnNetworkPolicyResource(customObjectsApi),
-    hasAwsApplicationNetworkPolicyResource(customObjectsApi),
+    hasManageableCustomPolicyResource({
+      customObjectsApi: params.customObjectsApi,
+      authApi: params.authApi,
+      namespace: params.namespace,
+      group: "cilium.io",
+      version: "v2",
+      resource: "ciliumnetworkpolicies",
+      logName: "Cilium",
+    }),
+    hasManageableCustomPolicyResource({
+      customObjectsApi: params.customObjectsApi,
+      authApi: params.authApi,
+      namespace: params.namespace,
+      group: "networking.gke.io",
+      version: "v1alpha1",
+      resource: "fqdnnetworkpolicies",
+      logName: "GKE FQDN",
+    }),
+    hasManageableCustomPolicyResource({
+      customObjectsApi: params.customObjectsApi,
+      authApi: params.authApi,
+      namespace: params.namespace,
+      group: "networking.k8s.aws",
+      version: "v1alpha1",
+      resource: "applicationnetworkpolicies",
+      logName: "AWS ApplicationNetworkPolicy",
+    }),
   ]);
   const provider = ciliumNetworkPolicy
     ? "cilium"
@@ -65,7 +95,10 @@ export async function getK8sCapabilitiesFromApi(
       }),
     },
   };
-  apiCapabilitiesCache.set(customObjectsApi, createCacheEntry(capabilities));
+  const apiCache =
+    apiCapabilitiesCache.get(params.customObjectsApi) ?? new Map();
+  apiCache.set(params.namespace, createCacheEntry(capabilities));
+  apiCapabilitiesCache.set(params.customObjectsApi, apiCache);
   return capabilities;
 }
 
@@ -85,7 +118,12 @@ type CacheEntry = {
 };
 
 let globalCapabilitiesCache: CacheEntry | null = null;
-let apiCapabilitiesCache = new WeakMap<k8s.CustomObjectsApi, CacheEntry>();
+let apiCapabilitiesCache = new WeakMap<
+  k8s.CustomObjectsApi,
+  Map<string, CacheEntry>
+>();
+
+const CUSTOM_POLICY_MANAGEMENT_VERBS = ["create", "update", "delete"] as const;
 
 function createCacheEntry(value: K8sCapabilities): CacheEntry {
   return {
@@ -101,17 +139,58 @@ function getValidCacheEntry(entry: CacheEntry | null | undefined) {
   return entry.value;
 }
 
-async function hasCiliumNetworkPolicyResource(
-  customObjectsApi: k8s.CustomObjectsApi,
-): Promise<boolean> {
+async function hasManageableCustomPolicyResource(params: {
+  customObjectsApi: k8s.CustomObjectsApi;
+  authApi: k8s.AuthorizationV1Api;
+  namespace: string;
+  group: string;
+  version: string;
+  resource: string;
+  logName: string;
+}): Promise<boolean> {
+  const exists = await hasCustomPolicyResource(params);
+  if (!exists) {
+    return false;
+  }
+
+  const accessResults = await Promise.all(
+    CUSTOM_POLICY_MANAGEMENT_VERBS.map(async (verb) => ({
+      verb,
+      allowed: await canManageCustomPolicyResource({ ...params, verb }),
+    })),
+  );
+  const deniedVerb = accessResults.find((result) => !result.allowed)?.verb;
+  if (deniedVerb) {
+    logger.warn(
+      {
+        namespace: params.namespace,
+        apiGroup: params.group,
+        resource: params.resource,
+        verb: deniedVerb,
+      },
+      `${params.logName} Kubernetes API resource detected, but the platform service account cannot manage it`,
+    );
+    return false;
+  }
+
+  return true;
+}
+
+async function hasCustomPolicyResource(params: {
+  customObjectsApi: k8s.CustomObjectsApi;
+  group: string;
+  version: string;
+  resource: string;
+  logName: string;
+}): Promise<boolean> {
   try {
-    const resourceList = await customObjectsApi.getAPIResources({
-      group: "cilium.io",
-      version: "v2",
+    const resourceList = await params.customObjectsApi.getAPIResources({
+      group: params.group,
+      version: params.version,
     });
     return (
       resourceList.resources?.some(
-        (resource) => resource.name === "ciliumnetworkpolicies",
+        (resource) => resource.name === params.resource,
       ) ?? false
     );
   } catch (error) {
@@ -120,7 +199,43 @@ async function hasCiliumNetworkPolicyResource(
     }
     logger.warn(
       { err: error },
-      "Failed to inspect Cilium Kubernetes API resources",
+      `Failed to inspect ${params.logName} Kubernetes API resources`,
+    );
+    return false;
+  }
+}
+
+async function canManageCustomPolicyResource(params: {
+  authApi: k8s.AuthorizationV1Api;
+  namespace: string;
+  group: string;
+  resource: string;
+  verb: (typeof CUSTOM_POLICY_MANAGEMENT_VERBS)[number];
+}): Promise<boolean> {
+  try {
+    const review = await params.authApi.createSelfSubjectAccessReview({
+      body: {
+        spec: {
+          resourceAttributes: {
+            namespace: params.namespace,
+            verb: params.verb,
+            group: params.group,
+            resource: params.resource,
+          },
+        },
+      },
+    });
+    return review.status?.allowed ?? false;
+  } catch (error) {
+    logger.warn(
+      {
+        err: error,
+        namespace: params.namespace,
+        apiGroup: params.group,
+        resource: params.resource,
+        verb: params.verb,
+      },
+      "Failed to inspect Kubernetes service account access",
     );
     return false;
   }
@@ -145,56 +260,6 @@ function capabilityMessage(params: {
     return "No supported FQDN policy provider detected. Kubernetes NetworkPolicy only enforces IP/CIDR egress.";
   }
   return "Network policy capabilities detected.";
-}
-
-async function hasGkeFqdnNetworkPolicyResource(
-  customObjectsApi: k8s.CustomObjectsApi,
-): Promise<boolean> {
-  try {
-    const resourceList = await customObjectsApi.getAPIResources({
-      group: "networking.gke.io",
-      version: "v1alpha1",
-    });
-    return (
-      resourceList.resources?.some(
-        (resource) => resource.name === "fqdnnetworkpolicies",
-      ) ?? false
-    );
-  } catch (error) {
-    if (isK8sNotFoundError(error)) {
-      return false;
-    }
-    logger.warn(
-      { err: error },
-      "Failed to inspect GKE FQDN Kubernetes API resources",
-    );
-    return false;
-  }
-}
-
-async function hasAwsApplicationNetworkPolicyResource(
-  customObjectsApi: k8s.CustomObjectsApi,
-): Promise<boolean> {
-  try {
-    const resourceList = await customObjectsApi.getAPIResources({
-      group: "networking.k8s.aws",
-      version: "v1alpha1",
-    });
-    return (
-      resourceList.resources?.some(
-        (resource) => resource.name === "applicationnetworkpolicies",
-      ) ?? false
-    );
-  } catch (error) {
-    if (isK8sNotFoundError(error)) {
-      return false;
-    }
-    logger.warn(
-      { err: error },
-      "Failed to inspect AWS ApplicationNetworkPolicy Kubernetes API resources",
-    );
-    return false;
-  }
 }
 
 function unavailableCapabilities(): K8sCapabilities {

--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
@@ -3752,6 +3752,51 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
     expect(createNamespacedCustomObject).not.toHaveBeenCalled();
   });
 
+  test("does not try to delete CiliumNetworkPolicy when Cilium is not manageable", async () => {
+    const deleteNamespacedCustomObject = vi
+      .fn()
+      .mockRejectedValue({ statusCode: 403 });
+    const createNamespacedNetworkPolicy = vi.fn().mockResolvedValue({});
+
+    const deployment = new K8sDeployment({
+      mcpServer: makeNetworkPolicyTestServer(),
+      k8sApi: {} as k8s.CoreV1Api,
+      k8sAppsApi: {} as k8s.AppsV1Api,
+      k8sNetworkingApi: {
+        createNamespacedNetworkPolicy,
+        deleteNamespacedNetworkPolicy: vi.fn().mockRejectedValue({
+          statusCode: 404,
+        }),
+      } as unknown as k8s.NetworkingV1Api,
+      k8sCustomObjectsApi: {
+        deleteNamespacedCustomObject,
+      } as unknown as k8s.CustomObjectsApi,
+      k8sAttach: {} as Attach,
+      k8sLog: {} as Log,
+      k8sExec: {} as Exec,
+      namespace: "default",
+      catalogItem: null,
+      effectiveNetworkPolicy: makeNetworkPolicy({
+        allowedCidrs: ["203.0.113.0/24"],
+      }),
+      networkPolicyCapabilities: {
+        kubernetesNetworkPolicy: true,
+        ciliumNetworkPolicy: false,
+        gkeFqdnNetworkPolicy: false,
+        awsApplicationNetworkPolicy: false,
+        provider: "kubernetes",
+        supportsFqdn: false,
+        supportsHttpMethods: false,
+        message: null,
+      },
+    });
+
+    await deployment.applyK8sNetworkPolicy();
+
+    expect(createNamespacedNetworkPolicy).toHaveBeenCalled();
+    expect(deleteNamespacedCustomObject).not.toHaveBeenCalled();
+  });
+
   test("throws a clear error when applying without the K8s networking API", async () => {
     const deployment = new K8sDeployment({
       mcpServer: makeNetworkPolicyTestServer(),

--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
@@ -376,8 +376,8 @@ export default class K8sDeployment {
       await this.applyCiliumNetworkPolicy(policyName, effectivePolicy);
       await Promise.all([
         this.deleteKubernetesNetworkPolicy(policyName),
-        this.deleteGkeFqdnNetworkPolicy(policyName),
-        this.deleteAwsApplicationNetworkPolicy(policyName),
+        this.deleteGkeFqdnNetworkPolicyIfManageable(policyName),
+        this.deleteAwsApplicationNetworkPolicyIfManageable(policyName),
       ]);
       return;
     }
@@ -393,8 +393,8 @@ export default class K8sDeployment {
       await this.applyKubernetesNetworkPolicy(policyName, effectivePolicy);
       await this.applyGkeFqdnNetworkPolicy(policyName, effectivePolicy);
       await Promise.all([
-        this.deleteCiliumNetworkPolicy(policyName),
-        this.deleteAwsApplicationNetworkPolicy(policyName),
+        this.deleteCiliumNetworkPolicyIfManageable(policyName),
+        this.deleteAwsApplicationNetworkPolicyIfManageable(policyName),
       ]);
       return;
     }
@@ -408,17 +408,17 @@ export default class K8sDeployment {
       await this.applyAwsApplicationNetworkPolicy(policyName, effectivePolicy);
       await Promise.all([
         this.deleteKubernetesNetworkPolicy(policyName),
-        this.deleteCiliumNetworkPolicy(policyName),
-        this.deleteGkeFqdnNetworkPolicy(policyName),
+        this.deleteCiliumNetworkPolicyIfManageable(policyName),
+        this.deleteGkeFqdnNetworkPolicyIfManageable(policyName),
       ]);
       return;
     }
 
     await this.applyKubernetesNetworkPolicy(policyName, effectivePolicy);
     await Promise.all([
-      this.deleteCiliumNetworkPolicy(policyName),
-      this.deleteGkeFqdnNetworkPolicy(policyName),
-      this.deleteAwsApplicationNetworkPolicy(policyName),
+      this.deleteCiliumNetworkPolicyIfManageable(policyName),
+      this.deleteGkeFqdnNetworkPolicyIfManageable(policyName),
+      this.deleteAwsApplicationNetworkPolicyIfManageable(policyName),
     ]);
   }
 
@@ -693,10 +693,37 @@ export default class K8sDeployment {
     const policyName = this.getK8sNetworkPolicyName();
     await Promise.all([
       this.deleteKubernetesNetworkPolicy(policyName),
-      this.deleteCiliumNetworkPolicy(policyName),
-      this.deleteGkeFqdnNetworkPolicy(policyName),
-      this.deleteAwsApplicationNetworkPolicy(policyName),
+      this.deleteCiliumNetworkPolicyIfManageable(policyName),
+      this.deleteGkeFqdnNetworkPolicyIfManageable(policyName),
+      this.deleteAwsApplicationNetworkPolicyIfManageable(policyName),
     ]);
+  }
+
+  private async deleteCiliumNetworkPolicyIfManageable(
+    policyName: string,
+  ): Promise<void> {
+    if (!this.networkPolicyCapabilities?.ciliumNetworkPolicy) {
+      return;
+    }
+    await this.deleteCiliumNetworkPolicy(policyName);
+  }
+
+  private async deleteGkeFqdnNetworkPolicyIfManageable(
+    policyName: string,
+  ): Promise<void> {
+    if (!this.networkPolicyCapabilities?.gkeFqdnNetworkPolicy) {
+      return;
+    }
+    await this.deleteGkeFqdnNetworkPolicy(policyName);
+  }
+
+  private async deleteAwsApplicationNetworkPolicyIfManageable(
+    policyName: string,
+  ): Promise<void> {
+    if (!this.networkPolicyCapabilities?.awsApplicationNetworkPolicy) {
+      return;
+    }
+    await this.deleteAwsApplicationNetworkPolicy(policyName);
   }
 
   private async deleteKubernetesNetworkPolicy(

--- a/platform/backend/src/k8s/mcp-server-runtime/manager.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager.ts
@@ -124,6 +124,7 @@ export class McpServerRuntimeManager {
     if (
       !this.k8sApi ||
       !this.k8sAppsApi ||
+      !this.k8sAuthApi ||
       !this.k8sNetworkingApi ||
       !this.k8sCustomObjectsApi
     ) {
@@ -164,16 +165,12 @@ export class McpServerRuntimeManager {
 
       logger.info(`Found ${localServers.length} local MCP servers to start`);
 
-      const networkPolicyCapabilities = (
-        await getK8sCapabilitiesFromApi(this.k8sCustomObjectsApi)
-      ).networkPolicy;
       const networkPolicyResolutionCache =
         await this.buildNetworkPolicyResolutionCache(localCatalogItems);
 
       // Start all local servers in parallel
       const startPromises = localServers.map(async (mcpServer) => {
         await this.startServer(mcpServer, undefined, undefined, {
-          networkPolicyCapabilities,
           networkPolicyResolutionCache,
         });
       });
@@ -496,6 +493,24 @@ export class McpServerRuntimeManager {
         }
       }
 
+      if (!this.k8sAuthApi) {
+        throw new Error("Kubernetes API client not initialized");
+      }
+
+      const namespace = await this.resolveNamespaceForCatalog(
+        catalogItem,
+        options?.networkPolicyResolutionCache,
+      );
+      const networkPolicyCapabilities =
+        options?.networkPolicyCapabilities ??
+        (
+          await getK8sCapabilitiesFromApi({
+            customObjectsApi: this.k8sCustomObjectsApi,
+            authApi: this.k8sAuthApi,
+            namespace,
+          })
+        ).networkPolicy;
+
       const k8sDeployment = new K8sDeployment({
         mcpServer,
         k8sApi: this.k8sApi,
@@ -504,10 +519,7 @@ export class McpServerRuntimeManager {
         k8sCustomObjectsApi: this.k8sCustomObjectsApi,
         k8sAttach: this.k8sAttach,
         k8sLog: this.k8sLog,
-        namespace: await this.resolveNamespaceForCatalog(
-          catalogItem,
-          options?.networkPolicyResolutionCache,
-        ),
+        namespace,
         catalogItem,
         userConfigValues,
         environmentValues: effectiveEnvironmentValues,
@@ -516,10 +528,7 @@ export class McpServerRuntimeManager {
           catalogItem,
           cache: options?.networkPolicyResolutionCache,
         }),
-        networkPolicyCapabilities:
-          options?.networkPolicyCapabilities ??
-          (await getK8sCapabilitiesFromApi(this.k8sCustomObjectsApi))
-            .networkPolicy,
+        networkPolicyCapabilities,
         k8sExec: this.k8sExec,
       });
 
@@ -668,6 +677,7 @@ export class McpServerRuntimeManager {
     if (
       !this.k8sApi ||
       !this.k8sAppsApi ||
+      !this.k8sAuthApi ||
       !this.k8sNetworkingApi ||
       !this.k8sCustomObjectsApi ||
       !this.k8sAttach ||
@@ -706,6 +716,13 @@ export class McpServerRuntimeManager {
       // Create the K8sDeployment object and register it
       // Note: We don't call startOrCreateDeployment() because the deployment
       // should already exist in K8s (created by another replica)
+      if (!this.k8sAuthApi) {
+        throw new Error("Kubernetes API client not initialized");
+      }
+
+      const namespace =
+        namespaceOverride ??
+        (await this.resolveNamespaceForCatalog(catalogItem));
       const k8sDeployment = new K8sDeployment({
         mcpServer,
         k8sApi: this.k8sApi,
@@ -714,16 +731,18 @@ export class McpServerRuntimeManager {
         k8sCustomObjectsApi: this.k8sCustomObjectsApi,
         k8sAttach: this.k8sAttach,
         k8sLog: this.k8sLog,
-        namespace:
-          namespaceOverride ??
-          (await this.resolveNamespaceForCatalog(catalogItem)),
+        namespace,
         catalogItem,
         effectiveNetworkPolicy: await this.resolveNetworkPolicyForDeployment({
           mcpServer,
           catalogItem,
         }),
         networkPolicyCapabilities: (
-          await getK8sCapabilitiesFromApi(this.k8sCustomObjectsApi)
+          await getK8sCapabilitiesFromApi({
+            customObjectsApi: this.k8sCustomObjectsApi,
+            authApi: this.k8sAuthApi,
+            namespace,
+          })
         ).networkPolicy,
         k8sExec: this.k8sExec,
       });


### PR DESCRIPTION
## What changed

- Require Kubernetes FQDN policy providers to pass self-access checks for create, update, and delete before reporting them as manageable capabilities.
- Cache Kubernetes capability inspection per namespace so namespace-scoped RBAC differences do not leak across deployments.
- Skip cleanup calls for custom FQDN policy resources that the platform service account cannot currently manage.

## Why

The runtime previously treated a custom FQDN policy provider as available when its CRD existed, even if the platform service account lacked the verbs needed to manage that resource. That could make network policy apply or cleanup fail with a Kubernetes authorization error.

## Validation

- `ARCHESTRA_DATABASE_URL=postgres://test:test@localhost:5432/test pnpm --filter @backend test src/k8s/capabilities.test.ts src/k8s/mcp-server-runtime/k8s-deployment.test.ts src/k8s/mcp-server-runtime/manager.test.ts`
- `ARCHESTRA_DATABASE_URL=postgres://test:test@localhost:5432/test pnpm --filter @backend type-check`
- `pnpm exec biome check backend/src/k8s/capabilities.ts backend/src/k8s/capabilities.test.ts backend/src/k8s/mcp-server-runtime/manager.ts backend/src/k8s/mcp-server-runtime/k8s-deployment.ts backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts`

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>