### PR TITLE
ci: add `arsenyinfo` to core team contributors

### DIFF
--- a/.github/workflows/random-issue-pr-assignee.yml
+++ b/.github/workflows/random-issue-pr-assignee.yml
@@ -22,7 +22,7 @@ permissions: {}
 
 env:
   ASSIGNEE_LOGINS: '["joeyorlando","iskhakov","Konstantinov-Innokentii","divineforest"]'
-  CORE_TEAM_LOGINS: '["joeyorlando","iskhakov","Konstantinov-Innokentii","Matvey-Kuk","divineforest"]'
+  CORE_TEAM_LOGINS: '["joeyorlando","iskhakov","Konstantinov-Innokentii","Matvey-Kuk","divineforest","arsenyinfo"]'
 
 concurrency:
   group: random-issue-pr-assignee-${{ github.event.issue.number || github.ref }}


### PR DESCRIPTION
## Summary

Adds `arsenyinfo` to the core team contributor login list used by the random issue assignee and PR reviewer workflow.

## Impact

PRs opened by this core team member will be skipped by the automatic random reviewer assignment logic, matching the existing core team behavior.