### PR TITLE
fix(bedrock): restrict 1h prompt-cache TTL to the documented 4.5 models

### DIFF
--- a/platform/backend/src/routes/chat/normalization/apply-prompt-cache.test.ts
+++ b/platform/backend/src/routes/chat/normalization/apply-prompt-cache.test.ts
@@ -207,13 +207,31 @@ describe("applyPromptCacheBreakpoints", () => {
     });
   });
 
-  it("uses a 1h TTL for a Bedrock Sonnet 4.5+ inference profile", () => {
+  it("uses a 1h TTL for a Bedrock Sonnet 4.5 inference profile", () => {
     const [result] = applyPromptCacheBreakpoints({
+      provider: "bedrock",
+      model: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+      messages: [userMessage("a")],
+    });
+    expect(bedrockCachePoint(result)).toEqual({ type: "default", ttl: "1h" });
+  });
+
+  it("keeps the 5m default for Opus 4.6 (1h is a 4.5-only feature)", () => {
+    // AWS docs list the 1-hour TTL only for Opus 4.5, Sonnet 4.5, and Haiku
+    // 4.5. Opus 4.6 is documented as 5-minute-only.
+    const [bedrock] = applyPromptCacheBreakpoints({
       provider: "bedrock",
       model: "us.anthropic.claude-opus-4-6-v1:0",
       messages: [userMessage("a")],
     });
-    expect(bedrockCachePoint(result)).toEqual({ type: "default", ttl: "1h" });
+    expect(bedrockCachePoint(bedrock)).toEqual({ type: "default" });
+
+    const [anthropic] = applyPromptCacheBreakpoints({
+      provider: "anthropic",
+      model: "claude-opus-4-6-v1",
+      messages: [userMessage("a")],
+    });
+    expect(anthropicCacheControl(anthropic)).toEqual({ type: "ephemeral" });
   });
 
   it("keeps the 5m default for older models and when model is absent", () => {

--- a/platform/backend/src/routes/chat/normalization/apply-prompt-cache.ts
+++ b/platform/backend/src/routes/chat/normalization/apply-prompt-cache.ts
@@ -14,14 +14,15 @@ const CACHE_BREAKPOINTS = {
 type CacheBreakpointConfig =
   (typeof CACHE_BREAKPOINTS)[keyof typeof CACHE_BREAKPOINTS];
 
-// Claude Sonnet/Haiku/Opus 4.5 and newer support a 1-hour cache TTL; older
-// models (and other providers) only support the 5-minute default. Matches bare
-// ids ("claude-sonnet-4-5") and Bedrock inference-profile ids
-// ("us.anthropic.claude-opus-4-6-..."). Claude Sonnet/Opus 4
-// ("claude-sonnet-4-20250514") and Claude 3.x are intentionally excluded.
-// `(?!\d)` stops the minor-version digit from matching the leading digit of a
-// dated id like "claude-sonnet-4-20250514" (Sonnet 4, not 4.5).
-const ONE_HOUR_CACHE_MODEL = /claude-(?:sonnet|haiku|opus)-4-[5-9](?!\d)/;
+// Per AWS's prompt-caching docs the 1-hour cache TTL is supported only by
+// Claude Opus 4.5, Sonnet 4.5, and Haiku 4.5. Every other model uses the
+// 5-minute default — including Opus 4.6 (documented 5-minute-only), Opus 4
+// ("claude-sonnet-4-20250514"), Claude 3.x, any newer model not yet listed,
+// and non-Anthropic providers. Matches bare ids ("claude-sonnet-4-5") and
+// Bedrock inference-profile ids ("us.anthropic.claude-sonnet-4-5-..."). `(?!\d)`
+// stops "4-5" from matching the leading digit of a dated Sonnet 4 id like
+// "claude-sonnet-4-20250514".
+const ONE_HOUR_CACHE_MODEL = /claude-(?:sonnet|haiku|opus)-4-5(?!\d)/;
 
 function supportsOneHourCache(model: string): boolean {
   return ONE_HOUR_CACHE_MODEL.test(model);

--- a/platform/backend/src/routes/chat/normalization/apply-prompt-cache.ts
+++ b/platform/backend/src/routes/chat/normalization/apply-prompt-cache.ts
@@ -20,8 +20,8 @@ type CacheBreakpointConfig =
 // ("claude-sonnet-4-20250514"), Claude 3.x, any newer model not yet listed,
 // and non-Anthropic providers. Matches bare ids ("claude-sonnet-4-5") and
 // Bedrock inference-profile ids ("us.anthropic.claude-sonnet-4-5-..."). `(?!\d)`
-// stops "4-5" from matching the leading digit of a dated Sonnet 4 id like
-// "claude-sonnet-4-20250514".
+// requires "4-5" to be the whole minor version (followed by "-" or end of
+// string), so a hypothetical "claude-opus-4-50" is not read as 4.5.
 const ONE_HOUR_CACHE_MODEL = /claude-(?:sonnet|haiku|opus)-4-5(?!\d)/;
 
 function supportsOneHourCache(model: string): boolean {


### PR DESCRIPTION
## Summary

The prompt-cache 1-hour TTL was applied to more models than support it. AWS's prompt-caching docs list 1-hour TTL support for exactly three models — Claude Opus 4.5, Sonnet 4.5, and Haiku 4.5 — and document Opus 4.6 as 5-minute-only. The eligibility regex matched `4-[5-9]`, so Opus 4.6, 4.7, 4.8 and any newer id were marked with `ttl: "1h"` outside the documented set. Those models fall back to 5-minute behavior, so the longer TTL the marker requested was never actually in effect.

This narrows the regex to the documented 4.5 family (`-4-5`), so any model not on AWS's 1-hour list uses the 5-minute default.

Conservative on purpose: newer Anthropic-on-Bedrock models (4.7+) are dropped to 5-minute until AWS documents 1-hour support for them. If a newer model is confirmed 1-hour-capable, add it to the regex then. A 5-minute TTL is always valid, so this never regresses correctness — only cache duration for models that weren't getting the longer TTL anyway.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>