### PR TITLE
feat(skills): auto-enable skill tools on startup when skills flag is on

### DIFF
--- a/platform/backend/src/database/seed.ts
+++ b/platform/backend/src/database/seed.ts
@@ -787,6 +787,31 @@ async function ensureExistingUsersHavePersonalMcpGateways(): Promise<void> {
   }
 }
 
+/**
+ * When the skills feature flag is enabled, turn on the Agent Skill tools for
+ * every organization that hasn't already opted in. This makes skills a default
+ * capability: newly created agents inherit the model-facing skill tools and the
+ * slash-command toggle unlocks without an admin first clicking "enable".
+ * Pre-existing agents are not retrofitted. No-op when the flag is off.
+ */
+async function enableSkillToolsWhenFeatureEnabled(): Promise<void> {
+  if (!config.agents.skillsEnabled) return;
+  try {
+    const enabled = await OrganizationModel.enableSkillToolsForAllOrgs();
+    if (enabled > 0) {
+      logger.info(
+        { count: enabled },
+        "Enabled Agent Skill tools by default for organizations",
+      );
+    }
+  } catch (error) {
+    logger.error(
+      { err: error },
+      "Failed to enable Agent Skill tools by default",
+    );
+  }
+}
+
 export async function seedRequiredStartingData(): Promise<void> {
   ensureEncryptionKeyAvailable();
   await migrateSecretsToEncrypted();
@@ -796,6 +821,7 @@ export async function seedRequiredStartingData(): Promise<void> {
   await syncBuiltInAgents();
   await syncBuiltInSkills();
   await seedArchestraCatalogAndTools();
+  await enableSkillToolsWhenFeatureEnabled();
   await seedPlaywrightCatalog();
   await migratePlaywrightToolsToDynamicCredential();
   await seedTestMcpServer();

--- a/platform/backend/src/models/organization.test.ts
+++ b/platform/backend/src/models/organization.test.ts
@@ -681,4 +681,34 @@ describe("OrganizationModel", () => {
       expect(fetched?.defaultAgentId).toBe(agent.id);
     });
   });
+
+  describe("enableSkillToolsForAllOrgs", () => {
+    test("flips orgs that haven't opted in and leaves enabled ones untouched", async ({
+      makeOrganization,
+    }) => {
+      const offOrg = await makeOrganization();
+      const onOrg = await makeOrganization();
+      await OrganizationModel.patch(onOrg.id, { skillToolsEnabled: true });
+
+      const flipped = await OrganizationModel.enableSkillToolsForAllOrgs();
+
+      // Only the org that was off counts as flipped.
+      expect(flipped).toBe(1);
+      expect(
+        (await OrganizationModel.getById(offOrg.id))?.skillToolsEnabled,
+      ).toBe(true);
+      expect(
+        (await OrganizationModel.getById(onOrg.id))?.skillToolsEnabled,
+      ).toBe(true);
+    });
+
+    test("is idempotent — a second run flips nothing", async ({
+      makeOrganization,
+    }) => {
+      await makeOrganization();
+
+      expect(await OrganizationModel.enableSkillToolsForAllOrgs()).toBe(1);
+      expect(await OrganizationModel.enableSkillToolsForAllOrgs()).toBe(0);
+    });
+  });
 });

--- a/platform/backend/src/models/organization.ts
+++ b/platform/backend/src/models/organization.ts
@@ -158,6 +158,27 @@ class OrganizationModel {
   }
 
   /**
+   * Turn on the Agent Skill tools for every organization that hasn't already
+   * opted in. Run at startup when the skills feature flag is enabled so the
+   * model-facing skill tools are on by default — newly created agents then
+   * inherit them via `ToolModel.assignSkillToolsToAgent`, and the
+   * slash-command toggle unlocks. Pre-existing agents are not retrofitted;
+   * admins add skill tools to them via the agent tools editor if needed.
+   * Idempotent; returns the number of orgs flipped on.
+   */
+  static async enableSkillToolsForAllOrgs(): Promise<number> {
+    const rows = await db
+      .update(schema.organizationsTable)
+      .set({ skillToolsEnabled: true })
+      .where(eq(schema.organizationsTable.skillToolsEnabled, false))
+      .returning({ id: schema.organizationsTable.id });
+    for (const { id } of rows) {
+      await cacheManager.delete(getOrganizationSettingsCacheKey(id));
+    }
+    return rows.length;
+  }
+
+  /**
    * List ids of organizations that have opted into the Agent Skill tools
    * (`skillToolsEnabled`). Used to backfill newly introduced skill tools.
    */


### PR DESCRIPTION
When `ARCHESTRA_AGENTS_SKILLS_ENABLED` is set, every organization gets `skillToolsEnabled` turned on at startup (gated, idempotent — only flips orgs that haven't opted in).

This unlocks the "use skills as slash commands" toggle and makes newly created agents inherit the skill tools automatically, instead of requiring an admin to click "enable" first.

Pre-existing agents are not retrofitted — admins add skill tools to them via the agent tools editor if needed.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>