### PR TITLE
refactor(sandbox): unify duplicated helpers, queue state, and validation vectors

### DIFF
--- a/platform/archestra-rs/sandbox-core/src/validation.rs
+++ b/platform/archestra-rs/sandbox-core/src/validation.rs
@@ -1,6 +1,12 @@
 //! input validation for the sandbox boundary. all checks run at the public core
 //! entry points (`crate::run_sandbox` / `read_artifact`) over untrusted JS input;
 //! replayed history is trusted on reuse (validated when first accepted).
+//!
+//! the TS adapter (`backend/src/skills-sandbox/skill-sandbox-runtime-service.ts`)
+//! runs twin checks before persistence for early, friendlier errors; this module
+//! is the trust boundary and stays authoritative regardless of what the TS layer
+//! accepts. the mirrored test vectors below and in the TS test twin keep the two
+//! implementations from drifting silently.
 
 use crate::{Result, SandboxError};
 
@@ -149,32 +155,80 @@ mod tests {
         assert!(validate_snapshot_file_path("a/../../etc/passwd").is_err());
     }
 
+    // mirrored with "path validation vectors (mirrored with sandbox-core)" in
+    // backend/src/skills-sandbox/skill-sandbox-runtime-service.test.ts — keep
+    // the two tables in sync when adding cases. the third column documents the
+    // TS layer's verdict on the same string so divergences are explicit:
+    // the TS layer resolves relative paths against the sandbox cwd before this
+    // layer sees them, and rejects uploads onto a root directory itself, while
+    // this layer alone rejects shell metacharacters in artifact paths.
+    //
+    // (path, accepted_here, accepted_by_ts)
+    const UPLOAD_PATH_VECTORS: &[(&str, bool, bool)] = &[
+        ("/home/sandbox/input.csv", true, true),
+        ("/skills/alpha/data/in.bin", true, true),
+        // relative: TS resolves against defaultCwd before this layer runs
+        ("input.csv", false, true),
+        // outside roots
+        ("/etc/passwd", false, false),
+        // traversal
+        ("/home/sandbox/../etc/passwd", false, false),
+        // directory, not a file
+        ("/home/sandbox/", false, false),
+        // a root itself: replay would fail on the existing directory, so the
+        // TS layer rejects it before it is persisted as an unreplayable event
+        ("/home/sandbox", true, false),
+        // shell metacharacters / control chars / null
+        ("/home/sandbox/a\"b", false, false),
+        ("/home/sandbox/a$b", false, false),
+        ("/home/sandbox/a`b", false, false),
+        ("/home/sandbox/a\\b", false, false),
+        ("/home/sandbox/a\nb", false, false),
+        ("/home/sandbox/a\rb", false, false),
+        ("/home/sandbox/a\0b", false, false),
+    ];
+
+    // (path, accepted_here, accepted_by_ts)
+    const ARTIFACT_PATH_VECTORS: &[(&str, bool, bool)] = &[
+        ("/skills/alpha/result.txt", true, true),
+        // relative artifact paths are resolved against cwd downstream
+        ("out/report.txt", true, true),
+        // outside roots
+        ("/etc/passwd", false, false),
+        // traversal
+        ("a/../b.txt", false, false),
+        // null byte
+        ("a\0b.txt", false, false),
+        // shell metacharacters: only this boundary rejects them; the TS layer
+        // passes them through and relies on the rejection here
+        ("/skills/alpha/foo\"bar", false, true),
+        ("/skills/alpha/foo$bar", false, true),
+        ("/skills/alpha/foo`bar", false, true),
+        ("/skills/alpha/foo\\bar", false, true),
+        ("/skills/alpha/foo\nbar", false, true),
+        ("/skills/alpha/foo\rbar", false, true),
+    ];
+
     #[test]
