### PR TITLE
fix: guard env-seeded providers that need a base URL

### DIFF
--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -366,6 +366,7 @@ The base URL can also be set globally via the `ARCHESTRA_VLLM_BASE_URL` environm
 ### Important Notes
 
 - **Configure base URL to enable vLLM**: The vLLM provider is only available when `ARCHESTRA_VLLM_BASE_URL` is set or a per-key base URL is configured in the UI. Without either, vLLM won't appear as an option.
+- **Auto-seeding needs the base URL**: Setting `ARCHESTRA_CHAT_VLLM_API_KEY` alone does not create a vLLM key at startup. `ARCHESTRA_VLLM_BASE_URL` must also be set, otherwise the provider is skipped (a key without a base URL would silently route to the public OpenAI endpoint).
 - **No API key required for most deployments**: Unlike cloud providers, self-hosted vLLM typically doesn't require authentication. When adding a vLLM key in the platform, the API key field is marked as optional.
 
 ## Ollama
@@ -689,6 +690,8 @@ Known region prefixes: `us`, `eu`, `ap`, `global`.
 | `ARCHESTRA_AZURE_OPENAI_RESPONSES_API_VERSION` | No | Azure Responses API version (default: `2025-04-01-preview`) |
 | `ARCHESTRA_AZURE_OPENAI_ENTRA_ID_ENABLED` | No | Set to `true` to use Microsoft Entra ID instead of an Azure API key |
 | `ARCHESTRA_CHAT_AZURE_OPENAI_API_KEY` | No | Default API key for Azure AI Foundry chat (can be overridden per conversation/team/org) |
+
+Setting `ARCHESTRA_CHAT_AZURE_OPENAI_API_KEY` alone does not create an Azure key at startup; `ARCHESTRA_AZURE_OPENAI_BASE_URL` must also be set (Azure has no usable default endpoint), otherwise the provider is skipped.
 
 ### Getting an Azure API Key
 

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -1333,3 +1333,18 @@ export function getProviderEnvApiKey(
   }
   return undefined;
 }
+
+/**
+ * Get the configured base URL for a provider, normalized to undefined when empty.
+ * Centralizes the config.llm[provider].baseUrl lookup; mirrors getProviderEnvApiKey.
+ */
+export function getProviderConfiguredBaseUrl(
+  provider: SupportedProvider,
+): string | undefined {
+  const entry = config.llm[provider as keyof typeof config.llm];
+  if (typeof entry === "object" && entry !== null && "baseUrl" in entry) {
+    const baseUrl = entry.baseUrl?.trim();
+    return baseUrl || undefined;
+  }
+  return undefined;
+}

--- a/platform/backend/src/database/seed.test.ts
+++ b/platform/backend/src/database/seed.test.ts
@@ -6,6 +6,8 @@ import {
   POLICY_CONFIG_SYSTEM_PROMPT,
 } from "@archestra/shared";
 import { and, eq } from "drizzle-orm";
+import { afterEach } from "vitest";
+import config from "@/config";
 import db, { schema } from "@/database";
 import { SkillFileModel, SkillModel } from "@/models";
 import AgentModel from "@/models/agent";
@@ -15,7 +17,7 @@ import {
   builtInSkillVersion,
 } from "@/skills/built-in-skills";
 import { describe, expect, test } from "@/test";
-import { syncBuiltInAgents, syncBuiltInSkills } from "./seed";
+import { decideEnvSeed, syncBuiltInAgents, syncBuiltInSkills } from "./seed";
 
 const [BASE_SKILL] = BUILT_IN_SKILLS;
 
@@ -281,5 +283,63 @@ describe("syncBuiltInSkills", () => {
       sourceRef,
     });
     expect(preserved?.content).toBe("EDITED BY USER");
