### PR TITLE
fix(llm): exclude OpenAI completions-only models from the chat catalog

### DIFF
--- a/platform/backend/src/routes/chat/model-fetchers/openai.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/openai.test.ts
@@ -1,5 +1,11 @@
+import { vi } from "vitest";
 import { describe, expect, test } from "@/test";
-import { mapOpenAiModelToModelInfo } from "./openai";
+import { fetchOpenAiModels, mapOpenAiModelToModelInfo } from "./openai";
+import { fetchModelsWithBearerAuth } from "./openai-compatible";
+
+vi.mock("./openai-compatible", () => ({
+  fetchModelsWithBearerAuth: vi.fn(),
+}));
 
 describe("mapOpenAiModelToModelInfo", () => {
   test("maps standard OpenAI model", () => {
@@ -58,5 +64,27 @@ describe("mapOpenAiModelToModelInfo", () => {
       provider: "openai",
       createdAt: undefined,
     });
+  });
+});
+
+describe("fetchOpenAiModels exclusion", () => {
+  test.each([
+    { id: "gpt-4o", included: true },
+    { id: "chatgpt-4o-latest", included: true },
+    { id: "gpt-5.5-pro", included: true },
+    { id: "babbage-002", included: false },
+    { id: "davinci-002", included: false },
+    { id: "gpt-3.5-turbo-instruct", included: false },
+    { id: "whisper-1", included: false },
+    { id: "dall-e-3", included: false },
+    { id: "tts-1", included: false },
+  ])("$id -> included=$included", async ({ id, included }) => {
+    vi.mocked(fetchModelsWithBearerAuth).mockResolvedValue({
+      data: [{ id, object: "model", owned_by: "openai", created: 1 }],
+    });
+
+    const models = await fetchOpenAiModels("test-key");
+
+    expect(models.some((model) => model.id === id)).toBe(included);
   });
 });

--- a/platform/backend/src/routes/chat/model-fetchers/openai.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/openai.test.ts
@@ -1,11 +1,5 @@
-import { vi } from "vitest";
 import { describe, expect, test } from "@/test";
