### PR TITLE
fix(skill-marketplace): install git in runtime image

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -239,8 +239,9 @@ COPY docker/certs/gcloud-sql-global.pem /tmp/gcloud-sql-ca.pem
 
 RUN apk --no-cache upgrade && \
     # Install PostgreSQL 17, pgvector, supervisord, and git.
-    # git (CLI + http-backend) backs the skill-marketplace smart-HTTP clone endpoint.
-    apk add --no-cache postgresql17 postgresql17-contrib postgresql-pgvector su-exec git && \
+    # The skill-marketplace clone endpoint needs the git CLI (materialize.ts) and
+    # git-http-backend, the smart-HTTP CGI — which Alpine ships in git-daemon, not git.
+    apk add --no-cache postgresql17 postgresql17-contrib postgresql-pgvector su-exec git git-daemon && \
     # Combine all CA bundles
     cat /tmp/aws-rds-ca.pem /tmp/gcloud-sql-ca.pem > /etc/ssl/certs/cloud-database-ca-bundle.pem && \
     rm -f /tmp/aws-rds-ca.pem /tmp/gcloud-sql-ca.pem && \

--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -238,8 +238,9 @@ COPY docker/certs/aws-rds-global-bundle.pem /tmp/aws-rds-ca.pem
 COPY docker/certs/gcloud-sql-global.pem /tmp/gcloud-sql-ca.pem
 
 RUN apk --no-cache upgrade && \
-    # Install PostgreSQL 17, pgvector, and supervisord
-    apk add --no-cache postgresql17 postgresql17-contrib postgresql-pgvector su-exec && \
+    # Install PostgreSQL 17, pgvector, supervisord, and git.
+    # git (CLI + http-backend) backs the skill-marketplace smart-HTTP clone endpoint.
+    apk add --no-cache postgresql17 postgresql17-contrib postgresql-pgvector su-exec git && \
     # Combine all CA bundles
     cat /tmp/aws-rds-ca.pem /tmp/gcloud-sql-ca.pem > /etc/ssl/certs/cloud-database-ca-bundle.pem && \
     rm -f /tmp/aws-rds-ca.pem /tmp/gcloud-sql-ca.pem && \


### PR DESCRIPTION
## Problem

`claude plugin marketplace add https://frontend.archestra.dev/skills/m/<token>/repo.git` (and any clone of a skill-marketplace share link) fails with:

```
fatal: unable to access '.../repo.git/': The requested URL returned error: 502
```

The `502 {"error":"Service unavailable"}` is the backend's own response at `skill-marketplace-public.ts:91`. The token validates (a bad token returns 404); the throw happens inside `buildServeContext → materialize() → initEmptyRepo() → spawn(git)`.

## Root cause

The `git` binary is **not installed in the runtime image**. `config.git.binaryPath` defaults to `"git"`, but the `unified` stage of `platform/Dockerfile` installed `postgresql / su-exec / supervisor` and never `git` (the `git` elsewhere in the Dockerfile lives only in the throwaway `go-builder` stage).

Logs confirm `ENOENT` on both paths:
- request path: `spawn git ENOENT` → "skill-marketplace: error preparing git response"
- startup probe (`onReady`): `spawnSync git ENOENT` → "git binary not usable — clone requests will 502 …"

**Initial error, not a regression:** the feature shipped in #5068 without touching the Dockerfile, and `git` has never been in the runtime `apk add` line in any revision — the endpoint has 502'd for every clone since it merged.

## Fix

Add `git` to the runtime `apk add`. Alpine's `git` package provides both the CLI (used by `materialize.ts`) and `git http-backend` (the CGI in `git-http-backend.ts`), covering both code paths. No code change needed.

## Update — `git-http-backend` lives in `git-daemon`

Codex review + verification against Alpine's package index (`pkgs.alpinelinux.org/contents?file=git-http-backend`) confirmed `/usr/libexec/git-core/git-http-backend` is shipped by the **`git-daemon`** package, not `git`. A `git`-only install would fix the current JSON 502 (materialize uses plain git) but reintroduce a 502 at the `git http-backend` CGI step in `git-http-backend.ts`. The fix installs **both** `git` and `git-daemon`.
