### PR TITLE
feat: improve usage limits visibility UX and DX (#4758)

### DIFF
--- a/platform/backend/src/models/limit.ts
+++ b/platform/backend/src/models/limit.ts
@@ -46,6 +46,7 @@ type LimitViolationResponse = [
   metadata?: {
     entityType: LimitEntityType;
     limitType: "token_cost";
+    entityId?: string;
   },
 ];
 
@@ -1287,7 +1288,7 @@ Please contact your administrator to increase the limit or wait for the usage to
   return [
     `${archestraMetadata}\n${contentMessage}`,
     contentMessage,
-    { entityType: params.entityType, limitType: "token_cost" },
+    { entityType: params.entityType, limitType: "token_cost", entityId: params.entityId },
   ];
 }
 

--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -318,7 +318,7 @@ function extractArchestraInternalCode(
 
 function extractUsageLimitError(
   responseBody: string | undefined,
-): { entityType?: string } | null {
+): { entityType?: string; entityId?: string } | null {
   if (!responseBody) return null;
   try {
     const parsed = JSON.parse(responseBody);
@@ -329,6 +329,10 @@ function extractUsageLimitError(
       entityType:
         typeof parsed.error.usage_limit?.entity_type === "string"
           ? parsed.error.usage_limit.entity_type
+          : undefined,
+      entityId:
+        typeof parsed.error.usage_limit?.entity_id === "string"
+          ? parsed.error.usage_limit.entity_id
           : undefined,
     };
   } catch {
@@ -1562,7 +1566,7 @@ function createErrorResponse(
   originalMessage: string,
   errorType: string | undefined,
   rawError: unknown,
-  usageLimitError?: { entityType?: string } | null,
+  usageLimitError?: { entityType?: string; entityId?: string } | null,
 ): ChatErrorResponse {
   const response: ChatErrorResponse = {
     code,
@@ -1581,6 +1585,7 @@ function createErrorResponse(
   if (usageLimitError) {
     response.usageLimitExceeded = true;
     response.usageLimitEntityType = usageLimitError.entityType;
+    response.usageLimitEntityId = usageLimitError.entityId;
   }
   return response;
 }
@@ -1833,6 +1838,7 @@ export function sanitizeChatErrorForFrontend(
   if (error.usageLimitExceeded) {
     sanitized.usageLimitExceeded = true;
     sanitized.usageLimitEntityType = error.usageLimitEntityType;
+    sanitized.usageLimitEntityId = error.usageLimitEntityId;
   }
   return sanitized;
 }

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -518,6 +518,7 @@ export async function handleLLMProxy<
             ? {
                 limit_type: limitMetadata.limitType,
                 entity_type: limitMetadata.entityType,
+                entity_id: (limitMetadata as any).entityId,
               }
             : undefined,
         },

--- a/platform/frontend/src/app/agents/agent-actions.tsx
+++ b/platform/frontend/src/app/agents/agent-actions.tsx
@@ -4,6 +4,7 @@ import {
   Copy,
   Download,
   Eye,
+  Gauge,
   MessageSquare,
   Pencil,
   Plug,
@@ -121,6 +122,14 @@ export function AgentActions({
       disabledTooltip: "Built-in agents cannot be scheduled",
       permissions: { scheduledTask: ["read"] },
       href: `/scheduled-tasks?agentId=${agent.id}`,
+    },
+    {
+      icon: <Gauge className="h-4 w-4" />,
+      label: "Manage limits",
+      permissions: { llmLimit: ["read"] },
+      disabled: isBuiltIn,
+      disabledTooltip: "Built-in agents cannot have limits",
+      href: `/llm/limits?appliedTo=agent&entityId=${agent.id}`,
     },
     {
       icon: <Copy className="h-4 w-4" />,

--- a/platform/frontend/src/app/llm/(costs)/limits/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.tsx
@@ -5,6 +5,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import {
   Building2,
   Edit,
+  Gauge,
   Info,
   Key,
   Network,
@@ -184,6 +185,7 @@ export default function LimitsPage() {
   const statusFilter = searchParams.get("status") || "all";
   const appliedToFilter = searchParams.get("appliedTo") || "all";
   const modelFilter = searchParams.get("model") || "all";
+  const entityIdFilter = searchParams.get("entityId") || "all";
   const [editingLimit, setEditingLimit] = useState<LimitData | null>(null);
   const [limitToDelete, setLimitToDelete] = useState<LimitData | null>(null);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -209,9 +211,28 @@ export default function LimitsPage() {
 
   const handleCreateOpen = useCallback(() => {
     setEditingLimit(null);
-    setFormState(DEFAULT_FORM_STATE);
+    const initialEntityType = appliedToFilter !== "all" ? (appliedToFilter as LimitFormEntityType) : "organization";
+    const initialEntityId = entityIdFilter !== "all" ? entityIdFilter : "";
+    setFormState({
+      entityType: initialEntityType,
+      entityId: initialEntityId,
+      limitValue: "",
+      cleanupInterval: DEFAULT_LIMIT_CLEANUP_INTERVAL,
+      models: [],
+      isAllModels: true,
+    });
     setIsDialogOpen(true);
-  }, []);
+  }, [appliedToFilter, entityIdFilter]);
+
+  // Handle 'create' URL parameter to open the Add Limit dialog
+  const createFromUrl = searchParams.get("create") === "true";
+  useEffect(() => {
+    if (createFromUrl) {
+      handleCreateOpen();
+      // Remove the 'create' parameter from URL after opening the dialog
+      updateQueryParams({ create: null });
+    }
+  }, [createFromUrl, handleCreateOpen, updateQueryParams]);
 
   useEffect(() => {
     setActionButton(
@@ -375,8 +396,10 @@ export default function LimitsPage() {
         modelFilter === "all" ||
         (Array.isArray(limit.model) && limit.model.includes(modelFilter)) ||
         isAllModelsLimit;
+      const matchesEntityId =
+        entityIdFilter === "all" || limit.entityId === entityIdFilter;
 
-      return matchesStatus && matchesAppliedTo && matchesModel;
+      return matchesStatus && matchesAppliedTo && matchesModel && matchesEntityId;
     });
   }, [
     appliedToFilter,
@@ -386,6 +409,7 @@ export default function LimitsPage() {
     getUsageStatus,
     agents,
     llmProxies,
+    entityIdFilter,
   ]);
 
   const columns = useMemo<ColumnDef<LimitData>[]>(
@@ -563,7 +587,8 @@ export default function LimitsPage() {
   const hasActiveFilters =
     statusFilter !== "all" ||
     appliedToFilter !== "all" ||
-    modelFilter !== "all";
+    modelFilter !== "all" ||
+    entityIdFilter !== "all";
   const shouldShowDefaultUserLimitNotice =
     formState.entityType === "user" && !!organization?.defaultUserLimitValue;
 
@@ -697,7 +722,7 @@ export default function LimitsPage() {
           hasActiveFilters={hasActiveFilters}
           filteredEmptyMessage="No limits match your filters. Try adjusting your search."
           onClearFilters={() => {
-            updateQueryParams({ status: null, appliedTo: null, model: null });
+            updateQueryParams({ status: null, appliedTo: null, model: null, entityId: null });
           }}
         />
       </LoadingWrapper>

--- a/platform/frontend/src/app/llm/credentials/virtual-keys/page.tsx
+++ b/platform/frontend/src/app/llm/credentials/virtual-keys/page.tsx
@@ -8,6 +8,7 @@ import {
 } from "@archestra/shared";
 import type { ColumnDef } from "@tanstack/react-table";
 import {
+  Gauge,
   Globe,
   Key,
   Loader2,
@@ -187,6 +188,12 @@ export default function VirtualKeysPage() {
                 icon: <Pencil className="h-4 w-4" />,
                 label: "Edit",
                 onClick: () => setEditingKey(row.original),
+              },
+              {
+                icon: <Gauge className="h-4 w-4" />,
+                label: "Manage limits",
+                permissions: { llmLimit: ["read"] },
+                href: `/llm/limits?appliedTo=virtual_key&entityId=${row.original.id}`,
               },
               {
                 icon: <Trash2 className="h-4 w-4" />,

--- a/platform/frontend/src/app/llm/proxies/llm-proxy-actions.tsx
+++ b/platform/frontend/src/app/llm/proxies/llm-proxy-actions.tsx
@@ -1,5 +1,6 @@
 import { E2eTestId } from "@archestra/shared";
-import { Pencil, Plug, RotateCcw, Trash2 } from "lucide-react";
+import { Gauge, Pencil, Plug, RotateCcw, Trash2 } from "lucide-react";
+import Link from "next/link";
 import { ButtonGroup } from "@/components/ui/button-group";
 import { PermissionButton } from "@/components/ui/permission-button";
 import type { useProfilesPaginated } from "@/lib/agent.query";
@@ -74,6 +75,20 @@ export function LlmProxyActions({
         }}
       >
         <Pencil className="h-4 w-4" />
+      </PermissionButton>
+      <PermissionButton
+        permissions={{ llmLimit: ["read"] }}
+        aria-label="Manage limits"
+        variant="outline"
+        size="icon-sm"
+        asChild
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+      >
+        <Link href={`/llm/limits?appliedTo=llm_proxy&entityId=${agent.id}`}>
+          <Gauge className="h-4 w-4" />
+        </Link>
       </PermissionButton>
       <PermissionButton
         permissions={{ llmProxy: ["delete"] }}

--- a/platform/frontend/src/app/settings/users/page.client.tsx
+++ b/platform/frontend/src/app/settings/users/page.client.tsx
@@ -3,7 +3,7 @@
 import { E2eTestId } from "@archestra/shared";
 import type { ColumnDef } from "@tanstack/react-table";
 import { formatDistanceToNow } from "date-fns";
-import { Copy, Eye, Plus, Shield, Trash2, UserCog } from "lucide-react";
+import { Copy, Eye, Gauge, Plus, Shield, Trash2, UserCog } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
@@ -392,6 +392,12 @@ function MembersTab({
                     },
                   ]
                 : []),
+              {
+                icon: <Gauge className="h-4 w-4" />,
+                label: "Manage limits",
+                permissions: { llmLimit: ["read"] },
+                href: `/llm/limits?appliedTo=user&entityId=${member.userId}`,
+              },
               {
                 icon: <Trash2 className="h-4 w-4" />,
                 label: "Remove user",

--- a/platform/frontend/src/components/chat/inline-chat-error.tsx
+++ b/platform/frontend/src/components/chat/inline-chat-error.tsx
@@ -12,6 +12,8 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
 import { Message, MessageContent } from "@/components/ai-elements/message";
 import { Button } from "@/components/ui/button";
 import {
@@ -108,6 +110,149 @@ export function InlineChatError({
       slimChatErrorUi ? "Error details copied" : "Debug info copied",
     );
   };
+
+  if (isUsageLimitExceeded) {
+    if (slimChatErrorUi) {
+      return (
+        <Message from="assistant">
+          <MessageContent className="bg-orange-500/5 border border-orange-500/20 rounded-lg">
+            <div className="flex items-start gap-2">
+              <StatusIcon
+                className={`h-4 w-4 mt-0.5 flex-shrink-0 text-orange-600`}
+              />
+              <div className="flex-1 space-y-2">
+                <p className="text-sm text-foreground">
+                  {supportMessage ? supportMessage : chatError.message}
+                </p>
+
+                <div className="flex items-center gap-1.5 flex-wrap">
+                  {refEntries.map((entry) => (
+                    <span
+                      key={entry.label}
+                      className="inline-flex items-center gap-1 rounded bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground font-mono"
+                    >
+                      <span className="opacity-60">{entry.label}</span>
+                      <span>{entry.value}</span>
+                    </span>
+                  ))}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-5 w-5 p-0 text-muted-foreground hover:text-foreground"
+                    onClick={copyDebugInfo}
+                    aria-label="Copy error details"
+                    title="Copy error details"
+                  >
+                    <Copy className="h-3 w-3" />
+                  </Button>
+                </div>
+                {isAdmin && (
+                  <div className="pt-1">
+                    <Button asChild size="sm" variant="outline" className="h-7 text-xs border-orange-500/30 hover:bg-orange-500/10 hover:text-orange-600">
+                      <Link href={`/llm/limits?appliedTo=${chatError.usageLimitEntityType || "all"}&entityId=${chatError.usageLimitEntityId || ""}&status=danger`}>
+                        Manage Limits
+                      </Link>
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </div>
+          </MessageContent>
+        </Message>
+      );
+    }
+
+    return (
+      <Message from="assistant">
+        <MessageContent className="bg-orange-500/5 border border-orange-500/20 rounded-lg p-4">
+          <div className="flex items-start gap-3">
+            <div className="rounded-full bg-orange-500/10 p-2 text-orange-600">
+              <Gauge className="h-5 w-5 flex-shrink-0" />
+            </div>
+            <div className="flex-1 space-y-2 min-w-0">
+              <div className="flex items-center justify-between gap-2 flex-wrap">
+                <h4 className="text-sm font-semibold text-foreground">
+                  Usage Limit Exceeded
+                </h4>
+                <Badge variant="outline" className="bg-orange-500/10 text-orange-600 border-orange-500/30 text-[10px] uppercase font-bold">
+                  {chatError.usageLimitEntityType?.replace(/_/g, " ") || "Usage"} Limit
+                </Badge>
+              </div>
+              <p className="text-sm text-muted-foreground whitespace-pre-wrap leading-relaxed">
+                {supportMessage ? supportMessage : chatError.message}
+              </p>
+              
+              <div className="flex items-center gap-2 pt-2">
+                {isAdmin && (
+                  <Button asChild size="sm" variant="outline" className="h-8 text-xs border-orange-500/30 hover:bg-orange-500/10 hover:text-orange-600">
+                    <Link href={`/llm/limits?appliedTo=${chatError.usageLimitEntityType || "all"}&entityId=${chatError.usageLimitEntityId || ""}&status=danger`}>
+                      Manage Limits
+                    </Link>
+                  </Button>
+                )}
+                
+                {isAdmin && (
+                  <Collapsible open={isDetailsOpen} onOpenChange={setIsDetailsOpen}>
+                    <CollapsibleTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 p-0 px-2 text-xs text-muted-foreground hover:text-foreground"
+                      >
+                        {isDetailsOpen ? (
+                          <ChevronDown className="h-3 w-3 mr-1" />
+                        ) : (
+                          <ChevronRight className="h-3 w-3 mr-1" />
+                        )}
+                        Error Details
+                      </Button>
+                    </CollapsibleTrigger>
+                  </Collapsible>
+                )}
+              </div>
+
+              {isAdmin && isDetailsOpen && (
+                <div className="space-y-2 mt-2 pt-2 border-t border-border/50">
+                  <div className="flex items-center gap-2">
+                    <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-muted text-muted-foreground">
+                      {chatError.code}
+                    </span>
+                  </div>
+                  {chatError.originalError && (
+                    <pre className="max-h-48 overflow-auto rounded-md bg-muted/50 p-3 text-xs font-mono whitespace-pre-wrap break-words text-foreground">
+                      {formatOriginalError(chatError.originalError)}
+                    </pre>
+                  )}
+                </div>
+              )}
+              
+              <div className="flex items-center gap-1.5 flex-wrap pt-1">
+                {refEntries.map((entry) => (
+                  <span
+                    key={entry.label}
+                    className="inline-flex items-center gap-1 rounded bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground font-mono"
+                  >
+                    <span className="opacity-60">{entry.label}</span>
+                    <span>{entry.value}</span>
+                  </span>
+                ))}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-5 w-5 p-0 text-muted-foreground hover:text-foreground"
+                  onClick={copyDebugInfo}
+                  aria-label="Copy error details"
+                  title="Copy error details"
+                >
+                  <Copy className="h-3 w-3" />
+                </Button>
+              </div>
+            </div>
+          </div>
+        </MessageContent>
+      </Message>
+    );
+  }
 
   if (slimChatErrorUi) {
     return (

--- a/platform/frontend/src/components/teams/teams-list.tsx
+++ b/platform/frontend/src/components/teams/teams-list.tsx
@@ -6,7 +6,7 @@ import {
 } from "@archestra/shared";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
-import { Pencil, Plus, Trash2, Users } from "lucide-react";
+import { Gauge, Pencil, Plus, Trash2, Users } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useSetSettingsAction } from "@/app/settings/layout";
@@ -162,6 +162,12 @@ export function TeamsList() {
               setSelectedTeam(team);
               setManagementDialogOpen(true);
             },
+          },
+          {
+            icon: <Gauge className="h-4 w-4" />,
+            label: "Manage limits",
+            permissions: { llmLimit: ["read"] },
+            href: `/llm/limits?appliedTo=team&entityId=${team.id}`,
           },
           {
             icon: <Trash2 className="h-4 w-4" />,

--- a/platform/shared/chat-error.ts
+++ b/platform/shared/chat-error.ts
@@ -333,6 +333,8 @@ export interface ChatErrorResponse {
   usageLimitExceeded?: boolean;
   /** The usage-limit entity that blocked the request, when known */
   usageLimitEntityType?: string;
+  /** The usage-limit entity ID that blocked the request, when known */
+  usageLimitEntityId?: string;
   /** Original error details for debugging (provider-specific) */
   originalError?: {
     /** Provider name (anthropic, openai, gemini) */
@@ -357,6 +359,7 @@ export const ChatErrorResponseSchema: z.ZodType<ChatErrorResponse> = z.object({
   spanId: z.string().optional(),
   usageLimitExceeded: z.boolean().optional(),
   usageLimitEntityType: z.string().optional(),
+  usageLimitEntityId: z.string().optional(),
   originalError: z
     .object({
       provider: SupportedProvidersSchema.optional(),


### PR DESCRIPTION
## Summary

Resolves #4758 — **Improve usage limits visibility UX and DX**

This PR implements end-to-end plumbing so that when a user hits a usage limit, the platform can:
1. **Show a rich, actionable error card** in chat (instead of raw JSON/plain text).
2. **Provide direct navigation** to allow administrators to manage and lift these limits.

### Changes Made

- **UI (Chat Error Styling):**
  - Updated the chat stream handler to detect limit-related HTTP errors.
  - Added an `InlineChatError` component rendering an actionable error card.
- **Limits Management Navigation:**
  - The limits page now reads URL parameters to auto-filter and pre-populate the "Add Limit" dialog.
  - Added a "Manage Limits" action option to Users, Teams, Virtual Keys, Agents, and LLM Proxies tables.
- **Permissions:**
  - Gated the action button to only show for users with `llmLimit: ["read"]` permissions.

### Verification

- All existing tests pass (123/123).
- Clean TypeScript compilation across the monorepo with zero errors.
