### PR TITLE
fix(cost): bill Bedrock 1-hour cache writes at 2x

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -61841,6 +61841,21 @@
                         },
                         "cacheWriteInputTokens": {
                           "type": "number"
+                        },
+                        "cacheDetails": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "ttl": {
+                                "type": "string"
+                              },
+                              "inputTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
                         }
                       },
                       "required": [
@@ -63108,6 +63123,21 @@
                         },
                         "cacheWriteInputTokens": {
                           "type": "number"
+                        },
+                        "cacheDetails": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "ttl": {
+                                "type": "string"
+                              },
+                              "inputTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
                         }
                       },
                       "required": [
@@ -66014,6 +66044,21 @@
                         },
                         "cacheWriteInputTokens": {
                           "type": "number"
+                        },
+                        "cacheDetails": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "ttl": {
+                                "type": "string"
+                              },
+                              "inputTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
                         }
                       },
                       "required": [
@@ -96502,6 +96547,21 @@
                                       },
                                       "cacheWriteInputTokens": {
                                         "type": "number"
+                                      },
+                                      "cacheDetails": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "ttl": {
+                                              "type": "string"
+                                            },
+                                            "inputTokens": {
+                                              "type": "number"
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
                                       }
                                     },
                                     "required": [
@@ -109814,6 +109874,21 @@
                                 },
                                 "cacheWriteInputTokens": {
                                   "type": "number"
+                                },
+                                "cacheDetails": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "ttl": {
+                                        "type": "string"
+                                      },
+                                      "inputTokens": {
+                                        "type": "number"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
                                 }
                               },
                               "required": [

--- a/platform/backend/src/routes/proxy/adapters/bedrock-openai.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock-openai.test.ts
@@ -169,6 +169,7 @@ describe("BedrockOpenai response adapter", () => {
       outputTokens: 1,
       cacheReadTokens: 0,
       cacheWriteTokens: 0,
+      cacheWrite1hTokens: 0,
     });
     expect(resp.getFinishReasons()).toEqual(["tool_use"]);
   });

--- a/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
@@ -368,3 +368,32 @@ describe("Bedrock client creation", () => {
     expect(client.config.baseUrl).toBe(customBaseUrl);
   });
 });
+
+describe("Bedrock getUsage", () => {
+  test("sums the 1h portion from the cacheDetails per-TTL breakdown", () => {
+    const response = {
+      output: { message: { role: "assistant", content: [{ text: "hi" }] } },
+      stopReason: "end_turn",
+      usage: {
+        inputTokens: 5,
+        outputTokens: 10,
+        cacheReadInputTokens: 2000,
+        cacheWriteInputTokens: 1000,
+        cacheDetails: [
+          { ttl: "1h", inputTokens: 400 },
+          { ttl: "5m", inputTokens: 600 },
+        ],
+      },
+    } as unknown as Bedrock.Types.ConverseResponse;
+
+    const adapter = bedrockAdapterFactory.createResponseAdapter(response);
+
+    expect(adapter.getUsage()).toEqual({
+      inputTokens: 5,
+      outputTokens: 10,
+      cacheReadTokens: 2000,
+      cacheWriteTokens: 1000,
+      cacheWrite1hTokens: 400,
+    });
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
@@ -396,4 +396,38 @@ describe("Bedrock getUsage", () => {
       cacheWrite1hTokens: 400,
     });
   });
+
+  test("preserves cache usage through execute() on the non-streaming path", async () => {
+    const client = {
+      converse: async () => ({
+        $metadata: { requestId: "r" },
+        output: { message: { role: "assistant", content: [{ text: "hi" }] } },
+        stopReason: "end_turn",
+        usage: {
+          inputTokens: 5,
+          outputTokens: 10,
+          cacheReadInputTokens: 2000,
+          cacheWriteInputTokens: 1000,
+          cacheDetails: [
+            { ttl: "1h", inputTokens: 400 },
+            { ttl: "5m", inputTokens: 600 },
+          ],
+        },
+      }),
+    };
+
+    const response = await bedrockAdapterFactory.execute(
+      client,
+      createConverseRequest(),
+    );
+    const adapter = bedrockAdapterFactory.createResponseAdapter(response);
+
+    expect(adapter.getUsage()).toEqual({
+      inputTokens: 5,
+      outputTokens: 10,
+      cacheReadTokens: 2000,
+      cacheWriteTokens: 1000,
+      cacheWrite1hTokens: 400,
+    });
+  });
 });

--- a/platform/backend/src/routes/proxy/adapters/bedrock.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.ts
@@ -1760,6 +1760,11 @@ export const bedrockAdapterFactory: LLMProvider<
       usage: {
         inputTokens: response.usage?.inputTokens ?? 0,
         outputTokens: response.usage?.outputTokens ?? 0,
+        // Preserve cache usage so getUsage() can report it on the non-streaming
+        // path; cacheDetails carries the per-TTL write split for 1h cost.
+        cacheReadInputTokens: response.usage?.cacheReadInputTokens,
+        cacheWriteInputTokens: response.usage?.cacheWriteInputTokens,
+        cacheDetails: response.usage?.cacheDetails,
       },
       metrics: response.metrics,
       additionalModelResponseFields: response.additionalModelResponseFields as

--- a/platform/backend/src/routes/proxy/adapters/bedrock.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.ts
@@ -840,6 +840,26 @@ class BedrockRequestAdapter
 // RESPONSE ADAPTER
 // =============================================================================
 
