### PR TITLE
fix: run Helm migrations before upgrades

### DIFF
--- a/.github/workflows/on-commits-to-main.yml
+++ b/.github/workflows/on-commits-to-main.yml
@@ -89,7 +89,8 @@ jobs:
             --namespace archestra \
             --create-namespace \
             --set "archestra.image=europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/platform:${PLATFORM_IMAGE_TAG}" \
-            --set "archestra.databaseUrl=${ARCHESTRA_STAGING_DATABASE_URL}" \
+            --set "postgresql.enabled=false" \
+            --set-string "postgresql.external_database_url=${ARCHESTRA_STAGING_DATABASE_URL}" \
             --set "archestra.env.ARCHESTRA_METRICS_SECRET=${ARCHESTRA_STAGING_METRICS_SECRET}" \
             --set "archestra.env.ARCHESTRA_OTEL_EXPORTER_OTLP_ENDPOINT=${ARCHESTRA_STAGING_OTEL_EXPORTER_OTLP_ENDPOINT}" \
             --set "archestra.env.ARCHESTRA_AUTH_SECRET=${ARCHESTRA_STAGING_AUTH_SECRET}" \

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -250,6 +250,8 @@ Environment network policies require the chart's default MCP manager RBAC so Arc
 - `archestra.worker.replicaCount` - Manual replica count for the separate worker Deployment
 - `archestra.worker.resources` - Resource requests/limits for worker pods (default: 2 vCPU request, 1Gi memory request, 2Gi memory limit)
 - `archestra.worker.deploymentStrategy` - Rolling update strategy for worker pods (default: `maxUnavailable: 25%`, `maxSurge: 25%`)
+- `archestra.migrationJob.enabled` - Run database migrations in a pre-upgrade Job before rolling web and worker pods (default: true)
+- `archestra.migrationJob.env`, `archestra.migrationJob.envFromSecrets`, `archestra.migrationJob.envWithValueFrom`, `archestra.migrationJob.envFrom` - Hook-only environment values for database credentials or secret sources that must be available to the migration Job
 
 #### HorizontalPodAutoscaler
 
@@ -462,6 +464,8 @@ helm upgrade archestra-platform \
 ```
 
 If you don't specify `postgresql.external_database_url`, the chart will deploy a managed PostgreSQL instance using the Bitnami PostgreSQL chart. For PostgreSQL-specific configuration options, see the [Bitnami PostgreSQL Helm chart documentation](https://artifacthub.io/packages/helm/bitnami/postgresql?modal=values-schema).
+
+During Helm upgrades, the chart runs `pnpm db:migrate` in a pre-upgrade Job before rolling the web and worker Deployments. Disable `archestra.migrationJob.enabled` only if your deployment pipeline applies migrations out of band. If your external database connection string depends on Kubernetes environment expansion, such as `$(PGPASSWORD)`, set the required hook-only variables through `archestra.migrationJob.envFromSecrets` or `archestra.migrationJob.env` so the hook receives them without post-render patches.
 
 #### SSRF Protection for MCP Server Pods
 

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -251,7 +251,7 @@ Environment network policies require the chart's default MCP manager RBAC so Arc
 - `archestra.worker.resources` - Resource requests/limits for worker pods (default: 2 vCPU request, 1Gi memory request, 2Gi memory limit)
 - `archestra.worker.deploymentStrategy` - Rolling update strategy for worker pods (default: `maxUnavailable: 25%`, `maxSurge: 25%`)
 - `archestra.migrationJob.enabled` - Run database migrations in a pre-upgrade Job before rolling web and worker pods (default: true)
-- `archestra.migrationJob.env`, `archestra.migrationJob.envFromSecrets`, `archestra.migrationJob.envWithValueFrom`, `archestra.migrationJob.envFrom` - Hook-only environment values for database credentials or secret sources that must be available to the migration Job
+- `archestra.migrationJob.envFromSecrets` - Optional hook-only secret values, usually only needed when `ARCHESTRA_DATABASE_URL` uses Kubernetes `$(VAR)` expansion
 
 #### HorizontalPodAutoscaler
 
@@ -459,13 +459,27 @@ helm upgrade archestra-platform \
   --install \
   --namespace archestra \
   --create-namespace \
+  --set postgresql.enabled=false \
   --set postgresql.external_database_url=postgresql://user:password@host:5432/database \
   --wait
 ```
 
 If you don't specify `postgresql.external_database_url`, the chart will deploy a managed PostgreSQL instance using the Bitnami PostgreSQL chart. For PostgreSQL-specific configuration options, see the [Bitnami PostgreSQL Helm chart documentation](https://artifacthub.io/packages/helm/bitnami/postgresql?modal=values-schema).
 
