### PR TITLE
feat(migration-kit): sandbox path/shell rewrite guidance + agent-hooks feature check

### DIFF
--- a/migration-kit/SKILL.md
+++ b/migration-kit/SKILL.md
@@ -100,6 +100,12 @@ Mark openclaw as `action:"manual"` with a `notes` explanation. Do the same for t
 observability hooks/scripts): map it to `manual` and, per `entity-mapping.md`, point the user at
 Archestra's native telemetry instead of migrating it.
 
+Before previewing, do a **reference-rewrite pass**: read each migrating skill/command/subagent/hook body
+and surgically fix paths and shell invocations that assumed the source machine — project-relative or
+`$CLAUDE_PROJECT_DIR` paths, host-only binaries/flags, inline env — so they resolve in the sandbox
+(`apply.py` ships bodies verbatim). See `entity-mapping.md`, "Rewrite environment-specific references".
+List anything you can't safely rewrite as a manual follow-up.
+
 Always show the user a concise preview and get explicit approval before applying. Use this shape:
 
 ```markdown
@@ -116,6 +122,9 @@ Needs your decision
 Manual after migration
 | Source | Why manual | Follow-up |
 | --- | --- | --- |
+
+Sandbox rewrites applied
+- <source body → path/shell reference rewritten for the sandbox, or "none">
 
 Behavior changes to expect
 - <only list differences that apply>

--- a/migration-kit/references/entity-mapping.md
+++ b/migration-kit/references/entity-mapping.md
@@ -40,12 +40,42 @@ It also tries to assign sandbox tools (`run_command`, `upload_file`, `download_f
 so bundled local tools can run from activated skills. Missing/disabled sandbox support is reported as a
 non-blocking warning.
 
