### PR TITLE
feat(llm): broaden OpenAI best-model markers (gpt-5.x, gpt-4.1, gpt-4o)

### DIFF
--- a/platform/backend/src/models/llm-provider-api-key-model.test.ts
+++ b/platform/backend/src/models/llm-provider-api-key-model.test.ts
@@ -528,4 +528,52 @@ describe("LlmProviderApiKeyModelLinkModel", () => {
       expect(bestModels.get(apiKey.id)?.id).toBe(chatModel.id);
     });
   });
+
+  describe("best-model marker priority", () => {
+    test.for([
+      { catalog: ["gpt-4o", "gpt-3.5-turbo"], expected: "gpt-4o" },
+      { catalog: ["gpt-4.1", "gpt-4o"], expected: "gpt-4.1" },
+      { catalog: ["gpt-5", "gpt-4o"], expected: "gpt-5" },
+      { catalog: ["gpt-5.4", "gpt-5"], expected: "gpt-5.4" },
+      { catalog: ["gpt-5.5", "gpt-5.4"], expected: "gpt-5.5" },
+      { catalog: ["gpt-5.5-pro", "gpt-5.5"], expected: "gpt-5.5-pro" },
+    ])("marks $expected as best for $catalog", async ({ catalog, expected }, {
+      makeOrganization,
+      makeSecret,
+      makeLlmProviderApiKey,
+    }) => {
+      const org = await makeOrganization();
+      const secret = await makeSecret();
+      const apiKey = await makeLlmProviderApiKey(org.id, secret.id, {
+        provider: "openai",
+      });
+
+      const models = [];
+      for (const modelId of catalog) {
+        models.push(
+          await ModelModel.create({
+            externalId: `openai/${modelId}`,
+            provider: "openai",
+            modelId,
+            description: modelId,
+            inputModalities: ["text"],
+            outputModalities: ["text"],
+            supportsToolCalling: true,
+            lastSyncedAt: new Date(),
+          }),
+        );
+      }
+
+      await LlmProviderApiKeyModelLinkModel.syncModelsForApiKey(
+        apiKey.id,
+        models.map((model) => ({ id: model.id, modelId: model.modelId })),
+        "openai",
+      );
+
+      const best = await LlmProviderApiKeyModelLinkModel.getBestModel(
+        apiKey.id,
+      );
+      expect(best?.modelId).toBe(expected);
+    });
+  });
 });

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -188,12 +188,21 @@ export const OPENROUTER_LATEST_ALIAS_PREFIX = "~";
  * Patterns are substrings that model IDs must contain (case-insensitive).
  * Used to identify "best" (highest quality) models.
  *
- * IMPORTANT: Patterns are checked in array order (first match wins).
- * More specific patterns should come before general ones.
+ * Patterns are checked in array order (first match wins), so list each
+ * provider's ids most- to least-preferred (more specific before general). The
+ * first listed id present in the account is the one marked best.
  */
 export const MODEL_MARKER_PATTERNS: Record<SupportedProvider, string[]> = {
   anthropic: ["opus-4-8", "opus-4-7"],
-  openai: ["gpt-5.5-pro", "gpt-5.5"],
+  openai: [
+    "gpt-5.5-pro",
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.3",
+    "gpt-5",
+    "gpt-4.1",
+    "gpt-4o",
+  ],
   gemini: ["gemini-3.1-pro-preview", "gemini-2.5-pro"],
   cerebras: ["zai-glm-4.7"],
   cohere: ["command-a-plus-05-2026"],


### PR DESCRIPTION
## Summary

`MODEL_MARKER_PATTERNS.openai` listed only `gpt-5.5-pro`/`gpt-5.5`, so an OpenAI account whose catalog has neither — e.g. a `gpt-4o`/`gpt-4.1` account — had no marker-matched "best" model. Default-model resolution then fell back to the alphabetically-first chat model, an arbitrary pick.

The list now covers the broader OpenAI lineup — `gpt-5.4`, `gpt-5.3`, `gpt-5`, `gpt-4.1`, `gpt-4o` — ordered most- to least-preferred, so those accounts get an intentional "best" model instead of an alphabetical accident. Most real accounts have `gpt-4o`, so this closes the marker-miss case for nearly all of them.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>