### PR TITLE
fix(mcp): treat image pull errors as transient so MCP deployments self-recover

### DIFF
--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
@@ -5883,3 +5883,223 @@ describe("K8sDeployment.streamLogs", () => {
     expect(k8sLogMock).not.toHaveBeenCalled();
   });
 });
+
+describe("K8sDeployment image pull failure handling", () => {
+  function makeDeploymentWithMockedApis(params: {
+    listNamespacedPod: ReturnType<typeof vi.fn>;
+    readNamespacedDeployment?: ReturnType<typeof vi.fn>;
+  }): K8sDeployment {
+    const mockMcpServer = {
+      id: "test-server-id",
+      name: "test-server",
+      // null catalogId so getCatalogItem() short-circuits without a DB lookup
+      catalogId: null,
+    } as unknown as McpServer;
+
+    return new K8sDeployment({
+      mcpServer: mockMcpServer,
+      k8sApi: {
+        listNamespacedPod: params.listNamespacedPod,
+      } as unknown as k8s.CoreV1Api,
+      k8sAppsApi: {
+        readNamespacedDeployment: params.readNamespacedDeployment ?? vi.fn(),
+      } as unknown as k8s.AppsV1Api,
+      k8sNetworkingApi: {} as k8s.NetworkingV1Api,
+      k8sAttach: {} as Attach,
+      k8sLog: {} as Log,
+      k8sExec: {} as Exec,
+      namespace: "default",
+      catalogItem: null,
+    });
+  }
+
+  function makeWaitingPod(reason: string, message: string): k8s.V1Pod {
+    return {
+      metadata: {
+        name: "test-server-abc123",
+        creationTimestamp: new Date(),
+      },
+      status: {
+        phase: "Pending",
+        containerStatuses: [
+          {
+            name: "mcp-server",
+            ready: false,
+            restartCount: 0,
+            state: { waiting: { reason, message } },
+          },
+        ],
+      },
+    } as k8s.V1Pod;
+  }
+
+  const runningPod = {
+    metadata: {
+      name: "test-server-abc123",
+      creationTimestamp: new Date(),
+    },
+    status: {
+      phase: "Running",
+      containerStatuses: [
+        {
+          name: "mcp-server",
+          ready: true,
+          restartCount: 0,
+          state: { running: {} },
+        },
+      ],
+    },
+  } as k8s.V1Pod;
+
+  const imagePullPod = makeWaitingPod(
+    "ImagePullBackOff",
+    'Back-off pulling image "ghcr.io/example/mcp:latest"',
+  );
+
+  describe("refreshState", () => {
+    test("keeps state pending on transient image pull errors", async () => {
+      const listNamespacedPod = vi
+        .fn()
+        .mockResolvedValue({ items: [imagePullPod] });
+      const readNamespacedDeployment = vi
+        .fn()
+        .mockResolvedValue({ status: { availableReplicas: 0 } });
+
+      const deployment = makeDeploymentWithMockedApis({
+        listNamespacedPod,
+        readNamespacedDeployment,
+      });
+      // @ts-expect-error - accessing private property for testing
+      deployment.state = "pending";
+
+      await deployment.refreshState();
+
+      expect(deployment.statusSummary.state).toBe("pending");
+      expect(deployment.statusSummary.error).toContain(
+        "Back-off pulling image",
+      );
+    });
+
+    test("recovers to running once the kubelet pull succeeds", async () => {
+      const listNamespacedPod = vi
+        .fn()
+        // first refresh: findAnyPodForDeployment + failure check see the pull error
+        .mockResolvedValueOnce({ items: [imagePullPod] })
+        .mockResolvedValueOnce({ items: [imagePullPod] })
+        // second refresh: pod is running
+        .mockResolvedValue({ items: [runningPod] });
+      const readNamespacedDeployment = vi
+        .fn()
+        .mockResolvedValueOnce({ status: { availableReplicas: 0 } })
+        .mockResolvedValue({ status: { availableReplicas: 1 } });
+
+      const deployment = makeDeploymentWithMockedApis({
+        listNamespacedPod,
+        readNamespacedDeployment,
+      });
+      // @ts-expect-error - accessing private property for testing
+      deployment.state = "pending";
+
+      await deployment.refreshState();
+      expect(deployment.statusSummary.state).toBe("pending");
+
+      await deployment.refreshState();
+      expect(deployment.statusSummary.state).toBe("running");
+      expect(deployment.statusSummary.error).toBeNull();
+    });
+
+    test("still marks terminal container failures as failed", async () => {
+      const crashLoopPod = makeWaitingPod(
+        "CrashLoopBackOff",
+        "back-off 5m0s restarting failed container",
+      );
+      const listNamespacedPod = vi
+        .fn()
+        .mockResolvedValue({ items: [crashLoopPod] });
+      const readNamespacedDeployment = vi
+        .fn()
+        .mockResolvedValue({ status: { availableReplicas: 0 } });
+
+      const deployment = makeDeploymentWithMockedApis({
+        listNamespacedPod,
+        readNamespacedDeployment,
+      });
+      // @ts-expect-error - accessing private property for testing
+      deployment.state = "running";
+
+      await deployment.refreshState();
+
+      expect(deployment.statusSummary.state).toBe("failed");
+      expect(deployment.statusSummary.error).toContain(
+        "restarting failed container",
+      );
+    });
+  });
+
+  describe("waitForDeploymentReady", () => {
+    test("keeps waiting through image pull errors and succeeds once the pull completes", async () => {
+      const listNamespacedPod = vi
+        .fn()
+        // attempt 1: failure scan sees the pull error (must not fail fast)
+        .mockResolvedValueOnce({ items: [imagePullPod] })
+        // attempt 2: pod is running
+        .mockResolvedValue({ items: [runningPod] });
+      const readNamespacedDeployment = vi
+        .fn()
+        .mockResolvedValueOnce({ status: { availableReplicas: 0 } })
+        .mockResolvedValue({ status: { availableReplicas: 1 } });
+
+      const deployment = makeDeploymentWithMockedApis({
+        listNamespacedPod,
+        readNamespacedDeployment,
+      });
+
+      await expect(
+        deployment.waitForDeploymentReady(5, 1),
+      ).resolves.toBeUndefined();
+      expect(deployment.statusSummary.state).toBe("running");
+      expect(deployment.statusSummary.error).toBeNull();
+    });
+
+    test("fails fast on terminal container states", async () => {
+      const crashLoopPod = makeWaitingPod(
+        "CrashLoopBackOff",
+        "back-off 5m0s restarting failed container",
+      );
+      const listNamespacedPod = vi
+        .fn()
+        .mockResolvedValue({ items: [crashLoopPod] });
+      const readNamespacedDeployment = vi
+        .fn()
+        .mockResolvedValue({ status: { availableReplicas: 0 } });
+
+      const deployment = makeDeploymentWithMockedApis({
+        listNamespacedPod,
+        readNamespacedDeployment,
+      });
+
+      await expect(deployment.waitForDeploymentReady(5, 1)).rejects.toThrow(
+        /CrashLoopBackOff/,
+      );
+      expect(deployment.statusSummary.state).toBe("failed");
+    });
+
+    test("includes the last image pull error when timing out", async () => {
+      const listNamespacedPod = vi
+        .fn()
+        .mockResolvedValue({ items: [imagePullPod] });
+      const readNamespacedDeployment = vi
+        .fn()
+        .mockResolvedValue({ status: { availableReplicas: 0 } });
+
+      const deployment = makeDeploymentWithMockedApis({
+        listNamespacedPod,
+        readNamespacedDeployment,
+      });
+
+      await expect(deployment.waitForDeploymentReady(2, 1)).rejects.toThrow(
+        /did not become ready after 2 attempts.*ImagePullBackOff/,
+      );
+    });
+  });
+});

