### PR TITLE
feat(chat): use 1h prompt-cache TTL on supported models

### DIFF
--- a/platform/backend/src/routes/chat/normalization/apply-prompt-cache.test.ts
+++ b/platform/backend/src/routes/chat/normalization/apply-prompt-cache.test.ts
@@ -194,4 +194,54 @@ describe("applyPromptCacheBreakpoints", () => {
     expect(bedrockCachePoint(result[0])).toEqual({ type: "default" });
     expect(bedrockCachePoint(result[4])).toEqual({ type: "default" });
   });
+
+  it("uses a 1h TTL for Anthropic models that support it", () => {
+    const [result] = applyPromptCacheBreakpoints({
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      messages: [userMessage("a")],
+    });
+    expect(anthropicCacheControl(result)).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
+  });
+
+  it("uses a 1h TTL for a Bedrock Sonnet 4.5+ inference profile", () => {
+    const [result] = applyPromptCacheBreakpoints({
+      provider: "bedrock",
+      model: "us.anthropic.claude-opus-4-6-v1:0",
+      messages: [userMessage("a")],
+    });
+    expect(bedrockCachePoint(result)).toEqual({ type: "default", ttl: "1h" });
+  });
+
+  it("keeps the 5m default for older models and when model is absent", () => {
+    const [sonnet4] = applyPromptCacheBreakpoints({
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      messages: [userMessage("a")],
+    });
+    expect(anthropicCacheControl(sonnet4)).toEqual({ type: "ephemeral" });
+
+    const [noModel] = applyPromptCacheBreakpoints({
+      provider: "anthropic",
+      messages: [userMessage("a")],
+    });
+    expect(anthropicCacheControl(noModel)).toEqual({ type: "ephemeral" });
+  });
+
+  it("stays 5m for a 1h-capable model when an attachment breakpoint already exists", () => {
+    // A 5m attachment marker placed before a 1h marker would violate the
+    // provider's "longer TTL must precede shorter" rule, so the request that
+    // already carries any breakpoint stays uniformly 5m.
+    const result = applyPromptCacheBreakpoints({
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      messages: [userMessage("first"), messageWithMarkedPart("withFile")],
+    });
+
+    // The unmarked first message gets a marker (last already has its own), 5m.
+    expect(anthropicCacheControl(result[0])).toEqual({ type: "ephemeral" });
+  });
 });

--- a/platform/backend/src/routes/chat/normalization/apply-prompt-cache.ts
+++ b/platform/backend/src/routes/chat/normalization/apply-prompt-cache.ts
@@ -7,16 +7,25 @@ import type { ModelMessage } from "ai";
 //   - Anthropic: `{ anthropic: { cacheControl: { type: "ephemeral" } } }`
 //   - Bedrock:   `{ bedrock:   { cachePoint:   { type: "default"   } } }`
 const CACHE_BREAKPOINTS = {
-  anthropic: {
-    key: "anthropic",
-    field: "cacheControl",
-    value: { type: "ephemeral" },
-  },
-  bedrock: { key: "bedrock", field: "cachePoint", value: { type: "default" } },
+  anthropic: { key: "anthropic", field: "cacheControl", type: "ephemeral" },
+  bedrock: { key: "bedrock", field: "cachePoint", type: "default" },
 } as const;
 
 type CacheBreakpointConfig =
   (typeof CACHE_BREAKPOINTS)[keyof typeof CACHE_BREAKPOINTS];
+
+// Claude Sonnet/Haiku/Opus 4.5 and newer support a 1-hour cache TTL; older
+// models (and other providers) only support the 5-minute default. Matches bare
+// ids ("claude-sonnet-4-5") and Bedrock inference-profile ids
+// ("us.anthropic.claude-opus-4-6-..."). Claude Sonnet/Opus 4
+// ("claude-sonnet-4-20250514") and Claude 3.x are intentionally excluded.
+// `(?!\d)` stops the minor-version digit from matching the leading digit of a
+// dated id like "claude-sonnet-4-20250514" (Sonnet 4, not 4.5).
+const ONE_HOUR_CACHE_MODEL = /claude-(?:sonnet|haiku|opus)-4-[5-9](?!\d)/;
+
+function supportsOneHourCache(model: string): boolean {
+  return ONE_HOUR_CACHE_MODEL.test(model);
+}
 
 // Anthropic and Bedrock both reject a request with more than 4 cache
 // breakpoints, and the AI SDK provider throws before the call. Breakpoints
@@ -43,15 +52,20 @@ const MAX_CACHE_BREAKPOINTS = 4;
  * budget. Messages that already carry a breakpoint for this provider are left
  * alone — their prefix is already cacheable and re-marking would waste budget.
  *
