### PR TITLE
chore(sandbox): drop stale references and pin MCP tool tests at the engine boundary

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -343,7 +343,7 @@ COPY docker/scripts/docker-banner.sh /app/docker-banner.sh
 COPY docker/scripts/docker-entrypoint.sh /docker-entrypoint.sh
 # slim Dagger Engine manifest (rendered in the dagger-manifest stage above)
 # applied into the embedded KinD cluster in quickstart mode; backs the skill
-# sandbox / code runtime (archestra__run_python).
+# sandbox / code runtime (archestra__run_command and friends).
 COPY --from=dagger-manifest /dagger-engine.quickstart.yaml /app/dagger-engine.quickstart.yaml
 # engine image baked in (kind-loaded into the node at boot to avoid a registry pull)
 COPY --from=dagger-engine-image /dagger-engine.tar /app/dagger-engine.tar

--- a/platform/backend/src/archestra-mcp-server/sandbox.test.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.test.ts
@@ -19,7 +19,6 @@ import {
 import { executionSandboxRegistry } from "@/skills-sandbox/execution-sandbox-registry";
 import {
   afterAll,
-  afterEach,
   beforeAll,
   beforeEach,
   describe,
@@ -128,6 +127,11 @@ describe("sandbox tools (runtime enabled)", () => {
   });
 
   beforeEach(() => {
+    // full reset (not just call history) so a test's mockRejectedValue /
+    // readArtifact stub cannot leak into the next test.
+    for (const mock of Object.values(nativeMock)) {
+      mock.mockReset();
+    }
     nativeMock.checkSession.mockResolvedValue(undefined);
     nativeMock.runSandbox.mockResolvedValue({
       stdout: "hi\n",
@@ -162,10 +166,6 @@ describe("sandbox tools (runtime enabled)", () => {
       };
     },
   );
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
 
   async function makeConversationCtx(): Promise<ArchestraContext> {
     const conversation = await ConversationModel.create({
@@ -763,57 +763,57 @@ describe("sandbox tools (runtime enabled)", () => {
         expect(log.filter((e) => e.kind === "upload")).toHaveLength(0);
       }
     });
+  });
 
-    describe("revocation gate", () => {
-      test("run_command fails before materialize when a mounted skill was deleted", async () => {
-        const ctx = await makeConversationCtx();
-        const skill = await SkillModel.createWithFiles({
-          skill: {
-            organizationId,
-            authorId: null,
-            name: "doomed",
-            description: "desc",
-            content: "# doomed",
-            metadata: {},
-            sourceType: "manual",
-            scope: "org",
-          },
-          files: [],
-        });
-        if (!skill) throw new Error("skill seed failed");
-        const v1 = await SkillVersionModel.findBySkillAndVersion(skill.id, 1);
-        if (!v1) throw new Error("missing v1");
-
-        const sandbox = await SkillSandboxModel.findOrCreateDefault({
+  describe("revocation gate", () => {
+    test("run_command fails before materialize when a mounted skill was deleted", async () => {
+      const ctx = await makeConversationCtx();
+      const skill = await SkillModel.createWithFiles({
+        skill: {
           organizationId,
-          userId,
-          conversationId: ctx.conversationId as string,
-          defaultCwd: "/home/sandbox",
-        });
-        await SkillSandboxReplayEventModel.appendSkillMount({
-          sandboxId: sandbox.id,
-          organizationId,
-          mount: {
-            skillId: skill.id,
-            skillName: skill.name,
-            skillVersionId: v1.id,
-          },
-        });
-
-        // revoke by deleting the source skill; the mount's durable skillId
-        // no longer resolves, so the gate fails closed.
-        await SkillModel.delete(skill.id);
-
-        const result = await executeArchestraTool(
-          TOOL_RUN_COMMAND_FULL_NAME,
-          { command: "echo hi" },
-          ctx,
-        );
-        expect(result.isError).toBe(true);
-        expect(textOf(result)).toContain("no longer exists");
-        // fail-closed means no engine call was made for this sandbox.
-        expect(nativeMock.runSandbox).not.toHaveBeenCalled();
+          authorId: null,
+          name: "doomed",
+          description: "desc",
+          content: "# doomed",
+          metadata: {},
+          sourceType: "manual",
+          scope: "org",
+        },
+        files: [],
       });
+      if (!skill) throw new Error("skill seed failed");
+      const v1 = await SkillVersionModel.findBySkillAndVersion(skill.id, 1);
+      if (!v1) throw new Error("missing v1");
+
+      const sandbox = await SkillSandboxModel.findOrCreateDefault({
+        organizationId,
+        userId,
+        conversationId: ctx.conversationId as string,
+        defaultCwd: "/home/sandbox",
+      });
+      await SkillSandboxReplayEventModel.appendSkillMount({
+        sandboxId: sandbox.id,
+        organizationId,
+        mount: {
+          skillId: skill.id,
+          skillName: skill.name,
+          skillVersionId: v1.id,
+        },
+      });
+
+      // revoke by deleting the source skill; the mount's durable skillId
+      // no longer resolves, so the gate fails closed.
+      await SkillModel.delete(skill.id);
+
+      const result = await executeArchestraTool(
+        TOOL_RUN_COMMAND_FULL_NAME,
+        { command: "echo hi" },
+        ctx,
+      );
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toContain("no longer exists");
+      // fail-closed means no engine call was made for this sandbox.
+      expect(nativeMock.runSandbox).not.toHaveBeenCalled();
     });
   });
 });

--- a/platform/backend/src/archestra-mcp-server/sandbox.test.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.test.ts
@@ -5,18 +5,18 @@ import {
   TOOL_RUN_COMMAND_FULL_NAME,
   TOOL_UPLOAD_FILE_FULL_NAME,
 } from "@archestra/shared";
+import { vi } from "vitest";
 import config from "@/config";
 import {
   ConversationAttachmentModel,
   ConversationModel,
   SkillModel,
+  SkillSandboxFileModel,
   SkillSandboxModel,
   SkillSandboxReplayEventModel,
   SkillVersionModel,
 } from "@/models";
 import { executionSandboxRegistry } from "@/skills-sandbox/execution-sandbox-registry";
-import { skillSandboxRuntimeService } from "@/skills-sandbox/skill-sandbox-runtime-service";
-import { SkillSandboxError } from "@/skills-sandbox/types";
 import {
   afterAll,
   afterEach,
@@ -25,7 +25,6 @@ import {
   describe,
   expect,
   test,
-  vi,
 } from "@/test";
 import type { Agent } from "@/types";
 import {
@@ -34,6 +33,17 @@ import {
   getArchestraMcpTools,
 } from ".";
 import { TOOL_PERMISSIONS } from "./rbac";
+
+// the Dagger engine is the process boundary: stub the NAPI surface and let the
+// real services (target resolution, queues, staging, persistence) run against
+// PGlite.
+const nativeMock = vi.hoisted(() => ({
+  checkSession: vi.fn(),
+  runSandbox: vi.fn(),
+  readArtifact: vi.fn(),
+  flushTelemetry: vi.fn(),
+}));
+vi.mock("@archestra/sandbox-rs", () => nativeMock);
 
 function textOf(result: { content: unknown[] }): string {
   return (result.content[0] as any).text as string;
@@ -105,13 +115,28 @@ describe("sandbox tools (runtime enabled)", () => {
   let userId: string;
   let context: ArchestraContext;
   const originalEnabled = config.skillsSandbox.enabled;
+  const originalDagger = config.daggerRuntime.enabled;
 
   beforeAll(() => {
     (config.skillsSandbox as { enabled: boolean }).enabled = true;
+    (config.daggerRuntime as { enabled: boolean }).enabled = true;
   });
 
   afterAll(() => {
     (config.skillsSandbox as { enabled: boolean }).enabled = originalEnabled;
+    (config.daggerRuntime as { enabled: boolean }).enabled = originalDagger;
+  });
+
+  beforeEach(() => {
+    nativeMock.checkSession.mockResolvedValue(undefined);
+    nativeMock.runSandbox.mockResolvedValue({
+      stdout: "hi\n",
+      stderr: "",
+      exitCode: 0,
+      durationMs: 12,
+      timedOut: false,
+      truncated: false,
+    });
   });
 
   beforeEach(
@@ -152,43 +177,9 @@ describe("sandbox tools (runtime enabled)", () => {
     return { ...context, conversationId: conversation.id };
   }
 
-  function stubRunCommand(sandboxId: string) {
-    return vi
-      .spyOn(skillSandboxRuntimeService, "runCommand")
-      .mockResolvedValue({
-        commandId: "cmd-1",
-        sandboxId: sandboxId as any,
-        command: "echo hi",
-        cwd: null,
-        stdout: "hi\n",
-        stderr: "",
-        exitCode: 0,
-        durationMs: 12,
-        timedOut: false,
-        truncated: false,
-        stagingNotices: [],
-      });
-  }
-
   describe("run_command", () => {
-    test("lazily creates the conversation default sandbox and delegates to it", async () => {
+    test("lazily creates the conversation default sandbox and runs in it", async () => {
       const ctx = await makeConversationCtx();
-      const runSpy = vi
-        .spyOn(skillSandboxRuntimeService, "runCommand")
-        .mockResolvedValue({
-          commandId: "cmd-1",
-          sandboxId: "placeholder" as any,
-          command: "echo hi",
-          cwd: null,
-          stdout: "hi\n",
-          stderr: "",
-          exitCode: 0,
-          durationMs: 1,
-          timedOut: false,
-          truncated: false,
-          stagingNotices: [],
-        });
-
       const result = await executeArchestraTool(
         TOOL_RUN_COMMAND_FULL_NAME,
         { command: "echo hi" },
@@ -204,19 +195,37 @@ describe("sandbox tools (runtime enabled)", () => {
       expect(sandboxes).toHaveLength(1);
       expect(sandboxes[0].isDefault).toBe(true);
       expect(sandboxes[0].defaultCwd).toBe("/home/sandbox");
-      // ...and the command was delegated to it.
-      expect(runSpy).toHaveBeenCalledWith({
-        sandboxId: sandboxes[0].id,
-        caller: { organizationId, userId },
-        command: "echo hi",
-        cwd: undefined,
-        timeoutSeconds: undefined,
-      });
+
+      // ...the command reached the engine in that sandbox's cwd with an empty
+      // replay (fresh sandbox)...
+      expect(nativeMock.runSandbox).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: "echo hi",
+          cwd: "/home/sandbox",
+          replayEntries: [],
+        }),
+      );
+
+      // ...the engine result came back to the model...
+      const structured = structuredOf<{
+        sandboxId: string;
+        stdout: string;
+        exitCode: number;
+      }>(result);
+      expect(structured.sandboxId).toBe(sandboxes[0].id);
+      expect(structured.stdout).toBe("hi\n");
+      expect(structured.exitCode).toBe(0);
+
+      // ...and the command was appended to the durable replay log.
+      const log = await SkillSandboxReplayEventModel.listBySandbox(
+        sandboxes[0].id,
+      );
+      expect(log).toHaveLength(1);
+      expect(log[0].kind).toBe("command");
     });
 
     test("reuses the same default sandbox across calls in a conversation", async () => {
       const ctx = await makeConversationCtx();
-      stubRunCommand("x");
 
       await executeArchestraTool(
         TOOL_RUN_COMMAND_FULL_NAME,
@@ -234,6 +243,13 @@ describe("sandbox tools (runtime enabled)", () => {
         organizationId,
       });
       expect(sandboxes).toHaveLength(1);
+
+      // the second run replayed the first command before executing.
+      const lastCall = nativeMock.runSandbox.mock.calls.at(-1)?.[0] as {
+        replayEntries: Array<{ kind: string }>;
+      };
+      expect(lastCall.replayEntries).toHaveLength(1);
+      expect(lastCall.replayEntries[0].kind).toBe("command");
     });
 
     test("rejects the default sandbox when there is neither a conversation nor an isolation scope", async () => {
@@ -248,7 +264,6 @@ describe("sandbox tools (runtime enabled)", () => {
 
     test("returns a clean error when the conversation was deleted mid-run", async () => {
       const ctx = await makeConversationCtx();
-      stubRunCommand("x");
       await ConversationModel.delete(
         ctx.conversationId as string,
         userId,
@@ -266,13 +281,13 @@ describe("sandbox tools (runtime enabled)", () => {
 
     test("target {fresh} creates a new non-default sandbox", async () => {
       const ctx = await makeConversationCtx();
-      const runSpy = stubRunCommand("x");
 
-      await executeArchestraTool(
+      const result = await executeArchestraTool(
         TOOL_RUN_COMMAND_FULL_NAME,
         { command: "echo hi", target: { fresh: true } },
         ctx,
       );
+      expect(result.isError).toBe(false);
 
       const sandboxes = await SkillSandboxModel.listForConversation({
         conversationId: ctx.conversationId as string,
@@ -280,14 +295,13 @@ describe("sandbox tools (runtime enabled)", () => {
       });
       expect(sandboxes).toHaveLength(1);
       expect(sandboxes[0].isDefault).toBe(false);
-      expect(runSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ sandboxId: sandboxes[0].id }),
+      expect(structuredOf<{ sandboxId: string }>(result).sandboxId).toBe(
+        sandboxes[0].id,
       );
     });
 
     test("target {id} from a different conversation is rejected", async () => {
       const ctxA = await makeConversationCtx();
-      stubRunCommand("x");
       // create a default sandbox in conversation A
       await executeArchestraTool(
         TOOL_RUN_COMMAND_FULL_NAME,
@@ -316,7 +330,6 @@ describe("sandbox tools (runtime enabled)", () => {
       makeMember,
     }) => {
       const ctx = await makeConversationCtx();
-      stubRunCommand("x");
       await executeArchestraTool(
         TOOL_RUN_COMMAND_FULL_NAME,
         { command: "echo hi" },
@@ -340,10 +353,12 @@ describe("sandbox tools (runtime enabled)", () => {
       expect(textOf(result)).toContain("No accessible sandbox");
     });
 
-    test("surfaces SkillSandboxError messages verbatim", async () => {
+    test("surfaces engine failures to the model as readable text", async () => {
       const ctx = await makeConversationCtx();
-      vi.spyOn(skillSandboxRuntimeService, "runCommand").mockRejectedValue(
-        new SkillSandboxError("the engine is unreachable"),
+      nativeMock.runSandbox.mockRejectedValue(
+        Object.assign(new Error("exit status 153"), {
+          code: "ARCHESTRA_COMMAND_FAILED",
+        }),
       );
       const result = await executeArchestraTool(
         TOOL_RUN_COMMAND_FULL_NAME,
@@ -351,7 +366,9 @@ describe("sandbox tools (runtime enabled)", () => {
         ctx,
       );
       expect(result.isError).toBe(true);
-      expect(textOf(result)).toContain("the engine is unreachable");
+      expect(textOf(result)).toContain(
+        "a setup or replay command in this sandbox failed: exit status 153",
+      );
     });
   });
 
@@ -360,17 +377,12 @@ describe("sandbox tools (runtime enabled)", () => {
       return { ...context, isolationKey: crypto.randomUUID() };
     }
 
-    function resolvedSandboxId(
-      runSpy: ReturnType<typeof stubRunCommand>,
-      callIndex: number,
-    ): string {
-      return (runSpy.mock.calls[callIndex][0] as { sandboxId: string })
-        .sandboxId;
+    function sandboxIdOf(result: { structuredContent?: unknown }): string {
+      return structuredOf<{ sandboxId: string }>(result).sandboxId;
     }
 
     test("default target creates one conversation-less sandbox and reuses it", async () => {
       const ctx = headlessCtx();
-      const runSpy = stubRunCommand("x");
 
       const first = await executeArchestraTool(
         TOOL_RUN_COMMAND_FULL_NAME,
@@ -385,8 +397,8 @@ describe("sandbox tools (runtime enabled)", () => {
       expect(first.isError).toBe(false);
       expect(second.isError).toBe(false);
 
-      const sandboxId = resolvedSandboxId(runSpy, 0);
-      expect(resolvedSandboxId(runSpy, 1)).toBe(sandboxId);
+      const sandboxId = sandboxIdOf(first);
+      expect(sandboxIdOf(second)).toBe(sandboxId);
 
       // never a fake conversation id, never default-flagged (the partial
       // unique index cannot protect null-conversation defaults).
@@ -397,7 +409,6 @@ describe("sandbox tools (runtime enabled)", () => {
 
     test("concurrent first calls share a single sandbox", async () => {
       const ctx = headlessCtx();
-      const runSpy = stubRunCommand("x");
 
       const [first, second] = await Promise.all([
         executeArchestraTool(
@@ -413,18 +424,17 @@ describe("sandbox tools (runtime enabled)", () => {
       ]);
       expect(first.isError).toBe(false);
       expect(second.isError).toBe(false);
-      expect(resolvedSandboxId(runSpy, 0)).toBe(resolvedSandboxId(runSpy, 1));
+      expect(sandboxIdOf(first)).toBe(sandboxIdOf(second));
     });
 
     test("explicit {id} is scoped to the owning execution", async () => {
       const ctxA = headlessCtx();
-      const runSpy = stubRunCommand("x");
-      await executeArchestraTool(
+      const created = await executeArchestraTool(
         TOOL_RUN_COMMAND_FULL_NAME,
         { command: "echo hi" },
         ctxA,
       );
-      const sandboxId = resolvedSandboxId(runSpy, 0);
+      const sandboxId = sandboxIdOf(created);
 
       // the owning execution can target it explicitly...
       const sameExecution = await executeArchestraTool(
@@ -454,13 +464,12 @@ describe("sandbox tools (runtime enabled)", () => {
 
     test("{fresh: true} sandbox is addressable by id within the same execution", async () => {
       const ctx = headlessCtx();
-      const runSpy = stubRunCommand("x");
-      await executeArchestraTool(
+      const created = await executeArchestraTool(
         TOOL_RUN_COMMAND_FULL_NAME,
         { command: "echo hi", target: { fresh: true } },
         ctx,
       );
-      const sandboxId = resolvedSandboxId(runSpy, 0);
+      const sandboxId = sandboxIdOf(created);
       const row = await SkillSandboxModel.findById(sandboxId);
       expect(row?.conversationId).toBeNull();
       expect(row?.isDefault).toBe(false);
@@ -482,38 +491,32 @@ describe("sandbox tools (runtime enabled)", () => {
 
     test("a released execution scope gets a fresh sandbox afterwards", async () => {
       const ctx = headlessCtx();
-      const runSpy = stubRunCommand("x");
-      await executeArchestraTool(
+      const first = await executeArchestraTool(
         TOOL_RUN_COMMAND_FULL_NAME,
         { command: "echo hi" },
         ctx,
       );
-      const before = resolvedSandboxId(runSpy, 0);
+      const before = sandboxIdOf(first);
 
       executionSandboxRegistry.release(ctx.isolationKey as string);
 
-      await executeArchestraTool(
+      const second = await executeArchestraTool(
         TOOL_RUN_COMMAND_FULL_NAME,
         { command: "echo hi" },
         ctx,
       );
-      expect(resolvedSandboxId(runSpy, 1)).not.toBe(before);
+      expect(sandboxIdOf(second)).not.toBe(before);
     });
   });
 
   describe("download_file", () => {
-    test("delegates to the runtime service and returns fileId + downloadUrl", async () => {
+    test("exports the file, persists it as an artifact, and returns fileId + downloadUrl", async () => {
       const ctx = await makeConversationCtx();
-      const exportSpy = vi
-        .spyOn(skillSandboxRuntimeService, "exportArtifact")
-        .mockResolvedValue({
-          artifactId: "artifact-1",
-          sandboxId: "sb" as any,
-          path: "/home/sandbox/out/file.txt",
-          mimeType: "text/plain",
-          sizeBytes: 42,
-          stagingNotices: [],
-        });
+      const bytes = Buffer.from("hello from the sandbox\n", "utf8");
+      nativeMock.readArtifact.mockResolvedValue({
+        dataBase64: bytes.toString("base64"),
+        sizeBytes: bytes.byteLength,
+      });
 
       const result = await executeArchestraTool(
         TOOL_DOWNLOAD_FILE_FULL_NAME,
@@ -521,22 +524,32 @@ describe("sandbox tools (runtime enabled)", () => {
         ctx,
       );
       expect(result.isError).toBe(false);
-      expect(exportSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          path: "out/file.txt",
-          mimeType: "text/plain",
-        }),
+
+      // the relative path resolved against the sandbox cwd at the engine boundary
+      expect(nativeMock.readArtifact).toHaveBeenCalledWith(
+        expect.objectContaining({ path: "/home/sandbox/out/file.txt" }),
       );
+
       const structured = structuredOf<{
         fileId: string;
+        path: string;
+        mimeType: string;
         sizeBytes: number;
         downloadUrl: string;
       }>(result);
-      expect(structured.fileId).toBe("artifact-1");
-      expect(structured.sizeBytes).toBe(42);
+      expect(structured.path).toBe("/home/sandbox/out/file.txt");
+      expect(structured.mimeType).toBe("text/plain");
+      expect(structured.sizeBytes).toBe(bytes.byteLength);
       expect(structured.downloadUrl).toBe(
-        "/api/skill-sandbox/artifacts/artifact-1",
+        `/api/skill-sandbox/artifacts/${structured.fileId}`,
       );
+
+      // the bytes were persisted durably as an artifact row
+      const row = await SkillSandboxFileModel.findArtifactById(
+        structured.fileId,
+      );
+      expect(row?.data.toString("utf8")).toBe(bytes.toString("utf8"));
+
       // text-only — bytes flow sandbox -> DB -> UI via the URL, never via the
       // MCP content array (which the chat layer would stringify into context).
       const contentTypes = (result.content as Array<{ type: string }>).map(
@@ -547,13 +560,13 @@ describe("sandbox tools (runtime enabled)", () => {
 
     test("never attaches inline image content even for small raster files", async () => {
       const ctx = await makeConversationCtx();
-      vi.spyOn(skillSandboxRuntimeService, "exportArtifact").mockResolvedValue({
-        artifactId: "tiny-png",
-        sandboxId: "sb" as any,
-        path: "/home/sandbox/preview.png",
-        mimeType: "image/png",
-        sizeBytes: 256,
-        stagingNotices: [],
+      // real PNG signature so the byte sniffer classifies it as an image
+      const png = Buffer.from([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00,
+      ]);
+      nativeMock.readArtifact.mockResolvedValue({
+        dataBase64: png.toString("base64"),
+        sizeBytes: png.byteLength,
       });
 
       const result = await executeArchestraTool(
@@ -562,43 +575,17 @@ describe("sandbox tools (runtime enabled)", () => {
         ctx,
       );
       expect(result.isError).toBe(false);
+      expect(structuredOf<{ mimeType: string }>(result).mimeType).toBe(
+        "image/png",
+      );
       const contents = result.content as Array<{ type: string }>;
       expect(contents.map((c) => c.type)).toEqual(["text"]);
     });
   });
 
   describe("upload_file", () => {
-    test("delegates to the runtime service and returns upload metadata", async () => {
-      const ctx = await makeConversationCtx();
-      const spy = vi
-        .spyOn(skillSandboxRuntimeService, "uploadFile")
-        .mockResolvedValue({
-          uploadId: "up-1",
-          sandboxId: "sb" as any,
-          path: "/home/sandbox/data.csv",
-          mimeType: "text/csv",
-          sizeBytes: 5,
-        });
-
-      const result = await executeArchestraTool(
-        TOOL_UPLOAD_FILE_FULL_NAME,
-        {
-          path: "data.csv",
-          source: {
-            type: "base64",
-            dataBase64: Buffer.from("a,b,c").toString("base64"),
-          },
-        },
-        ctx,
-      );
-      expect(result.isError).toBe(false);
-      expect(spy).toHaveBeenCalledOnce();
-      expect(structuredOf<{ uploadId: string }>(result).uploadId).toBe("up-1");
-    });
-
     test("enumerates the source variants when the discriminator is missing", async () => {
       const ctx = await makeConversationCtx();
-      const uploadSpy = vi.spyOn(skillSandboxRuntimeService, "uploadFile");
       // the failure from the transcript: a model guessing the source shape gets
       // an opaque "source.type: Invalid input" and never recovers.
       const result = await executeArchestraTool(
@@ -612,7 +599,12 @@ describe("sandbox tools (runtime enabled)", () => {
       expect(text).toContain(
         'source.type: set "type" to one of: "chat_attachment", "base64", "text"',
       );
-      expect(uploadSpy).not.toHaveBeenCalled();
+      // input validation fails before the handler runs, so nothing is created.
+      const sandboxes = await SkillSandboxModel.listForConversation({
+        conversationId: ctx.conversationId as string,
+        organizationId,
+      });
+      expect(sandboxes).toHaveLength(0);
     });
 
     test("rejects a chat attachment from another conversation", async () => {
@@ -635,7 +627,6 @@ describe("sandbox tools (runtime enabled)", () => {
         fileData: bytes,
       });
 
-      const uploadSpy = vi.spyOn(skillSandboxRuntimeService, "uploadFile");
       const result = await executeArchestraTool(
         TOOL_UPLOAD_FILE_FULL_NAME,
         {
@@ -646,139 +637,134 @@ describe("sandbox tools (runtime enabled)", () => {
       );
       expect(result.isError).toBe(true);
       expect(textOf(result)).toContain("different conversation");
-      expect(uploadSpy).not.toHaveBeenCalled();
+
+      // the foreign bytes never became part of any sandbox recipe.
+      const [sandbox] = await SkillSandboxModel.listForConversation({
+        conversationId: ctx.conversationId as string,
+        organizationId,
+      });
+      if (sandbox) {
+        const log = await SkillSandboxReplayEventModel.listBySandbox(
+          sandbox.id,
+        );
+        expect(log.filter((e) => e.kind === "upload")).toHaveLength(0);
+      }
     });
 
-    // uploadFile does no Dagger work, so enabling the runtime engine lets these
-    // exercise the real persistence + validation path against PGlite.
-    describe("with the runtime engine available", () => {
-      const originalDagger = config.daggerRuntime.enabled;
-      beforeAll(() => {
-        (config.daggerRuntime as { enabled: boolean }).enabled = true;
-      });
-      afterAll(() => {
-        (config.daggerRuntime as { enabled: boolean }).enabled = originalDagger;
-      });
+    // uploadFile does no Dagger work — these exercise the real persistence +
+    // validation path against PGlite end to end.
+    test("persists uploaded bytes as an ordered replay event", async () => {
+      const ctx = await makeConversationCtx();
+      const bytes = Buffer.from("col1,col2\n1,2\n", "utf8");
+      const result = await executeArchestraTool(
+        TOOL_UPLOAD_FILE_FULL_NAME,
+        {
+          path: "data/input.csv",
+          source: {
+            type: "base64",
+            dataBase64: bytes.toString("base64"),
+            mimeType: "text/csv",
+            originalName: "input.csv",
+          },
+        },
+        ctx,
+      );
+      expect(result.isError).toBe(false);
+      const structured = structuredOf<{
+        uploadId: string;
+        sandboxId: string;
+        path: string;
+        mimeType: string;
+        sizeBytes: number;
+      }>(result);
+      // default cwd is /home/sandbox, so a relative path resolves there.
+      expect(structured.path).toBe("/home/sandbox/data/input.csv");
+      expect(structured.sizeBytes).toBe(bytes.byteLength);
+      expect(structured.mimeType).toBe("text/csv");
+      expect(structured.uploadId).toBeTruthy();
 
-      test("persists uploaded bytes as an ordered replay event", async () => {
-        const ctx = await makeConversationCtx();
-        const bytes = Buffer.from("col1,col2\n1,2\n", "utf8");
+      const log = await SkillSandboxReplayEventModel.listBySandbox(
+        structured.sandboxId,
+      );
+      const uploads = log.filter((e) => e.kind === "upload");
+      expect(uploads).toHaveLength(1);
+      const [only] = uploads;
+      if (only.kind !== "upload") throw new Error("expected an upload event");
+      expect(only.upload.data.toString("utf8")).toBe(bytes.toString("utf8"));
+      expect(only.upload.path).toBe("/home/sandbox/data/input.csv");
+    });
+
+    test("rejects a path outside the sandbox roots", async () => {
+      const ctx = await makeConversationCtx();
+      const result = await executeArchestraTool(
+        TOOL_UPLOAD_FILE_FULL_NAME,
+        { path: "/etc/passwd", source: { type: "text", text: "x" } },
+        ctx,
+      );
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toContain("must be under");
+    });
+
+    test("rejects an upload larger than the configured limit", async () => {
+      const ctx = await makeConversationCtx();
+      const original = config.skillsSandbox.artifactBytesLimit;
+      (
+        config.skillsSandbox as { artifactBytesLimit: number }
+      ).artifactBytesLimit = 8;
+      try {
         const result = await executeArchestraTool(
           TOOL_UPLOAD_FILE_FULL_NAME,
           {
-            path: "data/input.csv",
-            source: {
-              type: "base64",
-              dataBase64: bytes.toString("base64"),
-              mimeType: "text/csv",
-              originalName: "input.csv",
-            },
+            path: "big.txt",
+            source: { type: "text", text: "way too many bytes" },
           },
           ctx,
         );
-        expect(result.isError).toBe(false);
-        const structured = structuredOf<{
-          sandboxId: string;
-          path: string;
-          sizeBytes: number;
-        }>(result);
-        // default cwd is /home/sandbox, so a relative path resolves there.
-        expect(structured.path).toBe("/home/sandbox/data/input.csv");
-        expect(structured.sizeBytes).toBe(bytes.byteLength);
-
-        const log = await SkillSandboxReplayEventModel.listBySandbox(
-          structured.sandboxId,
-        );
-        const uploads = log.filter((e) => e.kind === "upload");
-        expect(uploads).toHaveLength(1);
-        const [only] = uploads;
-        if (only.kind !== "upload") throw new Error("expected an upload event");
-        expect(only.upload.data.toString("utf8")).toBe(bytes.toString("utf8"));
-        expect(only.upload.path).toBe("/home/sandbox/data/input.csv");
-      });
-
-      test("rejects a path outside the sandbox roots", async () => {
-        const ctx = await makeConversationCtx();
-        const result = await executeArchestraTool(
-          TOOL_UPLOAD_FILE_FULL_NAME,
-          { path: "/etc/passwd", source: { type: "text", text: "x" } },
-          ctx,
-        );
         expect(result.isError).toBe(true);
-        expect(textOf(result)).toContain("must be under");
-      });
-
-      test("rejects an upload larger than the configured limit", async () => {
-        const ctx = await makeConversationCtx();
-        const original = config.skillsSandbox.artifactBytesLimit;
+        expect(textOf(result)).toContain("too large");
+      } finally {
         (
           config.skillsSandbox as { artifactBytesLimit: number }
-        ).artifactBytesLimit = 8;
-        try {
-          const result = await executeArchestraTool(
-            TOOL_UPLOAD_FILE_FULL_NAME,
-            {
-              path: "big.txt",
-              source: { type: "text", text: "way too many bytes" },
-            },
-            ctx,
-          );
-          expect(result.isError).toBe(true);
-          expect(textOf(result)).toContain("too large");
-        } finally {
-          (
-            config.skillsSandbox as { artifactBytesLimit: number }
-          ).artifactBytesLimit = original;
-        }
-      });
-
-      test("rejects an empty upload", async () => {
-        const ctx = await makeConversationCtx();
-        const result = await executeArchestraTool(
-          TOOL_UPLOAD_FILE_FULL_NAME,
-          { path: "empty.txt", source: { type: "text", text: "" } },
-          ctx,
-        );
-        expect(result.isError).toBe(true);
-        expect(textOf(result)).toContain("empty");
-      });
-
-      // a path the Rust replay validator would reject must fail the tool call up
-      // front; otherwise it persists as an event that breaks every later replay.
-      test("rejects a shell-metacharacter path without persisting anything", async () => {
-        const ctx = await makeConversationCtx();
-        const result = await executeArchestraTool(
-          TOOL_UPLOAD_FILE_FULL_NAME,
-          { path: "data/in$put.csv", source: { type: "text", text: "x" } },
-          ctx,
-        );
-        expect(result.isError).toBe(true);
-        expect(textOf(result)).toContain("invalid upload path");
-
-        const [sandbox] = await SkillSandboxModel.listForConversation({
-          conversationId: ctx.conversationId as string,
-          organizationId,
-        });
-        if (sandbox) {
-          const log = await SkillSandboxReplayEventModel.listBySandbox(
-            sandbox.id,
-          );
-          expect(log.filter((e) => e.kind === "upload")).toHaveLength(0);
-        }
-      });
+        ).artifactBytesLimit = original;
+      }
     });
 
-    // the real runtime is enabled here (no runCommand mock) so the revocation
-    // gate runs; a deleted skill must fail the call before any container build.
-    describe("revocation gate", () => {
-      const originalDagger = config.daggerRuntime.enabled;
-      beforeAll(() => {
-        (config.daggerRuntime as { enabled: boolean }).enabled = true;
-      });
-      afterAll(() => {
-        (config.daggerRuntime as { enabled: boolean }).enabled = originalDagger;
-      });
+    test("rejects an empty upload", async () => {
+      const ctx = await makeConversationCtx();
+      const result = await executeArchestraTool(
+        TOOL_UPLOAD_FILE_FULL_NAME,
+        { path: "empty.txt", source: { type: "text", text: "" } },
+        ctx,
+      );
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toContain("empty");
+    });
 
+    // a path the Rust replay validator would reject must fail the tool call up
+    // front; otherwise it persists as an event that breaks every later replay.
+    test("rejects a shell-metacharacter path without persisting anything", async () => {
+      const ctx = await makeConversationCtx();
+      const result = await executeArchestraTool(
+        TOOL_UPLOAD_FILE_FULL_NAME,
+        { path: "data/in$put.csv", source: { type: "text", text: "x" } },
+        ctx,
+      );
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toContain("invalid upload path");
+
+      const [sandbox] = await SkillSandboxModel.listForConversation({
+        conversationId: ctx.conversationId as string,
+        organizationId,
+      });
+      if (sandbox) {
+        const log = await SkillSandboxReplayEventModel.listBySandbox(
+          sandbox.id,
+        );
+        expect(log.filter((e) => e.kind === "upload")).toHaveLength(0);
+      }
+    });
+
+    describe("revocation gate", () => {
       test("run_command fails before materialize when a mounted skill was deleted", async () => {
         const ctx = await makeConversationCtx();
         const skill = await SkillModel.createWithFiles({
@@ -825,6 +811,8 @@ describe("sandbox tools (runtime enabled)", () => {
         );
         expect(result.isError).toBe(true);
         expect(textOf(result)).toContain("no longer exists");
+        // fail-closed means no engine call was made for this sandbox.
+        expect(nativeMock.runSandbox).not.toHaveBeenCalled();
       });
     });
   });

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -722,14 +722,12 @@ const isSupportedDaggerRunnerHost = (runnerHost: string): boolean =>
 // the code execution sandbox (run_command / upload_file / download_file, plus
 // skill activation-mounts) needs a Dagger runner host. it is independent of the
 // skills *read* feature — skills can be listed/activated/read with the sandbox
-// off. the former `run_python` code-runtime env vars now gate the sandbox.
+// off.
 const skillsSandboxRequested =
   process.env.ARCHESTRA_CODE_RUNTIME_ENABLED === "true";
 const skillsSandboxDaggerRunnerHost = parseCodeRuntimeDaggerRunnerHost({
   enabled: skillsSandboxRequested,
-  envValue:
-    process.env.ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST ||
-    process.env.ARCHESTRA_SKILLS_SANDBOX_DAGGER_RUNNER_HOST,
+  envValue: process.env.ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST,
 });
 // a missing/invalid runner host disables the feature instead of crashing boot.
 const skillsSandboxEnabled =
@@ -1123,7 +1121,6 @@ const config = {
     runnerHost: daggerRuntimeRunnerHost,
     cliBin:
       process.env.ARCHESTRA_DAGGER_RUNTIME_CLI_BIN ||
-      process.env.ARCHESTRA_SKILLS_SANDBOX_DAGGER_CLI_BIN ||
       process.env.ARCHESTRA_CODE_RUNTIME_DAGGER_CLI_BIN ||
       undefined,
     maxConcurrent: parsePositiveInt(

--- a/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.test.ts
+++ b/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.test.ts
@@ -5,6 +5,7 @@ import {
   SkillSandboxReplayEventModel,
 } from "@/models";
 import { afterEach, describe, expect, test, vi } from "@/test";
+import { asSandboxId } from "@/types";
 import {
   __internals,
   skillSandboxRuntimeService,
@@ -49,7 +50,7 @@ describe("skillSandboxRuntimeService", () => {
   test("runCommand rejects with SkillSandboxError while disabled", async () => {
     await expect(
       skillSandboxRuntimeService.runCommand({
-        sandboxId: __internals.asSandboxId(crypto.randomUUID()),
+        sandboxId: asSandboxId(crypto.randomUUID()),
         caller: { userId: "u", organizationId: "o" },
         command: "echo hi",
       }),
@@ -59,7 +60,7 @@ describe("skillSandboxRuntimeService", () => {
   test("exportArtifact rejects with SkillSandboxError while disabled", async () => {
     await expect(
       skillSandboxRuntimeService.exportArtifact({
-        sandboxId: __internals.asSandboxId(crypto.randomUUID()),
+        sandboxId: asSandboxId(crypto.randomUUID()),
         caller: { userId: "u", organizationId: "o" },
         path: "out/report.txt",
       }),
@@ -76,7 +77,7 @@ describe("skillSandboxRuntimeService", () => {
 
     await expect(
       enabled.runCommand({
-        sandboxId: __internals.asSandboxId(crypto.randomUUID()),
+        sandboxId: asSandboxId(crypto.randomUUID()),
         caller: { userId: "u", organizationId: "o" },
         command: "echo hi",
         timeoutSeconds,
@@ -89,7 +90,7 @@ describe("skillSandboxRuntimeService", () => {
 
     await expect(
       enabled.runCommand({
-        sandboxId: __internals.asSandboxId(crypto.randomUUID()),
+        sandboxId: asSandboxId(crypto.randomUUID()),
         caller: { userId: "u", organizationId: "o" },
         command: "   ",
       }),
@@ -100,7 +101,7 @@ describe("skillSandboxRuntimeService", () => {
     const enabled = await importEnabledService();
     const { SKILL_SANDBOX_LIMITS } = await import("./types");
 
-    const sandboxId = __internals.asSandboxId(crypto.randomUUID());
+    const sandboxId = asSandboxId(crypto.randomUUID());
     // all N+1 calls are created synchronously, so the first N take queue slots
     // (and later fail — no real Dagger engine) while only the last one trips
     // the guard before any await.
@@ -129,7 +130,7 @@ describe("skillSandboxRuntimeService", () => {
     const enabled = await importEnabledService();
     const { SKILL_SANDBOX_LIMITS } = await import("./types");
 
-    const sandboxId = __internals.asSandboxId(crypto.randomUUID());
+    const sandboxId = asSandboxId(crypto.randomUUID());
     await Promise.allSettled(
       Array.from(
         { length: SKILL_SANDBOX_LIMITS.maxSandboxQueueLength + 1 },
@@ -160,7 +161,7 @@ describe("skillSandboxRuntimeService", () => {
   test("a call enqueued right as the previous one settles is not lost", async () => {
     const enabled = await importEnabledService();
 
-    const sandboxId = __internals.asSandboxId(crypto.randomUUID());
+    const sandboxId = asSandboxId(crypto.randomUUID());
     const run = () =>
       enabled.runCommand({
         sandboxId,

--- a/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
+++ b/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
@@ -48,9 +48,6 @@ const REQUIREMENTS_FILE = "requirements.txt";
 // reserved at the skill root: the mount synthesizes this from the pinned
 // version body, so a resource file may not occupy it or any subpath of it.
 const SKILL_MANIFEST_FILE = "SKILL.md";
-// re-exported alias kept for the {@link} references below; the staging dir is
-// defined alongside the other container paths in runtime-image.
-const ATTACHMENTS_DIR = SKILL_SANDBOX_ATTACHMENTS_DIR;
 // covers the cold first install for a typical skill (pillow + a few siblings);
 // subsequent calls hit Dagger's layer cache and finish in ms.
 const REQUIREMENTS_INSTALL_TIMEOUT_SECONDS = 180;
@@ -847,7 +844,7 @@ function requirementsInstallCommands(
 
 /**
  * Stage the conversation's chat attachments into the default sandbox as upload
- * replay events under {@link ATTACHMENTS_DIR}, so the model can use files the
+ * replay events under {@link SKILL_SANDBOX_ATTACHMENTS_DIR}, so the model can use files the
  * user attached without knowing any attachment id. Idempotent and multi-turn
  * safe: only attachments not already staged (tracked via `source_attachment_id`)
  * are appended, and the DB-level partial unique index makes a concurrent repeat
@@ -961,7 +958,7 @@ function planAttachmentStaging(params: {
 
 /**
  * Map each conversation attachment to a deterministic, shell-safe absolute path
- * under {@link ATTACHMENTS_DIR}. Duplicate sanitized names get a short
+ * under {@link SKILL_SANDBOX_ATTACHMENTS_DIR}. Duplicate sanitized names get a short
  * attachment-id suffix; the input order (created_at, id) is stable, so a given
  * attachment always resolves to the same path across turns.
  */
@@ -982,7 +979,7 @@ function assignAttachmentPaths(
           : `${safe}-${short}`;
     }
     used.add(name);
-    paths.set(attachment.id, `${ATTACHMENTS_DIR}/${name}`);
+    paths.set(attachment.id, `${SKILL_SANDBOX_ATTACHMENTS_DIR}/${name}`);
   }
   return paths;
 }
@@ -1014,5 +1011,4 @@ export const __internals = {
   planAttachmentStaging,
   assignAttachmentPaths,
   sanitizeAttachmentName,
-  asSandboxId,
 };

--- a/platform/dev/Tiltfile.coderuntime
+++ b/platform/dev/Tiltfile.coderuntime
@@ -1,4 +1,5 @@
-# code execution runtime — the Dagger Engine that backs the archestra__run_python tool.
+# code execution runtime — the Dagger Engine that backs the sandbox tools
+# (archestra__run_command / upload_file / download_file).
 #
 # deployed through the dagger-runtime companion chart with network policies
 # disabled, because the backend runs on the developer machine and reaches dagger

--- a/platform/docker/scripts/docker-entrypoint.sh
+++ b/platform/docker/scripts/docker-entrypoint.sh
@@ -221,7 +221,7 @@ if [ "$ARCHESTRA_QUICKSTART" = "true" ]; then
     fi
 
     # Bundle the Dagger Engine that backs the skill sandbox / code runtime
-    # (archestra__run_python). It runs as a privileged pod in the embedded KinD
+    # (archestra__run_command and friends). It runs as a privileged pod in the embedded KinD
     # cluster; the backend reaches it over kube-pod:// (kubectl exec + buildctl
     # dial-stdio), so no Service or TCP port is needed. The manifest is the
     # helm/dagger-runtime chart rendered with laptop-sized resources.

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -168,9 +168,10 @@ archestra:
   envFrom: []
 
   # code execution runtime configuration.
-  # enables the archestra__run_python tool and points the backend at a Dagger
-  # runtime pod. The Python execution image remains a backend default;
-  # override ARCHESTRA_CODE_RUNTIME_IMAGE through archestra.env only when required.
+  # enables the sandbox tools (archestra__run_command / upload_file /
+  # download_file) and points the backend at a Dagger runtime pod. The
+  # execution image remains a backend default; override
+  # ARCHESTRA_DAGGER_RUNTIME_IMAGE through archestra.env only when required.
   codeRuntime:
     # enable or disable code execution runtime support.
     enabled: false

--- a/platform/shared/archestra-mcp-server.ts
+++ b/platform/shared/archestra-mcp-server.ts
@@ -113,7 +113,7 @@ export const TOOL_LOAD_SKILL_SHORT_NAME = "load_skill";
 export const TOOL_CREATE_SKILL_SHORT_NAME = "create_skill";
 export const TOOL_UPDATE_SKILL_SHORT_NAME = "update_skill";
 // code execution sandbox — implicit per-conversation sandbox; the create step
-// is hidden (lazy default) and run_python is folded into run_command.
+// is hidden (lazy default).
 export const TOOL_RUN_COMMAND_SHORT_NAME = "run_command";
 export const TOOL_DOWNLOAD_FILE_SHORT_NAME = "download_file";
 export const TOOL_UPLOAD_FILE_SHORT_NAME = "upload_file";


### PR DESCRIPTION
## Changes

- Drop stale `run_python` references: the tool was folded into `run_command`; comments in `helm/archestra/values.yaml`, `Dockerfile`, `dev/Tiltfile.coderuntime`, `docker/scripts/docker-entrypoint.sh`, `shared/archestra-mcp-server.ts`, and `backend/src/config.ts` now name the current tools.
- Fix the helm values comment that pointed operators at `ARCHESTRA_CODE_RUNTIME_IMAGE`; the backend reads `ARCHESTRA_DAGGER_RUNTIME_IMAGE`.
- Remove the undocumented env fallback aliases `ARCHESTRA_SKILLS_SANDBOX_DAGGER_RUNNER_HOST` / `ARCHESTRA_SKILLS_SANDBOX_DAGGER_CLI_BIN` (never listed in `.env.example`, docs, or any deployment manifest).
- Remove the `asSandboxId` re-export from `__internals` (tests import it from `@/types`) and inline the `ATTACHMENTS_DIR` alias.
- Rewrite `archestra-mcp-server/sandbox.test.ts`: replace `vi.spyOn(skillSandboxRuntimeService, …)` with `vi.mock("@archestra/sandbox-rs")` so the real services (target resolution, per-sandbox queues, attachment staging, replay assembly, persistence) run against PGlite and only the Dagger engine boundary is stubbed. The tests now also pin replay accumulation across calls, artifact persistence round-trips, the engine-error translation chain, and that the revocation gate fails closed before any engine call.

## Validation

- Full backend suite: 7949 passed, 8 skipped
- `pnpm lint`, `pnpm type-check`, `pnpm knip` (dev + production) clean
- `helm template` renders; repo-wide greps for `run_python`, `ARCHESTRA_CODE_RUNTIME_IMAGE`, and `ARCHESTRA_SKILLS_SANDBOX_DAGGER*` return no hits outside the changelog

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>