### PR TITLE
fix(chat): retry empty gemini finishes, present exhausted empty turns as a neutral outcome

### DIFF
--- a/platform/backend/src/routes/chat/errors.test.ts
+++ b/platform/backend/src/routes/chat/errors.test.ts
@@ -1742,6 +1742,25 @@ describe("mapProviderError - EmptyModelResponseError", () => {
     expect(result.code).toBe(ChatErrorCode.EmptyResponse);
     expect(result.isRetryable).toBe(true);
   });
+
+  it("maps an exhausted error finish to the retryable EmptyResponse card, preserving the raw finish reason", () => {
+    const result = mapProviderError(
+      new EmptyModelResponseError({
+        finishReason: "error",
+        rawFinishReason: "MALFORMED_FUNCTION_CALL",
+        attempts: 3,
+      }),
+      "gemini",
+    );
+
+    expect(result.code).toBe(ChatErrorCode.EmptyResponse);
+    expect(result.isRetryable).toBe(true);
+    expect(result.originalError?.raw).toEqual({
+      finishReason: "error",
+      rawFinishReason: "MALFORMED_FUNCTION_CALL",
+      attempts: 3,
+    });
+  });
 });
 
 describe("getUnavailableToolErrorDetails", () => {

--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -55,12 +55,18 @@ export class ProviderError extends Error {
  */
 export class EmptyModelResponseError extends Error {
   public readonly finishReason: string;
+  public readonly rawFinishReason?: string;
   public readonly attempts: number;
 
-  constructor(params: { finishReason: string; attempts: number }) {
+  constructor(params: {
+    finishReason: string;
+    rawFinishReason?: string;
+    attempts: number;
+  }) {
     super(`Model returned an empty response after ${params.attempts} attempts`);
     this.name = "EmptyModelResponseError";
     this.finishReason = params.finishReason;
+    this.rawFinishReason = params.rawFinishReason;
     this.attempts = params.attempts;
   }
 }
@@ -1646,7 +1652,11 @@ export function mapProviderError(
       undefined,
       ChatErrorMessages[code],
       "EmptyModelResponseError",
-      { finishReason: error.finishReason, attempts: error.attempts },
+      {
+        finishReason: error.finishReason,
+        rawFinishReason: error.rawFinishReason,
+        attempts: error.attempts,
+      },
     );
   }
 

--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -1640,8 +1640,8 @@ export function mapProviderError(
   if (error instanceof EmptyModelResponseError) {
     // A content-filter finish is a deterministic block, not a transient empty
     // turn — surface it as the non-retryable ContentFiltered card so the UI
-    // doesn't offer a pointless retry. Exhausted stop/length/unknown turns stay
-    // the retryable EmptyResponse.
+    // doesn't offer a pointless retry. Every other exhausted finish stays the
+    // retryable EmptyResponse.
     const code =
       error.finishReason === "content-filter"
         ? ChatErrorCode.ContentFiltered

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -947,6 +947,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                       {
                         conversationId,
                         finishReason: probe.finishReason,
+                        rawFinishReason: probe.rawFinishReason,
                         attempt: emptyResponseAttempts,
                       },
                       "[EmptyResponse] model produced no content, retrying",
@@ -975,6 +976,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   }
                   throw new EmptyModelResponseError({
                     finishReason: probe.finishReason,
+                    rawFinishReason: probe.rawFinishReason,
                     attempts: emptyResponseAttempts,
                   });
                 }

--- a/platform/backend/src/routes/chat/stream-probe.test.ts
+++ b/platform/backend/src/routes/chat/stream-probe.test.ts
@@ -105,6 +105,29 @@ describe("probeFirstRenderableEvent", () => {
     });
   });
 
+  test("surfaces the provider's raw finish reason on an empty error finish", async () => {
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "start-step" },
+      {
+        type: "finish-step",
+        finishReason: "error",
+        rawFinishReason: "MALFORMED_FUNCTION_CALL",
+      },
+      {
+        type: "finish",
+        finishReason: "error",
+        rawFinishReason: "MALFORMED_FUNCTION_CALL",
+      },
+    ];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "empty",
+      finishReason: "error",
+      rawFinishReason: "MALFORMED_FUNCTION_CALL",
+    });
+  });
+
   test("reports empty with unknown when the stream ends without a finish event", async () => {
     const events: StreamProbeEvent[] = [{ type: "start" }];
 
@@ -171,15 +194,16 @@ describe("probeFirstRenderableEvent", () => {
 });
 
 describe("isRetryableEmptyFinishReason", () => {
-  test("retries on stop, length, and unknown", () => {
+  test("retries on stop, length, unknown, error, and other", () => {
     expect(isRetryableEmptyFinishReason("stop")).toBe(true);
     expect(isRetryableEmptyFinishReason("length")).toBe(true);
     expect(isRetryableEmptyFinishReason("unknown")).toBe(true);
+    expect(isRetryableEmptyFinishReason("error")).toBe(true);
+    expect(isRetryableEmptyFinishReason("other")).toBe(true);
   });
 
-  test("does not retry on content-filter or other terminal reasons", () => {
+  test("does not retry on deterministic terminal reasons", () => {
     expect(isRetryableEmptyFinishReason("content-filter")).toBe(false);
-    expect(isRetryableEmptyFinishReason("error")).toBe(false);
-    expect(isRetryableEmptyFinishReason("other")).toBe(false);
+    expect(isRetryableEmptyFinishReason("tool-calls")).toBe(false);
   });
 });

--- a/platform/backend/src/routes/chat/stream-probe.ts
+++ b/platform/backend/src/routes/chat/stream-probe.ts
@@ -10,12 +10,13 @@
 export type StreamProbeEvent = {
   type: string;
   finishReason?: unknown;
+  rawFinishReason?: unknown;
   error?: unknown;
 };
 
 export type StreamProbeOutcome =
   | { kind: "renderable" }
-  | { kind: "empty"; finishReason: string }
+  | { kind: "empty"; finishReason: string; rawFinishReason?: string }
   | { kind: "aborted" }
   | { kind: "error"; error: unknown };
 
@@ -42,12 +43,20 @@ const RENDERABLE_EVENT_TYPES: ReadonlySet<string> = new Set([
 ]);
 
 // finishReasons where a content-free turn is plausibly a transient model/inference
-// glitch worth retrying. Excludes e.g. "content-filter" (deterministic block) and
-// "tool-calls" (which only finishes that way when tool calls — renderable — exist).
+// glitch worth retrying. A *finish* event carrying "error" or "other" with no content
+// is a provider-glitch shape, not a real API failure — those reach the probe as error
+// parts (or thrown stream errors) before any finish. Gemini's frequent
+// MALFORMED_FUNCTION_CALL maps to "error" and OTHER/FINISH_REASON_UNSPECIFIED to
+// "other"; some "other" raws may be deterministic, but with the hard attempt cap the
+// worst case is two wasted calls before the same error card. Excludes "content-filter"
+// (deterministic block) and "tool-calls" (which only finishes that way when tool
+// calls — renderable — exist).
 const RETRYABLE_EMPTY_FINISH_REASONS: ReadonlySet<string> = new Set([
   "stop",
   "length",
   "unknown",
+  "error",
+  "other",
 ]);
 
 export function isRetryableEmptyFinishReason(finishReason: string): boolean {
@@ -88,6 +97,9 @@ export async function probeFirstRenderableEvent(
             typeof event.finishReason === "string"
               ? event.finishReason
               : "unknown",
+          ...(typeof event.rawFinishReason === "string" && {
+            rawFinishReason: event.rawFinishReason,
+          }),
         };
       // control parts (start, start-step, finish-step, text-end, ...) carry no
       // content on their own — keep pulling until content, finish, or error.

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -1209,6 +1209,16 @@ const EMPTY_STREAM_EVENTS = [
   { type: "start" },
   { type: "finish", finishReason: "stop" },
 ];
+// Gemini MALFORMED_FUNCTION_CALL shape: a clean finish with unified "error",
+// the raw provider reason, and no content or error parts.
+const MALFORMED_FUNCTION_CALL_STREAM_EVENTS = [
+  { type: "start" },
+  {
+    type: "finish",
+    finishReason: "error",
+    rawFinishReason: "MALFORMED_FUNCTION_CALL",
+  },
+];
 const RENDERABLE_STREAM_EVENTS = [
   { type: "text-delta", text: "hi" },
   { type: "finish", finishReason: "stop" },
@@ -1333,6 +1343,40 @@ describe("POST /api/chat empty-response retry", () => {
 
     expect(mockStreamText).toHaveBeenCalledTimes(2);
     expect(capturedOuterErrorPayload).toBeUndefined();
+  });
+
+  test("retries an empty error finish (malformed tool call), then streams the renderable one", async ({
+    expect,
+  }) => {
+    mockStreamText
+      .mockImplementationOnce(() =>
+        fakeStreamResult(MALFORMED_FUNCTION_CALL_STREAM_EVENTS),
+      )
+      .mockImplementationOnce(() => fakeStreamResult(RENDERABLE_STREAM_EVENTS));
+
+    const response = await postMessage();
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    expect(mockStreamText).toHaveBeenCalledTimes(2);
+    expect(capturedOuterErrorPayload).toBeUndefined();
+  });
+
+  test("surfaces an EmptyResponse stream error after exhausting retries on error finishes", async ({
+    expect,
+  }) => {
+    mockStreamText.mockImplementation(() =>
+      fakeStreamResult(MALFORMED_FUNCTION_CALL_STREAM_EVENTS),
+    );
+
+    const response = await postMessage();
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    expect(mockStreamText).toHaveBeenCalledTimes(3);
+    expect(capturedOuterErrorPayload).toBeDefined();
+    const payload = JSON.parse(capturedOuterErrorPayload ?? "{}");
+    expect(payload.code).toBe("empty_response");
   });
 
   test("surfaces an EmptyResponse stream error after exhausting retries", async ({

--- a/platform/frontend/src/components/chat/inline-chat-error.test.tsx
+++ b/platform/frontend/src/components/chat/inline-chat-error.test.tsx
@@ -133,6 +133,49 @@ describe("InlineChatError", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders an empty-response turn as a neutral outcome, not a destructive error", () => {
+    const { container } = render(
+      <InlineChatError
+        error={
+          new Error(
+            JSON.stringify({
+              code: "empty_response",
+              message:
+                "The model ended its turn without a reply. Rephrasing your message may help.",
+              isRetryable: true,
+            }),
+          )
+        }
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "The model ended its turn without a reply. Rephrasing your message may help.",
+      ),
+    ).toBeInTheDocument();
+    expect(container.querySelector(".bg-destructive\\/10")).toBeNull();
+    expect(container.querySelector(".bg-muted\\/30")).not.toBeNull();
+  });
+
+  it("keeps destructive styling for genuine errors", () => {
+    const { container } = render(
+      <InlineChatError
+        error={
+          new Error(
+            JSON.stringify({
+              code: "server_error",
+              message: "The AI provider is experiencing issues.",
+              isRetryable: true,
+            }),
+          )
+        }
+      />,
+    );
+
+    expect(container.querySelector(".bg-destructive\\/10")).not.toBeNull();
+  });
+
   it("falls back to the structured error message and conversation ID as session", () => {
     render(
       <InlineChatError

--- a/platform/frontend/src/components/chat/inline-chat-error.tsx
+++ b/platform/frontend/src/components/chat/inline-chat-error.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { ChatErrorCode } from "@archestra/shared";
 import {
   AlertCircle,
   ChevronDown,
   ChevronRight,
   Copy,
   Gauge,
+  MessageSquareDashed,
   RefreshCw,
 } from "lucide-react";
 import { useState } from "react";
@@ -50,11 +52,20 @@ export function InlineChatError({
   });
   const chatError = parseErrorResponse(error) ?? mapClientError(error);
   const isUsageLimitExceeded = chatError.usageLimitExceeded === true;
-  const StatusIcon = isUsageLimitExceeded ? Gauge : AlertCircle;
-  const containerClassName = isUsageLimitExceeded
+  // An empty turn that survived the backend's auto-retries is the model's
+  // answer for this conversation, not a system failure — render it as a
+  // neutral outcome rather than a destructive error.
+  const isEmptyModelTurn = chatError.code === ChatErrorCode.EmptyResponse;
+  const isNeutralOutcome = isUsageLimitExceeded || isEmptyModelTurn;
+  const StatusIcon = isUsageLimitExceeded
+    ? Gauge
+    : isEmptyModelTurn
+      ? MessageSquareDashed
+      : AlertCircle;
+  const containerClassName = isNeutralOutcome
     ? "bg-muted/30 border border-border rounded-lg"
     : "bg-destructive/10 border border-destructive/20 rounded-lg";
-  const iconClassName = isUsageLimitExceeded
+  const iconClassName = isNeutralOutcome
     ? "text-muted-foreground"
     : "text-destructive";
   const usageLimitMessage =

--- a/platform/shared/chat-error.ts
+++ b/platform/shared/chat-error.ts
@@ -298,7 +298,7 @@ export const ChatErrorMessages: Record<ChatErrorCode, string> = {
   [ChatErrorCode.NetworkError]:
     "Connection error. Please check your network and try again.",
   [ChatErrorCode.EmptyResponse]:
-    "The model returned an empty response. Please try again.",
+    "The model ended its turn without a reply. Rephrasing your message may help.",
   [ChatErrorCode.Unknown]: "An unexpected error occurred. Please try again.",
 };
 


### PR DESCRIPTION
## Summary

Two related changes to how chat handles a model turn that produces no content:

1. **Empty `error`/`other` finishes are now auto-retried.** Gemini's `MALFORMED_FUNCTION_CALL` (unified finishReason `error`) and `OTHER`/`FINISH_REASON_UNSPECIFIED` (`other`) arrive as a clean, content-free finish. These bypassed the empty-response retry loop and surfaced the hard error card on the very first attempt. They now get the same silent retries as `stop`/`length` empties (cap stays 3 attempts, invisible to the user). This is safe: genuine API failures always reach the stream probe as error parts or thrown errors *before* any finish event, so a bare content-free finish is a transient provider glitch by construction. `content-filter` stays non-retryable.

2. **An exhausted empty turn renders as a neutral outcome, not an error.** If the model comes back empty three times with the identical payload, that is effectively its answer for this conversation — a valid (if unhelpful) response, not a system failure. The card drops the destructive red styling and the "Please try again" advice (a manual 4th identical attempt is unlikely to differ from the 3 that just failed) in favor of a muted notice: *"The model ended its turn without a reply. Rephrasing your message may help."* Genuine failures (auth, rate limit, server errors, content filter) keep the destructive card.

The provider's `rawFinishReason` is plumbed into the retry log and the admin-visible error details, so diagnostics show e.g. `MALFORMED_FUNCTION_CALL` instead of an opaque `error`.

## Why retry at all if empty can be valid?

The transient and the deterministic case are indistinguishable upfront. Retrying a deterministic empty wastes at most 2 bounded calls before the same (now neutral) notice; not retrying a transient glitch guarantees a user-visible non-answer. Most Gemini empty turns are the transient kind, so the retries absorb the majority invisibly.

## Out of scope

- A manual retry button for time-correlated failures (`rate_limit`, `server_error`, `network_error`) where waiting genuinely changes the odds — worth a separate PR.
- Mid-turn empty finishes (after content already streamed) are committed to the client and not retried.

## Tests

- Probe: `error`/`other` retryable, `content-filter`/`tool-calls` not; `rawFinishReason` surfaced on the empty outcome.
- Error mapper: exhausted `error` finish → EmptyResponse card with the raw reason preserved.
- Route: an empty `MALFORMED_FUNCTION_CALL` finish is retried then succeeds; exhausting all attempts still yields the structured `empty_response` stream error.
- UI: `empty_response` renders muted, genuine errors stay destructive.