### PR TITLE
fix(chat): re-land resume-on-409 with crash, error-flash, and text-blink fixes

### DIFF
--- a/platform/backend/src/services/active-chat-run.test.ts
+++ b/platform/backend/src/services/active-chat-run.test.ts
@@ -70,6 +70,61 @@ test("drainStreamToEvents compacts adjacent text and reasoning deltas before mar
   expect(terminalRun?.status).toBe("completed");
 });
 
+test("drainStreamToEvents fails the run as soon as an error chunk arrives, even if the stream never closes", async ({
+  makeAgent,
+  makeConversation,
+  makeOrganization,
+  makeUser,
+}) => {
+  const user = await makeUser();
+  const organization = await makeOrganization();
+  const agent = await makeAgent({ organizationId: organization.id });
+  const conversation = await makeConversation(agent.id, {
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const run = await ActiveChatRunModel.create({
+    conversationId: conversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+
+  // A provider error surfaced mid-turn while the upstream connection wedges
+  // open: the client already rendered the error, but the stream never ends.
+  const stream = new ReadableStream<UIMessageChunk>({
+    start(controller) {
+      controller.enqueue({ type: "start" });
+      controller.enqueue({ type: "error", errorText: "provider exploded" });
+      // intentionally never closed
+    },
+  });
+
+  activeChatRunService.drainStreamToEvents({
+    runId: run?.id ?? "",
+    conversationId: conversation.id,
+    stream,
+    getTerminalStatus: async () => ({ status: "completed" }),
+  });
+
+  // The run must flip to failed without waiting for the stream to close —
+  // otherwise the conversation stays 409-blocked until the stale reaper.
+  await waitForTerminalRun(run?.id ?? "");
+  const terminalRun = await ActiveChatRunModel.findById(run?.id ?? "");
+  expect(terminalRun?.status).toBe("failed");
+  expect(terminalRun?.error).toBe("provider exploded");
+
+  // The error event is flushed before the status flips, so a replaying
+  // client can never observe the failed run without the error chunk.
+  const events = await ActiveChatRunModel.readEventsAfter({
+    runId: run?.id ?? "",
+    seq: 0,
+  });
+  expect(events.flatMap((event) => event.payloads)).toContainEqual({
+    type: "error",
+    errorText: "provider exploded",
+  });
+});
+
 test("createReplayStream uses polling fallback when no notification arrives", async ({
   makeAgent,
   makeConversation,

--- a/platform/backend/src/services/active-chat-run.ts
+++ b/platform/backend/src/services/active-chat-run.ts
@@ -158,6 +158,25 @@ export class ActiveChatRunService {
           const { done, value } = await reader.read();
           if (done) break;
           await writer.write(value);
+
+          // An error chunk is terminal for the client (the error renders and
+          // the user can immediately retry/resend), but the row only flips to
+          // `failed` once this drain completes — and a wedged upstream stream
+          // can keep it `running` until the stale reaper, 409-blocking every
+          // send in the meantime. Fail the run the moment the error event is
+          // durably flushed: write-then-flush ordering guarantees a replaying
+          // client can never observe the failed status without the error
+          // event, and markTerminal's running-only guard makes the
+          // end-of-stream terminal write below a no-op.
+          if (value.type === "error") {
+            await writer.flush();
+            await this.markTerminal({
+              runId: params.runId,
+              status: "failed",
+              error: value.errorText,
+            });
+            await this.notifyEvent(params.runId);
+          }
         }
 
         await writer.flush();

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -947,8 +947,15 @@ export function ChatPageContent({
   const status = chatSession?.status ?? "ready";
   const setMessages = chatSession?.setMessages;
   const stop = chatSession?.stop;
+  // Hide the error while the session is auto-recovering (retry scheduled or
+  // reattaching to the still-running response) — flashing a "connection
+  // error" card for a turn that restores itself a second later reads as
+  // breakage. If recovery fails, the terminal error clears isRecovering and
+  // surfaces here.
   const error =
-    status === "submitted" || status === "streaming"
+    status === "submitted" ||
+    status === "streaming" ||
+    chatSession?.isRecovering
       ? undefined
       : chatSession?.error;
   const addToolResult = chatSession?.addToolResult;

--- a/platform/frontend/src/lib/chat/chat-session-utils.test.ts
+++ b/platform/frontend/src/lib/chat/chat-session-utils.test.ts
@@ -3,7 +3,74 @@ import { describe, expect, test } from "vitest";
 import {
   pruneEmptyTrailingAssistantMessage,
   restoreRenderableAssistantParts,
+  shouldFreezeChatMessages,
 } from "./chat-session-utils";
+
+describe("shouldFreezeChatMessages", () => {
+  const userMessage = {
+    id: "user-1",
+    role: "user",
+    parts: [{ type: "text", text: "write a story" }],
+  } as UIMessage;
+  const partialAssistant = {
+    id: "assistant-1",
+    role: "assistant",
+    parts: [{ type: "text", text: "Once upon a time" }],
+  } as UIMessage;
+  const emptyAssistant = {
+    id: "assistant-1",
+    role: "assistant",
+    parts: [],
+  } as unknown as UIMessage;
+  const frozen = [userMessage, partialAssistant];
+
+  test("freezes while recovering and the live tail has no renderable assistant content", () => {
+    // regenerate() dropped the partial answer — live list ends with the user message
+    expect(
+      shouldFreezeChatMessages({
+        isRecovering: true,
+        liveMessages: [userMessage],
+        frozenMessages: frozen,
+      }),
+    ).toBe(true);
+
+    // replay restarted the assistant message but no content has arrived yet
+    expect(
+      shouldFreezeChatMessages({
+        isRecovering: true,
+        liveMessages: [userMessage, emptyAssistant],
+        frozenMessages: frozen,
+      }),
+    ).toBe(true);
+  });
+
+  test("unfreezes once the recovered stream renders assistant content again", () => {
+    expect(
+      shouldFreezeChatMessages({
+        isRecovering: true,
+        liveMessages: [userMessage, partialAssistant],
+        frozenMessages: frozen,
+      }),
+    ).toBe(false);
+  });
+
+  test("never freezes outside recovery or without a frozen snapshot", () => {
+    expect(
+      shouldFreezeChatMessages({
+        isRecovering: false,
+        liveMessages: [userMessage],
+        frozenMessages: frozen,
+      }),
+    ).toBe(false);
+    expect(
+      shouldFreezeChatMessages({
+        isRecovering: true,
+        liveMessages: [userMessage],
+        frozenMessages: [],
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("restoreRenderableAssistantParts", () => {
   test("preserves previous assistant parts when the same assistant message becomes empty", () => {

--- a/platform/frontend/src/lib/chat/chat-session-utils.ts
+++ b/platform/frontend/src/lib/chat/chat-session-utils.ts
@@ -56,6 +56,35 @@ export function restoreRenderableAssistantParts(params: {
 }
 
 /**
+ * While a session auto-recovers from a severed stream (auto-retry or
+ * reattaching to the still-running response), the live message list passes
+ * through ugly intermediate states: regenerate() drops the partial assistant
+ * answer, and the replay rebuilds it from scratch a moment later. Rendering
+ * those states blinks the streamed text away and back. Instead, the UI keeps
+ * showing the frozen pre-recovery snapshot until the recovered stream has
+ * renderable assistant content again — the replay delivers its whole backlog
+ * in the first batch, so the swap happens at full length with no visible gap.
+ */
+export function shouldFreezeChatMessages(params: {
+  isRecovering: boolean;
+  liveMessages: UIMessage[];
+  frozenMessages: UIMessage[];
+}): boolean {
+  const { isRecovering, liveMessages, frozenMessages } = params;
+  if (!isRecovering || frozenMessages.length === 0) {
+    return false;
+  }
+
+  const lastMessage = liveMessages.at(-1);
+  // Once the recovered stream renders assistant content again, the live list
+  // has caught up with (or passed) the frozen snapshot — stop freezing.
+  return !(
+    lastMessage?.role === "assistant" &&
+    hasRenderableAssistantContent(lastMessage)
+  );
+}
+
+/**
  * Drops a trailing assistant message left with no renderable content. Mirrors the
  * backend's persist behavior (an empty last message is not stored), keeping the live
  * view consistent with what a reload would show — used after stripping dangling tool

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -79,6 +79,10 @@ describe("ChatProvider retries", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Model an in-flight replay by default: resumeStream() resolves only when
+    // the replayed stream concludes, so a plain vi.fn() (returning undefined)
+    // would misrepresent the SDK contract.
+    mocks.resumeStream.mockReturnValue(new Promise(() => {}));
     chatOptions = undefined;
     const messages: UIMessage[] = [];
     mocks.useChat.mockImplementation((options) => {
@@ -412,6 +416,85 @@ describe("ChatProvider retries", () => {
     // response they cannot see.
     expect(mocks.resumeStream).toHaveBeenCalledTimes(1);
     expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it("concludes recovery when the reattach finds the run already finished (204 no-op)", async () => {
+    let resolveResume: (() => void) | undefined;
+    mocks.resumeStream.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveResume = resolve;
+        }),
+    );
+
+    const latestSessionRef: { current: ChatSessionSnapshot } = {
+      current: undefined,
+    };
+
+    render(
+      <ChatProvider>
+        <RegisterChatSession />
+        <CaptureChatSession
+          onSession={(session) => {
+            latestSessionRef.current = session;
+          }}
+        />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(mocks.useChat).toHaveBeenCalled());
+
+    // Sever the stream, let the auto-retry fire, and land its duplicate-run
+    // 409 — the session is now reattaching via resumeStream().
+    vi.useFakeTimers();
+    act(() => {
+      chatOptions?.onError?.(new Error("Failed to fetch"));
+      chatOptions?.onFinish?.({
+        message: { parts: [] },
+        isAbort: false,
+        isError: true,
+        isDisconnect: true,
+      });
+      vi.advanceTimersByTime(1500);
+    });
+    act(() => {
+      chatOptions?.onError?.(
+        new Error("This conversation already has an active response."),
+      );
+      chatOptions?.onFinish?.({
+        message: { parts: [] },
+        isAbort: false,
+        isError: true,
+        isDisconnect: false,
+      });
+    });
+    expect(mocks.resumeStream).toHaveBeenCalledTimes(1);
+    expect(latestSessionRef.current?.isRecovering).toBe(true);
+
+    // The run finished before the reattach landed: reconnectToStream gets the
+    // 204 and the SDK resolves resumeStream() WITHOUT firing onFinish or
+    // onError (ai@6 makeRequest early-returns on a null reconnect stream).
+    await act(async () => {
+      resolveResume?.();
+    });
+
+    // Recovery must conclude — a stuck flag would misroute the next genuine
+    // concurrent submit's 409 into the reattach path (silently dropping the
+    // typed message) and keep the frozen snapshot rendered indefinitely.
+    expect(latestSessionRef.current?.isRecovering).toBe(false);
+    expect(mocks.clearError).toHaveBeenCalled();
+
+    // A later cold 409 is a genuine concurrent submit again: toast, no
+    // reattach.
+    act(() => {
+      chatOptions?.onError?.(
+        new Error("This conversation already has an active response."),
+      );
+    });
+    expect(mocks.resumeStream).toHaveBeenCalledTimes(1);
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      "This conversation already has a response in progress. Stop it before sending another message.",
+    );
   });
 
   it("marks the session as recovering while auto-retrying or reattaching, but not for terminal errors", async () => {

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -359,9 +359,59 @@ describe("ChatProvider retries", () => {
       "This conversation already has a response in progress. Stop it before sending another message.",
     );
     expect(mocks.regenerate).not.toHaveBeenCalled();
+    // A cold 409 (no auto-recovery in flight) is a genuine concurrent submit —
+    // reattaching would silently drop the message the user just typed.
+    expect(mocks.resumeStream).not.toHaveBeenCalled();
     // The SDK error is cleared so the benign guard never renders as a hard
     // inline error panel — the toast is the only surfaced feedback.
     expect(mocks.clearError).toHaveBeenCalledTimes(1);
+  });
+
+  it("reattaches to the active run when our own auto-recovery retry hits the duplicate-run 409", async () => {
+    render(
+      <ChatProvider>
+        <RegisterChatSession />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(mocks.useChat).toHaveBeenCalled());
+
+    // A transient network error severs the stream; the auto-retry re-POSTs
+    // into the still-running backend run and gets the duplicate-run 409.
+    // The AI SDK fires onFinish from a finally block right after onError
+    // (with isError set) — replicate that sequence, since clearing the
+    // recovery flag there would misclassify the upcoming 409 as a genuine
+    // duplicate submit.
+    vi.useFakeTimers();
+    act(() => {
+      chatOptions?.onError?.(new Error("Failed to fetch"));
+      chatOptions?.onFinish?.({
+        message: { parts: [] },
+        isAbort: false,
+        isError: true,
+        isDisconnect: true,
+      });
+      vi.advanceTimersByTime(1500);
+    });
+    expect(mocks.regenerate).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      chatOptions?.onError?.(
+        new Error("This conversation already has an active response."),
+      );
+      chatOptions?.onFinish?.({
+        message: { parts: [] },
+        isAbort: false,
+        isError: true,
+        isDisconnect: false,
+      });
+    });
+
+    // The 409 was provoked by our own recovery retry: reattach to the live
+    // run via the replay endpoint instead of telling the user to stop a
+    // response they cannot see.
+    expect(mocks.resumeStream).toHaveBeenCalledTimes(1);
+    expect(mocks.toastError).not.toHaveBeenCalled();
   });
 
   it("marks the session as recovering while auto-retrying or reattaching, but not for terminal errors", async () => {

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -363,6 +363,64 @@ describe("ChatProvider retries", () => {
     // inline error panel — the toast is the only surfaced feedback.
     expect(mocks.clearError).toHaveBeenCalledTimes(1);
   });
+
+  it("marks the session as recovering while auto-retrying or reattaching, but not for terminal errors", async () => {
+    const latestSessionRef: { current: ChatSessionSnapshot } = {
+      current: undefined,
+    };
+
+    render(
+      <ChatProvider>
+        <RegisterChatSession />
+        <CaptureChatSession
+          onSession={(session) => {
+            latestSessionRef.current = session;
+          }}
+        />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(latestSessionRef.current).toBeDefined());
+    expect(latestSessionRef.current?.isRecovering).toBe(false);
+
+    // Transient network error → auto-retry scheduled → recovering: the UI
+    // must not flash the error while the retry is in flight.
+    act(() => {
+      chatOptions?.onError?.(new Error("Failed to fetch"));
+    });
+    await waitFor(() =>
+      expect(latestSessionRef.current?.isRecovering).toBe(true),
+    );
+
+    // Duplicate-run 409 → resumeStream reattach → still recovering.
+    act(() => {
+      chatOptions?.onError?.(
+        new Error("This conversation already has an active response."),
+      );
+    });
+    await waitFor(() =>
+      expect(latestSessionRef.current?.isRecovering).toBe(true),
+    );
+
+    // Stream concluded → recovery over.
+    act(() => {
+      chatOptions?.onFinish?.({ message: { parts: [] }, isAbort: false });
+    });
+    await waitFor(() =>
+      expect(latestSessionRef.current?.isRecovering).toBe(false),
+    );
+
+    // Terminal (structured, non-retryable) error → not recovering: the
+    // error must surface.
+    act(() => {
+      chatOptions?.onError?.(
+        new Error(JSON.stringify({ code: "server_error", message: "boom" })),
+      );
+    });
+    await waitFor(() =>
+      expect(latestSessionRef.current?.isRecovering).toBe(false),
+    );
+  });
 });
 
 describe("ChatProvider auto title generation", () => {

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -454,6 +454,11 @@ function ChatSessionHook({
   // Auto-retry state for transient errors
   const retryCountRef = useRef(0);
   const retryTimerRef = useRef<NodeJS.Timeout | null>(null);
+  // Monotonically counts onError invocations. The duplicate-run reattach uses
+  // it to detect that nothing happened between calling resumeStream() and its
+  // promise resolving — the "run already finished" case, where the reconnect
+  // gets a 204 and the SDK early-returns without firing onFinish or onError.
+  const errorSeqRef = useRef(0);
   // True while a transient failure is being auto-recovered (retry scheduled
   // or reattaching to the active run); suppresses the inline error flash.
   // The ref is the source of truth: it is written synchronously inside
@@ -637,6 +642,7 @@ function ChatSessionHook({
       }
     },
     onError: (chatError) => {
+      errorSeqRef.current += 1;
       setOptimisticToolCalls([]);
       clearActiveContextCompaction();
       queryClient.invalidateQueries({
@@ -695,7 +701,30 @@ function ChatSessionHook({
         }
         previousMessagesRef.current = [];
         setIsRecovering(true);
-        void resumeStream();
+        const reattachErrorSeq = errorSeqRef.current;
+        void resumeStream().then(() => {
+          // If the run had already finished, reconnectToStream got a 204 and
+          // the SDK resolved this promise WITHOUT firing onFinish or onError
+          // (ai@6 makeRequest early-returns on a null reconnect stream) —
+          // nothing else would clear the recovery flag, and a stuck flag
+          // misroutes the next genuine concurrent submit's 409 into this
+          // reattach path (silently dropping the typed message) and keeps the
+          // frozen snapshot rendered. Detect that nothing happened while we
+          // waited (recovery still flagged, no new error) and conclude the
+          // recovery; the conversation refetch above already shows the
+          // persisted outcome. A successful replay clears the flag in
+          // onFinish; a failed replay re-enters onError (bumping the seq) and
+          // owns the flag from there.
+          if (
+            recoveringRef.current &&
+            errorSeqRef.current === reattachErrorSeq
+          ) {
+            setIsRecovering(false);
+            // Drop the stale duplicate-run error so the SDK returns to
+            // "ready" instead of idling in the suppressed error state.
+            clearErrorRef.current?.();
+          }
+        });
         return;
       }
 

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -32,13 +32,13 @@ import {
   useRef,
   useState,
 } from "react";
-import { toast } from "sonner";
 import { filterOptimisticToolCalls } from "@/components/chat/chat-messages.utils";
 import { useGenerateConversationTitle } from "@/lib/chat/chat.query";
 import { useUpdateChatMessage } from "@/lib/chat/chat-message.query";
 import {
   pruneEmptyTrailingAssistantMessage,
   restoreRenderableAssistantParts,
+  shouldFreezeChatMessages,
 } from "@/lib/chat/chat-session-utils";
 import {
   getChatExternalAgentId,
@@ -129,6 +129,13 @@ interface ChatSession {
     toolCallId: string;
     toolName: string;
   } | null;
+  /**
+   * True while the session is auto-recovering from a transient stream failure
+   * (auto-retry scheduled or reattaching to the still-running response).
+   * The UI should not surface the error while this is set — the recovery
+   * either restores the stream or ends with a terminal error that clears it.
+   */
+  isRecovering: boolean;
   optimisticToolCalls: Array<{
     toolCallId: string;
     toolName: string;
@@ -446,6 +453,24 @@ function ChatSessionHook({
   // Auto-retry state for transient errors
   const retryCountRef = useRef(0);
   const retryTimerRef = useRef<NodeJS.Timeout | null>(null);
+  // True while a transient failure is being auto-recovered (retry scheduled
+  // or reattaching to the active run); suppresses the inline error flash.
+  // The ref is the source of truth: it is written synchronously inside
+  // onError, BEFORE the SDK's error state reaches the page, so the very
+  // render that delivers the error already sees the suppression. The state
+  // mirror exists only to trigger re-renders/session sync — a state-only
+  // flag commits one render too late and the error card flashes for a frame.
+  const recoveringRef = useRef(false);
+  const [isRecoveringState, setIsRecoveringState] = useState(false);
+  const setIsRecovering = useCallback((value: boolean) => {
+    recoveringRef.current = value;
+    setIsRecoveringState(value);
+  }, []);
+  // Snapshot of the rendered messages at the moment recovery started; shown
+  // instead of the live list while recovery passes through its ugly
+  // intermediate states (answer dropped by regenerate, replay restarting from
+  // empty) so the streamed text never visibly blinks away.
+  const frozenMessagesRef = useRef<UIMessage[]>([]);
   const lastUserMessageIdRef = useRef<string | null>(null);
   const previousMessagesRef = useRef<UIMessage[]>([]);
 
@@ -516,6 +541,8 @@ function ChatSessionHook({
     onFinish: async ({ message, isAbort }) => {
       setOptimisticToolCalls([]);
       clearActiveContextCompaction();
+      // The stream concluded — any auto-recovery (retry/reattach) is over.
+      setIsRecovering(false);
 
       // When the user stops mid-tool-call, the assistant message is left with a
       // tool part that never produced output, which the UI renders as a
@@ -621,12 +648,31 @@ function ChatSessionHook({
       });
 
       if (isDuplicateActiveRunError(chatError)) {
-        toast.error(
-          "This conversation already has a response in progress. Stop it before sending another message.",
-        );
-        // Clear the SDK error so this benign guard does not also render as a
-        // hard inline error panel; the toast is the only surfaced feedback.
-        clearErrorRef.current?.();
+        // The backend refused the send because this conversation still has a
+        // run generating — typically after the stream connection was severed
+        // (LB cut, network blip) while the backend kept going, and the
+        // auto-retry below re-POSTed into the live run. Reattach to it via the
+        // active-run replay endpoint instead of dead-ending: the user sees the
+        // in-progress response (and the Stop button) again. If the run
+        // finished in the meantime, the reconnect returns 204 and is a no-op —
+        // the conversation refetch above already shows the persisted outcome.
+        //
+        // Clear the restore-on-regression buffer first: the auto-retry's
+        // regenerate() has already dropped the severed turn's partial
+        // assistant message, but previousMessagesRef still holds it and would
+        // keep resurrecting it while the replay rebuilds the same message id
+        // from empty — two writers fighting over one message in an update
+        // loop that crashes the page (React #185, "Maximum update depth").
+        // Emptying the buffer makes this path state-equivalent to the
+        // mount-time resume, which has always been safe; the replay re-streams
+        // everything the buffer was protecting anyway. The frozen snapshot
+        // (captured before clearing) keeps the text on screen meanwhile.
+        if (previousMessagesRef.current.length > 0) {
+          frozenMessagesRef.current = previousMessagesRef.current;
+        }
+        previousMessagesRef.current = [];
+        setIsRecovering(true);
+        void resumeStream();
         return;
       }
 
@@ -641,10 +687,25 @@ function ChatSessionHook({
         console.info(
           `[ChatSession] Auto-retrying (${retryCountRef.current}/${MAX_AUTO_RETRIES})...`,
         );
+        setIsRecovering(true);
         retryTimerRef.current = setTimeout(() => {
+          // Capture the view and break the restore-on-regression chain at the
+          // moment the rebuild starts (not earlier — previousMessagesRef is
+          // rebuilt every render, so clearing it before regenerate() would
+          // just re-establish). Without this, the restore logic resurrects
+          // the dropped partial answer while the retried stream rebuilds the
+          // message from empty — the update loop that crashes the page
+          // (React #185). The frozen snapshot keeps the text on screen
+          // instead.
+          frozenMessagesRef.current = previousMessagesRef.current;
+          previousMessagesRef.current = [];
           regenerate();
         }, AUTO_RETRY_DELAY_MS);
+        return;
       }
+
+      // Terminal: no recovery in flight — surface the error.
+      setIsRecovering(false);
     },
     onToolCall: ({ toolCall }) => {
       const toolShortName = getCurrentArchestraToolShortName(
@@ -810,6 +871,20 @@ function ChatSessionHook({
 
   const stableMessages = messagesWithRestoredAssistantParts;
 
+  // While auto-recovery passes through its intermediate states (partial
+  // answer dropped by regenerate, replay restarting from empty), keep showing
+  // the snapshot captured when recovery started so streamed text never blinks
+  // away. The replay delivers its whole backlog in the first batch, so by the
+  // time the live list has renderable assistant content again it is at least
+  // as long as the frozen view.
+  const displayedMessages = shouldFreezeChatMessages({
+    isRecovering: recoveringRef.current,
+    liveMessages: stableMessages,
+    frozenMessages: frozenMessagesRef.current,
+  })
+    ? frozenMessagesRef.current
+    : stableMessages;
+
   // Reset retry counter only when the user sends a genuinely new message.
   // We track the last user message ID to avoid resetting during regenerate(),
   // which manipulates the messages array without a new user message.
@@ -875,7 +950,7 @@ function ChatSessionHook({
   const sessionRef = useRef<ChatSession>(null as unknown as ChatSession);
   sessionRef.current = {
     conversationId,
-    messages: stableMessages,
+    messages: displayedMessages,
     sendMessage,
     regenerateUserMessage,
     stop,
@@ -885,6 +960,26 @@ function ChatSessionHook({
     addToolResult,
     addToolApprovalResponse,
     pendingCustomServerToolCall,
+    // Computed, not stored: the page paints the SDK error before onError has
+    // run (so no flag set inside onError can suppress the first frame), and
+    // consumers read the session from a map refreshed an effect-cycle later.
+    // Instead, derive "this error will be auto-recovered" synchronously from
+    // the same predicates onError uses — a pure function of the error and the
+    // retry budget, correct at any render including the very first one.
+    // recoveringRef keeps it true after onError consumed the error (retry
+    // timer pending / reattach in flight) and onFinish/terminal paths clear it.
+    get isRecovering() {
+      if (recoveringRef.current) {
+        return true;
+      }
+      if (!error) {
+        return false;
+      }
+      return (
+        isDuplicateActiveRunError(error) ||
+        (isRetryableError(error) && retryCountRef.current < MAX_AUTO_RETRIES)
+      );
+    },
     optimisticToolCalls,
     setPendingCustomServerToolCall,
     tokenUsage,
@@ -913,6 +1008,7 @@ function ChatSessionHook({
     addToolResult,
     addToolApprovalResponse,
     pendingCustomServerToolCall,
+    isRecoveringState,
     optimisticToolCalls,
     tokenUsage,
     contextTokensUsed,

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -32,6 +32,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { toast } from "sonner";
 import { filterOptimisticToolCalls } from "@/components/chat/chat-messages.utils";
 import { useGenerateConversationTitle } from "@/lib/chat/chat.query";
 import { useUpdateChatMessage } from "@/lib/chat/chat-message.query";
@@ -538,11 +539,19 @@ function ChatSessionHook({
 
     experimental_throttle: 100,
     id: conversationId,
-    onFinish: async ({ message, isAbort }) => {
+    onFinish: async ({ message, isAbort, isError }) => {
       setOptimisticToolCalls([]);
       clearActiveContextCompaction();
       // The stream concluded — any auto-recovery (retry/reattach) is over.
-      setIsRecovering(false);
+      // NOT on stream errors: the SDK fires onFinish from a finally block
+      // right after onError, so clearing here would wipe the recovery flag
+      // the error handler just set (and misroute the auto-retry's 409 to the
+      // genuine-duplicate toast). Error outcomes are owned by onError: it
+      // either keeps a recovery in flight or clears the flag for terminal
+      // errors.
+      if (!isError) {
+        setIsRecovering(false);
+      }
 
       // When the user stops mid-tool-call, the assistant message is left with a
       // tool part that never produced output, which the UI renders as a
@@ -648,14 +657,28 @@ function ChatSessionHook({
       });
 
       if (isDuplicateActiveRunError(chatError)) {
-        // The backend refused the send because this conversation still has a
-        // run generating — typically after the stream connection was severed
-        // (LB cut, network blip) while the backend kept going, and the
-        // auto-retry below re-POSTed into the live run. Reattach to it via the
-        // active-run replay endpoint instead of dead-ending: the user sees the
-        // in-progress response (and the Stop button) again. If the run
-        // finished in the meantime, the reconnect returns 204 and is a no-op —
-        // the conversation refetch above already shows the persisted outcome.
+        if (!recoveringRef.current) {
+          // A 409 outside auto-recovery is a genuine concurrent submit (e.g.
+          // a second tab racing this conversation): reattaching would
+          // silently drop the message the user just typed, so keep the
+          // honest guard instead.
+          toast.error(
+            "This conversation already has a response in progress. Stop it before sending another message.",
+          );
+          // Clear the SDK error so this benign guard does not also render as
+          // a hard inline error panel; the toast is the only surfaced
+          // feedback.
+          clearErrorRef.current?.();
+          return;
+        }
+        // The 409 was provoked by our own auto-recovery: the stream
+        // connection was severed (LB cut, network blip) while the backend
+        // kept generating, and the auto-retry below re-POSTed into the live
+        // run. Reattach to it via the active-run replay endpoint instead of
+        // dead-ending: the user sees the in-progress response (and the Stop
+        // button) again. If the run finished in the meantime, the reconnect
+        // returns 204 and is a no-op — the conversation refetch above
+        // already shows the persisted outcome.
         //
         // Clear the restore-on-regression buffer first: the auto-retry's
         // regenerate() has already dropped the severed turn's partial


### PR DESCRIPTION
## Context

#5363 made the chat reattach to the still-running response on a duplicate-run 409 (instead of dead-ending with a toast) — but it crashed the chat page in staging (React #185, "Maximum update depth exceeded") and was reverted in #5364. This PR re-lands it with the crash root-caused and fixed, plus recovery-UX issues fixed that the investigation surfaced.

## Root cause of the crash (reproduced deterministically)

Reproduced locally by severing the `/api/chat` response mid-stream (same as the staging LB's `timeoutSec` cut): **crashed 2/2** on the unfixed code.

The restore-on-regression buffer (`previousMessagesRef`, which resurrects assistant text that transiently disappears) fought any stream that **rebuilds the same/replacement assistant message from empty** — the 409-resume replay, and equally a retried `regenerate()` stream. Two writers per render over one message drove Radix composed-ref detach storms past React's nested-update limit. Unminified stack: `dispatchSetState → setRef (@radix-ui/react-compose-refs) → safelyDetachRef → commitMutationEffectsOnFiber`.

## Fixes (first commit)

1. **Crash**: break the restore chain *at the moment the rebuild starts* — before `resumeStream()` in the 409 path, and inside the retry timer right before `regenerate()` (clearing earlier is useless: the buffer is rebuilt every render). Both recovery paths become state-equivalent to the mount-time resume, which has always been safe.
2. **Error-card flash**: the page painted "Connection error. Please check your network…" for 1–2s during recoveries that succeed on their own. A flag set in `onError` cannot win that race (the SDK's error state renders first), so `ChatSession.isRecovering` is a **getter** deriving the decision synchronously from the error itself + retry budget. Terminal errors (retries exhausted / non-retryable) still surface.
3. **Text blink on resume**: `regenerate()` drops the partial answer and the replay rebuilds from empty — visible blink. New `shouldFreezeChatMessages()` keeps the pre-recovery snapshot rendered until the recovered stream has renderable content again; the replay delivers its full backlog in one batch, so reattach swaps at full length with no gap.

## Follow-up fixes (second commit — found by re-verifying live against the dev stack)

4. **Reattach is now scoped to auto-recovery.** A duplicate-run 409 only reattaches when it was provoked by our own auto-retry (`recoveringRef` already set). A cold 409 — e.g. a second tab submitting into a conversation whose run is still generating — keeps the original toast + `clearError()` behavior, because silently reattaching there would drop the message the user just typed.
5. **`onFinish` no longer wipes the recovery flag on stream errors.** The AI SDK (v6) calls `onFinish` from a `finally` block even when the stream errors, immediately after `onError` — so the unconditional `setIsRecovering(false)` erased the flag the error handler had just set, and **every** auto-retry 409 was misrouted to the genuine-duplicate path. Guarded with `if (!isError)`; the unit test now replays the SDK's real `onError → onFinish({isError: true})` ordering, which the previous manually-fired-callback tests never exercised (they passed while live behavior was broken).
6. **Backend: the active run is marked `failed` the moment an error chunk flows through the persistence drain**, instead of when the stream closes. A wedged upstream stream used to leave the row `running` until the stale reaper, 409-blocking every send after an error the user had already seen. The error event is flushed *before* the status flips, so a replaying client can never observe the failed run without its error chunk; `markTerminal`'s running-only guard makes the end-of-stream terminal write a no-op.

## Verification (live repro, dev server)

- 409-replay path: stream cut at 5s → auto-retry → 409 → reattach `GET …/active-run` 51ms later → replay streams to completion. No crash, no error card, no text blink, no toast — repeated runs
- Genuine concurrent submit while a run is live: toast surfaces, no reattach, typed message not silently dropped
- Backend resilience: run survives the client cut, full response persisted and shown on reload
- Retry exhaustion (every attempt severed): real error card surfaces at the end — recovery doesn't hide terminal failures
- `pnpm lint`, `pnpm type-check` clean; chat-lib tests 211/211; backend chat suites 470/470 (error-chunk early-fail covered by a PGlite integration test incl. the never-closing-stream case)

## Notes

- Merging this re-applies the #5363 behavior (now gated per fix 4)
- Pre-existing issues noticed while verifying, not addressed here: (a) typing in the chat prompt input can throw React "Maximum update depth exceeded" from `ai-elements/prompt-input.tsx` (`controller.textInput.setInput` loop) and remount the chat subtree; (b) a failed send is followed ~5–7s later by an unexplained duplicate ~290-byte submit POST; (c) the inline error card shows the model as a raw UUID with "auto-selected (best available)"

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
