### PR TITLE
chore(mcp-registry): tidy inert preset leftovers

### DIFF
--- a/platform/backend/src/database/schemas/internal-mcp-catalog.ts
+++ b/platform/backend/src/database/schemas/internal-mcp-catalog.ts
@@ -82,54 +82,54 @@ const internalMcpCatalogTable = pgTable(
     }),
     scope: mcpCatalogScopeEnum("scope").notNull().default("org"),
     /**
-     * Self-FK. NULL = root catalog item (parent / default preset).
-     * Non-NULL = child catalog item (UI-named "preset"); inherits all template
-     * columns from parent, overlays its own preset_field_values at runtime.
+     * Legacy preset column — the "preset" (child catalog item) feature was
+     * removed; retained inert (non-destructive, no migration). Self-FK:
+     * NULL = root catalog item, non-NULL = a legacy child row ("preset").
+     * Application code no longer creates children; the only live uses are an
+     * `IS NULL` filter that hides any pre-existing legacy child rows and the
+     * parent-delete cascade that tears down their servers/secrets.
      */
     parentCatalogItemId: uuid("parent_catalog_item_id").references(
       (): AnyPgColumn => internalMcpCatalogTable.id,
       { onDelete: "cascade" },
     ),
     /**
-     * For child catalog items (presets): the bare submitted name before
-     * composition. The `name` column on a child stores `${parent.name}-${childName}`.
-     * NULL for root catalog items.
+     * Legacy preset column (feature removed) — retained inert. Held a child
+     * row's bare name; the composed `name` was `${parent.name}-${childName}`.
+     * NULL for root rows; no longer read or written.
      */
     childName: text("child_name"),
     /**
      * Self-FK lineage pointer: the catalog item this one was cloned from.
      * NULL for non-clones. ON DELETE SET NULL so deleting the source leaves
-     * the clone intact (just untracked), unlike the cascade on parent presets.
+     * the clone intact (just untracked), unlike the legacy parent-catalog cascade.
      */
     clonedFrom: uuid("cloned_from").references(
       (): AnyPgColumn => internalMcpCatalogTable.id,
       { onDelete: "set null" },
     ),
     /**
-     * For child catalog items only: FK to the org-level preset entry this
-     * child configures (e.g. "Production", "Staging"). Cascade-deleted when
-     * the entry is removed at /mcp/registry/org-structure. NULL for root rows.
-     * Canonical link — `child_name` is just a denormalized display copy.
+     * Legacy preset column (feature removed) — retained inert. FK to the
+     * org-level preset-entry table a child row configured. NULL for root
+     * rows; no longer read or written.
      */
     presetEntryId: uuid("preset_entry_id").references(
       () => mcpPresetEntriesTable.id,
       { onDelete: "cascade" },
     ),
     /**
-     * Values for fields the parent declared with promptOnPreset: true.
-     * Meaningful on parent (= default preset values) AND child (= preset overlay).
-     * Stores only non-secret values; secret-typed preset values live in the
-     * secret bundle referenced by presetSecretId.
+     * Legacy preset column (feature removed) — retained inert. Held the
+     * non-secret preset field values for a row (secret-typed ones lived in
+     * the bundle referenced by presetSecretId). No longer read or written.
      */
     presetFieldValues: jsonb("preset_field_values")
       .$type<Record<string, UserConfigFieldDefault>>()
       .notNull()
       .default({}),
     /**
-     * Bundle of secret-typed preset values (userConfig.sensitive=true or env
-     * type=secret) for this catalog row. Same `{ <field_key>: <value> }`
-     * shape as clientSecretId / localConfigSecretId — one row per catalog
-     * row (parent or child).
+     * Legacy preset column (feature removed) — retained inert. Referenced a
+     * secret bundle of secret-typed preset values for the row. No longer read
+     * or written.
      */
     presetSecretId: uuid("preset_secret_id").references(() => secretTable.id, {
       onDelete: "set null",

--- a/platform/backend/src/database/schemas/mcp-preset-entry.ts
+++ b/platform/backend/src/database/schemas/mcp-preset-entry.ts
@@ -10,11 +10,10 @@ import {
 import organizationsTable from "./organization";
 
 /**
- * Org-level list of preset entries. Each entry is a named bucket (e.g.
- * "Production", "Staging") that catalog items can attach per-environment
- * configuration to. Names are immutable — the catalog UI uses the entry's
- * name verbatim as the `child_name` on per-catalog preset rows, so renaming
- * here would silently de-link existing configurations. Insert and delete only.
+ * Legacy preset table — the MCP-catalog "preset" feature was removed; this
+ * table is retained inert (non-destructive, no migration) and is no longer
+ * read or written by application code. It held an org-level list of named
+ * preset entries that catalog items attached per-environment configuration to.
  */
 const mcpPresetEntriesTable = pgTable(
   "mcp_preset_entry",
@@ -26,10 +25,9 @@ const mcpPresetEntriesTable = pgTable(
     name: text("name").notNull(),
     sortOrder: integer("sort_order").notNull().default(0),
     /**
-     * Optional JavaScript-compatible regex source applied to every
-     * preset-scoped field value and every prompted user field value when an
-     * MCP server is installed against this preset. The pattern is stored
-     * without delimiters or flags. NULL means no preset-level validation.
+     * Legacy preset column (feature removed) — retained inert. Held an
+     * optional JS-compatible regex source (no delimiters/flags) that
+     * validated field values at install time. No longer read or written.
      */
     validationRegex: text("validation_regex"),
     createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),

--- a/platform/backend/src/database/schemas/organization.ts
+++ b/platform/backend/src/database/schemas/organization.ts
@@ -221,20 +221,17 @@ const organizationsTable = pgTable("organization", {
   >(),
 
   /**
-   * Custom label admins choose for the child-configuration entity of every
-   * catalog item (internally still called "preset"). When both singular and
-   * plural are set, the catalog UI replaces "Preset"/"presets" copy.
-   *
-   * Deprecated/read-only: the registry admin UI and the write endpoints that
-   * set these were removed. Existing values are still read; no new writes.
+   * Legacy preset columns (feature removed) — retained inert (non-destructive,
+   * no migration) and no longer read or written. Held admin-chosen singular/
+   * plural labels that the catalog UI used to override "Preset"/"presets" copy.
    */
   presetEntityName: text("preset_entity_name"),
   presetEntityNamePlural: text("preset_entity_name_plural"),
 
   /**
-   * Custom display label for the implicit "default" preset row (parent catalog
-   * item). NULL falls back to "Default" in the UI. Deprecated/read-only — the
-   * write endpoint was removed.
+   * Legacy preset column (feature removed) — retained inert. Held the custom
+   * display label for the implicit "default" preset row. No longer read or
+   * written.
    */
   presetEntityDefaultLabel: text("preset_entity_default_label"),
 
@@ -292,10 +289,9 @@ const organizationsTable = pgTable("organization", {
     .default(false),
 
   /**
-   * Validation regex applied to default-scoped field values when installing an
-   * MCP server (mirrors `mcp_preset_entries.validation_regex` for the implicit
-   * default row). Stored without delimiters or flags. NULL disables validation.
-   * Deprecated/read-only — the write endpoint was removed.
+   * Legacy preset column (feature removed) — retained inert. Held a validation
+   * regex (no delimiters/flags) applied to default-scoped field values at
+   * install time. No longer read or written.
    */
   presetEntityDefaultValidationRegex: text(
     "preset_entity_default_validation_regex",

--- a/platform/backend/src/types/organization.ts
+++ b/platform/backend/src/types/organization.ts
@@ -336,7 +336,14 @@ export const SelectOrganizationSchema = InternalSelectOrganizationSchema.omit({
 export const InsertOrganizationSchema = createInsertSchema(
   schema.organizationsTable,
   extendedFields,
-);
+).omit({
+  // Preset feature removed; columns retained in DB (non-destructive) but no
+  // longer accepted by the API, mirroring SelectOrganizationSchema.
+  presetEntityName: true,
+  presetEntityNamePlural: true,
+  presetEntityDefaultLabel: true,
+  presetEntityDefaultValidationRegex: true,
+});
 export const UpdateAppearanceSettingsSchema = z.object({
   theme: OrganizationThemeSchema.optional(),
   customFont: OrganizationCustomFontSchema.optional(),

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
@@ -749,11 +749,9 @@ describe("transformFormToApiData", () => {
   });
 
   describe("round-trips the `sensitive` flag on additional headers", () => {
-    // Test 1 from the recommendation: form → API → form preserves
-    // `sensitive`. Covers both preset-scoped (where the flag is the only
-    // routing signal between `preset_field_values` and `preset_secret_id`)
-    // and installation-scoped (where the flag controls input masking but
-    // doesn't change storage).
+    // form → API → form preserves the `sensitive` flag on installation-scoped
+    // headers (where the flag controls input masking but doesn't change
+    // storage).
     type AdditionalHeader = NonNullable<
       McpCatalogFormValues["additionalHeaders"]
     >[number];


### PR DESCRIPTION
The catalog "preset" feature was removed non-destructively, so its columns and the `mcp_preset_entry` table still exist in the DB, inert. Their doc comments, however, still described presets as a live runtime feature ("overlays its own `preset_field_values` at runtime", "the catalog UI replaces Preset/presets copy"), which misleads anyone reading the schema into thinking the feature is active. This rewords those comments to mark the columns and table as retained-but-inert legacy, and fixes one test comment that referenced the removed `preset_field_values`/`preset_secret_id` secret-routing.

It also closes a real asymmetry: `SelectOrganizationSchema` omits the `presetEntity*` columns but `InsertOrganizationSchema` did not, so the org-create API still accepted those removed fields. The insert schema now omits them too, so the API rejects them — matching the read schema.

Intentional scaffolding is left untouched: the table and columns stay (no migration), as do the `omit()` plumbing, the legacy `parentCatalogItemId IS NULL` filters, and the parent-delete cascade that tears down any pre-existing legacy child rows.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>