### PR TITLE
feat(environments): make the environment editor reload-stable via URL params

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/environment-edit-link.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/environment-edit-link.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  clearEnvironmentDialogParams,
+  setEnvironmentCreateParam,
+  setEnvironmentEditParam,
+} from "./environment-edit-link";
+
+describe("setEnvironmentEditParam", () => {
+  it("adds the edit param to an empty search", () => {
+    expect(setEnvironmentEditParam("", "env-1")).toBe("edit=env-1");
+  });
+
+  it("preserves existing params", () => {
+    const result = new URLSearchParams(
+      setEnvironmentEditParam("foo=bar", "env-1"),
+    );
+    expect(result.get("foo")).toBe("bar");
+    expect(result.get("edit")).toBe("env-1");
+  });
+
+  it("overwrites an existing edit param", () => {
+    expect(setEnvironmentEditParam("edit=old", "new")).toBe("edit=new");
+  });
+
+  it("drops the create param (dialogs are mutually exclusive)", () => {
+    const result = new URLSearchParams(
+      setEnvironmentEditParam("create=1", "x"),
+    );
+    expect(result.has("create")).toBe(false);
+    expect(result.get("edit")).toBe("x");
+  });
+
+  it("accepts the default sentinel as an id", () => {
+    expect(setEnvironmentEditParam("", "default")).toBe("edit=default");
+  });
+});
+
+describe("setEnvironmentCreateParam", () => {
+  it("adds the create param to an empty search", () => {
+    expect(setEnvironmentCreateParam("")).toBe("create=1");
+  });
+
+  it("drops the edit param (dialogs are mutually exclusive)", () => {
+    const result = new URLSearchParams(setEnvironmentCreateParam("edit=env-1"));
+    expect(result.has("edit")).toBe(false);
+    expect(result.get("create")).toBe("1");
+  });
+});
+
+describe("clearEnvironmentDialogParams", () => {
+  it("removes both dialog params", () => {
+    expect(clearEnvironmentDialogParams("edit=env-1")).toBe("");
+    expect(clearEnvironmentDialogParams("create=1")).toBe("");
+  });
+
+  it("preserves other params", () => {
+    const result = new URLSearchParams(
+      clearEnvironmentDialogParams("foo=bar&edit=env-1"),
+    );
+    expect(result.get("foo")).toBe("bar");
+    expect(result.has("edit")).toBe(false);
+  });
+
+  it("is a no-op when there are no dialog params", () => {
+    expect(clearEnvironmentDialogParams("foo=bar")).toBe("foo=bar");
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/_parts/environment-edit-link.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/environment-edit-link.ts
@@ -1,0 +1,42 @@
+export const ENVIRONMENT_EDIT_PARAM = "edit";
+export const ENVIRONMENT_CREATE_PARAM = "create";
+// Sentinel `edit` value for the org-level default environment, which is a
+// virtual row (id `"default"`) rather than a real uuid environment.
+export const ENVIRONMENT_DEFAULT_VALUE = "default";
+
+/**
+ * Search string (without leading `?`) with `?edit=<id>` set, preserving other
+ * params, so an open environment editor is shareable via the address bar. The
+ * `create` param is removed since the two dialogs are mutually exclusive.
+ */
+export function setEnvironmentEditParam(
+  currentSearch: string,
+  id: string,
+): string {
+  const params = new URLSearchParams(currentSearch);
+  params.delete(ENVIRONMENT_CREATE_PARAM);
+  params.set(ENVIRONMENT_EDIT_PARAM, id);
+  return params.toString();
+}
+
+/**
+ * Search string with `?create` set, preserving other params and removing
+ * `edit` (the dialogs are mutually exclusive).
+ */
+export function setEnvironmentCreateParam(currentSearch: string): string {
+  const params = new URLSearchParams(currentSearch);
+  params.delete(ENVIRONMENT_EDIT_PARAM);
+  params.set(ENVIRONMENT_CREATE_PARAM, "1");
+  return params.toString();
+}
+
+/**
+ * Search string with both dialog params removed, preserving other params. Used
+ * when a dialog closes or an unknown `edit` id is ignored.
+ */
+export function clearEnvironmentDialogParams(currentSearch: string): string {
+  const params = new URLSearchParams(currentSearch);
+  params.delete(ENVIRONMENT_EDIT_PARAM);
+  params.delete(ENVIRONMENT_CREATE_PARAM);
+  return params.toString();
+}

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -90,8 +90,8 @@ export function EnvironmentsSection({ canEdit }: { canEdit: boolean }) {
     useState<EnvironmentWithAssignedCount | null>(null);
 
   // Which editor is open is derived from the URL (`?edit=<id|default>` /
-  // `?create`) so the form survives a reload and is shareable, matching the
-  // catalog editor's deep-link pattern. Only admins (canEdit) open one.
+  // `?create`) so the form survives a reload and is shareable. Only admins
+  // (canEdit) open one.
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -3,6 +3,7 @@
 import { DocsPage, getDocsUrl } from "@archestra/shared";
 import type { ColumnDef } from "@tanstack/react-table";
 import { Info, Pencil, Trash2 } from "lucide-react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { ExternalDocsLink } from "@/components/external-docs-link";
@@ -43,6 +44,13 @@ import {
   useDefaultEnvironment,
   useUpdateDefaultEnvironment,
 } from "@/lib/organization.query";
+import {
+  clearEnvironmentDialogParams,
+  ENVIRONMENT_CREATE_PARAM,
+  ENVIRONMENT_DEFAULT_VALUE,
+  ENVIRONMENT_EDIT_PARAM,
+  setEnvironmentEditParam,
+} from "./environment-edit-link";
 import { compileValidationRegex } from "./environment-validation-helpers";
 
 const NETWORK_POLICY_DOCS_URL = getDocsUrl(
@@ -71,26 +79,71 @@ type EnvironmentTableRow =
     }
   | (EnvironmentWithAssignedCount & { kind: "environment" });
 
-export function EnvironmentsSection({
-  canEdit,
-  createOpen,
-  onCreateOpenChange,
-}: {
-  canEdit: boolean;
-  createOpen: boolean;
-  onCreateOpenChange: (open: boolean) => void;
-}) {
+export function EnvironmentsSection({ canEdit }: { canEdit: boolean }) {
   const { data: environmentList, isLoading } = useEnvironments();
   const environments = environmentList?.environments ?? [];
   const defaultAssignedCatalogCount =
     environmentList?.defaultAssignedCatalogCount ?? 0;
   const { data: capabilities } = useK8sCapabilities(canEdit);
   const defaultEnvironment = useDefaultEnvironment();
-  const [editDefaultOpen, setEditDefaultOpen] = useState(false);
-  const [editTarget, setEditTarget] =
-    useState<EnvironmentWithAssignedCount | null>(null);
   const [deleteTarget, setDeleteTarget] =
     useState<EnvironmentWithAssignedCount | null>(null);
+
+  // Which editor is open is derived from the URL (`?edit=<id|default>` /
+  // `?create`) so the form survives a reload and is shareable, matching the
+  // catalog editor's deep-link pattern. Only admins (canEdit) open one.
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchString = searchParams.toString();
+  const editId = searchParams.get(ENVIRONMENT_EDIT_PARAM);
+  // An `edit` param wins over `create`, so a hand-crafted `?edit=…&create=1`
+  // opens a single editor rather than two stacked dialogs.
+  const createOpen =
+    canEdit && !editId && searchParams.has(ENVIRONMENT_CREATE_PARAM);
+  const editEnvironment = useMemo(
+    () =>
+      editId && editId !== ENVIRONMENT_DEFAULT_VALUE
+        ? (environments.find((environment) => environment.id === editId) ??
+          null)
+        : null,
+    [editId, environments],
+  );
+  const editDefaultOpen = canEdit && editId === ENVIRONMENT_DEFAULT_VALUE;
+  const editTargetOpen = canEdit && editEnvironment !== null;
+
+  const writeSearch = useCallback(
+    (search: string) => {
+      router.replace(search ? `${pathname}?${search}` : pathname, {
+        scroll: false,
+      });
+    },
+    [router, pathname],
+  );
+  const openEditor = useCallback(
+    (id: string) => writeSearch(setEnvironmentEditParam(searchString, id)),
+    [writeSearch, searchString],
+  );
+  const closeEditor = useCallback(
+    () => writeSearch(clearEnvironmentDialogParams(searchString)),
+    [writeSearch, searchString],
+  );
+
+  // A deep link to an `edit` id that isn't a real environment (deleted, typo)
+  // is cleared so it doesn't leave a stuck-open URL. Only act on a loaded,
+  // non-empty list: `useEnvironments` returns an empty list on a fetch error
+  // (not an error state), and clearing then would erase a valid deep link that
+  // a retry could still resolve.
+  useEffect(() => {
+    if (
+      environments.length > 0 &&
+      editId &&
+      editId !== ENVIRONMENT_DEFAULT_VALUE &&
+      !editEnvironment
+    ) {
+      closeEditor();
+    }
+  }, [environments.length, editId, editEnvironment, closeEditor]);
 
   const rows: EnvironmentTableRow[] = useMemo(
     () => [
@@ -174,13 +227,8 @@ export function EnvironmentsSection({
                   icon: <Pencil className="h-4 w-4" />,
                   label: `Edit ${item.name}`,
                   disabled: !canEdit,
-                  onClick: () => {
-                    if (item.kind === "default") {
-                      setEditDefaultOpen(true);
-                    } else {
-                      setEditTarget(item);
-                    }
-                  },
+                  // item.id is the `"default"` sentinel for the default row.
+                  onClick: () => openEditor(item.id),
                 },
                 ...(item.kind === "environment"
                   ? [
@@ -203,7 +251,7 @@ export function EnvironmentsSection({
         },
       },
     ],
-    [canEdit],
+    [canEdit, openEditor],
   );
 
   return (
@@ -219,23 +267,23 @@ export function EnvironmentsSection({
       <EnvironmentEditorDialog
         mode="create"
         open={createOpen}
-        onOpenChange={onCreateOpenChange}
+        onOpenChange={(open) => !open && closeEditor()}
         environment={null}
         capabilities={capabilities}
       />
 
       <EnvironmentEditorDialog
         mode="edit"
-        open={editTarget !== null}
-        onOpenChange={(v) => !v && setEditTarget(null)}
-        environment={editTarget}
+        open={editTargetOpen}
+        onOpenChange={(open) => !open && closeEditor()}
+        environment={editEnvironment}
         capabilities={capabilities}
       />
 
       <EnvironmentEditorDialog
         mode="default"
         open={editDefaultOpen}
-        onOpenChange={setEditDefaultOpen}
+        onOpenChange={(open) => !open && closeEditor()}
         environment={null}
         defaultEnvironment={defaultEnvironment}
         capabilities={capabilities}

--- a/platform/frontend/src/app/settings/environments/page.client.tsx
+++ b/platform/frontend/src/app/settings/environments/page.client.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { Plus } from "lucide-react";
-import { useEffect, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useRef } from "react";
 import { PermissionButton } from "@/components/ui/permission-button";
 import { useHasPermissions } from "@/lib/auth/auth.query";
+import { setEnvironmentCreateParam } from "../../mcp/registry/_parts/environment-edit-link";
 import { EnvironmentsSection } from "../../mcp/registry/_parts/environments-section";
 import { useSetSettingsAction } from "../layout";
 
@@ -12,13 +14,24 @@ export default function EnvironmentsPageClient() {
   const { data: canEdit } = useHasPermissions({
     environment: ["admin"],
   });
-  const [createOpen, setCreateOpen] = useState(false);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  // Keep the latest search in a ref so openCreate stays referentially stable —
+  // otherwise the action-button effect re-registers on every URL change.
+  const searchRef = useRef(searchParams);
+  searchRef.current = searchParams;
+
+  const openCreate = useCallback(() => {
+    const search = setEnvironmentCreateParam(searchRef.current.toString());
+    router.replace(`${pathname}?${search}`, { scroll: false });
+  }, [router, pathname]);
 
   useEffect(() => {
     setActionButton(
       <PermissionButton
         permissions={{ environment: ["admin"] }}
-        onClick={() => setCreateOpen(true)}
+        onClick={openCreate}
       >
         <Plus className="h-4 w-4" />
         Add environment
@@ -26,13 +39,7 @@ export default function EnvironmentsPageClient() {
     );
 
     return () => setActionButton(null);
-  }, [setActionButton]);
+  }, [setActionButton, openCreate]);
 
-  return (
-    <EnvironmentsSection
-      canEdit={canEdit ?? false}
-      createOpen={createOpen}
-      onCreateOpenChange={setCreateOpen}
-    />
-  );
+  return <EnvironmentsSection canEdit={canEdit ?? false} />;
 }


### PR DESCRIPTION
## Summary

Opening an environment to edit on `/settings/environments` left the URL on the list page, with the open editor and which record was being edited held only in React state. Reloading — or sharing the link — dropped the user back to the list and lost the form.

The edit, default-environment, and create dialogs are now driven by the URL (`?edit=<id>`, `?edit=default`, `?create=1`) instead of component state, reusing the MCP catalog editor's existing deep-link pattern (`catalog-edit-link.ts`) rather than adding new routing. User-visible result: an open editor survives a page reload and can be shared/bookmarked, and closing it returns to a clean `/settings/environments`.

Opening stays gated on the `environment: admin` permission. An `edit` param takes precedence over `create` so a hand-edited `?edit=…&create=1` link opens a single editor rather than two stacked dialogs, and an `edit` id that names no current environment self-clears once a real, non-empty list has loaded (guarded so a transient list-fetch failure can't erase a valid deep link).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>