### PR TITLE
chore: fix staging GKE ingress backends

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -94,6 +94,7 @@ archestra:
       # Maps backend port (9000) and frontend port (3000) to their respective BackendConfigs
       # These BackendConfigs are defined in archestra-ai/infra repo (gke/ingress.tf)
       cloud.google.com/backend-config: '{"ports": {"9000":"archestra-platform-backend-config", "3000":"archestra-platform-frontend-config"}}'
+      cloud.google.com/neg: '{"ingress": true}'
 
   ingress:
     enabled: true
@@ -113,10 +114,6 @@ archestra:
             pathType: Prefix
       - host: backend.archestra.dev
         paths:
-          # Block public access to metrics endpoint
-          - path: /metrics
-            port: 1
-            pathType: Exact
           - path: /
             port: 9000
             pathType: Prefix


### PR DESCRIPTION
## Summary
- add the GKE NEG annotation to the staging Service values
- remove the invalid `/metrics` Ingress path that targeted service port `1`

## Why
The staging GKE Ingress was rejected by the load balancer controller because the Service is `ClusterIP` and the Ingress referenced a non-existent service port. That left the external frontend/backend hosts serving 502s even though Helm and the pods were healthy.