### PR TITLE
fix(llm-proxy): forward non-local virtual keys from in-app chat to the downstream provider

### DIFF
--- a/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
@@ -6,7 +6,10 @@
  * 2. recordBlockedToolSpans is called when tool invocation policies block tool calls
  */
 
-import { CHAT_API_KEY_ID_HEADER } from "@archestra/shared";
+import {
+  CHAT_API_KEY_ID_HEADER,
+  PROVIDER_BASE_URL_HEADER,
+} from "@archestra/shared";
 import Fastify, { type FastifyInstance } from "fastify";
 import {
   serializerCompiler,
@@ -15,7 +18,11 @@ import {
 } from "fastify-type-provider-zod";
 import { vi } from "vitest";
 import type { PolicyBlockResult } from "@/guardrails/tool-invocation";
-import { LlmProviderApiKeyModel, ModelModel } from "@/models";
+import {
+  LlmProviderApiKeyModel,
+  ModelModel,
+  VirtualApiKeyModel,
+} from "@/models";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import {
   createAnthropicTestClient,
@@ -23,6 +30,7 @@ import {
   createOpenAiTestClient,
 } from "@/test/llm-provider-stubs";
 import type { Agent } from "@/types";
+import { ApiError } from "@/types";
 
 // Mock prom-client at module level (like llm-metrics.test.ts)
 const counterInc = vi.fn();
@@ -91,6 +99,7 @@ import {
   geminiAdapterFactory,
   openaiAdapterFactory,
 } from "./adapters";
+import { virtualKeyRateLimiter } from "./llm-proxy-auth";
 import anthropicProxyRoutes from "./routes/anthropic";
 import azureProxyRoutes from "./routes/azure";
 import geminiProxyRoutes from "./routes/gemini";
@@ -852,12 +861,31 @@ describe("LLM Proxy Handler — CHAT_API_KEY_ID_HEADER fallback", () => {
     app = Fastify().withTypeProvider<ZodTypeProvider>();
     app.setValidatorCompiler(validatorCompiler);
     app.setSerializerCompiler(serializerCompiler);
+    app.setErrorHandler((error, _request, reply) => {
+      if (error instanceof ApiError) {
+        return reply
+          .status(error.statusCode)
+          .send({ error: { message: error.message, type: error.type } });
+      }
+      return reply.status(500).send({
+        error: {
+          message: error instanceof Error ? error.message : String(error),
+          type: "api_internal_server_error",
+        },
+      });
+    });
 
     vi.spyOn(openaiAdapterFactory, "createClient").mockImplementation(
       (apiKey, options) => {
         createClientSpy(apiKey, options);
         return createOpenAiTestClient({}) as never;
       },
+    );
+    // The cache-backed rate limiter isn't started under PGLite tests; stub it
+    // so the virtual-key validation path exercises auth, not cache I/O.
+    vi.spyOn(virtualKeyRateLimiter, "check").mockResolvedValue(undefined);
+    vi.spyOn(virtualKeyRateLimiter, "recordFailure").mockResolvedValue(
+      undefined,
     );
 
     testAgent = await makeAgent({ name: "Test Extra Headers Agent" });
@@ -1022,6 +1050,162 @@ describe("LLM Proxy Handler — CHAT_API_KEY_ID_HEADER fallback", () => {
       expect.objectContaining({
         baseUrl: "https://runtime.example.com/openai/v1",
       }),
+    );
+  });
+
+  test("loopback chat forward of a non-local arch_ secret forwards it to the provider base URL", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+    const apiKey = await LlmProviderApiKeyModel.create({
+      organizationId: org.id,
+      secretId: null,
+      name: "Downstream Archestra proxy key",
+      provider: "openai",
+      scope: "org",
+      userId: null,
+      teamId: null,
+    });
+    const foreignVirtualKey = `arch_${"f".repeat(64)}`;
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/openai/${testAgent.id}/chat/completions`,
+      remoteAddress: "127.0.0.1",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${foreignVirtualKey}`,
+        [CHAT_API_KEY_ID_HEADER]: apiKey.id,
+        [PROVIDER_BASE_URL_HEADER]: "https://downstream.example.com/v1/openai",
+      },
+      payload: {
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "Hello!" }],
+        stream: false,
+      },
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(createClientSpy).toHaveBeenCalledWith(
+      foreignVirtualKey,
+      expect.objectContaining({
+        baseUrl: "https://downstream.example.com/v1/openai",
+      }),
+    );
+  });
+
+  test("non-loopback request with a non-local arch_ secret is still rejected with 401", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+    const apiKey = await LlmProviderApiKeyModel.create({
+      organizationId: org.id,
+      secretId: null,
+      name: "Downstream Archestra proxy key",
+      provider: "openai",
+      scope: "org",
+      userId: null,
+      teamId: null,
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/openai/${testAgent.id}/chat/completions`,
+      remoteAddress: "203.0.113.5",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer arch_${"f".repeat(64)}`,
+        [CHAT_API_KEY_ID_HEADER]: apiKey.id,
+        [PROVIDER_BASE_URL_HEADER]: "https://downstream.example.com/v1/openai",
+      },
+      payload: {
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "Hello!" }],
+        stream: false,
+      },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(createClientSpy).not.toHaveBeenCalled();
+  });
+
+  test("loopback chat forward of a non-local arch_ secret WITHOUT a provider base URL is still rejected with 401", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+    const apiKey = await LlmProviderApiKeyModel.create({
+      organizationId: org.id,
+      secretId: null,
+      name: "Downstream Archestra proxy key",
+      provider: "openai",
+      scope: "org",
+      userId: null,
+      teamId: null,
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/openai/${testAgent.id}/chat/completions`,
+      remoteAddress: "127.0.0.1",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer arch_${"f".repeat(64)}`,
+        [CHAT_API_KEY_ID_HEADER]: apiKey.id,
+      },
+      payload: {
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "Hello!" }],
+        stream: false,
+      },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(createClientSpy).not.toHaveBeenCalled();
+  });
+
+  test("loopback chat forward of a VALID local virtual key still resolves it locally", async ({
+    makeOrganization,
+    makeSecret,
+  }) => {
+    const org = await makeOrganization();
+    const secret = await makeSecret({ secret: { apiKey: "sk-resolved-real" } });
+    const providerKey = await LlmProviderApiKeyModel.create({
+      organizationId: org.id,
+      secretId: secret.id,
+      name: "Local OpenAI key behind a virtual key",
+      provider: "openai",
+      scope: "org",
+      userId: null,
+      teamId: null,
+    });
+    const { value: localVirtualKey } = await VirtualApiKeyModel.create({
+      name: "local-vk",
+      providerApiKeys: [
+        { provider: "openai", providerApiKeyId: providerKey.id },
+      ],
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/openai/${testAgent.id}/chat/completions`,
+      remoteAddress: "127.0.0.1",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${localVirtualKey}`,
+        [CHAT_API_KEY_ID_HEADER]: providerKey.id,
+      },
+      payload: {
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "Hello!" }],
+        stream: false,
+      },
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    // Resolved to the real provider secret, NOT forwarded as the arch_ token.
+    expect(createClientSpy).toHaveBeenCalledWith(
+      "sk-resolved-real",
+      expect.any(Object),
     );
   });
 });

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -11,6 +11,7 @@ import {
   type InteractionSource,
   InteractionSourceSchema,
   isProviderApiKeyOptional,
+  PROVIDER_BASE_URL_HEADER,
   SOURCE_HEADER,
   UNTRUSTED_CONTEXT_HEADER,
 } from "@archestra/shared";
