### PR TITLE
fix(llm-proxy): sanitize non-string enums in Gemini tool schemas

### DIFF
--- a/platform/backend/src/routes/proxy/adapters/gemini-schema.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-schema.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeGeminiToolSchema } from "./gemini-schema";
+
+describe("sanitizeGeminiToolSchema", () => {
+  it("removes a boolean enum nested in anyOf (the reported failure shape)", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        a: { type: "string" },
+        b: { type: "string" },
+        flag: {
+          anyOf: [
+            {
+              type: "object",
+              properties: {
+                discriminator: { type: "boolean", enum: [true] },
+              },
+            },
+            { type: "string" },
+          ],
+        },
+      },
+    };
+
+    expect(sanitizeGeminiToolSchema(schema)).toEqual({
+      type: "object",
+      properties: {
+        a: { type: "string" },
+        b: { type: "string" },
+        flag: {
+          anyOf: [
+            {
+              type: "object",
+              properties: {
+                discriminator: {
+                  type: "boolean",
+                  description: "Value must be `true`.",
+                },
+              },
+            },
+            { type: "string" },
+          ],
+        },
+      },
+    });
+  });
+
+  it("drops a numeric enum but keeps the numeric type", () => {
+    expect(
+      sanitizeGeminiToolSchema({ type: "number", enum: [1, 2, 3] }),
+    ).toEqual({
+      type: "number",
+      description: "Value must be one of: `1`, `2`, `3`.",
+    });
+  });
+
+  it("infers the type from the first value when none is declared", () => {
+    expect(sanitizeGeminiToolSchema({ enum: [true] })).toEqual({
+      type: "boolean",
+      description: "Value must be `true`.",
+    });
+    expect(sanitizeGeminiToolSchema({ enum: [7] })).toEqual({
+      type: "integer",
+      description: "Value must be `7`.",
+    });
+    expect(sanitizeGeminiToolSchema({ enum: [1.5] })).toEqual({
+      type: "number",
+      description: "Value must be `1.5`.",
+    });
+  });
+
+  it("appends the constraint to an existing description", () => {
+    expect(
+      sanitizeGeminiToolSchema({
+        type: "boolean",
+        enum: [true],
+        description: "Acknowledgement.",
+      }),
+    ).toEqual({
+      type: "boolean",
+      description: "Acknowledgement. Value must be `true`.",
+    });
+  });
+
+  it("drops mixed enums entirely", () => {
+    expect(
+      sanitizeGeminiToolSchema({ type: "string", enum: ["a", 1] }),
+    ).toEqual({
+      type: "string",
+      description: 'Value must be one of: `"a"`, `1`.',
+    });
+  });
+
+  it("drops an empty enum without adding a description", () => {
+    expect(sanitizeGeminiToolSchema({ type: "string", enum: [] })).toEqual({
+      type: "string",
+    });
+  });
+
+  it("leaves valid string enums untouched", () => {
+    const schema = { type: "string", enum: ["red", "green", "blue"] };
+    expect(sanitizeGeminiToolSchema(schema)).toEqual(schema);
+  });
+
+  it("recurses into items and $defs", () => {
+    expect(
+      sanitizeGeminiToolSchema({
+        type: "array",
+        items: { type: "boolean", enum: [true] },
+        $defs: { Flag: { type: "boolean", enum: [false] } },
+      }),
+    ).toEqual({
+      type: "array",
+      items: { type: "boolean", description: "Value must be `true`." },
+      $defs: {
+        Flag: { type: "boolean", description: "Value must be `false`." },
+      },
+    });
+  });
+
+  it("passes through non-schema inputs", () => {
+    expect(sanitizeGeminiToolSchema("text")).toBe("text");
+    expect(sanitizeGeminiToolSchema(42)).toBe(42);
+    expect(sanitizeGeminiToolSchema(null)).toBe(null);
+    expect(sanitizeGeminiToolSchema([1, 2])).toEqual([1, 2]);
+  });
+
+  it("does not mutate the input", () => {
+    const schema = {
+      type: "object",
+      properties: { flag: { type: "boolean", enum: [true] } },
+    };
+    const snapshot = structuredClone(schema);
+    sanitizeGeminiToolSchema(schema);
+    expect(schema).toEqual(snapshot);
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/gemini-schema.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-schema.test.ts
@@ -87,7 +87,48 @@ describe("sanitizeGeminiToolSchema", () => {
       sanitizeGeminiToolSchema({ type: "string", enum: ["a", 1] }),
     ).toEqual({
       type: "string",
-      description: 'Value must be one of: `"a"`, `1`.',
+      description: "Value must be one of: `a`, `1`.",
+    });
+  });
+
+  it("infers a safe type for null-only and heterogeneous untyped enums", () => {
+    // typeof null === "object" must not leak as type "object"
+    expect(sanitizeGeminiToolSchema({ enum: [null] })).toEqual({
+      type: "string",
+      description: "Value must be `null`.",
+    });
+    // mixed value types fall back to string rather than the first value's type
+    expect(sanitizeGeminiToolSchema({ enum: [1, "a"] })).toEqual({
+      type: "string",
+      description: "Value must be one of: `1`, `a`.",
+    });
+    // all-float numeric set stays number, not integer
+    expect(sanitizeGeminiToolSchema({ enum: [1, 1.5] })).toEqual({
+      type: "number",
+      description: "Value must be one of: `1`, `1.5`.",
+    });
+  });
+
+  it("recurses into dependencies and unevaluatedItems subschemas", () => {
+    expect(
+      sanitizeGeminiToolSchema({
+        type: "object",
+        dependencies: {
+          a: { type: "boolean", enum: [true] },
+          b: ["c"],
+        },
+        unevaluatedItems: { type: "boolean", enum: [false] },
+      }),
+    ).toEqual({
+      type: "object",
+      dependencies: {
+        a: { type: "boolean", description: "Value must be `true`." },
+        b: ["c"],
+      },
+      unevaluatedItems: {
+        type: "boolean",
+        description: "Value must be `false`.",
+      },
     });
   });
 

--- a/platform/backend/src/routes/proxy/adapters/gemini-schema.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-schema.ts
@@ -1,0 +1,130 @@
+// Gemini's tool/function schema validation only permits `enum` on string-typed
+// fields. JSON schemas produced upstream (e.g. `@ai-sdk/google` rewrites a zod
+// `const: true` into `enum: [true]`) can carry boolean/number enums, which Gemini
+// rejects with 400 INVALID_ARGUMENT. This sanitizer walks a tool parameter schema
+// and removes non-string enums while preserving the value type, folding the dropped
+// literal(s) into the field description so the model keeps the hint.
+
+type SchemaObject = Record<string, unknown>;
+
+// keywords whose value is a single subschema (recurse only when it is an object)
+const SINGLE_SUBSCHEMA_KEYS = [
+  "additionalProperties",
+  "unevaluatedProperties",
+  "propertyNames",
+  "contains",
+  "not",
+  "if",
+  "then",
+  "else",
+] as const;
+
+// keywords whose value is a map of named subschemas
+const SUBSCHEMA_MAP_KEYS = [
+  "properties",
+  "patternProperties",
+  "$defs",
+  "definitions",
+  "dependentSchemas",
+] as const;
+
+// keywords whose value is an array of subschemas
+const SUBSCHEMA_ARRAY_KEYS = [
+  "anyOf",
+  "oneOf",
+  "allOf",
+  "prefixItems",
+] as const;
+
+export function sanitizeGeminiToolSchema(schema: unknown): unknown {
+  if (Array.isArray(schema)) {
+    return schema.map(sanitizeGeminiToolSchema);
+  }
+  if (schema === null || typeof schema !== "object") {
+    return schema;
+  }
+
+  const result: SchemaObject = { ...(schema as SchemaObject) };
+  normalizeEnum(result);
+  recurseSubschemas(result);
+  return result;
+}
+
+function normalizeEnum(node: SchemaObject): void {
+  const enumValues = node.enum;
+  if (!Array.isArray(enumValues)) return;
+  if (enumValues.length > 0 && enumValues.every((v) => typeof v === "string")) {
+    return;
+  }
+
+  delete node.enum;
+
+  if (node.type === undefined && enumValues.length > 0) {
+    node.type = inferType(enumValues[0]);
+  }
+
+  if (enumValues.length > 0) {
+    node.description = appendConstraint(node.description, enumValues);
+  }
+}
+
+function recurseSubschemas(node: SchemaObject): void {
+  for (const key of SUBSCHEMA_MAP_KEYS) {
+    const map = node[key];
+    if (map !== null && typeof map === "object" && !Array.isArray(map)) {
+      const sanitized: SchemaObject = {};
+      for (const [name, sub] of Object.entries(map)) {
+        sanitized[name] = sanitizeGeminiToolSchema(sub);
+      }
+      node[key] = sanitized;
+    }
+  }
+
+  for (const key of SUBSCHEMA_ARRAY_KEYS) {
+    const arr = node[key];
+    if (Array.isArray(arr)) {
+      node[key] = arr.map(sanitizeGeminiToolSchema);
+    }
+  }
+
+  // `items` and `additionalItems` may be a single subschema or an array of them
+  for (const key of ["items", "additionalItems"] as const) {
+    const value = node[key];
+    if (Array.isArray(value)) {
+      node[key] = value.map(sanitizeGeminiToolSchema);
+    } else if (value !== null && typeof value === "object") {
+      node[key] = sanitizeGeminiToolSchema(value);
+    }
+  }
+
+  for (const key of SINGLE_SUBSCHEMA_KEYS) {
+    const value = node[key];
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      node[key] = sanitizeGeminiToolSchema(value);
+    }
+  }
+}
+
+function inferType(value: unknown): string {
+  switch (typeof value) {
+    case "boolean":
+      return "boolean";
+    case "number":
+      return Number.isInteger(value) ? "integer" : "number";
+    case "object":
+      return Array.isArray(value) ? "array" : "object";
+    default:
+      return "string";
+  }
+}
+
+function appendConstraint(description: unknown, values: unknown[]): string {
+  const rendered = values.map((v) => `\`${JSON.stringify(v)}\``);
+  const note =
+    rendered.length === 1
+      ? `Value must be ${rendered[0]}.`
+      : `Value must be one of: ${rendered.join(", ")}.`;
+  return typeof description === "string" && description.length > 0
+    ? `${description} ${note}`
+    : note;
+}

