### PR TITLE
fix(chat): first in-session edit regenerates pre-edit text; bubble width flickers at stream end

### DIFF
--- a/platform/frontend/src/components/chat/editable-assistant-message.tsx
+++ b/platform/frontend/src/components/chat/editable-assistant-message.tsx
@@ -168,19 +168,20 @@ export function EditableAssistantMessage({
 
   return (
     <Message from="assistant" className="group/message">
-      <div className="flex max-w-[80%] items-center justify-start gap-2">
-        <div className="min-w-0 flex-1">
-          <MessageContent className="max-w-none">
-            <Response isStreaming={isStreaming}>{text}</Response>
-            {citationParts && <KnowledgeGraphCitations parts={citationParts} />}
-          </MessageContent>
-        </div>
+      {/* The actions are absolutely positioned outside the flow: mounting
+          them when streaming ends must not steal width from the bubble,
+          which would make the finished text visibly rewrap. */}
+      <div className="relative max-w-[80%]">
+        <MessageContent className="max-w-none">
+          <Response isStreaming={isStreaming}>{text}</Response>
+          {citationParts && <KnowledgeGraphCitations parts={citationParts} />}
+        </MessageContent>
         {showActions && (
           <MessageActions
             textToCopy={text}
             onEditClick={handleStartEdit}
             editDisabled={editDisabled}
-            className="shrink-0 opacity-0 group-hover/message:opacity-100 transition-opacity"
+            className="absolute left-full top-1/2 ml-2 -translate-y-1/2 opacity-0 group-hover/message:opacity-100 transition-opacity"
           />
         )}
       </div>

--- a/platform/frontend/src/lib/chat/chat-utils.test.ts
+++ b/platform/frontend/src/lib/chat/chat-utils.test.ts
@@ -1,11 +1,13 @@
 import type { UIMessage } from "@ai-sdk/react";
 import { describe, expect, it } from "vitest";
 import {
+  applyTextEditToMessages,
   getChatExternalAgentId,
   getConversationDisplayTitle,
   getManualCompactionSkippedMessage,
   mergePersistedMessageMetadata,
   PERSISTED_MESSAGE_ID_METADATA_KEY,
+  resolveCanonicalMessageId,
 } from "./chat-utils";
 
 const DEFAULT_SESSION_NAME = "New Chat Session";
@@ -499,5 +501,117 @@ describe("mergePersistedMessageMetadata", () => {
     });
 
     expect(mergedMessages[0]?.parts).toBe(liveMessages[0]?.parts);
+  });
+});
+
+describe("resolveCanonicalMessageId", () => {
+  const liveMessages = [
+    {
+      id: "nanoid-user-1",
+      role: "user",
+      metadata: { [PERSISTED_MESSAGE_ID_METADATA_KEY]: "db-user-1" },
+      parts: [{ type: "text", text: "edited prompt" }],
+    },
+  ] as UIMessage[];
+
+  it("returns the message id when the saved thread already contains it", () => {
+    expect(
+      resolveCanonicalMessageId({
+        messageId: "db-user-1",
+        liveMessages: [],
+        canonicalMessages: [
+          { id: "db-user-1", role: "user", parts: [] },
+        ] as UIMessage[],
+      }),
+    ).toBe("db-user-1");
+  });
+
+  it("maps an in-session nanoid to its DB id via persisted metadata", () => {
+    expect(
+      resolveCanonicalMessageId({
+        messageId: "nanoid-user-1",
+        liveMessages,
+        canonicalMessages: [
+          { id: "db-user-1", role: "user", parts: [] },
+        ] as UIMessage[],
+      }),
+    ).toBe("db-user-1");
+  });
+
+  it("returns null when the live message has no mapping into the saved thread", () => {
+    expect(
+      resolveCanonicalMessageId({
+        messageId: "nanoid-user-1",
+        liveMessages: [
+          { id: "nanoid-user-1", role: "user", parts: [] },
+        ] as UIMessage[],
+        canonicalMessages: [
+          { id: "db-user-other", role: "user", parts: [] },
+        ] as UIMessage[],
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when the saved thread is missing", () => {
+    expect(
+      resolveCanonicalMessageId({
+        messageId: "nanoid-user-1",
+        liveMessages,
+        canonicalMessages: undefined,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("applyTextEditToMessages", () => {
+  it("replaces only the targeted text part and keeps other messages untouched", () => {
+    const messages = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [
+          { type: "file", url: "blob:a", mediaType: "image/png" },
+          { type: "text", text: "old text" },
+        ],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "answer" }],
+      },
+    ] as UIMessage[];
+
+    const updated = applyTextEditToMessages({
+      messages,
+      messageId: "user-1",
+      partIndex: 1,
+      text: "new text",
+    });
+
+    expect(updated[0]?.parts[1]).toMatchObject({
+      type: "text",
+      text: "new text",
+    });
+    expect(updated[0]?.parts[0]).toBe(messages[0]?.parts[0]);
+    expect(updated[1]).toBe(messages[1]);
+  });
+
+  it("does not touch a part whose index matches but is not text", () => {
+    const messages = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "file", url: "blob:a", mediaType: "image/png" }],
+      },
+    ] as UIMessage[];
+
+    const updated = applyTextEditToMessages({
+      messages,
+      messageId: "user-1",
+      partIndex: 0,
+      text: "new text",
+    });
+
+    expect(updated[0]?.parts[0]).toBe(messages[0]?.parts[0]);
   });
 });

--- a/platform/frontend/src/lib/chat/chat-utils.ts
+++ b/platform/frontend/src/lib/chat/chat-utils.ts
@@ -167,6 +167,68 @@ export function mergePersistedMessageMetadata(params: {
   return changed ? mergedMessages : params.liveMessages;
 }
 
+/**
+ * Resolve a live message's id in the saved thread. In-session messages keep
+ * their AI SDK nanoid as the live `id`, while the saved thread keys the same
+ * message by its DB UUID; mergePersistedMessageMetadata records that mapping
+ * in metadata.persistedMessageId. Returns null when the message cannot be
+ * found in the saved thread under either id.
+ */
+export function resolveCanonicalMessageId(params: {
+  messageId: string;
+  liveMessages: UIMessage[];
+  canonicalMessages: UIMessage[] | undefined;
+}): string | null {
+  const { messageId, liveMessages, canonicalMessages } = params;
+  if (!canonicalMessages) {
+    return null;
+  }
+
+  if (canonicalMessages.some((message) => message.id === messageId)) {
+    return messageId;
+  }
+
+  const liveMessage = liveMessages.find((message) => message.id === messageId);
+  if (!liveMessage) {
+    return null;
+  }
+
+  const persistedMessageId =
+    getObjectMetadata(liveMessage)[PERSISTED_MESSAGE_ID_METADATA_KEY];
+  if (
+    typeof persistedMessageId === "string" &&
+    persistedMessageId.length > 0 &&
+    canonicalMessages.some((message) => message.id === persistedMessageId)
+  ) {
+    return persistedMessageId;
+  }
+
+  return null;
+}
+
+/** Replace the text of one text part of one message, immutably. */
+export function applyTextEditToMessages(params: {
+  messages: UIMessage[];
+  messageId: string;
+  partIndex: number;
+  text: string;
+}): UIMessage[] {
+  return params.messages.map((message) => {
+    if (message.id !== params.messageId) {
+      return message;
+    }
+
+    return {
+      ...message,
+      parts: message.parts.map((part, index) =>
+        index === params.partIndex && part.type === "text"
+          ? { ...part, text: params.text }
+          : part,
+      ),
+    };
+  });
+}
+
 function messagesHaveSameRenderableContent(params: {
   liveMessage: UIMessage;
   persistedMessage: UIMessage;

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -42,8 +42,10 @@ import {
   shouldFreezeChatMessages,
 } from "@/lib/chat/chat-session-utils";
 import {
+  applyTextEditToMessages,
   getChatExternalAgentId,
   getConversationDisplayTitle,
+  resolveCanonicalMessageId,
 } from "@/lib/chat/chat-utils";
 import {
   extractSwapTargetAgentName,
@@ -972,11 +974,25 @@ function ChatSessionHook({
       partIndex: number;
       text: string;
     }) => {
+      // Snapshot the live thread before touching any state — it is the only
+      // place that knows the live↔saved id mapping for in-session messages
+      // (metadata.persistedMessageId, stamped by mergePersistedMessageMetadata).
+      const liveMessages = previousMessagesRef.current;
+
       // Persist the (possibly edited) text and get the saved thread back, which
       // carries each message under its DB id.
       const data = await updateChatMessageAsync({ messageId, partIndex, text });
       const canonical = data?.messages as UIMessage[] | undefined;
-      const anchor = canonical?.find((m) => m.id === messageId);
+      // In-session messages keep their AI SDK nanoid as the live id while the
+      // saved thread keys them by DB UUID, so a plain id lookup misses them.
+      // Resolve through metadata.persistedMessageId too — otherwise the first
+      // edit before a reload falls into the regenerate-in-place path below and
+      // re-sends the pre-edit text, making the model answer the old prompt.
+      const anchorId = resolveCanonicalMessageId({
+        messageId,
+        liveMessages,
+        canonicalMessages: canonical,
+      });
 
       // Break the restore-on-regression chain before regenerating, like the
       // auto-retry and 409-reattach paths do: regenerate() rebuilds the edited
@@ -988,11 +1004,11 @@ function ChatSessionHook({
       // snapshot is taken.
       previousMessagesRef.current = [];
 
-      if (canonical && anchor) {
+      if (canonical && anchorId) {
         // Normal path: the message is persisted. Sync to the saved thread and
         // regenerate from it. The server replaces the turn atomically.
         setMessages(canonical);
-        void regenerate({ messageId: anchor.id });
+        void regenerate({ messageId: anchorId });
         return;
       }
 
@@ -1000,7 +1016,17 @@ function ChatSessionHook({
       // After switching agents the target message can still be in-session: its
       // id is an AI SDK nanoid, so it isn't found in the saved thread above.
       // Regenerate in place using the live id (the backend matches it to the
-      // stored row by content id).
+      // stored row by content id). Apply the edited text to the live message
+      // first: regenerate() re-sends the live thread, which otherwise still
+      // holds the pre-edit text.
+      setMessages((current) =>
+        applyTextEditToMessages({
+          messages: current,
+          messageId,
+          partIndex,
+          text,
+        }),
+      );
       void regenerate({ messageId });
     },
     [updateChatMessageAsync, setMessages, regenerate],


### PR DESCRIPTION
## Context

Two chat bugs, both reproduced live against the dev stack with chrome-devtools:

1. **Editing a message for the first time in a chat doesn't take effect.** The model replies to the previous text, and the edited text only appears after a page refresh. Repro: send a message → response → edit the message → the regenerate `POST /api/chat` body still carries the **pre-edit** text (captured on the wire), while the PATCH had already persisted the edit — hence "fixed by refresh".

2. **The assistant bubble changes width at the end of generation** for longer responses (e.g. "generate 100 words"), visibly rewrapping the finished text. Measured with a ResizeObserver: the bubble shrank 684.8px → 612.8px at the exact moment streaming ended.

## Root causes

**Stale edit:** a live↔saved id mismatch. A message sent in the current session keeps its AI SDK nanoid as the live id, but the saved thread returned by the edit PATCH keys every message by its DB UUID (`addMessagePersistenceMetadata` overrides the content id). In `regenerateUserMessage`, `canonical.find((m) => m.id === messageId)` therefore never matches an in-session message, and the flow falls into the swap_agent fallback: `regenerate({ messageId })` against the unchanged live state, which still holds the pre-edit text. After a reload the live ids *are* DB UUIDs, so the same edit works — exactly the reported symptom.

**Width flicker:** when streaming ends, `showActions` flips true and mounts the copy/edit `MessageActions` toolbar inside the same flex row as the bubble. It is `opacity-0` until hover but still occupies layout, stealing toolbar-width + gap (72px) from the text and forcing a rewrap.

## Fix

- `resolveCanonicalMessageId` (new, `chat-utils.ts`): maps the live message id into the saved thread via `metadata.persistedMessageId` — the live↔DB mapping `mergePersistedMessageMetadata` already stamps — so in-session edits take the same proven setMessages(canonical) + regenerate path as post-refresh edits.
- Defense in depth for the swap_agent fallback: apply the edited text to the live message part (`applyTextEditToMessages`, new) before regenerating in place, so that path can never re-send pre-edit text either.
- `editable-assistant-message.tsx`: position the actions toolbar absolutely (`left-full ml-2 top-1/2 -translate-y-1/2`) so mounting it cannot steal width from the bubble. Same visual position (8px right of the bubble, vertically centered), zero layout impact.

## Verification

- Live (chrome-devtools, dev stack):
  - Before: edit in-session → request body carried the old prompt, model answered it. After: request carries the edited text under the resolved DB id, model answers the new prompt, UI updates immediately.
  - Post-refresh edits (the previously working path) still work; reloads show clean persisted threads with no duplicate or stale turns.
  - The #5457 multi-turn repro (edit the second in-session user message) runs clean with a `window.onerror` trap — 0 captured errors.
  - ResizeObserver before/after: bubble previously shrank 684.8 → 612.8px at stream end; now stays at 716.8px throughout — the only resize event is the out-of-flow toolbar itself mounting.
- 8 new unit tests for the two extracted helpers; chat suites 429/429; `pnpm type-check`, `pnpm lint`, `pnpm knip` clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>