### PR TITLE
feat(skills): add archestra-dev-smoke for live localhost testing

### DIFF
--- a/.claude/skills/archestra-dev-smoke/SKILL.md
+++ b/.claude/skills/archestra-dev-smoke/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: archestra-dev-smoke
+description: Use to smoke-test an Archestra feature against a running localhost stack — drive a real chat turn through the API (real LLM call, read back the reply + tokens/cost) and/or capture headless screenshots of the web app to visually evaluate. Use when asked to test/verify/exercise a feature live, check chat works end to end, or screenshot and judge the UI.
+---
+
+# Archestra live smoke testing
+
+Two ways to exercise a **running** local Archestra (`tilt up` / `pnpm dev`; frontend `:3000`,
+backend `:9000`) the way a human would when checking a feature actually works:
+
+- **Mode A — backend turn:** drive a real chat turn through the HTTP API (a real LLM call) and read
+  the result back. For "does chat / this agent / this tool actually work end to end".
+- **Mode B — visual:** screenshot pages headless, then **look at the PNGs and judge them**. For "does
+  this page render / look right".
+
+`$SKILL_DIR` is the directory containing this file. The backend helpers are zero-dependency Python
+≥3.10 at `$SKILL_DIR/scripts/` — `python3 <script>` works with nothing installed.
+
+This skill assumes the stack is already up and the instance already has a usable LLM provider key.
+It does **not** start the stack, seed data, or create/edit LLM keys.
+
+## Connect
+
+Backend scripts read connection from env (defaults target local dev):
+
+```bash
+export ARCHESTRA_BASE_URL=http://localhost:3000   # frontend origin serves /api/* (default)
+# auth: either an API key…
+export ARCHESTRA_API_KEY=arch_...
+# …or sign-in creds (default admin@example.com / password):
+export ARCHESTRA_EMAIL=admin@example.com
+export ARCHESTRA_PASSWORD=password
+```
+
+A failed connect prints a clear hint (stack down? wrong creds?). If you only need to confirm the
+stack is reachable, run any Mode A command — it connect-checks first.
+
+## Mode A — drive a real chat turn
+
+```bash
+python3 "$SKILL_DIR/scripts/chat_turn.py" --agent "My Assistant" --prompt "say hi in 3 words"
+python3 "$SKILL_DIR/scripts/chat_turn.py" --agent <agent-uuid> --prompt "…" --json
+```
+
+`--agent` takes an agent name or id (list them in the UI under Agents, or via the client below).
+It creates a conversation, sends the prompt, drains the stream (hard timeout — never hangs), then
+reads the persisted assistant reply and the turn's interaction back, printing the **reply, tool
+calls, model, and input/output tokens + cost**. Exit is non-zero if the turn errors or no reply
+persists. Model is auto-resolved by the backend; pass `--model <id>` only to override.
+
+If the turn fails because the instance has no LLM key configured, the script says so — fix it in the
+UI (Settings → LLM), not here.
+
+For features beyond a plain chat turn, compose `SmokeClient` directly — it exposes `list_agents`,
+`list_llm_keys`, `create_conversation`, `run_turn`, and the read-back helpers:
+
+```bash
+python3 - <<'PY'
+from smoke_client import SmokeClient
+with SmokeClient("http://localhost:3000") as c:
+    c.sign_in("admin@example.com", "password")
+    for a in c.list_agents():
+        print(a["name"], a["id"])
+PY
+```
+
+(For the broader API surface — skills, MCP, policies, hooks — use the sibling
+`migration-kit/scripts/archestra_client.py`.)
+
+## Mode B — capture screenshots and evaluate
+
+The Playwright capture lives in the e2e workspace so it reuses the installed browser and auth
+helpers. Run it **from `platform/e2e-tests/`**:
+
+```bash
+SMOKE_PATHS=/agents,/settings pnpm exec playwright test --config smoke/smoke.config.ts
+```
+
+- `SMOKE_PATHS` — comma-separated app routes (default `/`).
+- `SMOKE_OUT_DIR` — output dir for PNGs (default `/tmp/archestra-smoke`).
+
+It signs in as admin, navigates each path, writes a full-page PNG per route, and prints a
+`===SMOKE_MANIFEST===` JSON block listing each `{path, screenshot, errors}` (errors = console
+errors / page exceptions seen on that route).
+
+Then **do the evaluation yourself**: `Read` each PNG and judge it against what the feature should
+look like — layout, content, empty/error states, and anything in the manifest's `errors`. The
+capture only takes pictures; it asserts nothing about correctness.
+
+## What this skill does not do
+
+- Start or seed the stack (run `tilt up` / `pnpm dev` first).
+- Create or edit LLM provider keys (configure them in the UI).
+- Mock LLM calls — Mode A makes real calls and costs real tokens.

--- a/.claude/skills/archestra-dev-smoke/scripts/chat_turn.py
+++ b/.claude/skills/archestra-dev-smoke/scripts/chat_turn.py
@@ -26,6 +26,7 @@ import argparse
 import json
 import os
 import sys
+import uuid
 
 from smoke_client import ArchestraApiError, ChatTurnError, ChatTurnResult, SmokeClient
 
@@ -51,7 +52,10 @@ def main() -> int:
             return _fail(f"cannot reach a ready archestra at {base_url}: {exc}\n"
                          "is the local stack up (`tilt up` / `pnpm dev`)?")
 
-        agent_id = _resolve_agent(client, args.agent)
+        try:
+            agent_id = _resolve_agent(client, args.agent)
+        except _AmbiguousAgent as exc:
+            return _fail(str(exc))
         if agent_id is None:
             return _fail(f"no agent matched {args.agent!r}; create one in the UI or pass its id")
 
