### PR TITLE
fix(sandbox): close o11y, logging, and stale-permission gaps

### DIFF
--- a/docs/pages/platform-access-control.md
+++ b/docs/pages/platform-access-control.md
@@ -37,7 +37,7 @@ Full access to core resources and settings, but cannot manage users, roles, or i
 | Resource | Actions |
 |----------|--------|
 | Agents | `read`, `create`, `update`, `delete`, `team-admin` |
-| Skills | `read`, `create`, `update`, `delete`, `team-admin`, `execute` |
+| Skills | `read`, `create`, `update`, `delete`, `team-admin` |
 | Code Sandbox | `execute` |
 | Agent Triggers | `read`, `create`, `update`, `delete` |
 | Scheduled Tasks | `read`, `create`, `update`, `delete` |
@@ -82,7 +82,7 @@ Can manage agents, tools, and chat, with read-only access to most other resource
 | Resource | Actions |
 |----------|--------|
 | Agents | `read`, `create`, `update`, `delete` |
-| Skills | `read`, `create`, `update`, `delete`, `execute` |
+| Skills | `read`, `create`, `update`, `delete` |
 | Code Sandbox | `execute` |
 | Scheduled Tasks | `read`, `create`, `update`, `delete` |
 | LLM Proxies | `read`, `create`, `update`, `delete` |
@@ -254,7 +254,6 @@ The following table lists all available permissions that can be assigned to cust
 | `skill:delete` | Delete agent skills |
 | `skill:team-admin` | Manage team assignments for agent skills |
 | `skill:admin` | Full administrative control over all agent skills, bypassing team restrictions |
-| `skill:execute` | Execute skill scripts |
 | `team:read` | View teams and their members |
 | `team:create` | Create new teams |
 | `team:update` | Modify team settings |

--- a/platform/backend/src/archestra-mcp-server/rbac.ts
+++ b/platform/backend/src/archestra-mcp-server/rbac.ts
@@ -1,5 +1,6 @@
 import type { ArchestraToolShortName, Permission } from "@archestra/shared";
 import { userHasPermission } from "@/auth/utils";
+import logger from "@/logging";
 import { UserModel } from "@/models";
 import { archestraMcpBranding } from "./branding";
 import { errorResult } from "./helpers";
