### PR TITLE
docs(sandbox-core): correct tracing section

### DIFF
--- a/platform/archestra-rs/sandbox-core/README.md
+++ b/platform/archestra-rs/sandbox-core/README.md
@@ -27,11 +27,17 @@ Keep `dagger-sdk` in `Cargo.toml` in sync with `DAGGER_VERSION` in the platform
 `Dockerfile` and the managed Dagger Helm charts;
 `scripts/check-dagger-version-sync.sh` enforces this in CI.
 
-## Tracing
+## Tracing & telemetry
 
 Public async functions open `tracing` spans with `skip_all` and attach the
-incoming W3C `traceparent` as a remote parent in the shared `with_dagger`
-entrypoint. The host process must install a `tracing-opentelemetry` subscriber
-before calling the core — in the N-API host this happens once during backend
-observability startup, and in a daemon it belongs in server bootstrap before
-routes are registered.
+caller's W3C `traceparent` as a remote parent, so these spans nest under the
+originating trace instead of starting new roots.
+
+The crate owns its telemetry pipeline rather than borrowing the host's.
+`telemetry::init()` — gated by the `telemetry` feature and idempotent — installs
+a process-global OTLP exporter for traces and logs under
+`service.name=archestra-sandbox-rs`, aimed at the same collector the Node SDK
+uses. The N-API binding calls `init()` on every entry point, so the host
+forwards a `traceparent` but registers no subscriber for this crate. Call
+`flushTelemetry` (`telemetry::flush()`) on graceful shutdown to drain the final
+export batch.


### PR DESCRIPTION
The `sandbox-core` README's Tracing section had drifted from the code. Two claims were wrong:

- Referenced a `with_dagger` entrypoint that no longer exists anywhere in the workspace.
- Stated the host must install a `tracing-opentelemetry` subscriber before calling the core. In reality the crate self-installs its own process-global OTLP pipeline via `telemetry::init()` (gated by the `telemetry` feature), which the N-API binding calls on every entry point. The host only forwards a `traceparent`. This now matches `docs/pages/platform-observability.md` (`service.name=archestra-sandbox-rs`).

Also documents the `telemetry` feature flag and the `flushTelemetry` shutdown call. Docs-only; no code or behavior change.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>