### PR TITLE
feat(connection): add 5 clients and refresh flow ui

### DIFF
--- a/platform/frontend/src/app/connection/client-grid.tsx
+++ b/platform/frontend/src/app/connection/client-grid.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils";
 import { ClientIcon } from "./client-icon";
 import type { ConnectClient } from "./clients";
 
-const CLIENT_PICKER_PAGE_SIZE = 8;
+const CLIENT_PICKER_PAGE_SIZE = 12;
 
 interface ClientPickerProps {
   clients: ConnectClient[];

--- a/platform/frontend/src/app/connection/clients.ts
+++ b/platform/frontend/src/app/connection/clients.ts
@@ -88,8 +88,13 @@ export interface ProxyStep {
   /** Pre-rendered code for this step's terminal block. */
   code?: string;
   language?: "json" | "toml" | "bash";
-  /** Inline labelled values rendered as individual rows. Non-copyable rows render as plain text (e.g. for placeholder values the user must replace). */
-  fields?: { label: string; value: string; copyable?: boolean }[];
+  /** Inline labelled values rendered as individual rows. Non-copyable rows render as plain text (e.g. for placeholder values the user must replace). `hint` shows muted helper text beneath the row. */
+  fields?: {
+    label: string;
+    value: string;
+    copyable?: boolean;
+    hint?: string;
+  }[];
 }
 
 export type ProxyInstruction =
@@ -142,6 +147,10 @@ const N8N_PATH =
   "M21.4737 5.6842c-1.1772 0-2.1663.8051-2.4468 1.8947h-2.8955c-1.235 0-2.289.893-2.492 2.111l-.1038.623a1.263 1.263 0 0 1-1.246 1.0555H11.289c-.2805-1.0896-1.2696-1.8947-2.4468-1.8947s-2.1663.8051-2.4467 1.8947H4.973c-.2805-1.0896-1.2696-1.8947-2.4468-1.8947C1.1311 9.4737 0 10.6047 0 12s1.131 2.5263 2.5263 2.5263c1.1772 0 2.1663-.8051 2.4468-1.8947h1.4223c.2804 1.0896 1.2696 1.8947 2.4467 1.8947 1.1772 0 2.1663-.8051 2.4468-1.8947h1.0008a1.263 1.263 0 0 1 1.2459 1.0555l.1038.623c.203 1.218 1.257 2.111 2.492 2.111h.3692c.2804 1.0895 1.2696 1.8947 2.4468 1.8947 1.3952 0 2.5263-1.131 2.5263-2.5263s-1.131-2.5263-2.5263-2.5263c-1.1772 0-2.1664.805-2.4468 1.8947h-.3692a1.263 1.263 0 0 1-1.246-1.0555l-.1037-.623A2.52 2.52 0 0 0 13.9607 12a2.52 2.52 0 0 0 .821-1.4794l.1038-.623a1.263 1.263 0 0 1 1.2459-1.0555h2.8955c.2805 1.0896 1.2696 1.8947 2.4468 1.8947 1.3952 0 2.5263-1.131 2.5263-2.5263s-1.131-2.5263-2.5263-2.5263m0 1.2632a1.263 1.263 0 0 1 1.2631 1.2631 1.263 1.263 0 0 1-1.2631 1.2632 1.263 1.263 0 0 1-1.2632-1.2632 1.263 1.263 0 0 1 1.2632-1.2631M2.5263 10.7368A1.263 1.263 0 0 1 3.7895 12a1.263 1.263 0 0 1-1.2632 1.2632A1.263 1.263 0 0 1 1.2632 12a1.263 1.263 0 0 1 1.2631-1.2632m6.3158 0A1.263 1.263 0 0 1 10.1053 12a1.263 1.263 0 0 1-1.2632 1.2632A1.263 1.263 0 0 1 7.579 12a1.263 1.263 0 0 1 1.2632-1.2632m10.1053 3.7895a1.263 1.263 0 0 1 1.2631 1.2632 1.263 1.263 0 0 1-1.2631 1.2631 1.263 1.263 0 0 1-1.2632-1.2631 1.263 1.263 0 0 1 1.2632-1.2632";
 const COPILOT_PATH =
   "M19.245 5.364c1.322 1.36 1.877 3.216 2.11 5.817.622 0 1.2.135 1.592.654l.73.964c.21.278.323.61.323.955v2.62c0 .339-.173.669-.453.868C20.239 19.602 16.157 21.5 12 21.5c-4.6 0-9.205-2.583-11.547-4.258-.28-.2-.452-.53-.453-.868v-2.62c0-.345.113-.679.321-.956l.73-.963c.392-.517.974-.654 1.593-.654l.029-.297c.25-2.446.81-4.213 2.082-5.52 2.461-2.54 5.71-2.851 7.146-2.864h.198c1.436.013 4.685.323 7.146 2.864zm-7.244 4.328c-.284 0-.613.016-.962.05-.123.447-.305.85-.57 1.108-1.05 1.023-2.316 1.18-2.994 1.18-.638 0-1.306-.13-1.851-.464-.516.165-1.012.403-1.044.996a65.882 65.882 0 0 0-.063 2.884l-.002.48c-.002.563-.005 1.126-.013 1.69.002.326.204.63.51.765 2.482 1.102 4.83 1.657 6.99 1.657 2.156 0 4.504-.555 6.985-1.657a.854.854 0 0 0 .51-.766c.03-1.682.006-3.372-.076-5.053-.031-.596-.528-.83-1.046-.996-.546.333-1.212.464-1.85.464-.677 0-1.942-.157-2.993-1.18-.266-.258-.447-.661-.57-1.108-.32-.032-.64-.049-.96-.05zm-2.525 4.013c.539 0 .976.426.976.95v1.753c0 .525-.437.95-.976.95a.964.964 0 0 1-.976-.95v-1.752c0-.525.437-.951.976-.951zm5 0c.539 0 .976.426.976.95v1.753c0 .525-.437.95-.976.95a.964.964 0 0 1-.976-.95v-1.752c0-.525.437-.951.976-.951zM7.635 5.087c-1.05.102-1.935.438-2.385.906-.975 1.037-.765 3.668-.21 4.224.405.394 1.17.657 1.995.657h.09c.649-.013 1.785-.176 2.73-1.11.435-.41.705-1.433.675-2.47-.03-.834-.27-1.52-.63-1.813-.39-.336-1.275-.482-2.265-.394zm6.465.394c-.36.292-.6.98-.63 1.813-.03 1.037.24 2.06.675 2.47.968.957 2.136 1.104 2.776 1.11h.044c.825 0 1.59-.263 1.995-.657.555-.556.765-3.187-.21-4.224-.45-.468-1.335-.804-2.385-.906-.99-.088-1.875.058-2.265.394zM12 7.615c-.24 0-.525.015-.84.044.03.16.045.336.06.526l-.001.159a2.94 2.94 0 0 1-.014.25c.225-.022.425-.027.612-.028h.366c.187 0 .387.006.612.028-.015-.146-.015-.277-.015-.409.015-.19.03-.365.06-.526a9.29 9.29 0 0 0-.84-.044z";
+const WARP_PATH =
+  "M12.035 2.723h9.253A2.712 2.712 0 0 1 24 5.435v10.529a2.712 2.712 0 0 1-2.712 2.713H8.047Zm-1.681 2.6L6.766 19.677h5.598l-.399 1.6H2.712A2.712 2.712 0 0 1 0 18.565V8.036a2.712 2.712 0 0 1 2.712-2.712Z";
+const PI_PATH =
+  "M4.96 4.96H15.52V12H12V15.52H8.48V19.04H4.96ZM8.48 8.48V12H12V8.48ZM15.52 12H19.04V19.04H15.52Z";
 export const CONNECT_CLIENTS: ConnectClient[] = [
   {
     id: "claude-code",
@@ -631,6 +640,374 @@ export COPILOT_MODEL="<model-name>"`,
           ],
         };
       },
+    },
+  },
+  {
+    id: "claude-cowork",
+    label: "Claude Cowork",
+    sub: "Anthropic desktop agent",
+    svg: CLAUDE_PATH,
+    iconColor: "#D97757",
+    tileBg: "#fff1ea",
+    mcp: {
+      kind: "custom",
+      supportedAuth: "oauth",
+      configFile: "Cowork settings",
+      language: "bash",
+      steps: [
+        {
+          title: "Open Customize → Connectors",
+          body: "In the Claude Cowork desktop app, open Customize and switch to the Connectors tab.",
+        },
+        {
+          title: 'Click "+" → "Add custom connector"',
+          body: "Paste the gateway URL into the Remote MCP server URL field.",
+          terminalTitle: "Remote MCP server URL",
+          buildCommand: ({ url }) => url,
+        },
+        {
+          title: "Finish the OAuth flow",
+          body: "Cowork opens your browser to sign in and approve the gateway. Tools appear in the Connectors panel.",
+        },
+      ],
+    },
+    proxy: {
+      kind: "custom",
+      supportedProviders: ["anthropic"],
+      build: ({ url }) => ({
+        kind: "steps",
+        note: 'Requires Cowork\'s Developer Mode. Once applied, the status pill reads "Cowork 3P | Gateway".',
+        steps: [
+          {
+            title: "Enable Developer Mode",
+            body: "Help → Enable Developer Mode, then restart Cowork.",
+          },
+          {
+            title: "Open the gateway dialog",
+            body: 'Developer → Configure Third-party inference → "Gateway (Anthropic-compatible)".',
+          },
+          {
+            title: "Fill the gateway fields",
+            body: 'Set Credential kind to "Static API key", paste the values below, leave the auth scheme as "bearer", and click Apply locally.',
+            fields: [
+              { label: "Gateway base URL", value: url },
+              {
+                label: "Gateway API key",
+                value: "<archestra-virtual-key-or-anthropic-key>",
+                copyable: false,
+                hint: "Either an Archestra Virtual API Key (create one at LLM → Model Providers → API Keys) or your raw Anthropic key from console.anthropic.com (passthrough). The UUID in the base URL is the profile ID — it's routing, not auth.",
+              },
+              { label: "Gateway auth scheme", value: "bearer" },
+            ],
+          },
+          {
+            title: "Verify",
+            body: 'Send a message — the status pill should read "Cowork 3P | Gateway".',
+          },
+        ],
+      }),
+    },
+  },
+  {
+    id: "opencode",
+    label: "OpenCode",
+    sub: "AI coding agent CLI",
+    tileBg: "#f4f4f5",
+    iconOverride: { bg: "#211e1e", fg: "#fff", glyph: "oc" },
+    mcp: {
+      kind: "custom",
+      supportedAuth: "both",
+      preferredAuth: "oauth",
+      configFile: "~/.config/opencode/opencode.json",
+      language: "json",
+      steps: [
+        {
+          title: "Open the OpenCode config",
+          body: "Edit ~/.config/opencode/opencode.json (or opencode.json in your project root). Create the file if it doesn't exist.",
+        },
+        {
+          title: "Add the MCP server entry",
+          body: "Merge the snippet below into the file. With OAuth, OpenCode auto-detects the flow on the first 401 and opens your browser.",
+        },
+        {
+          title: "Restart OpenCode",
+          body: "Start a new session — tools appear in the /tools picker.",
+        },
+      ],
+      buildConfig: ({ url, token, serverName }) => {
+        const entry: Record<string, unknown> = {
+          type: "remote",
+          url,
+          enabled: true,
+        };
+        if (token) entry.headers = { Authorization: `Bearer ${token}` };
+        return JSON.stringify(
+          {
+            $schema: "https://opencode.ai/config.json",
+            mcp: { [serverName]: entry },
+          },
+          null,
+          2,
+        );
+      },
+    },
+    proxy: {
+      kind: "custom",
+      supportedProviders: [
+        "openai",
+        "anthropic",
+        "gemini",
+        "bedrock",
+        "cohere",
+        "cerebras",
+        "mistral",
+        "perplexity",
+        "groq",
+        "xai",
+        "openrouter",
+        "vllm",
+        "ollama",
+        "zhipuai",
+        "deepseek",
+        "minimax",
+        "azure",
+      ],
+      build: ({ provider, proxyName, url, tokenPlaceholder }) => {
+        const npm =
+          provider === "anthropic"
+            ? "@ai-sdk/anthropic"
+            : provider === "gemini"
+              ? "@ai-sdk/google"
+              : provider === "cohere"
+                ? "@ai-sdk/cohere"
+                : "@ai-sdk/openai-compatible";
+        const baseURL =
+          provider === "bedrock"
+            ? url.replace("/bedrock/", "/bedrock/openai/")
+            : url;
+        return {
+          kind: "snippet",
+          language: "json",
+          note:
+            provider === "bedrock"
+              ? "Add to ~/.config/opencode/opencode.json. Archestra exposes Bedrock through an OpenAI-compatible URL, so OpenCode talks to it like any OpenAI provider."
+              : "Add to ~/.config/opencode/opencode.json. Select the model at runtime with /models.",
+          code: JSON.stringify(
+            {
+              $schema: "https://opencode.ai/config.json",
+              provider: {
+                [proxyName]: {
+                  npm,
+                  name: "Archestra",
+                  options: { baseURL, apiKey: tokenPlaceholder },
+                },
+              },
+            },
+            null,
+            2,
+          ),
+        };
+      },
+    },
+  },
+  {
+    id: "open-webui",
+    label: "Open WebUI",
+    sub: "Self-hosted chat UI",
+    tileBg: "#f4f4f5",
+    iconOverride: { bg: "#000", fg: "#fff", glyph: "ow" },
+    mcp: {
+      kind: "custom",
+      supportedAuth: "both",
+      preferredAuth: "oauth",
+      configFile: "Open WebUI admin settings",
+      language: "bash",
+      steps: ({ token }) => [
+        {
+          title: "Open Admin Settings → External Tools",
+          body: "Requires Open WebUI 0.6.31 or newer. Only admins can register MCP servers.",
+        },
+        {
+          title: 'Click "+ Add Server"',
+          body: 'Set Type to "MCP (Streamable HTTP)".',
+        },
+        {
+          title: "Paste the Server URL",
+          terminalTitle: "Server URL",
+          buildCommand: ({ url }) => url,
+        },
+        token
+          ? {
+              title: "Set Auth to Bearer and paste the token",
+              showAuthHeader: true,
+              authHeaderBare: true,
+            }
+          : {
+              title: "Pick OAuth 2.1 for Auth",
+              body: "Open WebUI opens your browser to complete the OAuth handshake.",
+            },
+        {
+          title: "Save and enable",
+          body: "Tools appear in the model picker's Tools dropdown.",
+        },
+      ],
+    },
+    proxy: {
+      kind: "custom",
+      supportedProviders: [
+        "openai",
+        "anthropic",
+        "openrouter",
+        "mistral",
+        "groq",
+        "deepseek",
+        "xai",
+        "cerebras",
+        "perplexity",
+        "vllm",
+        "ollama",
+        "azure",
+      ],
+      build: ({ url, tokenPlaceholder }) => ({
+        kind: "steps",
+        steps: [
+          {
+            title: "Open Admin Settings → Connections",
+            body: "Expand the OpenAI section.",
+          },
+          {
+            title: 'Click "+ Add Connection"',
+            body: "Open WebUI talks to any OpenAI-compatible endpoint, including Anthropic via the OpenAI-compatible URL.",
+          },
+          {
+            title: "Fill in the connection",
+            body: "Paste the values below, then Save.",
+            fields: [
+              { label: "URL", value: url },
+              { label: "API Key", value: tokenPlaceholder, copyable: false },
+            ],
+          },
+          {
+            title: "Pick a model and chat",
+            body: "Models surface automatically in the model picker.",
+          },
+        ],
+      }),
+    },
+  },
+  {
+    id: "pi",
+    label: "Pi",
+    sub: "Open-source coding agent",
+    svg: PI_PATH,
+    iconColor: "#000",
+    tileBg: "#f4f4f5",
+    mcp: {
+      kind: "unsupported",
+      reason:
+        "Pi doesn't implement MCP by design — its author recommends CLI tools with READMEs (Skills) instead. Use the LLM Proxy tab to route Pi's model calls through Archestra.",
+    },
+    proxy: {
+      kind: "custom",
+      supportedProviders: ["openai", "anthropic", "gemini"],
+      build: ({ provider, proxyName, url, tokenPlaceholder }) => {
+        const api =
+          provider === "anthropic"
+            ? "anthropic-messages"
+            : provider === "gemini"
+              ? "google-generative-ai"
+              : "openai-completions";
+        return {
+          kind: "snippet",
+          language: "json",
+          note: "Add to ~/.pi/agent/models.json, then select with /model or --model.",
+          code: JSON.stringify(
+            {
+              providers: {
+                [proxyName]: {
+                  baseUrl: url,
+                  api,
+                  apiKey: tokenPlaceholder,
+                },
+              },
+            },
+            null,
+            2,
+          ),
+        };
+      },
+    },
+  },
+  {
+    id: "warp",
+    label: "Warp",
+    sub: "AI terminal",
+    svg: WARP_PATH,
+    iconColor: "#01a4ff",
+    tileBg: "#e6f5ff",
+    mcp: {
+      kind: "custom",
+      supportedAuth: "both",
+      preferredAuth: "oauth",
+      configFile: "Warp settings",
+      language: "json",
+      steps: [
+        {
+          title: "Open Settings → Agents → MCP servers",
+          body: 'In the Warp desktop app. Click "+ Add" to register a new server.',
+        },
+        {
+          title: "Paste the JSON config",
+          body: "Drop the snippet into the editor and click Start. Without headers, Warp triggers an OAuth flow in your browser.",
+        },
+        {
+          title: "Verify tools load",
+          body: "Tools appear in the Agent Mode picker.",
+        },
+      ],
+      buildConfig: ({ url, token, serverName }) => {
+        const entry: Record<string, unknown> = { url };
+        if (token) entry.headers = { Authorization: `Bearer ${token}` };
+        return JSON.stringify({ mcpServers: { [serverName]: entry } }, null, 2);
+      },
+    },
+    proxy: {
+      kind: "custom",
+      supportedProviders: [
+        "openai",
+        "anthropic",
+        "openrouter",
+        "mistral",
+        "groq",
+        "deepseek",
+        "xai",
+        "cerebras",
+        "perplexity",
+        "vllm",
+        "ollama",
+        "azure",
+      ],
+      build: ({ url, tokenPlaceholder }) => ({
+        kind: "steps",
+        steps: [
+          {
+            title: "Open Settings → AI → Manage models",
+            body: "BYOK is available on every plan, including Free.",
+          },
+          {
+            title: "Add a custom inference endpoint",
+            body: "Warp accepts any OpenAI-compatible base URL. Keys are stored in your OS keychain — never sent to Warp's servers.",
+            fields: [
+              { label: "Base URL", value: url },
+              { label: "API Key", value: tokenPlaceholder, copyable: false },
+            ],
+          },
+          {
+            title: "Pick the model in the agent header",
+            body: "Switch via the model selector at the top of Agent Mode.",
+          },
+        ],
+      }),
     },
   },
   {

--- a/platform/frontend/src/app/connection/connection-flow.tsx
+++ b/platform/frontend/src/app/connection/connection-flow.tsx
@@ -20,11 +20,10 @@ import { ConnectionUrlStep } from "./connection-url-step";
 import { McpClientInstructions } from "./mcp-client-instructions";
 import { ProxyClientInstructions } from "./proxy-client-instructions";
 import { SearchableSelect } from "./searchable-select";
+import { SectionHeading } from "./section-heading";
 import { SkillsMarketplaceStep } from "./skills-marketplace-step";
 import { StepCard, type StepState } from "./step-card";
 import { useUpdateUrlParams } from "./use-update-url-params";
-
-type OpenKey = "client" | "mcp" | "proxy" | "skills";
 
 interface ConnectionFlowProps {
   defaultMcpGatewayId?: string;
@@ -45,7 +44,7 @@ export function ConnectionFlow({
   defaultLlmProxyId,
   adminDefaultMcpGatewayId,
   adminDefaultLlmProxyId,
-  adminDefaultClientId,
+  adminDefaultClientId: _adminDefaultClientId,
   shownClientIds,
   shownProviders,
   connectionBaseUrls,
@@ -84,55 +83,22 @@ export function ConnectionFlow({
     return CONNECT_CLIENTS.filter((c) => c.id === "generic" || shown.has(c.id));
   }, [shownClientIds]);
 
-  // Pre-select a client so the flow never loads blank. URL param wins (for
-  // bookmarkable state), then the admin default, then "Any Client" as the
-  // system fallback.
+  // Only honor the URL param on first load. The picker intentionally starts
+  // empty so users explicitly choose their client; the admin default still
+  // affects the URL-based deep-link path via resolveInitialClientId callers
+  // elsewhere, but it does not auto-pick a tile here.
   const initialClientId = resolveInitialClientId({
     urlClientId,
-    adminDefaultClientId,
+    adminDefaultClientId: null,
     visibleClientIds: visibleClients.map((c) => c.id),
   });
   const [clientId, setClientId] = useState<string | null>(initialClientId);
   const client = visibleClients.find((c) => c.id === clientId) ?? null;
 
-  const [openSteps, setOpenSteps] = useState<Set<OpenKey>>(() => {
-    const initial = new Set<OpenKey>(["client"]);
-    if (initialClientId) {
-      // Mirror selectClient's auto-open logic for bookmarked URLs.
-      if (fromTable && urlGatewayId && !urlProxyId) initial.add("mcp");
-      else if (fromTable && urlProxyId && !urlGatewayId) initial.add("proxy");
-      else {
-        initial.add("mcp");
-        initial.add("proxy");
-        initial.add("skills");
-      }
-    }
-    return initial;
-  });
-  const isOpen = (k: OpenKey) => openSteps.has(k);
-  const toggleOne = (k: OpenKey) =>
-    setOpenSteps((s) => {
-      const n = new Set(s);
-      if (n.has(k)) n.delete(k);
-      else n.add(k);
-      return n;
-    });
-
   const selectClient = (id: string | null) => {
     setClientId(id);
     // Providers vary per client, so clear any bookmarked provider on switch.
     updateUrlParams({ clientId: id, providerId: null });
-    if (!id) return;
-    // When the user arrived from the MCP Gateway / LLM Proxy table
-    // (from=table + only one pinned id), auto-open just that side.
-    // Otherwise expand both steps so the full flow is visible.
-    const toOpen: OpenKey[] =
-      fromTable && urlGatewayId && !urlProxyId
-        ? ["mcp"]
-        : fromTable && urlProxyId && !urlGatewayId
-          ? ["proxy"]
-          : ["mcp", "proxy", "skills"];
-    setOpenSteps((s) => new Set<OpenKey>([...s, ...toOpen]));
   };
 
   const [selectedMcpId, setSelectedMcpId] = useState<string | null>(null);
@@ -197,17 +163,7 @@ export function ConnectionFlow({
   });
 
   const selectedMcp = mcpGateways?.find((g) => g.id === effectiveMcpId);
-
-  const mcpState: StepState = !clientId
-    ? "todo"
-    : isOpen("mcp")
-      ? "active"
-      : "todo";
-  const proxyState: StepState = !clientId
-    ? "todo"
-    : isOpen("proxy")
-      ? "active"
-      : "todo";
+  const stepState: StepState = clientId ? "active" : "todo";
 
   return (
     <div className="grid gap-3.5">
@@ -228,111 +184,122 @@ export function ConnectionFlow({
       />
 
       {/* Step 2 — MCP Gateway */}
-      {canReadMcpGateway && (
-        <StepCard
-          hideStatus
-          title="Connect the MCP Gateway to access tools"
-          state={mcpState}
-          expanded={isOpen("mcp") && !!client}
-          onToggle={client ? () => toggleOne("mcp") : undefined}
-          actions={
-            client &&
-            isOpen("mcp") &&
-            client.mcp.kind !== "unsupported" &&
-            (mcpGateways?.length ?? 0) > 1 ? (
-              <SearchableSelect
-                options={(mcpGateways ?? []).map((g) => ({
-                  value: g.id,
-                  label: g.name,
-                }))}
-                value={effectiveMcpId}
-                onValueChange={handleMcpSelect}
-                placeholder="Select gateway"
-              />
-            ) : null
-          }
+      {client && canReadMcpGateway && (
+        <div
+          key={`mcp-${client.id}`}
+          className="grid gap-3.5 animate-in fade-in slide-in-from-bottom-2 duration-500 [animation-delay:0ms] [animation-fill-mode:backwards]"
         >
-          {client && selectedMcp && effectiveMcpId && (
-            <McpClientInstructions
-              client={client}
-              gatewayId={effectiveMcpId}
-              gatewaySlug={selectedMcp.slug ?? effectiveMcpId}
-              gatewayName={selectedMcp.name}
-              baseUrl={baseUrl}
-            />
-          )}
-          {client && !effectiveMcpId && (
-            <div className="rounded-lg border border-dashed bg-muted/30 p-6 text-center text-sm text-muted-foreground">
-              No MCP gateways available.{" "}
-              <Link
-                href="/mcp/gateways"
-                className="underline hover:text-foreground"
-              >
-                Create one
-              </Link>{" "}
-              to continue.
-            </div>
-          )}
-        </StepCard>
+          <SectionHeading step={1} title="Connect the MCP Gateway" />
+          <StepCard
+            hideStatus
+            pinned
+            state={stepState}
+            expanded
+            actions={
+              client &&
+              client.mcp.kind !== "unsupported" &&
+              (mcpGateways?.length ?? 0) > 1 ? (
+                <SearchableSelect
+                  options={(mcpGateways ?? []).map((g) => ({
+                    value: g.id,
+                    label: g.name,
+                  }))}
+                  value={effectiveMcpId}
+                  onValueChange={handleMcpSelect}
+                  placeholder="Select gateway"
+                />
+              ) : null
+            }
+          >
+            {client && selectedMcp && effectiveMcpId && (
+              <McpClientInstructions
+                client={client}
+                gatewayId={effectiveMcpId}
+                gatewaySlug={selectedMcp.slug ?? effectiveMcpId}
+                gatewayName={selectedMcp.name}
+                baseUrl={baseUrl}
+              />
+            )}
+            {client && !effectiveMcpId && (
+              <div className="rounded-lg border border-dashed bg-muted/30 p-6 text-center text-sm text-muted-foreground">
+                No MCP gateways available.{" "}
+                <Link
+                  href="/mcp/gateways"
+                  className="underline hover:text-foreground"
+                >
+                  Create one
+                </Link>{" "}
+                to continue.
+              </div>
+            )}
+          </StepCard>
+        </div>
       )}
 
       {/* Step 3 — LLM Proxy */}
-      {canReadLlmProxy && (
-        <StepCard
-          hideStatus
-          title="Route through the LLM Proxy to make it secure"
-          state={proxyState}
-          expanded={isOpen("proxy") && !!client}
-          onToggle={client ? () => toggleOne("proxy") : undefined}
-          actions={
-            client &&
-            isOpen("proxy") &&
-            client.proxy.kind !== "unsupported" &&
-            (llmProxies?.length ?? 0) > 1 ? (
-              <SearchableSelect
-                options={(llmProxies ?? []).map((p) => ({
-                  value: p.id,
-                  label: p.name,
-                }))}
-                value={effectiveProxyId}
-                onValueChange={handleProxySelect}
-                placeholder="Select proxy"
-              />
-            ) : null
-          }
+      {client && canReadLlmProxy && (
+        <div
+          key={`proxy-${client.id}`}
+          className="grid gap-3.5 animate-in fade-in slide-in-from-bottom-2 duration-500 [animation-delay:140ms] [animation-fill-mode:backwards]"
         >
-          {client && effectiveProxyId && (
-            <ProxyClientInstructions
-              client={client}
-              profileId={effectiveProxyId}
-              profileName={
-                llmProxies?.find((p) => p.id === effectiveProxyId)?.name ?? ""
-              }
-              shownProviders={shownProviders}
-              baseUrl={baseUrl}
-            />
-          )}
-          {client && !effectiveProxyId && (
-            <div className="rounded-lg border border-dashed bg-muted/30 p-6 text-center text-sm text-muted-foreground">
-              No LLM proxies available.{" "}
-              <Link
-                href="/llm/proxies"
-                className="underline hover:text-foreground"
-              >
-                Create one
-              </Link>{" "}
-              to continue.
-            </div>
-          )}
-        </StepCard>
+          <SectionHeading step={2} title="Route through the LLM Proxy" />
+          <StepCard
+            hideStatus
+            pinned
+            state={stepState}
+            expanded
+            actions={
+              client &&
+              client.proxy.kind !== "unsupported" &&
+              (llmProxies?.length ?? 0) > 1 ? (
+                <SearchableSelect
+                  options={(llmProxies ?? []).map((p) => ({
+                    value: p.id,
+                    label: p.name,
+                  }))}
+                  value={effectiveProxyId}
+                  onValueChange={handleProxySelect}
+                  placeholder="Select proxy"
+                />
+              ) : null
+            }
+          >
+            {client && effectiveProxyId && (
+              <ProxyClientInstructions
+                client={client}
+                profileId={effectiveProxyId}
+                profileName={
+                  llmProxies?.find((p) => p.id === effectiveProxyId)?.name ?? ""
+                }
+                shownProviders={shownProviders}
+                baseUrl={baseUrl}
+              />
+            )}
+            {client && !effectiveProxyId && (
+              <div className="rounded-lg border border-dashed bg-muted/30 p-6 text-center text-sm text-muted-foreground">
+                No LLM proxies available.{" "}
+                <Link
+                  href="/llm/proxies"
+                  className="underline hover:text-foreground"
+                >
+                  Create one
+                </Link>{" "}
+                to continue.
+              </div>
+            )}
+          </StepCard>
+        </div>
       )}
 
       {/* Step 4 — Skills marketplace (no-ops when feature off or non-admin) */}
-      <SkillsMarketplaceStep
-        client={client}
-        expanded={isOpen("skills")}
-        onToggle={client ? () => toggleOne("skills") : undefined}
-      />
+      {client && (
+        <div
+          key={`skills-${client.id}`}
+          className="grid gap-3.5 animate-in fade-in slide-in-from-bottom-2 duration-500 [animation-delay:280ms] [animation-fill-mode:backwards]"
+        >
+          <SkillsMarketplaceStep client={client} />
+        </div>
+      )}
     </div>
   );
 }

--- a/platform/frontend/src/app/connection/proxy-client-instructions.tsx
+++ b/platform/frontend/src/app/connection/proxy-client-instructions.tsx
@@ -9,7 +9,6 @@ import { AlertTriangle, Check, Copy, Search } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { CopyableCode } from "@/components/copyable-code";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import type { ConnectClient, ProxyStep } from "./clients";
@@ -399,12 +398,18 @@ function StepList({ steps }: { steps: ProxyStep[] }) {
             {s.fields && s.fields.length > 0 && (
               <div className="grid gap-2">
                 {s.fields.map((f) => (
-                  <FieldRow
-                    key={f.label}
-                    label={f.label}
-                    value={f.value}
-                    copyable={f.copyable ?? true}
-                  />
+                  <div key={f.label} className="grid gap-1">
+                    <FieldRow
+                      label={f.label}
+                      value={f.value}
+                      copyable={f.copyable ?? true}
+                    />
+                    {f.hint && (
+                      <div className="pl-1 text-[12px] leading-snug text-muted-foreground">
+                        {f.hint}
+                      </div>
+                    )}
+                  </div>
                 ))}
               </div>
             )}
@@ -497,29 +502,14 @@ function ProviderGrid({
   selected,
   onSelect,
 }: ProviderGridProps) {
-  const PRIMARY: SupportedProvider[] = [
-    "openai",
-    "anthropic",
-    "gemini",
-    "bedrock",
-    "groq",
-  ];
-  const [showAll, setShowAll] = useState(false);
   const [query, setQuery] = useState("");
-  const compact = providers.filter((p) => PRIMARY.includes(p));
-  // If the admin's allow-list excludes every primary provider, there's
-  // nothing to collapse to — fall through to the full list instead of
-  // rendering an empty grid behind a "Show all" button.
-  const canCollapse = compact.length > 0 && compact.length < providers.length;
   const normalizedQuery = query.trim().toLowerCase();
   const searching = normalizedQuery.length > 0;
-  // When searching, ignore the compact/expanded toggle and search all providers.
-  const base = searching || showAll || !canCollapse ? providers : compact;
   const visible = searching
-    ? base.filter((p) =>
+    ? providers.filter((p) =>
         providerDisplayNames[p].toLowerCase().includes(normalizedQuery),
       )
-    : base;
+    : providers;
 
   return (
     <div>
@@ -527,29 +517,16 @@ function ProviderGrid({
         <h3 className="text-[17px] font-bold tracking-tight text-foreground">
           Select a provider
         </h3>
-        {canCollapse && (
-          <div className="flex items-center gap-3">
-            {!searching && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-9 text-xs"
-                onClick={() => setShowAll((v) => !v)}
-              >
-                {showAll ? "Show fewer" : `Show all (${providers.length})`}
-              </Button>
-            )}
-            <div className="relative">
-              <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                type="search"
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                placeholder="Search"
-                className="h-9 w-56 rounded-full pl-8"
-              />
-            </div>
+        {providers.length > 6 && (
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search"
+              className="h-9 w-56 rounded-full pl-8"
+            />
           </div>
         )}
       </div>

--- a/platform/frontend/src/app/connection/section-heading.tsx
+++ b/platform/frontend/src/app/connection/section-heading.tsx
@@ -1,0 +1,13 @@
+interface SectionHeadingProps {
+  step: number;
+  title: string;
+}
+
+export function SectionHeading({ step, title }: SectionHeadingProps) {
+  return (
+    <h2 className="mt-3 pl-1 text-2xl font-bold tracking-tight text-foreground sm:text-[26px]">
+      <span className="mr-2 text-muted-foreground/70">Step {step}:</span>
+      {title}
+    </h2>
+  );
+}

--- a/platform/frontend/src/app/connection/skills-marketplace-step.test.tsx
+++ b/platform/frontend/src/app/connection/skills-marketplace-step.test.tsx
@@ -120,16 +120,16 @@ describe("SkillsMarketplaceStep", () => {
     });
   });
 
-  it("returns null for non-admin users", () => {
+  it("shows an admin-required message for non-admin users", () => {
     hasPermissionsMock.mockReturnValue({ data: false });
     listLinksMock.mockReturnValue({
       data: { links: [] },
       isPending: false,
     });
-    const { container } = render(
-      <SkillsMarketplaceStep client={anyClient} expanded onToggle={() => {}} />,
-    );
-    expect(container.textContent).toBe("");
+    render(<SkillsMarketplaceStep client={anyClient} />);
+    expect(
+      screen.getByText(/Ask an admin to set up skill sharing/i),
+    ).toBeInTheDocument();
   });
 
   it("renders the create panel when no active link exists", async () => {
@@ -137,9 +137,7 @@ describe("SkillsMarketplaceStep", () => {
       data: { links: [] },
       isPending: false,
     });
-    renderWithClient(
-      <SkillsMarketplaceStep client={anyClient} expanded onToggle={() => {}} />,
-    );
+    renderWithClient(<SkillsMarketplaceStep client={anyClient} />);
     await waitFor(() =>
       expect(screen.getByTestId("skills-marketplace-create")).toBeVisible(),
     );
@@ -153,9 +151,7 @@ describe("SkillsMarketplaceStep", () => {
     });
     createLinkMock.mockResolvedValue(CREATE_RESPONSE);
 
-    renderWithClient(
-      <SkillsMarketplaceStep client={anyClient} expanded onToggle={() => {}} />,
-    );
+    renderWithClient(<SkillsMarketplaceStep client={anyClient} />);
 
     await waitFor(() =>
       expect(screen.getByTestId("skills-marketplace-create")).toBeVisible(),
@@ -176,9 +172,7 @@ describe("SkillsMarketplaceStep", () => {
     });
     createLinkMock.mockResolvedValue(CREATE_RESPONSE);
 
-    renderWithClient(
-      <SkillsMarketplaceStep client={anyClient} expanded onToggle={() => {}} />,
-    );
+    renderWithClient(<SkillsMarketplaceStep client={anyClient} />);
 
     await userEvent.click(
       await screen.findByTestId("skills-marketplace-create"),
@@ -207,20 +201,22 @@ describe("SkillsMarketplaceStep", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders nothing when the picked client doesn't support skill marketplaces", () => {
+  it("falls back to the generic clone-path guide for clients without a dedicated snippet", async () => {
     listLinksMock.mockReturnValue({
       data: { links: [] },
       isPending: false,
     });
+    createLinkMock.mockResolvedValue(CREATE_RESPONSE);
     const unsupportedClient = findClient("n8n");
-    const { container } = render(
-      <SkillsMarketplaceStep
-        client={unsupportedClient}
-        expanded
-        onToggle={() => {}}
-      />,
+    renderWithClient(<SkillsMarketplaceStep client={unsupportedClient} />);
+    await userEvent.click(
+      await screen.findByTestId("skills-marketplace-create"),
     );
-    expect(container.textContent).toBe("");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("skills-marketplace-snippets-generic"),
+      ).toBeInTheDocument(),
+    );
   });
 
   it("filters snippets to the chosen client", async () => {
@@ -230,13 +226,7 @@ describe("SkillsMarketplaceStep", () => {
     });
     createLinkMock.mockResolvedValue(CREATE_RESPONSE);
 
-    renderWithClient(
-      <SkillsMarketplaceStep
-        client={claudeClient}
-        expanded
-        onToggle={() => {}}
-      />,
-    );
+    renderWithClient(<SkillsMarketplaceStep client={claudeClient} />);
 
     await userEvent.click(
       await screen.findByTestId("skills-marketplace-create"),
@@ -259,13 +249,7 @@ describe("SkillsMarketplaceStep", () => {
     });
     createLinkMock.mockResolvedValue(CREATE_RESPONSE);
 
-    renderWithClient(
-      <SkillsMarketplaceStep
-        client={copilotClient}
-        expanded
-        onToggle={() => {}}
-      />,
-    );
+    renderWithClient(<SkillsMarketplaceStep client={copilotClient} />);
 
     await userEvent.click(
       await screen.findByTestId("skills-marketplace-create"),
@@ -302,9 +286,7 @@ describe("SkillsMarketplaceStep", () => {
       revokeError: undefined,
     });
 
-    renderWithClient(
-      <SkillsMarketplaceStep client={anyClient} expanded onToggle={() => {}} />,
-    );
+    renderWithClient(<SkillsMarketplaceStep client={anyClient} />);
 
     // panel mounts in hidden-URL state — no install snippets and no implicit rotation
     expect(
@@ -327,9 +309,7 @@ describe("SkillsMarketplaceStep", () => {
       revokeError: undefined,
     });
 
-    renderWithClient(
-      <SkillsMarketplaceStep client={anyClient} expanded onToggle={() => {}} />,
-    );
+    renderWithClient(<SkillsMarketplaceStep client={anyClient} />);
 
     await userEvent.click(
       await screen.findByRole("button", { name: /Refresh to reveal URL/i }),
@@ -357,9 +337,7 @@ describe("SkillsMarketplaceStep", () => {
     });
     revokeLinkMock.mockResolvedValue({ success: true });
 
-    renderWithClient(
-      <SkillsMarketplaceStep client={anyClient} expanded onToggle={() => {}} />,
-    );
+    renderWithClient(<SkillsMarketplaceStep client={anyClient} />);
 
     await userEvent.click(
       await screen.findByRole("button", { name: /^Revoke$/i }),

--- a/platform/frontend/src/app/connection/skills-marketplace-step.tsx
+++ b/platform/frontend/src/app/connection/skills-marketplace-step.tsx
@@ -30,19 +30,18 @@ import {
 } from "@/lib/skills/skill-share.query";
 import { handleApiError } from "@/lib/utils";
 import type { ConnectClient } from "./clients";
+import { SectionHeading } from "./section-heading";
 import {
   computeSkillMarketplaceExpiresAt,
   SKILL_MARKETPLACE_CLIENTS,
   SKILL_MARKETPLACE_TTL_PRESETS,
   type SkillMarketplaceClient,
 } from "./skills-marketplace-clients";
-import { StepCard, type StepState } from "./step-card";
+import { StepCard } from "./step-card";
 import { TerminalBlock } from "./terminal-block";
 
 interface SkillsMarketplaceStepProps {
   client: ConnectClient | null;
-  expanded: boolean;
-  onToggle: (() => void) | undefined;
 }
 
 /**
@@ -55,33 +54,25 @@ interface RevealedClone {
   marketplaceName: string;
 }
 
-export function SkillsMarketplaceStep({
-  client,
-  expanded,
-  onToggle,
-}: SkillsMarketplaceStepProps) {
+export function SkillsMarketplaceStep({ client }: SkillsMarketplaceStepProps) {
   const skillsEnabled = useFeature("agentSkillsEnabled") === true;
   const { data: canAdmin } = useHasPermissions({ skill: ["admin"] });
 
-  if (!skillsEnabled || !canAdmin) return null;
-
-  // hide the step entirely when the picked client doesn't support installable
-  // skill marketplaces — the user already knows their tool doesn't support it,
-  // we don't need to apologize in the UI.
-  if (client && !isClientSupported(client)) return null;
-
-  const state: StepState = !client ? "todo" : expanded ? "active" : "todo";
+  if (!skillsEnabled || !client) return null;
 
   return (
-    <StepCard
-      hideStatus
-      title="Install shared skills"
-      state={state}
-      expanded={expanded && !!client}
-      onToggle={client ? onToggle : undefined}
-    >
-      {client && <SkillsMarketplaceBody client={client} />}
-    </StepCard>
+    <>
+      <SectionHeading step={3} title="Install shared skills" />
+      <StepCard hideStatus pinned state="active" expanded>
+        {!canAdmin ? (
+          <div className="rounded-lg border border-dashed bg-muted/30 p-6 text-center text-sm text-muted-foreground">
+            Ask an admin to set up skill sharing for your org.
+          </div>
+        ) : (
+          <SkillsMarketplaceBody client={client} />
+        )}
+      </StepCard>
+    </>
   );
 }
 
@@ -483,17 +474,6 @@ function SecurityNote() {
         local git config after they run the marketplace add command.
       </p>
     </div>
-  );
-}
-
-function isClientSupported(client: ConnectClient | null): boolean {
-  if (!client) return false;
-  return (
-    client.id === "claude-code" ||
-    client.id === "codex" ||
-    client.id === "copilot-cli" ||
-    client.id === "cursor" ||
-    client.id === "generic"
   );
 }
 

--- a/platform/frontend/src/app/connection/step-card.tsx
+++ b/platform/frontend/src/app/connection/step-card.tsx
@@ -74,7 +74,7 @@ function StatusChip({ state }: { state: StepState }) {
 
 interface StepCardProps {
   number?: number;
-  title: ReactNode;
+  title?: ReactNode;
   subtitle?: ReactNode;
   state: StepState;
   expanded: boolean;
@@ -105,6 +105,8 @@ export function StepCard({
 }: StepCardProps) {
   const dimmed = !onToggle && !pinned;
   const showChevron = !!onToggle;
+  const hasTitleContent = !!title || !!subtitle || !hideStatus;
+  const hasHeader = hasTitleContent || !!actions || showChevron;
 
   return (
     <section
@@ -114,56 +116,84 @@ export function StepCard({
         dimmed && "opacity-55",
       )}
     >
-      <div className="flex select-none flex-wrap items-center gap-3 px-5 py-4 sm:gap-3.5">
-        <button
-          type="button"
-          disabled={!onToggle}
-          onClick={onToggle}
+      {hasHeader && (
+        <div
           className={cn(
-            "flex min-w-0 flex-1 basis-full items-center gap-3.5 bg-transparent text-left outline-none sm:basis-0",
-            onToggle && "cursor-pointer focus-visible:opacity-80",
+            "flex select-none flex-wrap items-center gap-3 px-5 sm:gap-3.5",
+            hasTitleContent ? "py-4" : "py-2",
           )}
-          aria-expanded={expanded}
         >
-          {!hideStatus && <StepNumber n={number} state={state} />}
+          {hasTitleContent && (
+            <button
+              type="button"
+              disabled={!onToggle}
+              onClick={onToggle}
+              className={cn(
+                "flex min-w-0 flex-1 basis-full items-center gap-3.5 bg-transparent text-left outline-none sm:basis-0",
+                onToggle && "cursor-pointer focus-visible:opacity-80",
+              )}
+              aria-expanded={expanded}
+            >
+              {!hideStatus && <StepNumber n={number} state={state} />}
 
-          <div className="min-w-0 flex-1">
-            <div className="flex flex-wrap items-center gap-2">
-              <h3 className="text-[17px] font-bold tracking-tight text-foreground">
-                {title}
-              </h3>
-              {!hideStatus && <StatusChip state={state} />}
-            </div>
-            {subtitle && (
-              <div className="mt-0.5 text-xs text-muted-foreground">
-                {subtitle}
+              <div className="min-w-0 flex-1">
+                {(title || !hideStatus) && (
+                  <div className="flex flex-wrap items-center gap-2">
+                    {title && (
+                      <h3 className="text-[17px] font-bold tracking-tight text-foreground">
+                        {title}
+                      </h3>
+                    )}
+                    {!hideStatus && <StatusChip state={state} />}
+                  </div>
+                )}
+                {subtitle && (
+                  <div className="mt-0.5 text-xs text-muted-foreground">
+                    {subtitle}
+                  </div>
+                )}
               </div>
-            )}
-          </div>
-        </button>
+            </button>
+          )}
 
-        {actions && (
-          <div className="ml-[42px] flex shrink-0 flex-wrap items-center gap-2 sm:ml-0">
-            {actions}
-          </div>
-        )}
+          {actions && (
+            <div
+              className={cn(
+                "flex shrink-0 flex-wrap items-center gap-2",
+                hasTitleContent ? "ml-[42px] sm:ml-0" : "ml-auto",
+              )}
+            >
+              {actions}
+            </div>
+          )}
 
-        {showChevron && (
-          <button
-            type="button"
-            onClick={onToggle}
-            aria-label={expanded ? "Collapse step" : "Expand step"}
-            className={cn(
-              "ml-auto flex size-7 shrink-0 items-center justify-center rounded text-muted-foreground transition-transform hover:bg-muted sm:ml-1",
-              expanded && "rotate-180",
-            )}
-          >
-            <ChevronDown className="size-3.5" strokeWidth={2.2} />
-          </button>
-        )}
-      </div>
+          {showChevron && (
+            <button
+              type="button"
+              onClick={onToggle}
+              aria-label={expanded ? "Collapse step" : "Expand step"}
+              className={cn(
+                "flex size-7 shrink-0 items-center justify-center rounded text-muted-foreground transition-transform hover:bg-muted",
+                hasTitleContent ? "ml-auto sm:ml-1" : "ml-1",
+                expanded && "rotate-180",
+              )}
+            >
+              <ChevronDown className="size-3.5" strokeWidth={2.2} />
+            </button>
+          )}
+        </div>
+      )}
 
-      {expanded && <div className="border-t px-5 pb-5 pt-4">{children}</div>}
+      {expanded && (
+        <div
+          className={cn(
+            "px-5 pb-5",
+            hasTitleContent ? "border-t pt-4" : "pt-4",
+          )}
+        >
+          {children}
+        </div>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
Add OpenCode, Open WebUI, Pi (pi.dev), Warp, and Claude Cowork to the connection clients picker with MCP and LLM-proxy instructions per client. Bump picker page size to fit all clients in 3 rows without pagination.

Drop the no-default-client auto-pick and the per-step collapse — MCP Gateway / LLM Proxy / Skills sections render unconditionally once a client is picked, each as a "Step N: ..." heading above the card. Cards no longer show the empty title strip. Sections fade in staggered when the client changes.

Skills card falls back to the generic clone-path guide for clients without a dedicated marketplace snippet (cowork/opencode/openwebui/pi/ warp/n8n) instead of rendering a "doesn't support" placeholder.

ProxyStep fields gain an optional hint for per-field helper text; Cowork's "Gateway API key" uses it to clarify Archestra virtual key vs raw Anthropic key. Provider grid no longer collapses behind a "Show all" toggle.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>