-During Helm upgrades, the chart runs `pnpm db:migrate` in a pre-upgrade Job before rolling the web and worker Deployments. Disable `archestra.migrationJob.enabled` only if your deployment pipeline applies migrations out of band. If your external database connection string depends on Kubernetes environment expansion, such as `$(PGPASSWORD)`, set the required hook-only variables through `archestra.migrationJob.envFromSecrets` or `archestra.migrationJob.env` so the hook receives them without post-render patches.
+During Helm upgrades, the chart runs `pnpm db:migrate` in a pre-upgrade Job before rolling the web and worker Deployments. Disable `archestra.migrationJob.enabled` only if your deployment pipeline applies migrations out of band.
+
+For external Postgres, the simplest setup is a complete `postgresql.external_database_url`; the chart stores it in a Kubernetes Secret and passes it to the migration Job automatically.
+
+If your deployment intentionally keeps the password in a separate Secret and uses `ARCHESTRA_DATABASE_URL=postgresql://user:$(PGPASSWORD)@host:5432/database`, provide `PGPASSWORD` to the migration Job through chart values:
+
+```yaml
+archestra:
+  migrationJob:
+    envFromSecrets:
+      - name: PGPASSWORD
+        secretName: my-db-secret
+        secretKey: password
+```
 
 #### SSRF Protection for MCP Server Pods
 

--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -351,6 +351,24 @@ app.kubernetes.io/part-of: archestra
 {{- end }}
 
 {{/*
+Database migration Job labels.
+
+The name label is suffixed with `-migrate` so the platform Service selector
+never routes traffic to the short-lived migration pod.
+*/}}
+{{- define "archestra-platform.migrationJobLabels" -}}
+helm.sh/chart: {{ include "archestra-platform.chart" . }}
+app.kubernetes.io/name: {{ include "archestra-platform.name" . }}-migrate
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: migrate
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: archestra
+{{- end }}
+
+{{/*
 Shared init containers for both platform and worker Deployments.
 Handles Vault secret injection, pgvector extension setup, and PostgreSQL readiness.
 */}}
@@ -453,6 +471,43 @@ Handles Vault secret injection, pgvector extension setup, and PostgreSQL readine
       {{- else }}
       echo "Skipping PostgreSQL readiness check"
       {{- end }}
