### PR TITLE
feat(llm): broaden best-model markers for the remaining providers

### DIFF
--- a/platform/backend/src/models/llm-provider-api-key-model.test.ts
+++ b/platform/backend/src/models/llm-provider-api-key-model.test.ts
@@ -1,3 +1,4 @@
+import type { SupportedProvider } from "@archestra/shared";
 import { describe, expect, test } from "@/test";
 import LlmProviderApiKeyModelLinkModel from "./llm-provider-api-key-model";
 import ModelModel from "./model";
@@ -568,6 +569,80 @@ describe("LlmProviderApiKeyModelLinkModel", () => {
         apiKey.id,
         models.map((model) => ({ id: model.id, modelId: model.modelId })),
         "openai",
+      );
+
+      const best = await LlmProviderApiKeyModelLinkModel.getBestModel(
+        apiKey.id,
+      );
+      expect(best?.modelId).toBe(expected);
+    });
+  });
+
+  describe("best-model marker priority across providers", () => {
+    const cases: Array<{
+      provider: SupportedProvider;
+      catalog: string[];
+      expected: string;
+    }> = [
+      {
+        provider: "anthropic",
+        catalog: ["claude-sonnet-4-8", "claude-haiku-4-5"],
+        expected: "claude-sonnet-4-8",
+      },
+      {
+        provider: "azure",
+        catalog: ["gpt-4o", "gpt-3.5-turbo"],
+        expected: "gpt-4o",
+      },
+      {
+        provider: "gemini",
+        catalog: ["gemini-2.5-flash"],
+        expected: "gemini-2.5-flash",
+      },
+      {
+        provider: "bedrock",
+        catalog: ["anthropic.claude-sonnet-4-8"],
+        expected: "anthropic.claude-sonnet-4-8",
+      },
+      { provider: "xai", catalog: ["grok-3"], expected: "grok-3" },
+      {
+        provider: "cohere",
+        catalog: ["command-r-plus"],
+        expected: "command-r-plus",
+      },
+    ];
+
+    test.for(cases)("$provider marks $expected as best for $catalog", async ({
+      provider,
+      catalog,
+      expected,
+    }, { makeOrganization, makeSecret, makeLlmProviderApiKey }) => {
+      const org = await makeOrganization();
+      const secret = await makeSecret();
+      const apiKey = await makeLlmProviderApiKey(org.id, secret.id, {
+        provider,
+      });
+
+      const models = [];
+      for (const modelId of catalog) {
+        models.push(
+          await ModelModel.create({
+            externalId: `${provider}/${modelId}`,
+            provider,
+            modelId,
+            description: modelId,
+            inputModalities: ["text"],
+            outputModalities: ["text"],
+            supportsToolCalling: true,
+            lastSyncedAt: new Date(),
+          }),
+        );
+      }
+
+      await LlmProviderApiKeyModelLinkModel.syncModelsForApiKey(
+        apiKey.id,
+        models.map((model) => ({ id: model.id, modelId: model.modelId })),
+        provider,
       );
 
       const best = await LlmProviderApiKeyModelLinkModel.getBestModel(

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -206,7 +206,7 @@ export const OPENROUTER_LATEST_ALIAS_PREFIX = "~";
  * first listed id present in the account is the one marked best.
  */
 export const MODEL_MARKER_PATTERNS: Record<SupportedProvider, string[]> = {
-  anthropic: ["opus-4-8", "opus-4-7"],
+  anthropic: ["opus-4-8", "opus-4-7", "opus", "sonnet"],
   openai: [
     "gpt-5.5-pro",
     "gpt-5.5",
@@ -216,13 +216,23 @@ export const MODEL_MARKER_PATTERNS: Record<SupportedProvider, string[]> = {
     "gpt-4.1",
     "gpt-4o",
   ],
-  gemini: ["gemini-3.1-pro-preview", "gemini-2.5-pro"],
+  gemini: ["gemini-3.1-pro-preview", "gemini-2.5-pro", "flash"],
   cerebras: ["zai-glm-4.7"],
-  cohere: ["command-a-plus-05-2026"],
-  mistral: ["mistral-medium-2604"],
-  perplexity: ["sonar-deep-research", "sonar-reasoning-pro", "sonar-pro"],
-  groq: ["openai/gpt-oss-120b"],
-  xai: ["grok-4.3"],
+  cohere: ["command-a-plus", "command-a", "command-r-plus", "command-r"],
+  mistral: [
+    "mistral-medium-2604",
+    "mistral-large",
+    "mistral-medium",
+    "mistral-small",
+  ],
+  perplexity: [
+    "sonar-deep-research",
+    "sonar-reasoning-pro",
+    "sonar-pro",
+    "sonar",
+  ],
+  groq: ["openai/gpt-oss-120b", "gpt-oss", "llama-4", "llama-3.3"],
+  xai: ["grok-4.3", "grok-4", "grok-3"],
   openrouter: [
     "anthropic/claude-opus-4.8",
     "anthropic/claude-opus-4.7",
@@ -234,11 +244,25 @@ export const MODEL_MARKER_PATTERNS: Record<SupportedProvider, string[]> = {
   ],
   ollama: ["gpt-oss:120b", "llama4:maverick", "llama4:scout", "qwen3:235b"],
   vllm: ["gpt-oss-120b", "llama-4-maverick", "llama-4-scout", "qwen3-235b"],
-  zhipuai: ["glm-5.1"],
-  deepseek: ["deepseek-v4-pro"],
+  zhipuai: ["glm-5.1", "glm-5", "glm-4.7", "glm-4"],
+  deepseek: ["deepseek-v4-pro", "deepseek-v4", "deepseek-v3", "deepseek-chat"],
   minimax: ["minimax-m3", "minimax-m2.7"],
-  azure: ["gpt-5.5"],
-  bedrock: ["anthropic.claude-opus-4-8", "anthropic.claude-opus-4-7"],
+  azure: [
+    "gpt-5.5-pro",
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.3",
+    "gpt-5",
+    "gpt-4.1",
+    "gpt-4o",
+  ],
+  bedrock: [
+    "anthropic.claude-opus-4-8",
+    "anthropic.claude-opus-4-7",
+    "claude-opus",
+    "claude-sonnet",
+    "amazon.nova-pro",
+  ],
 };
 
 /**


### PR DESCRIPTION
## Summary

`MODEL_MARKER_PATTERNS` listed only a single flagship id for most providers, so an account whose catalog lacks that exact model had no marker-matched "best" — default-model resolution then fell back to the alphabetically-first chat model, an arbitrary pick. (OpenAI was already broadened in a prior PR.)

Each remaining provider now lists versioned same-family fallbacks and current-tier markers — Azure mirrors the OpenAI list, Anthropic adds `opus`/`sonnet`, Bedrock adds Claude Sonnet + Nova Pro, Gemini adds `flash`, and xAI / Zhipu / DeepSeek / Cohere / Mistral / Groq get version ladders — so those accounts get an intentional "best".

Lowest-tier and legacy-catching substrings are deliberately omitted (no bare `haiku`, `-pro`, `claude`, `llama`, `grok`). Two reasons: marking a low tier "best" adds no within-provider value — the no-marker fallback already returns it — and it would let that low-tier model win the *cross-provider* best-available pick ahead of a stronger flagship from an alphabetically-earlier provider. That cross-provider provider-ordering bias is the deeper limitation here; the durable fix is ranking the no-marker fallback by capability/recency instead of alphabetically.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>