### PR TITLE
test(web-crawler): skip flaky connector test suite

### DIFF
--- a/platform/backend/src/knowledge-base/connectors/web-crawler/web-crawler-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/web-crawler/web-crawler-connector.test.ts
@@ -15,7 +15,7 @@ type RouteHandler = (
 
 const servers: Array<{ close: () => Promise<void> }> = [];
 
-describe("WebCrawlerConnector", () => {
+describe.skip("WebCrawlerConnector", () => {
   afterEach(async () => {
     await Promise.all(servers.splice(0).map((server) => server.close()));
   });


### PR DESCRIPTION
**Draft / temporary.** Skips the entire `web-crawler-connector.test.ts` suite via `describe.skip` to unblock CI while the underlying redirect flakiness (30s timeout on the cross-host-redirect case) is fixed properly in #5605.

This is a stopgap, not the real fix — #5605 makes the redirect tests deterministic (reject redirects before dialing) and keeps full coverage. Merge that instead unless an immediate unblock is needed.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>