### PR TITLE
fix: create migration hook database secret

### DIFF
--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -67,28 +67,15 @@ false
 {{/*
 Environment variables for the Archestra Platform container
 */}}
-{{- define "archestra-platform.env" -}}
-{{/*
-List of sensitive environment variables that should be stored in the Secret
-and referenced via secretKeyRef instead of being exposed as plaintext in Pod specs.
-This must match the list in secret.yaml.
-Additionally, any env var matching ARCHESTRA_CHAT_*_API_KEY is treated as sensitive.
-*/}}
-{{- $sensitiveEnvVars := list
-  "ARCHESTRA_AUTH_SECRET"
-  "ARCHESTRA_AUTH_ADMIN_PASSWORD"
-  "ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_PASSWORD"
-  "ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_BEARER"
-  "ARCHESTRA_METRICS_SECRET"
-  "ARCHESTRA_HASHICORP_VAULT_TOKEN"
-}}
+{{- define "archestra-platform.databaseEnv" -}}
+{{- $databaseSecretName := .migrationDatabaseSecretNameOverride | default (include "archestra-platform.authSecretName" .) -}}
 {{- if eq (toString .Values.postgresql.external_database_url) "from_vault" }}
 {{/* Database URL provided by vault-secrets init container — no env var generated */}}
 {{- else if .Values.postgresql.external_database_url }}
 - name: ARCHESTRA_DATABASE_URL
   valueFrom:
     secretKeyRef:
-      name: {{ include "archestra-platform.authSecretName" . }}
+      name: {{ $databaseSecretName }}
       key: database-url
 {{- else if .Values.postgresql.enabled }}
 {{/*
@@ -104,6 +91,24 @@ The Bitnami chart auto-generates a strong password and persists it across helm u
 - name: ARCHESTRA_DATABASE_URL
   value: postgresql://{{ .Values.postgresql.auth.username }}:$(PGPASSWORD)@{{ include "archestra-platform.fullname" . }}-postgresql:5432/{{ .Values.postgresql.auth.database }}
 {{- end }}
+{{- end }}
+
+{{- define "archestra-platform.env" -}}
+{{/*
+List of sensitive environment variables that should be stored in the Secret
+and referenced via secretKeyRef instead of being exposed as plaintext in Pod specs.
+This must match the list in secret.yaml.
+Additionally, any env var matching ARCHESTRA_CHAT_*_API_KEY is treated as sensitive.
+*/}}
+{{- $sensitiveEnvVars := list
+  "ARCHESTRA_AUTH_SECRET"
+  "ARCHESTRA_AUTH_ADMIN_PASSWORD"
+  "ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_PASSWORD"
+  "ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_BEARER"
+  "ARCHESTRA_METRICS_SECRET"
+  "ARCHESTRA_HASHICORP_VAULT_TOKEN"
+}}
+{{- include "archestra-platform.databaseEnv" . }}
 {{/*
 When both external_database_url is null and postgresql.enabled is false,
 ARCHESTRA_DATABASE_URL is not set here. Use archestra.envFromSecrets to inject it from a pre-existing K8s secret.
@@ -252,6 +257,13 @@ Auth secret name for the Archestra Platform
 */}}
 {{- define "archestra-platform.authSecretName" -}}
 {{- default (printf "%s-auth" (include "archestra-platform.fullname" .)) .Values.archestra.authSecret.existingSecretName -}}
+{{- end }}
+
+{{/*
+Hook-only auth secret name for the database migration Job.
+*/}}
+{{- define "archestra-platform.migrationJobAuthSecretName" -}}
+{{- printf "%s-migrate-auth" (include "archestra-platform.fullname" .) -}}
 {{- end }}
 
 {{/*

--- a/platform/helm/archestra/templates/migration-job-secret.yaml
+++ b/platform/helm/archestra/templates/migration-job-secret.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.archestra.migrationJob.enabled (ne (include "archestra-platform.maintenanceModeEnabled" .) "true") .Values.postgresql.external_database_url (ne (toString .Values.postgresql.external_database_url) "from_vault") }}
+{{/*
+Hook-only database URL Secret for the migration Job.
+
+Pre-upgrade hooks run before normal chart resources are applied, so the Job
+cannot rely on an updated chart-managed auth Secret during the same upgrade.
+*/}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "archestra-platform.migrationJobAuthSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "archestra-platform.migrationJobLabels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+type: Opaque
+data:
+  database-url: {{ .Values.postgresql.external_database_url | b64enc }}
+{{- end }}

--- a/platform/helm/archestra/templates/migration-job.yaml
+++ b/platform/helm/archestra/templates/migration-job.yaml
@@ -7,6 +7,10 @@ schema is applied before web and worker Deployments roll. Fresh installs are
 covered by the web pod running migrations on startup plus the worker
 wait-for-migrations init container.
 */}}
