### PR TITLE
fix: allow optional knowledge API key name

### DIFF
--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -137,7 +137,6 @@ function AddApiKeyDialog({
   const formValues = form.watch();
   const isValid =
     formValues.apiKey !== LLM_PROVIDER_API_KEY_PLACEHOLDER &&
-    formValues.name &&
     (formValues.scope !== "team" || formValues.teamId) &&
     (byosEnabled
       ? formValues.vaultSecretPath && formValues.vaultSecretKey


### PR DESCRIPTION
## Summary

Fixes #4733.

The Knowledge settings Add API Key dialog labels the Name field as optional, but the submit button still required `formValues.name` before enabling. This removes the name check from the dialog validity condition so the button behavior matches the UI label.

## Verification

- `git diff --check`

Note: I was not able to run the frontend lint/type-check locally because dependency installation did not complete in this environment.