### PR TITLE
fix(llm-proxy,harness): cross-review cleanup of today's LLM/harness work

### DIFF
--- a/platform/backend/src/archestra-mcp-server/index.ts
+++ b/platform/backend/src/archestra-mcp-server/index.ts
@@ -66,6 +66,7 @@ import {
   toolEntries as toolAssignmentToolEntries,
   tools as toolAssignmentTools,
 } from "./tool-assignment";
+import { toolDiscoverySteer } from "./tool-recovery-messages";
 import type { ArchestraContext } from "./types";
 
 export { archestraMcpBranding } from "./branding";
@@ -235,16 +236,6 @@ async function checkToolAssignedToAgent(
       toolName,
     },
   });
-}
-
-// Recovery steer pointing a model at the tool-discovery path. Branded so the
-// names match what the model sees (custom-branded orgs use a different prefix);
-// mirrors run-tool's unavailableThirdPartyToolMessage.
-function toolDiscoverySteer(): string {
-  const searchToolsName = archestraMcpBranding.getToolName(
-    TOOL_SEARCH_TOOLS_SHORT_NAME,
-  );
-  return `Call ${searchToolsName} to discover the tools available to you, then use an exact name it returns. Do not guess tool names.`;
 }
 
 function resolveArchestraToolName(toolName: string): string | null {

--- a/platform/backend/src/archestra-mcp-server/tool-recovery-messages.ts
+++ b/platform/backend/src/archestra-mcp-server/tool-recovery-messages.ts
@@ -4,16 +4,16 @@ import {
 } from "@archestra/shared";
 import { archestraMcpBranding } from "./branding";
 
+// Branded tool names (`archestraMcpBranding.getToolName`) are used throughout so
+// the names match exactly what the model sees in its tool list and system prompt:
+// a custom-branded org exposes these tools under a different prefix, and naming
+// the canonical `archestra__*` form would point the model at a tool it cannot
+// see, defeating the recovery loop.
+
 /**
  * Recovery-oriented message for a third-party tool name that is not available to
  * the agent (hallucinated or simply not assigned). Steers the model at
  * search_tools — the intended discovery path — then run_tool.
- *
- * Uses branded tool names (`archestraMcpBranding.getToolName`) so the names here
- * match exactly what the model sees in its tool list and system prompt — a
- * custom-branded org exposes these tools under a different prefix, and naming the
- * canonical `archestra__*` form would point the model at a tool it cannot see,
- * defeating the recovery loop.
  *
  * Shared by the run_tool dispatcher (`run-tool.ts`) and the gateway execution
  * path (`clients/mcp-client.ts`) so both surfaces stay verbatim-consistent.
@@ -31,4 +31,16 @@ export function unavailableThirdPartyToolMessage(toolName: string): string {
     "description of the capability you need to find the exact tool name, then " +
     `call ${runToolName} again. Do not guess tool names.`
   );
+}
+
+/**
+ * Generic discovery steer appended after an "unknown tool"/"not assigned"
+ * preamble. Single source of truth for the dispatch-surface recovery hint used
+ * by `executeArchestraTool` (`index.ts`).
+ */
+export function toolDiscoverySteer(): string {
+  const searchToolsName = archestraMcpBranding.getToolName(
+    TOOL_SEARCH_TOOLS_SHORT_NAME,
+  );
+  return `Call ${searchToolsName} to discover the tools available to you, then use an exact name it returns. Do not guess tool names.`;
 }

--- a/platform/backend/src/routes/proxy/routes/proxy-model-listing.test.ts
+++ b/platform/backend/src/routes/proxy/routes/proxy-model-listing.test.ts
@@ -116,6 +116,44 @@ describe("provider-specific proxy GET /models (virtual-key-aware)", () => {
     );
   });
 
