### PR TITLE
chore(deps): drop redundant defu override

### DIFF
--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -73,7 +73,6 @@ overrides:
   picomatch@>=4: '>=4.0.4'
   picomatch@<4: '>=2.3.2'
   fastify: '>=5.8.5'
-  defu: '>=6.1.5'
   postcss: '>=8.5.10'
   uuid@^11: '>=11.1.1'
   ip-address: '>=10.1.1'

--- a/platform/pnpm-workspace.yaml
+++ b/platform/pnpm-workspace.yaml
@@ -71,7 +71,6 @@ overrides:
   picomatch@>=4: '>=4.0.4'
   picomatch@<4: '>=2.3.2'
   fastify: '>=5.8.5'
-  defu: '>=6.1.5'
   postcss: '>=8.5.10'
   uuid@^11: '>=11.1.1'
   ip-address: '>=10.1.1'


### PR DESCRIPTION
## Summary

Removes the `defu: '>=6.1.5'` entry from `platform/pnpm-workspace.yaml` `overrides`. The dependency graph already resolves `defu` to `6.1.7` — above the floor — on its own, so the override does nothing.

Removing it leaves the lockfile resolution unchanged: the only `pnpm-lock.yaml` delta is the dropped override line, with no shift under `importers`/`packages`/`snapshots`. No new high/critical `pnpm audit` advisories, and backend + frontend type-check stay green.

This keeps the override list scoped to pins that are actually load-bearing.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>