@@ -70,16 +74,26 @@ def main() -> int:
     return 0
 
 
+class _AmbiguousAgent(RuntimeError):
+    """more than one agent matched the given name -- the caller must disambiguate with an id."""
+
+
 def _resolve_agent(client: SmokeClient, agent: str) -> str | None:
-    """match by exact id first, then by exact name. ambiguous names resolve to the first match."""
-    agents = client.list_agents()
-    for row in agents:
-        if row.get("id") == agent:
-            return agent
-    for row in agents:
-        if row.get("name") == agent and isinstance(row.get("id"), str):
-            return row["id"]
-    return None
+    """resolve --agent to an id. a UUID is used directly (create_conversation 404s if it is wrong);
+    otherwise match exactly by name. an ambiguous name is a hard error -- a smoke check against the
+    wrong agent could report a misleading pass."""
+    try:
+        uuid.UUID(agent)
+        return agent
+    except ValueError:
+        pass
+    matches = [row["id"] for row in client.list_agents(name=agent)
+               if row.get("name") == agent and isinstance(row.get("id"), str)]
+    if len(matches) > 1:
+        raise _AmbiguousAgent(
+            f"{len(matches)} agents are named {agent!r}; pass the agent id instead"
+        )
+    return matches[0] if matches else None
 
 
 def _report(result: ChatTurnResult, *, as_json: bool) -> None:

--- a/.claude/skills/archestra-dev-smoke/scripts/chat_turn.py
+++ b/.claude/skills/archestra-dev-smoke/scripts/chat_turn.py
@@ -1,0 +1,134 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""drive one real chat turn against a running local archestra instance and print the result.
+
+this makes a REAL llm call through the running stack: pick an agent, send a prompt, drain the
+chat stream, then read the persisted assistant reply and the turn's token usage / cost back.
+the instance is assumed to already have a usable llm provider key + a model resolvable for the
+agent -- this script never creates or edits keys.
+
+connection comes from env:
+    ARCHESTRA_BASE_URL   (default http://localhost:3000 -- the frontend origin serves /api/*)
+    ARCHESTRA_API_KEY    raw api key (Authorization header), OR sign in with:
+    ARCHESTRA_EMAIL      (default admin@example.com)
+    ARCHESTRA_PASSWORD   (default password)
+
+usage:
+    python3 chat_turn.py --agent "My Agent" --prompt "say hi in 3 words"
+    python3 chat_turn.py --agent <agent-uuid> --prompt "..." --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+from smoke_client import ArchestraApiError, ChatTurnError, ChatTurnResult, SmokeClient
+
+DEFAULT_BASE_URL = "http://localhost:3000"
+DEFAULT_EMAIL = "admin@example.com"
+DEFAULT_PASSWORD = "password"
+
+
+def main() -> int:
+    args = _parse_args()
+    base_url = os.environ.get("ARCHESTRA_BASE_URL", DEFAULT_BASE_URL)
+    api_key = os.environ.get("ARCHESTRA_API_KEY")
+
+    with SmokeClient(base_url, api_key=api_key) as client:
+        try:
+            if api_key is None:
+                client.sign_in(
+                    os.environ.get("ARCHESTRA_EMAIL", DEFAULT_EMAIL),
+                    os.environ.get("ARCHESTRA_PASSWORD", DEFAULT_PASSWORD),
+                )
+            client.connect_check()
+        except (ArchestraApiError, ValueError) as exc:
+            return _fail(f"cannot reach a ready archestra at {base_url}: {exc}\n"
+                         "is the local stack up (`tilt up` / `pnpm dev`)?")
+
+        agent_id = _resolve_agent(client, args.agent)
+        if agent_id is None:
+            return _fail(f"no agent matched {args.agent!r}; create one in the UI or pass its id")
+
+        try:
+            result = client.run_turn(agent_id, args.prompt, title=args.title, model_id=args.model)
+        except ChatTurnError as exc:
+            hint = "" if client.list_llm_keys() else (
+                "\nthe instance has no llm provider key configured -- add one in Settings -> LLM "
+                "before running a live turn"
+            )
+            return _fail(f"chat turn failed: {exc}{hint}")
+        except ArchestraApiError as exc:
+            return _fail(f"chat turn failed (api error): {exc}")
+
+    _report(result, as_json=args.json)
+    return 0
+
+
+def _resolve_agent(client: SmokeClient, agent: str) -> str | None:
+    """match by exact id first, then by exact name. ambiguous names resolve to the first match."""
+    agents = client.list_agents()
+    for row in agents:
+        if row.get("id") == agent:
+            return agent
+    for row in agents:
+        if row.get("name") == agent and isinstance(row.get("id"), str):
+            return row["id"]
+    return None
+
+
+def _report(result: ChatTurnResult, *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps({
+            "conversationId": result.conversation_id,
+            "text": result.text,
+            "toolCalls": result.tool_calls,
+            "model": result.model,
+            "inputTokens": result.input_tokens,
+            "outputTokens": result.output_tokens,
+            "cost": result.cost,
+        }, indent=2))
+        return
+    print(f"conversation: {result.conversation_id}")
+    if result.model:
+        print(f"model:        {result.model}")
+    if result.tool_calls:
+        print(f"tool calls:   {', '.join(result.tool_calls)}")
+    tokens = _fmt_tokens(result)
+    if tokens:
+        print(f"usage:        {tokens}")
+    print("\n--- assistant reply ---")
+    print(result.text or "(no text in reply)")
+
+
+def _fmt_tokens(result: ChatTurnResult) -> str:
+    parts: list[str] = []
+    if result.input_tokens is not None or result.output_tokens is not None:
+        parts.append(f"in={result.input_tokens} out={result.output_tokens}")
+    if result.cost is not None:
+        parts.append(f"cost=${result.cost:.6f}")
+    return " ".join(parts)
+
+
+def _fail(message: str) -> int:
+    print(f"error: {message}", file=sys.stderr)
+    return 1
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="drive one real chat turn against local archestra")
+    parser.add_argument("--agent", required=True, help="agent name or id to chat with")
+    parser.add_argument("--prompt", required=True, help="the user message to send")
+    parser.add_argument("--model", default=None, help="optional model id override (else auto-resolved)")
+    parser.add_argument("--title", default=None, help="optional conversation title")
+    parser.add_argument("--json", action="store_true", help="print the result as json")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/archestra-dev-smoke/scripts/smoke_client.py
+++ b/.claude/skills/archestra-dev-smoke/scripts/smoke_client.py
@@ -75,6 +75,10 @@ class SmokeClient:
     def __init__(self, base_url: str, api_key: str | None = None, timeout: float = 30.0) -> None:
         self.base_url = base_url.rstrip("/") + "/"
         self.timeout = timeout
