### PR TITLE
fix(chat): stop spurious 'active response' blocks from orphaned chat runs

### DIFF
--- a/platform/backend/src/models/chat-active-run.test.ts
+++ b/platform/backend/src/models/chat-active-run.test.ts
@@ -225,3 +225,100 @@ test("marks stale running runs failed and deletes old terminal runs", async ({
   );
   expect(deleted).toBe(1);
 });
+
+test("markTerminal does not overwrite an already-terminal run", async ({
+  makeAgent,
+  makeConversation,
+  makeOrganization,
+  makeUser,
+}) => {
+  const user = await makeUser();
+  const organization = await makeOrganization();
+  const agent = await makeAgent({ organizationId: organization.id });
+  const conversation = await makeConversation(agent.id, {
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const run = await ActiveChatRunModel.create({
+    conversationId: conversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+
+  const completed = await ActiveChatRunModel.markTerminal({
+    runId: run?.id ?? "",
+    status: "completed",
+  });
+  expect(completed?.status).toBe("completed");
+
+  // A late drain finishing after the run was already marked terminal must not
+  // transition it again (e.g. reaper-set failed -> completed).
+  const reMarked = await ActiveChatRunModel.markTerminal({
+    runId: run?.id ?? "",
+    status: "failed",
+    error: "late drain",
+  });
+  expect(reMarked).toBeNull();
+
+  const finalRun = await ActiveChatRunModel.findById(run?.id ?? "");
+  expect(finalRun?.status).toBe("completed");
+  expect(finalRun?.error).toBeNull();
+});
+
+test("markRunningAsFailedByIds fails only running runs", async ({
+  makeAgent,
+  makeConversation,
+  makeOrganization,
+  makeUser,
+}) => {
+  const user = await makeUser();
+  const organization = await makeOrganization();
+  const agent = await makeAgent({ organizationId: organization.id });
+  const runningConversation = await makeConversation(agent.id, {
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const completedConversation = await makeConversation(agent.id, {
+    userId: user.id,
+    organizationId: organization.id,
+  });
+
+  const runningRun = await ActiveChatRunModel.create({
+    conversationId: runningConversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const completedRun = await ActiveChatRunModel.create({
+    conversationId: completedConversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  await ActiveChatRunModel.markTerminal({
+    runId: completedRun?.id ?? "",
+    status: "completed",
+  });
+
+  const failedCount = await ActiveChatRunModel.markRunningAsFailedByIds({
+    ids: [runningRun?.id ?? "", completedRun?.id ?? ""],
+    error: "Server shut down before the chat stream completed.",
+  });
+  expect(failedCount).toBe(1);
+
+  const formerlyRunning = await ActiveChatRunModel.findById(
+    runningRun?.id ?? "",
+  );
+  expect(formerlyRunning?.status).toBe("failed");
+  const stillCompleted = await ActiveChatRunModel.findById(
+    completedRun?.id ?? "",
+  );
+  expect(stillCompleted?.status).toBe("completed");
+});
+
+test("markRunningAsFailedByIds is a no-op for an empty id list", async () => {
+  expect(
+    await ActiveChatRunModel.markRunningAsFailedByIds({
+      ids: [],
+      error: "unused",
+    }),
+  ).toBe(0);
+});

--- a/platform/backend/src/models/chat-active-run.ts
+++ b/platform/backend/src/models/chat-active-run.ts
@@ -1,5 +1,5 @@
 import type { UIMessageChunk } from "ai";
-import { and, asc, desc, eq, gt, lt, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, lt, sql } from "drizzle-orm";
 import db, { schema, withDbTransaction } from "@/database";
 import type {
   ChatActiveRun,
@@ -141,6 +141,9 @@ class ActiveChatRunModel {
     return run ?? null;
   }
 
+  // Only a 'running' row transitions to terminal. Guarding on status makes
+  // terminal->terminal a no-op, so a late-finishing drain cannot overwrite a
+  // status the stale reaper or shutdown cleanup already set.
   static async markTerminal(params: {
     runId: string;
     status: Exclude<ChatActiveRunStatus, "running">;
@@ -153,10 +156,41 @@ class ActiveChatRunModel {
         error: params.error ?? null,
         updatedAt: new Date(),
       })
-      .where(eq(schema.chatActiveRunsTable.id, params.runId))
+      .where(
+        and(
+          eq(schema.chatActiveRunsTable.id, params.runId),
+          eq(schema.chatActiveRunsTable.status, "running"),
+        ),
+      )
       .returning();
 
     return run ?? null;
+  }
+
+  static async markRunningAsFailedByIds(params: {
+    ids: string[];
+    error: string;
+  }): Promise<number> {
+    if (params.ids.length === 0) {
+      return 0;
+    }
+
+    const runs = await db
+      .update(schema.chatActiveRunsTable)
+      .set({
+        status: "failed",
+        error: params.error,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          inArray(schema.chatActiveRunsTable.id, params.ids),
+          eq(schema.chatActiveRunsTable.status, "running"),
+        ),
+      )
+      .returning({ id: schema.chatActiveRunsTable.id });
+
+    return runs.length;
   }
 
   static async markStaleRunningAsFailed(staleMs: number): Promise<number> {

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -270,6 +270,12 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
       });
 
       if (!activeRun) {
+        if (activeChatRunService.shuttingDown) {
+          throw new ApiError(
+            503,
+            "The server is shutting down. Please retry in a moment.",
+          );
+        }
         throw new ApiError(
           409,
           "This conversation already has an active response. Stop it before sending another message.",

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -294,7 +294,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
           uploadedByUserId: user.id,
         });
       } catch (error) {
-        await ActiveChatRunModel.markTerminal({
+        await activeChatRunService.markTerminal({
           runId: activeRun.id,
           status: "failed",
           error: error instanceof Error ? error.message : String(error),
@@ -1176,7 +1176,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
           chatAbortController.abort();
         }
         stopActiveRunPolling();
-        await ActiveChatRunModel.markTerminal({
+        await activeChatRunService.markTerminal({
           runId: activeRun.id,
           status: "failed",
           error: error instanceof Error ? error.message : String(error),

--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -952,7 +952,9 @@ const startWebServer = async () => {
     }, PROCESSED_EMAIL_CLEANUP_INTERVAL_MS);
 
     // Safety net for chat runs orphaned 'running' by a hard kill that skipped
-    // graceful shutdown. Runs only on the web server, which owns chat streams.
+    // graceful shutdown. Registered only on the web server (workers never create
+    // chat runs); every web replica runs it, which is safe because the underlying
+    // UPDATE is filtered on status='running' and is idempotent across pods.
     const activeChatRunReaperIntervalId = setInterval(() => {
       void activeChatRunService.reapStaleRuns();
     }, ACTIVE_CHAT_RUN_REAPER_INTERVAL_MS);
@@ -1062,6 +1064,10 @@ function registerWebServerShutdown(
 ): void {
   const gracefulShutdown = async (signal: string) => {
     fastify.log.info(`Received ${signal}, shutting down gracefully...`);
+
+    // Stop accepting new runs before snapshotting, so nothing created after this
+    // point escapes the cleanup below.
+    activeChatRunService.beginShutdown();
 
     // Fail this pod's in-flight chat runs first: a long SSE stream keeps Fastify
     // connections open, so waiting for fastify.close() risks SIGKILL before the

--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -63,6 +63,7 @@ import { initAuditRegistry } from "@/middleware/audit-log-registry";
 import OrganizationModel from "@/models/organization";
 import { initializeObservabilityMetrics } from "@/observability";
 import { enrichOpenApiWithRbac } from "@/openapi/enrich-openapi-with-rbac";
+import { activeChatRunService } from "@/services/active-chat-run";
 import { instanceAnalyticsService } from "@/services/instance-analytics";
 import { systemKeyManager } from "@/services/system-key-manager";
 import { skillSandboxRuntimeService } from "@/skills-sandbox/skill-sandbox-runtime-service";
@@ -102,6 +103,7 @@ import {
 
 /** Max time to wait for cleanup operations during graceful shutdown before exiting */
 const SHUTDOWN_CLEANUP_TIMEOUT_MS = 3000;
+const ACTIVE_CHAT_RUN_REAPER_INTERVAL_MS = 60 * 1000;
 
 // Load enterprise routes if license is activated OR if running in codegen mode
 // (codegen mode ensures OpenAPI spec always includes all enterprise routes)
@@ -949,6 +951,12 @@ const startWebServer = async () => {
       });
     }, PROCESSED_EMAIL_CLEANUP_INTERVAL_MS);
 
+    // Safety net for chat runs orphaned 'running' by a hard kill that skipped
+    // graceful shutdown. Runs only on the web server, which owns chat streams.
+    const activeChatRunReaperIntervalId = setInterval(() => {
+      void activeChatRunService.reapStaleRuns();
+    }, ACTIVE_CHAT_RUN_REAPER_INTERVAL_MS);
+
     /**
      * Here we don't expose the metrics endpoint on the main API port, but we do collect metrics
      * inside of this server instance. Metrics are actually exposed on a different port
@@ -1017,6 +1025,7 @@ const startWebServer = async () => {
     registerWebServerShutdown(fastify, {
       emailRenewalIntervalId,
       processedEmailCleanupIntervalId,
+      activeChatRunReaperIntervalId,
     });
   } catch (err) {
     fastify.log.error(err);
@@ -1048,12 +1057,29 @@ function registerWebServerShutdown(
   intervalIds: {
     emailRenewalIntervalId?: NodeJS.Timeout;
     processedEmailCleanupIntervalId?: NodeJS.Timeout;
+    activeChatRunReaperIntervalId?: NodeJS.Timeout;
   } = {},
 ): void {
   const gracefulShutdown = async (signal: string) => {
     fastify.log.info(`Received ${signal}, shutting down gracefully...`);
 
+    // Fail this pod's in-flight chat runs first: a long SSE stream keeps Fastify
+    // connections open, so waiting for fastify.close() risks SIGKILL before the
+    // runs are freed, leaving their conversations blocked until the reaper runs.
+    // This is a single fast UPDATE, bounded so a slow DB cannot stall shutdown.
+    await Promise.race([
+      activeChatRunService.failInFlightRuns().catch((error) => {
+        fastify.log.error({ error }, "Failed to fail in-flight chat runs");
+      }),
+      new Promise<void>((resolve) =>
+        setTimeout(resolve, SHUTDOWN_CLEANUP_TIMEOUT_MS),
+      ),
+    ]);
+
     try {
+      if (intervalIds.activeChatRunReaperIntervalId) {
+        clearInterval(intervalIds.activeChatRunReaperIntervalId);
+      }
       if (metricsServerInstance) {
         await metricsServerInstance.close();
         fastify.log.info("Metrics server closed");

--- a/platform/backend/src/services/active-chat-run.test.ts
+++ b/platform/backend/src/services/active-chat-run.test.ts
@@ -340,6 +340,42 @@ test("failInFlightRuns fails this pod's running runs and clears the set", async 
   expect(await service.failInFlightRuns()).toBe(0);
 });
 
+test("createRun refuses new runs once shutdown has begun", async ({
+  makeAgent,
+  makeConversation,
+  makeOrganization,
+  makeUser,
+}) => {
+  const user = await makeUser();
+  const organization = await makeOrganization();
+  const agent = await makeAgent({ organizationId: organization.id });
+  const conversation = await makeConversation(agent.id, {
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const service = new ActiveChatRunService(
+    new InMemoryActiveChatRunNotifier(),
+    10_000,
+    10_000,
+  );
+
+  service.beginShutdown();
+  expect(service.shuttingDown).toBe(true);
+
+  const run = await service.createRun({
+    conversationId: conversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+
+  // No run is created after shutdown begins, so there is nothing to orphan.
+  expect(run).toBeNull();
+  expect(
+    await ActiveChatRunModel.findRunningByConversation(conversation.id),
+  ).toBeNull();
+  expect(await service.failInFlightRuns()).toBe(0);
+});
+
 test("reapStaleRuns fails runs past the stale cutoff", async ({
   makeAgent,
   makeConversation,

--- a/platform/backend/src/services/active-chat-run.test.ts
+++ b/platform/backend/src/services/active-chat-run.test.ts
@@ -1,5 +1,7 @@
 import type { UIMessageChunk } from "ai";
+import { eq } from "drizzle-orm";
 import { vi } from "vitest";
+import db, { schema } from "@/database";
 import ActiveChatRunModel from "@/models/chat-active-run";
 import {
   ActiveChatRunService,
@@ -285,6 +287,93 @@ test("createRun throttles terminal cleanup and only checks stale runs after conf
 
   deleteSpy.mockRestore();
   staleSpy.mockRestore();
+});
+
+test("failInFlightRuns fails this pod's running runs and clears the set", async ({
+  makeAgent,
+  makeConversation,
+  makeOrganization,
+  makeUser,
+}) => {
+  const user = await makeUser();
+  const organization = await makeOrganization();
+  const agent = await makeAgent({ organizationId: organization.id });
+  const runningConversation = await makeConversation(agent.id, {
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const completedConversation = await makeConversation(agent.id, {
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const service = new ActiveChatRunService(
+    new InMemoryActiveChatRunNotifier(),
+    10_000,
+    10_000,
+  );
+
+  const runningRun = await service.createRun({
+    conversationId: runningConversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const completedRun = await service.createRun({
+    conversationId: completedConversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  // A completed run leaves the in-flight set and must not be re-failed.
+  await service.markTerminal({
+    runId: completedRun?.id ?? "",
+    status: "completed",
+  });
+
+  expect(await service.failInFlightRuns()).toBe(1);
+  expect(
+    (await ActiveChatRunModel.findById(runningRun?.id ?? ""))?.status,
+  ).toBe("failed");
+  expect(
+    (await ActiveChatRunModel.findById(completedRun?.id ?? ""))?.status,
+  ).toBe("completed");
+
+  // The set is cleared, so a second shutdown pass fails nothing.
+  expect(await service.failInFlightRuns()).toBe(0);
+});
+
+test("reapStaleRuns fails runs past the stale cutoff", async ({
+  makeAgent,
+  makeConversation,
+  makeOrganization,
+  makeUser,
+}) => {
+  const user = await makeUser();
+  const organization = await makeOrganization();
+  const agent = await makeAgent({ organizationId: organization.id });
+  const conversation = await makeConversation(agent.id, {
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const service = new ActiveChatRunService(
+    new InMemoryActiveChatRunNotifier(),
+    10_000,
+    10_000,
+  );
+
+  const run = await service.createRun({
+    conversationId: conversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  await db
+    .update(schema.chatActiveRunsTable)
+    .set({ updatedAt: new Date(Date.now() - 11 * 60 * 1000) })
+    .where(eq(schema.chatActiveRunsTable.id, run?.id ?? ""));
+
+  await service.reapStaleRuns();
+
+  expect((await ActiveChatRunModel.findById(run?.id ?? ""))?.status).toBe(
+    "failed",
+  );
 });
 
 function createChunkStream(

--- a/platform/backend/src/services/active-chat-run.ts
+++ b/platform/backend/src/services/active-chat-run.ts
@@ -6,6 +6,7 @@ import {
   type ActiveChatRunNotifier,
   createActiveChatRunNotifier,
 } from "@/services/active-chat-run-notifier";
+import type { ChatActiveRunStatus } from "@/types/chat-active-run";
 
 const EVENT_FLUSH_INTERVAL_MS = 500;
 const EVENT_BATCH_SIZE = 256;
@@ -20,6 +21,9 @@ export const ACTIVE_CHAT_RUN_TERMINAL_REPLAY_GRACE_MS = 2 * 60 * 1000;
  */
 export class ActiveChatRunService {
   private nextTerminalCleanupAt = 0;
+  // Run ids this process created and believes may still be 'running'. Used to
+  // fail only this pod's runs on graceful shutdown (no schema-level pod id).
+  private readonly inFlightRunIds = new Set<string>();
 
   constructor(
     private readonly notifier: ActiveChatRunNotifier,
@@ -36,6 +40,7 @@ export class ActiveChatRunService {
 
     const run = await ActiveChatRunModel.create(params);
     if (run) {
+      this.inFlightRunIds.add(run.id);
       return run;
     }
 
@@ -48,7 +53,54 @@ export class ActiveChatRunService {
       );
     }
 
-    return ActiveChatRunModel.create(params);
+    const retriedRun = await ActiveChatRunModel.create(params);
+    if (retriedRun) {
+      this.inFlightRunIds.add(retriedRun.id);
+    }
+
+    return retriedRun;
+  }
+
+  // Single terminal-transition entry point so the in-flight set stays bounded.
+  async markTerminal(params: {
+    runId: string;
+    status: Exclude<ChatActiveRunStatus, "running">;
+    error?: string | null;
+  }): Promise<void> {
+    this.inFlightRunIds.delete(params.runId);
+    await ActiveChatRunModel.markTerminal(params);
+  }
+
+  // Periodic safety net for runs orphaned by a hard kill (OOM/SIGKILL) that
+  // never reached graceful shutdown. Graceful shutdown handles the common case.
+  async reapStaleRuns(): Promise<void> {
+    try {
+      const reaped =
+        await ActiveChatRunModel.markStaleRunningAsFailed(STALE_RUNNING_MS);
+      if (reaped > 0) {
+        logger.info({ reaped }, "Reaped stale active chat runs");
+      }
+    } catch (error) {
+      logger.warn({ error }, "Failed to reap stale active chat runs");
+    }
+  }
+
+  // Best-effort cleanup on graceful shutdown: fail this pod's still-running runs
+  // so their conversations are not blocked until the stale reaper catches up.
+  async failInFlightRuns(): Promise<number> {
+    const ids = Array.from(this.inFlightRunIds);
+    this.inFlightRunIds.clear();
+
+    const failed = await ActiveChatRunModel.markRunningAsFailedByIds({
+      ids,
+      error: "Server shut down before the chat stream completed.",
+    });
+
+    if (failed > 0) {
+      logger.info({ failed }, "Failed in-flight active chat runs on shutdown");
+    }
+
+    return failed;
   }
 
   async requestStop(params: {
@@ -88,7 +140,7 @@ export class ActiveChatRunService {
 
         await writer.flush();
         const terminal = await params.getTerminalStatus();
-        await ActiveChatRunModel.markTerminal({
+        await this.markTerminal({
           runId: params.runId,
           status: terminal.status,
           error: terminal.error,
@@ -110,7 +162,7 @@ export class ActiveChatRunService {
             "Failed to flush active chat run events after drain error",
           );
         });
-        await ActiveChatRunModel.markTerminal({
+        await this.markTerminal({
           runId: params.runId,
           status: "failed",
           error: error instanceof Error ? error.message : String(error),

--- a/platform/backend/src/services/active-chat-run.ts
+++ b/platform/backend/src/services/active-chat-run.ts
@@ -24,6 +24,7 @@ export class ActiveChatRunService {
   // Run ids this process created and believes may still be 'running'. Used to
   // fail only this pod's runs on graceful shutdown (no schema-level pod id).
   private readonly inFlightRunIds = new Set<string>();
+  private isShuttingDown = false;
 
   constructor(
     private readonly notifier: ActiveChatRunNotifier,
@@ -31,17 +32,26 @@ export class ActiveChatRunService {
     private readonly stopPollIntervalMs: number,
   ) {}
 
+  get shuttingDown(): boolean {
+    return this.isShuttingDown;
+  }
+
   async createRun(params: {
     conversationId: string;
     userId: string;
     organizationId: string;
   }) {
+    // Refuse new runs once shutdown started, so nothing is created after
+    // failInFlightRuns() has already snapshotted this pod's runs to fail.
+    if (this.isShuttingDown) {
+      return null;
+    }
+
     this.cleanupTerminalRunsIfNeeded(params.conversationId);
 
     const run = await ActiveChatRunModel.create(params);
     if (run) {
-      this.inFlightRunIds.add(run.id);
-      return run;
+      return this.registerCreatedRun(run);
     }
 
     try {
@@ -54,25 +64,30 @@ export class ActiveChatRunService {
     }
 
     const retriedRun = await ActiveChatRunModel.create(params);
-    if (retriedRun) {
-      this.inFlightRunIds.add(retriedRun.id);
-    }
+    return retriedRun ? this.registerCreatedRun(retriedRun) : null;
+  }
 
-    return retriedRun;
+  beginShutdown(): void {
+    this.isShuttingDown = true;
   }
 
   // Single terminal-transition entry point so the in-flight set stays bounded.
+  // Removes from the set only after the DB write resolves: if it throws, the id
+  // is retained so failInFlightRuns()/the reaper still fail the run later.
   async markTerminal(params: {
     runId: string;
     status: Exclude<ChatActiveRunStatus, "running">;
     error?: string | null;
   }): Promise<void> {
-    this.inFlightRunIds.delete(params.runId);
     await ActiveChatRunModel.markTerminal(params);
+    this.inFlightRunIds.delete(params.runId);
   }
 
   // Periodic safety net for runs orphaned by a hard kill (OOM/SIGKILL) that
   // never reached graceful shutdown. Graceful shutdown handles the common case.
+  // Intentionally does not prune inFlightRunIds: a leftover id is a harmless
+  // no-op for failInFlightRuns (it re-asserts status='running' in SQL), and the
+  // set is fully cleared on shutdown.
   async reapStaleRuns(): Promise<void> {
     try {
       const reaped =
@@ -283,6 +298,25 @@ export class ActiveChatRunService {
       stopped = true;
       waitController.abort();
     };
+  }
+
+  // Track a freshly created run, closing the window where shutdown began while
+  // ActiveChatRunModel.create was awaiting: fail it now rather than orphan it.
+  private async registerCreatedRun(
+    run: NonNullable<Awaited<ReturnType<typeof ActiveChatRunModel.create>>>,
+  ): Promise<typeof run | null> {
+    this.inFlightRunIds.add(run.id);
+
+    if (this.isShuttingDown) {
+      await this.markTerminal({
+        runId: run.id,
+        status: "failed",
+        error: "Server shut down before the chat stream completed.",
+      });
+      return null;
+    }
+
+    return run;
   }
 
   private async notifyEvent(runId: string): Promise<void> {

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -11,6 +11,7 @@ type ChatSessionSnapshot = ReturnType<
 const mocks = vi.hoisted(() => ({
   addToolApprovalResponse: vi.fn(),
   addToolResult: vi.fn(),
+  clearError: vi.fn(),
   getQueryData: vi.fn(),
   invalidateQueries: vi.fn(),
   mutate: vi.fn(),
@@ -81,6 +82,7 @@ describe("ChatProvider retries", () => {
       return {
         addToolApprovalResponse: mocks.addToolApprovalResponse,
         addToolResult: mocks.addToolResult,
+        clearError: mocks.clearError,
         error: undefined,
         messages,
         regenerate: mocks.regenerate,
@@ -353,6 +355,9 @@ describe("ChatProvider retries", () => {
       "This conversation already has a response in progress. Stop it before sending another message.",
     );
     expect(mocks.regenerate).not.toHaveBeenCalled();
+    // The SDK error is cleared so the benign guard never renders as a hard
+    // inline error panel — the toast is the only surfaced feedback.
+    expect(mocks.clearError).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -95,10 +95,9 @@ function isRetryableError(error: Error): boolean {
 }
 
 function isDuplicateActiveRunError(error: Error): boolean {
-  return (
-    error.message.includes("409") ||
-    error.message.includes("already has an active response")
-  );
+  // Match the backend's exact duplicate-run message rather than a bare "409",
+  // which could collide with unrelated error text (e.g. "4096 tokens").
+  return error.message.includes("already has an active response");
 }
 
 function shouldResumeActiveRun(messages: UIMessage[]): boolean {
@@ -429,6 +428,9 @@ function ChatSessionHook({
       ) => void)
     | null
   >(null);
+  // useChat returns clearError, but onError is defined inside the useChat config
+  // (before the hook returns), so reach it through a ref like sendMessageRef.
+  const clearErrorRef = useRef<(() => void) | null>(null);
   // Auto-retry state for transient errors
   const retryCountRef = useRef(0);
   const retryTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -479,6 +481,7 @@ function ChatSessionHook({
     setMessages,
     stop,
     error,
+    clearError,
     addToolResult,
     addToolApprovalResponse,
   } = useChat({
@@ -609,6 +612,9 @@ function ChatSessionHook({
         toast.error(
           "This conversation already has a response in progress. Stop it before sending another message.",
         );
+        // Clear the SDK error so this benign guard does not also render as a
+        // hard inline error panel; the toast is the only surfaced feedback.
+        clearErrorRef.current?.();
         return;
       }
 
@@ -787,6 +793,8 @@ function ChatSessionHook({
 
   // Keep sendMessageRef up-to-date for onFinish callback
   sendMessageRef.current = sendMessage;
+  // Keep clearErrorRef up-to-date for the duplicate-run branch in onError
+  clearErrorRef.current = clearError;
 
   const stableMessages = messagesWithRestoredAssistantParts;
 


### PR DESCRIPTION
## Problem

Chat conversations could be blocked from sending new messages by a 409 **"This conversation already has an active response"**, surfaced to the user as a hard inline error panel.

Root cause: a `chat_active_runs` row stuck at `status='running'` blocks new sends (partial unique index on `conversation_id WHERE status='running'`). Such rows were **orphaned on pod shutdown** — graceful shutdown never marked in-flight runs terminal, and the drain runs detached from the HTTP request, so it isn't awaited by `fastify.close()`. The only stale-reaper ran *lazily* inside `createRun` on a later conflicting send (10-minute cutoff), so an orphan could block a conversation for up to 10 minutes. Live streams are unaffected — the 5s heartbeat flushes and touches `updatedAt` well under the cutoff.

Separately, the duplicate-run guard is benign but was rendered as a full red error bubble: `onError` showed a toast but left the SDK error state set, so the inline panel rendered anyway.

## When this was introduced

Not a regression in an existing system — this bisects to a single commit, **#4219 "feat: add resume/reconnect chat feature" (2026-05-25)**, which introduced the whole `chat_active_runs` mechanism. Both halves of the problem shipped with it (confirmed via `git log -S`): the backend 409 guard + lazy-only reaper (graceful-shutdown cleanup never existed), and the frontend toast-that-leaves-the-error-set. Of the two commits touching this code since then, neither added shutdown cleanup or a reaper: #5109 only swapped `db.transaction`→`withDbTransaction` in `appendEvents`; #5171 introduced the throttled `updatedAt` touch (`RUN_TOUCH_INTERVAL_MS = 30s`) and larger event batching. #5171 didn't create or widen the orphan gap — a dead producer never touches `updatedAt` regardless — but it's why a *live* run's staleness timestamp now advances only ~every 30s, which is exactly why this PR keeps `STALE_RUNNING_MS` generous rather than shortening it. The path is not feature-flagged, so it has been live on staging since ~2026-05-25. Frequent staging deploys are what surface it: each rollout that kills an in-flight stream leaves an orphaned `running` row.

## Changes

**Backend — eliminate orphaned runs**
- `markTerminal` now guards on `status='running'`, making terminal→terminal a no-op so a late-finishing drain can't overwrite a reaped/failed run.
- `ActiveChatRunService` tracks the run ids this process created and fails *its own* still-running runs early on graceful shutdown (bounded by the existing cleanup timeout, before `fastify.close()`), so conversations are freed immediately on deploys instead of waiting for the reaper.
- An `isShuttingDown` gate refuses new runs once shutdown begins (with a post-create re-check to close the await window); the chat route returns **503** during shutdown instead of a misleading 409.
- A **web-only background reaper** (60s) is the safety net for hard kills (OOM/SIGKILL) that skip graceful shutdown. The underlying UPDATE is filtered on `status='running'`, so it's idempotent across replicas.
- `STALE_RUNNING_MS` stays at 10 min: the heartbeat touches only the stream, not the DB, so a shorter cutoff could wrongly reap a live-but-quiet run.

**Frontend — stop surfacing the guard as a hard error**
- Tightened the duplicate-run predicate (dropped the broad `includes("409")` match in favor of the exact phrase).
- `onError` now clears the SDK error state for the duplicate case, so it shows only a toast — no inline error panel.

## Tests
- Backend: idempotent `markTerminal`; `markRunningAsFailedByIds`; `failInFlightRuns` (fails running, skips completed, clears set); `reapStaleRuns`; `createRun` refuses runs after shutdown.
- Frontend: a duplicate-run error clears the SDK error and shows a toast only.
- Full suites green: type-check, lint, knip (dev+production), backend chat-route tests (413), frontend chat-context tests.

## Review
Both an external (Codex) and internal review gate ran on the branch diff; findings (shutdown-race window, terminal-write ordering, comment clarity) are addressed in the second commit.

## Notes
- No schema/migration changes. No new env vars.
- DB-side confirmation of orphaned `running` rows on staging is pending an interactive `gcloud auth login`; code + log evidence already established the root cause.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>

