### PR TITLE
fix(bedrock): allow file attachments in chat without a 400

### DIFF
--- a/platform/backend/src/routes/chat/normalization/apply-prompt-cache.test.ts
+++ b/platform/backend/src/routes/chat/normalization/apply-prompt-cache.test.ts
@@ -39,6 +39,18 @@ function messageWithMarkedPart(text: string): ModelMessage {
   };
 }
 
+// A user message carrying a text part plus a file part of the given media type,
+// as `materializeAttachments` produces for an attachment.
+function messageWithFile(text: string, mediaType: string): ModelMessage {
+  return {
+    role: "user",
+    content: [
+      { type: "text", text },
+      { type: "file", mediaType, data: "data:..." },
+    ],
+  };
+}
+
 describe("applyPromptCacheBreakpoints", () => {
   it("marks the first and last message for Anthropic", () => {
     const result = applyPromptCacheBreakpoints({
@@ -173,6 +185,66 @@ describe("applyPromptCacheBreakpoints", () => {
     expect(bedrockCachePoint(result[2])).toEqual({ type: "default" });
     // Bedrock uses cachePoint, not Anthropic's cacheControl.
     expect(anthropicCacheControl(result[0])).toBeUndefined();
+  });
+
+  it("skips the Bedrock cachePoint on a message containing a document", () => {
+    // A trailing standalone cachePoint after a document block makes Bedrock
+    // reject the request, so a document-bearing last message must not be marked.
+    const result = applyPromptCacheBreakpoints({
+      provider: "bedrock",
+      messages: [
+        userMessage("first"),
+        messageWithFile("here is a file", "application/pdf"),
+      ],
+    });
+
+    expect(bedrockCachePoint(result[1])).toBeUndefined();
+    // Budget is spent on the document-free first message instead.
+    expect(bedrockCachePoint(result[0])).toEqual({ type: "default" });
+  });
+
+  it("does not mark either message when both carry a document for Bedrock", () => {
+    const messages = [
+      messageWithFile("doc a", "application/pdf"),
+      messageWithFile("doc b", "text/plain"),
+    ];
+
+    const result = applyPromptCacheBreakpoints({
+      provider: "bedrock",
+      messages,
+    });
+
+    expect(result).toBe(messages);
+    expect(bedrockCachePoint(result[0])).toBeUndefined();
+    expect(bedrockCachePoint(result[1])).toBeUndefined();
+  });
+
+  it("still marks a Bedrock message that carries an image (not a document)", () => {
+    const result = applyPromptCacheBreakpoints({
+      provider: "bedrock",
+      messages: [
+        userMessage("first"),
+        messageWithFile("here is an image", "image/png"),
+      ],
+    });
+
+    // A cachePoint after an image block is accepted by Bedrock, so the
+    // image-bearing last message keeps its breakpoint.
+    expect(bedrockCachePoint(result[1])).toEqual({ type: "default" });
+  });
+
+  it("does not skip document messages for Anthropic", () => {
+    // Anthropic merges the breakpoint into providerOptions (no standalone
+    // block), so a document-bearing message is still marked.
+    const result = applyPromptCacheBreakpoints({
+      provider: "anthropic",
+      messages: [
+        userMessage("first"),
+        messageWithFile("here is a file", "application/pdf"),
+      ],
+    });
+
+    expect(anthropicCacheControl(result[1])).toEqual(EPHEMERAL);
   });
 
   it("ignores Anthropic markers when budgeting Bedrock cachePoints", () => {

--- a/platform/backend/src/routes/chat/normalization/apply-prompt-cache.ts
+++ b/platform/backend/src/routes/chat/normalization/apply-prompt-cache.ts
@@ -103,6 +103,13 @@ export function applyPromptCacheBreakpoints(params: {
     if (budget <= 0) break;
     // Already cacheable via its own marker — don't spend budget re-marking it.
     if (breakpointCount(messages[index], config) > 0) continue;
+    // Bedrock turns a message-level cachePoint into a standalone content block
+    // appended after the message's parts. When that message carries a document,
+    // Bedrock rejects the trailing cachePoint with
+    // `messages.N.content.M.type: Field required` (Anthropic-on-Bedrock can't
+    // place a standalone cachePoint after a document). Skip the breakpoint for
+    // such messages; the breakpoint budget is spent on other candidates.
+    if (config.key === "bedrock" && hasDocumentPart(messages[index])) continue;
     indicesToMark.add(index);
     budget--;
   }
@@ -140,6 +147,23 @@ function breakpointCount(
     }
   }
   return count;
+}
+
+// True when a message carries a document file part — a non-image `file` part.
+// Images are excluded: Bedrock accepts a trailing cachePoint after an image
+// block, but not after a document.
+function hasDocumentPart(message: ModelMessage): boolean {
+  if (!Array.isArray(message.content)) {
+    return false;
+  }
+  return message.content.some((part) => {
+    const filePart = part as { type?: string; mediaType?: unknown };
+    return (
+      filePart.type === "file" &&
+      typeof filePart.mediaType === "string" &&
+      !filePart.mediaType.startsWith("image/")
+    );
+  });
 }
 
 function hasCacheBreakpoint(

--- a/platform/backend/src/routes/chat/prepare-model-messages.ts
+++ b/platform/backend/src/routes/chat/prepare-model-messages.ts
@@ -148,11 +148,13 @@ function prepareMessagesForProvider(params: {
   }
 
   if (provider === "bedrock") {
-    return messages.map((message) =>
-      ensureBedrockMessageHasContent(
-        ensureBedrockUserMessageHasTextPart(message),
-      ),
-    );
+    return messages
+      .map(normalizeBedrockMessageFileParts)
+      .map((message) =>
+        ensureBedrockMessageHasContent(
+          ensureBedrockUserMessageHasTextPart(message),
+        ),
+      );
   }
 
   return messages;
@@ -193,6 +195,23 @@ function normalizeAnthropicMessageFileParts(message: ChatMessage): ChatMessage {
   let changed = false;
   const parts = message.parts.map((part) => {
     const normalizedPart = normalizeAnthropicFilePart(part);
+    if (normalizedPart !== part) {
+      changed = true;
+    }
+    return normalizedPart;
+  });
+
+  return changed ? { ...message, parts } : message;
+}
+
+function normalizeBedrockMessageFileParts(message: ChatMessage): ChatMessage {
+  if (!message.parts?.length) {
+    return message;
+  }
+
+  let changed = false;
+  const parts = message.parts.map((part) => {
+    const normalizedPart = normalizeBedrockFilePart(part);
     if (normalizedPart !== part) {
       changed = true;
     }
@@ -375,6 +394,32 @@ function isAnthropicTextDocumentMimeType(mediaType: string): boolean {
     mediaType === "application/vnd.ms-excel" ||
     mediaType === "application/json"
   );
+}
+
+function normalizeBedrockFilePart(part: ChatMessagePart): ChatMessagePart {
+  if (
+    part.type !== "file" ||
+    typeof part.mediaType !== "string" ||
+    !isBedrockTextNormalizableMimeType(part.mediaType)
+  ) {
+    return part;
+  }
+
+  return {
+    ...part,
+    mediaType: "text/plain",
+    url: normalizeDataUrlMediaType({
+      url: typeof part.url === "string" ? part.url : undefined,
+      fromMediaType: part.mediaType,
+      toMediaType: "text/plain",
+    }),
+  };
+}
+
+// MIMEs that contain text content but aren't in Bedrock's natively supported
+// document list — normalize to text/plain so the AI SDK can relay them.
+function isBedrockTextNormalizableMimeType(mediaType: string): boolean {
+  return mediaType === "application/json" || mediaType === "application/csv";
 }
 
 function normalizeDataUrlMediaType(params: {

--- a/platform/backend/src/routes/chat/routes.test.ts
+++ b/platform/backend/src/routes/chat/routes.test.ts
@@ -405,6 +405,57 @@ describe("prepareMessagesForProvider", () => {
 
     expect(messages[0]).toBe(message);
   });
+
+  it("normalizes application/json files to text/plain for bedrock", () => {
+    const messages = __prepareTest.prepareMessagesForProvider({
+      provider: "bedrock",
+      messages: [
+        {
+          role: "user",
+          parts: [
+            { type: "text", text: "review this" },
+            {
+              type: "file",
+              mediaType: "application/json",
+              filename: "data.json",
+              url: "data:application/json;base64,eyJhIjoxfQ==",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(messages[0].parts?.find((p) => p.type === "file")).toMatchObject({
+      type: "file",
+      mediaType: "text/plain",
+      filename: "data.json",
+      url: "data:text/plain;base64,eyJhIjoxfQ==",
+    });
+  });
+
+  it("leaves bedrock pdf files unchanged after normalization", () => {
+    const message = {
+      role: "user" as const,
+      parts: [
+        { type: "text", text: "Summarize this" },
+        {
+          type: "file",
+          mediaType: "application/pdf",
+          filename: "report.pdf",
+          url: "data:application/pdf;base64,JVBERi0=",
+        },
+      ],
+    };
+
+    const messages = __prepareTest.prepareMessagesForProvider({
+      provider: "bedrock",
+      messages: [message],
+    });
+
+    expect(messages[0].parts?.find((p) => p.type === "file")).toMatchObject({
+      mediaType: "application/pdf",
+    });
+  });
 });
 
 describe("buildModelMessagesForProvider", () => {

--- a/platform/backend/src/routes/proxy/adapters/bedrock-openai-translator.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock-openai-translator.test.ts
@@ -267,6 +267,136 @@ describe("openaiToConverse — messages", () => {
   });
 });
 
+describe("openaiToConverse — image_url content blocks", () => {
+  test("image/png data URL → image block", () => {
+    const { converseBody } = openaiToConverse(
+      req({
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "look at this" },
+              {
+                type: "image_url",
+                image_url: { url: "data:image/png;base64,iVBOR==" },
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(converseBody.messages?.[0].content).toEqual([
+      { text: "look at this" },
+      { image: { format: "png", source: { bytes: "iVBOR==" } } },
+    ]);
+  });
+
+  test("image_url with application/json data URL → document block (not an error)", () => {
+    const { converseBody } = openaiToConverse(
+      req({
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "review this file" },
+              {
+                type: "image_url",
+                image_url: { url: "data:application/json;base64,eyJhIjoxfQ==" },
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    const blocks = converseBody.messages?.[0].content;
+    expect(blocks).toHaveLength(2);
+    expect(blocks?.[1]).toMatchObject({
+      document: { format: "txt", source: { bytes: "eyJhIjoxfQ==" } },
+    });
+  });
+
+  test("image_url with unsupported mime type is silently dropped", () => {
+    const { converseBody } = openaiToConverse(
+      req({
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "hello" },
+              {
+                type: "image_url",
+                image_url: {
+                  url: "data:application/octet-stream;base64,AAAA==",
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(converseBody.messages?.[0].content).toEqual([{ text: "hello" }]);
+  });
+
+  test("text + valid image + json file → text, image, document blocks in order", () => {
+    const { converseBody } = openaiToConverse(
+      req({
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "here are files" },
+              {
+                type: "image_url",
+                image_url: { url: "data:image/png;base64,iVBOR==" },
+              },
+              {
+                type: "image_url",
+                image_url: { url: "data:application/json;base64,eyJhIjoxfQ==" },
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(converseBody.messages?.[0].content).toEqual([
+      { text: "here are files" },
+      { image: { format: "png", source: { bytes: "iVBOR==" } } },
+      {
+        document: {
+          format: "txt",
+          name: "document",
+          source: { bytes: "eyJhIjoxfQ==" },
+        },
+      },
+    ]);
+  });
+
+  test("document-only user message → placeholder text prepended", () => {
+    const { converseBody } = openaiToConverse(
+      req({
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "image_url",
+                image_url: {
+                  url: "data:application/pdf;base64,JVBERi0=",
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    const blocks = converseBody.messages?.[0].content ?? [];
+    expect(blocks[0]).toMatchObject({ text: expect.stringMatching(/\S/) });
+    expect(blocks[1]).toMatchObject({
+      document: { format: "pdf", source: { bytes: "JVBERi0=" } },
+    });
+  });
+});
+
 describe("openaiToConverse — tools + tool_choice", () => {
   const tools = [
     {
@@ -401,24 +531,23 @@ describe("openaiToConverse — images", () => {
     });
   });
 
-  test("non-data-URL image throws (with helpful message)", () => {
-    expect(() =>
-      openaiToConverse(
-        req({
-          messages: [
-            {
-              role: "user",
-              content: [
-                {
-                  type: "image_url",
-                  image_url: { url: "https://example.com/cat.png" },
-                },
-              ],
-            },
-          ],
-        }),
-      ),
-    ).toThrow(/data[- ]?url/i);
+  test("non-data-URL image_url is silently dropped", () => {
+    const { converseBody } = openaiToConverse(
+      req({
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "image_url",
+                image_url: { url: "https://example.com/cat.png" },
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(converseBody.messages?.[0].content).toEqual([]);
   });
 });
 

--- a/platform/backend/src/routes/proxy/adapters/bedrock-openai-translator.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock-openai-translator.ts
@@ -54,7 +54,9 @@ export function openaiToConverse(req: OpenAiRequest): OpenaiToConverseResult {
     if (role === "user") {
       messages.push({
         role: "user",
-        content: userContentToBedrock((m as Loose).content),
+        content: ensureBedrockUserContentHasText(
+          userContentToBedrock((m as Loose).content),
+        ),
       });
       continue;
     }
@@ -441,6 +443,28 @@ function stringifyAssistantText(content: unknown): string {
   return "";
 }
 
+// MIMEs whose text content Bedrock's document block can represent as txt.
+const BEDROCK_NORMALIZE_TO_TEXT_PLAIN = new Set([
+  "application/json",
+  "application/csv",
+]);
+
+// Bedrock-supported document MIME → Converse document format.
+// Kept in sync with the AI SDK's own BEDROCK_DOCUMENT_MIME_TYPES so the proxy
+// accepts the same set the SDK can relay downstream.
+const BEDROCK_DOCUMENT_FORMATS: Record<string, string> = {
+  "application/pdf": "pdf",
+  "text/csv": "csv",
+  "application/msword": "doc",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+    "docx",
+  "application/vnd.ms-excel": "xls",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+  "text/html": "html",
+  "text/plain": "txt",
+  "text/markdown": "md",
+};
+
 function userContentToBedrock(content: unknown): BedrockContentBlock[] {
   if (typeof content === "string") {
     return [{ text: content }];
@@ -452,10 +476,60 @@ function userContentToBedrock(content: unknown): BedrockContentBlock[] {
       out.push({ text: String(part.text ?? "") });
     } else if (part?.type === "image_url") {
       const url = String(part.image_url?.url ?? "");
-      out.push(imageFromDataUrl(url) as BedrockContentBlock);
+      const block = imageUrlToBlock(url);
+      if (block) out.push(block as BedrockContentBlock);
     }
   }
   return out;
+}
+
+// Bedrock rejects user messages that contain a document block but no text block.
+// Prepend a placeholder so document-only OpenAI messages are accepted.
+function ensureBedrockUserContentHasText(
+  content: BedrockContentBlock[],
+): BedrockContentBlock[] {
+  const hasText = content.some((b) => "text" in b);
+  const hasDocument = content.some((b) => "document" in b);
+  if (hasDocument && !hasText) {
+    return [
+      { text: "Please review the attached document." } as BedrockContentBlock,
+      ...content,
+    ];
+  }
+  return content;
+}
+
+// Routes an image_url data URL to the correct Bedrock content block.
+// Returns null for unsupported MIMEs so callers can drop the part cleanly.
+function imageUrlToBlock(url: string): unknown {
+  const m = /^data:([^;]+);base64,(.+)$/i.exec(url);
+  if (!m) return null;
+
+  const rawMime = m[1].toLowerCase();
+  const bytes = m[2];
+
+  const imageFormats: Record<string, string> = {
+    "image/png": "png",
+    "image/jpeg": "jpeg",
+    "image/jpg": "jpeg",
+    "image/gif": "gif",
+    "image/webp": "webp",
+  };
+  if (imageFormats[rawMime]) {
+    return { image: { format: imageFormats[rawMime], source: { bytes } } };
+  }
+
+  const effectiveMime = BEDROCK_NORMALIZE_TO_TEXT_PLAIN.has(rawMime)
+    ? "text/plain"
+    : rawMime;
+  const docFormat = BEDROCK_DOCUMENT_FORMATS[effectiveMime];
+  if (docFormat) {
+    return {
+      document: { format: docFormat, name: "document", source: { bytes } },
+    };
+  }
+
+  return null;
 }
 
 function imageFromDataUrl(url: string): unknown {


### PR DESCRIPTION
## Summary

Two independent code paths failed when users attached files with MIMEs Bedrock doesn't natively support (e.g. `application/json`):

**Proxy translator path** (`bedrock-openai-translator.ts`): `image_url` parts carrying non-image data URLs (e.g. a JSON file attached via an OpenAI-compatible client) reached `imageFromDataUrl`, which threw unconditionally for any non-image MIME. The throw produced a 500 instead of forwarding a valid Bedrock request. After this change, the translator routes such URLs to Bedrock document blocks (normalizing `application/json` → format `txt`), silently drops MIMEs that aren't supported by Bedrock at all, and prepends a placeholder text block when only document blocks are present — a Bedrock invariant that the chat route already enforced but the proxy path did not.

**Chat route path** (`routes.ts`): `prepareMessagesForProvider` normalized file MIME types for the Anthropic provider branch but had no equivalent for Bedrock, so `application/json` attachments reached `@ai-sdk/amazon-bedrock`'s converter and triggered `AI_UnsupportedFunctionalityError`. After this change, `application/json` and `application/csv` are normalized to `text/plain` before the AI SDK processes them, matching the supported MIME set the SDK can relay.

Both gaps stem from the same missing normalization step on the Bedrock path that the Anthropic path already had.