### PR TITLE
Revert "Revert "fix(chat): auto-retry empty model responses (#5240)" — incident: stuck active runs cause 409"

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -68119,6 +68119,7 @@
                                     "content_filtered",
                                     "server_error",
                                     "network_error",
+                                    "empty_response",
                                     "unknown"
                                   ]
                                 },
@@ -68803,6 +68804,7 @@
                                   "content_filtered",
                                   "server_error",
                                   "network_error",
+                                  "empty_response",
                                   "unknown"
                                 ]
                               },
@@ -69464,6 +69466,7 @@
                                   "content_filtered",
                                   "server_error",
                                   "network_error",
+                                  "empty_response",
                                   "unknown"
                                 ]
                               },
@@ -70166,6 +70169,7 @@
                                   "content_filtered",
                                   "server_error",
                                   "network_error",
+                                  "empty_response",
                                   "unknown"
                                 ]
                               },
@@ -71705,6 +71709,7 @@
                                   "content_filtered",
                                   "server_error",
                                   "network_error",
+                                  "empty_response",
                                   "unknown"
                                 ]
                               },
@@ -72733,6 +72738,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -74350,6 +74356,7 @@
                                   "content_filtered",
                                   "server_error",
                                   "network_error",
+                                  "empty_response",
                                   "unknown"
                                 ]
                               },
@@ -75035,6 +75042,7 @@
                                   "content_filtered",
                                   "server_error",
                                   "network_error",
+                                  "empty_response",
                                   "unknown"
                                 ]
                               },
@@ -75712,6 +75720,7 @@
                                   "content_filtered",
                                   "server_error",
                                   "network_error",
+                                  "empty_response",
                                   "unknown"
                                 ]
                               },
@@ -76399,6 +76408,7 @@
                                   "content_filtered",
                                   "server_error",
                                   "network_error",
+                                  "empty_response",
                                   "unknown"
                                 ]
                               },
@@ -89510,6 +89520,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -90345,6 +90356,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -90888,6 +90900,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -91295,6 +91308,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -91713,6 +91727,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -93939,6 +93954,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -94357,6 +94373,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -94775,6 +94792,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -95193,6 +95211,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -95611,6 +95630,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -96029,6 +96049,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -96447,6 +96468,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -96865,6 +96887,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -97272,6 +97295,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -97679,6 +97703,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -98097,6 +98122,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -98515,6 +98541,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -98933,6 +98960,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -99577,6 +99605,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -100412,6 +100441,7 @@
                                             "content_filtered",
                                             "server_error",
                                             "network_error",
+                                            "empty_response",
                                             "unknown"
                                           ]
                                         },
@@ -102309,6 +102339,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -103144,6 +103175,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -103687,6 +103719,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -104094,6 +104127,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -104512,6 +104546,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -106738,6 +106773,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -107156,6 +107192,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -107574,6 +107611,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -107992,6 +108030,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -108410,6 +108449,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -108828,6 +108868,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -109246,6 +109287,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -109664,6 +109706,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -110071,6 +110114,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -110478,6 +110522,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -110896,6 +110941,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -111314,6 +111360,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -111732,6 +111779,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -112376,6 +112424,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -113211,6 +113260,7 @@
                                       "content_filtered",
                                       "server_error",
                                       "network_error",
+                                      "empty_response",
                                       "unknown"
                                     ]
                                   },
@@ -183444,6 +183494,7 @@
                                   "content_filtered",
                                   "server_error",
                                   "network_error",
+                                  "empty_response",
                                   "unknown"
                                 ]
                               },

--- a/platform/backend/src/routes/chat/errors.test.ts
+++ b/platform/backend/src/routes/chat/errors.test.ts
@@ -18,6 +18,7 @@ vi.mock("@sentry/node", () => ({
 }));
 
 import {
+  EmptyModelResponseError,
   mapProviderError,
   ProviderError,
   sanitizeChatErrorForFrontend,
@@ -1712,5 +1713,30 @@ describe("ProviderError", () => {
       usageLimitExceeded: true,
       usageLimitEntityType: "organization",
     });
+  });
+});
+
+describe("mapProviderError - EmptyModelResponseError", () => {
+  it("maps a content-filter finish to the non-retryable ContentFiltered card", () => {
+    const result = mapProviderError(
+      new EmptyModelResponseError({
+        finishReason: "content-filter",
+        attempts: 1,
+      }),
+      "openai",
+    );
+
+    expect(result.code).toBe(ChatErrorCode.ContentFiltered);
+    expect(result.isRetryable).toBe(false);
+  });
+
+  it("maps an exhausted stop finish to the retryable EmptyResponse card", () => {
+    const result = mapProviderError(
+      new EmptyModelResponseError({ finishReason: "stop", attempts: 3 }),
+      "openai",
+    );
+
+    expect(result.code).toBe(ChatErrorCode.EmptyResponse);
+    expect(result.isRetryable).toBe(true);
   });
 });

--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -40,6 +40,26 @@ export class ProviderError extends Error {
   }
 }
 
+/**
+ * Thrown when the provider finishes a turn cleanly (finishReason stop/length)
+ * but produces no renderable content, after the empty-response auto-retries are
+ * exhausted (or immediately for a non-retryable finishReason). Carries the last
+ * finishReason for diagnostics. mapProviderError turns it into a structured
+ * error card: a content-filter finish becomes the non-retryable ContentFiltered
+ * card, everything else the retryable EmptyResponse card.
+ */
+export class EmptyModelResponseError extends Error {
+  public readonly finishReason: string;
+  public readonly attempts: number;
+
+  constructor(params: { finishReason: string; attempts: number }) {
+    super(`Model returned an empty response after ${params.attempts} attempts`);
+    this.name = "EmptyModelResponseError";
+    this.finishReason = params.finishReason;
+    this.attempts = params.attempts;
+  }
+}
+
 // =============================================================================
 // Safe Serialization
 // =============================================================================
@@ -1503,6 +1523,28 @@ export function mapProviderError(
           : undefined,
       };
     }
