### PR TITLE
chore: use bundled postgres for staging deploy

### DIFF
--- a/.github/workflows/on-commits-to-main.yml
+++ b/.github/workflows/on-commits-to-main.yml
@@ -70,7 +70,6 @@ jobs:
       - name: Deploy to staging
         env:
           PLATFORM_IMAGE_TAG: ${{ github.sha }}
-          ARCHESTRA_STAGING_DATABASE_URL: ${{ secrets.ARCHESTRA_STAGING_DATABASE_URL }}
           ARCHESTRA_STAGING_METRICS_SECRET: ${{ secrets.ARCHESTRA_STAGING_METRICS_SECRET }}
           ARCHESTRA_STAGING_OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.ARCHESTRA_STAGING_OTEL_EXPORTER_OTLP_ENDPOINT }}
           ARCHESTRA_STAGING_AUTH_SECRET: ${{ secrets.ARCHESTRA_STAGING_AUTH_SECRET }}
@@ -89,8 +88,6 @@ jobs:
             --namespace archestra \
             --create-namespace \
             --set "archestra.image=europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/platform:${PLATFORM_IMAGE_TAG}" \
-            --set "postgresql.enabled=false" \
-            --set-string "postgresql.external_database_url=${ARCHESTRA_STAGING_DATABASE_URL}" \
             --set "archestra.env.ARCHESTRA_METRICS_SECRET=${ARCHESTRA_STAGING_METRICS_SECRET}" \
             --set "archestra.env.ARCHESTRA_OTEL_EXPORTER_OTLP_ENDPOINT=${ARCHESTRA_STAGING_OTEL_EXPORTER_OTLP_ENDPOINT}" \
             --set "archestra.env.ARCHESTRA_AUTH_SECRET=${ARCHESTRA_STAGING_AUTH_SECRET}" \
@@ -103,4 +100,5 @@ jobs:
             --set "archestra.env.ARCHESTRA_AGENTS_INCOMING_EMAIL_OUTLOOK_CLIENT_SECRET=${ARCHESTRA_STAGING_OUTLOOK_CLIENT_SECRET}" \
             --set "archestra.env.ARCHESTRA_CHAT_ANTHROPIC_API_KEY=${ARCHESTRA_STAGING_CHAT_ANTHROPIC_API_KEY}" \
             --values .github/values-staging.yaml \
-            --wait
+            --wait \
+            --timeout 15m


### PR DESCRIPTION
## Summary
- stop forcing the staging Helm deploy into external-Postgres mode
- keep staging on the chart's bundled PostgreSQL path
- add a 15m Helm timeout so pre-upgrade hooks and GKE scheduling have enough time