### PR TITLE
test(backend): complete virtual-api-key per-endpoint tests + tighten GET assertions

### DIFF
--- a/platform/backend/src/routes/virtual-api-key/get.virtual-api-key.route.test.ts
+++ b/platform/backend/src/routes/virtual-api-key/get.virtual-api-key.route.test.ts
@@ -139,13 +139,13 @@ describe("GET /api/llm-virtual-keys", () => {
     expect(names).toEqual(
       expect.arrayContaining(["Org Visible", "My Personal", "Team Visible"]),
     );
-    expect(names).not.toEqual(
-      expect.arrayContaining([
-        "Other Personal",
-        "Other Team Key",
-        "Different Org Key",
-      ]),
-    );
+    for (const hidden of [
+      "Other Personal",
+      "Other Team Key",
+      "Different Org Key",
+    ]) {
+      expect(names).not.toContain(hidden);
+    }
   });
 
   test("GET /api/llm-virtual-keys includes org-scoped keys for llmVirtualKey admins", async ({
@@ -262,13 +262,11 @@ describe("GET /api/llm-virtual-keys", () => {
         }),
       ]),
     );
-    expect(body).not.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          id: otherResponse.json().id,
-          name: "key-gamma",
-        }),
-      ]),
+    expect(body).not.toContainEqual(
+      expect.objectContaining({
+        id: otherResponse.json().id,
+        name: "key-gamma",
+      }),
     );
     for (const key of body) {
       expect(key.value).toBeUndefined();

--- a/platform/backend/src/routes/virtual-api-key/update.virtual-api-key.route.test.ts
+++ b/platform/backend/src/routes/virtual-api-key/update.virtual-api-key.route.test.ts
@@ -1,0 +1,166 @@
+import { vi } from "vitest";
+import type { FastifyInstanceWithZod } from "@/server";
+import { createFastifyInstance } from "@/server";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import type { User } from "@/types";
+
+vi.mock("@/auth", () => ({
+  userHasPermission: vi.fn(),
+}));
+
+import { userHasPermission } from "@/auth";
+
+const mockUserHasPermission = vi.mocked(userHasPermission);
+
+describe("PATCH /api/llm-virtual-keys/:id", () => {
+  let app: FastifyInstanceWithZod;
+  let organizationId: string;
+  let user: User;
+
+  beforeEach(async ({ makeOrganization, makeUser }) => {
+    const organization = await makeOrganization();
+    organizationId = organization.id;
+    user = await makeUser();
+    mockUserHasPermission.mockReset();
+    mockUserHasPermission.mockResolvedValue(false);
+
+    app = createFastifyInstance();
+    app.addHook("onRequest", async (request) => {
+      (
+        request as typeof request & {
+          organizationId: string;
+          user: User;
+        }
+      ).organizationId = organizationId;
+      (request as typeof request & { user: User }).user = user;
+    });
+
+    const { default: virtualApiKeysRoutes } = await import(
+      "./virtual-api-key.routes"
+    );
+    await app.register(virtualApiKeysRoutes);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  test("PATCH /api/llm-virtual-keys/:id updates the name and provider mappings without re-exposing the token", async ({
+    makeLlmProviderApiKey,
+    makeSecret,
+  }) => {
+    mockUserHasPermission.mockResolvedValue(true);
+
+    const secret = await makeSecret({ secret: { apiKey: "sk-real" } });
+    const parentKey = await makeLlmProviderApiKey(organizationId, secret.id, {
+      provider: "openai",
+      name: "OpenAI Parent",
+    });
+
+    const createResponse = await app.inject({
+      method: "POST",
+      url: "/api/llm-virtual-keys",
+      payload: {
+        name: "before-rename",
+        providerApiKeys: [
+          { provider: parentKey.provider, providerApiKeyId: parentKey.id },
+        ],
+      },
+    });
+    expect(createResponse.statusCode).toBe(200);
+    const id = createResponse.json().id;
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: `/api/llm-virtual-keys/${id}`,
+      payload: {
+        name: "after-rename",
+        providerApiKeys: [
+          { provider: parentKey.provider, providerApiKeyId: parentKey.id },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.id).toBe(id);
+    expect(body.name).toBe("after-rename");
+    expect(body.value).toBeUndefined();
+    expect(body.providerApiKeys).toEqual([
+      {
+        provider: "openai",
+        providerApiKeyId: parentKey.id,
+        providerApiKeyName: "OpenAI Parent",
+      },
+    ]);
+  });
+
+  test("PATCH /api/llm-virtual-keys/:id returns 404 for an unknown key", async ({
+    makeLlmProviderApiKey,
+    makeSecret,
+  }) => {
+    mockUserHasPermission.mockResolvedValue(true);
+
+    const secret = await makeSecret({ secret: { apiKey: "sk-real" } });
+    const parentKey = await makeLlmProviderApiKey(organizationId, secret.id, {
+      provider: "openai",
+    });
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/llm-virtual-keys/00000000-0000-0000-0000-000000000000",
+      payload: {
+        name: "ghost",
+        providerApiKeys: [
+          { provider: parentKey.provider, providerApiKeyId: parentKey.id },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toMatchObject({
+      error: { message: "Virtual API key not found" },
+    });
+  });
+
+  test("PATCH /api/llm-virtual-keys/:id rejects past expiration dates", async ({
+    makeLlmProviderApiKey,
+    makeSecret,
+  }) => {
+    mockUserHasPermission.mockResolvedValue(true);
+
+    const secret = await makeSecret({ secret: { apiKey: "sk-real" } });
+    const parentKey = await makeLlmProviderApiKey(organizationId, secret.id, {
+      provider: "openai",
+    });
+
+    const createResponse = await app.inject({
+      method: "POST",
+      url: "/api/llm-virtual-keys",
+      payload: {
+        name: "expiry-target",
+        providerApiKeys: [
+          { provider: parentKey.provider, providerApiKeyId: parentKey.id },
+        ],
+      },
+    });
+    expect(createResponse.statusCode).toBe(200);
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: `/api/llm-virtual-keys/${createResponse.json().id}`,
+      payload: {
+        name: "expiry-target",
+        providerApiKeys: [
+          { provider: parentKey.provider, providerApiKeyId: parentKey.id },
+        ],
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      error: { message: "Expiration date must be in the future" },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Two correctness improvements to the virtual-api-key route tests, now that the per-entity layout is on main.

**Tighten GET exclusion assertions.** The visibility and `providerApiKeyId`-filter tests asserted that out-of-scope keys are excluded with `expect(names).not.toEqual(expect.arrayContaining([a, b, c]))` — a matcher that only fails when *all* listed keys are present, so a single cross-scope key leaking into a user's results (the exact authorization regression these tests guard) would pass silently. Switched to per-key absence checks (`.not.toContain` / `.not.toContainEqual`) so any single leak fails.

**Complete the per-endpoint set.** The convention is one test file per endpoint, but `PATCH /api/llm-virtual-keys/:id` had no file — the entity shipped with create/get/delete only. Adds `update.virtual-api-key.route.test.ts` covering the rename happy path (200, token not re-exposed, provider mappings returned), 404 for an unknown key, and 400 for a past expiration date. All four endpoints (create/get/update/delete) now have a dedicated file.

No production code changes; the route already behaves correctly. `virtual-api-key` is the canonical per-endpoint reference, so both the stronger exclusion pattern and the complete endpoint coverage are what future entities will copy.