### PR TITLE
fix(llm): exclude hidden and non-chat models from default model resolution

### DIFF
--- a/platform/backend/src/models/llm-provider-api-key-model.test.ts
+++ b/platform/backend/src/models/llm-provider-api-key-model.test.ts
@@ -326,4 +326,206 @@ describe("LlmProviderApiKeyModelLinkModel", () => {
       expect(linkedSelections).toEqual(new Set([`${apiKey.id}:${model.id}`]));
     });
   });
+
+  describe("chat-capable filtering in resolution fallbacks", () => {
+    test("getFirstModelForApiKey skips ignored models", async ({
+      makeOrganization,
+      makeSecret,
+      makeLlmProviderApiKey,
+    }) => {
+      const org = await makeOrganization();
+      const secret = await makeSecret();
+      const apiKey = await makeLlmProviderApiKey(org.id, secret.id, {
+        provider: "openai",
+      });
+
+      const hiddenModel = await ModelModel.create({
+        externalId: "openai/babbage-002",
+        provider: "openai",
+        modelId: "babbage-002",
+        description: "Babbage",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        supportsToolCalling: false,
+        lastSyncedAt: new Date(),
+      });
+      await ModelModel.update(hiddenModel.id, { ignored: true });
+
+      const chatModel = await ModelModel.create({
+        externalId: "openai/gpt-5.4",
+        provider: "openai",
+        modelId: "gpt-5.4",
+        description: "GPT-5.4",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        supportsToolCalling: true,
+        lastSyncedAt: new Date(),
+      });
+
+      await LlmProviderApiKeyModelLinkModel.linkModelsToApiKey(apiKey.id, [
+        hiddenModel.id,
+        chatModel.id,
+      ]);
+
+      const first =
+        await LlmProviderApiKeyModelLinkModel.getFirstModelForApiKey(apiKey.id);
+      expect(first?.id).toBe(chatModel.id);
+    });
+
+    test("getRankedModelsForApiKeys excludes ignored and embedding models", async ({
+      makeOrganization,
+      makeSecret,
+      makeLlmProviderApiKey,
+    }) => {
+      const org = await makeOrganization();
+      const secret = await makeSecret();
+      const apiKey = await makeLlmProviderApiKey(org.id, secret.id, {
+        provider: "openai",
+      });
+
+      const hiddenModel = await ModelModel.create({
+        externalId: "openai/babbage-002",
+        provider: "openai",
+        modelId: "babbage-002",
+        description: "Babbage",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        supportsToolCalling: false,
+        lastSyncedAt: new Date(),
+      });
+      await ModelModel.update(hiddenModel.id, { ignored: true });
+
+      const embeddingModel = await ModelModel.create({
+        externalId: "openai/text-embedding-3-small",
+        provider: "openai",
+        modelId: "text-embedding-3-small",
+        description: "Embedding",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        embeddingDimensions: 1536,
+        lastSyncedAt: new Date(),
+      });
+
+      const chatModel = await ModelModel.create({
+        externalId: "openai/gpt-5.4",
+        provider: "openai",
+        modelId: "gpt-5.4",
+        description: "GPT-5.4",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        supportsToolCalling: true,
+        lastSyncedAt: new Date(),
+      });
+
+      await LlmProviderApiKeyModelLinkModel.linkModelsToApiKey(apiKey.id, [
+        hiddenModel.id,
+        embeddingModel.id,
+        chatModel.id,
+      ]);
+
+      const ranked =
+        await LlmProviderApiKeyModelLinkModel.getRankedModelsForApiKeys([
+          apiKey.id,
+        ]);
+
+      expect(ranked.map((r) => r.modelId)).toEqual([chatModel.id]);
+    });
+
+    test("getBestModel skips an ignored best-marked model", async ({
+      makeOrganization,
+      makeSecret,
+      makeLlmProviderApiKey,
+    }) => {
+      const org = await makeOrganization();
+      const secret = await makeSecret();
+      const apiKey = await makeLlmProviderApiKey(org.id, secret.id, {
+        provider: "openai",
+      });
+
+      const hiddenBest = await ModelModel.create({
+        externalId: "openai/gpt-5.5",
+        provider: "openai",
+        modelId: "gpt-5.5",
+        description: "GPT-5.5",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        supportsToolCalling: true,
+        lastSyncedAt: new Date(),
+      });
+      const chatModel = await ModelModel.create({
+        externalId: "openai/gpt-5.4",
+        provider: "openai",
+        modelId: "gpt-5.4",
+        description: "GPT-5.4",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        supportsToolCalling: true,
+        lastSyncedAt: new Date(),
+      });
+
+      await LlmProviderApiKeyModelLinkModel.syncModelsForApiKey(
+        apiKey.id,
+        [
+          { id: hiddenBest.id, modelId: hiddenBest.modelId },
+          { id: chatModel.id, modelId: chatModel.modelId },
+        ],
+        "openai",
+      );
+      await ModelModel.update(hiddenBest.id, { ignored: true });
+
+      const best = await LlmProviderApiKeyModelLinkModel.getBestModel(
+        apiKey.id,
+      );
+      expect(best?.id).toBe(chatModel.id);
+    });
+
+    test("getBestModelsForApiKeys skips an ignored best-marked model", async ({
+      makeOrganization,
+      makeSecret,
+      makeLlmProviderApiKey,
+    }) => {
+      const org = await makeOrganization();
+      const secret = await makeSecret();
+      const apiKey = await makeLlmProviderApiKey(org.id, secret.id, {
+        provider: "openai",
+      });
+
+      const hiddenBest = await ModelModel.create({
+        externalId: "openai/gpt-5.5",
+        provider: "openai",
+        modelId: "gpt-5.5",
+        description: "GPT-5.5",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        supportsToolCalling: true,
+        lastSyncedAt: new Date(),
+      });
+      const chatModel = await ModelModel.create({
+        externalId: "openai/gpt-5.4",
+        provider: "openai",
+        modelId: "gpt-5.4",
+        description: "GPT-5.4",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        supportsToolCalling: true,
+        lastSyncedAt: new Date(),
+      });
+
+      await LlmProviderApiKeyModelLinkModel.syncModelsForApiKey(
+        apiKey.id,
+        [
+          { id: hiddenBest.id, modelId: hiddenBest.modelId },
+          { id: chatModel.id, modelId: chatModel.modelId },
+        ],
+        "openai",
+      );
+      await ModelModel.update(hiddenBest.id, { ignored: true });
+
+      const bestModels =
+        await LlmProviderApiKeyModelLinkModel.getBestModelsForApiKeys([
+          apiKey.id,
+        ]);
+      expect(bestModels.get(apiKey.id)?.id).toBe(chatModel.id);
+    });
+  });
 });