--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
@@ -82,6 +82,26 @@ const AWS_APPLICATION_NETWORK_POLICY_RESOURCE = {
 // Ready before giving up. 5 minutes covers a slow image pull on first install.
 const POD_READY_WAIT_MS = 5 * TimeInMs.Minute;
 
+// Container waiting reasons that won't resolve without user action (bad
+// config, invalid image name, crashing server) — treat as terminal failures.
+const TERMINAL_CONTAINER_WAITING_REASONS = [
+  "CrashLoopBackOff",
+  "ErrImageNeverPull",
+  "CreateContainerConfigError",
+  "CreateContainerError",
+  "RunContainerError",
+  "InvalidImageName",
+];
+
+// Image pull failures are usually transient (registry hiccup, network blip,
+// rate limiting). The kubelet keeps retrying the pull on its own with
+// exponential backoff, so the pod recovers without intervention once the
+// pull succeeds — treat these as "still starting", not as terminal failures.
+const TRANSIENT_IMAGE_PULL_WAITING_REASONS = [
+  "ImagePullBackOff",
+  "ErrImagePull",
+];
+
 interface ManagedCustomPolicyResource {
   group: string;
   version: string;
@@ -2355,14 +2375,24 @@ export default class K8sDeployment {
 
         // Check pod container statuses for failure states (e.g. CrashLoopBackOff)
         const failureCheck = await this.checkPodContainerStatusesForFailure();
-        if (failureCheck.hasFailed) {
+        if (failureCheck.hasFailed && !failureCheck.isTransientImagePull) {
           this.state = "failed";
           this.errorMessage = failureCheck.message;
           logger.warn(
             `Deployment ${this.deploymentName} is in a failure state: ${failureCheck.message}`,
           );
         } else {
+          // Image pull errors stay "pending": the kubelet retries the pull
+          // on its own and the deployment recovers once it succeeds.
           this.state = "pending";
+          this.errorMessage = failureCheck.isTransientImagePull
+            ? failureCheck.message
+            : null;
+          if (failureCheck.isTransientImagePull) {
+            logger.info(
+              `Deployment ${this.deploymentName} is waiting on an image pull (kubelet will retry): ${failureCheck.message}`,
+            );
+          }
         }
 
         // Even if pending/failed, ensure HTTP configuration (Service + URL) is set up
@@ -2671,12 +2701,18 @@ export default class K8sDeployment {
 
   /**
    * Check all pods for container failure states (e.g. CrashLoopBackOff, ImagePullBackOff).
-   * Used on startup to detect deployments that are stuck in a failure state.
+   * Used on startup and during state refresh to detect deployments stuck in a
+   * failure state. Image pull failures are reported separately
+   * (`isTransientImagePull`) because the kubelet retries pulls on its own and
+   * the pod recovers once the pull succeeds.
    */
   private async checkPodContainerStatusesForFailure(): Promise<{
     hasFailed: boolean;
+    isTransientImagePull: boolean;
     message: string;
   }> {
+    let transientImagePullMessage: string | null = null;
+
     try {
       const sanitizedId = sanitizeLabelValue(this.mcpServer.id);
       const pods = await this.k8sApi.listNamespacedPod({
@@ -2684,26 +2720,19 @@ export default class K8sDeployment {
         labelSelector: `mcp-server-id=${sanitizedId}`,
       });
 
-      const failureStates = [
-        "CrashLoopBackOff",
-        "ImagePullBackOff",
-        "ErrImagePull",
-        "ErrImageNeverPull",
-        "CreateContainerConfigError",
-        "CreateContainerError",
-        "RunContainerError",
-        "InvalidImageName",
-      ];
-
       for (const pod of pods.items) {
         for (const cs of pod.status?.containerStatuses ?? []) {
           const reason = cs.state?.waiting?.reason;
-          if (reason && failureStates.includes(reason)) {
-            return {
-              hasFailed: true,
-              message:
-                cs.state?.waiting?.message || `Container in ${reason} state`,
-            };
+          if (!reason) {
+            continue;
+          }
+          const message =
+            cs.state?.waiting?.message || `Container in ${reason} state`;
+          if (TERMINAL_CONTAINER_WAITING_REASONS.includes(reason)) {
+            return { hasFailed: true, isTransientImagePull: false, message };
+          }
+          if (TRANSIENT_IMAGE_PULL_WAITING_REASONS.includes(reason)) {
+            transientImagePullMessage = message;
           }
         }
       }
@@ -2714,7 +2743,15 @@ export default class K8sDeployment {
       );
     }
 
-    return { hasFailed: false, message: "" };
+    if (transientImagePullMessage) {
+      return {
+        hasFailed: true,
+        isTransientImagePull: true,
+        message: transientImagePullMessage,
+      };
+    }
+
+    return { hasFailed: false, isTransientImagePull: false, message: "" };
   }
 
   private checkPodConditionsForFailure(pod: k8s.V1Pod): {
@@ -2914,6 +2951,8 @@ export default class K8sDeployment {
     maxAttempts = 60,
     intervalMs = 2000,
   ): Promise<void> {
+    let lastImagePullError: string | null = null;
+
     for (let i = 0; i < maxAttempts; i++) {
       try {
         const deployment = await this.k8sAppsApi.readNamespacedDeployment({
@@ -2931,6 +2970,7 @@ export default class K8sDeployment {
             await this.assignHttpPortIfNeeded(pod);
             // Update state to running now that deployment is confirmed ready
             this.state = "running";
+            this.errorMessage = null;
             return;
           }
         }
@@ -2987,25 +3027,28 @@ export default class K8sDeployment {
             for (const containerStatus of pod.status.containerStatuses) {
               const waitingReason = containerStatus.state?.waiting?.reason;
               if (waitingReason) {
-                const failureStates = [
-                  "CrashLoopBackOff",
-                  "ImagePullBackOff",
-                  "ErrImagePull",
-                  "ErrImageNeverPull",
-                  "CreateContainerConfigError",
-                  "CreateContainerError",
-                  "RunContainerError",
-                  "InvalidImageName",
-                ];
-                if (failureStates.includes(waitingReason)) {
-                  const message =
-                    containerStatus.state?.waiting?.message ||
-                    `Container in ${waitingReason} state`;
+                const message =
+                  containerStatus.state?.waiting?.message ||
+                  `Container in ${waitingReason} state`;
+
+                if (
+                  TERMINAL_CONTAINER_WAITING_REASONS.includes(waitingReason)
+                ) {
                   this.state = "failed";
                   this.errorMessage = message;
                   throw new Error(
                     `Deployment ${this.deploymentName} failed: ${waitingReason} - ${message}`,
                   );
+                }
+
+                // Image pull errors are retried by the kubelet itself with
+                // exponential backoff — keep waiting instead of failing fast,
+                // but surface the error so status polling can display it.
+                if (
+                  TRANSIENT_IMAGE_PULL_WAITING_REASONS.includes(waitingReason)
+                ) {
+                  lastImagePullError = `${waitingReason} - ${message}`;
+                  this.errorMessage = message;
                 }
               }
             }
@@ -3026,7 +3069,11 @@ export default class K8sDeployment {
     }
 
     throw new Error(
-      `Deployment ${this.deploymentName} did not become ready after ${maxAttempts} attempts`,
+      `Deployment ${this.deploymentName} did not become ready after ${maxAttempts} attempts${
+        lastImagePullError
+          ? ` (last image pull error: ${lastImagePullError})`
+          : ""
+      }`,
     );
   }
 
@@ -3541,8 +3588,18 @@ export default class K8sDeployment {
       // No available replicas — check for container failure states
       const failureCheck = await this.checkPodContainerStatusesForFailure();
       if (failureCheck.hasFailed) {
-        this.state = "failed";
-        this.errorMessage = failureCheck.message;
+        if (failureCheck.isTransientImagePull) {
+          // Image pull errors self-heal: the kubelet retries the pull with
+          // exponential backoff. Stay "pending" (with the error visible) so
+          // the next refresh flips to "running" once the pull succeeds —
+          // marking it "failed" here would latch the state forever and
+          // require a manual restart.
+          this.state = "pending";
+          this.errorMessage = failureCheck.message;
+        } else {
+          this.state = "failed";
+          this.errorMessage = failureCheck.message;
+        }
         this.runningMissCount = 0;
       } else if (this.state === "running") {
         // Debounce: only downgrade to "pending" after several consecutive

--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -77,6 +77,7 @@ overrides:
   yaml: '>=2.8.3'
   '@opentelemetry/exporter-prometheus': 0.217.0
   '@opentelemetry/sdk-node': 0.217.0
+  '@grpc/grpc-js': '>=1.14.4'
 
 packageExtensionsChecksum: sha256-OtX37i1Ryo9P6g4B33ec8l4gf38qd6EPAZjHSLupRlQ=
 
@@ -628,7 +629,7 @@ importers:
         version: 1.2.2(@types/react@19.2.14)(react@19.2.4)
       '@sentry/nextjs':
         specifier: ^10.42.0
-        version: 10.43.0(@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.27.0))
+        version: 10.43.0(@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.104.1)
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.90.21(react@19.2.4)
@@ -2043,8 +2044,8 @@ packages:
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
-  '@grpc/grpc-js@1.14.3':
-    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+  '@grpc/grpc-js@1.14.4':
+    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
 
   '@grpc/proto-loader@0.8.0':
@@ -12723,7 +12724,7 @@ snapshots:
     dependencies:
       graphql: 16.13.2
 
-  '@grpc/grpc-js@1.14.3':
+  '@grpc/grpc-js@1.14.4':
     dependencies:
       '@grpc/proto-loader': 0.8.0
       '@js-sdsl/ordered-map': 4.4.2
@@ -13831,7 +13832,7 @@ snapshots:
 
   '@opentelemetry/exporter-logs-otlp-grpc@0.217.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.0)
@@ -13870,7 +13871,7 @@ snapshots:
 
   '@opentelemetry/exporter-metrics-otlp-grpc@0.217.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/exporter-metrics-otlp-http': 0.217.0(@opentelemetry/api@1.9.0)
@@ -13909,7 +13910,7 @@ snapshots:
 
   '@opentelemetry/exporter-trace-otlp-grpc@0.217.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.0)
@@ -14534,7 +14535,7 @@ snapshots:
 
   '@opentelemetry/otlp-grpc-exporter-base@0.217.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.0)
@@ -15997,7 +15998,7 @@ snapshots:
 
   '@sentry/core@10.43.0': {}
 
-  '@sentry/nextjs@10.43.0(@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.27.0))':
+  '@sentry/nextjs@10.43.0(@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.104.1)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -16009,7 +16010,7 @@ snapshots:
       '@sentry/opentelemetry': 10.43.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.40.0)
       '@sentry/react': 10.43.0(react@19.2.4)
       '@sentry/vercel-edge': 10.43.0
-      '@sentry/webpack-plugin': 5.1.1(webpack@5.104.1(esbuild@0.27.0))
+      '@sentry/webpack-plugin': 5.1.1(webpack@5.104.1)
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       rollup: 4.59.0
       stacktrace-parser: 0.1.11
@@ -16123,11 +16124,11 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@sentry/core': 10.43.0
 
-  '@sentry/webpack-plugin@5.1.1(webpack@5.104.1(esbuild@0.27.0))':
+  '@sentry/webpack-plugin@5.1.1(webpack@5.104.1)':
     dependencies:
       '@sentry/bundler-plugin-core': 5.1.1
       uuid: 9.0.1
-      webpack: 5.104.1(esbuild@0.27.0)
+      webpack: 5.104.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -21771,15 +21772,13 @@ snapshots:
     dependencies:
       bintrees: 1.0.2
 
-  terser-webpack-plugin@5.4.0(esbuild@0.27.0)(webpack@5.104.1(esbuild@0.27.0)):
+  terser-webpack-plugin@5.4.0(webpack@5.104.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.1
-      webpack: 5.104.1(esbuild@0.27.0)
-    optionalDependencies:
-      esbuild: 0.27.0
+      webpack: 5.104.1
 
   terser@5.46.1:
     dependencies:
@@ -22234,7 +22233,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack@5.104.1(esbuild@0.27.0):
+  webpack@5.104.1:
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -22258,7 +22257,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.2
-      terser-webpack-plugin: 5.4.0(esbuild@0.27.0)(webpack@5.104.1(esbuild@0.27.0))
+      terser-webpack-plugin: 5.4.0(webpack@5.104.1)
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:

--- a/platform/pnpm-workspace.yaml
+++ b/platform/pnpm-workspace.yaml
@@ -65,6 +65,8 @@ overrides:
   yaml: '>=2.8.3'
   '@opentelemetry/exporter-prometheus': 0.217.0
   '@opentelemetry/sdk-node': 0.217.0
+  # CVE-2026-48068 / CVE-2026-48069 (uncaught exception) fixed in 1.14.4
+  '@grpc/grpc-js': '>=1.14.4'
 packageExtensions:
   '@hookform/resolvers@*':
     dependencies:


### PR DESCRIPTION
## Problem

Users report that MCP server deployments sometimes get stuck with an image pull error ("not able to pull the image"), and a manual **restart** of the MCP server fixes it.

The question raised was whether we can configure the K8s Deployment to retry pulling images by itself. It turns out Kubernetes **already does this**: the kubelet retries failed image pulls indefinitely with exponential backoff — there is no extra Deployment config needed. The pod recovers on its own once the pull succeeds.

The actual bug is in our deployment state machine in `k8s-deployment.ts`:

1. `ErrImagePull` / `ImagePullBackOff` were classified as **terminal** failure states, in the same bucket as `CrashLoopBackOff` and `InvalidImageName`.
2. When the periodic `refreshState()` poll saw one of these (e.g. a registry hiccup, network blip, or rate limit), it set `state = "failed"`.
3. `refreshState()` early-returns for any state other than `pending`/`running` — so once "failed", the state was **latched forever**, even after the kubelet successfully pulled the image and the pod was Running.

That's exactly why a manual restart "helps": it just resets the in-memory state.

## Fix

Split container waiting reasons into terminal vs. transient:

- **Transient** (`ImagePullBackOff`, `ErrImagePull`): the deployment stays/returns to `pending`, with the pull error surfaced in `errorMessage` so the UI still shows what's going on. The next refresh flips it to `running` once the kubelet's own retry succeeds — no manual restart needed.
- **Terminal** (`CrashLoopBackOff`, `InvalidImageName`, `ErrImageNeverPull`, `CreateContainerConfigError`, `CreateContainerError`, `RunContainerError`): unchanged, still fail fast.

Applied in all three places that evaluated the old combined list:

- `refreshState()` (periodic status poll) — the main fix for the latched-failed bug
- `waitForDeploymentReady()` — no longer aborts on the first pull error; keeps waiting for the overall timeout and includes the last pull error in the timeout message
- `startOrCreateDeployment()` startup check — reports `pending` instead of `failed` for pull errors