### PR TITLE
feat(search-tools): compact per-tool params into a one-line signature

### DIFF
--- a/docs/pages/platform-archestra-mcp-server.md
+++ b/docs/pages/platform-archestra-mcp-server.md
@@ -1547,18 +1547,10 @@ Required RBAC permission: None (no additional RBAC permission required)
 | `hint` | `string \| null` | Yes | Actionable guidance when results were truncated or empty. |
 | `tools` | `object[]` | Yes |  |
 | `tools[].toolName` | `string` | Yes | Exact tool name to pass to run_tool. |
-| `tools[].title` | `string \| null` | Yes | Human-friendly title when available. |
 | `tools[].description` | `string \| null` | Yes | Short tool description, if available. |
 | `tools[].source` | `"archestra" \| "mcp" \| "agent_delegation"` | Yes | Where the tool comes from. |
 | `tools[].server` | `string \| null` | Yes | MCP server prefix for third-party MCP tools when available. |
-| `tools[].catalogName` | `string \| null` | Yes | Catalog name for installed MCP tools when available. |
-| `tools[].inputParameters` | `object[]` | Yes |  |
-| `tools[].inputParameters[].name` | `string` | Yes | Top-level input parameter name. |
-| `tools[].inputParameters[].required` | `boolean` | Yes | Whether the parameter is required. |
-| `tools[].inputParameters[].type` | `string \| null` | Yes | JSON Schema type (e.g. 'string', 'number', 'object'). |
-| `tools[].inputParameters[].enum` | `any[] \| null` | Yes | Allowed values when the parameter is constrained by an enum. |
-| `tools[].inputParameters[].description` | `string \| null` | Yes | Parameter description, if available. |
-| `tools[].inputParameters[].properties` | `object[] \| null` | Yes | One-level summary of nested properties for object (or array-of-object) parameters. |
+| `tools[].params` | `string` | Yes | Compact one-line input signature. Parameters are joined by '; ', each rendered as `name<!\|?>:<type>` where `!` marks required and `?` optional. Object parameters are expanded one level as `{child<!\|?>:type, …}`, enums as `enum(<json-values>)`, and a trailing ` — description` is added when available. Empty string when the tool takes no input. Pass matching values inside tool_args when calling run_tool. |
 
 #### run_tool
 

--- a/platform/backend/src/archestra-mcp-server/search-tools.test.ts
+++ b/platform/backend/src/archestra-mcp-server/search-tools.test.ts
@@ -540,14 +540,70 @@ describe("search_tools", () => {
       ).toBe("payload?:object{id!:number, note?:string}");
     });
 
