### PR TITLE
fix: deduplicate LLM log sessions across profiles

### DIFF
--- a/platform/backend/src/models/interaction.test.ts
+++ b/platform/backend/src/models/interaction.test.ts
@@ -1279,6 +1279,78 @@ describe("InteractionModel", () => {
     });
   });
 
+  describe("getSessions aggregation", () => {
+    test("groups a session once when interactions come from multiple profiles", async ({
+      makeAdmin,
+    }) => {
+      const admin = await makeAdmin();
+      const primaryAgent = await AgentModel.create({
+        name: "Primary Agent",
+        teams: [],
+        scope: "org",
+      });
+      const subAgent = await AgentModel.create({
+        name: "Sub Agent",
+        teams: [],
+        scope: "org",
+      });
+
+      await InteractionModel.create({
+        profileId: primaryAgent.id,
+        sessionId: "shared-session",
+        externalAgentId: primaryAgent.id,
+        model: "gpt-4",
+        request: {
+          model: "gpt-4",
+          messages: [{ role: "user", content: "Plan the task" }],
+        },
+        response: {
+          id: "r1",
+          object: "chat.completion",
+          created: Date.now(),
+          model: "gpt-4",
+          choices: [],
+        },
+        type: "openai:chatCompletions",
+      });
+      await InteractionModel.create({
+        profileId: subAgent.id,
+        sessionId: "shared-session",
+        externalAgentId: subAgent.id,
+        model: "gpt-4o",
+        request: {
+          model: "gpt-4o",
+          messages: [{ role: "user", content: "Run the delegated step" }],
+        },
+        response: {
+          id: "r2",
+          object: "chat.completion",
+          created: Date.now(),
+          model: "gpt-4o",
+          choices: [],
+        },
+        type: "openai:chatCompletions",
+      });
+
+      const sessions = await InteractionModel.getSessions(
+        { limit: 100, offset: 0 },
+        admin.id,
+        true,
+        { sessionId: "shared-session" },
+      );
+
+      expect(sessions.data).toHaveLength(1);
+      expect(sessions.pagination.total).toBe(1);
+      expect(sessions.data[0].requestCount).toBe(2);
+      expect(sessions.data[0].models).toEqual(
+        expect.arrayContaining(["gpt-4", "gpt-4o"]),
+      );
+      expect(sessions.data[0].externalAgentIds).toEqual(
+        expect.arrayContaining([primaryAgent.id, subAgent.id]),
+      );
+    });
+  });
+
   describe("getSessions search filtering", () => {
     test("searches by request message content (case insensitive)", async ({
       makeAdmin,

--- a/platform/backend/src/models/interaction.ts
+++ b/platform/backend/src/models/interaction.ts
@@ -979,11 +979,7 @@ class InteractionModel {
           sql`CASE WHEN LENGTH(${schema.interactionsTable.sessionId}) = 36 THEN ${schema.interactionsTable.sessionId}::uuid END = ${schema.conversationsTable.id}`,
         )
         .where(whereClause)
-        .groupBy(
-          sessionGroupExpr,
-          schema.interactionsTable.profileId,
-          schema.agentsTable.name,
-        )
+        .groupBy(sessionGroupExpr)
         .orderBy(desc(max(schema.interactionsTable.createdAt)))
         .limit(pagination.limit)
         .offset(pagination.offset),


### PR DESCRIPTION
Fixes #2505

## Problem
LLM log sessions can show up more than once when the same session contains interactions from multiple profiles or delegated agents. The count query already treats the session id as a single session, but the data query also grouped by profile fields.

## What changed
- Group session summaries only by the existing session key.
- Keep the existing response shape and aggregate profile/session metadata as before.
- Add a regression test covering one session with interactions from two profiles.

## How to test
- `PATH="/Users/chiragarora/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" ARCHESTRA_DATABASE_URL="postgresql://archestra:archestra_dev_password@localhost:5432/archestra_dev?schema=public" pnpm --filter @backend exec vitest run src/models/interaction.test.ts`
- `PATH="/Users/chiragarora/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm --filter @backend type-check`
- `PATH="/Users/chiragarora/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm --filter @backend lint`

## Checklist
- Tests added/updated
- No breaking changes
- Follows the Archestra contributing guide