-import { fetchOpenAiModels, mapOpenAiModelToModelInfo } from "./openai";
-import { fetchModelsWithBearerAuth } from "./openai-compatible";
-
-vi.mock("./openai-compatible", () => ({
-  fetchModelsWithBearerAuth: vi.fn(),
-}));
+import { isChatModelId, mapOpenAiModelToModelInfo } from "./openai";
 
 describe("mapOpenAiModelToModelInfo", () => {
   test("maps standard OpenAI model", () => {
@@ -67,24 +61,31 @@ describe("mapOpenAiModelToModelInfo", () => {
   });
 });
 
-describe("fetchOpenAiModels exclusion", () => {
+describe("isChatModelId", () => {
   test.each([
-    { id: "gpt-4o", included: true },
-    { id: "chatgpt-4o-latest", included: true },
-    { id: "gpt-5.5-pro", included: true },
-    { id: "babbage-002", included: false },
-    { id: "davinci-002", included: false },
-    { id: "gpt-3.5-turbo-instruct", included: false },
-    { id: "whisper-1", included: false },
-    { id: "dall-e-3", included: false },
-    { id: "tts-1", included: false },
-  ])("$id -> included=$included", async ({ id, included }) => {
-    vi.mocked(fetchModelsWithBearerAuth).mockResolvedValue({
-      data: [{ id, object: "model", owned_by: "openai", created: 1 }],
-    });
+    "gpt-5.5-pro",
+    "gpt-5.5",
+    "gpt-4.1",
+    "gpt-4o",
+    "chatgpt-4o-latest",
+    "gpt-4-turbo",
+    "gpt-4",
+    "gpt-3.5-turbo",
+    "o1",
+    "o3",
+  ])("keeps standard chat model %s", (id) => {
+    expect(isChatModelId(id)).toBe(true);
+  });
 
-    const models = await fetchOpenAiModels("test-key");
-
-    expect(models.some((model) => model.id === id)).toBe(included);
+  test.each([
+    "babbage-002",
+    "davinci-002",
+    "gpt-3.5-turbo-instruct",
+    "gpt-4o-audio-preview",
+    "whisper-1",
+    "tts-1",
+    "dall-e-3",
+  ])("drops non-chat model %s", (id) => {
+    expect(isChatModelId(id)).toBe(false);
   });
 });

--- a/platform/backend/src/routes/chat/model-fetchers/openai.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/openai.ts
@@ -42,6 +42,9 @@ export async function fetchOpenAiModels(
     extraHeaders,
   });
 
+  // babbage/davinci are OpenAI's legacy completions-only base models: they 404
+  // on /chat/completions ("not a chat model"), so exclude them alongside the
+  // other non-chat families to keep them out of the chat catalog.
   const excludePatterns = [
     "instruct",
     "tts",
@@ -50,6 +53,8 @@ export async function fetchOpenAiModels(
     "audio",
     "sora",
     "dall-e",
+    "babbage",
+    "davinci",
   ];
 
   return data.data

--- a/platform/backend/src/routes/chat/model-fetchers/openai.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/openai.ts
@@ -27,6 +27,27 @@ export function mapOpenAiModelToModelInfo(
   };
 }
 
+// babbage/davinci are OpenAI's legacy completions-only base models: they 404 on
+// /chat/completions ("not a chat model"). They, and the other non-chat families,
+// are dropped so they never enter the selectable chat catalog.
+const NON_CHAT_MODEL_ID_PATTERNS = [
+  "instruct",
+  "tts",
+  "whisper",
+  "image",
+  "audio",
+  "sora",
+  "dall-e",
+  "babbage",
+  "davinci",
+];
+
+/** @public — exported for unit tests; the chat-catalog filter fetchOpenAiModels applies. */
+export function isChatModelId(id: string): boolean {
+  const lower = id.toLowerCase();
+  return !NON_CHAT_MODEL_ID_PATTERNS.some((pattern) => lower.includes(pattern));
+}
+
 export async function fetchOpenAiModels(
   apiKey: string,
   baseUrlOverride?: string | null,
@@ -42,25 +63,7 @@ export async function fetchOpenAiModels(
     extraHeaders,
   });
 
-  // babbage/davinci are OpenAI's legacy completions-only base models: they 404
-  // on /chat/completions ("not a chat model"), so exclude them alongside the
-  // other non-chat families to keep them out of the chat catalog.
-  const excludePatterns = [
-    "instruct",
-    "tts",
-    "whisper",
-    "image",
-    "audio",
-    "sora",
-    "dall-e",
-    "babbage",
-    "davinci",
-  ];
-
   return data.data
-    .filter((model) => {
-      const id = model.id.toLowerCase();
-      return !excludePatterns.some((pattern) => id.includes(pattern));
-    })
+    .filter((model) => isChatModelId(model.id))
     .map(mapOpenAiModelToModelInfo);
 }


### PR DESCRIPTION
## Summary

On a fresh install, adding an OpenAI API key and starting a chat could fail immediately with *"The selected model is not available. Please choose a different model."* — a 404 `api_not_found_error` ("not a chat model"). OpenAI's `/models` includes the legacy completions-only base models `babbage-002` and `davinci-002`, which were synced into the chat catalog. They pass the chat-capability filter (they're text models by modality) and sort first alphabetically, so on any account whose catalog has no marker-matched model, the "best available" fallback auto-selected `babbage-002` — which only `/v1/completions` serves, not `/chat/completions`.

These models are now dropped at the OpenAI model fetcher, alongside the other non-chat families (`instruct`, `tts`, `whisper`, …), so they never become selectable chat candidates. The fresh-install first chat now lands on a working chat model instead of 404ing.

Already-synced installs clear the stale `babbage`/`davinci` rows on their next model re-sync (provider TTL, key edit, or a manual "sync models").

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>