-    test("caps long enums and reports the overflow", () => {
-      const values = Array.from({ length: 25 }, (_, index) => `v${index}`);
-      const signature = signatureFor({
+    test("expands array-of-object items", () => {
+      expect(
+        signatureFor({
+          type: "object",
+          properties: {
+            todos: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: { content: { type: "string" } },
+                required: ["content"],
+              },
+            },
+          },
+        }),
+      ).toBe("todos?:array{content!:string}");
+    });
+
+    test("renders type, object shape, and enum together", () => {
+      expect(
+        signatureFor({
+          type: "object",
+          properties: {
+            target: {
+              type: "object",
+              properties: { id: { type: "string" } },
+              enum: [{ id: "a" }],
+            },
+          },
+        }),
+      ).toBe('target?:object{id?:string} enum({"id":"a"})');
+    });
+
+    test("collapses whitespace in descriptions to keep the signature single-line", () => {
+      expect(
+        signatureFor({
+          type: "object",
+          properties: {
+            body: { type: "string", description: "Line one.\n  Line two." },
+          },
+        }),
+      ).toBe("body?:string — Line one. Line two.");
+    });
+
+    const enumSignatureFor = (count: number) =>
+      signatureFor({
         type: "object",
-        properties: { kind: { type: "string", enum: values } },
+        properties: {
+          kind: {
+            type: "string",
+            enum: Array.from({ length: count }, (_, index) => `v${index}`),
+          },
+        },
       });
-      expect(signature.startsWith('kind?:string enum("v0"|')).toBe(true);
-      expect(signature.endsWith('"v19"|…(+5 more))')).toBe(true);
+
+    test("renders every enum value at exactly the cap with no overflow marker", () => {
+      const signature = enumSignatureFor(20);
+      expect(signature.endsWith('"v19")')).toBe(true);
+      expect(signature).not.toContain("more");
+    });
+
+    test("caps long enums and reports the overflow count", () => {
+      expect(enumSignatureFor(21).endsWith('"v19"|…(+1 more))')).toBe(true);
+      expect(enumSignatureFor(25).endsWith('"v19"|…(+5 more))')).toBe(true);
     });
 
     test("returns an empty string when there are no parameters", () => {

--- a/platform/backend/src/archestra-mcp-server/search-tools.test.ts
+++ b/platform/backend/src/archestra-mcp-server/search-tools.test.ts
@@ -39,7 +39,10 @@ type SearchToolsStructuredContent = {
   hint: string | null;
   tools: Array<{
     toolName: string;
-    catalogName: string | null;
+    description: string | null;
+    source: "archestra" | "mcp" | "agent_delegation";
+    server: string | null;
+    params: string;
   }>;
 };
 
@@ -108,29 +111,11 @@ describe("search_tools", () => {
     expect(structuredContent.total).toBeGreaterThan(0);
     expect(firstResult).toEqual({
       toolName: "github__search_repositories",
-      title: null,
       description: "Search repositories by topic, language, or owner.",
       source: "mcp",
       server: "github",
-      catalogName: "GitHub MCP",
-      inputParameters: [
-        {
-          name: "query",
-          required: true,
-          type: "string",
-          enum: null,
-          description: "Repository search query string.",
-          properties: null,
-        },
-        {
-          name: "language",
-          required: false,
-          type: "string",
-          enum: null,
-          description: "Optional language filter.",
-          properties: null,
-        },
-      ],
+      params:
+        "query!:string — Repository search query string.; language?:string — Optional language filter.",
     });
 
     const genericQueryResult = await executeArchestraTool(
@@ -494,6 +479,80 @@ describe("search_tools", () => {
       });
       expect(union.type).toBe("string|null");
       expect(missing.type).toBeNull();
+    });
+  });
+
+  describe("formatParamsSignature", () => {
+    const signatureFor = (schema: Record<string, unknown>) =>
+      __test.formatParamsSignature(__test.summarizeInputParameters(schema));
+
+    test("renders required-first ordering with types and descriptions", () => {
+      expect(
+        signatureFor({
+          type: "object",
+          properties: {
+            language: {
+              type: "string",
+              description: "Optional language filter.",
+            },
+            query: {
+              type: "string",
+              description: "Repository search query string.",
+            },
+          },
+          required: ["query"],
+        }),
+      ).toBe(
+        "query!:string — Repository search query string.; language?:string — Optional language filter.",
+      );
+    });
+
+    test("renders type and enum together", () => {
+      expect(
+        signatureFor({
+          type: "object",
+          properties: { sort: { type: "string", enum: ["asc", "desc"] } },
+        }),
+      ).toBe('sort?:string enum("asc"|"desc")');
+    });
+
+    test("json-encodes non-string enum values and omits a null type", () => {
+      expect(
+        signatureFor({
+          type: "object",
+          properties: { level: { enum: [1, true, null] } },
+        }),
+      ).toBe("level?:enum(1|true|null)");
+    });
+
+    test("expands one-level object shape", () => {
+      expect(
+        signatureFor({
+          type: "object",
+          properties: {
+            payload: {
+              type: "object",
+              properties: { id: { type: "number" }, note: { type: "string" } },
+              required: ["id"],
+            },
+          },
+        }),
+      ).toBe("payload?:object{id!:number, note?:string}");
+    });
+
+    test("caps long enums and reports the overflow", () => {
+      const values = Array.from({ length: 25 }, (_, index) => `v${index}`);
+      const signature = signatureFor({
+        type: "object",
+        properties: { kind: { type: "string", enum: values } },
+      });
+      expect(signature.startsWith('kind?:string enum("v0"|')).toBe(true);
+      expect(signature.endsWith('"v19"|…(+5 more))')).toBe(true);
+    });
+
+    test("returns an empty string when there are no parameters", () => {
+      expect(__test.formatParamsSignature([])).toBe("");
+      expect(signatureFor({ type: "object", properties: {} })).toBe("");
     });
   });
 

--- a/platform/backend/src/archestra-mcp-server/search-tools.ts
+++ b/platform/backend/src/archestra-mcp-server/search-tools.ts
@@ -563,7 +563,12 @@ function formatParamSignature(param: InputParameterSummary): string {
   const requiredMark = param.required ? "!" : "?";
   const typePart = formatParamType(param);
   const typeSuffix = typePart ? `:${typePart}` : "";
-  const descriptionSuffix = param.description ? ` — ${param.description}` : "";
+  // collapse whitespace so a multiline schema description cannot break the
+  // one-line signature contract.
+  const description = param.description
+    ? param.description.replace(/\s+/g, " ").trim()
+    : "";
+  const descriptionSuffix = description ? ` — ${description}` : "";
   return `${param.name}${requiredMark}${typeSuffix}${descriptionSuffix}`;
 }
 

--- a/platform/backend/src/archestra-mcp-server/search-tools.ts
+++ b/platform/backend/src/archestra-mcp-server/search-tools.ts
@@ -82,6 +82,11 @@ const InputParameterSchema = z.object({
 });
 
 type InputParameterSummary = z.infer<typeof InputParameterSchema>;
+type NestedParameterSummary = z.infer<typeof NestedParameterSchema>;
+
+// cap on enum values rendered inline in a parameter signature; the full list
+// stays recoverable via run_tool validation feedback.
+const PARAM_ENUM_VALUE_CAP = 20;
 
 const SearchToolsOutputSchema = z.object({
   total: z.number().int().nonnegative().describe("Number of returned tools."),
@@ -106,10 +111,6 @@ const SearchToolsOutputSchema = z.object({
       toolName: z
         .string()
         .describe(`Exact tool name to pass to ${TOOL_RUN_TOOL_SHORT_NAME}.`),
-      title: z
-        .string()
-        .nullable()
-        .describe("Human-friendly title when available."),
       description: z
         .string()
         .nullable()
@@ -123,11 +124,15 @@ const SearchToolsOutputSchema = z.object({
         .describe(
           "MCP server prefix for third-party MCP tools when available.",
         ),
-      catalogName: z
+      params: z
         .string()
-        .nullable()
-        .describe("Catalog name for installed MCP tools when available."),
-      inputParameters: z.array(InputParameterSchema),
+        .describe(
+          "Compact one-line input signature. Parameters are joined by '; ', each rendered as " +
+            "`name<!|?>:<type>` where `!` marks required and `?` optional. Object parameters are " +
+            "expanded one level as `{child<!|?>:type, …}`, enums as `enum(<json-values>)`, and a " +
+            "trailing ` — description` is added when available. Empty string when the tool takes " +
+            `no input. Pass matching values inside tool_args when calling ${TOOL_RUN_TOOL_SHORT_NAME}.`,
+        ),
     }),
   ),
 });
@@ -245,6 +250,7 @@ export const __test = {
   rankCandidatesByKeyword,
   rankCandidatesByRegex,
   summarizeInputParameters,
+  formatParamsSignature,
   makeRankingCandidate(input: {
     toolName: string;
     title?: string | null;
@@ -537,13 +543,65 @@ function prepareSearchQuery(query: string): PreparedSearchQuery {
 function toSearchResult(candidate: SearchCandidate) {
   return {
     toolName: candidate.toolName,
-    title: candidate.title,
     description: candidate.description,
     source: candidate.source,
     server: candidate.server,
-    catalogName: candidate.catalogName,
-    inputParameters: candidate.inputParameters,
+    params: formatParamsSignature(candidate.inputParameters),
   };
+}
+
+// Render the structured per-tool parameter summaries as a single compact line so
+// repeated search_tools calls do not accumulate verbose nested JSON in context.
+// Intentionally bounded (see PARAM_ENUM_VALUE_CAP) — the full schema stays
+// recoverable through run_tool's validation feedback, matching the existing
+// "deeper structure is left to the actual call" design above.
+function formatParamsSignature(params: InputParameterSummary[]): string {
+  return params.map(formatParamSignature).join("; ");
+}
+
+function formatParamSignature(param: InputParameterSummary): string {
+  const requiredMark = param.required ? "!" : "?";
+  const typePart = formatParamType(param);
+  const typeSuffix = typePart ? `:${typePart}` : "";
+  const descriptionSuffix = param.description ? ` — ${param.description}` : "";
+  return `${param.name}${requiredMark}${typeSuffix}${descriptionSuffix}`;
+}
+
+// Additive: a parameter can carry a scalar type, a one-level object shape, and an
+// enum constraint at once, so each present part is appended rather than replacing
+// the others (e.g. `sort?:string enum("asc"|"desc")`).
+function formatParamType(param: InputParameterSummary): string {
+  let type = param.type ?? "";
+  if (param.properties && param.properties.length > 0) {
+    type += formatNestedProperties(param.properties);
+  }
+  if (param.enum && param.enum.length > 0) {
+    const enumClause = formatEnumValues(param.enum);
+    type = type ? `${type} ${enumClause}` : enumClause;
+  }
+  return type;
+}
+
+function formatNestedProperties(properties: NestedParameterSummary[]): string {
+  const inner = properties
+    .map((property) => {
+      const requiredMark = property.required ? "!" : "?";
+      const typeSuffix = property.type ? `:${property.type}` : "";
+      return `${property.name}${requiredMark}${typeSuffix}`;
+    })
+    .join(", ");
+  return `{${inner}}`;
+}
+
+// enum values are arbitrary JSON (number/boolean/null/object, or strings that may
+// contain "|"), so JSON-encode each to keep the signature unambiguous.
+function formatEnumValues(values: unknown[]): string {
+  const shown = values
+    .slice(0, PARAM_ENUM_VALUE_CAP)
+    .map((value) => JSON.stringify(value));
+  const overflow = values.length - PARAM_ENUM_VALUE_CAP;
+  const suffix = overflow > 0 ? `|…(+${overflow} more)` : "";
+  return `enum(${shown.join("|")}${suffix})`;
 }
 
 type RegexRankResult =


### PR DESCRIPTION
## Problem

In `search_and_run_only` mode the model discovers tools by calling `search_tools` repeatedly. Each result carried, per matched tool, a full nested `inputParameters` array (`name, required, type, enum, description, properties`) plus `title` and `catalogName`. After a few searches, the verbose param schemas of candidates the model never ran accumulate as dead weight in context — the real cost is cumulative, not per-call.

## Why not just change the format (md/yaml/toon)?

- Only `content[0].text` reaches the model (`structuredContent` is stripped at `chat-mcp-client.ts`), and there is a **default-on** generic TOON compression layer in the LLM proxy that does `JSON.parse → toonEncode` and keeps the result only when it saves tokens.
- Switching this tool to markdown/YAML would break that `JSON.parse` precondition and **silently disable** the default-on optimization. No format change reduces *accumulation* either.

So the lever is **shape**, not format.

## Change

- Collapse each tool's params into a single one-line `params` signature string.
- Drop `title`/`catalogName` from the **output** only — both remain on the internal `SearchCandidate` and still feed ranking (`searchText`) and the empty-results "Available servers" hint.
- Output stays JSON, so the default-on TOON layer keeps working and now tabularizes the flatter `tools` array more reliably.

```
before:  tools[].inputParameters[]{name,required,type,enum,description,properties} ×N  + title + catalogName
after:   params: "query!:string — Repository search query; sort?:string enum(\"asc\"|\"desc\"); filter?:object{id!:number}"
```

### Signature rules
`!`/`?` = required/optional; scalar `:type`; object/array-of-object expand one level `{child!/?:type}`; enums JSON-encoded (handles non-string values + `|` in strings), capped at 20 with `…(+N more)`; trailing ` — description` with whitespace collapsed to stay single-line. Parts are additive (a param can render type + object shape + enum together).

Roughly ⅓–¼ the size for typical tools, more for object-param tools, shrinking proportionally across repeated searches.

### Deliberately not done
- **Param description truncation** — kept intact (only whitespace-normalized). Descriptions carry semantics the model needs to fill args correctly; unlike enum values they are not recoverable from `run_tool` validation feedback.
- **Stale-result pruning from history** — the largest conceptual lever for accumulation, but a much larger proxy-history change. Possible follow-up.

## Tests & checks
- `search-tools.test.ts`: updated result assertion + 9 `formatParamsSignature` cases (ordering, scalar/null type, type+enum, object & array-of-object expansion, non-string enum encoding, cap boundary 20 vs 21, whitespace collapse, empty → `""`). 35/35 passing.
- `docs/pages/platform-archestra-mcp-server.md` regenerated via `pnpm codegen:archestra-mcp-server-docs`.
- type-check ✓, knip (dev+production) ✓, biome ✓.

## Review
External (codex) + internal review gates; both converged. Shared Medium (multiline descriptions breaking the one-line contract) fixed via whitespace normalization; test-coverage Lows filled.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>