### PR TITLE
perf(frontend): auto-select Turbopack for dev on Linux, webpack on macOS arm64

### DIFF
--- a/platform/dev/Tiltfile.dev
+++ b/platform/dev/Tiltfile.dev
@@ -127,11 +127,12 @@ else:
   # silently hitting the real backend.
   local_resource(
     dev_resource_name + '-frontend-int-tests',
-    # --webpack mirrors the main frontend workaround for the next@16.2.6 turbopack
-    # idle-CPU bug (vercel/next.js#92055); see the "//dev" comment in frontend/package.json.
-    # `pnpm exec next dev` bypasses that package.json script, so the flag must be set here too.
-    serve_cmd='trap "pkill -TERM -P $$" EXIT INT TERM; cd ../frontend && pnpm exec next dev --webpack -H 127.0.0.1 -p ' + frontend_int_tests_port + ' & wait $!',
-    serve_cmd_bat='cd ..\\frontend && pnpm exec next dev --webpack -H 127.0.0.1 -p ' + frontend_int_tests_port,
+    # Route through scripts/dev.mjs so the int-tests frontend gets the same
+    # platform-aware bundler choice as `pnpm dev`: Turbopack on Linux/CI, webpack
+    # on macOS arm64 (the unfixed @next/swc-darwin-arm64 memory bug, see the
+    # "//dev" comment in frontend/package.json). The script adds `-H 127.0.0.1`.
+    serve_cmd='trap "pkill -TERM -P $$" EXIT INT TERM; cd ../frontend && node ./scripts/dev.mjs -p ' + frontend_int_tests_port + ' & wait $!',
+    serve_cmd_bat='cd ..\\frontend && node .\\scripts\\dev.mjs -p ' + frontend_int_tests_port,
     labels=['dev'],
     deps=['../.env'],
     serve_env={

--- a/platform/frontend/package.json
+++ b/platform/frontend/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "//dev": "TEMP local workaround: next@16.2.6 turbopack dev server pegs CPU (300-760%) at idle on macOS arm64 (vercel/next.js#92055). Reverted from --turbopack to --webpack. Restore --turbopack once a fixed next ships.",
-    "dev": "next dev --webpack -H 127.0.0.1",
+    "//dev": "Auto-selects the Next dev bundler in scripts/dev.mjs: Turbopack on Linux/CI/Intel-Mac (2-6x faster compiles), webpack on macOS arm64 to dodge the unfixed @next/swc-darwin-arm64 IOAccelerator (Apple GPU) memory leak under Turbopack (vercel/next.js#92055). Override with ARCHESTRA_DEV_BUNDLER=turbopack|webpack, or use dev:turbo / dev:webpack.",
+    "dev": "node ./scripts/dev.mjs",
+    "dev:webpack": "next dev --webpack -H 127.0.0.1",
     "dev:profile": "next dev --webpack --experimental-cpu-prof -H 127.0.0.1",
     "dev:turbo": "next dev --turbopack -H 127.0.0.1",
     "dev:turbo:profile": "next dev --turbopack --experimental-cpu-prof -H 127.0.0.1",

--- a/platform/frontend/scripts/dev.mjs
+++ b/platform/frontend/scripts/dev.mjs
@@ -1,0 +1,78 @@
+import { spawn } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const VALID = new Set(["turbopack", "webpack"]);
+
+/**
+ * Choose the Next.js dev bundler. Turbopack compiles 2-6x faster, but
+ * @next/swc-darwin-arm64 leaks multi-GB non-reclaimable IOAccelerator (Apple
+ * GPU) memory under Turbopack on Apple Silicon (vercel/next.js#92055, still
+ * open), so macOS arm64 stays on webpack until the upstream native fix ships.
+ * Set ARCHESTRA_DEV_BUNDLER=turbopack|webpack to override.
+ */
+export function pickBundler({ override, platform, arch }) {
+  if (override) {
+    if (!VALID.has(override)) {
+      throw new Error(
+        `ARCHESTRA_DEV_BUNDLER must be "turbopack" or "webpack" (got "${override}")`,
+      );
+    }
+    return override;
+  }
+  return platform === "darwin" && arch === "arm64" ? "webpack" : "turbopack";
+}
+
+function main() {
+  let bundler;
+  try {
+    bundler = pickBundler({
+      override: process.env.ARCHESTRA_DEV_BUNDLER,
+      platform: process.platform,
+      arch: process.arch,
+    });
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+
+  const require = createRequire(import.meta.url);
+  const nextPkg = require("next/package.json");
+  const nextBin = join(
+    dirname(require.resolve("next/package.json")),
+    typeof nextPkg.bin === "string" ? nextPkg.bin : nextPkg.bin.next,
+  );
+
+  const child = spawn(
+    process.execPath,
+    [nextBin, "dev", `--${bundler}`, "-H", "127.0.0.1", ...process.argv.slice(2)],
+    { stdio: "inherit" },
+  );
+
+  const forward = (signal) => {
+    if (!child.killed) child.kill(signal);
+  };
+  process.on("SIGINT", forward);
+  process.on("SIGTERM", forward);
+
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      // Re-raise with our handlers removed so the default disposition terminates
+      // this process with the same signal the child died from — otherwise the
+      // still-installed handler swallows it and we'd exit 0, hiding the
+      // interruption from callers (Tilt, the shell).
+      process.off("SIGINT", forward);
+      process.off("SIGTERM", forward);
+      process.kill(process.pid, signal);
+    } else {
+      process.exit(code ?? 0);
+    }
+  });
+}
+
+const entry = process.argv[1];
+if (entry && import.meta.url === pathToFileURL(realpathSync(entry)).href) {
+  main();
+}


### PR DESCRIPTION
## Summary

`pnpm dev`'s first navigation to a route like `/agents` or `/chat` blocks while webpack compiles that route's entire module graph on demand — the dev server itself is `Ready` in well under a second, but the first render is the slow part. Turbopack compiles the same graph 2–6× faster and already powers `next build`, yet `dev` was globally pinned to `--webpack`.

That pin existed for exactly one reason: `@next/swc-darwin-arm64` leaks multi-GB, non-reclaimable **IOAccelerator (Apple GPU) memory** under Turbopack on Apple Silicon — [vercel/next.js#92055](https://github.com/vercel/next.js/issues/92055), still open, present from 15.5.x through the current 16.2.x / 16.3 canary. IOAccelerator is an Apple Metal subsystem, so the bug **cannot occur on Linux** — Linux developers and CI were paying the webpack compile tax for a macOS-only defect. (The flag was also a slight misnomer: the upstream issue is a memory leak, not idle CPU.)

`scripts/dev.mjs` now selects the dev bundler by platform — **Turbopack on Linux / CI / Intel Mac, webpack on macOS arm64** until the upstream native fix ships. On Linux, `pnpm dev` first-paint of a heavy route drops accordingly; on macOS arm64, behavior is unchanged. The Tilt int-tests frontend (previously hardcoded to `--webpack` for the same bug) routes through the same script, so the bundler choice lives in one place instead of being duplicated.

Override with `ARCHESTRA_DEV_BUNDLER=turbopack|webpack`, or use the explicit `dev:turbo` / `dev:webpack` scripts.

No CI job runs `pnpm dev`, and `build` already uses Turbopack, so the blast radius is local dev compile time only.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>