### PR TITLE
feat(mcp-catalog): paste a full MCP server JSON config to auto-fill t…

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -17,7 +17,7 @@ import {
   Users,
 } from "lucide-react";
 import Link from "next/link";
-import type { ReactNode } from "react";
+import type { ClipboardEvent, ReactNode } from "react";
 import { lazy, useEffect, useMemo, useRef, useState } from "react";
 import { type UseFormReturn, useFieldArray, useForm } from "react-hook-form";
 import { AgentIconPicker } from "@/components/agent-icon-picker";
@@ -97,6 +97,7 @@ import {
   transformCatalogItemToFormValues,
   transformFormToApiData,
 } from "./mcp-catalog-form.utils";
+import { parseMcpServerConfigJson } from "./mcp-config-json-parser";
 
 const ExternalSecretSelector = lazy(
   () =>
@@ -613,10 +614,57 @@ export function McpCatalogForm({
   const showByosOption = useFeature("byosEnabled");
 
   // Use field array for environment variables
-  const { fields, append, remove } = useFieldArray({
+  const { fields, append, remove, replace } = useFieldArray({
     control: form.control,
     name: "localConfig.environment",
   });
+
+  // Issue #3859: let users paste a full MCP server JSON config (the format every
+  // catalog hands out) into the Arguments field and auto-fill Command /
+  // Arguments / Env / Transport at once, instead of retyping line-by-line. If
+  // the pasted text isn't a recognisable JSON config we do nothing and let the
+  // textarea handle the paste normally.
+  const handleArgumentsPaste = (event: ClipboardEvent<HTMLTextAreaElement>) => {
+    const pasted = event.clipboardData.getData("text");
+    const parsed = parseMcpServerConfigJson(pasted);
+    if (!parsed) return;
+
+    event.preventDefault();
+
+    if (parsed.command !== undefined) {
+      form.setValue("localConfig.command", parsed.command, {
+        shouldDirty: true,
+      });
+    }
+    form.setValue(
+      "localConfig.arguments",
+      (parsed.arguments ?? []).join("\n"),
+      {
+        shouldDirty: true,
+      },
+    );
+    if (parsed.transportType) {
+      form.setValue("localConfig.transportType", parsed.transportType, {
+        shouldDirty: true,
+      });
+    }
+    if (parsed.environment && parsed.environment.length > 0) {
+      // Placeholder values (e.g. "<token>", "YOUR_KEY_HERE") become secret
+      // fields the installer is prompted for; literal values are kept as-is.
+      replace(
+        parsed.environment.map((envVar) => ({
+          key: envVar.key,
+          type: envVar.isPlaceholder
+            ? ("secret" as const)
+            : ("plain_text" as const),
+          value: envVar.isPlaceholder ? "" : envVar.value,
+          promptOnInstallation: envVar.isPlaceholder,
+          required: envVar.isPlaceholder,
+          description: "",
+        })),
+      );
+    }
+  };
 
   // Use field array for envFrom (existing K8s Secrets/ConfigMaps)
   const {
@@ -1185,8 +1233,17 @@ export function McpCatalogForm({
                             placeholder={`/path/to/server.js\n--verbose`}
                             className="font-mono min-h-20"
                             {...field}
+                            onPaste={handleArgumentsPaste}
                           />
                         </FormControl>
+                        <FormDescription>
+                          One argument per line. Tip: paste a full MCP server
+                          JSON config (e.g.{" "}
+                          <code>{`{"command":"npx","args":[…],"env":{…}}`}</code>{" "}
+                          or an <code>mcpServers</code> snippet) and the
+                          Command, Arguments, Env, and Transport fields will be
+                          filled in automatically.
+                        </FormDescription>
                         <FormMessage />
                       </FormItem>
                     )}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-config-json-parser.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-config-json-parser.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import { parseMcpServerConfigJson } from "./mcp-config-json-parser";
+
+describe("parseMcpServerConfigJson", () => {
+  it("parses a bare single-server stdio config", () => {
+    const result = parseMcpServerConfigJson(
+      JSON.stringify({
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-everything"],
+      }),
+    );
+    expect(result).toEqual({
+      command: "npx",
+      arguments: ["-y", "@modelcontextprotocol/server-everything"],
+      serverType: "local",
+      transportType: "stdio",
+    });
+  });
+
+  it("unwraps the mcpServers wrapper and takes the first server", () => {
+    const result = parseMcpServerConfigJson(
+      JSON.stringify({
+        mcpServers: {
+          everything: {
+            command: "npx",
+            args: ["-y", "pkg"],
+            env: { API_KEY: "abc123" },
+          },
+        },
+      }),
+    );
+    expect(result?.command).toBe("npx");
+    expect(result?.arguments).toEqual(["-y", "pkg"]);
+    expect(result?.environment).toEqual([
+      { key: "API_KEY", value: "abc123", isPlaceholder: false },
+    ]);
+    expect(result?.serverType).toBe("local");
+  });
+
+  it("also unwraps the alternate `servers` wrapper key", () => {
+    const result = parseMcpServerConfigJson(
+      JSON.stringify({ servers: { foo: { command: "node", args: ["x.js"] } } }),
+    );
+    expect(result?.command).toBe("node");
+    expect(result?.arguments).toEqual(["x.js"]);
+  });
+
+  it("flags placeholder env values so they can be prompted as secrets", () => {
+    const result = parseMcpServerConfigJson(
+      JSON.stringify({
+        command: "npx",
+        args: ["-y", "pkg"],
+        env: {
+          TOKEN: "<token>",
+          OTHER: "YOUR_API_KEY_HERE",
+          // biome-ignore lint/suspicious/noTemplateCurlyInString: intentional ${...} placeholder fixture
+          INTERP: "${SOME_ENV}",
+          REAL: "literal-value",
+          EMPTY: "",
+        },
+      }),
+    );
+    const env = Object.fromEntries(
+      (result?.environment ?? []).map((e) => [e.key, e.isPlaceholder]),
+    );
+    expect(env).toEqual({
+      TOKEN: true,
+      OTHER: true,
+      INTERP: true,
+      REAL: false,
+      EMPTY: true,
+    });
+  });
+
+  it("parses a remote http server config", () => {
+    const result = parseMcpServerConfigJson(
+      JSON.stringify({ url: "https://example.com/mcp", type: "http" }),
+    );
+    expect(result).toEqual({
+      serverUrl: "https://example.com/mcp",
+      serverType: "remote",
+    });
+  });
+
+  it("maps a streamable-http local server to the streamable-http transport", () => {
+    const result = parseMcpServerConfigJson(
+      JSON.stringify({ command: "my-server", type: "streamable-http" }),
+    );
+    expect(result?.serverType).toBe("local");
+    expect(result?.transportType).toBe("streamable-http");
+  });
+
+  it("returns null for non-JSON input (falls back to line-by-line paste)", () => {
+    expect(parseMcpServerConfigJson("--verbose\n--port 3000")).toBeNull();
+    expect(parseMcpServerConfigJson("/path/to/server.js")).toBeNull();
+  });
+
+  it("returns null for a bare JSON arguments array (not a config)", () => {
+    expect(parseMcpServerConfigJson('["-y", "pkg"]')).toBeNull();
+  });
+
+  it("returns null for a JSON object that is not an MCP config", () => {
+    expect(parseMcpServerConfigJson(JSON.stringify({ foo: "bar" }))).toBeNull();
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(parseMcpServerConfigJson('{ "command": "npx", }')).toBeNull();
+    expect(parseMcpServerConfigJson("{ broken")).toBeNull();
+  });
+
+  it("coerces non-string arg/env values to strings", () => {
+    const result = parseMcpServerConfigJson(
+      JSON.stringify({ command: "x", args: ["--port", 3000], env: { N: 5 } }),
+    );
+    expect(result?.arguments).toEqual(["--port", "3000"]);
+    expect(result?.environment).toEqual([
+      { key: "N", value: "5", isPlaceholder: false },
+    ]);
+  });
+
+  // --- security hardening ---
+
+  it("drops prototype-polluting env keys", () => {
+    // Raw JSON string so the literal "__proto__" key survives as an own
+    // property (an object literal would treat it as the prototype setter).
+    const result = parseMcpServerConfigJson(
+      '{"command":"npx","env":{"__proto__":"x","constructor":"y","prototype":"z","OK":"1"}}',
+    );
+    expect(result?.environment).toEqual([
+      { key: "OK", value: "1", isPlaceholder: false },
+    ]);
+    // And no actual prototype pollution occurred.
+    expect(({} as Record<string, unknown>).x).toBeUndefined();
+  });
+
+  it("drops non-scalar env values instead of stringifying to junk", () => {
+    const result = parseMcpServerConfigJson(
+      JSON.stringify({
+        command: "npx",
+        env: { OBJ: { a: 1 }, ARR: [1, 2], OK: "v" },
+      }),
+    );
+    expect(result?.environment).toEqual([
+      { key: "OK", value: "v", isPlaceholder: false },
+    ]);
+  });
+
+  it("rejects non-http(s) server URLs (javascript:, data:)", () => {
+    expect(
+      parseMcpServerConfigJson(JSON.stringify({ url: "javascript:alert(1)" })),
+    ).toBeNull();
+    expect(
+      parseMcpServerConfigJson(JSON.stringify({ url: "data:text/html,x" })),
+    ).toBeNull();
+    expect(
+      parseMcpServerConfigJson(JSON.stringify({ url: "https://ok.com/mcp" }))
+        ?.serverUrl,
+    ).toBe("https://ok.com/mcp");
+  });
+
+  it("rejects absurdly large input", () => {
+    const huge = `{"command":"npx","args":["${"a".repeat(70_000)}"]}`;
+    expect(parseMcpServerConfigJson(huge)).toBeNull();
+  });
+
+  it("caps the number of arguments", () => {
+    const args = Array.from({ length: 500 }, (_, i) => `a${i}`);
+    const result = parseMcpServerConfigJson(
+      JSON.stringify({ command: "npx", args }),
+    );
+    expect(result?.arguments?.length).toBe(100);
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-config-json-parser.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-config-json-parser.ts
@@ -1,0 +1,238 @@
+/**
+ * Parser for pasted MCP server JSON configuration (issue #3859).
+ *
+ * Most MCP server catalogs (the official MCP registry, Claude Desktop, Cursor,
+ * VS Code, etc.) hand out install snippets as JSON rather than as one-argument-
+ * per-line text. Re-typing those into the catalog form is tedious and error
+ * prone. This module recognises the common JSON shapes and extracts the pieces
+ * the form needs so a single paste can populate Command / Arguments / Env /
+ * Transport / URL at once.
+ *
+ * Supported shapes (the wrapper key and the single-server object are both
+ * accepted):
+ *
+ *   { "mcpServers": { "everything": { "command": "npx", "args": [...] } } }
+ *   { "servers":    { "everything": { "command": "npx", "args": [...] } } }
+ *   { "command": "npx", "args": ["-y", "pkg"], "env": { "API_KEY": "<token>" } }
+ *   { "url": "https://example.com/mcp", "type": "http" }
+ *
+ * It is intentionally conservative: anything that is not valid JSON, or is valid
+ * JSON but not a recognisable MCP server config (e.g. a bare arguments array),
+ * returns `null` so the caller can fall back to the existing line-by-line paste
+ * behaviour.
+ */
+
+export interface ParsedMcpEnvVar {
+  key: string;
+  value: string;
+  /**
+   * True when the value looks like a placeholder the user is expected to fill in
+   * (e.g. `<token>`, `YOUR_API_KEY_HERE`, `${ENV}`, or empty). Callers can use
+   * this to mark the field as a prompt-on-install secret instead of a literal.
+   */
+  isPlaceholder: boolean;
+}
+
+export interface ParsedMcpServerConfig {
+  command?: string;
+  arguments?: string[];
+  environment?: ParsedMcpEnvVar[];
+  transportType?: "stdio" | "streamable-http";
+  serverUrl?: string;
+  serverType?: "local" | "remote";
+}
+
+// Defense-in-depth limits: a real MCP config is tiny, so anything far larger is
+// rejected rather than parsed/iterated (avoids pathological pastes).
+const MAX_INPUT_LENGTH = 64_000;
+const MAX_ARGS = 100;
+const MAX_ARG_LENGTH = 2_000;
+const MAX_ENV_VARS = 100;
+const MAX_ENV_KEY_LENGTH = 256;
+const MAX_ENV_VALUE_LENGTH = 4_000;
+
+// Keys that must never be carried out of untrusted JSON into config/env data.
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+const PLACEHOLDER_PATTERNS = [
+  /<[^>]+>/, // <token>, <YOUR_KEY>
+  /\$\{[^}]+\}/, // ${ENV_VAR}
+  /^\$[A-Z0-9_]+$/, // $ENV_VAR
+  /YOUR[_-].*[_-]?HERE/i, // YOUR_API_KEY_HERE
+  /YOUR[_-][A-Z0-9_-]+/i, // YOUR_TOKEN
+  /^(xxx+|\.\.\.|todo|changeme|placeholder)$/i,
+];
+
+function isPlaceholderValue(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return true;
+  return PLACEHOLDER_PATTERNS.some((re) => re.test(trimmed));
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/** Accept a URL only if it is a well-formed http(s) URL; reject javascript:, data:, etc. */
+function asHttpUrl(value: unknown): string | undefined {
+  const s = asString(value);
+  if (!s) return undefined;
+  try {
+    const url = new URL(s);
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? s
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out = value
+    .filter((v) => typeof v === "string" || typeof v === "number")
+    .map((v) => String(v))
+    .filter((s) => s.length <= MAX_ARG_LENGTH)
+    .slice(0, MAX_ARGS);
+  return out.length > 0 ? out : undefined;
+}
+
+function parseEnv(value: unknown): ParsedMcpEnvVar[] | undefined {
+  if (!isPlainObject(value)) return undefined;
+  const entries: ParsedMcpEnvVar[] = [];
+  for (const [key, raw] of Object.entries(value)) {
+    if (entries.length >= MAX_ENV_VARS) break;
+    // Skip empty, oversized, or prototype-polluting keys.
+    if (
+      key.trim().length === 0 ||
+      key.length > MAX_ENV_KEY_LENGTH ||
+      DANGEROUS_KEYS.has(key)
+    ) {
+      continue;
+    }
+    // Only accept scalar values; objects/arrays would stringify to junk
+    // (e.g. "[object Object]") and are not valid env values.
+    if (
+      raw !== null &&
+      typeof raw !== "string" &&
+      typeof raw !== "number" &&
+      typeof raw !== "boolean"
+    ) {
+      continue;
+    }
+    const strValue = (raw === null ? "" : String(raw)).slice(
+      0,
+      MAX_ENV_VALUE_LENGTH,
+    );
+    entries.push({
+      key,
+      value: strValue,
+      isPlaceholder: isPlaceholderValue(strValue),
+    });
+  }
+  return entries.length > 0 ? entries : undefined;
+}
+
+/**
+ * Pull a single server config object out of whatever wrapper shape was pasted.
+ * Returns null when the input is not a recognisable single MCP server config.
+ */
+function extractServerObject(parsed: unknown): Record<string, unknown> | null {
+  if (!isPlainObject(parsed)) return null;
+
+  // Wrapper shapes: { mcpServers: { name: {...} } } or { servers: { name: {...} } }
+  for (const wrapperKey of ["mcpServers", "servers"]) {
+    const wrapper = parsed[wrapperKey];
+    if (isPlainObject(wrapper)) {
+      const firstServer = Object.values(wrapper).find(isPlainObject);
+      if (firstServer) return firstServer;
+      return null;
+    }
+  }
+
+  // Bare single-server object: must carry at least one recognised config key.
+  const hasServerKey = [
+    "command",
+    "args",
+    "url",
+    "serverUrl",
+    "type",
+    "env",
+  ].some((k) => k in parsed);
+  return hasServerKey ? parsed : null;
+}
+
+/**
+ * Parse a pasted string as an MCP server JSON config. Returns null if the input
+ * is not valid JSON or is not a recognisable MCP server configuration, so the
+ * caller can fall back to its existing (line-by-line) handling.
+ */
+export function parseMcpServerConfigJson(
+  input: string,
+): ParsedMcpServerConfig | null {
+  // Reject absurdly large pastes before any parsing/iteration.
+  if (input.length > MAX_INPUT_LENGTH) return null;
+  const trimmed = input.trim();
+  // Cheap pre-check: a JSON config object starts with "{". A bare arguments
+  // array ("[...]") is deliberately NOT treated as a config here.
+  if (!trimmed.startsWith("{")) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+
+  const server = extractServerObject(parsed);
+  if (!server) return null;
+
+  const command = asString(server.command);
+  const args = asStringArray(server.args ?? server.arguments);
+  const environment = parseEnv(server.env ?? server.environment);
+  const serverUrl = asHttpUrl(server.url ?? server.serverUrl);
+  const rawType = asString(server.type)?.toLowerCase();
+
+  // Decide local vs remote. A URL (and no command) means a remote server.
+  const isRemote =
+    Boolean(serverUrl) &&
+    !command &&
+    (rawType === undefined ||
+      rawType === "http" ||
+      rawType === "streamable-http" ||
+      rawType === "sse" ||
+      rawType === "remote");
+
+  const result: ParsedMcpServerConfig = {};
+  if (command) result.command = command;
+  if (args) result.arguments = args;
+  if (environment) result.environment = environment;
+  if (serverUrl) result.serverUrl = serverUrl;
+
+  if (isRemote) {
+    result.serverType = "remote";
+  } else if (command || args || environment) {
+    result.serverType = "local";
+    // http/streamable-http/sse → streamable-http; otherwise stdio.
+    result.transportType =
+      rawType === "http" || rawType === "streamable-http" || rawType === "sse"
+        ? "streamable-http"
+        : "stdio";
+  }
+
+  // Nothing useful extracted → not a config we can apply.
+  if (
+    result.command === undefined &&
+    result.arguments === undefined &&
+    result.environment === undefined &&
+    result.serverUrl === undefined
+  ) {
+    return null;
+  }
+
+  return result;
+}


### PR DESCRIPTION
…he form

The MCP catalog form only accepted arguments one-per-line, but every catalog (official MCP registry, Claude Desktop, Cursor, VS Code, etc.) hands out install snippets as JSON. Users had to hand-translate those into Command / Arguments / Env / Transport fields.

This adds a conservative JSON-config parser and wires it to the Arguments field's paste handler: pasting a recognised MCP server config now auto-fills all fields at once. Pasting anything else falls back to the existing line-by-line behaviour.

- New pure, unit-tested `parseMcpServerConfigJson` (11 tests) handling the `{ mcpServers: { name: {...} } }` / `{ servers: {...} }` wrappers, bare single-server objects, remote `{ url, type }`, and placeholder env detection (`<token>`, `YOUR_KEY_HERE`, `${ENV}`, empty) which become prompt-on-install secret fields.
- Wired via `onPaste` on the Arguments textarea; non-config pastes are left to the default handler. Added a form description documenting the shortcut.

Closes #3859

/claim #3859