### PR TITLE
fix(tilt): allow db-migrate to run in parallel

### DIFF
--- a/platform/dev/Tiltfile.database
+++ b/platform/dev/Tiltfile.database
@@ -112,6 +112,10 @@ exit /b 1
   dir='../backend',
   deps=['../backend/src/database/migrations'],
   resource_deps=['pnpm-install', 'postgresql'],
+  # The retry loop busy-spins for up to ~60s. Without this, a non-parallel
+  # local_resource holds Tilt's global build queue while running, which can
+  # block the postgresql re-apply that the loop is itself waiting for.
+  allow_parallel=True,
   labels=['database']
 )
 


### PR DESCRIPTION
## Summary

Recovering a local dev environment after the `archestra-dev` namespace is wiped (or Postgres is otherwise destroyed mid-session) can hang for ~60s in a self-inflicted deadlock.

The `db-migrate` `local_resource` busy-spins in a 30×2s retry loop waiting for PostgreSQL. As a non-parallel `local_resource`, it holds Tilt's global build queue for the entire duration the command runs — so a pending `postgresql` re-apply is parked with hold reason `waiting-for-local` and cannot proceed until the loop exhausts all 30 attempts and releases the lock. When Postgres is gone, the loop is waiting for the very re-apply it is blocking: a circular wait that only self-resolves after the loop gives up.

`allow_parallel=True` opts `db-migrate` out of that exclusive queue hold, so the `postgresql` re-apply runs concurrently with the retrying loop and unblocks it.

The nearby DB-mutating local resources (`db-clean`, `db-seed-mock-data`, `db-generate`) are all `TRIGGER_MODE_MANUAL` + `auto_init=False`, so none run automatically alongside migrations; the residual race only exists if a developer manually triggers `db-clean`/`db-seed` while migrations are mid-flight.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>