+  }
+
+  // Handle EmptyModelResponseError — the provider finished cleanly but gave no
+  // content, and the empty-response retries were exhausted. Surface it as a
+  // structured, retryable EmptyResponse error.
+  if (error instanceof EmptyModelResponseError) {
+    // A content-filter finish is a deterministic block, not a transient empty
+    // turn — surface it as the non-retryable ContentFiltered card so the UI
+    // doesn't offer a pointless retry. Exhausted stop/length/unknown turns stay
+    // the retryable EmptyResponse.
+    const code =
+      error.finishReason === "content-filter"
+        ? ChatErrorCode.ContentFiltered
+        : ChatErrorCode.EmptyResponse;
+    return createErrorResponse(
+      code,
+      provider,
+      undefined,
+      ChatErrorMessages[code],
+      "EmptyModelResponseError",
+      { finishReason: error.finishReason, attempts: error.attempts },
+    );
   }
 
   // Handle NoOutputGeneratedError — the provider failed before producing any

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -107,10 +107,10 @@ import {
 } from "./context-compaction";
 import {
   parseMaxInputTokens,
-  shouldProbeTextStreamForContextTrimRetry,
   trimMessagesToTokenLimit,
 } from "./context-trimming";
 import {
+  EmptyModelResponseError,
   getActiveTraceContext,
   mapProviderError,
   ProviderError,
@@ -125,6 +125,11 @@ import {
   normalizeChatMessages,
   normalizeChatMessagesForPersistence,
 } from "./normalization/normalize-chat-messages";
+import {
+  isRetryableEmptyFinishReason,
+  probeFirstRenderableEvent,
+} from "./stream-probe";
+import { createToolUiStartTransform } from "./tool-ui-stream";
 
 const PromoteChatAttachmentResultSchema = z.object({
   filename: z.string(),
@@ -638,12 +643,13 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   }
                 }, 5000);
 
-                // Prefetch all UI resources eagerly before streaming starts
-                // so onChunk can write data-tool-ui-start synchronously.
-                // Even with LRU caching, .then() on a resolved promise runs
-                // as a microtask — the stream processes more chunks before
-                // the microtask fires, causing data-tool-ui-start to arrive
-                // after all tool deltas instead of right after tool-input-start.
+                // Prefetch all UI resources eagerly before streaming starts so
+                // the merge transform below can emit data-tool-ui-start
+                // synchronously right after each tool-input-start chunk. A
+                // .then() on a resolved promise runs as a microtask — the stream
+                // would process more chunks before it fires, landing
+                // data-tool-ui-start after all tool deltas instead of right
+                // after tool-input-start.
                 const MAX_SSE_HTML_BYTES = 1024 * 1024;
                 const prefetchedUiResources = new Map<
                   string,
@@ -689,31 +695,6 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                     ),
                   );
                 }