--- a/platform/backend/src/routes/proxy/adapters/gemini-schema.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-schema.ts
@@ -17,6 +17,7 @@ const SINGLE_SUBSCHEMA_KEYS = [
   "if",
   "then",
   "else",
+  "unevaluatedItems",
 ] as const;
 
 // keywords whose value is a map of named subschemas
@@ -26,6 +27,9 @@ const SUBSCHEMA_MAP_KEYS = [
   "$defs",
   "definitions",
   "dependentSchemas",
+  // draft-07 `dependencies` may hold subschemas (or property-name arrays, which
+  // pass through the walk unchanged)
+  "dependencies",
 ] as const;
 
 // keywords whose value is an array of subschemas
@@ -60,7 +64,7 @@ function normalizeEnum(node: SchemaObject): void {
   delete node.enum;
 
   if (node.type === undefined && enumValues.length > 0) {
-    node.type = inferType(enumValues[0]);
+    node.type = inferType(enumValues);
   }
 
   if (enumValues.length > 0) {
@@ -105,21 +109,25 @@ function recurseSubschemas(node: SchemaObject): void {
   }
 }
 
-function inferType(value: unknown): string {
-  switch (typeof value) {
-    case "boolean":
-      return "boolean";
-    case "number":
-      return Number.isInteger(value) ? "integer" : "number";
-    case "object":
-      return Array.isArray(value) ? "array" : "object";
-    default:
-      return "string";
+// Infer a single JSON-schema type for a dropped non-string enum. `string` is the
+// safe fallback for empty/null-only/heterogeneous value sets (always valid for
+// Gemini), so we only commit to a narrower type when every value agrees.
+function inferType(values: unknown[]): string {
+  const nonNull = values.filter((v) => v !== null);
+  if (nonNull.length === 0) return "string";
+  if (nonNull.every((v) => typeof v === "boolean")) return "boolean";
+  if (nonNull.every((v) => typeof v === "number")) {
+    return nonNull.every((v) => Number.isInteger(v)) ? "integer" : "number";
   }
+  if (nonNull.every((v) => Array.isArray(v))) return "array";
+  if (nonNull.every((v) => typeof v === "object")) return "object";
+  return "string";
 }
 
 function appendConstraint(description: unknown, values: unknown[]): string {
-  const rendered = values.map((v) => `\`${JSON.stringify(v)}\``);
+  const rendered = values.map((v) =>
+    typeof v === "string" ? `\`${v}\`` : `\`${JSON.stringify(v)}\``,
+  );
   const note =
     rendered.length === 1
       ? `Value must be ${rendered[0]}.`

--- a/platform/backend/src/routes/proxy/adapters/gemini.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini.test.ts
@@ -1,7 +1,11 @@
 import { FinishReason, type GenerateContentResponse } from "@google/genai";
 import { describe, expect, test } from "@/test";
 import type { Gemini } from "@/types";
-import { type GeminiRequestWithModel, geminiAdapterFactory } from "./gemini";
+import {
+  type GeminiRequestWithModel,
+  geminiAdapterFactory,
+  restToSdkGenerateContentParams,
+} from "./gemini";
 
 type GeminiStreamChunk = GenerateContentResponse;
 
@@ -949,5 +953,71 @@ describe("GeminiStreamAdapter", () => {
       expect(parts).toHaveLength(1);
       expect(parts[0]).toEqual({ text: "Simple response" });
     });
+  });
+});
+
+describe("restToSdkGenerateContentParams tool-schema sanitization", () => {
+  // a non-string enum nested under a property — Gemini rejects this verbatim
+  const badParamSchema = {
+    type: "object",
+    properties: { flag: { type: "boolean", enum: [true] } },
+  };
+
+  function flagEnum(schema: unknown): unknown {
+    const props = (schema as { properties?: Record<string, unknown> })
+      .properties;
+    return (props?.flag as { enum?: unknown } | undefined)?.enum;
+  }
+
+  function firstFd(params: ReturnType<typeof restToSdkGenerateContentParams>): {
+    parameters?: unknown;
+    parametersJsonSchema?: unknown;
+    response?: unknown;
+    responseJsonSchema?: unknown;
+  } {
+    const tools = params.config?.tools as
+      | Array<{ functionDeclarations: Array<Record<string, unknown>> }>
+      | undefined;
+    const fd = tools?.[0]?.functionDeclarations?.[0];
+    if (!fd) throw new Error("expected a function declaration");
+    return fd;
+  }
+
+  test("sanitizes all four schema fields of a function declaration", () => {
+    const tools: Gemini.Types.Tool[] = [
+      {
+        functionDeclarations: [
+          {
+            name: "do_thing",
+            description: "does a thing",
+            parameters: structuredClone(badParamSchema),
+            parametersJsonSchema: structuredClone(badParamSchema),
+            response: structuredClone(badParamSchema),
+            responseJsonSchema: structuredClone(badParamSchema),
+          },
+        ],
+      },
+    ];
+
+    const fd = firstFd(
+      restToSdkGenerateContentParams({ contents: [] }, "gemini-2.5-pro", tools),
+    );
+
+    expect(flagEnum(fd.parameters)).toBeUndefined();
+    expect(flagEnum(fd.parametersJsonSchema)).toBeUndefined();
+    expect(flagEnum(fd.response)).toBeUndefined();
+    expect(flagEnum(fd.responseJsonSchema)).toBeUndefined();
+  });
+
+  test("leaves a declaration without parameters untouched", () => {
+    const tools: Gemini.Types.Tool[] = [
+      { functionDeclarations: [{ name: "no_args", description: "no args" }] },
+    ];
+
+    const fd = firstFd(
+      restToSdkGenerateContentParams({ contents: [] }, "gemini-2.5-pro", tools),
+    );
+
+    expect(fd.parameters).toBeUndefined();
   });
 });

