### PR TITLE
fix(docker): bump node:24-alpine3.23 digest so cached apk upgrade re-runs (openssl CVEs)

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -2,7 +2,7 @@
 # the Alpine packages/binaries have historically lagged on Go patch releases, so
 # we compile these tools ourselves to pick up upstream fixes without local vendoring hacks.
 ARG GOLANG_IMAGE=golang:1.25.11-alpine@sha256:c05ba4b73604069d376c4f41346b05374335b5ca0c46fb6dfede5a59f5196931
-ARG NODE_IMAGE=node:24-alpine3.23@sha256:7fddd9ddeae8196abf4a3ef2de34e11f7b1a722119f91f28ddf1e99dcafdf114
+ARG NODE_IMAGE=node:24-alpine3.23@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14
 ARG KIND_VERSION=v0.31.0
 ARG KIND_COMMIT=a323333ff9efd8099f95a8a6b5c86c75a210d00f
 ARG DOCKER_CLI_VERSION=v29.3.0


### PR DESCRIPTION
## Context

The merge-queue **Docker Image Scanning (Platform)** job is failing for every queue entry (e.g. #5475, #5445): Docker Scout finds `openssl 3.5.6-r0` in the image with **CVE-2026-45447 (critical)** plus five highs (CVE-2026-7383, -9076, -45445, -42764, -34180). All six are fixed by `openssl 3.5.7-r0`, which Alpine 3.23 already ships — and the scan runs with `only-fixed: true`, so it blocks exactly on fixed-but-not-applied CVEs.

## Root cause

The final image stage already runs `apk --no-cache upgrade`, but that RUN layer is cache-keyed on the instruction text plus the parent image — and `NODE_IMAGE` is pinned by digest in `platform/Dockerfile`. Neither has changed, so the Blacksmith runner's persistent BuildKit cache (~77 GB sticky disk) keeps serving an upgrade layer built before openssl 3.5.7-r0 existed. Security upgrades are frozen in cache.

## Fix

Bump the `node:24-alpine3.23` pin to the current multi-arch index digest (`sha256:2bdb65ed…`, rebuilt 2026-05-21, amd64+arm64). This invalidates the downstream layers, the `apk upgrade` re-runs, and the image picks up openssl 3.5.7-r0.

## Verification

Ran the new base image locally: it still ships `libssl3-3.5.6-r0`, and after `apk --no-cache upgrade` (what the Dockerfile's final stage does on an uncached build):

```
libcrypto3-3.5.7-r0 aarch64 {openssl} (Apache-2.0) [installed]
libssl3-3.5.7-r0   aarch64 {openssl} (Apache-2.0) [installed]
```

The `run-docker-scan` label is set so the real scan runs on this PR before it hits the merge queue.

Note: this failure mode will recur whenever Alpine ships a security fix while the digest pin stays unchanged — a periodic cache-bust for the apk-upgrade layer (e.g. a date-derived build arg) would prevent that, left out of scope here.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>