### PR TITLE
feat(llm): support OpenAI pro reasoning models via the Responses API

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -57849,9 +57849,6 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
                           "additionalProperties": {},
                           "description": "https://developers.openai.com/api/reference/resources/responses/methods/create"
                         }
@@ -58434,9 +58431,6 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
                           "additionalProperties": {},
                           "description": "https://developers.openai.com/api/reference/resources/responses/methods/create"
                         }
@@ -89480,9 +89474,6 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "type"
-                                          ],
                                           "additionalProperties": {},
                                           "description": "https://developers.openai.com/api/reference/resources/responses/methods/create"
                                         }
@@ -89606,9 +89597,6 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "type"
-                                          ],
                                           "additionalProperties": {},
                                           "description": "https://developers.openai.com/api/reference/resources/responses/methods/create"
                                         }
@@ -99475,9 +99463,6 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "type"
-                                          ],
                                           "additionalProperties": {},
                                           "description": "https://developers.openai.com/api/reference/resources/responses/methods/create"
                                         }
@@ -99601,9 +99586,6 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "type"
-                                          ],
                                           "additionalProperties": {},
                                           "description": "https://developers.openai.com/api/reference/resources/responses/methods/create"
                                         }
@@ -102215,9 +102197,6 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "type"
-                                    ],
                                     "additionalProperties": {},
                                     "description": "https://developers.openai.com/api/reference/resources/responses/methods/create"
                                   }
@@ -102341,9 +102320,6 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "type"
-                                    ],
                                     "additionalProperties": {},
                                     "description": "https://developers.openai.com/api/reference/resources/responses/methods/create"
                                   }
@@ -112210,9 +112186,6 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "type"
-                                    ],
                                     "additionalProperties": {},
                                     "description": "https://developers.openai.com/api/reference/resources/responses/methods/create"
                                   }
@@ -112336,9 +112309,6 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "type"
-                                    ],
                                     "additionalProperties": {},
                                     "description": "https://developers.openai.com/api/reference/resources/responses/methods/create"
                                   }
@@ -159939,9 +159909,6 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
                           "additionalProperties": {},
                           "description": "https://developers.openai.com/api/reference/resources/responses/methods/create"
                         }
@@ -160524,9 +160491,6 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
                           "additionalProperties": {},
                           "description": "https://developers.openai.com/api/reference/resources/responses/methods/create"
                         }
@@ -164519,9 +164483,6 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
                           "additionalProperties": {},
                           "description": "https://developers.openai.com/api/reference/resources/responses/methods/create"
                         }
