### PR TITLE
fix(skills): soften compatibility badge to neutral styling

### DIFF
--- a/platform/frontend/src/app/agents/skills/page.client.tsx
+++ b/platform/frontend/src/app/agents/skills/page.client.tsx
@@ -3,9 +3,9 @@
 import type { archestraApiTypes } from "@archestra/shared";
 import type { ColumnDef } from "@tanstack/react-table";
 import {
-  AlertTriangle,
   BookOpen,
   Braces,
+  Info,
   Pencil,
   Plus,
   RotateCcw,
@@ -174,11 +174,8 @@ function SkillsList() {
             {skill.compatibility && (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Badge
-                    variant="outline"
-                    className="gap-1 text-amber-600 dark:text-amber-500"
-                  >
-                    <AlertTriangle className="h-3 w-3" />
+                  <Badge variant="outline" className="gap-1">
+                    <Info className="h-3 w-3" />
                     compatibility
                   </Badge>
                 </TooltipTrigger>


### PR DESCRIPTION
## What

The per-skill `compatibility` field is a non-forcing meta hint, but the skills table rendered it as an amber **warning** (`AlertTriangle` + `text-amber-600`), reading as a blocker.

Switch to a neutral `Info` icon with default `variant="outline"` styling — matching the sibling `templated` badge in the same table and the import/connect dialog, which already rendered this field neutrally.

Tooltip content (the raw compatibility text) is unchanged.

## Before / after

| | icon | color |
|---|---|---|
| before | ⚠️ AlertTriangle | amber-600 |
| after | ℹ️ Info | default (muted outline) |

## Scope

- One file: `frontend/src/app/agents/skills/page.client.tsx`.
- No data/API change; `skill.compatibility` is untouched.
- Tooltip wording (authored in each skill's SKILL.md frontmatter) is out of scope.

## Validation

- `type-check` + Biome lint pass.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>