-
-                // Emit data-tool-ui-start synchronously in onChunk so it
-                // arrives right after tool-input-start, before any deltas.
-                const streamTextOnChunk: NonNullable<
-                  Parameters<typeof streamText>[0]["onChunk"]
-                > = ({ chunk }) => {
-                  if (chunk.type === "tool-input-start" && chunk.toolName) {
-                    const prefetched = prefetchedUiResources.get(
-                      chunk.toolName,
-                    );
-                    if (prefetched) {
-                      writer.write({
-                        type: "data-tool-ui-start",
-                        data: {
-                          toolCallId: chunk.id,
-                          toolName: chunk.toolName,
-                          uiResourceUri: toolUiResourceUris[chunk.toolName],
-                          html: prefetched.html,
-                          csp: prefetched.csp,
-                          permissions: prefetched.permissions,
-                        },
-                      });
-                    }
-                  }
-                };
 
                 let compactionStarted = false;
                 const compactionResult = await compactMessagesForChat({
@@ -775,7 +756,6 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   ...(supportsToolCalling && { tools: mcpTools }),
                   stopWhen: buildChatStopConditions(),
                   abortSignal: chatAbortController.signal,
-                  onChunk: streamTextOnChunk,
                   // Emit per-step usage so the context indicator tracks the
                   // prompt growing across tool round-trips, instead of jumping
                   // only once when the whole turn finishes.
@@ -790,7 +770,10 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                     });
                   },
                   onFinish: async ({ usage, finishReason }) => {
-                    removeAbortListeners();
+                    // abort listeners are removed in the toUIMessageStream
+                    // onFinish, which fires only for the final merged result —
+                    // not for discarded empty-response retry attempts, whose
+                    // streams we also consume here.
                     logger.info(
                       {
                         conversationId,
@@ -815,29 +798,46 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   };
                 }
 
-                // Stream tokens to the client in real-time while also
-                // handling context-length errors from vLLM/LiteLLM.
-                //
-                // Context-length errors (400) are rejected by the provider
-                // before any tokens are emitted. We detect this by reading
-                // the first chunk from textStream — if the provider rejects,
-                // the iterator throws immediately. We then parse the error,
-                // trim messages, and retry with a new streamText call.
-                //
-                // For successful requests, the first chunk arrives quickly
-                // and we proceed to merge the full stream to the client.
-                let result = streamText(streamTextConfig);
+                // Probe each attempt's stream for its first renderable event
+                // before merging it to the client. This lets us, before anything
+                // reaches the user:
+                //   - trim + retry on a context-length rejection (vLLM/LiteLLM), and
+                //   - silently retry a clean-but-empty response (a stupid-model /
+                //     inference glitch), then surface a stream error if it persists.
+                // tee() buffers the stream, so consuming the probe prefix does not
+                // drop events from the toUIMessageStream merge below. Returning on
+                // the first *renderable* event (not first text) keeps Gemini's
+                // tool-call-before-text turns streaming the tool indicator promptly.
+                const MAX_EMPTY_RESPONSE_ATTEMPTS = 3;
+                // a still-too-long trimmed payload reproduces the same context
+                // error (trim is deterministic from the unchanged messages), so
+                // cap trim retries to avoid an unbounded loop; on the cap we fall
+                // through to merge and let the existing onError surface it.
+                const MAX_CONTEXT_TRIM_ATTEMPTS = 1;
+                let emptyResponseAttempts = 0;
+                let contextTrimAttempts = 0;
+                // the config the loop retries from; trim replaces its messages so
+                // a later empty-response retry reuses the trimmed payload instead
+                // of resending the original (too-large) one.
+                let currentConfig = streamTextConfig;
+                let result = streamText(currentConfig);
 
-                // Try reading the first text chunk to detect immediate provider errors.
-                // Context-length errors fire before any tokens, so this catches them
-                // without blocking normal streaming (first token arrives in ~100-500ms).
-                if (shouldProbeTextStreamForContextTrimRetry(provider)) {
-                  try {
-                    const reader = result.textStream[Symbol.asyncIterator]();
-                    await reader.next();
-                  } catch (error) {
-                    const maxTokens = parseMaxInputTokens(error);
-                    if (maxTokens !== null) {
+                while (true) {
+                  const probe = await probeFirstRenderableEvent(
+                    result.fullStream[Symbol.asyncIterator](),
+                  );
+
+                  if (probe.kind === "renderable" || probe.kind === "aborted") {
+                    break;
+                  }
+
+                  if (probe.kind === "error") {
+                    const maxTokens = parseMaxInputTokens(probe.error);
+                    if (
+                      maxTokens !== null &&
+                      contextTrimAttempts < MAX_CONTEXT_TRIM_ATTEMPTS
+                    ) {
+                      contextTrimAttempts++;
                       const trimmed = trimMessagesToTokenLimit({
                         messages: modelMessages,
                         maxTokens,
@@ -852,31 +852,60 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                         },
                         "[ContextTrimming] retrying with trimmed messages",
                       );
-                      result = streamText({
-                        ...streamTextConfig,
+                      currentConfig = {
+                        ...currentConfig,
                         messages: trimmed,
-                      });
-                    } else {
-                      // Save messages before throwing — this error path runs before
-                      // writer.merge(), so onError/onFinish callbacks won't fire.
-                      if (!messagesPersisted && conversationId) {
-                        messagesPersisted = true;
-                        try {
-                          await persistNewMessages(
-                            conversationId,
-                            messages,
-                            "onExecuteError",
-                          );
-                        } catch (persistError) {
-                          logger.error(
-                            { persistError, conversationId },
-                            "Failed to persist messages during execute error",
-                          );
-                        }
-                      }
-                      throw error;
+                      };
+                      result = streamText(currentConfig);
+                      continue;
+                    }
+                    // Non-context error, or context-trim retries exhausted: fall
+                    // through to the merge so the existing toUIMessageStream
+                    // onError surfaces it (preserving e.g. unavailable-tool
+                    // handling). tee() replays the error.
+                    break;
+                  }
+
+                  // probe.kind === "empty": the provider finished with no content.
+                  emptyResponseAttempts++;
+                  const canRetryEmptyResponse =
+                    isRetryableEmptyFinishReason(probe.finishReason) &&
+                    emptyResponseAttempts < MAX_EMPTY_RESPONSE_ATTEMPTS;
+                  if (canRetryEmptyResponse) {
+                    logger.warn(
+                      {
+                        conversationId,
+                        finishReason: probe.finishReason,
+                        attempt: emptyResponseAttempts,
+                      },
+                      "[EmptyResponse] model produced no content, retrying",
+                    );
+                    result = streamText(currentConfig);
+                    continue;
+                  }
+
+                  // Exhausted retries (or a non-retryable finishReason): treat the
+                  // empty turn as a stream error. Persist first — this runs before
+                  // writer.merge(), so the stream onError/onFinish won't fire.
+                  if (!messagesPersisted && conversationId) {
+                    messagesPersisted = true;
+                    try {
+                      await persistNewMessages(
+                        conversationId,
+                        messages,
+                        "onExecuteError",
+                      );
+                    } catch (persistError) {
+                      logger.error(
+                        { persistError, conversationId },
+                        "Failed to persist messages during empty-response error",
+                      );
                     }
                   }
+                  throw new EmptyModelResponseError({
+                    finishReason: probe.finishReason,
+                    attempts: emptyResponseAttempts,
+                  });
                 }
 
                 // toUIMessageStream invokes onError twice for the same upstream
@@ -891,161 +920,169 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 // (e.g. two unavailable tools in one step) independently.
                 const returnedChatErrorPayloads = new Set<string>();
 
-                writer.merge(
-                  result.toUIMessageStream({
-                    originalMessages: messages as UIMessage[],
-                    // Give the streamed assistant message a stable id. Without
-                    // generateMessageId the AI SDK leaves the response message
-                    // id empty, so the persisted assistant row can't be matched
-                    // when the approval resume re-sends the turn — the resolved
-                    // turn is appended as new rows while the original
-                    // approval-requested row is orphaned and re-renders a stale
-                    // prompt on reload (#4030).
-                    generateMessageId: generateId,
-                    onError: (error) => {
-                      const incomingErrorMessage =
-                        error instanceof Error ? error.message : String(error);
-                      if (returnedChatErrorPayloads.has(incomingErrorMessage)) {
-                        return incomingErrorMessage;
-                      }
+                const modelUiStream = result.toUIMessageStream({
+                  originalMessages: messages as UIMessage[],
+                  // Give the streamed assistant message a stable id. Without
+                  // generateMessageId the AI SDK leaves the response message
+                  // id empty, so the persisted assistant row can't be matched
+                  // when the approval resume re-sends the turn — the resolved
+                  // turn is appended as new rows while the original
+                  // approval-requested row is orphaned and re-renders a stale
+                  // prompt on reload (#4030).
+                  generateMessageId: generateId,
+                  onError: (error) => {
+                    const incomingErrorMessage =
+                      error instanceof Error ? error.message : String(error);
+                    if (returnedChatErrorPayloads.has(incomingErrorMessage)) {
+                      return incomingErrorMessage;
+                    }
 
-                      const unavailableToolError =
-                        getUnavailableToolErrorDetails(error);
-                      if (unavailableToolError) {
-                        const serializedToolError =
-                          formatUnavailableToolErrorDetails(
-                            unavailableToolError,
-                          );
-                        returnedChatErrorPayloads.add(serializedToolError);
-                        logger.info(
-                          {
-                            conversationId,
-                            unavailableToolError,
-                          },
-                          "Returning unavailable tool error as tool-level error",
-                        );
-                        return serializedToolError;
-                      }
-
-                      const traceContext = getActiveTraceContext();
-                      const correlationLogFields =
-                        getCorrelationLogFields(traceContext);
-
-                      // Use pre-built error from subagent if available (preserves correct provider),
-                      // otherwise map the error with the current provider
-                      const mappedError: ChatErrorResponse =
-                        error instanceof ProviderError
-                          ? error.chatErrorResponse
-                          : mapProviderError(error, provider);
-                      const fullError = { ...mappedError, ...traceContext };
-                      const errorForFrontend = slimChatErrorUi
-                        ? sanitizeChatErrorForFrontend(fullError)
-                        : fullError;
-
-                      // mapProviderError safely serializes raw errors, but add defensive try-catch
-                      let serializedChatError: string;
-                      try {
-                        serializedChatError = JSON.stringify(errorForFrontend);
-                      } catch (stringifyError) {
-                        logger.error(
-                          {
-                            stringifyError,
-                            errorCode: mappedError.code,
-                            ...correlationLogFields,
-                          },
-                          "Failed to stringify mapped error, returning minimal error",
-                        );
-                        serializedChatError = JSON.stringify(
-                          getMinimalFrontendError(errorForFrontend),
-                        );
-                      }
-                      returnedChatErrorPayloads.add(serializedChatError);
-
-                      activeRunError =
-                        error instanceof Error ? error.message : String(error);
-                      // Claim persistence before the async work below starts,
-                      // otherwise onFinish can race and also persist (duplicates).
-                      const shouldPersist =
-                        !messagesPersisted && !!conversationId;
-                      if (shouldPersist) {
-                        messagesPersisted = true;
-                      }
-
-                      (async () => {
-                        logger.error(
-                          {
-                            error,
-                            conversationId,
-                            agentId,
-                            ...correlationLogFields,
-                          },
-                          "Chat stream error occurred",
-                        );
-
-                        // Persist messages despite error so they have a valid ID for editing
-                        if (shouldPersist) {
-                          try {
-                            await persistNewMessages(
-                              conversationId,
-                              messages,
-                              "onError",
-                            );
-                          } catch (persistError) {
-                            // Log persistence error but don't prevent the error response
-                            logger.error(
-                              { persistError, conversationId },
-                              "Failed to persist messages during error handling",
-                            );
-                          }
-                        }
-                      })().catch((err) => {
-                        // Log any errors from the async IIFE but don't crash
-                        logger.error(
-                          { err },
-                          "Unexpected error in onError async handler",
-                        );
-                      });
-
-                      persistConversationChatError({
-                        conversationId,
-                        error: errorForFrontend,
-                      });
-
+                    const unavailableToolError =
+                      getUnavailableToolErrorDetails(error);
+                    if (unavailableToolError) {
+                      const serializedToolError =
+                        formatUnavailableToolErrorDetails(unavailableToolError);
+                      returnedChatErrorPayloads.add(serializedToolError);
                       logger.info(
                         {
-                          mappedError: fullError,
-                          originalErrorType:
-                            error instanceof Error ? error.name : typeof error,
-                          willBeSentToFrontend: true,
+                          conversationId,
+                          unavailableToolError,
+                        },
+                        "Returning unavailable tool error as tool-level error",
+                      );
+                      return serializedToolError;
+                    }
+
+                    const traceContext = getActiveTraceContext();
+                    const correlationLogFields =
+                      getCorrelationLogFields(traceContext);
+
+                    // Use pre-built error from subagent if available (preserves correct provider),
+                    // otherwise map the error with the current provider
+                    const mappedError: ChatErrorResponse =
+                      error instanceof ProviderError
+                        ? error.chatErrorResponse
+                        : mapProviderError(error, provider);
+                    const fullError = { ...mappedError, ...traceContext };
+                    const errorForFrontend = slimChatErrorUi
+                      ? sanitizeChatErrorForFrontend(fullError)
+                      : fullError;
+
+                    // mapProviderError safely serializes raw errors, but add defensive try-catch
+                    let serializedChatError: string;
+                    try {
+                      serializedChatError = JSON.stringify(errorForFrontend);
+                    } catch (stringifyError) {
+                      logger.error(
+                        {
+                          stringifyError,
+                          errorCode: mappedError.code,
                           ...correlationLogFields,
                         },
-                        "Returning mapped error to frontend via stream",
+                        "Failed to stringify mapped error, returning minimal error",
+                      );
+                      serializedChatError = JSON.stringify(
+                        getMinimalFrontendError(errorForFrontend),
+                      );
+                    }
+                    returnedChatErrorPayloads.add(serializedChatError);
+
+                    activeRunError =
+                      error instanceof Error ? error.message : String(error);
+                    // Claim persistence before the async work below starts,
+                    // otherwise onFinish can race and also persist (duplicates).
+                    const shouldPersist =
+                      !messagesPersisted && !!conversationId;
+                    if (shouldPersist) {
+                      messagesPersisted = true;
+                    }
+
+                    (async () => {
+                      logger.error(
+                        {
+                          error,
+                          conversationId,
+                          agentId,
+                          ...correlationLogFields,
+                        },
+                        "Chat stream error occurred",
                       );
 
-                      return serializedChatError;
-                    },
-                    onFinish: async ({ messages: finalMessages }) => {
-                      removeAbortListeners();
-                      stopActiveRunPolling();
-
-                      // Only persist if not already persisted by onError
-                      if (!messagesPersisted && conversationId) {
+                      // Persist messages despite error so they have a valid ID for editing
+                      if (shouldPersist) {
                         try {
                           await persistNewMessages(
                             conversationId,
-                            finalMessages,
-                            "onFinish",
+                            messages,
+                            "onError",
                           );
-                          messagesPersisted = true;
-                        } catch (error) {
+                        } catch (persistError) {
+                          // Log persistence error but don't prevent the error response
                           logger.error(
-                            { error, conversationId },
-                            "Failed to persist messages during onFinish",
+                            { persistError, conversationId },
+                            "Failed to persist messages during error handling",
                           );
                         }
                       }
-                    },
-                  }),
+                    })().catch((err) => {
+                      // Log any errors from the async IIFE but don't crash
+                      logger.error(
+                        { err },
+                        "Unexpected error in onError async handler",
+                      );
+                    });
+
+                    persistConversationChatError({
+                      conversationId,
+                      error: errorForFrontend,
+                    });
+
+                    logger.info(
+                      {
+                        mappedError: fullError,
+                        originalErrorType:
+                          error instanceof Error ? error.name : typeof error,
+                        willBeSentToFrontend: true,
+                        ...correlationLogFields,
+                      },
+                      "Returning mapped error to frontend via stream",
+                    );
+
+                    return serializedChatError;
+                  },
+                  onFinish: async ({ messages: finalMessages }) => {
+                    removeAbortListeners();
+                    stopActiveRunPolling();
+
+                    // Only persist if not already persisted by onError
+                    if (!messagesPersisted && conversationId) {
+                      try {
+                        await persistNewMessages(
+                          conversationId,
+                          finalMessages,
+                          "onFinish",
+                        );
+                        messagesPersisted = true;
+                      } catch (error) {
+                        logger.error(
+                          { error, conversationId },
+                          "Failed to persist messages during onFinish",
+                        );
+                      }
+                    }
+                  },
+                });
+
+                // Inject data-tool-ui-start right after each tool-input-start
+                // chunk (see createToolUiStartTransform — kept out of onChunk so
+                // the empty-response probe can't emit it before its own tool).
+                writer.merge(
+                  modelUiStream.pipeThrough(
+                    createToolUiStartTransform({
+                      prefetchedUiResources,
+                      toolUiResourceUris,
+                    }),
+                  ),
                 );
 
                 // Wait for the stream to complete and get usage data.

--- a/platform/backend/src/routes/chat/stream-probe.test.ts
+++ b/platform/backend/src/routes/chat/stream-probe.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "vitest";
+import {
+  isRetryableEmptyFinishReason,
+  probeFirstRenderableEvent,
+  type StreamProbeEvent,
+} from "./stream-probe";
+
+// builds a real async iterator over the given events; `onReturn` records whether
+// the iterator was cancelled (which would cancel the underlying stream).
+function iteratorOf(
+  events: StreamProbeEvent[],
+  onReturn?: () => void,
+): AsyncIterator<StreamProbeEvent> {
+  let index = 0;
+  return {
+    next() {
+      if (index < events.length) {
+        return Promise.resolve({ value: events[index++], done: false });
+      }
+      return Promise.resolve({ value: undefined, done: true });
+    },
+    return() {
+      onReturn?.();
+      return Promise.resolve({ value: undefined, done: true });
+    },
+  };
+}
+
+describe("probeFirstRenderableEvent", () => {
+  test("returns renderable on the first text-delta", async () => {
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "start-step" },
+      { type: "text-start" },
+      { type: "text-delta" },
+      { type: "finish", finishReason: "stop" },
+    ];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "renderable",
+    });
+  });
+
+  test("treats a tool-only turn as renderable, not empty", async () => {
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "start-step" },
+      { type: "tool-input-start" },
+      { type: "tool-call" },
+      { type: "finish", finishReason: "tool-calls" },
+    ];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "renderable",
+    });
+  });
+
+  test("treats a resume turn opening with tool-output-denied as renderable", async () => {
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "start-step" },
+      { type: "tool-output-denied" },
+      { type: "finish", finishReason: "stop" },
+    ];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "renderable",
+    });
+  });
+
+  test("treats a tool-error opening as renderable", async () => {
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "tool-error" },
+      { type: "finish", finishReason: "stop" },
+    ];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "renderable",
+    });
+  });
+
+  test("treats a reasoning-only opening as renderable", async () => {
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "reasoning-start" },
+    ];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "renderable",
+    });
+  });
+
+  test("reports empty with finishReason when the turn finishes with no content", async () => {
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "start-step" },
+      { type: "finish-step", finishReason: "stop" },
+      { type: "finish", finishReason: "stop" },
+    ];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "empty",
+      finishReason: "stop",
+    });
+  });
+
+  test("reports empty with unknown when the stream ends without a finish event", async () => {
+    const events: StreamProbeEvent[] = [{ type: "start" }];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "empty",
+      finishReason: "unknown",
+    });
+  });
+
+  test("surfaces an error event before any content", async () => {
+    const boom = new Error("provider exploded");
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "error", error: boom },
+    ];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "error",
+      error: boom,
+    });
+  });
+
+  test("surfaces a thrown error from the iterator", async () => {
+    const boom = new Error("context length exceeded");
+    const iterator: AsyncIterator<StreamProbeEvent> = {
+      next() {
+        return Promise.reject(boom);
+      },
+    };
+
+    expect(await probeFirstRenderableEvent(iterator)).toEqual({
+      kind: "error",
+      error: boom,
+    });
+  });
+
+  test("reports aborted when the stream is aborted before content", async () => {
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "abort", reason: "user stopped" } as StreamProbeEvent,
+    ];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "aborted",
+    });
+  });
+
+  test("does not cancel the iterator when it finds content (so the merge can replay)", async () => {
+    let returned = false;
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "text-delta" },
+      { type: "finish", finishReason: "stop" },
+    ];
+
+    await probeFirstRenderableEvent(
+      iteratorOf(events, () => {
+        returned = true;
+      }),
+    );
+
+    expect(returned).toBe(false);
+  });
+});
+
+describe("isRetryableEmptyFinishReason", () => {
+  test("retries on stop, length, and unknown", () => {
+    expect(isRetryableEmptyFinishReason("stop")).toBe(true);
+    expect(isRetryableEmptyFinishReason("length")).toBe(true);
+    expect(isRetryableEmptyFinishReason("unknown")).toBe(true);
+  });
+
+  test("does not retry on content-filter or other terminal reasons", () => {
+    expect(isRetryableEmptyFinishReason("content-filter")).toBe(false);
+    expect(isRetryableEmptyFinishReason("error")).toBe(false);
+    expect(isRetryableEmptyFinishReason("other")).toBe(false);
+  });
+});