+{{- end }}
+
+{{/*
+Worker-only init container that blocks worker startup until the web Deployment
+has applied database migrations.
+
+This is reliable on fresh installs, where no previous web pods exist. Upgrades
+are covered by the pre-upgrade migration Job.
+*/}}
+{{- define "archestra-platform.waitForMigrationsInitContainer" -}}
+{{- if .Values.archestra.initContainers.waitForMigrations.enabled }}
+- name: wait-for-migrations
+  image: {{ .Values.archestra.initContainers.busyboxImage | default "busybox:1.36" }}
+  {{- with .Values.archestra.initContainers.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  command:
+    - sh
+    - -c
+    - |
+      HOST={{ include "archestra-platform.fullname" . | quote }}
+      PORT=9000
+      echo "Waiting for migrations (platform web server at ${HOST}:${PORT})..."
+      max_attempts={{ .Values.archestra.initContainers.waitForMigrations.timeoutSeconds | default 600 }}
+      attempt=0
+      until nc -z "${HOST}" "${PORT}"; do
+        attempt=$((attempt + 1))
+        if [ "$attempt" -ge "$max_attempts" ]; then
+          echo "Platform web server at ${HOST}:${PORT} did not become reachable after ${max_attempts}s - giving up" >&2
+          exit 1
+        fi
+        echo "Platform web server is unavailable - sleeping (${attempt}/${max_attempts})"
+        sleep 1
+      done
+      echo "Platform web server is up - migrations applied, continuing"
+{{- end }}
 {{- end }}
 
 {{/*

--- a/platform/helm/archestra/templates/archestra-worker.yaml
+++ b/platform/helm/archestra/templates/archestra-worker.yaml
@@ -34,6 +34,7 @@ spec:
       serviceAccountName: {{ include "archestra-platform.serviceAccountName" . }}
       initContainers:
         {{- include "archestra-platform.initContainers" . | nindent 8 }}
+        {{- include "archestra-platform.waitForMigrationsInitContainer" . | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}-worker
           image: {{ include "archestra-platform.image" . }}

--- a/platform/helm/archestra/templates/migration-job.yaml
+++ b/platform/helm/archestra/templates/migration-job.yaml
@@ -1,0 +1,104 @@
+{{- if and .Values.archestra.migrationJob.enabled (ne (include "archestra-platform.maintenanceModeEnabled" .) "true") }}
+{{/*
+Database migration Job.
+
+Runs `pnpm db:migrate` as a Helm pre-upgrade hook so the target version's
+schema is applied before web and worker Deployments roll. Fresh installs are
+covered by the web pod running migrations on startup plus the worker
+wait-for-migrations init container.
+*/}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "archestra-platform.fullname" . }}-migrate
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "archestra-platform.migrationJobLabels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.archestra.migrationJob.backoffLimit | default 3 }}
+  {{- with .Values.archestra.migrationJob.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ . }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "archestra-platform.migrationJobLabels" . | nindent 8 }}
+        {{- with .Values.archestra.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "archestra-platform.serviceAccountName" . }}
+      restartPolicy: Never
+      initContainers:
+        {{- include "archestra-platform.initContainers" . | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}-migrate
+          image: {{ include "archestra-platform.image" . }}
+          imagePullPolicy: {{ .Values.archestra.imagePullPolicy | default "IfNotPresent" }}
+          workingDir: /app/backend
+          {{- if .Values.archestra.initContainers.vaultSecrets.enabled }}
+          {{- include "archestra-platform.vaultSecretsCommand" "pnpm db:migrate" | nindent 10 }}
+          {{- else }}
+          command: ["pnpm", "db:migrate"]
+          {{- end }}
+          env:
+            {{- range $key, $value := .Values.archestra.migrationJob.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- range .Values.archestra.migrationJob.envFromSecrets }}
+            - name: {{ .name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .secretName }}
+                  key: {{ .secretKey }}
+            {{- end }}
+            {{- range .Values.archestra.migrationJob.envWithValueFrom }}
+            - name: {{ .name }}
+              valueFrom:
+                {{- toYaml .valueFrom | nindent 16 }}
+            {{- end }}
+            {{- include "archestra-platform.env" . | nindent 12 }}
+          {{- if or .Values.archestra.envFrom .Values.archestra.migrationJob.envFrom }}
+          envFrom:
+            {{- with .Values.archestra.envFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.archestra.migrationJob.envFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- with (.Values.archestra.migrationJob.resources | default .Values.archestra.resources) }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- /*
+          The migration container only needs the Vault secrets volume for DB URL
+          injection. Avoid mounting shared diagnostics PVCs here because the
+          hook overlaps running web/worker pods during upgrades.
+          */}}
+          {{- if .Values.archestra.initContainers.vaultSecrets.enabled }}
+          volumeMounts:
+            - name: vault-secrets
+              mountPath: /vault/secrets
+              readOnly: true
+          {{- end }}
+      {{- with .Values.archestra.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.archestra.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.archestra.initContainers.vaultSecrets.enabled }}
+      volumes:
+        - name: vault-secrets
+          emptyDir:
+            medium: Memory
+      {{- end }}
+{{- end }}

