### PR TITLE
fix(proxy): avoid Anthropic SDK stream helper crash on malformed tool deltas

### DIFF
--- a/platform/backend/src/routes/proxy/adapters/anthropic.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.test.ts
@@ -1,3 +1,4 @@
+import AnthropicProvider from "@anthropic-ai/sdk";
 import { describe, expect, test } from "@/test";
 import type { Anthropic } from "@/types";
 import { anthropicAdapterFactory } from "./anthropic";
@@ -440,5 +441,140 @@ describe("AnthropicRequestAdapter", () => {
         { type: "text", text: "[Image omitted due to size]" },
       ]);
     });
+  });
+});
+
+describe("anthropicAdapterFactory.executeStream", () => {
+  function sseEvent(event: string, data: unknown): string {
+    return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+  }
+
+  // builds a real Anthropic client whose transport returns a canned SSE body,
+  // so the real SDK stream parsing runs without hitting the network.
+  function clientWithSseBody(body: string): AnthropicProvider {
+    const fakeFetch = (async () =>
+      new Response(body, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      })) as unknown as typeof globalThis.fetch;
+    return new AnthropicProvider({ apiKey: "test-key", fetch: fakeFetch });
+  }
+
+  // partial_json fragments that concatenate into more than one JSON value. The
+  // SDK's messages.stream() helper eagerly partial-parses the accumulated buffer
+  // and throws on this; the raw create() stream must tolerate it.
+  test("does not throw when tool input deltas concatenate into two JSON values", async () => {
+    const body =
+      sseEvent("message_start", {
+        type: "message_start",
+        message: {
+          id: "msg_1",
+          type: "message",
+          role: "assistant",
+          model: "claude-3-5-sonnet-20241022",
+          content: [],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        },
+      }) +
+      sseEvent("content_block_start", {
+        type: "content_block_start",
+        index: 0,
+        content_block: {
+          type: "tool_use",
+          id: "toolu_1",
+          name: "do_thing",
+          input: {},
+        },
+      }) +
+      sseEvent("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: '{"city":"SF"}' },
+      }) +
+      sseEvent("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: '{"unit":"c"}' },
+      }) +
+      sseEvent("content_block_stop", { type: "content_block_stop", index: 0 }) +
+      sseEvent("message_delta", {
+        type: "message_delta",
+        delta: { stop_reason: "tool_use", stop_sequence: null },
+        usage: { output_tokens: 2 },
+      }) +
+      sseEvent("message_stop", { type: "message_stop" });
+
+    const client = clientWithSseBody(body);
+    const stream = await anthropicAdapterFactory.executeStream(
+      client,
+      createMockRequest([{ role: "user", content: "hi" }]),
+    );
+
+    const adapter = anthropicAdapterFactory.createStreamAdapter();
+    for await (const event of stream) {
+      adapter.processChunk(event);
+    }
+
+    const response = adapter.toProviderResponse();
+    const toolUse = response.content.find((block) => block.type === "tool_use");
+    expect(toolUse).toBeDefined();
+    // malformed accumulated arguments fall back to empty input rather than crashing.
+    expect((toolUse as { input: unknown }).input).toEqual({});
+  });
+
+  test("parses tool input from well-formed incremental deltas", async () => {
+    const body =
+      sseEvent("message_start", {
+        type: "message_start",
+        message: {
+          id: "msg_2",
+          type: "message",
+          role: "assistant",
+          model: "claude-3-5-sonnet-20241022",
+          content: [],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        },
+      }) +
+      sseEvent("content_block_start", {
+        type: "content_block_start",
+        index: 0,
+        content_block: {
+          type: "tool_use",
+          id: "toolu_2",
+          name: "do_thing",
+          input: {},
+        },
+      }) +
+      sseEvent("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: '{"city":' },
+      }) +
+      sseEvent("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: '"SF"}' },
+      }) +
+      sseEvent("content_block_stop", { type: "content_block_stop", index: 0 }) +
+      sseEvent("message_stop", { type: "message_stop" });
+
+    const client = clientWithSseBody(body);
+    const stream = await anthropicAdapterFactory.executeStream(
+      client,
+      createMockRequest([{ role: "user", content: "hi" }]),
+    );
+
+    const adapter = anthropicAdapterFactory.createStreamAdapter();
+    for await (const event of stream) {
+      adapter.processChunk(event);
+    }
+
+    const response = adapter.toProviderResponse();
+    const toolUse = response.content.find((block) => block.type === "tool_use");
+    expect((toolUse as { input: unknown }).input).toEqual({ city: "SF" });
   });
 });

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -1197,18 +1197,15 @@ export const anthropicAdapterFactory: LLMProvider<
     request: AnthropicRequest,
   ): Promise<AsyncIterable<AnthropicStreamChunk>> {
     const anthropicClient = client as AnthropicProvider;
-    const stream = anthropicClient.messages.stream({
+    // use the raw create() stream rather than the messages.stream() helper: the
+    // helper eagerly partial-parses accumulated input_json_delta fragments and
+    // throws (unguarded) when a non-conformant upstream emits deltas that
+    // concatenate into more than one JSON value. we do our own guarded tool-call
+    // accumulation in processChunk, so the raw event stream is all we need.
+    return anthropicClient.messages.create({
       ...request,
+      stream: true,
     } as AnthropicProvider.Messages.MessageCreateParamsStreaming);
-
-    // Return async iterable that yields stream events
-    return {
-      [Symbol.asyncIterator]: async function* () {
-        for await (const event of stream) {
-          yield event;
-        }
-      },
-    };
   },
 
   extractInternalCode(error: unknown): ArchestraInternalErrorCode | undefined {

--- a/platform/backend/src/routes/proxy/routes/provider-matrix.test.ts
+++ b/platform/backend/src/routes/proxy/routes/provider-matrix.test.ts
@@ -672,6 +672,109 @@ function createAnthropicHarness(options: HarnessOptions = {}) {
   const model = options.model ?? "claude-3-5-sonnet-20241022";
   const text = options.text ?? "Mocked Anthropic response";
 
+  function createStreamEvents(): AsyncIterable<Anthropic.Messages.MessageStreamEvent> {
+    const events: Anthropic.Messages.MessageStreamEvent[] = [
+      {
+        type: "message_start",
+        message: {
+          id: "msg_stream",
+          type: "message",
+          container: null,
+          role: "assistant",
+          content: [],
+          model,
+          stop_reason: null,
+          stop_sequence: null,
+          usage: {
+            input_tokens: usage.inputTokens,
+            output_tokens: usage.outputTokens,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          } as Anthropic.Messages.Usage,
+        },
+      },
+    ];
+
+    if (options.streamingToolCall) {
+      events.push(
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: {
+            type: "tool_use",
+            id: "toolu_123",
+            caller: { type: "direct" },
+            name: options.streamingToolCall.name,
+            input: {},
+          },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: {
+            type: "input_json_delta",
+            partial_json: options.streamingToolCall.arguments,
+          },
+        },
+        {
+          type: "content_block_stop",
+          index: 0,
+        },
+        {
+          type: "message_delta",
+          delta: {
+            container: null,
+            stop_reason: "tool_use",
+            stop_sequence: null,
+          },
+          usage: {
+            output_tokens: usage.outputTokens,
+          } as Anthropic.Messages.Usage,
+        },
+        {
+          type: "message_stop",
+        },
+      );
+    } else {
+      events.push(
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: {
+            type: "text",
+            text: "",
+            citations: [],
+          },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text },
+        },
+        {
+          type: "content_block_stop",
+          index: 0,
+        },
+        {
+          type: "message_delta",
+          delta: {
+            container: null,
+            stop_reason: "end_turn",
+            stop_sequence: null,
+          },
+          usage: {
+            output_tokens: usage.outputTokens,
+          } as Anthropic.Messages.Usage,
+        },
+        {
+          type: "message_stop",
+        },
+      );
+    }
+
+    return createAsyncIterable(events);
+  }
+
   return {
     requests,
     client: {
@@ -679,6 +782,10 @@ function createAnthropicHarness(options: HarnessOptions = {}) {
         create: async (request: Record<string, unknown>) => {
           requests.push(request);
           options.onRequest?.(request);
+          if (request.stream === true) {
+            return createStreamEvents();
+          }
+
           return {
             id: "msg_nonstream",
             type: "message",
@@ -707,107 +814,7 @@ function createAnthropicHarness(options: HarnessOptions = {}) {
         stream: (request: Record<string, unknown>) => {
           requests.push(request);
           options.onRequest?.(request);
-
-          const events: Anthropic.Messages.MessageStreamEvent[] = [
-            {
-              type: "message_start",
-              message: {
-                id: "msg_stream",
-                type: "message",
-                container: null,
-                role: "assistant",
-                content: [],
-                model,
-                stop_reason: null,
-                stop_sequence: null,
-                usage: {
-                  input_tokens: usage.inputTokens,
-                  output_tokens: usage.outputTokens,
-                  cache_creation_input_tokens: 0,
-                  cache_read_input_tokens: 0,
-                } as Anthropic.Messages.Usage,
-              },
-            },
-          ];
-
-          if (options.streamingToolCall) {
-            events.push(
-              {
-                type: "content_block_start",
-                index: 0,
-                content_block: {
-                  type: "tool_use",
-                  id: "toolu_123",
-                  caller: { type: "direct" },
-                  name: options.streamingToolCall.name,
-                  input: {},
-                },
-              },
-              {
-                type: "content_block_delta",
-                index: 0,
-                delta: {
-                  type: "input_json_delta",
-                  partial_json: options.streamingToolCall.arguments,
-                },
-              },
-              {
-                type: "content_block_stop",
-                index: 0,
-              },
-              {
-                type: "message_delta",
-                delta: {
-                  container: null,
-                  stop_reason: "tool_use",
-                  stop_sequence: null,
-                },
-                usage: {
-                  output_tokens: usage.outputTokens,
-                } as Anthropic.Messages.Usage,
-              },
-              {
-                type: "message_stop",
-              },
-            );
-          } else {
-            events.push(
-              {
-                type: "content_block_start",
-                index: 0,
-                content_block: {
-                  type: "text",
-                  text: "",
-                  citations: [],
-                },
-              },
-              {
-                type: "content_block_delta",
-                index: 0,
-                delta: { type: "text_delta", text },
-              },
-              {
-                type: "content_block_stop",
-                index: 0,
-              },
-              {
-                type: "message_delta",
-                delta: {
-                  container: null,
-                  stop_reason: "end_turn",
-                  stop_sequence: null,
-                },
-                usage: {
-                  output_tokens: usage.outputTokens,
-                } as Anthropic.Messages.Usage,
-              },
-              {
-                type: "message_stop",
-              },
-            );
-          }
-
-          return createAsyncIterable(events);
+          return createStreamEvents();
         },
       },
     },

--- a/platform/backend/src/test/llm-provider-stubs.ts
+++ b/platform/backend/src/test/llm-provider-stubs.ts
@@ -89,8 +89,12 @@ export function createOpenAiTestClient(options: OpenAiStubOptions = {}) {
 export function createAnthropicTestClient(options: AnthropicStubOptions = {}) {
   return {
     messages: {
-      create: async () =>
-        ({
+      create: async (params: Anthropic.Messages.MessageCreateParams) => {
+        if (params.stream) {
+          return createAnthropicStream(options);
+        }
+
+        return {
           id: "msg-test-anthropic",
           type: "message",
           container: null,
@@ -111,7 +115,8 @@ export function createAnthropicTestClient(options: AnthropicStubOptions = {}) {
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
           },
-        }) as unknown as Anthropic.Message,
+        } as unknown as Anthropic.Message;
+      },
       stream: () => createAnthropicStream(options),
     },
   };


### PR DESCRIPTION
## Problem

A chat request through the model-router proxy with an Anthropic provider could crash mid-stream with:

> Unexpected non-whitespace character after JSON at position N

The proxy's Anthropic adapter (`executeStream`) consumed the upstream stream via the `@anthropic-ai/sdk` `messages.stream()` helper. That helper eagerly partial-parses the accumulated `input_json_delta` tool-call fragments and calls an **unguarded** `JSON.parse`. When a non-conformant upstream emits tool-input deltas that concatenate into more than one JSON value (e.g. `{"a":1}{"b":2}`), the parse throws and the whole stream dies. Because headers are already sent, the proxy forwards it as an SSE `{"type":"api_error", ...}` event, which surfaces to the client as a generic provider error.

Notably, we never used the helper's accumulated result — the adapter does its own tool-call accumulation in `processChunk` and parses arguments under a guarded `try/catch` in `toProviderResponse`.

This is not fixed by upgrading either SDK: Vercel `ai` only forwards the error, and `@anthropic-ai/sdk` leaves the parse unguarded on latest as well.

## Fix

Switch `executeStream` from `messages.stream()` to the raw `messages.create({ stream: true })`. It returns `Stream<RawMessageStreamEvent>` — the exact same raw events `processChunk` already consumes — without the eager partial-parse accumulation. Our guarded accumulation handles malformed arguments by falling back to empty input instead of crashing the stream.

## Test

Added a regression test that drives a pathological SSE stream (tool-input deltas concatenating into two JSON values) through the **real** SDK via a canned `fetch` transport. It reproduces the exact crash on the old code path and passes with the fix; a positive-control test confirms well-formed incremental deltas still parse correctly.

- `pnpm vitest run` (anthropic adapter): 12 passed
- `pnpm type-check`, `pnpm lint`: clean

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>