### PR TITLE
feat(frontend): add Chats/Studio sidebar toggle

### DIFF
--- a/platform/frontend/src/app/_parts/chat-sidebar-section.test.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.test.tsx
@@ -302,4 +302,21 @@ describe("ChatSidebarSection", () => {
     expect(screen.getByText("Only Chat")).toBeInTheDocument();
     expect(screen.queryByText("More")).not.toBeInTheDocument();
   });
+
+  it("honors a custom slots count (used by the Chats tab Recents list)", () => {
+    mockConversations = Array.from({ length: 6 }, (_, i) =>
+      makeConv(`c${i + 1}`, `Chat ${i + 1}`, {
+        updatedAt: `2026-01-0${6 - i}T00:00:00Z`,
+      }),
+    );
+
+    render(<ChatSidebarSection slots={5} />);
+
+    // First 5 show, the 6th is hidden behind "More"
+    for (let i = 1; i <= 5; i++) {
+      expect(screen.getByText(`Chat ${i}`)).toBeInTheDocument();
+    }
+    expect(screen.queryByText("Chat 6")).not.toBeInTheDocument();
+    expect(screen.getByText("More")).toBeInTheDocument();
+  });
 });

--- a/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
@@ -51,7 +51,7 @@ import {
 import { useGlobalChat } from "@/lib/chat/global-chat.context";
 import { cn } from "@/lib/utils";
 
-const SIDEBAR_CHAT_SLOTS = 3;
+const DEFAULT_SIDEBAR_CHAT_SLOTS = 3;
 const MAX_TITLE_LENGTH = 100;
 
 function AISparkleIcon({ isAnimating = false }: { isAnimating?: boolean }) {
@@ -63,7 +63,15 @@ function AISparkleIcon({ isAnimating = false }: { isAnimating?: boolean }) {
   );
 }
 
-export function ChatSidebarSection() {
+export function ChatSidebarSection({
+  slots = DEFAULT_SIDEBAR_CHAT_SLOTS,
+  flat = false,
+}: {
+  /** How many chats to show before the "More" affordance. */
+  slots?: number;
+  /** Render without the sub-menu indentation (used by the Chats tab). */
+  flat?: boolean;
+} = {}) {
   const router = useRouter();
   const pathname = usePathname();
   const isAuthenticated = useIsAuthenticated();
@@ -100,12 +108,10 @@ export function ChatSidebarSection() {
     ? (pathname.split("/").at(-1) ?? null)
     : null;
 
-  const pinnedChats = conversations
-    .filter((c) => c.pinnedAt)
-    .slice(0, SIDEBAR_CHAT_SLOTS);
+  const pinnedChats = conversations.filter((c) => c.pinnedAt).slice(0, slots);
   const recentUnpinnedChats = conversations
     .filter((c) => !c.pinnedAt)
-    .slice(0, Math.max(0, SIDEBAR_CHAT_SLOTS - pinnedChats.length));
+    .slice(0, Math.max(0, slots - pinnedChats.length));
 
   useEffect(() => {
     if (editingId && inputRef.current) {
@@ -389,7 +395,9 @@ export function ChatSidebarSection() {
 
   return (
     <>
-      <SidebarMenuSub className="mx-0 ml-3.5 px-0 pl-2.5">
+      <SidebarMenuSub
+        className={flat ? "mx-0 border-l-0 px-0" : "mx-0 ml-3.5 px-0 pl-2.5"}
+      >
         {isLoading ? (
           <SidebarMenuSubItem>
             <div className="flex items-center gap-2 px-2 py-1.5">

--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -20,6 +20,7 @@ import {
   MessagesSquare,
   MoreHorizontal,
   Network,
+  PencilRuler,
   Route,
   Slack,
   Star,
@@ -37,6 +38,7 @@ import {
   SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
@@ -78,8 +80,12 @@ interface NavGroup {
   items: NavItem[];
 }
 
-// Primary nav items shown in the header (flat list, like sidebar-10 NavMain)
-const headerNavItems: NavItem[] = [
+type SidebarMode = "chats" | "studio";
+
+const SIDEBAR_MODE_STORAGE_KEY = "archestra-sidebar-mode";
+
+// Items of the Chats tab (flat list above Recents)
+const chatsNavItems: NavItem[] = [
   {
     title: "New Chat",
     url: "/chat",
@@ -87,6 +93,96 @@ const headerNavItems: NavItem[] = [
     customIsActive: (pathname: string) => pathname === "/chat",
   },
 ];
+
+/** Which tab a route belongs to; null = no opinion (keep the current tab). */
+function routeSidebarMode(pathname: string): SidebarMode | null {
+  const chatPrefixes = ["/chat"];
+  if (
+    chatPrefixes.some((p) => pathname === p || pathname.startsWith(`${p}/`))
+  ) {
+    return "chats";
+  }
+  const studioPrefixes = [
+    "/agents",
+    "/scheduled-tasks",
+    "/mcp",
+    "/llm",
+    "/knowledge",
+    "/audit",
+    "/connection",
+  ];
+  if (
+    studioPrefixes.some((p) => pathname === p || pathname.startsWith(`${p}/`))
+  ) {
+    return "studio";
+  }
+  return null;
+}
+
+/**
+ * Chats/Studio tab state: explicit picks persist, and navigation that
+ * clearly belongs to one tab (deep links included) switches to it.
+ */
+function useSidebarMode(pathname: string) {
+  const [mode, setMode] = React.useState<SidebarMode>(
+    () => routeSidebarMode(pathname) ?? "chats",
+  );
+
+  React.useEffect(() => {
+    const stored = window.localStorage.getItem(SIDEBAR_MODE_STORAGE_KEY);
+    if (
+      (stored === "chats" || stored === "studio") &&
+      routeSidebarMode(window.location.pathname) === null
+    ) {
+      setMode(stored);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    const routeMode = routeSidebarMode(pathname);
+    if (routeMode) setMode(routeMode);
+  }, [pathname]);
+
+  const pick = React.useCallback((next: SidebarMode) => {
+    setMode(next);
+    window.localStorage.setItem(SIDEBAR_MODE_STORAGE_KEY, next);
+  }, []);
+
+  return [mode, pick] as const;
+}
+
+/** Segmented Chats/Studio control (hidden when the sidebar is collapsed). */
+function SidebarModeToggle({
+  mode,
+  onPick,
+}: {
+  mode: SidebarMode;
+  onPick: (mode: SidebarMode) => void;
+}) {
+  const segment = (value: SidebarMode, label: string, Icon: LucideIcon) => (
+    <button
+      type="button"
+      key={value}
+      onClick={() => onPick(value)}
+      className={cn(
+        "flex flex-1 items-center justify-center gap-1 rounded-md px-1.5 py-1 text-xs transition-colors",
+        mode === value
+          ? "bg-background font-medium text-foreground shadow-sm"
+          : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      <Icon className="h-3.5 w-3.5" />
+      {label}
+    </button>
+  );
+
+  return (
+    <div className="mx-2 mt-1 flex rounded-lg border bg-muted p-0.5 group-data-[collapsible=icon]:hidden">
+      {segment("chats", "Chats", MessageCircle)}
+      {segment("studio", "Studio", PencilRuler)}
+    </div>
+  );
+}
 
 // Labeled groups shown in the scrollable content (like sidebar-10 Favorites/Workspaces)
 const contentNavGroups: NavGroup[] = [
@@ -244,14 +340,12 @@ const NavPrimary = ({
   pathname,
   searchParams,
   permissionMap,
-  chatSection,
 }: {
   items: NavItem[];
   groups: NavGroup[];
   pathname: string;
   searchParams: URLSearchParams;
   permissionMap: Record<string, boolean>;
-  chatSection?: React.ReactNode;
 }) => {
   const { isMobile, setOpenMobile } = useSidebar();
 
@@ -276,7 +370,6 @@ const NavPrimary = ({
           <span>{item.title}</span>
         </SidebarPrefetchLink>
       </SidebarMenuButton>
-      {item.title === "New Chat" && chatSection}
       {item.subItems && item.subItems.length > 0 && (
         <SidebarMenuSub className="mx-0 ml-3.5 px-0 pl-2.5">
           {item.subItems
@@ -480,6 +573,7 @@ export function AppSidebar() {
 
   // Skills are gated behind the ARCHESTRA_AGENTS_SKILLS_ENABLED env var.
   const skillsEnabled = useFeature("agentSkillsEnabled") === true;
+  const [sidebarMode, pickSidebarMode] = useSidebarMode(pathname);
   // Apps are gated behind the ARCHESTRA_APPS_ENABLED env var.
   const appsEnabled = useFeature("appsEnabled") === true;
 
@@ -525,14 +619,36 @@ export function AppSidebar() {
       <SidebarContent>
         {isAuthenticated && permissionMap && (
           <>
-            <NavPrimary
-              items={headerNavItems}
-              groups={filteredNavGroups}
-              pathname={pathname}
-              searchParams={searchParams}
-              permissionMap={permissionMap}
-              chatSection={<ChatSidebarSection />}
-            />
+            <SidebarModeToggle mode={sidebarMode} onPick={pickSidebarMode} />
+            {sidebarMode === "chats" ? (
+              <>
+                <NavPrimary
+                  items={chatsNavItems}
+                  groups={[]}
+                  pathname={pathname}
+                  searchParams={searchParams}
+                  permissionMap={permissionMap}
+                />
+                <SidebarGroup className="pt-0">
+                  <SidebarGroupLabel>Recents</SidebarGroupLabel>
+                  <SidebarGroupContent>
+                    <SidebarMenu>
+                      <SidebarMenuItem>
+                        <ChatSidebarSection slots={15} flat />
+                      </SidebarMenuItem>
+                    </SidebarMenu>
+                  </SidebarGroupContent>
+                </SidebarGroup>
+              </>
+            ) : (
+              <NavPrimary
+                items={[]}
+                groups={filteredNavGroups}
+                pathname={pathname}
+                searchParams={searchParams}
+                permissionMap={permissionMap}
+              />
+            )}
             <NavSecondary
               items={[]}
               pathname={pathname}


### PR DESCRIPTION
## Summary

Reorganizes the app sidebar into two segmented tabs, toggled by a control at the top:

- **Chats** — New Chat + a flat **Recents** list (up to 15 conversations)
- **Studio** — the existing workspace nav groups (Agents, MCP, LLM, Knowledge, etc.)

Tab state persists in `localStorage` and auto-switches based on the current route (deep links included). `ChatSidebarSection` gains `slots` / `flat` props so the Recents list can render flat with a configurable chat count (the Chats tab uses 15; the default stays 3).

This is **extracted from #5599**, deliberately leaving out that PR's Projects / My Files feature surface (nav items, the `projectName` badge, and the `sandbox`-flag gating) so the sidebar UX restructure can land on its own without the projects/files backend.

## Test Plan

- [x] `pnpm type-check` — clean
- [x] Biome lint on changed files — clean
- [x] `chat-sidebar-section.test.tsx` — 7/7 pass (added a case covering the new `slots` cap)
- [ ] Manual: Chats/Studio toggle switches tabs, persists across reloads, and auto-selects the right tab on deep links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>