+  test("anthropic: discovery targets the provider's canonical baseUrl, not the inference override", async ({
+    makeOrganization,
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    vi.mocked(fetchAnthropicModels).mockResolvedValue(ANTHROPIC_MODELS);
+    const app = await buildApp(anthropicProxyRoutes);
+
+    const org = await makeOrganization();
+    const secret = await makeSecret({ secret: { apiKey: "sk-ant-real" } });
+    // A custom inference gateway that does not serve /models: discovery must use
+    // baseUrl, never inferenceBaseUrl.
+    const providerKey = await makeLlmProviderApiKey(org.id, secret.id, {
+      provider: "anthropic",
+      baseUrl: "https://discovery.example.com",
+      inferenceBaseUrl: "https://inference.example.com",
+    });
+    const { value } = await VirtualApiKeyModel.create({
+      name: "vk-anthropic-discovery-base",
+      providerApiKeys: [
+        { provider: "anthropic", providerApiKeyId: providerKey.id },
+      ],
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/v1/anthropic/${randomUUID()}/v1/models`,
+      headers: { "x-api-key": value },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(fetchAnthropicModels).toHaveBeenCalledWith(
+      "sk-ant-real",
+      "https://discovery.example.com",
+      null,
+    );
+  });
+
   test("anthropic: default-agent route lists models", async ({
     makeOrganization,
     makeSecret,

--- a/platform/backend/src/routes/proxy/routes/proxy-model-listing.test.ts
+++ b/platform/backend/src/routes/proxy/routes/proxy-model-listing.test.ts
@@ -154,6 +154,44 @@ describe("provider-specific proxy GET /models (virtual-key-aware)", () => {
     );
   });
 
+  test("anthropic: discovery falls back to the provider default when only inferenceBaseUrl is set", async ({
+    makeOrganization,
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    vi.mocked(fetchAnthropicModels).mockResolvedValue(ANTHROPIC_MODELS);
+    const app = await buildApp(anthropicProxyRoutes);
+
+    const org = await makeOrganization();
+    const secret = await makeSecret({ secret: { apiKey: "sk-ant-real" } });
+    // baseUrl null + inferenceBaseUrl set: discovery must not borrow the
+    // inference override; it falls back to the provider default (undefined).
+    const providerKey = await makeLlmProviderApiKey(org.id, secret.id, {
+      provider: "anthropic",
+      baseUrl: null,
+      inferenceBaseUrl: "https://inference.example.com",
+    });
+    const { value } = await VirtualApiKeyModel.create({
+      name: "vk-anthropic-inference-only",
+      providerApiKeys: [
+        { provider: "anthropic", providerApiKeyId: providerKey.id },
+      ],
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/v1/anthropic/${randomUUID()}/v1/models`,
+      headers: { "x-api-key": value },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(fetchAnthropicModels).toHaveBeenCalledWith(
+      "sk-ant-real",
+      undefined,
+      null,
+    );
+  });
+
   test("anthropic: default-agent route lists models", async ({
     makeOrganization,
     makeSecret,

--- a/platform/backend/src/routes/proxy/routes/proxy-model-listing.ts
+++ b/platform/backend/src/routes/proxy/routes/proxy-model-listing.ts
@@ -88,9 +88,13 @@ export async function resolveProxyModelsApiKey(params: {
     const providerKey = resolved.chatApiKeyId
       ? await LlmProviderApiKeyModel.findById(resolved.chatApiKeyId)
       : null;
+    // Model discovery targets the provider's canonical base URL, not the
+    // inference override: `resolved.baseUrl` is coalesce(inferenceBaseUrl,
+    // baseUrl), and a custom inference gateway may not serve `/models`. Fall
+    // back to the provider default (undefined) when no base is configured.
     return {
       apiKey: resolved.apiKey,
-      baseUrl: resolved.baseUrl,
+      baseUrl: providerKey?.baseUrl ?? undefined,
       extraHeaders: providerKey?.extraHeaders ?? null,
     };
   } catch (error) {

--- a/platform/backend/src/services/active-chat-run.ts
+++ b/platform/backend/src/services/active-chat-run.ts
@@ -104,12 +104,15 @@ export class ActiveChatRunService {
   // so their conversations are not blocked until the stale reaper catches up.
   async failInFlightRuns(): Promise<number> {
     const ids = Array.from(this.inFlightRunIds);
-    this.inFlightRunIds.clear();
 
     const failed = await ActiveChatRunModel.markRunningAsFailedByIds({
       ids,
       error: "Server shut down before the chat stream completed.",
     });
+
+    // Clear only after the write resolves (mirrors markTerminal): if it throws,
+    // the ids are retained so the stale-run reaper still fails them later.
+    this.inFlightRunIds.clear();
 
     if (failed > 0) {
       logger.info({ failed }, "Failed in-flight active chat runs on shutdown");

--- a/platform/backend/src/services/active-chat-run.ts
+++ b/platform/backend/src/services/active-chat-run.ts
@@ -110,9 +110,13 @@ export class ActiveChatRunService {
       error: "Server shut down before the chat stream completed.",
     });
 
-    // Clear only after the write resolves (mirrors markTerminal): if it throws,
-    // the ids are retained so the stale-run reaper still fails them later.
-    this.inFlightRunIds.clear();
+    // Remove only the snapshotted ids, and only after the write resolves
+    // (mirrors markTerminal): on throw the ids are retained for the stale-run
+    // reaper, and a run registered concurrently during the shutdown window is
+    // left to its own registerCreatedRun/markTerminal rather than clobbered.
+    for (const id of ids) {
+      this.inFlightRunIds.delete(id);
+    }
 
     if (failed > 0) {
       logger.info({ failed }, "Failed in-flight active chat runs on shutdown");

--- a/platform/backend/src/test/fixtures.ts
+++ b/platform/backend/src/test/fixtures.ts
@@ -808,7 +808,13 @@ async function makeLlmProviderApiKey(
   overrides: Partial<
     Pick<
       InsertLlmProviderApiKey,
-      "name" | "provider" | "scope" | "userId" | "teamId"
+      | "name"
+      | "provider"
+      | "scope"
+      | "userId"
+      | "teamId"
+      | "baseUrl"
+      | "inferenceBaseUrl"
     >
   > = {},
 ) {
@@ -821,6 +827,8 @@ async function makeLlmProviderApiKey(
     scope: overrides.scope ?? "org",
     userId: overrides.userId ?? null,
     teamId: overrides.teamId ?? null,
+    baseUrl: overrides.baseUrl ?? null,
+    inferenceBaseUrl: overrides.inferenceBaseUrl ?? null,
   });
 }
 


### PR DESCRIPTION
## What

Cross-review of today's LLM-proxy + agent-harness PRs (5407/5409/5413 flagged, plus peers' 5400/5408/5402 and the run-tool/skills stack). The flagged PRs reviewed **clean**; this PR addresses three genuine findings the review surfaced.

## Findings fixed

1. **`GET /models` discovery used the inference base URL** (peer PR #5400). `validateVirtualApiKey` resolves `baseUrl` as `coalesce(inferenceBaseUrl, baseUrl)` — correct for inference routing, wrong for discovery: a custom inference gateway may not serve `/models`. Discovery now uses the provider key's canonical `baseUrl` (falling back to the provider default when null). The schema documents this exact boundary: `inferenceBaseUrl` is "the override when discovery and inference use different provider URLs." Inference callers are untouched.
   - ⚠️ **@abalashov** — this changes your #5400 behavior. A key that set *only* `inferenceBaseUrl` (baseUrl null) and relied on coalesce for discovery will now fall back to the provider default. That's spec-aligned per the column's documented intent, but please confirm it matches what you intended.

2. **Shutdown `failInFlightRuns` could strand running rows** (#5352). It cleared the whole in-flight set *before* the DB write resolved, violating this file's own `markTerminal` "clear-only-after-resolve" invariant. Now deletes only the snapshotted ids after the write resolves — so a throw retains them for the stale-run reaper, and a run registered concurrently during the shutdown window isn't clobbered (caught by the external review gate).

3. **Duplicated tool-discovery steer** (#5395/#5405). `index.ts` defined its own `toolDiscoverySteer()` that "mirrors run-tool's" message in a second file. Consolidated into `tool-recovery-messages.ts` as the single source.

## Not changed (reviewed, ruled out)
- **5409** (Anthropic raw-stream switch) — clean; loses no abort/cleanup behavior.
- **5407** (Gemini enum sanitize) — correct; not made redundant by the 5413 SDK bump.
- **5413** (ai 6.0.193 bump) — sound; dropped patch's invariant pinned by the new regression test.
- Gemini `const` (vs `enum`) sanitization gap — left out pending confirmation that Gemini actually rejects bare `const` (the in-app path is safe; @ai-sdk/google rewrites const→enum).

## Tests
- New: discovery targets `baseUrl` not `inferenceBaseUrl`; discovery falls back to provider default when only `inferenceBaseUrl` is set.
- Fixture: `makeLlmProviderApiKey` now accepts `baseUrl`/`inferenceBaseUrl`.
- ✅ type-check, lint, knip, affected suites green.

Reviewed via external (codex) + internal gates.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>