+  });
+});
+
+describe("decideEnvSeed", () => {
+  const originals = {
+    vllm: config.llm.vllm.baseUrl,
+    azure: config.llm.azure.baseUrl,
+    openai: config.llm.openai.baseUrl,
+    bedrock: config.llm.bedrock.baseUrl,
+  };
+
+  afterEach(() => {
+    config.llm.vllm.baseUrl = originals.vllm;
+    config.llm.azure.baseUrl = originals.azure;
+    config.llm.openai.baseUrl = originals.openai;
+    config.llm.bedrock.baseUrl = originals.bedrock;
+  });
+
+  test("skips vLLM when no base URL is configured", () => {
+    config.llm.vllm.baseUrl = undefined;
+    expect(decideEnvSeed("vllm").kind).toBe("skip");
+  });
+
+  test("creates vLLM with the base URL persisted when configured", () => {
+    config.llm.vllm.baseUrl = "https://vllm.example.com/v1";
+    expect(decideEnvSeed("vllm")).toEqual({
+      kind: "create",
+      persistedBaseUrl: "https://vllm.example.com/v1",
+    });
+  });
+
+  test("skips Azure when no base URL is configured", () => {
+    config.llm.azure.baseUrl = "";
+    expect(decideEnvSeed("azure").kind).toBe("skip");
+  });
+
+  test("creates Azure with the base URL persisted when configured", () => {
+    config.llm.azure.baseUrl = "https://my-resource.openai.azure.com/openai";
+    expect(decideEnvSeed("azure")).toEqual({
+      kind: "create",
+      persistedBaseUrl: "https://my-resource.openai.azure.com/openai",
+    });
+  });
+
+  test("creates a normal provider without persisting its base URL", () => {
+    config.llm.openai.baseUrl = "https://api.openai.com/v1";
+    expect(decideEnvSeed("openai")).toEqual({
+      kind: "create",
+      persistedBaseUrl: null,
+    });
+  });
+
+  test("creates Bedrock without a base URL (region fallback)", () => {
+    config.llm.bedrock.baseUrl = "";
+    expect(decideEnvSeed("bedrock")).toEqual({
+      kind: "create",
+      persistedBaseUrl: null,
+    });
   });
 });

--- a/platform/backend/src/database/seed.test.ts
+++ b/platform/backend/src/database/seed.test.ts
@@ -319,6 +319,11 @@ describe("decideEnvSeed", () => {
     expect(decideEnvSeed("azure").kind).toBe("skip");
   });
 
