### PR TITLE
fix(github-copilot): non-streaming response schema + virtual-key mapping UI follow-ups

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -97356,10 +97356,7 @@
                       "type": "string"
                     },
                     "object": {
-                      "type": "string",
-                      "enum": [
-                        "chat.completion"
-                      ]
+                      "type": "string"
                     },
                     "server_tier": {
                       "type": "string"
@@ -97399,9 +97396,7 @@
                   "required": [
                     "id",
                     "choices",
-                    "created",
-                    "model",
-                    "object"
+                    "model"
                   ],
                   "additionalProperties": {}
                 }
@@ -98798,10 +98793,7 @@
                       "type": "string"
                     },
                     "object": {
-                      "type": "string",
-                      "enum": [
-                        "chat.completion"
-                      ]
+                      "type": "string"
                     },
                     "server_tier": {
                       "type": "string"
@@ -98841,9 +98833,7 @@
                   "required": [
                     "id",
                     "choices",
-                    "created",
-                    "model",
-                    "object"
+                    "model"
                   ],
                   "additionalProperties": {}
                 }
@@ -116127,10 +116117,7 @@
                                     "type": "string"
                                   },
                                   "object": {
-                                    "type": "string",
-                                    "enum": [
-                                      "chat.completion"
-                                    ]
+                                    "type": "string"
                                   },
                                   "server_tier": {
                                     "type": "string"
@@ -116170,9 +116157,7 @@
                                 "required": [
                                   "id",
                                   "choices",
-                                  "created",
-                                  "model",
-                                  "object"
+                                  "model"
                                 ],
                                 "additionalProperties": {}
                               },
@@ -132883,10 +132868,7 @@
                               "type": "string"
                             },
                             "object": {
-                              "type": "string",
-                              "enum": [
-                                "chat.completion"
-                              ]
+                              "type": "string"
                             },
                             "server_tier": {
                               "type": "string"
@@ -132926,9 +132908,7 @@
                           "required": [
                             "id",
                             "choices",
-                            "created",
-                            "model",
-                            "object"
+                            "model"
                           ],
                           "additionalProperties": {}
                         },

