### PR TITLE
feat(chat): prompt-cache the stable prefix on Anthropic chat requests

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -60663,6 +60663,28 @@
                                 "required": [
                                   "toolResult"
                                 ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "cachePoint": {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "ttl": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "cachePoint"
+                                ]
                               }
                             ]
                           }
@@ -60743,6 +60765,28 @@
                           },
                           "required": [
                             "guardContent"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "cachePoint": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string"
+                                },
+                                "ttl": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "cachePoint"
                           ]
                         }
                       ]
@@ -61876,6 +61920,28 @@
                                 "required": [
                                   "toolResult"
                                 ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "cachePoint": {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "ttl": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "cachePoint"
+                                ]
                               }
                             ]
                           }
@@ -61956,6 +62022,28 @@
                           },
                           "required": [
                             "guardContent"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "cachePoint": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string"
+                                },
+                                "ttl": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "cachePoint"
                           ]
                         }
                       ]
@@ -63099,6 +63187,28 @@
                                 "required": [
                                   "toolResult"
                                 ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "cachePoint": {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "ttl": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "cachePoint"
+                                ]
                               }
                             ]
                           }
@@ -63179,6 +63289,28 @@
                           },
                           "required": [
                             "guardContent"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "cachePoint": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string"
+                                },
+                                "ttl": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "cachePoint"
                           ]
                         }
                       ]
@@ -63867,6 +63999,28 @@
                                 "required": [
                                   "toolResult"
                                 ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "cachePoint": {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "ttl": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "cachePoint"
+                                ]
                               }
                             ]
                           }
@@ -63947,6 +64101,28 @@
                           },
                           "required": [
                             "guardContent"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "cachePoint": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string"
+                                },
+                                "ttl": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "cachePoint"
                           ]
                         }
                       ]
@@ -64645,6 +64821,28 @@
                                 "required": [
                                   "toolResult"
                                 ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "cachePoint": {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "ttl": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "cachePoint"
+                                ]
                               }
                             ]
                           }
@@ -64725,6 +64923,28 @@
                           },
                           "required": [
                             "guardContent"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "cachePoint": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string"
+                                },
+                                "ttl": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "cachePoint"
                           ]
                         }
                       ]
@@ -65873,6 +66093,28 @@
                                 "required": [
                                   "toolResult"
                                 ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "cachePoint": {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "ttl": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "cachePoint"
+                                ]
                               }
                             ]
                           }
@@ -65953,6 +66195,28 @@
                           },
                           "required": [
                             "guardContent"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "cachePoint": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string"
+                                },
+                                "ttl": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "cachePoint"
                           ]
                         }
                       ]
@@ -92128,6 +92392,30 @@
                                                   "toolResult"
                                                 ],
                                                 "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "cachePoint": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string"
+                                                      },
+                                                      "ttl": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "required": [
+                                                  "cachePoint"
+                                                ],
+                                                "additionalProperties": false
                                               }
                                             ]
                                           }
@@ -92194,6 +92482,30 @@
                                           },
                                           "required": [
                                             "guardContent"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "cachePoint": {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string"
+                                                },
+                                                "ttl": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "type"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "required": [
+                                            "cachePoint"
                                           ],
                                           "additionalProperties": false
                                         }
@@ -92885,6 +93197,30 @@
                                                   "toolResult"
                                                 ],
                                                 "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "cachePoint": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string"
+                                                      },
+                                                      "ttl": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "required": [
+                                                  "cachePoint"
+                                                ],
+                                                "additionalProperties": false
                                               }
                                             ]
                                           }
@@ -92951,6 +93287,30 @@
                                           },
                                           "required": [
                                             "guardContent"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "cachePoint": {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string"
+                                                },
+                                                "ttl": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "type"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "required": [
+                                            "cachePoint"
                                           ],
                                           "additionalProperties": false
                                         }
@@ -104863,6 +105223,30 @@
                                             "toolResult"
                                           ],
                                           "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "cachePoint": {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string"
+                                                },
+                                                "ttl": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "type"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "required": [
+                                            "cachePoint"
+                                          ],
+                                          "additionalProperties": false
                                         }
                                       ]
                                     }
@@ -104929,6 +105313,30 @@
                                     },
                                     "required": [
                                       "guardContent"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "cachePoint": {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string"
+                                          },
+                                          "ttl": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "type"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "cachePoint"
                                     ],
                                     "additionalProperties": false
                                   }
@@ -105620,6 +106028,30 @@
                                             "toolResult"
                                           ],
                                           "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "cachePoint": {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string"
+                                                },
+                                                "ttl": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "type"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "required": [
+                                            "cachePoint"
+                                          ],
+                                          "additionalProperties": false
                                         }
                                       ]
                                     }
@@ -105686,6 +106118,30 @@
                                     },
                                     "required": [
                                       "guardContent"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "cachePoint": {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string"
+                                          },
+                                          "ttl": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "type"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "cachePoint"
                                     ],
                                     "additionalProperties": false
                                   }