@@ -339,6 +340,26 @@ export async function handleLLMProxy<
   // a "Bearer:<token>" sentinel so downstream client creation can distinguish
   // auth tokens from raw API keys. Normalize both forms before virtual-key lookup.
   const rawApiKey = normalizeVirtualKeyCandidate(apiKey);
+
+  // In-app chat forwards a stored provider secret through the local proxy
+  // (loopback) tagged with CHAT_API_KEY_ID_HEADER and a downstream
+  // PROVIDER_BASE_URL_HEADER. That secret can itself be an `arch_*` virtual key
+  // whose mapped provider is ANOTHER Archestra instance — not one of this
+  // instance's keys — so it must be forwarded to that downstream base URL
+  // rather than rejected by local virtual-key lookup. Requiring the base-URL
+  // header keeps the clean local 401 when there is no downstream to forward to
+  // (an `arch_*` secret would otherwise leak to the default public provider).
+  const chatApiKeyIdHeader =
+    headersForExtraction[CHAT_API_KEY_ID_HEADER.toLowerCase()];
+  const providerBaseUrlHeaderValue =
+    headersForExtraction[PROVIDER_BASE_URL_HEADER.toLowerCase()];
+  const isInternalChatForward =
+    isLoopbackAddress(request.ip) &&
+    typeof chatApiKeyIdHeader === "string" &&
+    chatApiKeyIdHeader.length > 0 &&
+    typeof providerBaseUrlHeaderValue === "string" &&
+    providerBaseUrlHeaderValue.length > 0;
+
   if (
     !wasJwksAuthenticated &&
     !authOverride &&
@@ -382,10 +403,26 @@ export async function handleLLMProxy<
       virtualKeyId = virtualResult.virtualKeyId;
       authMethod = "virtual_key";
     } catch (error) {
-      if (error instanceof ApiError && error.statusCode === 401) {
-        await virtualKeyRateLimiter.recordFailure(request.ip);
+      // The token resolved as a local virtual key on success above. If it
+      // didn't and this is an internal chat forward, the secret belongs to a
+      // downstream Archestra instance: leave `apiKey` as the raw secret so it
+      // is forwarded to the provider base URL (which validates it), rather than
+      // failing or penalizing the loopback caller's rate limit.
+      if (
+        isInternalChatForward &&
+        error instanceof ApiError &&
+        error.statusCode === 401
+      ) {
+        logger.info(
+          { chatApiKeyId: chatApiKeyIdHeader },
+          `[${providerName}Proxy] forwarding non-local virtual key to provider base URL`,
+        );
+      } else {
+        if (error instanceof ApiError && error.statusCode === 401) {
+          await virtualKeyRateLimiter.recordFailure(request.ip);
+        }
+        throw error;
       }
-      throw error;
     }
   }
 


### PR DESCRIPTION
## Summary

You can now use one Archestra LLM proxy as an Anthropic/OpenAI **Model Provider inside another Archestra** and have it work in **in-app Chat**, not just model listing.

In-app chat always routes through the local LLM proxy, forwarding the selected provider key's stored secret verbatim. When that secret is itself an `arch_*` **virtual key belonging to a different Archestra instance** (the "use Archestra as a provider" / proxy-chaining setup), the local proxy validated it against its *own* virtual-key table and returned `401 Invalid virtual API key` — before the loopback `X-Archestra-Provider-Base-Url` header could forward it to the downstream instance. The result: chat with such a provider showed "Invalid API key. Please check your Chat Settings."

The proxy now resolves local virtual keys first (so genuine local keys keep their cost-limit / usage tracking). Only when the token is **not** a valid local key **and** the request is an internal loopback chat-forward carrying a downstream provider base URL does it forward the raw secret to that base URL — where the downstream proxy validates it. Without a downstream base URL the clean local `401` is preserved, so an `arch_*` token is never forwarded to the default public provider. External (non-loopback) callers are unaffected: an unknown `arch_*` key still rejects with `401`.

No new configuration or environment variables — the change rides the existing loopback trust boundary that already gates the chat-forward headers.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>