### PR TITLE
fix(chat): recover stringified unavailable-tool errors instead of failing the run

### DIFF
--- a/platform/backend/src/agents/a2a-executor.test.ts
+++ b/platform/backend/src/agents/a2a-executor.test.ts
@@ -1,4 +1,5 @@
 import { TOOL_ACTIVATE_SKILL_FULL_NAME } from "@archestra/shared";
+import { NoSuchToolError } from "ai";
 import { describe, expect, test, vi } from "vitest";
 import { MIN_IMAGE_ATTACHMENT_SIZE } from "@/agents/incoming-email/constants";
 import {
@@ -457,6 +458,93 @@ describe("executeA2AMessage model selection", () => {
       role: "assistant",
       parts: [{ type: "text", text: "Delegated response" }],
     });
+  });
+});
+
+describe("executeA2AMessage unavailable tool errors", () => {
+  test("recovers unavailable-tool stream errors instead of failing the run", async () => {
+    vi.mocked(AgentModel.findById).mockResolvedValue({
+      id: "agent-child",
+      name: "Child Agent",
+      agentType: "agent",
+      systemPrompt: "Handle the task.",
+      llmApiKeyId: null,
+      modelId: null,
+    } as never);
+    vi.mocked(McpServerModel.getUserPersonalServerForCatalog).mockResolvedValue(
+      null,
+    );
+    mockResolveConversationLlmSelectionForAgent.mockResolvedValue({
+      chatApiKeyId: "org-key",
+      selectedModel: "claude-sonnet-4-6",
+      selectedProvider: "anthropic",
+    });
+    mockGetChatMcpTools.mockResolvedValue({});
+    mockCreateLLMModelForAgent.mockResolvedValue({
+      model: { provider: "mock" },
+      provider: "anthropic",
+      apiKeySource: "org",
+    });
+
+    let capturedOnError: ((error: unknown) => string) | undefined;
+    mockStreamText.mockReturnValue({
+      toUIMessageStream: vi.fn((options) => {
+        capturedOnError = options?.onError;
+        const responseMessage = {
+          id: "msg-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "Recovered response" }],
+        };
+
+        options?.onFinish?.({
+          messages: [responseMessage],
+          isContinuation: false,
+          isAborted: false,
+          responseMessage,
+          finishReason: "stop",
+        });
+
+        return new ReadableStream({
+          start(controller) {
+            controller.close();
+          },
+        });
+      }),
+      text: Promise.resolve("Recovered response"),
+      usage: Promise.resolve(undefined),
+      finishReason: Promise.resolve("stop"),
+    });
+
+    await executeA2AMessage({
+      agentId: "agent-child",
+      message: "Handle this",
+      organizationId: "org-1",
+      userId: "user-1",
+      conversationId: "conv-1",
+    });
+
+    expect(capturedOnError).toBeDefined();
+
+    const fromInstance = capturedOnError?.(
+      new NoSuchToolError({
+        toolName: "ghost_tool",
+        availableTools: ["real_tool"],
+      }),
+    );
+    expect(fromInstance).toContain(
+      "The requested tool is not available in this chat.",
+    );
+    expect(fromInstance).toContain('"requestedToolName": "ghost_tool"');
+
+    // the SDK's duplicate tool-error part arrives pre-stringified; it must be
+    // recognized the same way, not escalated into a failed run
+    const fromString = capturedOnError?.(
+      "Model tried to call unavailable tool 'ghost_tool'. Available tools: real_tool.",
+    );
+    expect(fromString).toBe(fromInstance);
+
+    // unrelated stream errors keep failing the run
+    expect(() => capturedOnError?.(new Error("boom"))).toThrow("boom");
   });
 });
 

--- a/platform/backend/src/agents/a2a-executor.ts
+++ b/platform/backend/src/agents/a2a-executor.ts
@@ -20,7 +20,12 @@ import { createLLMModelForAgent } from "@/clients/llm-client";
 import mcpClient from "@/clients/mcp-client";
 import logger from "@/logging";
 import { AgentModel, McpServerModel, TeamModel, UserModel } from "@/models";
