### PR TITLE
feat(chat): show prompt-cache hit rate in the Context Usage tooltip

### DIFF
--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -790,6 +790,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                         inputTokens: usage.inputTokens,
                         outputTokens: usage.outputTokens,
                         totalTokens: usage.totalTokens,
+                        cacheReadTokens: usage.cachedInputTokens,
                       } satisfies TokenUsage,
                     });
                   },
@@ -1147,6 +1148,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                       inputTokens: usage.inputTokens,
                       outputTokens: usage.outputTokens,
                       totalTokens: usage.totalTokens,
+                      cacheReadTokens: usage.cachedInputTokens,
                     } satisfies TokenUsage,
                   });
                 }

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -2293,6 +2293,7 @@ export function ChatPageContent({
                           }
                           isModelsLoading={isModelsLoading}
                           tokensUsed={tokensUsed}
+                          cachedTokens={tokenUsage?.cacheReadTokens}
                           maxContextLength={selectedModelContextLength}
                           inputModalities={selectedModelInputModalities}
                           agentLlmApiKeyId={

--- a/platform/frontend/src/app/chat/prompt-input-tools.tsx
+++ b/platform/frontend/src/app/chat/prompt-input-tools.tsx
@@ -58,6 +58,8 @@ export interface ChatPromptInputToolsProps {
   isModelsLoading?: boolean;
   /** Estimated tokens used in the conversation (for context indicator) */
   tokensUsed?: number;
+  /** Input tokens served from the prompt cache on the latest response (for context indicator) */
+  cachedTokens?: number;
   /** Maximum context length of the selected model (for context indicator) */
   maxContextLength?: number | null;
   /** Input modalities supported by the selected model (for file type filtering) */
@@ -89,6 +91,7 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
   allowFileUploads = false,
   isModelsLoading = false,
   tokensUsed = 0,
+  cachedTokens,
   maxContextLength,
   inputModalities,
   agentLlmApiKeyId,
@@ -263,6 +266,7 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
                     </p>
                     <ContextIndicator
                       tokensUsed={tokensUsed}
+                      cachedTokens={cachedTokens}
                       maxTokens={maxContextLength}
                       size="sm"
                     />
@@ -411,6 +415,7 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
           {tokensUsed > 0 && maxContextLength && (
             <ContextIndicator
               tokensUsed={tokensUsed}
+              cachedTokens={cachedTokens}
               maxTokens={maxContextLength}
               size="sm"
             />

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -103,6 +103,7 @@ const PromptInputContent = ({
   allowFileUploads = false,
   isModelsLoading = false,
   tokensUsed = 0,
+  cachedTokens,
   maxContextLength,
   inputModalities,
   agentLlmApiKeyId,
@@ -539,6 +540,7 @@ const PromptInputContent = ({
             allowFileUploads={allowFileUploads}
             isModelsLoading={isModelsLoading}
             tokensUsed={tokensUsed}
+            cachedTokens={cachedTokens}
             maxContextLength={maxContextLength}
             inputModalities={inputModalities}
             agentLlmApiKeyId={agentLlmApiKeyId}
@@ -587,6 +589,7 @@ const ArchestraPromptInput = ({
   allowFileUploads = false,
   isModelsLoading = false,
   tokensUsed = 0,
+  cachedTokens,
   maxContextLength,
   inputModalities,
   agentLlmApiKeyId,
@@ -638,6 +641,7 @@ const ArchestraPromptInput = ({
           allowFileUploads={allowFileUploads}
           isModelsLoading={isModelsLoading}
           tokensUsed={tokensUsed}
+          cachedTokens={cachedTokens}
           maxContextLength={maxContextLength}
           inputModalities={inputModalities}
           agentLlmApiKeyId={agentLlmApiKeyId}

--- a/platform/frontend/src/components/chat/context-indicator.tsx
+++ b/platform/frontend/src/components/chat/context-indicator.tsx
@@ -14,6 +14,8 @@ interface ContextIndicatorProps {
   tokensUsed: number;
   /** Maximum context window size for the model */
   maxTokens: number | null;
+  /** Input tokens served from the prompt cache on the latest response, a subset of tokensUsed. */
+  cachedTokens?: number;
   /** Optional className for the container */
   className?: string;
   /** Size of the indicator */
@@ -61,9 +63,14 @@ function getStrokeColor(percentage: number): string {
 export function ContextIndicator({
   tokensUsed,
   maxTokens,
+  cachedTokens,
   className,
   size = "sm",
 }: ContextIndicatorProps) {
+  const cacheHitPercent =
+    cachedTokens && cachedTokens > 0 && tokensUsed > 0
+      ? Math.round((Math.min(cachedTokens, tokensUsed) / tokensUsed) * 100)
+      : null;
   const { percentage, circumference, strokeDashoffset } = useMemo(() => {
     if (!maxTokens || maxTokens === 0) {
       return { percentage: 0, circumference: 0, strokeDashoffset: 0 };
@@ -157,6 +164,11 @@ export function ContextIndicator({
               {formatTokenCount(tokensUsed)} / {formatTokenCount(maxTokens)}{" "}
               tokens ({Math.round(percentage)}%)
             </span>
+            {cacheHitPercent !== null && cacheHitPercent > 0 && (
+              <span className="text-muted-foreground">
+                {cacheHitPercent}% served from cache
+              </span>
+            )}
           </div>
         </TooltipContent>
       </Tooltip>

--- a/platform/shared/chat.ts
+++ b/platform/shared/chat.ts
@@ -12,6 +12,8 @@ export interface TokenUsage {
   inputTokens: number | undefined;
   outputTokens: number | undefined;
   totalTokens: number | undefined;
+  /** Input tokens served from the provider's prompt cache, a subset of inputTokens. */
+  cacheReadTokens?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

A long-running chat accumulates a large context (system prompt, tools, history), and the Context Usage indicator shows it climbing toward the window limit, which reads as expensive. With prompt caching, most of that prefix is reused at a fraction of the price, but the UI gave no sign of it. This adds a "<N>% served from cache" line to the indicator's hover tooltip so a large context reads as cheap reuse rather than runaway spend. The line is hidden when the latest response read nothing from cache.

The chat path's AI SDK usage already exposes the cache read (`cachedInputTokens`); this forwards it through the existing `data-token-usage` stream event and the `TokenUsage` type into the indicator. Independent of the cache cost-accuracy work in #5431 (which instruments the proxy adapters and persistence) — this only reads the live per-turn stream usage.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>