+{{- $migrationContext := . -}}
+{{- if and .Values.postgresql.external_database_url (ne (toString .Values.postgresql.external_database_url) "from_vault") -}}
+{{- $migrationContext = merge (dict "migrationDatabaseSecretNameOverride" (include "archestra-platform.migrationJobAuthSecretName" .)) . -}}
+{{- end }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -34,7 +38,7 @@ spec:
       serviceAccountName: {{ include "archestra-platform.serviceAccountName" . }}
       restartPolicy: Never
       initContainers:
-        {{- include "archestra-platform.initContainers" . | nindent 8 }}
+        {{- include "archestra-platform.initContainers" $migrationContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}-migrate
           image: {{ include "archestra-platform.image" . }}
@@ -62,7 +66,7 @@ spec:
               valueFrom:
                 {{- toYaml .valueFrom | nindent 16 }}
             {{- end }}
-            {{- include "archestra-platform.env" . | nindent 12 }}
+            {{- include "archestra-platform.env" $migrationContext | nindent 12 }}
           {{- if or .Values.archestra.envFrom .Values.archestra.migrationJob.envFrom }}
           envFrom:
             {{- with .Values.archestra.envFrom }}

--- a/platform/helm/archestra/tests/archestra_migration_job_secret_test.yaml
+++ b/platform/helm/archestra/tests/archestra_migration_job_secret_test.yaml
@@ -1,0 +1,52 @@
+suite: archestra migration job secret
+templates:
+  - migration-job-secret.yaml
+values:
+  - ../ci/test-values.yaml
+tests:
+  - it: creates a pre-upgrade database URL secret before the migration job
+    set:
+      postgresql.enabled: false
+      postgresql.external_database_url: postgresql://external:pass@external-host:5432/externaldb
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-archestra-platform-migrate-auth
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-10"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+      - equal:
+          path: data.database-url
+          value: cG9zdGdyZXNxbDovL2V4dGVybmFsOnBhc3NAZXh0ZXJuYWwtaG9zdDo1NDMyL2V4dGVybmFsZGI=
+
+  - it: does not create the hook secret when the migration job is disabled
+    set:
+      archestra.migrationJob.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not create the hook secret when external database URL is not chart-managed
+    set:
+      postgresql.enabled: false
+      postgresql.external_database_url: null
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not create the hook secret for vault-provided database URLs
+    set:
+      postgresql.external_database_url: "from_vault"
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/platform/helm/archestra/tests/archestra_migration_job_test.yaml
+++ b/platform/helm/archestra/tests/archestra_migration_job_test.yaml
@@ -49,18 +49,26 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: uses a complete external database URL from the chart-managed auth secret
+  - it: uses a complete external database URL from the hook auth secret
     set:
       postgresql.enabled: false
       postgresql.external_database_url: postgresql://external:pass@external-host:5432/externaldb
     asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-archestra-platform-migrate-auth
+                key: database-url
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: ARCHESTRA_DATABASE_URL
             valueFrom:
               secretKeyRef:
-                name: RELEASE-NAME-archestra-platform-auth
+                name: RELEASE-NAME-archestra-platform-migrate-auth
                 key: database-url
 
   - it: prepends migration-job env before shared env for Kubernetes variable expansion


### PR DESCRIPTION
## Summary
- add a pre-upgrade hook Secret for the migration Job database URL
- make migration Job init/container env reference that hook Secret instead of the normal auth Secret during external-DB upgrades
- add Helm unit coverage for the hook Secret and migration Job env references

## Why
Pre-upgrade hooks run before normal chart resources are applied. On the first upgrade that switches to postgresql.external_database_url, the normal auth Secret may not yet have the database-url key, so the migration Job pod cannot start.