@@ -165104,9 +165065,6 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
                           "additionalProperties": {},
                           "description": "https://developers.openai.com/api/reference/resources/responses/methods/create"
                         }

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -14,6 +14,7 @@ import {
   CHAT_API_KEY_ID_HEADER,
   EXTERNAL_AGENT_ID_HEADER,
   PROVIDER_BASE_URL_HEADER,
+  requiresOpenAiResponsesApi,
   SESSION_ID_HEADER,
   SOURCE_HEADER,
   type SupportedProvider,
@@ -390,8 +391,14 @@ const providerModelConfigs: Record<SupportedProvider, ProviderModelConfig> = {
   // --- OpenAI-compatible providers (use createOpenAI with .chat()) ---
 
   openai: {
-    createModel: ({ apiKey, modelName, baseURL, headers, fetch }) =>
-      createOpenAI({ apiKey, baseURL, headers, fetch }).chat(modelName),
+    createModel: ({ apiKey, modelName, baseURL, headers, fetch }) => {
+      const client = createOpenAI({ apiKey, baseURL, headers, fetch });
+      // "pro" reasoning models are Responses-API-only; routing them through
+      // .chat() hits /chat/completions and 404s. See requiresOpenAiResponsesApi.
+      return requiresOpenAiResponsesApi(modelName)
+        ? client.responses(modelName)
+        : client.chat(modelName);
+    },
     defaultBaseUrl: config.llm.openai.baseUrl,
     apiKeyRequiredMessage:
       "OpenAI API key is required. Please configure OPENAI_API_KEY.",

--- a/platform/backend/src/routes/proxy/adapters/openai-responses.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-responses.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+import type { OpenAi } from "@/types";
+import { openAiResponsesAdapterFactory } from "./openai-responses";
+
+describe("OpenAiResponsesRequestAdapter.getMessages", () => {
+  // The AI SDK emits Responses "easy input" messages: role/content with no
+  // `type`. getMessages() feeds trusted-data / Dual LLM policy evaluation, so
+  // dropping these would silently bypass those policies for routed chats.
+  test("includes easy-input message items that omit a top-level type", () => {
+    const request = {
+      model: "gpt-5.5-pro",
+      input: [
+        { role: "user", content: [{ type: "input_text", text: "hello" }] },
+      ],
+    } as unknown as OpenAi.Types.ResponsesRequest;
+
+    const messages = openAiResponsesAdapterFactory
+      .createRequestAdapter(request)
+      .getMessages();
+
+    expect(messages).toEqual([{ role: "user", content: "hello" }]);
+  });
+
+  test("still includes typed message items", () => {
+    const request = {
+      model: "gpt-5.5-pro",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "typed" }],
+        },
+      ],
+    } as unknown as OpenAi.Types.ResponsesRequest;
+
+    const messages = openAiResponsesAdapterFactory
+      .createRequestAdapter(request)
+      .getMessages();
+
+    expect(messages).toEqual([{ role: "user", content: "typed" }]);
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/openai-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-responses.ts
@@ -733,7 +733,11 @@ function createEmptyToolCompressionStats(): ToolCompressionStats {
 }
 
 function toCommonMessages(item: ResponseInputItem): CommonMessage[] {
-  if (item.type === "message") {
+  // "easy input message" items carry role/content and omit `type` (it defaults
+  // to "message"); the AI SDK emits this shape. Without handling it here,
+  // getMessages() drops the user's prompt and trusted-data / Dual LLM policy
+  // evaluation (llm-proxy-handler) silently sees an empty conversation.
+  if ((item.type === "message" || item.type === undefined) && "role" in item) {
     return [
       {
         role: normalizeResponseMessageRole(item.role),

--- a/platform/backend/src/types/llm-providers/openai/api.test.ts
+++ b/platform/backend/src/types/llm-providers/openai/api.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import { ResponsesRequestSchema } from "./api";
+
+describe("ResponsesRequestSchema", () => {
+  test("accepts easy-input message items that omit a top-level type", () => {
+    const result = ResponsesRequestSchema.safeParse({
+      model: "gpt-5.5-pro",
+      input: [{ role: "user", content: [{ type: "input_text", text: "hi" }] }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("still accepts typed input items (function calls)", () => {
+    const result = ResponsesRequestSchema.safeParse({
+      model: "gpt-5.5-pro",
+      input: [
+        { type: "function_call", call_id: "c1", name: "f", arguments: "{}" },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/platform/backend/src/types/llm-providers/openai/api.ts
+++ b/platform/backend/src/types/llm-providers/openai/api.ts
@@ -98,7 +98,9 @@ export const ChatCompletionResponseSchema = z
 
 const ResponsesInputItemSchema = z
   .object({
-    type: z.string(),
+    // Optional: Responses "easy input message" items carry only role/content
+    // and omit `type` (it defaults to "message"); the AI SDK emits this shape.
+    type: z.string().optional(),
   })
   .passthrough()
   .describe(

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -16814,7 +16814,7 @@ export type AzureResponsesWithDefaultAgentData = {
     body: {
         model: string;
         input?: string | Array<{
-            type: string;
+            type?: string;
             [key: string]: unknown;
         }>;
         instructions?: string | null;
@@ -16983,7 +16983,7 @@ export type AzureResponsesWithAgentData = {
     body: {
         model: string;
         input?: string | Array<{
-            type: string;
+            type?: string;
             [key: string]: unknown;
         }>;
         instructions?: string | null;
@@ -25520,7 +25520,7 @@ export type GetInteractionsResponses = {
             request: {
                 model: string;
                 input?: string | Array<{
-                    type: string;
+                    type?: string;
                     [key: string]: unknown;
                 }>;
                 instructions?: string | null;
@@ -25556,7 +25556,7 @@ export type GetInteractionsResponses = {
             processedRequest?: {
                 model: string;
                 input?: string | Array<{
-                    type: string;
+                    type?: string;
                     [key: string]: unknown;
                 }>;
                 instructions?: string | null;
@@ -27335,7 +27335,7 @@ export type GetInteractionsResponses = {
             request: {
                 model: string;
                 input?: string | Array<{
-                    type: string;
+                    type?: string;
                     [key: string]: unknown;
                 }>;
                 instructions?: string | null;
@@ -27371,7 +27371,7 @@ export type GetInteractionsResponses = {
             processedRequest?: {
                 model: string;
                 input?: string | Array<{
-                    type: string;
+                    type?: string;
                     [key: string]: unknown;
                 }>;
                 instructions?: string | null;
@@ -28003,7 +28003,7 @@ export type GetInteractionResponses = {
         request: {
             model: string;
             input?: string | Array<{
-                type: string;
+                type?: string;
                 [key: string]: unknown;
             }>;
             instructions?: string | null;
@@ -28039,7 +28039,7 @@ export type GetInteractionResponses = {
         processedRequest?: {
             model: string;
             input?: string | Array<{
-                type: string;
+                type?: string;
                 [key: string]: unknown;
             }>;
             instructions?: string | null;
@@ -29818,7 +29818,7 @@ export type GetInteractionResponses = {
         request: {
             model: string;
             input?: string | Array<{
-                type: string;
+                type?: string;
                 [key: string]: unknown;
             }>;
             instructions?: string | null;
@@ -29854,7 +29854,7 @@ export type GetInteractionResponses = {
         processedRequest?: {
             model: string;
             input?: string | Array<{
-                type: string;
+                type?: string;
                 [key: string]: unknown;
             }>;
             instructions?: string | null;
@@ -42007,7 +42007,7 @@ export type ModelRouterResponsesWithDefaultAgentData = {
     body: {
         model: string;
         input?: string | Array<{
-            type: string;
+            type?: string;
             [key: string]: unknown;
         }>;
         instructions?: string | null;
@@ -42176,7 +42176,7 @@ export type ModelRouterResponsesWithAgentData = {
     body: {
         model: string;
         input?: string | Array<{
-            type: string;
+            type?: string;
             [key: string]: unknown;
         }>;
         instructions?: string | null;
@@ -43381,7 +43381,7 @@ export type OpenAiResponsesWithDefaultAgentData = {
     body: {
         model: string;
         input?: string | Array<{
-            type: string;
+            type?: string;
             [key: string]: unknown;
         }>;
         instructions?: string | null;
@@ -43550,7 +43550,7 @@ export type OpenAiResponsesWithAgentData = {
     body: {
         model: string;
         input?: string | Array<{
-            type: string;
+            type?: string;
             [key: string]: unknown;
         }>;
         instructions?: string | null;

--- a/platform/shared/model-constants.test.ts
+++ b/platform/shared/model-constants.test.ts
@@ -2,7 +2,22 @@ import { describe, expect, test } from "vitest";
 import {
   getProvidersWithOptionalApiKey,
   isProviderApiKeyOptional,
+  requiresOpenAiResponsesApi,
 } from "./model-constants";
+
+describe("requiresOpenAiResponsesApi", () => {
+  test("matches pro reasoning models, including dated snapshots", () => {
+    expect(requiresOpenAiResponsesApi("gpt-5.5-pro")).toBe(true);
+    expect(requiresOpenAiResponsesApi("gpt-5.5-pro-2026-01-01")).toBe(true);
+    expect(requiresOpenAiResponsesApi("o3-pro")).toBe(true);
+  });
+
+  test("does not match chat-completions models", () => {
+    expect(requiresOpenAiResponsesApi("gpt-5.5")).toBe(false);
+    expect(requiresOpenAiResponsesApi("gpt-4o")).toBe(false);
+    expect(requiresOpenAiResponsesApi("babbage-002")).toBe(false);
+  });
+});
 
 describe("provider API key optional helpers", () => {
   test("treats self-hosted providers as optional", () => {

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -242,6 +242,19 @@ export const DEFAULT_MODELS: Record<SupportedProvider, string> = {
   minimax: "MiniMax-M3",
   azure: "gpt-5.5",
 };
+
+/**
+ * True for OpenAI "pro" reasoning models, which OpenAI serves only through the
+ * Responses API (`/v1/responses`). Calling them on `/v1/chat/completions`
+ * returns `api_not_found_error` ("not a chat model"), so the chat client must
+ * route these models to the Responses transport instead. "pro" is matched as a
+ * hyphen/slash-delimited token, so dated snapshots (`gpt-5.5-pro-2026-01-01`)
+ * are covered.
+ */
+export function requiresOpenAiResponsesApi(modelId: string): boolean {
+  return /(?:^|[-/])pro(?:[-/]|$)/i.test(modelId);
+}
+
 /**
  * Maps models.dev provider IDs to Archestra provider names.
  * This is the single source of truth for all synchronization logic.


### PR DESCRIPTION
## Summary

OpenAI "pro" reasoning models (e.g. `gpt-5.5-pro`) are served only by the OpenAI Responses API. The chat proxy always called `/v1/chat/completions`, so when one of these models was auto-selected as an organization's "best available" model, every new chat failed with a 404 `api_not_found_error` ("not a chat model") and the user saw *"The selected model is not available. Please choose a different model."* These models now route through the Responses API (`/v1/responses`) and work in chat; all other OpenAI models continue to use chat completions.

Routing chat traffic through the Responses adapter required two correctness fixes so it matches the chat path:

- the proxy `/responses` request schema accepts the "easy input" message shape the AI SDK emits (`role`/`content` with no `type`), and
- the Responses request adapter's message extraction includes those items — otherwise trusted-data and Dual LLM policy evaluation would see an empty conversation for these models and silently skip enforcement.