--- a/platform/helm/archestra/tests/archestra_migration_job_test.yaml
+++ b/platform/helm/archestra/tests/archestra_migration_job_test.yaml
@@ -1,0 +1,133 @@
+suite: archestra migration job
+templates:
+  - migration-job.yaml
+values:
+  - ../ci/test-values.yaml
+tests:
+  - it: creates a pre-upgrade migration job by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-5"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+      - matchRegex:
+          path: metadata.name
+          pattern: -archestra-platform-migrate$
+      - equal:
+          path: spec.template.spec.restartPolicy
+          value: Never
+      - equal:
+          path: spec.template.spec.containers[0].workingDir
+          value: /app/backend
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - pnpm
+            - db:migrate
+
+  - it: does not create the migration job when disabled
+    set:
+      archestra.migrationJob.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not create the migration job in maintenance mode
+    set:
+      archestra.env:
+        ARCHESTRA_MAINTENANCE_MODE_MESSAGE: "Scheduled maintenance"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: uses a complete external database URL from the chart-managed auth secret
+    set:
+      postgresql.enabled: false
+      postgresql.external_database_url: postgresql://external:pass@external-host:5432/externaldb
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-archestra-platform-auth
+                key: database-url
+
+  - it: prepends migration-job env before shared env for Kubernetes variable expansion
+    set:
+      postgresql.enabled: false
+      postgresql.external_database_url: null
+      archestra.env:
+        ARCHESTRA_DATABASE_URL: postgresql://external:$(PGPASSWORD)@external-host:5432/externaldb
+      archestra.migrationJob.env:
+        PGPASSWORD: external-secret-password
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0]
+          value:
+            name: PGPASSWORD
+            value: external-secret-password
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_URL
+            value: postgresql://external:$(PGPASSWORD)@external-host:5432/externaldb
+
+  - it: supports migration-job secret-backed env
+    set:
+      archestra.migrationJob.envFromSecrets:
+        - name: PGPASSWORD
+          secretName: external-db-secret
+          secretKey: password
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0]
+          value:
+            name: PGPASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: external-db-secret
+                key: password
+
+  - it: supports migration-job envFrom entries
+    set:
+      archestra.migrationJob.envFrom:
+        - secretRef:
+            name: migration-job-env
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: migration-job-env
+
+  - it: uses only the vault volume mount and not shared diagnostics mounts
+    set:
+      archestra.diagnostics.enabled: true
+      archestra.initContainers.vaultSecrets.enabled: true
+      archestra.initContainers.vaultSecrets.secrets:
+        - envVar: ARCHESTRA_DATABASE_URL
+          path: secret/data/team/database_url
+          key: url
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: vault-secrets
+            mountPath: /vault/secrets
+            readOnly: true
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: diagnostics
+          any: true

--- a/platform/helm/archestra/tests/archestra_worker_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_worker_deployment_test.yaml
@@ -161,6 +161,25 @@ tests:
           path: spec.template.spec.initContainers[0].image
           value: registry.internal.example.com/platform/busybox:1.36
 
+  - it: worker waits for migrations after postgres is reachable by default
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-postgres
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: wait-for-migrations
+
+  - it: worker can disable the wait-for-migrations init container
+    set:
+      archestra.initContainers.waitForMigrations.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.initContainers
+          content:
+            name: wait-for-migrations
+          any: true
+
   - it: worker applies shared resources to chart-managed init containers
     set:
       archestra.initContainers.resources:

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -268,6 +268,16 @@ archestra:
       # cause). The setup-postgres-extensions init container uses the same budget.
       timeoutSeconds: 300
 
+    # Worker pods only: block startup until the web Deployment has applied
+    # database migrations. This gate covers fresh installs. Upgrades are covered
+    # by archestra.migrationJob, because the platform Service can still route to
+    # previous-revision web pods while the new release is rolling out.
+    waitForMigrations:
+      enabled: true
+      # Maximum seconds to wait for the web Deployment to finish migrations
+      # before the init container gives up and fails.
+      timeoutSeconds: 600
+
     # Vault secret injection init container
     # Similar to Vault Agent Injector (writes secrets to a shared volume) but:
     # - No extra infrastructure needed (no Vault Agent Injector deployment)
