### PR TITLE
fix(migration-kit): #5357 follow-up — harden scripts, flip install ref, telemetry mapping, docs

### DIFF
--- a/docs/pages/platform-migration-kit.md
+++ b/docs/pages/platform-migration-kit.md
@@ -10,14 +10,13 @@ Check ../docs_writer_prompt.md before changing this file.
 
 # Migrate to Archestra
 
-> **Experimental.** The migration kit is new and still evolving — review its output before applying
-> it to anything you care about.
+> **Experimental.** The migration kit is new and still evolving.
 
-The migration kit turns an existing agentic PoC into an Archestra pilot. Typical sources are the
-messy setups left by tools like Claude Code, OpenClaw, or Hermes: project instruction files, MCP
+The migration kit turns an existing agentic setup into an Archestra setup. Typical sources are the
+unsorted configs left by tools like Claude Code, OpenClaw, or Hermes: project instruction files, MCP
 configs, hooks, local scripts, and whatever else accumulated during evaluation.
 
-It ships as a Claude Code skill (`migrate-to-archestra`), so the migration runs as a guided,
+It ships as a Skill (`migrate-to-archestra`) for your favorite coding agent (e.g. Claude Code), so the migration runs as a guided,
 agentic flow rather than a one-shot script. The deterministic work — discovering source artifacts,
 redacting secrets, building and validating API payloads — lives in zero-dependency Python helpers;
 the model owns the judgment calls (what maps to what, what to skip, what needs review).
@@ -45,14 +44,14 @@ locked-down or air-gapped hosts. Then open Claude Code near the source project a
 
 ## Flow
 
-1. Connect to an Archestra instance, or start a local one.
+1. Connect to an Archestra instance, or start a local one (skill can help with that too).
 2. Discover the source setup into a secret-redacted `inventory.json`.
 3. Draft a preview plan and confirm the few decisions that matter (scope, which MCP servers to
    install, which keys to migrate).
 4. Dry-run, then apply the approved plan.
 5. Get a report with migrated items, manual follow-up, and behavioral differences.
 
-## What needs review
+## Typical migration plan
 
 - **Subagents** become skills — instructions migrate, but isolation and tool allowlists are
   documented, not enforced.

--- a/docs/pages/platform-migration-kit.md
+++ b/docs/pages/platform-migration-kit.md
@@ -1,0 +1,68 @@
+---
+title: Migrate to Archestra
+category: Archestra Platform
+order: 7
+---
+
+<!--
+Check ../docs_writer_prompt.md before changing this file.
+-->
+
+# Migrate to Archestra
+
+> **Experimental.** The migration kit is new and still evolving — review its output before applying
+> it to anything you care about.
+
+The migration kit turns an existing agentic PoC into an Archestra pilot. Typical sources are the
+messy setups left by tools like Claude Code, OpenClaw, or Hermes: project instruction files, MCP
+configs, hooks, local scripts, and whatever else accumulated during evaluation.
+
+It ships as a Claude Code skill (`migrate-to-archestra`), so the migration runs as a guided,
+agentic flow rather than a one-shot script. The deterministic work — discovering source artifacts,
+redacting secrets, building and validating API payloads — lives in zero-dependency Python helpers;
+the model owns the judgment calls (what maps to what, what to skip, what needs review).
+
+The goal is not a byte-for-byte port. It is to get the pilot running in Archestra quickly, with the
+important behavior differences surfaced before anything is applied.
+
+## What it produces
+
+- A primary agent from the project's instruction file.
+- Skills from existing skills, subagents, slash commands, and local tools.
+- Private MCP catalog items, installed only on request.
+- LLM provider keys, only when you paste the replacement secret.
+- A report separating what moved, what was skipped, what failed, and what needs hands-on review.
+
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/archestra-ai/archestra/main/migration-kit/install.py | python3
+```
+
+The kit is zero-dependency (stock `python3` ≥ 3.10, standard library only), so the helpers run on
+locked-down or air-gapped hosts. Then open Claude Code near the source project and ask it to use the
+`migrate-to-archestra` skill against your Archestra instance.
+
+## Flow
+
+1. Connect to an Archestra instance, or start a local one.
+2. Discover the source setup into a secret-redacted `inventory.json`.
+3. Draft a preview plan and confirm the few decisions that matter (scope, which MCP servers to
+   install, which keys to migrate).
+4. Dry-run, then apply the approved plan.
+5. Get a report with migrated items, manual follow-up, and behavioral differences.
+
+## What needs review
+
+- **Subagents** become skills — instructions migrate, but isolation and tool allowlists are
+  documented, not enforced.
+- **MCP servers** become catalog items; installing them is opt-in because local stdio servers run
+  inside Archestra's Kubernetes-backed runtime.
+- **Guard hooks** become tool policies only when the target tool exists in Archestra.
+- **Passive hooks, openclaw config, and unknown files** are reported for manual follow-up.
+- **Telemetry/observability** is reported, not migrated: Archestra emits OpenTelemetry traces and
+  Prometheus metrics natively (see [Observability](/docs/platform-observability)), so the report
+  points you at that instead.
+
+The full source, reference docs, and contributor tooling live in the
+[`migration-kit/`](https://github.com/archestra-ai/archestra/tree/main/migration-kit) directory.

--- a/migration-kit/README.md
+++ b/migration-kit/README.md
@@ -20,10 +20,8 @@ important behavior differences surfaced before anything is applied.
 ## Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/archestra-ai/archestra/feat/migrate-to-archestra-skill/migration-kit/install.py | python3
+curl -fsSL https://raw.githubusercontent.com/archestra-ai/archestra/main/migration-kit/install.py | python3
 ```
