### PR TITLE
fix(chat): stop active-run delete race from crashing the backend

### DIFF
--- a/platform/backend/src/models/chat-active-run.test.ts
+++ b/platform/backend/src/models/chat-active-run.test.ts
@@ -1,6 +1,7 @@
 import type { UIMessageChunk } from "ai";
 import { eq } from "drizzle-orm";
 import db, { schema } from "@/database";
+import { ConversationModel } from "@/models";
 import ActiveChatRunModel from "@/models/chat-active-run";
 import { expect, test } from "@/test";
 
@@ -321,4 +322,113 @@ test("markRunningAsFailedByIds is a no-op for an empty id list", async () => {
       error: "unused",
     }),
   ).toBe(0);
+});
+
+test("appendEvents reports run_missing after the run row is cascade-deleted (non-touch path)", async ({
+  makeAgent,
+  makeConversation,
+  makeOrganization,
+  makeUser,
+}) => {
+  const user = await makeUser();
+  const organization = await makeOrganization();
+  const agent = await makeAgent({ organizationId: organization.id });
+  const conversation = await makeConversation(agent.id, {
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const run = await ActiveChatRunModel.create({
+    conversationId: conversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+
+  await ConversationModel.delete(conversation.id, user.id, organization.id);
+
+  // The run row is gone via cascade, so the insert hits the run_id FK. The model
+  // must report this lifecycle race rather than throw a raw FK error that would
+  // escape as an unhandled rejection.
+  await expect(
+    ActiveChatRunModel.appendEvents({
+      runId: run?.id ?? "",
+      seq: 1,
+      payloads: [{ type: "start" }],
+    }),
+  ).resolves.toBe("run_missing");
+});
+
+test("appendEvents reports run_missing after the run row is cascade-deleted (touchRun path)", async ({
+  makeAgent,
+  makeConversation,
+  makeOrganization,
+  makeUser,
+}) => {
+  const user = await makeUser();
+  const organization = await makeOrganization();
+  const agent = await makeAgent({ organizationId: organization.id });
+  const conversation = await makeConversation(agent.id, {
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const run = await ActiveChatRunModel.create({
+    conversationId: conversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+
+  await ConversationModel.delete(conversation.id, user.id, organization.id);
+
+  // The transaction path (insert + run touch) must classify the FK identically.
+  await expect(
+    ActiveChatRunModel.appendEvents({
+      runId: run?.id ?? "",
+      seq: 1,
+      payloads: [{ type: "start" }],
+      touchRun: true,
+    }),
+  ).resolves.toBe("run_missing");
+});
+
+test("appendEvents reports appended for a live run on both write paths", async ({
+  makeAgent,
+  makeConversation,
+  makeOrganization,
+  makeUser,
+}) => {
+  const user = await makeUser();
+  const organization = await makeOrganization();
+  const agent = await makeAgent({ organizationId: organization.id });
+  const conversation = await makeConversation(agent.id, {
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const run = await ActiveChatRunModel.create({
+    conversationId: conversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+
+  await expect(
+    ActiveChatRunModel.appendEvents({
+      runId: run?.id ?? "",
+      seq: 1,
+      payloads: [{ type: "start" }],
+    }),
+  ).resolves.toBe("appended");
+  await expect(
+    ActiveChatRunModel.appendEvents({
+      runId: run?.id ?? "",
+      seq: 2,
+      payloads: [{ type: "finish", finishReason: "stop" }],
+      touchRun: true,
+    }),
+  ).resolves.toBe("appended");
+  // An empty payload is a no-op write, not a missing run.
+  await expect(
+    ActiveChatRunModel.appendEvents({
+      runId: run?.id ?? "",
+      seq: 3,
+      payloads: [],
+    }),
+  ).resolves.toBe("appended");
 });

--- a/platform/backend/src/models/chat-active-run.ts
+++ b/platform/backend/src/models/chat-active-run.ts
@@ -7,6 +7,11 @@ import type {
   ChatActiveRunStatus,
 } from "@/types";
 
+// "run_missing" means the parent run row was deleted (e.g. its conversation was
+// hard-deleted and cascaded) before this append landed, so the write is a
+// no-longer-relevant lifecycle event rather than a failure to surface.
+type AppendEventsResult = "appended" | "run_missing";
+
 class ActiveChatRunModel {
   static async create(params: {
     conversationId: string;
@@ -30,31 +35,39 @@ class ActiveChatRunModel {
     seq: number;
     payloads: UIMessageChunk[];
     touchRun?: boolean;
-  }): Promise<void> {
+  }): Promise<AppendEventsResult> {
     if (params.payloads.length === 0) {
-      return;
+      return "appended";
     }
 
-    if (!params.touchRun) {
-      await db.insert(schema.chatActiveRunEventsTable).values({
-        runId: params.runId,
-        seq: params.seq,
-        payloads: params.payloads,
-      });
-      return;
-    }
+    try {
+      if (!params.touchRun) {
+        await db.insert(schema.chatActiveRunEventsTable).values({
+          runId: params.runId,
+          seq: params.seq,
+          payloads: params.payloads,
+        });
+        return "appended";
+      }
 
-    await withDbTransaction(async (tx) => {
-      await tx.insert(schema.chatActiveRunEventsTable).values({
-        runId: params.runId,
-        seq: params.seq,
-        payloads: params.payloads,
+      await withDbTransaction(async (tx) => {
+        await tx.insert(schema.chatActiveRunEventsTable).values({
+          runId: params.runId,
+          seq: params.seq,
+          payloads: params.payloads,
+        });
+        await tx
+          .update(schema.chatActiveRunsTable)
+          .set({ updatedAt: new Date() })
+          .where(eq(schema.chatActiveRunsTable.id, params.runId));
       });
-      await tx
-        .update(schema.chatActiveRunsTable)
-        .set({ updatedAt: new Date() })
-        .where(eq(schema.chatActiveRunsTable.id, params.runId));
-    });
+      return "appended";
+    } catch (error) {
+      if (isRunEventsFkViolation(error)) {
+        return "run_missing";
+      }
+      throw error;
+    }
   }
 
   static async findReplayableByConversation(params: {
@@ -230,3 +243,29 @@ class ActiveChatRunModel {
 }
 
 export default ActiveChatRunModel;
+
+// === internal helpers ===
+
+const RUN_EVENTS_RUN_FK_CONSTRAINT =
+  "chat_active_run_events_run_id_chat_active_runs_id_fk";
+
+// Only the exact run_id foreign key counts as "run gone": a generic FK helper
+// would also swallow unrelated violations. Drizzle wraps the pg error as
+// `cause`, so walk the chain. Mirrors skill-sandbox.ts's isConversationFkViolation.
+function isRunEventsFkViolation(error: unknown): boolean {
+  let current: unknown = error;
+  while (current instanceof Error) {
+    const candidate = current as Error & {
+      code?: unknown;
+      constraint?: unknown;
+    };
+    if (
+      candidate.code === "23503" &&
+      candidate.constraint === RUN_EVENTS_RUN_FK_CONSTRAINT
+    ) {
+      return true;
+    }
+    current = candidate.cause;
+  }
+  return false;
+}

--- a/platform/backend/src/routes/chat/active-run-routes.test.ts
+++ b/platform/backend/src/routes/chat/active-run-routes.test.ts
@@ -269,6 +269,74 @@ describe("chat active-run routes", () => {
     expect(response.statusCode).toBe(200);
     expect(readSsePayloads(response.body)).toContainEqual({ type: "start" });
   });
+
+  test("DELETE removes a conversation with a running active run and cascades its run rows", async () => {
+    const run = await ActiveChatRunModel.create({
+      conversationId,
+      userId: user.id,
+      organizationId,
+    });
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: `/api/chat/conversations/${conversationId}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ success: true });
+    expect(
+      await ConversationModel.findById({
+        id: conversationId,
+        userId: user.id,
+        organizationId,
+      }),
+    ).toBeNull();
+    expect(await ActiveChatRunModel.findById(run?.id ?? "")).toBeNull();
+    expect(
+      await ActiveChatRunModel.findRunningByConversation(conversationId),
+    ).toBeNull();
+  });
+
+  test("DELETE of an inaccessible conversation does not delete or stop another user's running run", async ({
+    makeAgent,
+    makeConversation,
+    makeUser,
+  }) => {
+    const otherUser = await makeUser();
+    const agent = await makeAgent({ organizationId });
+    const inaccessibleConversation = await makeConversation(agent.id, {
+      userId: otherUser.id,
+      organizationId,
+    });
+    const otherRun = await ActiveChatRunModel.create({
+      conversationId: inaccessibleConversation.id,
+      userId: otherUser.id,
+      organizationId,
+    });
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: `/api/chat/conversations/${inaccessibleConversation.id}`,
+    });
+
+    // The owner-scoped delete is a no-op for a conversation this user does not
+    // own, and capturing the run to wake is gated on that same lookup, so the
+    // other user's conversation and running run are left fully intact. The 200
+    // reflects DELETE's existing idempotent contract (unchanged by this fix).
+    expect(response.statusCode).toBe(200);
+    expect(
+      await ConversationModel.findById({
+        id: inaccessibleConversation.id,
+        userId: otherUser.id,
+        organizationId,
+      }),
+    ).not.toBeNull();
+    const run = await ActiveChatRunModel.findRunningByConversation(
+      inaccessibleConversation.id,
+    );
+    expect(run?.id).toBe(otherRun?.id);
+    expect(run?.stopRequestedAt).toBeNull();
+  });
 });
 
 function readSsePayloads(body: string): unknown[] {

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -1997,12 +1997,35 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
       },
     },
     async ({ params: { id }, user, organizationId }, reply) => {
-      // Get conversation to retrieve agentId before deletion
+      // Look up the conversation (owner+org-scoped) before deletion so we can
+      // capture its agent and any running active run for post-delete cleanup.
       const conversation = await ConversationModel.findById({
         id,
         userId: user.id,
         organizationId,
       });
+
+      // Capture the running run id before deletion: the cascade removes the run
+      // row, and we need its id afterward to wake the stream's stop/poll loop.
+      // Gated on the owner+org-scoped lookup above, so it never observes another
+      // tenant's run.
+      const runningRunId = conversation
+        ? ((await ActiveChatRunModel.findRunningByConversation(id))?.id ?? null)
+        : null;
+
+      // The delete is the source of truth. Do not stop the stream or tear down
+      // browser runtime before it succeeds: a failed delete must leave the
+      // conversation and its in-flight response intact.
+      await ConversationModel.delete(id, user.id, organizationId);
+
+      // Post-delete best-effort cleanup; failures here must not fail the
+      // already-successful delete. The run row is now cascade-gone, so waking
+      // its stop/poll loop makes the stream observe the missing row promptly.
+      // The run_missing append path and missing-row poll remain as safety nets
+      // if this wake is lost.
+      if (runningRunId) {
+        await activeChatRunService.notifyConversationDeleted(runningRunId);
+      }
 
       if (conversation?.agentId && browserStreamFeature.isEnabled()) {
         // Close browser tab for this conversation (best effort, don't fail if it errors)
@@ -2019,7 +2042,6 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
         }
       }
 
-      await ConversationModel.delete(id, user.id, organizationId);
       return reply.send({ success: true });
     },
   );

--- a/platform/backend/src/services/active-chat-run.test.ts
+++ b/platform/backend/src/services/active-chat-run.test.ts
@@ -2,6 +2,7 @@ import type { UIMessageChunk } from "ai";
 import { eq } from "drizzle-orm";
 import { vi } from "vitest";
 import db, { schema } from "@/database";
+import { ConversationModel } from "@/models";
 import ActiveChatRunModel from "@/models/chat-active-run";
 import {
   ActiveChatRunService,
@@ -467,6 +468,110 @@ test("reapStaleRuns fails runs past the stale cutoff", async ({
   );
 });
 
+test("startStopPolling aborts when the run row no longer exists", async ({
+  makeAgent,
+  makeConversation,
+  makeOrganization,
+  makeUser,
+}) => {
+  const user = await makeUser();
+  const organization = await makeOrganization();
+  const agent = await makeAgent({ organizationId: organization.id });
+  const conversation = await makeConversation(agent.id, {
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const run = await ActiveChatRunModel.create({
+    conversationId: conversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const notifier = new InMemoryActiveChatRunNotifier();
+  const service = new ActiveChatRunService(notifier, 10_000, 20);
+  const abortController = new AbortController();
+  const stopPolling = service.startStopPolling({
+    runId: run?.id ?? "",
+    conversationId: conversation.id,
+    abortController,
+  });
+
+  // Deleting the conversation cascades the run row away. The stop poll observes
+  // the now-missing row and aborts, the same as DELETE waking it via notify.
+  await ConversationModel.delete(conversation.id, user.id, organization.id);
+  await notifier.notifyStop(run?.id ?? "");
+
+  await waitForAbort(abortController.signal);
+  stopPolling();
+});
+
+test("drainStreamToEvents stops cleanly when the run is deleted before a scheduled flush", async ({
+  makeAgent,
+  makeConversation,
+  makeOrganization,
+  makeUser,
+}) => {
+  const user = await makeUser();
+  const organization = await makeOrganization();
+  const agent = await makeAgent({ organizationId: organization.id });
+  const conversation = await makeConversation(agent.id, {
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const service = new ActiveChatRunService(
+    new InMemoryActiveChatRunNotifier(),
+    10_000,
+    10_000,
+  );
+  const run = await service.createRun({
+    conversationId: conversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+
+  // One chunk then the stream stays open: the batcher schedules a timer flush
+  // rather than an immediate batch flush, so the flush fires only after the
+  // conversation is deleted out from under the drain.
+  let sourceCancelled = false;
+  const stream = new ReadableStream<UIMessageChunk>({
+    start(controller) {
+      controller.enqueue({ type: "start" });
+    },
+    cancel() {
+      sourceCancelled = true;
+    },
+  });
+  const abortController = new AbortController();
+
+  const rejections: unknown[] = [];
+  const onRejection = (reason: unknown) => rejections.push(reason);
+  process.on("unhandledRejection", onRejection);
+
+  try {
+    service.drainStreamToEvents({
+      runId: run?.id ?? "",
+      conversationId: conversation.id,
+      stream,
+      abortController,
+      getTerminalStatus: async () => ({ status: "completed" }),
+    });
+
+    await ConversationModel.delete(conversation.id, user.id, organization.id);
+
+    // The scheduled flush sees run_missing, so the drain aborts the chat and
+    // cancels the source instead of leaving a process-level unhandled rejection.
+    // These waits throw if the controlled run-gone path does not run.
+    await waitForCondition(() => abortController.signal.aborted, 3_000);
+    await waitForCondition(() => sourceCancelled, 1_000);
+    // Brief settle so any stray rejection surfaces before we stop listening.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  } finally {
+    process.off("unhandledRejection", onRejection);
+  }
+
+  expect(rejections).toEqual([]);
+  expect(await ActiveChatRunModel.findById(run?.id ?? "")).toBeNull();
+});
+
 function createChunkStream(
   payloads: UIMessageChunk[],
 ): ReadableStream<UIMessageChunk> {
@@ -516,4 +621,19 @@ async function waitForAbort(signal: AbortSignal): Promise<void> {
   }
 
   throw new Error("Active chat run was not aborted");
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  throw new Error("Condition was not met within timeout");
 }

--- a/platform/backend/src/services/active-chat-run.ts
+++ b/platform/backend/src/services/active-chat-run.ts
@@ -137,6 +137,15 @@ export class ActiveChatRunService {
     return run;
   }
 
+  // Wake the stop-poll loop for a run whose conversation was just deleted. The
+  // run row is already cascade-gone, so the woken poll observes the missing row
+  // and aborts the stream (see startStopPolling). Best-effort: the underlying
+  // notify swallows its own errors, so a lost wake falls back to the poll
+  // interval and never fails the caller's delete.
+  async notifyConversationDeleted(runId: string): Promise<void> {
+    await this.notifyStop(runId);
+  }
+
   drainStreamToEvents(params: {
     runId: string;
     conversationId: string;
@@ -148,10 +157,26 @@ export class ActiveChatRunService {
     abortController?: AbortController;
   }): void {
     void (async () => {
-      const writer = new ActiveChatRunEventBatcher(params.runId, () =>
-        this.notifyEvent(params.runId),
-      );
       const reader = params.stream.getReader();
+      // A timer-triggered flush can fail (or observe the run as gone) while the
+      // drain is blocked on reader.read(). The batcher owns that failure and
+      // wakes us here: abort the chat so upstream stops producing, and cancel
+      // the reader so the pending read resolves and the loop reaches its catch.
+      const writer = new ActiveChatRunEventBatcher({
+        runId: params.runId,
+        onFlush: () => this.notifyEvent(params.runId),
+        onAsyncFailure: () => {
+          if (!params.abortController?.signal.aborted) {
+            params.abortController?.abort();
+          }
+          void reader.cancel().catch((cancelError) => {
+            logger.warn(
+              { cancelError, runId: params.runId },
+              "Failed to cancel active chat run event reader after async flush failure",
+            );
+          });
+        },
+      });
 
       try {
         while (true) {
@@ -197,6 +222,22 @@ export class ActiveChatRunService {
             "Failed to cancel active chat run event reader after drain error",
           );
         });
+
+        // The run row was deleted (its conversation was hard-deleted and
+        // cascaded) while this drain was alive. This is an expected lifecycle
+        // exit, not a persistence failure: stop draining, do not retry inserts
+        // for the gone row, and route through markTerminal only to drop the id
+        // from in-flight tracking (its running-only guard makes the write a
+        // no-op against the missing row).
+        if (error instanceof ActiveChatRunGoneError) {
+          logger.info(
+            { runId: params.runId, conversationId: params.conversationId },
+            "Active chat run row gone during drain, stopping persistence",
+          );
+          await this.markTerminal({ runId: params.runId, status: "cancelled" });
+          return;
+        }
+
         await writer.flush().catch((flushError) => {
           logger.error(
             { flushError, runId: params.runId },
@@ -303,7 +344,20 @@ export class ActiveChatRunService {
 
         try {
           const run = await ActiveChatRunModel.findById(params.runId);
-          if (run?.stopRequestedAt && !params.abortController.signal.aborted) {
+          // The row existed when polling started, so a null read now means the
+          // run was deleted — its conversation was hard-deleted and cascaded.
+          // Treat that as cancellation: there is nothing left to stream into.
+          if (!run) {
+            if (!params.abortController.signal.aborted) {
+              logger.info(
+                { conversationId: params.conversationId, runId: params.runId },
+                "Active chat run row no longer exists, aborting stream",
+              );
+              params.abortController.abort();
+            }
+            return;
+          }
+          if (run.stopRequestedAt && !params.abortController.signal.aborted) {
             logger.info(
               { conversationId: params.conversationId, runId: params.runId },
               "Active chat run stop requested, aborting stream",
@@ -387,13 +441,26 @@ class ActiveChatRunEventBatcher {
   private flushTimer: NodeJS.Timeout | null = null;
   private flushPromise: Promise<void> = Promise.resolve();
   private lastRunTouchAt = 0;
+  private asyncFailure: unknown = null;
+  private readonly runId: string;
+  private readonly onFlush: () => Promise<void>;
+  private readonly onAsyncFailure: (error: unknown) => void;
 
-  constructor(
-    private readonly runId: string,
-    private readonly onFlush: () => Promise<void>,
-  ) {}
+  constructor(params: {
+    runId: string;
+    onFlush: () => Promise<void>;
+    onAsyncFailure: (error: unknown) => void;
+  }) {
+    this.runId = params.runId;
+    this.onFlush = params.onFlush;
+    this.onAsyncFailure = params.onAsyncFailure;
+  }
 
   async write(payload: UIMessageChunk): Promise<void> {
+    if (this.asyncFailure) {
+      throw this.asyncFailure;
+    }
+
     this.pending.push(payload);
 
     if (this.pending.length >= EVENT_BATCH_SIZE) {
@@ -402,13 +469,25 @@ class ActiveChatRunEventBatcher {
     }
 
     if (!this.flushTimer) {
+      // Own the timer-triggered flush: an unowned rejection here (e.g. the FK
+      // violation from a deleted run) would escape as a process-level
+      // unhandledRejection and trip the DB safety net into exiting. Store it so
+      // the next write()/flush() surfaces it into the drain catch, and wake an
+      // idle drain immediately via onAsyncFailure.
       this.flushTimer = setTimeout(() => {
-        void this.flush();
+        void this.flush().catch((error) => {
+          this.asyncFailure ??= error;
+          this.onAsyncFailure(error);
+        });
       }, EVENT_FLUSH_INTERVAL_MS);
     }
   }
 
   async flush(): Promise<void> {
+    if (this.asyncFailure) {
+      throw this.asyncFailure;
+    }
+
     if (this.flushTimer) {
       clearTimeout(this.flushTimer);
       this.flushTimer = null;
@@ -425,14 +504,18 @@ class ActiveChatRunEventBatcher {
     this.pending = [];
     this.nextSeq += 1;
 
-    this.flushPromise = this.flushPromise.then(() =>
-      ActiveChatRunModel.appendEvents({
+    this.flushPromise = this.flushPromise.then(async () => {
+      const result = await ActiveChatRunModel.appendEvents({
         runId: this.runId,
         seq,
         payloads,
         touchRun,
-      }).then(() => this.onFlush()),
-    );
+      });
+      if (result === "run_missing") {
+        throw new ActiveChatRunGoneError(this.runId);
+      }
+      await this.onFlush();
+    });
 
     await this.flushPromise;
   }
@@ -448,6 +531,15 @@ class ActiveChatRunEventBatcher {
 
     this.lastRunTouchAt = now;
     return true;
+  }
+}
+
+// Signals that the run row was deleted out from under an in-flight drain, so
+// the drain should stop persisting rather than treat it as a generic failure.
+class ActiveChatRunGoneError extends Error {
+  constructor(runId: string) {
+    super(`Active chat run ${runId} no longer exists`);
+    this.name = "ActiveChatRunGoneError";
   }
 }
 


### PR DESCRIPTION
## Problem

Deleting a chat conversation while its stream is still draining into `chat_active_run_events` crashed the backend.

Sequence:
1. Deleting the conversation cascade-deletes `chat_active_runs` (and its events).
2. A later timer-triggered event flush inserts with the now-deleted `runId`, raising FK violation `23503` (`chat_active_run_events_run_id_chat_active_runs_id_fk`).
3. The flush was fire-and-forget (`void this.flush()`), so the rejection was unhandled.
4. The process-level DB safety net exits on any non-transient unhandled rejection → backend down.

## Fix

- **Model**: `appendEvents` returns `"appended" | "run_missing"`, detecting only the exact `run_id` FK via a local cause-chain helper (mirrors `skill-sandbox.ts`'s `isConversationFkViolation`). All other errors still throw. Covers both the plain insert and the `touchRun` transaction path.
- **Batcher/drain**: the timer flush is owned (`.catch`), stores the failure, and wakes an idle drain via a callback that aborts the chat and cancels the reader. A `run_missing` result becomes a controlled run-gone exit (logged at `info`, routed through `markTerminal` to drop in-flight tracking) rather than a generic failure.
- **Stop polling**: a missing run row (`findById === null`) is treated as cancellation.
- **DELETE route**: deletes the conversation first (source of truth), then best-effort wakes the run's stop/poll loop and closes the browser tab. A failed delete never pre-cancels the stream or tears down browser runtime; post-delete cleanup failures never fail the successful delete.

Safety nets are layered: `run_missing` append, the missing-row stop poll, and the post-delete wake.

## Tests

Real DB / real models (no mocking of the system under test):
- Model: `run_missing` on both append paths after cascade delete; `appended` for a live run incl. empty payloads.
- Service: stop polling aborts on a missing row; a drain whose run is deleted before its scheduled flush stops cleanly with no unhandled rejection (aborts + cancels source).
- Route: DELETE with a running run cascades the run rows; DELETE of an inaccessible conversation leaves another user's run untouched.

## Notes

- No schema/API change → no OpenAPI/codegen or access-control changes; no docs change.
- Pre-existing unrelated failure in `stream-route.test.ts` (`passes compacted messages to streamText`, prompt-cache breakpoints) reproduces on clean `main` and is out of scope.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>