+        # an api key is a credential too: refuse to attach it over cleartext non-loopback
+        # transport, the same guard sign_in applies to a password.
+        if api_key is not None:
+            _require_secure_transport(self.base_url)
         self._auth = api_key
         self._jar = http.cookiejar.CookieJar()
         self._opener = urllib.request.build_opener(
@@ -102,8 +106,11 @@ class SmokeClient:
 
     # --- agents & keys (read-only; the skill never mutates keys) ----------------------------
 
-    def list_agents(self) -> list[dict[str, JsonValue]]:
-        return _items(self._request("GET", "/api/agents"))
+    def list_agents(self, name: str | None = None) -> list[dict[str, JsonValue]]:
+        """pass `name` to filter server-side: /api/agents is paginated (default 20 rows), so an
+        unfiltered list would silently miss agents on a larger instance."""
+        params = {"name": name} if name else None
+        return _items(self._request("GET", "/api/agents", params=params))
 
     def list_llm_keys(self) -> list[dict[str, JsonValue]]:
         """only used to enrich the 'no llm key configured' diagnostic when a turn fails."""
@@ -144,15 +151,17 @@ class SmokeClient:
         if stream_error is not None:
             raise ChatTurnError(f"chat stream returned an error: {stream_error}")
         text, tool_calls = self._read_assistant_reply(conversation_id, timeout_s=readback_timeout_s)
-        interaction = self._latest_interaction(conversation_id)
+        interactions = self._session_interactions(conversation_id)
         return ChatTurnResult(
             conversation_id=conversation_id,
             text=text,
             tool_calls=tool_calls,
-            input_tokens=_opt_int(interaction, "inputTokens"),
-            output_tokens=_opt_int(interaction, "outputTokens"),
-            cost=_opt_float(interaction, "cost"),
-            model=_opt_str(interaction, "model"),
+            # a tool-loop turn issues several llm calls, each its own interaction row -- sum them
+            # so the reported usage is the whole turn, not just the final step.
+            input_tokens=_sum_int(interactions, "inputTokens"),
+            output_tokens=_sum_int(interactions, "outputTokens"),
+            cost=_sum_float(interactions, "cost"),
+            model=_opt_str(interactions[0] if interactions else None, "model"),
         )
 
     # --- internals --------------------------------------------------------------------------
@@ -167,10 +176,12 @@ class SmokeClient:
         }
         req = self._build_request("POST", "/api/chat", json_body=body)
         deadline = time.monotonic() + timeout_s
-        # per-read socket timeout bounds a single stalled read; the deadline bounds the whole turn.
-        per_read = min(self.timeout, timeout_s)
+        # the socket timeout is the whole turn budget, not a tight per-chunk window: a tool-using or
+        # reasoning turn can legitimately go quiet for many seconds between chunks, and treating that
+        # as a stall is a false failure. the budget caps both a single dead read and (via the
+        # post-read deadline check) the turn overall.
         try:
-            resp = self._opener.open(req, timeout=per_read)
+            resp = self._opener.open(req, timeout=timeout_s)
         except urllib.error.HTTPError as exc:
             raise ArchestraApiError("POST", req.full_url, exc.code, _decode_error(exc)) from exc
         except (OSError, http.client.HTTPException) as exc:
@@ -178,15 +189,15 @@ class SmokeClient:
         try:
             chunks: list[str] = []
             while True:
-                if time.monotonic() > deadline:
-                    raise ChatTurnError(f"chat stream did not finish within {timeout_s:.0f}s")
                 try:
                     block = resp.read(8192)
                 except socket.timeout as exc:
-                    raise ChatTurnError(f"chat stream stalled (no data for {per_read:.0f}s)") from exc
+                    raise ChatTurnError(f"chat stream did not finish within {timeout_s:.0f}s") from exc
                 if not block:
                     break
                 chunks.append(block.decode("utf-8", errors="replace"))
+                if time.monotonic() > deadline:
+                    raise ChatTurnError(f"chat stream did not finish within {timeout_s:.0f}s")
             return _scan_stream_error("".join(chunks))
         finally:
             resp.close()
@@ -204,9 +215,12 @@ class SmokeClient:
             messages = messages if isinstance(messages, list) else []
             for message in reversed(messages):
                 if isinstance(message, dict) and message.get("role") == "assistant":