--- a/platform/backend/src/routes/chat/normalization/apply-prompt-cache.test.ts
+++ b/platform/backend/src/routes/chat/normalization/apply-prompt-cache.test.ts
@@ -16,8 +16,16 @@ function anthropicCacheControl(message: ModelMessage) {
   )?.anthropic?.cacheControl;
 }
 
-// A message whose content part already carries a cache_control marker, as
-// `materializeAttachments` produces for file/document parts.
+function bedrockCachePoint(message: ModelMessage) {
+  return (
+    message.providerOptions as
+      | { bedrock?: { cachePoint?: unknown } }
+      | undefined
+  )?.bedrock?.cachePoint;
+}
+
+// A message whose content part already carries an Anthropic cache_control
+// marker, as `materializeAttachments` produces for file/document parts.
 function messageWithMarkedPart(text: string): ModelMessage {
   return {
     role: "user",
@@ -53,14 +61,14 @@ describe("applyPromptCacheBreakpoints", () => {
     expect(anthropicCacheControl(result[0])).toEqual(EPHEMERAL);
   });
 
-  it("does not annotate messages for non-Anthropic providers", () => {
+  it("does not annotate messages for auto-caching providers", () => {
     const messages = [userMessage("a"), userMessage("b")];
 
-    for (const provider of ["openai", "gemini", "bedrock"]) {
+    for (const provider of ["openai", "gemini", "deepseek"]) {
       const result = applyPromptCacheBreakpoints({ provider, messages });
       expect(result).toBe(messages);
       expect(anthropicCacheControl(result[0])).toBeUndefined();
-      expect(anthropicCacheControl(result[result.length - 1])).toBeUndefined();
+      expect(bedrockCachePoint(result[0])).toBeUndefined();
     }
   });
 
@@ -152,5 +160,38 @@ describe("applyPromptCacheBreakpoints", () => {
     expect(anthropicCacheControl(result[0])).toEqual(EPHEMERAL);
     // The already-marked message keeps only its part-level marker.
     expect(anthropicCacheControl(result[1])).toBeUndefined();
+  });
+
+  it("marks the first and last message for Bedrock with cachePoint", () => {
+    const result = applyPromptCacheBreakpoints({
+      provider: "bedrock",
+      messages: [userMessage("a"), userMessage("b"), userMessage("c")],
+    });
+
+    expect(bedrockCachePoint(result[0])).toEqual({ type: "default" });
+    expect(bedrockCachePoint(result[1])).toBeUndefined();
+    expect(bedrockCachePoint(result[2])).toEqual({ type: "default" });
+    // Bedrock uses cachePoint, not Anthropic's cacheControl.
+    expect(anthropicCacheControl(result[0])).toBeUndefined();
+  });
+
+  it("ignores Anthropic markers when budgeting Bedrock cachePoints", () => {
+    // 4 parts carry an Anthropic cacheControl marker, but those do not count as
+    // Bedrock cache points, so Bedrock still has its full budget of 4.
+    const messages = [
+      messageWithMarkedPart("a"),
+      messageWithMarkedPart("b"),
+      messageWithMarkedPart("c"),
+      messageWithMarkedPart("d"),
+      userMessage("e"),
+    ];
+
+    const result = applyPromptCacheBreakpoints({
+      provider: "bedrock",
+      messages,
+    });
+
+    expect(bedrockCachePoint(result[0])).toEqual({ type: "default" });
+    expect(bedrockCachePoint(result[4])).toEqual({ type: "default" });
   });
 });

--- a/platform/backend/src/routes/chat/normalization/apply-prompt-cache.test.ts
+++ b/platform/backend/src/routes/chat/normalization/apply-prompt-cache.test.ts
@@ -1,0 +1,156 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import { applyPromptCacheBreakpoints } from "./apply-prompt-cache";
+
+const EPHEMERAL = { type: "ephemeral" };
+
+function userMessage(text: string): ModelMessage {
+  return { role: "user", content: [{ type: "text", text }] };
+}
+
+function anthropicCacheControl(message: ModelMessage) {
+  return (
+    message.providerOptions as
+      | { anthropic?: { cacheControl?: unknown } }
+      | undefined
+  )?.anthropic?.cacheControl;
+}
+
+// A message whose content part already carries a cache_control marker, as
+// `materializeAttachments` produces for file/document parts.
+function messageWithMarkedPart(text: string): ModelMessage {
+  return {
+    role: "user",
+    content: [
+      {
+        type: "text",
+        text,
+        providerOptions: { anthropic: { cacheControl: { type: "ephemeral" } } },
+      },
+    ],
+  };
+}
+
+describe("applyPromptCacheBreakpoints", () => {
+  it("marks the first and last message for Anthropic", () => {
+    const result = applyPromptCacheBreakpoints({
+      provider: "anthropic",
+      messages: [userMessage("a"), userMessage("b"), userMessage("c")],
+    });
+
+    expect(anthropicCacheControl(result[0])).toEqual(EPHEMERAL);
+    expect(anthropicCacheControl(result[1])).toBeUndefined();
+    expect(anthropicCacheControl(result[2])).toEqual(EPHEMERAL);
+  });
+
+  it("marks a single message exactly once (no first/last collision)", () => {
+    const result = applyPromptCacheBreakpoints({
+      provider: "anthropic",
+      messages: [userMessage("only")],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(anthropicCacheControl(result[0])).toEqual(EPHEMERAL);
+  });
+
+  it("does not annotate messages for non-Anthropic providers", () => {
+    const messages = [userMessage("a"), userMessage("b")];
+
+    for (const provider of ["openai", "gemini", "bedrock"]) {
+      const result = applyPromptCacheBreakpoints({ provider, messages });
+      expect(result).toBe(messages);
+      expect(anthropicCacheControl(result[0])).toBeUndefined();
+      expect(anthropicCacheControl(result[result.length - 1])).toBeUndefined();
+    }
+  });
+
+  it("returns the empty list unchanged for Anthropic", () => {
+    const messages: ModelMessage[] = [];
+    expect(
+      applyPromptCacheBreakpoints({ provider: "anthropic", messages }),
+    ).toBe(messages);
+  });
+
+  it("preserves existing providerOptions while adding cacheControl", () => {
+    const message: ModelMessage = {
+      role: "user",
+      content: [{ type: "text", text: "a" }],
+      providerOptions: {
+        anthropic: { existingFlag: true },
+        openai: { foo: "bar" },
+      },
+    };
+
+    const [result] = applyPromptCacheBreakpoints({
+      provider: "anthropic",
+      messages: [message],
+    });
+
+    const providerOptions = result.providerOptions as {
+      anthropic: { existingFlag: boolean; cacheControl: unknown };
+      openai: { foo: string };
+    };
+    expect(providerOptions.anthropic.cacheControl).toEqual(EPHEMERAL);
+    expect(providerOptions.anthropic.existingFlag).toBe(true);
+    expect(providerOptions.openai).toEqual({ foo: "bar" });
+  });
+
+  it("does not mutate the input messages", () => {
+    const message = userMessage("a");
+    applyPromptCacheBreakpoints({ provider: "anthropic", messages: [message] });
+    expect(message.providerOptions).toBeUndefined();
+  });
+
+  it("adds nothing when existing breakpoints already saturate the budget", () => {
+    // 4 attachment-marked parts == Anthropic's max of 4 breakpoints.
+    const messages = [
+      messageWithMarkedPart("a"),
+      messageWithMarkedPart("b"),
+      messageWithMarkedPart("c"),
+      messageWithMarkedPart("d"),
+      userMessage("e"),
+    ];
+
+    const result = applyPromptCacheBreakpoints({
+      provider: "anthropic",
+      messages,
+    });
+
+    expect(result).toBe(messages);
+    // The unmarked first/last messages stay unmarked — no message-level marker.
+    expect(anthropicCacheControl(result[4])).toBeUndefined();
+  });
+
+  it("spends the remaining budget on the last message before the first", () => {
+    // 3 existing breakpoints → budget of 1 → only the last gets a marker.
+    const messages = [
+      userMessage("first"),
+      messageWithMarkedPart("b"),
+      messageWithMarkedPart("c"),
+      messageWithMarkedPart("d"),
+      userMessage("last"),
+    ];
+
+    const result = applyPromptCacheBreakpoints({
+      provider: "anthropic",
+      messages,
+    });
+
+    expect(anthropicCacheControl(result[4])).toEqual(EPHEMERAL);
+    expect(anthropicCacheControl(result[0])).toBeUndefined();
+  });
+
+  it("skips a candidate that already carries a breakpoint and uses the budget elsewhere", () => {
+    // Last message is already marked (attachment) → first message gets the marker.
+    const messages = [userMessage("first"), messageWithMarkedPart("last")];
+
+    const result = applyPromptCacheBreakpoints({
+      provider: "anthropic",
+      messages,
+    });
+
+    expect(anthropicCacheControl(result[0])).toEqual(EPHEMERAL);
+    // The already-marked message keeps only its part-level marker.
+    expect(anthropicCacheControl(result[1])).toBeUndefined();
+  });
+});

--- a/platform/backend/src/routes/chat/normalization/apply-prompt-cache.ts
+++ b/platform/backend/src/routes/chat/normalization/apply-prompt-cache.ts
@@ -1,20 +1,37 @@
 import type { ModelMessage } from "ai";
 
-const EPHEMERAL_CACHE_CONTROL = { type: "ephemeral" as const };
+// Per-provider cache-breakpoint marker, written into a message's
+// `providerOptions`. Anthropic and Amazon Bedrock both require explicit
+// breakpoints and both cap at 4 per request; only the providerOptions key and
+// value shape differ:
+//   - Anthropic: `{ anthropic: { cacheControl: { type: "ephemeral" } } }`
+//   - Bedrock:   `{ bedrock:   { cachePoint:   { type: "default"   } } }`
+const CACHE_BREAKPOINTS = {
+  anthropic: {
+    key: "anthropic",
+    field: "cacheControl",
+    value: { type: "ephemeral" },
+  },
+  bedrock: { key: "bedrock", field: "cachePoint", value: { type: "default" } },
+} as const;
 
-// Anthropic rejects a request with more than 4 `cache_control` breakpoints, and
-// the @ai-sdk/anthropic provider throws before the call. Breakpoints already
-// present (e.g. `materializeAttachments` marks each file/document part) count
-// against this budget, so the markers added here must fit in what's left.
-const MAX_ANTHROPIC_CACHE_BREAKPOINTS = 4;
+type CacheBreakpointConfig =
+  (typeof CACHE_BREAKPOINTS)[keyof typeof CACHE_BREAKPOINTS];
+
+// Anthropic and Bedrock both reject a request with more than 4 cache
+// breakpoints, and the AI SDK provider throws before the call. Breakpoints
+// already present (e.g. `materializeAttachments` marks each Anthropic
+// file/document part) count against this budget, so the markers added here
+// must fit in what's left.
+const MAX_CACHE_BREAKPOINTS = 4;
 
 /**
- * Adds Anthropic `cache_control` breakpoints so the chat request's stable
- * prefix is prompt-cached across turns. Without a breakpoint Anthropic caches
+ * Adds provider cache breakpoints so the chat request's stable prefix is
+ * prompt-cached across turns. Without a breakpoint Anthropic and Bedrock cache
  * nothing, re-billing the full system prompt + tool definitions + history on
  * every turn.
  *
- * A breakpoint caches everything rendered before it — Anthropic renders
+ * A breakpoint caches everything rendered before it — the prefix is
  * `tools → system → messages` — so placing the markers on messages also caches
  * the system prompt and tools. Up to two breakpoints are added:
  *   - last message: a rolling breakpoint that extends the cached prefix to the
@@ -23,28 +40,30 @@ const MAX_ANTHROPIC_CACHE_BREAKPOINTS = 4;
  *     changes, so it stays a cache hit on every later turn.
  *
  * Last is prioritized over first when only one slot is left in the breakpoint
- * budget. Messages that already carry a breakpoint (attachment parts) are left
+ * budget. Messages that already carry a breakpoint for this provider are left
  * alone — their prefix is already cacheable and re-marking would waste budget.
  *
- * No-op for providers other than Anthropic: OpenAI, Gemini, DeepSeek, etc.
- * cache prefixes automatically and reject or ignore explicit markers. (Bedrock
- * also supports caching but via `providerOptions.bedrock.cachePoint`, handled
- * separately.)
+ * No-op for providers other than Anthropic and Bedrock: OpenAI, Gemini,
+ * DeepSeek, etc. cache prefixes automatically and reject or ignore explicit
+ * markers.
  */
 export function applyPromptCacheBreakpoints(params: {
   provider: string;
   messages: ModelMessage[];
 }): ModelMessage[] {
   const { provider, messages } = params;
-  if (provider !== "anthropic" || messages.length === 0) {
+  const config = (CACHE_BREAKPOINTS as Record<string, CacheBreakpointConfig>)[
+    provider
+  ];
+  if (!config || messages.length === 0) {
     return messages;
   }
 
   const existingBreakpoints = messages.reduce(
-    (total, message) => total + anthropicBreakpointCount(message),
+    (total, message) => total + breakpointCount(message, config),
     0,
   );
-  let budget = MAX_ANTHROPIC_CACHE_BREAKPOINTS - existingBreakpoints;
+  let budget = MAX_CACHE_BREAKPOINTS - existingBreakpoints;
   if (budget <= 0) {
     return messages;
   }
@@ -58,7 +77,7 @@ export function applyPromptCacheBreakpoints(params: {
   for (const index of candidates) {
     if (budget <= 0) break;
     // Already cacheable via its own marker — don't spend budget re-marking it.
-    if (anthropicBreakpointCount(messages[index]) > 0) continue;
+    if (breakpointCount(messages[index], config) > 0) continue;
     indicesToMark.add(index);
     budget--;
   }
@@ -68,24 +87,27 @@ export function applyPromptCacheBreakpoints(params: {
   }
 
   return messages.map((message, index) =>
-    indicesToMark.has(index) ? withAnthropicCacheControl(message) : message,
+    indicesToMark.has(index) ? withCacheBreakpoint(message, config) : message,
   );
 }
 
-// Counts `cache_control` breakpoints a message already contributes: one per
-// content part that carries the marker, plus the message-level marker. May
+// Counts cache breakpoints a message already contributes for this provider: one
+// per content part that carries the marker, plus the message-level marker. May
 // slightly over-count (a message-level marker only takes effect on the last
 // part when that part has none), which is the safe direction — over-counting
 // makes us add fewer breakpoints, never more than the cap allows.
-function anthropicBreakpointCount(message: ModelMessage): number {
-  let count = hasAnthropicCacheControl(message.providerOptions) ? 1 : 0;
+function breakpointCount(
+  message: ModelMessage,
+  config: CacheBreakpointConfig,
+): number {
+  let count = hasCacheBreakpoint(message.providerOptions, config) ? 1 : 0;
   if (Array.isArray(message.content)) {
     for (const part of message.content) {
       // Not every content part type declares `providerOptions`; read it
       // structurally rather than narrowing the wide part union.
       const partProviderOptions = (part as { providerOptions?: unknown })
         .providerOptions;
-      if (hasAnthropicCacheControl(partProviderOptions)) {
+      if (hasCacheBreakpoint(partProviderOptions, config)) {
         count++;
       }
     }
@@ -93,21 +115,30 @@ function anthropicBreakpointCount(message: ModelMessage): number {
   return count;
 }
 
-function hasAnthropicCacheControl(providerOptions: unknown): boolean {
-  return Boolean(
-    (providerOptions as { anthropic?: { cacheControl?: unknown } } | undefined)
-      ?.anthropic?.cacheControl,
-  );
+function hasCacheBreakpoint(
+  providerOptions: unknown,
+  config: CacheBreakpointConfig,
+): boolean {
+  const providerEntry = (
+    providerOptions as Record<string, Record<string, unknown>> | undefined
+  )?.[config.key];
+  return Boolean(providerEntry?.[config.field]);
 }
 
-function withAnthropicCacheControl(message: ModelMessage): ModelMessage {
-  const providerOptions = message.providerOptions ?? {};
-  const anthropic = providerOptions.anthropic ?? {};
+function withCacheBreakpoint(
+  message: ModelMessage,
+  config: CacheBreakpointConfig,
+): ModelMessage {
+  const providerOptions = (message.providerOptions ?? {}) as Record<
+    string,
+    Record<string, unknown>
+  >;
+  const providerEntry = providerOptions[config.key] ?? {};
   return {
     ...message,
     providerOptions: {
       ...providerOptions,
-      anthropic: { ...anthropic, cacheControl: EPHEMERAL_CACHE_CONTROL },
+      [config.key]: { ...providerEntry, [config.field]: config.value },
     },
-  };
+  } as ModelMessage;
 }

--- a/platform/backend/src/routes/chat/normalization/apply-prompt-cache.ts
+++ b/platform/backend/src/routes/chat/normalization/apply-prompt-cache.ts
@@ -1,0 +1,113 @@
+import type { ModelMessage } from "ai";
+
+const EPHEMERAL_CACHE_CONTROL = { type: "ephemeral" as const };
+
+// Anthropic rejects a request with more than 4 `cache_control` breakpoints, and
+// the @ai-sdk/anthropic provider throws before the call. Breakpoints already
+// present (e.g. `materializeAttachments` marks each file/document part) count
+// against this budget, so the markers added here must fit in what's left.
+const MAX_ANTHROPIC_CACHE_BREAKPOINTS = 4;
+
+/**
+ * Adds Anthropic `cache_control` breakpoints so the chat request's stable
+ * prefix is prompt-cached across turns. Without a breakpoint Anthropic caches
+ * nothing, re-billing the full system prompt + tool definitions + history on
+ * every turn.
+ *
+ * A breakpoint caches everything rendered before it — Anthropic renders
+ * `tools → system → messages` — so placing the markers on messages also caches
+ * the system prompt and tools. Up to two breakpoints are added:
+ *   - last message: a rolling breakpoint that extends the cached prefix to the
+ *     most recent turn (each turn writes the new tail; the next turn reads it);
+ *   - first message: the stable prefix (tools + system + first turn) that never
+ *     changes, so it stays a cache hit on every later turn.
+ *
+ * Last is prioritized over first when only one slot is left in the breakpoint
+ * budget. Messages that already carry a breakpoint (attachment parts) are left
+ * alone — their prefix is already cacheable and re-marking would waste budget.
+ *
+ * No-op for providers other than Anthropic: OpenAI, Gemini, DeepSeek, etc.
+ * cache prefixes automatically and reject or ignore explicit markers. (Bedrock
+ * also supports caching but via `providerOptions.bedrock.cachePoint`, handled
+ * separately.)
+ */
+export function applyPromptCacheBreakpoints(params: {
+  provider: string;
+  messages: ModelMessage[];
+}): ModelMessage[] {
+  const { provider, messages } = params;
+  if (provider !== "anthropic" || messages.length === 0) {
+    return messages;
+  }
+
+  const existingBreakpoints = messages.reduce(
+    (total, message) => total + anthropicBreakpointCount(message),
+    0,
+  );
+  let budget = MAX_ANTHROPIC_CACHE_BREAKPOINTS - existingBreakpoints;
+  if (budget <= 0) {
+    return messages;
+  }
+
+  const lastIndex = messages.length - 1;
+  // Prefer the rolling (last) breakpoint, then the stable (first) one. A single
+  // message collapses both candidates to index 0.
+  const candidates = lastIndex === 0 ? [0] : [lastIndex, 0];
+
+  const indicesToMark = new Set<number>();
+  for (const index of candidates) {
+    if (budget <= 0) break;
+    // Already cacheable via its own marker — don't spend budget re-marking it.
+    if (anthropicBreakpointCount(messages[index]) > 0) continue;
+    indicesToMark.add(index);
+    budget--;
+  }
+
+  if (indicesToMark.size === 0) {
+    return messages;
+  }
+
+  return messages.map((message, index) =>
+    indicesToMark.has(index) ? withAnthropicCacheControl(message) : message,
+  );
+}
+
+// Counts `cache_control` breakpoints a message already contributes: one per
+// content part that carries the marker, plus the message-level marker. May
+// slightly over-count (a message-level marker only takes effect on the last
+// part when that part has none), which is the safe direction — over-counting
+// makes us add fewer breakpoints, never more than the cap allows.
+function anthropicBreakpointCount(message: ModelMessage): number {
+  let count = hasAnthropicCacheControl(message.providerOptions) ? 1 : 0;
+  if (Array.isArray(message.content)) {
+    for (const part of message.content) {
+      // Not every content part type declares `providerOptions`; read it
+      // structurally rather than narrowing the wide part union.
+      const partProviderOptions = (part as { providerOptions?: unknown })
+        .providerOptions;
+      if (hasAnthropicCacheControl(partProviderOptions)) {
+        count++;
+      }
+    }
+  }
+  return count;
+}
+
+function hasAnthropicCacheControl(providerOptions: unknown): boolean {
+  return Boolean(
+    (providerOptions as { anthropic?: { cacheControl?: unknown } } | undefined)
+      ?.anthropic?.cacheControl,
+  );
+}
+
+function withAnthropicCacheControl(message: ModelMessage): ModelMessage {
+  const providerOptions = message.providerOptions ?? {};
+  const anthropic = providerOptions.anthropic ?? {};
+  return {
+    ...message,
+    providerOptions: {
+      ...providerOptions,
+      anthropic: { ...anthropic, cacheControl: EPHEMERAL_CACHE_CONTROL },
+    },
+  };
+}

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -117,6 +117,7 @@ import {
   sanitizeChatErrorForFrontend,
 } from "./errors";
 import { injectSkillActivation } from "./inject-skill-activation";
+import { applyPromptCacheBreakpoints } from "./normalization/apply-prompt-cache";
 import { cloneAttachmentsForFork } from "./normalization/clone-attachments-for-fork";
 import { extractInlineAttachments } from "./normalization/extract-inline-attachments";
 import { materializeAttachments } from "./normalization/materialize-attachments";
@@ -740,10 +741,13 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   });
                 }
 
-                const modelMessages = await buildModelMessagesForProvider({
-                  messages: compactionResult.messages,
+                const modelMessages = applyPromptCacheBreakpoints({
                   provider,
-                  conversationId,
+                  messages: await buildModelMessagesForProvider({
+                    messages: compactionResult.messages,
+                    provider,
+                    conversationId,
+                  }),
                 });
                 const streamTextConfig: Parameters<typeof streamText>[0] = {
                   model,

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -595,9 +595,16 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
     await executionPromise;
 
     expect(mockStreamText).toHaveBeenCalledTimes(1);
-    expect(mockStreamText.mock.calls[0]?.[0].messages).toEqual(
-      compactedMessages,
-    );
+    // applyPromptCacheBreakpoints marks the first and last message (the stable
+    // prefix + rolling tail) with Anthropic cache_control before streamText, so
+    // the compacted messages reach the model carrying that breakpoint.
+    const cacheBreakpoint = {
+      providerOptions: { anthropic: { cacheControl: { type: "ephemeral" } } },
+    };
+    expect(mockStreamText.mock.calls[0]?.[0].messages).toEqual([
+      { ...compactedMessages[0], ...cacheBreakpoint },
+      { ...compactedMessages[1], ...cacheBreakpoint },
+    ]);
   });
 
   test("prepends load-tools guidance when the agent loads tools when needed", async () => {

--- a/platform/backend/src/types/llm-providers/bedrock/messages.ts
+++ b/platform/backend/src/types/llm-providers/bedrock/messages.ts
@@ -124,6 +124,19 @@ const ToolResultContentBlockSchema = z.object({
   }),
 });
 
+// Cache point block — a prompt-caching breakpoint. Bedrock Converse caches the
+// content rendered before this block. Emitted by @ai-sdk/amazon-bedrock from
+// `providerOptions.bedrock.cachePoint` and inserted into the message content
+// array, so the proxy schema must accept it on every message role. `ttl` is
+// kept so a pass-through request's cache duration ("5m"/"1h") survives instead
+// of being silently dropped; `type` stays a string since AWS validates it.
+const CachePointContentBlockSchema = z.object({
+  cachePoint: z.object({
+    type: z.string(),
+    ttl: z.string().optional(),
+  }),
+});
+
 // =============================================================================
 // EXPORTED CONTENT BLOCK UNIONS
 // =============================================================================
@@ -135,12 +148,14 @@ export const UserContentBlockSchema = z.union([
   DocumentContentBlockSchema,
   GuardContentBlockSchema,
   ToolResultContentBlockSchema,
+  CachePointContentBlockSchema,
 ]);
 
 // Content block union for assistant messages
 export const AssistantContentBlockSchema = z.union([
   TextContentBlockSchema,
   ToolUseContentBlockSchema,
+  CachePointContentBlockSchema,
 ]);
 
 // Content block union for all messages
@@ -151,6 +166,7 @@ export const ContentBlockSchema = z.union([
   GuardContentBlockSchema,
   ToolUseContentBlockSchema,
   ToolResultContentBlockSchema,
+  CachePointContentBlockSchema,
 ]);
 
 // =============================================================================
@@ -175,6 +191,7 @@ const SystemContentBlockSchema = z.union([
     .transform(({ text }) => ({ text })),
   z.object({ text: z.string() }),
   GuardContentBlockSchema,
+  CachePointContentBlockSchema,
 ]);
 
 export const SystemSchema = z.array(SystemContentBlockSchema);

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -17633,6 +17633,11 @@ export type BedrockConverseWithDefaultAgentData = {
                     }>;
                     status?: 'success' | 'error';
                 };
+            } | {
+                cachePoint: {
+                    type: string;
+                    ttl?: string;
+                };
             }>;
         }>;
         system?: Array<{
@@ -17646,6 +17651,11 @@ export type BedrockConverseWithDefaultAgentData = {
                     text: string;
                     qualifiers?: Array<'grounding_source' | 'query' | 'guard_content'>;
                 };
+            };
+        } | {
+            cachePoint: {
+                type: string;
+                ttl?: string;
             };
         }>;
         inferenceConfig?: {
@@ -17943,6 +17953,11 @@ export type BedrockConverseWithAgentData = {
                     }>;
                     status?: 'success' | 'error';
                 };
+            } | {
+                cachePoint: {
+                    type: string;
+                    ttl?: string;
+                };
             }>;
         }>;
         system?: Array<{
@@ -17956,6 +17971,11 @@ export type BedrockConverseWithAgentData = {
                     text: string;
                     qualifiers?: Array<'grounding_source' | 'query' | 'guard_content'>;
                 };
+            };
+        } | {
+            cachePoint: {
+                type: string;
+                ttl?: string;
             };
         }>;
         inferenceConfig?: {
@@ -18255,6 +18275,11 @@ export type BedrockConverseStreamWithDefaultAgentData = {
                     }>;
                     status?: 'success' | 'error';
                 };
+            } | {
+                cachePoint: {
+                    type: string;
+                    ttl?: string;
+                };
             }>;
         }>;
         system?: Array<{
@@ -18268,6 +18293,11 @@ export type BedrockConverseStreamWithDefaultAgentData = {
                     text: string;
                     qualifiers?: Array<'grounding_source' | 'query' | 'guard_content'>;
                 };
+            };
+        } | {
+            cachePoint: {
+                type: string;
+                ttl?: string;
             };
         }>;
         inferenceConfig?: {
@@ -18440,6 +18470,11 @@ export type BedrockConverseStreamWithAgentData = {
                     }>;
                     status?: 'success' | 'error';
                 };
+            } | {
+                cachePoint: {
+                    type: string;
+                    ttl?: string;
+                };
             }>;
         }>;
         system?: Array<{
@@ -18453,6 +18488,11 @@ export type BedrockConverseStreamWithAgentData = {
                     text: string;
                     qualifiers?: Array<'grounding_source' | 'query' | 'guard_content'>;
                 };
+            };
+        } | {
+            cachePoint: {
+                type: string;
+                ttl?: string;
             };
         }>;
         inferenceConfig?: {
@@ -18627,6 +18667,11 @@ export type BedrockConverseWithAgentAndModelData = {
                     }>;
                     status?: 'success' | 'error';
                 };
