### PR TITLE
fix(incoming-email): retry on transient agent failure

### DIFF
--- a/platform/backend/src/agents/incoming-email/index.test.ts
+++ b/platform/backend/src/agents/incoming-email/index.test.ts
@@ -558,6 +558,58 @@ describe("processIncomingEmail", () => {
     await processIncomingEmail(email, mockProvider);
     expect(vi.mocked(executeA2AMessage)).not.toHaveBeenCalled();
   });
+
+  test("reprocesses an email after a transient execution failure", async ({
+    makeUser,
+    makeOrganization,
+    makeTeam,
+  }) => {
+    const user = await makeUser();
+    const org = await makeOrganization();
+    const team = await makeTeam(org.id, user.id);
+
+    const internalAgent = await createTestInternalAgent(org.id, {
+      incomingEmailEnabled: true,
+      incomingEmailSecurityMode: "public",
+    });
+    const agentId = internalAgent.id;
+
+    await db
+      .insert(schema.agentTeamsTable)
+      .values({ agentId, teamId: team.id });
+
+    const mockProvider = {
+      providerId: "outlook",
+      displayName: "Outlook",
+      isConfigured: () => true,
+      initialize: vi.fn(),
+      generateEmailAddress: vi.fn(),
+      getEmailDomain: () => "test.com",
+      parseWebhookNotification: vi.fn(),
+      validateWebhookRequest: vi.fn(),
+      handleValidationChallenge: vi.fn(),
+      cleanup: vi.fn(),
+      extractPromptIdFromEmail: () => agentId,
+    } as unknown as OutlookEmailProvider;
+
+    const email: IncomingEmail = {
+      messageId: "test-transient-msg-1",
+      toAddress: `agents+agent-${agentId}@test.com`,
+      fromAddress: "sender@example.com",
+      subject: "Test Subject",
+      body: "Hello, agent!",
+      receivedAt: new Date(),
+    };
+
+    vi.mocked(executeA2AMessage).mockRejectedValueOnce(
+      new Error("LLM provider returned 429"),
+    );
+    await expect(processIncomingEmail(email, mockProvider)).rejects.toThrow();
+
+    vi.mocked(executeA2AMessage).mockClear();
+    await processIncomingEmail(email, mockProvider);
+    expect(vi.mocked(executeA2AMessage)).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("email deduplication helpers", () => {

--- a/platform/backend/src/agents/incoming-email/index.ts
+++ b/platform/backend/src/agents/incoming-email/index.ts
@@ -796,33 +796,39 @@ ${formattedHistory}
   // userId is determined by security mode:
   // - private: actual user ID from email lookup
   // - internal/public: "system" (anonymous)
-  const result = await startActiveChatSpan({
-    agentName: agent.name,
-    agentId,
-    teams: await AgentTeamModel.getTeamLabelInfoForAgent(agentId),
-    userTeams: emailUser
-      ? await TeamModel.getTeamLabelInfoForUser({
-          userId: emailUser.id,
+  let result: Awaited<ReturnType<typeof executeA2AMessage>>;
+  try {
+    result = await startActiveChatSpan({
+      agentName: agent.name,
+      agentId,
+      teams: await AgentTeamModel.getTeamLabelInfoForAgent(agentId),
+      userTeams: emailUser
+        ? await TeamModel.getTeamLabelInfoForUser({
+            userId: emailUser.id,
+            organizationId: organization,
+          })
+        : [],
+      routeCategory: RouteCategory.EMAIL,
+      triggerSource: "email",
+      user: emailUser
+        ? { id: emailUser.id, email: emailUser.email, name: emailUser.name }
+        : null,
+      callback: async () => {
+        return executeA2AMessage({
+          agentId,
+          message,
           organizationId: organization,
-        })
-      : [],
-    routeCategory: RouteCategory.EMAIL,
-    triggerSource: "email",
-    user: emailUser
-      ? { id: emailUser.id, email: emailUser.email, name: emailUser.name }
-      : null,
-    callback: async () => {
-      return executeA2AMessage({
-        agentId,
-        message,
-        organizationId: organization,
-        userId,
-        sessionId: buildEmailSessionId(email.conversationId),
-        source: "email",
-        attachments: a2aAttachments.length > 0 ? a2aAttachments : undefined,
-      });
-    },
-  });
+          userId,
+          sessionId: buildEmailSessionId(email.conversationId),
+          source: "email",
+          attachments: a2aAttachments.length > 0 ? a2aAttachments : undefined,
+        });
+      },
+    });
+  } catch (error) {
+    await ProcessedEmailModel.deleteByMessageId(email.messageId);
+    throw error;
+  }
 
   logger.info(
     {

--- a/platform/backend/src/models/processed-email.ts
+++ b/platform/backend/src/models/processed-email.ts
@@ -36,6 +36,12 @@ class ProcessedEmailModel {
     }
   }
 
+  static async deleteByMessageId(messageId: string): Promise<void> {
+    await db
+      .delete(schema.processedEmailsTable)
+      .where(eq(schema.processedEmailsTable.messageId, messageId));
+  }
+
   /**
    * Check if an email has been processed.
    * Note: For deduplication, prefer tryMarkAsProcessed() which is atomic.


### PR DESCRIPTION
Releases the processed-email claim when the agent run fails, so a transient failure (provider 429/5xx, timeout) is retried on redelivery instead of being silently deduplicated away.

## Fix
- Add `ProcessedEmailModel.deleteByMessageId`.
- Wrap the agent execution in try/catch; on failure, release the claim and rethrow.

Validation failures (agent not found, email disabled) stay marked, since retrying won't help.

## Testing
Added a `processIncomingEmail` test: first delivery fails mid-execution, redelivery is reprocessed instead of dropped. Fails before the fix (`expected called 1 times, got 0`), passes after. `pnpm --filter @backend test src/agents/incoming-email/index.test.ts` -> 45 passed.

A narrow window remains: a concurrent redelivery that arrives while the first attempt is still executing and then fails is still skipped. Fully closing it would need a `processing`/`completed` status on `processed_emails`; left out to keep this focused.

Fixes #5580