-                    text, tool_calls = _extract_parts(message.get("parts"))
-                    if text or tool_calls:
-                        return text, tool_calls
+                    parts = message.get("parts")
+                    # the read-back is post-drain, so a persisted assistant message with any parts
+                    # is final. return it even if it has no text (e.g. a tool-only or file reply)
+                    # rather than looping to a false "no reply" timeout.
+                    if isinstance(parts, list) and parts:
+                        return _extract_parts(parts)
             if time.monotonic() > deadline:
                 raise ChatTurnError(
                     f"no assistant reply persisted within {timeout_s:.0f}s "
@@ -214,11 +228,11 @@ class SmokeClient:
                 )
             time.sleep(1.0)
 
-    def _latest_interaction(self, conversation_id: str) -> dict[str, JsonValue] | None:
-        """conversationId is passed to the llm proxy as sessionId, so the turn's interaction is
-        retrievable by that filter. missing interaction is non-fatal -- the reply still stands."""
-        rows = _items(self._request("GET", "/api/interactions", params={"sessionId": conversation_id}))
-        return rows[0] if rows else None
+    def _session_interactions(self, conversation_id: str) -> list[dict[str, JsonValue]]:
+        """conversationId is passed to the llm proxy as sessionId, so every llm call in the turn is
+        retrievable by that filter (newest first). missing interactions are non-fatal -- the reply
+        still stands; usage just reports unknown."""
+        return _items(self._request("GET", "/api/interactions", params={"sessionId": conversation_id}))
 
     def _request(
         self,
@@ -294,9 +308,15 @@ def _items(body: JsonValue) -> list[dict[str, JsonValue]]:
     return out
 
 
+# AI-SDK v5 names a tool part 'tool-<actualToolName>'. the legacy generic 'tool-call'/'tool-result'
+# types carry the name elsewhere, so naively stripping the prefix would report phantom tools named
+# 'call'/'result'; skip them and let 'dynamic-tool' / typed parts carry the real names.
+_LEGACY_TOOL_TYPES = frozenset({"tool-call", "tool-result"})
+
+
 def _extract_parts(parts: JsonValue) -> tuple[str, list[str]]:
     """pull visible text and tool-call names out of a persisted assistant message's parts.
-    AI-SDK tool parts are typed 'tool-<name>' (or carry a toolName); text parts are 'text'."""
+    AI-SDK tool parts are typed 'tool-<name>' (or a 'dynamic-tool' carrying toolName)."""
     text_segments: list[str] = []
     tool_calls: list[str] = []
     if not isinstance(parts, list):
@@ -307,10 +327,14 @@ def _extract_parts(parts: JsonValue) -> tuple[str, list[str]]:
         part_type = part.get("type")
         if part_type == "text" and isinstance(part.get("text"), str):
             text_segments.append(part["text"])
-        elif isinstance(part_type, str) and part_type.startswith("tool-"):
-            tool_calls.append(part_type.removeprefix("tool-"))
         elif part_type == "dynamic-tool" and isinstance(part.get("toolName"), str):
             tool_calls.append(part["toolName"])
+        elif (
+            isinstance(part_type, str)
+            and part_type.startswith("tool-")
+            and part_type not in _LEGACY_TOOL_TYPES
+        ):
+            tool_calls.append(part_type.removeprefix("tool-"))
     return "".join(text_segments).strip(), tool_calls
 
 
@@ -350,14 +374,20 @@ def _opt_str(obj: dict[str, JsonValue] | None, key: str) -> str | None:
     return value if isinstance(value, str) else None
 
 
-def _opt_int(obj: dict[str, JsonValue] | None, key: str) -> int | None:
-    value = obj.get(key) if obj else None
-    return value if isinstance(value, int) else None
+def _sum_int(rows: list[dict[str, JsonValue]], key: str) -> int | None:
+    """sum an integer column across rows; None when no row carries it (unknown, not zero)."""
+    values = [row[key] for row in rows if isinstance(row.get(key), int)]
+    return sum(values) if values else None
 
 
-def _opt_float(obj: dict[str, JsonValue] | None, key: str) -> float | None:
+def _sum_float(rows: list[dict[str, JsonValue]], key: str) -> float | None:
+    """sum a numeric column across rows; None when no row carries it (unknown, not zero)."""
+    values = [v for row in rows if (v := _coerce_float(row.get(key))) is not None]
+    return sum(values) if values else None
+
+
+def _coerce_float(value: JsonValue) -> float | None:
     """cost is a numeric column serialized as a decimal string; coerce it."""
-    value = obj.get(key) if obj else None
     match value:
         case int() | float():
             return float(value)

--- a/.claude/skills/archestra-dev-smoke/scripts/smoke_client.py
+++ b/.claude/skills/archestra-dev-smoke/scripts/smoke_client.py
@@ -1,0 +1,386 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""stdlib-only client for driving a live archestra instance during smoke testing.
+
+scope: the few calls needed to run one real chat turn end to end and read the result back --
+auth, agent lookup, conversation create, the streaming chat turn, and the persisted read-back
+(messages + the llm interaction's tokens/cost). it is NOT a general api client; for the broader
+surface (skills, mcp, policies, hooks) use migration-kit/scripts/archestra_client.py.
+
+the request/error/cookie plumbing follows that sibling client: a private opener owns a cookie jar
+so the session cookie from sign_in carries forward, redirects are treated as errors (a redirect on
+a fixed base url could silently rewrite a POST), and every non-2xx raises ArchestraApiError verbatim.
+
+the chat turn cannot reuse the json _request path: POST /api/chat returns an open AI-SDK UIMessage
+stream, so it has its own streaming request that drains the body with a hard read+wall-clock
+deadline (a stalled llm call must fail loudly, never hang). stream bytes are opaque -- the
+authoritative result is the persisted conversation read back afterward, not reconstructed chunks.
+"""
+
+from __future__ import annotations
+
+import http.client
+import http.cookiejar
+import json
+import socket
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from dataclasses import dataclass
+
+JsonValue = object  # the api returns arbitrary json; callers narrow with isinstance/require_*
+
+
+class ArchestraApiError(RuntimeError):
+    """a non-2xx response (or an unexpected redirect / transport failure). carries the body."""
+
+    def __init__(self, method: str, url: str, status: int, body: str) -> None:
+        super().__init__(f"{method} {url} -> {status}: {body}")
+        self.method = method
+        self.url = url
+        self.status = status
+        self.body = body
+
+
+class ChatTurnError(RuntimeError):
+    """the chat turn itself failed: an error frame in the stream, a drain timeout, or no
+    assistant message persisted within the read-back window. distinct from ArchestraApiError
+    (an http-level failure) so chat_turn.py can report the turn outcome separately."""
+
+
+@dataclass(frozen=True)
+class ChatTurnResult:
+    conversation_id: str
+    text: str
+    tool_calls: list[str]
+    input_tokens: int | None
+    output_tokens: int | None
+    cost: float | None
+    model: str | None
+
+
+class _RaiseOnRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        raise urllib.error.HTTPError(req.full_url, code, f"unexpected redirect to {newurl}", headers, fp)
+
+
+class SmokeClient:
+    """talks to one running archestra instance. auth is either an api key (raw Authorization
+    header, no Bearer) or a better-auth session cookie established by sign_in."""
+
+    def __init__(self, base_url: str, api_key: str | None = None, timeout: float = 30.0) -> None:
+        self.base_url = base_url.rstrip("/") + "/"
+        self.timeout = timeout
+        self._auth = api_key
+        self._jar = http.cookiejar.CookieJar()
+        self._opener = urllib.request.build_opener(
+            urllib.request.HTTPCookieProcessor(self._jar),
+            _RaiseOnRedirect(),
+        )
+
+    def __enter__(self) -> "SmokeClient":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._opener.close()
+
+    # --- auth & connectivity ---------------------------------------------------------------
+
+    def sign_in(self, email: str, password: str) -> None:
+        """better-auth email sign-in; the session cookie persists on this client's jar."""
+        _require_secure_transport(self.base_url)
+        self._request("POST", "/api/auth/sign-in/email", json_body={"email": email, "password": password})
+
+    def connect_check(self) -> dict[str, JsonValue]:
+        """authed probe that proves frontend + backend + db + our credential all work. /ready and
+        /health live on the backend origin only, so an authed /api route is the real local gate."""
+        return _require_dict(self._request("GET", "/api/config"), ctx="GET /api/config")
+
+    # --- agents & keys (read-only; the skill never mutates keys) ----------------------------
+
+    def list_agents(self) -> list[dict[str, JsonValue]]:
+        return _items(self._request("GET", "/api/agents"))
+
+    def list_llm_keys(self) -> list[dict[str, JsonValue]]:
+        """only used to enrich the 'no llm key configured' diagnostic when a turn fails."""
+        return _items(self._request("GET", "/api/llm-provider-api-keys"))
+
+    # --- one chat turn, end to end ----------------------------------------------------------
+
+    def create_conversation(
+        self, agent_id: str, *, title: str | None = None, model_id: str | None = None
+    ) -> str:
+        """create a conversation bound to an agent. modelId is optional -- the backend resolves
+        member -> agent -> org -> best-available, so omit it unless explicitly overriding."""
+        body: dict[str, JsonValue] = {"agentId": agent_id}
+        if title is not None:
+            body["title"] = title
+        if model_id is not None:
+            body["modelId"] = model_id
+        created = _require_dict(
+            self._request("POST", "/api/chat/conversations", json_body=body),
+            ctx="POST /api/chat/conversations",
+        )
+        return _require_str(created, "id", ctx="conversation create response")
+
+    def run_turn(
+        self,
+        agent_id: str,
+        prompt: str,
+        *,
+        title: str | None = None,
+        model_id: str | None = None,
+        stream_timeout_s: float = 180.0,
+        readback_timeout_s: float = 20.0,
+    ) -> ChatTurnResult:
+        """create a conversation, send one user message, drain the stream, then read the
+        persisted assistant message + interaction back. raises ChatTurnError on any turn failure."""
+        conversation_id = self.create_conversation(agent_id, title=title, model_id=model_id)
+        stream_error = self._send_message(conversation_id, prompt, timeout_s=stream_timeout_s)
+        if stream_error is not None:
+            raise ChatTurnError(f"chat stream returned an error: {stream_error}")
+        text, tool_calls = self._read_assistant_reply(conversation_id, timeout_s=readback_timeout_s)
+        interaction = self._latest_interaction(conversation_id)
+        return ChatTurnResult(
+            conversation_id=conversation_id,
+            text=text,
+            tool_calls=tool_calls,
+            input_tokens=_opt_int(interaction, "inputTokens"),
+            output_tokens=_opt_int(interaction, "outputTokens"),
+            cost=_opt_float(interaction, "cost"),
+            model=_opt_str(interaction, "model"),
+        )
+
+    # --- internals --------------------------------------------------------------------------
+
+    def _send_message(self, conversation_id: str, prompt: str, *, timeout_s: float) -> str | None:
+        """POST /api/chat and drain the AI-SDK stream to completion. returns an error string if
+        the stream carried an error frame, else None. raises ChatTurnError on a drain timeout."""
+        body = {
+            "id": conversation_id,
+            "messages": [{"id": str(uuid.uuid4()), "role": "user", "parts": [{"type": "text", "text": prompt}]}],
+            "trigger": "submit-message",
+        }
+        req = self._build_request("POST", "/api/chat", json_body=body)
+        deadline = time.monotonic() + timeout_s
+        # per-read socket timeout bounds a single stalled read; the deadline bounds the whole turn.
+        per_read = min(self.timeout, timeout_s)
+        try:
+            resp = self._opener.open(req, timeout=per_read)
+        except urllib.error.HTTPError as exc:
+            raise ArchestraApiError("POST", req.full_url, exc.code, _decode_error(exc)) from exc
+        except (OSError, http.client.HTTPException) as exc:
+            raise ArchestraApiError("POST", req.full_url, 0, f"{type(exc).__name__}: {exc}") from exc
+        try:
+            chunks: list[str] = []
+            while True:
+                if time.monotonic() > deadline:
+                    raise ChatTurnError(f"chat stream did not finish within {timeout_s:.0f}s")
+                try:
+                    block = resp.read(8192)
+                except socket.timeout as exc:
+                    raise ChatTurnError(f"chat stream stalled (no data for {per_read:.0f}s)") from exc
+                if not block:
+                    break
+                chunks.append(block.decode("utf-8", errors="replace"))
+            return _scan_stream_error("".join(chunks))
+        finally:
+            resp.close()
+
+    def _read_assistant_reply(self, conversation_id: str, *, timeout_s: float) -> tuple[str, list[str]]:
+        """poll the persisted conversation for the assistant message. persistence happens in the
+        backend onFinish, slightly after the stream ends, so this is a bounded retry not one read."""
+        deadline = time.monotonic() + timeout_s
+        while True:
+            conversation = _require_dict(
+                self._request("GET", f"/api/chat/conversations/{conversation_id}"),
+                ctx="GET conversation",
+            )
+            messages = conversation.get("messages")
+            messages = messages if isinstance(messages, list) else []
+            for message in reversed(messages):
+                if isinstance(message, dict) and message.get("role") == "assistant":
+                    text, tool_calls = _extract_parts(message.get("parts"))
+                    if text or tool_calls:
+                        return text, tool_calls
+            if time.monotonic() > deadline:
+                raise ChatTurnError(
+                    f"no assistant reply persisted within {timeout_s:.0f}s "
+                    f"(conversation {conversation_id})"
+                )
+            time.sleep(1.0)
+
+    def _latest_interaction(self, conversation_id: str) -> dict[str, JsonValue] | None:
+        """conversationId is passed to the llm proxy as sessionId, so the turn's interaction is
+        retrievable by that filter. missing interaction is non-fatal -- the reply still stands."""
+        rows = _items(self._request("GET", "/api/interactions", params={"sessionId": conversation_id}))
+        return rows[0] if rows else None
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, str] | None = None,
+        json_body: dict[str, JsonValue] | None = None,
+    ) -> JsonValue:
+        req = self._build_request(method, path, params=params, json_body=json_body)
+        try:
+            with self._opener.open(req, timeout=self.timeout) as resp:
+                return _decode_body(resp.read(), resp.headers)
+        except urllib.error.HTTPError as exc:
+            raise ArchestraApiError(method, req.full_url, exc.code, _decode_error(exc)) from exc
+        except (OSError, http.client.HTTPException, LookupError, json.JSONDecodeError) as exc:
+            raise ArchestraApiError(method, req.full_url, 0, f"{type(exc).__name__}: {exc}") from exc
+
+    def _build_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, str] | None = None,
+        json_body: dict[str, JsonValue] | None = None,
+    ) -> urllib.request.Request:
+        url = urllib.parse.urljoin(self.base_url, path.lstrip("/"))
+        if params:
+            url = f"{url}?{urllib.parse.urlencode(params)}"
+        headers = {"Accept-Encoding": "identity"}
+        if self._auth:
+            headers["Authorization"] = self._auth
+        data: bytes | None = None
+        if json_body is not None:
+            data = json.dumps(json_body, allow_nan=False).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        return urllib.request.Request(url, data=data, headers=headers, method=method)
+
+
+# --- response decoding & shape helpers -----------------------------------------------------
+
+
+def _decode_body(raw: bytes, headers: http.client.HTTPMessage) -> JsonValue:
+    charset = headers.get_content_charset() or "utf-8"
+    text = raw.decode(charset, errors="replace")
+    if headers.get_content_type() == "application/json":
+        return json.loads(text) if text.strip() else None
+    return text
+
+
+def _decode_error(exc: urllib.error.HTTPError) -> str:
+    raw = exc.read()
+    charset = exc.headers.get_content_charset() if exc.headers else None
+    return raw.decode(charset or "utf-8", errors="replace")
+
+
+def _items(body: JsonValue) -> list[dict[str, JsonValue]]:
+    """unwrap a list endpoint (bare array or {data|items: [...]} envelope). raises on an
+    unrecognized shape rather than hiding it as an empty list."""
+    match body:
+        case list():
+            rows = body
+        case {"data": list() as data}:
+            rows = data
+        case {"items": list() as data}:
+            rows = data
+        case _:
+            raise ArchestraApiError("GET", "<list>", 0, f"unexpected list shape: {str(body)[:200]}")
+    out: list[dict[str, JsonValue]] = []
+    for row in rows:
+        if isinstance(row, dict):
+            out.append(row)
+    return out
+
+
+def _extract_parts(parts: JsonValue) -> tuple[str, list[str]]:
+    """pull visible text and tool-call names out of a persisted assistant message's parts.
+    AI-SDK tool parts are typed 'tool-<name>' (or carry a toolName); text parts are 'text'."""
+    text_segments: list[str] = []
+    tool_calls: list[str] = []
+    if not isinstance(parts, list):
+        return "", []
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+        part_type = part.get("type")
+        if part_type == "text" and isinstance(part.get("text"), str):
+            text_segments.append(part["text"])
+        elif isinstance(part_type, str) and part_type.startswith("tool-"):
+            tool_calls.append(part_type.removeprefix("tool-"))
+        elif part_type == "dynamic-tool" and isinstance(part.get("toolName"), str):
+            tool_calls.append(part["toolName"])
+    return "".join(text_segments).strip(), tool_calls
+
+
+def _scan_stream_error(stream_text: str) -> str | None:
+    """best-effort: surface an AI-SDK error frame from the drained stream. the stream is a series
+    of `data: {json}` lines; an error part looks like {"type":"error","errorText":"..."}."""
+    for line in stream_text.splitlines():
+        line = line.strip()
+        payload = line[len("data:"):].strip() if line.startswith("data:") else line
+        if not payload.startswith("{") or '"error"' not in payload:
+            continue
+        try:
+            frame = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(frame, dict) and frame.get("type") == "error":
+            detail = frame.get("errorText") or frame.get("error") or frame
+            return str(detail)
+    return None
+
+
+def _require_dict(value: JsonValue, *, ctx: str) -> dict[str, JsonValue]:
+    if not isinstance(value, dict):
+        raise ArchestraApiError("?", ctx, 0, f"expected an object, got {type(value).__name__}")
+    return value
+
+
+def _require_str(obj: dict[str, JsonValue], key: str, *, ctx: str) -> str:
+    value = obj.get(key)
+    if not isinstance(value, str) or not value:
+        raise ArchestraApiError("?", ctx, 0, f"missing string field {key!r}")
+    return value
+
+
+def _opt_str(obj: dict[str, JsonValue] | None, key: str) -> str | None:
+    value = obj.get(key) if obj else None
+    return value if isinstance(value, str) else None
+
+
+def _opt_int(obj: dict[str, JsonValue] | None, key: str) -> int | None:
+    value = obj.get(key) if obj else None
+    return value if isinstance(value, int) else None
+
+
+def _opt_float(obj: dict[str, JsonValue] | None, key: str) -> float | None:
+    """cost is a numeric column serialized as a decimal string; coerce it."""
+    value = obj.get(key) if obj else None
+    match value:
+        case int() | float():
+            return float(value)
+        case str() if value.strip():
+            try:
+                return float(value)
+            except ValueError:
+                return None
+        case _:
+            return None
+
+
+def _require_secure_transport(base_url: str) -> None:
+    """refuse to send credentials over cleartext. https always; plain http only for loopback."""
+    parsed = urllib.parse.urlparse(base_url)
+    if parsed.scheme == "https":
+        return
+    if (parsed.hostname or "").lower() in {"localhost", "127.0.0.1", "::1"}:
+        return
+    raise ValueError(
+        f"refusing to send credentials over insecure transport: {base_url!r} "
+        "(use https, or localhost/127.0.0.1 for local dev)"
+    )
+
+
+__all__ = ["SmokeClient", "ChatTurnResult", "ArchestraApiError", "ChatTurnError"]