--- a/platform/backend/src/models/llm-provider-api-key-model.ts
+++ b/platform/backend/src/models/llm-provider-api-key-model.ts
@@ -6,6 +6,7 @@ import {
 import { and, asc, desc, eq, inArray, or, sql } from "drizzle-orm";
 import db, { schema, withDbTransaction } from "@/database";
 import type { LlmProviderApiKey, Model } from "@/types";
+import ModelModel from "./model";
 
 /** Aggregate of an API key's linked-model count and oldest sync timestamp. */
 export interface ModelSyncState {
@@ -417,6 +418,10 @@ class LlmProviderApiKeyModelLinkModel {
    * model" fallback for resolution. Rows are ordered is_best first, then by
    * provider and model id, so the first row is a deterministic best pick.
    * `modelId` is the models.id UUID (matches the model_id FK columns).
+   *
+   * Only chat-capable, non-ignored models are returned, matching the model
+   * picker (`supportsTextChat`), so resolution never auto-selects a model the
+   * UI hides or that cannot serve chat.
    */
   static async getRankedModelsForApiKeys(
     apiKeyIds: string[],
@@ -424,9 +429,9 @@ class LlmProviderApiKeyModelLinkModel {
     if (apiKeyIds.length === 0) {
       return [];
     }
-    return db
+    const rows = await db
       .select({
-        modelId: schema.llmProviderApiKeyModelsTable.modelId,
+        model: schema.modelsTable,
         apiKeyId: schema.llmProviderApiKeyModelsTable.apiKeyId,
         isBest: schema.llmProviderApiKeyModelsTable.isBest,
       })
@@ -441,6 +446,14 @@ class LlmProviderApiKeyModelLinkModel {
         asc(schema.modelsTable.provider),
         asc(schema.modelsTable.modelId),
       );
+
+    return rows
+      .filter((row) => ModelModel.supportsTextChat(row.model))
+      .map((row) => ({
+        modelId: row.model.id,
+        apiKeyId: row.apiKeyId,
+        isBest: row.isBest,
+      }));
   }
 
   static async getBestModel(apiKeyId: string): Promise<Model | null> {
@@ -459,7 +472,7 @@ class LlmProviderApiKeyModelLinkModel {
       )
       .limit(1);
 
-    if (result?.model) {
+    if (result?.model && ModelModel.supportsTextChat(result.model)) {
       return result.model;
     }
 
@@ -468,7 +481,9 @@ class LlmProviderApiKeyModelLinkModel {
 
   /**
    * Get the "best" model for multiple API keys in two batched queries.
-   * Returns the model marked with is_best=true, or falls back to the first model.
+   * Returns the model marked with is_best=true, or falls back to the first
+   * model. Both candidates are filtered through `supportsTextChat`, so a hidden
+   * or non-chat model is never returned as a key's best.
    */
   static async getBestModelsForApiKeys(
     apiKeyIds: string[],
@@ -500,7 +515,9 @@ class LlmProviderApiKeyModelLinkModel {
 
     const modelsByApiKeyId = new Map<string, Model>();
     for (const result of bestModels) {
-      modelsByApiKeyId.set(result.apiKeyId, result.model);
+      if (ModelModel.supportsTextChat(result.model)) {
+        modelsByApiKeyId.set(result.apiKeyId, result.model);
+      }
     }
 
     const missingApiKeyIds = apiKeyIds.filter(
@@ -530,7 +547,10 @@ class LlmProviderApiKeyModelLinkModel {
       );
 
     for (const result of fallbackModels) {
-      if (!modelsByApiKeyId.has(result.apiKeyId)) {
+      if (
+        !modelsByApiKeyId.has(result.apiKeyId) &&
+        ModelModel.supportsTextChat(result.model)
+      ) {
         modelsByApiKeyId.set(result.apiKeyId, result.model);
       }
     }
@@ -539,10 +559,12 @@ class LlmProviderApiKeyModelLinkModel {
   }
 
   /**
-   * Get the first model linked to an API key (used as fallback).
+   * Get the first chat-capable, non-ignored model linked to an API key (used as
+   * fallback). Honors `supportsTextChat` so a hidden or non-chat model — e.g. a
+   * legacy completions-only model that sorts first alphabetically — is skipped.
    */
   static async getFirstModelForApiKey(apiKeyId: string): Promise<Model | null> {
-    const [result] = await db
+    const rows = await db
       .select({ model: schema.modelsTable })
       .from(schema.llmProviderApiKeyModelsTable)
       .innerJoin(
@@ -550,10 +572,11 @@ class LlmProviderApiKeyModelLinkModel {
         eq(schema.llmProviderApiKeyModelsTable.modelId, schema.modelsTable.id),
       )
       .where(eq(schema.llmProviderApiKeyModelsTable.apiKeyId, apiKeyId))
-      .orderBy(asc(schema.modelsTable.modelId))
-      .limit(1);
+      .orderBy(asc(schema.modelsTable.modelId));
 
-    return result?.model ?? null;
+    return (
+      rows.find((row) => ModelModel.supportsTextChat(row.model))?.model ?? null
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

The backend's "best available" model fallback queried the API-key/model link rows directly, without the `supportsTextChat` filter the model picker applies. As a result a hidden (`ignored`) model — or a non-chat model such as an embedding model — could be auto-selected and persisted onto a new conversation even though the picker never offers it, and hiding a model in the UI did not stop it from being chosen for chat.

The resolution fallback (`getRankedModelsForApiKeys`, `getBestModel`, `getBestModelsForApiKeys`, `getFirstModelForApiKey`) now runs each candidate through `ModelModel.supportsTextChat`, so resolution and the picker agree on the selectable set: hidden and non-chat models are excluded from auto-selection.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>