### PR TITLE
fix(chat): accept .json file attachments

### DIFF
--- a/platform/backend/src/routes/chat/routes.test.ts
+++ b/platform/backend/src/routes/chat/routes.test.ts
@@ -88,6 +88,32 @@ describe("prepareMessagesForProvider", () => {
     });
   });
 
+  it("normalizes json files to text/plain for anthropic", () => {
+    const messages = __test.prepareMessagesForProvider({
+      provider: "anthropic",
+      messages: [
+        {
+          role: "user",
+          parts: [
+            {
+              type: "file",
+              mediaType: "application/json",
+              filename: "data.json",
+              url: "data:application/json;base64,eyJhIjoxfQ==",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(messages[0].parts?.[0]).toMatchObject({
+      type: "file",
+      mediaType: "text/plain",
+      filename: "data.json",
+      url: "data:text/plain;base64,eyJhIjoxfQ==",
+    });
+  });
+
   it("leaves non-anthropic file parts unchanged", () => {
     const message = {
       role: "user" as const,

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -3506,7 +3506,8 @@ function isAnthropicTextDocumentMimeType(mediaType: string): boolean {
     mediaType === "text/csv" ||
     mediaType === "text/markdown" ||
     mediaType === "application/csv" ||
-    mediaType === "application/vnd.ms-excel"
+    mediaType === "application/vnd.ms-excel" ||
+    mediaType === "application/json"
   );
 }
 

--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -370,7 +370,7 @@ describe("ArchestraPromptInput", () => {
         screen.getByTestId(E2eTestId.ChatFileUploadButton),
       ).toBeInTheDocument();
       expect(screen.getByTestId("tooltip-content")).toHaveTextContent(
-        "Supports: chat prompts, .txt, .csv, and .md uploads",
+        "Supports: chat prompts, .txt, .csv, .md, and .json uploads",
       );
     });
 

--- a/platform/shared/chat.test.ts
+++ b/platform/shared/chat.test.ts
@@ -10,7 +10,7 @@ import {
 } from "./chat";
 
 describe("chat file upload helpers", () => {
-  test("treats text modality as supporting txt, md, and csv uploads", () => {
+  test("treats text modality as supporting txt, md, csv, and json uploads", () => {
     expect(getAcceptedFileTypes(["text"])).toBe(
       [
         "text/plain",
@@ -18,11 +18,12 @@ describe("chat file upload helpers", () => {
         "text/csv",
         "application/csv",
         "application/vnd.ms-excel",
+        "application/json",
       ].join(","),
     );
     expect(supportsFileUploads(["text"])).toBe(true);
     expect(getSupportedFileTypesDescription(["text"])).toBe(
-      "chat prompts, .txt, .csv, and .md uploads",
+      "chat prompts, .txt, .csv, .md, and .json uploads",
     );
   });
 
@@ -34,6 +35,7 @@ describe("chat file upload helpers", () => {
         "text/csv",
         "application/csv",
         "application/vnd.ms-excel",
+        "application/json",
         "application/pdf",
       ].join(","),
     );
@@ -50,7 +52,9 @@ describe("chat file upload helpers", () => {
   test("builds a readable description for multiple upload modalities", () => {
     expect(
       getSupportedFileTypesDescription(["text", "image", "pdf", "audio"]),
-    ).toBe("chat prompts, .txt, .csv, and .md uploads, images, PDFs, audio");
+    ).toBe(
+      "chat prompts, .txt, .csv, .md, and .json uploads, images, PDFs, audio",
+    );
   });
 
   test("uses explicit file media types when present", () => {

--- a/platform/shared/chat.ts
+++ b/platform/shared/chat.ts
@@ -305,13 +305,14 @@ const MODALITY_TO_MIME_TYPES: Record<
   ModelInputModality,
   SupportedChatUploadMimeType[] | null
 > = {
-  // Text-capable models can accept plain text and CSV documents.
+  // Text-capable models can accept plain text, CSV, and JSON documents.
   text: [
     "text/plain",
     "text/markdown",
     "text/csv",
     "application/csv",
     "application/vnd.ms-excel",
+    "application/json",
   ],
   // Image formats commonly supported by vision models
   image: [
@@ -337,7 +338,7 @@ const MODALITY_TO_MIME_TYPES: Record<
 };
 
 const MODALITY_TO_FILE_TYPE_DESCRIPTION: Record<ModelInputModality, string> = {
-  text: "chat prompts, .txt, .csv, and .md uploads",
+  text: "chat prompts, .txt, .csv, .md, and .json uploads",
   image: "images",
   audio: "audio",
   video: "video",


### PR DESCRIPTION
## Why

Chat attachments rejected `.json` files. `application/json` was already a member of the `SupportedChatUploadMimeType` union and the extension-fallback map in `getMediaType()`, but it was never added to `MODALITY_TO_MIME_TYPES`, so `getAcceptedFileTypes()` excluded it from the file input's `accept` attribute and the drop/paste filter rejected the files with "No files match the accepted types."

## What

- `shared/chat.ts`: add `application/json` to the `text` modality MIME list; update the upload tooltip copy to mention `.json`.
- `backend/src/routes/chat/routes.ts`: add `application/json` to `isAnthropicTextDocumentMimeType` so JSON attachments are normalized to `text/plain` for Anthropic, matching the existing handling for csv/markdown (Anthropic only accepts text documents as `text/plain`).

## Tests

- `shared/chat.test.ts`: accept list, cross-modality dedup, and description copy now cover `application/json`.
- `backend/src/routes/chat/routes.test.ts`: new test asserting a JSON file part is normalized to `text/plain` (media type and data URL) for Anthropic.
- `frontend/src/app/chat/prompt-input.test.tsx`: tooltip copy assertion updated.

All written test-first and verified failing before the fix. Shared 314/314, backend chat routes 44/44, frontend prompt-input 20/20, Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>