--- a/platform/backend/src/routes/chat/stream-probe.ts
+++ b/platform/backend/src/routes/chat/stream-probe.ts
@@ -1,0 +1,98 @@
+// Probes a streamText `fullStream` just far enough to decide whether the turn
+// will produce anything renderable, so the chat route can silently retry a
+// clean-but-empty response before committing the stream to the client.
+//
+// It pulls the stream iterator manually (never via `for await`) and returns
+// without calling `iterator.return()` — an early `for await` break would cancel
+// the underlying generation and break the subsequent `toUIMessageStream` merge.
+// This mirrors the existing context-trim first-chunk probe.
+
+export type StreamProbeEvent = {
+  type: string;
+  finishReason?: unknown;
+  error?: unknown;
+};
+
+export type StreamProbeOutcome =
+  | { kind: "renderable" }
+  | { kind: "empty"; finishReason: string }
+  | { kind: "aborted" }
+  | { kind: "error"; error: unknown };
+
+// fullStream event types that carry (or commit to) content the chat UI renders.
+// Seeing any of these means the turn is not empty and should stream normally.
+const RENDERABLE_EVENT_TYPES: ReadonlySet<string> = new Set([
+  "text-start",
+  "text-delta",
+  "reasoning-start",
+  "reasoning-delta",
+  "tool-input-start",
+  "tool-input-delta",
+  "tool-input-end",
+  "tool-call",
+  "tool-result",
+  // tool failure, denial, and approval-request parts are all UI-rendered turn
+  // state. A resume turn (input arrived in a prior turn) can open with one of
+  // these and no preceding tool-input-start, so they must count as renderable.
+  "tool-error",
+  "tool-output-denied",
+  "tool-approval-request",
+  "source",
+  "file",
+]);
+
+// finishReasons where a content-free turn is plausibly a transient model/inference
+// glitch worth retrying. Excludes e.g. "content-filter" (deterministic block) and
+// "tool-calls" (which only finishes that way when tool calls — renderable — exist).
+const RETRYABLE_EMPTY_FINISH_REASONS: ReadonlySet<string> = new Set([
+  "stop",
+  "length",
+  "unknown",
+]);
+
+export function isRetryableEmptyFinishReason(finishReason: string): boolean {
+  return RETRYABLE_EMPTY_FINISH_REASONS.has(finishReason);
+}
+
+export async function probeFirstRenderableEvent(
+  iterator: AsyncIterator<StreamProbeEvent>,
+): Promise<StreamProbeOutcome> {
+  while (true) {
+    let result: IteratorResult<StreamProbeEvent>;
+    try {
+      result = await iterator.next();
+    } catch (error) {
+      return { kind: "error", error };
+    }
+
+    if (result.done) {
+      // stream ended without a terminal finish event — nothing renderable seen.
+      return { kind: "empty", finishReason: "unknown" };
+    }
+
+    const event = result.value;
+
+    if (RENDERABLE_EVENT_TYPES.has(event.type)) {
+      return { kind: "renderable" };
+    }
+
+    switch (event.type) {
+      case "error":
+        return { kind: "error", error: event.error };
+      case "abort":
+        return { kind: "aborted" };
+      case "finish":
+        return {
+          kind: "empty",
+          finishReason:
+            typeof event.finishReason === "string"
+              ? event.finishReason
+              : "unknown",
+        };
+      // control parts (start, start-step, finish-step, text-end, ...) carry no
+      // content on their own — keep pulling until content, finish, or error.
+      default:
+        break;
+    }
+  }
+}

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -278,6 +278,24 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
             next: async () => ({ done: true, value: undefined }),
           }),
         },