--- a/platform/backend/src/types/llm-providers/github-copilot/api.test.ts
+++ b/platform/backend/src/types/llm-providers/github-copilot/api.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { ChatCompletionResponseSchema } from "./api";
+
+describe("github-copilot ChatCompletionResponseSchema", () => {
+  // GitHub Copilot's non-streaming completions are OpenAI-shaped but omit the
+  // top-level `created` and `object` fields; the response must still serialize
+  // (it previously 500'd on the stricter OpenAI response schema).
+  it("accepts a non-streaming response missing created/object", () => {
+    const result = ChatCompletionResponseSchema.safeParse({
+      id: "chatcmpl-Dqz9PlJXiBJeFr08tCJz1Ns4vzy0x",
+      model: "gpt-4o-2024-11-20",
+      system_fingerprint: "fp_23ef75ba80",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: "hello from copilot" },
+          finish_reason: "stop",
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("still accepts a standard response with created/object", () => {
+    const result = ChatCompletionResponseSchema.safeParse({
+      id: "chatcmpl-x",
+      object: "chat.completion",
+      created: 1781520491,
+      model: "gpt-4o",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: "hi" },
+          finish_reason: "stop",
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/platform/backend/src/types/llm-providers/github-copilot/api.ts
+++ b/platform/backend/src/types/llm-providers/github-copilot/api.ts
@@ -8,6 +8,7 @@
  * @see https://docs.github.com/en/copilot
  */
 
+import { z } from "zod";
 import {
   ChatCompletionsHeadersSchema,
   ChatCompletionUsageSchema,
@@ -27,6 +28,15 @@ export {
 export const ChatCompletionRequestSchema =
   OpenAIChatCompletionRequestSchema.passthrough();
 
-/** Response schema with passthrough for Copilot-specific fields. */
+/**
+ * Response schema with passthrough for Copilot-specific fields. Copilot's
+ * responses are OpenAI-shaped but non-standard: a non-streaming completion can
+ * omit the top-level `created` and `object` fields (and `object` isn't always
+ * the literal "chat.completion"). Relax both so response serialization doesn't
+ * 500 — clients still receive Copilot's actual fields via passthrough.
+ */
 export const ChatCompletionResponseSchema =
-  OpenAIChatCompletionResponseSchema.passthrough();
+  OpenAIChatCompletionResponseSchema.extend({
+    created: z.number().optional(),
+    object: z.string().optional(),
+  }).passthrough();

--- a/platform/frontend/src/components/provider-key-mappings-field.tsx
+++ b/platform/frontend/src/components/provider-key-mappings-field.tsx
@@ -3,6 +3,7 @@
 import {
   E2eTestId,
   providerDisplayNames,
+  providerRequiresPerUserCredential,
   type SupportedProvider,
 } from "@archestra/shared";
 import { Plus, Trash2 } from "lucide-react";
@@ -65,6 +66,26 @@ export function ProviderKeyMappingsField({
         ([provider]) => provider === selectedProvider,
       )?.[1] ?? [])
     : [];
+  // Per-user providers (e.g. GitHub Copilot) self-map to the caller's own
+  // account — there's no key to pick, so the provider change handler below
+  // auto-selects it and the key field renders read-only.
+  const isPerUserProvider = selectedProvider
+    ? providerRequiresPerUserCredential(selectedProvider)
+    : false;
+  const selectedKey = selectedProviderKeys.find(
+    (apiKey) => apiKey.id === selectedApiKeyId,
+  );
+
+  const handleProviderChange = (value: SupportedProvider) => {
+    setSelectedProvider(value);
+    if (providerRequiresPerUserCredential(value)) {
+      const keys =
+        providerGroups.find(([provider]) => provider === value)?.[1] ?? [];
+      setSelectedApiKeyId(keys[0]?.id ?? "");
+    } else {
+      setSelectedApiKeyId("");
+    }
+  };
 
   const handleAddProviderKey = () => {
     if (!selectedProvider || !selectedApiKeyId) {
@@ -92,10 +113,9 @@ export function ProviderKeyMappingsField({
           <Label>Provider</Label>
           <Select
             value={selectedProvider}
-            onValueChange={(value) => {
-              setSelectedProvider(value as SupportedProvider);
-              setSelectedApiKeyId("");
-            }}
+            onValueChange={(value) =>
+              handleProviderChange(value as SupportedProvider)
+            }
           >
             <SelectTrigger
               className="w-full"
@@ -127,23 +147,32 @@ export function ProviderKeyMappingsField({
 
         <div className="space-y-2">
           <Label>Provider API Key</Label>
-          <LlmProviderApiKeyDropdown
-            availableKeys={selectedProviderKeys}
-            selectedApiKeyId={selectedApiKeyId || null}
-            disabled={!selectedProvider}
-            open={apiKeySelectorOpen}
-            onOpenChange={setApiKeySelectorOpen}
-            onSelectKey={(keyId) => {
-              setSelectedApiKeyId(keyId);
-              setApiKeySelectorOpen(false);
-            }}
-            triggerVariant="select"
-            triggerClassName="w-full h-10 text-sm"
-            popoverClassName="w-[var(--radix-popover-trigger-width)]"
-            popoverPortal={false}
-            emptyTriggerLabel="Select key"
-            triggerTestId={E2eTestId.VirtualKeyParentKeySelect}
-          />
+          {isPerUserProvider ? (
+            <div
+              className="flex h-9 w-full items-center rounded-md border border-input bg-muted px-3 text-sm text-muted-foreground"
+              data-testid={E2eTestId.VirtualKeyParentKeySelect}
+            >
+              {selectedKey?.name ?? "Your own account"} — per-user
+            </div>
+          ) : (
+            <LlmProviderApiKeyDropdown
+              availableKeys={selectedProviderKeys}
+              selectedApiKeyId={selectedApiKeyId || null}
+              disabled={!selectedProvider}
+              open={apiKeySelectorOpen}
+              onOpenChange={setApiKeySelectorOpen}
+              onSelectKey={(keyId) => {
+                setSelectedApiKeyId(keyId);
+                setApiKeySelectorOpen(false);
+              }}
+              triggerVariant="select"
+              triggerClassName="w-full text-sm"
+              popoverClassName="w-[var(--radix-popover-trigger-width)]"
+              popoverPortal={false}
+              emptyTriggerLabel="Select key"
+              triggerTestId={E2eTestId.VirtualKeyParentKeySelect}
+            />
+          )}
         </div>
 
         <div className="space-y-2">

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -27636,9 +27636,9 @@ export type GithubCopilotChatCompletionsWithDefaultAgentResponses = {
                 }> | null;
             };
         }>;
-        created: number;
+        created?: number;
         model: string;
-        object: 'chat.completion';
+        object?: string;
         server_tier?: string;
         system_fingerprint?: string | null;
         /**
@@ -28083,9 +28083,9 @@ export type GithubCopilotChatCompletionsWithAgentResponses = {
                 }> | null;
             };
         }>;
-        created: number;
+        created?: number;
         model: string;
-        object: 'chat.completion';
+        object?: string;
         server_tier?: string;
         system_fingerprint?: string | null;
         /**
@@ -31971,9 +31971,9 @@ export type GetInteractionsResponses = {
                         }> | null;
                     };
                 }>;
-                created: number;
+                created?: number;
                 model: string;
-                object: 'chat.completion';
+                object?: string;
                 server_tier?: string;
                 system_fingerprint?: string | null;
                 /**
@@ -35359,9 +35359,9 @@ export type GetInteractionResponses = {
                     }> | null;
                 };
             }>;
-            created: number;
+            created?: number;
             model: string;
-            object: 'chat.completion';
+            object?: string;
             server_tier?: string;
             system_fingerprint?: string | null;
             /**


### PR DESCRIPTION
Follow-ups to #5539 (GitHub Copilot per-user LLM provider), which has already merged. Two small, independent fixes.

## Non-streaming Copilot responses no longer 500

GitHub Copilot's chat completions API is OpenAI-compatible but non-standard: a **non-streaming** completion omits the top-level `created` and `object` fields (and `object` isn't always the literal `"chat.completion"`). Our response schema reused OpenAI's stricter schema, so serializing a non-streaming Copilot response 500'd with "Response doesn't match the schema".

Relaxed the Copilot response schema to make `created`/`object` optional (and `object` a free string), keeping `.passthrough()` so clients still receive Copilot's actual fields. Added unit tests covering both the missing-fields and standard shapes.

## Virtual-key provider/key mapping UI

- **Dropdown heights**: the Provider select rendered at `h-9` while the Provider API Key dropdown was `h-10`, so the two controls were visibly misaligned. Standardized the Provider select, key dropdown, Add button, and the new read-only field on the shadcn default `h-9`.
- **Per-user providers are read-only**: a virtual key for a per-user provider (GitHub Copilot) self-maps to the caller's *own* account — there is no key to pick. Selecting such a provider now auto-selects the caller's key and renders the key field read-only ("<key> — per-user") instead of an editable dropdown, mirroring the per-user treatment already used in the connect-settings dialog and the chat model chip.

## Testing

- `pnpm --filter @frontend type-check` + Biome clean.
- Backend Copilot schema unit tests added (`backend/src/types/llm-providers/github-copilot/api.test.ts`).
- Manually verified in-browser: the two dropdowns now align, and selecting GitHub Copilot renders the read-only "GitHub Copilot — per-user" key field.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>