### PR TITLE
ci: harden staging Postgres availability

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -117,3 +117,37 @@ archestra:
           - path: /
             port: 9000
             pathType: Prefix
+
+postgresql:
+  # Staging still uses the bundled PostgreSQL chart. This is not HA, but these
+  # settings keep routine app deploys and voluntary node disruptions from
+  # bouncing the only database pod.
+  primary:
+    priorityClassName: platform-default
+    terminationGracePeriodSeconds: 120
+    pdb:
+      create: true
+      maxUnavailable: 0
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 30
+    livenessProbe:
+      initialDelaySeconds: 60
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 12
+    readinessProbe:
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 5
+      failureThreshold: 12
+    resources:
+      requests:
+        cpu: "1000m"
+        memory: "1Gi"
+      limits:
+        cpu: "1000m"
+        memory: "2Gi"


### PR DESCRIPTION
## Summary
- add staging-specific bundled PostgreSQL hardening values
- block voluntary eviction of the singleton DB pod with `maxUnavailable: 0`
- give the DB pod staging priority, a longer graceful termination window, explicit resources, and less aggressive probes

## Why
The recent backend alerts were DB connectivity interruptions, not response-schema or migration ordering failures. Staging still uses the bundled singleton PostgreSQL chart, so routine node disruption or a probe/resource blip can still create short DB unavailability. These values reduce that risk without pretending the bundled singleton is a true HA database.

## PostgreSQL chart recommendation
The regular Bitnami `postgresql` chart is fine for bundled/dev/staging convenience, but it is not the recommended HA path. The chart README points HA users at `postgresql-ha`; for production-grade availability I would prefer managed Postgres or a Postgres operator rather than trying to turn this singleton subchart into HA with read replicas.