### PR TITLE
chore(deps): drop redundant yaml override

### DIFF
--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -79,7 +79,6 @@ overrides:
   ip-address: '>=10.1.1'
   brace-expansion: '>=5.0.6'
   smol-toml: '>=1.6.1'
-  yaml: '>=2.8.3'
   '@opentelemetry/exporter-prometheus': 0.217.0
   '@opentelemetry/sdk-node': 0.217.0
   '@grpc/grpc-js': '>=1.14.4'
@@ -10621,7 +10620,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: '>=2.8.3'
+      yaml: ^2.4.2
     peerDependenciesMeta:
       '@types/node':
         optional: true

--- a/platform/pnpm-workspace.yaml
+++ b/platform/pnpm-workspace.yaml
@@ -77,7 +77,6 @@ overrides:
   ip-address: '>=10.1.1'
   brace-expansion: '>=5.0.6'
   smol-toml: '>=1.6.1'
-  yaml: '>=2.8.3'
   '@opentelemetry/exporter-prometheus': 0.217.0
   '@opentelemetry/sdk-node': 0.217.0
   # CVE-2026-48068 / CVE-2026-48069 (uncaught exception) fixed in 1.14.4


### PR DESCRIPTION
## Summary

Removes the `yaml: '>=2.8.3'` entry from `platform/pnpm-workspace.yaml` `overrides`. The dependency graph already resolves `yaml` to `2.8.4` — above the floor — on its own, so the override no longer affects resolution.

The only `pnpm-lock.yaml` delta beyond the dropped override line is a `peerDependencies` specifier reverting from the override-forced `>=2.8.3` back to the package's declared `^2.4.2`; no `yaml@` package key or snapshot edge moves, and `yaml` stays at `2.8.4` everywhere. No new high/critical `pnpm audit` advisories.

Keeps the override list scoped to pins that are actually load-bearing.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>