### PR TITLE
feat(chat): render HTML files in the Files panel (sandboxed iframe)

### DIFF
--- a/platform/frontend/src/components/chat/conversation-files-panel.tsx
+++ b/platform/frontend/src/components/chat/conversation-files-panel.tsx
@@ -310,6 +310,7 @@ function FilePreview({
       {kind === "markdown" && (
         <RemoteMarkdownPreview contentUrl={file.contentUrl} onClose={onClose} />
       )}
+      {kind === "html" && <HtmlPreview contentUrl={file.contentUrl} />}
       {kind === "image" && (
         <div className="flex h-full items-center justify-center p-4">
           <img
@@ -387,6 +388,37 @@ function RemoteMarkdownPreview({
       onToggle={onClose}
       embedded
       hideHeader
+    />
+  );
+}
+
+/**
+ * Render an HTML file in a sandboxed iframe. `allow-scripts` WITHOUT
+ * `allow-same-origin` puts the document in an opaque origin (the same isolation
+ * Claude uses for artifacts): scripts run so interactive HTML works, but it
+ * cannot read the app's cookies/session/localStorage, reach the parent DOM, or
+ * call same-origin APIs as the user. Served bytes are octet-stream, so we fetch
+ * the text and inline it via `srcDoc` rather than navigating the iframe to it.
+ */
+function HtmlPreview({ contentUrl }: { contentUrl: string }) {
+  const { text, failed } = useFileText(contentUrl);
+  if (failed) {
+    return (
+      <p className="p-4 text-xs text-muted-foreground">
+        Failed to load preview.
+      </p>
+    );
+  }
+  if (text === null) {
+    return <p className="p-4 text-xs text-muted-foreground">Loading…</p>;
+  }
+  return (
+    <iframe
+      title="HTML preview"
+      srcDoc={text}
+      sandbox="allow-scripts"
+      referrerPolicy="no-referrer"
+      className="h-full w-full border-0 bg-white"
     />
   );
 }

--- a/platform/frontend/src/lib/chat/file-preview-kind.test.ts
+++ b/platform/frontend/src/lib/chat/file-preview-kind.test.ts
@@ -17,6 +17,16 @@ describe("getFilePreviewKind", () => {
     expect(getFilePreviewKind("image/svg+xml", "x.svg")).toBe("unsupported");
   });
 
+  it("detects html by mime or extension, before generic text", () => {
+    expect(getFilePreviewKind("text/html", "page")).toBe("html");
+    expect(getFilePreviewKind("application/octet-stream", "report.html")).toBe(
+      "html",
+    );
+    expect(getFilePreviewKind("application/octet-stream", "x.htm")).toBe(
+      "html",
+    );
+  });
+
   it("detects csv before generic text", () => {
     expect(getFilePreviewKind("text/csv", "data")).toBe("csv");
     expect(getFilePreviewKind("application/octet-stream", "data.csv")).toBe(

--- a/platform/frontend/src/lib/chat/file-preview-kind.ts
+++ b/platform/frontend/src/lib/chat/file-preview-kind.ts
@@ -1,5 +1,6 @@
 export type FilePreviewKind =
   | "markdown"
+  | "html"
   | "image"
   | "text"
   | "csv"
@@ -25,6 +26,14 @@ export function getFilePreviewKind(
   const lowerName = name.toLowerCase();
 
   if (mime === "text/markdown" || lowerName.endsWith(".md")) return "markdown";
+  // Checked before the generic `text/*` branch (text/html starts with text/).
+  if (
+    mime === "text/html" ||
+    lowerName.endsWith(".html") ||
+    lowerName.endsWith(".htm")
+  ) {
+    return "html";
+  }
   if (INLINE_IMAGE_MIMES.has(mime)) return "image";
   if (mime === "text/csv" || lowerName.endsWith(".csv")) return "csv";
   if (mime.startsWith("text/") || mime === "application/json") return "text";


### PR DESCRIPTION
## Summary

`download_file` outputs with `text/html` (or `.html`/`.htm`) now **render as HTML** in the chat Files panel preview, instead of being shown as raw source text.

- `getFilePreviewKind` gains an `"html"` kind, matched **before** the generic `text/*` branch.
- New `HtmlPreview` fetches the bytes and renders them in a sandboxed iframe via `srcDoc`.

**Frontend-only — no backend or schema change.** The markdown artifact is unchanged (still markdown).

## Security model (mirrors how Claude renders artifacts)

```jsx
<iframe srcDoc={html} sandbox="allow-scripts" referrerPolicy="no-referrer" … />
```

- **`allow-scripts` WITHOUT `allow-same-origin`** → the document runs in an **opaque origin**. Scripts execute (so interactive artifacts work), but it **cannot** read the app's cookies/session/localStorage, reach the parent DOM, or call same-origin APIs as the user — **no account takeover**.
- Default sandbox keeps **top-navigation, forms, popups, downloads** blocked (none granted).
- `srcDoc` (inline) — no navigable same-origin document. Bytes are fetched and inlined; the existing endpoint keeps serving `application/octet-stream` so the browser never parses them as HTML directly.
- External resources/network remain allowed (CDN React/Tailwind render), matching Claude. Accepted, bounded residual: a prompt-injected artifact could exfiltrate **its own content** — never the user's session.

## Test plan
- [x] `getFilePreviewKind` unit tests extended for `text/html` + `.html`/`.htm` → `"html"` (6 passing)
- [x] `pnpm type-check`, biome on changed files
- [ ] Manual: a `download_file` `.html` output renders in the Files preview; verify the iframe is sandboxed (no cookie/session access); confirm non-HTML text/CSV/markdown/images still render as before

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>