### PR TITLE
feat(mcp-catalog): block save when stored config values violate the environment rule

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/create-catalog-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/create-catalog-dialog.tsx
@@ -79,12 +79,15 @@ export function CreateCatalogDialog({
     setStep("form");
   };
 
-  const footer = (
+  const footer = ({ hasBlockingErrors }: { hasBlockingErrors: boolean }) => (
     <DialogStickyFooter className="mt-0">
       <Button variant="outline" onClick={handleClose} type="button">
         Cancel
       </Button>
-      <Button type="submit" disabled={createMutation.isPending}>
+      <Button
+        type="submit"
+        disabled={createMutation.isPending || hasBlockingErrors}
+      >
         {createMutation.isPending ? "Adding..." : "Add Server"}
       </Button>
     </DialogStickyFooter>

--- a/platform/frontend/src/app/mcp/registry/_parts/edit-catalog-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/edit-catalog-dialog.tsx
@@ -118,7 +118,7 @@ export function EditCatalogContent({
       onDirtyChange={onDirtyChange}
       submitRef={submitRef}
       affectedServerCount={affectedServerCount}
-      footer={({ isDirty, onReset }) => {
+      footer={({ isDirty, onReset, hasBlockingErrors }) => {
         if (keepOpenOnSave && !isDirty) return null;
         const Footer = keepOpenOnSave ? DialogStickyFooter : DialogFooter;
         return (
@@ -134,7 +134,9 @@ export function EditCatalogContent({
             )}
             <Button
               type="submit"
-              disabled={updateMutation.isPending || !isDirty}
+              disabled={
+                updateMutation.isPending || !isDirty || hasBlockingErrors
+              }
             >
               {updateMutation.isPending ? "Saving..." : "Save Changes"}
             </Button>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { type archestraApiTypes, DocsPage } from "@archestra/shared";
+import { type archestraApiTypes, DocsPage, E2eTestId } from "@archestra/shared";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
+  AlertTriangle,
   Ban,
   Code,
   ExternalLink,
@@ -119,7 +120,16 @@ interface McpCatalogFormProps {
   onSubmit: (values: McpCatalogFormValues) => void | Promise<void>;
   footer?:
     | React.ReactNode
-    | ((opts: { isDirty: boolean; onReset: () => void }) => React.ReactNode);
+    | ((opts: {
+        isDirty: boolean;
+        onReset: () => void;
+        /**
+         * True when stored config values violate the bound environment's
+         * validation rule — the footer's Save button should disable on it.
+         * Saving is also guarded internally, but disabling gives a visible cue.
+         */
+        hasBlockingErrors: boolean;
+      }) => React.ReactNode);
   nameDisabled?: boolean;
   catalogButton?: React.ReactNode;
   /** Optional banner/notice rendered at the very top of the form body. */
@@ -572,6 +582,44 @@ export function McpCatalogForm({
           environmentName: boundEnvironmentName,
         })
     : undefined;
+  // Already-stored static values that violate the bound environment's rule —
+  // e.g. after switching the item to a stricter environment. The add/edit
+  // dialogs block typing a bad value, but a value entered under a laxer
+  // environment only surfaces here, where it blocks Save until fixed.
+  //
+  // Only scan the fields actually live for the current server type: env vars
+  // for local, headers for remote. A local server submits no headers and a
+  // remote one submits no localConfig.environment, so scanning the inactive
+  // (and hidden) set would block Save on a field the user can't even see.
+  const watchedEnvVars = form.watch("localConfig.environment");
+  const watchedHeaders = form.watch("additionalHeaders");
+  const envRuleViolations: string[] = [];
+  if (validateConfigValue) {
+    if (currentServerType === "local") {
+      for (const envVar of watchedEnvVars ?? []) {
+        if (
+          envVar.type === "plain_text" &&
+          !envVar.promptOnInstallation &&
+          envVar.value &&
+          validateConfigValue(envVar.value)
+        ) {
+          envRuleViolations.push(envVar.key);
+        }
+      }
+    } else {
+      for (const header of watchedHeaders ?? []) {
+        if (
+          !header.promptOnInstallation &&
+          !header.sensitive &&
+          header.value &&
+          validateConfigValue(header.value)
+        ) {
+          envRuleViolations.push(header.headerName);
+        }
+      }
+    }
+  }
+  const hasEnvRuleViolations = envRuleViolations.length > 0;
   const currentScope = form.watch("scope");
   const canShareWithTeams = (isAdmin ?? false) || (isTeamAdmin ?? false);
   // Shared items are one-way: an item that is already team/org-scoped cannot be
@@ -758,6 +806,10 @@ export function McpCatalogForm({
   };
 
   const handleSubmit = async (values: McpCatalogFormValues) => {
+    // Stored values may violate the bound environment's rule (e.g. after an
+    // environment switch). The Save button is disabled in that state, but guard
+    // here too so an Enter-key submit can't bypass it.
+    if (hasEnvRuleViolations) return;
     // Cascade-confirm decision delegated to a pure function so it can be
     // matrix-tested without rendering, and so frontend + backend share
     // the same decision tree shape. See `cascade-decision.ts`.
@@ -962,7 +1014,10 @@ export function McpCatalogForm({
                             )
                           }
                         >
-                          <SelectTrigger className="w-full">
+                          <SelectTrigger
+                            className="w-full"
+                            data-testid={E2eTestId.SelectEnvironment}
+                          >
                             <SelectValue />
                           </SelectTrigger>
                           <SelectContent position="popper">
@@ -1001,6 +1056,29 @@ export function McpCatalogForm({
                   );
                 }}
               />
+              {hasEnvRuleViolations && (
+                <div
+                  role="alert"
+                  className="flex items-start gap-3 rounded-md border border-amber-500/40 bg-amber-50/40 p-3 text-sm dark:bg-amber-950/20"
+                >
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-500" />
+                  <div className="space-y-1 text-foreground/90">
+                    <div className="font-semibold text-foreground">
+                      {envRuleViolations.length} value
+                      {envRuleViolations.length === 1 ? "" : "s"} not allowed in
+                      “{boundEnvironmentName}”
+                    </div>
+                    <div>
+                      Edit or remove{" "}
+                      {envRuleViolations.length === 1 ? "it" : "them"}, or
+                      choose another environment, before saving:{" "}
+                      <span className="font-mono">
+                        {envRuleViolations.join(", ")}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              )}
               {mode === "create" && (
                 <div className="space-y-2">
                   <Label>Server Type</Label>
@@ -2386,6 +2464,7 @@ export function McpCatalogForm({
               form.reset();
               setLabels(labelsBaseline);
             },
+            hasBlockingErrors: hasEnvRuleViolations,
           })
         ) : (
           footer

--- a/platform/frontend/tests-integration/mcp-environment-validation.spec.ts
+++ b/platform/frontend/tests-integration/mcp-environment-validation.spec.ts
@@ -293,4 +293,64 @@ test.describe("MCP environment validation rule", () => {
       varDialog.getByRole("button", { name: "Add variable" }),
     ).toBeEnabled();
   });
+
+  test("the header dialog blocks a value that violates the rule", async ({
+    page,
+    mcpRegistryPage,
+    mswControl,
+  }) => {
+    // Headers (a separate dialog from env vars) are edited on remote servers
+    // and persist as userConfig defaults — so the same rule applies.
+    const item = makeCatalogItem({
+      id: "test-catalog-header",
+      name: "header-test",
+      serverType: "remote",
+      serverUrl: "https://example.test/mcp",
+    });
+
+    await mswControl.use({
+      method: "get",
+      url: "/api/internal_mcp_catalog",
+      body: [item],
+    });
+    await mswControl.use({
+      method: "get",
+      url: "/api/organization",
+      body: orgWithDefaultRule(BLOCK_PROD),
+    });
+
+    await mcpRegistryPage.goto();
+    await expect(mcpRegistryPage.heading).toBeVisible();
+    await mcpRegistryPage.settingsButtonFor("header-test").click();
+
+    const editor = page.getByRole("dialog", { name: /header-test Settings/i });
+    await expect(editor).toBeVisible();
+    await editor.getByRole("button", { name: "Add Header" }).click();
+
+    const headerDialog = page.getByRole("dialog", { name: /Add header/i });
+    await expect(headerDialog).toBeVisible();
+    await headerDialog.locator("#header-name").fill("X-Upstream");
+    // Switch scope to Static so the value input appears.
+    await headerDialog
+      .getByTestId(E2eTestId.PromptOnInstallationCheckbox)
+      .click();
+    await page.getByRole("option", { name: "Static" }).click();
+
+    const valueInput = headerDialog.locator("#header-value");
+    await valueInput.fill("https://production.example.com");
+    await expect(
+      headerDialog.getByText(/does not match the Default validation rule/i),
+    ).toBeVisible();
+    await expect(
+      headerDialog.getByRole("button", { name: "Add header" }),
+    ).toBeDisabled();
+
+    await valueInput.fill("https://staging.example.com");
+    await expect(
+      headerDialog.getByText(/does not match the Default validation rule/i),
+    ).toBeHidden();
+    await expect(
+      headerDialog.getByRole("button", { name: "Add header" }),
+    ).toBeEnabled();
+  });
 });

--- a/platform/frontend/tests-integration/mcp-environment-validation.spec.ts
+++ b/platform/frontend/tests-integration/mcp-environment-validation.spec.ts
@@ -1,0 +1,296 @@
+import { E2eTestId } from "@archestra/shared/e2e-test-ids";
+import { makeCatalogItem } from "../src/mocks/data/catalog";
+import { organizationSeed } from "../src/mocks/data/organization";
+import { expect, test } from "./fixtures";
+
+// An environment's "validation rule" is an ALLOWLIST regex: a config value is
+// accepted only if it matches. These specs cover the UI wiring of that rule in
+// the catalog editor and install dialog — the form-level env-switch block, the
+// per-field inline errors, and that an unconfigured environment blocks nothing.
+// The regex semantics themselves are unit-tested in
+// environment-validation-helpers.test.ts; the backend enforcement has backend
+// tests. Here we only assert the user-facing behavior.
+
+// Blocks any value containing "prod"/"production".
+const BLOCK_PROD = "^(?!.*(prod|production)).*$";
+
+/** Minimal /api/environments payload (only the fields the form reads). */
+function envList(
+  environments: Array<{
+    id: string;
+    name: string;
+    validationRegex: string | null;
+  }>,
+) {
+  return {
+    environments: environments.map((e) => ({
+      organizationId: "test-org",
+      description: "",
+      namespace: null,
+      networkPolicy: null,
+      restricted: false,
+      sortOrder: 0,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      assignedCatalogCount: 0,
+      ...e,
+    })),
+    defaultAssignedCatalogCount: 0,
+  };
+}
+
+const orgWithDefaultRule = (validationRegex: string | null) => ({
+  ...organizationSeed,
+  defaultEnvironmentValidationRegex: validationRegex,
+});
+
+test.describe("MCP environment validation rule", () => {
+  test("switching to a stricter environment flags stored values and blocks Save", async ({
+    page,
+    mcpRegistryPage,
+    mswControl,
+  }) => {
+    // Item lives in "Production" (allows prod) with a static env var holding a
+    // prod URL. The default environment forbids prod. Switching to Default must
+    // surface the violation and disable Save.
+    const item = makeCatalogItem({
+      id: "test-catalog-switch",
+      name: "switch-test",
+      serverType: "local",
+      environmentId: "env-prod",
+      localConfig: {
+        command: "node",
+        environment: [
+          {
+            key: "TEST_URL",
+            type: "plain_text",
+            value: "https://prod.example.com",
+            promptOnInstallation: false,
+            required: false,
+          },
+        ],
+      },
+    });
+
+    await mswControl.use({
+      method: "get",
+      url: "/api/internal_mcp_catalog",
+      body: [item],
+    });
+    await mswControl.use({
+      method: "get",
+      url: "/api/environments",
+      body: envList([
+        { id: "env-prod", name: "Production", validationRegex: null },
+      ]),
+    });
+    await mswControl.use({
+      method: "get",
+      url: "/api/organization",
+      body: orgWithDefaultRule(BLOCK_PROD),
+    });
+
+    await mcpRegistryPage.goto();
+    await expect(mcpRegistryPage.heading).toBeVisible();
+    await mcpRegistryPage.settingsButtonFor("switch-test").click();
+
+    const dialog = page.getByRole("dialog", { name: /switch-test Settings/i });
+    await expect(dialog).toBeVisible();
+
+    // No violation while bound to Production.
+    await expect(dialog.getByRole("alert")).toBeHidden();
+
+    await dialog.getByTestId(E2eTestId.SelectEnvironment).click();
+    await page.getByRole("option", { name: "Default" }).click();
+
+    // The warning bar names the offending field and Save is disabled.
+    const alert = dialog.getByRole("alert");
+    await expect(alert).toBeVisible();
+    await expect(alert).toContainText("TEST_URL");
+    await expect(alert).toContainText("Default");
+    await expect(
+      dialog.getByRole("button", { name: "Save Changes" }),
+    ).toBeDisabled();
+
+    // Switching back to Production clears the violation.
+    await dialog.getByTestId(E2eTestId.SelectEnvironment).click();
+    await page.getByRole("option", { name: "Production" }).click();
+    await expect(dialog.getByRole("alert")).toBeHidden();
+  });
+
+  test("the env-var dialog blocks a value that violates the rule", async ({
+    page,
+    mcpRegistryPage,
+    mswControl,
+  }) => {
+    const item = makeCatalogItem({
+      id: "test-catalog-envvar",
+      name: "envvar-test",
+      serverType: "local",
+      localConfig: { command: "node", environment: [] },
+    });
+
+    await mswControl.use({
+      method: "get",
+      url: "/api/internal_mcp_catalog",
+      body: [item],
+    });
+    await mswControl.use({
+      method: "get",
+      url: "/api/organization",
+      body: orgWithDefaultRule(BLOCK_PROD),
+    });
+
+    await mcpRegistryPage.goto();
+    await expect(mcpRegistryPage.heading).toBeVisible();
+    await mcpRegistryPage.settingsButtonFor("envvar-test").click();
+
+    const editor = page.getByRole("dialog", { name: /envvar-test Settings/i });
+    await expect(editor).toBeVisible();
+    await editor.getByRole("button", { name: "Add Variable" }).click();
+
+    const varDialog = page.getByRole("dialog", {
+      name: /Add environment variable/i,
+    });
+    await expect(varDialog).toBeVisible();
+    await varDialog.locator("#env-var-key").fill("TEST_URL");
+    // Switch scope to Static so the value input appears.
+    await varDialog.getByTestId(E2eTestId.PromptOnInstallationCheckbox).click();
+    await page.getByRole("option", { name: "Static" }).click();
+
+    const valueInput = varDialog.locator("#env-var-value");
+    await valueInput.fill("https://production.example.com");
+    await expect(
+      varDialog.getByText(/does not match the Default validation rule/i),
+    ).toBeVisible();
+    await expect(
+      varDialog.getByRole("button", { name: "Add variable" }),
+    ).toBeDisabled();
+
+    // A compliant value clears the error and re-enables confirm.
+    await valueInput.fill("https://staging.example.com");
+    await expect(
+      varDialog.getByText(/does not match the Default validation rule/i),
+    ).toBeHidden();
+    await expect(
+      varDialog.getByRole("button", { name: "Add variable" }),
+    ).toBeEnabled();
+  });
+
+  test("the install dialog blocks a violating value and disables Install", async ({
+    page,
+    mcpRegistryPage,
+    mswControl,
+  }) => {
+    // The just-created remote item carries a non-secret prompted field and is
+    // bound to the default environment, whose rule forbids prod.
+    const created = makeCatalogItem({
+      id: "test-catalog-install",
+      name: "install-test",
+      serverType: "remote",
+      multitenant: true,
+      serverUrl: "https://example.test/mcp",
+      environmentId: null,
+      userConfig: {
+        ENDPOINT: {
+          type: "string",
+          title: "Endpoint",
+          description: "Upstream endpoint",
+          required: true,
+          promptOnInstallation: true,
+        },
+      },
+    });
+
+    await mswControl.use({
+      method: "get",
+      url: "/api/organization",
+      body: orgWithDefaultRule(BLOCK_PROD),
+    });
+    await mswControl.use({
+      method: "post",
+      url: "/api/internal_mcp_catalog",
+      body: created,
+    });
+
+    await mcpRegistryPage.goto();
+    await expect(mcpRegistryPage.heading).toBeVisible();
+
+    await page.getByRole("button", { name: "Add MCP Server" }).click();
+    await page.getByRole("button", { name: /^Remote/ }).click();
+    await page.getByRole("textbox", { name: "Name *" }).fill("install-test");
+    await page
+      .getByRole("textbox", { name: "Server URL *" })
+      .fill("https://example.test/mcp");
+    await page.getByRole("button", { name: "Add Server" }).click();
+
+    const installDialog = page
+      .getByRole("dialog")
+      .filter({ hasText: /Install Server/ });
+    await expect(installDialog).toBeVisible();
+
+    const endpoint = installDialog.getByRole("textbox", { name: /Endpoint/ });
+    await endpoint.fill("https://prod.example.com");
+    await expect(
+      installDialog.getByText(/does not match the Default validation rule/i),
+    ).toBeVisible();
+    await expect(
+      installDialog.getByRole("button", { name: "Install" }),
+    ).toBeDisabled();
+
+    await endpoint.fill("https://staging.example.com");
+    await expect(
+      installDialog.getByText(/does not match the Default validation rule/i),
+    ).toBeHidden();
+    await expect(
+      installDialog.getByRole("button", { name: "Install" }),
+    ).toBeEnabled();
+  });
+
+  test("no rule configured blocks nothing", async ({
+    page,
+    mcpRegistryPage,
+    mswControl,
+  }) => {
+    // Default seed: organization has no validation regex and there are no named
+    // environments. A "prod" value must be accepted (the feature is inert when
+    // unconfigured).
+    const item = makeCatalogItem({
+      id: "test-catalog-norule",
+      name: "norule-test",
+      serverType: "local",
+      localConfig: { command: "node", environment: [] },
+    });
+
+    await mswControl.use({
+      method: "get",
+      url: "/api/internal_mcp_catalog",
+      body: [item],
+    });
+
+    await mcpRegistryPage.goto();
+    await expect(mcpRegistryPage.heading).toBeVisible();
+    await mcpRegistryPage.settingsButtonFor("norule-test").click();
+
+    const editor = page.getByRole("dialog", { name: /norule-test Settings/i });
+    await expect(editor).toBeVisible();
+    await editor.getByRole("button", { name: "Add Variable" }).click();
+
+    const varDialog = page.getByRole("dialog", {
+      name: /Add environment variable/i,
+    });
+    await expect(varDialog).toBeVisible();
+    await varDialog.locator("#env-var-key").fill("TEST_URL");
+    await varDialog.getByTestId(E2eTestId.PromptOnInstallationCheckbox).click();
+    await page.getByRole("option", { name: "Static" }).click();
+    await varDialog
+      .locator("#env-var-value")
+      .fill("https://production.host.com");
+
+    // No rule → no error, confirm stays enabled.
+    await expect(varDialog.getByText(/validation rule/i)).toBeHidden();
+    await expect(
+      varDialog.getByRole("button", { name: "Add variable" }),
+    ).toBeEnabled();
+  });
+});

--- a/platform/shared/e2e-test-ids.ts
+++ b/platform/shared/e2e-test-ids.ts
@@ -63,6 +63,7 @@ export const E2eTestId = {
   RevokeCredentialButton: "revoke-credential-button",
   ExternalSecretSelector: "external-secret-selector",
   SelectEnvironmentVariableType: "select-environment-variable-type",
+  SelectEnvironment: "select-environment",
   AddCatalogItemButton: "add-catalog-item-button",
   ConfigureVaultFolderButton: "configure-vault-folder-button",
   ExternalSecretSelectorTeamTrigger: "external-secret-selector-team-trigger",


### PR DESCRIPTION
Switching a catalog item's environment to one whose validation rule its already-stored config values violate previously slipped past the editor — the form looked fine and only a backend 400 stopped the save. The editor now checks proactively: a warning bar under the environment selector names the offending field(s) and the Save button is disabled until they're fixed or a different environment is chosen.

The scan only considers the fields live for the current server type — environment variables for a local server, headers for a remote one — so it never blocks Save on a field that's hidden in the current mode.

Also adds Playwright + MSW integration coverage: the env-switch block, the per-field inline checks in the environment-variable and header dialogs, and the guard that an unconfigured environment blocks nothing.

Builds on the environment validation rule shipped in #5406.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>