### PR TITLE
fix(run-tool): recover from hallucinated tool names instead of a dead-end refusal

### DIFF
--- a/platform/backend/src/archestra-mcp-server/run-tool.test.ts
+++ b/platform/backend/src/archestra-mcp-server/run-tool.test.ts
@@ -242,7 +242,18 @@ describe("run_tool", () => {
     expect(mcpClient.executeToolCall).not.toHaveBeenCalled();
   });
 
-  test("dispatches third-party MCP tools through the MCP client", async () => {
+  test("dispatches third-party MCP tools through the MCP client", async ({
+    makeAgentTool,
+    makeInternalMcpCatalog,
+    makeTool,
+  }) => {
+    const catalog = await makeInternalMcpCatalog();
+    const tool = await makeTool({
+      name: "github__search_repositories",
+      catalogId: catalog.id,
+    });
+    await makeAgentTool(testAgent.id, tool.id);
+
     vi.mocked(mcpClient.executeToolCall).mockResolvedValueOnce({
       content: [{ type: "text", text: "Third-party response" }],
       isError: false,
@@ -279,9 +290,57 @@ describe("run_tool", () => {
     ]);
   });
 
+  test("returns a search_tools recovery message for an unavailable third-party tool", async () => {
+    const result = await executeArchestraTool(
+      TOOL_RUN_TOOL_FULL_NAME,
+      {
+        tool_name: "giphy__image_search_tool",
+        tool_args: { query: "cat" },
+      },
+      mockContext,
+    );
+
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as any).text;
+    expect(text).toContain('No tool named "giphy__image_search_tool"');
+    expect(text).toContain("search_tools");
+    expect(text).not.toContain("not enabled for this conversation");
+    expect(mcpClient.executeToolCall).not.toHaveBeenCalled();
+  });
+
+  test("recovery message wins over the policy refusal when the agent has other tools", async ({
+    makeAgentTool,
+    makeInternalMcpCatalog,
+    makeTool,
+  }) => {
+    // Reproduces the staging case: the agent HAS an assigned tool, so the
+    // policy gate's disabled-tool filter is active (non-empty enabled set) and
+    // would otherwise emit "not enabled for this conversation" for a
+    // hallucinated name. The pre-check must intercept first.
+    const catalog = await makeInternalMcpCatalog();
+    const assigned = await makeTool({
+      name: "github__search_repositories",
+      catalogId: catalog.id,
+    });
+    await makeAgentTool(testAgent.id, assigned.id);
+
+    const result = await executeArchestraTool(
+      TOOL_RUN_TOOL_FULL_NAME,
+      { tool_name: "giphy__image_search_tool", tool_args: { query: "cat" } },
+      mockContext,
+    );
+
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as any).text;
+    expect(text).toContain('No tool named "giphy__image_search_tool"');
+    expect(text).not.toContain("not enabled for this conversation");
+    expect(mcpClient.executeToolCall).not.toHaveBeenCalled();
+  });
+
   test("blocks third-party MCP tools when target invocation policy denies the call", async ({
     makeAgent,
     makeAgentTool,
+    makeInternalMcpCatalog,
     makeMember,
     makeOrganization,
     makeTool,
@@ -295,8 +354,10 @@ describe("run_tool", () => {
       name: "Run Tool Policy Agent",
       organizationId: org.id,
     });
+    const catalog = await makeInternalMcpCatalog();
     const tool = await makeTool({
       name: `workspace__export_${crypto.randomUUID().slice(0, 8)}`,
+      catalogId: catalog.id,
     });
     await makeAgentTool(agent.id, tool.id);
     await makeToolPolicy(tool.id, {
@@ -333,6 +394,7 @@ describe("run_tool", () => {
   test("blocks third-party MCP tools that require approval when approval was not handled", async ({
     makeAgent,
     makeAgentTool,
+    makeInternalMcpCatalog,
     makeMember,
     makeOrganization,
     makeTool,
@@ -346,8 +408,10 @@ describe("run_tool", () => {
       name: "Run Tool Approval Agent",
       organizationId: org.id,
     });
+    const catalog = await makeInternalMcpCatalog();
     const tool = await makeTool({
       name: `workspace__approve_${crypto.randomUUID().slice(0, 8)}`,
+      catalogId: catalog.id,
     });
     await makeAgentTool(agent.id, tool.id);
     await makeToolPolicy(tool.id, {
@@ -381,6 +445,7 @@ describe("run_tool", () => {
   test("dispatches approval-required third-party MCP tools after chat approval was handled", async ({
     makeAgent,
     makeAgentTool,
+    makeInternalMcpCatalog,
     makeMember,
     makeOrganization,
     makeTool,
@@ -394,8 +459,10 @@ describe("run_tool", () => {
       name: "Run Tool Approved Agent",
       organizationId: org.id,
     });
+    const catalog = await makeInternalMcpCatalog();
     const tool = await makeTool({
       name: `workspace__approved_${crypto.randomUUID().slice(0, 8)}`,
+      catalogId: catalog.id,
     });
     await makeAgentTool(agent.id, tool.id);
     await makeToolPolicy(tool.id, {
@@ -438,7 +505,18 @@ describe("run_tool", () => {
     ]);
   });
 
-  test("normalizes non-array third-party content to a text result", async () => {
+  test("normalizes non-array third-party content to a text result", async ({
+    makeAgentTool,
+    makeInternalMcpCatalog,
+    makeTool,
+  }) => {
+    const catalog = await makeInternalMcpCatalog();
+    const tool = await makeTool({
+      name: "github__get_repository",
+      catalogId: catalog.id,
+    });
+    await makeAgentTool(testAgent.id, tool.id);
+
     vi.mocked(mcpClient.executeToolCall).mockResolvedValueOnce({
       content: { ok: true },
       isError: false,

--- a/platform/backend/src/archestra-mcp-server/run-tool.ts
+++ b/platform/backend/src/archestra-mcp-server/run-tool.ts
@@ -10,6 +10,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { evaluateSingleMcpToolInvocationPolicy } from "@/guardrails/tool-invocation";
 import logger from "@/logging";
+import { ToolModel } from "@/models";
 import { archestraMcpBranding } from "./branding";
 import {
   defineArchestraTool,
@@ -84,11 +85,29 @@ const registry = defineArchestraTools([
         return executeArchestraTool(resolvedName, args.tool_args, context);
       }
 
-      // Third-party MCP Gateway path.
+      // Third-party MCP Gateway path. Hallucinated archestra-prefixed names and
+      // bogus agent-<id> delegations are handled by the "archestra" route above
+      // (executeArchestraTool / checkToolAssignedToAgent), not this check.
       if (!context.agentId) {
         return errorResult(
           `${TOOL_RUN_TOOL_SHORT_NAME} requires agent context to dispatch to third-party MCP tools`,
         );
+      }
+
+      // Reject hallucinated or unassigned tool names before policy evaluation.
+      // The policy gate below already requires exact membership in
+      // getMcpToolsByAgent (see evaluatePolicies), so checking the same set here
+      // is regression-safe; it lets us return an actionable recovery message
+      // instead of the misleading "not enabled for this conversation" refusal
+      // (which implies the tool exists). In search_and_run_only mode the
+      // intended recovery is search_tools, so we point the model there.
+      const assignedTools = await ToolModel.getMcpToolsByAgent(context.agentId);
+      if (!assignedTools.some((tool) => tool.name === resolvedName)) {
+        logger.info(
+          { agentId: context.agentId, requestedName, resolvedName },
+          `${TOOL_RUN_TOOL_SHORT_NAME} dispatched to an unavailable tool`,
+        );
+        return errorResult(unavailableThirdPartyToolMessage(resolvedName));
       }
 
       const toolInput = args.tool_args ?? {};
@@ -136,3 +155,32 @@ const registry = defineArchestraTools([
 
 export const toolEntries = registry.toolEntries;
 export const tools = registry.tools;
+
+// === Internal helpers ===
+
+/**
+ * Recovery-oriented message for a third-party `tool_name` that is not assigned
+ * to the agent (hallucinated or simply not enabled). Mirrors the spirit of the
+ * chat route's UNAVAILABLE_TOOL_ERROR_MESSAGE but steers the model at
+ * search_tools, the intended discovery path in search_and_run_only mode.
+ *
+ * Uses branded tool names (`archestraMcpBranding.getToolName`) so the names here
+ * match exactly what the model sees in its tool list and system prompt — a
+ * custom-branded org exposes these tools under a different prefix, and naming
+ * the canonical `archestra__*` form would point the model at a tool it cannot
+ * see, defeating the recovery loop.
+ */
+function unavailableThirdPartyToolMessage(toolName: string): string {
+  const searchToolsName = archestraMcpBranding.getToolName(
+    TOOL_SEARCH_TOOLS_SHORT_NAME,
+  );
+  const runToolName = archestraMcpBranding.getToolName(
+    TOOL_RUN_TOOL_SHORT_NAME,
+  );
+  return (
+    `No tool named "${toolName}" is available to this agent. It may not exist ` +
+    `or is not assigned to this conversation. Call ${searchToolsName} with a ` +
+    "description of the capability you need to find the exact tool name, then " +
+    `call ${runToolName} again. Do not guess tool names.`
+  );
+}

--- a/platform/backend/src/clients/chat-mcp-client.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.test.ts
@@ -686,6 +686,9 @@ describe("executeMcpTool error handling", () => {
 describe("chat-mcp-client tool caching", () => {
   test("passes token auth context when chat executes archestra run_tool", async ({
     makeAgent,
+    makeAgentTool,
+    makeInternalMcpCatalog,
+    makeTool,
     makeUser,
     makeOrganization,
     makeMember,
@@ -697,6 +700,12 @@ describe("chat-mcp-client tool caching", () => {
       organizationId: org.id,
       name: "Chat Run Tool Agent",
     });
+    const catalog = await makeInternalMcpCatalog();
+    const targetTool = await makeTool({
+      name: "workspace__find_projects",
+      catalogId: catalog.id,
+    });
+    await makeAgentTool(agent.id, targetTool.id);
 
     const conversationId = "conversation-1";
     const cacheKey = chatClient.__test.getCacheKey(
@@ -782,6 +791,8 @@ describe("chat-mcp-client tool caching", () => {
 
   test("requests approval for run_tool when the target tool requires approval", async ({
     makeAgent,
+    makeAgentTool,
+    makeInternalMcpCatalog,
     makeUser,
     makeOrganization,
     makeMember,
@@ -795,9 +806,12 @@ describe("chat-mcp-client tool caching", () => {
       organizationId: org.id,
       name: "Chat Wrapped Approval Agent",
     });
+    const catalog = await makeInternalMcpCatalog();
     const targetTool = await makeTool({
       name: `workspace__export_${crypto.randomUUID().slice(0, 8)}`,
+      catalogId: catalog.id,
     });
+    await makeAgentTool(agent.id, targetTool.id);
     await makeToolPolicy(targetTool.id, {
       action: "require_approval",
       conditions: [

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -177,7 +177,7 @@ function buildLoadToolsWhenNeededSystemPrompt(): string {
     TOOL_RUN_TOOL_SHORT_NAME,
   );
 
-  return `Some available tools are not listed upfront. If the visible tools do not fit the task, use \`${searchToolsName}\` to find relevant tools, then call \`${runToolName}\` with the selected tool name and arguments. Do not guess hidden tool names without searching unless the exact tool name is already known from the conversation.`;
+  return `Some available tools are not listed upfront and must be discovered. If the visible tools do not fit the task, call \`${searchToolsName}\` to find relevant tools, then call \`${runToolName}\` with a tool name it returned. Never invent or guess a tool name: only pass \`${runToolName}\` a tool name that \`${searchToolsName}\` returned or that appeared verbatim earlier in this conversation. If you do not have an exact name, call \`${searchToolsName}\` first rather than guessing.`;
 }
 
 const UNAVAILABLE_TOOL_ERROR_MESSAGE =

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -638,7 +638,7 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
       "Some available tools are not listed upfront",
     );
     expect(systemPrompt).toContain(
-      `use \`${archestraMcpBranding.getToolName(TOOL_SEARCH_TOOLS_SHORT_NAME)}\` to find relevant tools`,
+      `call \`${archestraMcpBranding.getToolName(TOOL_SEARCH_TOOLS_SHORT_NAME)}\` to find relevant tools`,
     );
     expect(systemPrompt).toContain(
       `then call \`${archestraMcpBranding.getToolName(TOOL_RUN_TOOL_SHORT_NAME)}\``,
@@ -680,7 +680,7 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
       "Some available tools are not listed upfront",
     );
     expect(systemPrompt).toContain(
-      `use \`${archestraMcpBranding.getToolName(TOOL_SEARCH_TOOLS_SHORT_NAME)}\` to find relevant tools`,
+      `call \`${archestraMcpBranding.getToolName(TOOL_SEARCH_TOOLS_SHORT_NAME)}\` to find relevant tools`,
     );
     expect(systemPrompt).toContain(
       `then call \`${archestraMcpBranding.getToolName(TOOL_RUN_TOOL_SHORT_NAME)}\``,
@@ -719,10 +719,10 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
 
     const systemPrompt = mockStreamText.mock.calls[0]?.[0].system;
     expect(systemPrompt).toContain(
-      "use `custom_ops__search_tools` to find relevant tools",
+      "call `custom_ops__search_tools` to find relevant tools",
     );
     expect(systemPrompt).toContain("then call `custom_ops__run_tool`");
-    expect(systemPrompt).not.toContain("use `search_tools`");
+    expect(systemPrompt).not.toContain("call `search_tools`");
     expect(systemPrompt).not.toContain("then call `run_tool`");
   });
 


### PR DESCRIPTION
## Problem

In `search_and_run_only` tool-exposure mode the model only sees `archestra__search_tools` and `archestra__run_tool` — the real tools are hidden. A model (observed with Gemini 2.5 Pro) hallucinated a tool name and passed it as `run_tool`'s `tool_name` arg, e.g.:

```
create a gif for slack using a skill
→ run_tool({ tool_name: "giphy__image_search_tool", ... })
→ Error: I attempted to use the tools "giphy__image_search_tool", but they are not enabled for this conversation.
```

Because `archestra__run_tool` is itself a valid tool, the AI SDK dispatched it fine. Inside, the third-party branch sent the hallucinated name straight to `evaluateSingleMcpToolInvocationPolicy`, which returned the proxy-style refusal as the **tool result**. That message is wrong for this case:

- *"not enabled for this conversation"* implies the tool **exists** but is toggled off — so the model can't recover (there's nothing to enable); it's a hallucinated name.
- It's phrased first-person ("I attempted to use the tools…"), fine as a proxy-level refusal but reading like the assistant already gave up when returned as a tool result — so weak models surface it verbatim as a user-facing "Error:".
- It carries **no recovery guidance and no steer to `search_tools`**, the entire intended recovery path in this mode.

Contrast: a fake tool called *directly* (not via `run_tool`) flows through the AI SDK's `NoSuchToolError` → `UNAVAILABLE_TOOL_ERROR_MESSAGE`, which is actionable. `run_tool`'s internal path never got that treatment.

## Fix

1. **Existence pre-check in `run_tool`'s third-party branch** (`run-tool.ts`): exact-match the resolved name against the agent's assigned tools — the same set the policy gate immediately following already enforces, so there's no behavioral regression — and on a miss return an actionable message that names the gap and steers the model at `search_tools`. The message uses **branded** tool names (`archestraMcpBranding.getToolName`) so they match exactly what the model sees in its tool list / system prompt (custom-branded orgs expose a different prefix).

   This also makes behavior consistent: today a hallucinated name reads differently depending on whether the agent has ≥1 tool (policy refusal) vs zero tools (an empty-enabled-set bypass let it fall through to `executeToolCall`'s own "not found").

2. **Hardened the `search_and_run_only` system prompt** (`routes.ts`): turn the soft "don't guess" into an explicit rule — the tool list is hidden, never invent names, only pass `run_tool` a name `search_tools` returned or seen verbatim in the conversation.

## Tests

- New recovery-path test, plus a test reproducing the exact production scenario (agent **has** assigned tools → the recovery message must win over the policy refusal).
- Updated 7 existing third-party `run_tool` tests that dispatched **unassigned** tools and were implicitly relying on the empty-enabled-set bypass (the bug itself) — they now assign real catalog-backed tools, matching how production assigns MCP tools.

## Out of scope

- Rewording the shared proxy-level `evaluatePolicies` "not enabled for this conversation" message (also the message a model gets calling a hallucinated tool *directly* in `full` mode).
- The non-`run_tool` direct `tools/call` gateway path for hallucinated names.
- A schema-level enum on `tool_name` (would fight the hidden-tools design; the existence check at dispatch is the right layer).

## Verification

`run-tool` 16/16, `chat-mcp-client` 58/58, `stream-route` 18/18, plus adjacent run_tool suites; `type-check`, `biome`, and full `knip` (dev+production) all pass.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>