+  test("treats a whitespace-only base URL as not configured", () => {
+    config.llm.azure.baseUrl = "   ";
+    expect(decideEnvSeed("azure").kind).toBe("skip");
+  });
+
   test("creates Azure with the base URL persisted when configured", () => {
     config.llm.azure.baseUrl = "https://my-resource.openai.azure.com/openai";
     expect(decideEnvSeed("azure")).toEqual({

--- a/platform/backend/src/database/seed.ts
+++ b/platform/backend/src/database/seed.ts
@@ -603,8 +603,9 @@ export function decideEnvSeed(provider: SupportedProvider): EnvSeedDecision {
 
 /**
  * Sync models for an API key. Bedrock's fetcher throws without a base URL; that is
- * caught here so a key-only/IAM Bedrock seed still succeeds with a best-effort model
- * list (its runtime falls back to the us-east-1 region).
+ * caught here so a key-only/IAM Bedrock seed still creates a usable key (chat falls
+ * back to the us-east-1 region) — its model list just stays empty until a base URL
+ * is configured.
  */
 async function syncModelsForApiKey(
   apiKeyId: string,

--- a/platform/backend/src/database/seed.ts
+++ b/platform/backend/src/database/seed.ts
@@ -11,13 +11,17 @@ import {
   PLAYWRIGHT_MCP_ICON,
   PLAYWRIGHT_MCP_SERVER_NAME,
   POLICY_CONFIG_SYSTEM_PROMPT,
+  PROVIDERS_REQUIRING_BASE_URL,
   type PredefinedRoleName,
   type SupportedProvider,
   SupportedProviders,
   testMcpServerCommand,
 } from "@archestra/shared";
 import { and, eq, inArray, isNull } from "drizzle-orm";
-import config, { getProviderEnvApiKey } from "@/config";
+import config, {
+  getProviderConfiguredBaseUrl,
+  getProviderEnvApiKey,
+} from "@/config";
 import db, { schema, withDbTransaction } from "@/database";
 import logger from "@/logging";
 import {
@@ -505,6 +509,15 @@ async function seedChatApiKeysFromEnv(): Promise<void> {
       continue;
     }
 
+    const decision = decideEnvSeed(provider);
+    if (decision.kind === "skip") {
+      logger.warn(
+        { provider },
+        `Skipping env-seeded provider: ${decision.reason}`,
+      );
+      continue;
+    }
+
     // Check if API key already exists for this provider
     const existing = await LlmProviderApiKeyModel.findByScope(
       org.id,
@@ -514,7 +527,12 @@ async function seedChatApiKeysFromEnv(): Promise<void> {
 
     if (existing) {
       // Sync models if not already synced
-      await syncModelsForApiKey(existing.id, provider, apiKeyValue);
+      await syncModelsForApiKey(
+        existing.id,
+        provider,
+        apiKeyValue,
+        decision.persistedBaseUrl,
+      );
       continue;
     }
 
@@ -533,6 +551,8 @@ async function seedChatApiKeysFromEnv(): Promise<void> {
       scope: "org",
       userId: null,
       teamId: null,
+      baseUrl: decision.persistedBaseUrl,
+      isPrimary: true,
     });
 
     logger.info(
@@ -540,24 +560,64 @@ async function seedChatApiKeysFromEnv(): Promise<void> {
       "Created chat API key from environment variable",
     );
 
-    // Sync models from provider
-    await syncModelsForApiKey(apiKey.id, provider, apiKeyValue);
+    // Sync models from provider. persistedBaseUrl carries the required endpoint for
+    // azure/vllm (so their fetchers hit the right host) and null elsewhere (the
+    // fetchers fall back to their own default — unchanged from before).
+    await syncModelsForApiKey(
+      apiKey.id,
+      provider,
+      apiKeyValue,
+      decision.persistedBaseUrl,
+    );
   }
 }
 
+type EnvSeedDecision =
+  | { kind: "skip"; reason: string }
+  | { kind: "create"; persistedBaseUrl: string | null };
+
 /**
- * Sync models for an API key.
+ * Decide how to seed a provider whose env API key is set. Pure (config-only, no IO)
+ * so the gap-handling logic is unit-testable without DB or network.
+ *
+ * @public — unit-tested in seed.test.ts
+ */
+export function decideEnvSeed(provider: SupportedProvider): EnvSeedDecision {
+  const baseUrl = getProviderConfiguredBaseUrl(provider);
+
+  if (PROVIDERS_REQUIRING_BASE_URL.has(provider) && baseUrl === undefined) {
+    return { kind: "skip", reason: "required base URL is not configured" };
+  }
+
+  // Persist the base URL only for providers that require one (azure/vllm): it pins
+  // the required infra endpoint on the key, same as a manual UI add. Other providers
+  // keep null so a later ARCHESTRA_*_BASE_URL change still takes effect via the
+  // runtime fallback (the per-key URL is preferred over config when set).
+  return {
+    kind: "create",
+    persistedBaseUrl: PROVIDERS_REQUIRING_BASE_URL.has(provider)
+      ? (baseUrl ?? null)
+      : null,
+  };
+}
+
+/**
+ * Sync models for an API key. Bedrock's fetcher throws without a base URL; that is
+ * caught here so a key-only/IAM Bedrock seed still succeeds with a best-effort model
+ * list (its runtime falls back to the us-east-1 region).
  */
 async function syncModelsForApiKey(
   apiKeyId: string,
   provider: SupportedProvider,
   apiKeyValue: string,
+  baseUrl?: string | null,
 ): Promise<void> {
   try {
     await modelSyncService.syncModelsForApiKey({
       apiKeyId,
       provider,
       apiKeyValue,
+      baseUrl,
     });
     logger.info({ provider, apiKeyId }, "Synced models for API key");
   } catch (error) {

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -97,8 +97,9 @@ const PROVIDERS_WITH_OPTIONAL_API_KEY = new Set<SupportedProvider>([
  * Providers that have no usable default endpoint, so an env-seeded key without an
  * explicit base URL is unusable: vLLM has no default at all (the OpenAI-compatible
  * SDK would silently fall back to api.openai.com), and Azure has no resource URL.
- * Bedrock is intentionally excluded — it infers a region (us-east-1 fallback) and
- * works key-only/IAM. Gemini is excluded — its SDK supplies its own default.
+ * Bedrock is intentionally excluded — at runtime it infers a region (us-east-1
+ * fallback) so chat works key-only/IAM even without a base URL (only its model-list
+ * sync needs one). Gemini is excluded — its SDK supplies its own default.
  */
 export const PROVIDERS_REQUIRING_BASE_URL = new Set<SupportedProvider>([
   "azure",

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -93,6 +93,18 @@ const PROVIDERS_WITH_OPTIONAL_API_KEY = new Set<SupportedProvider>([
   "vllm",
 ]);
 
+/**
+ * Providers that have no usable default endpoint, so an env-seeded key without an
+ * explicit base URL is unusable: vLLM has no default at all (the OpenAI-compatible
+ * SDK would silently fall back to api.openai.com), and Azure has no resource URL.
+ * Bedrock is intentionally excluded — it infers a region (us-east-1 fallback) and
+ * works key-only/IAM. Gemini is excluded — its SDK supplies its own default.
+ */
+export const PROVIDERS_REQUIRING_BASE_URL = new Set<SupportedProvider>([
+  "azure",
+  "vllm",
+]);
+
 export function isProviderApiKeyOptional(params: {
   provider: SupportedProvider;
   azureEntraIdEnabled?: boolean;


### PR DESCRIPTION
## What

The startup provider auto-seed (`seedChatApiKeysFromEnv`) creates an org-scope `chat_api_keys` row for every provider whose `ARCHESTRA_CHAT_<P>_API_KEY` is set. For providers with **no usable default endpoint**, setting only the API key produced a broken or dangerous key:

- **vLLM**: with no base URL, the OpenAI-compatible SDK silently falls back to `https://api.openai.com/v1` — your vLLM key + prompts would go to public OpenAI.
- **Azure**: resolves to an empty base URL → non-functional key, and model sync returns nothing.

## Changes

- `PROVIDERS_REQUIRING_BASE_URL = {azure, vllm}` (shared) — providers with no working default endpoint.
- `getProviderConfiguredBaseUrl(provider)` (backend config) — centralizes the `config.llm[*].baseUrl` lookup, normalizing empty/whitespace to `undefined`.
- Pure `decideEnvSeed(provider)` helper in `seed.ts`:
  - **skip + warn** azure/vllm when their base URL is unconfigured (fail loud, no silent OpenAI routing);
  - **persist `baseUrl`** on the seeded key only for those providers (pins required infra, like a manual UI add). The other 15 keep `null` and rely on the runtime fallback so a later `ARCHESTRA_*_BASE_URL` change still takes effect;
  - **`isPrimary: true`** for the seeded org key → deterministic per-provider selection.
- Model sync now receives the persisted base URL (the required endpoint for azure/vllm; `null` ≈ previous `undefined` for everyone else).
- Docs notes for vLLM and Azure auto-seeding.

**Bedrock is intentionally not gated** — at runtime it infers a region (`us-east-1` fallback) so chat works key-only/IAM. Its model-list sync still needs a base URL, but that failure is caught and non-fatal (key stays usable, model list empty until a base URL is set).

## Behavior note

The skip decision runs before the existing-key lookup, so an env-set azure/vllm provider with no configured base URL won't re-sync an already-existing key on startup either. This is not a regression — the previous code synced existing azure/vllm keys *without* their base URL, so that sync failed anyway.

## Tests

- Unit tests for `decideEnvSeed` (skip/create/persist/`null`/whitespace cases), mock-free (config mutation + restore).
- End-to-end seed + model sync over WireMock is already exercised by the e2e suite.

## Review

Plan and diff reviewed via Codex (external) + an internal review subagent across two rounds; correctness/comment-accuracy findings addressed.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>