+            } | {
+                cachePoint: {
+                    type: string;
+                    ttl?: string;
+                };
             }>;
         }>;
         system?: Array<{
@@ -18640,6 +18685,11 @@ export type BedrockConverseWithAgentAndModelData = {
                     text: string;
                     qualifiers?: Array<'grounding_source' | 'query' | 'guard_content'>;
                 };
+            };
+        } | {
+            cachePoint: {
+                type: string;
+                ttl?: string;
             };
         }>;
         inferenceConfig?: {
@@ -18940,6 +18990,11 @@ export type BedrockConverseStreamWithAgentAndModelData = {
                     }>;
                     status?: 'success' | 'error';
                 };
+            } | {
+                cachePoint: {
+                    type: string;
+                    ttl?: string;
+                };
             }>;
         }>;
         system?: Array<{
@@ -18953,6 +19008,11 @@ export type BedrockConverseStreamWithAgentAndModelData = {
                     text: string;
                     qualifiers?: Array<'grounding_source' | 'query' | 'guard_content'>;
                 };
+            };
+        } | {
+            cachePoint: {
+                type: string;
+                ttl?: string;
             };
         }>;
         inferenceConfig?: {
@@ -26009,6 +26069,11 @@ export type GetInteractionsResponses = {
                             }>;
                             status?: 'success' | 'error';
                         };
