### PR TITLE
fix(sandbox): decode base64 skill files as root so binary skill mounts materialize

### DIFF
--- a/platform/archestra-rs/sandbox-core/src/backends/dagger.rs
+++ b/platform/archestra-rs/sandbox-core/src/backends/dagger.rs
@@ -390,9 +390,9 @@ const SKILL_MOUNT_CHOWN_CHAIN_LINKS: usize = 3;
 fn snapshot_chain_links(encoding: &str) -> usize {
     match encoding {
         "utf8" => 1,
-        // base64 stages the bytes with `with_new_file` then decodes via
-        // `with_exec`.
-        _ => 2,
+        // base64 runs the decode as root: `with_user` + `with_new_file` +
+        // `with_exec` + `with_user`.
+        _ => 4,
     }
 }
 
@@ -589,7 +589,12 @@ fn apply_snapshot_file(container: Container, root: &str, file: &SnapshotFile) ->
                 .rsplit_once('/')
                 .map(|(parent, _)| parent)
                 .unwrap_or(root);
+            // decode as root: `with_new_file` stages the temp bytes root-owned
+            // (and creates the skill dir tree root-owned), so the redirect must
+            // run as root too. the per-mount `chown -R` below hands the tree back
+            // to the sandbox user once every file in the mount is written.
             Ok(container
+                .with_user("root")
                 .with_new_file(&temp_path, &file.content)
                 .with_exec(vec![
                     "bash".to_string(),
@@ -601,7 +606,8 @@ fn apply_snapshot_file(container: Container, root: &str, file: &SnapshotFile) ->
                         shell_quote(&target),
                         shell_quote(&temp_path),
                     ),
-                ]))
+                ])
+                .with_user(SKILL_SANDBOX_USER))
         }
         other => Err(SandboxError::InvalidInput(format!(
             "unsupported snapshot encoding: {other}"
@@ -839,9 +845,10 @@ mod tests {
     #[test]
     fn snapshot_chain_links_charges_per_encoding() {
         // utf8 snapshot files chain a single with_new_file; base64 files add a
-        // decode exec on top.
+        // root-sandwiched decode exec (with_user + with_new_file + with_exec +
+        // with_user).
         assert_eq!(snapshot_chain_links("utf8"), 1);
-        assert_eq!(snapshot_chain_links("base64"), 2);
+        assert_eq!(snapshot_chain_links("base64"), 4);
     }
 
     #[test]

--- a/platform/archestra-rs/sandbox-core/src/validation.rs
+++ b/platform/archestra-rs/sandbox-core/src/validation.rs
@@ -14,6 +14,14 @@ pub(crate) const SKILL_SANDBOX_ROOT: &str = "/skills";
 pub(crate) const SKILL_SANDBOX_HOME: &str = "/home/sandbox";
 pub(crate) const SKILL_SANDBOX_USER: &str = "1000:1000";
 
+/// validate a skill-relative snapshot file path. rejects absolute paths and
+/// traversal only — intentionally narrower than [`validate_upload_path`] /
+/// [`validate_artifact_path`], and that asymmetry is load-bearing. snapshot
+/// paths are persisted, authored skill content that the upstream skill
+/// validators gate solely on traversal/absolute, so rejecting anything more here
+/// would strand an already-persisted mount as permanently unreplayable. there is
+/// no injection surface to harden: the utf8 branch writes via the Dagger API (no
+/// shell) and the base64 branch shell-quotes the path.
 pub(crate) fn validate_snapshot_file_path(path: &str) -> Result<()> {
     if path.starts_with('/') || path.split('/').any(|segment| segment == "..") {
         return Err(SandboxError::InvalidInput(format!(
@@ -153,6 +161,13 @@ mod tests {
         assert!(validate_snapshot_file_path("/etc/passwd").is_err());
         assert!(validate_snapshot_file_path("../etc/passwd").is_err());
         assert!(validate_snapshot_file_path("a/../../etc/passwd").is_err());
+        // contract: this boundary is intentionally narrower than the
+        // upload/artifact validators. shell metacharacters and control chars are
+        // accepted here because snapshot paths are persisted skill content gated
+        // upstream — rejecting more would strand a persisted mount — and the
+        // downstream writers (Dagger API / shell-quoting) neutralise them.
+        assert!(validate_snapshot_file_path("weights/$MODEL.bin").is_ok());
+        assert!(validate_snapshot_file_path("a\tb").is_ok());
     }
 
     // mirrored with "path validation vectors (mirrored with sandbox-core)" in


### PR DESCRIPTION
## Problem

A skill that mounts at least one **binary file** (any non-UTF-8 file — image, archive, compiled artifact, pickle) bricked every subsequent `run_command` / `download_file` in that conversation.

In `apply_snapshot_file` (Dagger backend), the `base64` branch staged the encoded bytes with `with_new_file` — which Dagger creates **root-owned**, along with the `/skills/<name>` directory tree — and then ran the decode `with_exec` (`base64 -d {temp} > {target}`) as the **sandbox user (uid 1000)**. A redirect into a root-owned directory by an unprivileged user fails with `Permission denied`; the exec isn't built with `expect=Any`, so it surfaces as a hard materialization failure on every replay.

The sibling `apply_upload_file` already handled this correctly with a root-sandwich; the base64 snapshot branch was missing it.

## Fix

- Run the base64 decode under `.with_user("root")` … `.with_user(SKILL_SANDBOX_USER)`, mirroring `apply_upload_file`. The existing per-mount `chown -R` hands the tree back to the sandbox user once every file in the mount is written. The utf8 branch is unchanged (it writes via the Dagger API, no shell exec runs before the chown).
- Bump `snapshot_chain_links("base64")` 2 → 4 for the two added `with_user` calls, so the checkpoint budget keeps each chained GraphQL query under serde_json's 128-level recursion limit. (The old value of 2 was itself unsafe — it under-counted and could let many base64 files slip past a checkpoint.)

## Snapshot-path validation

A second commit **documents** (not changes) `validate_snapshot_file_path`'s intentional narrowness. It validates only traversal/absolute — byte-identical to the upstream skill validators. Tightening it to reject shell metacharacters or control chars (as the upload/artifact validators do) would be a bug: snapshot paths are persisted, authored skill content, so a rejection here strands an already-persisted mount as permanently unreplayable, with no injection benefit (utf8 → Dagger API, base64 → shell-quoted). A doc comment and contract tests lock the invariant.

## Testing

- `cargo test -p sandbox_core` (24 tests) and `cargo clippy` clean.
- The ownership fix itself has no unit test: the crate never materializes against a live Dagger engine, so file ownership/permissions are unobservable in unit tests. A faithful test belongs in the e2e suite (mount a skill with a binary file). The reachable surface — the chain-link budget — is unit-tested.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>