+        // the route probes fullStream for the first renderable event before
+        // merging; yield one so the probe proceeds to the merge these tests
+        // capture (errors are then injected via capturedInnerOnError).
+        fullStream: {
+          [Symbol.asyncIterator]: () => {
+            const events = [
+              { type: "text-delta", text: "" },
+              { type: "finish", finishReason: "stop" },
+            ];
+            let index = 0;
+            return {
+              next: async () =>
+                index < events.length
+                  ? { done: false, value: events[index++] }
+                  : { done: true, value: undefined },
+            };
+          },
+        },
         usage: Promise.resolve(null),
       }));
 
@@ -995,3 +1013,257 @@ function toSseStream(stream: ReadableStream<unknown>): ReadableStream<string> {
 function delay(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+// streamText result whose fullStream yields the given events. Used to drive the
+// route's empty-response probe/retry loop without a live provider.
+function fakeStreamResult(events: Array<Record<string, unknown>>) {
+  return {
+    fullStream: {
+      [Symbol.asyncIterator]: () => {
+        let index = 0;
+        return {
+          next: async () =>
+            index < events.length
+              ? { done: false, value: events[index++] }
+              : { done: true, value: undefined },
+        };
+      },
+    },
+    toUIMessageStream: () =>
+      new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }),
+    usage: Promise.resolve(null),
+  };
+}
+
+// streamText result whose fullStream throws a context-length error on first read,
+// matching parseMaxInputTokens. Used to exercise the bounded context-trim retry.
+function fakeContextLengthErrorResult() {
+  return {
+    fullStream: {
+      [Symbol.asyncIterator]: () => ({
+        next: async () => {
+          throw new Error("maximum input length of 100 tokens");
+        },
+      }),
+    },
+    toUIMessageStream: () =>
+      new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }),
+    usage: Promise.resolve(null),
+  };
+}
+
+const EMPTY_STREAM_EVENTS = [
+  { type: "start" },
+  { type: "finish", finishReason: "stop" },
+];
+const RENDERABLE_STREAM_EVENTS = [
+  { type: "text-delta", text: "hi" },
+  { type: "finish", finishReason: "stop" },
+];
+
+describe("POST /api/chat empty-response retry", () => {
+  let app: FastifyInstanceWithZod;
+  let user: User;
+  let organizationId: string;
+  let conversationId: string;
+  let executionPromise: Promise<void> | undefined;
+  let capturedOuterErrorPayload: string | undefined;
+
+  beforeEach(
+    async ({ makeAgent, makeConversation, makeOrganization, makeUser }) => {
+      executionPromise = undefined;
+      capturedOuterErrorPayload = undefined;
+
+      user = await makeUser();
+      const organization = await makeOrganization({ name: "Test Org" });
+      organizationId = organization.id;
+      const agent = await makeAgent({
+        organizationId,
+        name: "Router Agent",
+        systemPrompt: "",
+      });
+      const conversation = await makeConversation(agent.id, {
+        userId: user.id,
+        organizationId,
+      });
+      conversationId = conversation.id;
+
+      mockCreateLLMModelForAgent.mockResolvedValue({ model: "mock-model" });
+      mockGetChatMcpTools.mockResolvedValue({});
+      mockGetChatMcpToolUiResourceUris.mockResolvedValue({});
+      mockExtractAndIngestDocuments.mockResolvedValue(undefined);
+      mockCompactMessagesForChat.mockImplementation(
+        async ({ messages }: { messages: unknown[] }) => ({
+          messages,
+          status: "skipped",
+          compaction: null,
+          reason: "below_threshold",
+        }),
+      );
+      mockStartActiveChatSpan.mockImplementation(
+        async ({ callback }: { callback: () => Promise<Response> }) =>
+          callback(),
+      );
+      mockCreateUIMessageStream.mockImplementation(
+        ({
+          execute,
+          onError,
+        }: {
+          execute: (args: {
+            writer: {
+              write: (x: unknown) => void;
+              merge: (s: unknown) => void;
+            };
+          }) => Promise<void>;
+          onError: (error: unknown) => string;
+        }) => {
+          const writer = { write: vi.fn(), merge: vi.fn() };
+          // route the pre-merge throw (exhausted empty response) to onError,
+          // mirroring how createUIMessageStream surfaces an execute() rejection.
+          executionPromise = execute({ writer }).catch((error) => {
+            capturedOuterErrorPayload = onError(error);
+          });
+          return new ReadableStream({
+            start(controller) {
+              controller.close();
+            },
+          });
+        },
+      );
+      mockCreateUIMessageStreamResponse.mockImplementation(
+        ({ stream }: { stream: ReadableStream }) =>
+          new Response(stream, {
+            status: 200,
+            headers: { "content-type": "text/plain" },
+          }),
+      );
+
+      app = createFastifyInstance();
+      app.addHook("onRequest", async (request) => {
+        (request as typeof request & { user: User }).user = user;
+        (
+          request as typeof request & { organizationId: string }
+        ).organizationId = organizationId;
+      });
+      const { default: chatRoutes } = await import("./routes");
+      await app.register(chatRoutes);
+    },
+  );
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  async function postMessage() {
+    return app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: conversationId,
+        messages: [
+          { id: "msg-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        ],
+      },
+    });
+  }
+
+  test("retries a clean-but-empty response, then streams the renderable one", async ({
+    expect,
+  }) => {
+    mockStreamText
+      .mockImplementationOnce(() => fakeStreamResult(EMPTY_STREAM_EVENTS))
+      .mockImplementationOnce(() => fakeStreamResult(RENDERABLE_STREAM_EVENTS));
+
+    const response = await postMessage();
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    expect(mockStreamText).toHaveBeenCalledTimes(2);
+    expect(capturedOuterErrorPayload).toBeUndefined();
+  });
+
+  test("surfaces an EmptyResponse stream error after exhausting retries", async ({
+    expect,
+  }) => {
+    mockStreamText.mockImplementation(() =>
+      fakeStreamResult(EMPTY_STREAM_EVENTS),
+    );
+
+    const response = await postMessage();
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    expect(mockStreamText).toHaveBeenCalledTimes(3);
+    expect(capturedOuterErrorPayload).toBeDefined();
+    const payload = JSON.parse(capturedOuterErrorPayload ?? "{}");
+    expect(payload.code).toBe("empty_response");
+  });
+
+  test("reuses the trimmed payload when a trimmed attempt then returns empty", async ({
+    expect,
+  }) => {
+    // messages large enough that trimMessagesToTokenLimit (400-char budget for the
+    // mocked 100-token limit) actually drops content, so the trimmed payload is
+    // observably different from the original.
+    const longContent = "x".repeat(300);
+    mockCompactMessagesForChat.mockImplementation(async () => ({
+      messages: [
+        { role: "user", content: longContent },
+        { role: "assistant", content: longContent },
+        { role: "user", content: longContent },
+      ],
+      status: "skipped",
+      compaction: null,
+      reason: "below_threshold",
+    }));
+    mockStreamText
+      .mockImplementationOnce(() => fakeContextLengthErrorResult())
+      .mockImplementationOnce(() => fakeStreamResult(EMPTY_STREAM_EVENTS))
+      .mockImplementationOnce(() => fakeStreamResult(RENDERABLE_STREAM_EVENTS));
+
+    const response = await postMessage();
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    expect(mockStreamText).toHaveBeenCalledTimes(3);
+    const originalMessages = mockStreamText.mock.calls[0][0].messages;
+    const trimmedMessages = mockStreamText.mock.calls[1][0].messages;
+    const emptyRetryMessages = mockStreamText.mock.calls[2][0].messages;
+    // the trim must have actually changed the payload, otherwise this test proves
+    // nothing about which payload the empty-retry resends.
+    expect(trimmedMessages).not.toEqual(originalMessages);
+    // the empty-response retry resends the trimmed payload, not the original.
+    expect(emptyRetryMessages).toEqual(trimmedMessages);
+  });
+
+  test("bounds context-trim retries instead of looping on a repeated context-length error", async ({
+    expect,
+  }) => {
+    // content-shaped model messages so trimMessagesToTokenLimit runs cleanly and
+    // the cap (not a crash) is what bounds the loop.
+    mockCompactMessagesForChat.mockImplementation(async () => ({
+      messages: [{ role: "user", content: "hi" }],
+      status: "skipped",
+      compaction: null,
+      reason: "below_threshold",
+    }));
+    // every attempt rejects with the same max-token error; trimming is
+    // deterministic, so without a cap this would retry forever.
+    mockStreamText.mockImplementation(() => fakeContextLengthErrorResult());
+
+    const response = await postMessage();
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    // initial attempt + exactly one trim retry, then fall through to the merge.
+    expect(mockStreamText).toHaveBeenCalledTimes(2);
+  });
+});

