### PR TITLE
fix(ci): add release artifact recovery dispatch

### DIFF
--- a/.github/workflows/build-base-mcp-server-docker-image.yml
+++ b/.github/workflows/build-base-mcp-server-docker-image.yml
@@ -11,6 +11,11 @@ on:
         description: "Version tag for the Docker image"
         required: true
         type: string
+      checkout_ref:
+        description: "Optional ref to checkout when building the image"
+        required: false
+        type: string
+        default: ""
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER:
         required: false
@@ -38,6 +43,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 1
+          ref: ${{ inputs.checkout_ref != '' && inputs.checkout_ref || github.sha }}
 
       - name: Setup uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -70,6 +76,7 @@ jobs:
       push_image: ${{ inputs.push_to_gcr }}
       auth_provider: gar
       include_latest_tag: true
+      checkout_ref: ${{ inputs.checkout_ref }}
     secrets:
       GCP_SERVICE_ACCOUNT_NAME: ${{ secrets.GCP_SERVICE_ACCOUNT_NAME }}
       GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER }}

--- a/.github/workflows/build-dockerhub-image.yml
+++ b/.github/workflows/build-dockerhub-image.yml
@@ -20,6 +20,11 @@ on:
         description: "Whether to push the image to Docker Hub"
         required: true
         type: boolean
+      checkout_ref:
+        description: "Optional ref to checkout when building the image"
+        required: false
+        type: string
+        default: ""
     secrets:
       DOCKER_USERNAME:
         required: false
@@ -54,6 +59,7 @@ jobs:
       auth_provider: dockerhub
       include_latest_tag: ${{ inputs.version != 'dev' }}
       checkout_fetch_depth: 0
+      checkout_ref: ${{ inputs.checkout_ref }}
       # supply-chain-policy: allow-latest internal release channel
       previous_image: docker.io/archestra/${{ inputs.image_name }}:latest
     secrets:

--- a/.github/workflows/publish-platform-helm-chart.yml
+++ b/.github/workflows/publish-platform-helm-chart.yml
@@ -11,6 +11,11 @@ on:
         description: "Whether to push the Helm chart to the repository"
         required: true
         type: boolean
+      checkout_ref:
+        description: "Optional ref to checkout when packaging the chart"
+        required: false
+        type: string
+        default: ""
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER:
         required: false
@@ -41,6 +46,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          ref: ${{ inputs.checkout_ref != '' && inputs.checkout_ref || github.sha }}
 
       - name: Authenticate to Google Artifact Registry
         if: inputs.push_chart

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,40 @@ on:
       - main
       - "release/*"
   workflow_dispatch:
+    inputs:
+      publish_existing_release:
+        description: "Publish artifacts for an existing release instead of creating a new release-please release"
+        required: false
+        default: false
+        type: boolean
+      version:
+        description: "Existing platform version to publish, without the v prefix (for example, 1.2.59)"
+        required: false
+        type: string
+      tag_name:
+        description: "Existing release tag to publish (for example, platform-v1.2.59)"
+        required: false
+        type: string
+      publish_mcp_server_image:
+        description: "Publish the MCP server base image"
+        required: false
+        default: true
+        type: boolean
+      publish_platform_image:
+        description: "Publish the platform image to Docker Hub"
+        required: false
+        default: true
+        type: boolean
+      publish_helm_chart:
+        description: "Publish the platform Helm chart"
+        required: false
+        default: true
+        type: boolean
+      finalize_github_release:
+        description: "Un-draft the GitHub release after selected artifacts publish"
+        required: false
+        default: true
+        type: boolean
 
 permissions: {}
 
@@ -25,9 +59,10 @@ jobs:
       issues: write # Required for release-please issue comments and labels.
       id-token: write # Required for Workload Identity Federation in downstream release jobs.
     outputs:
