### PR TITLE
fix(archestra-mcp-server): guide LLMs through tool-schema mismatches and surface output truncation

### DIFF
--- a/platform/backend/src/archestra-mcp-server/__snapshots__/skill-tool-text.test.ts.snap
+++ b/platform/backend/src/archestra-mcp-server/__snapshots__/skill-tool-text.test.ts.snap
@@ -351,7 +351,7 @@ exports[`skill and sandbox tool text > archestra__update_skill 1`] = `
 
 exports[`skill and sandbox tool text > archestra__upload_file 1`] = `
 {
-  "description": "Upload a file into the conversation's sandbox from a chat attachment, inline base64, or inline text. The bytes become part of the sandbox recipe, so the file is present on every later run_command and download_file call. Note: files the user attached to the chat are already auto-staged under /home/sandbox/attachments/ — use this tool to write inline content, place a file at a specific path, or upload into a non-default sandbox. Requires \`sandbox:execute\`.",
+  "description": "Upload a file into the conversation's sandbox from a chat attachment, inline base64, inline text, or a file from the user's persistent storage (the my_file source). The bytes become part of the sandbox recipe, so the file is present on every later run_command and download_file call. Note: files the user attached to the chat are already auto-staged under /home/sandbox/attachments/ — use this tool to write inline content, place a file at a specific path, or upload into a non-default sandbox. Requires \`sandbox:execute\`.",
   "inputSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
@@ -363,7 +363,7 @@ exports[`skill and sandbox tool text > archestra__upload_file 1`] = `
         "type": "string",
       },
       "source": {
-        "description": "Where the file bytes come from: a chat attachment, inline base64, or inline text. Use this to place input bytes; to create a file the sandbox will then run or read, write it with run_command instead.",
+        "description": "Where the file bytes come from. One of four shapes, each tagged by a \`type\`: a chat attachment (\`{"type":"chat_attachment","attachmentId":...}\`), inline base64 (\`{"type":"base64","dataBase64":...}\`), inline text (\`{"type":"text","text":"print(1)"}\`), or a file from the user's persistent storage (\`{"type":"my_file","filename":...}\`, found via search_files). Use this to place input bytes; to create a file the sandbox will then run or read, write it with run_command instead.",
         "oneOf": [
           {
             "additionalProperties": false,

--- a/platform/backend/src/archestra-mcp-server/helpers.test.ts
+++ b/platform/backend/src/archestra-mcp-server/helpers.test.ts
@@ -192,4 +192,55 @@ describe("formatZodErrorWithSchema", () => {
     const error = parseError(schema, { outer: "nested", inner: {} });
     expect(() => formatZodErrorWithSchema(error, schema)).not.toThrow();
   });
+
+  test("lists valid keys and suggests the closest for an unrecognized key", () => {
+    const schema = z.strictObject({
+      command: z.string(),
+      timeoutSeconds: z.number().optional(),
+    });
+    const error = parseError(schema, { command: "ls", timeout: 5 });
+    const message = formatZodErrorWithSchema(error, schema);
+    // a truncated name (`timeout` → `timeoutSeconds`) is matched by substring,
+    // not edit distance, which would be far too large.
+    expect(message).toBe(
+      'unrecognized key "timeout" (did you mean "timeoutSeconds"?) — ' +
+        'valid keys are "command", "timeoutSeconds"',
+    );
+  });
+
+  test("suggests the closest key for an ordinary typo", () => {
+    const schema = z.strictObject({ command: z.string(), cwd: z.string() });
+    const error = parseError(schema, { commnd: "ls" });
+    expect(formatZodErrorWithSchema(error, schema)).toContain(
+      'did you mean "command"?',
+    );
+  });
+
+  test("reports every unrecognized key in one issue", () => {
+    const schema = z.strictObject({ command: z.string() });
+    const error = parseError(schema, { command: "ls", foo: 1, bar: 2 });
+    const message = formatZodErrorWithSchema(error, schema);
+    expect(message).toContain("unrecognized keys");
+    expect(message).toContain('"foo"');
+    expect(message).toContain('"bar"');
+    expect(message).toContain('valid keys are "command"');
+  });
+
+  test("omits a suggestion when no key is close", () => {
+    const schema = z.strictObject({ command: z.string() });
+    const error = parseError(schema, { command: "ls", xyzzy: 1 });
+    const message = formatZodErrorWithSchema(error, schema);
+    expect(message).toContain('unrecognized key "xyzzy"');
+    expect(message).not.toContain("did you mean");
+  });
+
+  test("prefixes the path for an unrecognized key on a nested object", () => {
+    const schema = z.strictObject({
+      nested: z.strictObject({ command: z.string() }),
+    });
+    const error = parseError(schema, { nested: { command: "ls", timeout: 5 } });
+    expect(formatZodErrorWithSchema(error, schema)).toContain(
+      'nested: unrecognized key "timeout"',
+    );
+  });
 });

--- a/platform/backend/src/archestra-mcp-server/helpers.test.ts
+++ b/platform/backend/src/archestra-mcp-server/helpers.test.ts
@@ -226,6 +226,16 @@ describe("formatZodErrorWithSchema", () => {
     expect(message).toContain('valid keys are "command"');
   });
 
+  test("omits a coincidental edit-distance match on short keys", () => {
+    // `cmd` is one edit from `cwd` but four from `command`; suggesting `cwd`
+    // would mislead, so on short keys we list the valid keys without guessing.
+    const schema = z.strictObject({ command: z.string(), cwd: z.string() });
+    const error = parseError(schema, { cmd: "ls" });
+    const message = formatZodErrorWithSchema(error, schema);
+    expect(message).not.toContain("did you mean");
+    expect(message).toContain('valid keys are "command", "cwd"');
+  });
+
   test("omits a suggestion when no key is close", () => {
     const schema = z.strictObject({ command: z.string() });
     const error = parseError(schema, { command: "ls", xyzzy: 1 });

--- a/platform/backend/src/archestra-mcp-server/helpers.ts
+++ b/platform/backend/src/archestra-mcp-server/helpers.ts
@@ -443,14 +443,17 @@ export function formatZodError(error: ZodError): string {
 }
 
 /**
- * Like {@link formatZodError}, but uses the validating schema to enrich
- * discriminated-union failures. A missing/invalid discriminator otherwise
- * renders as the opaque "type: Invalid input", which gives a model no way to
- * recover (it cannot tell what values the discriminator accepts). With the
- * schema in hand we enumerate the allowed values, e.g.
- * `source.type: set "type" to one of: "base64", "text"`. Best-effort: every
- * introspection step is guarded, so any shape we cannot read falls back to the
- * plain message rather than throwing.
+ * Like {@link formatZodError}, but uses the validating schema to enrich two
+ * issue classes that otherwise leave a model no way to recover:
+ *  - a missing/invalid discriminated-union discriminator renders as the opaque
+ *    "type: Invalid input"; with the schema in hand we enumerate the allowed
+ *    values, e.g. `source.type: set "type" to one of: "base64", "text"`;
+ *  - an unrecognized key on a strict object renders as `Unrecognized key:
+ *    "timeout"` without naming the keys that ARE accepted; we list them and
+ *    suggest the closest match, e.g.
+ *    `unrecognized key "timeout" — did you mean "timeoutSeconds"? ...`.
+ * Best-effort: every introspection step is guarded, so any shape we cannot read
+ * falls back to the plain message rather than throwing.
  */
 export function formatZodErrorWithSchema(
   error: ZodError,
@@ -458,12 +461,14 @@ export function formatZodErrorWithSchema(
 ): string {
   return error.issues
     .map((issue) => {
-      const enumerated = enumerateDiscriminatorValues(issue, schema);
-      if (!enumerated) {
+      const enriched =
+        enumerateDiscriminatorValues(issue, schema) ??
+        enumerateUnknownKeys(issue, schema);
+      if (!enriched) {
         return formatZodIssue(issue);
       }
       const path = formatIssuePath(issue.path);
-      return path ? `${path}: ${enumerated}` : enumerated;
+      return path ? `${path}: ${enriched}` : enriched;
     })
     .join("; ");
 }
@@ -580,6 +585,77 @@ function isRenderableLiteral(
     typeof value === "number" ||
     typeof value === "boolean"
   );
+}
+
+/**
+ * For an `unrecognized_keys` issue on a strict object, list the keys the object
+ * DOES accept and suggest the closest match per rejected key, or null when the
+ * issue is unrelated or the object schema cannot be introspected (e.g. the bad
+ * key sits inside a discriminated-union variant {@link navigateSchema} declines
+ * to traverse). The issue carries every rejected key in one `keys` array.
+ */
+function enumerateUnknownKeys(
+  issue: z.core.$ZodIssue,
+  root: ZodType,
+): string | null {
+  if (issue.code !== "unrecognized_keys") return null;
+  const badKeys = (issue as { keys?: unknown }).keys;
+  if (!Array.isArray(badKeys) || badKeys.length === 0) return null;
+
+  const container = navigateSchema(root, issue.path ?? []);
+  const shape = container ? defOf(container)?.shape : undefined;
+  if (!shape) return null;
+  const validKeys = Object.keys(shape);
+  if (validKeys.length === 0) return null;
+
+  const rendered = badKeys.map((key) => {
+    const name = String(key);
+    const suggestion = suggestClosestKey(name, validKeys);
+    return suggestion
+      ? `"${name}" (did you mean "${suggestion}"?)`
+      : `"${name}"`;
+  });
+  const noun = rendered.length === 1 ? "key" : "keys";
+  const allowed = validKeys.map((key) => `"${key}"`).join(", ");
+  return `unrecognized ${noun} ${rendered.join(", ")} — valid keys are ${allowed}`;
+}
+
+/**
+ * Closest accepted key for a rejected one, or null when nothing is close.
+ * Substring containment is checked first so a truncated/extended name like
+ * `timeout` → `timeoutSeconds` matches (their edit distance is large); a small
+ * edit distance then catches ordinary typos.
+ */
+function suggestClosestKey(badKey: string, validKeys: string[]): string | null {
+  const lower = badKey.toLowerCase();
+  let best: { key: string; score: number } | null = null;
+  for (const key of validKeys) {
+    const candidate = key.toLowerCase();
+    let score: number | null = null;
+    if (candidate.includes(lower) || lower.includes(candidate)) {
+      score = Math.abs(candidate.length - lower.length);
+    } else {
+      const distance = levenshtein(lower, candidate);
+      if (distance <= 2) score = 10 + distance;
+    }
+    if (score !== null && (!best || score < best.score)) {
+      best = { key, score };
+    }
+  }
+  return best?.key ?? null;
+}
+
+function levenshtein(a: string, b: string): number {
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    const curr = [i];
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+    }
+    prev = curr;
+  }
+  return prev[b.length];
 }
 
 function formatIssuePath(path: PropertyKey[] | undefined): string {

--- a/platform/backend/src/archestra-mcp-server/helpers.ts
+++ b/platform/backend/src/archestra-mcp-server/helpers.ts
@@ -624,7 +624,10 @@ function enumerateUnknownKeys(
  * Closest accepted key for a rejected one, or null when nothing is close.
  * Substring containment is checked first so a truncated/extended name like
  * `timeout` → `timeoutSeconds` matches (their edit distance is large); a small
- * edit distance then catches ordinary typos.
+ * edit distance then catches ordinary typos. Edit-distance matching is gated on
+ * a minimum length: on very short keys (`cwd`, `env`) a one-character distance
+ * is mostly coincidence (`cmd` is as near `cwd` as `command`), so we skip it and
+ * let the always-shown valid-keys list guide instead of a misleading guess.
  */
 function suggestClosestKey(badKey: string, validKeys: string[]): string | null {
   const lower = badKey.toLowerCase();
@@ -634,7 +637,7 @@ function suggestClosestKey(badKey: string, validKeys: string[]): string | null {
     let score: number | null = null;
     if (candidate.includes(lower) || lower.includes(candidate)) {
       score = Math.abs(candidate.length - lower.length);
-    } else {
+    } else if (Math.min(lower.length, candidate.length) >= 4) {
       const distance = levenshtein(lower, candidate);
       if (distance <= 2) score = 10 + distance;
     }

--- a/platform/backend/src/archestra-mcp-server/sandbox.test.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.test.ts
@@ -218,6 +218,46 @@ describe("sandbox tools (runtime enabled)", () => {
       });
     });
 
+    test("surfaces the truncation warning before stdout", async () => {
+      const ctx = await makeConversationCtx();
+      vi.spyOn(skillSandboxRuntimeService, "runCommand").mockResolvedValue({
+        commandId: "cmd-1",
+        sandboxId: "x" as any,
+        command: "cat big",
+        cwd: null,
+        stdout: "partial output\n",
+        stderr: "",
+        exitCode: 0,
+        durationMs: 5,
+        timedOut: false,
+        truncated: true,
+        stagingNotices: [],
+      });
+
+      const result = await executeArchestraTool(
+        TOOL_RUN_COMMAND_FULL_NAME,
+        { command: "cat big" },
+        ctx,
+      );
+      const text = textOf(result);
+      expect(text).toContain("Output was truncated");
+      // the model must see the warning before it starts reading the blob.
+      expect(text.indexOf("Output was truncated")).toBeLessThan(
+        text.indexOf("stdout:"),
+      );
+    });
+
+    test("guides to timeoutSeconds when the model passes timeout", async () => {
+      const ctx = await makeConversationCtx();
+      const result = await executeArchestraTool(
+        TOOL_RUN_COMMAND_FULL_NAME,
+        { command: "echo hi", timeout: 5 } as any,
+        ctx,
+      );
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toContain('did you mean "timeoutSeconds"?');
+    });
+
     test("reuses the same default sandbox across calls in a conversation", async () => {
       const ctx = await makeConversationCtx();
       stubRunCommand("x");

--- a/platform/backend/src/archestra-mcp-server/sandbox.test.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.test.ts
@@ -245,6 +245,20 @@ describe("sandbox tools (runtime enabled)", () => {
       expect(text.indexOf("Output was truncated")).toBeLessThan(
         text.indexOf("stdout:"),
       );
+      // the old trailing marker is gone — no duplicate warning at the end.
+      expect(text).not.toContain("(output was truncated)");
+    });
+
+    test("omits the truncation warning when output is complete", async () => {
+      const ctx = await makeConversationCtx();
+      stubRunCommand("x");
+
+      const result = await executeArchestraTool(
+        TOOL_RUN_COMMAND_FULL_NAME,
+        { command: "echo hi" },
+        ctx,
+      );
+      expect(textOf(result)).not.toContain("truncated");
     });
 
     test("guides to timeoutSeconds when the model passes timeout", async () => {

--- a/platform/backend/src/archestra-mcp-server/sandbox.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.ts
@@ -258,8 +258,12 @@ const UploadFileSchema = z
           "/home/sandbox, or relative to the sandbox's working directory.",
       ),
     source: UploadSourceSchema.describe(
-      "Where the file bytes come from: a chat attachment, inline base64, or " +
-        "inline text. Use this to place input bytes; to create a file the " +
+      "Where the file bytes come from. One of four shapes, each tagged by a " +
+        '`type`: a chat attachment (`{"type":"chat_attachment","attachmentId":...}`), ' +
+        'inline base64 (`{"type":"base64","dataBase64":...}`), inline text ' +
+        '(`{"type":"text","text":"print(1)"}`), or a file from the user\'s ' +
+        'persistent storage (`{"type":"my_file","filename":...}`, found via ' +
+        "search_files). Use this to place input bytes; to create a file the " +
         "sandbox will then run or read, write it with run_command instead.",
     ),
     target: SandboxTargetSchema,
@@ -491,7 +495,8 @@ const registry = defineArchestraTools([
     title: "Upload File",
     description:
       "Upload a file into the conversation's sandbox from a chat attachment, " +
-      "inline base64, or inline text. The bytes become part of the sandbox " +
+      "inline base64, inline text, or a file from the user's persistent " +
+      "storage (the my_file source). The bytes become part of the sandbox " +
       "recipe, so the file is present on every later run_command and " +
       `download_file call. Note: files the user attached to the chat are already auto-staged under ${SKILL_SANDBOX_ATTACHMENTS_DIR}/ — use this tool ` +
       "to write inline content, place a file at a specific path, or upload " +
@@ -1134,12 +1139,15 @@ function formatCommandSummary(result: {
   if (result.timedOut) {
     lines.push("The command was killed by the wall-clock timeout.");
   }
+  if (result.truncated) {
+    lines.push(
+      "Output was truncated; re-run with a narrower command " +
+        "(grep/head/tail/sed) to read the rest.",
+    );
+  }
   lines.push("", "stdout:", result.stdout || "(empty)");
   if (result.stderr) {
     lines.push("", "stderr:", result.stderr);
-  }
-  if (result.truncated) {
-    lines.push("", "(output was truncated)");
   }
   return lines.join("\n");
 }


### PR DESCRIPTION
## What

Three model-facing ergonomics fixes to Archestra's built-in MCP tools. Strict Zod schemas reject common LLM mistakes with opaque errors, costing turns; this keeps the schemas strict but makes the failures recoverable on the next turn — no input coercion.

- **Enrich `unrecognized_keys` errors** (`helpers.ts`): the message now lists the keys the object accepts and suggests the closest match, so e.g. `run_command{timeout}` is told to use `timeoutSeconds`. Generic across every strict-object tool. Suggestion uses substring containment first (catches `timeout`→`timeoutSeconds`), then edit distance for typos — gated on a minimum key length so short keys (`cwd`) don't get coincidental guesses; the full valid-key list is always shown regardless.
- **Document `upload_file`'s `my_file` source** (`sandbox.ts`): both descriptions only listed chat-attachment / base64 / text, so models never used the `search_files`→`upload_file` persistent-storage path the schema already supports. Added it with a concrete JSON example per variant.
- **Surface `run_command` truncation first** (`sandbox.ts`): the truncation warning now sits above stdout (was a trailing line a model could miss), with actionable guidance to re-run with a narrower command.

## Scope

Extends the existing `formatZodErrorWithSchema` enumerate-and-guide pattern; the discriminator path is unchanged. No schema/handler behavior changes, no API/data-contract changes — only model-facing strings.

## Tests

New unit tests for the error enrichment (valid-key listing, closest-match, multi-key, short-key non-suggestion, nested-path prefix, end-to-end `run_command{timeout}`) and truncation ordering. `skill-tool-text` snapshot updated for the `upload_file` description. Full `archestra-mcp-server` suite, type-check, lint, and knip pass.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>