--- a/platform/backend/src/routes/chat/tool-ui-stream.test.ts
+++ b/platform/backend/src/routes/chat/tool-ui-stream.test.ts
@@ -1,0 +1,105 @@
+import type { UIMessageChunk } from "ai";
+import { describe, expect, test } from "vitest";
+import type { ToolUiResourceData } from "@/clients/chat-mcp-client";
+import { createToolUiStartTransform } from "./tool-ui-stream";
+
+async function pipeThroughTransform(
+  chunks: UIMessageChunk[],
+  transform: TransformStream<UIMessageChunk, UIMessageChunk>,
+): Promise<UIMessageChunk[]> {
+  const source = new ReadableStream<UIMessageChunk>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+
+  const out: UIMessageChunk[] = [];
+  const reader = source.pipeThrough(transform).getReader();
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    out.push(value);
+  }
+  return out;
+}
+
+describe("createToolUiStartTransform", () => {
+  test("injects data-tool-ui-start immediately after its tool-input-start", async () => {
+    const prefetched = new Map<string, ToolUiResourceData>([
+      ["search", { html: "<div>app</div>" }],
+    ]);
+    const transform = createToolUiStartTransform({
+      prefetchedUiResources: prefetched,
+      toolUiResourceUris: { search: "ui://search" },
+    });
+
+    const out = await pipeThroughTransform(
+      [
+        { type: "text-start", id: "t0" },
+        { type: "tool-input-start", toolCallId: "call-1", toolName: "search" },
+        { type: "tool-input-delta", toolCallId: "call-1", inputTextDelta: "{" },
+      ],
+      transform,
+    );
+
+    const types = out.map((c) => c.type);
+    const startIdx = types.indexOf("tool-input-start");
+    expect(types[startIdx + 1]).toBe("data-tool-ui-start");
+    // arrives before any tool input delta
+    expect(startIdx + 1).toBeLessThan(types.indexOf("tool-input-delta"));
+
+    const uiStart = out[startIdx + 1] as unknown as {
+      data: { toolCallId: string; uiResourceUri: string; html: string };
+    };
+    expect(uiStart.data).toMatchObject({
+      toolCallId: "call-1",
+      uiResourceUri: "ui://search",
+      html: "<div>app</div>",
+    });
+  });
+
+  test("leaves a tool without a prefetched resource untouched", async () => {
+    const transform = createToolUiStartTransform({
+      prefetchedUiResources: new Map(),
+      toolUiResourceUris: {},
+    });
+
+    const input: UIMessageChunk[] = [
+      { type: "tool-input-start", toolCallId: "call-1", toolName: "plain" },
+      { type: "tool-input-delta", toolCallId: "call-1", inputTextDelta: "{}" },
+    ];
+    const out = await pipeThroughTransform(input, transform);
+
+    expect(out.map((c) => c.type)).toEqual([
+      "tool-input-start",
+      "tool-input-delta",
+    ]);
+  });
+
+  test("injects once per tool when several tools open in one turn", async () => {
+    const prefetched = new Map<string, ToolUiResourceData>([
+      ["search", { html: "<a/>" }],
+      ["browse", { html: "<b/>" }],
+    ]);
+    const transform = createToolUiStartTransform({
+      prefetchedUiResources: prefetched,
+      toolUiResourceUris: { search: "ui://search", browse: "ui://browse" },
+    });
+
+    const out = await pipeThroughTransform(
+      [
+        { type: "tool-input-start", toolCallId: "c1", toolName: "search" },
+        { type: "tool-input-start", toolCallId: "c2", toolName: "browse" },
+      ],
+      transform,
+    );
+
+    expect(out.map((c) => c.type)).toEqual([
+      "tool-input-start",
+      "data-tool-ui-start",
+      "tool-input-start",
+      "data-tool-ui-start",
+    ]);
+  });
+});