--- a/platform/backend/src/routes/proxy/adapters/gemini.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini.ts
@@ -1221,8 +1221,11 @@ function sanitizeFdSchema<T>(schema: T): T {
  *
  * Note: Gemini SDK and REST API have different schemas. See:
  * https://ai.google.dev/api/generate-content
+ *
+ * @public — exercised by gemini.test.ts to verify tool-schema sanitization on
+ * the outbound path.
  */
-function restToSdkGenerateContentParams(
+export function restToSdkGenerateContentParams(
   body: Partial<Gemini.Types.GenerateContentRequest>,
   model: string,
   mergedTools?: Gemini.Types.Tool[] | undefined,

--- a/platform/backend/src/routes/proxy/adapters/gemini.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini.ts
@@ -41,6 +41,7 @@ import {
   isMcpImageBlock,
 } from "../utils/mcp-image";
 import { unwrapToolContent } from "../utils/unwrap-tool-content";
+import { sanitizeGeminiToolSchema } from "./gemini-schema";
 
 // =============================================================================
 // TYPE ALIASES
@@ -1203,6 +1204,14 @@ function sdkResponseToRestResponse(
   } as Gemini.Types.GenerateContentResponse;
 }
 
+// Strip Gemini-incompatible JSON-schema constructs (non-string enums) from a
+// function declaration schema field before handing it to the SDK. Returns the
+// input untouched when absent.
+function sanitizeFdSchema<T>(schema: T): T {
+  if (schema === undefined || schema === null) return schema;
+  return sanitizeGeminiToolSchema(schema) as T;
+}
+
 /**
  * Convert a Gemini REST-style GenerateContentRequest body into the SDK's
  * GenerateContentParameters shape. The SDK and REST shapes differ significantly:
@@ -1266,10 +1275,10 @@ function restToSdkGenerateContentParams(
           name: fd.name,
           description: fd.description,
           behavior: mappedBehavior,
-          parameters: fd.parameters,
-          parametersJsonSchema: fd.parametersJsonSchema,
-          response: fd.response,
-          responseJsonSchema: fd.responseJsonSchema,
+          parameters: sanitizeFdSchema(fd.parameters),
+          parametersJsonSchema: sanitizeFdSchema(fd.parametersJsonSchema),
+          response: sanitizeFdSchema(fd.response),
+          responseJsonSchema: sanitizeFdSchema(fd.responseJsonSchema),
         };
       });
 


### PR DESCRIPTION
## Problem

Chat with `gemini-2.5-pro` + MCP tools fails with HTTP 400 `INVALID_ARGUMENT`:

```
Invalid value at 'tools[0].function_declarations[0].parameters
  .properties[2].value.any_of[0].properties[0].value.enum[0]' (TYPE_STRING), true
```

Gemini's `function_declaration` schema validation only permits `enum` on **string-typed** fields. A boolean `true` inside `enum` is rejected.

## Root cause

`@ai-sdk/google` (verified in installed `3.0.43` and latest `3.0.80`) converts a zod `const: true` (e.g. a boolean acknowledgement flag / discriminated-union discriminator) into `enum: [true]` and never coerces enum values to strings:

```js
if (constValue !== void 0) { result.enum = [constValue]; }  // const -> enum, verbatim
if (enumValues !== void 0) { result.enum = enumValues; }    // enum verbatim, no coercion
```

The proxy then forwarded `fd.parameters` verbatim through `@google/genai` to Gemini in `restToSdkGenerateContentParams`, so the boolean enum reached Gemini unchanged. Bumping the AI SDK would **not** fix this (latest has identical handling), and the proxy also serves external clients, so sanitizing in the proxy is the correct layer.

## Fix

A recursive sanitizer (`gemini-schema.ts`) applied at the single chokepoint `restToSdkGenerateContentParams` — shared by both the native-Gemini and OpenAI-compat-to-Gemini paths. For any schema node with an empty or non-string `enum`:

- drop the `enum` (Gemini cannot express the literal anyway);
- preserve the existing `type`, or infer a safe one from the values (null-only/heterogeneous → `string`, all-float → `number`);
- fold the dropped literal(s) into `description` (e.g. *"Value must be `true`."*) so the model keeps the hint.

Valid string enums are left untouched. The walk covers all JSON-schema applicator keywords (`properties`, `anyOf`/`oneOf`/`allOf`, `items`/`prefixItems`, `$defs`/`definitions`, `additionalProperties`, `dependencies`/`dependentSchemas`, `unevaluatedItems`, `if`/`then`/`else`, `not`, `contains`, ...) and never recurses into data-bearing keys (`enum`/`const`/`default`/`examples`).

### Why drop, not stringify
For tool params forwarded to a strict MCP server, stringifying (`type:string, enum:["true"]`) would make the model emit `"true"` and break downstream validation. Dropping keeps the correct JSON type.

## Tests

- `gemini-schema.test.ts` — reported `anyOf` shape, boolean/numeric/empty/mixed/untyped enums, type inference, description folding, recursion into `items`/`$defs`/`dependencies`/`unevaluatedItems`, no input mutation.
- `gemini.test.ts` — wiring: all four fd schema fields (`parameters`, `parametersJsonSchema`, `response`, `responseJsonSchema`) sanitized on the outbound path, plus the no-parameters short-circuit.

`type-check`, `lint`, full `knip` all clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>

## References / prior art

- Vercel AI SDK — [`convert-json-schema-to-openapi-schema.ts`](https://github.com/vercel/ai/blob/main/packages/google/src/convert-json-schema-to-openapi-schema.ts): rewrites `const` → `enum: [const]` and passes `enum` through verbatim (no string coercion) — the upstream source of the boolean enum.
- Gemini API — [structured output / enum docs](https://ai.google.dev/gemini-api/docs/structured-output): `enum` is only valid on `STRING`-typed fields.
- [Google AI forum: Gemini rejecting enum schema (Zod cannot set `type: "string"`)](https://discuss.ai.google.dev/t/gemini-rejecting-enum-schema-zod-cannot-set-type-string/90681)
- [`gemini-cli` #2237](https://github.com/google-gemini/gemini-cli/issues/2237): only `enum`/`date-time` supported for STRING type — same class of validation.
- [`opencode` #12784](https://github.com/anomalyco/opencode/issues/12784): handles the same problem by **stringifying** numeric enums. We deliberately **drop** instead: stringifying changes the JSON type the model emits, which breaks tool args validated by a strict downstream MCP server. Dropping preserves the type and keeps the literal as a description hint.