+ * On models that support it the breakpoints use a 1-hour TTL; both breakpoints
+ * share the same TTL so there is no ordering constraint between them.
+ *
  * No-op for providers other than Anthropic and Bedrock: OpenAI, Gemini,
  * DeepSeek, etc. cache prefixes automatically and reject or ignore explicit
  * markers.
  */
 export function applyPromptCacheBreakpoints(params: {
   provider: string;
+  /** Resolved model id; used to decide cache TTL. Absent → 5-minute default. */
+  model?: string;
   messages: ModelMessage[];
 }): ModelMessage[] {
-  const { provider, messages } = params;
+  const { provider, model, messages } = params;
   const config = (CACHE_BREAKPOINTS as Record<string, CacheBreakpointConfig>)[
     provider
   ];
@@ -67,6 +81,17 @@ export function applyPromptCacheBreakpoints(params: {
   if (budget <= 0) {
     return messages;
   }
+
+  // Only opt into the 1h TTL when this request has no other breakpoints. Other
+  // breakpoints (e.g. `materializeAttachments`' per-part markers) use the 5m
+  // default, and Anthropic/Bedrock reject a longer TTL placed after a shorter
+  // one — so mixing 1h here with those 5m markers can fail the request. Staying
+  // uniformly 5m when any marker pre-exists keeps ordering valid.
+  const useOneHour =
+    !!model && supportsOneHourCache(model) && existingBreakpoints === 0;
+  const markerValue = useOneHour
+    ? { type: config.type, ttl: "1h" }
+    : { type: config.type };
 
   const lastIndex = messages.length - 1;
   // Prefer the rolling (last) breakpoint, then the stable (first) one. A single
@@ -87,7 +112,9 @@ export function applyPromptCacheBreakpoints(params: {
   }
 
   return messages.map((message, index) =>
-    indicesToMark.has(index) ? withCacheBreakpoint(message, config) : message,
+    indicesToMark.has(index)
+      ? withCacheBreakpoint(message, config, markerValue)
+      : message,
   );
 }
 
@@ -128,6 +155,7 @@ function hasCacheBreakpoint(
 function withCacheBreakpoint(
   message: ModelMessage,
   config: CacheBreakpointConfig,
+  markerValue: { type: string; ttl?: string },
 ): ModelMessage {
   const providerOptions = (message.providerOptions ?? {}) as Record<
     string,
@@ -138,7 +166,7 @@ function withCacheBreakpoint(
     ...message,
     providerOptions: {
       ...providerOptions,
-      [config.key]: { ...providerEntry, [config.field]: config.value },
+      [config.key]: { ...providerEntry, [config.field]: markerValue },
     },
   } as ModelMessage;
 }

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -767,6 +767,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
 
                 const modelMessages = applyPromptCacheBreakpoints({
                   provider,
+                  model: selectedModel,
                   messages: await buildModelMessagesForProvider({
                     messages: compactionResult.messages,
                     provider,

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -599,9 +599,12 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
     expect(mockStreamText).toHaveBeenCalledTimes(1);
     // applyPromptCacheBreakpoints marks the first and last message (the stable
     // prefix + rolling tail) with Anthropic cache_control before streamText, so
-    // the compacted messages reach the model carrying that breakpoint.
+    // the compacted messages reach the model carrying that breakpoint. The
+    // default chat model is a Claude 4.5+ model, which uses the 1h cache TTL.
     const cacheBreakpoint = {
-      providerOptions: { anthropic: { cacheControl: { type: "ephemeral" } } },
+      providerOptions: {
+        anthropic: { cacheControl: { type: "ephemeral", ttl: "1h" } },
+      },
     };
     expect(mockStreamText.mock.calls[0]?.[0].messages).toEqual([
       { ...compactedMessages[0], ...cacheBreakpoint },


### PR DESCRIPTION
> Draft: the model→TTL eligibility (esp. Bedrock 4.6+) needs live confirmation that those models accept `ttl: "1h"` without erroring before this merges. Ships after the multi-turn live verification.

## Summary

Anthropic and Bedrock prompt-cache entries default to a 5-minute TTL, so a conversation left idle for more than 5 minutes between turns loses its cached prefix and re-pays the full system-prompt + tools + history on the next turn. Claude Sonnet/Haiku/Opus 4.5+ support a 1-hour cache TTL; this opts those models into it, so longer human gaps between turns still land as cache hits.

The TTL is applied to both breakpoints (Anthropic `cacheControl`, Bedrock `cachePoint`) and only when the request carries no other cache breakpoints. `materializeAttachments` writes 5-minute markers on file/document parts, and the providers reject a longer-TTL breakpoint placed after a shorter one — so a request that already carries any breakpoint stays uniformly 5-minute to keep the ordering valid. Model eligibility is matched on the resolved model id (bare ids and Bedrock inference-profile ids), excluding Sonnet/Opus 4 and Claude 3.x.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>