--- a/platform/e2e-tests/smoke/capture.smoke.ts
+++ b/platform/e2e-tests/smoke/capture.smoke.ts
@@ -61,7 +61,9 @@ test("capture", async ({ page }) => {
     }
     await page.waitForLoadState("networkidle").catch(() => {});
 
-    const screenshot = path.join(outDir, `${slug(appPath)}.png`);
+    // Index-prefix the filename so two routes that slug to the same name (e.g. "/foo-bar" and
+    // "/foo_bar") get distinct files instead of silently overwriting each other.
+    const screenshot = path.join(outDir, `${index}-${slug(appPath)}.png`);
     await page.screenshot({ path: screenshot, fullPage: true });
     manifest.push({ path: appPath, screenshot, errors: [...pageErrors] });
   }

--- a/platform/e2e-tests/smoke/capture.smoke.ts
+++ b/platform/e2e-tests/smoke/capture.smoke.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { ADMIN_EMAIL, ADMIN_PASSWORD } from "../consts";
+import { expectAuthenticated, loginViaApi } from "../utils/auth";
+
+/**
+ * Headless screenshot capture for the `archestra-dev-smoke` skill. Navigates each path in
+ * SMOKE_PATHS, captures a full-page PNG, and prints a JSON manifest of files + page errors to
+ * stdout. The agent then `Read`s the PNGs and does the visual evaluation — this file only
+ * captures, it makes no assertions about what "looks right".
+ *
+ * Env:
+ *   SMOKE_PATHS    comma-separated app routes, e.g. "/agents,/settings" (default "/")
+ *   SMOKE_OUT_DIR  output directory for PNGs (default "/tmp/archestra-smoke")
+ */
+const paths = (process.env.SMOKE_PATHS || "/")
+  .split(",")
+  .map((p) => p.trim())
+  .filter(Boolean);
+const outDir = process.env.SMOKE_OUT_DIR || "/tmp/archestra-smoke";
+
+interface CaptureEntry {
+  path: string;
+  screenshot: string;
+  errors: string[];
+}
+
+test("capture", async ({ page }) => {
+  fs.mkdirSync(outDir, { recursive: true });
+  const manifest: CaptureEntry[] = [];
+
+  // Attach error listeners once; reset the buffer per path so each entry only carries its own.
+  const pageErrors: string[] = [];
+  page.on("pageerror", (err) => pageErrors.push(`pageerror: ${err.message}`));
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      pageErrors.push(`console.error: ${msg.text()}`);
+    }
+  });
+
+  // Authenticate proactively: the app renders its sign-in view client-side without changing the
+  // URL, so a reactive URL check can't detect it. loginViaApi seeds the context's session cookie
+  // (a no-op refresh when storageState already supplied a valid one) so every navigation below is
+  // authenticated.
+  if (!(await loginViaApi(page, ADMIN_EMAIL, ADMIN_PASSWORD))) {
+    throw new Error(
+      "sign-in failed — is the local stack up and are the admin credentials correct?",
+    );
+  }
+
+  for (const [index, appPath] of paths.entries()) {
+    pageErrors.length = 0;
+    // "domcontentloaded", not the default "load": the Next.js dev server compiles a route on first
+    // hit (can exceed 30s) and some pages hold long-lived connections that defer the load event.
+    await page.goto(appPath, { waitUntil: "domcontentloaded" });
+    if (index === 0) {
+      // Fail loudly on the first path if the session didn't take, rather than silently
+      // capturing the sign-in view for every route.
+      await expectAuthenticated(page);
+    }
+    await page.waitForLoadState("networkidle").catch(() => {});
+
+    const screenshot = path.join(outDir, `${slug(appPath)}.png`);
+    await page.screenshot({ path: screenshot, fullPage: true });
+    manifest.push({ path: appPath, screenshot, errors: [...pageErrors] });
+  }
+
+  // Single delimited block, written straight to stdout, so it is unambiguous to find in the
+  // runner's output and survives the line reporter.
+  process.stdout.write(
+    `\n===SMOKE_MANIFEST===\n${JSON.stringify(manifest, null, 2)}\n===END===\n`,
+  );
+  expect(manifest.length).toBe(paths.length);
+});
+
+function slug(appPath: string): string {
+  const cleaned = appPath
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return cleaned || "root";
+}

