### PR TITLE
feat(agents): scope agent MCP servers to the selected environment

### DIFF
--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -49,6 +49,7 @@ import {
 import {
   AgentToolsEditor,
   type AgentToolsEditorRef,
+  type McpEnvConflict,
 } from "@/components/agent-tools-editor";
 import { ModelSelector } from "@/components/chat/model-selector";
 import { ExternalDocsLink } from "@/components/external-docs-link";
@@ -58,7 +59,7 @@ import {
   PermissionRequirementHint,
 } from "@/components/permission-requirement-hint";
 import { SystemPromptEditor } from "@/components/system-prompt-editor";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
   AssignmentCombobox,
   type AssignmentComboboxItem,
@@ -615,6 +616,10 @@ export function AgentDialog({
   const accessibleEnvironments = environments.filter(
     (env) => !env.restricted || canDeployRestricted,
   );
+  // Scope the agent's MCP list to its environment only when the feature is on
+  // for an internal agent (same gate as the environment selector).
+  const environmentScopingEnabled =
+    agentType === "agent" && !!agentEnvironmentsEnabled;
   const { data: knowledgeBasesData } = useKnowledgeBases({
     enabled: shouldLoadKnowledgeSources && !!canReadKnowledgeBase,
   });
@@ -675,6 +680,7 @@ export function AgentDialog({
   const [environmentId, setEnvironmentId] = useState<string | null | undefined>(
     undefined,
   );
+  const [mcpEnvConflicts, setMcpEnvConflicts] = useState<McpEnvConflict[]>([]);
   const [scope, setScope] = useState<AgentScope>("personal");
   const [knowledgeBaseIds, setKnowledgeBaseIds] = useState<string[]>([]);
   const [connectorIds, setConnectorIds] = useState<string[]>([]);
@@ -1337,12 +1343,10 @@ export function AgentDialog({
                       }
                     >
                       <SelectTrigger>
-                        <SelectValue placeholder="Default runtime" />
+                        <SelectValue placeholder="Default" />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="none">
-                          Default runtime (no environment)
-                        </SelectItem>
+                        <SelectItem value="none">Default</SelectItem>
                         {accessibleEnvironments.map((env) => (
                           <SelectItem key={env.id} value={env.id}>
                             {env.name}
@@ -1543,6 +1547,13 @@ export function AgentDialog({
                       assignmentScope={scope}
                       assignmentTeamIds={assignedTeamIds}
                       onSelectedCountChange={setSelectedToolsCount}
+                      environmentScopingEnabled={environmentScopingEnabled}
+                      agentEnvironmentId={environmentId ?? null}
+                      agentEnvironmentName={
+                        environments.find((env) => env.id === environmentId)
+                          ?.name ?? null
+                      }
+                      onConflictsChange={setMcpEnvConflicts}
                       openComboboxOnMount={openToolsCombobox}
                     />
                   </div>
@@ -2090,6 +2101,36 @@ export function AgentDialog({
               )}
             </div>
           </fieldset>
+          {!readOnly && mcpEnvConflicts.length > 0 && (
+            <Alert variant="warning" className="mt-4">
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>
+                {mcpEnvConflicts.length} MCP server
+                {mcpEnvConflicts.length === 1 ? "" : "s"} not in this
+                environment
+              </AlertTitle>
+              <AlertDescription>
+                <p>
+                  Remove {mcpEnvConflicts.length === 1 ? "it" : "them"} or
+                  change the environment before saving:{" "}
+                  <span className="font-medium text-foreground">
+                    {mcpEnvConflicts.map((c) => c.name).join(", ")}
+                  </span>
+                </p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="mt-2"
+                  onClick={() =>
+                    agentToolsEditorRef.current?.removeIncompatibleTools()
+                  }
+                >
+                  Remove incompatible
+                </Button>
+              </AlertDescription>
+            </Alert>
+          )}
           <DialogStickyFooter className="mt-0">
             <Button type="button" variant="outline" onClick={handleClose}>
               {readOnly ? "Close" : "Cancel"}
@@ -2103,6 +2144,7 @@ export function AgentDialog({
                   createAgent.isPending ||
                   updateAgent.isPending ||
                   requiresTeamSelection ||
+                  mcpEnvConflicts.length > 0 ||
                   (!isAdmin && scope === "team" && hasNoAvailableTeams)
                 }
               >

--- a/platform/frontend/src/components/agent-tools-editor.tsx
+++ b/platform/frontend/src/components/agent-tools-editor.tsx
@@ -46,7 +46,9 @@ import { useMcpServersGroupedByCatalog } from "@/lib/mcp/mcp-server.query";
 import { useOrganization } from "@/lib/organization.query";
 import { cn } from "@/lib/utils";
 import {
+  computeMcpEnvConflicts,
   getDefaultArchestraToolIds,
+  isCatalogInEnvironment,
   sortAndFilterTools,
   sortCatalogItems,
 } from "./agent-tools-editor.utils";
@@ -76,11 +78,15 @@ interface PendingCatalogChanges {
   isActive?: boolean;
 }
 
+export type McpEnvConflict = { catalogId: string; name: string };
+
 export interface AgentToolsEditorRef {
   saveChanges: (params?: {
     agentId?: string;
     resourceLabel?: string;
   }) => Promise<void>;
+  /** Unselect every MCP catalog flagged as not belonging to the agent's environment. */
+  removeIncompatibleTools: () => void;
 }
 
 interface AgentToolsEditorProps {
@@ -88,6 +94,23 @@ interface AgentToolsEditorProps {
   assignmentScope?: AgentScope;
   assignmentTeamIds?: string[];
   onSelectedCountChange?: (count: number) => void;
+  /**
+   * When true (the agent-environments feature is on), scope the MCP list to
+   * `agentEnvironmentId` and report cross-environment selections via
+   * `onConflictsChange`. When false, all catalogs are shown and no conflicts
+   * are computed.
+   */
+  environmentScopingEnabled?: boolean;
+  /** The agent's environment id; `null` = the Default runtime bucket. */
+  agentEnvironmentId?: string | null;
+  /** Display name of the agent's environment for the filter hint (null = Default runtime). */
+  agentEnvironmentName?: string | null;
+  /**
+   * Reports MCP catalogs that are selected but don't belong to the agent's
+   * environment. Pass a referentially-stable callback (e.g. a `useState`
+   * setter) to avoid effect loops.
+   */
+  onConflictsChange?: (conflicts: McpEnvConflict[]) => void;
   /** "pills" (default): compact pills + dropdown combobox. "cards": inline grid of MCP server cards. */
   layout?: "pills" | "cards";
   /** When true, the "Add MCP server" combobox starts open. */
@@ -103,6 +126,10 @@ export const AgentToolsEditor = forwardRef<
     assignmentScope,
     assignmentTeamIds,
     onSelectedCountChange,
+    environmentScopingEnabled,
+    agentEnvironmentId,
+    agentEnvironmentName,
+    onConflictsChange,
     layout = "pills",
     openComboboxOnMount,
   },
@@ -114,6 +141,10 @@ export const AgentToolsEditor = forwardRef<
       assignmentScope={assignmentScope}
       assignmentTeamIds={assignmentTeamIds}
       onSelectedCountChange={onSelectedCountChange}
+      environmentScopingEnabled={environmentScopingEnabled}
+      agentEnvironmentId={agentEnvironmentId}
+      agentEnvironmentName={agentEnvironmentName}
+      onConflictsChange={onConflictsChange}
       layout={layout}
       openComboboxOnMount={openComboboxOnMount}
       ref={ref}
@@ -130,6 +161,10 @@ const AgentToolsEditorContent = forwardRef<
     assignmentScope,
     assignmentTeamIds,
     onSelectedCountChange,
+    environmentScopingEnabled = false,
+    agentEnvironmentId = null,
+    agentEnvironmentName,
+    onConflictsChange,
     layout = "pills",
     openComboboxOnMount,
   },
@@ -201,6 +236,26 @@ const AgentToolsEditorContent = forwardRef<
     );
   }, [catalogItems, assignedToolsByCatalog, toolCountByCatalog]);
 
+  // A catalog belongs to the agent's environment when it's a builtin (always
+  // available everywhere, e.g. the Archestra platform tools) or its environment
+  // matches — `null` (Default runtime) is its own bucket.
+  const isEnvCompatible = useCallback(
+    (catalog: InternalMcpCatalogItem) =>
+      isCatalogInEnvironment(catalog, agentEnvironmentId ?? null),
+    [agentEnvironmentId],
+  );
+
+  // Catalogs offered for selection. When environment scoping is on, hide
+  // catalogs that don't belong to the agent's environment (already-selected
+  // incompatible ones still render as pills so they can be removed).
+  const visibleCatalogItems = useMemo(
+    () =>
+      environmentScopingEnabled
+        ? sortedCatalogItems.filter(isEnvCompatible)
+        : sortedCatalogItems,
+    [sortedCatalogItems, environmentScopingEnabled, isEnvCompatible],
+  );
+
   // State counter to force re-renders when pendingChangesRef updates
   const [pendingVersion, setPendingVersion] = useState(0);
 
@@ -216,6 +271,10 @@ const AgentToolsEditorContent = forwardRef<
 
   // Track whether default tools have been pre-selected for new agent creation
   const defaultToolsInitializedRef = useRef(false);
+
+  // Latest cross-environment conflicts, mirrored to a ref so the imperative
+  // `removeIncompatibleTools()` can read them without a render dependency.
+  const conflictsRef = useRef<McpEnvConflict[]>([]);
 
   const { data: organization } = useOrganization();
   const skillToolsEnabled = organization?.skillToolsEnabled === true;
@@ -402,6 +461,20 @@ const AgentToolsEditorContent = forwardRef<
       // Clear all pending changes after save
       pendingChangesRef.current.clear();
     },
+    removeIncompatibleTools: () => {
+      for (const { catalogId } of conflictsRef.current) {
+        const catalog = catalogItems.find((c) => c.id === catalogId);
+        if (!catalog) continue;
+        const pending = pendingChangesRef.current.get(catalogId);
+        registerPendingChanges(catalogId, {
+          selectedToolIds: new Set(),
+          credentialSourceId: pending?.credentialSourceId ?? null,
+          catalogItem: catalog,
+          selectAll: false,
+          isActive: false,
+        });
+      }
+    },
   }));
 
   // Compute which catalog IDs are "selected" (have tools assigned or pending)
@@ -421,6 +494,39 @@ const AgentToolsEditorContent = forwardRef<
     }
     return ids;
   }, [sortedCatalogItems, assignedToolsByCatalog, pendingVersion]);
+
+  // Catalogs that are selected but don't belong to the agent's environment.
+  // Builtins are exempt. Empty when scoping is off.
+  const mcpEnvConflicts = useMemo<McpEnvConflict[]>(
+    () =>
+      environmentScopingEnabled
+        ? computeMcpEnvConflicts(
+            catalogItems,
+            selectedCatalogIds,
+            agentEnvironmentId ?? null,
+          )
+        : [],
+    [
+      environmentScopingEnabled,
+      selectedCatalogIds,
+      catalogItems,
+      agentEnvironmentId,
+    ],
+  );
+
+  // Mirror conflicts to a ref for the imperative remove, and report upward.
+  // `mcpEnvConflicts` is recomputed (new array) on every render because its
+  // dependency chain bottoms out in non-stable query results, so we diff by
+  // content and only call up on a real change — otherwise the parent's setState
+  // would re-render us in an infinite loop.
+  useEffect(() => {
+    const prev = conflictsRef.current;
+    const changed =
+      prev.length !== mcpEnvConflicts.length ||
+      mcpEnvConflicts.some((c, i) => prev[i]?.catalogId !== c.catalogId);
+    conflictsRef.current = mcpEnvConflicts;
+    if (changed) onConflictsChange?.(mcpEnvConflicts);
+  }, [mcpEnvConflicts, onConflictsChange]);
 
   // Handle toggling a catalog on/off from the combobox
   const handleCatalogToggle = useCallback(
@@ -475,7 +581,7 @@ const AgentToolsEditorContent = forwardRef<
   // Build combobox items
   // biome-ignore lint/correctness/useExhaustiveDependencies: pendingVersion triggers re-computation when pendingChangesRef updates
   const comboboxItems: AssignmentComboboxItem[] = useMemo(() => {
-    return sortedCatalogItems.map((catalog) => {
+    return visibleCatalogItems.map((catalog) => {
       const pending = pendingChangesRef.current.get(catalog.id);
       const assignedCount = pending
         ? pending.selectedToolIds.size
@@ -514,7 +620,7 @@ const AgentToolsEditorContent = forwardRef<
       };
     });
   }, [
-    sortedCatalogItems,
+    visibleCatalogItems,
     assignedToolsByCatalog,
     toolCountByCatalog,
     allCredentials,
@@ -547,7 +653,7 @@ const AgentToolsEditorContent = forwardRef<
   if (layout === "cards") {
     return (
       <div className="grid grid-cols-3 gap-2">
-        {sortedCatalogItems.map((catalog) => {
+        {visibleCatalogItems.map((catalog) => {
           const isSelected = selectedCatalogIds.includes(catalog.id);
           const pending = pendingChangesRef.current.get(catalog.id);
           const assignedCount = pending
@@ -582,39 +688,50 @@ const AgentToolsEditorContent = forwardRef<
   }
 
   return (
-    <div className="flex flex-wrap gap-2">
-      {selectedCatalogs.map((catalog) => (
-        <McpServerPill
-          key={catalog.id}
-          catalogItem={catalog}
-          displayName={
-            catalog.id === ARCHESTRA_MCP_CATALOG_ID ? catalogName : catalog.name
-          }
-          assignedTools={assignedToolsByCatalog.get(catalog.id) ?? []}
-          assignmentScope={assignmentScope}
-          assignmentTeamIds={assignmentTeamIds}
-          initialPendingChanges={pendingChangesRef.current.get(catalog.id)}
-          onPendingChanges={registerPendingChanges}
-          onClearPendingChanges={clearPendingChanges}
-          onRemove={handleCatalogToggle}
-          autoOpen={catalog.id === autoOpenCatalogId}
-          onAutoOpened={() => setAutoOpenCatalogId(null)}
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-2">
+        {selectedCatalogs.map((catalog) => (
+          <McpServerPill
+            key={catalog.id}
+            catalogItem={catalog}
+            displayName={
+              catalog.id === ARCHESTRA_MCP_CATALOG_ID
+                ? catalogName
+                : catalog.name
+            }
+            assignedTools={assignedToolsByCatalog.get(catalog.id) ?? []}
+            assignmentScope={assignmentScope}
+            assignmentTeamIds={assignmentTeamIds}
+            initialPendingChanges={pendingChangesRef.current.get(catalog.id)}
+            onPendingChanges={registerPendingChanges}
+            onClearPendingChanges={clearPendingChanges}
+            onRemove={handleCatalogToggle}
+            autoOpen={catalog.id === autoOpenCatalogId}
+            onAutoOpened={() => setAutoOpenCatalogId(null)}
+          />
+        ))}
+        <AssignmentCombobox
+          items={comboboxItems}
+          selectedIds={selectedCatalogIds}
+          onToggle={handleCatalogToggle}
+          onItemAdded={setAutoOpenCatalogId}
+          placeholder="Search MCP servers..."
+          emptyMessage="No MCP servers found."
+          testId={E2eTestId.AgentToolsAddButton}
+          defaultOpen={openComboboxOnMount}
+          createAction={{
+            label: "Install New MCP Server",
+            href: "/mcp/registry",
+          }}
         />
-      ))}
-      <AssignmentCombobox
-        items={comboboxItems}
-        selectedIds={selectedCatalogIds}
-        onToggle={handleCatalogToggle}
-        onItemAdded={setAutoOpenCatalogId}
-        placeholder="Search MCP servers..."
-        emptyMessage="No MCP servers found."
-        testId={E2eTestId.AgentToolsAddButton}
-        defaultOpen={openComboboxOnMount}
-        createAction={{
-          label: "Install New MCP Server",
-          href: "/mcp/registry",
-        }}
-      />
+      </div>
+      {environmentScopingEnabled && (
+        <p className="text-xs text-muted-foreground">
+          MCP servers are filtered to the selected environment
+          {agentEnvironmentName ? ` ("${agentEnvironmentName}")` : " (Default)"}
+          .
+        </p>
+      )}
     </div>
   );
 });

--- a/platform/frontend/src/components/agent-tools-editor.utils.test.ts
+++ b/platform/frontend/src/components/agent-tools-editor.utils.test.ts
@@ -4,7 +4,9 @@ import {
 } from "@archestra/shared";
 import { describe, expect, it } from "vitest";
 import {
+  computeMcpEnvConflicts,
   getDefaultArchestraToolIds,
+  isCatalogInEnvironment,
   sortAndFilterTools,
   sortCatalogItems,
 } from "./agent-tools-editor.utils";
@@ -260,5 +262,90 @@ describe("sortCatalogItems", () => {
       "slack",
       "empty",
     ]);
+  });
+});
+
+describe("isCatalogInEnvironment", () => {
+  const env = (environmentId: string | null, serverType = "local") => ({
+    id: "c1",
+    name: "Cat",
+    serverType,
+    environmentId,
+  });
+
+  it("matches when catalog and agent share an environment id", () => {
+    expect(isCatalogInEnvironment(env("env-a"), "env-a")).toBe(true);
+    expect(isCatalogInEnvironment(env("env-a"), "env-b")).toBe(false);
+  });
+
+  it("treats null (Default runtime) as its own bucket on both sides", () => {
+    expect(isCatalogInEnvironment(env(null), null)).toBe(true);
+    expect(isCatalogInEnvironment(env(null), "env-a")).toBe(false);
+    expect(isCatalogInEnvironment(env("env-a"), null)).toBe(false);
+  });
+
+  it("treats missing environmentId as the Default runtime bucket", () => {
+    expect(isCatalogInEnvironment({ id: "c1", name: "Cat" }, null)).toBe(true);
+    expect(isCatalogInEnvironment({ id: "c1", name: "Cat" }, "env-a")).toBe(
+      false,
+    );
+  });
+
+  it("exempts builtin catalogs from every environment", () => {
+    expect(isCatalogInEnvironment(env("env-a", "builtin"), "env-b")).toBe(true);
+    expect(isCatalogInEnvironment(env(null, "builtin"), "env-a")).toBe(true);
+  });
+});
+
+describe("computeMcpEnvConflicts", () => {
+  const catalogs = [
+    {
+      id: "default-mcp",
+      name: "Default MCP",
+      serverType: "local",
+      environmentId: null,
+    },
+    {
+      id: "prod-mcp",
+      name: "Prod MCP",
+      serverType: "local",
+      environmentId: "prod",
+    },
+    {
+      id: "builtin",
+      name: "Archestra",
+      serverType: "builtin",
+      environmentId: null,
+    },
+  ];
+
+  it("flags selected catalogs not in the agent's environment", () => {
+    const conflicts = computeMcpEnvConflicts(
+      catalogs,
+      ["default-mcp", "prod-mcp", "builtin"],
+      "prod",
+    );
+    expect(conflicts).toEqual([
+      { catalogId: "default-mcp", name: "Default MCP" },
+    ]);
+  });
+
+  it("never flags builtin catalogs", () => {
+    const conflicts = computeMcpEnvConflicts(catalogs, ["builtin"], "prod");
+    expect(conflicts).toEqual([]);
+  });
+
+  it("returns no conflicts when everything matches the Default runtime", () => {
+    const conflicts = computeMcpEnvConflicts(
+      catalogs,
+      ["default-mcp", "builtin"],
+      null,
+    );
+    expect(conflicts).toEqual([]);
+  });
+
+  it("skips unknown catalog ids", () => {
+    const conflicts = computeMcpEnvConflicts(catalogs, ["ghost"], "prod");
+    expect(conflicts).toEqual([]);
   });
 });

--- a/platform/frontend/src/components/agent-tools-editor.utils.ts
+++ b/platform/frontend/src/components/agent-tools-editor.utils.ts
@@ -61,6 +61,50 @@ export function getDefaultArchestraToolIds(
   return { toolIds, catalogIndex };
 }
 
+type EnvScopedCatalog = {
+  id: string;
+  name: string;
+  serverType?: string | null;
+  environmentId?: string | null;
+};
+
+/**
+ * A catalog belongs to an agent's environment when it's a builtin (the
+ * Archestra platform tools, available in every environment) or its environment
+ * matches. `null`/`undefined` (Default runtime) is its own bucket.
+ */
+export function isCatalogInEnvironment(
+  catalog: EnvScopedCatalog,
+  agentEnvironmentId: string | null,
+): boolean {
+  return (
+    catalog.serverType === "builtin" ||
+    (catalog.environmentId ?? null) === (agentEnvironmentId ?? null)
+  );
+}
+
+/**
+ * The selected catalogs that don't belong to the agent's environment (builtins
+ * are always compatible). Drives the save-blocking conflict alert. Unknown
+ * catalog ids are skipped.
+ */
+export function computeMcpEnvConflicts(
+  catalogItems: EnvScopedCatalog[],
+  selectedCatalogIds: Iterable<string>,
+  agentEnvironmentId: string | null,
+): { catalogId: string; name: string }[] {
+  const byId = new Map(catalogItems.map((c) => [c.id, c]));
+  const conflicts: { catalogId: string; name: string }[] = [];
+  for (const catalogId of selectedCatalogIds) {
+    const catalog = byId.get(catalogId);
+    if (!catalog || isCatalogInEnvironment(catalog, agentEnvironmentId)) {
+      continue;
+    }
+    conflicts.push({ catalogId, name: catalog.name });
+  }
+  return conflicts;
+}
+
 export function sortCatalogItems<
   T extends { id: string; name: string; serverType?: string | null },
 >(


### PR DESCRIPTION
## Summary

Binds the agent create/edit dialog's MCP-server selection to the agent's **Environment**, so an agent only uses MCP servers that belong to its environment. Previously the Environment and the MCP servers were chosen independently, letting you assemble an agent whose MCPs live in a different environment than its runtime — which contradicts the per-environment runtime/egress isolation the Environment exists to provide.

With an Environment selected, the "Add MCP server" list shows only catalogs in that environment (plus builtin Archestra tools), with a hint naming the environment. `Default` is its own bucket — a Default agent sees only no-environment MCPs. If an agent already has MCPs that don't match a newly-chosen environment, a warning bar names them, **disables Save**, and offers a one-click **"Remove incompatible"**.

The MCP↔environment link already rides on the catalog item (`internal_mcp_catalog.environment_id`), exposed on the catalog list response, so this is a frontend-only change. Gated behind the existing `agentEnvironmentsEnabled` feature flag.

## Limitations / follow-ups

- Scoping is **client-side/advisory**: the backend does not yet reject cross-environment tool assignment, so this nudges rather than enforces. Backend enforcement is a deliberate follow-up.
- `handleSave` commits tool changes before the agent/environment update; reordering it so a failed environment update can't leave tools removed is a related follow-up.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>