### PR TITLE
fix(test): stabilize MSW integration tests (next-dev cold-compile timeout + blocked port)

### DIFF
--- a/platform/dev/Tiltfile.dev
+++ b/platform/dev/Tiltfile.dev
@@ -142,8 +142,11 @@ else:
       # If only the server var is overridden, a .env value for the public mirror
       # (e.g. set by `dev:stack:up`) reaches the browser and defeats the
       # fail-loudly behavior for escaped client-side fetches.
-      'ARCHESTRA_INTERNAL_API_BASE_URL': 'http://127.0.0.1:1',
-      'NEXT_PUBLIC_ARCHESTRA_INTERNAL_API_BASE_URL': 'http://127.0.0.1:1',
+      # Port 65535, not 1: port 1 is on undici's blocked-ports list, so an
+      # escaped fetch throws "bad port" before dialing instead of the intended
+      # ECONNREFUSED, which breaks SSR rendering. Mirrors frontend/playwright.config.ts.
+      'ARCHESTRA_INTERNAL_API_BASE_URL': 'http://127.0.0.1:65535',
+      'NEXT_PUBLIC_ARCHESTRA_INTERNAL_API_BASE_URL': 'http://127.0.0.1:65535',
       'NEXT_PUBLIC_SENTRY_DSN': '',
     }
   )

--- a/platform/frontend/playwright.config.ts
+++ b/platform/frontend/playwright.config.ts
@@ -41,7 +41,11 @@ export default defineConfig({
   workers: 1,
   forbidOnly: IS_CI,
   retries: IS_CI ? 2 : 0,
-  timeout: 60_000,
+  // Generous timeouts: the suite runs against `next dev`, which compiles each
+  // route on first request and re-renders lazily. On loaded CI runners that
+  // cold path routinely exceeds a 10s assertion budget (the same render is
+  // near-instant locally), so the first test to touch a route would flake.
+  timeout: 90_000,
   reporter: IS_CI
     ? [["github"], ["html", { open: "never" }]]
     : [["list"], ["html", { open: "never" }]],
@@ -50,10 +54,10 @@ export default defineConfig({
     trace: "on-first-retry",
     screenshot: "only-on-failure",
     video: "retain-on-failure",
-    actionTimeout: 15_000,
-    navigationTimeout: 30_000,
+    actionTimeout: 20_000,
+    navigationTimeout: 45_000,
   },
-  expect: { timeout: 10_000 },
+  expect: { timeout: 30_000 },
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
   webServer: {
     command: `next dev -H 127.0.0.1 -p ${INT_TESTS_PORT}`,


### PR DESCRIPTION
## Summary

The **Frontend Integration Tests (MSW)** job fails on the same five specs (agents, mcp-registry, mcp-reinstall) on essentially every run, blocking PRs from merging. Two independent integration-test config issues underlie it.

**`next dev` cold-compile exceeds the assertion timeout — the PR-blocker.** The suite runs against `next dev`, which compiles each route on first request and re-renders lazily. On loaded CI runners that cold path exceeds the 10s `expect` budget, so the first test to touch each route times out on `toBeVisible()` on every attempt — retries don't rescue it because the runner stays slow. The same render is near-instant on a developer machine, which is why the failure is CI-only and looked like flake. Raising the budgets — `expect` 10s→30s, navigation 30s→45s, action 15s→20s, per-test 60s→90s — covers the cold path so the first-touch render is no longer a race.

**Unreachable base URL used a blocked port.** The escaped-fetch backstop points the SDK at an unreachable address so any request that slips past MSW fails loudly instead of hitting a real backend. It used `http://127.0.0.1:1`, but port 1 is on undici's blocked-ports list, so the fetch throws `bad port` before dialing instead of the intended `ECONNREFUSED` — a different failure mode that breaks SSR rendering. `playwright.config.ts` was already moved to `:65535` (#5343); this applies the same to `dev/Tiltfile.dev`, the last remaining `:1`.
