### PR TITLE
fix(chat): cap title-gen output tokens to avoid Anthropic streaming-required error

### DIFF
--- a/platform/backend/src/routes/chat/routes.test.ts
+++ b/platform/backend/src/routes/chat/routes.test.ts
@@ -1174,7 +1174,29 @@ describe("generateConversationTitle", () => {
       model: "mocked-model",
       system: "Return only a title.",
       prompt: "Chat conversation messages:\n\nUser: Hello\n\nAssistant: Hi!",
+      maxOutputTokens: 64,
     });
+  });
+
+  it("caps output tokens so non-streaming requests stay under the provider limit", async () => {
+    mockGenerateText.mockResolvedValueOnce({ text: "Short Title" });
+
+    await generateConversationTitle({
+      provider: "anthropic",
+      apiKey: "test-key",
+      modelName: "claude-test",
+      baseUrl: null,
+      agentId: "title-agent-id",
+      userId: "user-id",
+      conversationId: "conversation-id",
+      systemPrompt: "Generate a title.",
+      firstUserMessage: "Hello",
+      firstAssistantMessage: "Hi!",
+    });
+
+    const callArg = mockGenerateText.mock.calls[0][0];
+    expect(callArg.maxOutputTokens).toBeLessThanOrEqual(64);
+    expect(callArg.maxOutputTokens).toBeGreaterThan(0);
   });
 });
 

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -2762,6 +2762,7 @@ export async function generateConversationTitle(
       model,
       system: systemPrompt,
       prompt: titlePrompt,
+      maxOutputTokens: 64,
     });
 
     logger.debug(


### PR DESCRIPTION
## Summary

New chat conversations silently kept their default/empty title. The cause was `generateConversationTitle()` calling `generateText()` with no `maxOutputTokens`, so the AI SDK defaulted to a 32000-token output budget. Anthropic rejects **non-streaming** requests with a budget that large — `invalid_request_error: "Streaming is required for operations that may take longer than 10 minutes"` — which surfaced in logs as "Failed to generate conversation title" → `AI_RetryError`. The title generation never reached the model.

A title is 3–6 words, so the unbounded budget was both wrong and the trigger. Capping the call at `maxOutputTokens: 64` keeps the request well under Anthropic's non-streaming limit, so titles generate again. With the fix, a new chat receives a non-empty title and the path logs "Title generation: generateText succeeded".

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>