### PR TITLE
refactor(migration-kit): unify accreted helpers into single mechanisms

### DIFF
--- a/migration-kit/scripts/apply.py
+++ b/migration-kit/scripts/apply.py
@@ -47,7 +47,6 @@ from archestra_client import (
 )
 from contracts import (
     SECRET_KEY_RE,
-    SECRET_TOKEN_RE,
     ClaudeMdItem,
     CommandItem,
     ContractError,
@@ -66,6 +65,7 @@ from contracts import (
     optional_action,
     parse_inventory,
     parse_plan,
+    redact_tokens,
     require_answer,
     require_dict,
     require_list,
@@ -353,12 +353,6 @@ def _build_payload(decision: Decision, item: Item) -> tuple[str, Built]:
             )
 
 
-def _scrub_secrets(text: str) -> str:
-    """mask credential-shaped tokens embedded in a string before it is printed (e.g. an MCP
-    launch command like ``npx server --token=sk-...``). belt-and-suspenders for dry-run output."""
-    return SECRET_TOKEN_RE.sub("<redacted>", text)
-
-
 # url credentials that aren't token-shaped: basic-auth userinfo and secret-named query params.
 _URL_USERINFO_RE = re.compile(r"(//)[^/@\s]+@")
 _URL_SECRET_QUERY_RE = re.compile(
@@ -370,7 +364,7 @@ def _scrub_url(url: str) -> str:
     params, plus any token-shaped value)."""
     url = _URL_USERINFO_RE.sub(r"\1<redacted>@", url)
     url = _URL_SECRET_QUERY_RE.sub(r"\1<redacted>", url)
-    return _scrub_secrets(url)
+    return redact_tokens(url)
 
 
 def _redacted_for_print(built: Built) -> dict[str, JsonValue]:
@@ -395,8 +389,8 @@ def _redacted_for_print(built: Built) -> dict[str, JsonValue]:
                 # (e.g. --token=sk-...) -- all on the typed dataclass, before serializing.
                 payload = replace(payload, localConfig=replace(
                     local,
-                    command=_scrub_secrets(local.command),
-                    arguments=[_scrub_secrets(a) for a in local.arguments],
+                    command=redact_tokens(local.command),
+                    arguments=[redact_tokens(a) for a in local.arguments],
                     # keep value-less vars value-less (don't fabricate a redacted value).
                     environment=[replace(e, value="<redacted>" if e.value is not None else None)
                                  for e in local.environment],

--- a/migration-kit/scripts/apply.py
+++ b/migration-kit/scripts/apply.py
@@ -226,6 +226,9 @@ def _str_answers(value: object, *, ctx: str) -> list[str]:
     return out
 
 
+# when a plan carries both answers, precedence diverges by kind: _team_ids (multi-team
+# payloads: agent/skill/catalog) prefers teamIds; _team_id (single-team payloads:
+# install/llm_key) prefers teamId. each falls back to the other answer.
 def _team_ids(decision: Decision, *, ctx: str) -> list[str] | None:
     if decision.scope != "team":
         return None
@@ -564,11 +567,11 @@ def main() -> int:
     built.sort(key=lambda b: _ORDER.get(b.decision.target_kind, 99))
 
     if args.dry_run:
-        return _finish(_run_dry(built, verbose=args.verbose), args.out)
+        return _finish(_run_validation(built, verbose=args.verbose, label="dry-run"), args.out)
 
     if any(_invalid_build(b) for b in built):
         print("error: migration plan has invalid operations; no network changes were made", file=sys.stderr)
-        return _finish(_run_preflight(built, verbose=args.verbose), args.out)
+        return _finish(_run_validation(built, verbose=args.verbose, label="preflight"), args.out)
 
     base_url = os.environ.get("ARCHESTRA_BASE_URL")
     api_key = os.environ.get("ARCHESTRA_API_KEY")
@@ -577,14 +580,6 @@ def main() -> int:
         return 2
 
     return _finish(_run_apply(built, base_url, api_key), args.out)
-
-
-def _run_dry(built: list[_Built], *, verbose: bool) -> list[ResultOp]:
-    return _run_validation(built, verbose=verbose, label="dry-run")
-
-
-def _run_preflight(built: list[_Built], *, verbose: bool) -> list[ResultOp]:
-    return _run_validation(built, verbose=verbose, label="preflight")
 
 
 def _run_validation(built: list[_Built], *, verbose: bool, label: str) -> list[ResultOp]:

--- a/migration-kit/scripts/contracts.py
+++ b/migration-kit/scripts/contracts.py
@@ -363,7 +363,7 @@ _LiteralT = TypeVar("_LiteralT", bound=str)
 def _require_literal(
     value: object, allowed: tuple[_LiteralT, ...], *, what: str, ctx: str
 ) -> _LiteralT:
-    """the single mechanism behind every enum-shaped field crossing a trust boundary."""
+    """the one mechanism behind enum-shaped fields crossing a trust boundary."""
     if value not in allowed:
         raise ContractError(f"{ctx}: {what} {value!r} must be one of {'|'.join(allowed)}")
     return cast("_LiteralT", value)

--- a/migration-kit/scripts/contracts.py
+++ b/migration-kit/scripts/contracts.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field, fields, is_dataclass
-from typing import Literal, Mapping, Union, cast
+from typing import Literal, Mapping, TypeVar, Union, cast
 
 SCHEMA_VERSION = 1
 
@@ -349,20 +349,28 @@ _TARGET_KINDS: tuple[TargetKind, ...] = (
     "agent", "skill", "mcp_catalog", "mcp_install", "llm_key", "tool_policy",
 )
 _PLAN_ACTIONS: tuple[Literal["migrate", "skip", "manual"], ...] = ("migrate", "skip", "manual")
+_ENCODINGS: tuple[Literal["utf8", "base64"], ...] = ("utf8", "base64")
+
+_LiteralT = TypeVar("_LiteralT", bound=str)
+
+
+def _require_literal(
+    value: object, allowed: tuple[_LiteralT, ...], *, what: str, ctx: str
+) -> _LiteralT:
+    """the single mechanism behind every enum-shaped field crossing a trust boundary."""
+    if value not in allowed:
+        raise ContractError(f"{ctx}: {what} {value!r} must be one of {'|'.join(allowed)}")
+    return cast("_LiteralT", value)
 
 
 def require_provider(answers: Mapping[str, JsonValue], *, ctx: str) -> Provider:
     value = require_str_field(answers, "provider", ctx=ctx)
-    if value not in _PROVIDERS:
-        raise ContractError(f"{ctx}: provider {value!r} is not a known provider")
-    return cast("Provider", value)
+    return _require_literal(value, _PROVIDERS, what="provider", ctx=ctx)
 
 
 def require_operator(answers: Mapping[str, JsonValue], *, ctx: str) -> ConditionOperator:
     value = require_str_field(answers, "operator", ctx=ctx)
-    if value not in _OPERATORS:
-        raise ContractError(f"{ctx}: operator {value!r} is not a known condition operator")
-    return cast("ConditionOperator", value)
+    return _require_literal(value, _OPERATORS, what="operator", ctx=ctx)
 
 
 def optional_action(answers: Mapping[str, JsonValue], *, ctx: str) -> PolicyAction:
@@ -370,9 +378,7 @@ def optional_action(answers: Mapping[str, JsonValue], *, ctx: str) -> PolicyActi
     value = answers.get("action")
     if value is None:
         return "block_always"
-    if value not in _ACTIONS:
-        raise ContractError(f"{ctx}: action {value!r} is not a known policy action")
-    return cast("PolicyAction", value)
+    return _require_literal(value, _ACTIONS, what="action", ctx=ctx)
 
 
 # --- parsing external JSON into typed objects --------------------------------------------
@@ -380,44 +386,13 @@ def optional_action(answers: Mapping[str, JsonValue], *, ctx: str) -> PolicyActi
 
 def parse_bundled_file(value: object, *, ctx: str) -> BundledFile:
     obj = require_dict(value, ctx=ctx)
-    encoding = require_str_field(obj, "encoding", ctx=ctx)
-    if encoding not in ("utf8", "base64"):
-        raise ContractError(f"{ctx}.encoding: {encoding!r} must be 'utf8' or 'base64'")
     return BundledFile(
         path=require_str_field(obj, "path", ctx=ctx),
         content=require_str_field(obj, "content", ctx=ctx),
-        encoding=cast('Literal["utf8", "base64"]', encoding),
+        encoding=_require_literal(
+            require_str_field(obj, "encoding", ctx=ctx), _ENCODINGS, what="encoding", ctx=ctx
+        ),
     )
-
-
-def _scope(value: object, *, ctx: str) -> Scope:
-    if value not in _SCOPES:
-        raise ContractError(f"{ctx}: scope {value!r} must be personal|team|org")
-    return cast("Scope", value)
-
-
-def _server_type(value: object, *, ctx: str) -> ServerType:
-    if value not in _SERVER_TYPES:
-        raise ContractError(f"{ctx}: transport {value!r} must be local|remote")
-    return cast("ServerType", value)
-
-
-def _intent(value: object, *, ctx: str) -> HookIntent:
-    if value not in _INTENTS:
-        raise ContractError(f"{ctx}: intent {value!r} must be guard|passive")
-    return cast("HookIntent", value)
-
-
-def _target_kind(value: object, *, ctx: str) -> TargetKind:
-    if value not in _TARGET_KINDS:
-        raise ContractError(f"{ctx}: {value!r} is not a known target kind")
-    return cast("TargetKind", value)
-
-
-def _plan_action(value: object, *, ctx: str) -> Literal["migrate", "skip", "manual"]:
-    if value not in _PLAN_ACTIONS:
-        raise ContractError(f"{ctx}: {value!r} must be migrate|skip|manual")
-    return cast('Literal["migrate", "skip", "manual"]', value)
 
 
 def parse_item(value: object, *, ctx: str) -> Item:
@@ -480,7 +455,9 @@ def parse_item(value: object, *, ctx: str) -> Item:
             return McpServerItem(
                 id=item_id, name=name, path=path, summary=summary, files=files, redacted_refs=refs,
                 data=McpServerData(
-                    transport=_server_type(data.get("transport"), ctx=dctx),
+                    transport=_require_literal(
+                        data.get("transport"), _SERVER_TYPES, what="transport", ctx=dctx
+                    ),
                     command=_opt_str(data, "command", ctx=dctx),
                     args=_str_list(data.get("args", []), ctx=f"{dctx}.args"),
                     env=_str_map(data.get("env", {}), ctx=f"{dctx}.env"),
@@ -493,7 +470,7 @@ def parse_item(value: object, *, ctx: str) -> Item:
                 data=HookData(
                     event=require_str_field(data, "event", ctx=dctx),
                     command=require_str_field(data, "command", ctx=dctx),
-                    intent=_intent(data.get("intent"), ctx=dctx),
+                    intent=_require_literal(data.get("intent"), _INTENTS, what="intent", ctx=dctx),
                     matcher=_opt_str(data, "matcher", ctx=dctx),
                 ),
             )
@@ -537,9 +514,13 @@ def parse_decision(value: object, *, ctx: str) -> Decision:
     obj = require_dict(value, ctx=ctx)
     return Decision(
         source_id=require_str_field(obj, "source_id", ctx=ctx),
-        target_kind=_target_kind(obj.get("target_kind"), ctx=f"{ctx}.target_kind"),
-        scope=_scope(obj.get("scope"), ctx=f"{ctx}.scope"),
-        action=_plan_action(obj.get("action", "migrate"), ctx=f"{ctx}.action"),
+        target_kind=_require_literal(
+            obj.get("target_kind"), _TARGET_KINDS, what="target kind", ctx=f"{ctx}.target_kind"
+        ),
+        scope=_require_literal(obj.get("scope"), _SCOPES, what="scope", ctx=f"{ctx}.scope"),
+        action=_require_literal(
+            obj.get("action", "migrate"), _PLAN_ACTIONS, what="action", ctx=f"{ctx}.action"
+        ),
         name_override=_opt_str(obj, "name_override", ctx=ctx),
         notes=_opt_str(obj, "notes", ctx=ctx),
         user_answers=require_dict(obj.get("user_answers", {}), ctx=f"{ctx}.user_answers"),
@@ -554,7 +535,9 @@ def parse_plan(value: object, *, ctx: str = "plan") -> MigrationPlan:
     ]
     return MigrationPlan(
         schema_version=_require_int(obj.get("schema_version", SCHEMA_VERSION), ctx=f"{ctx}.schema_version"),
-        default_scope=_scope(obj.get("default_scope"), ctx=f"{ctx}.default_scope"),
+        default_scope=_require_literal(
+            obj.get("default_scope"), _SCOPES, what="scope", ctx=f"{ctx}.default_scope"
+        ),
         decisions=decisions,
     )
 

--- a/migration-kit/scripts/contracts.py
+++ b/migration-kit/scripts/contracts.py
@@ -42,6 +42,12 @@ SECRET_TOKEN_RE = re.compile(
     r"|AIza[A-Za-z0-9_-]{8,}|ya29\.[A-Za-z0-9_-]{8,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)"
 )
 
+
+def redact_tokens(text: str) -> str:
+    """replace credential-shaped tokens embedded in a string (a hook command, an MCP launch
+    command, a URL) before it is stored or printed."""
+    return SECRET_TOKEN_RE.sub("<redacted>", text)
+
 # --- shared Literal vocabularies (imported by archestra_client to avoid a cycle) ----------
 
 Scope = Literal["personal", "team", "org"]

--- a/migration-kit/scripts/discover.py
+++ b/migration-kit/scripts/discover.py
@@ -54,6 +54,7 @@ from contracts import (
     SubagentItem,
     as_array,
     as_object,
+    redact_tokens,
     require_dict,
     to_jsonable,
 )
@@ -72,11 +73,6 @@ def _style(text: str, code: str) -> str:
 def _is_secret_value(value: str) -> bool:
     # a prefix that looks like a credential, OR a credential-shaped token embedded anywhere.
     return bool(_SECRET_VALUE.match(value) or _SECRET_TOKEN.search(value))
-
-
-def _redact_inline(text: str) -> str:
-    """replace credential-shaped tokens inside a config string (e.g. a hook command)."""
-    return _SECRET_TOKEN.sub("<redacted>", text)
 
 
 def _redact_value(value: str, ref: str, sink: list[str]) -> str:
@@ -375,18 +371,13 @@ def _discover_hooks(inv: Inventory, hooks: JsonValue, rel: str) -> None:
                 if h_obj is None:
                     continue
                 raw_command = h_obj.get("command")
-                command = _redact_inline(raw_command if isinstance(raw_command, str) else "")
+                command = redact_tokens(raw_command if isinstance(raw_command, str) else "")
                 intent = _classify_hook(event, command)
                 inv.items.append(HookItem(
                     id=f"hook:{event}:{i}:{j}", name=f"{event}#{i}.{j}", path=rel,
                     summary=f"{event} hook ({intent})",
                     data=HookData(event=event, matcher=matcher, command=command, intent=intent),
                 ))
-
-
-def _kind_counts(inv: Inventory) -> str:
-    counts = Counter(it.kind for it in inv.items)
-    return ", ".join(f"{kind}={count}" for kind, count in sorted(counts.items())) or "none"
 
 
 def _print_summary(inv: Inventory, out: Path) -> None:
@@ -402,7 +393,9 @@ def _print_summary(inv: Inventory, out: Path) -> None:
     redacted = sum(len(it.redacted_refs) for it in inv.items)
 
     print(_style(f"🔎 discovered {len(inv.items)} items; wrote {out}", "36;1"))
-    print(f"  inventory: {_kind_counts(inv)}")
+    counts = Counter(it.kind for it in inv.items)
+    kinds = ", ".join(f"{kind}={count}" for kind, count in sorted(counts.items())) or "none"
+    print(f"  inventory: {kinds}")
     print(f"  {_style('✅ likely migrates', '32;1')}: {likely} item(s) (agent prompt, skills, commands, local tools)")
     print(f"  {_style('⚠️  needs review', '33;1')}: {review} item(s) (subagents, MCP install choices, guard hooks)")
     print(f"  {_style('🛠️  manual/report-only', '34;1')}: {manual} item(s) (passive hooks, openclaw, unknown files)")

--- a/migration-kit/tests/test_apply_build.py
+++ b/migration-kit/tests/test_apply_build.py
@@ -1,5 +1,7 @@
 """offline tests for the deterministic decision->payload builder."""
 import json
+import os
+import subprocess
 import sys
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -18,13 +20,13 @@ from apply import (
     BuiltSkill,
     _build_payload,
     _redacted_for_print,
-    main,
 )
 from archestra_client import CatalogCreate, LlmKeyCreate, LocalConfig, McpEnvVar
 from contracts import ContractError, Decision, Item, SkillItem, to_jsonable
 from discover import discover
 
 FIXTURE = Path(__file__).parent / "fixtures" / "sample-setup"
+SCRIPTS = Path(__file__).parent.parent / "scripts"
 
 
 @pytest.fixture(scope="module")
@@ -254,7 +256,24 @@ def test_tool_policy_requires_extracted_semantics(index: dict[str, Item]) -> Non
     assert built.action == "block_always"
 
 
-def test_real_apply_preflight_invalid_plan_makes_no_network(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def _run_apply_cli(tmp_path: Path, plan: dict[str, object], *args: str,
+                   env: dict[str, str]) -> tuple[subprocess.CompletedProcess[str], Path]:
+    """run apply.py as a real subprocess: real argv, explicit env, no in-process patching."""
+    inventory_path = tmp_path / "inventory.json"
+    plan_path = tmp_path / "migration_plan.json"
+    result_path = tmp_path / "migration_result.json"
+    inventory_path.write_text(json.dumps(to_jsonable(discover(FIXTURE))), encoding="utf-8")
+    plan_path.write_text(json.dumps(plan), encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "apply.py"),
+         "--inventory", str(inventory_path), "--plan", str(plan_path),
+         "--out", str(result_path), *args],
+        capture_output=True, text=True, env=env, check=False,
+    )
+    return proc, result_path
+
+
+def test_real_apply_preflight_invalid_plan_makes_no_network(tmp_path: Path) -> None:
     requests: list[str] = []
 
     class Handler(BaseHTTPRequestHandler):
@@ -275,29 +294,20 @@ def test_real_apply_preflight_invalid_plan_makes_no_network(tmp_path: Path, monk
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        inventory_path = tmp_path / "inventory.json"
-        plan_path = tmp_path / "migration_plan.json"
-        result_path = tmp_path / "migration_result.json"
-        inventory_path.write_text(json.dumps(to_jsonable(discover(FIXTURE))), encoding="utf-8")
-        plan_path.write_text(json.dumps({
+        proc, result_path = _run_apply_cli(tmp_path, {
             "schema_version": 1,
             "default_scope": "team",
             "decisions": [
                 {"source_id": "claude_md", "target_kind": "agent", "scope": "team"},
                 {"source_id": "skill:summarize-text", "target_kind": "skill", "scope": "team"},
             ],
-        }), encoding="utf-8")
+        }, env={
+            **os.environ,
+            "ARCHESTRA_BASE_URL": f"http://127.0.0.1:{server.server_address[1]}",
+            "ARCHESTRA_API_KEY": "arch_test",
+        })
 
-        monkeypatch.setenv("ARCHESTRA_BASE_URL", f"http://127.0.0.1:{server.server_address[1]}")
-        monkeypatch.setenv("ARCHESTRA_API_KEY", "arch_test")
-        monkeypatch.setattr(sys, "argv", [
-            "apply.py",
-            "--inventory", str(inventory_path),
-            "--plan", str(plan_path),
-            "--out", str(result_path),
-        ])
-
-        assert main() == 1
+        assert proc.returncode == 1
         assert requests == []
         result = json.loads(result_path.read_text(encoding="utf-8"))
         assert result["summary"] == {"invalid": 2}
@@ -306,32 +316,18 @@ def test_real_apply_preflight_invalid_plan_makes_no_network(tmp_path: Path, monk
         thread.join()
 
 
-def test_dry_run_writes_planned_result_without_network(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """pins main()'s --dry-run dispatch: exits 0, writes the result file, needs no env vars."""
-    inventory_path = tmp_path / "inventory.json"
-    plan_path = tmp_path / "migration_plan.json"
-    result_path = tmp_path / "migration_result.json"
-    inventory_path.write_text(json.dumps(to_jsonable(discover(FIXTURE))), encoding="utf-8")
-    plan_path.write_text(json.dumps({
+def test_dry_run_writes_planned_result_without_network(tmp_path: Path) -> None:
+    """pins the --dry-run dispatch: exits 0, writes the result file, needs no env vars."""
+    env = {k: v for k, v in os.environ.items()
+           if k not in ("ARCHESTRA_BASE_URL", "ARCHESTRA_API_KEY")}
+    proc, result_path = _run_apply_cli(tmp_path, {
         "schema_version": 1,
         "default_scope": "personal",
         "decisions": [{"source_id": "claude_md", "target_kind": "agent", "scope": "personal"}],
-    }), encoding="utf-8")
+    }, "--dry-run", env=env)
 
-    monkeypatch.delenv("ARCHESTRA_BASE_URL", raising=False)
-    monkeypatch.delenv("ARCHESTRA_API_KEY", raising=False)
-    monkeypatch.setattr(sys, "argv", [
-        "apply.py",
-        "--inventory", str(inventory_path),
-        "--plan", str(plan_path),
-        "--out", str(result_path),
-        "--dry-run",
-    ])
-
-    assert main() == 0
-    assert "[dry-run]" in capsys.readouterr().out
+    assert proc.returncode == 0
+    assert "[dry-run]" in proc.stdout
     result = json.loads(result_path.read_text(encoding="utf-8"))
     assert result["summary"] == {"planned": 1}
     assert result["ops"][0]["target_kind"] == "agent"

--- a/migration-kit/tests/test_apply_build.py
+++ b/migration-kit/tests/test_apply_build.py
@@ -306,7 +306,9 @@ def test_real_apply_preflight_invalid_plan_makes_no_network(tmp_path: Path, monk
         thread.join()
 
 
-def test_dry_run_writes_planned_result_without_network(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_dry_run_writes_planned_result_without_network(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
     """pins main()'s --dry-run dispatch: exits 0, writes the result file, needs no env vars."""
     inventory_path = tmp_path / "inventory.json"
     plan_path = tmp_path / "migration_plan.json"
@@ -329,6 +331,7 @@ def test_dry_run_writes_planned_result_without_network(tmp_path: Path, monkeypat
     ])
 
     assert main() == 0
+    assert "[dry-run]" in capsys.readouterr().out
     result = json.loads(result_path.read_text(encoding="utf-8"))
     assert result["summary"] == {"planned": 1}
     assert result["ops"][0]["target_kind"] == "agent"

--- a/migration-kit/tests/test_apply_build.py
+++ b/migration-kit/tests/test_apply_build.py
@@ -145,6 +145,26 @@ def test_team_scoped_llm_key_carries_team_id(index: dict[str, Item]) -> None:
     assert built.payload.teamId == "team-a"
 
 
+def test_team_answer_precedence_when_both_present(index: dict[str, Item]) -> None:
+    """pins the divergent precedence: multi-team kinds prefer teamIds, single-team kinds
+    prefer teamId, when a plan carries both answers."""
+    both = {"teamIds": ["team-a", "team-b"], "teamId": "team-c"}
+    _, built = _build_payload(
+        Decision(source_id="claude_md", target_kind="agent", scope="team", user_answers=both),
+        index["claude_md"],
+    )
+    assert isinstance(built, BuiltAgent)
+    assert built.payload.teams == ["team-a", "team-b"]
+    _, built = _build_payload(
+        Decision(
+            source_id="mcp:github", target_kind="mcp_install", scope="team", user_answers=both,
+        ),
+        index["mcp:github"],
+    )
+    assert isinstance(built, BuiltInstall)
+    assert built.team_id == "team-c"
+
+
 def test_stdio_mcp_redacted_env_becomes_prompted_secret(index: dict[str, Item]) -> None:
     _, built = _decide(index, "mcp:github", "mcp_catalog")
     assert isinstance(built, BuiltCatalog)
@@ -284,3 +304,31 @@ def test_real_apply_preflight_invalid_plan_makes_no_network(tmp_path: Path, monk
     finally:
         server.shutdown()
         thread.join()
+
+
+def test_dry_run_writes_planned_result_without_network(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """pins main()'s --dry-run dispatch: exits 0, writes the result file, needs no env vars."""
+    inventory_path = tmp_path / "inventory.json"
+    plan_path = tmp_path / "migration_plan.json"
+    result_path = tmp_path / "migration_result.json"
+    inventory_path.write_text(json.dumps(to_jsonable(discover(FIXTURE))), encoding="utf-8")
+    plan_path.write_text(json.dumps({
+        "schema_version": 1,
+        "default_scope": "personal",
+        "decisions": [{"source_id": "claude_md", "target_kind": "agent", "scope": "personal"}],
+    }), encoding="utf-8")
+
+    monkeypatch.delenv("ARCHESTRA_BASE_URL", raising=False)
+    monkeypatch.delenv("ARCHESTRA_API_KEY", raising=False)
+    monkeypatch.setattr(sys, "argv", [
+        "apply.py",
+        "--inventory", str(inventory_path),
+        "--plan", str(plan_path),
+        "--out", str(result_path),
+        "--dry-run",
+    ])
+
+    assert main() == 0
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    assert result["summary"] == {"planned": 1}
+    assert result["ops"][0]["target_kind"] == "agent"


### PR DESCRIPTION
## What

Behavior-preserving consolidation of `migration-kit/` internals. Net −82 lines in `scripts/`, +52 in tests.

- `contracts.py`: eight copy-paste literal-membership validators (`_scope`, `_server_type`, `_intent`, `_target_kind`, `_plan_action`, and the membership checks in `require_provider`/`require_operator`/`optional_action`) collapse into one generic `_require_literal`; `parse_bundled_file`'s encoding check joins it.
- token redaction: `discover._redact_inline` and `apply._scrub_secrets` were the same one-liner over `SECRET_TOKEN_RE`; now a single `contracts.redact_tokens` next to the regex it uses.
- `apply.py`: label-only wrappers `_run_dry`/`_run_preflight` inlined at their single call sites.
- `discover.py`: single-caller `_kind_counts` inlined.
- new characterization tests: `--dry-run` dispatch of `main()` (exit 0, `[dry-run]` output, result JSON, no env vars) and team-id answer precedence when a plan carries both `teamId` and `teamIds` (multi-team kinds prefer `teamIds`, single-team kinds prefer `teamId`).

No CLI, JSON-format, API-call, or redaction changes. Only observable delta: validator error wording now uniformly enumerates the allowed set (e.g. `scope 'galaxy' must be one of personal|team|org`), and `parse_bundled_file` reports a missing `path` before a bad `encoding`.

## Testing

Kit gates (pytest + ruff + ty + zero-dependency): 85 passed (83 existing + 2 new).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>