### PR TITLE
fix(tools): harden 0285 dedup against three-plus prefix siblings

### DIFF
--- a/platform/backend/src/database/migrations/0285_dedup_archestra_builtin_tools_by_short_name.sql
+++ b/platform/backend/src/database/migrations/0285_dedup_archestra_builtin_tools_by_short_name.sql
@@ -24,8 +24,19 @@ DELETE FROM "agent_tools" a
 USING remap r
 WHERE a.tool_id = r.loser_id
   AND EXISTS (
-    SELECT 1 FROM "agent_tools" s
-    WHERE s.agent_id = a.agent_id AND s.tool_id = r.survivor_id
+    -- Drop this loser assignment when another row for the same agent already
+    -- resolves to the survivor: the survivor itself, or an earlier-sorted loser
+    -- in the same short-name group. Without this, three-plus siblings collide
+    -- on agent_tools' unique(agent_id, tool_id) during the repoint UPDATE below.
+    SELECT 1 FROM "agent_tools" keep
+    LEFT JOIN remap kr ON kr.loser_id = keep.tool_id
+    WHERE keep.agent_id = a.agent_id
+      AND keep.tool_id <> a.tool_id
+      AND COALESCE(kr.survivor_id, keep.tool_id) = r.survivor_id
+      AND (
+        keep.tool_id = r.survivor_id
+        OR (kr.survivor_id IS NOT NULL AND keep.tool_id < a.tool_id)
+      )
   );
 --> statement-breakpoint
 WITH ranked AS (
@@ -57,8 +68,18 @@ DELETE FROM "conversation_enabled_tools" c
 USING remap r
 WHERE c.tool_id = r.loser_id
   AND EXISTS (
-    SELECT 1 FROM "conversation_enabled_tools" s
-    WHERE s.conversation_id = c.conversation_id AND s.tool_id = r.survivor_id
+    -- Same loser-vs-loser guard as agent_tools, against the composite primary
+    -- key (conversation_id, tool_id): keep one source row per conversation per
+    -- short-name group so the repoint UPDATE cannot produce a duplicate.
+    SELECT 1 FROM "conversation_enabled_tools" keep
+    LEFT JOIN remap kr ON kr.loser_id = keep.tool_id
+    WHERE keep.conversation_id = c.conversation_id
+      AND keep.tool_id <> c.tool_id
+      AND COALESCE(kr.survivor_id, keep.tool_id) = r.survivor_id
+      AND (
+        keep.tool_id = r.survivor_id
+        OR (kr.survivor_id IS NOT NULL AND keep.tool_id < c.tool_id)
+      )
   );
 --> statement-breakpoint
 WITH ranked AS (

--- a/platform/backend/src/database/migrations/0285_dedup_archestra_builtin_tools_by_short_name.test.ts
+++ b/platform/backend/src/database/migrations/0285_dedup_archestra_builtin_tools_by_short_name.test.ts
@@ -114,6 +114,77 @@ describe("0285 migration: dedupe Archestra built-in tools by short name", () => 
     expect(enabled[0].toolId).toBe(legacy.id);
   });
 
+  test("collapses three+ prefix siblings when an agent/conversation holds multiple losers", async ({
+    makeAgent,
+    makeConversation,
+  }) => {
+    await db.insert(schema.internalMcpCatalogTable).values({
+      id: ARCHESTRA_MCP_CATALOG_ID,
+      name: "Archestra",
+      serverType: "builtin",
+    });
+
+    const insertSibling = async (name: string, createdAt: string) => {
+      const [row] = await db
+        .insert(schema.toolsTable)
+        .values({
+          name,
+          parameters: {},
+          catalogId: ARCHESTRA_MCP_CATALOG_ID,
+          agentId: null,
+          createdAt: new Date(createdAt),
+        })
+        .returning();
+      return row;
+    };
+
+    // Three prefixes for the same short name (install cycled white-label brands).
+    const survivor = await insertSibling(
+      "archestra__whoami",
+      "2026-01-01T00:00:00Z",
+    );
+    const loserA = await insertSibling("acme__whoami", "2026-02-01T00:00:00Z");
+    const loserB = await insertSibling("beta__whoami", "2026-03-01T00:00:00Z");
+
+    const agent = await makeAgent();
+    // Agent holds BOTH losers but not the survivor: naive repoint would rewrite
+    // both to the survivor id and violate unique(agent_id, tool_id).
+    await db.insert(schema.agentToolsTable).values([
+      { agentId: agent.id, toolId: loserA.id },
+      { agentId: agent.id, toolId: loserB.id },
+    ]);
+    const conversation = await makeConversation(agent.id);
+    await db.insert(schema.conversationEnabledToolsTable).values([
+      { conversationId: conversation.id, toolId: loserA.id },
+      { conversationId: conversation.id, toolId: loserB.id },
+    ]);
+
+    await runDedup();
+
+    const survivors = await builtInRowsForShortName("whoami");
+    expect(survivors).toHaveLength(1);
+    expect(survivors[0].id).toBe(survivor.id);
+
+    const assignments = await db
+      .select()
+      .from(schema.agentToolsTable)
+      .where(eq(schema.agentToolsTable.agentId, agent.id));
+    expect(assignments).toHaveLength(1);
+    expect(assignments[0].toolId).toBe(survivor.id);
+
+    const enabled = await db
+      .select()
+      .from(schema.conversationEnabledToolsTable)
+      .where(
+        eq(
+          schema.conversationEnabledToolsTable.conversationId,
+          conversation.id,
+        ),
+      );
+    expect(enabled).toHaveLength(1);
+    expect(enabled[0].toolId).toBe(survivor.id);
+  });
+
   test("drops the redundant agent assignment when the agent already holds the survivor", async ({
     makeAgent,
   }) => {


### PR DESCRIPTION
Follow-up to #5535.

## Problem

The `agent_tools` / `conversation_enabled_tools` repoint in migration 0285 only deleted loser rows that collided with the **survivor**, not losers that collide with **each other** after the rewrite.

With three or more siblings for one short name (an install that cycled through multiple white-label prefixes, e.g. `archestra__whoami` / `acme__whoami` / `beta__whoami`) and the same agent or conversation linked to two losers, the repoint `UPDATE` rewrites both rows to the survivor id and violates `unique(agent_id, tool_id)` / the `conversation_enabled_tools` primary key — crashing the migration.

## Fix

Drop a loser assignment when another row for the same agent/conversation already resolves to the survivor (the survivor itself, or an earlier-sorted loser in the same group), so exactly one source row per parent per short-name group survives to be repointed.

## Tests

Added a three-sibling case (agent and conversation each holding two losers, not the survivor) that reproduced the unique-violation crash and now converges to the survivor with assignments preserved.

Note: the same loser-vs-loser gap exists in migration 0283 (full-name dedup); it has not hit the three-duplicate + double-assignment scenario.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>