### PR TITLE
feat(helm): default to prebuilt sandbox base image when code runtime is enabled

### DIFF
--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -155,6 +155,16 @@ If ARCHESTRA_AUTH_SECRET env variable is explicitly set, it will override the au
 - name: ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST
   value: {{ include "archestra-platform.codeRuntimeDaggerRunnerHost" . | quote }}
 {{- end }}
+{{- if .Values.archestra.codeRuntime.prebuiltBase.enabled }}
+{{- if not (hasKey .Values.archestra.env "ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT") }}
+- name: ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT
+  value: "true"
+{{- end }}
+{{- if not (hasKey .Values.archestra.env "ARCHESTRA_DAGGER_RUNTIME_IMAGE") }}
+- name: ARCHESTRA_DAGGER_RUNTIME_IMAGE
+  value: {{ .Values.archestra.codeRuntime.prebuiltBase.image | quote }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- if .Values.archestra.diagnostics.enabled }}
 - name: ARCHESTRA_NODE_DIAGNOSTIC_DIR

--- a/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
@@ -520,6 +520,67 @@ tests:
             name: ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST
             value: kube-pod://dagger-engine-3?namespace=code-runtime&container=custom-engine&context=prod-cluster
 
+  - it: should set prebuilt base env vars when code runtime is enabled
+    documentIndex: 1
+    set:
+      archestra.codeRuntime.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DAGGER_RUNTIME_IMAGE
+            value: "europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/sandbox-base:1.2.65"
+
+  - it: should not set prebuilt base env vars when prebuiltBase is disabled
+    documentIndex: 1
+    set:
+      archestra.codeRuntime.enabled: true
+      archestra.codeRuntime.prebuiltBase.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DAGGER_RUNTIME_IMAGE
+
+  - it: should support custom prebuilt base image
+    documentIndex: 1
+    set:
+      archestra.codeRuntime.enabled: true
+      archestra.codeRuntime.prebuiltBase.image: "my-registry.example.com/sandbox-base:custom"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DAGGER_RUNTIME_IMAGE
+            value: "my-registry.example.com/sandbox-base:custom"
+
+  - it: should not override ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT when set in archestra.env
+    documentIndex: 1
+    set:
+      archestra.codeRuntime.enabled: true
+      archestra.env:
+        ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT: "false"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT
+            value: "false"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT
+            value: "true"
+
   - it: should include ARCHESTRA_DATABASE_URL alongside custom env vars
     documentIndex: 1
     set:

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -169,15 +169,26 @@ archestra:
 
   # code execution runtime configuration.
   # enables the sandbox tools (archestra__run_command / upload_file /
-  # download_file) and points the backend at a Dagger runtime pod. The
-  # execution image remains a backend default; override
-  # ARCHESTRA_DAGGER_RUNTIME_IMAGE through archestra.env only when required.
+  # download_file) and points the backend at a Dagger runtime pod.
   codeRuntime:
     # enable or disable code execution runtime support.
     enabled: false
 
     # runtime limits (timeouts, concurrency, output caps) are env-driven via
     # ARCHESTRA_SKILLS_SANDBOX_* / ARCHESTRA_DAGGER_RUNTIME_* in archestra.env.
+
+    # Pre-baked sandbox base image: skips apt/uv setup at runtime so a
+    # network-restricted engine (e.g. egress-filtered EKS) never needs to
+    # reach ghcr.io, debian mirrors, or PyPI during warm-base initialisation.
+    # Requires the image to contain /etc/archestra-sandbox-base (written by
+    # sandbox_base/Dockerfile). Set enabled to false to build the warm base
+    # at runtime from a stock image instead.
+    prebuiltBase:
+      enabled: true
+      # Image published by the Archestra release pipeline. Keep the tag in
+      # sync with the platform version; override ARCHESTRA_DAGGER_RUNTIME_IMAGE
+      # in archestra.env to point at a self-hosted copy.
+      image: "europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/sandbox-base:1.2.65" # x-release-please-version
 
     dagger:
       # explicit Dagger runner host. Leave empty to use the kube-pod:// pod target below.


### PR DESCRIPTION
## Summary

The sandbox warm-base build runs apt/uv setup execs that pull from `ghcr.io`, Debian mirrors, and PyPI at engine startup. On egress-filtered clusters (EKS with strict `ApplicationNetworkPolicy`, GKE with `FQDNNetworkPolicy`), these calls are blocked, causing the engine to fail to warm and report "engine unreachable."

The `sandbox_base/` pre-baked image (published alongside every platform release) already contains those layers. When `ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT=true` and `ARCHESTRA_DAGGER_RUNTIME_IMAGE` points at it, the warm-base step only verifies a provenance marker — no network calls needed from the engine.

This PR adds `codeRuntime.prebuiltBase` to the Helm chart and defaults `enabled: true`, so code-runtime deployments automatically use the pre-baked image from GCR without any operator configuration. The image tag is annotated with `x-release-please-version` so it bumps automatically on each release.

Operators can opt out with `codeRuntime.prebuiltBase.enabled: false` (reverts to the runtime-build path) or override the image via `archestra.env.ARCHESTRA_DAGGER_RUNTIME_IMAGE`.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>