-    fn validate_artifact_path_rejects_shell_metacharacters() {
-        assert!(validate_artifact_path("/skills/alpha/result.txt").is_ok());
-        assert!(validate_artifact_path("/skills/alpha/foo\"bar").is_err());
-        assert!(validate_artifact_path("/skills/alpha/foo$bar").is_err());
-        assert!(validate_artifact_path("/skills/alpha/foo`bar").is_err());
-        assert!(validate_artifact_path("/skills/alpha/foo\\bar").is_err());
-        assert!(validate_artifact_path("/skills/alpha/foo\nbar").is_err());
+    fn validate_upload_path_matches_mirrored_vectors() {
+        for (path, accepted, _ts) in UPLOAD_PATH_VECTORS {
+            assert_eq!(
+                validate_upload_path(path).is_ok(),
+                *accepted,
+                "upload path: {path:?}"
+            );
+        }
     }
 
     #[test]
-    fn validate_upload_path_requires_absolute_file_under_roots() {
-        assert!(validate_upload_path("/home/sandbox/input.csv").is_ok());
-        assert!(validate_upload_path("/skills/alpha/data/in.bin").is_ok());
-        // not absolute
-        assert!(validate_upload_path("input.csv").is_err());
-        // outside roots
-        assert!(validate_upload_path("/etc/passwd").is_err());
-        // traversal
-        assert!(validate_upload_path("/home/sandbox/../etc/passwd").is_err());
-        // directory, not a file
-        assert!(validate_upload_path("/home/sandbox/").is_err());
-        // shell metacharacters / null
-        assert!(validate_upload_path("/home/sandbox/a$b").is_err());
-        assert!(validate_upload_path("/home/sandbox/a`b").is_err());
-        assert!(validate_upload_path("/home/sandbox/a\0b").is_err());
+    fn validate_artifact_path_matches_mirrored_vectors() {
+        for (path, accepted, _ts) in ARTIFACT_PATH_VECTORS {
+            assert_eq!(
+                validate_artifact_path(path).is_ok(),
+                *accepted,
+                "artifact path: {path:?}"
+            );
+        }
     }
 
     #[test]

--- a/platform/backend/src/database/schemas/skill-sandbox-command.ts
+++ b/platform/backend/src/database/schemas/skill-sandbox-command.ts
@@ -9,8 +9,9 @@ import {
 import skillSandboxesTable from "./skill-sandbox";
 
 /**
- * Ordered command log for a sandbox. Reading this in `createdAt` order
- * reproduces the sandbox state via Dagger replay; rows are append-only.
+ * Executed commands for a sandbox; rows are append-only. Replay order is NOT
+ * this table's `createdAt` — it is `skill_sandbox_replay_events.sequence`,
+ * which interleaves commands with uploads and skill mounts.
  */
 const skillSandboxCommandsTable = pgTable(
   "skill_sandbox_commands",

--- a/platform/backend/src/hooks/hook-runner.ts
+++ b/platform/backend/src/hooks/hook-runner.ts
@@ -3,6 +3,7 @@ import logger from "@/logging";
 import { skillSandboxRuntimeService } from "@/skills-sandbox/skill-sandbox-runtime-service";
 import type { HookFile, HookOutcome } from "@/types/hook";
 import { asSandboxId } from "@/types/skill-sandbox";
+import { shellQuote } from "@/utils/shell-quote";
 
 interface HookRunResult {
   exitCode: number | null;
@@ -119,7 +120,7 @@ function deterministicUuid(input: string): string {
 
 /**
  * Build the small exec command that runs an already-uploaded script with an
- * already-uploaded payload on stdin.  Paths are single-quoted via `shQuote`.
+ * already-uploaded payload on stdin.  Paths are single-quoted via `shellQuote`.
  * No base64, no mkdir — the files are already in place from `uploadFile`.
  */
 function buildExecCommand(
@@ -129,14 +130,10 @@ function buildExecCommand(
 ): string {
   if (hookFile.fileName.endsWith(".py")) {
     const withs = hookFile.requirements
-      .map((r) => `--with ${shQuote(r)}`)
+      .map((r) => `--with ${shellQuote(r)}`)
       .join(" ");
     const prefix = withs ? `uv run ${withs} python3` : "python3";
-    return `${prefix} ${shQuote(scriptPath)} < ${shQuote(payloadPath)}`;
+    return `${prefix} ${shellQuote(scriptPath)} < ${shellQuote(payloadPath)}`;
   }
-  return `sh ${shQuote(scriptPath)} < ${shQuote(payloadPath)}`;
-}
-
-function shQuote(value: string): string {
-  return `'${value.replace(/'/g, "'\\''")}'`;
+  return `sh ${shellQuote(scriptPath)} < ${shellQuote(payloadPath)}`;
 }

--- a/platform/backend/src/models/conversation-attachment.ts
+++ b/platform/backend/src/models/conversation-attachment.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { and, asc, eq, inArray, isNull } from "drizzle-orm";
 import db, { schema } from "@/database";
+import { normalizeByteaField } from "@/utils/normalize-bytea";
 
 type ConversationAttachment =
   typeof schema.conversationAttachmentsTable.$inferSelect;
@@ -63,7 +64,7 @@ class ConversationAttachmentModel {
           isNull(schema.conversationAttachmentsTable.deletedAt),
         ),
       );
-    return result ? normalizeFileData(result) : null;
+    return result ? normalizeByteaField(result, "fileData") : null;
   }
 
   static async findByIdsWithData(
@@ -79,7 +80,7 @@ class ConversationAttachmentModel {
           isNull(schema.conversationAttachmentsTable.deletedAt),
         ),
       );
-    return rows.map(normalizeFileData);
+    return rows.map((row) => normalizeByteaField(row, "fileData"));
   }
 
   static async findByConversationAndContentHash(
@@ -153,15 +154,6 @@ class ConversationAttachmentModel {
   static computeContentHash(buffer: Buffer): string {
     return createHash("sha256").update(buffer).digest("hex");
   }
-}
-
-function normalizeFileData(
-  row: ConversationAttachment,
-): ConversationAttachment {
-  // pg returns Buffer; PGlite returns Uint8Array. Callers rely on Buffer
-  // methods (.toString("base64"), .equals()) — normalize at the read boundary.
-  if (Buffer.isBuffer(row.fileData)) return row;
-  return { ...row, fileData: Buffer.from(row.fileData as Uint8Array) };
 }
 
 export default ConversationAttachmentModel;

--- a/platform/backend/src/models/skill-sandbox-file.ts
+++ b/platform/backend/src/models/skill-sandbox-file.ts
@@ -1,6 +1,7 @@
 import { and, asc, eq, isNotNull } from "drizzle-orm";
 import db, { schema } from "@/database";
 import type { InsertSkillSandboxFile, SkillSandboxFile } from "@/types";
+import { normalizeByteaField } from "@/utils/normalize-bytea";
 
 /** Artifact row without its bytes — what the Files panel needs to list outputs. */
 type SkillSandboxArtifactMeta = {
@@ -28,7 +29,7 @@ class SkillSandboxFileModel {
     if (!row) {
       throw new Error("failed to insert sandbox artifact");
     }
-    return normalizeFileData(row);
+    return normalizeByteaField(row, "data");
   }
 
   static async findArtifactById(id: string): Promise<SkillSandboxFile | null> {
@@ -41,7 +42,7 @@ class SkillSandboxFileModel {
           eq(schema.skillSandboxFilesTable.kind, "artifact"),
         ),
       );
-    return row ? normalizeFileData(row) : null;
+    return row ? normalizeByteaField(row, "data") : null;
   }
 
   /**
@@ -102,7 +103,7 @@ class SkillSandboxFileModel {
           eq(schema.skillSandboxFilesTable.kind, "upload"),
         ),
       );
-    return row ? normalizeFileData(row) : null;
+    return row ? normalizeByteaField(row, "data") : null;
   }
 
   /**
@@ -128,14 +129,3 @@ class SkillSandboxFileModel {
 }
 
 export default SkillSandboxFileModel;
-
-// === internal helpers ===
-
-/**
- * pg returns `bytea` as Buffer; PGlite returns Uint8Array. Callers rely on
- * Buffer semantics, so normalize at the read boundary.
- */
-function normalizeFileData(row: SkillSandboxFile): SkillSandboxFile {
-  if (Buffer.isBuffer(row.data)) return row;
-  return { ...row, data: Buffer.from(row.data as unknown as Uint8Array) };
-}

--- a/platform/backend/src/models/skill-sandbox-replay-event.ts
+++ b/platform/backend/src/models/skill-sandbox-replay-event.ts
@@ -7,6 +7,7 @@ import type {
   SkillSandboxSkillMount,
   SkillVersionFile,
 } from "@/types";
+import { normalizeByteaField } from "@/utils/normalize-bytea";
 
 /** Bytes for an uploaded input file, written into the replay log. */
 interface UploadInput {
@@ -123,7 +124,7 @@ class SkillSandboxReplayEventModel {
         kind: "upload",
         fileId: row.id,
       });
-      return normalizeFileData(row);
+      return normalizeByteaField(row, "data");
     });
   }
 
@@ -309,7 +310,7 @@ class SkillSandboxReplayEventModel {
           return {
             kind: "upload",
             sequence: row.sequence,
-            upload: normalizeFileData(row.upload),
+            upload: normalizeByteaField(row.upload, "data"),
           };
         case "skill_mount":
           if (!row.mount || row.versionContent == null) {
@@ -359,13 +360,4 @@ async function allocateSequence(
     );
   }
   return row.next - 1;
-}
-
-/**
- * pg returns `bytea` as Buffer; PGlite returns Uint8Array. Callers rely on
- * Buffer semantics (`.toString("base64")`), so normalize at the read boundary.
- */
-function normalizeFileData(row: SkillSandboxFile): SkillSandboxFile {
-  if (Buffer.isBuffer(row.data)) return row;
-  return { ...row, data: Buffer.from(row.data as unknown as Uint8Array) };
 }

--- a/platform/backend/src/routes/chat/normalization/materialize-attachments.ts
+++ b/platform/backend/src/routes/chat/normalization/materialize-attachments.ts
@@ -112,14 +112,8 @@ function materializePart(
     return { ...part };
   }
 
-  // PGlite (used by tests) returns bytea as a Uint8Array; node-postgres
-  // returns a Buffer. Normalize before encoding so .toString("base64") is the
-  // real Node Buffer method, not Array.prototype.toString (which gives a
-  // comma-separated decimal list).
-  const buffer = Buffer.isBuffer(attachment.fileData)
-    ? attachment.fileData
-    : Buffer.from(attachment.fileData as Uint8Array);
-  const dataUrl = `data:${attachment.mimeType};base64,${buffer.toString("base64")}`;
+  // findByIdsWithData normalizes bytea to Buffer at the model boundary
+  const dataUrl = `data:${attachment.mimeType};base64,${attachment.fileData.toString("base64")}`;
   return {
     ...part,
     url: dataUrl,

--- a/platform/backend/src/routes/skill-sandbox-artifact.ts
+++ b/platform/backend/src/routes/skill-sandbox-artifact.ts
@@ -64,11 +64,8 @@ const skillSandboxArtifactRoutes: FastifyPluginAsyncZod = async (fastify) => {
         ? artifact.mimeType
         : "application/octet-stream";
 
-      // bytea round-trips as Buffer in production (pg) but as something
-      // string-like under PGlite; coerce so reply.send always streams bytes.
-      const data = Buffer.isBuffer(artifact.data)
-        ? artifact.data
-        : Buffer.from(artifact.data);
+      // findArtifactById normalizes bytea to Buffer at the model boundary
+      const data = artifact.data;
 
       reply
         .header("Content-Type", contentType)

--- a/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.test.ts
+++ b/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.test.ts
@@ -150,7 +150,106 @@ describe("skillSandboxRuntimeService", () => {
     );
     expect(queueErrors.length).toBeGreaterThanOrEqual(1);
   });
+
+  test("queue guard rejects exactly the calls beyond maxSandboxQueueLength", async () => {
+    const enabled = await importEnabledService();
+    const { SKILL_SANDBOX_LIMITS } = await import("./types");
+
+    const sandboxId = __internals.asSandboxId(crypto.randomUUID());
+    // all N+1 calls are created synchronously, so the first N take queue slots
+    // and only the last one trips the guard.
+    const results = await Promise.allSettled(
+      Array.from(
+        { length: SKILL_SANDBOX_LIMITS.maxSandboxQueueLength + 1 },
+        () =>
+          enabled.runCommand({
+            sandboxId,
+            caller: { userId: "u", organizationId: "o" },
+            command: "echo hi",
+          }),
+      ),
+    );
+    const queueErrors = results.filter(
+      (r) =>
+        r.status === "rejected" &&
+        (r.reason as Error)?.message?.includes("too many requests"),
+    );
+    expect(queueErrors).toHaveLength(1);
+  });
+
+  test("queue guard resets after the saturated queue drains", async () => {
+    const enabled = await importEnabledService();
+    const { SKILL_SANDBOX_LIMITS } = await import("./types");
+
+    const sandboxId = __internals.asSandboxId(crypto.randomUUID());
+    await Promise.allSettled(
+      Array.from(
+        { length: SKILL_SANDBOX_LIMITS.maxSandboxQueueLength + 1 },
+        () =>
+          enabled.runCommand({
+            sandboxId,
+            caller: { userId: "u", organizationId: "o" },
+            command: "echo hi",
+          }),
+      ),
+    );
+
+    // the queue fully drained, so the next call must reach the sandbox load
+    // (and fail there — no sandbox row) instead of tripping the queue guard.
+    const [after] = await Promise.allSettled([
+      enabled.runCommand({
+        sandboxId,
+        caller: { userId: "u", organizationId: "o" },
+        command: "echo hi",
+      }),
+    ]);
+    expect(after.status).toBe("rejected");
+    expect((after as PromiseRejectedResult).reason?.message).not.toContain(
+      "too many requests",
+    );
+  });
+
+  test("a call enqueued right as the previous one settles is not lost", async () => {
+    const enabled = await importEnabledService();
+
+    const sandboxId = __internals.asSandboxId(crypto.randomUUID());
+    const run = () =>
+      enabled.runCommand({
+        sandboxId,
+        caller: { userId: "u", organizationId: "o" },
+        command: "echo hi",
+      });
+
+    // enqueue the second call in the microtask window where the first call's
+    // queue-cleanup callbacks may still be pending; it must execute normally.
+    const [first] = await Promise.allSettled([run()]);
+    const [second] = await Promise.allSettled([run()]);
+    for (const result of [first, second]) {
+      expect(result.status).toBe("rejected");
+      expect((result as PromiseRejectedResult).reason?.message).not.toContain(
+        "too many requests",
+      );
+    }
+  });
 });
+
+/**
+ * the queue tests need the service compiled with the sandbox feature on; each
+ * gets a fresh module registry so the singleton's queue state starts empty.
+ */
+async function importEnabledService() {
+  vi.resetModules();
+  vi.stubEnv("ARCHESTRA_AGENTS_SKILLS_ENABLED", "true");
+  vi.stubEnv("ARCHESTRA_CODE_RUNTIME_ENABLED", "true");
+  vi.stubEnv(
+    "ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST",
+    "tcp://dagger-runtime.dagger.svc.cluster.local:1234",
+  );
+  const { skillSandboxRuntimeService: enabled } = await import(
+    "./skill-sandbox-runtime-service"
+  );
+  return enabled;
+}
 
 describe("__internals", () => {
   test("requirementsInstallCommands picks up root and nested requirements.txt in path order", () => {

--- a/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.test.ts
+++ b/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.test.ts
@@ -72,16 +72,7 @@ describe("skillSandboxRuntimeService", () => {
     1.5,
     Number.NaN,
   ])("runCommand rejects invalid timeoutSeconds=%s before initializing", async (timeoutSeconds) => {
-    vi.resetModules();
-    vi.stubEnv("ARCHESTRA_AGENTS_SKILLS_ENABLED", "true");
-    vi.stubEnv("ARCHESTRA_CODE_RUNTIME_ENABLED", "true");
-    vi.stubEnv(
-      "ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST",
-      "tcp://dagger-runtime.dagger.svc.cluster.local:1234",
-    );
-    const { skillSandboxRuntimeService: enabled } = await import(
-      "./skill-sandbox-runtime-service"
-    );
+    const enabled = await importEnabledService();
 
     await expect(
       enabled.runCommand({
@@ -94,16 +85,7 @@ describe("skillSandboxRuntimeService", () => {
   });
 
   test("runCommand rejects empty commands", async () => {
-    vi.resetModules();
-    vi.stubEnv("ARCHESTRA_AGENTS_SKILLS_ENABLED", "true");
-    vi.stubEnv("ARCHESTRA_CODE_RUNTIME_ENABLED", "true");
-    vi.stubEnv(
-      "ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST",
-      "tcp://dagger-runtime.dagger.svc.cluster.local:1234",
-    );
-    const { skillSandboxRuntimeService: enabled } = await import(
-      "./skill-sandbox-runtime-service"
-    );
+    const enabled = await importEnabledService();
 
     await expect(
       enabled.runCommand({
@@ -114,50 +96,14 @@ describe("skillSandboxRuntimeService", () => {
     ).rejects.toThrow("command must be a non-empty string");
   });
 
-  test("runCommand rejects after maxSandboxQueueLength requests for the same sandbox", async () => {
-    vi.resetModules();
-    vi.stubEnv("ARCHESTRA_AGENTS_SKILLS_ENABLED", "true");
-    vi.stubEnv("ARCHESTRA_CODE_RUNTIME_ENABLED", "true");
-    vi.stubEnv(
-      "ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST",
-      "tcp://dagger-runtime.dagger.svc.cluster.local:1234",
-    );
-    const { skillSandboxRuntimeService: enabled } = await import(
-      "./skill-sandbox-runtime-service"
-    );
-    const { SKILL_SANDBOX_LIMITS } = await import("./types");
-
-    const sandboxId = __internals.asSandboxId(crypto.randomUUID());
-    // fire maxSandboxQueueLength+1 concurrent calls; all will fail (no real
-    // Dagger engine) but the first N reach the per-sandbox chain while the
-    // (N+1)th is rejected immediately by the queue-length guard before any await.
-    const calls = Array.from(
-      { length: SKILL_SANDBOX_LIMITS.maxSandboxQueueLength + 1 },
-      () =>
-        enabled.runCommand({
-          sandboxId,
-          caller: { userId: "u", organizationId: "o" },
-          command: "echo hi",
-        }),
-    );
-    const results = await Promise.allSettled(calls);
-    // use message check rather than instanceof: vi.resetModules creates a fresh
-    // class so instanceof against the top-level import would always be false.
-    const queueErrors = results.filter(
-      (r) =>
-        r.status === "rejected" &&
-        (r.reason as Error)?.message?.includes("too many requests"),
-    );
-    expect(queueErrors.length).toBeGreaterThanOrEqual(1);
-  });
-
   test("queue guard rejects exactly the calls beyond maxSandboxQueueLength", async () => {
     const enabled = await importEnabledService();
     const { SKILL_SANDBOX_LIMITS } = await import("./types");
 
     const sandboxId = __internals.asSandboxId(crypto.randomUUID());
     // all N+1 calls are created synchronously, so the first N take queue slots
-    // and only the last one trips the guard.
+    // (and later fail — no real Dagger engine) while only the last one trips
+    // the guard before any await.
     const results = await Promise.allSettled(
       Array.from(
         { length: SKILL_SANDBOX_LIMITS.maxSandboxQueueLength + 1 },
@@ -169,6 +115,8 @@ describe("skillSandboxRuntimeService", () => {
           }),
       ),
     );
+    // use message check rather than instanceof: vi.resetModules creates a fresh
+    // class so instanceof against the top-level import would always be false.
     const queueErrors = results.filter(
       (r) =>
         r.status === "rejected" &&
@@ -220,8 +168,9 @@ describe("skillSandboxRuntimeService", () => {
         command: "echo hi",
       });
 
-    // enqueue the second call in the microtask window where the first call's
-    // queue-cleanup callbacks may still be pending; it must execute normally.
+    // sequential reuse of the same sandbox right after the previous call
+    // settled: guards against cleanup schemes (e.g. tail-attached deletion)
+    // that could evict or reject a freshly enqueued call.
     const [first] = await Promise.allSettled([run()]);
     const [second] = await Promise.allSettled([run()]);
     for (const result of [first, second]) {
@@ -810,9 +759,15 @@ describe("path validation vectors (mirrored with sandbox-core)", () => {
     };
     for (const [path, accepted] of UPLOAD_PATH_VECTORS) {
       if (accepted) {
-        expect(() => stageUpload(path), `upload path: ${JSON.stringify(path)}`).not.toThrow();
+        expect(
+          () => stageUpload(path),
+          `upload path: ${JSON.stringify(path)}`,
+        ).not.toThrow();
       } else {
-        expect(() => stageUpload(path), `upload path: ${JSON.stringify(path)}`).toThrow();
+        expect(
+          () => stageUpload(path),
+          `upload path: ${JSON.stringify(path)}`,
+        ).toThrow();
       }
     }
   });

--- a/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.test.ts
+++ b/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.test.ts
@@ -745,3 +745,87 @@ describe("uploadFile dedupeId idempotency (db)", () => {
     expect(logFinal.filter((e) => e.kind === "upload")).toHaveLength(3);
   });
 });
+
+describe("path validation vectors (mirrored with sandbox-core)", () => {
+  // mirrored with UPLOAD_PATH_VECTORS / ARTIFACT_PATH_VECTORS in
+  // archestra-rs/sandbox-core/src/validation.rs — keep the two tables in sync
+  // when adding cases. the Rust module is the trust boundary and stays
+  // authoritative; this layer rejects early for friendlier errors and to keep
+  // unreplayable events out of the log. the third column documents the Rust
+  // verdict on the same string so divergences are explicit.
+  const DEFAULT_CWD = "/home/sandbox";
+
+  // (path, acceptedHere, acceptedByRust)
+  const UPLOAD_PATH_VECTORS: Array<[string, boolean, boolean]> = [
+    ["/home/sandbox/input.csv", true, true],
+    ["/skills/alpha/data/in.bin", true, true],
+    // relative: resolved against defaultCwd before validation, so it is
+    // accepted here while the raw string would be rejected at the boundary
+    ["input.csv", true, false],
+    // outside roots
+    ["/etc/passwd", false, false],
+    // traversal
+    ["/home/sandbox/../etc/passwd", false, false],
+    // directory, not a file
+    ["/home/sandbox/", false, false],
+    // a root itself: rejected here before it is persisted as an unreplayable
+    // event; the boundary alone would accept it
+    ["/home/sandbox", false, true],
+    // shell metacharacters / control chars / null
+    ['/home/sandbox/a"b', false, false],
+    ["/home/sandbox/a$b", false, false],
+    ["/home/sandbox/a`b", false, false],
+    ["/home/sandbox/a\\b", false, false],
+    ["/home/sandbox/a\nb", false, false],
+    ["/home/sandbox/a\rb", false, false],
+    ["/home/sandbox/a\0b", false, false],
+  ];
+
+  // (path, acceptedHere, acceptedByRust)
+  const ARTIFACT_PATH_VECTORS: Array<[string, boolean, boolean]> = [
+    ["/skills/alpha/result.txt", true, true],
+    ["out/report.txt", true, true],
+    // outside roots
+    ["/etc/passwd", false, false],
+    // traversal
+    ["a/../b.txt", false, false],
+    // null byte
+    ["a\0b.txt", false, false],
+    // shell metacharacters: pass through here; the Rust boundary rejects them
+    ['/skills/alpha/foo"bar', true, false],
+    ["/skills/alpha/foo$bar", true, false],
+    ["/skills/alpha/foo`bar", true, false],
+    ["/skills/alpha/foo\\bar", true, false],
+    ["/skills/alpha/foo\nbar", true, false],
+    ["/skills/alpha/foo\rbar", true, false],
+  ];
+
+  test("upload path vectors", () => {
+    const stageUpload = (path: string) => {
+      const resolved = __internals.resolveArtifactPath({
+        path,
+        defaultCwd: DEFAULT_CWD,
+      });
+      __internals.validateUploadPath(resolved);
+    };
+    for (const [path, accepted] of UPLOAD_PATH_VECTORS) {
+      if (accepted) {
+        expect(() => stageUpload(path), `upload path: ${JSON.stringify(path)}`).not.toThrow();
+      } else {
+        expect(() => stageUpload(path), `upload path: ${JSON.stringify(path)}`).toThrow();
+      }
+    }
+  });
+
+  test("artifact path vectors", () => {
+    for (const [path, accepted] of ARTIFACT_PATH_VECTORS) {
+      const resolve = () =>
+        __internals.resolveArtifactPath({ path, defaultCwd: DEFAULT_CWD });
+      if (accepted) {
+        expect(resolve, `artifact path: ${JSON.stringify(path)}`).not.toThrow();
+      } else {
+        expect(resolve, `artifact path: ${JSON.stringify(path)}`).toThrow();
+      }
+    }
+  });
+});

--- a/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
+++ b/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
@@ -55,6 +55,14 @@ const ATTACHMENTS_DIR = SKILL_SANDBOX_ATTACHMENTS_DIR;
 // subsequent calls hit Dagger's layer cache and finish in ms.
 const REQUIREMENTS_INSTALL_TIMEOUT_SECONDS = 180;
 
+/** per-sandbox serialization chain plus its queued-operation count. */
+interface SandboxQueueState {
+  /** settles once every queued operation has finished; never rejects. */
+  tail: Promise<unknown>;
+  /** operations queued or running; the entry is dropped when the last one settles. */
+  pending: number;
+}
+
 /**
  * Orchestrates DB-backed skill sandboxes: loads snapshots + replay log,
  * delegates execution to the unified `sandboxRuntimeService`, appends the
@@ -64,14 +72,6 @@ const REQUIREMENTS_INSTALL_TIMEOUT_SECONDS = 180;
  * concurrent calls cannot observe stale replay state or record commands out of
  * execution order.
  */
-/** per-sandbox serialization chain plus its queued-operation count. */
-interface SandboxQueueState {
-  /** settles once every queued operation has finished; never rejects. */
-  tail: Promise<unknown>;
-  /** operations queued or running; the entry is dropped when this hits 0. */
-  pending: number;
-}
-
 class SkillSandboxRuntimeService {
   // per-sandbox promise chain: ensures load + exec + append are atomic per sandbox.
   private readonly sandboxQueues = new Map<SandboxId, SandboxQueueState>();

--- a/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
+++ b/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
@@ -17,6 +17,7 @@ import {
 import { assertMountedSkillsReadable } from "@/skills/assert-mounted-skills-readable";
 import type { SkillSandbox } from "@/types";
 import { asSandboxId, type SandboxId } from "@/types";
+import { shellQuote } from "@/utils/shell-quote";
 import { resolveArtifactMime } from "./mime-sniff";
 import {
   SKILL_SANDBOX_ATTACHMENTS_DIR,
@@ -664,10 +665,6 @@ function validateCommand(command: string): void {
       `command is too large (> ${SKILL_SANDBOX_LIMITS.maxCommandBytes} bytes)`,
     );
   }
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 /**

--- a/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
+++ b/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
@@ -715,6 +715,13 @@ function rejectPath(reason: string, message: string): never {
   throw new SkillSandboxError(message);
 }
 
+/**
+ * TS-side path checks reject bad input at the tool call for an early,
+ * friendly error and to keep unreplayable events out of the log; the Rust
+ * boundary (`archestra-rs/sandbox-core/src/validation.rs`) re-validates
+ * everything and stays authoritative. Mirrored test vectors in this file's
+ * test twin and in `validation.rs` keep the two implementations in sync.
+ */
 function resolveArtifactPath(params: {
   path: string;
   defaultCwd: string;

--- a/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
+++ b/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
@@ -63,11 +63,17 @@ const REQUIREMENTS_INSTALL_TIMEOUT_SECONDS = 180;
  * concurrent calls cannot observe stale replay state or record commands out of
  * execution order.
  */
+/** per-sandbox serialization chain plus its queued-operation count. */
+interface SandboxQueueState {
+  /** settles once every queued operation has finished; never rejects. */
+  tail: Promise<unknown>;
+  /** operations queued or running; the entry is dropped when this hits 0. */
+  pending: number;
+}
+
 class SkillSandboxRuntimeService {
   // per-sandbox promise chain: ensures load + exec + append are atomic per sandbox.
-  private readonly sandboxQueues = new Map<string, Promise<unknown>>();
-  // per-sandbox pending counter for queue capacity enforcement.
-  private readonly sandboxPendingCounts = new Map<string, number>();
+  private readonly sandboxQueues = new Map<SandboxId, SandboxQueueState>();
 
   get isEnabled(): boolean {
     return config.skillsSandbox.enabled && sandboxRuntimeService.isEnabled;
@@ -594,49 +600,53 @@ class SkillSandboxRuntimeService {
    * Serializes operations on the same sandbox so concurrent calls observe a
    * consistent replay state. Also enforces a per-sandbox queue cap.
    */
-  private runExclusive<T>(sandboxId: string, fn: () => Promise<T>): Promise<T> {
-    const pending = this.sandboxPendingCounts.get(sandboxId) ?? 0;
-    if (pending >= SKILL_SANDBOX_LIMITS.maxSandboxQueueLength) {
+  private runExclusive<T>(
+    sandboxId: SandboxId,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    const state = this.sandboxQueues.get(sandboxId);
+    if (state && state.pending >= SKILL_SANDBOX_LIMITS.maxSandboxQueueLength) {
       return Promise.reject(
         new SkillSandboxError(
           "too many requests are already queued for this sandbox",
         ),
       );
     }
-    this.sandboxPendingCounts.set(sandboxId, pending + 1);
 
-    const prev = this.sandboxQueues.get(sandboxId) ?? Promise.resolve();
+    const prev = state?.tail ?? Promise.resolve();
     const next = prev.then(
       () => fn(),
       () => fn(),
     );
     const counted = next.then(
       (v) => {
-        this.decrementSandboxPending(sandboxId);
+        this.releaseQueueSlot(sandboxId);
         return v;
       },
       (e) => {
-        this.decrementSandboxPending(sandboxId);
+        this.releaseQueueSlot(sandboxId);
         throw e;
       },
     );
-    const tail = counted.catch(() => {});
-    this.sandboxQueues.set(sandboxId, tail);
-    tail.then(() => {
-      if (this.sandboxQueues.get(sandboxId) === tail) {
-        this.sandboxQueues.delete(sandboxId);
-      }
+    this.sandboxQueues.set(sandboxId, {
+      tail: counted.catch(() => {}),
+      pending: (state?.pending ?? 0) + 1,
     });
     return counted;
   }
 
-  private decrementSandboxPending(sandboxId: string): void {
-    const count = this.sandboxPendingCounts.get(sandboxId) ?? 0;
-    if (count <= 1) {
-      this.sandboxPendingCounts.delete(sandboxId);
-    } else {
-      this.sandboxPendingCounts.set(sandboxId, count - 1);
+  /**
+   * Slots are released in settle order, one per queued operation, so the
+   * entry's pending count reaches 0 exactly when the chain has drained — at
+   * which point the whole entry is dropped and the map cannot leak.
+   */
+  private releaseQueueSlot(sandboxId: SandboxId): void {
+    const state = this.sandboxQueues.get(sandboxId);
+    if (!state || state.pending <= 1) {
+      this.sandboxQueues.delete(sandboxId);
+      return;
     }
+    state.pending -= 1;
   }
 }
 

--- a/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
+++ b/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
@@ -32,6 +32,7 @@ import {
   type MountRef,
   type MountSkillParams,
   type RunCommandParams,
+  type SandboxCaller,
   SKILL_SANDBOX_LIMITS,
   SkillSandboxError,
   type UploadFileParams,
@@ -97,14 +98,12 @@ class SkillSandboxRuntimeService {
     validateCommand(params.command);
     const timeoutSeconds = this.resolveTimeout(params.timeoutSeconds);
 
-    return this.runExclusive(params.sandboxId, async () => {
-      const sandbox = await this.loadSandbox(params.sandboxId);
-      await this.assertMountsReadable(params.sandboxId, params.caller);
-      // stage chat attachments before building context so they're part of this
-      // run's replay (the model sees them under /home/sandbox/attachments/).
-      const stagingNotices = await stageConversationAttachments(sandbox);
+    return this.runWithSandbox(params.sandboxId, async (sandbox) => {
+      const { stagingNotices, replayEntries } = await this.prepareExecution(
+        sandbox,
+        params.caller,
+      );
       const cwd = params.cwd ?? sandbox.defaultCwd;
-      const { replayEntries } = await this.buildContext(sandbox);
 
       let executed: Awaited<
         ReturnType<typeof sandboxRuntimeService.runCommand>
@@ -189,15 +188,15 @@ class SkillSandboxRuntimeService {
   async exportArtifact(params: ExportArtifactParams): Promise<ArtifactRef> {
     this.ensureEnabled();
 
-    return this.runExclusive(params.sandboxId, async () => {
-      const sandbox = await this.loadSandbox(params.sandboxId);
-      await this.assertMountsReadable(params.sandboxId, params.caller);
-      const stagingNotices = await stageConversationAttachments(sandbox);
+    return this.runWithSandbox(params.sandboxId, async (sandbox) => {
+      const { stagingNotices, replayEntries } = await this.prepareExecution(
+        sandbox,
+        params.caller,
+      );
       const resolvedPath = resolveArtifactPath({
         path: params.path,
         defaultCwd: sandbox.defaultCwd,
       });
-      const { replayEntries } = await this.buildContext(sandbox);
 
       let artifact: Awaited<
         ReturnType<typeof sandboxRuntimeService.readArtifact>
@@ -261,8 +260,7 @@ class SkillSandboxRuntimeService {
   async uploadFile(params: UploadFileParams): Promise<UploadRef> {
     this.ensureEnabled();
 
-    return this.runExclusive(params.sandboxId, async () => {
-      const sandbox = await this.loadSandbox(params.sandboxId);
+    return this.runWithSandbox(params.sandboxId, async (sandbox) => {
       const resolvedPath = resolveArtifactPath({
         path: params.path,
         defaultCwd: sandbox.defaultCwd,
@@ -357,9 +355,7 @@ class SkillSandboxRuntimeService {
   async mountSkill(params: MountSkillParams): Promise<MountRef | null> {
     this.ensureEnabled();
 
-    return this.runExclusive(params.sandboxId, async () => {
-      const sandbox = await this.loadSandbox(params.sandboxId);
-
+    return this.runWithSandbox(params.sandboxId, async (sandbox) => {
       const files = await SkillVersionModel.findFiles(
         params.skill.skillVersionId,
       );
@@ -450,6 +446,38 @@ class SkillSandboxRuntimeService {
       throw new SkillSandboxError(`sandbox ${sandboxId} does not exist`);
     }
     return sandbox;
+  }
+
+  /**
+   * Shared per-operation ceremony: serialize on the sandbox queue, then load
+   * the sandbox row inside the critical section so `fn` observes a replay
+   * state no concurrent operation can move under it.
+   */
+  private runWithSandbox<T>(
+    sandboxId: SandboxId,
+    fn: (sandbox: SkillSandbox) => Promise<T>,
+  ): Promise<T> {
+    return this.runExclusive(sandboxId, async () =>
+      fn(await this.loadSandbox(sandboxId)),
+    );
+  }
+
+  /**
+   * Shared pre-flight for the two operations that materialize a container
+   * (`runCommand`, `exportArtifact`): fail closed if any mounted skill is no
+   * longer readable by the caller, stage chat attachments so they're part of
+   * this run's replay (the model sees them under the attachments dir), and
+   * load the replay context. The append-only recipe mutations (`uploadFile`,
+   * `mountSkill`) deliberately skip this — see {@link SandboxCaller}.
+   */
+  private async prepareExecution(
+    sandbox: SkillSandbox,
+    caller: SandboxCaller,
+  ): Promise<{ stagingNotices: string[]; replayEntries: ReplayEntry[] }> {
+    await this.assertMountsReadable(asSandboxId(sandbox.id), caller);
+    const stagingNotices = await stageConversationAttachments(sandbox);
+    const { replayEntries } = await this.buildContext(sandbox);
+    return { stagingNotices, replayEntries };
   }
 
   /**

--- a/platform/backend/src/skills-sandbox/types.ts
+++ b/platform/backend/src/skills-sandbox/types.ts
@@ -13,6 +13,13 @@ export const SKILL_SANDBOX_LIMITS = {
  * Caller identity threaded into the materializing tools so the revocation gate
  * can re-check the caller's `skill:read` on every mounted skill before a
  * container is built.
+ *
+ * Deliberately absent from {@link UploadFileParams} and
+ * {@link MountSkillParams}: those are append-only recipe mutations that build
+ * no container and execute no skill bytes, so the gate re-runs on the next
+ * materializing call (`runCommand` / `exportArtifact`), which is where a
+ * revoked skill must fail closed. A future operation that materializes the
+ * sandbox must take a caller and go through the same gate.
  */
 export interface SandboxCaller {
   userId: string;

--- a/platform/backend/src/utils/normalize-bytea.ts
+++ b/platform/backend/src/utils/normalize-bytea.ts
@@ -1,0 +1,13 @@
+/**
+ * pg returns `bytea` columns as Buffer; PGlite (used in tests) returns
+ * Uint8Array. Callers rely on Buffer semantics (`.toString("base64")`,
+ * `.equals()`), so models normalize at the read boundary with this helper.
+ */
+export function normalizeByteaField<
+  Key extends string,
+  Row extends Record<Key, Buffer>,
+>(row: Row, key: Key): Row {
+  if (Buffer.isBuffer(row[key])) return row;
+  // the runtime value is a Uint8Array here, which the static type can't see
+  return { ...row, [key]: Buffer.from(row[key] as unknown as Uint8Array) };
+}

--- a/platform/backend/src/utils/shell-quote.ts
+++ b/platform/backend/src/utils/shell-quote.ts
@@ -1,0 +1,7 @@
+/**
+ * quote a value for safe interpolation into a POSIX shell command: wrap in
+ * single quotes, escaping embedded single quotes via the `'\''` idiom.
+ */
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}

--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -155,18 +155,6 @@ If ARCHESTRA_AUTH_SECRET env variable is explicitly set, it will override the au
 - name: ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST
   value: {{ include "archestra-platform.codeRuntimeDaggerRunnerHost" . | quote }}
 {{- end }}
-{{- if not (hasKey .Values.archestra.env "ARCHESTRA_CODE_RUNTIME_TIMEOUT_SECONDS") }}
-- name: ARCHESTRA_CODE_RUNTIME_TIMEOUT_SECONDS
-  value: {{ .Values.archestra.codeRuntime.timeoutSeconds | quote }}
-{{- end }}
-{{- if not (hasKey .Values.archestra.env "ARCHESTRA_CODE_RUNTIME_MAX_CONCURRENT") }}
-- name: ARCHESTRA_CODE_RUNTIME_MAX_CONCURRENT
-  value: {{ .Values.archestra.codeRuntime.maxConcurrent | quote }}
-{{- end }}
-{{- if not (hasKey .Values.archestra.env "ARCHESTRA_CODE_RUNTIME_MAX_OUTPUT_BYTES") }}
-- name: ARCHESTRA_CODE_RUNTIME_MAX_OUTPUT_BYTES
-  value: {{ .Values.archestra.codeRuntime.maxOutputBytes | quote }}
-{{- end }}
 {{- end }}
 {{- if .Values.archestra.diagnostics.enabled }}
 - name: ARCHESTRA_NODE_DIAGNOSTIC_DIR

--- a/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
@@ -480,21 +480,6 @@ tests:
           content:
             name: ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST
             value: kube-pod://dagger-runtime-engine-0?namespace=dagger&container=dagger-engine
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: ARCHESTRA_CODE_RUNTIME_TIMEOUT_SECONDS
-            value: "60"
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: ARCHESTRA_CODE_RUNTIME_MAX_CONCURRENT
-            value: "10"
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: ARCHESTRA_CODE_RUNTIME_MAX_OUTPUT_BYTES
-            value: "65536"
 
   - it: should support custom code runtime Dagger runner host
     documentIndex: 1

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -175,14 +175,8 @@ archestra:
     # enable or disable code execution runtime support.
     enabled: false
 
-    # hard wall-clock limit per run, and the default when the caller omits one.
-    timeoutSeconds: 60
-
-    # maximum number of concurrent runs across all conversations per backend process.
-    maxConcurrent: 10
-
-    # stdout and stderr are each truncated to this many bytes.
-    maxOutputBytes: 65536
+    # runtime limits (timeouts, concurrency, output caps) are env-driven via
+    # ARCHESTRA_SKILLS_SANDBOX_* / ARCHESTRA_DAGGER_RUNTIME_* in archestra.env.
 
     dagger:
       # explicit Dagger runner host. Leave empty to use the kube-pod:// pod target below.


### PR DESCRIPTION
Behavior-preserving cleanup pass over the skill-sandbox component, plus one manifest-only Helm cleanup.

- one shared `normalizeByteaField` util replaces three identical per-model bytea normalizers; two redundant call-site re-normalizations removed (the model layer already returns `Buffer`)
- one shared `shellQuote` util replaces identical copies in the sandbox service and hook-runner
- the per-sandbox queue's parallel maps (`sandboxQueues` + `sandboxPendingCounts`) collapse into one `Map<SandboxId, SandboxQueueState>`; characterization tests (exact saturation count, guard reset after drain, settle-boundary reuse) were added before the change and pass on both implementations
- `runWithSandbox` and `prepareExecution` extract the ceremony shared by the four public sandbox operations; per-operation error mapping is intentionally untouched, and `SandboxCaller` now documents why `uploadFile`/`mountSkill` take no caller
- path-validation test vectors are mirrored between `sandbox-core/src/validation.rs` and the TS adapter tests, with each table annotating the other layer's verdict so deliberate divergences stay pinned
- stale `skill_sandbox_commands` comment fixed: replay order is `skill_sandbox_replay_events.sequence`, not command `createdAt`
- Helm: `ARCHESTRA_CODE_RUNTIME_{TIMEOUT_SECONDS,MAX_CONCURRENT,MAX_OUTPUT_BYTES}` env emissions, their `values.yaml` keys, and test assertions removed — nothing reads them (the real knobs are `ARCHESTRA_SKILLS_SANDBOX_*` / `ARCHESTRA_DAGGER_RUNTIME_*`). This is the only externally visible change: those env entries disappear from rendered manifests.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>