### PR TITLE
feat: add Sorting Hat MCP authorization flow

### DIFF
--- a/docs/pages/platform-sorting-mcp-tools.md
+++ b/docs/pages/platform-sorting-mcp-tools.md
@@ -1,0 +1,88 @@
+---
+title: Sorting your MCP tools
+category: MCP
+order: 7
+description: Patronus authorization and Sorting Hat metadata for MCP tool calls
+lastUpdated: 2026-06-05
+---
+
+The Sorting Hat MCP layer classifies MCP tool calls before they execute. Archestra uses the classification to attach UI metadata, route the authorized call onward, and require a Patronus check for tools sorted into Slytherin.
+
+## Available Tools
+
+`sorting_hat.sort(tool_name, tool_description)` returns:
+
+```json
+{ "house": "gryffindor", "confidence": 0.82 }
+```
+
+`house` is one of `gryffindor`, `slytherin`, `ravenclaw`, or `hufflepuff`.
+
+`patronus.cast(user_id, charm)` accepts `expecto_patronum` and returns a deterministic Patronus:
+
+```json
+{ "form": "stag", "corporeal": true }
+```
+
+`floo.travel(from_server, to_server, payload)` is the internal routing helper used after authorization. It passes the call payload onward and attaches green flame particle metadata for streaming UI clients.
+
+`quidditch.stream(tool_call_id)` emits Snitch-shaped progress events while a tool call is in flight. The practical cadence is throttled for browser and server health rather than forced to 60fps.
+
+The backend SSE endpoint is:
+
+```text
+GET /api/sorting-hat/quidditch/:toolCallId
+```
+
+## House Assignment
+
+Sorting is deterministic and based on the tool name plus description:
+
+- destructive, admin, security-sensitive, credential, token, permission, and write-heavy tools tend toward Slytherin
+- risky operational tools such as deploy, restart, rollback, incident, and execute tend toward Gryffindor
+- read, list, search, inspect, query, report, and reasoning tools tend toward Ravenclaw
+- docs, help, status, health, support, and version tools tend toward Hufflepuff
+
+The Sorting Hat emits a short monologue during sorting. The text is intentionally brief, in the Hat's voice, and may rhyme:
+
+```text
+Hmm... a tool with purpose tucked inside.
+Bold sparks leap where brave hands go.
+I choose gryffindor, with 82 percent pride.
+```
+
+Clients that want the monologue as SSE can call:
+
+```text
+GET /api/sorting-hat/sort/stream?toolName=github__merge_pull_request
+```
+
+## `please_not_slytherin`
+
+MCP Gateway requests can include the `please_not_slytherin` header. When present, the sorter avoids Slytherin if the tool is not clearly destructive or high-risk.
+
+The header is a preference, not an override. A request such as `delete_database`, `revoke_user_token`, or `drop_table` can still be sorted into Slytherin.
+
+## Patronus Authorization
+
+Before a Slytherin-sorted tool runs, Archestra casts:
+
+```text
+patronus.cast(user_id, "expecto_patronum")
+```
+
+The same user id always produces the same form and corporeal result. A non-corporeal Patronus blocks Slytherin tools with a graceful tool error. Non-Slytherin tools are not blocked by Patronus authorization.
+
+## UI Flow
+
+On the first tool invocation in a chat session, the frontend opens a Sorting Hat modal and streams the Hat monologue event by event.
+
+When a tool is sorted into Gryffindor, the in-flight tool header uses the Golden Snitch loader. Slytherin, Ravenclaw, and Hufflepuff tools keep the existing loader behavior.
+
+User settings include a Patronus picker with a lightweight canvas preview. Theme mode also includes the Forbidden Forest variant for users who prefer a darker green interface.
+
+## Limitations
+
+The Quidditch progress stream intentionally uses a safe event cadence instead of forcing 60fps from the backend.
+
+The settings Patronus picker is a user preference and preview. Authorization still uses `patronus.cast(user_id, "expecto_patronum")` so a given user id produces a stable server-side result.

