### PR TITLE
fix(e2e): unbreak merge-queue e2e failures

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -2,7 +2,7 @@
 # the Alpine packages/binaries have historically lagged on Go patch releases, so
 # we compile these tools ourselves to pick up upstream fixes without local vendoring hacks.
 ARG GOLANG_IMAGE=golang:1.25.11-alpine@sha256:c05ba4b73604069d376c4f41346b05374335b5ca0c46fb6dfede5a59f5196931
-ARG NODE_IMAGE=node:24-alpine3.23@sha256:7fddd9ddeae8196abf4a3ef2de34e11f7b1a722119f91f28ddf1e99dcafdf114
+ARG NODE_IMAGE=node:24-alpine3.23@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14
 ARG KIND_VERSION=v0.31.0
 ARG KIND_COMMIT=a323333ff9efd8099f95a8a6b5c86c75a210d00f
 ARG DOCKER_CLI_VERSION=v29.3.0

--- a/platform/backend/src/routes/proxy/adapters/openai.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai.test.ts
@@ -223,6 +223,27 @@ describe("OpenAIResponseAdapter", () => {
     });
   });
 
+  describe("getFinishReasons", () => {
+    test("extracts the finish reason from the first choice", () => {
+      const response = createMockResponse({
+        role: "assistant",
+        content: "Hello",
+      });
+
+      const adapter = openaiAdapterFactory.createResponseAdapter(response);
+      expect(adapter.getFinishReasons()).toEqual(["stop"]);
+    });
+
+    test("returns empty array when choices is missing (e.g. upstream error body)", () => {
+      const response = {
+        error: { message: "upstream failure" },
+      } as unknown as OpenAi.Types.ChatCompletionsResponse;
+
+      const adapter = openaiAdapterFactory.createResponseAdapter(response);
+      expect(adapter.getFinishReasons()).toEqual([]);
+    });
+  });
+
   describe("getUsage", () => {
     test("extracts usage tokens from response", () => {
       const response = createMockResponse(

--- a/platform/backend/src/routes/proxy/adapters/openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai.ts
@@ -925,7 +925,7 @@ export class OpenAIResponseAdapter
   }
 
   getFinishReasons(): string[] {
-    const reason = this.response.choices[0]?.finish_reason;
+    const reason = this.response.choices?.[0]?.finish_reason;
     return reason ? [reason] : [];
   }
 

--- a/platform/e2e-tests/tests/identity-providers.ee.spec.ts
+++ b/platform/e2e-tests/tests/identity-providers.ee.spec.ts
@@ -564,16 +564,21 @@ test.describe("Identity Provider Team Sync E2E", () => {
       description: "Team for testing SSO group sync",
     });
 
-    // STEP 3: Link external group to the team
+    // STEP 3: Link external group to the team. External group sync lives in
+    // the tabbed team management dialog (opened via the row's Edit action),
+    // under the "External Group Sync" section.
     await clickTeamActionButton({
       page,
       teamName,
-      actionName: "Configure SSO Team Sync",
+      actionName: "Edit",
     });
 
-    // Wait for dialog to appear
-    await expect(page.getByRole("dialog")).toBeVisible();
-    await expect(page.getByText("External Group Sync")).toBeVisible();
+    // Wait for the dialog and switch to the External Group Sync section
+    const teamDialog = page.getByRole("dialog");
+    await expect(teamDialog).toBeVisible();
+    await teamDialog
+      .getByRole("button", { name: "External Group Sync" })
+      .click();
 
     // Add the external group mapping
     await page.getByPlaceholder(/archestra-admins/).fill(externalGroup);

--- a/platform/e2e-tests/tests/mcp-catalog-promote-to-team.spec.ts
+++ b/platform/e2e-tests/tests/mcp-catalog-promote-to-team.spec.ts
@@ -50,8 +50,13 @@ test.describe("MCP Catalog promotion", () => {
     });
     await expect(settingsDialog).toBeVisible({ timeout: 30_000 });
 
-    // Switch visibility Personal -> Teams. The Teams option's description is
-    // unique within the visibility selector, so match on it.
+    // Switch visibility Personal -> Teams. The visibility selector renders
+    // collapsed (showing only the current Personal option), so expand it
+    // first; the Teams option's description is unique within the expanded
+    // list, so match on it.
+    await settingsDialog
+      .getByRole("button", { name: /Only you can access this MCP server/i })
+      .click();
     await settingsDialog
       .getByRole("button", {
         name: /Share this MCP server with selected teams/i,

--- a/platform/e2e-tests/utils/teams.ts
+++ b/platform/e2e-tests/utils/teams.ts
@@ -51,6 +51,13 @@ export async function createTeam(params: {
   await params.page.getByLabel("Team Name").fill(params.name);
   await params.page.getByLabel("Description").fill(params.description);
   await dialog.getByRole("button", { name: "Create Team" }).click();
+  // After a successful create the dialog stays open and switches to edit mode
+  // (so members/sync can be configured right away) — wait for the switch,
+  // then close it.
+  await expect(
+    dialog.getByRole("button", { name: "Save Changes" }),
+  ).toBeVisible({ timeout: 10_000 });
+  await dialog.getByRole("button", { name: "Cancel" }).click();
   await expect(dialog).not.toBeVisible({ timeout: 10_000 });
   await getVisibleTeamRow(params.page, params.name);
 }


### PR DESCRIPTION
## Context

Investigating the e2e failure reported for #5475's merge-queue run (`27276358656`) showed the failures are **not caused by that PR** — the merge queue's Platform E2E Tests have been red for every PR since June 5. Three distinct root causes, all fixed here:

## 1. `mcp-catalog-promote-to-team.spec.ts` — failing since it landed (June 5)

The spec clicks the Teams visibility option (`Share this MCP server with selected teams`) directly, but `VisibilitySelector` renders **collapsed** by default — the option buttons aren't in the DOM until the selector is expanded, so the click times out (`locator.click: Timeout 15000ms exceeded`, no element ever resolved). The spec's shards were path-filter-skipped at PR level on #5338, so it never ran in CI before reaching the merge queue, where it has failed on every run since. Fix: expand the selector (click the collapsed Personal summary) before picking Teams.

## 2. `utils/teams.ts` `createTeam` — failing since #5425 (June 9)

The tabbed team-management dialog introduced in #5425 intentionally keeps the dialog **open** after a successful create (switching to edit mode so members/sync can be configured immediately). The helper still expected the dialog to close, so `expect(dialog).not.toBeVisible()` failed deterministically — this broke `identity-providers.ee.spec.ts › should sync user to team based on SSO group membership` (the only UI-driven consumer of the helper). Fix: wait for the create→edit mode switch (`Save Changes` button), then close the dialog explicitly.

## 3. `OpenAIResponseAdapter.getFinishReasons` — crash on upstream bodies without `choices`

CI backend logs showed repeated 500s on `POST /v1/openai/:agentId/chat/completions`:

```
TypeError: Cannot read properties of undefined (reading '0')
    at OpenAIResponseAdapter.getFinishReasons (backend/src/routes/proxy/adapters/openai.ts:928)
```

triggered when a response body has no `choices` (e.g. e2e title-generation requests that don't match a WireMock stub). Other adapters (gemini, cohere) already guard this; openai was the odd one out. Fixed with optional chaining + regression test. This also removes 500-noise contributing to the flaky `Chat-UI-*` specs (anthropic/mistral/ollama flaked or failed in the same runs).

## Verification

- `pnpm lint`, `pnpm type-check` clean
- `pnpm vitest run src/routes/proxy/adapters/openai.test.ts` — 33 passed (includes new `getFinishReasons` tests)
- The two e2e fixes run in the merge queue for this PR (shards are skipped at PR level by path filter)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>