+## Rewrite environment-specific references before applying (judgment)
+Skill, command, subagent, and hook bodies migrate **verbatim** — `apply.py` ships them unchanged. So any
+path or shell invocation inside a body that assumed the source machine breaks in the Archestra sandbox.
+Before the preview, read each migrating body and surgically rewrite it (ordinary file edits in the source):
+
+- **Paths.** The sandbox is not the source checkout. `$CLAUDE_PROJECT_DIR`/`$CLAUDE_*` are gone, and a
+  skill's bundled files mount writable at `/skills/<name>/` — but `cwd` is the sandbox home
+  (`/home/sandbox`), **never** the skill root, so a bundled script that reads its own files by relative
+  path must use the absolute `/skills/<name>/<rel>` form. Rewrite project-relative (`tools/x.py`,
+  `./data/foo.json`), home (`~/...`), and `$CLAUDE_PROJECT_DIR` paths to absolute sandbox paths:
+  bundled-with-the-skill → `/skills/<name>/<rel>`, scratch output → under `/home/sandbox`. A cross-skill
+  reference (`python3 tools/x.py` in skill A pointing at a script that lands in skill B's mount) is the
+  classic break — see "Local tools" below.
+- **Shell.** Commands run **non-root** (uid 1000) on a Debian-slim image with `python3`/`uv`, `git`, and
+  `curl` baked in — there is **no `apt`/`apk` at runtime**, so host-only OS binaries (`jq`, `rg`,
+  `gtimeout`, GNU-only flags) can't be installed and must be rewritten to portable `python3`/POSIX `sh`.
+  Python deps *are* installable: add a `requirements.txt` at the skill root (auto-installed via `uv` on
+  mount) or run `uv add --project /home/sandbox <pkg>` as part of the command — never `pip install`, which
+  is shimmed off. Also drop inline env (`TOKEN=… cmd`) and absolute host tool paths, and move secrets out
+  (hooks take no env/argv at all).
+
+Every reference you can't safely rewrite goes in the report as a manual follow-up — never leave a body
+pointing at a path or binary that won't exist at runtime.
+
 ## Hooks → native lifecycle hooks (preferred)
 Archestra runs per-agent `.py`/`.sh` lifecycle hooks at `session_start`/`pre_tool_use`/`post_tool_use`,
 in the conversation sandbox, with a **Claude-compatible** stdin payload (`hook_event_name`, `tool_name`,
 `tool_input`, `tool_response`, `session_id`, `cwd`) and the same exit-code protocol (`2` blocks with
 stderr as the reason; `0` proceeds with stdout injected; errors/timeout fail open). So most Claude Code
 hooks for those three events port near-1:1 as a `hook` target — that is the default.
+
+Native hooks require the **agent-hooks feature**, which is off by default: it needs
+`ARCHESTRA_AGENT_HOOKS_ENABLED=true` **and** the sandbox runtime to be on (hooks run in the conversation
+sandbox). `POST /api/hooks` still persists a migrated hook when the feature is off, but the hook never
+fires and is hidden in the agent UI until an admin enables it — `apply.py` probes `/api/config` after
+creating hooks and warns when the feature is off.
 
 `discover.py` does the mechanical part and records it on each `hook` item's `data.source`:
 - **bundled** — the command referenced a script in the tree (e.g. `python3 "$CLAUDE_PROJECT_DIR/hooks/x.py"`);

--- a/migration-kit/scripts/apply.py
+++ b/migration-kit/scripts/apply.py
@@ -755,6 +755,7 @@ def _invalid_build(b: _Built) -> bool:
 def _run_apply(built: list[_Built], base_url: str, api_key: str) -> list[ResultOp]:
     results: list[ResultOp] = []
     created_skill_or_agent = False
+    hook_landed = False
     agent_ids: list[str] = []
     primary_agent_id: str | None = None
     with ArchestraClient(base_url, api_key=api_key) as client:
@@ -786,7 +787,11 @@ def _run_apply(built: list[_Built], base_url: str, api_key: str) -> list[ResultO
                     primary_agent_id = op.archestra_id
             if op.target_kind in ("skill", "agent") and op.outcome in ("created", "skipped"):
                 created_skill_or_agent = True
+            if op.target_kind == "hook" and op.outcome in ("created", "skipped"):
+                hook_landed = True
 
+        if hook_landed:
+            results.append(_hook_feature_check(client))
         if created_skill_or_agent:
             try:
                 client.enable_skill_defaults()
@@ -843,6 +848,27 @@ def _enable_sandbox_tools(client: ArchestraClient, agent_ids: list[str]) -> Resu
         outcome="created",
         detail=f"assigned sandbox tools to {len(agent_ids)} migrated agent(s)",
     )
+
+
+def _hook_feature_check(client: ArchestraClient) -> ResultOp:
+    """warn when migrated hooks landed but the agent-hooks feature is off: POST /api/hooks persists
+    them, yet they never fire and stay hidden in the UI until an admin enables the feature."""
+    try:
+        enabled = client.agent_hooks_enabled()
+    except (ArchestraApiError, ContractError, ValueError) as exc:
+        return _hook_warning(f"could not verify the agent-hooks feature is enabled: {exc}")
+    if enabled:
+        return ResultOp(source_id="-", target_kind="hook", name="agent-hooks-feature",
+                        outcome="created", detail="agent-hooks feature is enabled; migrated hooks will fire")
+    return _hook_warning(
+        "agent-hooks feature is OFF on this instance -- migrated hooks are saved but will not fire "
+        "and stay hidden in the agent UI until an admin sets ARCHESTRA_AGENT_HOOKS_ENABLED=true and the "
+        "sandbox runtime is on")
+
+
+def _hook_warning(detail: str) -> ResultOp:
+    return ResultOp(source_id="-", target_kind="hook", name="agent-hooks-feature",
+                    outcome="manual", detail=f"warning: {detail}")
 
 
 def _sandbox_warning(detail: str) -> ResultOp:

--- a/migration-kit/scripts/archestra_client.py
+++ b/migration-kit/scripts/archestra_client.py
@@ -361,6 +361,13 @@ class ArchestraClient:
         return require_dict(self._request("POST", "/api/hooks", json_body=to_payload(payload)),
                             ctx="POST /api/hooks")
 
+    def agent_hooks_enabled(self) -> bool:
+        """whether the instance's agent-hooks feature is on (env flag AND the sandbox runtime).
+        When off, POST /api/hooks still persists hooks but they never fire and are hidden in the UI."""
+        config = require_dict(self._request("GET", "/api/config"), ctx="GET /api/config")
+        features = config.get("features")
+        return bool(features.get("agentHooksEnabled")) if isinstance(features, dict) else False
+
 
 # --- response decoding & shape helpers -----------------------------------------------------
 


### PR DESCRIPTION
## What

Two refinements to the migration kit, both targeting migrations that silently break at runtime in the Archestra sandbox.

### Sandbox rewrite guidance (docs)
Skill/command/subagent/hook bodies migrate **verbatim** (`apply.py` ships them unchanged), so any path or shell invocation that assumed the source machine breaks in the sandbox. Adds an explicit pre-apply "reference-rewrite pass" so the migration agent fixes these before previewing:

- **Paths** — `$CLAUDE_PROJECT_DIR`/`$CLAUDE_*` are gone; bundled files mount writable at `/skills/<name>/` but `cwd` is `/home/sandbox` (never the skill root), so relative-path scripts must use absolute `/skills/<name>/<rel>`. Rewrite project-relative / `~` / `$CLAUDE_PROJECT_DIR` paths accordingly.
- **Shell** — commands run non-root (uid 1000) on a Debian-slim image with no `apt`/`apk` at runtime, so host-only binaries (`jq`, `rg`, GNU-only flags) can't be installed and must be rewritten to portable `python3`/POSIX `sh`. Python deps install via `requirements.txt` at the skill root or `uv add --project /home/sandbox <pkg>` — never `pip install` (shimmed off).

Adds a `Sandbox rewrites applied` row to the preview shape and a Step 3 pointer in `SKILL.md`. Path/user/install facts verified against `sandbox-core` (`dagger.rs`, `skill-sandbox-runtime-service.ts`).

### agent-hooks feature check (apply.py)
`POST /api/hooks` persists a migrated hook even when the agent-hooks feature is off, but it never fires and is hidden in the UI. `apply.py` now probes `/api/config` after creating hooks and emits a warning when the feature is off so it surfaces in the report.

## Test
`ruff`, `ty`, and `pytest` (119 passed) all green.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>