### PR TITLE
fix(mcp): steer agent recovery on tool/resource lookup misses

### DIFF
--- a/platform/backend/src/archestra-mcp-server/agent-resources.ts
+++ b/platform/backend/src/archestra-mcp-server/agent-resources.ts
@@ -1,3 +1,4 @@
+import { TOOL_LIST_AGENTS_SHORT_NAME } from "@archestra/shared";
 import { z } from "zod";
 import {
   getAgentTypePermissionChecker,
@@ -22,6 +23,7 @@ import {
   ToolExposureModeSchema,
   UuidIdSchema,
 } from "@/types";
+import { archestraMcpBranding } from "./branding";
 import {
   assignSubAgentDelegations,
   assignToolAssignments,
@@ -407,7 +409,12 @@ export async function handleGetResource<
     }
 
     if (!record) {
-      return errorResult(`${getLabel} not found`);
+      // only agents have a discovery tool; proxies/gateways have no list tool.
+      const steer =
+        expectedType === "agent"
+          ? ` Call ${archestraMcpBranding.getToolName(TOOL_LIST_AGENTS_SHORT_NAME)} to find the exact id or name.`
+          : "";
+      return errorResult(`${getLabel} not found.${steer}`);
     }
 
     if (record.agentType !== expectedType) {

--- a/platform/backend/src/archestra-mcp-server/agents.test.ts
+++ b/platform/backend/src/archestra-mcp-server/agents.test.ts
@@ -2,6 +2,7 @@
 import {
   ARCHESTRA_MCP_SERVER_NAME,
   MCP_SERVER_TOOL_NAME_SEPARATOR,
+  TOOL_LIST_AGENTS_SHORT_NAME,
 } from "@archestra/shared";
 import { and, eq } from "drizzle-orm";
 import db, { schema } from "@/database";
@@ -9,6 +10,7 @@ import { AgentKnowledgeBaseModel, AgentModel } from "@/models";
 import { beforeEach, describe, expect, test } from "@/test";
 import type { Agent } from "@/types";
 import { type ArchestraContext, executeArchestraTool } from ".";
+import { archestraMcpBranding } from "./branding";
 
 describe("agent tool execution", () => {
   let testAgent: Agent;
@@ -549,6 +551,9 @@ describe("agent RBAC visibility", () => {
 
     expect(result.isError).toBe(true);
     expect((result.content[0] as any).text).toContain("not found");
+    expect((result.content[0] as any).text).toContain(
+      archestraMcpBranding.getToolName(TOOL_LIST_AGENTS_SHORT_NAME),
+    );
   });
 });
 

--- a/platform/backend/src/archestra-mcp-server/delegation.test.ts
+++ b/platform/backend/src/archestra-mcp-server/delegation.test.ts
@@ -76,9 +76,10 @@ describe("delegation tool execution", () => {
       mockContext,
     );
     expect(result.isError).toBe(true);
-    expect((result.content[0] as any).text).toContain(
-      "not found or not configured for delegation",
-    );
+    const text = (result.content[0] as any).text;
+    expect(text).toContain("No delegation is configured");
+    expect(text).toContain(`${AGENT_TOOL_PREFIX}*`);
+    expect(text).toContain("Do not guess delegation names");
   });
 
   test("propagates the current trust state to delegated subagents", async ({

--- a/platform/backend/src/archestra-mcp-server/delegation.ts
+++ b/platform/backend/src/archestra-mcp-server/delegation.ts
@@ -112,7 +112,9 @@ export async function handleDelegation(
   );
 
   if (!delegation) {
-    return errorResult("Agent not found or not configured for delegation.");
+    return errorResult(
+      `No delegation is configured for "${toolName}". Use an exact agent delegation tool name (${AGENT_TOOL_PREFIX}*) from your tools list. Do not guess delegation names.`,
+    );
   }
 
   // Check user access when a real caller is available. The caller user can be

--- a/platform/backend/src/archestra-mcp-server/index.test.ts
+++ b/platform/backend/src/archestra-mcp-server/index.test.ts
@@ -2,10 +2,12 @@
 import {
   ARCHESTRA_MCP_SERVER_NAME,
   MCP_SERVER_TOOL_NAME_SEPARATOR,
+  TOOL_SEARCH_TOOLS_SHORT_NAME,
 } from "@archestra/shared";
 import { beforeEach, describe, expect, test } from "@/test";
 import type { Agent } from "@/types";
 import { __test, type ArchestraContext, executeArchestraTool } from ".";
+import { archestraMcpBranding } from "./branding";
 
 describe("executeArchestraTool", () => {
   let testAgent: Agent;
@@ -27,13 +29,20 @@ describe("executeArchestraTool", () => {
   });
 
   describe("unknown tool", () => {
-    test("should throw error for unknown tool name", async () => {
-      await expect(
-        executeArchestraTool("unknown_tool", undefined, mockContext),
-      ).rejects.toMatchObject({
-        code: -32601,
-        message: "Tool 'unknown_tool' not found",
-      });
+    test("steers an unknown tool name at the discovery path", async () => {
+      const error = await executeArchestraTool(
+        "unknown_tool",
+        undefined,
+        mockContext,
+      ).catch((e: unknown) => e);
+
+      expect(error).toMatchObject({ code: -32601 });
+      const message = (error as { message: string }).message;
+      expect(message).toContain('No tool named "unknown_tool" exists');
+      expect(message).toContain(
+        archestraMcpBranding.getToolName(TOOL_SEARCH_TOOLS_SHORT_NAME),
+      );
+      expect(message).toContain("Do not guess tool names");
     });
   });
 

--- a/platform/backend/src/archestra-mcp-server/index.ts
+++ b/platform/backend/src/archestra-mcp-server/index.ts
@@ -21,6 +21,7 @@ import {
   type ArchestraRuntimeToolEntry,
   errorResult,
   formatZodError,
+  structuredToolErrorResult,
 } from "./helpers";
 import {
   toolEntries as identityToolEntries,
@@ -166,7 +167,7 @@ export async function executeArchestraTool(
   if (!toolEntry) {
     throw {
       code: -32601,
-      message: `Tool '${toolName}' not found`,
+      message: `No tool named "${toolName}" exists. ${toolDiscoverySteer()}`,
     };
   }
 
@@ -225,9 +226,25 @@ async function checkToolAssignedToAgent(
   const isAssigned = assignedTools.some(
     (tool) => archestraMcpBranding.getToolShortName(tool.name) === shortName,
   );
-  return isAssigned
-    ? null
-    : errorResult(`Tool '${toolName}' is not assigned to this agent.`);
+  if (isAssigned) return null;
+  return structuredToolErrorResult({
+    error: {
+      type: "tool_state",
+      code: "tool_not_assigned",
+      message: `Tool "${toolName}" is not assigned to this agent. ${toolDiscoverySteer()}`,
+      toolName,
+    },
+  });
+}
+
+// Recovery steer pointing a model at the tool-discovery path. Branded so the
+// names match what the model sees (custom-branded orgs use a different prefix);
+// mirrors run-tool's unavailableThirdPartyToolMessage.
+function toolDiscoverySteer(): string {
+  const searchToolsName = archestraMcpBranding.getToolName(
+    TOOL_SEARCH_TOOLS_SHORT_NAME,
+  );
+  return `Call ${searchToolsName} to discover the tools available to you, then use an exact name it returns. Do not guess tool names.`;
 }
 
 function resolveArchestraToolName(toolName: string): string | null {

--- a/platform/backend/src/archestra-mcp-server/knowledge-management.test.ts
+++ b/platform/backend/src/archestra-mcp-server/knowledge-management.test.ts
@@ -4,6 +4,7 @@ import {
   ARCHESTRA_MCP_SERVER_NAME,
   MCP_SERVER_TOOL_NAME_SEPARATOR,
   TOOL_GET_KNOWLEDGE_BASES_SHORT_NAME,
+  TOOL_GET_KNOWLEDGE_CONNECTORS_SHORT_NAME,
 } from "@archestra/shared";
 import { vi } from "vitest";
 import {
@@ -755,6 +756,14 @@ describe("knowledge-management tool execution", () => {
       );
       expect(result.isError).toBe(true);
       expect((result.content[0] as any).text).toContain("not found");
+      expect((result.content[0] as any).text).toContain(
+        archestraMcpBranding.getToolName(
+          TOOL_GET_KNOWLEDGE_CONNECTORS_SHORT_NAME,
+        ),
+      );
+      expect((result._meta as any)?.archestraError?.code).toBe(
+        "unknown_knowledge_connector",
+      );
     });
 
     test("update_knowledge_connector returns error when no fields", async () => {

--- a/platform/backend/src/archestra-mcp-server/knowledge-management.test.ts
+++ b/platform/backend/src/archestra-mcp-server/knowledge-management.test.ts
@@ -3,6 +3,7 @@
 import {
   ARCHESTRA_MCP_SERVER_NAME,
   MCP_SERVER_TOOL_NAME_SEPARATOR,
+  TOOL_GET_KNOWLEDGE_BASES_SHORT_NAME,
 } from "@archestra/shared";
 import { vi } from "vitest";
 import {
@@ -13,6 +14,7 @@ import { KbChunkModel, KbDocumentModel, TeamModel } from "@/models";
 import { beforeEach, describe, expect, test } from "@/test";
 import type { Agent, KnowledgeBase, KnowledgeBaseConnector } from "@/types";
 import { type ArchestraContext, executeArchestraTool } from ".";
+import { archestraMcpBranding } from "./branding";
 
 const t = (name: string) =>
   `${ARCHESTRA_MCP_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}${name}`;
@@ -581,6 +583,12 @@ describe("knowledge-management tool execution", () => {
       );
       expect(result.isError).toBe(true);
       expect((result.content[0] as any).text).toContain("not found");
+      expect((result.content[0] as any).text).toContain(
+        archestraMcpBranding.getToolName(TOOL_GET_KNOWLEDGE_BASES_SHORT_NAME),
+      );
+      expect((result._meta as any)?.archestraError?.code).toBe(
+        "unknown_knowledge_base",
+      );
     });
 
     test("update_knowledge_base returns error when no fields provided", async () => {

--- a/platform/backend/src/archestra-mcp-server/knowledge-management.ts
+++ b/platform/backend/src/archestra-mcp-server/knowledge-management.ts
@@ -51,6 +51,7 @@ import {
   EmptyToolArgsSchema,
   errorResult,
   structuredSuccessResult,
+  structuredToolErrorResult,
   successResult,
 } from "./helpers";
 import type { ArchestraContext } from "./types";
@@ -657,7 +658,7 @@ async function handleGetKnowledgeBase(params: {
 
     const kb = await KnowledgeBaseModel.findById(args.id);
     if (!kb || kb.organizationId !== context.organizationId) {
-      return errorResult(`Knowledge base not found: ${args.id}`);
+      return knowledgeBaseNotFound(args.id);
     }
     return structuredSuccessResult(
       { knowledgeBase: kb },
@@ -688,11 +689,11 @@ async function handleUpdateKnowledgeBase(params: {
 
     const existing = await KnowledgeBaseModel.findById(args.id);
     if (!existing || existing.organizationId !== context.organizationId) {
-      return errorResult(`Knowledge base not found: ${args.id}`);
+      return knowledgeBaseNotFound(args.id);
     }
     const kb = await KnowledgeBaseModel.update(args.id, updates);
     if (!kb) {
-      return errorResult(`Knowledge base not found: ${args.id}`);
+      return knowledgeBaseNotFound(args.id);
     }
     return structuredSuccessResult(
       { knowledgeBase: kb },
@@ -716,7 +717,7 @@ async function handleDeleteKnowledgeBase(params: {
 
     const existing = await KnowledgeBaseModel.findById(args.id);
     if (!existing || existing.organizationId !== context.organizationId) {
-      return errorResult(`Knowledge base not found: ${args.id}`);
+      return knowledgeBaseNotFound(args.id);
     }
     await KnowledgeBaseModel.delete(args.id);
     return successResult(`Knowledge base deleted: ${args.id}`);
@@ -830,7 +831,7 @@ async function handleGetKnowledgeConnector(params: {
           connector,
         ))
     ) {
-      return errorResult(`Knowledge connector not found: ${args.id}`);
+      return knowledgeConnectorNotFound(args.id);
     }
     return structuredSuccessResult(
       { knowledgeConnector: connector },
@@ -884,7 +885,7 @@ async function handleUpdateKnowledgeConnector(params: {
           existingConnector,
         ))
     ) {
-      return errorResult(`Knowledge connector not found: ${args.id}`);
+      return knowledgeConnectorNotFound(args.id);
     }
     const nextVisibility = updates.visibility ?? existingConnector.visibility;
     const nextTeamIds = updates.teamIds ?? existingConnector.teamIds;
@@ -903,7 +904,7 @@ async function handleUpdateKnowledgeConnector(params: {
       updates,
     );
     if (!connector) {
-      return errorResult(`Knowledge connector not found: ${args.id}`);
+      return knowledgeConnectorNotFound(args.id);
     }
     if (
       didKnowledgeSourceAclInputsChange({
@@ -958,7 +959,7 @@ async function handleDeleteKnowledgeConnector(params: {
           existing,
         ))
     ) {
-      return errorResult(`Knowledge connector not found: ${args.id}`);
+      return knowledgeConnectorNotFound(args.id);
     }
     await KnowledgeBaseConnectorModel.delete(args.id);
     return successResult(`Knowledge connector deleted: ${args.id}`);
@@ -1103,4 +1104,35 @@ async function handleUnassignKnowledgeConnectorFromAgent(params: {
   } catch (error) {
     return catchError(error, "unassigning knowledge connector from agent");
   }
+}
+
+// === Internal helpers ===
+
+// Recovery-oriented results for unknown knowledge ids: a missing/inaccessible id
+// is recoverable by listing the accessible entries first. Branded so the tool
+// name matches what the model sees.
+function knowledgeBaseNotFound(id: string) {
+  const listTool = archestraMcpBranding.getToolName(
+    TOOL_GET_KNOWLEDGE_BASES_SHORT_NAME,
+  );
+  return structuredToolErrorResult({
+    error: {
+      type: "tool_state",
+      code: "unknown_knowledge_base",
+      message: `Knowledge base not found: ${id}. Call ${listTool} to list accessible knowledge bases and use an exact id.`,
+    },
+  });
+}
+
+function knowledgeConnectorNotFound(id: string) {
+  const listTool = archestraMcpBranding.getToolName(
+    TOOL_GET_KNOWLEDGE_CONNECTORS_SHORT_NAME,
+  );
+  return structuredToolErrorResult({
+    error: {
+      type: "tool_state",
+      code: "unknown_knowledge_connector",
+      message: `Knowledge connector not found: ${id}. Call ${listTool} to list accessible connectors and use an exact id.`,
+    },
+  });
 }

--- a/platform/backend/src/archestra-mcp-server/mcp-servers.test.ts
+++ b/platform/backend/src/archestra-mcp-server/mcp-servers.test.ts
@@ -2,6 +2,7 @@
 import {
   ARCHESTRA_MCP_SERVER_NAME,
   MCP_SERVER_TOOL_NAME_SEPARATOR,
+  TOOL_GET_MCP_SERVERS_SHORT_NAME,
 } from "@archestra/shared";
 import { EnvironmentModel, InternalMcpCatalogModel } from "@/models";
 import { createEnvironment } from "@/services/environments/environment";
@@ -171,6 +172,18 @@ describe("mcp server tool execution", () => {
     const names = parsed.map((t: any) => t.name);
     expect(names).toContain("test_tool_1");
     expect(names).toContain("test_tool_2");
+  });
+
+  test("get_mcp_server_tools steers an unknown id at the listing tool", async () => {
+    const result = await executeArchestraTool(
+      `${ARCHESTRA_MCP_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}get_mcp_server_tools`,
+      { mcpServerId: "00000000-0000-4000-8000-000000000abc" },
+      mockContext,
+    );
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as any).text;
+    expect(text).toContain("not found or you don't have access");
+    expect(text).toContain(TOOL_GET_MCP_SERVERS_SHORT_NAME);
   });
 
   test("edit_mcp_description updates an existing catalog item", async ({

--- a/platform/backend/src/archestra-mcp-server/mcp-servers.ts
+++ b/platform/backend/src/archestra-mcp-server/mcp-servers.ts
@@ -643,7 +643,9 @@ async function handleGetMcpServerTools(
       },
     );
     if (!catalogItem) {
-      return errorResult("MCP server not found or you don't have access.");
+      return errorResult(
+        `MCP server not found or you don't have access. Call ${TOOL_GET_MCP_SERVERS_SHORT_NAME} to list the MCP servers available to you and use an exact catalog id.`,
+      );
     }
 
     const tools = await ToolModel.findByCatalogId(args.mcpServerId);

--- a/platform/backend/src/archestra-mcp-server/mcp-servers.ts
+++ b/platform/backend/src/archestra-mcp-server/mcp-servers.ts
@@ -40,6 +40,7 @@ import {
   UuidIdSchema,
 } from "@/types";
 import { broadcastMcpInstallationStatus } from "@/websocket";
+import { archestraMcpBranding } from "./branding";
 import {
   catchError,
   deduplicateLabels,
@@ -643,8 +644,11 @@ async function handleGetMcpServerTools(
       },
     );
     if (!catalogItem) {
+      const getMcpServersName = archestraMcpBranding.getToolName(
+        TOOL_GET_MCP_SERVERS_SHORT_NAME,
+      );
       return errorResult(
-        `MCP server not found or you don't have access. Call ${TOOL_GET_MCP_SERVERS_SHORT_NAME} to list the MCP servers available to you and use an exact catalog id.`,
+        `MCP server not found or you don't have access. Call ${getMcpServersName} to list the MCP servers available to you and use an exact catalog id.`,
       );
     }
 

--- a/platform/backend/src/archestra-mcp-server/run-tool.test.ts
+++ b/platform/backend/src/archestra-mcp-server/run-tool.test.ts
@@ -186,6 +186,9 @@ describe("run_tool", () => {
     expect((result.content[0] as any).text).toContain(
       "is not assigned to this agent",
     );
+    expect((result._meta?.archestraError as any)?.code).toBe(
+      "tool_not_assigned",
+    );
     expect(mcpClient.executeToolCall).not.toHaveBeenCalled();
   });
 

--- a/platform/backend/src/archestra-mcp-server/run-tool.ts
+++ b/platform/backend/src/archestra-mcp-server/run-tool.ts
@@ -17,6 +17,7 @@ import {
   defineArchestraTools,
   errorResult,
 } from "./helpers";
+import { unavailableThirdPartyToolMessage } from "./tool-recovery-messages";
 
 const RunToolArgsSchema = z
   .object({
@@ -160,32 +161,3 @@ const registry = defineArchestraTools([
 
 export const toolEntries = registry.toolEntries;
 export const tools = registry.tools;
-
-// === Internal helpers ===
-
-/**
- * Recovery-oriented message for a third-party `tool_name` that is not assigned
- * to the agent (hallucinated or simply not enabled). Mirrors the spirit of the
- * chat route's UNAVAILABLE_TOOL_ERROR_MESSAGE but steers the model at
- * search_tools, the intended discovery path in search_and_run_only mode.
- *
- * Uses branded tool names (`archestraMcpBranding.getToolName`) so the names here
- * match exactly what the model sees in its tool list and system prompt — a
- * custom-branded org exposes these tools under a different prefix, and naming
- * the canonical `archestra__*` form would point the model at a tool it cannot
- * see, defeating the recovery loop.
- */
-function unavailableThirdPartyToolMessage(toolName: string): string {
-  const searchToolsName = archestraMcpBranding.getToolName(
-    TOOL_SEARCH_TOOLS_SHORT_NAME,
-  );
-  const runToolName = archestraMcpBranding.getToolName(
-    TOOL_RUN_TOOL_SHORT_NAME,
-  );
-  return (
-    `No tool named "${toolName}" is available to this agent. It may not exist ` +
-    `or is not assigned to this conversation. Call ${searchToolsName} with a ` +
-    "description of the capability you need to find the exact tool name, then " +
-    `call ${runToolName} again. Do not guess tool names.`
-  );
-}

--- a/platform/backend/src/archestra-mcp-server/sandbox.test.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.test.ts
@@ -287,6 +287,7 @@ describe("sandbox tools (runtime enabled)", () => {
       );
       expect(result.isError).toBe(true);
       expect(textOf(result)).toContain("No accessible sandbox");
+      expect(textOf(result)).toContain("fresh: true");
     });
 
     test("target {id} owned by another user is rejected", async ({

--- a/platform/backend/src/archestra-mcp-server/sandbox.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.ts
@@ -482,7 +482,9 @@ async function resolveTarget(params: {
         },
         "[Sandbox] rejected out-of-scope sandbox id",
       );
-      return { error: `No accessible sandbox with id ${target.id} exists.` };
+      return {
+        error: `No accessible sandbox with id ${target.id} exists. Omit \`target\` to use the conversation's default sandbox, or pass \`target: { fresh: true }\` to create a new one.`,
+      };
     }
     return { sandboxId: asSandboxId(sandbox.id) };
   }

--- a/platform/backend/src/archestra-mcp-server/search-tools.ts
+++ b/platform/backend/src/archestra-mcp-server/search-tools.ts
@@ -103,9 +103,11 @@ type SearchCandidate = {
 };
 
 // search_tools only runs in search_and_run_only mode. The meta tools and the
-// always-exposed runtime path are already top-level there, so returning them as
-// search results would be redundant noise.
-const EXCLUDED_SHORT_NAMES = new Set<string>([
+// always-exposed runtime tools (skills + sandbox) are already top-level there,
+// so returning them as search results would be redundant noise. This set spans
+// both categories — not just meta tools — so it gates search-result membership,
+// not "is this a meta tool".
+const EXCLUDED_FROM_SEARCH_SHORT_NAMES = new Set<string>([
   TOOL_SEARCH_TOOLS_SHORT_NAME,
   TOOL_RUN_TOOL_SHORT_NAME,
   ...ALWAYS_EXPOSED_ARCHESTRA_TOOL_SHORT_NAMES,
@@ -185,7 +187,7 @@ async function getSearchableTools(params: {
   const filteredAssignedTools = assignedTools.filter(
     (tool) =>
       permittedNames.has(tool.name) &&
-      !isExcludedArchestraMetaTool(tool.name) &&
+      !isExcludedFromSearchResults(tool.name) &&
       !tool.name.startsWith("agent__"),
   );
 
@@ -443,9 +445,9 @@ function visitSchema(
   }
 }
 
-function isExcludedArchestraMetaTool(toolName: string): boolean {
+function isExcludedFromSearchResults(toolName: string): boolean {
   const shortName = archestraMcpBranding.getToolShortName(toolName);
-  return shortName != null && EXCLUDED_SHORT_NAMES.has(shortName);
+  return shortName != null && EXCLUDED_FROM_SEARCH_SHORT_NAMES.has(shortName);
 }
 
 function formatArchestraToolTitle(toolName: string): string | null {

--- a/platform/backend/src/archestra-mcp-server/skills.test.ts
+++ b/platform/backend/src/archestra-mcp-server/skills.test.ts
@@ -143,6 +143,10 @@ describe("skill tool execution", () => {
 
     expect(result.isError).toBe(true);
     expect(textOf(result)).toContain("does-not-exist");
+    expect(
+      (result._meta as { archestraError?: { code?: string } } | undefined)
+        ?.archestraError?.code,
+    ).toBe("unknown_skill");
   });
 
   test("read_skill_file returns a bundled resource file", async () => {
@@ -444,6 +448,10 @@ describe("skill tool execution", () => {
 
     expect(result.isError).toBe(true);
     expect(textOf(result)).toContain("does-not-exist");
+    expect(
+      (result._meta as { archestraError?: { code?: string } } | undefined)
+        ?.archestraError?.code,
+    ).toBe("unknown_skill");
   });
 
   test("update_skill denies a non-admin editing an org-scoped skill", async ({

--- a/platform/backend/src/archestra-mcp-server/skills.test.ts
+++ b/platform/backend/src/archestra-mcp-server/skills.test.ts
@@ -195,6 +195,11 @@ describe("skill tool execution", () => {
 
     expect(result.isError).toBe(true);
     expect(textOf(result)).toContain("MISSING.md");
+    expect(textOf(result)).toContain("activate_skill");
+    expect(
+      (result._meta as { archestraError?: { code?: string } } | undefined)
+        ?.archestraError?.code,
+    ).toBe("unknown_skill_file");
   });
 
   test("skill tools are denied without skill:read", async ({ makeUser }) => {

--- a/platform/backend/src/archestra-mcp-server/skills.test.ts
+++ b/platform/backend/src/archestra-mcp-server/skills.test.ts
@@ -1,10 +1,12 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: test
 import {
   ADMIN_ROLE_NAME,
+  getArchestraToolFullName,
   MEMBER_ROLE_NAME,
   TOOL_ACTIVATE_SKILL_FULL_NAME,
   TOOL_CREATE_SKILL_FULL_NAME,
   TOOL_LIST_SKILLS_FULL_NAME,
+  TOOL_LIST_SKILLS_SHORT_NAME,
   TOOL_READ_SKILL_FILE_FULL_NAME,
   TOOL_UPDATE_SKILL_FULL_NAME,
 } from "@archestra/shared";
@@ -13,6 +15,7 @@ import { beforeEach, describe, expect, test } from "@/test";
 import type { Agent, InsertSkill, InsertSkillFile } from "@/types";
 import {
   type ArchestraContext,
+  archestraMcpBranding,
   executeArchestraTool,
   getArchestraMcpTools,
 } from ".";
@@ -147,6 +150,38 @@ describe("skill tool execution", () => {
       (result._meta as { archestraError?: { code?: string } } | undefined)
         ?.archestraError?.code,
     ).toBe("unknown_skill");
+  });
+
+  test("unknown-skill recovery steers to the branded tool name under white-labeling", async () => {
+    const config = (await import("@/config")).default;
+    const original = config.enterpriseFeatures.fullWhiteLabeling;
+    (
+      config.enterpriseFeatures as { fullWhiteLabeling: boolean }
+    ).fullWhiteLabeling = true;
+    archestraMcpBranding.syncFromOrganization({
+      appName: "Acme Copilot",
+      iconLogo: null,
+    });
+
+    try {
+      const result = await executeArchestraTool(
+        TOOL_ACTIVATE_SKILL_FULL_NAME,
+        { name: "does-not-exist" },
+        context,
+      );
+
+      const brandedListSkills = getArchestraToolFullName(
+        TOOL_LIST_SKILLS_SHORT_NAME,
+        { appName: "Acme Copilot", fullWhiteLabeling: true },
+      );
+      expect(brandedListSkills).not.toBe(TOOL_LIST_SKILLS_FULL_NAME);
+      expect(textOf(result)).toContain(brandedListSkills);
+    } finally {
+      archestraMcpBranding.syncFromOrganization(null);
+      (
+        config.enterpriseFeatures as { fullWhiteLabeling: boolean }
+      ).fullWhiteLabeling = original;
+    }
   });
 
   test("read_skill_file returns a bundled resource file", async () => {

--- a/platform/backend/src/archestra-mcp-server/skills.ts
+++ b/platform/backend/src/archestra-mcp-server/skills.ts
@@ -204,9 +204,13 @@ const registry = defineArchestraTools([
 
       const skill = await findAccessibleSkill(ctx, args.name);
       if (!skill) {
-        return errorResult(
-          `No skill named "${args.name}" exists. Call list_skills to see available skills.`,
-        );
+        return structuredToolErrorResult({
+          error: {
+            type: "tool_state",
+            code: "unknown_skill",
+            message: `No skill named "${args.name}" exists. Call list_skills to see available skills.`,
+          },
+        });
       }
 
       const canRunSandbox = await canRunSkillSandbox(ctx, context.agent.id);
@@ -397,9 +401,13 @@ const registry = defineArchestraTools([
 
       const skill = await findAccessibleSkill(ctx, args.name);
       if (!skill) {
-        return errorResult(
-          `No skill named "${args.name}" exists. Call list_skills to see available skills.`,
-        );
+        return structuredToolErrorResult({
+          error: {
+            type: "tool_state",
+            code: "unknown_skill",
+            message: `No skill named "${args.name}" exists. Call list_skills to see available skills.`,
+          },
+        });
       }
 
       // read access (findAccessibleSkill) is not enough to modify a skill —

--- a/platform/backend/src/archestra-mcp-server/skills.ts
+++ b/platform/backend/src/archestra-mcp-server/skills.ts
@@ -44,6 +44,7 @@ import {
   refineUniqueFilePaths,
 } from "@/skills/validation";
 import { ApiError, type Skill, SkillFileEncodingSchema } from "@/types";
+import { archestraMcpBranding } from "./branding";
 import {
   defineArchestraTool,
   defineArchestraTools,
@@ -204,13 +205,7 @@ const registry = defineArchestraTools([
 
       const skill = await findAccessibleSkill(ctx, args.name);
       if (!skill) {
-        return structuredToolErrorResult({
-          error: {
-            type: "tool_state",
-            code: "unknown_skill",
-            message: `No skill named "${args.name}" exists. Call list_skills to see available skills.`,
-          },
-        });
+        return unknownSkillError(args.name);
       }
 
       const canRunSandbox = await canRunSkillSandbox(ctx, context.agent.id);
@@ -284,13 +279,7 @@ const registry = defineArchestraTools([
 
       const skill = await findAccessibleSkill(ctx, args.skill);
       if (!skill) {
-        return structuredToolErrorResult({
-          error: {
-            type: "tool_state",
-            code: "unknown_skill",
-            message: `No skill named "${args.skill}" exists. Call list_skills to see available skills.`,
-          },
-        });
+        return unknownSkillError(args.skill);
       }
 
       // read from the effective version (the mounted one if mounted, else
@@ -306,11 +295,14 @@ const registry = defineArchestraTools([
         ? await SkillVersionModel.findFileByPath(version.id, args.path)
         : null;
       if (!file) {
+        const activateSkillName = archestraMcpBranding.getToolName(
+          TOOL_ACTIVATE_SKILL_SHORT_NAME,
+        );
         return structuredToolErrorResult({
           error: {
             type: "tool_state",
             code: "unknown_skill_file",
-            message: `Skill "${args.skill}" has no file at "${args.path}". Check the <skill_resources> list returned by activate_skill for the available file paths.`,
+            message: `Skill "${args.skill}" has no file at "${args.path}". Check the <skill_resources> list returned by ${activateSkillName} for the available file paths.`,
           },
         });
       }
@@ -401,13 +393,7 @@ const registry = defineArchestraTools([
 
       const skill = await findAccessibleSkill(ctx, args.name);
       if (!skill) {
-        return structuredToolErrorResult({
-          error: {
-            type: "tool_state",
-            code: "unknown_skill",
-            message: `No skill named "${args.name}" exists. Call list_skills to see available skills.`,
-          },
-        });
+        return unknownSkillError(args.name);
       }
 
       // read access (findAccessibleSkill) is not enough to modify a skill —
@@ -456,6 +442,21 @@ const registry = defineArchestraTools([
 ] as const);
 
 // ===== Internal helpers =====
+
+// recovery errors steer the model by a tool's exposed (branded) name, so a
+// white-label org receives a name the model can actually call back.
+function unknownSkillError(skillName: string) {
+  const listSkillsName = archestraMcpBranding.getToolName(
+    TOOL_LIST_SKILLS_SHORT_NAME,
+  );
+  return structuredToolErrorResult({
+    error: {
+      type: "tool_state",
+      code: "unknown_skill",
+      message: `No skill named "${skillName}" exists. Call ${listSkillsName} to see available skills.`,
+    },
+  });
+}
 
 interface UserContext {
   organizationId: string;

--- a/platform/backend/src/archestra-mcp-server/skills.ts
+++ b/platform/backend/src/archestra-mcp-server/skills.ts
@@ -48,6 +48,7 @@ import {
   defineArchestraTool,
   defineArchestraTools,
   errorResult,
+  structuredToolErrorResult,
   successResult,
 } from "./helpers";
 import type { ArchestraContext } from "./types";
@@ -279,7 +280,13 @@ const registry = defineArchestraTools([
 
       const skill = await findAccessibleSkill(ctx, args.skill);
       if (!skill) {
-        return errorResult(`No skill named "${args.skill}" exists.`);
+        return structuredToolErrorResult({
+          error: {
+            type: "tool_state",
+            code: "unknown_skill",
+            message: `No skill named "${args.skill}" exists. Call list_skills to see available skills.`,
+          },
+        });
       }
 
       // read from the effective version (the mounted one if mounted, else
@@ -295,9 +302,13 @@ const registry = defineArchestraTools([
         ? await SkillVersionModel.findFileByPath(version.id, args.path)
         : null;
       if (!file) {
-        return errorResult(
-          `Skill "${args.skill}" has no file at "${args.path}".`,
-        );
+        return structuredToolErrorResult({
+          error: {
+            type: "tool_state",
+            code: "unknown_skill_file",
+            message: `Skill "${args.skill}" has no file at "${args.path}". Check the <skill_resources> list returned by activate_skill for the available file paths.`,
+          },
+        });
       }
 
       if (file.encoding === "base64") {

--- a/platform/backend/src/archestra-mcp-server/tool-recovery-messages.ts
+++ b/platform/backend/src/archestra-mcp-server/tool-recovery-messages.ts
@@ -1,0 +1,34 @@
+import {
+  TOOL_RUN_TOOL_SHORT_NAME,
+  TOOL_SEARCH_TOOLS_SHORT_NAME,
+} from "@archestra/shared";
+import { archestraMcpBranding } from "./branding";
+
+/**
+ * Recovery-oriented message for a third-party tool name that is not available to
+ * the agent (hallucinated or simply not assigned). Steers the model at
+ * search_tools — the intended discovery path — then run_tool.
+ *
+ * Uses branded tool names (`archestraMcpBranding.getToolName`) so the names here
+ * match exactly what the model sees in its tool list and system prompt — a
+ * custom-branded org exposes these tools under a different prefix, and naming the
+ * canonical `archestra__*` form would point the model at a tool it cannot see,
+ * defeating the recovery loop.
+ *
+ * Shared by the run_tool dispatcher (`run-tool.ts`) and the gateway execution
+ * path (`clients/mcp-client.ts`) so both surfaces stay verbatim-consistent.
+ */
+export function unavailableThirdPartyToolMessage(toolName: string): string {
+  const searchToolsName = archestraMcpBranding.getToolName(
+    TOOL_SEARCH_TOOLS_SHORT_NAME,
+  );
+  const runToolName = archestraMcpBranding.getToolName(
+    TOOL_RUN_TOOL_SHORT_NAME,
+  );
+  return (
+    `No tool named "${toolName}" is available to this agent. It may not exist ` +
+    `or is not assigned to this conversation. Call ${searchToolsName} with a ` +
+    "description of the capability you need to find the exact tool name, then " +
+    `call ${runToolName} again. Do not guess tool names.`
+  );
+}

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -275,8 +275,13 @@ describe("McpClient", () => {
       expect(result).toMatchObject({
         id: "call_123",
         isError: true,
-        error: expect.stringContaining("Tool not found"),
+        error: expect.stringContaining("No tool named"),
       });
+      expect(result.error).toContain("Do not guess tool names");
+      expect(
+        (result._meta as { archestraError?: { code?: string } } | undefined)
+          ?.archestraError?.code,
+      ).toBe("unknown_tool");
     });
 
     test("declares MCP Apps and enterprise auth extensions during initialize", async () => {
@@ -4402,7 +4407,7 @@ describe("McpClient", () => {
         const result = await mcpClient.executeToolCall(toolCall, agentId);
 
         expect(result.isError).toBe(true);
-        expect(result.error).toContain("Tool not found");
+        expect(result.error).toContain("No tool named");
       });
     });
 

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -28,6 +28,7 @@ import type {
   Tool,
 } from "@modelcontextprotocol/sdk/types.js";
 import QuickLRU from "quick-lru";
+import { unavailableThirdPartyToolMessage } from "@/archestra-mcp-server/tool-recovery-messages";
 import { LRUCacheManager } from "@/cache-manager";
 import config from "@/config";
 import { McpServerRuntimeManager } from "@/k8s/mcp-server-runtime";
@@ -1137,11 +1138,20 @@ class McpClient {
     const tool = mcpTools[0];
 
     if (!tool) {
+      const message = unavailableThirdPartyToolMessage(toolCall.name);
       return {
         error: await this.createErrorResult(
           toolCall,
           agentId,
-          "Tool not found or not assigned to agent",
+          message,
+          "unknown",
+          undefined,
+          {
+            type: "tool_state",
+            code: "unknown_tool",
+            message,
+            toolName: toolCall.name,
+          },
         ),
       };
     }

--- a/platform/backend/src/guardrails/tool-invocation.test.ts
+++ b/platform/backend/src/guardrails/tool-invocation.test.ts
@@ -2,6 +2,7 @@ import {
   getArchestraToolFullName,
   TOOL_INVOCATION_DISABLED_FOR_CONVERSATION_REASON,
   TOOL_LIST_AGENTS_SHORT_NAME,
+  TOOL_SEARCH_TOOLS_SHORT_NAME,
 } from "@archestra/shared";
 import { archestraMcpBranding } from "@/archestra-mcp-server";
 import { AgentTeamModel, OrganizationModel } from "@/models";
@@ -115,6 +116,11 @@ describe("evaluatePolicies", () => {
     expect(result?.allToolCallNames).toEqual(["disabled_tool"]);
     expect(result?.contentMessage).toContain("disabled_tool");
     expect(result?.contentMessage).toContain("not enabled");
+    // non-first-person and steered at the discovery path (see PR #5395)
+    expect(result?.contentMessage).not.toContain("I attempted");
+    expect(result?.contentMessage).toContain(
+      archestraMcpBranding.getToolName(TOOL_SEARCH_TOOLS_SHORT_NAME),
+    );
   });
 
   test("white-labeled built-in tools bypass enabledToolNames filtering", async ({

--- a/platform/backend/src/guardrails/tool-invocation.ts
+++ b/platform/backend/src/guardrails/tool-invocation.ts
@@ -3,6 +3,7 @@ import {
   isAgentTool,
   TOOL_INVOCATION_APPROVAL_REQUIRED_AUTONOMOUS_REASON,
   TOOL_INVOCATION_DISABLED_FOR_CONVERSATION_REASON,
+  TOOL_SEARCH_TOOLS_SHORT_NAME,
 } from "@archestra/shared";
 import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import logger from "@/logging";
@@ -171,7 +172,13 @@ export const evaluatePolicies = async (
   // If any tools were disabled, return distinct message about them
   if (disabledToolNames.length > 0) {
     const toolList = disabledToolNames.join(", ");
-    const message = `I attempted to use the tools "${toolList}", but they are not enabled for this conversation.`;
+    const searchToolsName = archestraMcpBranding.getToolName(
+      TOOL_SEARCH_TOOLS_SHORT_NAME,
+    );
+    const message =
+      `The tools "${toolList}" are not enabled for this conversation and were ` +
+      `not run. Do not call them again here. Use a tool that is available to ` +
+      `you, or call ${searchToolsName} to discover the tools you can use.`;
     const reason = TOOL_INVOCATION_DISABLED_FOR_CONVERSATION_REASON;
     return {
       refusalMessage: message,

--- a/platform/backend/src/routes/mcp-gateway.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.test.ts
@@ -3,11 +3,14 @@ import {
   MCP_ENTERPRISE_AUTH_EXTENSION_ID,
   TOOL_ACTIVATE_SKILL_FULL_NAME,
   TOOL_ARTIFACT_WRITE_FULL_NAME,
+  TOOL_DOWNLOAD_FILE_FULL_NAME,
   TOOL_INVOCATION_APPROVAL_REQUIRED_AUTONOMOUS_REASON,
   TOOL_LIST_SKILLS_FULL_NAME,
   TOOL_READ_SKILL_FILE_FULL_NAME,
+  TOOL_RUN_COMMAND_FULL_NAME,
   TOOL_RUN_TOOL_FULL_NAME,
   TOOL_SEARCH_TOOLS_FULL_NAME,
+  TOOL_UPLOAD_FILE_FULL_NAME,
 } from "@archestra/shared";
 import Fastify, { type FastifyInstance } from "fastify";
 import {
@@ -15,7 +18,7 @@ import {
   validatorCompiler,
   type ZodTypeProvider,
 } from "fastify-type-provider-zod";
-import { TeamTokenModel } from "@/models";
+import { TeamTokenModel, UserTokenModel } from "@/models";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import mcpGatewayRoutes from "./mcp-gateway";
 
@@ -942,6 +945,83 @@ describe("MCP Gateway (stateless mode)", () => {
       ].sort(),
     );
     expect(toolNames).not.toContain(TOOL_ARTIFACT_WRITE_FULL_NAME);
+  });
+
+  test("also keeps sandbox runtime tools top-level in tools/list when the sandbox feature is enabled", async ({
+    makeAgent,
+    makeMember,
+    makeOrganization,
+    makeUser,
+    seedAndAssignArchestraTools,
+  }) => {
+    const config = (await import("@/config")).default;
+    const originalSandboxEnabled = config.skillsSandbox.enabled;
+    (config.skillsSandbox as { enabled: boolean }).enabled = true;
+
+    try {
+      const org = await makeOrganization();
+      // sandbox tools are gated by sandbox:execute — authenticate as an admin so
+      // RBAC does not strip them before exposure filtering runs.
+      const adminUser = await makeUser();
+      await makeMember(adminUser.id, org.id, { role: "admin" });
+      const agent = await makeAgent({
+        organizationId: org.id,
+        agentType: "mcp_gateway",
+        toolExposureMode: "search_and_run_only",
+      });
+      await seedAndAssignArchestraTools(agent.id);
+
+      const token = await UserTokenModel.create(adminUser.id, org.id);
+
+      const initResponse = await app.inject({
+        method: "POST",
+        url: `/v1/mcp/${agent.id}`,
+        headers: makeMcpHeaders(token.value),
+        payload: {
+          jsonrpc: "2.0",
+          method: "initialize",
+          params: {
+            protocolVersion: "2024-11-05",
+            capabilities: {},
+            clientInfo: { name: "test-client", version: "1.0.0" },
+          },
+          id: 1,
+        },
+      });
+      expect(initResponse.statusCode).toBe(200);
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/mcp/${agent.id}`,
+        headers: makeMcpHeaders(token.value),
+        payload: {
+          jsonrpc: "2.0",
+          method: "tools/list",
+          params: {},
+          id: 2,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const toolNames = response
+        .json()
+        .result.tools.map((tool: { name: string }) => tool.name);
+      expect(toolNames.sort()).toEqual(
+        [
+          TOOL_ACTIVATE_SKILL_FULL_NAME,
+          TOOL_DOWNLOAD_FILE_FULL_NAME,
+          TOOL_LIST_SKILLS_FULL_NAME,
+          TOOL_READ_SKILL_FILE_FULL_NAME,
+          TOOL_RUN_COMMAND_FULL_NAME,
+          TOOL_RUN_TOOL_FULL_NAME,
+          TOOL_SEARCH_TOOLS_FULL_NAME,
+          TOOL_UPLOAD_FILE_FULL_NAME,
+        ].sort(),
+      );
+    } finally {
+      (config.skillsSandbox as { enabled: boolean }).enabled =
+        originalSandboxEnabled;
+    }
   });
 
   test("exposes implicit search_tools and run_tool without manual assignment when toolExposureMode is search_and_run_only", async ({

--- a/platform/backend/src/routes/mcp-proxy.test.ts
+++ b/platform/backend/src/routes/mcp-proxy.test.ts
@@ -148,6 +148,36 @@ describe("mcpProxyRoutes POST /api/mcp/:agentId", () => {
     expect(body.error?.message).toContain("not accessible from MCP Apps");
   });
 
+  test("steers an unknown tools/call name at tools/list", async ({
+    makeUser,
+    makeAgent,
+  }) => {
+    const user = await makeUser();
+    const agent = await makeAgent({ authorId: user.id });
+    vi.spyOn(auth, "hasAnyAgentTypeAdminPermission").mockResolvedValue(true);
+
+    app = await buildApp(user.id, agent.organizationId);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp/${agent.id}`,
+      headers: { "content-type": "application/json" },
+      payload: {
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: { name: "hallucinated__tool", arguments: {} },
+        id: 1,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.error?.code).toBe(-32601);
+    expect(body.error?.message).toContain("hallucinated__tool");
+    expect(body.error?.message).toContain("tools/list");
+    expect(body.error?.message).toContain("Do not guess tool names");
+  });
+
   test("allows tools/call for a tool with visibility including 'app'", async ({
     makeUser,
     makeAgent,

--- a/platform/backend/src/routes/mcp-proxy.ts
+++ b/platform/backend/src/routes/mcp-proxy.ts
@@ -131,7 +131,7 @@ const mcpProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
             jsonrpc: "2.0",
             error: {
               code: -32601,
-              message: `Tool "${toolName}" not found`,
+              message: `No tool named "${toolName}" is available here. Call tools/list to see the available tools and use an exact name from it. Do not guess tool names.`,
             },
             id: body.id ?? null,
           };


### PR DESCRIPTION
## Problem

Extends PR #5395 repo-wide. When an error is returned **to an LLM agent** (as an MCP tool-call result or JSON-RPC error) and a real self-recovery path exists, the message should name that path so the model can self-correct — instead of dead-ending.

An audit (4 independent passes) found the recoverable-but-unguided sites still live across tool dispatch, the gateway/proxy, guardrails, skills, knowledge, sandbox, agent, and mcp-server lookups.

## Fix

Each touched error now names a concrete recovery path (the exact tool to call) and tells the model not to guess names. Recoverable errors also carry a machine-readable `tool_state` code via the existing `structuredToolErrorResult` / `_meta.archestraError` channel (no new shared-schema variant, no frontend change). Recovery messages name tools by their **exposed (branded) name** via `archestraMcpBranding.getToolName`, so the steer stays callable in white-label orgs.

| Site | Before | After |
|---|---|---|
| `index.ts` built-in dispatch (unknown / not-assigned) | `Tool '…' not found` / `… is not assigned` | steer to `search_tools` / `tools/list`, `code: tool_not_assigned` |
| `mcp-client.ts` third-party gateway | `Tool not found or not assigned to agent` | shared `unavailableThirdPartyToolMessage` → `search_tools`/`run_tool`, `code: unknown_tool` |
| `mcp-proxy.ts` raw proxy | `Tool "…" not found` | steer to `tools/list` |
| `guardrails/tool-invocation.ts` | first-person `I attempted to use the tools …` | non-first-person, steer to `search_tools` |
| `skills.ts` activate/update/read_skill_file | `No skill named …` / `has no file at …` | steer to (branded) `list_skills` / `activate_skill` resources, `code: unknown_skill[_file]` |
| `knowledge-management.ts` KB/connector not-found (×8) | `Knowledge base/connector not found: id` | steer to `get_knowledge_bases` / `get_knowledge_connectors` |
| `sandbox.ts` target id | `No accessible sandbox with id …` | "omit \`target\` or pass \`{ fresh: true }\`" |
| `delegation.ts` | `Agent not found or not configured for delegation` | name exact `agent__*` from `tools/list` |
| `agent-resources.ts` get_agent | `… not found` | steer to `list_agents` (agent type only — proxies/gateways have no list tool) |
| `mcp-servers.ts` get_mcp_server_tools | `… not found or you don't have access` | steer to (branded) `get_mcp_servers` |

A shared `tool-recovery-messages.ts` holds `unavailableThirdPartyToolMessage`, reused by `run_tool` and the gateway so the two surfaces stay verbatim-consistent.

## Also in this PR — #5403 follow-ups

This branch already touches #5403's skills code, so two small nitpicker items from #5403 are folded in here rather than a separate PR:

- **`search-tools.ts`** — renamed `EXCLUDED_SHORT_NAMES` / `isExcludedArchestraMetaTool` → `EXCLUDED_FROM_SEARCH_SHORT_NAMES` / `isExcludedFromSearchResults`. The set now spans meta **and** always-exposed (skill/sandbox) tools, so the old "MetaTool" name was misleading.
- **`mcp-gateway.test.ts`** — added an HTTP integration test asserting the sandbox runtime tools (`run_command` / `download_file` / `upload_file`) pass through the real gateway route in `search_and_run_only` when the sandbox feature is enabled (the existing assertion only covered the feature-off case).

## Deliberately out of scope

- **Architectural-invariant errors** ("no agent context", "org context not available") — not agent-recoverable; guidance would be noise.
- **Infrastructure errors** (engine unreachable, panics, capacity).
- **Gateway/proxy catch-alls** (`mcp-gateway.utils.ts:538`, `mcp-gateway.ts:144`, `mcp-proxy.ts:212`) — review confirmed these are *unexpected-exception* / transport sinks (real downstream errors are already converted upstream), and surfacing their detail would risk leaking internal info. Left generic.

## Deferred to their own follow-ups (#5403 nitpicker)

- **`buildSkillCatalogPrompt` sequential DB** — leaving it sequential. Parallelizing the sandbox-availability step saves one roundtrip on the has-skills path but adds a wasted roundtrip on the reachable no-skills path (agent has `activate_skill` but zero accessible skills → early-returns); marginal net win, not worth the added complexity on a hot path.
- **`archestraMcpBranding` singleton used as a per-request behavior gate** (`chat/routes.ts`, `a2a-executor.ts`) — a confirmed latent race, but **only under enterprise full-white-labeling**. The correct fix is to stop using the mutable global for this gate (thread org identity through `getChatMcpTools`' key generation) — a broader branding-architecture change that belongs in its own PR, not here.

## Tests

Each touched path has a test asserting the new recovery wording and, where applicable, the `tool_state` code — plus a white-label regression test asserting recovery messages name the **branded** tool name. All affected suites pass; type-check, lint, knip (dev+production) clean.

## Review

Reviewed by an internal subagent (APPROVE) and an external Codex pass. Codex caught the white-label literal-name bug in `skills.ts` / `mcp-servers.ts` recovery messages (non-callable in branded orgs) — fixed in this branch, with the regression test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
