### PR TITLE
fix(cost): bill 1-hour prompt-cache writes at 2x (TTL-aware cache cost)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4121,6 +4121,20 @@
               "cache_creation_input_tokens": {
                 "nullable": true,
                 "type": "number"
+              },
+              "cache_creation": {
+                "nullable": true,
+                "type": "object",
+                "properties": {
+                  "ephemeral_1h_input_tokens": {
+                    "nullable": true,
+                    "type": "number"
+                  },
+                  "ephemeral_5m_input_tokens": {
+                    "nullable": true,
+                    "type": "number"
+                  }
+                }
               }
             },
             "required": [
@@ -21240,6 +21254,21 @@
               "cache_creation_input_tokens": {
                 "nullable": true,
                 "type": "number"
+              },
+              "cache_creation": {
+                "nullable": true,
+                "type": "object",
+                "properties": {
+                  "ephemeral_1h_input_tokens": {
+                    "nullable": true,
+                    "type": "number"
+                  },
+                  "ephemeral_5m_input_tokens": {
+                    "nullable": true,
+                    "type": "number"
+                  }
+                },
+                "additionalProperties": false
               }
             },
             "required": [

--- a/platform/backend/src/routes/proxy/adapters/anthropic.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.test.ts
@@ -118,6 +118,34 @@ describe("AnthropicResponseAdapter", () => {
       ]);
     });
   });
+
+  describe("getUsage", () => {
+    test("captures the 1h portion of the cache-creation split", () => {
+      const response = {
+        ...createMockResponse([{ type: "text", text: "hi" }]),
+        usage: {
+          input_tokens: 5,
+          output_tokens: 10,
+          cache_read_input_tokens: 2000,
+          cache_creation_input_tokens: 1000,
+          cache_creation: {
+            ephemeral_1h_input_tokens: 400,
+            ephemeral_5m_input_tokens: 600,
+          },
+        },
+      } as Anthropic.Types.MessagesResponse;
+
+      const adapter = anthropicAdapterFactory.createResponseAdapter(response);
+
+      expect(adapter.getUsage()).toEqual({
+        inputTokens: 5,
+        outputTokens: 10,
+        cacheReadTokens: 2000,
+        cacheWriteTokens: 1000,
+        cacheWrite1hTokens: 400,
+      });
+    });
+  });
 });
 
 describe("AnthropicRequestAdapter", () => {

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -555,14 +555,14 @@ class AnthropicResponseAdapter
   }
 
   getUsage(): UsageView {
-    const { input, output, cacheRead, cacheWrite } = getUsageTokens(
-      this.response.usage,
-    );
+    const { input, output, cacheRead, cacheWrite, cacheWrite1h } =
+      getUsageTokens(this.response.usage);
     return {
       inputTokens: input,
       outputTokens: output,
       cacheReadTokens: cacheRead,
       cacheWriteTokens: cacheWrite,
+      cacheWrite1hTokens: cacheWrite1h,
     };
   }
 
@@ -642,6 +642,9 @@ class AnthropicStreamAdapter
             cacheReadTokens: chunk.message.usage.cache_read_input_tokens ?? 0,
             cacheWriteTokens:
               chunk.message.usage.cache_creation_input_tokens ?? 0,
+            cacheWrite1hTokens:
+              chunk.message.usage.cache_creation?.ephemeral_1h_input_tokens ??
+              0,
           };
         }
         sseData = `event: message_start\ndata: ${JSON.stringify(chunk)}\n\n`;
