### PR TITLE
fix: improve image pull secret selection

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -121466,10 +121466,17 @@
                     "properties": {
                       "name": {
                         "type": "string"
+                      },
+                      "registryServers": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
                       }
                     },
                     "required": [
-                      "name"
+                      "name",
+                      "registryServers"
                     ],
                     "additionalProperties": false
                   }

--- a/platform/backend/src/k8s/mcp-server-runtime/manager.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager.test.ts
@@ -1528,6 +1528,18 @@ describe("McpServerRuntimeManager", () => {
 });
 
 describe("McpServerRuntimeManager.listDockerRegistrySecrets", () => {
+  function dockerConfigData(registryServers: string[]) {
+    return {
+      ".dockerconfigjson": Buffer.from(
+        JSON.stringify({
+          auths: Object.fromEntries(
+            registryServers.map((server) => [server, { auth: "redacted" }]),
+          ),
+        }),
+      ).toString("base64"),
+    };
+  }
+
   test("returns empty array when k8sApi is not initialized", async () => {
     const { McpServerRuntimeManager } = await import("./manager");
     const manager = new McpServerRuntimeManager();
@@ -1573,6 +1585,7 @@ describe("McpServerRuntimeManager.listDockerRegistrySecrets", () => {
               "team-id": "team-a",
             },
           },
+          data: dockerConfigData(["registry-b.example.com"]),
         },
         {
           metadata: {
@@ -1583,6 +1596,7 @@ describe("McpServerRuntimeManager.listDockerRegistrySecrets", () => {
               "team-id": "team-b",
             },
           },
+          data: dockerConfigData(["registry-a.example.com"]),
         },
       ],
     });
@@ -1592,8 +1606,14 @@ describe("McpServerRuntimeManager.listDockerRegistrySecrets", () => {
 
     const result = await manager.listDockerRegistrySecrets({ isAdmin: true });
     expect(result).toEqual([
-      { name: "regcred-team-a" },
-      { name: "regcred-team-b" },
+      {
+        name: "regcred-team-a",
+        registryServers: ["registry-b.example.com"],
+      },
+      {
+        name: "regcred-team-b",
+        registryServers: ["registry-a.example.com"],
+      },
     ]);
 
     expect(mockListSecrets).toHaveBeenCalledWith(
@@ -1644,7 +1664,7 @@ describe("McpServerRuntimeManager.listDockerRegistrySecrets", () => {
     const result = await manager.listDockerRegistrySecrets({
       teamIds: ["team-a"],
     });
-    expect(result).toEqual([{ name: "regcred-team-a" }]);
+    expect(result).toEqual([{ name: "regcred-team-a", registryServers: [] }]);
   });
 
   test("non-admin with no teams sees no secrets", async () => {
@@ -1671,6 +1691,74 @@ describe("McpServerRuntimeManager.listDockerRegistrySecrets", () => {
 
     const result = await manager.listDockerRegistrySecrets({ teamIds: [] });
     expect(result).toEqual([]);
+  });
+
+  test("returns sorted registry servers parsed from docker config json", async () => {
+    const { McpServerRuntimeManager } = await import("./manager");
+    const manager = new McpServerRuntimeManager();
+
+    (manager as unknown as { k8sApi: unknown }).k8sApi = {
+      listNamespacedSecret: vi.fn().mockResolvedValue({
+        items: [
+          {
+            metadata: {
+              name: "regcred-private",
+              labels: {
+                app: "mcp-server",
+                type: "regcred",
+                "team-id": "team-a",
+              },
+            },
+            data: dockerConfigData([
+              "z.registry.example.com",
+              "a.registry.example.com",
+            ]),
+          },
+        ],
+      }),
+    };
+
+    const result = await manager.listDockerRegistrySecrets({
+      teamIds: ["team-a"],
+    });
+
+    expect(result).toEqual([
+      {
+        name: "regcred-private",
+        registryServers: ["a.registry.example.com", "z.registry.example.com"],
+      },
+    ]);
+  });
+
+  test("returns empty registry server list when docker config json is invalid", async () => {
+    const { McpServerRuntimeManager } = await import("./manager");
+    const manager = new McpServerRuntimeManager();
+
+    (manager as unknown as { k8sApi: unknown }).k8sApi = {
+      listNamespacedSecret: vi.fn().mockResolvedValue({
+        items: [
+          {
+            metadata: {
+              name: "regcred-private",
+              labels: {
+                app: "mcp-server",
+                type: "regcred",
+                "team-id": "team-a",
+              },
+            },
+            data: {
+              ".dockerconfigjson": Buffer.from("not-json").toString("base64"),
+            },
+          },
+        ],
+      }),
+    };
+
+    const result = await manager.listDockerRegistrySecrets({
+      teamIds: ["team-a"],
+    });
+
+    expect(result).toEqual([{ name: "regcred-private", registryServers: [] }]);
   });
 });
 

--- a/platform/backend/src/k8s/mcp-server-runtime/manager.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager.ts
@@ -40,6 +40,10 @@ type NetworkPolicyResolutionCache = {
   environmentsById: Map<string, EnvironmentRow>;
   organizationsById: Map<string, OrganizationRow>;
 };
+type DockerRegistrySecretSummary = {
+  name: string;
+  registryServers: string[];
+};
 
 /**
  * McpServerRuntimeManager manages MCP servers running in Kubernetes.
@@ -1165,7 +1169,7 @@ export class McpServerRuntimeManager {
   async listDockerRegistrySecrets(options?: {
     isAdmin?: boolean;
     teamIds?: string[];
-  }): Promise<Array<{ name: string }>> {
+  }): Promise<DockerRegistrySecretSummary[]> {
     if (!this.k8sApi) {
       return [];
     }
@@ -1194,7 +1198,10 @@ export class McpServerRuntimeManager {
       }
 
       return filtered
-        .map((s) => ({ name: s.metadata?.name ?? "" }))
+        .map((s) => ({
+          name: s.metadata?.name ?? "",
+          registryServers: getDockerConfigRegistryServers(s),
+        }))
         .filter((s) => s.name.length > 0);
     } catch (error) {
       logger.warn(
@@ -1389,6 +1396,34 @@ export class McpServerRuntimeManager {
 
 function uniqueStrings(values: string[]): string[] {
   return Array.from(new Set(values));
+}
+
+function getDockerConfigRegistryServers(secret: k8s.V1Secret): string[] {
+  const encodedDockerConfig = secret.data?.[".dockerconfigjson"];
+  if (!encodedDockerConfig) {
+    return [];
+  }
+
+  try {
+    const dockerConfig = JSON.parse(
+      Buffer.from(encodedDockerConfig, "base64").toString("utf8"),
+    );
+    if (
+      !dockerConfig ||
+      typeof dockerConfig !== "object" ||
+      !("auths" in dockerConfig) ||
+      !dockerConfig.auths ||
+      typeof dockerConfig.auths !== "object" ||
+      Array.isArray(dockerConfig.auths)
+    ) {
+      return [];
+    }
+
+    return Object.keys(dockerConfig.auths).sort((a, b) => a.localeCompare(b));
+  } catch (error) {
+    logger.warn({ err: error }, "Failed to parse docker-registry secret data");
+    return [];
+  }
 }
 
 export default new McpServerRuntimeManager();

--- a/platform/backend/src/routes/internal-mcp-catalog.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.ts
@@ -1427,7 +1427,12 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
           "List Kubernetes docker-registry secrets available for imagePullSecrets",
         tags: ["MCP Catalog"],
         response: constructResponseSchema(
-          z.array(z.object({ name: z.string() })),
+          z.array(
+            z.object({
+              name: z.string(),
+              registryServers: z.array(z.string()),
+            }),
+          ),
         ),
       },
     },

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.enterprise.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.enterprise.test.tsx
@@ -1,12 +1,16 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useEnterpriseFeature, useFeature } from "@/lib/config/config.query";
 import { useEnvironments } from "@/lib/environment.query";
 import { McpCatalogForm } from "./mcp-catalog-form";
 
-const { useIdentityProvidersMock } = vi.hoisted(() => ({
-  useIdentityProvidersMock: vi.fn(() => ({ data: [] })),
-}));
+const { useIdentityProvidersMock, useK8sImagePullSecretsMock } = vi.hoisted(
+  () => ({
+    useIdentityProvidersMock: vi.fn(() => ({ data: [] })),
+    useK8sImagePullSecretsMock: vi.fn(() => ({ data: [] })),
+  }),
+);
 
 vi.mock("@/lib/config/config.query", () => ({
   useFeature: vi.fn((feature: string) => {
@@ -57,7 +61,7 @@ vi.mock("@/lib/teams/team.query", () => ({
 }));
 
 vi.mock("@/lib/mcp/internal-mcp-catalog.query", () => ({
-  useK8sImagePullSecrets: vi.fn(() => ({ data: [] })),
+  useK8sImagePullSecrets: useK8sImagePullSecretsMock,
 }));
 
 vi.mock("@/lib/secrets.query", () => ({
@@ -101,6 +105,7 @@ describe("McpCatalogForm enterprise gating", () => {
       return undefined;
     });
     useIdentityProvidersMock.mockReturnValue({ data: [] });
+    useK8sImagePullSecretsMock.mockReturnValue({ data: [] });
     global.ResizeObserver = class ResizeObserver {
       observe() {}
       unobserve() {}
@@ -275,5 +280,67 @@ describe("McpCatalogForm enterprise gating", () => {
     expect(
       screen.getByRole("link", { name: "Manage environments" }),
     ).toHaveAttribute("href", "/settings/environments");
+  });
+
+  it("labels image pull secret options by registry server", async () => {
+    useK8sImagePullSecretsMock.mockReturnValue({
+      data: [
+        {
+          name: "mcp-server-123-regcred-containerregistry-example-com-user",
+          registryServers: ["containerregistry.example.com/strangepod"],
+        },
+      ] as never,
+    });
+
+    const { container } = render(
+      <McpCatalogForm
+        mode="edit"
+        onSubmit={vi.fn()}
+        initialValues={
+          {
+            id: "catalog-1",
+            name: "Local MCP",
+            description: "",
+            icon: null,
+            serverType: "local",
+            serverUrl: "",
+            oauthConfig: null,
+            userConfig: {},
+            enterpriseManagedConfig: null,
+            localConfig: {
+              command: "",
+              arguments: [],
+              environment: [],
+              envFrom: [],
+              dockerImage: "containerregistry.example.com/strangepod/server",
+              transportType: "stdio",
+              httpPort: "",
+              httpPath: "/mcp",
+              imagePullSecrets: [{ source: "existing", name: "" }],
+            },
+            deploymentSpecYaml: null,
+            scope: "personal",
+            teams: [],
+            labels: [],
+          } as never
+        }
+      />,
+    );
+
+    const imagePullSecretSelect = container.querySelector(
+      '[data-slot="popover-trigger"][role="combobox"]',
+    );
+    expect(imagePullSecretSelect).toBeInTheDocument();
+
+    await userEvent.click(imagePullSecretSelect as HTMLElement);
+
+    expect(
+      screen.getByText("containerregistry.example.com/strangepod"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "mcp-server-123-regcred-containerregistry-example-com-user",
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -687,6 +687,41 @@ export function McpCatalogForm({
 
   // Fetch available k8s docker-registry secrets for the "existing" dropdown
   const { data: k8sSecrets = [] } = useK8sImagePullSecrets();
+  const imagePullSecretItems = useMemo(
+    () =>
+      k8sSecrets.map((secret) => {
+        const registryLabel = formatRegistryServers(secret.registryServers);
+        const primaryLabel = registryLabel || secret.name;
+        const secondaryLabel = registryLabel ? secret.name : undefined;
+
+        return {
+          value: secret.name,
+          label: primaryLabel,
+          searchText: [secret.name, ...secret.registryServers].join(" "),
+          content: (
+            <span className="block min-w-0">
+              <span className="block truncate font-medium">{primaryLabel}</span>
+              {secondaryLabel ? (
+                <span className="block truncate text-xs text-muted-foreground">
+                  {secondaryLabel}
+                </span>
+              ) : null}
+            </span>
+          ),
+          selectedContent: (
+            <span className="block min-w-0">
+              <span className="block truncate">{primaryLabel}</span>
+              {secondaryLabel ? (
+                <span className="block truncate text-xs text-muted-foreground">
+                  {secondaryLabel}
+                </span>
+              ) : null}
+            </span>
+          ),
+        };
+      }),
+    [k8sSecrets],
+  );
 
   // Update form values when BYOS paths/keys change
   useEffect(() => {
@@ -1473,14 +1508,14 @@ export function McpCatalogForm({
                           <SearchableSelect
                             value={watchField("name")}
                             onValueChange={(val) => setField("name", val)}
-                            items={k8sSecrets.map((s) => ({
-                              value: s.name,
-                              label: s.name,
-                            }))}
+                            items={imagePullSecretItems}
                             placeholder="Select a secret..."
                             searchPlaceholder="Search secrets..."
                             allowCustom
+                            multiline
                             className="w-full"
+                            contentClassName="w-[min(var(--radix-popover-trigger-width),calc(100vw-2rem))]"
+                            emptyMessage="No image pull secrets found."
                           />
                         ) : (
                           <div className="grid grid-cols-2 gap-3">
@@ -2800,4 +2835,17 @@ function applyHeaderDraftToRow(
   set("description", draft.description);
   set("includeBearerPrefix", draft.includeBearerPrefix);
   set("sensitive", draft.scope === "static" ? false : draft.sensitive);
+}
+
+function formatRegistryServers(registryServers: string[]): string {
+  if (registryServers.length === 0) {
+    return "";
+  }
+
+  const [firstRegistry, ...remainingRegistries] = registryServers;
+  if (remainingRegistries.length === 0) {
+    return firstRegistry;
+  }
+
+  return `${firstRegistry} +${remainingRegistries.length} more`;
 }

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -32219,6 +32219,7 @@ export type GetK8sImagePullSecretsResponses = {
      */
     200: Array<{
         name: string;
+        registryServers: Array<string>;
     }>;
 };
 


### PR DESCRIPTION
## Summary

- Add registry host metadata to the Kubernetes image pull secrets endpoint by parsing safe keys from docker config data.
- Show registry hosts as the primary label in the MCP Registry image pull secret dropdown, with the Kubernetes secret name as secondary context.