--- a/platform/e2e-tests/smoke/smoke.config.ts
+++ b/platform/e2e-tests/smoke/smoke.config.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import { defineConfig } from "@playwright/test";
+import { adminAuthFile, UI_BASE_URL } from "../consts";
+
+/**
+ * Standalone Playwright config for the `archestra-dev-smoke` skill's visual capture.
+ *
+ * Deliberately separate from the main `playwright.config.ts`: a single chromium project, no
+ * setup-chain dependency, and screenshots taken explicitly (not on failure). It reuses the
+ * already-installed `@playwright/test` and the e2e-tests auth helpers, but `pnpm test:e2e`
+ * never picks this up because it lives outside `testDir: ./tests`.
+ *
+ * Auth: reuse the admin storageState produced by a prior `pnpm test:e2e` run when present;
+ * otherwise the capture test signs in itself via `loginViaApi` (the file is gitignored and
+ * absent on a clean checkout, so the fallback is the common case).
+ *
+ * Run from `platform/e2e-tests/`:
+ *   SMOKE_PATHS=/agents,/settings pnpm exec playwright test --config smoke/smoke.config.ts
+ */
+export default defineConfig({
+  testDir: __dirname,
+  testMatch: /capture\.smoke\.ts$/,
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  timeout: 240_000,
+  reporter: "line",
+  use: {
+    baseURL: UI_BASE_URL,
+    navigationTimeout: 60_000,
+    actionTimeout: 15_000,
+    storageState: fs.existsSync(adminAuthFile) ? adminAuthFile : undefined,
+  },
+});