--- a/platform/backend/src/routes/chat/tool-ui-stream.ts
+++ b/platform/backend/src/routes/chat/tool-ui-stream.ts
@@ -1,0 +1,36 @@
+import type { UIMessageChunk } from "ai";
+import type { ToolUiResourceData } from "@/clients/chat-mcp-client";
+
+// Injects a `data-tool-ui-start` chunk right after each `tool-input-start` chunk
+// that has a prefetched UI resource, so the frontend renders the MCP App iframe
+// as soon as the tool call opens. This deliberately lives in a transform over
+// the merged UI message stream rather than in streamText's `onChunk`: `onChunk`
+// runs upstream of the SDK's internal stream tee, so the empty-response probe
+// (which pulls the first renderable chunk ahead of the merge) would fire it and
+// emit `data-tool-ui-start` before its own `tool-input-start` ever reaches the
+// client. Emitting in stream order keeps the UI-start right after its tool.
+export function createToolUiStartTransform(params: {
+  prefetchedUiResources: ReadonlyMap<string, ToolUiResourceData>;
+  toolUiResourceUris: Record<string, string>;
+}): TransformStream<UIMessageChunk, UIMessageChunk> {
+  const { prefetchedUiResources, toolUiResourceUris } = params;
+  return new TransformStream({
+    transform(chunk, controller) {
+      controller.enqueue(chunk);
+      if (chunk.type !== "tool-input-start") return;
+      const prefetched = prefetchedUiResources.get(chunk.toolName);
+      if (!prefetched) return;
+      controller.enqueue({
+        type: "data-tool-ui-start",
+        data: {
+          toolCallId: chunk.toolCallId,
+          toolName: chunk.toolName,
+          uiResourceUri: toolUiResourceUris[chunk.toolName],
+          html: prefetched.html,
+          csp: prefetched.csp,
+          permissions: prefetched.permissions,
+        },
+      });
+    },
+  });
+}

