### PR TITLE
fix(chat): redesign tool call panel

### DIFF
--- a/platform/frontend/src/components/ai-elements/tool.test.tsx
+++ b/platform/frontend/src/components/ai-elements/tool.test.tsx
@@ -28,9 +28,6 @@ describe("Tool copy actions", () => {
 
     render(<ToolInput input={{ city: "Toronto", limit: 5 }} />);
 
-    // Expand the collapsible to reveal the copy button
-    await user.click(screen.getByText("Parameters"));
-
     await user.click(screen.getByRole("button", { name: "Copy to clipboard" }));
 
     expect(writeText).toHaveBeenCalledWith(
@@ -60,15 +57,12 @@ describe("Tool copy actions", () => {
     mockClipboard(writeText);
 
     render(
-      <ToolInput
-        defaultOpen
-        input={{ command: "echo hi\necho bye", cwd: "/tmp" }}
-      />,
+      <ToolInput input={{ command: "echo hi\necho bye", cwd: "/tmp" }} />,
     );
 
-    // per-field labels instead of one JSON dump with escaped \n
-    expect(screen.getByText("command")).toBeInTheDocument();
-    expect(screen.getByText("cwd")).toBeInTheDocument();
+    // per-field blocks instead of one JSON dump with escaped \n
+    expect(screen.getByText("echo hi")).toBeInTheDocument();
+    expect(screen.getByText("echo bye")).toBeInTheDocument();
     expect(screen.queryByText(/\\n/)).not.toBeInTheDocument();
 
     // the field copy button copies the raw string, not JSON

--- a/platform/frontend/src/components/ai-elements/tool.test.tsx
+++ b/platform/frontend/src/components/ai-elements/tool.test.tsx
@@ -56,9 +56,7 @@ describe("Tool copy actions", () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     mockClipboard(writeText);
 
-    render(
-      <ToolInput input={{ command: "echo hi\necho bye", cwd: "/tmp" }} />,
-    );
+    render(<ToolInput input={{ command: "echo hi\necho bye", cwd: "/tmp" }} />);
 
     // per-field blocks instead of one JSON dump with escaped \n
     expect(screen.getByText("echo hi")).toBeInTheDocument();

--- a/platform/frontend/src/components/ai-elements/tool.tsx
+++ b/platform/frontend/src/components/ai-elements/tool.tsx
@@ -6,13 +6,11 @@ import {
   ChevronDownIcon,
   CircleIcon,
   ClockIcon,
-  WrenchIcon,
   XCircleIcon,
 } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
 import { createContext, useContext, useRef, useState } from "react";
 import { CopyButton } from "@/components/copy-button";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Collapsible,
@@ -47,7 +45,10 @@ export const Tool = ({
       <Collapsible
         defaultOpen={false}
         open={open}
-        className={cn("not-prose mb-4 w-full rounded-md border", className)}
+        className={cn(
+          "not-prose mb-4 w-full overflow-hidden rounded-lg border border-border/60 bg-card shadow-sm",
+          className,
+        )}
         onOpenChange={handleOpenChange}
         {...props}
       >
@@ -74,32 +75,30 @@ const getStatusBadge = (
   const labels = {
     "input-streaming": "Pending",
     "input-available": "Running",
-    "approval-requested": "Approval Requested",
-    "approval-responded": "Approval Responded",
+    "approval-requested": "Approval requested",
+    "approval-responded": "Approval responded",
     "output-available": "Completed",
-    "output-available-dual-llm": "Completed with dual LLM",
+    "output-available-dual-llm": "Completed (dual LLM)",
     "output-error": "Error",
     "output-denied": "Denied",
   } as const;
 
-  const icons = {
-    "input-streaming": <CircleIcon className="size-4" />,
-    "input-available": <ClockIcon className="size-4 animate-pulse" />,
-    "approval-requested": <ClockIcon className="size-4 text-yellow-600" />,
-    "approval-responded": <CheckCircleIcon className="size-4 text-blue-600" />,
-    "output-available": <CheckCircleIcon className="size-4 text-green-600" />,
-    "output-available-dual-llm": (
-      <CheckCircleIcon className="size-4 text-green-600" />
-    ),
-    "output-error": <XCircleIcon className="size-4 text-destructive" />,
-    "output-denied": <XCircleIcon className="size-4 text-orange-600" />,
+  const dotClass = {
+    "input-streaming": "bg-muted-foreground/50",
+    "input-available": "bg-blue-500 animate-pulse",
+    "approval-requested": "bg-amber-500",
+    "approval-responded": "bg-blue-500",
+    "output-available": "bg-emerald-500",
+    "output-available-dual-llm": "bg-emerald-500",
+    "output-error": "bg-destructive",
+    "output-denied": "bg-orange-500",
   } as const;
 
   return (
-    <Badge className="gap-1.5 rounded-full text-xs" variant="secondary">
-      {icons[status]}
+    <div className="flex items-center gap-1.5 text-[10px] font-medium text-muted-foreground">
+      <span className={cn("size-1.5 rounded-full", dotClass[status])} />
       {labels[status]}
-    </Badge>
+    </div>
   );
 };
 
@@ -115,34 +114,34 @@ export const ToolHeader = ({
 }: ToolHeaderProps) => (
   <CollapsibleTrigger
     className={cn(
-      "flex w-full items-center justify-between gap-4 p-3 cursor-pointer group",
+      "group flex w-full items-center justify-between gap-3 border-b border-border/60 bg-muted/40 px-3 py-2 cursor-pointer",
       isCollapsible ? "cursor-pointer" : "!cursor-default",
       className,
     )}
     {...props}
   >
-    <div className="flex-1">
-      <div className="flex items-center gap-2">
-        {icon ?? <WrenchIcon className={`size-4 text-muted-foreground`} />}
-        <span className="font-medium text-sm">
-          {title ?? type.split("-").slice(1).join("-")}
-        </span>
-        {getStatusBadge(state)}
-      </div>
+    <div className="flex min-w-0 flex-1 items-center gap-2">
+      {icon}
+      <span className="truncate font-mono text-xs font-medium text-foreground">
+        {title ?? type.split("-").slice(1).join("-")}
+      </span>
     </div>
-    {actionButton && (
-      // biome-ignore lint/a11y/noStaticElementInteractions: Wrapper needs to stop event propagation
-      <div
-        onMouseDown={(e) => e.stopPropagation()}
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
-        {actionButton}
-      </div>
-    )}
-    {isCollapsible && (
-      <ChevronDownIcon className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
-    )}
+    <div className="flex items-center gap-3">
+      {getStatusBadge(state)}
+      {actionButton && (
+        // biome-ignore lint/a11y/noStaticElementInteractions: Wrapper needs to stop event propagation
+        <div
+          onMouseDown={(e) => e.stopPropagation()}
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          {actionButton}
+        </div>
+      )}
+      {isCollapsible && (
+        <ChevronDownIcon className="size-3.5 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+      )}
+    </div>
   </CollapsibleTrigger>
 );
 
@@ -186,36 +185,41 @@ export const ToolContent = ({
 
 export type ToolInputProps = ComponentProps<"div"> & {
   input: ToolUIPart["input"];
-  /** Render the Parameters section expanded instead of collapsed. */
+  /** Deprecated — parameters are always rendered expanded. */
   defaultOpen?: boolean;
 };
 
 export const ToolInput = ({
   className,
   input,
-  defaultOpen = false,
+  defaultOpen: _defaultOpen,
   ...props
 }: ToolInputProps) => {
   return (
-    <Collapsible
-      defaultOpen={defaultOpen}
-      className={cn("space-y-2 overflow-hidden p-4", className)}
+    <div
+      className={cn("overflow-hidden px-3 pt-3 space-y-1.5", className)}
       {...props}
     >
-      <div className="space-y-2">
-        <CollapsibleTrigger className="group flex w-full items-center justify-between gap-2 cursor-pointer">
-          <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
-            Parameters
-          </h4>
-          <ChevronDownIcon className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
-        </CollapsibleTrigger>
-        <CollapsibleContent className="data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 text-popover-foreground outline-none data-[state=closed]:animate-out data-[state=open]:animate-in">
-          <ToolInputBody input={input} />
-        </CollapsibleContent>
-      </div>
-    </Collapsible>
+      <SectionLabel accent="bg-sky-400">Request</SectionLabel>
+      <ToolInputBody input={input} />
+    </div>
   );
 };
+
+const SectionLabel = ({
+  children,
+  accent,
+}: {
+  children: ReactNode;
+  accent: string;
+}) => (
+  <div className="flex items-center gap-2">
+    <span className={cn("h-3 w-[3px] rounded-full", accent)} />
+    <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+      {children}
+    </span>
+  </div>
+);
 
 /**
  * Parameters body. An object input carrying a multi-line string value (e.g.
@@ -230,34 +234,120 @@ const ToolInputBody = ({ input }: { input: ToolUIPart["input"] }) => {
   if (!entries) {
     const serializedInput = JSON.stringify(input, null, 2);
     return (
-      <div className="rounded-md bg-muted/50 mt-2">
-        <CodeBlock code={serializedInput} language="json">
-          <CopyButton text={serializedInput} />
-        </CodeBlock>
-      </div>
+      <TruncatedCodeBlock
+        code={serializedInput}
+        language="json"
+        copyText={serializedInput}
+      />
     );
   }
 
   return (
-    <div className="mt-2 space-y-2">
+    <div className="space-y-1.5">
       {entries.map(([key, value]) => {
         const isString = typeof value === "string";
         const code = isString ? value : JSON.stringify(value, null, 2);
         return (
-          <div key={key} className="space-y-1">
-            <div className="font-mono text-muted-foreground text-xs">{key}</div>
-            <div className="rounded-md bg-muted/50">
-              <CodeBlock
-                code={code}
-                language={isString ? "text" : "json"}
-                wrapLongLines
-              >
-                <CopyButton text={code} />
-              </CodeBlock>
-            </div>
-          </div>
+          <TruncatedCodeBlock
+            key={key}
+            code={code}
+            language={isString ? "text" : "json"}
+            copyText={code}
+            wrapLongLines
+          />
         );
       })}
+    </div>
+  );
+};
+
+const COMPACT_CODE_STYLE = {
+  fontSize: "0.6875rem",
+  padding: "0.4rem 0.6rem",
+} as const;
+
+// Force-override the `text-sm` Tailwind class baked into CodeBlock's inner
+// <code> element so the params/output text actually shrinks.
+const COMPACT_CODE_CLASS =
+  "[&_code]:!text-[0.6875rem] [&_code]:!leading-[1rem] [&>pre]:!text-[0.6875rem]";
+
+const TRUNCATED_CODE_MAX_LINES = 20;
+
+/**
+ * Renders a CodeBlock that collapses long content to TRUNCATED_CODE_MAX_LINES
+ * with a "Show N more lines" affordance over a gradient fade. Used for both
+ * tool request bodies and tool response output so neither side overruns the
+ * chat when a tool dumps a large JSON payload.
+ */
+const TruncatedCodeBlock = ({
+  code,
+  language,
+  copyText,
+  wrapLongLines = false,
+}: {
+  code: string;
+  language: string;
+  copyText: string;
+  wrapLongLines?: boolean;
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const lines = code.split("\n");
+  const isLarge = lines.length > TRUNCATED_CODE_MAX_LINES;
+
+  const displayCode =
+    isExpanded || !isLarge
+      ? code
+      : `${lines.slice(0, TRUNCATED_CODE_MAX_LINES).join("\n")}\n... (${
+          lines.length - TRUNCATED_CODE_MAX_LINES
+        } more lines)`;
+
+  return (
+    <div ref={containerRef} className="relative group">
+      <CodeBlock
+        code={displayCode}
+        language={language}
+        wrapLongLines={wrapLongLines}
+        contentStyle={COMPACT_CODE_STYLE}
+        contentClassName={COMPACT_CODE_CLASS}
+        className="border-border/50"
+      >
+        <CopyButton text={copyText} className="-translate-y-1" />
+      </CodeBlock>
+      {isLarge && (
+        <div
+          className={cn(
+            "absolute bottom-1 left-0 right-0 flex justify-center transition-all duration-200",
+            !isExpanded &&
+              "pt-12 pb-1 bg-gradient-to-t from-background/80 to-transparent",
+          )}
+        >
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={(e) => {
+              e.stopPropagation();
+              const el = containerRef.current;
+              const scrollTop = el
+                ? el.getBoundingClientRect().top
+                : undefined;
+              setIsExpanded(!isExpanded);
+              if (el && scrollTop !== undefined) {
+                requestAnimationFrame(() => {
+                  const newTop = el.getBoundingClientRect().top;
+                  window.scrollBy(0, newTop - scrollTop);
+                });
+              }
+            }}
+            className="h-6 text-[10px] shadow-sm bg-background/80 backdrop-blur-sm hover:bg-background border"
+          >
+            {isExpanded
+              ? "Show Less"
+              : `Show ${lines.length - TRUNCATED_CODE_MAX_LINES} more lines`}
+          </Button>
+        </div>
+      )}
     </div>
   );
 };
@@ -271,10 +361,7 @@ export const ToolErrorDetails = ({
   errorText,
   ...props
 }: ToolErrorDetailsProps) => (
-  <div className={cn("space-y-2 overflow-hidden p-4", className)} {...props}>
-    <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
-      Details
-    </h4>
+  <div className={cn("overflow-hidden px-3 py-2", className)} {...props}>
     <div className="rounded-md bg-destructive/10 p-3 text-destructive text-xs whitespace-pre-wrap break-words select-text">
       {errorText}
     </div>
@@ -299,9 +386,8 @@ export const ToolOutput = ({
   conversations,
   ...props
 }: ToolOutputProps) => {
-  const [isExpanded, setIsExpanded] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-  const labelText = label ?? (errorText ? "Error" : "Result");
+  const labelText = label ?? (errorText ? "Error" : "Response");
 
   if (!(output || errorText || conversations)) {
     return null;
@@ -311,10 +397,10 @@ export const ToolOutput = ({
   // Note: In Dual LLM context, "user" = Main Profile (questions), "assistant" = Quarantined Profile (answers)
   if (conversations && conversations.length > 0) {
     return (
-      <div className={cn("space-y-2 p-4", className)} {...props}>
-        <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+      <div className={cn("px-3 py-3 space-y-1.5", className)} {...props}>
+        <SectionLabel accent="bg-emerald-400">
           {label ?? "Conversation"}
-        </h4>
+        </SectionLabel>
         <div className="space-y-3 rounded-md bg-muted/50 p-3">
           {conversations.map((conv, idx) => {
             // Create a stable key combining index and content hash
@@ -351,7 +437,6 @@ export const ToolOutput = ({
   }
 
   let Output: ReactNode;
-  let copyText: string | undefined;
   const displayOutput = normalizeToolOutput(output);
 
   if (typeof displayOutput === "object" || typeof displayOutput === "string") {
@@ -368,78 +453,33 @@ export const ToolOutput = ({
       typeof formattedOutput === "object"
         ? JSON.stringify(formattedOutput, null, 2)
         : String(formattedOutput);
-    copyText = codeString;
-    const lines = codeString.split("\n");
-    const MAX_LINES = 20;
-    const isLarge = lines.length > MAX_LINES;
-
-    const displayCode =
-      isExpanded || !isLarge
-        ? codeString
-        : `${lines.slice(0, MAX_LINES).join("\n")}\n... (${
-            lines.length - MAX_LINES
-          } more lines)`;
 
     Output = (
-      <div className="relative group">
-        <CodeBlock code={displayCode} language="json">
-          <CopyButton text={copyText} />
-        </CodeBlock>
-        {isLarge && (
-          <div
-            className={cn(
-              "absolute bottom-4 left-0 right-0 flex justify-center transition-all duration-200",
-              !isExpanded &&
-                "pt-16 pb-2 bg-gradient-to-t from-background/80 to-transparent",
-            )}
-          >
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={(e) => {
-                e.stopPropagation();
-                const el = containerRef.current;
-                const scrollTop = el
-                  ? el.getBoundingClientRect().top
-                  : undefined;
-                setIsExpanded(!isExpanded);
-                if (el && scrollTop !== undefined) {
-                  requestAnimationFrame(() => {
-                    const newTop = el.getBoundingClientRect().top;
-                    window.scrollBy(0, newTop - scrollTop);
-                  });
-                }
-              }}
-              className="h-7 text-xs shadow-sm bg-background/80 backdrop-blur-sm hover:bg-background border"
-            >
-              {isExpanded
-                ? "Show Less"
-                : `Show ${lines.length - MAX_LINES} more lines`}
-            </Button>
-          </div>
-        )}
-      </div>
+      <TruncatedCodeBlock
+        code={codeString}
+        language="json"
+        copyText={codeString}
+      />
     );
   } else {
-    copyText = String(displayOutput);
     Output = <div>{String(displayOutput)}</div>;
   }
+
+  const accent = errorText ? "bg-destructive" : "bg-emerald-400";
 
   return (
     <div
       ref={containerRef}
-      className={cn("space-y-2 p-4", className)}
+      className={cn("px-3 pb-3 pt-2 space-y-1.5", className)}
       {...props}
     >
-      <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
-        {labelText}
-      </h4>
+      <SectionLabel accent={accent}>{labelText}</SectionLabel>
       <div
         className={cn(
           "overflow-x-auto rounded-md text-xs [&_table]:w-full",
           errorText
             ? "bg-destructive/10 text-destructive"
-            : "bg-muted/50 text-foreground",
+            : "text-foreground",
         )}
       >
         {Output}

--- a/platform/frontend/src/components/ai-elements/tool.tsx
+++ b/platform/frontend/src/components/ai-elements/tool.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import type { ToolUIPart } from "ai";
-import {
-  CheckCircleIcon,
-  ChevronDownIcon,
-  CircleIcon,
-  ClockIcon,
-  XCircleIcon,
-} from "lucide-react";
+import { ChevronDownIcon } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
 import { createContext, useContext, useRef, useState } from "react";
 import { CopyButton } from "@/components/copy-button";
@@ -329,9 +323,7 @@ const TruncatedCodeBlock = ({
             onClick={(e) => {
               e.stopPropagation();
               const el = containerRef.current;
-              const scrollTop = el
-                ? el.getBoundingClientRect().top
-                : undefined;
+              const scrollTop = el ? el.getBoundingClientRect().top : undefined;
               setIsExpanded(!isExpanded);
               if (el && scrollTop !== undefined) {
                 requestAnimationFrame(() => {
@@ -477,9 +469,7 @@ export const ToolOutput = ({
       <div
         className={cn(
           "overflow-x-auto rounded-md text-xs [&_table]:w-full",
-          errorText
-            ? "bg-destructive/10 text-destructive"
-            : "text-foreground",
+          errorText ? "bg-destructive/10 text-destructive" : "text-foreground",
         )}
       >
         {Output}

--- a/platform/frontend/src/components/chat/compact-tool-call.tsx
+++ b/platform/frontend/src/components/chat/compact-tool-call.tsx
@@ -275,13 +275,6 @@ function ExpandedToolCard({
   const artifact = errorText ? null : extractArtifact(toolResultPart, part);
   const hasInput = part.input && Object.keys(part.input).length > 0;
   const isApprovalRequested = part.state === "approval-requested";
-  const hasContent = Boolean(
-    hasInput ||
-      errorText ||
-      isApprovalRequested ||
-      (toolResultPart && Boolean(toolResultPart.output)) ||
-      (!toolResultPart && Boolean(part.output)),
-  );
 
   const logsButton = errorText ? (
     <ToolErrorLogsButton toolName={toolName} />
@@ -293,11 +286,11 @@ function ExpandedToolCard({
   });
 
   return (
-    <Tool defaultOpen={true}>
+    <Tool open>
       <ToolHeader
         type={`tool-${toolName}`}
         state={headerState}
-        isCollapsible={hasContent}
+        isCollapsible={false}
         actionButton={logsButton}
       />
       <ToolContent>


### PR DESCRIPTION
Cleaner tool call panel in the chat view:

- Always-expanded request/response blocks (the outer tool-call circle already controls show/hide).
- Removed the wrench icon and right-side chevron.
- Tool name in `font-mono`; status `Badge` replaced with a compact colored dot + label.
- `SectionLabel` with a small colored accent bar — sky for Request, emerald for Response, destructive for Error.
- Smaller code font (`0.6875rem`) with an `!important` override since CodeBlock's inner `<code>` carries a hardcoded `text-sm`.
- `TruncatedCodeBlock` extracted so the request body now also shows "Show N more lines" when long (previously only the response did).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>