@@ -191,6 +192,16 @@ export async function checkToolPermission(
   );
 
   if (!allowed) {
+    logger.warn(
+      {
+        organizationId: context.organizationId,
+        userId: context.userId,
+        toolName,
+        resource: perm.resource,
+        action: perm.action,
+      },
+      "[ArchestraMCP] rbac denied tool execution",
+    );
     return errorResult(
       `You do not have permission to perform this action (requires ${perm.resource}:${perm.action}).`,
     );

--- a/platform/backend/src/archestra-mcp-server/sandbox.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.ts
@@ -472,6 +472,16 @@ async function resolveTarget(params: {
       sandbox.userId !== userCtx.userId ||
       sandbox.conversationId !== conversationId
     ) {
+      logger.warn(
+        {
+          organizationId: userCtx.organizationId,
+          userId: userCtx.userId,
+          conversationId,
+          targetId: target.id,
+          reason: "out_of_scope_sandbox_id",
+        },
+        "[Sandbox] rejected out-of-scope sandbox id",
+      );
       return { error: `No accessible sandbox with id ${target.id} exists.` };
     }
     return { sandboxId: asSandboxId(sandbox.id) };
@@ -560,6 +570,15 @@ async function loadUploadSource(params: {
     }
     case "chat_attachment": {
       if (!conversationId) {
+        logger.warn(
+          {
+            organizationId: userCtx.organizationId,
+            userId: userCtx.userId,
+            attachmentId: source.attachmentId,
+            reason: "no_conversation_context",
+          },
+          "[Sandbox] rejected chat_attachment upload",
+        );
         return {
           error:
             "chat_attachment uploads require a conversation context; use a base64 or text source instead.",
@@ -569,11 +588,31 @@ async function loadUploadSource(params: {
         source.attachmentId,
       );
       if (!attachment || attachment.organizationId !== userCtx.organizationId) {
+        logger.warn(
+          {
+            organizationId: userCtx.organizationId,
+            userId: userCtx.userId,
+            conversationId,
+            attachmentId: source.attachmentId,
+            reason: "attachment_not_found_or_wrong_org",
+          },
+          "[Sandbox] rejected chat_attachment upload",
+        );
         return {
           error: `No accessible attachment with id ${source.attachmentId} exists.`,
         };
       }
       if (attachment.conversationId !== conversationId) {
+        logger.warn(
+          {
+            organizationId: userCtx.organizationId,
+            userId: userCtx.userId,
+            conversationId,
+            attachmentId: source.attachmentId,
+            reason: "cross_conversation_attachment",
+          },
+          "[Sandbox] rejected chat_attachment upload",
+        );
         return {
           error:
             "That attachment belongs to a different conversation and cannot be used here.",

--- a/platform/backend/src/auth/skill-permissions.test.ts
+++ b/platform/backend/src/auth/skill-permissions.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "@/test";
 import { getSkillPermissionChecker } from "./skill-permissions";
 
 describe("getSkillPermissionChecker", () => {
-  test("admin role gets canRead, canExecute, isAdmin", async ({
+  test("admin role gets canRead and isAdmin", async ({
     makeUser,
     makeOrganization,
     makeMember,
@@ -19,11 +19,10 @@ describe("getSkillPermissionChecker", () => {
     });
 
     expect(checker.canRead).toBe(true);
-    expect(checker.canExecute).toBe(true);
     expect(checker.isAdmin).toBe(true);
   });
 
-  test("member role gets canRead and canExecute (but not isAdmin) by default", async ({
+  test("member role gets canRead but not isAdmin by default", async ({
     makeUser,
     makeOrganization,
     makeMember,
@@ -38,11 +37,10 @@ describe("getSkillPermissionChecker", () => {
     });
 
     expect(checker.canRead).toBe(true);
-    expect(checker.canExecute).toBe(true);
     expect(checker.isAdmin).toBe(false);
   });
 
-  test("custom role with skill:read but no skill:execute is denied execute", async ({
+  test("custom role without skill:read is denied read", async ({
     makeUser,
     makeOrganization,
     makeMember,
@@ -51,8 +49,8 @@ describe("getSkillPermissionChecker", () => {
     const user = await makeUser();
     const org = await makeOrganization();
     const role = await makeCustomRole(org.id, {
-      role: "reader_only",
-      permission: { skill: ["read"] },
+      role: "no_skill_access",
+      permission: { agent: ["read"] },
     });
     await makeMember(user.id, org.id, { role: role.role });
 
@@ -61,31 +59,8 @@ describe("getSkillPermissionChecker", () => {
       organizationId: org.id,
     });
 
-    expect(checker.canRead).toBe(true);
-    expect(checker.canExecute).toBe(false);
-  });
-
-  test("custom role with skill:read AND skill:execute can execute", async ({
-    makeUser,
-    makeOrganization,
-    makeMember,
-    makeCustomRole,
-  }) => {
-    const user = await makeUser();
-    const org = await makeOrganization();
-    const role = await makeCustomRole(org.id, {
-      role: "reader_executor",
-      permission: { skill: ["read", "execute"] },
-    });
-    await makeMember(user.id, org.id, { role: role.role });
-
-    const checker = await getSkillPermissionChecker({
-      userId: user.id,
-      organizationId: org.id,
-    });
-
-    expect(checker.canRead).toBe(true);
-    expect(checker.canExecute).toBe(true);
+    expect(checker.canRead).toBe(false);
+    expect(checker.isAdmin).toBe(false);
   });
 
   test("service-account synthetic user id resolves the account's role permissions", async ({
@@ -106,7 +81,6 @@ describe("getSkillPermissionChecker", () => {
     // Before the fix this returned an empty permission set (all false) because
     // the synthetic service-account id has no member row.
     expect(checker.canRead).toBe(true);
-    expect(checker.canExecute).toBe(true);
     expect(checker.isAdmin).toBe(true);
   });
 });

--- a/platform/backend/src/auth/skill-permissions.ts
+++ b/platform/backend/src/auth/skill-permissions.ts
@@ -11,8 +11,6 @@ import { getPermissionsForUserContext } from "./utils";
 export interface SkillPermissionChecker {
   /** Holds `skill:read` — may view and use skills within their scope. */
   canRead: boolean;
-  /** Holds `skill:execute` — may run skill scripts in a sandboxed runtime. */
-  canExecute: boolean;
   /** Holds `skill:admin` — bypasses scope restrictions. */
   isAdmin: boolean;
   /** Holds `skill:team-admin` — may manage team-scoped skills in their teams. */
@@ -36,7 +34,6 @@ export async function getSkillPermissionChecker(params: {
   const skill = permissions.skill ?? [];
   return {
     canRead: skill.includes("read"),
-    canExecute: skill.includes("execute"),
     isAdmin: skill.includes("admin"),
     isTeamAdmin: skill.includes("team-admin"),
   };

--- a/platform/backend/src/observability/index.ts
+++ b/platform/backend/src/observability/index.ts
@@ -20,6 +20,7 @@ export async function initializeObservabilityMetrics(params?: {
   }
 
   metrics.rag.initializeRagMetrics();
+  metrics.sandbox.initializeSandboxMetrics();
   metrics.scheduleTrigger.initializeScheduleTriggerMetrics();
   metrics.taskQueue.initializeTaskQueueMetrics();
   metrics.audit.initializeAuditMetrics();

--- a/platform/backend/src/observability/metrics/index.ts
+++ b/platform/backend/src/observability/metrics/index.ts
@@ -3,5 +3,6 @@ export * as audit from "./audit";
 export * as llm from "./llm";
 export * as mcp from "./mcp";
 export * as rag from "./rag";
+export * as sandbox from "./sandbox";
 export * as scheduleTrigger from "./schedule-trigger";
 export * as taskQueue from "./task-queue";

--- a/platform/backend/src/observability/metrics/sandbox.test.ts
+++ b/platform/backend/src/observability/metrics/sandbox.test.ts
@@ -1,0 +1,56 @@
+import client from "prom-client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "@/test";
+
+describe("sandbox metrics", () => {
+  beforeEach(() => {
+    client.register.clear();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    client.register.clear();
+    vi.resetModules();
+  });
+
+  test("does not report commands before metrics are initialized", async () => {
+    const { reportCommand } = await import("./sandbox");
+
+    expect(() =>
+      reportCommand({ status: "ok", durationSeconds: 1 }),
+    ).not.toThrow();
+    expect(await client.register.metrics()).not.toContain(
+      "sandbox_commands_total",
+    );
+  });
+
+  test("classifyCommandStatus maps execution outcomes", async () => {
+    const { classifyCommandStatus } = await import("./sandbox");
+
+    expect(classifyCommandStatus({ timedOut: false, exitCode: 0 })).toBe("ok");
+    expect(classifyCommandStatus({ timedOut: false, exitCode: 1 })).toBe(
+      "script_error",
+    );
+    expect(classifyCommandStatus({ timedOut: true, exitCode: 0 })).toBe(
+      "timeout",
+    );
+    // timeout takes precedence over a non-zero exit code
+    expect(classifyCommandStatus({ timedOut: true, exitCode: 137 })).toBe(
+      "timeout",
+    );
+  });
+
+  test("records command metrics after initialization", async () => {
+    const { initializeSandboxMetrics, reportCommand } = await import(
+      "./sandbox"
+    );
+
+    initializeSandboxMetrics();
+    reportCommand({ status: "timeout", durationSeconds: 1.5 });
+
+    const metrics = await client.register.metrics();
+    expect(metrics).toContain('sandbox_commands_total{status="timeout"} 1');
+    expect(metrics).toContain(
+      'sandbox_command_duration_seconds_count{status="timeout"} 1',
+    );
+  });
+});

--- a/platform/backend/src/observability/metrics/sandbox.ts
+++ b/platform/backend/src/observability/metrics/sandbox.ts
@@ -1,0 +1,73 @@
+/**
+ * Prometheus metrics for the code-execution sandbox (`run_command`).
+ *
+ * Command throughput:
+ * rate(sandbox_commands_total[5m])
+ *
+ * Timeout rate:
+ * rate(sandbox_commands_total{status="timeout"}[5m])
+ *
+ * Average command duration:
+ * rate(sandbox_command_duration_seconds_sum[5m]) / rate(sandbox_command_duration_seconds_count[5m])
+ */
+
+import client from "prom-client";
+import logger from "@/logging";
+
+/**
+ * - `ok` — command exited 0
+ * - `script_error` — command ran but exited non-zero
+ * - `timeout` — command exceeded its timeout
+ * - `runtime_error` — the engine call itself failed (unreachable / internal)
+ */
+type SandboxCommandStatus = "ok" | "script_error" | "timeout" | "runtime_error";
+
+/**
+ * Classify a completed command execution. Timeout takes precedence over exit
+ * code (a timed-out command may also report a non-zero exit). The thrown
+ * engine-failure case (`runtime_error`) is handled by the caller's catch.
+ */
+export function classifyCommandStatus(executed: {
+  timedOut: boolean;
+  exitCode: number;
+}): SandboxCommandStatus {
+  if (executed.timedOut) return "timeout";
+  return executed.exitCode === 0 ? "ok" : "script_error";
+}
+
+let sandboxCommandsTotal: client.Counter<string>;
+let sandboxCommandDuration: client.Histogram<string>;
+
+let initialized = false;
+
+export function initializeSandboxMetrics(): void {
+  if (initialized) return;
+
+  sandboxCommandsTotal = new client.Counter({
+    name: "sandbox_commands_total",
+    help: "Total sandbox commands executed via run_command",
+    labelNames: ["status"],
+  });
+
+  sandboxCommandDuration = new client.Histogram({
+    name: "sandbox_command_duration_seconds",
+    help: "Sandbox command execution duration in seconds",
+    labelNames: ["status"],
+    buckets: [0.5, 1, 2, 5, 10, 30, 60, 120],
+  });
+
+  initialized = true;
+  logger.info("Sandbox metrics initialized");
+}
+
+export function reportCommand(params: {
+  status: SandboxCommandStatus;
+  durationSeconds: number;
+}): void {
+  if (!initialized) return;
+  sandboxCommandsTotal.inc({ status: params.status });
+  sandboxCommandDuration.observe(
+    { status: params.status },
+    params.durationSeconds,
+  );
+}

--- a/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
+++ b/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
@@ -9,6 +9,7 @@ import {
   SkillSandboxReplayEventModel,
   SkillVersionModel,
 } from "@/models";
+import * as metrics from "@/observability/metrics";
 import {
   SandboxRuntimeError,
   sandboxRuntimeService,
@@ -100,6 +101,7 @@ class SkillSandboxRuntimeService {
       let executed: Awaited<
         ReturnType<typeof sandboxRuntimeService.runCommand>
       >;
+      const startedAt = Date.now();
       try {
         executed = await sandboxRuntimeService.runCommand({
           command: params.command,
@@ -116,6 +118,12 @@ class SkillSandboxRuntimeService {
         // may have already run inside Dagger but we lost the result. Record a
         // synthetic row so subsequent replays re-execute it instead of
         // silently dropping it from the log, then surface the error.
+        // wall-clock of the failed engine call (the inner durationMs is lost on
+        // throw); the success path below observes the engine-reported duration.
+        metrics.sandbox.reportCommand({
+          status: "runtime_error",
+          durationSeconds: (Date.now() - startedAt) / 1000,
+        });
         if (shouldRecordOnFailure(error)) {
           await this.appendSyntheticRow({
             sandboxId: params.sandboxId,
@@ -127,6 +135,11 @@ class SkillSandboxRuntimeService {
         }
         throw this.toSkillError(error);
       }
+
+      metrics.sandbox.reportCommand({
+        status: metrics.sandbox.classifyCommandStatus(executed),
+        durationSeconds: executed.durationMs / 1000,
+      });
 
       let row: Awaited<
         ReturnType<typeof SkillSandboxReplayEventModel.appendCommand>
@@ -434,6 +447,15 @@ class SkillSandboxRuntimeService {
       organizationId: caller.organizationId,
     });
     if (!result.ok) {
+      logger.warn(
+        {
+          sandboxId,
+          userId: caller.userId,
+          organizationId: caller.organizationId,
+          reason: result.code,
+        },
+        "[SkillSandbox] revocation gate blocked sandbox access",
+      );
       throw new SkillSandboxError(result.reason);
     }
   }
@@ -635,17 +657,29 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
+/**
+ * Reject a sandbox path with a stable reason code logged for audit. The raw
+ * path stays in the model-facing message only — never in the structured log —
+ * to avoid leaking user-supplied content into operational logs.
+ */
+function rejectPath(reason: string, message: string): never {
+  logger.warn({ reason }, "[SkillSandbox] rejected sandbox path");
+  throw new SkillSandboxError(message);
+}
+
 function resolveArtifactPath(params: {
   path: string;
   defaultCwd: string;
 }): string {
   if (params.path.includes("\0")) {
-    throw new SkillSandboxError(
+    rejectPath(
+      "artifact_path_nul",
       `invalid artifact path: ${JSON.stringify(params.path)}`,
     );
   }
   if (params.path.split("/").some((segment) => segment === "..")) {
-    throw new SkillSandboxError(
+    rejectPath(
+      "artifact_path_traversal",
       `invalid artifact path: ${JSON.stringify(params.path)}`,
     );
   }
@@ -655,7 +689,8 @@ function resolveArtifactPath(params: {
       (root) => params.path === root || params.path.startsWith(`${root}/`),
     );
     if (!isAllowed) {
-      throw new SkillSandboxError(
+      rejectPath(
+        "artifact_path_outside_roots",
         `artifact path must be under ${SKILL_SANDBOX_ROOT} or ${SKILL_SANDBOX_HOME}: ${JSON.stringify(params.path)}`,
       );
     }
@@ -676,10 +711,14 @@ function resolveArtifactPath(params: {
  */
 function validateUploadPath(path: string): void {
   if (/["$`\\\n\r]/.test(path)) {
-    throw new SkillSandboxError(`invalid upload path: ${JSON.stringify(path)}`);
+    rejectPath(
+      "upload_path_shell_metachar",
+      `invalid upload path: ${JSON.stringify(path)}`,
+    );
   }
   if (path.endsWith("/")) {
-    throw new SkillSandboxError(
+    rejectPath(
+      "upload_path_directory",
       `upload path must be a file, not a directory: ${JSON.stringify(path)}`,
     );
   }
@@ -688,7 +727,8 @@ function validateUploadPath(path: string): void {
   // regular file and break every later skill mount. reject before it is
   // persisted as an unreplayable event.
   if (path === SKILL_SANDBOX_ROOT || path === SKILL_SANDBOX_HOME) {
-    throw new SkillSandboxError(
+    rejectPath(
+      "upload_path_root_directory",
       `upload path must be a file, not a directory: ${JSON.stringify(path)}`,
     );
   }
@@ -744,11 +784,26 @@ async function stageConversationAttachments(
   const stagedIds = await SkillSandboxFileModel.listStagedAttachmentIds(
     sandbox.id,
   );
-  const { toStage, notices } = planAttachmentStaging({
+  const limit = config.skillsSandbox.artifactBytesLimit;
+  const { toStage, notices, oversized } = planAttachmentStaging({
     attachments,
     stagedIds,
-    limit: config.skillsSandbox.artifactBytesLimit,
+    limit,
   });
+  for (const skip of oversized) {
+    // debug, not warn: an oversize attachment is expected and recoverable (the
+    // model gets a notice + download URL), and staging re-runs every op — a warn
+    // here would repeat for the whole conversation.
+    logger.debug(
+      {
+        sandboxId: sandbox.id,
+        attachmentId: skip.attachmentId,
+        sizeBytes: skip.sizeBytes,
+        limit,
+      },
+      "[SkillSandbox] skipped oversize attachment during auto-staging",
+    );
+  }
   if (toStage.length === 0) return notices;
 
   const withData = await ConversationAttachmentModel.findByIdsWithData(
@@ -785,10 +840,15 @@ function planAttachmentStaging(params: {
   attachments: { id: string; originalName: string | null; fileSize: number }[];
   stagedIds: Set<string>;
   limit: number;
-}): { toStage: { id: string; path: string }[]; notices: string[] } {
+}): {
+  toStage: { id: string; path: string }[];
+  notices: string[];
+  oversized: { attachmentId: string; sizeBytes: number }[];
+} {
   const { attachments, stagedIds, limit } = params;
   const pathByAttachment = assignAttachmentPaths(attachments);
   const notices: string[] = [];
+  const oversized: { attachmentId: string; sizeBytes: number }[] = [];
   const toStage: { id: string; path: string }[] = [];
   for (const attachment of attachments) {
     if (stagedIds.has(attachment.id)) continue;
@@ -796,12 +856,16 @@ function planAttachmentStaging(params: {
       notices.push(
         `attachment ${JSON.stringify(attachment.originalName ?? attachment.id)} (${attachment.fileSize} bytes) was not auto-staged into the sandbox: it exceeds the ${limit}-byte file limit. Reference it via its download URL instead.`,
       );
+      oversized.push({
+        attachmentId: attachment.id,
+        sizeBytes: attachment.fileSize,
+      });
       continue;
     }
     const path = pathByAttachment.get(attachment.id);
     if (path) toStage.push({ id: attachment.id, path });
   }
-  return { toStage, notices };
+  return { toStage, notices, oversized };
 }
 
 /**

--- a/platform/backend/src/skills/assert-mounted-skills-readable.ts
+++ b/platform/backend/src/skills/assert-mounted-skills-readable.ts
@@ -1,8 +1,16 @@
 import { getSkillPermissionChecker } from "@/auth/skill-permissions";
 import { SkillModel, SkillSandboxModel, SkillTeamModel } from "@/models";
 
+/** Stable reason code for the revocation gate (for logs/metrics, never prose). */
+type MountReadabilityFailureCode =
+  | "skill_read_revoked"
+  | "skill_deleted"
+  | "skill_access_revoked";
+
 /** Result of the revocation gate: ok, or a model-facing reason it failed. */
-type MountReadabilityResult = { ok: true } | { ok: false; reason: string };
+type MountReadabilityResult =
+  | { ok: true }
+  | { ok: false; code: MountReadabilityFailureCode; reason: string };
 
 /**
  * Revocation gate for the materializing sandbox tools. Before a container is
@@ -30,6 +38,7 @@ export async function assertMountedSkillsReadable(params: {
   if (!checker.canRead) {
     return {
       ok: false,
+      code: "skill_read_revoked",
       reason:
         "you no longer have permission to read the skills mounted in this sandbox",
     };
@@ -40,6 +49,7 @@ export async function assertMountedSkillsReadable(params: {
     if (!skill || skill.organizationId !== params.organizationId) {
       return {
         ok: false,
+        code: "skill_deleted",
         reason:
           "a skill mounted in this sandbox no longer exists; start a fresh sandbox to continue",
       };
@@ -53,6 +63,7 @@ export async function assertMountedSkillsReadable(params: {
     if (!hasAccess) {
       return {
         ok: false,
+        code: "skill_access_revoked",
         reason: `you no longer have access to the skill "${skill.name}" mounted in this sandbox`,
       };
     }

--- a/platform/backend/src/skills/skill-activation.ts
+++ b/platform/backend/src/skills/skill-activation.ts
@@ -34,7 +34,7 @@ export function formatSkillActivation({
   files: Pick<SkillFile, "path" | "kind">[];
   /**
    * Whether the sandbox tools are usable for this caller (feature enabled +
-   * `skill:execute`). When false, omit the sandbox hint so we never point the
+   * `sandbox:execute`). When false, omit the sandbox hint so we never point the
    * model at tools that would just refuse.
    */
   canRunSandbox: boolean;

--- a/platform/shared/access-control.test.ts
+++ b/platform/shared/access-control.test.ts
@@ -86,8 +86,8 @@ describe("access-control", () => {
 
   describe("sandbox artifact route", () => {
     // the download_file tool (sandbox:execute) hands out this artifact URL, so
-    // the fetch route must require the same permission — otherwise a role with
-    // sandbox:execute but not skill:execute gets a 403 on a URL it just earned.
+    // the fetch route must require the same permission — otherwise a role that
+    // produced an artifact gets a 403 on a URL it just earned.
     test("getSkillSandboxArtifact requires sandbox:execute", () => {
       const required =
         requiredEndpointPermissionsMap[RouteId.GetSkillSandboxArtifact];

--- a/platform/shared/access-control.ts
+++ b/platform/shared/access-control.ts
@@ -26,15 +26,7 @@ export const allAvailableActions: Record<Resource, Action[]> = {
 
   // Agents
   agent: ["read", "create", "update", "delete", "team-admin", "admin"],
-  skill: [
-    "read",
-    "create",
-    "update",
-    "delete",
-    "team-admin",
-    "admin",
-    "execute",
-  ],
+  skill: ["read", "create", "update", "delete", "team-admin", "admin"],
   sandbox: ["execute"],
   agentTrigger: ["read", "create", "update", "delete"],
   scheduledTask: ["read", "create", "update", "delete", "admin"],
@@ -97,7 +89,7 @@ export const allAvailableActions: Record<Resource, Action[]> = {
 export const editorPermissions: Record<Resource, Action[]> = {
   // Agents
   agent: ["read", "create", "update", "delete", "team-admin"],
-  skill: ["read", "create", "update", "delete", "team-admin", "execute"],
+  skill: ["read", "create", "update", "delete", "team-admin"],
   sandbox: ["execute"],
   agentTrigger: ["read", "create", "update", "delete"],
   scheduledTask: ["read", "create", "update", "delete"],
@@ -160,7 +152,7 @@ export const editorPermissions: Record<Resource, Action[]> = {
 export const memberPermissions: Record<Resource, Action[]> = {
   // Agents
   agent: ["read", "create", "update", "delete"],
-  skill: ["read", "create", "update", "delete", "execute"],
+  skill: ["read", "create", "update", "delete"],
   sandbox: ["execute"],
   agentTrigger: [],
   scheduledTask: ["read", "create", "update", "delete"],
@@ -258,7 +250,6 @@ export const permissionDescriptions: Record<string, string> = {
   "skill:team-admin": "Manage team assignments for agent skills",
   "skill:admin":
     "Full administrative control over all agent skills, bypassing team restrictions",
-  "skill:execute": "Execute skill scripts",
   "sandbox:execute":
     "Run commands and upload/download files in code execution sandboxes",
   "agentTrigger:read":


### PR DESCRIPTION
Follow-up to #5253 (merged). Closes gaps surfaced in post-merge review.

- **Remove dead `skill:execute`** — it was granted to roles and computed into `canExecute` but never enforced; the real gate is `sandbox:execute`. Pure code removal (predefined roles are code constants; custom-role JSON is sanitized on read → no migration); regenerated access-control docs.
- **Restore sandbox command metrics** — the `code-runtime` removal dropped timeout visibility (a timed-out `run_command` returns success, so it was counted as success at the MCP gateway). New `observability/metrics/sandbox.ts` with `sandbox_commands_total{status}` + `sandbox_command_duration_seconds{status}`, status `ok|script_error|timeout|runtime_error`, emitted in the runtime service so denials aren't miscounted; status mapping extracted to a pure helper and unit-tested.
- **Log fail-closed denials** (reason codes + ids only, no raw paths) — central RBAC denial (execution path), out-of-scope `{id}` rejection, cross-conversation/wrong-org/no-conversation attachment rejection, the revocation gate (added a stable code so logs never carry skill names), and the path-security validators. Oversize attachment skip logged at debug (expected, recurs each turn).

Verified: type-check (6 workspaces incl. Rust), biome, knip (dev+prod), and the affected backend/shared suites are green. Reviewed by external (codex) and internal gates — no correctness/security findings.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>