--- a/platform/shared/chat-error.ts
+++ b/platform/shared/chat-error.ts
@@ -270,6 +270,8 @@ export enum ChatErrorCode {
   ServerError = "server_error",
   /** Network/connection issues - retryable */
   NetworkError = "network_error",
+  /** Provider finished cleanly but produced no content - retryable */
+  EmptyResponse = "empty_response",
   /** Catch-all for unrecognized errors */
   Unknown = "unknown",
 }
@@ -295,6 +297,8 @@ export const ChatErrorMessages: Record<ChatErrorCode, string> = {
   [ChatErrorCode.ServerError]: "The AI provider is experiencing issues.",
   [ChatErrorCode.NetworkError]:
     "Connection error. Please check your network and try again.",
+  [ChatErrorCode.EmptyResponse]:
+    "The model returned an empty response. Please try again.",
   [ChatErrorCode.Unknown]: "An unexpected error occurred. Please try again.",
 };
 
@@ -305,6 +309,7 @@ export const RetryableErrorCodes: Set<ChatErrorCode> = new Set([
   ChatErrorCode.RateLimit,
   ChatErrorCode.ServerError,
   ChatErrorCode.NetworkError,
+  ChatErrorCode.EmptyResponse,
 ]);
 
 /**

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -19648,7 +19648,7 @@ export type GetChatConversationsResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -19800,7 +19800,7 @@ export type CreateChatConversationResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -20034,7 +20034,7 @@ export type GetChatConversationResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -20190,7 +20190,7 @@ export type UpdateChatConversationResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -20506,7 +20506,7 @@ export type ForkChatConversationResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -20759,7 +20759,7 @@ export type CompactChatConversationResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -21182,7 +21182,7 @@ export type GetSharedConversationResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -21334,7 +21334,7 @@ export type ForkSharedConversationResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -21488,7 +21488,7 @@ export type GenerateChatConversationTitleResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -21641,7 +21641,7 @@ export type UpdateChatMessageResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -25539,7 +25539,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -25724,7 +25724,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -25815,7 +25815,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -25882,7 +25882,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -25951,7 +25951,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -26414,7 +26414,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -26483,7 +26483,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -26552,7 +26552,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -26621,7 +26621,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -26690,7 +26690,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -26759,7 +26759,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -26828,7 +26828,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -26897,7 +26897,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -26964,7 +26964,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -27031,7 +27031,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -27100,7 +27100,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -27169,7 +27169,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -27238,7 +27238,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -27374,7 +27374,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -27559,7 +27559,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -28042,7 +28042,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -28227,7 +28227,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -28318,7 +28318,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -28385,7 +28385,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -28454,7 +28454,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -28917,7 +28917,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -28986,7 +28986,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -29055,7 +29055,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -29124,7 +29124,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -29193,7 +29193,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -29262,7 +29262,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -29331,7 +29331,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -29400,7 +29400,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -29467,7 +29467,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -29534,7 +29534,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -29603,7 +29603,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -29672,7 +29672,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -29741,7 +29741,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -29877,7 +29877,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -30062,7 +30062,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -48221,7 +48221,7 @@ export type CreateScheduleTriggerRunConversationResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'unknown';
+                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;


### PR DESCRIPTION
Reverts archestra-ai/archestra#5368

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>