### PR TITLE
fix(archestra-mcp): enforce agent tool assignment when executing tools

### DIFF
--- a/platform/backend/src/archestra-mcp-server/index.ts
+++ b/platform/backend/src/archestra-mcp-server/index.ts
@@ -1,13 +1,17 @@
 import {
   ARCHESTRA_TOOL_PREFIX,
   type ArchestraToolFullName,
+  type ArchestraToolShortName,
   getArchestraToolFullName,
   getArchestraToolShortName,
   isAgentTool,
+  TOOL_RUN_TOOL_SHORT_NAME,
+  TOOL_SEARCH_TOOLS_SHORT_NAME,
 } from "@archestra/shared";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { ZodError, type ZodType } from "zod";
 import config from "@/config";
+import { ToolModel } from "@/models";
 // Import all groups
 import { toolEntries as agentToolEntries, tools as agentTools } from "./agents";
 import { archestraMcpBranding } from "./branding";
@@ -145,6 +149,13 @@ export async function executeArchestraTool(
   const rbacDenied = await checkToolPermission(toolName, context);
   if (rbacDenied) return rbacDenied;
 
+  // Centralized assignment check — an agent may only execute Archestra tools
+  // that are actually assigned to it (the same set advertised by tools/list and
+  // search_tools). Without this, run_tool or a raw tools/call could invoke any
+  // Archestra tool the user has RBAC for, regardless of assignment.
+  const assignmentDenied = await checkToolAssignedToAgent(toolName, context);
+  if (assignmentDenied) return assignmentDenied;
+
   const resolvedToolName =
     toolEntries[toolName as ArchestraToolFullName] != null
       ? toolName
@@ -192,6 +203,31 @@ export async function executeArchestraTool(
     }
     throw error;
   }
