### PR TITLE
chore: update pnpm to 11.5.2

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -124,7 +124,7 @@ runs:
           "${KUBE_ARGS[@]}" \
           "${ENV_ARGS[@]}" \
           "mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-noble" \
-          /bin/bash -c "corepack enable && corepack prepare pnpm@11.4.0 --activate && pnpm test:e2e -- --project=${PROJECTS} ${SHARD} ${EXTRA_ARGS}" \
+          /bin/bash -c "corepack enable && corepack prepare pnpm@11.5.2 --activate && pnpm test:e2e -- --project=${PROJECTS} ${SHARD} ${EXTRA_ARGS}" \
           2>&1 | tee "${WORKING_DIRECTORY}/playwright-output.txt"
 
     - name: Check for flaky tests

--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -105,7 +105,7 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
 
-RUN corepack prepare pnpm@11.4.0 --activate
+RUN corepack prepare pnpm@11.5.2 --activate
 
 # Dependencies stage
 FROM base AS deps

--- a/platform/package.json
+++ b/platform/package.json
@@ -45,7 +45,7 @@
     "tsx": "^4.21.0",
     "turbo": "^2.9.14"
   },
-  "packageManager": "pnpm@11.4.0",
+  "packageManager": "pnpm@11.5.2",
   "dependencies": {
     "croner": "^10.0.1"
   }

--- a/platform/scripts/e2e-local.sh
+++ b/platform/scripts/e2e-local.sh
@@ -109,7 +109,7 @@ docker run --rm \
   -v "$HOME/.kube:/root/.kube:ro" \
   -e KUBECONFIG=/root/.kube/config \
   "mcr.microsoft.com/playwright:v${PW_VERSION}-noble" \
-  /bin/bash -c "corepack enable && corepack prepare pnpm@11.4.0 --activate && pnpm test:e2e -- $PLAYWRIGHT_ARGS"
+  /bin/bash -c "corepack enable && corepack prepare pnpm@11.5.2 --activate && pnpm test:e2e -- $PLAYWRIGHT_ARGS"
 
 echo ""
 echo "=== E2E tests complete ==="


### PR DESCRIPTION
## Summary

- Update the platform package manager pin to pnpm 11.5.2.
- Align Docker and e2e runner Corepack pnpm activation with 11.5.2.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>