### PR TITLE
fix(sandbox): regenerate sandbox_base lockfile to unblock staging deploy

### DIFF
--- a/platform/sandbox_base/requirements.lock
+++ b/platform/sandbox_base/requirements.lock
@@ -21,7 +21,7 @@ httpcore==1.0.9 \
 httpx==0.28.1 \
     --hash=sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc \
     --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
-    # via archestra-sandbox-base (pyproject.toml)
+    # via sandbox (pyproject.toml)
 idna==3.18 \
     --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2 \
     --hash=sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848
@@ -102,7 +102,7 @@ numpy==2.4.6 \
     --hash=sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6 \
     --hash=sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20
     # via
-    #   archestra-sandbox-base (pyproject.toml)
+    #   sandbox (pyproject.toml)
     #   pandas
 pandas==3.0.3 \
     --hash=sha256:0383c72c75cdcca61a9e116e611143902dbfd08bff356829c2f6d1cf40a9ca8c \
@@ -153,7 +153,7 @@ pandas==3.0.3 \
     --hash=sha256:e3a2ec42c98ffa2565a67e08e218d06d72576d758d90facb7c00805194d8f360 \
     --hash=sha256:f8894dc474d648fe7b6ff0ca9b0bd73950d19952bc1a6534540762c5d79d305c \
     --hash=sha256:fed2ff7fd9779120e388e285fc029bd5cf9490cdd2e4166a9ee22c0e49a9ab09
-    # via archestra-sandbox-base (pyproject.toml)
+    # via sandbox (pyproject.toml)
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427


### PR DESCRIPTION
## Problem

`Deploy to staging` has been **skipped on every commit to `main` since #5524** (~12:50 UTC), so release `1.2.64` and later commits are not on staging.

Root cause: #5524 added `sandbox_base/pyproject.toml` with `name = "sandbox"` but committed a `requirements.lock` whose `# via` annotations still read `archestra-sandbox-base`. The **Sandbox Base Python Lockfile Check** regenerates the lock, finds a non-empty `git diff`, and exits 1 — failing the sandbox-base build and skipping the deploy job.

## Fix

`make -C sandbox_base update-lockfile`. Comment-only diff (`archestra-sandbox-base` → `sandbox`); package versions and hashes are unchanged.

## Validation

After merge, the "On commits to main" run should pass the lockfile check and reach `Deploy to staging`.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>