### PR TITLE
fix(sandbox): regenerate stale sandbox-base lockfile (project-name drift)

### DIFF
--- a/platform/sandbox_base/requirements.lock
+++ b/platform/sandbox_base/requirements.lock
@@ -21,7 +21,7 @@ httpcore==1.0.9 \
 httpx==0.28.1 \
     --hash=sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc \
     --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
-    # via archestra-sandbox-base (pyproject.toml)
+    # via sandbox (pyproject.toml)
 idna==3.18 \
     --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2 \
     --hash=sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848
@@ -102,7 +102,7 @@ numpy==2.4.6 \
     --hash=sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6 \
     --hash=sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20
     # via
-    #   archestra-sandbox-base (pyproject.toml)
+    #   sandbox (pyproject.toml)
     #   pandas
 pandas==3.0.3 \
     --hash=sha256:0383c72c75cdcca61a9e116e611143902dbfd08bff356829c2f6d1cf40a9ca8c \
@@ -153,7 +153,7 @@ pandas==3.0.3 \
     --hash=sha256:e3a2ec42c98ffa2565a67e08e218d06d72576d758d90facb7c00805194d8f360 \
     --hash=sha256:f8894dc474d648fe7b6ff0ca9b0bd73950d19952bc1a6534540762c5d79d305c \
     --hash=sha256:fed2ff7fd9779120e388e285fc029bd5cf9490cdd2e4166a9ee22c0e49a9ab09
-    # via archestra-sandbox-base (pyproject.toml)
+    # via sandbox (pyproject.toml)
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427


### PR DESCRIPTION
## Summary

The `sandbox-base` image failed to publish at the 1.2.64 release: `Release Please` succeeded, but the **Sandbox Base Python Lockfile Check** failed, which skipped the image build — the registry has no `sandbox-base` tags.

Root cause: `platform/sandbox_base/requirements.lock` was committed referencing the project name `archestra-sandbox-base`, while `pyproject.toml` names the project `sandbox`. The two have been mismatched since the directory's first commit — the lock was generated locally under an `archestra-sandbox-base` name that was renamed to `sandbox` before committing, without regenerating the lock. The lockfile check runs only at **release** time (never on the PR that introduced the file), so the drift stayed hidden until 1.2.64 tried to publish.

`sandbox` is the correct name and is deliberately kept: the baked image's `pyproject.toml` is copied into `/home/sandbox` and must stay identical to the project the runtime itself materializes there — `PYPROJECT_SETUP` in `sandbox-core/src/backends/dagger.rs` writes `name = "sandbox"`. So the lock is reconciled to the pyproject, not the reverse. Regenerated with uv 0.9.26 (the version CI pins); the only change is the `# via … (pyproject.toml)` project-name comment — no dependency versions or hashes change.

With this in, the lockfile check passes and the next release publishes the image. 1.2.64 was cut from the pre-fix tree, so it won't receive the image retroactively.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
