### PR TITLE
fix(skills): white-label the built-in skill in list_skills/load_skill output

### DIFF
--- a/platform/backend/src/database/seed.test.ts
+++ b/platform/backend/src/database/seed.test.ts
@@ -1,4 +1,5 @@
 import {
+  ARCHESTRA_TOOL_PREFIX,
   BUILT_IN_AGENT_IDS,
   BUILT_IN_AGENT_NAMES,
   CHAT_TITLE_GENERATION_SYSTEM_PROMPT,
@@ -7,9 +8,10 @@ import {
 } from "@archestra/shared";
 import { and, eq } from "drizzle-orm";
 import { afterEach } from "vitest";
+import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import config from "@/config";
 import db, { schema } from "@/database";
-import { SkillFileModel, SkillModel } from "@/models";
+import { OrganizationModel, SkillFileModel, SkillModel } from "@/models";
 import AgentModel from "@/models/agent";
 import {
   BUILT_IN_SKILLS,
@@ -146,6 +148,12 @@ Examples:
 - Code execution: invocation="block_always", result="mark_as_untrusted"`;
 
 describe("syncBuiltInSkills", () => {
+  // syncBuiltInSkills syncs branding per org; reset the singleton so it never
+  // leaks an app name into a later (shuffled) test.
+  afterEach(() => {
+    archestraMcpBranding.syncFromOrganization(null);
+  });
+
   async function countBuiltInSkills(organizationId: string): Promise<number> {
     const rows = await db
       .select()
@@ -283,6 +291,60 @@ describe("syncBuiltInSkills", () => {
       sourceRef,
     });
     expect(preserved?.content).toBe("EDITED BY USER");
+  });
+
+  test("brands the seeded skill under the org's white-label app name", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+    await OrganizationModel.patch(org.id, { appName: "Acme Copilot" });
+
+    await syncBuiltInSkills();
+
+    const skill = await SkillModel.findBuiltIn({
+      organizationId: org.id,
+      sourceRef: builtInSkillSourceRef(BASE_SKILL.builtInSkillId),
+    });
+    // the stored row itself is branded, so every read path (catalog, load_skill,
+    // sandbox mount) shows the app name with no per-read rewriting.
+    expect(skill?.name).toBe("Acme Copilot Platform Operations");
+    expect(skill?.content).not.toContain("Archestra");
+    expect(skill?.content).not.toContain(ARCHESTRA_TOOL_PREFIX);
+    // sourceCommit is hashed over the branded body, so a pristine branded copy
+    // is recognised on re-sync (and re-brands if the app name later changes).
+    expect(skill?.sourceCommit).not.toBe(builtInSkillVersion(BASE_SKILL));
+
+    const files = await SkillFileModel.findBySkillId(skill?.id ?? "");
+    for (const file of files) {
+      expect(file.content).not.toContain("Archestra");
+    }
+  });
+
+  test("re-brands a pristine copy when the app name changes", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+    const sourceRef = builtInSkillSourceRef(BASE_SKILL.builtInSkillId);
+
+    // first seed with no app name → canonical "Archestra" copy.
+    await syncBuiltInSkills();
+    const before = await SkillModel.findBuiltIn({
+      organizationId: org.id,
+      sourceRef,
+    });
+    expect(before?.name).toBe("Archestra Platform Operations");
+
+    // set an app name and re-sync — the untouched copy auto-upgrades to branded.
+    await OrganizationModel.patch(org.id, { appName: "Acme Copilot" });
+    await syncBuiltInSkills();
+
+    const after = await SkillModel.findBuiltIn({
+      organizationId: org.id,
+      sourceRef,
+    });
+    expect(after?.id).toBe(before?.id);
+    expect(after?.name).toBe("Acme Copilot Platform Operations");
+    expect(after?.content).not.toContain("Archestra");
   });
 });
 

--- a/platform/backend/src/database/seed.ts
+++ b/platform/backend/src/database/seed.ts
@@ -47,6 +47,7 @@ import {
   builtInSkillSourceRef,
   builtInSkillVersion,
 } from "@/skills/built-in-skills";
+import type { Organization } from "@/types";
 import {
   encryptSecretValue,
   ensureEncryptionKeyAvailable,
@@ -212,94 +213,109 @@ export async function syncBuiltInSkills(): Promise<void> {
   const organizations = await getOrganizationsForBuiltInAgentSync();
 
   for (const organization of organizations) {
-    // Brand the shipped built-in skills under this org's white-label identity
-    // (a no-op unless full white-labeling is active), mirroring how built-in MCP
-    // tools are seeded under the org's branded tool name. builtInSkillShippedWrite
-    // reads the synced singleton, so this must run before it.
     const orgRecord = await OrganizationModel.getById(organization.id);
-    archestraMcpBranding.syncFromOrganization(orgRecord);
+    if (!orgRecord) continue;
+    await syncBuiltInSkillsForOrganization(orgRecord);
+  }
+}
 
-    for (const builtInSkill of BUILT_IN_SKILLS) {
-      const sourceRef = builtInSkillSourceRef(builtInSkill.builtInSkillId);
-      const shipped = builtInSkillShippedWrite(builtInSkill);
+/**
+ * Reconcile the built-in skills into a single organization, branded under its
+ * white-label app name. Called per-org by {@link syncBuiltInSkills} on startup
+ * and directly when an admin changes the app name (so list_skills/load_skill
+ * reflect the new brand immediately, mirroring the built-in MCP tool re-seed).
+ *
+ * @public — invoked from the organization route on app-name change.
+ */
+export async function syncBuiltInSkillsForOrganization(
+  organization: Pick<Organization, "id" | "appName" | "iconLogo">,
+): Promise<void> {
+  // Brand the shipped built-in skills under this org's white-label identity (a
+  // no-op unless full white-labeling is active), mirroring how built-in MCP
+  // tools are seeded under the org's branded tool name. builtInSkillShippedWrite
+  // reads the synced singleton, so this must run before it.
+  archestraMcpBranding.syncFromOrganization(organization);
 
-      const existing = await SkillModel.findBuiltIn({
-        organizationId: organization.id,
-        sourceRef,
-      });
+  for (const builtInSkill of BUILT_IN_SKILLS) {
+    const sourceRef = builtInSkillSourceRef(builtInSkill.builtInSkillId);
+    const shipped = builtInSkillShippedWrite(builtInSkill);
 
-      if (!existing) {
-        const created = await SkillModel.createWithFiles({
-          skill: {
-            organizationId: organization.id,
-            scope: "org",
-            sourceType: "built_in",
-            sourceRef,
-            ...shipped.skill,
-          },
-          files: shipped.files,
-        });
-        // createWithFiles is ON CONFLICT DO NOTHING on the per-org shared-name
-        // index, so a null means a pre-existing non-built-in skill already
-        // holds this name. Surface it instead of reporting a phantom seed — that
-        // org has no built-in copy and thus no reset path until the clash clears.
-        if (!created) {
-          logger.warn(
-            {
-              builtInSkillId: builtInSkill.builtInSkillId,
-              organizationId: organization.id,
-              name: builtInSkill.name,
-            },
-            "Skipped seeding built-in skill: a skill with this name already exists",
-          );
-          continue;
-        }
-        logger.info(
-          {
-            builtInSkillId: builtInSkill.builtInSkillId,
-            organizationId: organization.id,
-          },
-          "Seeded built-in skill",
-        );
-        continue;
-      }
+    const existing = await SkillModel.findBuiltIn({
+      organizationId: organization.id,
+      sourceRef,
+    });
 
-      if (existing.sourceCommit === shipped.skill.sourceCommit) {
-        continue;
-      }
-
-      const liveFiles = await SkillFileModel.findBySkillId(existing.id);
-      const liveVersion = builtInSkillVersion({
-        content: existing.content,
-        files: liveFiles,
-      });
-
-      // Only auto-upgrade copies that still match the revision we last wrote; a
-      // diverged copy was edited by the user and is reset explicitly instead.
-      if (liveVersion !== existing.sourceCommit) {
-        logger.info(
-          {
-            builtInSkillId: builtInSkill.builtInSkillId,
-            organizationId: organization.id,
-          },
-          "Built-in skill was edited, preserving user changes",
-        );
-        continue;
-      }
-
-      await SkillModel.updateWithFiles({
-        id: existing.id,
-        skill: shipped.skill,
+    if (!existing) {
+      const created = await SkillModel.createWithFiles({
+        skill: {
+          organizationId: organization.id,
+          scope: "org",
+          sourceType: "built_in",
+          sourceRef,
+          ...shipped.skill,
+        },
         files: shipped.files,
       });
+      // createWithFiles is ON CONFLICT DO NOTHING on the per-org shared-name
+      // index, so a null means a pre-existing non-built-in skill already
+      // holds this name. Surface it instead of reporting a phantom seed — that
+      // org has no built-in copy and thus no reset path until the clash clears.
+      if (!created) {
+        logger.warn(
+          {
+            builtInSkillId: builtInSkill.builtInSkillId,
+            organizationId: organization.id,
+            name: builtInSkill.name,
+          },
+          "Skipped seeding built-in skill: a skill with this name already exists",
+        );
+        continue;
+      }
       logger.info(
         {
           builtInSkillId: builtInSkill.builtInSkillId,
           organizationId: organization.id,
         },
-        "Upgraded built-in skill to current revision",
+        "Seeded built-in skill",
       );
+      continue;
     }
+
+    if (existing.sourceCommit === shipped.skill.sourceCommit) {
+      continue;
+    }
+
+    const liveFiles = await SkillFileModel.findBySkillId(existing.id);
+    const liveVersion = builtInSkillVersion({
+      content: existing.content,
+      files: liveFiles,
+    });
+
+    // Only auto-upgrade copies that still match the revision we last wrote; a
+    // diverged copy was edited by the user and is reset explicitly instead.
+    if (liveVersion !== existing.sourceCommit) {
+      logger.info(
+        {
+          builtInSkillId: builtInSkill.builtInSkillId,
+          organizationId: organization.id,
+        },
+        "Built-in skill was edited, preserving user changes",
+      );
+      continue;
+    }
+
+    await SkillModel.updateWithFiles({
+      id: existing.id,
+      skill: shipped.skill,
+      files: shipped.files,
+    });
+    logger.info(
+      {
+        builtInSkillId: builtInSkill.builtInSkillId,
+        organizationId: organization.id,
+      },
+      "Upgraded built-in skill to current revision",
+    );
   }
 }
 

--- a/platform/backend/src/database/seed.ts
+++ b/platform/backend/src/database/seed.ts
@@ -18,6 +18,7 @@ import {
   testMcpServerCommand,
 } from "@archestra/shared";
 import { and, eq, inArray, isNull } from "drizzle-orm";
+import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import config, {
   getProviderConfiguredBaseUrl,
   getProviderEnvApiKey,
@@ -211,6 +212,13 @@ export async function syncBuiltInSkills(): Promise<void> {
   const organizations = await getOrganizationsForBuiltInAgentSync();
 
   for (const organization of organizations) {
+    // Brand the shipped built-in skills under this org's white-label identity
+    // (a no-op unless full white-labeling is active), mirroring how built-in MCP
+    // tools are seeded under the org's branded tool name. builtInSkillShippedWrite
+    // reads the synced singleton, so this must run before it.
+    const orgRecord = await OrganizationModel.getById(organization.id);
+    archestraMcpBranding.syncFromOrganization(orgRecord);
+
     for (const builtInSkill of BUILT_IN_SKILLS) {
       const sourceRef = builtInSkillSourceRef(builtInSkill.builtInSkillId);
       const shipped = builtInSkillShippedWrite(builtInSkill);

--- a/platform/backend/src/routes/organization.test.ts
+++ b/platform/backend/src/routes/organization.test.ts
@@ -1,4 +1,5 @@
 import { vi } from "vitest";
+import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import type * as originalConfigModule from "@/config";
 import * as embeddingClients from "@/knowledge-base/embedding-clients";
 import LlmProviderApiKeyModel from "@/models/llm-provider-api-key";
@@ -53,6 +54,9 @@ describe("organization routes", () => {
 
   afterEach(async () => {
     vi.restoreAllMocks();
+    // appearance-settings updates sync the branding singleton; reset it so an
+    // app name never leaks into a later (shuffled) test.
+    archestraMcpBranding.syncFromOrganization(null);
     await app.close();
   });
 
@@ -75,6 +79,40 @@ describe("organization routes", () => {
         appName: "Acme Copilot",
       }),
     });
+  });
+
+  test("re-brands the built-in skill rows when appName changes", async () => {
+    vi.spyOn(ToolModel, "syncArchestraBuiltInCatalog").mockResolvedValue();
+    const { syncBuiltInSkillsForOrganization } = await import(
+      "@/database/seed"
+    );
+    const { SkillModel } = await import("@/models");
+    const { BUILT_IN_SKILLS, builtInSkillSourceRef } = await import(
+      "@/skills/built-in-skills"
+    );
+    const [base] = BUILT_IN_SKILLS;
+    const sourceRef = builtInSkillSourceRef(base.builtInSkillId);
+
+    // seed the canonical (un-branded) built-in skill first.
+    await syncBuiltInSkillsForOrganization({
+      id: organizationId,
+      appName: null,
+      iconLogo: null,
+    });
+    const before = await SkillModel.findBuiltIn({ organizationId, sourceRef });
+    expect(before?.name).toBe("Archestra Platform Operations");
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/organization/appearance-settings",
+      payload: { appName: "Acme Copilot" },
+    });
+    expect(response.statusCode).toBe(200);
+
+    // the stored row re-brands immediately — no backend restart needed.
+    const after = await SkillModel.findBuiltIn({ organizationId, sourceRef });
+    expect(after?.name).toBe("Acme Copilot Platform Operations");
+    expect(after?.content).not.toContain("Archestra");
   });
 
   describe("PATCH /api/organization/agent-settings - model/key pair", () => {

--- a/platform/backend/src/routes/organization.ts
+++ b/platform/backend/src/routes/organization.ts
@@ -9,6 +9,7 @@ import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
 import config from "@/config";
 import db, { schema } from "@/database";
+import { syncBuiltInSkillsForOrganization } from "@/database/seed";
 import mcpServerRuntimeManager from "@/k8s/mcp-server-runtime/manager";
 import { callEmbedding } from "@/knowledge-base/embedding-clients";
 import { resolveApiKeyFromChatApiKey } from "@/knowledge-base/kb-llm-client";
@@ -108,6 +109,14 @@ const organizationRoutes: FastifyPluginAsyncZod = async (fastify) => {
           await ToolModel.syncArchestraBuiltInCatalog({
             organization: organization,
           });
+        }
+
+        // appName is baked into the built-in skills' stored rows (name, body,
+        // tool-prefix references), so re-brand them now — without this the
+        // catalog/load_skill output only updates after a backend restart. A
+        // pristine copy auto-rebrands; an admin-edited copy is preserved.
+        if (appNameChanged) {
+          await syncBuiltInSkillsForOrganization(organization);
         }
       }
 

--- a/platform/backend/src/routes/skill/skill.routes.ts
+++ b/platform/backend/src/routes/skill/skill.routes.ts
@@ -8,6 +8,7 @@ import {
 } from "@archestra/shared";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
+import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import {
   getAgentTypePermissionChecker,
   requireAgentModifyPermission,
@@ -810,6 +811,12 @@ const skillRoutes: FastifyPluginAsyncZod = async (fastify) => {
         userTeamIds,
         userId: user.id,
       });
+
+      // brand the shipped default under this org's white-label identity before
+      // writing it, matching syncBuiltInSkills (no-op unless full white-labeling
+      // is active). builtInSkillShippedWrite reads the synced singleton.
+      const organization = await OrganizationModel.getById(organizationId);
+      archestraMcpBranding.syncFromOrganization(organization);
 
       const shipped = builtInSkillShippedWrite(definition);
       const reset = await SkillModel.updateWithFiles({

--- a/platform/backend/src/skills/built-in-skill-branding.test.ts
+++ b/platform/backend/src/skills/built-in-skill-branding.test.ts
@@ -1,0 +1,81 @@
+import { ARCHESTRA_TOOL_PREFIX, DEFAULT_APP_NAME } from "@archestra/shared";
+import { afterEach, describe, expect, test } from "vitest";
+import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
+import config from "@/config";
+import { applyBuiltInSkillBranding } from "./built-in-skill-branding";
+
+/**
+ * The swap reads the synced `archestraMcpBranding` singleton and
+ * `config.enterpriseFeatures`, so the tests toggle full white-labeling and sync
+ * an org exactly as the seed path does, then restore both.
+ */
+function setFullWhiteLabeling(enabled: boolean): boolean {
+  const original = config.enterpriseFeatures.fullWhiteLabeling;
+  (
+    config.enterpriseFeatures as { fullWhiteLabeling: boolean }
+  ).fullWhiteLabeling = enabled;
+  return original;
+}
+
+const SAMPLE = `# Archestra Platform Operations
+
+Operate the Archestra platform with its built-in tools (prefixed
+\`archestra__\`, e.g. \`archestra__create_agent\`). Archestra blocks leaks.`;
+
+describe("applyBuiltInSkillBranding", () => {
+  afterEach(() => {
+    archestraMcpBranding.syncFromOrganization(null);
+  });
+
+  test("is a no-op without full white-labeling", () => {
+    // even with an app name set, the brand stays "Archestra" until the
+    // enterprise flag is on — mirroring getArchestraMcpCatalogName. The backend
+    // test env force-enables full white-labeling, so disable it explicitly here.
+    const original = setFullWhiteLabeling(false);
+    archestraMcpBranding.syncFromOrganization({
+      appName: "Acme Copilot",
+      iconLogo: null,
+    });
+    try {
+      expect(applyBuiltInSkillBranding(SAMPLE)).toBe(SAMPLE);
+    } finally {
+      setFullWhiteLabeling(original);
+    }
+  });
+
+  test("is a no-op when full white-labeling is on but no app name is set", () => {
+    const original = setFullWhiteLabeling(true);
+    archestraMcpBranding.syncFromOrganization({
+      appName: null,
+      iconLogo: null,
+    });
+    try {
+      expect(applyBuiltInSkillBranding(SAMPLE)).toBe(SAMPLE);
+    } finally {
+      setFullWhiteLabeling(original);
+    }
+  });
+
+  test("rewrites the brand and tool prefix under full white-labeling", () => {
+    const original = setFullWhiteLabeling(true);
+    archestraMcpBranding.syncFromOrganization({
+      appName: "Acme Copilot",
+      iconLogo: null,
+    });
+    try {
+      const branded = applyBuiltInSkillBranding(SAMPLE);
+
+      expect(branded).not.toContain(DEFAULT_APP_NAME);
+      expect(branded).not.toContain(ARCHESTRA_TOOL_PREFIX);
+      expect(branded).toContain(archestraMcpBranding.catalogName);
+      expect(branded).toContain("Acme Copilot Platform Operations");
+      // a full tool name carries the branded prefix, so the model calls the
+      // name that actually exists for this org.
+      expect(branded).toContain(
+        `${archestraMcpBranding.toolPrefix}create_agent`,
+      );
+    } finally {
+      setFullWhiteLabeling(original);
+    }
+  });
+});

--- a/platform/backend/src/skills/built-in-skill-branding.ts
+++ b/platform/backend/src/skills/built-in-skill-branding.ts
@@ -1,0 +1,42 @@
+import { ARCHESTRA_TOOL_PREFIX, DEFAULT_APP_NAME } from "@archestra/shared";
+import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
+
+/**
+ * White-label rebranding for built-in skill text.
+ *
+ * The shipped built-in skill definitions (`skills/built-in-skills.ts`) hardcode
+ * the "Archestra" brand and the default `archestra__` tool-name prefix. When a
+ * built-in skill is reconciled into an organization (`syncBuiltInSkills`, and
+ * the reset-to-default route), its name, description, body, and bundled files
+ * are branded to the org's white-label app name and tool prefix before being
+ * written — so the stored row, the `list_skills` catalog, the `load_skill`
+ * activation block, and the sandbox mount path all read the org's brand without
+ * any per-read rewriting. This mirrors how built-in MCP tools are seeded under
+ * the branded tool name.
+ *
+ * The swap is a no-op unless full white-labeling is active — the branded values
+ * then equal the canonical ones — exactly mirroring `getArchestraMcpCatalogName`
+ * / `getArchestraToolPrefix`. It relies on the `archestraMcpBranding` singleton
+ * already being synced for the target organization, the same assumption every
+ * other branded built-in string makes.
+ *
+ * Only built-in skill text is ever passed through here; user- and import-authored
+ * skills are stored verbatim.
+ */
+export function applyBuiltInSkillBranding(text: string): string {
+  const toolPrefix = archestraMcpBranding.toolPrefix;
+  const appName = archestraMcpBranding.catalogName;
+
+  let out = text;
+  // The two search tokens never overlap — the prefix is lowercase
+  // (`archestra__`) and the app name is the capitalized brand (`Archestra`) — so
+  // the order is independent. A `from === to` pair (no white-labeling) is
+  // skipped so non-branded orgs pay nothing.
+  if (toolPrefix !== ARCHESTRA_TOOL_PREFIX) {
+    out = out.split(ARCHESTRA_TOOL_PREFIX).join(toolPrefix);
+  }
+  if (appName !== DEFAULT_APP_NAME) {
+    out = out.split(DEFAULT_APP_NAME).join(appName);
+  }
+  return out;
+}

--- a/platform/backend/src/skills/built-in-skills.ts
+++ b/platform/backend/src/skills/built-in-skills.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import type { SkillFileKind } from "@/types/skill";
+import { applyBuiltInSkillBranding } from "./built-in-skill-branding";
 
 /**
  * Default Agent Skills shipped with Archestra.
@@ -75,6 +76,15 @@ export function builtInSkillVersion(params: {
  * Skill row fields and resource files for writing a shipped definition to the
  * database, shared by startup sync and reset-to-default so the two can never
  * drift on what a pristine copy looks like.
+ *
+ * The shipped definitions hardcode the "Archestra" brand and `archestra__` tool
+ * prefix; both are rewritten to the target org's white-label app name and tool
+ * prefix here (a no-op unless full white-labeling is active, just like built-in
+ * MCP tool names). Callers MUST have synced `archestraMcpBranding` to the target
+ * organization first. `sourceCommit` is hashed over the *branded* body and files
+ * so a pristine copy's live hash matches — and a later app-name change yields a
+ * new `sourceCommit`, so `syncBuiltInSkills` re-brands the pristine copy on the
+ * next run (an edited copy stays preserved).
  */
 export function builtInSkillShippedWrite(definition: BuiltInSkill): {
   skill: {
@@ -85,18 +95,20 @@ export function builtInSkillShippedWrite(definition: BuiltInSkill): {
   };
   files: { path: string; content: string; kind: SkillFileKind }[];
 } {
+  const content = applyBuiltInSkillBranding(definition.content);
+  const files = definition.files.map((file) => ({
+    path: file.path,
+    content: applyBuiltInSkillBranding(file.content),
+    kind: file.kind,
+  }));
   return {
     skill: {
-      name: definition.name,
-      description: definition.description,
-      content: definition.content,
-      sourceCommit: builtInSkillVersion(definition),
+      name: applyBuiltInSkillBranding(definition.name),
+      description: applyBuiltInSkillBranding(definition.description),
+      content,
+      sourceCommit: builtInSkillVersion({ content, files }),
     },
-    files: definition.files.map((file) => ({
-      path: file.path,
-      content: file.content,
-      kind: file.kind,
-    })),
+    files,
   };
 }
 

--- a/platform/frontend/src/app/agents/skills/page.client.tsx
+++ b/platform/frontend/src/app/agents/skills/page.client.tsx
@@ -43,6 +43,7 @@ import {
 } from "@/components/ui/tooltip";
 import { DEFAULT_TABLE_LIMIT } from "@/consts";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
+import { useAppName } from "@/lib/hooks/use-app-name";
 import {
   useOrganization,
   useUpdateAgentSettings,
@@ -72,6 +73,7 @@ function SkillsList() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
+  const appName = useAppName();
 
   const pageIndex = Number(searchParams.get("page") || "1") - 1;
   const pageSize = Number(searchParams.get("pageSize") || DEFAULT_TABLE_LIMIT);
@@ -141,7 +143,7 @@ function SkillsList() {
                 <span className="truncate font-medium">{skill.name}</span>
                 {skill.sourceType === "built_in" && (
                   <Badge variant="secondary" className="shrink-0">
-                    Archestra
+                    {appName}
                   </Badge>
                 )}
                 {repo && (
@@ -410,6 +412,11 @@ function SkillSlashCommandToggle() {
 /** Extract `owner/repo` from a `source_ref` shaped like `owner/repo@ref:path`. */
 function parseRepoFromSourceRef(sourceRef: string | null): string | null {
   if (!sourceRef) return null;
+  // Built-in skills carry an internal `builtin:<id>` ref (e.g.
+  // `builtin:archestra-platform-operations`); it is an identity token, not a
+  // source repo, and would leak the unbranded "archestra" id into the UI. The
+  // app-name badge already marks these as built-in, so show nothing here.
+  if (sourceRef.startsWith("builtin:")) return null;
   const atIdx = sourceRef.indexOf("@");
   return atIdx === -1 ? sourceRef : sourceRef.slice(0, atIdx);
 }
@@ -512,6 +519,7 @@ function ResetSkillDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const resetSkill = useResetSkill();
+  const appName = useAppName();
 
   const handleReset = useCallback(async () => {
     const result = await resetSkill.mutateAsync(skill.id);
@@ -525,7 +533,7 @@ function ResetSkillDialog({
       open={open}
       onOpenChange={onOpenChange}
       title="Reset Skill"
-      description={`Reset "${skill.name}" to the version Archestra ships? Any local edits to its instructions and resource files will be overwritten.`}
+      description={`Reset "${skill.name}" to the version ${appName} ships? Any local edits to its instructions and resource files will be overwritten.`}
       isPending={resetSkill.isPending}
       onConfirm={handleReset}
       confirmLabel="Reset to default"

--- a/platform/frontend/src/lib/organization.query.ts
+++ b/platform/frontend/src/lib/organization.query.ts
@@ -328,7 +328,7 @@ export function useUpdateAppearanceSettings(
 
       return updatedOrganization;
     },
-    onSuccess: (updatedOrganization) => {
+    onSuccess: (updatedOrganization, variables) => {
       if (!updatedOrganization) return;
       queryClient.setQueryData(organizationKeys.details(), updatedOrganization);
       queryClient.setQueryData(appearanceKeys.public(), {
@@ -348,6 +348,13 @@ export function useUpdateAppearanceSettings(
         slimChatErrorUi: updatedOrganization.slimChatErrorUi,
         animateChatPlaceholders: updatedOrganization.animateChatPlaceholders,
       });
+      // The app name is baked into the built-in skills' and tools' names on the
+      // backend, so a rename re-brands those rows. Drop their cached lists so the
+      // Skills/Tools pages show the new name without a manual page refresh.
+      if (variables.appName !== undefined) {
+        queryClient.invalidateQueries({ queryKey: ["skills"] });
+        queryClient.invalidateQueries({ queryKey: ["tools"] });
+      }
       toast.success(onSuccessMessage);
     },
   });


### PR DESCRIPTION
## Problem

The built-in **Archestra Platform Operations** skill hardcodes the `Archestra` brand and the default `archestra__` tool prefix in its name, description, and body (`skills/built-in-skills.ts`). Those bytes are seeded verbatim into every org, so a **fully white-labeled** org saw "Archestra" in:

- the skill catalog / **search output** (`list_skills` + eager system-prompt injection)
- the `load_skill` activation block
- bundled-file reads (`load_skill` with a path)

…even though the rest of the gateway (catalog name, MCP tool names) already swaps to the org's configured app name.

## Fix

Brand the built-in skill **at seed time** — the same pattern used for built-in MCP tools (seeded under the org's branded tool name).

- `builtInSkillShippedWrite` (the shared write shape for startup sync **and** reset-to-default) rewrites the `Archestra` brand → app name and `archestra__` → the org's branded tool prefix, and hashes `source_commit` over the **branded** body.
- `syncBuiltInSkills` and the `/api/skills/:id/reset` route sync `archestraMcpBranding` to the target org before writing.
- The swap is a **no-op unless full white-labeling is active** (mirrors `getArchestraMcpCatalogName` / `getArchestraToolPrefix`); only built-in skill text is ever branded.

Because the brand lives in the **stored row**, every read path is fixed with zero read-side changes: catalog, `load_skill` body, bundled files, and the **sandbox mount path** all show the app name, and a `load_skill` call resolves the branded name directly (no name-resolution shim).

### Auto-upgrade / migration semantics (the one wrinkle vs. built-in tools)

Built-in skills — unlike tools — have edit-preservation keyed on a content hash. Hashing `source_commit` over the *branded* body keeps that intact:

- a pristine (unedited) copy stays recognized as pristine;
- if the org's app name later changes, the shipped hash changes, so the pristine copy **auto-rebrands** on the next `syncBuiltInSkills`;
- an admin-edited copy is preserved untouched;
- **existing orgs migrate on deploy** via the normal sync — no hand-written SQL migration.

## Tests

- `built-in-skill-branding.test.ts` — unit tests for the swap, incl. both no-op cases (flag off; flag on but no app name).
- `database/seed.test.ts` — seeding brands the row under the app name, and a pristine copy re-brands when the app name changes. Existing seed assertions (no-app-name orgs) stay canonical.

Backend `type-check`, `knip`, `biome`, and the touched vitest suites (328 tests across `skills`, `seed`, `routes/skill`, `archestra-mcp-server`) pass locally.