@@ -1099,6 +1102,7 @@ export function getUsageTokens(usage: Anthropic.Types.Usage) {
     output: usage.output_tokens,
     cacheRead: usage.cache_read_input_tokens ?? 0,
     cacheWrite: usage.cache_creation_input_tokens ?? 0,
+    cacheWrite1h: usage.cache_creation?.ephemeral_1h_input_tokens ?? 0,
   };
 }
 

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -1109,6 +1109,7 @@ async function handleStreaming<
             {
               readTokens: state.usage.cacheReadTokens,
               writeTokens: state.usage.cacheWriteTokens,
+              write1hTokens: state.usage.cacheWrite1hTokens,
             },
           );
           if (cost !== undefined) {
@@ -1417,6 +1418,7 @@ async function handleNonStreaming<
         {
           readTokens: usage.cacheReadTokens,
           writeTokens: usage.cacheWriteTokens,
+          write1hTokens: usage.cacheWrite1hTokens,
         },
       );
       if (cost !== undefined) {

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
@@ -199,7 +199,7 @@ describe("calculateInteractionCosts", () => {
       cacheSavings: 0.0009,
     });
     expect(mockCalculateCost).toHaveBeenCalledTimes(2);
-    const cacheTokens = { readTokens: 0, writeTokens: 0 };
+    const cacheTokens = { readTokens: 0, writeTokens: 0, write1hTokens: 0 };
     expect(mockCalculateCost).toHaveBeenCalledWith(
       "gpt-4",
       100,

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
@@ -86,6 +86,7 @@ export async function calculateInteractionCosts(params: {
   const cacheTokens = {
     readTokens: params.usage.cacheReadTokens ?? 0,
     writeTokens: params.usage.cacheWriteTokens ?? 0,
+    write1hTokens: params.usage.cacheWrite1hTokens ?? 0,
   };
   const baselineCost = await utils.costOptimization.calculateCost(
     params.baselineModel,

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
@@ -106,6 +106,7 @@ export async function calculateInteractionCosts(params: {
     params.providerName,
     cacheTokens.readTokens,
     cacheTokens.writeTokens,
+    params.usage.cacheWrite1hTokens ?? 0,
   );
   return {
     baselineCost,

--- a/platform/backend/src/routes/proxy/utils/cost-optimization.test.ts
+++ b/platform/backend/src/routes/proxy/utils/cost-optimization.test.ts
@@ -173,6 +173,33 @@ describe("calculateCacheCost", () => {
     expect(result?.cacheCost).toBeCloseTo(0.0145);
     expect(result?.cacheSavings).toBeCloseTo(0.0155);
   });
+
+  test("bills the 1-hour write portion at 2x, the rest at the 5m rate", async () => {
+    await ModelModel.create({
+      externalId: "anthropic/cache-1h",
+      provider: "anthropic",
+      modelId: "cache-1h",
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      promptPricePerToken: "0.000010", // $10/M input
+      completionPricePerToken: "0.000030",
+      lastSyncedAt: new Date(),
+    });
+
+    // read 2000 → 0.002 cost / 0.018 saved.
+    // of 1000 write tokens, 400 are 1h (2x) and 600 are 5m (1.25x):
+    //   cost  = 0.002 + 600/1M*$10*1.25 (0.0075) + 400/1M*$10*2 (0.008) = 0.0175
+    //   saved = 0.018 - 600/1M*$10*0.25 (0.0015) - 400/1M*$10*1.0 (0.004) = 0.0125
+    const result = await calculateCacheCost(
+      "cache-1h",
+      "anthropic",
+      2000,
+      1000,
+      400,
+    );
+    expect(result?.cacheCost).toBeCloseTo(0.0175);
+    expect(result?.cacheSavings).toBeCloseTo(0.0125);
+  });
 });
 
 describe("estimateToolTokens", () => {

--- a/platform/backend/src/routes/proxy/utils/cost-optimization.test.ts
+++ b/platform/backend/src/routes/proxy/utils/cost-optimization.test.ts
@@ -143,6 +143,29 @@ describe("calculateCost", () => {
     });
     expect(cost).toBeCloseTo(0.0395);
   });
+
+  test("bills the 1h cache-write portion at 2x in the all-in cost", async () => {
+    await ModelModel.create({
+      externalId: "anthropic/cache-cost-1h",
+      provider: "anthropic",
+      modelId: "cache-cost-1h",
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      promptPricePerToken: "0.000010", // $10/M input
+      completionPricePerToken: "0.000030", // $30/M output
+      lastSyncedAt: new Date(),
+    });
+
+    // input 0.01 + output 0.015 + read 0.002 (2000*$10*0.1)
+    // of 1000 writes, 400 are 1h (2x = 0.008) and 600 are 5m (1.25x = 0.0075)
+    // total = 0.01 + 0.015 + 0.002 + 0.0075 + 0.008 = 0.0425
+    const cost = await calculateCost("cache-cost-1h", 1000, 500, "anthropic", {
+      readTokens: 2000,
+      writeTokens: 1000,
+      write1hTokens: 400,
+    });
+    expect(cost).toBeCloseTo(0.0425);
+  });
 });
 
 describe("calculateCacheCost", () => {

--- a/platform/backend/src/routes/proxy/utils/cost-optimization.ts
+++ b/platform/backend/src/routes/proxy/utils/cost-optimization.ts
@@ -187,6 +187,8 @@ export const CACHE_PRICE_MULTIPLIERS: Record<
 interface CacheTokenCounts {
   readTokens?: number;
   writeTokens?: number;
+  /** Portion of writeTokens written at the 1-hour TTL (billed at write1h, the rest at write). */
+  write1hTokens?: number;
 }
 
 /**
@@ -216,13 +218,23 @@ export async function calculateCost(
   const pricing = ModelModel.getEffectivePricing(model_entry, model);
   const priceIn = Number.parseFloat(pricing.pricePerMillionInput);
   const priceOut = Number.parseFloat(pricing.pricePerMillionOutput);
-  const mult = CACHE_PRICE_MULTIPLIERS[provider] ?? { read: 0, write: 0 };
+  const mult: { read: number; write: number; write1h?: number } =
+    CACHE_PRICE_MULTIPLIERS[provider] ?? { read: 0, write: 0 };
+
+  // Cache writes are billed per TTL: 1h costs more than the 5m default.
+  const write1h = Math.min(
+    Math.max(cacheTokens?.write1hTokens ?? 0, 0),
+    writeTokens,
+  );
+  const write5m = writeTokens - write1h;
+  const write1hMult = mult.write1h ?? mult.write;
 
   return (
     ((inputTokens ?? 0) / 1_000_000) * priceIn +
     ((outputTokens ?? 0) / 1_000_000) * priceOut +
     (readTokens / 1_000_000) * priceIn * mult.read +
-    (writeTokens / 1_000_000) * priceIn * mult.write
+    (write5m / 1_000_000) * priceIn * mult.write +
+    (write1h / 1_000_000) * priceIn * write1hMult
   );
 }
 

--- a/platform/backend/src/routes/proxy/utils/cost-optimization.ts
+++ b/platform/backend/src/routes/proxy/utils/cost-optimization.ts
@@ -173,10 +173,12 @@ export async function getOptimizedModel<
  */
 export const CACHE_PRICE_MULTIPLIERS: Record<
   string,
-  { read: number; write: number }
+  { read: number; write: number; write1h?: number }
 > = {
-  anthropic: { read: 0.1, write: 1.25 },
-  bedrock: { read: 0.1, write: 1.25 },
+  // write = 5-minute cache-write surcharge; write1h = 1-hour cache-write
+  // surcharge (Anthropic/Bedrock bill the 1h write at 2x input, the 5m at 1.25x).
+  anthropic: { read: 0.1, write: 1.25, write1h: 2 },
+  bedrock: { read: 0.1, write: 1.25, write1h: 2 },
   openai: { read: 0.25, write: 0 },
   gemini: { read: 0.25, write: 0 },
   deepseek: { read: 0.1, write: 0 },
@@ -237,6 +239,8 @@ export async function calculateCacheCost(
   provider: SupportedProvider,
   readTokens: number,
   writeTokens: number,
+  /** Portion of writeTokens written at the 1-hour TTL (the rest is costed at the 5m rate). */
+  write1hTokens = 0,
 ): Promise<{ cacheCost: number; cacheSavings: number } | undefined> {
   if (!readTokens && !writeTokens) {
     return undefined;
@@ -253,11 +257,21 @@ export async function calculateCacheCost(
   const pricing = ModelModel.getEffectivePricing(model_entry, model);
   const priceIn = Number.parseFloat(pricing.pricePerMillionInput);
 
+  // Split writes by TTL: 1h is billed at a higher surcharge than the 5m default.
+  const write1h = Math.min(Math.max(write1hTokens, 0), writeTokens);
+  const write5m = writeTokens - write1h;
+  const write1hMult = mult.write1h ?? mult.write;
+
   const readFull = (readTokens / 1_000_000) * priceIn;
-  const writeFull = (writeTokens / 1_000_000) * priceIn;
-  const cacheCost = readFull * mult.read + writeFull * mult.write;
+  const write5mFull = (write5m / 1_000_000) * priceIn;
+  const write1hFull = (write1h / 1_000_000) * priceIn;
+
+  const cacheCost =
+    readFull * mult.read + write5mFull * mult.write + write1hFull * write1hMult;
   const cacheSavings =
-    readFull * (1 - mult.read) - writeFull * (mult.write - 1);
+    readFull * (1 - mult.read) -
+    write5mFull * (mult.write - 1) -
+    write1hFull * (write1hMult - 1);
 
   return { cacheCost, cacheSavings };
 }

--- a/platform/backend/src/types/llm-provider.ts
+++ b/platform/backend/src/types/llm-provider.ts
@@ -437,6 +437,8 @@ export interface UsageView {
   cacheReadTokens?: number;
   /** Tokens written to the prompt cache (0/absent for providers that auto-cache without a write surcharge). */
   cacheWriteTokens?: number;
+  /** Portion of cacheWriteTokens written at the 1-hour TTL (billed higher than 5m). Anthropic-only; absent elsewhere. */
+  cacheWrite1hTokens?: number;
 }
 
 /**

--- a/platform/backend/src/types/llm-providers/anthropic/api.ts
+++ b/platform/backend/src/types/llm-providers/anthropic/api.ts
@@ -98,6 +98,14 @@ export const UsageSchema = z.object({
   output_tokens: z.number(),
   cache_read_input_tokens: z.number().nullish(),
   cache_creation_input_tokens: z.number().nullish(),
+  // Per-TTL split of cache_creation_input_tokens. 1h writes are billed higher
+  // than 5m, so the cost calc needs the breakdown, not just the total.
+  cache_creation: z
+    .object({
+      ephemeral_1h_input_tokens: z.number().nullish(),
+      ephemeral_5m_input_tokens: z.number().nullish(),
+    })
+    .nullish(),
 });
 
 export const MessagesResponseSchema = z.object({

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -1478,6 +1478,10 @@ export type AnthropicMessagesResponseInput = {
         output_tokens: number;
         cache_read_input_tokens?: number | null;
         cache_creation_input_tokens?: number | null;
+        cache_creation?: {
+            ephemeral_1h_input_tokens?: number | null;
+            ephemeral_5m_input_tokens?: number | null;
+        } | null;
     };
 };
 
@@ -6757,6 +6761,10 @@ export type AnthropicMessagesResponse = {
         output_tokens: number;
         cache_read_input_tokens?: number | null;
         cache_creation_input_tokens?: number | null;
+        cache_creation?: {
+            ephemeral_1h_input_tokens?: number | null;
+            ephemeral_5m_input_tokens?: number | null;
+        } | null;
     };
 };
 


### PR DESCRIPTION
## Summary

Anthropic and Bedrock bill a **1-hour** cache write at **2x** base input, versus **1.25x** for the 5-minute default ([prompt-caching docs](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)). The cache cost math used a flat 1.25x for every write, so once 1h caching went live for Claude 4.5+ models, `interaction.cost`, `baselineCost`, `cache_cost`, `cache_savings`, and the `archestra.cost` span attribute all under-reported the write surcharge.

This makes cache-write cost TTL-aware. Anthropic's response reports the per-TTL split (`usage.cache_creation.ephemeral_1h_input_tokens`); that is captured into `UsageView.cacheWrite1hTokens` and threaded into both the cache-cost breakdown (`calculateCacheCost`) and the all-in cost (`calculateCost`, which feeds the persisted cost, baseline cost, and span cost). The 1h portion is billed at 2x, the remainder at 1.25x.

Verified against the docs (rate + the exact response field) and unit-tested at three layers: the adapter capture, the breakdown cost, and the all-in cost.

### Known limitation
Bedrock 1h writes still bill at 1.25x — its Converse `usage` does not expose the per-TTL split, so the 1h portion can't be distinguished from the response. Tracked as a follow-up (would need request-side TTL inference for Bedrock).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>