### PR TITLE
docs: fix default admin email in deployment guide

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -853,7 +853,7 @@ The following environment variables can be used to configure Archestra Platform.
   - **Warning:** Do not change this value after deployment. Rotating this secret will invalidate all user sessions (forcing re-login), make existing encrypted secrets unreadable, break JWT signing (JWKS private keys are encrypted with this secret), and break two-factor authentication for enrolled users.
 
 - **`ARCHESTRA_AUTH_ADMIN_EMAIL`** - Email address for the default Archestra Admin user, created on startup.
-  - Default: `admin@localhost.ai`
+  - Default: `admin@example.com`
 
 - **`ARCHESTRA_AUTH_ADMIN_PASSWORD`** - Password for the default Archestra Admin user. Set once on first-run.
   - Default: `password`


### PR DESCRIPTION
## What

The deployment guide listed the default admin email as `admin@localhost.ai`, but the code seeds and checks `admin@example.com` (`shared/consts.ts`, also matching `.env.example`). An SRE following the guide would type the wrong email and fail to log in on first boot.

## Change

One-line doc fix in `docs/pages/platform-deployment.md` to match the actual default.

## Verification

Confirmed `admin@example.com` is the value in `platform/shared/consts.ts` and `platform/.env.example`; the doc was the only outlier.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>