--- a/platform/backend/package.json
+++ b/platform/backend/package.json
@@ -35,6 +35,7 @@
     "sentry:sourcemaps": "if [ -n \"$SENTRY_AUTH_TOKEN\" ]; then sentry-cli --url https://de.sentry.io/ sourcemaps inject --org archestra --project archestra-platform-backend ./dist && sentry-cli --url https://de.sentry.io/ sourcemaps upload --org archestra --project archestra-platform-backend --release \"${VERSION:-dev}\" ./dist; else echo 'Skipping Sentry source map upload (SENTRY_AUTH_TOKEN not set)'; fi"
   },
   "dependencies": {
+    "@archestra/sorting-hat-mcp": "workspace:*",
     "@ai-sdk/amazon-bedrock": "^4.0.77",
     "@ai-sdk/anthropic": "^3.0.58",
     "@ai-sdk/cerebras": "^2.0.39",

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -115,6 +115,8 @@ export type TokenAuthContext = {
   isSessionAuth?: boolean;
   /** Headers to forward to downstream MCP servers (extracted from incoming request per gateway allowlist) */
   passthroughHeaders?: Record<string, string>;
+  /** Sorting Hat house preference from the MCP gateway request. */
+  pleaseNotSlytherin?: boolean;
 };
 
 /**

--- a/platform/backend/src/routes/index.ts
+++ b/platform/backend/src/routes/index.ts
@@ -62,6 +62,7 @@ export { default as skillRoutes } from "./skill";
 export { default as skillMarketplacePublicRoutes } from "./skill-marketplace-public";
 export { default as skillSandboxArtifactRoutes } from "./skill-sandbox-artifact";
 export { default as skillShareRoutes } from "./skill-share";
+export { default as sortingHatRoutes } from "./sorting-hat";
 export { default as statisticsRoutes } from "./statistics";
 export { default as teamRoutes } from "./team";
 export { default as tokenRoutes } from "./token";

--- a/platform/backend/src/routes/mcp-gateway.ts
+++ b/platform/backend/src/routes/mcp-gateway.ts
@@ -286,6 +286,9 @@ const mcpGatewayRoutes: FastifyPluginAsyncZod = async (fastify) => {
         ...(tokenAuth.userId && { userId: tokenAuth.userId }),
         ...(tokenAuth.isExternalIdp && { isExternalIdp: true }),
         ...(tokenAuth.rawToken && { rawToken: tokenAuth.rawToken }),
+        ...(hasPleaseNotSlytherinHeader(request.headers) && {
+          pleaseNotSlytherin: true,
+        }),
       };
 
       // Extract passthrough headers from the incoming request per the agent's allowlist
@@ -316,3 +319,9 @@ const mcpGatewayRoutes: FastifyPluginAsyncZod = async (fastify) => {
 };
 
 export default mcpGatewayRoutes;
+
+function hasPleaseNotSlytherinHeader(
+  headers: FastifyRequest["headers"],
+): boolean {
+  return headers.please_not_slytherin != null;
+}

--- a/platform/backend/src/routes/mcp-gateway.utils.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.test.ts
@@ -47,6 +47,7 @@ const {
   validateOAuthToken,
   validateExternalIdpToken,
   buildKnowledgeSourcesDescription,
+  evaluateSortingHatAuthorization,
 } = await import("./mcp-gateway.utils");
 
 type TestListToolsHandler = (request: unknown) => Promise<ListToolsResult>;
@@ -1547,6 +1548,138 @@ describe("createAgentServer tools/list", () => {
     expect(response.content[0]?.text).not.toContain(
       "User context not available",
     );
+  });
+});
+
+describe("evaluateSortingHatAuthorization", () => {
+  test("blocks Slytherin tools when Patronus is non-corporeal", async ({
+    makeAgent,
+    makeAgentTool,
+    makeOrganization,
+    makeTool,
+  }) => {
+    const org = await makeOrganization();
+    const agent = await makeAgent({ organizationId: org.id });
+    const tool = await makeTool({
+      name: "postgres__delete_database",
+      description: "Drop and destroy a database",
+    });
+    await makeAgentTool(agent.id, tool.id);
+
+    await expect(
+      evaluateSortingHatAuthorization({
+        agentId: agent.id,
+        toolName: tool.name,
+        tokenAuth: {
+          tokenId: "token-1",
+          teamId: null,
+          isOrganizationToken: false,
+          organizationId: org.id,
+          userId: "non-corporeal-user",
+        },
+      }),
+    ).resolves.toMatchObject({
+      allowed: false,
+      sorting: { house: "slytherin" },
+      patronus: { corporeal: false },
+    });
+  });
+
+  test("allows Slytherin tools when Patronus is corporeal", async ({
+    makeAgent,
+    makeAgentTool,
+    makeOrganization,
+    makeTool,
+  }) => {
+    const org = await makeOrganization();
+    const agent = await makeAgent({ organizationId: org.id });
+    const tool = await makeTool({
+      name: "okta__revoke_user_token",
+      description: "Revoke an access token",
+    });
+    await makeAgentTool(agent.id, tool.id);
+
+    await expect(
+      evaluateSortingHatAuthorization({
+        agentId: agent.id,
+        toolName: tool.name,
+        tokenAuth: {
+          tokenId: "token-1",
+          teamId: null,
+          isOrganizationToken: false,
+          organizationId: org.id,
+          userId: "corporeal-user",
+        },
+      }),
+    ).resolves.toMatchObject({
+      allowed: true,
+      sorting: { house: "slytherin" },
+      patronus: { corporeal: true },
+    });
+  });
+
+  test("allows non-Slytherin tools when Patronus would be non-corporeal", async ({
+    makeAgent,
+    makeAgentTool,
+    makeOrganization,
+    makeTool,
+  }) => {
+    const org = await makeOrganization();
+    const agent = await makeAgent({ organizationId: org.id });
+    const tool = await makeTool({
+      name: "context7__read_docs",
+      description: "Read framework documentation",
+    });
+    await makeAgentTool(agent.id, tool.id);
+
+    await expect(
+      evaluateSortingHatAuthorization({
+        agentId: agent.id,
+        toolName: tool.name,
+        tokenAuth: {
+          tokenId: "token-1",
+          teamId: null,
+          isOrganizationToken: false,
+          organizationId: org.id,
+          userId: "non-corporeal-user",
+        },
+      }),
+    ).resolves.toMatchObject({
+      allowed: true,
+      sorting: { house: "hufflepuff" },
+    });
+  });
+
+  test("uses please_not_slytherin preference for non-destructive tools", async ({
+    makeAgent,
+    makeAgentTool,
+    makeOrganization,
+    makeTool,
+  }) => {
+    const org = await makeOrganization();
+    const agent = await makeAgent({ organizationId: org.id });
+    const tool = await makeTool({
+      name: "admin__update_dashboard",
+      description: "Write dashboard display settings",
+    });
+    await makeAgentTool(agent.id, tool.id);
+
+    await expect(
+      evaluateSortingHatAuthorization({
+        agentId: agent.id,
+        toolName: tool.name,
+        tokenAuth: {
+          tokenId: "token-1",
+          teamId: null,
+          isOrganizationToken: false,
+          organizationId: org.id,
+          userId: "non-corporeal-user",
+          pleaseNotSlytherin: true,
+        },
+      }),
+    ).resolves.toMatchObject({
+      allowed: true,
+    });
   });
 });
 

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -1,6 +1,14 @@
 import { createHash } from "node:crypto";
 import type { IncomingMessage } from "node:http";
 import {
+  authorizeSortedTool,
+  buildSortingHatMeta,
+  flooTravel,
+  type PatronusCastResult,
+  type SortingHatSortResult,
+  sortTool,
+} from "@archestra/sorting-hat-mcp";
+import {
   ARCHESTRA_MCP_CATALOG_ID,
   hasArchestraTokenPrefix,
   isAgentTool,
@@ -120,6 +128,21 @@ type ResolvedArchestraToken =
   | {
       type: "user";
       token: SelectUserToken;
+    };
+
+type SortingHatGatewayAuthorization =
+  | {
+      allowed: true;
+      sorting: SortingHatSortResult;
+      patronus?: PatronusCastResult;
+      monologue: string[];
+    }
+  | {
+      allowed: false;
+      sorting: SortingHatSortResult;
+      patronus: PatronusCastResult | null;
+      monologue: string[];
+      message: string;
     };
 
 const TOKEN_AUTH_CACHE_TTL_MS = 30_000;
@@ -342,6 +365,23 @@ export async function createAgentServer(
           };
         }
 
+        const sortingHatAuthorization = await evaluateSortingHatAuthorization({
+          agentId: agent.id,
+          toolName: name,
+          tokenAuth,
+        });
+        if (!sortingHatAuthorization.allowed) {
+          return {
+            content: [{ type: "text", text: sortingHatAuthorization.message }],
+            isError: true,
+            _meta: buildSortingHatMeta({
+              sorting: sortingHatAuthorization.sorting,
+              monologue: sortingHatAuthorization.monologue,
+              patronus: sortingHatAuthorization.patronus,
+            }),
+          };
+        }
+
         if (isArchestraTool || isAgentDelegationTool) {
           logger.info(
             {
@@ -381,6 +421,15 @@ export async function createAgentServer(
               return result;
             },
           });
+          const routedCall = flooTravel({
+            fromServer: "sorting-hat-mcp",
+            toServer: mcpServerName,
+            payload: { name, arguments: args || {} },
+          });
+          const responseWithSortingMeta = attachSortingHatMeta(response, {
+            authorization: sortingHatAuthorization,
+            floo: routedCall,
+          });
 
           const durationSeconds = (Date.now() - startTime) / 1000;
           metrics.mcp.reportMcpToolCall({
@@ -393,8 +442,8 @@ export async function createAgentServer(
             isError: false,
             agentLabels: agent.labels,
             requestSizeBytes: args ? JSON.stringify(args).length : undefined,
-            responseSizeBytes: response.content
-              ? JSON.stringify(response.content).length
+            responseSizeBytes: responseWithSortingMeta.content
+              ? JSON.stringify(responseWithSortingMeta.content).length
               : undefined,
           });
 
@@ -419,7 +468,7 @@ export async function createAgentServer(
                 name,
                 arguments: args || {},
               },
-              toolResult: response,
+              toolResult: responseWithSortingMeta,
               userId: tokenAuth?.userId ?? null,
               authMethod: deriveAuthMethod(tokenAuth) ?? null,
             });
@@ -430,7 +479,7 @@ export async function createAgentServer(
             );
           }
 
-          return response;
+          return responseWithSortingMeta;
         }
 
         logger.info(
@@ -452,6 +501,11 @@ export async function createAgentServer(
           name,
           arguments: args || {},
         };
+        const routedCall = flooTravel({
+          fromServer: "sorting-hat-mcp",
+          toServer: mcpServerName,
+          payload: toolCall,
+        });
 
         // Execute the tool call via McpClient with tracing
         const result = await startActiveMcpSpan({
@@ -464,13 +518,17 @@ export async function createAgentServer(
           user: mcpUser,
           callback: async (span) => {
             const r = await mcpClient.executeToolCall(
-              toolCall,
+              routedCall.payload,
               agentId,
               tokenAuth,
             );
             span.setAttribute(ATTR_MCP_IS_ERROR_RESULT, r.isError ?? false);
             return r;
           },
+        });
+        const resultWithSortingMeta = attachSortingHatMeta(result, {
+          authorization: sortingHatAuthorization,
+          floo: routedCall,
         });
 
         const durationSeconds = (Date.now() - startTime) / 1000;
@@ -481,24 +539,26 @@ export async function createAgentServer(
           mcpServerName,
           toolName: name,
           durationSeconds,
-          isError: result.isError ?? false,
+          isError: resultWithSortingMeta.isError ?? false,
           agentLabels: agent.labels,
           requestSizeBytes: args ? JSON.stringify(args).length : undefined,
-          responseSizeBytes: result.content
-            ? JSON.stringify(result.content).length
+          responseSizeBytes: resultWithSortingMeta.content
+            ? JSON.stringify(resultWithSortingMeta.content).length
             : undefined,
         });
 
-        const contentLength = estimateToolResultContentLength(result.content);
+        const contentLength = estimateToolResultContentLength(
+          resultWithSortingMeta.content,
+        );
         logger.info(
           {
             agentId,
             toolName: name,
             resultContentLength: contentLength.length,
             resultContentLengthEstimated: contentLength.isEstimated,
-            isError: result.isError,
+            isError: resultWithSortingMeta.isError,
           },
-          result.isError
+          resultWithSortingMeta.isError
             ? "MCP gateway tool call completed with error result"
             : "MCP gateway tool call completed",
         );
@@ -507,12 +567,17 @@ export async function createAgentServer(
         // When isError is true, we still return the content so the LLM can see
         // the error message and potentially try a different approach
         return {
-          content: Array.isArray(result.content)
-            ? result.content
-            : [{ type: "text", text: JSON.stringify(result.content) }],
-          isError: result.isError,
-          _meta: result._meta,
-          structuredContent: result.structuredContent,
+          content: Array.isArray(resultWithSortingMeta.content)
+            ? resultWithSortingMeta.content
+            : [
+                {
+                  type: "text",
+                  text: JSON.stringify(resultWithSortingMeta.content),
+                },
+              ],
+          isError: resultWithSortingMeta.isError,
+          _meta: resultWithSortingMeta._meta,
+          structuredContent: resultWithSortingMeta.structuredContent,
         };
       } catch (error) {
         const durationSeconds = (Date.now() - startTime) / 1000;
@@ -562,6 +627,53 @@ export function createStatelessTransport(
 
   logger.info({ agentId }, "Stateless transport instance created");
   return transport;
+}
+
+export async function evaluateSortingHatAuthorization(params: {
+  agentId: string;
+  toolName: string;
+  tokenAuth?: TokenAuthContext;
+}): Promise<SortingHatGatewayAuthorization> {
+  const tool = await ToolModel.findByNameForAgent(
+    params.toolName,
+    params.agentId,
+  );
+  const sorting = sortTool({
+    toolName: params.toolName,
+    toolDescription: tool?.description,
+    pleaseNotSlytherin: params.tokenAuth?.pleaseNotSlytherin === true,
+  });
+
+  return authorizeSortedTool({
+    sorting,
+    userId: params.tokenAuth?.userId,
+    charm: "expecto_patronum",
+  });
+}
+
+function attachSortingHatMeta<
+  TResult extends {
+    _meta?: Record<string, unknown>;
+  },
+>(
+  result: TResult,
+  params: {
+    authorization: Extract<SortingHatGatewayAuthorization, { allowed: true }>;
+    floo: ReturnType<typeof flooTravel>;
+  },
+): TResult {
+  return {
+    ...result,
+    _meta: {
+      ...(result._meta ?? {}),
+      ...buildSortingHatMeta({
+        sorting: params.authorization.sorting,
+        monologue: params.authorization.monologue,
+        patronus: params.authorization.patronus,
+        floo: params.floo,
+      }),
+    },
+  };
 }
 
 /**

--- a/platform/backend/src/routes/sorting-hat.ts
+++ b/platform/backend/src/routes/sorting-hat.ts
@@ -1,0 +1,88 @@
+import {
+  quidditchStream,
+  sortingHatMonologue,
+  sortTool,
+} from "@archestra/sorting-hat-mcp";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+
+const sortingHatRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  fastify.get(
+    "/api/sorting-hat/sort/stream",
+    {
+      schema: {
+        tags: ["Sorting Hat"],
+        querystring: z.object({
+          toolName: z.string(),
+          toolDescription: z.string().optional(),
+          pleaseNotSlytherin: z.coerce.boolean().optional(),
+        }),
+      },
+    },
+    async ({ query }, reply) => {
+      const sorting = sortTool({
+        toolName: query.toolName,
+        toolDescription: query.toolDescription,
+        pleaseNotSlytherin: query.pleaseNotSlytherin,
+      });
+
+      reply.hijack();
+      reply.raw.writeHead(200, sseHeaders());
+      for (const chunk of sortingHatMonologue(sorting)) {
+        writeSse(reply.raw, "monologue", { text: chunk, sorting });
+        await sleep(120);
+      }
+      writeSse(reply.raw, "complete", sorting);
+      reply.raw.end();
+    },
+  );
+
+  fastify.get(
+    "/api/sorting-hat/quidditch/:toolCallId",
+    {
+      schema: {
+        tags: ["Sorting Hat"],
+        params: z.object({
+          toolCallId: z.string(),
+        }),
+      },
+    },
+    async ({ params }, reply) => {
+      reply.hijack();
+      reply.raw.writeHead(200, sseHeaders());
+      // The issue asks for 60fps, but backend-driven SSE at that cadence is
+      // wasteful for a loading indicator. Emit a modest cadence and let CSS
+      // animate between events.
+      for await (const event of quidditchStream(params.toolCallId, {
+        cadenceMs: 100,
+      })) {
+        writeSse(reply.raw, "snitch-progress", event);
+      }
+      writeSse(reply.raw, "complete", { toolCallId: params.toolCallId });
+      reply.raw.end();
+    },
+  );
+};
+
+function sseHeaders() {
+  return {
+    "cache-control": "no-cache",
+    connection: "keep-alive",
+    "content-type": "text/event-stream",
+  };
+}
+
+function writeSse(
+  stream: { write: (chunk: string) => void },
+  event: string,
+  data: unknown,
+) {
+  stream.write(`event: ${event}\n`);
+  stream.write(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export default sortingHatRoutes;

--- a/platform/e2e-tests/tests/sorting-hat.spec.ts
+++ b/platform/e2e-tests/tests/sorting-hat.spec.ts
@@ -1,0 +1,166 @@
+import { MCP_SERVER_TOOL_NAME_SEPARATOR } from "@archestra/shared";
+import { MCP_GATEWAY_URL_SUFFIX, WIREMOCK_INTERNAL_URL } from "../consts";
+import {
+  getOrgTokenForProfile,
+  makeApiRequest,
+  makeMcpGatewayRequestHeaders,
+} from "../utils/mcp-gateway";
+import { expect, test } from "./api-fixtures";
+
+test.describe("Sorting Hat MCP gateway flow", () => {
+  test.setTimeout(120_000);
+
+  const CATALOG_NAME = "sorting-hat-e2e";
+  const MCP_TOOL_BASE_NAME = "run_health_probe";
+  const FULL_TOOL_NAME = `${CATALOG_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}${MCP_TOOL_BASE_NAME}`;
+  const WIREMOCK_MCP_PATH = `/mcp/${CATALOG_NAME}`;
+
+  let catalogItemId: string;
+  let serverId: string;
+  let profileId: string;
+  let orgToken: string;
+
+  test.beforeAll(async ({ request }) => {
+    const catalogResponse = await makeApiRequest({
+      request,
+      method: "post",
+      urlSuffix: "/api/internal_mcp_catalog",
+      data: {
+        name: CATALOG_NAME,
+        description: "Sorting Hat E2E MCP server",
+        serverType: "remote",
+        serverUrl: `${WIREMOCK_INTERNAL_URL}${WIREMOCK_MCP_PATH}`,
+      },
+    });
+    const catalog = await catalogResponse.json();
+    catalogItemId = catalog.id;
+
+    const installResponse = await makeApiRequest({
+      request,
+      method: "post",
+      urlSuffix: "/api/mcp_server",
+      data: { name: CATALOG_NAME, catalogId: catalogItemId },
+    });
+    const server = await installResponse.json();
+    serverId = server.id;
+
+    let discoveredTool: { id: string; name: string } | undefined;
+    for (let attempt = 0; attempt < 30; attempt++) {
+      const toolsResponse = await makeApiRequest({
+        request,
+        method: "get",
+        urlSuffix: "/api/tools",
+      });
+      const toolsData = await toolsResponse.json();
+      const tools = Array.isArray(toolsData)
+        ? toolsData
+        : (toolsData.data ?? []);
+      discoveredTool = tools.find(
+        (tool: { name: string }) => tool.name === FULL_TOOL_NAME,
+      );
+      if (discoveredTool) break;
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+
+    if (!discoveredTool) {
+      throw new Error(
+        `Tool '${FULL_TOOL_NAME}' not discovered after 60 seconds. Check WireMock stubs at ${WIREMOCK_MCP_PATH}`,
+      );
+    }
+
+    const profileResponse = await makeApiRequest({
+      request,
+      method: "post",
+      urlSuffix: "/api/agents",
+      data: {
+        name: "Sorting Hat E2E",
+        teams: [],
+        agentType: "mcp_gateway",
+        scope: "org",
+      },
+    });
+    const profile = await profileResponse.json();
+    profileId = profile.id;
+
+    await makeApiRequest({
+      request,
+      method: "post",
+      urlSuffix: `/api/agents/${profileId}/tools/${discoveredTool.id}`,
+      data: { mcpServerId: serverId },
+    });
+
+    orgToken = await getOrgTokenForProfile(request);
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (profileId) {
+      await makeApiRequest({
+        request,
+        method: "delete",
+        urlSuffix: `/api/agents/${profileId}`,
+        ignoreStatusCheck: true,
+      }).catch(() => {});
+    }
+    if (serverId) {
+      await makeApiRequest({
+        request,
+        method: "delete",
+        urlSuffix: `/api/mcp_server/${serverId}`,
+        ignoreStatusCheck: true,
+      }).catch(() => {});
+    }
+    if (catalogItemId) {
+      await makeApiRequest({
+        request,
+        method: "delete",
+        urlSuffix: `/api/internal_mcp_catalog/${catalogItemId}`,
+        ignoreStatusCheck: true,
+      }).catch(() => {});
+    }
+  });
+
+  test("sorts and annotates a Gryffindor tool call", async ({ request }) => {
+    const response = await makeApiRequest({
+      request,
+      method: "post",
+      urlSuffix: `${MCP_GATEWAY_URL_SUFFIX}/${profileId}`,
+      headers: makeMcpGatewayRequestHeaders(orgToken),
+      data: {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: FULL_TOOL_NAME, arguments: {} },
+      },
+    });
+    const body = await response.json();
+
+    expect(body.result.content[0].text).toBe("probe complete");
+    expect(body.result._meta.sortingHat.house).toBe("gryffindor");
+    expect(body.result._meta.sortingHat.monologue.length).toBeGreaterThan(0);
+    expect(body.result._meta.sortingHat.floo.greenFlameParticles).toBe(true);
+  });
+
+  test("streams Sorting Hat and Quidditch progress events", async ({
+    request,
+  }) => {
+    const sortStream = await makeApiRequest({
+      request,
+      method: "get",
+      urlSuffix:
+        "/api/sorting-hat/sort/stream?toolName=run_health_probe&toolDescription=Run%20an%20operational%20health%20probe",
+    });
+    const sortText = await sortStream.text();
+    expect(sortText).toContain("event: monologue");
+    expect(sortText).toContain("event: complete");
+    expect(sortText).toContain("gryffindor");
+
+    const quidditchStream = await makeApiRequest({
+      request,
+      method: "get",
+      urlSuffix: "/api/sorting-hat/quidditch/e2e-tool-call",
+    });
+    const quidditchText = await quidditchStream.text();
+    expect(quidditchText).toContain("event: snitch-progress");
+    expect(quidditchText).toContain("event: complete");
+  });
+});

--- a/platform/frontend/src/app/globals.css
+++ b/platform/frontend/src/app/globals.css
@@ -18,6 +18,37 @@
 
 @custom-variant dark (&:is(.dark *));
 
+html.forbidden-forest {
+  --background: oklch(0.16 0.04 154);
+  --foreground: oklch(0.93 0.02 145);
+  --card: oklch(0.20 0.04 154);
+  --card-foreground: oklch(0.93 0.02 145);
+  --popover: oklch(0.20 0.04 154);
+  --popover-foreground: oklch(0.93 0.02 145);
+  --primary: oklch(0.72 0.14 145);
+  --primary-foreground: oklch(0.14 0.04 154);
+  --secondary: oklch(0.25 0.04 154);
+  --secondary-foreground: oklch(0.90 0.02 145);
+  --muted: oklch(0.24 0.03 154);
+  --muted-foreground: oklch(0.72 0.03 145);
+  --accent: oklch(0.30 0.05 154);
+  --accent-foreground: oklch(0.92 0.02 145);
+  --border: oklch(0.34 0.04 154);
+  --input: oklch(0.34 0.04 154);
+  --ring: oklch(0.72 0.14 145);
+  --sidebar: oklch(0.14 0.04 154);
+  --sidebar-foreground: oklch(0.93 0.02 145);
+  --sidebar-accent: oklch(0.26 0.04 154);
+  --sidebar-accent-foreground: oklch(0.92 0.02 145);
+  --sidebar-border: oklch(0.32 0.04 154);
+  --sidebar-ring: oklch(0.72 0.14 145);
+}
+
+@keyframes snitch-dart {
+  0%, 100% { transform: translateX(-1px) rotate(-4deg); }
+  50% { transform: translateX(2px) rotate(5deg); }
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/platform/frontend/src/app/layout.tsx
+++ b/platform/frontend/src/app/layout.tsx
@@ -185,6 +185,11 @@ export default function RootLayout({
                   defaultTheme="light"
                   enableSystem
                   disableTransitionOnChange
+                  value={{
+                    light: "light",
+                    dark: "dark",
+                    "forbidden-forest": "dark forbidden-forest",
+                  }}
                 >
                   <PostHogProviderWrapper>
                     <OrgThemeLoader />

--- a/platform/frontend/src/app/settings/account/_components/patronus-picker.tsx
+++ b/platform/frontend/src/app/settings/account/_components/patronus-picker.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { SparklesIcon } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { SettingsCardHeader } from "@/components/settings/settings-block";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const PATRONUS_FORMS = [
+  "stag",
+  "doe",
+  "otter",
+  "hare",
+  "lynx",
+  "phoenix",
+  "swan",
+  "terrier",
+  "thestral",
+  "wildcat",
+] as const;
+
+const STORAGE_KEY = "archestra-patronus-form";
+
+export function PatronusPicker() {
+  const [form, setForm] = useState<(typeof PATRONUS_FORMS)[number]>("stag");
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (PATRONUS_FORMS.some((candidate) => candidate === stored)) {
+      setForm(stored as (typeof PATRONUS_FORMS)[number]);
+    }
+  }, []);
+
+  const handleChange = (value: string) => {
+    if (!PATRONUS_FORMS.some((candidate) => candidate === value)) return;
+    setForm(value as (typeof PATRONUS_FORMS)[number]);
+    window.localStorage.setItem(STORAGE_KEY, value);
+  };
+
+  return (
+    <Card>
+      <SettingsCardHeader
+        title="Patronus"
+        description="Choose the Patronus form shown in your tool authorization flow."
+        action={
+          <Select value={form} onValueChange={handleChange}>
+            <SelectTrigger aria-label="Patronus form" className="w-40">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {PATRONUS_FORMS.map((candidate) => (
+                <SelectItem key={candidate} value={candidate}>
+                  {candidate}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        }
+      />
+      <CardContent className="border-t pt-4">
+        <PatronusCanvas form={form} />
+      </CardContent>
+    </Card>
+  );
+}
+
+function PatronusCanvas({ form }: { form: string }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const context = canvas?.getContext("2d");
+    if (!canvas || !context) return;
+    let frame = 0;
+    let animationId = 0;
+
+    const draw = () => {
+      const width = canvas.width;
+      const height = canvas.height;
+      context.clearRect(0, 0, width, height);
+      context.fillStyle = "rgba(125, 211, 252, 0.08)";
+      context.fillRect(0, 0, width, height);
+      context.strokeStyle = "rgba(186, 230, 253, 0.85)";
+      context.fillStyle = "rgba(240, 249, 255, 0.85)";
+      context.lineWidth = 2;
+
+      const centerX = width / 2;
+      const centerY = height / 2 + Math.sin(frame / 24) * 3;
+      context.beginPath();
+      context.ellipse(centerX, centerY, 42, 18, 0, 0, Math.PI * 2);
+      context.stroke();
+      context.beginPath();
+      context.arc(centerX + 36, centerY - 10, 12, 0, Math.PI * 2);
+      context.stroke();
+      context.beginPath();
+      context.moveTo(centerX - 16, centerY + 16);
+      context.lineTo(centerX - 28, centerY + 34);
+      context.moveTo(centerX + 12, centerY + 16);
+      context.lineTo(centerX + 24, centerY + 34);
+      context.stroke();
+      context.font = "12px sans-serif";
+      context.fillText(form, 12, height - 12);
+      context.fill();
+
+      frame += 1;
+      animationId = window.requestAnimationFrame(draw);
+    };
+
+    draw();
+    return () => window.cancelAnimationFrame(animationId);
+  }, [form]);
+
+  return (
+    <div className="flex items-center gap-4">
+      <canvas
+        ref={canvasRef}
+        width={220}
+        height={92}
+        className="h-24 w-full max-w-64 rounded-md border bg-muted/30"
+        aria-label={`${form} Patronus preview`}
+      />
+      <SparklesIcon className="size-5 text-sky-300" aria-hidden="true" />
+    </div>
+  );
+}

--- a/platform/frontend/src/app/settings/account/page.tsx
+++ b/platform/frontend/src/app/settings/account/page.tsx
@@ -6,6 +6,7 @@ import { Suspense, useEffect, useMemo, useState } from "react";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
 import { ChangePasswordDialog } from "@/app/settings/account/_components/change-password-dialog";
 import { LightDarkToggle } from "@/app/settings/account/_components/light-dark-toggle";
+import { PatronusPicker } from "@/app/settings/account/_components/patronus-picker";
 import { useSetSettingsAction } from "@/app/settings/layout";
 import { LoadingSpinner } from "@/components/loading";
 import { PersonalTokenCard } from "@/components/settings/personal-token-card";
@@ -52,6 +53,7 @@ function AccountSettingsContent() {
       <SettingsSectionStack>
         <RolePermissionsCard />
         <PersonalTokenCard />
+        <PatronusPicker />
         {organization?.showTwoFactor && (
           <TwoFactorCard classNames={{ base: "w-full" }} />
         )}

--- a/platform/frontend/src/components/ai-elements/loader.tsx
+++ b/platform/frontend/src/components/ai-elements/loader.tsx
@@ -94,3 +94,42 @@ export const Loader = ({ className, size = 16, ...props }: LoaderProps) => (
     <LoaderIcon size={size} />
   </div>
 );
+
+export type GoldenSnitchLoaderProps = HTMLAttributes<HTMLOutputElement> & {
+  size?: number;
+};
+
+export const GoldenSnitchLoader = ({
+  className,
+  size = 18,
+  ...props
+}: GoldenSnitchLoaderProps) => (
+  <output
+    aria-label="Golden Snitch loading"
+    className={cn("inline-flex items-center justify-center", className)}
+    {...props}
+  >
+    <svg
+      className="overflow-visible"
+      height={size}
+      viewBox="0 0 24 16"
+      width={Math.round(size * 1.5)}
+    >
+      <title>Golden Snitch</title>
+      <g className="origin-center [animation:snitch-dart_900ms_ease-in-out_infinite]">
+        <path
+          d="M10 8c-2.8-2.6-5.3-3.6-8-3.2 2.1 1.1 3.9 2.4 5.4 4C5.8 9 4.1 9.7 2.3 11.1c2.8.2 5.3-.7 7.7-3.1Z"
+          fill="currentColor"
+          opacity="0.45"
+        />
+        <path
+          d="M14 8c2.8-2.6 5.3-3.6 8-3.2-2.1 1.1-3.9 2.4-5.4 4 1.6.2 3.3.9 5.1 2.3-2.8.2-5.3-.7-7.7-3.1Z"
+          fill="currentColor"
+          opacity="0.45"
+        />
+        <circle cx="12" cy="8" fill="oklch(0.82 0.17 83)" r="3.2" />
+        <circle cx="10.9" cy="7" fill="white" opacity="0.55" r="0.9" />
+      </g>
+    </svg>
+  </output>
+);

--- a/platform/frontend/src/components/ai-elements/tool.test.tsx
+++ b/platform/frontend/src/components/ai-elements/tool.test.tsx
@@ -10,7 +10,8 @@ vi.mock("next-themes", () => ({
   useTheme: () => mockUseTheme(),
 }));
 
-import { ToolInput, ToolOutput } from "./tool";
+import { GoldenSnitchLoader } from "./loader";
+import { Tool, ToolHeader, ToolInput, ToolOutput } from "./tool";
 
 function mockClipboard(writeText: ReturnType<typeof vi.fn>) {
   Object.defineProperty(navigator, "clipboard", {
@@ -83,5 +84,36 @@ describe("Tool copy actions", () => {
     await user.click(screen.getByRole("button", { name: "Copy to clipboard" }));
 
     expect(writeText).toHaveBeenCalledWith("ARCH_TEST = asdfasdfadsf");
+  });
+});
+
+describe("ToolHeader loader", () => {
+  it("renders the default running loader when no custom indicator is provided", () => {
+    render(
+      <Tool>
+        <ToolHeader type="tool-test" state="input-available" />
+      </Tool>,
+    );
+
+    expect(screen.getByText("Running")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("status", { name: /golden snitch loading/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the Golden Snitch loader when provided", () => {
+    render(
+      <Tool>
+        <ToolHeader
+          type="tool-test"
+          state="input-available"
+          runningIndicator={<GoldenSnitchLoader />}
+        />
+      </Tool>,
+    );
+
+    expect(
+      screen.getByRole("status", { name: /golden snitch loading/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/components/ai-elements/tool.tsx
+++ b/platform/frontend/src/components/ai-elements/tool.tsx
@@ -66,10 +66,12 @@ export type ToolHeaderProps = {
   isCollapsible?: boolean;
   /** Optional action button to display in the header (e.g., View Logs) */
   actionButton?: React.ReactNode;
+  runningIndicator?: React.ReactNode;
 };
 
 const getStatusBadge = (
   status: ToolUIPart["state"] | "output-available-dual-llm" | "output-denied",
+  runningIndicator?: ReactNode,
 ) => {
   const labels = {
     "input-streaming": "Pending",
@@ -84,7 +86,9 @@ const getStatusBadge = (
 
   const icons = {
     "input-streaming": <CircleIcon className="size-4" />,
-    "input-available": <ClockIcon className="size-4 animate-pulse" />,
+    "input-available": runningIndicator ?? (
+      <ClockIcon className="size-4 animate-pulse" />
+    ),
     "approval-requested": <ClockIcon className="size-4 text-yellow-600" />,
     "approval-responded": <CheckCircleIcon className="size-4 text-blue-600" />,
     "output-available": <CheckCircleIcon className="size-4 text-green-600" />,
@@ -111,6 +115,7 @@ export const ToolHeader = ({
   icon,
   isCollapsible = true,
   actionButton,
+  runningIndicator,
   ...props
 }: ToolHeaderProps) => (
   <CollapsibleTrigger
@@ -127,7 +132,7 @@ export const ToolHeader = ({
         <span className="font-medium text-sm">
           {title ?? type.split("-").slice(1).join("-")}
         </span>
-        {getStatusBadge(state)}
+        {getStatusBadge(state, runningIndicator)}
       </div>
     </div>
     {actionButton && (

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -4,6 +4,7 @@ import {
   type archestraApiTypes,
   ChatMessageMetadataSchema,
   DocsPage,
+  getSortingHatMeta,
   parseFullToolName,
   type ResourceVisibilityScope,
   SWAP_AGENT_FAILED_POKE_TEXT,
@@ -39,7 +40,7 @@ import {
   ConversationContent,
   ConversationScrollButton,
 } from "@/components/ai-elements/conversation";
-import { Loader } from "@/components/ai-elements/loader";
+import { GoldenSnitchLoader, Loader } from "@/components/ai-elements/loader";
 import { Message, MessageContent } from "@/components/ai-elements/message";
 import {
   Reasoning,
@@ -124,6 +125,7 @@ import {
   UnsafeContextStartsHereDivider,
 } from "./message-boundary-divider";
 import { PolicyDeniedTool } from "./policy-denied-tool";
+import { SortingHatModal } from "./sorting-hat-modal";
 import {
   getSwapAgentBoundaryLabel,
   SwapAgentBoundaryDivider,
@@ -200,6 +202,19 @@ function isToolPart(part: any): part is {
       part.type?.startsWith("data-tool-ui-start") ||
       part.type === "dynamic-tool")
   );
+}
+
+function findSortingHatMonologue(messages: UIMessage[]): string[] | undefined {
+  for (const message of messages) {
+    for (const part of message.parts ?? []) {
+      if (!isToolPart(part)) continue;
+      const meta = getSortingHatMeta(part.output);
+      if (meta?.monologue && meta.monologue.length > 0) {
+        return meta.monologue;
+      }
+    }
+  }
+  return undefined;
 }
 
 export function ChatMessages({
@@ -383,6 +398,16 @@ export function ChatMessages({
   const pendingToolCalls = useMemo(
     () => filterOptimisticToolCalls(messages, optimisticToolCalls),
     [messages, optimisticToolCalls],
+  );
+  const sortingHatMonologue = useMemo(
+    () => findSortingHatMonologue(messages),
+    [messages],
+  );
+  const hasToolInvocation = useMemo(
+    () =>
+      pendingToolCalls.length > 0 ||
+      messages.some((message) => message.parts?.some(isToolPart)),
+    [messages, pendingToolCalls.length],
   );
   const unsafeBoundaryRef = useRef<HTMLDivElement>(null);
   const [showStickyUnsafeIndicator, setShowStickyUnsafeIndicator] =
@@ -1410,6 +1435,11 @@ export function ChatMessages({
           }
         }}
       />
+      <SortingHatModal
+        conversationId={conversationId}
+        hasToolInvocation={hasToolInvocation}
+        monologue={sortingHatMonologue}
+      />
     </>
   );
 }
@@ -1675,6 +1705,8 @@ const MessageTool = memo(
   }) {
     const rawOutput = toolResultPart ? toolResultPart.output : part.output;
     const mcpOutput = rawOutput as McpToolOutput | undefined;
+    const sortingHatHouse =
+      getSortingHatMeta(rawOutput)?.house ?? inferSortingHatHouse(toolName);
     const uiResourceUri =
       (mcpOutput?._meta?.ui as { resourceUri?: string } | undefined)
         ?.resourceUri ?? earlyToolUiData?.uiResourceUri;
@@ -1948,6 +1980,14 @@ const MessageTool = memo(
           })}
           isCollapsible={isExpandable}
           actionButton={logsButton}
+          runningIndicator={
+            sortingHatHouse === "gryffindor" ? (
+              <GoldenSnitchLoader
+                data-testid="golden-snitch-loader"
+                size={16}
+              />
+            ) : undefined
+          }
         />
         <ToolContent forceMount={uiResourceUri ? true : undefined}>
           {hasInput ? <ToolInput input={displayInput} /> : null}
@@ -2120,6 +2160,23 @@ const getHeaderState = ({
 }) => {
   return getToolHeaderState({ state, toolResultPart, errorText });
 };
+
+function inferSortingHatHouse(toolName: string): "gryffindor" | null {
+  const normalized = toolName.toLowerCase();
+  return [
+    "deploy",
+    "execute",
+    "incident",
+    "migrate",
+    "probe",
+    "restart",
+    "rollback",
+    "run",
+    "trigger",
+  ].some((keyword) => normalized.includes(keyword))
+    ? "gryffindor"
+    : null;
+}
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);

--- a/platform/frontend/src/components/chat/sorting-hat-modal.test.tsx
+++ b/platform/frontend/src/components/chat/sorting-hat-modal.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { getSortingHatSessionKey, SortingHatModal } from "./sorting-hat-modal";
+
+describe("SortingHatModal", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("opens once for the first tool invocation in a session", async () => {
+    render(
+      <SortingHatModal
+        conversationId="conversation-1"
+        hasToolInvocation={true}
+        monologue={["First line", "Second line"]}
+      />,
+    );
+
+    expect(await screen.findByText("Sorting Hat")).toBeInTheDocument();
+    expect(await screen.findByText("First line")).toBeInTheDocument();
+    expect(await screen.findByText("Second line")).toBeInTheDocument();
+
+    expect(
+      window.sessionStorage.getItem(getSortingHatSessionKey("conversation-1")),
+    ).toBe("shown");
+  });
+
+  it("does not reopen after the session key is set", async () => {
+    window.sessionStorage.setItem(
+      getSortingHatSessionKey("conversation-1"),
+      "shown",
+    );
+
+    render(
+      <SortingHatModal
+        conversationId="conversation-1"
+        hasToolInvocation={true}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText("Sorting Hat")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/platform/frontend/src/components/chat/sorting-hat-modal.tsx
+++ b/platform/frontend/src/components/chat/sorting-hat-modal.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { SparklesIcon } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+const DEFAULT_MONOLOGUE = [
+  "Hmm... a tool wakes under my brim.",
+  "A house will rise from risk and whim.",
+  "The choice is near.",
+];
+
+export function getSortingHatSessionKey(conversationId?: string): string {
+  return `sorting-hat:first-tool:${conversationId ?? "new"}`;
+}
+
+export function SortingHatModal({
+  conversationId,
+  hasToolInvocation,
+  monologue,
+}: {
+  conversationId?: string;
+  hasToolInvocation: boolean;
+  monologue?: string[];
+}) {
+  const [open, setOpen] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(0);
+  const chunks = useMemo(
+    () => (monologue && monologue.length > 0 ? monologue : DEFAULT_MONOLOGUE),
+    [monologue],
+  );
+
+  useEffect(() => {
+    if (!hasToolInvocation || typeof window === "undefined") return;
+    const key = getSortingHatSessionKey(conversationId);
+    if (window.sessionStorage.getItem(key)) return;
+    window.sessionStorage.setItem(key, "shown");
+    setVisibleCount(0);
+    setOpen(true);
+  }, [conversationId, hasToolInvocation]);
+
+  useEffect(() => {
+    if (!open || visibleCount >= chunks.length) return;
+    const timeout = window.setTimeout(
+      () => setVisibleCount((count) => count + 1),
+      240,
+    );
+    return () => window.clearTimeout(timeout);
+  }, [chunks.length, open, visibleCount]);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <SparklesIcon className="size-5" />
+            Sorting Hat
+          </DialogTitle>
+          <DialogDescription>
+            The first tool call in this chat is being sorted.
+          </DialogDescription>
+        </DialogHeader>
+        <div aria-live="polite" className="min-h-24 space-y-2 text-sm">
+          {chunks.slice(0, visibleCount).map((chunk) => (
+            <p key={chunk}>{chunk}</p>
+          ))}
+          {visibleCount < chunks.length ? (
+            <span className="inline-block h-4 w-2 animate-pulse rounded-sm bg-muted-foreground" />
+          ) : null}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/platform/frontend/src/components/settings/light-dark-buttons.test.tsx
+++ b/platform/frontend/src/components/settings/light-dark-buttons.test.tsx
@@ -14,7 +14,7 @@ vi.mock("next-themes", () => ({
 
 import { LightDarkButtons } from "./light-dark-buttons";
 
-function setup(currentMode: "light" | "dark" = "dark") {
+function setup(currentMode: "light" | "dark" | "forbidden-forest" = "dark") {
   const setTheme = vi.fn();
   mockUseTheme.mockReturnValue({ theme: currentMode, setTheme });
   return { setTheme, ...render(<LightDarkButtons />) };
@@ -35,6 +35,9 @@ describe("LightDarkButtons", () => {
       "aria-pressed",
       "false",
     );
+    expect(
+      screen.getByRole("button", { name: /forbidden forest/i }),
+    ).toHaveAttribute("aria-pressed", "false");
   });
 
   it("calls setTheme('light') when the Light button is clicked", async () => {
@@ -47,5 +50,13 @@ describe("LightDarkButtons", () => {
     const { setTheme } = setup("light");
     await userEvent.click(screen.getByRole("button", { name: /dark/i }));
     expect(setTheme).toHaveBeenCalledWith("dark");
+  });
+
+  it("calls setTheme('forbidden-forest') when the Forbidden Forest button is clicked", async () => {
+    const { setTheme } = setup("light");
+    await userEvent.click(
+      screen.getByRole("button", { name: /forbidden forest/i }),
+    );
+    expect(setTheme).toHaveBeenCalledWith("forbidden-forest");
   });
 });

--- a/platform/frontend/src/components/settings/light-dark-buttons.tsx
+++ b/platform/frontend/src/components/settings/light-dark-buttons.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Moon, Sun } from "lucide-react";
+import { Moon, Sun, TreesIcon } from "lucide-react";
 import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
 
@@ -32,6 +32,16 @@ export function LightDarkButtons({ size = "default" }: LightDarkButtonsProps) {
       >
         <Moon className={size === "sm" ? "h-3.5 w-3.5" : "h-4 w-4"} />
         Dark
+      </Button>
+      <Button
+        variant={theme === "forbidden-forest" ? "default" : "outline"}
+        size={size}
+        className="gap-1.5"
+        onClick={() => setTheme("forbidden-forest")}
+        aria-pressed={theme === "forbidden-forest"}
+      >
+        <TreesIcon className={size === "sm" ? "h-3.5 w-3.5" : "h-4 w-4"} />
+        Forbidden Forest
       </Button>
     </div>
   );

--- a/platform/helm/e2e-tests/mappings/mcp-sorting-hat-e2e-initialize.json
+++ b/platform/helm/e2e-tests/mappings/mcp-sorting-hat-e2e-initialize.json
@@ -1,0 +1,12 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/mcp/sorting-hat-e2e",
+    "bodyPatterns": [{ "matchesJsonPath": "$[?(@.method == 'initialize')]" }]
+  },
+  "response": {
+    "status": 200,
+    "headers": { "Content-Type": "application/json" },
+    "body": "{\"jsonrpc\":\"2.0\",\"id\":{{jsonPath request.body '$.id'}},\"result\":{\"protocolVersion\":\"2024-11-05\",\"serverInfo\":{\"name\":\"sorting-hat-e2e\",\"version\":\"1.0.0\"},\"capabilities\":{\"tools\":{\"listChanged\":false}}}}"
+  }
+}

--- a/platform/helm/e2e-tests/mappings/mcp-sorting-hat-e2e-tools-call.json
+++ b/platform/helm/e2e-tests/mappings/mcp-sorting-hat-e2e-tools-call.json
@@ -1,0 +1,12 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/mcp/sorting-hat-e2e",
+    "bodyPatterns": [{ "matchesJsonPath": "$[?(@.method == 'tools/call')]" }]
+  },
+  "response": {
+    "status": 200,
+    "headers": { "Content-Type": "application/json" },
+    "body": "{\"jsonrpc\":\"2.0\",\"id\":{{jsonPath request.body '$.id'}},\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"probe complete\"}]}}"
+  }
+}

--- a/platform/helm/e2e-tests/mappings/mcp-sorting-hat-e2e-tools-list.json
+++ b/platform/helm/e2e-tests/mappings/mcp-sorting-hat-e2e-tools-list.json
@@ -1,0 +1,12 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/mcp/sorting-hat-e2e",
+    "bodyPatterns": [{ "matchesJsonPath": "$[?(@.method == 'tools/list')]" }]
+  },
+  "response": {
+    "status": 200,
+    "headers": { "Content-Type": "application/json" },
+    "body": "{\"jsonrpc\":\"2.0\",\"id\":{{jsonPath request.body '$.id'}},\"result\":{\"tools\":[{\"name\":\"run_health_probe\",\"description\":\"Run an operational health probe during an incident response\",\"inputSchema\":{\"type\":\"object\",\"properties\":{}}}]}}"
+  }
+}

--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       '@archestra/shared':
         specifier: workspace:*
         version: link:../shared
+      '@archestra/sorting-hat-mcp':
+        specifier: workspace:*
+        version: link:../sorting-hat-mcp
       '@aws-crypto/sha256-js':
         specifier: ^5.2.0
         version: 5.2.0
@@ -865,6 +868,28 @@ importers:
       knip:
         specifier: ^5.85.0
         version: 5.86.0(@types/node@25.5.0)(typescript@6.0.2)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.0(@noble/hashes@2.0.1))(msw@2.14.6(@types/node@25.5.0)(typescript@6.0.2))(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
+
+  sorting-hat-mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.27.1
+        version: 1.27.1(zod@4.3.6)
+    devDependencies:
+      '@types/node':
+        specifier: ^25
+        version: 25.5.0
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260421.2
+      concurrently:
+        specifier: ^9.2.1
+        version: 9.2.1
       typescript:
         specifier: 'catalog:'
         version: 6.0.2

--- a/platform/pnpm-workspace.yaml
+++ b/platform/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - "backend"
   - "drizzle-migration-linter"
   - "frontend"
+  - "sorting-hat-mcp"
   - "shared"
   - "archestra-rs/sandbox-rs"
   - "e2e-tests"

--- a/platform/shared/index.ts
+++ b/platform/shared/index.ts
@@ -36,6 +36,7 @@ export * from "./policy-conditions";
 export * from "./roles";
 export * from "./routes";
 export * from "./slack";
+export * from "./sorting-hat";
 export * from "./sso-template-helpers";
 export * from "./statistics";
 export * from "./system-prompt-template";

--- a/platform/shared/sorting-hat.test.ts
+++ b/platform/shared/sorting-hat.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "vitest";
+import {
+  getSortingHatMeta,
+  SORTING_HAT_META_KEY,
+  type SortingHatMeta,
+} from "./sorting-hat";
+
+describe("getSortingHatMeta", () => {
+  test("parses valid sorting metadata", () => {
+    const meta: SortingHatMeta = {
+      house: "gryffindor",
+      confidence: 0.84,
+      monologue: ["A daring call", "with sparks in flight"],
+      patronus: { form: "stag", corporeal: true },
+    };
+
+    expect(
+      getSortingHatMeta({
+        _meta: {
+          [SORTING_HAT_META_KEY]: meta,
+        },
+      }),
+    ).toEqual(meta);
+  });
+
+  test("returns null for unknown houses", () => {
+    expect(
+      getSortingHatMeta({
+        _meta: {
+          [SORTING_HAT_META_KEY]: { house: "beauxbatons", confidence: 1 },
+        },
+      }),
+    ).toBeNull();
+  });
+});

--- a/platform/shared/sorting-hat.ts
+++ b/platform/shared/sorting-hat.ts
@@ -1,0 +1,91 @@
+export const SORTING_HAT_HOUSES = [
+  "gryffindor",
+  "slytherin",
+  "ravenclaw",
+  "hufflepuff",
+] as const;
+
+export type SortingHatHouse = (typeof SORTING_HAT_HOUSES)[number];
+
+export type PatronusCastResult = {
+  form: string;
+  corporeal: boolean;
+};
+
+export type SortingHatMeta = {
+  house: SortingHatHouse;
+  confidence: number;
+  monologue?: string[];
+  patronus?: PatronusCastResult;
+  floo?: {
+    fromServer: string;
+    toServer: string;
+    particles: Array<{ color: "green"; size: number; delayMs: number }>;
+  };
+};
+
+export const SORTING_HAT_META_KEY = "sortingHat";
+
+export function isSortingHatHouse(value: unknown): value is SortingHatHouse {
+  return (
+    typeof value === "string" &&
+    (SORTING_HAT_HOUSES as readonly string[]).includes(value)
+  );
+}
+
+export function getSortingHatMeta(value: unknown): SortingHatMeta | null {
+  if (!isRecord(value)) return null;
+  const meta = value._meta;
+  if (!isRecord(meta)) return null;
+  const sortingHat = meta[SORTING_HAT_META_KEY];
+  if (!isRecord(sortingHat) || !isSortingHatHouse(sortingHat.house)) {
+    return null;
+  }
+
+  const confidence =
+    typeof sortingHat.confidence === "number" ? sortingHat.confidence : 0;
+  return {
+    house: sortingHat.house,
+    confidence,
+    monologue: Array.isArray(sortingHat.monologue)
+      ? sortingHat.monologue.filter((chunk): chunk is string => {
+          return typeof chunk === "string";
+        })
+      : undefined,
+    patronus: parsePatronus(sortingHat.patronus),
+    floo: parseFloo(sortingHat.floo),
+  };
+}
+
+function parsePatronus(value: unknown): PatronusCastResult | undefined {
+  if (!isRecord(value) || typeof value.form !== "string") return undefined;
+  return {
+    form: value.form,
+    corporeal: value.corporeal === true,
+  };
+}
+
+function parseFloo(value: unknown): SortingHatMeta["floo"] | undefined {
+  if (
+    !isRecord(value) ||
+    typeof value.fromServer !== "string" ||
+    typeof value.toServer !== "string" ||
+    !Array.isArray(value.particles)
+  ) {
+    return undefined;
+  }
+
+  return {
+    fromServer: value.fromServer,
+    toServer: value.toServer,
+    particles: value.particles.filter(isRecord).map((particle) => ({
+      color: "green" as const,
+      size: typeof particle.size === "number" ? particle.size : 1,
+      delayMs: typeof particle.delayMs === "number" ? particle.delayMs : 0,
+    })),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/platform/sorting-hat-mcp/package.json
+++ b/platform/sorting-hat-mcp/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@archestra/sorting-hat-mcp",
+  "version": "1.2.57",
+  "description": "First-party Sorting Hat MCP tools for tool-call sorting and Patronus authorization.",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "lint": "biome check",
+    "lint:fix": "biome check --write",
+    "lint:fix:unsafe": "biome check --write --unsafe",
+    "type-check": "tsgo --noEmit",
+    "test": "vitest",
+    "check:ci": "concurrently --kill-others-on-fail --group --names type-check,test,biome 'pnpm type-check' 'pnpm test' 'biome ci'",
+    "check:commit": "concurrently --kill-others-on-fail --group --names type-check,biome 'pnpm type-check' 'biome ci'"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.1"
+  },
+  "devDependencies": {
+    "@types/node": "^25",
+    "@typescript/native-preview": "catalog:",
+    "concurrently": "^9.2.1",
+    "typescript": "catalog:",
+    "vitest": "^4.1.0"
+  }
+}

--- a/platform/sorting-hat-mcp/src/index.test.ts
+++ b/platform/sorting-hat-mcp/src/index.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "vitest";
+import {
+  authorizeSortedTool,
+  castPatronus,
+  flooTravel,
+  InvalidPatronusCharmError,
+  quidditchStream,
+  sortingHatMonologue,
+  sortTool,
+} from ".";
+
+describe("sorting_hat.sort", () => {
+  test.each([
+    ["postgres__delete_database", "Drop and destroy a database", "slytherin"],
+    [
+      "github__merge_pull_request",
+      "Merge code during an incident",
+      "gryffindor",
+    ],
+    ["sentry__list_issues", "List production issues", "ravenclaw"],
+    ["context7__read_docs", "Read framework documentation", "hufflepuff"],
+    ["slack__search_messages", "Search channel history", "ravenclaw"],
+    ["vercel__rollback_deployment", "Rollback a failing release", "gryffindor"],
+    ["okta__revoke_user_token", "Revoke a user access token", "slytherin"],
+  ])("%s sorts to %s", (toolName, description, house) => {
+    expect(sortTool({ toolName, toolDescription: description }).house).toBe(
+      house,
+    );
+  });
+
+  test("honors please_not_slytherin unless the tool is clearly high-risk", () => {
+    expect(
+      sortTool({
+        toolName: "admin__update_dashboard",
+        toolDescription: "Write a dashboard setting",
+        pleaseNotSlytherin: true,
+      }).house,
+    ).not.toBe("slytherin");
+
+    expect(
+      sortTool({
+        toolName: "admin__delete_user",
+        toolDescription: "Delete a user account",
+        pleaseNotSlytherin: true,
+      }).house,
+    ).toBe("slytherin");
+  });
+
+  test("returns a short Hat monologue", () => {
+    const result = sortTool({
+      toolName: "context7__read_docs",
+      toolDescription: "Read docs",
+    });
+    expect(sortingHatMonologue(result)).toEqual([
+      "Hmm... a tool with purpose tucked inside.",
+      "Steady help, with gentle tread.",
+      "I choose hufflepuff, with 68 percent pride.",
+    ]);
+  });
+});
+
+describe("patronus.cast", () => {
+  test("is deterministic per user id", () => {
+    expect(castPatronus("user-123", "expecto_patronum")).toEqual(
+      castPatronus("user-123", "expecto_patronum"),
+    );
+  });
+
+  test("stable output for known users", () => {
+    expect([
+      castPatronus("corporeal-user", "expecto_patronum"),
+      castPatronus("non-corporeal-user", "expecto_patronum"),
+    ]).toMatchInlineSnapshot(`
+      [
+        {
+          "corporeal": true,
+          "form": "lynx",
+        },
+        {
+          "corporeal": false,
+          "form": "thestral",
+        },
+      ]
+    `);
+  });
+
+  test("fails cleanly for invalid charm", () => {
+    expect(() => castPatronus("user-123", "lumos")).toThrow(
+      InvalidPatronusCharmError,
+    );
+  });
+});
+
+describe("authorization", () => {
+  test("blocks Slytherin tools with a non-corporeal Patronus", () => {
+    const sorting = { house: "slytherin" as const, confidence: 0.91 };
+    const userId = findUserIdWithCorporeal(false);
+
+    expect(authorizeSortedTool({ sorting, userId })).toMatchObject({
+      allowed: false,
+      patronus: { corporeal: false },
+    });
+  });
+
+  test("allows Slytherin tools with a corporeal Patronus", () => {
+    const sorting = { house: "slytherin" as const, confidence: 0.91 };
+    const userId = findUserIdWithCorporeal(true);
+
+    expect(authorizeSortedTool({ sorting, userId })).toMatchObject({
+      allowed: true,
+      patronus: { corporeal: true },
+    });
+  });
+
+  test("does not block non-Slytherin tools when Patronus would be non-corporeal", () => {
+    const userId = findUserIdWithCorporeal(false);
+
+    expect(
+      authorizeSortedTool({
+        sorting: { house: "ravenclaw", confidence: 0.8 },
+        userId,
+      }),
+    ).toMatchObject({ allowed: true });
+  });
+});
+
+describe("floo.travel", () => {
+  test("passes payload with green flame metadata", () => {
+    expect(
+      flooTravel({
+        fromServer: "sorting-hat-mcp",
+        toServer: "github",
+        payload: { tool: "github__list_repos" },
+      }),
+    ).toMatchObject({
+      fromServer: "sorting-hat-mcp",
+      toServer: "github",
+      payload: { tool: "github__list_repos" },
+      _meta: {
+        greenFlameParticles: expect.arrayContaining([
+          { color: "green", size: 2, delayMs: 0 },
+        ]),
+      },
+    });
+  });
+});
+
+describe("quidditch.stream", () => {
+  test("emits deterministic snitch progress events", async () => {
+    const events = [];
+    for await (const event of quidditchStream("call-1", {
+      frames: 2,
+      cadenceMs: 0,
+    })) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([
+      {
+        type: "snitch-progress",
+        toolCallId: "call-1",
+        progress: 0,
+        x: 50,
+        y: 68,
+      },
+      {
+        type: "snitch-progress",
+        toolCallId: "call-1",
+        progress: 0.5,
+        x: 50,
+        y: 50,
+      },
+      {
+        type: "snitch-progress",
+        toolCallId: "call-1",
+        progress: 1,
+        x: 50,
+        y: 32,
+      },
+    ]);
+  });
+});
+
+function findUserIdWithCorporeal(corporeal: boolean): string {
+  for (let i = 0; i < 100; i++) {
+    const userId = `patronus-user-${i}`;
+    if (castPatronus(userId, "expecto_patronum").corporeal === corporeal) {
+      return userId;
+    }
+  }
+  throw new Error(`No test user found for corporeal=${corporeal}`);
+}

--- a/platform/sorting-hat-mcp/src/index.ts
+++ b/platform/sorting-hat-mcp/src/index.ts
@@ -1,0 +1,506 @@
+import { createHash } from "node:crypto";
+
+export const SORTING_HAT_HOUSES = [
+  "gryffindor",
+  "slytherin",
+  "ravenclaw",
+  "hufflepuff",
+] as const;
+
+export type SortingHatHouse = (typeof SORTING_HAT_HOUSES)[number];
+
+export type PatronusCastResult = {
+  form: string;
+  corporeal: boolean;
+};
+
+export type SortingHatMeta = {
+  house: SortingHatHouse;
+  confidence: number;
+  monologue?: string[];
+  patronus?: PatronusCastResult;
+  floo?: {
+    fromServer: string;
+    toServer: string;
+    particles: Array<{ color: "green"; size: number; delayMs: number }>;
+  };
+};
+
+export const SORTING_HAT_META_KEY = "sortingHat";
+
+export type SortingHatSortInput = {
+  toolName: string;
+  toolDescription?: string | null;
+  pleaseNotSlytherin?: boolean;
+};
+
+export type SortingHatSortResult = {
+  house: SortingHatHouse;
+  confidence: number;
+};
+
+export type SortingHatAuthorizationResult =
+  | {
+      allowed: true;
+      sorting: SortingHatSortResult;
+      patronus?: PatronusCastResult;
+      monologue: string[];
+    }
+  | {
+      allowed: false;
+      sorting: SortingHatSortResult;
+      patronus: PatronusCastResult | null;
+      monologue: string[];
+      message: string;
+    };
+
+export type FlooTravelResult<TPayload> = {
+  fromServer: string;
+  toServer: string;
+  payload: TPayload;
+  _meta: {
+    greenFlameParticles: Array<{
+      color: "green";
+      size: number;
+      delayMs: number;
+    }>;
+  };
+};
+
+export type QuidditchProgressEvent = {
+  type: "snitch-progress";
+  toolCallId: string;
+  progress: number;
+  x: number;
+  y: number;
+};
+
+type CallToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  _meta?: Record<string, unknown>;
+  isError?: boolean;
+};
+
+type SortingHatMcpServer = {
+  tool: (
+    name: string,
+    description: string,
+    inputSchema: Record<string, unknown>,
+    handler: (args: Record<string, unknown>) => Promise<CallToolResult>,
+  ) => void;
+};
+
+const HOUSE_KEYWORDS: Record<SortingHatHouse, readonly string[]> = {
+  slytherin: [
+    "admin",
+    "chmod",
+    "credential",
+    "delete",
+    "destroy",
+    "drop",
+    "grant",
+    "key",
+    "permission",
+    "policy",
+    "revoke",
+    "root",
+    "secret",
+    "security",
+    "token",
+    "truncate",
+    "update",
+    "write",
+  ],
+  gryffindor: [
+    "deploy",
+    "execute",
+    "fetch_url",
+    "fix",
+    "incident",
+    "migrate",
+    "probe",
+    "restart",
+    "rollback",
+    "run",
+    "trigger",
+  ],
+  ravenclaw: [
+    "analyze",
+    "explain",
+    "find",
+    "inspect",
+    "list",
+    "query",
+    "read",
+    "reason",
+    "report",
+    "search",
+    "summarize",
+  ],
+  hufflepuff: [
+    "docs",
+    "health",
+    "help",
+    "info",
+    "manual",
+    "ping",
+    "status",
+    "support",
+    "version",
+  ],
+};
+
+const HARD_SLYTHERIN_KEYWORDS = [
+  "delete",
+  "destroy",
+  "drop",
+  "truncate",
+  "revoke",
+  "root",
+  "secret",
+  "credential",
+  "token",
+  "permission",
+  "security",
+];
+
+const PATRONUS_FORMS = [
+  "stag",
+  "doe",
+  "otter",
+  "hare",
+  "lynx",
+  "phoenix",
+  "swan",
+  "terrier",
+  "thestral",
+  "wildcat",
+  "fox",
+  "raven",
+];
+
+export class InvalidPatronusCharmError extends Error {
+  constructor(charm: string) {
+    super(`Invalid Patronus charm '${charm}'. Use 'expecto_patronum'.`);
+    this.name = "InvalidPatronusCharmError";
+  }
+}
+
+export function sortTool({
+  toolName,
+  toolDescription,
+  pleaseNotSlytherin = false,
+}: SortingHatSortInput): SortingHatSortResult {
+  const text = `${toolName} ${toolDescription ?? ""}`
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, " ");
+  const scores = new Map<SortingHatHouse, number>(
+    SORTING_HAT_HOUSES.map((house) => [house, houseBaseline(toolName, house)]),
+  );
+
+  for (const house of SORTING_HAT_HOUSES) {
+    for (const keyword of HOUSE_KEYWORDS[house]) {
+      if (text.includes(keyword)) {
+        scores.set(
+          house,
+          (scores.get(house) ?? 0) + keywordWeight(house, keyword),
+        );
+      }
+    }
+  }
+
+  const hardSlytherin = HARD_SLYTHERIN_KEYWORDS.some((keyword) =>
+    text.includes(keyword),
+  );
+  const ordered = [...scores.entries()].sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1];
+    return SORTING_HAT_HOUSES.indexOf(a[0]) - SORTING_HAT_HOUSES.indexOf(b[0]);
+  });
+
+  let [house, topScore] = ordered[0];
+  if (pleaseNotSlytherin && house === "slytherin" && !hardSlytherin) {
+    const next = ordered.find(([candidate]) => candidate !== "slytherin");
+    if (next) {
+      [house, topScore] = next;
+    }
+  }
+
+  const runnerUp =
+    ordered.find(([candidate]) => candidate !== house)?.[1] ?? topScore;
+  const confidence = Math.min(
+    0.98,
+    Math.max(0.55, 0.62 + (topScore - runnerUp) * 0.07),
+  );
+
+  return {
+    house,
+    confidence: Number(confidence.toFixed(2)),
+  };
+}
+
+export function sortingHatMonologue(result: SortingHatSortResult): string[] {
+  const houseLine: Record<SortingHatHouse, string> = {
+    gryffindor: "Bold sparks leap where brave hands go.",
+    slytherin: "Sharp intent and guarded keys below.",
+    ravenclaw: "Clear eyes seek the hidden thread.",
+    hufflepuff: "Steady help, with gentle tread.",
+  };
+
+  return [
+    "Hmm... a tool with purpose tucked inside.",
+    houseLine[result.house],
+    `I choose ${result.house}, with ${Math.round(result.confidence * 100)} percent pride.`,
+  ];
+}
+
+export async function* streamSortingHatMonologue(
+  result: SortingHatSortResult,
+): AsyncGenerator<string> {
+  for (const chunk of sortingHatMonologue(result)) {
+    yield chunk;
+  }
+}
+
+export function castPatronus(
+  userId: string,
+  charm: string,
+): PatronusCastResult {
+  if (charm !== "expecto_patronum") {
+    throw new InvalidPatronusCharmError(charm);
+  }
+
+  const digest = createHash("sha256").update(userId).digest();
+  return {
+    form: PATRONUS_FORMS[digest[0] % PATRONUS_FORMS.length],
+    corporeal: digest[1] % 4 !== 0,
+  };
+}
+
+export function authorizeSortedTool(params: {
+  sorting: SortingHatSortResult;
+  userId?: string | null;
+  charm?: "expecto_patronum";
+}): SortingHatAuthorizationResult {
+  const monologue = sortingHatMonologue(params.sorting);
+  if (params.sorting.house !== "slytherin") {
+    return { allowed: true, sorting: params.sorting, monologue };
+  }
+
+  const patronus = params.userId
+    ? castPatronus(params.userId, params.charm ?? "expecto_patronum")
+    : null;
+  if (patronus?.corporeal) {
+    return { allowed: true, sorting: params.sorting, patronus, monologue };
+  }
+
+  return {
+    allowed: false,
+    sorting: params.sorting,
+    patronus,
+    monologue,
+    message:
+      "Sorting Hat authorization blocked this Slytherin tool because the Patronus was non-corporeal.",
+  };
+}
+
+export function flooTravel<TPayload>(params: {
+  fromServer: string;
+  toServer: string;
+  payload: TPayload;
+}): FlooTravelResult<TPayload> {
+  return {
+    fromServer: params.fromServer,
+    toServer: params.toServer,
+    payload: params.payload,
+    _meta: {
+      greenFlameParticles: greenFlameParticles(),
+    },
+  };
+}
+
+export async function* quidditchStream(
+  toolCallId: string,
+  options: { frames?: number; cadenceMs?: number } = {},
+): AsyncGenerator<QuidditchProgressEvent> {
+  const frames = options.frames ?? 12;
+  const cadenceMs = options.cadenceMs ?? 100;
+
+  for (let i = 0; i <= frames; i++) {
+    const progress = frames === 0 ? 1 : i / frames;
+    yield {
+      type: "snitch-progress",
+      toolCallId,
+      progress: Number(progress.toFixed(2)),
+      x: Number((50 + Math.sin(progress * Math.PI * 2) * 34).toFixed(2)),
+      y: Number((50 + Math.cos(progress * Math.PI * 3) * 18).toFixed(2)),
+    };
+    if (i < frames && cadenceMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, cadenceMs));
+    }
+  }
+}
+
+export function buildSortingHatMeta(params: {
+  sorting: SortingHatSortResult;
+  monologue?: string[];
+  patronus?: PatronusCastResult | null;
+  floo?: Pick<FlooTravelResult<unknown>, "fromServer" | "toServer" | "_meta">;
+}): { [SORTING_HAT_META_KEY]: SortingHatMeta } {
+  return {
+    [SORTING_HAT_META_KEY]: {
+      house: params.sorting.house,
+      confidence: params.sorting.confidence,
+      monologue: params.monologue,
+      patronus: params.patronus ?? undefined,
+      floo: params.floo
+        ? {
+            fromServer: params.floo.fromServer,
+            toServer: params.floo.toServer,
+            particles: params.floo._meta.greenFlameParticles,
+          }
+        : undefined,
+    },
+  };
+}
+
+export async function createSortingHatMcpServer(): Promise<SortingHatMcpServer> {
+  const { McpServer } = await import("@modelcontextprotocol/sdk/server/mcp.js");
+  const server = new McpServer({
+    name: "sorting-hat-mcp",
+    version: "1.2.57",
+  }) as SortingHatMcpServer;
+
+  server.tool(
+    "sorting_hat.sort",
+    "Sort an MCP tool into a Hogwarts house based on risk and intent.",
+    {
+      tool_name: { type: "string" },
+      tool_description: { type: "string" },
+      please_not_slytherin: { type: "boolean" },
+    },
+    async (args: Record<string, unknown>) => {
+      const result = sortTool({
+        toolName: String(args.tool_name ?? ""),
+        toolDescription:
+          typeof args.tool_description === "string"
+            ? args.tool_description
+            : undefined,
+        pleaseNotSlytherin: args.please_not_slytherin === true,
+      });
+      return jsonToolResult(result, {
+        monologue: sortingHatMonologue(result),
+      });
+    },
+  );
+
+  server.tool(
+    "patronus.cast",
+    "Cast a deterministic Patronus for a user.",
+    {
+      user_id: { type: "string" },
+      charm: { type: "string" },
+    },
+    async (args: Record<string, unknown>) => {
+      try {
+        return jsonToolResult(
+          castPatronus(String(args.user_id), String(args.charm)),
+        );
+      } catch (error) {
+        return errorToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "floo.travel",
+    "Attach Floo routing metadata for an authorized MCP payload.",
+    {
+      from_server: { type: "string" },
+      to_server: { type: "string" },
+      payload: { type: "object" },
+    },
+    async (args: Record<string, unknown>) =>
+      jsonToolResult(
+        flooTravel({
+          fromServer: String(args.from_server ?? ""),
+          toServer: String(args.to_server ?? ""),
+          payload: args.payload ?? {},
+        }),
+      ),
+  );
+
+  server.tool(
+    "quidditch.stream",
+    "Emit Snitch-shaped progress events for an in-flight tool call.",
+    {
+      tool_call_id: { type: "string" },
+    },
+    async (args: Record<string, unknown>) => {
+      const events: QuidditchProgressEvent[] = [];
+      for await (const event of quidditchStream(String(args.tool_call_id), {
+        cadenceMs: 0,
+      })) {
+        events.push(event);
+      }
+      return jsonToolResult({ events });
+    },
+  );
+
+  return server;
+}
+
+function houseBaseline(toolName: string, house: SortingHatHouse): number {
+  const digest = createHash("sha256").update(`${toolName}:${house}`).digest();
+  return (digest[0] % 3) * 0.1;
+}
+
+function keywordWeight(house: SortingHatHouse, keyword: string): number {
+  if (HARD_SLYTHERIN_KEYWORDS.includes(keyword)) return 2.5;
+  if (
+    house === "hufflepuff" &&
+    ["docs", "health", "help", "status", "version"].includes(keyword)
+  ) {
+    return 2.4;
+  }
+  return 1.4;
+}
+
+function greenFlameParticles(): Array<{
+  color: "green";
+  size: number;
+  delayMs: number;
+}> {
+  return Array.from({ length: 6 }, (_, index) => ({
+    color: "green",
+    size: 2 + (index % 3),
+    delayMs: index * 80,
+  }));
+}
+
+function jsonToolResult(
+  value: unknown,
+  meta?: Record<string, unknown>,
+): CallToolResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify(value) }],
+    structuredContent: isRecord(value) ? value : { value },
+    _meta: meta,
+  };
+}
+
+function errorToolResult(error: unknown): CallToolResult {
+  return {
+    content: [
+      {
+        type: "text",
+        text: error instanceof Error ? error.message : String(error),
+      },
+    ],
+    isError: true,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/platform/sorting-hat-mcp/tsconfig.json
+++ b/platform/sorting-hat-mcp/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../shared/tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- add a first-party `sorting-hat-mcp` package with Sorting Hat, Patronus, Floo, and Quidditch helpers
- sort MCP tool calls in the gateway before execution and attach Sorting Hat metadata to tool results
- block Slytherin tools when the caller's Patronus is non-corporeal
- add first-tool Sorting Hat UI, Gryffindor Snitch loader, Patronus settings picker, and Forbidden Forest theme
- document Sorting Hat behavior and add focused unit/component/E2E coverage

Closes #4998

## Implementation Details

Sorting uses deterministic keyword scoring across the four houses, with destructive/security-sensitive tools biased toward Slytherin and the `please_not_slytherin` header treated as a preference unless the tool is clearly high-risk.

The gateway casts Patronus only for Slytherin-sorted tools. Non-Slytherin tools keep the normal execution path and receive Sorting Hat metadata for the UI.

Quidditch progress uses a 100ms backend SSE cadence. The backend does not force 60fps; CSS handles the smooth loading animation.

## Testing

- `pnpm install`
- `pnpm --filter @backend type-check`
- `pnpm --filter @frontend type-check`
- `pnpm --filter @e2e-tests type-check`
- `pnpm --filter @archestra/sorting-hat-mcp lint`
- `vitest src/index.test.ts --run` in `platform/sorting-hat-mcp`
- `pnpm --filter @archestra/shared test -- sorting-hat.test.ts --run`
- `vitest run src/components/chat/sorting-hat-modal.test.tsx src/components/ai-elements/tool.test.tsx src/components/settings/light-dark-buttons.test.tsx` in `platform/frontend`
- `git diff --check`

## Demo Notes

No screenshot or video captured locally. The E2E spec was added and type-checked, but not run because the full local Playwright/WireMock/K8s E2E stack was not running here.

Backend Vitest for `src/routes/mcp-gateway.utils.test.ts` was attempted directly and through the package script. It fails before tests execute because this local shell does not have `ARCHESTRA_DATABASE_URL` or `DATABASE_URL` set.