+                    } | {
+                        cachePoint: {
+                            type: string;
+                            ttl?: string;
+                        };
                     }>;
                 }>;
                 system?: Array<{
@@ -26019,6 +26084,11 @@ export type GetInteractionsResponses = {
                             text: string;
                             qualifiers?: Array<'grounding_source' | 'query' | 'guard_content'>;
                         };
+                    };
+                } | {
+                    cachePoint: {
+                        type: string;
+                        ttl?: string;
                     };
                 }>;
                 inferenceConfig?: {
@@ -26168,6 +26238,11 @@ export type GetInteractionsResponses = {
                             }>;
                             status?: 'success' | 'error';
                         };
+                    } | {
+                        cachePoint: {
+                            type: string;
+                            ttl?: string;
+                        };
                     }>;
                 }>;
                 system?: Array<{
@@ -26178,6 +26253,11 @@ export type GetInteractionsResponses = {
                             text: string;
                             qualifiers?: Array<'grounding_source' | 'query' | 'guard_content'>;
                         };
+                    };
+                } | {
+                    cachePoint: {
+                        type: string;
+                        ttl?: string;
                     };
                 }>;
                 inferenceConfig?: {
@@ -28492,6 +28572,11 @@ export type GetInteractionResponses = {
                         }>;
                         status?: 'success' | 'error';
                     };
