### PR TITLE
test(e2e): cover editor promoting a personal catalog item to their team

### DIFF
--- a/platform/e2e-tests/playwright.config.ts
+++ b/platform/e2e-tests/playwright.config.ts
@@ -51,6 +51,7 @@ const uiTestMatch = [
   "**/invitation.spec.ts",
   "**/llm-provider-api-keys.spec.ts",
   "**/mcp-catalog-clone.spec.ts",
+  "**/mcp-catalog-promote-to-team.spec.ts",
   "**/mcp-install.spec.ts",
   "**/quickstart.spec.ts",
   "**/skill-share.spec.ts",

--- a/platform/e2e-tests/tests/mcp-catalog-promote-to-team.spec.ts
+++ b/platform/e2e-tests/tests/mcp-catalog-promote-to-team.spec.ts
@@ -1,0 +1,88 @@
+import {
+  E2eTestId,
+  ENGINEERING_TEAM_NAME,
+  getE2eRequestUrl,
+  UI_BASE_URL,
+} from "../consts";
+import { expect, test } from "../fixtures";
+import { goToMcpRegistry } from "../utils";
+
+/**
+ * Promotion story: an Editor (who holds mcpRegistry:team-admin and is a member
+ * of the Engineering team) creates a personal catalog item and then promotes it
+ * to their team via the registry's edit form — the team-scoping capability
+ * shipped for non-admin editors.
+ */
+test.describe("MCP Catalog promotion", () => {
+  test("an editor promotes their own personal catalog item to a team they belong to", async ({
+    editorPage,
+    makeRandomString,
+  }) => {
+    const name = makeRandomString(6, "promote-src");
+
+    // The editor creates a personal catalog item (setup, via the editor's
+    // own authenticated request context).
+    const createResponse = await editorPage.request.post(
+      getE2eRequestUrl("/api/internal_mcp_catalog"),
+      {
+        headers: { "Content-Type": "application/json", Origin: UI_BASE_URL },
+        data: {
+          name,
+          description: "promotion story e2e",
+          serverType: "remote",
+          serverUrl: "https://example.test/mcp",
+          scope: "personal",
+        },
+      },
+    );
+    expect(createResponse.ok()).toBeTruthy();
+    const created = await createResponse.json();
+    expect(created.scope).toBe("personal");
+
+    // The editor promotes it to the Engineering team through the edit form.
+    await goToMcpRegistry(editorPage);
+    await editorPage
+      .getByTestId(`${E2eTestId.McpServerSettingsButton}-${name}`)
+      .click();
+
+    const settingsDialog = editorPage.getByRole("dialog", {
+      name: new RegExp(`${name} Settings`, "i"),
+    });
+    await expect(settingsDialog).toBeVisible({ timeout: 30_000 });
+
+    // Switch visibility Personal -> Teams. The Teams option's description is
+    // unique within the visibility selector, so match on it.
+    await settingsDialog
+      .getByRole("button", {
+        name: /Share this MCP server with selected teams/i,
+      })
+      .click();
+
+    // Pick the Engineering team (the editor is a member of it).
+    await settingsDialog.getByPlaceholder("Select teams...").click();
+    await editorPage
+      .getByRole("option", { name: ENGINEERING_TEAM_NAME })
+      .click();
+
+    await settingsDialog.getByRole("button", { name: /Save Changes/i }).click();
+
+    // The item is now team-scoped and assigned to Engineering.
+    await expect
+      .poll(
+        async () => {
+          const res = await editorPage.request.get(
+            getE2eRequestUrl(`/api/internal_mcp_catalog/${created.id}`),
+            { headers: { Origin: UI_BASE_URL } },
+          );
+          if (!res.ok()) return null;
+          const item = await res.json();
+          return {
+            scope: item.scope,
+            teams: (item.teams ?? []).map((t: { name: string }) => t.name),
+          };
+        },
+        { timeout: 30_000 },
+      )
+      .toEqual({ scope: "team", teams: [ENGINEERING_TEAM_NAME] });
+  });
+});


### PR DESCRIPTION
## Summary

Adds end-to-end coverage for the editor-driven catalog promotion flow shipped in #5298: an Editor who holds `mcpRegistry:team-admin` and belongs to the Engineering team creates a personal MCP catalog item, then promotes it to that team through the registry's edit form. The test drives the real UI (settings → Configuration → switch visibility to Teams → pick Engineering → save) and verifies via an independent API read that the item is now `team`-scoped and assigned to Engineering, so a regression in the promote path (scope not switching, team not persisted, or wrong team) would fail it.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>