### PR TITLE
refactor(environments): order network egress fields by mechanism

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -805,6 +805,24 @@ function NetworkPolicyFields({
 
       <div className="space-y-2">
         <FieldLabel
+          htmlFor="network-policy-cidrs"
+          label="Allowed CIDRs"
+          description="IPv4 or IPv6 CIDR ranges that restricted workloads may reach. These rules are enforced by standard Kubernetes NetworkPolicy."
+        />
+        <Textarea
+          id="network-policy-cidrs"
+          value={allowedCidrsText}
+          onChange={(e) => setAllowedCidrsText(e.target.value)}
+          placeholder={"203.0.113.0/24\n2001:db8::/32"}
+          className="min-h-20 font-mono text-sm"
+          disabled={
+            disabled || enforcementUnavailable || egressMode !== "restricted"
+          }
+        />
+      </div>
+
+      <div className="space-y-2">
+        <FieldLabel
           label="Domain preset"
           description={
             <>
@@ -833,24 +851,6 @@ function NetworkPolicyFields({
             <SelectItem value="package_managers">Package managers</SelectItem>
           </SelectContent>
         </Select>
-      </div>
-
-      <div className="space-y-2">
-        <FieldLabel
-          htmlFor="network-policy-cidrs"
-          label="Allowed CIDRs"
-          description="IPv4 or IPv6 CIDR ranges that restricted workloads may reach. These rules are enforced by standard Kubernetes NetworkPolicy."
-        />
-        <Textarea
-          id="network-policy-cidrs"
-          value={allowedCidrsText}
-          onChange={(e) => setAllowedCidrsText(e.target.value)}
-          placeholder={"203.0.113.0/24\n2001:db8::/32"}
-          className="min-h-20 font-mono text-sm"
-          disabled={
-            disabled || enforcementUnavailable || egressMode !== "restricted"
-          }
-        />
       </div>
 
       <div className="space-y-2">


### PR DESCRIPTION
## Summary

In the environment editor's Network Egress section, the "Allowed CIDRs" field was rendered between "Domain preset" and "Allowed domains" — splitting the two FQDN/domain controls that belong together (the preset is a maintained domain set; "Allowed domains" is the custom set, and both share the same `restricted + supportsFqdn` gate). CIDR rules are a different mechanism with a different gate (plain Kubernetes NetworkPolicy, no FQDN provider needed).

This reorders the section to **Egress → Allowed CIDRs → Domain preset → Allowed domains**: the universally-enforceable CIDR rules come first, then the two provider-dependent domain controls grouped together. The user-visible payoff is clearest on a cluster without an FQDN provider, where both domain fields are disabled — they now form one trailing disabled block instead of a disabled–enabled–disabled sandwich, matching the "Domain allowlists unavailable" alert already shown there.

JSX reorder only — no state, validation, save logic, or persisted shape changes.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>