-import { mapProviderError, ProviderError } from "@/routes/chat/errors";
+import {
+  formatUnavailableToolErrorDetails,
+  getUnavailableToolErrorDetails,
+  mapProviderError,
+  ProviderError,
+} from "@/routes/chat/errors";
 import { buildSkillCatalogPrompt } from "@/skills/skill-catalog-prompt";
 import {
   promptNeedsRendering,
@@ -333,6 +338,17 @@ export async function executeA2AMessage(
           responseUiMessage = responseMessage;
         },
         onError: (error) => {
+          // a nonexistent-tool call is recoverable: the SDK already feeds the
+          // tool-error back to the model and continues the loop, so return the
+          // recovery text as the part's errorText instead of killing the run
+          const unavailableToolError = getUnavailableToolErrorDetails(error);
+          if (unavailableToolError) {
+            logger.info(
+              { agentId: agent.id, unavailableToolError },
+              "Returning unavailable tool error as tool-level error in A2A execution",
+            );
+            return formatUnavailableToolErrorDetails(unavailableToolError);
+          }
           logger.error(
             { agentId: agent.id, error },
             "Error stream.toUIMessageStream when parsing A2A execution response",

--- a/platform/backend/src/routes/chat/errors.test.ts
+++ b/platform/backend/src/routes/chat/errors.test.ts
@@ -17,8 +17,11 @@ vi.mock("@sentry/node", () => ({
   captureException: mockSentryCaptureException,
 }));
 
+import { NoSuchToolError } from "ai";
 import {
   EmptyModelResponseError,
+  formatUnavailableToolErrorDetails,
+  getUnavailableToolErrorDetails,
   mapProviderError,
   ProviderError,
   sanitizeChatErrorForFrontend,
@@ -1738,5 +1741,88 @@ describe("mapProviderError - EmptyModelResponseError", () => {
 
     expect(result.code).toBe(ChatErrorCode.EmptyResponse);
     expect(result.isRetryable).toBe(true);
+  });
+});
+
+describe("getUnavailableToolErrorDetails", () => {
+  it("recognizes a NoSuchToolError instance", () => {
+    const details = getUnavailableToolErrorDetails(
+      new NoSuchToolError({
+        toolName: "ghost_tool",
+        availableTools: ["real_tool", "other_tool"],
+      }),
+    );
+
+    expect(details).not.toBeNull();
+    expect(details?.requestedToolName).toBe("ghost_tool");
+    expect(details?.availableToolNames).toEqual(["real_tool", "other_tool"]);
+  });
+
+  it("recognizes the stringified message the SDK emits for the duplicate tool-error part", () => {
+    // runToolsTransformation stringifies the error before onError sees it,
+    // so only the message text is available — no NoSuchToolError identity
+    const details = getUnavailableToolErrorDetails(
+      "Model tried to call unavailable tool 'ghost_tool'. Available tools: real_tool, other_tool.",
+    );
+
+    expect(details).not.toBeNull();
+    expect(details?.requestedToolName).toBe("ghost_tool");
+    expect(details?.availableToolNames).toEqual(["real_tool", "other_tool"]);
+  });
+
+  it("recognizes the message wrapped in a plain Error", () => {
+    const details = getUnavailableToolErrorDetails(
+      new Error(
+        "Model tried to call unavailable tool 'ghost_tool'. Available tools: real_tool.",
+      ),
+    );
+
+    expect(details?.requestedToolName).toBe("ghost_tool");
+    expect(details?.availableToolNames).toEqual(["real_tool"]);
+  });
+
+  it("recognizes the no-tools-available variant", () => {
+    const details = getUnavailableToolErrorDetails(
+      "Model tried to call unavailable tool 'ghost_tool'. No tools are available.",
+    );
+
+    expect(details?.requestedToolName).toBe("ghost_tool");
+    expect(details?.availableToolNames).toEqual([]);
+  });
+
+  it("produces identical formatted payloads for the instance and its stringified duplicate", () => {
+    const instance = new NoSuchToolError({
+      toolName: "ghost_tool",
+      availableTools: ["real_tool"],
+    });
+
+    const fromInstance = getUnavailableToolErrorDetails(instance);
+    const fromString = getUnavailableToolErrorDetails(instance.message);
+
+    expect(fromInstance).not.toBeNull();
+    expect(fromString).not.toBeNull();
+    if (!fromInstance || !fromString) return;
+    expect(formatUnavailableToolErrorDetails(fromString)).toBe(
+      formatUnavailableToolErrorDetails(fromInstance),
+    );
+  });
+
+  it("does not match its own formatted recovery payload", () => {
+    const details = getUnavailableToolErrorDetails(
+      "Model tried to call unavailable tool 'ghost_tool'. Available tools: real_tool.",
+    );
+    expect(details).not.toBeNull();
+    if (!details) return;
+
+    const formatted = formatUnavailableToolErrorDetails(details);
+    expect(getUnavailableToolErrorDetails(formatted)).toBeNull();
+    expect(getUnavailableToolErrorDetails(new Error(formatted))).toBeNull();
+  });
+
+  it("returns null for unrelated errors and non-string values", () => {
+    expect(getUnavailableToolErrorDetails(new Error("boom"))).toBeNull();
+    expect(getUnavailableToolErrorDetails("some other failure")).toBeNull();
+    expect(getUnavailableToolErrorDetails(undefined)).toBeNull();
+    expect(getUnavailableToolErrorDetails({ code: -32601 })).toBeNull();
   });
 });

--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -19,7 +19,12 @@ import {
   context as otelContext,
   trace,
 } from "@opentelemetry/api";
-import { APICallError, NoOutputGeneratedError, RetryError } from "ai";
+import {
+  APICallError,
+  NoOutputGeneratedError,
+  NoSuchToolError,
+  RetryError,
+} from "ai";
 import logger from "@/logging";
 import { getActiveSessionId } from "@/observability/request-context";
 import { captureRawProviderErrorInSentry } from "@/observability/sentry";
@@ -58,6 +63,104 @@ export class EmptyModelResponseError extends Error {
     this.finishReason = params.finishReason;
     this.attempts = params.attempts;
   }
+}
+
+// =============================================================================
+// Unavailable tool errors — model called a tool that doesn't exist
+// =============================================================================
+
+const UNAVAILABLE_TOOL_ERROR_MESSAGE =
+  "The requested tool is not available in this chat. Available tools are listed in the details below; use an exact available tool name for the next tool call.";
+
+type UnavailableToolErrorDetails = {
+  type: "unavailable_tool";
+  message: string;
+  requestedToolName: string;
+  availableToolNames: string[];
+  originalErrorMessage: string;
+};
+
+/**
+ * Recognize the AI SDK's "model called a nonexistent tool" failure in both
+ * shapes it reaches stream onError handlers: the genuine NoSuchToolError
+ * instance (from the invalid tool-call part), and the duplicate tool-error
+ * part for the same call, whose error the SDK stringifies in
+ * runToolsTransformation before it gets here — so an isInstance check alone
+ * misses it and the recoverable failure escalates into a failed run.
+ */
+export function getUnavailableToolErrorDetails(
+  error: unknown,
+): UnavailableToolErrorDetails | null {
+  if (NoSuchToolError.isInstance(error)) {
+    return {
+      type: "unavailable_tool",
+      message: UNAVAILABLE_TOOL_ERROR_MESSAGE,
+      requestedToolName: error.toolName,
+      availableToolNames: error.availableTools ?? [],
+      originalErrorMessage: error.message,
+    };
+  }
+
+  const parsed = parseUnavailableToolErrorMessage(error);
+  if (!parsed) {
+    return null;
+  }
+
+  return {
+    type: "unavailable_tool",
+    message: UNAVAILABLE_TOOL_ERROR_MESSAGE,
+    ...parsed,
+  };
+}
+
+export function formatUnavailableToolErrorDetails(
+  details: UnavailableToolErrorDetails,
+): string {
+  return `${details.message}\n\nDetails:\n${JSON.stringify(
+    {
+      type: details.type,
+      requestedToolName: details.requestedToolName,
+      availableToolNames: details.availableToolNames,
+      originalErrorMessage: details.originalErrorMessage,
+    },
+    null,
+    2,
+  )}`;
+}
+
+// matches NoSuchToolError's message verbatim (parse-tool-call.ts in the ai
+// package), covering both the "Available tools: ..." and "No tools are
+// available." variants
+function parseUnavailableToolErrorMessage(error: unknown): {
+  requestedToolName: string;
+  availableToolNames: string[];
+  originalErrorMessage: string;
+} | null {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : null;
+  if (message === null) {
+    return null;
+  }
+
+  const match = message.match(
+    /^Model tried to call unavailable tool '([^']+)'\. (?:No tools are available\.|Available tools: (.*)\.)$/s,
+  );
+  if (!match) {
+    return null;
+  }
+
+  return {
+    requestedToolName: match[1],
+    availableToolNames: (match[2] ?? "")
+      .split(",")
+      .map((toolName) => toolName.trim())
+      .filter(Boolean),
+    originalErrorMessage: message,
+  };
 }
 
 // =============================================================================

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -22,7 +22,6 @@ import {
   generateId,
   generateText,
   hasToolCall,
-  NoSuchToolError,
   stepCountIs,
   streamText,
   type UIMessage,
@@ -122,7 +121,9 @@ import {
 } from "./context-trimming";
 import {
   EmptyModelResponseError,
+  formatUnavailableToolErrorDetails,
   getActiveTraceContext,
+  getUnavailableToolErrorDetails,
   mapProviderError,
   ProviderError,
   sanitizeChatErrorForFrontend,
@@ -190,17 +191,6 @@ function buildLoadToolsWhenNeededSystemPrompt(): string {
 
   return `Some available tools are not listed upfront and must be discovered. If the visible tools do not fit the task, call \`${searchToolsName}\` to find relevant tools, then call \`${runToolName}\` with a tool name it returned. Only pass \`${runToolName}\` a tool name that \`${searchToolsName}\` returned or that appeared verbatim earlier in this conversation; if you do not have an exact name, call \`${searchToolsName}\` first.`;
 }
-
-const UNAVAILABLE_TOOL_ERROR_MESSAGE =
-  "The requested tool is not available in this chat. Available tools are listed in the details below; use an exact available tool name for the next tool call.";
-
-type UnavailableToolErrorDetails = {
-  type: "unavailable_tool";
-  message: string;
-  requestedToolName: string;
-  availableToolNames: string[];
-  originalErrorMessage: string;
-};
 
 const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
   fastify.post(
@@ -2791,37 +2781,6 @@ export async function generateConversationTitle(
 // ============================================================================
 // Helper Functions
 // ============================================================================
-
-function getUnavailableToolErrorDetails(
-  error: unknown,
-): UnavailableToolErrorDetails | null {
-  if (!NoSuchToolError.isInstance(error)) {
-    return null;
-  }
-
-  return {
-    type: "unavailable_tool",
-    message: UNAVAILABLE_TOOL_ERROR_MESSAGE,
-    requestedToolName: error.toolName,
-    availableToolNames: error.availableTools ?? [],
-    originalErrorMessage: error.message,
-  };
-}
-
-function formatUnavailableToolErrorDetails(
-  details: UnavailableToolErrorDetails,
-): string {
-  return `${details.message}\n\nDetails:\n${JSON.stringify(
-    {
-      type: details.type,
-      requestedToolName: details.requestedToolName,
-      availableToolNames: details.availableToolNames,
-      originalErrorMessage: details.originalErrorMessage,
-    },
-    null,
-    2,
-  )}`;
-}
 
 /**
  * Regenerate a turn: find the user message being regenerated, delete the stale

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -437,11 +437,16 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
       availableTools: ["known_tool"],
     });
     const payload1 = capturedInnerOnError?.(unavailableToolError);
-    // the AI SDK re-invokes onError downstream with `new Error(errorText)`,
-    // wrapping the first return value — that duplicate must replay the payload.
-    const payload2 = capturedInnerOnError?.(new Error(payload1));
+    // the SDK emits a duplicate tool-error part for the same invalid call and
+    // stringifies its error in runToolsTransformation, so the second onError
+    // invocation receives the raw message string — no NoSuchToolError identity
+    const payload2 = capturedInnerOnError?.(unavailableToolError.message);
+    // stream-level error chunks can also re-fire onError with the previous
+    // return value wrapped in `new Error(errorText)` — replay, don't reprocess
+    const payload3 = capturedInnerOnError?.(new Error(payload1));
 
-    expect(payload1).toBe(payload2);
+    expect(payload2).toBe(payload1);
+    expect(payload3).toBe(payload1);
     expect(payload1).toContain(
       "The requested tool is not available in this chat.",
     );
@@ -449,6 +454,50 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
     expect(payload1).toContain('"availableToolNames"');
     expect(payload1).toContain("known_tool");
     expect(payload1).toContain("Model tried to call unavailable tool");
+
+    await new Promise((resolve) => setImmediate(resolve));
+    const persistedErrors =
+      await ConversationChatErrorModel.findByConversation(conversationId);
+    expect(persistedErrors).toHaveLength(0);
+  });
+
+  test("recovers when only the stringified unavailable-tool message reaches onError", async ({
+    expect,
+  }) => {
+    const { default: ConversationChatErrorModel } = await import(
+      "@/models/conversation-chat-error"
+    );
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: conversationId,
+        messages: [
+          {
+            id: "msg-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+    expect(capturedInnerOnError).toBeDefined();
+
+    // regression: this exact shape used to fall through to mapProviderError,
+    // marking the run failed and persisting a fatal chat error
+    const payload = capturedInnerOnError?.(
+      "Model tried to call unavailable tool 'missing_tool'. Available tools: known_tool.",
+    );
+
+    expect(payload).toContain(
+      "The requested tool is not available in this chat.",
+    );
+    expect(payload).toContain('"requestedToolName": "missing_tool"');
+    expect(payload).toContain("known_tool");
 
     await new Promise((resolve) => setImmediate(resolve));
     const persistedErrors =


### PR DESCRIPTION
## Why

When the model calls a nonexistent tool, the AI SDK fires the stream `onError` handler twice for the same invalid call: first with the genuine `NoSuchToolError` instance, then again for the duplicate `tool-error` part whose error the SDK already stringified in `runToolsTransformation`. The chat route only matched `NoSuchToolError.isInstance`, so the second (string) invocation fell through to `mapProviderError`, set `activeRunError` (run marked `failed`), and persisted a fatal conversation chat error — the user saw an error card even though the model recovers and continues the loop. The A2A executor had no handling at all and threw on any stream error, killing the run outright.

## Changes

- `routes/chat/errors.ts`: moved `getUnavailableToolErrorDetails` / `formatUnavailableToolErrorDetails` here (next to `ProviderError` / `mapProviderError`) and added a fallback parser that recognizes the SDK's stringified message format (both `Available tools: ...` and `No tools are available.` variants). Both shapes produce identical recovery payloads, so the existing dedupe in `routes.ts` keeps working.
- `routes/chat/routes.ts`: imports the shared helpers; local copies removed.
- `agents/a2a-executor.ts`: `toUIMessageStream` `onError` now returns recovery text for unavailable-tool errors instead of throwing; other errors still fail the run.
- Tests: `stream-route.test.ts` now models the real second invocation (raw string) plus a regression test asserting no chat error is persisted; `errors.test.ts` unit-tests the parser edge cases; `a2a-executor.test.ts` covers the new recovery path.

If the message doesn't match the parser (e.g. unexpected format), behavior falls back to the previous fatal path — no new failure modes.

## Testing

- `pnpm --filter @backend exec vitest run src/routes/chat/errors.test.ts src/routes/chat/stream-route.test.ts src/agents/a2a-executor.test.ts` (146 passed)
- `pnpm --filter @backend type-check`
- `pnpm exec biome check` on touched files
- `cd backend && pnpm knip` (dev + production)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>