+                } | {
+                    cachePoint: {
+                        type: string;
+                        ttl?: string;
+                    };
                 }>;
             }>;
             system?: Array<{
@@ -28502,6 +28587,11 @@ export type GetInteractionResponses = {
                         text: string;
                         qualifiers?: Array<'grounding_source' | 'query' | 'guard_content'>;
                     };
+                };
+            } | {
+                cachePoint: {
+                    type: string;
+                    ttl?: string;
                 };
             }>;
             inferenceConfig?: {
@@ -28651,6 +28741,11 @@ export type GetInteractionResponses = {
                         }>;
                         status?: 'success' | 'error';
                     };
+                } | {
+                    cachePoint: {
+                        type: string;
+                        ttl?: string;
+                    };
                 }>;
             }>;
             system?: Array<{
@@ -28661,6 +28756,11 @@ export type GetInteractionResponses = {
                         text: string;
                         qualifiers?: Array<'grounding_source' | 'query' | 'guard_content'>;
                     };
+                };
+            } | {
+                cachePoint: {
+                    type: string;
+                    ttl?: string;
                 };
             }>;
             inferenceConfig?: {


### PR DESCRIPTION
## Summary

Multi-turn chats on Anthropic and Amazon Bedrock were paying full input-token price for the system prompt, tool definitions, and conversation history on **every** turn. Both providers only prompt-cache a request when it carries an explicit breakpoint (unlike OpenAI/Gemini/DeepSeek, which cache automatically), and the chat path emitted none — so nothing was ever cached and the stable prefix was re-billed each turn.

This makes Anthropic and Bedrock chat requests reuse a cached prefix across turns: after the first turn writes the cache, later turns read the system prompt + tools + prior history from cache (charged at the reduced cache-read rate) instead of as fresh input tokens. The observable effect is lower input-token cost and faster time-to-first-token on multi-turn conversations, with no change to model output.

A breakpoint caches everything rendered before it (the prefix is `tools → system → messages`), so the markers are placed on messages: the first message (stable prefix that never changes — a hit on every later turn) and the last message (rolling, extends the cached prefix to the newest turn). The same placement serves both providers via their respective markers — Anthropic `cacheControl: ephemeral` and Bedrock `cachePoint` — and stays within each providers hard limit of 4 breakpoints by counting markers that attachment handling already places, so file-heavy conversations never overflow the cap and fail the request.

Enabling Bedrock additionally required the LLM proxy Bedrock Converse request schema to accept the `cachePoint` content block — without it the proxy rejected the cache-point blocks with a 400, so Bedrock requests cached nothing.

OpenAI, Gemini, DeepSeek, etc. cache prefixes automatically and need no markers, so this is a no-op for them.