+/**
+ * Cache-creation tokens written at the 1-hour TTL, from Bedrock's per-TTL
+ * `cacheDetails` breakdown (the remainder of cacheWriteInputTokens is 5m). Used
+ * to bill the 1h write portion at the higher rate.
+ */
+function bedrockCacheWrite1hTokens(
+  usage:
+    | {
+        cacheDetails?: ({ ttl?: string; inputTokens?: number } | null)[] | null;
+      }
+    | null
+    | undefined,
+): number {
+  return (usage?.cacheDetails ?? []).reduce(
+    (sum, detail) =>
+      detail?.ttl === "1h" ? sum + (detail.inputTokens ?? 0) : sum,
+    0,
+  );
+}
+
 class BedrockResponseAdapter implements LLMResponseAdapter<BedrockResponse> {
   readonly provider = "bedrock" as const;
   private response: BedrockResponse;
@@ -899,6 +919,7 @@ class BedrockResponseAdapter implements LLMResponseAdapter<BedrockResponse> {
       outputTokens: this.response.usage?.outputTokens ?? 0,
       cacheReadTokens: this.response.usage?.cacheReadInputTokens ?? 0,
       cacheWriteTokens: this.response.usage?.cacheWriteInputTokens ?? 0,
+      cacheWrite1hTokens: bedrockCacheWrite1hTokens(this.response.usage),
     };
   }
 
@@ -1088,6 +1109,7 @@ class BedrockStreamAdapter
           outputTokens?: number;
           cacheReadInputTokens?: number;
           cacheWriteInputTokens?: number;
+          cacheDetails?: ({ ttl?: string; inputTokens?: number } | null)[];
         };
         metrics?: { latencyMs?: number };
         trace?: unknown;
@@ -1098,6 +1120,7 @@ class BedrockStreamAdapter
           outputTokens: metadata.usage.outputTokens ?? 0,
           cacheReadTokens: metadata.usage.cacheReadInputTokens ?? 0,
           cacheWriteTokens: metadata.usage.cacheWriteInputTokens ?? 0,
+          cacheWrite1hTokens: bedrockCacheWrite1hTokens(metadata.usage),
         };
       }
       if (metadata.metrics?.latencyMs !== undefined) {

--- a/platform/backend/src/types/llm-providers/bedrock/api.ts
+++ b/platform/backend/src/types/llm-providers/bedrock/api.ts
@@ -88,6 +88,16 @@ export const UsageSchema = z.object({
   totalTokens: z.number().optional(),
   cacheReadInputTokens: z.number().optional(),
   cacheWriteInputTokens: z.number().optional(),
+  // Per-TTL split of cache writes (sorted 1h before 5m). Needed to bill the 1h
+  // write portion at the higher rate; Zod would strip it without this field.
+  cacheDetails: z
+    .array(
+      z.object({
+        ttl: z.string().optional(),
+        inputTokens: z.number().optional(),
+      }),
+    )
+    .optional(),
 });
 
 // Metrics

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -18036,6 +18036,10 @@ export type BedrockConverseWithDefaultAgentResponses = {
             totalTokens?: number;
             cacheReadInputTokens?: number;
             cacheWriteInputTokens?: number;
+            cacheDetails?: Array<{
+                ttl?: string;
+                inputTokens?: number;
+            }>;
         };
         metrics?: {
             latencyMs?: number;
@@ -18358,6 +18362,10 @@ export type BedrockConverseWithAgentResponses = {
             totalTokens?: number;
             cacheReadInputTokens?: number;
             cacheWriteInputTokens?: number;
+            cacheDetails?: Array<{
+                ttl?: string;
+                inputTokens?: number;
+            }>;
         };
         metrics?: {
             latencyMs?: number;
@@ -19073,6 +19081,10 @@ export type BedrockConverseWithAgentAndModelResponses = {
             totalTokens?: number;
             cacheReadInputTokens?: number;
             cacheWriteInputTokens?: number;
+            cacheDetails?: Array<{
+                ttl?: string;
+                inputTokens?: number;
+            }>;
         };
         metrics?: {
             latencyMs?: number;
@@ -27153,6 +27165,10 @@ export type GetInteractionsResponses = {
                     totalTokens?: number;
                     cacheReadInputTokens?: number;
                     cacheWriteInputTokens?: number;
+                    cacheDetails?: Array<{
+                        ttl?: string;
+                        inputTokens?: number;
+                    }>;
                 };
                 metrics?: {
                     latencyMs?: number;
@@ -29739,6 +29755,10 @@ export type GetInteractionResponses = {
                 totalTokens?: number;
                 cacheReadInputTokens?: number;
                 cacheWriteInputTokens?: number;
+                cacheDetails?: Array<{
+                    ttl?: string;
+                    inputTokens?: number;
+                }>;
             };
             metrics?: {
                 latencyMs?: number;


### PR DESCRIPTION
## Summary

Follow-up to #5466, which billed Anthropic 1h cache writes at 2x but left Bedrock at a flat 1.25x on the assumption that Bedrock's Converse usage had no per-TTL split. That assumption was wrong: AWS exposes the breakdown via `usage.cacheDetails` (`[{ ttl, inputTokens }]`, sorted 1h before 5m). Since the chat path sends `cachePoint.ttl = "1h"` to Bedrock for 4.5+ models and AWS bills those writes at 2x, leaving them at 1.25x under-reported the cost.

The Bedrock adapter now sums the 1h portion from `cacheDetails` into `UsageView.cacheWrite1hTokens` (response + streaming paths), which the existing TTL-aware cost calc already bills at 2x. The `cacheDetails` field is added to the Bedrock `UsageSchema` so Zod doesn't strip it, with a capture test.

This closes the "known limitation" noted in #5466 — both Anthropic and Bedrock 1h writes are now costed correctly.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>