### PR TITLE
feat(usage-limits): improve usage limits visibility UX and DX (#4758)

### DIFF
--- a/platform/frontend/src/app/agents/page.client.tsx
+++ b/platform/frontend/src/app/agents/page.client.tsx
@@ -30,6 +30,7 @@ import { LoadingSpinner, LoadingWrapper } from "@/components/loading";
 import { PageLayout } from "@/components/page-layout";
 import { PermissionRequirementHint } from "@/components/permission-requirement-hint";
 import { ResourceVisibilityBadge } from "@/components/resource-visibility-badge";
+import { LimitUsageCell } from "@/components/limit-usage-cell";
 import { SearchInput } from "@/components/search-input";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
@@ -440,6 +441,14 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
           } satisfies ColumnDef<AgentData>,
         ]
       : []),
+    {
+      id: "usage",
+      header: "Usage",
+      size: 180,
+      cell: ({ row }) => (
+        <LimitUsageCell entityType="agent" entityId={row.original.id} />
+      ),
+    },
     {
       id: "actions",
       header: "Actions",

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -55,6 +55,7 @@ import {
   RightSidePanel,
 } from "@/components/chat/right-side-panel";
 import { ShareConversationDialog } from "@/components/chat/share-conversation-dialog";
+import { ChatUsageLimitBar } from "@/components/chat/chat-usage-limit-bar";
 import { StreamTimeoutWarning } from "@/components/chat/stream-timeout-warning";
 import { CreateLlmProviderApiKeyDialog } from "@/components/create-llm-provider-api-key-dialog";
 import type { LlmProviderApiKeyFormValues } from "@/components/llm-provider-api-key-form";
@@ -2342,6 +2343,11 @@ export function ChatPageContent({
                           }
                         />
                         <div className="text-center">
+                          <div className="flex items-center justify-center gap-4 mb-1">
+                            <ChatUsageLimitBar
+                              agentId={promptAgentId ?? activeAgentId}
+                            />
+                          </div>
                           <Version inline />
                         </div>
                       </div>

--- a/platform/frontend/src/app/llm/(costs)/limits/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.tsx
@@ -43,6 +43,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { PermissionButton } from "@/components/ui/permission-button";
 import { Progress } from "@/components/ui/progress";
+import { formatResetsIn } from "@/lib/limit-usage.utils";
 import { SearchableSelect } from "@/components/ui/searchable-select";
 import {
   Select,
@@ -494,14 +495,23 @@ export default function LimitsPage() {
           const cleanupInterval =
             (row.original.cleanupInterval as LimitCleanupInterval | null) ??
             DEFAULT_LIMIT_CLEANUP_INTERVAL;
+          const resetsIn = formatResetsIn(
+            row.original.lastCleanup,
+            cleanupInterval,
+          );
           return (
             <div className="space-y-0.5">
               <div>{CLEANUP_INTERVAL_LABELS[cleanupInterval]}</div>
-              <div className="text-xs text-muted-foreground">
-                {formatNextLimitReset(
-                  row.original.lastCleanup,
-                  cleanupInterval,
-                )}
+              <div className="flex items-center gap-1.5">
+                <div className="text-xs text-muted-foreground">
+                  {formatNextLimitReset(
+                    row.original.lastCleanup,
+                    cleanupInterval,
+                  )}
+                </div>
+                <span className="inline-flex items-center rounded-full bg-muted/70 border border-border/50 px-1.5 py-0.5 text-[10px] text-muted-foreground font-mono whitespace-nowrap">
+                  {resetsIn}
+                </span>
               </div>
             </div>
           );

--- a/platform/frontend/src/app/llm/credentials/virtual-keys/page.tsx
+++ b/platform/frontend/src/app/llm/credentials/virtual-keys/page.tsx
@@ -48,6 +48,7 @@ import {
   VisibilitySelector,
 } from "@/components/visibility-selector";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
+import { LimitUsageCell } from "@/components/limit-usage-cell";
 import { useFeature } from "@/lib/config/config.query";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
 import { useLlmProviderApiKeys } from "@/lib/llm-provider-api-keys.query";
@@ -176,6 +177,17 @@ export default function VirtualKeysPage() {
           ) : (
             <span className="text-sm text-muted-foreground">Never</span>
           ),
+      },
+      {
+        id: "usage",
+        header: "Usage",
+        size: 180,
+        cell: ({ row }) => (
+          <LimitUsageCell
+            entityType="virtual_key"
+            entityId={row.original.id}
+          />
+        ),
       },
       {
         id: "actions",

--- a/platform/frontend/src/app/llm/proxies/page.client.tsx
+++ b/platform/frontend/src/app/llm/proxies/page.client.tsx
@@ -21,6 +21,7 @@ import { LoadingSpinner, LoadingWrapper } from "@/components/loading";
 import { PageLayout } from "@/components/page-layout";
 import { PermissionRequirementHint } from "@/components/permission-requirement-hint";
 import { ResourceVisibilityBadge } from "@/components/resource-visibility-badge";
+import { LimitUsageCell } from "@/components/limit-usage-cell";
 import { SearchInput } from "@/components/search-input";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -308,6 +309,15 @@ function LlmProxies({ initialData }: { initialData?: LlmProxiesInitialData }) {
           } satisfies ColumnDef<ProxyData>,
         ]
       : []),
+    {
+      id: "usage",
+      header: "Usage",
+      size: 180,
+      // LLM proxies are agents with agentType; use entityType "agent" for limits
+      cell: ({ row }) => (
+        <LimitUsageCell entityType="agent" entityId={row.original.id} />
+      ),
+    },
     {
       id: "actions",
       header: "Actions",

--- a/platform/frontend/src/app/settings/users/page.client.tsx
+++ b/platform/frontend/src/app/settings/users/page.client.tsx
@@ -8,6 +8,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
 import { AuthProviderIcon } from "@/components/auth-provider-icon";
+import { LimitUsageCell } from "@/components/limit-usage-cell";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { FormDialog } from "@/components/form-dialog";
 import { InviteByLinkCard } from "@/components/invite-by-link-card";
@@ -328,6 +329,17 @@ function MembersTab({
             })}
           </span>
         ),
+    },
+    {
+      id: "usage",
+      header: "Usage",
+      size: 180,
+      cell: ({ row }) => {
+        const member = row.original;
+        // PendingSignupMember won't have a stable ID yet; skip
+        if ("provider" in member) return <span className="text-xs text-muted-foreground">–</span>;
+        return <LimitUsageCell entityType="user" entityId={member.id} />;
+      },
     },
     {
       id: "actions",

--- a/platform/frontend/src/components/chat/chat-usage-limit-bar.tsx
+++ b/platform/frontend/src/components/chat/chat-usage-limit-bar.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { Gauge } from "lucide-react";
+import { useEffect, useMemo, useRef } from "react";
+import { toast } from "sonner";
+import { Progress } from "@/components/ui/progress";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  type LimitData,
+  computeLimitUsage,
+  formatResetsIn,
+  getLimitCleanupInterval,
+  selectMostConstrainedLimit,
+} from "@/lib/limit-usage.utils";
+import { useLimits } from "@/lib/limits.query";
+
+interface ChatUsageLimitBarProps {
+  /** Active agent ID (to include agent-specific limits) */
+  agentId?: string | null;
+  /**
+   * The current user's member record ID (NOT user ID) for user-scoped limits.
+   * Pass `member.id` from the org members list where `member.userId === session.user.id`.
+   * Optional – only org and agent limits are shown if not provided.
+   */
+  memberId?: string | null;
+}
+
+const TOAST_DEBOUNCE_MS = 60_000; // Don't re-toast the same threshold within 1 minute
+
+type ToastThreshold = "warning" | "danger" | "exceeded";
+
+export function ChatUsageLimitBar({
+  agentId,
+  memberId,
+}: ChatUsageLimitBarProps) {
+  const { data: allLimits = [] } = useLimits();
+
+  // Filter limits relevant to this chat session context:
+  // organization-wide limits + agent limits + user limits
+  const relevantLimits: LimitData[] = useMemo(() => {
+    return allLimits.filter((limit) => {
+      if (limit.entityType === "organization") return true;
+      if (limit.entityType === "agent" && agentId && limit.entityId === agentId)
+        return true;
+      if (limit.entityType === "user" && memberId && limit.entityId === memberId)
+        return true;
+      return false;
+    });
+  }, [allLimits, agentId, memberId]);
+
+  const worstLimit = selectMostConstrainedLimit(relevantLimits);
+
+  // Toast tracking: avoid re-showing the same threshold toast repeatedly
+  const lastToastedThreshold = useRef<Record<string, { threshold: ToastThreshold; ts: number }>>({});
+
+  const worstUsage = worstLimit ? computeLimitUsage(worstLimit) : null;
+  const worstStatus = worstUsage?.status ?? null;
+
+  useEffect(() => {
+    if (!worstLimit || !worstUsage) return;
+    const key = worstLimit.id;
+    const now = Date.now();
+    const prev = lastToastedThreshold.current[key];
+
+    let threshold: ToastThreshold | null = null;
+    if (worstUsage.percentage >= 100) threshold = "exceeded";
+    else if (worstUsage.percentage >= 90) threshold = "danger";
+    else if (worstUsage.percentage >= 75) threshold = "warning";
+
+    if (!threshold) return;
+
+    // Only toast if we haven't shown this threshold recently
+    if (prev?.ts && now - prev.ts < TOAST_DEBOUNCE_MS && prev.threshold === threshold)
+      return;
+
+    const interval = getLimitCleanupInterval(worstLimit);
+    const resetsIn = formatResetsIn(worstLimit.lastCleanup, interval);
+    const pct = Math.round(worstUsage.percentage);
+
+    if (threshold === "exceeded") {
+      toast.error(`Usage limit reached (${pct}%)`, {
+        description: `${worstUsage.limitKindLabel} limit exceeded. Resets ${resetsIn}.`,
+        duration: 8000,
+      });
+    } else if (threshold === "danger") {
+      toast.warning(`Approaching usage limit (${pct}%)`, {
+        description: `${worstUsage.limitKindLabel} limit is at ${pct}%. Resets ${resetsIn}.`,
+        duration: 6000,
+      });
+    } else {
+      toast(`Usage at ${pct}%`, {
+        description: `${worstUsage.limitKindLabel} limit is at ${pct}%. Resets ${resetsIn}.`,
+        duration: 5000,
+        icon: <Gauge className="h-4 w-4 text-yellow-500" />,
+      });
+    }
+
+    lastToastedThreshold.current[key] = { threshold, ts: now };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [worstLimit?.id, worstStatus]);
+
+  if (!worstLimit || !worstUsage) return null;
+
+  const interval = getLimitCleanupInterval(worstLimit);
+  const resetsIn = formatResetsIn(worstLimit.lastCleanup, interval);
+
+  const progressColor =
+    worstUsage.status === "exceeded" || worstUsage.status === "danger"
+      ? "[&>[data-slot=progress-indicator]]:bg-destructive bg-destructive/20"
+      : worstUsage.status === "warning"
+        ? "[&>[data-slot=progress-indicator]]:bg-orange-500 bg-orange-100"
+        : undefined;
+
+  const tooltipContent = [
+    `Used: ${formatUsageValue(worstUsage.actualUsage, worstLimit.limitType)} / ${formatUsageValue(worstUsage.actualLimit, worstLimit.limitType)}`,
+    `Type: ${worstUsage.limitKindLabel}`,
+    `Resets: ${resetsIn}`,
+    ...(worstUsage.modelCount > 0
+      ? [`Models: ${(worstLimit.model ?? []).join(", ")}`]
+      : ["Models: All"]),
+  ].join("\n");
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className="flex items-center gap-2 min-w-[120px] max-w-[200px] cursor-help">
+          <Gauge className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <div className="flex-1">
+            <Progress
+              value={Math.min(worstUsage.percentage, 100)}
+              className={progressColor}
+            />
+          </div>
+          <span className="text-xs text-muted-foreground whitespace-nowrap">
+            {Math.round(worstUsage.percentage)}%
+          </span>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent className="whitespace-pre-line max-w-xs" side="top">
+        {tooltipContent}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function formatUsageValue(
+  value: number,
+  limitType: LimitData["limitType"],
+): string {
+  if (limitType === "token_cost") {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 2,
+    }).format(value);
+  }
+  return value.toLocaleString("en-US");
+}

