### PR TITLE
Revert "fix(chat): reattach to the active run on duplicate-run 409 instead of dead-ending"

### DIFF
--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -334,7 +334,7 @@ describe("ChatProvider retries", () => {
     });
   });
 
-  it("reattaches to the active run instead of dead-ending on duplicate active-run submits", async () => {
+  it("shows a toast for duplicate active-run submits", async () => {
     render(
       <ChatProvider>
         <RegisterChatSession />
@@ -349,13 +349,10 @@ describe("ChatProvider retries", () => {
       );
     });
 
-    // A duplicate-run 409 means the backend is still generating (e.g. the
-    // stream connection was severed but the run survived). Reattach to the
-    // live run via the replay endpoint rather than telling the user to stop
-    // a response they cannot see.
-    expect(mocks.resumeStream).toHaveBeenCalledTimes(1);
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      "This conversation already has a response in progress. Stop it before sending another message.",
+    );
     expect(mocks.regenerate).not.toHaveBeenCalled();
-    expect(mocks.toastError).not.toHaveBeenCalled();
   });
 });
 

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -32,6 +32,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { toast } from "sonner";
 import { filterOptimisticToolCalls } from "@/components/chat/chat-messages.utils";
 import { useGenerateConversationTitle } from "@/lib/chat/chat.query";
 import {
@@ -605,15 +606,9 @@ function ChatSessionHook({
       });
 
       if (isDuplicateActiveRunError(chatError)) {
-        // The backend refused the send because this conversation still has a
-        // run generating — typically after the stream connection was severed
-        // (LB cut, network blip) while the backend kept going, and the
-        // auto-retry below re-POSTed into the live run. Reattach to it via the
-        // active-run replay endpoint instead of dead-ending: the user sees the
-        // in-progress response (and the Stop button) again. If the run
-        // finished in the meantime, the reconnect returns 204 and is a no-op —
-        // the conversation refetch above already shows the persisted outcome.
-        void resumeStream();
+        toast.error(
+          "This conversation already has a response in progress. Stop it before sending another message.",
+        );
         return;
       }
 


### PR DESCRIPTION
Reverts archestra-ai/archestra#5363

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>