--- a/platform/e2e-tests/tsconfig.json
+++ b/platform/e2e-tests/tsconfig.json
@@ -3,7 +3,8 @@
   "include": [
     "*.ts",
     "tests/**/*.ts",
-    "utils/**/*.ts"
+    "utils/**/*.ts",
+    "smoke/**/*.ts"
   ],
   "exclude": ["test-mcp-servers/**/*"],
   "compilerOptions": {


### PR DESCRIPTION
A skill for smoke-testing Archestra features against a running localhost stack, in two modes.

## Mode A — backend (Python, stdlib, zero-dependency)
- `scripts/smoke_client.py` — sign-in (cookie) or `ARCHESTRA_API_KEY`, create a conversation, POST `/api/chat` and drain the AI-SDK stream with a hard timeout, then read back the persisted assistant reply and the turn's interactions.
- `scripts/chat_turn.py` — CLI that drives one real chat turn and prints the reply, tool calls, model, and summed token usage/cost; non-zero exit with a clear message on a failed turn / unreachable stack / unresolved agent.

## Mode B — visual (Playwright, reuses `platform/e2e-tests`)
- `smoke/capture.smoke.ts` + `smoke.config.ts` — sign in as admin, navigate `SMOKE_PATHS`, capture full-page PNGs and a JSON manifest of per-route console/page errors for visual evaluation. Run from `platform/e2e-tests/`:
  ```
  SMOKE_PATHS=/agents,/settings pnpm exec playwright test --config smoke/smoke.config.ts
  ```
  Lives outside `testDir: ./tests`, so `pnpm test:e2e` does not pick it up; `tsconfig.json` gains a `smoke/**` include.

Assumes the stack is already up and an LLM provider key is configured; it does not start the stack or manage keys, and Mode A makes real LLM calls.

Validated live against a running instance (real reply + token/cost; authenticated screenshots). `tsc`, `biome`, and `ruff` clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>