### PR TITLE
fix: browser network policy fallback

### DIFF
--- a/platform/backend/src/k8s/mcp-server-runtime/manager.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager.test.ts
@@ -4,7 +4,7 @@ import * as k8s from "@kubernetes/client-node";
 import { vi } from "vitest";
 import type * as originalConfigModule from "@/config";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
-import type { McpServer } from "@/types";
+import type { McpServer, NetworkPolicy } from "@/types";
 
 // Mock fs module first
 vi.mock("node:fs");
@@ -1219,6 +1219,53 @@ describe("McpServerRuntimeManager", () => {
       expect(mockCreateK8sSecret).toHaveBeenCalledWith({
         SOME_KEY: "some-value",
         OTHER_KEY: "other-value",
+      });
+
+      cleanup();
+    });
+
+    test("uses the organization default network policy for global catalog installs", async () => {
+      const defaultNetworkPolicy = {
+        egressMode: "restricted",
+        domainPreset: "package_managers",
+        allowedDomains: ["docs.example.com"],
+        allowedCidrs: [],
+      } satisfies NetworkPolicy;
+      const OrganizationModel = (await import("@/models/organization")).default;
+      vi.mocked(OrganizationModel.getFirst).mockResolvedValueOnce({
+        id: "org-with-network-policy",
+        defaultNetworkPolicy,
+      } as unknown as Awaited<ReturnType<typeof OrganizationModel.getFirst>>);
+
+      const { resolveEffectiveNetworkPolicy } = await import(
+        "@/services/environments/network-policy"
+      );
+      vi.mocked(resolveEffectiveNetworkPolicy).mockResolvedValueOnce({
+        source: "organization_default",
+        policy: defaultNetworkPolicy,
+      });
+
+      const { manager, mcpServer, cleanup } = await setupStartServerTest({
+        vaultSecret: {},
+        catalogEnvironment: [],
+        mcpServerOverrides: {
+          secretId: null,
+        },
+      });
+
+      await manager.startServer(mcpServer);
+
+      expect(resolveEffectiveNetworkPolicy).toHaveBeenCalledWith({
+        organizationId: "org-with-network-policy",
+        environmentId: undefined,
+        environmentNetworkPolicy: undefined,
+        defaultNetworkPolicy,
+      });
+      expect(mockK8sDeploymentInstances.at(-1)?.options).toMatchObject({
+        effectiveNetworkPolicy: {
+          source: "organization_default",
+          policy: defaultNetworkPolicy,
+        },
       });
 
       cleanup();

--- a/platform/backend/src/k8s/mcp-server-runtime/manager.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager.ts
@@ -257,16 +257,16 @@ export class McpServerRuntimeManager {
     const organizationId =
       params.catalogItem?.organizationId ?? environment?.organizationId ?? null;
 
-    if (!organizationId) {
-      return { source: "built_in", policy: null };
-    }
+    const organization = organizationId
+      ? params.cache
+        ? params.cache.organizationsById.get(organizationId)
+        : await OrganizationModel.getById(organizationId)
+      : await OrganizationModel.getFirst();
 
-    const organization = params.cache
-      ? params.cache.organizationsById.get(organizationId)
-      : await OrganizationModel.getById(organizationId);
+    if (!organization) return { source: "built_in", policy: null };
 
     return resolveEffectiveNetworkPolicy({
-      organizationId,
+      organizationId: organization.id,
       environmentId: params.catalogItem?.environmentId,
       environmentNetworkPolicy: environment?.networkPolicy,
       defaultNetworkPolicy: organization?.defaultNetworkPolicy,


### PR DESCRIPTION
## Summary

Fixes MCP runtime network policy resolution for global catalog installs such as the built-in Playwright browser server. When a global catalog item has no organization or environment context, the runtime now falls back to the platform organization before resolving the effective policy, so organization default network policies are applied instead of silently using the built-in unrestricted policy.

## Root Cause

The Playwright browser catalog item is global. During pod startup, `resolveNetworkPolicyForDeployment` derived the organization only from catalog/environment context. For global catalog rows that value is absent, so the runtime returned the built-in policy and skipped the organization default network policy. On clusters with external baseline restrictions, that can make browser navigation fail with DNS-style errors even when the requested domains are present in the configured allow-list.