@@ -298,6 +308,31 @@ archestra:
     # Resource requests/limits applied to ALL init containers.
     # Required on clusters that enforce ResourceQuota (e.g., OpenShift restricted-v2 SCC).
     resources: {}
+
+  # Database migration Job.
+  #
+  # Runs `pnpm db:migrate` as a Helm pre-upgrade hook so the target version's
+  # schema is applied before web and worker Deployments roll. Disable this if
+  # migrations are applied by an external deployment pipeline.
+  migrationJob:
+    enabled: true
+    # Number of retries before the Job is marked failed and aborts the upgrade.
+    backoffLimit: 3
+    # Hard cap on Job runtime. Set to null to disable the deadline.
+    activeDeadlineSeconds: 600
+    # Resource requests/limits for the migration container.
+    # If not set, inherits from archestra.resources.
+    resources: {}
+    # Extra environment variables rendered before the shared platform env.
+    # Use this for hook-only credentials such as PGPASSWORD when
+    # ARCHESTRA_DATABASE_URL contains Kubernetes $(VAR) references.
+    env: {}
+    # Extra secret-backed environment variables rendered before shared env.
+    envFromSecrets: []
+    # Extra valueFrom environment variables rendered before shared env.
+    envWithValueFrom: []
+    # Extra envFrom entries for the migration Job.
+    envFrom: []
 
   # Resource requests and limits for the Archestra container
   # See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -314,6 +314,11 @@ archestra:
   # Runs `pnpm db:migrate` as a Helm pre-upgrade hook so the target version's
   # schema is applied before web and worker Deployments roll. Disable this if
   # migrations are applied by an external deployment pipeline.
+  #
+  # Most external Postgres deployments should not need any migrationJob env
+  # settings. Prefer setting postgresql.external_database_url to a complete
+  # connection string; the chart stores it in a Secret and passes it to the
+  # migration Job automatically.
   migrationJob:
     enabled: true
     # Number of retries before the Job is marked failed and aborts the upgrade.
@@ -323,11 +328,16 @@ archestra:
     # Resource requests/limits for the migration container.
     # If not set, inherits from archestra.resources.
     resources: {}
-    # Extra environment variables rendered before the shared platform env.
-    # Use this for hook-only credentials such as PGPASSWORD when
-    # ARCHESTRA_DATABASE_URL contains Kubernetes $(VAR) references.
+    # Extra environment variables rendered before the shared platform env. Use
+    # this only when ARCHESTRA_DATABASE_URL contains Kubernetes $(VAR)
+    # references, such as $(PGPASSWORD), that the hook must expand.
     env: {}
-    # Extra secret-backed environment variables rendered before shared env.
+    # Extra secret-backed environment variables rendered before shared env. This
+    # is the recommended hook-only option when ARCHESTRA_DATABASE_URL contains
+    # $(PGPASSWORD):
+    #   - name: PGPASSWORD
+    #     secretName: my-db-secret
+    #     secretKey: password
     envFromSecrets: []
     # Extra valueFrom environment variables rendered before shared env.
     envWithValueFrom: []


### PR DESCRIPTION
## Summary
- add a Helm pre-upgrade migration Job that runs `pnpm db:migrate` before web/worker Deployments roll
- restore worker `wait-for-migrations` gating for fresh installs
- add migration Job env hooks so external Postgres credentials can be supplied to hook pods without post-render patches
- document migration Job settings in platform deployment docs

## External Postgres fix
The migration Job renders hook-specific env values before the shared platform env. This lets operators provide values like `PGPASSWORD` through `archestra.migrationJob.envFromSecrets` or `archestra.migrationJob.env` when `ARCHESTRA_DATABASE_URL` uses Kubernetes `$(VAR)` expansion. For `postgresql.external_database_url`, the Job uses the chart-managed complete URL secret.