### PR TITLE
refactor(run-tool): reuse assigned-tool set across pre-check and policy gate

### DIFF
--- a/platform/backend/src/archestra-mcp-server/run-tool.ts
+++ b/platform/backend/src/archestra-mcp-server/run-tool.ts
@@ -95,14 +95,17 @@ const registry = defineArchestraTools([
       }
 
       // Reject hallucinated or unassigned tool names before policy evaluation.
-      // The policy gate below already requires exact membership in
-      // getMcpToolsByAgent (see evaluatePolicies), so checking the same set here
-      // is regression-safe; it lets us return an actionable recovery message
+      // The policy gate below already requires exact membership in this same
+      // assigned-tool set (see evaluatePolicies), so checking it here is
+      // regression-safe; it lets us return an actionable recovery message
       // instead of the misleading "not enabled for this conversation" refusal
       // (which implies the tool exists). In search_and_run_only mode the
-      // intended recovery is search_tools, so we point the model there.
-      const assignedTools = await ToolModel.getMcpToolsByAgent(context.agentId);
-      if (!assignedTools.some((tool) => tool.name === resolvedName)) {
+      // intended recovery is search_tools, so we point the model there. The set
+      // is passed into the gate below so it is fetched only once.
+      const assignedToolNames = await ToolModel.getAssignedToolNames(
+        context.agentId,
+      );
+      if (!assignedToolNames.has(resolvedName)) {
         logger.info(
           { agentId: context.agentId, requestedName, resolvedName },
           `${TOOL_RUN_TOOL_SHORT_NAME} dispatched to an unavailable tool`,
@@ -111,6 +114,7 @@ const registry = defineArchestraTools([
       }
 
       const toolInput = args.tool_args ?? {};
+      // Reuse the set computed above so the policy gate does not re-query it.
       const policyBlock = await evaluateSingleMcpToolInvocationPolicy({
         agentId: context.agentId,
         toolName: resolvedName,
@@ -118,6 +122,7 @@ const registry = defineArchestraTools([
         organizationId: context.organizationId,
         contextIsTrusted: context.contextIsTrusted ?? true,
         enforceApprovalRequired: !context.approvalRequiredPoliciesHandled,
+        enabledToolNames: assignedToolNames,
       });
       if (policyBlock) {
         return errorResult(policyBlock.refusalMessage);

--- a/platform/backend/src/guardrails/tool-invocation.ts
+++ b/platform/backend/src/guardrails/tool-invocation.ts
@@ -38,6 +38,12 @@ export async function evaluateSingleMcpToolInvocationPolicy(params: {
   contextIsTrusted: boolean;
   externalAgentId?: string;
   enforceApprovalRequired?: boolean;
+  /**
+   * Pre-fetched set of the agent's assigned tool names. When supplied (e.g. the
+   * run_tool dispatch already computed it for its existence pre-check), it is
+   * reused instead of re-querying ToolModel.getAssignedToolNames here.
+   */
+  enabledToolNames?: Set<string>;
 }): Promise<PolicyBlockResult | null> {
   if (
     archestraMcpBranding.isToolName(params.toolName) ||
@@ -46,14 +52,14 @@ export async function evaluateSingleMcpToolInvocationPolicy(params: {
     return null;
   }
 
-  const [teamIds, organizationPolicy, enabledTools] = await Promise.all([
+  const [teamIds, organizationPolicy, enabledToolNames] = await Promise.all([
     AgentTeamModel.getTeamsForAgent(params.agentId),
     params.organizationId
       ? OrganizationModel.getById(params.organizationId).then(
           (organization) => organization?.globalToolPolicy,
         )
       : Promise.resolve(undefined),
-    ToolModel.getMcpToolsByAgent(params.agentId),
+    params.enabledToolNames ?? ToolModel.getAssignedToolNames(params.agentId),
   ]);
   const globalToolPolicy =
     organizationPolicy ?? (await getGlobalToolPolicy(params.agentId));
@@ -72,7 +78,7 @@ export async function evaluateSingleMcpToolInvocationPolicy(params: {
     params.agentId,
     policyContext,
     params.contextIsTrusted,
-    new Set(enabledTools.map((tool) => tool.name)),
+    enabledToolNames,
     globalToolPolicy,
   );
   if (policyBlock) {

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -581,6 +581,16 @@ class ToolModel {
   }
 
   /**
+   * Names of the MCP tools assigned to an agent, as a membership set. Single
+   * source of truth for "is tool X enabled for this agent" checks, shared by the
+   * run_tool dispatch pre-check and the tool-invocation guardrail.
+   */
+  static async getAssignedToolNames(agentId: string): Promise<Set<string>> {
+    const tools = await ToolModel.getMcpToolsByAgent(agentId);
+    return new Set(tools.map((tool) => tool.name));
+  }
+
+  /**
    * Bulk create tools for an MCP server (catalog-based tools)
    * Fetches existing tools in a single query, then bulk inserts only new tools
    * Returns all tools (existing + newly created) to avoid N+1 queries


### PR DESCRIPTION
Follow-up to #5395, addressing the nitpicker P2 on that PR ([comment](https://github.com/archestra-ai/archestra/pull/5395#issuecomment-4644161858)): the third-party `run_tool` path queried `getMcpToolsByAgent` **twice** per successful dispatch — once in the new existence pre-check, then again inside `evaluateSingleMcpToolInvocationPolicy`.

## Change
- Add `ToolModel.getAssignedToolNames(agentId): Promise<Set<string>>` — single source of truth for the agent's assigned-tool name set.
- `run-tool.ts` computes the set once; the existence pre-check is now `assignedToolNames.has(resolvedName)`.
- `evaluateSingleMcpToolInvocationPolicy` gains an optional `enabledToolNames` param; `run_tool` passes its pre-fetched set so the guardrail **skips its own fetch**. Default callers (chat, `mcp-gateway.utils.ts`) are unchanged.

Net: one DB query instead of two on the hot path, one shared membership predicate. The empty-set safety net stays in `run_tool`'s pre-check, so the shared guardrail's bypass behavior is untouched.

## Verification
- type-check, biome, knip (dev+production) clean.
- 90 tests pass across `run-tool`, `tool-invocation`, and `chat-mcp-client` suites.
- codex review: behavior-equivalent to the prior two-query path (the threaded set equals `new Set(getMcpToolsByAgent(...).map(t => t.name))`); no other caller affected.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>