### PR TITLE
fix(frontend): correct network policy docs anchor to #network-egress-policies

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -47,7 +47,7 @@ import { compileValidationRegex } from "./environment-validation-helpers";
 
 const NETWORK_POLICY_DOCS_URL = getDocsUrl(
   DocsPage.PlatformPrivateRegistry,
-  "network-policies",
+  "network-egress-policies",
 );
 const DOMAIN_PRESETS_DOCS_URL = getDocsUrl(
   DocsPage.PlatformPrivateRegistry,


### PR DESCRIPTION
The anchor `network-policies` does not exist on the `platform-private-registry` docs page. The correct heading is `#network-egress-policies`, confirmed against the live docs. Both "View docs" links in the environment network egress UI (the section description and the "Domain allowlists unavailable" alert) were pointing to a broken fragment.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>