-
-<!-- TODO: after merge, switch the URL to .../archestra/main/migration-kit/install.py -->
 
 Zero-dependency (stock `python3` ≥ 3.10, stdlib only). The installer pulls **only the files the skill
 needs** — `SKILL.md`, `scripts/`, `references/` (~90 KB) — into `~/.claude/skills/migrate-to-archestra/`.
@@ -44,7 +42,7 @@ Use the migrate-to-archestra skill to migrate /path/to/pilot into http://localho
 
 | Flag | Default | Meaning |
 | --- | --- | --- |
-| `--ref` | `feat/migrate-to-archestra-skill` | Git ref (branch, tag, or commit SHA) to install from. |
+| `--ref` | `main` | Git ref (branch, tag, or commit SHA) to install from. |
 | `--dest` | `~/.claude/skills/migrate-to-archestra` | Install directory. |
 | `--force` | off | Overwrite an existing non-empty destination. |
 

--- a/migration-kit/README.md
+++ b/migration-kit/README.md
@@ -1,16 +1,19 @@
-# migration-kit
+# Migrate to Archestra
 
 Turn an existing agentic PoC into an [Archestra](https://github.com/archestra-ai/archestra) pilot.
 
-> **Experimental.** This kit is new and still evolving — review its output before applying it to
-> anything you care about.
+> **Experimental.** The migration kit is new and still evolving.
 
-Packaged as a Claude Code **skill** (`migrate-to-archestra`) so the migration runs as a guided,
-agentic flow. Typical sources are messy agentic PoCs built with tools like Claude Code, OpenClaw,
-or Hermes — Claude Code-style files, MCP configs, local scripts, hooks, openclaw config, and
-whatever else accumulated during evaluation.
+The migration kit turns an existing agentic setup into an Archestra setup. Typical sources are the
+unsorted configs left by tools like Claude Code, OpenClaw, or Hermes: project instruction files, MCP
+configs, hooks, local scripts, and whatever else accumulated during evaluation.
 
-The goal is not a byte-for-byte port — it's to get the pilot running in Archestra quickly, with the
+It ships as a Skill (`migrate-to-archestra`) for your favorite coding agent (e.g. Claude Code), so the migration runs as a guided,
+agentic flow rather than a one-shot script. The deterministic work — discovering source artifacts,
+redacting secrets, building and validating API payloads — lives in zero-dependency Python helpers;
+the model owns the judgment calls (what maps to what, what to skip, what needs review).
+
+The goal is not a byte-for-byte port. It is to get the pilot running in Archestra quickly, with the
 important behavior differences surfaced before anything is applied.
 
 ## What you get

--- a/migration-kit/README.md
+++ b/migration-kit/README.md
@@ -2,9 +2,13 @@
 
 Turn an existing agentic PoC into an [Archestra](https://github.com/archestra-ai/archestra) pilot.
 
+> **Experimental.** This kit is new and still evolving — review its output before applying it to
+> anything you care about.
+
 Packaged as a Claude Code **skill** (`migrate-to-archestra`) so the migration runs as a guided,
-agentic flow. The source setup can be messy: Claude Code-style files, MCP configs, local scripts,
-hooks, openclaw config, and whatever else accumulated during evaluation.
+agentic flow. Typical sources are messy agentic PoCs built with tools like Claude Code, OpenClaw,
+or Hermes — Claude Code-style files, MCP configs, local scripts, hooks, openclaw config, and
+whatever else accumulated during evaluation.
 
 The goal is not a byte-for-byte port — it's to get the pilot running in Archestra quickly, with the
 important behavior differences surfaced before anything is applied.

--- a/migration-kit/SKILL.md
+++ b/migration-kit/SKILL.md
@@ -55,7 +55,9 @@ After reading the inventory, summarize it in product terms before mapping:
 - likely to migrate cleanly;
 - needs user choice or review;
 - report-only/manual follow-up;
-- secret redactions or content warnings.
+- secret redactions or content warnings;
+- telemetry/observability (OTEL env, metrics-shipping hooks/scripts) — report-only: Archestra emits
+  telemetry natively, so guide the user to leverage that rather than migrating it (`entity-mapping.md`).
 
 ## Step 3 — Map and ask
 Using `references/entity-mapping.md`, turn the inventory into `migration_plan.json`:
@@ -86,7 +88,9 @@ Use `AskUserQuestion` only for genuine ambiguities, e.g.:
 - for each `guard` hook, extract its semantics into `user_answers`
   (`tool_name`, `key`, `operator`, `value`, optional `action`/`reason`) per `entity-mapping.md`.
 
-Mark passive hooks and openclaw as `action:"manual"` with a `notes` explanation.
+Mark passive hooks and openclaw as `action:"manual"` with a `notes` explanation. Do the same for
+telemetry (OTEL env, observability hooks/scripts): map it to `manual` and, per `entity-mapping.md`,
+point the user at Archestra's native telemetry instead of migrating it.
 
 Always show the user a concise preview and get explicit approval before applying. Use this shape:
 

--- a/migration-kit/install.py
+++ b/migration-kit/install.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 """one-command installer for the migrate-to-archestra skill.
 
-    curl -fsSL https://raw.githubusercontent.com/archestra-ai/archestra/feat/migrate-to-archestra-skill/migration-kit/install.py | python3
-    # TODO: switch the URL above to .../archestra-ai/archestra/main/... once this merges to main.
+    curl -fsSL https://raw.githubusercontent.com/archestra-ai/archestra/main/migration-kit/install.py | python3
 
 it downloads only the files needed to RUN the skill (SKILL.md + scripts/ + references/) via the
 GitHub contents API -- a few hundred KB, not the whole repo -- and writes them into your Claude Code
@@ -24,8 +23,7 @@ import urllib.request
 from pathlib import Path, PurePosixPath
 
 REPO = "archestra-ai/archestra"
-# TODO: switch to "main" after this merges (the branch is deleted on merge).
-DEFAULT_REF = "feat/migrate-to-archestra-skill"
+DEFAULT_REF = "main"
 KIT_SUBDIR = "migration-kit"
 # only these are needed to RUN the skill, and they are the only paths the installer manages.
 # tests/, pyproject.toml, this installer, and the README are contributor/meta artifacts.

--- a/migration-kit/references/entity-mapping.md
+++ b/migration-kit/references/entity-mapping.md
@@ -21,6 +21,7 @@ same `name`/`name_override`: the install resolves its catalog item **by name**, 
 | `hook` (intent `passive`) | `manual` | report | logging/inject hooks have no Archestra equivalent |
 | `openclaw` | `manual` | report | runtime config; schema unverified — report, don't translate |
 | LLM key (user-provided) | `llm_key` | best-effort | user pastes the secret in `user_answers.apiKey` |
+| telemetry (OTEL env, observability hooks, metrics-shipping scripts) | `manual` | report | no target — Archestra emits telemetry natively; redirect the collector (see "Telemetry" below) |
 
 ## Scope
 Ask for ONE default migration scope up front (default `personal`); use per-decision overrides only as
@@ -49,6 +50,29 @@ are not Archestra tools, so a guard on `Bash` has no target. Therefore:
 - `apply.py` resolves `tool_name` against `GET /api/tools`. If found → creates the policy. If not found
   (the common case for built-ins) → records `manual` with the ready-to-paste policy in the report.
 - Policies only enforce when the org `globalToolPolicy` is `restrictive`. Tell the user; don't flip it silently.
+
+## Telemetry & observability → leverage Archestra's native telemetry (report-only)
+If the source ships its own telemetry, **don't migrate it** — Archestra already emits richer telemetry
+natively and automatically: an OpenTelemetry span per LLM call and per MCP tool invocation, plus
+Prometheus metrics (tokens, cost, latency, blocked-tools), with no per-agent setup. So a setup's
+telemetry instrumentation is redundant. Map it to `manual` and, in the report, point the pilot owner at
+the native capability instead.
+
+Watch for telemetry in any of: an OTEL `env` block in `settings*.json` (`CLAUDE_CODE_ENABLE_TELEMETRY`,
+`OTEL_*`), hooks that POST spans/metrics to a collector, or plain `local_tool`/hook scripts that ship
+metrics or logs. Naming won't always say so — read the body when a hook/tool looks observability-shaped.
+
+Redirect, don't translate:
+
+| Source telemetry | Use Archestra's instead |
+|---|---|
+| per-tool-call timing/usage hooks | OTEL span + Prometheus metrics per MCP tool call (automatic) |
+| LLM token/cost logging | `llm_tokens_total`, `llm_cost_total`, `llm_request_duration_seconds` |
+| custom OTLP exporter (env/hook) | native OTLP export via `ARCHESTRA_OTEL_EXPORTER_OTLP_ENDPOINT` (`/v1/traces`, `/v1/logs`) |
+| scraping a local metrics file | Prometheus `/metrics` on `ARCHESTRA_METRICS_PORT` (default `:9050`) |
+
+Telemetry is **instance-level env config** — no API, no per-agent knob. To keep an existing
+Grafana/collector, the pilot owner sets `ARCHESTRA_OTEL_EXPORTER_OTLP_ENDPOINT` on the instance.
 
 ## Behavioral differences to put in the report
 - **Subagent isolation & tool allowlists are not preserved.** Archestra skills are instructions, not

--- a/migration-kit/references/report-template.md
+++ b/migration-kit/references/report-template.md
@@ -63,6 +63,9 @@ List only the differences that apply to this migration.
 - Passive hooks such as logging, banners, or context injection have no direct Archestra equivalent.
 - Tool policies only enforce when the organization tool policy mode is restrictive.
 - Prompt-only filename or artifact conventions migrated as instructions, not hard runtime checks.
+- Telemetry: any source telemetry (OTEL env, observability hooks/scripts) is reported, not migrated —
+  Archestra emits OTEL spans + Prometheus metrics natively. To keep an existing collector/Grafana,
+  set `ARCHESTRA_OTEL_EXPORTER_OTLP_ENDPOINT` on the instance (see `entity-mapping.md`).
 
 ## Secrets and safety notes
 

--- a/migration-kit/scripts/apply.py
+++ b/migration-kit/scripts/apply.py
@@ -421,9 +421,10 @@ def _preview_detail(built: Built) -> str:
                 case "remote":
                     return f"scope={payload.scope}; remote MCP catalog item"
                 case "local":
-                    local = payload.localConfig
-                    command = _scrub_secrets(local.command) if local else "<missing command>"
-                    return f"scope={payload.scope}; local MCP catalog item; command={command}"
+                    # don't echo the launch command here -- a flag can carry a plaintext secret
+                    # that token-shape scrubbing won't catch; the verbose --dry-run shows the
+                    # full (scrubbed) payload for anyone who needs the exact command.
+                    return f"scope={payload.scope}; local MCP catalog item"
         case BuiltInstall():
             team = f"; team_id={built.team_id}" if built.team_id else ""
             return (

--- a/migration-kit/scripts/apply.py
+++ b/migration-kit/scripts/apply.py
@@ -24,8 +24,9 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Union
 
@@ -46,6 +47,7 @@ from archestra_client import (
 )
 from contracts import (
     SECRET_KEY_RE,
+    SECRET_TOKEN_RE,
     ClaudeMdItem,
     CommandItem,
     ContractError,
@@ -351,6 +353,26 @@ def _build_payload(decision: Decision, item: Item) -> tuple[str, Built]:
             )
 
 
+def _scrub_secrets(text: str) -> str:
+    """mask credential-shaped tokens embedded in a string before it is printed (e.g. an MCP
+    launch command like ``npx server --token=sk-...``). belt-and-suspenders for dry-run output."""
+    return SECRET_TOKEN_RE.sub("<redacted>", text)
+
+
+# url credentials that aren't token-shaped: basic-auth userinfo and secret-named query params.
+_URL_USERINFO_RE = re.compile(r"(//)[^/@\s]+@")
+_URL_SECRET_QUERY_RE = re.compile(
+    r"([?&][^=&\s#]*(?:key|token|secret|password|auth|credential)[^=&\s#]*=)[^&\s#]*", re.I)
+
+
+def _scrub_url(url: str) -> str:
+    """mask credentials in a remote server URL before printing it (user:pass@ and secret query
+    params, plus any token-shaped value)."""
+    url = _URL_USERINFO_RE.sub(r"\1<redacted>@", url)
+    url = _URL_SECRET_QUERY_RE.sub(r"\1<redacted>", url)
+    return _scrub_secrets(url)
+
+
 def _redacted_for_print(built: Built) -> dict[str, JsonValue]:
     """strip user-supplied secrets before printing a built op in --dry-run."""
     match built:
@@ -365,15 +387,21 @@ def _redacted_for_print(built: Built) -> dict[str, JsonValue]:
         case BuiltAgent(payload) | BuiltSkill(payload):
             return to_payload(payload)
         case BuiltCatalog(payload):
-            shown = to_payload(payload)
-            local = shown.get("localConfig")
-            if isinstance(local, dict):
-                env = local.get("environment")
-                if isinstance(env, list):
-                    for item in env:
-                        if isinstance(item, dict) and "value" in item:
-                            item["value"] = "<redacted>"
-            return shown
+            if payload.serverUrl is not None:
+                payload = replace(payload, serverUrl=_scrub_url(payload.serverUrl))
+            local = payload.localConfig
+            if local is not None:
+                # redact env values, and scrub credentials embedded in the launch command/args
+                # (e.g. --token=sk-...) -- all on the typed dataclass, before serializing.
+                payload = replace(payload, localConfig=replace(
+                    local,
+                    command=_scrub_secrets(local.command),
+                    arguments=[_scrub_secrets(a) for a in local.arguments],
+                    # keep value-less vars value-less (don't fabricate a redacted value).
+                    environment=[replace(e, value="<redacted>" if e.value is not None else None)
+                                 for e in local.environment],
+                ))
+            return to_payload(payload)
         case BuiltPolicy():
             return {"tool_name": built.tool_name,
                     "conditions": [to_jsonable(c) for c in built.conditions],
@@ -394,7 +422,7 @@ def _preview_detail(built: Built) -> str:
                     return f"scope={payload.scope}; remote MCP catalog item"
                 case "local":
                     local = payload.localConfig
-                    command = local.command if local else "<missing command>"
+                    command = _scrub_secrets(local.command) if local else "<missing command>"
                     return f"scope={payload.scope}; local MCP catalog item; command={command}"
         case BuiltInstall():
             team = f"; team_id={built.team_id}" if built.team_id else ""

--- a/migration-kit/scripts/archestra_client.py
+++ b/migration-kit/scripts/archestra_client.py
@@ -8,6 +8,10 @@ this module does request/response plumbing and typed payloads only -- no idempot
 migration logic (that lives in apply.py). every non-2xx response raises ArchestraApiError
 verbatim, and a 3xx redirect is treated as an error rather than silently followed (the base
 URL is fixed and user-supplied, so a redirect is unexpected and could change a POST's method).
+transport and decode failures (connection reset, unknown charset, non-JSON body) are also
+converted to ArchestraApiError (status 0) so a single failing call records a real `failed`
+outcome in apply.py instead of crashing the whole migration loop; an unexpected list-response
+shape raises ContractError, which apply.py handles the same way.
 
 HTTP is the standard library's urllib. a private opener owns a cookie jar so the session
 cookie set by sign_in carries to mint_api_key (httpx.Client did this implicitly).
@@ -27,6 +31,7 @@ from typing import Literal
 
 from contracts import (
     ConditionOperator,
+    ContractError,
     JsonValue,
     PolicyAction,
     Provider,
@@ -208,7 +213,9 @@ class ArchestraClient:
             headers["Authorization"] = self._auth
         data: bytes | None = None
         if json_body is not None:
-            data = json.dumps(json_body).encode("utf-8")
+            # allow_nan=False: a NaN/inf field is a programming error, not valid JSON -- fail
+            # loudly here rather than emit a body the server silently rejects.
+            data = json.dumps(json_body, allow_nan=False).encode("utf-8")
             headers["Content-Type"] = "application/json"
         req = urllib.request.Request(url, data=data, headers=headers, method=method)
         try:
@@ -216,6 +223,11 @@ class ArchestraClient:
                 return _decode_body(resp.read(), resp.headers)
         except urllib.error.HTTPError as exc:
             raise ArchestraApiError(method, url, exc.code, _decode_error(exc)) from exc
+        except (OSError, http.client.HTTPException, LookupError, json.JSONDecodeError) as exc:
+            # transport/decode failure with no HTTP status (URLError is an OSError; LookupError
+            # is an unknown charset; JSONDecodeError is a non-JSON body). status 0 keeps
+            # wait_ready polling (it is not a 4xx) and lets apply.py record a `failed` op.
+            raise ArchestraApiError(method, url, 0, f"{type(exc).__name__}: {exc}") from exc
 
     # --- connectivity & auth ---------------------------------------------------------------
 
@@ -228,11 +240,9 @@ class ArchestraClient:
                 body = self._request("GET", "ready")
             except ArchestraApiError as exc:
                 # a 4xx is a misconfiguration (wrong base URL / auth) -> fail fast, don't spin.
-                # 5xx is transient during boot -> keep polling.
+                # 5xx and transport errors (status 0) are transient during boot -> keep polling.
                 if 400 <= exc.status < 500:
                     raise
-                last = str(exc)
-            except (urllib.error.URLError, json.JSONDecodeError) as exc:
                 last = str(exc)
             else:
                 if isinstance(body, dict) and body.get("database") == "connected":
@@ -243,6 +253,7 @@ class ArchestraClient:
 
     def sign_in(self, email: str, password: str) -> None:
         """better-auth email sign-in; the session cookie persists on this client's jar."""
+        _require_secure_transport(self.base_url)
         self._request("POST", "/api/auth/sign-in/email", json_body={"email": email, "password": password})
 
     def mint_api_key(self, name: str) -> str:
@@ -364,10 +375,24 @@ def _items(body: JsonValue) -> list[dict[str, JsonValue]]:
         case {"data": list() as items}:
             rows = items
         case _:
-            raise ValueError(f"unexpected list-response shape: {type(body).__name__}: {str(body)[:200]}")
+            raise ContractError(f"unexpected list-response shape: {type(body).__name__}: {str(body)[:200]}")
     out: list[dict[str, JsonValue]] = []
     for row in rows:
         if not isinstance(row, dict):
-            raise ValueError(f"unexpected list item (not an object): {type(row).__name__}")
+            raise ContractError(f"unexpected list item (not an object): {type(row).__name__}")
         out.append(row)
     return out
+
+
+def _require_secure_transport(base_url: str) -> None:
+    """refuse to send sign-in credentials over a cleartext channel. https is always allowed;
+    plain http is allowed only for loopback (local docker), where there is no network exposure."""
+    parsed = urllib.parse.urlparse(base_url)
+    if parsed.scheme == "https":
+        return
+    if (parsed.hostname or "").lower() in {"localhost", "127.0.0.1", "::1"}:
+        return
+    raise ValueError(
+        f"refusing to send sign-in credentials over insecure transport: {base_url!r} "
+        "(use https, or localhost/127.0.0.1 for local docker)"
+    )

--- a/migration-kit/scripts/contracts.py
+++ b/migration-kit/scripts/contracts.py
@@ -24,8 +24,16 @@ from typing import Literal, Mapping, Union, cast
 SCHEMA_VERSION = 1
 
 # --- secret detection (single source, shared by discover redaction + apply env handling) --
-# key names whose values must be treated as secrets.
-SECRET_KEY_RE = re.compile(r"(key|token|secret|password|passwd|api[_-]?key|authorization|credential)", re.I)
+# key names whose values must be treated as secrets. a credential word only counts as a
+# delimited *component* of the key -- the boundary is a string end, a non-alphanumeric
+# (``_``/``-``/``.``), or a camelCase hump -- so ``API_KEY``/``apiKey``/``access-token`` match
+# but ``monkey``/``tokenize``/``secretary`` do not. the alternation is case-insensitive; the
+# surrounding boundary classes are deliberately case-sensitive (camelCase detection).
+SECRET_KEY_RE = re.compile(
+    r"(?:^|[^A-Za-z0-9]|(?<=[a-z0-9])(?=[A-Z]))"
+    r"(?i:(?:api[_-]?key|key|token|secret|passwd|password|authorization|credential)s?)"
+    r"(?![a-z])"
+)
 # value shapes that look like credentials even under an innocuous key (anchored prefix).
 SECRET_VALUE_RE = re.compile(r"^(sk-|gh[psoru]_|xox[baprs]-|AIza|ya29\.|eyJ[A-Za-z0-9_-]{10,})")
 # credential-shaped tokens embedded anywhere inside a string (commands, prose, config values).

--- a/migration-kit/scripts/discover.py
+++ b/migration-kit/scripts/discover.py
@@ -129,6 +129,12 @@ def _as_str_list(value: JsonValue) -> list[str]:
     return [v for v in arr if isinstance(v, str)] if arr is not None else []
 
 
+def _is_contained_file(path: Path, root: Path) -> bool:
+    """a real file that resolves inside root. excludes symlinks escaping the source tree --
+    following one would embed an arbitrary external file (e.g. /etc/shadow) into the inventory."""
+    return path.is_file() and path.resolve().is_relative_to(root.resolve())
+
+
 def _read_bundled(path: Path, rel_to: Path) -> BundledFile:
     rel = path.relative_to(rel_to).as_posix()
     raw = path.read_bytes()
@@ -177,7 +183,7 @@ def discover(root: Path) -> Inventory:
 
     # 1. root CLAUDE.md -> primary agent
     for cm in (root / "CLAUDE.md", root / ".claude" / "CLAUDE.md"):
-        if cm.is_file():
+        if _is_contained_file(cm, root):
             doc = parse_frontmatter(read(cm))
             rel = cm.relative_to(root).as_posix()
             note_unparsed(doc.unparsed_lines, rel)
@@ -192,6 +198,8 @@ def discover(root: Path) -> Inventory:
 
     # 2. subagents -> skills (preferred)
     for f in sorted((root / ".claude" / "agents").glob("*.md")):
+        if not _is_contained_file(f, root):
+            continue
         doc = parse_frontmatter(read(f))
         name = _meta_str(doc.frontmatter, "name") or f.stem
         rel = f.relative_to(root).as_posix()
@@ -207,6 +215,9 @@ def discover(root: Path) -> Inventory:
 
     # 3. skills -> skills (clean)
     for skill_md in sorted((root / ".claude" / "skills").glob("*/SKILL.md")):
+        # reject a skill reached through a symlinked dir that escapes the source tree.
+        if not _is_contained_file(skill_md, root):
+            continue
         skill_dir = skill_md.parent
         content = read(skill_md)
         doc = parse_frontmatter(content)
@@ -216,7 +227,7 @@ def discover(root: Path) -> Inventory:
         files = [
             _read_bundled(p, skill_dir)
             for p in sorted(skill_dir.rglob("*"))
-            if p.is_file() and p != skill_md
+            if p != skill_md and _is_contained_file(p, skill_dir)
         ]
         _warn_if_secret(content, rel, inv.warnings)
         for bf in files:
@@ -232,6 +243,8 @@ def discover(root: Path) -> Inventory:
 
     # 4. slash commands -> skills (best-effort)
     for f in sorted((root / ".claude" / "commands").glob("*.md")):
+        if not _is_contained_file(f, root):
+            continue
         doc = parse_frontmatter(read(f))
         name = _meta_str(doc.frontmatter, "name") or f.stem
         rel = f.relative_to(root).as_posix()
@@ -246,6 +259,8 @@ def discover(root: Path) -> Inventory:
 
     # 5. local python tools -> skills (best-effort). heuristic: *.py under a tools/ dir.
     for f in sorted((root / "tools").glob("*.py")):
+        if not _is_contained_file(f, root):
+            continue
         bundled = _read_bundled(f, root)
         if bundled.encoding == "utf8":
             _warn_if_secret(bundled.content, bundled.path, inv.warnings)

--- a/migration-kit/scripts/frontmatter.py
+++ b/migration-kit/scripts/frontmatter.py
@@ -44,12 +44,15 @@ class ParsedDoc:
 
 def parse_frontmatter(text: str) -> ParsedDoc:
     """split a markdown doc into frontmatter + body, surfacing unparsable frontmatter lines."""
+    # normalize CRLF (the editors that touch these files) so '\r' neither breaks exact fence
+    # matching nor lingers in the body. bare-CR line endings are not handled (not seen in practice).
+    text = text.replace("\r\n", "\n")
     lines = text.split("\n")
-    # the opening fence must be a line that is exactly '---' (not '--- text' or '----').
-    if not lines or lines[0].strip() != _FENCE:
+    # the opening fence must be a line that is exactly '---' (not '--- text', '----', or '  ---').
+    if not lines or lines[0] != _FENCE:
         return ParsedDoc(body=text)
     # find the closing fence (first line that is exactly '---' after the opening one).
-    close = next((i for i in range(1, len(lines)) if lines[i].strip() == _FENCE), None)
+    close = next((i for i in range(1, len(lines)) if lines[i] == _FENCE), None)
     if close is None:
         return ParsedDoc(body=text)
 

--- a/migration-kit/tests/test_apply_build.py
+++ b/migration-kit/tests/test_apply_build.py
@@ -198,9 +198,11 @@ def test_dry_run_redaction_hides_user_secrets() -> None:
         name="github",
         serverType="local",
         scope="personal",
-        localConfig=LocalConfig(command="npx", environment=[
-            McpEnvVar(key="GITHUB_TOKEN", type="secret", value="ghp_real"),
-        ]),
+        localConfig=LocalConfig(
+            command="run --token=ghp_commandsecret00000",
+            arguments=["--key", "sk-argsecret00000000"],
+            environment=[McpEnvVar(key="GITHUB_TOKEN", type="secret", value="ghp_real")],
+        ),
     )))
     local = catalog["localConfig"]
     assert isinstance(local, dict)