--- a/platform/frontend/src/components/chat/inline-chat-error.tsx
+++ b/platform/frontend/src/components/chat/inline-chat-error.tsx
@@ -10,6 +10,7 @@ import {
   MessageSquareDashed,
   RefreshCw,
 } from "lucide-react";
+import Link from "next/link";
 import { useState } from "react";
 import { toast } from "sonner";
 import { Message, MessageContent } from "@/components/ai-elements/message";
@@ -148,6 +149,11 @@ export function InlineChatError({
                   {usageLimitMessage}
                 </p>
               )}
+              {isUsageLimitExceeded && chatError.usageLimitEntityType && (
+                <span className="inline-flex items-center rounded-full bg-muted/70 border border-border/50 px-1.5 py-0.5 text-[10px] text-muted-foreground font-mono capitalize">
+                  {chatError.usageLimitEntityType.replace(/_/g, " ")} limit
+                </span>
+              )}
             </div>
           </div>
         </MessageContent>
@@ -216,6 +222,34 @@ export function InlineChatError({
               <p className="text-xs text-muted-foreground">
                 {usageLimitMessage}
               </p>
+            )}
+
+            {isUsageLimitExceeded && (
+              <div className="rounded-md bg-muted/40 border border-border/50 p-2.5 space-y-1.5">
+                <div className="flex items-center gap-1.5">
+                  <Gauge className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                  <span className="text-xs font-medium text-foreground">
+                    Usage limit exceeded
+                  </span>
+                  {chatError.usageLimitEntityType && (
+                    <span className="ml-auto inline-flex items-center rounded-full bg-muted/70 border border-border/50 px-1.5 py-0.5 text-[10px] text-muted-foreground font-mono capitalize">
+                      {chatError.usageLimitEntityType.replace(/_/g, " ")}
+                    </span>
+                  )}
+                </div>
+                {isAdmin && (
+                  <p className="text-xs text-muted-foreground">
+                    Review your{" "}
+                    <Link
+                      href="/llm/limits"
+                      className="underline underline-offset-2 hover:text-foreground"
+                    >
+                      usage limits
+                    </Link>{" "}
+                    to adjust budgets or reset periods.
+                  </p>
+                )}
+              </div>
             )}
 
             {isAdmin && (

--- a/platform/frontend/src/components/limit-usage-cell.tsx
+++ b/platform/frontend/src/components/limit-usage-cell.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { Gauge } from "lucide-react";
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Progress } from "@/components/ui/progress";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  computeLimitUsage,
+  formatResetsIn,
+  getLimitCleanupInterval,
+  selectMostConstrainedLimit,
+  type LimitData,
+} from "@/lib/limit-usage.utils";
+import { useLimits } from "@/lib/limits.query";
+
+interface LimitUsageCellProps {
+  entityType: LimitData["entityType"];
+  entityId: string;
+}
+
+/**
+ * Table cell that shows remaining usage for the most-constrained limit
+ * applicable to a given entity.
+ *
+ * - Shows a compact progress badge with remaining % 
+ * - Tooltip shows used/limit, limit kind, resets-in
+ * - If there are multiple limits, shows "View all" button opening a modal
+ */
+export function LimitUsageCell({ entityType, entityId }: LimitUsageCellProps) {
+  const { data: limits = [] } = useLimits({ entityType, entityId });
+  const [showAll, setShowAll] = useState(false);
+
+  if (limits.length === 0) {
+    return <span className="text-xs text-muted-foreground">–</span>;
+  }
+
+  const worst = selectMostConstrainedLimit(limits);
+  if (!worst) return null;
+
+  const usage = computeLimitUsage(worst);
+  const interval = getLimitCleanupInterval(worst);
+  const resetsIn = formatResetsIn(worst.lastCleanup, interval);
+
+  const progressColor =
+    usage.status === "exceeded" || usage.status === "danger"
+      ? "[&>[data-slot=progress-indicator]]:bg-destructive bg-destructive/20"
+      : usage.status === "warning"
+        ? "[&>[data-slot=progress-indicator]]:bg-orange-500 bg-orange-100"
+        : undefined;
+
+  const badgeVariant =
+    usage.status === "exceeded" || usage.status === "danger"
+      ? ("destructive" as const)
+      : usage.status === "warning"
+        ? ("outline" as const)
+        : ("secondary" as const);
+
+  const remainingPct = Math.max(0, 100 - usage.percentage);
+
+  const tooltipLines = [
+    `Used: ${formatUsageValue(usage.actualUsage, worst.limitType)} / ${formatUsageValue(usage.actualLimit, worst.limitType)}`,
+    `Type: ${usage.limitKindLabel}`,
+    `Resets: ${resetsIn}`,
+    ...(Array.isArray(worst.model) && worst.model.length > 0
+      ? [`Models: ${worst.model.join(", ")}`]
+      : ["Models: All"]),
+  ].join("\n");
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="flex items-center gap-1.5 cursor-help">
+            <Progress
+              value={Math.min(usage.percentage, 100)}
+              className={`w-16 h-1.5 ${progressColor ?? ""}`}
+            />
+            <Badge
+              variant={badgeVariant}
+              className={
+                badgeVariant === "outline" && usage.status === "warning"
+                  ? "border-orange-500/50 text-orange-600 text-xs px-1.5"
+                  : "text-xs px-1.5"
+              }
+            >
+              {remainingPct.toFixed(0)}% left
+            </Badge>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent className="whitespace-pre-line max-w-xs" side="top">
+          {tooltipLines}
+        </TooltipContent>
+      </Tooltip>
+
+      {limits.length > 1 && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-5 text-xs px-1.5 text-muted-foreground hover:text-foreground"
+          onClick={() => setShowAll(true)}
+        >
+          View all
+        </Button>
+      )}
+
+      {showAll && (
+        <LimitUsageAllDialog
+          limits={limits}
+          open={showAll}
+          onOpenChange={setShowAll}
+        />
+      )}
+    </div>
+  );
+}
+
+// ─── "View all" modal ────────────────────────────────────────────────────────
+
+interface LimitUsageAllDialogProps {
+  limits: LimitData[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function LimitUsageAllDialog({
+  limits,
+  open,
+  onOpenChange,
+}: LimitUsageAllDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Gauge className="h-4 w-4" />
+            All Usage Limits
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3 p-4">
+          {limits.map((limit) => {
+            const usage = computeLimitUsage(limit);
+            const interval = getLimitCleanupInterval(limit);
+            const resetsIn = formatResetsIn(limit.lastCleanup, interval);
+            const progressColor =
+              usage.status === "exceeded" || usage.status === "danger"
+                ? "[&>[data-slot=progress-indicator]]:bg-destructive bg-destructive/20"
+                : usage.status === "warning"
+                  ? "[&>[data-slot=progress-indicator]]:bg-orange-500 bg-orange-100"
+                  : undefined;
+
+            const models =
+              Array.isArray(limit.model) && limit.model.length > 0
+                ? limit.model.join(", ")
+                : "All models";
+
+            return (
+              <div
+                key={limit.id}
+                className="rounded-md border p-3 space-y-2"
+              >
+                <div className="flex items-center justify-between gap-2 text-sm">
+                  <span className="font-medium">{usage.limitKindLabel}</span>
+                  <span className="text-muted-foreground text-xs">{resetsIn}</span>
+                </div>
+                <Progress
+                  value={Math.min(usage.percentage, 100)}
+                  className={progressColor}
+                />
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                  <span>
+                    {formatUsageValue(usage.actualUsage, limit.limitType)} /{" "}
+                    {formatUsageValue(usage.actualLimit, limit.limitType)} (
+                    {usage.percentage.toFixed(1)}%)
+                  </span>
+                  <span className="truncate max-w-[140px]" title={models}>
+                    {models}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function formatUsageValue(
+  value: number,
+  limitType: LimitData["limitType"],
+): string {
+  if (limitType === "token_cost") {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 2,
+    }).format(value);
+  }
+  return value.toLocaleString("en-US");
+}

--- a/platform/frontend/src/components/teams/teams-list.tsx
+++ b/platform/frontend/src/components/teams/teams-list.tsx
@@ -20,6 +20,7 @@ import {
   serializeLabels,
 } from "@/components/label-select";
 import { LabelTags } from "@/components/label-tags";
+import { LimitUsageCell } from "@/components/limit-usage-cell";
 import { SearchInput } from "@/components/search-input";
 import {
   type TableRowAction,
@@ -181,6 +182,14 @@ export function TeamsList() {
           </div>
         );
       },
+    },
+    {
+      id: "usage",
+      header: "Usage",
+      size: 180,
+      cell: ({ row }) => (
+        <LimitUsageCell entityType="team" entityId={row.original.id} />
+      ),
     },
     {
       id: "actions",

--- a/platform/frontend/src/lib/limit-usage.utils.ts
+++ b/platform/frontend/src/lib/limit-usage.utils.ts
@@ -1,0 +1,210 @@
+import type { archestraApiTypes } from "@archestra/shared";
+import {
+  DEFAULT_LIMIT_CLEANUP_INTERVAL,
+  type LimitCleanupInterval,
+} from "@/components/limit-cleanup-interval-select";
+
+export type LimitData = archestraApiTypes.GetLimitsResponses["200"][number];
+export type UsageStatus = "safe" | "warning" | "danger" | "exceeded";
+
+export interface LimitUsage {
+  percentage: number;
+  status: UsageStatus;
+  actualUsage: number;
+  actualLimit: number;
+  /** Human-readable label for the limit type */
+  limitKindLabel: string;
+  /** Number of models this limit applies to (0 = all models) */
+  modelCount: number;
+}
+
+/**
+ * Compute usage stats for a single limit record.
+ * Currently the API returns modelUsage (cost) for token_cost limits.
+ * For other limit types, usage will show as 0 until the API exposes it.
+ */
+export function computeLimitUsage(limit: LimitData): LimitUsage {
+  const actualUsage = (limit.modelUsage ?? []).reduce(
+    (sum, u) => sum + u.cost,
+    0,
+  );
+  const actualLimit = limit.limitValue;
+  const percentage = actualLimit > 0 ? (actualUsage / actualLimit) * 100 : 0;
+
+  let status: UsageStatus;
+  if (percentage >= 100) {
+    status = "exceeded";
+  } else if (percentage >= 90) {
+    status = "danger";
+  } else if (percentage >= 75) {
+    status = "warning";
+  } else {
+    status = "safe";
+  }
+
+  const limitKindLabel =
+    limit.limitType === "token_cost"
+      ? "Token cost"
+      : limit.limitType === "mcp_server_calls"
+        ? "MCP server calls"
+        : "Tool calls";
+
+  const modelCount = Array.isArray(limit.model) ? limit.model.length : 0;
+
+  return { percentage, status, actualUsage, actualLimit, limitKindLabel, modelCount };
+}
+
+/**
+ * From a list of limits applicable to the current chat session, select the one
+ * with the most consumed percentage (i.e. least remaining capacity).
+ *
+ * Hierarchy: user > agent > organization (higher priority shown first, but we
+ * pick the most-consumed one across all that apply).
+ */
+export function selectMostConstrainedLimit(
+  limits: LimitData[],
+): LimitData | null {
+  if (limits.length === 0) return null;
+  return limits.reduce<LimitData>((worst, current) => {
+    const worstPct = computeLimitUsage(worst).percentage;
+    const currentPct = computeLimitUsage(current).percentage;
+    return currentPct > worstPct ? current : worst;
+  });
+}
+
+// ─── Reset-time helpers (shared with limits page) ───────────────────────────
+
+function isCalendarCleanupInterval(
+  interval: LimitCleanupInterval,
+): interval is Extract<
+  LimitCleanupInterval,
+  | "calendar_day"
+  | "calendar_week_sunday"
+  | "calendar_week_monday"
+  | "calendar_month"
+> {
+  return interval.startsWith("calendar_");
+}
+
+function getNextCalendarResetDate(
+  date: Date,
+  interval: Extract<
+    LimitCleanupInterval,
+    | "calendar_day"
+    | "calendar_week_sunday"
+    | "calendar_week_monday"
+    | "calendar_month"
+  >,
+): Date {
+  const next = new Date(date);
+  next.setHours(0, 0, 0, 0);
+  switch (interval) {
+    case "calendar_day":
+      next.setDate(next.getDate() + 1);
+      return next;
+    case "calendar_week_sunday": {
+      const days = (7 - next.getDay()) % 7 || 7;
+      next.setDate(next.getDate() + days);
+      return next;
+    }
+    case "calendar_week_monday": {
+      const days = (8 - next.getDay()) % 7 || 7;
+      next.setDate(next.getDate() + days);
+      return next;
+    }
+    case "calendar_month":
+      next.setMonth(next.getMonth() + 1, 1);
+      return next;
+  }
+}
+
+export function addCleanupInterval(date: Date, interval: LimitCleanupInterval): Date {
+  const next = new Date(date);
+  switch (interval) {
+    case "1h":
+      next.setHours(next.getHours() + 1);
+      return next;
+    case "12h":
+      next.setHours(next.getHours() + 12);
+      return next;
+    case "24h":
+      next.setDate(next.getDate() + 1);
+      return next;
+    case "1w":
+      next.setDate(next.getDate() + 7);
+      return next;
+    case "1m":
+      next.setMonth(next.getMonth() + 1);
+      return next;
+    case "calendar_day":
+    case "calendar_week_sunday":
+    case "calendar_week_monday":
+    case "calendar_month":
+      return getNextCalendarResetDate(next, interval);
+  }
+}
+
+export function getNextResetDate(
+  lastCleanup: LimitData["lastCleanup"],
+  cleanupInterval: LimitCleanupInterval,
+): Date | null {
+  if (isCalendarCleanupInterval(cleanupInterval)) {
+    return getNextCalendarResetDate(new Date(), cleanupInterval);
+  }
+  if (!lastCleanup) return null;
+  const next = addCleanupInterval(new Date(lastCleanup), cleanupInterval);
+  if (Number.isNaN(next.getTime())) return null;
+  return next;
+}
+
+/**
+ * Returns a human-readable "resets in X" string for a limit.
+ */
+export function formatResetsIn(
+  lastCleanup: LimitData["lastCleanup"],
+  cleanupInterval: LimitCleanupInterval,
+): string {
+  const next = getNextResetDate(lastCleanup, cleanupInterval);
+  if (!next) return "Resets on next check";
+
+  const now = Date.now();
+  const msLeft = next.getTime() - now;
+  if (msLeft <= 0) return "Resetting soon";
+
+  const totalSeconds = Math.floor(msLeft / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+
+  if (days > 0) return `in ${days}d ${hours}h`;
+  if (hours > 0) return `in ${hours}h ${minutes}m`;
+  if (minutes > 0) return `in ${minutes}m`;
+  return "in <1m";
+}
+
+/**
+ * Format the exact reset date/time.
+ */
+export function formatResetDate(date: Date): string {
+  return `Resets ${date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year:
+      date.getFullYear() === new Date().getFullYear() ? undefined : "numeric",
+  })}`;
+}
+
+export function formatNextLimitReset(
+  lastCleanup: LimitData["lastCleanup"],
+  cleanupInterval: LimitCleanupInterval,
+): string {
+  const next = getNextResetDate(lastCleanup, cleanupInterval);
+  if (!next) return "Resets on next check";
+  return formatResetDate(next);
+}
+
+export function getLimitCleanupInterval(
+  limit: LimitData,
+): LimitCleanupInterval {
+  return (limit.cleanupInterval as LimitCleanupInterval | null | undefined) ?? DEFAULT_LIMIT_CLEANUP_INTERVAL;
+}


### PR DESCRIPTION
## Summary

Implements [#4758](https://github.com/archestra-ai/archestra/issues/4758) — improve usage limits visibility UX and DX.

/attempt #4758
/claim #4758

## Changes

### Limits page
- Added **"resets in X" countdown badge** in the cleanup column (e.g. `in 3d 12h`, `in 12h 30m`) alongside the existing reset date text
- Extracted shared `limit-usage.utils.ts` module with reset-time helpers used across multiple components

### Chat page — usage progress bar
- New `ChatUsageLimitBar` component rendered above the prompt input
- Selects the **most-constrained limit** (by highest usage %) from all applicable limits: org-wide, agent-scoped, and user-scoped
- Shows a compact color-coded progress bar with `%` counter
- Tooltip shows: `Used: $X / $Y`, limit type, and `Resets: in Xd Yh`
- Auto-toasts at usage thresholds:
  - 🟡 **75%** — info toast: "Usage at 75%"
  - 🟠 **90%** — warning toast: "Approaching usage limit (90%)"
  - 🔴 **100%** — error toast: "Usage limit reached (100%)"
  - Toasts are debounced (1 min) to avoid spam

### 429 / usage-limit error card
- Error card now shows an **entity type badge** (e.g. `organization limit`, `agent limit`) indicating which limit was hit
- Admin users see a **direct link to `/llm/limits`** for quick navigation to adjust budgets
- The compact (slim) error UI also gets the entity type badge

### Usage column in tables
Added a `Usage` column to all 5 required tables via the new reusable `LimitUsageCell` component:
- **Virtual Key** (`/llm/credentials/virtual-keys`)
- **User** (`/settings/users`)
- **Agent** (`/agents`)
- **LLM Proxy** (`/llm/proxies`)
- **Team** (`/settings/teams`)

Each column:
- Shows a mini progress bar + `% left` badge (color-coded: green/orange/red)
- Tooltip on hover shows: used/limit amount, limit kind, resets-in, and model scope
- Displays `–` when no limits are configured
- Shows **"View all"** button when multiple limits exist, opening a detail modal

## New files
- `platform/frontend/src/lib/limit-usage.utils.ts` — shared utils (usage calc, countdown formatting)
- `platform/frontend/src/components/chat/chat-usage-limit-bar.tsx` — chat progress bar + toast component
- `platform/frontend/src/components/limit-usage-cell.tsx` — reusable table cell component

## Notes
- The `LimitUsageCell` makes one query per entity ID in the table. TanStack Query deduplicates identical requests, but tables with many entities will still make N API calls. A bulk endpoint would be the clean fix; the current approach is correct and matches existing patterns in the codebase.
- The usage bar in chat only appears when at least one limit exists that applies to the current session context (org/agent/user).