+}
+
+// run_tool / search_tools are the dispatch surface (advertised implicitly in
+// search_and_run_only mode), so they bypass the assignment check.
+const ASSIGNMENT_EXEMPT_SHORT_NAMES = new Set<ArchestraToolShortName>([
+  TOOL_RUN_TOOL_SHORT_NAME,
+  TOOL_SEARCH_TOOLS_SHORT_NAME,
+]);
+
+async function checkToolAssignedToAgent(
+  toolName: string,
+  context: ArchestraContext,
+): Promise<CallToolResult | null> {
+  const shortName = archestraMcpBranding.getToolShortName(toolName);
+  // Assignment is agent-scoped; org/team-token sessions rely on RBAC alone.
+  if (!context.agentId || !shortName) return null;
+  if (ASSIGNMENT_EXEMPT_SHORT_NAMES.has(shortName)) return null;
+
+  const assignedTools = await ToolModel.getMcpToolsByAgent(context.agentId);
+  const isAssigned = assignedTools.some(
+    (tool) => archestraMcpBranding.getToolShortName(tool.name) === shortName,
+  );
+  return isAssigned
+    ? null
+    : errorResult(`Tool '${toolName}' is not assigned to this agent.`);
 }
 
 function resolveArchestraToolName(toolName: string): string | null {

--- a/platform/backend/src/archestra-mcp-server/run-tool.test.ts
+++ b/platform/backend/src/archestra-mcp-server/run-tool.test.ts
@@ -98,7 +98,10 @@ describe("run_tool", () => {
     expect(mcpClient.executeToolCall).not.toHaveBeenCalled();
   });
 
-  test("dispatches built-in tools by short name", async () => {
+  test("dispatches built-in tools by short name", async ({
+    seedAndAssignArchestraTools,
+  }) => {
+    await seedAndAssignArchestraTools(testAgent.id);
     const result = await executeArchestraTool(
       TOOL_RUN_TOOL_FULL_NAME,
       { tool_name: "whoami" },
@@ -113,7 +116,10 @@ describe("run_tool", () => {
     expect(mcpClient.executeToolCall).not.toHaveBeenCalled();
   });
 
-  test("dispatches built-in tools by full name", async () => {
+  test("dispatches built-in tools by full name", async ({
+    seedAndAssignArchestraTools,
+  }) => {
+    await seedAndAssignArchestraTools(testAgent.id);
     const result = await executeArchestraTool(
       TOOL_RUN_TOOL_FULL_NAME,
       { tool_name: TOOL_WHOAMI_FULL_NAME },
@@ -128,7 +134,10 @@ describe("run_tool", () => {
     expect(mcpClient.executeToolCall).not.toHaveBeenCalled();
   });
 
-  test("returns target built-in tool validation errors", async () => {
+  test("returns target built-in tool validation errors", async ({
+    seedAndAssignArchestraTools,
+  }) => {
+    await seedAndAssignArchestraTools(testAgent.id);
     const result = await executeArchestraTool(
       TOOL_RUN_TOOL_FULL_NAME,
       {
@@ -151,6 +160,32 @@ describe("run_tool", () => {
       "Validation error in archestra__todo_write",
     );
     expect((result.content[0] as any).text).toContain("todos[0].status:");
+    expect(mcpClient.executeToolCall).not.toHaveBeenCalled();
+  });
+
+  test("blocks built-in Archestra tools that are not assigned to the agent", async ({
+    makeAgent,
+  }) => {
+    // Fresh agent with no Archestra tools assigned.
+    const unassignedAgent = await makeAgent({
+      name: "Unassigned Agent",
+      organizationId: mockContext.organizationId,
+    });
+
+    const result = await executeArchestraTool(
+      TOOL_RUN_TOOL_FULL_NAME,
+      { tool_name: "swap_agent", tool_args: { agentId: "some-agent-id" } },
+      {
+        ...mockContext,
+        agent: { id: unassignedAgent.id, name: unassignedAgent.name },
+        agentId: unassignedAgent.id,
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain(
+      "is not assigned to this agent",
+    );
     expect(mcpClient.executeToolCall).not.toHaveBeenCalled();
   });
 

--- a/platform/backend/src/archestra-mcp-server/run-tool.ts
+++ b/platform/backend/src/archestra-mcp-server/run-tool.ts
@@ -40,7 +40,7 @@ const registry = defineArchestraTools([
   defineArchestraTool({
     shortName: TOOL_RUN_TOOL_SHORT_NAME,
     title: "Run Tool",
-    description: `Dispatch to any tool available to this agent, including built-in platform tools, agent delegation tools ('agent-<id>'), or third-party MCP tools exposed through the MCP Gateway (e.g. 'context7__resolve-library-id'). Pass the tool name exactly as it appears in the tools list or use a built-in platform tool short name like 'whoami' or 'get_agent'. Prefer using ${TOOL_SEARCH_TOOLS_SHORT_NAME} first when you need to discover the right exact name. Target-tool RBAC, argument validation, and output validation all still apply.`,
+    description: `Dispatch to any tool available to this agent, including built-in platform tools, agent delegation tools ('agent-<id>'), or third-party MCP tools exposed through the MCP Gateway (e.g. 'context7__resolve-library-id'). Pass the tool name exactly as it appears in the tools list or use a built-in platform tool short name like 'whoami' or 'get_agent'. Prefer using ${TOOL_SEARCH_TOOLS_SHORT_NAME} first when you need to discover the right exact name. The target tool must be assigned to this agent; target-tool RBAC, argument validation, and output validation all still apply.`,
     schema: RunToolArgsSchema,
     async handler({ args, context }) {
       const requestedName = args.tool_name;

--- a/platform/backend/src/archestra-mcp-server/sandbox.test.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.test.ts
@@ -71,7 +71,21 @@ describe("sandbox tools (runtime disabled)", () => {
     expect(TOOL_PERMISSIONS.upload_file).toEqual(perm);
   });
 
-  test("run_command returns a clean error when the runtime is disabled", async () => {
+  test("run_command returns a clean error when the runtime is disabled", async ({
+    makeInternalMcpCatalog,
+    makeTool,
+    makeAgentTool,
+  }) => {
+    // The runtime-disabled catalog omits sandbox tools, so seeding can't assign
+    // run_command. Assign it directly so execution reaches the "not enabled"
+    // handler rather than the assignment gate.
+    const catalog = await makeInternalMcpCatalog();
+    const tool = await makeTool({
+      name: TOOL_RUN_COMMAND_FULL_NAME,
+      catalogId: catalog.id,
+    });
+    await makeAgentTool(context.agentId as string, tool.id);
+
     const result = await executeArchestraTool(
       TOOL_RUN_COMMAND_FULL_NAME,
       { command: "echo hi" },
@@ -97,19 +111,29 @@ describe("sandbox tools (runtime enabled)", () => {
     (config.skillsSandbox as { enabled: boolean }).enabled = originalEnabled;
   });
 
-  beforeEach(async ({ makeAgent, makeUser, makeMember }) => {
-    agent = await makeAgent({ name: "Sandbox Agent" });
-    organizationId = agent.organizationId;
-    const user = await makeUser();
-    await makeMember(user.id, organizationId, { role: ADMIN_ROLE_NAME });
-    userId = user.id;
-    context = {
-      agent: { id: agent.id, name: agent.name },
-      agentId: agent.id,
-      organizationId,
-      userId,
-    };
-  });
+  beforeEach(
+    async ({
+      makeAgent,
+      makeUser,
+      makeMember,
+      seedAndAssignArchestraTools,
+    }) => {
+      agent = await makeAgent({ name: "Sandbox Agent" });
+      organizationId = agent.organizationId;
+      const user = await makeUser();
+      await makeMember(user.id, organizationId, { role: ADMIN_ROLE_NAME });
+      userId = user.id;
+      // Sandbox tools are gated by per-agent assignment (plus sandbox:execute),
+      // so assign the full Archestra set (seeded with the runtime enabled).
+      await seedAndAssignArchestraTools(agent.id);
+      context = {
+        agent: { id: agent.id, name: agent.name },
+        agentId: agent.id,
+        organizationId,
+        userId,
+      };
+    },
+  );
 
   afterEach(() => {
     vi.restoreAllMocks();


### PR DESCRIPTION
run_tool (and raw tools/call) only enforced RBAC, never agent tool-assignment, so any Archestra tool the user had permission for could be invoked regardless of whether it was assigned to the agent — even though search_tools/tools-list only advertise assigned tools.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>