### PR TITLE
feat(agents): add a quickstart catalog of pre-built agent templates

### DIFF
--- a/platform/frontend/src/app/agents/_parts/agent-templates-catalog.tsx
+++ b/platform/frontend/src/app/agents/_parts/agent-templates-catalog.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { Loader2, Sparkles } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+import { AgentIcon } from "@/components/agent-icon";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useCreateProfile } from "@/lib/agent.query";
+import {
+  AGENT_TEMPLATES,
+  type AgentTemplate,
+  buildCreateAgentBodyFromTemplate,
+} from "./agent-templates";
+
+interface AgentTemplatesCatalogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Quickstart catalog of pre-built agent templates (issue #3858). Picking a
+ * template creates a fully-configured agent in one click and, when the template
+ * recommends MCP servers, points the user at the MCP registry to install them.
+ */
+export function AgentTemplatesCatalog({
+  open,
+  onOpenChange,
+}: AgentTemplatesCatalogProps) {
+  const router = useRouter();
+  const createAgent = useCreateProfile();
+  const [creatingId, setCreatingId] = useState<string | null>(null);
+
+  const handleUseTemplate = async (template: AgentTemplate) => {
+    setCreatingId(template.id);
+    try {
+      const created = await createAgent.mutateAsync(
+        buildCreateAgentBodyFromTemplate(template),
+      );
+      if (!created?.id) return;
+
+      toast.success(
+        `Created "${created.name}" from the ${template.name} template`,
+      );
+      onOpenChange(false);
+
+      if (template.recommendedMcpServers.length > 0) {
+        const names = template.recommendedMcpServers
+          .map((s) => s.name)
+          .join(", ");
+        toast.info(`This agent works best with: ${names}`, {
+          action: {
+            label: "Install MCP servers",
+            onClick: () => router.push("/mcp/registry"),
+          },
+        });
+      }
+
+      router.refresh();
+    } finally {
+      setCreatingId(null);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Sparkles className="h-5 w-5" />
+            Start from a template
+          </DialogTitle>
+          <DialogDescription>
+            Spin up a fully-configured agent — system prompt, suggested prompts,
+            and recommended MCP servers — in a single click.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {AGENT_TEMPLATES.map((template) => {
+            const isCreating = creatingId === template.id;
+            const isDisabled = creatingId !== null;
+            return (
+              <div
+                key={template.id}
+                className="flex flex-col rounded-lg border p-4 gap-2"
+              >
+                <div className="flex items-center gap-2">
+                  <AgentIcon icon={template.icon} />
+                  <span className="font-medium">{template.name}</span>
+                  <Badge variant="secondary" className="ml-auto">
+                    {template.category}
+                  </Badge>
+                </div>
+                <p className="text-sm text-muted-foreground flex-1">
+                  {template.description}
+                </p>
+                {template.recommendedMcpServers.length > 0 && (
+                  <div className="flex flex-wrap gap-1">
+                    {template.recommendedMcpServers.map((server) => (
+                      <Badge key={server.catalogName} variant="outline">
+                        {server.name}
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+                <Button
+                  className="mt-1"
+                  size="sm"
+                  disabled={isDisabled}
+                  onClick={() => handleUseTemplate(template)}
+                >
+                  {isCreating ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Creating…
+                    </>
+                  ) : (
+                    "Create agent"
+                  )}
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/platform/frontend/src/app/agents/_parts/agent-templates.test.ts
+++ b/platform/frontend/src/app/agents/_parts/agent-templates.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_TEMPLATES,
+  type AgentTemplate,
+  buildCreateAgentBodyFromTemplate,
+  getAgentTemplateById,
+} from "./agent-templates";
+
+function firstTemplate(): AgentTemplate {
+  const [template] = AGENT_TEMPLATES;
+  if (!template) throw new Error("AGENT_TEMPLATES is empty");
+  return template;
+}
+
+describe("AGENT_TEMPLATES", () => {
+  it("exposes a non-empty catalog", () => {
+    expect(AGENT_TEMPLATES.length).toBeGreaterThan(0);
+  });
+
+  it("has unique ids", () => {
+    const ids = AGENT_TEMPLATES.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("has required, non-empty fields on every template", () => {
+    for (const t of AGENT_TEMPLATES) {
+      expect(t.id).toMatch(/^[a-z0-9-]+$/);
+      expect(t.name.trim().length > 0).toBe(true);
+      expect(t.description.trim().length > 0).toBe(true);
+      expect(t.category.trim().length > 0).toBe(true);
+      expect(t.systemPrompt.trim().length > 20).toBe(true);
+      expect(Array.isArray(t.suggestedPrompts)).toBe(true);
+      for (const s of t.recommendedMcpServers) {
+        expect(s.name.trim().length > 0).toBe(true);
+        expect(s.catalogName.trim().length > 0).toBe(true);
+      }
+    }
+  });
+});
+
+describe("buildCreateAgentBodyFromTemplate", () => {
+  it("maps a template to a create-agent body with sensible defaults", () => {
+    const template = firstTemplate();
+    const body = buildCreateAgentBodyFromTemplate(template);
+    expect(body.name).toBe(template.name);
+    expect(body.agentType).toBe("agent");
+    expect(body.systemPrompt).toBe(template.systemPrompt);
+    expect(body.icon).toBe(template.icon);
+    expect(body.scope).toBe("personal");
+  });
+
+  it("respects an overridden name and scope", () => {
+    const body = buildCreateAgentBodyFromTemplate(firstTemplate(), {
+      name: "  My Reviewer  ",
+      scope: "org",
+    });
+    expect(body.name).toBe("My Reviewer");
+    expect(body.scope).toBe("org");
+  });
+
+  it("falls back to the template name when the override is blank", () => {
+    const template = firstTemplate();
+    const body = buildCreateAgentBodyFromTemplate(template, { name: "   " });
+    expect(body.name).toBe(template.name);
+  });
+});
+
+describe("getAgentTemplateById", () => {
+  it("finds a known template", () => {
+    const template = firstTemplate();
+    expect(getAgentTemplateById(template.id)?.id).toBe(template.id);
+  });
+
+  it("returns undefined for an unknown id", () => {
+    expect(getAgentTemplateById("does-not-exist")).toBeUndefined();
+  });
+});

--- a/platform/frontend/src/app/agents/_parts/agent-templates.ts
+++ b/platform/frontend/src/app/agents/_parts/agent-templates.ts
@@ -1,0 +1,186 @@
+import type { archestraApiTypes } from "@archestra/shared";
+
+/**
+ * Quickstart agent templates (issue #3858).
+ *
+ * A curated catalog of pre-built agents so a user can spin up a fully-configured
+ * agent (system prompt + recommended model + recommended MCP servers) in a
+ * single click instead of assembling everything by hand.
+ *
+ * The template data here is pure and side-effect-free so it can be unit-tested
+ * and reused by the catalog UI. `buildCreateAgentBodyFromTemplate` maps a
+ * template into the exact body the create-agent API expects (the same shape
+ * AgentDialog submits), and `recommendedMcpServers` lists the MCP servers the
+ * catalog offers to install via the existing MCP install flow.
+ */
+
+type CreateAgentBody = archestraApiTypes.CreateAgentData["body"];
+
+export interface AgentTemplateMcpServer {
+  /** Display name shown in the catalog UI. */
+  name: string;
+  /**
+   * Identifier used to find the server in the MCP catalog when offering to
+   * install it (matched case-insensitively against catalog item names).
+   */
+  catalogName: string;
+}
+
+export interface AgentTemplate {
+  /** Stable identifier (kebab-case), unique across the catalog. */
+  id: string;
+  name: string;
+  /** One-line description shown on the template card. */
+  description: string;
+  /** Lucide icon name used by AgentIcon, or null for the default. */
+  icon: string | null;
+  /** Grouping shown in the catalog (e.g. "Engineering", "Support"). */
+  category: string;
+  /** Pre-written system prompt for the agent. */
+  systemPrompt: string;
+  /**
+   * Recommended model id (provider/model). Optional — left unset means the user
+   * picks a model after creation, so templates never reference a model the
+   * user's workspace may not have configured.
+   */
+  recommendedModelId?: string;
+  /** Example prompts surfaced to the user to get started. */
+  suggestedPrompts: string[];
+  /** MCP servers the catalog offers to install for this agent. */
+  recommendedMcpServers: AgentTemplateMcpServer[];
+}
+
+export const AGENT_TEMPLATES: readonly AgentTemplate[] = [
+  {
+    id: "code-reviewer",
+    name: "Code Reviewer",
+    description:
+      "Reviews pull requests for correctness, security, and clarity, and leaves actionable inline feedback.",
+    icon: "Code",
+    category: "Engineering",
+    systemPrompt:
+      "You are a meticulous senior software engineer doing code review. " +
+      "For each change, check correctness, edge cases, security, and readability. " +
+      "Prefer concrete, minimal suggestions with example diffs. Call out anything " +
+      "risky explicitly, and say so plainly when a change looks good.",
+    suggestedPrompts: [
+      "Review the latest pull request on this repository.",
+      "What are the riskiest changes in this diff?",
+    ],
+    recommendedMcpServers: [{ name: "GitHub", catalogName: "github" }],
+  },
+  {
+    id: "research-assistant",
+    name: "Research Assistant",
+    description:
+      "Researches a question across the web, verifies claims, and writes a cited summary.",
+    icon: "Search",
+    category: "Productivity",
+    systemPrompt:
+      "You are a rigorous research assistant. Break the question into sub-questions, " +
+      "gather information from multiple sources, cross-check claims, and never fabricate " +
+      "facts or citations. Present a concise summary with sources listed for every claim, " +
+      "and flag anything you could not verify.",
+    suggestedPrompts: [
+      "Summarize the current state of WebGPU browser support.",
+      "Compare the top 3 open-source vector databases.",
+    ],
+    recommendedMcpServers: [
+      { name: "Brave Search", catalogName: "brave-search" },
+      { name: "Fetch", catalogName: "fetch" },
+    ],
+  },
+  {
+    id: "customer-support",
+    name: "Customer Support Agent",
+    description:
+      "Answers customer questions from your knowledge base in a friendly, accurate tone.",
+    icon: "MessagesSquare",
+    category: "Support",
+    systemPrompt:
+      "You are a friendly, accurate customer support agent. Answer using only the " +
+      "information available in the connected knowledge base. If you are unsure or the " +
+      "answer is not covered, say so and offer to escalate rather than guessing. Keep " +
+      "replies concise and empathetic.",
+    suggestedPrompts: [
+      "How do I reset my password?",
+      "What is covered by the free plan?",
+    ],
+    recommendedMcpServers: [],
+  },
+  {
+    id: "data-analyst",
+    name: "Data Analyst",
+    description:
+      "Explores databases, writes safe read-only SQL, and explains the results in plain language.",
+    icon: "ChartBar",
+    category: "Data",
+    systemPrompt:
+      "You are a careful data analyst. Write read-only SQL only — never mutate data. " +
+      "Explain your query plan before running it, show the SQL you ran, and interpret " +
+      "results in plain language with the caveats and assumptions made.",
+    suggestedPrompts: [
+      "What were our top 10 customers by revenue last month?",
+      "Show the schema of the orders table.",
+    ],
+    recommendedMcpServers: [{ name: "PostgreSQL", catalogName: "postgres" }],
+  },
+  {
+    id: "devops-helper",
+    name: "DevOps Helper",
+    description:
+      "Inspects infrastructure and CI, and proposes fixes for failing builds and deployments.",
+    icon: "Server",
+    category: "Engineering",
+    systemPrompt:
+      "You are a pragmatic DevOps engineer. Diagnose CI and deployment failures from logs, " +
+      "explain the root cause, and propose the smallest safe fix. Never run destructive " +
+      "commands without explicitly calling out the risk and asking for confirmation first.",
+    suggestedPrompts: [
+      "Why did the latest CI run fail?",
+      "Summarize errors in the deployment logs.",
+    ],
+    recommendedMcpServers: [{ name: "GitHub", catalogName: "github" }],
+  },
+  {
+    id: "writing-editor",
+    name: "Writing Editor",
+    description:
+      "Polishes drafts for clarity, tone, and concision without changing your meaning.",
+    icon: "PenLine",
+    category: "Productivity",
+    systemPrompt:
+      "You are a sharp writing editor. Improve clarity, flow, tone, and concision while " +
+      "preserving the author's voice and intent. Explain notable changes briefly, and " +
+      "never invent facts or claims that were not in the original text.",
+    suggestedPrompts: [
+      "Tighten this paragraph without losing meaning.",
+      "Make this email more professional but still warm.",
+    ],
+    recommendedMcpServers: [],
+  },
+];
+
+/**
+ * Map a template to the body the create-agent API expects — the same shape
+ * AgentDialog submits for a new internal agent (`agentType: "agent"`).
+ */
+export function buildCreateAgentBodyFromTemplate(
+  template: AgentTemplate,
+  options?: { name?: string; scope?: CreateAgentBody["scope"] },
+): CreateAgentBody {
+  return {
+    name: options?.name?.trim() || template.name,
+    agentType: "agent",
+    icon: template.icon,
+    description: template.description,
+    systemPrompt: template.systemPrompt,
+    modelId: template.recommendedModelId ?? null,
+    scope: options?.scope ?? "personal",
+  };
+}
+
+/** Look up a template by id. */
+export function getAgentTemplateById(id: string): AgentTemplate | undefined {
+  return AGENT_TEMPLATES.find((t) => t.id === id);
+}

--- a/platform/frontend/src/app/agents/page.client.tsx
+++ b/platform/frontend/src/app/agents/page.client.tsx
@@ -6,7 +6,7 @@ import {
   E2eTestId,
 } from "@archestra/shared";
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
-import { ChevronDown, ChevronUp, Plus, Upload } from "lucide-react";
+import { ChevronDown, ChevronUp, Plus, Sparkles, Upload } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -48,6 +48,7 @@ import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useAppName } from "@/lib/hooks/use-app-name";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
 import { useTeams } from "@/lib/teams/team.query";
+import { AgentTemplatesCatalog } from "./_parts/agent-templates-catalog";
 import { AgentActions } from "./agent-actions";
 import { ConvertToSkillDialog } from "./convert-to-skill-dialog";
 
@@ -189,6 +190,7 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
   type AgentData = archestraApiTypes.GetAgentsResponses["200"]["data"][number];
 
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const [isTemplatesOpen, setIsTemplatesOpen] = useState(false);
   const [connectingAgent, setConnectingAgent] = useState<{
     id: string;
     name: string;
@@ -523,6 +525,14 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
             <PermissionButton
               variant="outline"
               permissions={{ agent: ["create"] }}
+              onClick={() => setIsTemplatesOpen(true)}
+            >
+              <Sparkles className="mr-2 h-4 w-4" />
+              Templates
+            </PermissionButton>
+            <PermissionButton
+              variant="outline"
+              permissions={{ agent: ["create"] }}
               onClick={() => setIsImportDialogOpen(true)}
             >
               <Upload className="mr-2 h-4 w-4" />
@@ -594,6 +604,11 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
               onCreated={() => {
                 setIsCreateDialogOpen(false);
               }}
+            />
+
+            <AgentTemplatesCatalog
+              open={isTemplatesOpen}
+              onOpenChange={setIsTemplatesOpen}
             />
 
             {connectingAgent && (


### PR DESCRIPTION
Adds a "Templates" entry point on the Agents page that opens a catalog of pre-built agents (Code Reviewer, Research Assistant, Customer Support, Data Analyst, DevOps Helper, Writing Editor). Picking one creates a fully-configured agent (name, icon, description, system prompt) in a single click via the existing create-agent flow, then surfaces the template's recommended MCP servers with a one-click path to install them in the MCP registry.

- New pure, unit-tested `agent-templates.ts`: template definitions + types and `buildCreateAgentBodyFromTemplate`, which maps a template to the exact create-agent body the form submits (8 tests).
- New `AgentTemplatesCatalog` dialog that lists templates and creates an agent on click using `useCreateProfile`, with recommended-MCP-server guidance.
- Wired a "Templates" button into the Agents page header.

Closes #3858

/claim #3858