### PR TITLE
fix(cost): count team members per team

### DIFF
--- a/platform/backend/src/models/statistics.test.ts
+++ b/platform/backend/src/models/statistics.test.ts
@@ -136,6 +136,71 @@ describe("StatisticsModel", () => {
       expect(result).toBeDefined();
       expect(Array.isArray(result)).toBe(true);
     });
+
+    test("counts team members per team instead of per organization", async ({
+      makeAgent,
+      makeInteraction,
+      makeMember,
+      makeOrganization,
+      makeTeam,
+      makeTeamMember,
+      makeUser,
+    }) => {
+      const org = await makeOrganization();
+      const users = await Promise.all([
+        makeUser(),
+        makeUser(),
+        makeUser(),
+        makeUser(),
+      ]);
+
+      await Promise.all(users.map((user) => makeMember(user.id, org.id)));
+
+      const teamAlpha = await makeTeam(org.id, users[0].id, {
+        name: "Team Alpha",
+      });
+      const teamBeta = await makeTeam(org.id, users[0].id, {
+        name: "Team Beta",
+      });
+
+      await makeTeamMember(teamAlpha.id, users[0].id);
+      await Promise.all(
+        users.slice(1).map((user) => makeTeamMember(teamBeta.id, user.id)),
+      );
+
+      const alphaAgent = await makeAgent({
+        organizationId: org.id,
+        teams: [teamAlpha.id],
+      });
+      const betaAgent = await makeAgent({
+        organizationId: org.id,
+        teams: [teamBeta.id],
+      });
+
+      await makeInteraction(alphaAgent.id, {
+        inputTokens: 100,
+        outputTokens: 50,
+      });
+      await makeInteraction(betaAgent.id, {
+        inputTokens: 300,
+        outputTokens: 80,
+      });
+
+      const stats = await StatisticsModel.getTeamStatistics(
+        "24h",
+        users[0].id,
+        true,
+      );
+
+      expect(
+        Object.fromEntries(
+          stats.map((team) => [team.teamName, team.members] as const),
+        ),
+      ).toMatchObject({
+        "Team Alpha": 1,
+        "Team Beta": 3,
+      });
+    });
   });
 
   describe("getAgentStatistics", () => {

--- a/platform/backend/src/models/statistics.ts
+++ b/platform/backend/src/models/statistics.ts
@@ -397,15 +397,12 @@ class StatisticsModel {
     const teamMemberCounts = await db
       .select({
         teamId: schema.teamsTable.id,
-        memberCount: sql<number>`CAST(COUNT(DISTINCT ${schema.membersTable.userId}) AS INTEGER)`,
+        memberCount: sql<number>`CAST(COUNT(DISTINCT ${schema.teamMembersTable.userId}) AS INTEGER)`,
       })
       .from(schema.teamsTable)
       .leftJoin(
-        schema.membersTable,
-        eq(
-          schema.teamsTable.organizationId,
-          schema.membersTable.organizationId,
-        ),
+        schema.teamMembersTable,
+        eq(schema.teamsTable.id, schema.teamMembersTable.teamId),
       )
       .groupBy(schema.teamsTable.id);
 


### PR DESCRIPTION
## Summary
Fixes team statistics to count members from `team_member` per team instead of counting all organization members.

Closes #5534.