### PR TITLE
fix: reuse duplicate approved MCP tool executions

### DIFF
--- a/platform/backend/src/clients/chat-mcp-client.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.test.ts
@@ -60,6 +60,7 @@ beforeEach(() => {
   vi.mocked(mcpClient.executeToolCall).mockReset();
   vi.mocked(resolveSessionExternalIdpToken).mockResolvedValue(null);
   vi.mocked(StreamableHTTPClientTransport).mockClear();
+  chatClient.__test.clearApprovedToolExecutionCache();
 });
 
 describe("isBrowserMcpTool", () => {
@@ -582,6 +583,39 @@ describe("executeMcpTool error handling", () => {
 
     const result = await chatClient.__test.executeMcpTool(baseCtx);
     expect(result.content).toBe("Tool execution failed");
+  });
+
+  test("reuses approved executions with the same tool call id", async () => {
+    const approvedCtx = {
+      ...baseCtx,
+      conversationId: "conversation-1",
+      toolCallId: "call_approved_1",
+      approvedToolExecutionKey:
+        "00000000-0000-4000-8000-000000000001:conversation-1:call_approved_1",
+    };
+    vi.mocked(mcpClient.executeToolCall).mockResolvedValue(
+      mockResult({
+        content: [{ type: "text", text: "created" }],
+        isError: false,
+      }),
+    );
+
+    const [firstResult, secondResult] = await Promise.all([
+      chatClient.__test.executeMcpTool(approvedCtx),
+      chatClient.__test.executeMcpTool(approvedCtx),
+    ]);
+    const thirdResult = await chatClient.__test.executeMcpTool(approvedCtx);
+
+    expect(mcpClient.executeToolCall).toHaveBeenCalledTimes(1);
+    expect(mcpClient.executeToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "call_approved_1" }),
+      approvedCtx.agentId,
+      undefined,
+      { conversationId: "conversation-1" },
+    );
+    expect(firstResult.content).toBe("created");
+    expect(secondResult.content).toBe("created");
+    expect(thirdResult.content).toBe("created");
   });
 
   test("preserves structured error metadata for auth-expired tool errors", async () => {

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -157,6 +157,14 @@ const uiResourceCache = new LRUCacheManager<ToolUiResourceData | null>({
   defaultTtl: UI_RESOURCE_CACHE_TTL_MS,
 });
 
+const APPROVED_TOOL_EXECUTION_TTL_MS = 10 * TimeInMs.Minute;
+const approvedToolExecutionCache = new LRUCacheManager<
+  Promise<Awaited<ReturnType<typeof mcpClient.executeToolCall>>>
+>({
+  maxSize: 1000,
+  defaultTtl: APPROVED_TOOL_EXECUTION_TTL_MS,
+});
+
 /** @public — exported for testability (test cleanup) */
 export function clearUiResourceCache(): void {
   uiResourceCache.clear();
@@ -217,6 +225,9 @@ export const __test = {
   pingClientWithTimeout,
   resolveApprovalPolicyTarget,
   throwIfApprovalRequired,
+  clearApprovedToolExecutionCache() {
+    approvedToolExecutionCache.clear();
+  },
 };
 
 /**
@@ -947,6 +958,22 @@ export async function getChatMcpTools({
                 globalToolPolicy,
               );
             }
+            const approvalTarget = resolveApprovalPolicyTarget(
+              mcpTool.name,
+              args,
+            );
+            const requiresApproval =
+              !blockOnApprovalRequired &&
+              (await ToolInvocationPolicyModel.checkApprovalRequired(
+                approvalTarget.toolName,
+                approvalTarget.toolInput,
+                {
+                  teamIds: [],
+                  externalAgentId: getChatExternalAgentId(),
+                },
+                globalToolPolicy,
+              ));
+            const toolCallId = getToolCallIdFromExecuteOptions(options);
 
             logger.info(
               { agentId, userId, toolName: mcpTool.name, arguments: args },
@@ -1049,6 +1076,15 @@ export async function getChatMcpTools({
                     globalToolPolicy,
                     considerContextUntrusted,
                     abortSignal,
+                    toolCallId: requiresApproval ? toolCallId : undefined,
+                    approvedToolExecutionKey:
+                      requiresApproval && toolCallId
+                        ? buildApprovedToolExecutionKey({
+                            agentId,
+                            conversationId,
+                            toolCallId,
+                          })
+                        : undefined,
                   });
                 } catch (error) {
                   reportToolMetrics({
@@ -1439,6 +1475,8 @@ interface ToolExecutionContext {
   globalToolPolicy: GlobalToolPolicy;
   considerContextUntrusted: boolean;
   abortSignal?: AbortSignal;
+  toolCallId?: string;
+  approvedToolExecutionKey?: string;
 }
 
 /**
@@ -1469,6 +1507,8 @@ async function executeMcpTool(ctx: ToolExecutionContext): Promise<{
     conversationId,
     mcpGwToken,
     abortSignal,
+    toolCallId,
+    approvedToolExecutionKey,
   } = ctx;
   throwIfAborted(abortSignal);
   const startTime = Date.now();
@@ -1504,27 +1544,34 @@ async function executeMcpTool(ctx: ToolExecutionContext): Promise<{
 
   // Execute via mcpClient
   const toolCall = {
-    id: randomUUID(),
+    id: toolCallId ?? randomUUID(),
     name: toolName,
     arguments: toolArguments ?? {},
   };
 
   let result: Awaited<ReturnType<typeof mcpClient.executeToolCall>>;
   try {
-    result = await mcpClient.executeToolCall(
-      toolCall,
-      agentId,
-      mcpGwToken
-        ? {
-            tokenId: mcpGwToken.tokenId,
-            teamId: mcpGwToken.teamId,
-            isOrganizationToken: mcpGwToken.isOrganizationToken,
-            organizationId,
-            userId,
-          }
-        : undefined,
-      { conversationId },
-    );
+    const executeToolCall = () =>
+      mcpClient.executeToolCall(
+        toolCall,
+        agentId,
+        mcpGwToken
+          ? {
+              tokenId: mcpGwToken.tokenId,
+              teamId: mcpGwToken.teamId,
+              isOrganizationToken: mcpGwToken.isOrganizationToken,
+              organizationId,
+              userId,
+            }
+          : undefined,
+        { conversationId },
+      );
+    result = await (approvedToolExecutionKey
+      ? executeApprovedMcpToolCallOnce(
+          approvedToolExecutionKey,
+          executeToolCall,
+        )
+      : executeToolCall());
     reportToolMetrics({
       toolName,
       agentId,
@@ -1905,6 +1952,46 @@ function throwIfAborted(abortSignal?: AbortSignal): void {
   const abortError = new Error("Chat execution aborted");
   abortError.name = "AbortError";
   throw abortError;
+}
+
+function getToolCallIdFromExecuteOptions(options: unknown): string | undefined {
+  if (!isRecord(options)) {
+    return undefined;
+  }
+
+  return typeof options.toolCallId === "string"
+    ? options.toolCallId
+    : undefined;
+}
+
+function buildApprovedToolExecutionKey({
+  agentId,
+  conversationId,
+  toolCallId,
+}: {
+  agentId: string;
+  conversationId?: string;
+  toolCallId: string;
+}): string {
+  return `${agentId}:${conversationId ?? "no-conversation"}:${toolCallId}`;
+}
+
+function executeApprovedMcpToolCallOnce(
+  executionKey: string,
+  executeToolCall: () => ReturnType<typeof mcpClient.executeToolCall>,
+): ReturnType<typeof mcpClient.executeToolCall> {
+  const existingExecution = approvedToolExecutionCache.get(executionKey);
+  if (existingExecution) {
+    logger.info(
+      { executionKey },
+      "Reusing approved MCP tool execution for duplicate tool call",
+    );
+    return existingExecution;
+  }
+
+  const execution = executeToolCall();
+  approvedToolExecutionCache.set(executionKey, execution);
+  return execution;
 }
 
 function isAbortLikeError(error: unknown): boolean {


### PR DESCRIPTION
Addresses #5132

## Problem
An approved MCP tool call can be submitted more than once from the same pending approval turn. When the backend receives duplicate resumes for the same approved `toolCallId`, it can dispatch the external MCP call more than once.

## What changed
- Use the AI SDK `toolCallId` as the downstream MCP call id for approval-gated MCP tools.
- Add an LRU-backed in-process execution guard keyed by agent, conversation, and tool call id. Concurrent duplicates and immediate repeat clicks reuse the first execution promise/result instead of dispatching again.
- Add a regression test for duplicate approved executions.

## Notes
This keeps the scope small and avoids schema changes. It protects the duplicate-submit path within a backend instance; a durable cross-instance ledger can still be added later if the deployment model needs it.

## How to test
- `PATH="/Users/chiragarora/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" ARCHESTRA_DATABASE_URL="postgresql://archestra:archestra_dev_password@localhost:5432/archestra_dev?schema=public" pnpm --filter @backend exec vitest run src/clients/chat-mcp-client.test.ts`
- `PATH="/Users/chiragarora/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm --filter @backend type-check`
- `PATH="/Users/chiragarora/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm --filter @backend lint`

## Checklist
- Tests added/updated
- No breaking changes
- Follows the Archestra contributing guide