### PR TITLE
chore: share GitHub auth config fields

### DIFF
--- a/platform/frontend/src/app/agents/skills/_parts/import-skills-dialog.tsx
+++ b/platform/frontend/src/app/agents/skills/_parts/import-skills-dialog.tsx
@@ -15,6 +15,10 @@ import {
   SearchX,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
+import {
+  GithubAuthConfigFields,
+  type GithubAuthMethod,
+} from "@/components/github-auth-config-fields";
 import { SearchInput } from "@/components/search-input";
 import { StandardDialog } from "@/components/standard-dialog";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -30,13 +34,6 @@ import {
 } from "@/components/ui/empty";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import {
   Tooltip,
   TooltipContent,
@@ -145,6 +142,13 @@ export function ImportSkillsDialog({
   const handleClose = (isOpen: boolean) => {
     if (!isOpen) reset();
     onOpenChange(isOpen);
+  };
+
+  const handleAuthMethodChange = (value: GithubAuthMethod) => {
+    setAuthMethod(value);
+    if (value === "pat") {
+      setGithubAppConfigId("");
+    }
   };
 
   const handleDiscover = async (overrideRepoUrl?: string) => {
@@ -646,28 +650,21 @@ export function ImportSkillsDialog({
               directories under this path.
             </p>
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="skill-auth-method">
-              Authentication
-              <span className="text-muted-foreground font-normal">
-                (optional)
-              </span>
-            </Label>
-            <Select
-              value={authMethod}
-              onValueChange={(value) =>
-                setAuthMethod(value as "pat" | "github_app")
-              }
-            >
-              <SelectTrigger id="skill-auth-method" className="w-full">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="pat">Personal Access Token</SelectItem>
-                <SelectItem value="github_app">GitHub App</SelectItem>
-              </SelectContent>
-            </Select>
-            {authMethod === "pat" ? (
+          <GithubAuthConfigFields
+            authMethod={authMethod}
+            onAuthMethodChange={handleAuthMethodChange}
+            githubAppConfigId={githubAppConfigId}
+            onGithubAppConfigIdChange={setGithubAppConfigId}
+            githubAppConfigs={githubAppConfigs}
+            authLabel="Authentication"
+            authOptional
+            configuredDescription={
+              <>
+                Mints a short-lived installation token for this import. Manage
+                configurations in
+              </>
+            }
+            patFields={
               <>
                 <Input
                   id="skill-token"
@@ -693,34 +690,8 @@ export function ImportSkillsDialog({
                   .
                 </p>
               </>
-            ) : githubAppConfigs.length > 0 ? (
-              <>
-                <Select
-                  value={githubAppConfigId}
-                  onValueChange={setGithubAppConfigId}
-                >
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder="Select a GitHub App configuration" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {githubAppConfigs.map((appConfig) => (
-                      <SelectItem key={appConfig.id} value={appConfig.id}>
-                        {appConfig.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <p className="text-sm text-muted-foreground">
-                  Mints a short-lived installation token for this import.
-                </p>
-              </>
-            ) : (
-              <p className="text-sm text-muted-foreground">
-                No GitHub App configurations exist yet. Create one under
-                Settings → GitHub Apps.
-              </p>
-            )}
-          </div>
+            }
+          />
           <SkillScopeSelector
             scope={scope}
             onScopeChange={setScope}

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/github-config-fields.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/github-config-fields.tsx
@@ -1,7 +1,11 @@
 "use client";
 
-import Link from "next/link";
+import { useEffect } from "react";
 import type { UseFormReturn } from "react-hook-form";
+import {
+  GithubAuthConfigFields,
+  type GithubAuthMethod,
+} from "@/components/github-auth-config-fields";
 import {
   FormControl,
   FormDescription,
@@ -11,13 +15,6 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { useGithubAppConfigs } from "@/lib/github-app-config.query";
 
@@ -40,11 +37,40 @@ export function GithubConfigFields({
   hideRepositoryOptions = false,
 }: GithubConfigFieldsProps) {
   const authMethod = form.watch(`${prefix}.authMethod`) as string | undefined;
+  const githubAppConfigId = form.watch(`${prefix}.githubAppConfigId`) as
+    | string
+    | undefined;
   const includeRepositoryFiles = form.watch(
     `${prefix}.includeRepositoryFiles`,
   ) as boolean | undefined;
-  const usesGithubApp = authMethod === "github_app";
   const { data: githubAppConfigs = [] } = useGithubAppConfigs();
+  const appConfigError = hideAuth
+    ? undefined
+    : getFieldError(form.formState.errors, `${prefix}.githubAppConfigId`);
+
+  useEffect(() => {
+    if (hideAuth) return;
+    form.register(`${prefix}.authMethod`);
+    form.register(`${prefix}.githubAppConfigId`, {
+      validate: (value) =>
+        form.getValues(`${prefix}.authMethod`) !== "github_app" ||
+        Boolean(value) ||
+        "Select a GitHub App configuration",
+    });
+  }, [form, hideAuth, prefix]);
+
+  const handleAuthMethodChange = (value: GithubAuthMethod) => {
+    form.setValue(`${prefix}.authMethod`, value, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+    if (value === "pat") {
+      form.setValue(`${prefix}.githubAppConfigId`, "", {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+    }
+  };
 
   return (
     <div className="space-y-4">
@@ -90,80 +116,19 @@ export function GithubConfigFields({
       )}
 
       {!hideAuth && (
-        <>
-          <FormField
-            control={form.control}
-            name={`${prefix}.authMethod`}
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Authentication Method</FormLabel>
-                <Select
-                  onValueChange={field.onChange}
-                  value={(field.value as string | undefined) ?? "pat"}
-                >
-                  <FormControl>
-                    <SelectTrigger className="w-full">
-                      <SelectValue />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    <SelectItem value="pat">Personal Access Token</SelectItem>
-                    <SelectItem value="github_app">GitHub App</SelectItem>
-                  </SelectContent>
-                </Select>
-                <FormDescription>
-                  Use GitHub App authentication for organization-managed
-                  installs.
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          {usesGithubApp && (
-            <FormField
-              control={form.control}
-              name={`${prefix}.githubAppConfigId`}
-              rules={{ required: "Select a GitHub App configuration" }}
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>GitHub App Configuration</FormLabel>
-                  {githubAppConfigs.length > 0 ? (
-                    <Select
-                      onValueChange={field.onChange}
-                      value={(field.value as string | undefined) ?? ""}
-                    >
-                      <FormControl>
-                        <SelectTrigger className="w-full">
-                          <SelectValue placeholder="Select a configuration" />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        {githubAppConfigs.map((appConfig) => (
-                          <SelectItem key={appConfig.id} value={appConfig.id}>
-                            {appConfig.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  ) : (
-                    <FormDescription>
-                      No GitHub App configurations exist yet. Create one under{" "}
-                      <Link
-                        href="/settings/integrations/github-apps"
-                        className="font-medium text-primary underline-offset-4 hover:underline"
-                      >
-                        Settings → Integrations → GitHub Apps
-                      </Link>
-                      .
-                    </FormDescription>
-                  )}
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          )}
-        </>
+        <GithubAuthConfigFields
+          authMethod={(authMethod as GithubAuthMethod | undefined) ?? "pat"}
+          onAuthMethodChange={handleAuthMethodChange}
+          githubAppConfigId={githubAppConfigId ?? ""}
+          onGithubAppConfigIdChange={(value) =>
+            form.setValue(`${prefix}.githubAppConfigId`, value, {
+              shouldDirty: true,
+              shouldValidate: true,
+            })
+          }
+          githubAppConfigs={githubAppConfigs}
+          appConfigError={appConfigError}
+        />
       )}
 
       {!hideRepositoryOptions && (
@@ -289,4 +254,21 @@ export function GithubConfigFields({
       )}
     </div>
   );
+}
+
+function getFieldError(
+  errors: Record<string, unknown> | undefined,
+  path: string,
+): string | undefined {
+  const error = path.split(".").reduce<unknown>((current, part) => {
+    if (!current || typeof current !== "object") return undefined;
+    return (current as Record<string, unknown>)[part];
+  }, errors);
+
+  if (!error || typeof error !== "object" || !("message" in error)) {
+    return undefined;
+  }
+
+  const message = (error as { message?: unknown }).message;
+  return typeof message === "string" ? message : undefined;
 }

--- a/platform/frontend/src/components/github-auth-config-fields.test.tsx
+++ b/platform/frontend/src/components/github-auth-config-fields.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { GithubAuthConfigFields } from "./github-auth-config-fields";
+
+describe("GithubAuthConfigFields", () => {
+  it("links to GitHub App settings when no configurations exist", async () => {
+    render(
+      <GithubAuthConfigFields
+        authMethod="github_app"
+        onAuthMethodChange={vi.fn()}
+        githubAppConfigId=""
+        onGithubAppConfigIdChange={vi.fn()}
+        githubAppConfigs={[]}
+      />,
+    );
+
+    expect(screen.getByText(/Create one in/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: "Settings → Integrations → GitHub Apps",
+      }),
+    ).toHaveAttribute("href", "/settings/integrations/github-apps");
+  });
+
+  it("links to GitHub App settings when configurations exist", async () => {
+    render(
+      <GithubAuthConfigFields
+        authMethod="github_app"
+        onAuthMethodChange={vi.fn()}
+        githubAppConfigId=""
+        onGithubAppConfigIdChange={vi.fn()}
+        githubAppConfigs={[{ id: "app-1", name: "Org app" }]}
+      />,
+    );
+
+    expect(
+      screen.getByRole("link", {
+        name: "Settings → Integrations → GitHub Apps",
+      }),
+    ).toHaveAttribute("href", "/settings/integrations/github-apps");
+  });
+
+  it("renders PAT fields only for PAT auth", async () => {
+    const { rerender } = render(
+      <GithubAuthConfigFields
+        authMethod="pat"
+        onAuthMethodChange={vi.fn()}
+        githubAppConfigId=""
+        onGithubAppConfigIdChange={vi.fn()}
+        githubAppConfigs={[]}
+        patFields={<div>PAT input</div>}
+      />,
+    );
+
+    expect(screen.getByText("PAT input")).toBeInTheDocument();
+
+    rerender(
+      <GithubAuthConfigFields
+        authMethod="github_app"
+        onAuthMethodChange={vi.fn()}
+        githubAppConfigId=""
+        onGithubAppConfigIdChange={vi.fn()}
+        githubAppConfigs={[]}
+        patFields={<div>PAT input</div>}
+      />,
+    );
+
+    expect(screen.queryByText("PAT input")).not.toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/components/github-auth-config-fields.tsx
+++ b/platform/frontend/src/components/github-auth-config-fields.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export type GithubAuthMethod = "pat" | "github_app";
+
+export interface GithubAppConfigOption {
+  id: string;
+  name: string;
+}
+
+interface GithubAuthConfigFieldsProps {
+  authMethod: GithubAuthMethod;
+  onAuthMethodChange: (authMethod: GithubAuthMethod) => void;
+  githubAppConfigId: string;
+  onGithubAppConfigIdChange: (githubAppConfigId: string) => void;
+  githubAppConfigs: GithubAppConfigOption[];
+  authLabel?: string;
+  authOptional?: boolean;
+  authDescription?: ReactNode;
+  configuredDescription?: ReactNode;
+  appConfigError?: ReactNode;
+  patFields?: ReactNode;
+}
+
+export function GithubAuthConfigFields({
+  authMethod,
+  onAuthMethodChange,
+  githubAppConfigId,
+  onGithubAppConfigIdChange,
+  githubAppConfigs,
+  authLabel = "Authentication Method",
+  authOptional = false,
+  authDescription = "Use GitHub App authentication for organization-managed installs.",
+  configuredDescription = "Manage GitHub App configurations in",
+  appConfigError,
+  patFields,
+}: GithubAuthConfigFieldsProps) {
+  return (
+    <>
+      <div className="space-y-2">
+        <Label htmlFor="github-auth-method">
+          {authLabel}
+          {authOptional && (
+            <span className="text-muted-foreground font-normal">
+              {" "}
+              (optional)
+            </span>
+          )}
+        </Label>
+        <Select value={authMethod} onValueChange={onAuthMethodChange}>
+          <SelectTrigger id="github-auth-method" className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="pat">Personal Access Token</SelectItem>
+            <SelectItem value="github_app">GitHub App</SelectItem>
+          </SelectContent>
+        </Select>
+        {authDescription && (
+          <p className="text-sm text-muted-foreground">{authDescription}</p>
+        )}
+      </div>
+
+      {authMethod === "pat" && patFields}
+
+      {authMethod === "github_app" && (
+        <div className="space-y-2">
+          <Label htmlFor="github-app-config">GitHub App Configuration</Label>
+          {githubAppConfigs.length > 0 ? (
+            <>
+              <Select
+                value={githubAppConfigId}
+                onValueChange={onGithubAppConfigIdChange}
+              >
+                <SelectTrigger id="github-app-config" className="w-full">
+                  <SelectValue placeholder="Select a GitHub App configuration" />
+                </SelectTrigger>
+                <SelectContent>
+                  {githubAppConfigs.map((appConfig) => (
+                    <SelectItem key={appConfig.id} value={appConfig.id}>
+                      {appConfig.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-sm text-muted-foreground">
+                {configuredDescription} <GithubAppSettingsLink />.
+              </p>
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Create one in <GithubAppSettingsLink />.
+            </p>
+          )}
+          {appConfigError && (
+            <p className="text-sm font-medium text-destructive">
+              {appConfigError}
+            </p>
+          )}
+        </div>
+      )}
+    </>
+  );
+}
+
+function GithubAppSettingsLink() {
+  return (
+    <Link
+      href="/settings/integrations/github-apps"
+      className="font-medium text-primary underline-offset-4 hover:underline"
+    >
+      Settings → Integrations → GitHub Apps
+    </Link>
+  );
+}


### PR DESCRIPTION
## What changed

- Extracted the GitHub PAT/GitHub App auth selection UI into a shared frontend component.
- Reused the shared component in the knowledge connector GitHub config fields and the skill import dialog.
- Shortened the empty GitHub App config copy and linked both empty and configured states to Settings → Integrations → GitHub Apps.