### PR TITLE
test(limits): make calendar_month cleanup tests date-independent

### DIFF
--- a/platform/backend/src/models/limit.test.ts
+++ b/platform/backend/src/models/limit.test.ts
@@ -2831,9 +2831,11 @@ describe("checkLimitsBeforeRequest cleanup integration", () => {
       300,
     );
 
-    // Set old lastCleanup (far in the past)
+    // First day of the previous calendar month, so the default calendar_month
+    // cleanup fires regardless of today's day-of-month.
     const oldDate = new Date();
-    oldDate.setDate(oldDate.getDate() - 7);
+    oldDate.setDate(1);
+    oldDate.setMonth(oldDate.getMonth() - 1);
     await LimitModel.patch(oldLimit.id, { lastCleanup: oldDate });
 
     // Set recent lastCleanup (just now)

--- a/platform/backend/src/routes/limits.test.ts
+++ b/platform/backend/src/routes/limits.test.ts
@@ -285,8 +285,11 @@ describe("limits routes", () => {
         500,
       );
 
+      // First day of the previous calendar month, so the default
+      // calendar_month cleanup fires regardless of today's day-of-month.
       const oldDate = new Date();
-      oldDate.setDate(oldDate.getDate() - 7);
+      oldDate.setDate(1);
+      oldDate.setMonth(oldDate.getMonth() - 1);
       await LimitModel.patch(limit.id, { lastCleanup: oldDate });
 
       const response = await app.inject({


### PR DESCRIPTION
## Summary

`backend/src/routes/limits.test.ts` and `backend/src/models/limit.test.ts` each set a `calendar_month` limit's `lastCleanup` to `now − 7 days` and assert that usage gets reset on the next request. The default cleanup interval resets only when `lastCleanup` precedes the **start of the current calendar month**, so once the current date is past the 7th, "7 days ago" is still the same month, the reset correctly does not fire, and both tests fail. They have been failing on every branch this month.

Anchors `lastCleanup` to the first day of the previous calendar month instead, so the reset fires regardless of the current day-of-month. No product code changes.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>