### PR TITLE
fix(chat): reattach to the active run on duplicate-run 409 instead of dead-ending

### DIFF
--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -334,7 +334,7 @@ describe("ChatProvider retries", () => {
     });
   });
 
-  it("shows a toast for duplicate active-run submits", async () => {
+  it("reattaches to the active run instead of dead-ending on duplicate active-run submits", async () => {
     render(
       <ChatProvider>
         <RegisterChatSession />
@@ -349,10 +349,13 @@ describe("ChatProvider retries", () => {
       );
     });
 
-    expect(mocks.toastError).toHaveBeenCalledWith(
-      "This conversation already has a response in progress. Stop it before sending another message.",
-    );
+    // A duplicate-run 409 means the backend is still generating (e.g. the
+    // stream connection was severed but the run survived). Reattach to the
+    // live run via the replay endpoint rather than telling the user to stop
+    // a response they cannot see.
+    expect(mocks.resumeStream).toHaveBeenCalledTimes(1);
     expect(mocks.regenerate).not.toHaveBeenCalled();
+    expect(mocks.toastError).not.toHaveBeenCalled();
   });
 });
 

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -32,7 +32,6 @@ import {
   useRef,
   useState,
 } from "react";
-import { toast } from "sonner";
 import { filterOptimisticToolCalls } from "@/components/chat/chat-messages.utils";
 import { useGenerateConversationTitle } from "@/lib/chat/chat.query";
 import {
@@ -606,9 +605,15 @@ function ChatSessionHook({
       });
 
       if (isDuplicateActiveRunError(chatError)) {
-        toast.error(
-          "This conversation already has a response in progress. Stop it before sending another message.",
-        );
+        // The backend refused the send because this conversation still has a
+        // run generating — typically after the stream connection was severed
+        // (LB cut, network blip) while the backend kept going, and the
+        // auto-retry below re-POSTed into the live run. Reattach to it via the
+        // active-run replay endpoint instead of dead-ending: the user sees the
+        // in-progress response (and the Stop button) again. If the run
+        // finished in the meantime, the reconnect returns 204 and is a no-op —
+        // the conversation refetch above already shows the persisted outcome.
+        void resumeStream();
         return;
       }
 


### PR DESCRIPTION
## Problem

When a chat stream's connection is severed mid-response (LB timeout, network blip, rollout), the backend deliberately keeps the run alive and persists chunks to the replay log. But the frontend's auto-retry re-POSTs the turn, hits the per-conversation active-run **409**, and dead-ends with a toast telling the user to *"Stop it before sending another message"* — while showing no stream and no Stop button. The conversation stays locked from the user's perspective until the background run finishes (or the 10-min stale sweep reaps it).

Observed live on staging: stream cut mid-flight → auto-retry (`regenerate()`) → 409 → unactionable toast, while the backend finished the answer in the background (it appeared after a page reload, because mount-time resume *does* reattach).

## Fix

On a duplicate-active-run 409, call `resumeStream()` instead of toasting. This reattaches to the in-progress response through the existing `GET /api/chat/conversations/:id/active-run` replay endpoint (already wired via `prepareReconnectToStreamRequest`), restoring the live stream and the Stop button.

- If the run already finished, the reconnect returns 204 / replays the terminal run within the grace window, and the conversation refetch (already triggered in `onError`) shows the persisted outcome.
- Same machinery the mount-time resume uses — this just closes the asymmetry where reattach only happened on page load, never on 409.
- Also fixes the second-tab case: sending from another tab while a run is active now attaches that tab to the live stream instead of dead-ending.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>