### PR TITLE
feat(k8s): report NetworkPolicy enforcement honestly in the environment editor

### DIFF
--- a/platform/backend/src/k8s/capabilities.test.ts
+++ b/platform/backend/src/k8s/capabilities.test.ts
@@ -37,7 +37,7 @@ describe("Kubernetes capability inspection", () => {
     });
   });
 
-  test("falls back to Kubernetes NetworkPolicy when the Cilium CRD is absent", async () => {
+  test("reports enforcement unavailable when no provider CRD exists", async () => {
     const customObjectsApi = {
       getAPIResources: vi.fn().mockRejectedValue({ statusCode: 404 }),
     };
@@ -47,13 +47,77 @@ describe("Kubernetes capability inspection", () => {
     );
 
     expect(capabilities.networkPolicy).toMatchObject({
+      kubernetesNetworkPolicy: false,
+      ciliumNetworkPolicy: false,
+      gkeFqdnNetworkPolicy: false,
+      awsApplicationNetworkPolicy: false,
+      provider: "none",
+      supportsFqdn: false,
+      supportsHttpMethods: false,
+    });
+  });
+
+  test("reports enforcement unavailable when only stock GKE CRDs exist (NetworkPolicy addon off)", async () => {
+    // A GKE cluster with the NetworkPolicy addon off (LEGACY datapath, only
+    // `netd` running): the Calico, Cilium, and AWS groups are absent, and
+    // networking.gke.io resolves to stock CRDs with no fqdnnetworkpolicies. The
+    // capability must report no enforcer.
+    const customObjectsApi = {
+      getAPIResources: vi.fn(async ({ group }: { group: string }) => {
+        if (group === "networking.gke.io") {
+          return {
+            resources: [
+              { name: "frontendconfigs" },
+              { name: "gkenetworkparamsets" },
+              { name: "managedcertificates" },
+              { name: "networks" },
+              { name: "serviceattachments" },
+            ],
+          };
+        }
+        throw { statusCode: 404 };
+      }),
+    };
+
+    const capabilities = await getK8sCapabilitiesFromApi(
+      customObjectsApi as never,
+    );
+
+    expect(capabilities.networkPolicy).toMatchObject({
+      kubernetesNetworkPolicy: false,
+      gkeFqdnNetworkPolicy: false,
+      provider: "none",
+      supportsFqdn: false,
+    });
+  });
+
+  test("reports enforcement via Calico when the projectcalico CRDs exist", async () => {
+    const customObjectsApi = {
+      getAPIResources: vi.fn(async ({ group }: { group: string }) => ({
+        resources:
+          group === "crd.projectcalico.org"
+            ? [{ name: "felixconfigurations" }, { name: "ippools" }]
+            : [],
+      })),
+    };
+
+    const capabilities = await getK8sCapabilitiesFromApi(
+      customObjectsApi as never,
+    );
+
+    expect(customObjectsApi.getAPIResources).toHaveBeenCalledWith({
+      group: "crd.projectcalico.org",
+      version: "v1",
+    });
+    expect(capabilities.networkPolicy).toMatchObject({
+      // Calico enforces standard NetworkPolicy (IP/CIDR), so enforcement is
+      // available but FQDN/domain allowlists are not.
       kubernetesNetworkPolicy: true,
       ciliumNetworkPolicy: false,
       gkeFqdnNetworkPolicy: false,
       awsApplicationNetworkPolicy: false,
       provider: "kubernetes",
       supportsFqdn: false,
-      supportsHttpMethods: false,
     });
   });
 
@@ -115,7 +179,7 @@ describe("Kubernetes capability inspection", () => {
     await getK8sCapabilitiesFromApi(customObjectsApi as never);
     await getK8sCapabilitiesFromApi(customObjectsApi as never);
 
-    expect(customObjectsApi.getAPIResources).toHaveBeenCalledTimes(3);
+    expect(customObjectsApi.getAPIResources).toHaveBeenCalledTimes(4);
   });
 
   test("reprobes after the capability cache TTL expires", async () => {
@@ -129,6 +193,6 @@ describe("Kubernetes capability inspection", () => {
     vi.advanceTimersByTime(5 * 60 * 1000 + 1);
     await getK8sCapabilitiesFromApi(customObjectsApi as never);
 
-    expect(customObjectsApi.getAPIResources).toHaveBeenCalledTimes(6);
+    expect(customObjectsApi.getAPIResources).toHaveBeenCalledTimes(8);
   });
 });

--- a/platform/backend/src/k8s/capabilities.test.ts
+++ b/platform/backend/src/k8s/capabilities.test.ts
@@ -118,6 +118,7 @@ describe("Kubernetes capability inspection", () => {
       awsApplicationNetworkPolicy: false,
       provider: "kubernetes",
       supportsFqdn: false,
+      supportsHttpMethods: false,
     });
   });
 

--- a/platform/backend/src/k8s/capabilities.ts
+++ b/platform/backend/src/k8s/capabilities.ts
@@ -30,27 +30,41 @@ export async function getK8sCapabilitiesFromApi(
   if (cached) return cached;
 
   const [
+    calicoNetworkPolicy,
     ciliumNetworkPolicy,
     gkeFqdnNetworkPolicy,
     awsApplicationNetworkPolicy,
   ] = await Promise.all([
+    hasCalicoNetworkPolicyResource(customObjectsApi),
     hasCiliumNetworkPolicyResource(customObjectsApi),
     hasGkeFqdnNetworkPolicyResource(customObjectsApi),
     hasAwsApplicationNetworkPolicyResource(customObjectsApi),
   ]);
-  const provider = ciliumNetworkPolicy
-    ? "cilium"
-    : gkeFqdnNetworkPolicy
-      ? "gke-fqdn"
-      : awsApplicationNetworkPolicy
-        ? "aws-application-network-policy"
-        : "kubernetes";
   const supportsFqdn =
     ciliumNetworkPolicy || gkeFqdnNetworkPolicy || awsApplicationNetworkPolicy;
+  // A NetworkPolicy is only enforced if a dataplane agent backs it. Calico,
+  // Cilium, and the FQDN providers each install a provider-exclusive CRD group
+  // we can discover; absent all of them — e.g. GKE with the NetworkPolicy addon
+  // off, only `netd` running — the API accepts NetworkPolicy objects but nothing
+  // enforces them, so we report "none" rather than a false promise of isolation.
+  // Known limitation: plain GKE Dataplane V2 enforces standard NetworkPolicy but
+  // exposes no discoverable CRD (its FQDN CRD is feature-gated), so it is not
+  // detected here and would report "none". Acceptable while no environment runs
+  // plain Dataplane V2; revisit (probe the `anetd` DaemonSet) if one does.
+  const enforced = supportsFqdn || calicoNetworkPolicy;
+  const provider = !enforced
+    ? "none"
+    : ciliumNetworkPolicy
+      ? "cilium"
+      : gkeFqdnNetworkPolicy
+        ? "gke-fqdn"
+        : awsApplicationNetworkPolicy
+          ? "aws-application-network-policy"
+          : "kubernetes";
 
   const capabilities: K8sCapabilities = {
     networkPolicy: {
-      kubernetesNetworkPolicy: true,
+      kubernetesNetworkPolicy: enforced,
       ciliumNetworkPolicy,
       gkeFqdnNetworkPolicy,
       awsApplicationNetworkPolicy,
@@ -58,6 +72,7 @@ export async function getK8sCapabilitiesFromApi(
       supportsFqdn,
       supportsHttpMethods: false,
       message: capabilityMessage({
+        enforced,
         ciliumNetworkPolicy,
         gkeFqdnNetworkPolicy,
         awsApplicationNetworkPolicy,
@@ -127,6 +142,7 @@ async function hasCiliumNetworkPolicyResource(
 }
 
 function capabilityMessage(params: {
+  enforced: boolean;
   ciliumNetworkPolicy: boolean;
   gkeFqdnNetworkPolicy: boolean;
   awsApplicationNetworkPolicy: boolean;
@@ -141,10 +157,38 @@ function capabilityMessage(params: {
   if (params.awsApplicationNetworkPolicy) {
     return "AWS ApplicationNetworkPolicy API detected. Domain allowlists can be enforced by EKS Auto Mode.";
   }
-  if (!params.supportsFqdn) {
-    return "No supported FQDN policy provider detected. Kubernetes NetworkPolicy only enforces IP/CIDR egress.";
+  if (!params.enforced) {
+    return "No NetworkPolicy enforcer detected (no Calico, Cilium, or FQDN policy provider). NetworkPolicy objects are accepted by the API but not enforced.";
   }
-  return "Network policy capabilities detected.";
+  return "NetworkPolicy enforcement detected. IP/CIDR egress is enforced; domain allowlists require a supported FQDN policy provider.";
+}
+
+async function hasCalicoNetworkPolicyResource(
+  customObjectsApi: k8s.CustomObjectsApi,
+): Promise<boolean> {
+  // Calico (the legacy GKE NetworkPolicy addon or self-managed) installs the
+  // provider-exclusive `crd.projectcalico.org` group; `felixconfigurations` is
+  // its dataplane (Felix) config, present wherever Calico's CRDs are installed.
+  try {
+    const resourceList = await customObjectsApi.getAPIResources({
+      group: "crd.projectcalico.org",
+      version: "v1",
+    });
+    return (
+      resourceList.resources?.some(
+        (resource) => resource.name === "felixconfigurations",
+      ) ?? false
+    );
+  } catch (error) {
+    if (isK8sNotFoundError(error)) {
+      return false;
+    }
+    logger.warn(
+      { err: error },
+      "Failed to inspect Calico Kubernetes API resources",
+    );
+    return false;
+  }
 }
 
 async function hasGkeFqdnNetworkPolicyResource(

--- a/platform/backend/src/k8s/mcp-server-runtime/manager.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager.test.ts
@@ -540,9 +540,11 @@ describe("McpServerRuntimeManager", () => {
       const deploymentOptions = mockK8sDeploymentInstances.at(-1)?.options;
       expect(deploymentOptions).toHaveProperty("k8sCustomObjectsApi");
       expect(deploymentOptions).toMatchObject({
+        // The mock exposes no provider CRDs, so no NetworkPolicy enforcer is
+        // detected and the capability reports "none".
         networkPolicyCapabilities: {
-          kubernetesNetworkPolicy: true,
-          provider: "kubernetes",
+          kubernetesNetworkPolicy: false,
+          provider: "none",
           supportsFqdn: false,
         },
       });

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -691,9 +691,9 @@ function NetworkPolicyFields({
           <AlertTitle>Network policy enforcement unavailable</AlertTitle>
           <AlertDescription className="block leading-6">
             No Kubernetes NetworkPolicy enforcer (Calico, Cilium, or a supported
-            FQDN provider) was detected, or Kubernetes access isn't configured.
-            Egress rules set here would be accepted but not enforced — install a
-            network policy provider before relying on them.{" "}
+            FQDN provider) was detected, or Kubernetes access isn't configured,
+            so egress can't be enforced on this cluster. These controls are
+            disabled until a supported network policy provider is available.{" "}
             <ExternalDocsLink href={NETWORK_POLICY_DOCS_URL}>
               View docs
             </ExternalDocsLink>

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -400,17 +400,34 @@ function EnvironmentEditorDialog({
       : null;
   const canSave = trimmedName.length > 0 && validationRegexError === null;
   const supportsFqdn = capabilities?.networkPolicy.supportsFqdn === true;
-  const networkPolicy = {
-    egressMode,
-    domainPreset:
-      egressMode === "restricted" && supportsFqdn ? domainPreset : "none",
-    allowedDomains:
-      egressMode === "restricted" && supportsFqdn
-        ? splitPolicyList(allowedDomainsText)
-        : [],
-    allowedCidrs:
-      egressMode === "restricted" ? splitPolicyList(allowedCidrsText) : [],
-  };
+  const enforcementUnavailable =
+    capabilities?.networkPolicy.provider === "none";
+  // With no enforcer the egress controls are disabled, so the form can't express
+  // intent. Persisting the default "restricted" + empty allowlists would silently
+  // become a deny-all once an enforcer is installed. Keep an existing policy
+  // untouched; for a new/policy-less environment save a non-enforcing one.
+  const originalNetworkPolicy =
+    mode === "default"
+      ? (defaultEnvironment?.networkPolicy ?? null)
+      : (environment?.networkPolicy ?? null);
+  const networkPolicy: NetworkPolicy = enforcementUnavailable
+    ? (originalNetworkPolicy ?? {
+        egressMode: "unrestricted",
+        domainPreset: "none",
+        allowedDomains: [],
+        allowedCidrs: [],
+      })
+    : {
+        egressMode,
+        domainPreset:
+          egressMode === "restricted" && supportsFqdn ? domainPreset : "none",
+        allowedDomains:
+          egressMode === "restricted" && supportsFqdn
+            ? splitPolicyList(allowedDomainsText)
+            : [],
+        allowedCidrs:
+          egressMode === "restricted" ? splitPolicyList(allowedCidrsText) : [],
+      };
 
   // The current value is included so editing an environment whose namespace
   // predates the configured list never silently drops it.

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -679,16 +679,24 @@ function NetworkPolicyFields({
   provider: string | null;
   disabled: boolean;
 }) {
+  // No enforcer on the cluster: every rule below would be accepted but never
+  // enforced, so the whole egress section is disabled rather than offering
+  // controls that silently do nothing.
+  const enforcementUnavailable = provider === "none";
   return (
     <div className="space-y-4">
-      {provider === "none" ? (
+      {enforcementUnavailable ? (
         <Alert variant="info">
           <Info className="h-4 w-4" />
           <AlertTitle>Network policy enforcement unavailable</AlertTitle>
           <AlertDescription className="block leading-6">
-            Kubernetes access is not configured, or network policy capabilities
-            could not be inspected. Enable a Kubernetes network policy provider
-            before relying on these policies.
+            No Kubernetes NetworkPolicy enforcer (Calico, Cilium, or a supported
+            FQDN provider) was detected, or Kubernetes access isn't configured.
+            Egress rules set here would be accepted but not enforced — install a
+            network policy provider before relying on them.{" "}
+            <ExternalDocsLink href={NETWORK_POLICY_DOCS_URL}>
+              View docs
+            </ExternalDocsLink>
           </AlertDescription>
         </Alert>
       ) : !supportsFqdn ? (
@@ -717,7 +725,7 @@ function NetworkPolicyFields({
         <Select
           value={egressMode}
           onValueChange={(value) => setEgressMode(value as EgressMode)}
-          disabled={disabled}
+          disabled={disabled || enforcementUnavailable}
         >
           <SelectTrigger className="w-full">
             <SelectValue />
@@ -774,7 +782,9 @@ function NetworkPolicyFields({
           onChange={(e) => setAllowedCidrsText(e.target.value)}
           placeholder={"203.0.113.0/24\n2001:db8::/32"}
           className="min-h-20 font-mono text-sm"
-          disabled={disabled || egressMode !== "restricted"}
+          disabled={
+            disabled || enforcementUnavailable || egressMode !== "restricted"
+          }
         />
       </div>
 


### PR DESCRIPTION
## Summary

The environment editor lets you scope an environment's egress with a Kubernetes NetworkPolicy (Restricted mode, Allowed CIDRs, domain allowlists). But `getK8sCapabilities` hard-coded `kubernetesNetworkPolicy: true`, so on a cluster with **no NetworkPolicy enforcer installed** (e.g. GKE with the NetworkPolicy add-on off — the API server accepts `NetworkPolicy` objects but nothing enforces them) the editor still presented those controls as functional. An operator could configure a "Restricted" egress policy that silently does nothing, believing the environment was isolated.

This makes the capability honest. The backend already probed for FQDN-capable providers (Cilium, GKE FQDN, AWS); it now also probes Calico's provider-exclusive `crd.projectcalico.org` group and derives an `enforced` flag. When **no** enforcer is detected, it reports `provider: "none"` and `kubernetesNetworkPolicy: false` instead of `"kubernetes"`/`true`.

The editor responds to that: when `provider === "none"` it shows a **"Network policy enforcement unavailable"** alert that names the missing enforcer and states that rules would be accepted but not enforced, and it disables the Egress mode select and the Allowed CIDRs textarea (the domain controls were already gated on FQDN support). Previously those two stayed enabled regardless.

This changes only the reported capability and the editor's affordances — it does not change which policy objects the runtime applies (`kubernetesNetworkPolicy` has no other consumer, and no policy builder branches on `provider`).

Detection is by discoverable CRD, so a cluster running **plain GKE Dataplane V2** (which enforces standard NetworkPolicy but whose FQDN CRD is feature-gated) would report `"none"`; this is called out in a code comment with a concrete revisit path (probe the `anetd` DaemonSet) for if an environment ever runs that configuration.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