-      platform_release_created: ${{ steps.release-please.outputs['platform--release_created'] }}
-      platform_version: ${{ steps.release-please.outputs['platform--version'] }}
-      platform_tag_name: ${{ steps.release-please.outputs['platform--tag_name'] }}
+      platform_should_publish: ${{ steps.resolve-release.outputs.should_publish }}
+      platform_version: ${{ steps.resolve-release.outputs.version }}
+      platform_tag_name: ${{ steps.resolve-release.outputs.tag_name }}
+      platform_checkout_ref: ${{ steps.resolve-release.outputs.checkout_ref }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -43,6 +78,7 @@ jobs:
           private-key: ${{ secrets.ARCHESTRA_RELEASER_GITHUB_APP_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        if: ${{ !inputs.publish_existing_release }}
         id: release-please
         with:
           token: ${{ steps.generate-token.outputs.token }}
@@ -58,21 +94,58 @@ jobs:
         run: |
           echo "$OUTPUTS"
 
+      - name: Resolve release to publish
+        id: resolve-release
+        env:
+          ACTION_RELEASE_CREATED: ${{ steps.release-please.outputs['platform--release_created'] }}
+          ACTION_VERSION: ${{ steps.release-please.outputs['platform--version'] }}
+          ACTION_TAG_NAME: ${{ steps.release-please.outputs['platform--tag_name'] }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          INPUT_PUBLISH_EXISTING_RELEASE: ${{ inputs.publish_existing_release }}
+          INPUT_TAG_NAME: ${{ inputs.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "${INPUT_PUBLISH_EXISTING_RELEASE}" = "true" ]; then
+            if [ -z "${INPUT_VERSION}" ]; then
+              echo "::error::version is required when publish_existing_release is true"
+              exit 1
+            fi
+
+            TAG_NAME="${INPUT_TAG_NAME:-platform-v${INPUT_VERSION}}"
+            gh release view "${TAG_NAME}" --json tagName,isDraft,targetCommitish
+
+            {
+              echo "should_publish=true"
+              echo "version=${INPUT_VERSION}"
+              echo "tag_name=${TAG_NAME}"
+              echo "checkout_ref=${TAG_NAME}"
+            } >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          {
+            echo "should_publish=${ACTION_RELEASE_CREATED:-false}"
+            echo "version=${ACTION_VERSION}"
+            echo "tag_name=${ACTION_TAG_NAME}"
+            echo "checkout_ref=${ACTION_TAG_NAME}"
+          } >> "${GITHUB_OUTPUT}"
+
       # Re-draft the release so it's not visible until all artifacts are built.
       # We removed "draft: true" from release-please-config.json because draft releases
       # don't create git tags, and release-please needs the tag to exist when calculating
       # the next version (otherwise it creates bogus PRs with stale versions).
       - name: Re-draft release until artifacts are ready
-        if: steps.release-please.outputs['platform--release_created']
+        if: steps.resolve-release.outputs.should_publish == 'true'
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
-          TAG_NAME: ${{ steps.release-please.outputs['platform--tag_name'] }}
+          TAG_NAME: ${{ steps.resolve-release.outputs.tag_name }}
         run: gh release edit "$TAG_NAME" --draft=true
 
   build-and-push-mcp-server-docker-image:
     name: Build and push MCP Server Docker image
-    if: needs.release-please.outputs.platform_release_created
+    if: ${{ needs.release-please.outputs.platform_should_publish == 'true' && (github.event_name != 'workflow_dispatch' || inputs.publish_mcp_server_image) }}
     uses: ./.github/workflows/build-base-mcp-server-docker-image.yml
     needs:
       - release-please
@@ -82,6 +155,7 @@ jobs:
     with:
       push_to_gcr: true
       version: ${{ needs.release-please.outputs.platform_version }}
+      checkout_ref: ${{ needs.release-please.outputs.platform_checkout_ref }}
     secrets:
       GCP_SERVICE_ACCOUNT_NAME: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_SERVICE_ACCOUNT_NAME }}
       GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER }}
@@ -93,7 +167,7 @@ jobs:
     # The tag is baked as a default value at build time, so the MCP server image doesn't need to
     # exist yet. Both images are built in parallel and the publish-github-release job gates on
     # all artifacts being ready before un-drafting the release.
-    if: needs.release-please.outputs.platform_release_created
+    if: ${{ needs.release-please.outputs.platform_should_publish == 'true' && (github.event_name != 'workflow_dispatch' || inputs.publish_platform_image) }}
     uses: ./.github/workflows/build-dockerhub-image.yml
     needs:
       - release-please
@@ -105,6 +179,7 @@ jobs:
       image_name: platform
       version: ${{ needs.release-please.outputs.platform_version }}
       push_image: true
+      checkout_ref: ${{ needs.release-please.outputs.platform_checkout_ref }}
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -117,7 +192,7 @@ jobs:
     # The Helm chart only references the version tag (not image content), so it can run
     # in parallel with Docker image builds. The publish-github-release job ensures all
     # artifacts are ready before the release is made visible.
-    if: needs.release-please.outputs.platform_release_created
+    if: ${{ needs.release-please.outputs.platform_should_publish == 'true' && (github.event_name != 'workflow_dispatch' || inputs.publish_helm_chart) }}
     uses: ./.github/workflows/publish-platform-helm-chart.yml
     needs:
       - release-please
@@ -127,6 +202,7 @@ jobs:
     with:
       version: ${{ needs.release-please.outputs.platform_version }}
       push_chart: true
+      checkout_ref: ${{ needs.release-please.outputs.platform_checkout_ref }}
     secrets:
       GCP_SERVICE_ACCOUNT_NAME: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_SERVICE_ACCOUNT_NAME }}
       GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER }}
@@ -135,7 +211,7 @@ jobs:
     name: Publish GitHub Release
     # Un-drafts the GitHub release and triggers the website deploy only after ALL artifacts
     # (MCP server image, platform Docker image, Helm chart) are published.
-    if: needs.release-please.outputs.platform_release_created
+    if: ${{ always() && needs.release-please.outputs.platform_should_publish == 'true' && (github.event_name != 'workflow_dispatch' || inputs.finalize_github_release) && (needs.build-and-push-mcp-server-docker-image.result == 'success' || needs.build-and-push-mcp-server-docker-image.result == 'skipped') && (needs.build-and-push-platform-docker-image-to-dockerhub.result == 'success' || needs.build-and-push-platform-docker-image-to-dockerhub.result == 'skipped') && (needs.publish-platform-helm-chart.result == 'success' || needs.publish-platform-helm-chart.result == 'skipped') }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
     needs:
       - release-please


### PR DESCRIPTION
## Summary

- Add a manual recovery mode to the Release Please workflow for already-created releases whose artifact publishing failed.
- Build release artifacts from the resolved release tag instead of the workflow-triggering SHA.
- Allow recovery dispatches to republish only selected artifacts, then un-draft the GitHub release after selected jobs succeed.

## Root cause

The v1.2.59 release object was created and re-drafted, but the platform image publish failed during a Docker Hub blob upload. A later Release Please run found the release already existed, returned `releases_created=false`, and skipped all artifact jobs because the workflow only gated on release creation in that exact run.