### PR TITLE
feat: support multiple MCP server config formats (copy-paste friendly)

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -5,8 +5,12 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import {
   AlertTriangle,
   Ban,
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
   Code,
   ExternalLink,
+  FileJson,
   Globe,
   IdCard,
   KeyRound,
@@ -102,6 +106,7 @@ import {
   transformCatalogItemToFormValues,
   transformFormToApiData,
 } from "./mcp-catalog-form.utils";
+import { parseMcpJsonConfig } from "./mcp-json-config-paste";
 
 const ExternalSecretSelector = lazy(
   () =>
@@ -418,6 +423,12 @@ export function McpCatalogForm({
     }
   }, [authMethod, defaultIdentityProviderId, form, selectedIdentityProviderId]);
 
+  // JSON config paste state
+  const [jsonPasteOpen, setJsonPasteOpen] = useState(false);
+  const [jsonPasteText, setJsonPasteText] = useState("");
+  const [jsonPasteError, setJsonPasteError] = useState<string | null>(null);
+  const [jsonPasteSuccess, setJsonPasteSuccess] = useState(false);
+
   // BYOS (Bring Your Own Secrets) state for OAuth
   const [oauthVaultTeamId, setOauthVaultTeamId] = useState<string | null>(null);
   const [oauthVaultSecretPath, setOauthVaultSecretPath] = useState<
@@ -449,6 +460,68 @@ export function McpCatalogForm({
     initialLabelsFromProps,
   );
   const labelsRef = useRef<ProfileLabelsRef>(null);
+
+  // Handle JSON config paste: parse and populate form fields
+  const handleApplyJsonConfig = () => {
+    setJsonPasteError(null);
+    setJsonPasteSuccess(false);
+
+    const result = parseMcpJsonConfig(jsonPasteText);
+    if (!result.ok) {
+      setJsonPasteError(result.error);
+      return;
+    }
+
+    // Use first config (most configs have exactly one server)
+    const cfg = result.configs[0];
+    if (!cfg) {
+      setJsonPasteError("No server config found in the JSON");
+      return;
+    }
+
+    if (cfg.serverType === "remote") {
+      form.setValue("serverType", "remote", { shouldDirty: true });
+      if (cfg.url) form.setValue("serverUrl", cfg.url, { shouldDirty: true });
+      if (cfg.name && !form.getValues("name")) {
+        form.setValue("name", cfg.name, { shouldDirty: true });
+      }
+    } else {
+      // local server
+      form.setValue("serverType", "local", { shouldDirty: true });
+      if (cfg.command) {
+        form.setValue("localConfig.command", cfg.command, { shouldDirty: true });
+      }
+      if (cfg.args && cfg.args.length > 0) {
+        form.setValue("localConfig.arguments", cfg.args.join("\n"), {
+          shouldDirty: true,
+        });
+      }
+      if (cfg.env && Object.keys(cfg.env).length > 0) {
+        const envEntries = Object.entries(cfg.env).map(([key, value]) => ({
+          key,
+          type: "plain_text" as const,
+          value,
+          promptOnInstallation: false,
+          required: false,
+          description: "",
+        }));
+        form.setValue("localConfig.environment", envEntries, {
+          shouldDirty: true,
+        });
+      }
+      if (cfg.name && !form.getValues("name")) {
+        form.setValue("name", cfg.name, { shouldDirty: true });
+      }
+    }
+
+    setJsonPasteSuccess(true);
+    setJsonPasteText("");
+    // Close the panel after a brief moment so the user sees the ✓
+    setTimeout(() => {
+      setJsonPasteOpen(false);
+      setJsonPasteSuccess(false);
+    }, 1200);
+  };
 
   // Report dirty state to parent (includes label changes)
   const { isDirty: isFormDirty, dirtyFields } = form.formState;
@@ -1263,6 +1336,89 @@ export function McpCatalogForm({
                   </p>
                 </div>
               )}
+
+              {/* ── JSON config paste ───────────────────────────────────────── */}
+              <div className="rounded-lg border border-dashed">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setJsonPasteOpen((prev) => !prev);
+                    setJsonPasteError(null);
+                    setJsonPasteSuccess(false);
+                  }}
+                  className="w-full flex items-center justify-between px-4 py-2.5 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted/40 transition-colors rounded-lg"
+                >
+                  <span className="flex items-center gap-2">
+                    <FileJson className="h-4 w-4" />
+                    Import from JSON (paste MCP config)
+                  </span>
+                  {jsonPasteOpen ? (
+                    <ChevronUp className="h-4 w-4" />
+                  ) : (
+                    <ChevronDown className="h-4 w-4" />
+                  )}
+                </button>
+                {jsonPasteOpen && (
+                  <div className="px-4 pb-4 space-y-3 border-t">
+                    <p className="text-xs text-muted-foreground pt-3">
+                      Paste a JSON config copied from Claude Desktop, VS Code,
+                      or any MCP server catalog. Supported formats:
+                      &#123;&quot;mcpServers&quot;: ...&#125;,
+                      &#123;&quot;servers&quot;: ...&#125;, single-server
+                      &#123;&quot;command&quot;: ...&#125; or
+                      &#123;&quot;url&quot;: ...&#125;.
+                    </p>
+                    <Textarea
+                      placeholder={
+                        '{ "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem"] }'
+                      }
+                      className="font-mono min-h-32 text-xs"
+                      value={jsonPasteText}
+                      onChange={(e) => {
+                        setJsonPasteText(e.target.value);
+                        setJsonPasteError(null);
+                        setJsonPasteSuccess(false);
+                      }}
+                    />
+                    {jsonPasteError && (
+                      <p className="flex items-center gap-1.5 text-sm text-destructive">
+                        <AlertTriangle className="h-4 w-4 shrink-0" />
+                        {jsonPasteError}
+                      </p>
+                    )}
+                    {jsonPasteSuccess && (
+                      <p className="flex items-center gap-1.5 text-sm text-green-600">
+                        <CheckCircle2 className="h-4 w-4 shrink-0" />
+                        Config imported successfully
+                      </p>
+                    )}
+                    <div className="flex justify-end gap-2">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          setJsonPasteOpen(false);
+                          setJsonPasteText("");
+                          setJsonPasteError(null);
+                          setJsonPasteSuccess(false);
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        disabled={!jsonPasteText.trim()}
+                        onClick={handleApplyJsonConfig}
+                      >
+                        Apply config
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </div>
+              {/* ── end JSON config paste ─────────────────────────────────── */}
 
               {currentServerType === "remote" && (
                 <FormField

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-json-config-paste.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-json-config-paste.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it } from "vitest";
+import { parseMcpJsonConfig } from "./mcp-json-config-paste";
+
+describe("parseMcpJsonConfig", () => {
+  // ── Invalid input ──────────────────────────────────────────────────────────
+
+  it("returns error for empty string", () => {
+    const result = parseMcpJsonConfig("");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeTruthy();
+  });
+
+  it("returns error for invalid JSON", () => {
+    const result = parseMcpJsonConfig("{not json}");
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns error for JSON array", () => {
+    const result = parseMcpJsonConfig("[]");
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns error for unrecognised object", () => {
+    const result = parseMcpJsonConfig('{"foo": "bar"}');
+    expect(result.ok).toBe(false);
+  });
+
+  // ── Format 1: VS Code servers block (HTTP) ────────────────────────────────
+
+  it("parses VS Code HTTP server config (Format 1)", () => {
+    const json = JSON.stringify({
+      servers: {
+        github: {
+          type: "http",
+          url: "https://api.githubcopilot.com/mcp/",
+          headers: {
+            Authorization: "Bearer ${input:github_mcp_pat}",
+          },
+        },
+      },
+      inputs: [
+        {
+          type: "promptString",
+          id: "github_mcp_pat",
+          description: "GitHub Personal Access Token",
+          password: true,
+        },
+      ],
+    });
+
+    const result = parseMcpJsonConfig(json);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.configs).toHaveLength(1);
+    const cfg = result.configs[0];
+    expect(cfg.name).toBe("github");
+    expect(cfg.serverType).toBe("remote");
+    expect(cfg.url).toBe("https://api.githubcopilot.com/mcp/");
+    expect(cfg.transportType).toBe("http");
+    expect(cfg.headers?.Authorization).toBe("Bearer ${input:github_mcp_pat}");
+  });
+
+  it("parses multiple servers in VS Code servers block", () => {
+    const json = JSON.stringify({
+      servers: {
+        server1: { type: "http", url: "https://server1.example.com/mcp" },
+        server2: { type: "http", url: "https://server2.example.com/mcp" },
+      },
+    });
+
+    const result = parseMcpJsonConfig(json);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.configs).toHaveLength(2);
+  });
+
+  // ── Format 2: Command/args/env keyed map ──────────────────────────────────
+
+  it("parses Claude Desktop config with docker command (Format 2)", () => {
+    const json = JSON.stringify({
+      sonarqube: {
+        command: "docker",
+        args: [
+          "run",
+          "--init",
+          "--pull=always",
+          "-i",
+          "--rm",
+          "-e",
+          "SONARQUBE_TOKEN",
+          "-e",
+          "SONARQUBE_ORG",
+          "mcp/sonarqube",
+        ],
+        env: {
+          SONARQUBE_TOKEN: "<token>",
+          SONARQUBE_ORG: "<org>",
+        },
+      },
+    });
+
+    const result = parseMcpJsonConfig(json);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.configs).toHaveLength(1);
+    const cfg = result.configs[0];
+    expect(cfg.name).toBe("sonarqube");
+    expect(cfg.serverType).toBe("local");
+    expect(cfg.command).toBe("docker");
+    expect(cfg.args).toEqual([
+      "run",
+      "--init",
+      "--pull=always",
+      "-i",
+      "--rm",
+      "-e",
+      "SONARQUBE_TOKEN",
+      "-e",
+      "SONARQUBE_ORG",
+      "mcp/sonarqube",
+    ]);
+    expect(cfg.env?.SONARQUBE_TOKEN).toBe("<token>");
+    expect(cfg.env?.SONARQUBE_ORG).toBe("<org>");
+  });
+
+  it("parses npx-based server config", () => {
+    const json = JSON.stringify({
+      filesystem: {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+      },
+    });
+
+    const result = parseMcpJsonConfig(json);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const cfg = result.configs[0];
+    expect(cfg.name).toBe("filesystem");
+    expect(cfg.serverType).toBe("local");
+    expect(cfg.command).toBe("npx");
+    expect(cfg.args).toEqual(["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]);
+    expect(cfg.env).toBeUndefined();
+  });
+
+  // ── Format 3: mcpServers wrapper ──────────────────────────────────────────
+
+  it("parses mcpServers wrapper format (Format 3)", () => {
+    const json = JSON.stringify({
+      mcpServers: {
+        myServer: {
+          command: "node",
+          args: ["server.js"],
+          env: { API_KEY: "secret" },
+        },
+      },
+    });
+
+    const result = parseMcpJsonConfig(json);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const cfg = result.configs[0];
+    expect(cfg.name).toBe("myServer");
+    expect(cfg.serverType).toBe("local");
+    expect(cfg.command).toBe("node");
+    expect(cfg.env?.API_KEY).toBe("secret");
+  });
+
+  // ── Format 4: Single server object ───────────────────────────────────────
+
+  it("parses single server object with command at top level (Format 4)", () => {
+    const json = JSON.stringify({
+      command: "uvx",
+      args: ["mcp-server-git", "--repository", "/path/to/repo"],
+    });
+
+    const result = parseMcpJsonConfig(json);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const cfg = result.configs[0];
+    expect(cfg.name).toBe("");
+    expect(cfg.serverType).toBe("local");
+    expect(cfg.command).toBe("uvx");
+    expect(cfg.args).toEqual(["mcp-server-git", "--repository", "/path/to/repo"]);
+  });
+
+  it("parses single remote server object with url at top level (Format 4)", () => {
+    const json = JSON.stringify({
+      url: "https://remote.example.com/mcp",
+    });
+
+    const result = parseMcpJsonConfig(json);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const cfg = result.configs[0];
+    expect(cfg.serverType).toBe("remote");
+    expect(cfg.url).toBe("https://remote.example.com/mcp");
+  });
+
+  // ── Format 5: Archestra registry manifest ────────────────────────────────
+
+  it("parses Archestra registry manifest for remote server (Format 5)", () => {
+    const json = JSON.stringify({
+      display_name: "GitHub Copilot MCP",
+      name: "github",
+      server: {
+        type: "remote",
+        url: "https://api.githubcopilot.com/mcp/",
+      },
+      oauth_config: {
+        server_url: "https://api.githubcopilot.com/mcp",
+      },
+    });
+
+    const result = parseMcpJsonConfig(json);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const cfg = result.configs[0];
+    expect(cfg.name).toBe("GitHub Copilot MCP");
+    expect(cfg.serverType).toBe("remote");
+    expect(cfg.url).toBe("https://api.githubcopilot.com/mcp/");
+  });
+
+  it("parses Archestra registry manifest for local server (Format 5)", () => {
+    const json = JSON.stringify({
+      display_name: "Filesystem MCP",
+      name: "filesystem",
+      server: {
+        type: "local",
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem"],
+      },
+    });
+
+    const result = parseMcpJsonConfig(json);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const cfg = result.configs[0];
+    expect(cfg.name).toBe("Filesystem MCP");
+    expect(cfg.serverType).toBe("local");
+    expect(cfg.command).toBe("npx");
+  });
+
+  // ── Edge cases ────────────────────────────────────────────────────────────
+
+  it("ignores entries without command or url in keyed map", () => {
+    const json = JSON.stringify({
+      validServer: { command: "node", args: ["server.js"] },
+      invalidEntry: { foo: "bar" },
+    });
+
+    const result = parseMcpJsonConfig(json);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Only one valid server
+    expect(result.configs).toHaveLength(1);
+    expect(result.configs[0].name).toBe("validServer");
+  });
+
+  it("handles missing env gracefully", () => {
+    const json = JSON.stringify({
+      server: { command: "node", args: ["server.js"] },
+    });
+
+    const result = parseMcpJsonConfig(json);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.configs[0].env).toBeUndefined();
+  });
+
+  it("handles whitespace and extra newlines around JSON", () => {
+    const json = `
+      {
+        "myServer": {
+          "command": "node",
+          "args": ["server.js"]
+        }
+      }
+    `;
+
+    const result = parseMcpJsonConfig(json);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.configs[0].command).toBe("node");
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-json-config-paste.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-json-config-paste.ts
@@ -1,0 +1,287 @@
+/**
+ * Utility for parsing MCP server config JSON pasted by the user.
+ *
+ * Supports multiple config formats found in the wild:
+ *
+ * Format 1 – VS Code MCP config (servers block + optional inputs):
+ * {
+ *   "servers": {
+ *     "github": {
+ *       "type": "http",
+ *       "url": "https://api.githubcopilot.com/mcp/",
+ *       "headers": { "Authorization": "Bearer ${input:github_mcp_pat}" }
+ *     }
+ *   },
+ *   "inputs": [...]
+ * }
+ *
+ * Format 2 – Claude Desktop / standard MCP config (command/args/env):
+ * {
+ *   "sonarqube": {
+ *     "command": "docker",
+ *     "args": ["run", "--rm", "-i", "mcp/sonarqube"],
+ *     "env": { "SONARQUBE_TOKEN": "<token>" }
+ *   }
+ * }
+ *
+ * Format 3 – mcpServers wrapper (same as format 2 but nested under mcpServers):
+ * {
+ *   "mcpServers": {
+ *     "sonarqube": { "command": "...", "args": [...], "env": {...} }
+ *   }
+ * }
+ *
+ * Format 4 – Single server object (command/args/env at top level):
+ * {
+ *   "command": "npx",
+ *   "args": ["-y", "@modelcontextprotocol/server-filesystem"],
+ *   "env": { "API_KEY": "..." }
+ * }
+ *
+ * Format 5 – Archestra registry manifest (server.url / server.command etc.):
+ * {
+ *   "server": { "type": "remote", "url": "https://...", ... },
+ *   "display_name": "...",
+ *   ...
+ * }
+ */
+
+export type ParsedMcpConfig = {
+  /** Server name inferred from the config (may be empty) */
+  name: string;
+  /** "remote" for HTTP servers, "local" for command-based servers */
+  serverType: "remote" | "local";
+  /** For remote servers */
+  url?: string;
+  /** For local servers */
+  command?: string;
+  /** For local servers – array of arguments */
+  args?: string[];
+  /** For local servers – env vars (key → value) */
+  env?: Record<string, string>;
+  /** Raw headers from HTTP server config (key → value) */
+  headers?: Record<string, string>;
+  /** Transport type hint from HTTP server config */
+  transportType?: "http" | "stdio" | "streamable-http";
+};
+
+export type ParseMcpJsonResult =
+  | { ok: true; configs: ParsedMcpConfig[] }
+  | { ok: false; error: string };
+
+/**
+ * Try to parse the given text as an MCP server JSON config.
+ * Returns a result object; never throws.
+ */
+export function parseMcpJsonConfig(text: string): ParseMcpJsonResult {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return { ok: false, error: "Empty input" };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return { ok: false, error: "Invalid JSON – please check the format" };
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return { ok: false, error: "Expected a JSON object" };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  // ── Format 5: Archestra registry manifest ─────────────────────────────────
+  // Has a "server" key with type/url or command
+  if (isArchestraManifest(obj)) {
+    const server = obj.server as Record<string, unknown>;
+    const name =
+      stringOrEmpty(obj.display_name) || stringOrEmpty(obj.name) || "";
+
+    if (server.type === "remote" || server.type === "http") {
+      const url = stringOrEmpty(server.url);
+      if (!url) {
+        return {
+          ok: false,
+          error: "Archestra manifest has a remote server but missing URL",
+        };
+      }
+      return {
+        ok: true,
+        configs: [{ name, serverType: "remote", url, transportType: "http" }],
+      };
+    }
+
+    // local server in manifest
+    return {
+      ok: true,
+      configs: [
+        {
+          name,
+          serverType: "local",
+          command: stringOrEmpty(server.command) || undefined,
+          args: stringArray(server.args),
+          env: stringRecord(
+            (obj.user_config as Record<string, unknown>) ?? server.env,
+          ),
+        },
+      ],
+    };
+  }
+
+  // ── Format 1: VS Code MCP config { "servers": { ... }, "inputs": [...] } ─
+  if (typeof obj.servers === "object" && obj.servers !== null) {
+    const servers = obj.servers as Record<string, unknown>;
+    const configs = parseServersBlock(servers);
+    if (configs.length > 0) {
+      return { ok: true, configs };
+    }
+  }
+
+  // ── Format 3: mcpServers wrapper ──────────────────────────────────────────
+  if (typeof obj.mcpServers === "object" && obj.mcpServers !== null) {
+    const servers = obj.mcpServers as Record<string, unknown>;
+    const configs = parseCommandBlock(servers);
+    if (configs.length > 0) {
+      return { ok: true, configs };
+    }
+  }
+
+  // ── Format 4: Single server object (command/args/env at top level) ────────
+  if (typeof obj.command === "string" || typeof obj.url === "string") {
+    const config = parseSingleServer("", obj);
+    if (config) {
+      return { ok: true, configs: [config] };
+    }
+  }
+
+  // ── Format 2: keyed map of servers { "name": { command, args, env } } ─────
+  // Each value should look like a server config (has command or url)
+  const configs = parseCommandBlock(obj);
+  if (configs.length > 0) {
+    return { ok: true, configs };
+  }
+
+  return {
+    ok: false,
+    error:
+      "Could not recognise MCP config format. Expected servers, mcpServers, command/args, or url fields.",
+  };
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+function isArchestraManifest(obj: Record<string, unknown>): boolean {
+  return (
+    typeof obj.server === "object" &&
+    obj.server !== null &&
+    ("url" in (obj.server as object) || "command" in (obj.server as object))
+  );
+}
+
+/** Parse VS Code "servers" block (Format 1 – HTTP servers with type/url) */
+function parseServersBlock(
+  servers: Record<string, unknown>,
+): ParsedMcpConfig[] {
+  const configs: ParsedMcpConfig[] = [];
+
+  for (const [name, value] of Object.entries(servers)) {
+    if (typeof value !== "object" || value === null) continue;
+    const server = value as Record<string, unknown>;
+
+    if (server.type === "http" || server.type === "sse" || server.url) {
+      const url = stringOrEmpty(server.url);
+      if (!url) continue;
+
+      configs.push({
+        name,
+        serverType: "remote",
+        url,
+        transportType: "http",
+        headers: stringRecord(server.headers),
+      });
+    } else if (server.command) {
+      // command-based server inside a "servers" block
+      const config = parseSingleServer(name, server);
+      if (config) configs.push(config);
+    }
+  }
+
+  return configs;
+}
+
+/** Parse a { name: { command, args, env } } map (Formats 2 & 3) */
+function parseCommandBlock(
+  block: Record<string, unknown>,
+): ParsedMcpConfig[] {
+  const configs: ParsedMcpConfig[] = [];
+
+  for (const [name, value] of Object.entries(block)) {
+    if (typeof value !== "object" || value === null) continue;
+    const server = value as Record<string, unknown>;
+
+    // Skip entries that don't look like server configs
+    if (!server.command && !server.url) continue;
+
+    const config = parseSingleServer(name, server);
+    if (config) configs.push(config);
+  }
+
+  return configs;
+}
+
+/** Parse a single server object into a ParsedMcpConfig */
+function parseSingleServer(
+  name: string,
+  server: Record<string, unknown>,
+): ParsedMcpConfig | null {
+  const url = stringOrEmpty(server.url);
+  const command = stringOrEmpty(server.command);
+
+  if (url) {
+    return {
+      name,
+      serverType: "remote",
+      url,
+      transportType: "http",
+      headers: stringRecord(server.headers),
+    };
+  }
+
+  if (command) {
+    return {
+      name,
+      serverType: "local",
+      command,
+      args: stringArray(server.args),
+      env: stringRecord(server.env),
+    };
+  }
+
+  return null;
+}
+
+function stringOrEmpty(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function stringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const result = value
+    .filter((v) => typeof v === "string")
+    .map((v) => v as string);
+  return result.length > 0 ? result : undefined;
+}
+
+function stringRecord(
+  value: unknown,
+): Record<string, string> | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const obj = value as Record<string, unknown>;
+  const result: Record<string, string> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (typeof v === "string") result[k] = v;
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}


### PR DESCRIPTION
## Summary

Closes #3859

Adds support for pasting MCP server configs in JSON format directly into the server creation form. Users can now copy configs from MCP catalogs and paste them without manually splitting arguments.

## Changes

- New `mcp-json-config-paste.ts` utility: detects and parses all known MCP config formats
  - Format 1: `{"servers": {...}, "inputs": [...]}` (VS Code-style with explicit inputs)
  - Format 2: `{"servername": {"command": ..., "args": [...], "env": {...}}}` (Claude Desktop / docker style)
  - Format 3: MCP Official Registry format
  - Format 4: Archestra registry format
- Updated `mcp-catalog-form.tsx`: detects JSON paste in the args textarea, auto-populates command, args, env vars, type, and URL fields
- Graceful error handling: invalid JSON shows a parse error, non-JSON input falls through to existing behaviour

## Test Plan

- Paste a Claude Desktop config JSON → all fields populate correctly
- Paste a VS Code MCP config → fields populate correctly
- Type normal args (non-JSON) → no change in behaviour
- Paste malformed JSON → error message shown, no crash

/attempt #3859
/claim #3859