@@ -208,6 +210,17 @@ def test_dry_run_redaction_hides_user_secrets() -> None:
     assert isinstance(catalog_env, list)
     assert isinstance(catalog_env[0], dict)
     assert catalog_env[0]["value"] == "<redacted>"
+    # a credential embedded in the launch command/args is scrubbed (CodeQL clear-text logging).
+    assert "ghp_commandsecret00000" not in json.dumps(catalog)
+    assert "sk-argsecret00000000" not in json.dumps(catalog)
+    # a remote server URL with basic-auth + a secret query param is scrubbed too.
+    remote = _redacted_for_print(BuiltCatalog(CatalogCreate(
+        name="weather", serverType="remote", scope="personal",
+        serverUrl="https://user:hunter2@mcp.example.com/w?api_key=plaintextsecret&region=us")))
+    shown_url = json.dumps(remote)
+    assert "hunter2" not in shown_url
+    assert "plaintextsecret" not in shown_url
+    assert "region=us" in shown_url  # non-secret query param preserved
 
 def test_tool_policy_requires_extracted_semantics(index: dict[str, Item]) -> None:
     with pytest.raises(ContractError, match="user_answers"):

--- a/migration-kit/tests/test_client_http.py
+++ b/migration-kit/tests/test_client_http.py
@@ -4,6 +4,7 @@ these exercise the stdlib pieces that replaced httpx: cookie-jar persistence acr
 error-body preservation, the no-silent-redirect policy, and content-type decoding.
 """
 import json
+import socket
 import threading
 from collections.abc import Iterator
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -11,6 +12,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 import pytest
 
 from archestra_client import ArchestraApiError, ArchestraClient, _items
+from contracts import ContractError
 
 
 class _Handler(BaseHTTPRequestHandler):
@@ -50,6 +52,8 @@ class _Handler(BaseHTTPRequestHandler):
                 self._send(200, json.dumps({"status": "ok", "database": "connected"}))
             case "/text":
                 self._send(200, "plain words", ctype="text/plain")
+            case "/api/badjson":
+                self._send(200, "{not valid json", ctype="application/json")
             case _:
                 self._send(404, json.dumps({"error": "not found"}))
 
@@ -101,10 +105,43 @@ def test_text_and_json_decoding(base_url: str) -> None:
 
 def test_items_raises_on_unexpected_shape() -> None:
     # a silent [] would make idempotency checks miss existing entities -> duplicate creates.
-    with pytest.raises(ValueError, match="unexpected list-response"):
+    # ContractError (a ValueError) is what apply.py's except clause handles -> recorded as failed.
+    with pytest.raises(ContractError, match="unexpected list-response"):
         _items({"unexpected": "envelope"})
-    with pytest.raises(ValueError, match="not an object"):
+    with pytest.raises(ContractError, match="not an object"):
         _items([{"ok": 1}, "not-an-object"])
+
+
+def test_malformed_json_body_becomes_api_error(base_url: str) -> None:
+    # a non-JSON body under an application/json content-type must not crash the migration loop.
+    with ArchestraClient(base_url) as client:
+        with pytest.raises(ArchestraApiError) as excinfo:
+            client._request("GET", "/api/badjson")
+        assert excinfo.value.status == 0  # no HTTP status -> apply.py records a failed op
+
+
+def test_transport_error_becomes_api_error() -> None:
+    # a closed port -> URLError (an OSError) -> ArchestraApiError(status 0), not an uncaught crash.
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    with ArchestraClient(f"http://127.0.0.1:{port}", timeout=2.0) as client:
+        with pytest.raises(ArchestraApiError) as excinfo:
+            client._request("GET", "/ready")
+        assert excinfo.value.status == 0
+
+
+def test_sign_in_refuses_insecure_transport() -> None:
+    with ArchestraClient("http://api.example.com") as client:
+        with pytest.raises(ValueError, match="insecure transport"):
+            client.sign_in("a@b.c", "pw")
+
+
+def test_sign_in_allows_localhost_http(base_url: str) -> None:
+    # local docker over loopback http is fine -- no network exposure of the credentials.
+    with ArchestraClient(base_url) as client:
+        client.sign_in("a@b.c", "pw")
 
 
 class _NotReadyHandler(BaseHTTPRequestHandler):

--- a/migration-kit/tests/test_contracts.py
+++ b/migration-kit/tests/test_contracts.py
@@ -90,3 +90,13 @@ def test_require_dict_and_list_raise_on_wrong_shape() -> None:
         c.require_dict([1, 2], ctx="x")
     with pytest.raises(c.ContractError, match="array"):
         c.require_list({"a": 1}, ctx="x")
+
+
+def test_secret_key_regex_matches_real_keys_not_innocent_words() -> None:
+    # delimited credential components match (component boundary = end / non-alnum / camelCase hump).
+    for key in ("API_KEY", "apiKey", "access_token", "ANTHROPIC_API_KEY", "client-secret",
+                "DB_PASSWORD", "authorization", "credentials", "X-Api-Key"):
+        assert c.SECRET_KEY_RE.search(key), f"{key} should be detected as secret-named"
+    # words that merely contain a credential substring must NOT match.
+    for key in ("monkey", "tokenize", "secretary", "keynote", "keyboard", "donkey"):
+        assert not c.SECRET_KEY_RE.search(key), f"{key} should not be a false positive"

--- a/migration-kit/tests/test_discover.py
+++ b/migration-kit/tests/test_discover.py
@@ -136,3 +136,38 @@ def test_no_structured_secret_leaks_in_serialized_inventory(inv: Inventory) -> N
     assert "ghp_examplesecret" not in blob  # mcp env (structured)
     assert "sk-ant-examplesecret" not in blob  # openclaw (structured)
     assert "ghp_hooksecret" not in blob  # hook command (inline-redacted)
+
+
+def test_symlink_escaping_source_is_not_bundled(tmp_path: Path) -> None:
+    # a symlink under a skill dir pointing outside the source tree must not embed its target.
+    secret = tmp_path / "outside" / "secret.txt"
+    secret.parent.mkdir(parents=True)
+    secret.write_text("TOP_SECRET_EXTERNAL_FILE")
+    skill_dir = tmp_path / "src" / ".claude" / "skills" / "evil"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: evil\n---\nbody")
+    (skill_dir / "leak.txt").symlink_to(secret)
+
+    inv = discover(tmp_path / "src")
+    item = _by_id(inv, "skill:evil")
+    assert isinstance(item, SkillItem)
+    assert all(f.path != "leak.txt" for f in item.files)
+    assert "TOP_SECRET_EXTERNAL_FILE" not in json.dumps(to_jsonable(inv))
+
+
+def test_symlinked_skill_dir_is_skipped(tmp_path: Path) -> None:
+    # the skill DIRECTORY itself is a symlink escaping the source tree -> skip it entirely,
+    # else its SKILL.md + all its files would be read in from outside.
+    external = tmp_path / "external_skill"
+    external.mkdir()
+    (external / "SKILL.md").write_text("---\nname: ext\n---\nEXTERNAL_SKILL_BODY")
+    (external / "data.txt").write_text("EXTERNAL_BUNDLED_FILE")
+    skills = tmp_path / "src" / ".claude" / "skills"
+    skills.mkdir(parents=True)
+    (skills / "ext").symlink_to(external, target_is_directory=True)
+
+    inv = discover(tmp_path / "src")
+    assert all(not it.id.startswith("skill:") for it in inv.items)
+    blob = json.dumps(to_jsonable(inv))
+    assert "EXTERNAL_SKILL_BODY" not in blob
+    assert "EXTERNAL_BUNDLED_FILE" not in blob

--- a/migration-kit/tests/test_frontmatter.py
+++ b/migration-kit/tests/test_frontmatter.py
@@ -89,3 +89,19 @@ def test_emit_roundtrips_through_parser_and_pyyaml() -> None:
     assert doc.frontmatter["name"] == hostile
     # ...and it is genuinely valid YAML (independent oracle).
     assert yaml.safe_load(emitted.split("---", 2)[1])["name"] == hostile
+
+
+def test_crlf_is_normalized_in_body() -> None:
+    doc = parse_frontmatter("---\r\nname: x\r\n---\r\nline1\r\nline2\r\n")
+    assert doc.frontmatter == {"name": "x"}
+    assert "\r" not in doc.body
+    assert doc.body == "line1\nline2\n"
+
+
+def test_indented_fence_does_not_close_frontmatter() -> None:
+    # an indented '  ---' is not a closing fence; the real '---' below it closes the block.
+    doc = parse_frontmatter("---\nname: x\n  ---\ndescription: y\n---\nbody")
+    assert doc.frontmatter.get("name") == "x"
+    assert doc.frontmatter.get("description") == "y"
+    assert doc.body == "body"
+    assert any("---" in line for line in doc.unparsed_lines)  # the indented line is surfaced

--- a/platform/shared/docs.ts
+++ b/platform/shared/docs.ts
@@ -37,6 +37,7 @@ export const DocsPage = {
   PlatformLlmProxy: "platform-llm-proxy",
   PlatformMastraExample: "platform-mastra-example",
   PlatformMcpGateway: "platform-mcp-gateway",
+  PlatformMigrationKit: "platform-migration-kit",
   PlatformMsTeams: "platform-ms-teams",
   PlatformN8nExample: "platform-n8n-example",
   PlatformObservability: "platform-observability",


### PR DESCRIPTION
## What

Follow-up to the merged migration-kit (#5357). Five streams:

### 1. Flip install ref to `main`
`install.py` `DEFAULT_REF` and the README/docstring curl URL now point at `main` (the PR branch is gone post-merge).

### 2. Review-finding fixes (correctness + security)
Triaged the nitpicker + CodeQL comments on #5357 against current code. Two were **already stale** (BuiltCatalog env redaction and catalog name+scope lookup were fixed before merge) — left untouched. The live ones:

- **`archestra_client.py`** — transport/decode failures (`OSError`, `http.client.HTTPException`, `LookupError`, `JSONDecodeError`) now convert to `ArchestraApiError(status 0)`, and an unexpected list-response shape raises `ContractError`, so one bad call records a `failed` op instead of crashing the whole migration loop. `allow_nan=False` on request bodies. `sign_in` refuses non-https (except loopback for local docker).
- **`discover.py`** — reject symlinks that escape the source tree on **every** content-reading path (CLAUDE.md, agents, skills + bundled files, commands, tools). Previously a symlink (file *or* skill directory) could embed an arbitrary external file (e.g. `/etc/shadow`) into `inventory.json`.
- **`frontmatter.py`** — normalize CRLF and require an exact `---` fence: an indented `---` no longer closes the block early, and no stray `\r` lingers in the migrated body.
- **`contracts.py`** — `SECRET_KEY_RE` matches credential words only as delimited components (`API_KEY`/`apiKey`/`access-token`), not substrings (`monkey`/`tokenize`/`secretary`).
- **`apply.py`** — scrub credentials from the MCP launch command/args **and** remote `serverUrl` (basic-auth + secret query params) in dry-run output (CodeQL clear-text logging). Uses typed `dataclasses.replace` instead of walking the serialized dict.

**Deliberately skipped:** `SECRET_KEY_RE` still matches `MAX_TOKENS`/`tokenCount`. That is *over*-redaction (safe direction); a precise lexical fix can't separate `tokenCount` (not secret) from `tokenValue` (secret) without risking *under*-redaction — the dangerous direction for a security tool.

### 3. Telemetry mapping (docs/prompts only)
`entity-mapping.md`, `report-template.md`, and `SKILL.md` guide the model to recognize source telemetry (OTEL env, observability hooks/scripts) and map it to `manual` — Archestra emits richer telemetry natively (OTEL spans per LLM/MCP call + Prometheus metrics). The report redirects the pilot owner to point their existing collector at `ARCHESTRA_OTEL_EXPORTER_OTLP_ENDPOINT` rather than migrating instrumentation. Intentionally **shallow** — no detection code.

### 4. CI
Added the always-on `Migration Kit Checks` job to the `main` ruleset's required status checks (repo settings — not in this diff). Kept the job unfiltered (no `paths:`) so it reports on the merge queue.

### 5. Docs & packaging
- New main-docs page `docs/pages/platform-migration-kit.md` (`category: Archestra Platform`), registered as `PlatformMigrationKit` in `shared/docs.ts`, so the kit is published on the docs site.
- An **Experimental** label on the README and the new page.
- The README and docs page name example source tools (Claude Code, OpenClaw, Hermes) for discoverability — as examples only, with no per-tool compatibility claims. The skill's own `description`/instructions stay brand-free (the README is not shipped into the installed skill).

## Testing
`cd migration-kit && uv run --python 3.10 --frozen --group dev pytest -q` → **83 passed** (ty + ruff + zero-dependency gates included). New tests cover: client transport/decode + sign_in TLS, symlink traversal (file and symlinked skill-dir), frontmatter CRLF/indented-fence, secret-key boundaries, and command/args/url dry-run scrubbing. (Stream 5 is docs/prose only — no tests.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
