### PR TITLE
fix(skills): clean-or-null skill description generation

### DIFF
--- a/platform/backend/src/skills/skill-description.ts
+++ b/platform/backend/src/skills/skill-description.ts
@@ -64,7 +64,11 @@ export async function suggestSkillDescription(params: {
       tag: "description",
       system: SKILL_DESCRIPTION_SYSTEM_PROMPT,
       prompt: buildSkillDescriptionPrompt(agent),
-      maxOutputTokens: 512,
+      // generous headroom so a reasoning model doesn't spend its whole budget
+      // on hidden reasoning and leave the tagged answer truncated or empty. The
+      // proxy forwards this value verbatim, so it stays within the output
+      // ceiling common chat models accept; the answer itself is one short line.
+      maxOutputTokens: 4096,
       sanitize: sanitizeDescription,
     });
   } catch (error) {

--- a/platform/backend/src/utils/generate-tagged-text.ts
+++ b/platform/backend/src/utils/generate-tagged-text.ts
@@ -1,20 +1,22 @@
 import { generateText, type ModelMessage } from "ai";
 import type { LLMModel } from "@/clients/llm-client";
+import logger from "@/logging";
 
 /**
  * Generate a single piece of text the model must wrap in one `<tag>…</tag>`
  * block, then extract the tagged content. If the first response omits the tag,
  * retry once with a correction turn that shows the model its own bad reply and
- * re-states the contract. Falls back to the sanitized raw first response when
- * both attempts miss the tag, so a model that answers correctly but ignores the
- * wrapper is still usable.
+ * re-states the contract.
  *
- * This is the robustness pattern the context-compaction summary uses, lifted
- * out so any single-field generation gets it: a tag is far more reliable than
+ * Clean-or-nothing: the result is the content of the first `<tag>…</tag>` pair,
+ * never salvaged raw model output. When both attempts miss the tag we return
+ * `null` so the caller fails cleanly (e.g. "write one manually") rather than
+ * persist raw untagged output. A tag is far more reliable than
  * `Output.object` across models that don't emit structured JSON (free/reasoning
- * models return prose and fail JSON parsing, yielding nothing).
+ * models return prose and fail JSON parsing), which is why we ask for a tag
+ * rather than a schema.
  *
- * Returns `null` only when nothing usable remains.
+ * Returns `null` when no tagged content was produced.
  */
 export async function generateTaggedText(params: {
   model: LLMModel;
@@ -25,7 +27,7 @@ export async function generateTaggedText(params: {
   maxOutputTokens?: number;
   temperature?: number;
   abortSignal?: AbortSignal;
-  /** Normalize the extracted (or fallback) text. Defaults to trimming. */
+  /** Normalize the extracted text. Defaults to trimming. */
   sanitize?: (text: string) => string;
 }): Promise<string | null> {
   const { model, tag, prompt } = params;
@@ -39,18 +41,41 @@ export async function generateTaggedText(params: {
 
   const first = await generateText({ model, system, prompt, ...options });
   let extracted = extractTaggedText(first.text, tag);
+  let retriedFinishReason: string | undefined;
 
   if (extracted === null) {
+    logger.info(
+      {
+        tag,
+        finishReason: first.finishReason,
+        textLength: first.text.length,
+      },
+      "generateTaggedText: first attempt missed the tag, retrying",
+    );
     const messages: ModelMessage[] = [
       { role: "user", content: prompt },
       { role: "assistant", content: first.text },
       { role: "user", content: correctionPrompt(tag) },
     ];
     const retried = await generateText({ model, system, messages, ...options });
+    retriedFinishReason = retried.finishReason;
     extracted = extractTaggedText(retried.text, tag);
   }
 
-  const result = sanitize(extracted ?? first.text);
+  if (extracted === null) {
+    logger.warn(
+      {
+        tag,
+        firstFinishReason: first.finishReason,
+        retriedFinishReason,
+        firstTextLength: first.text.length,
+      },
+      "generateTaggedText: no tagged content after retry, returning null",
+    );
+    return null;
+  }
+
+  const result = sanitize(extracted);
   return result.length > 0 ? result : null;
 }
 


### PR DESCRIPTION
## Problem

The **Generate** button in the agent→skill conversion dialog (LLM-suggested `description`) was buggy on staging:
- one conversion **leaked a literal `<description>` tag** into the saved description;
- another **failed fully** (502 "Could not generate a description").

## Root cause

`generateTaggedText` asks the model to wrap its answer in `<description>…</description>`, extracts it strictly, then **fell back to the raw model text** via `sanitize(extracted ?? first.text)` — and `sanitizeDescription` doesn't strip tags.

- **Leaked tag:** model emits the open tag but the close is missing/truncated (the 512-token budget gets consumed by hidden reasoning) → strict extraction returns null → fallback returns the raw text *with the literal `<description>` still in it*.
- **Failed fully:** model text is empty (reasoning ate the whole budget) → `null` → route throws 502.

## Fix

- **`generate-tagged-text.ts`** — remove the raw-text fallback. The result is now the content of the first `<tag>…</tag>` pair, or `null` (clean-or-nothing; no salvage). The single correction retry is kept. Added `info`/`warn` logging at the miss/retry/give-up points with safe fields only (tag, `finishReason`, text lengths — never raw model output/prompts).
- **`skill-description.ts`** — raise `maxOutputTokens` 512 → 4096 so a reasoning model has headroom to emit the tagged answer. 4096 (not higher) because the proxy forwards `max_tokens` verbatim with no clamping, and a larger value risks a 400 on models with a lower output ceiling.

Considered and rejected a per-provider reasoning-effort mapping (`reasoningEffort`/`thinkingBudget`) as too brittle (model-name regexes, per-version knobs); the token headroom achieves the same robustness more simply.

## Why logging

This path's logs/spans don't reach Sentry, so the two failure modes were invisible. The new structured logs make them diagnosable on staging.

## Testing

- `pnpm test` (affected: `skill-description.test.ts`, `generate-tagged-text.test.ts`), `pnpm type-check`, `pnpm lint`, `pnpm knip` (dev+production) — all pass.
- Reviewed via external (Codex) and internal review gates; no correctness/security findings.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>