### PR TITLE
feat(sandbox): default code runtime to the prebuilt sandbox base image

### DIFF
--- a/platform/.env.example
+++ b/platform/.env.example
@@ -326,11 +326,16 @@ ARCHESTRA_CODE_RUNTIME_ENABLED=false
 # kube-pod://dagger-runtime-engine-0?namespace=dagger&container=dagger-engine
 # tcp://dagger-runtime.dagger.svc.cluster.local:1234
 # ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST=
-# Set "true" when ARCHESTRA_DAGGER_RUNTIME_IMAGE points at a pre-baked sandbox
-# base (the `sandbox_base/` image, which already contains the apt toolbelt + uv
-# venv + deps). The runtime then skips the apt/uv build execs, so a restricted
-# engine doesn't need ghcr.io/debian/pypi at run time — only the base registry.
-# ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT=false
+# Sandbox base image. Defaults to the baked `sandbox-base:<version>` published
+# with each release (already contains the apt toolbelt + uv venv + deps).
+# Override to pull from a private registry / air-gapped mirror.
+# ARCHESTRA_DAGGER_RUNTIME_IMAGE=
+# Whether the base image is pre-baked: when "true" (the default) the runtime
+# skips the apt/uv build execs and only verifies the image's provenance marker,
+# so a restricted engine never needs ghcr.io/debian/pypi at run time. Set
+# "false" only when ARCHESTRA_DAGGER_RUNTIME_IMAGE points at a non-baked image
+# that must build its toolchain at warm time.
+# ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT=true
 
 # agent lifecycle hooks
 # "true" enables user-defined hook scripts that run at chat lifecycle events

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -330,12 +330,13 @@ ARCHESTRA_CODE_RUNTIME_ENABLED=false
 # with each release (already contains the apt toolbelt + uv venv + deps).
 # Override to pull from a private registry / air-gapped mirror.
 # ARCHESTRA_DAGGER_RUNTIME_IMAGE=
-# Whether the base image is pre-baked: when "true" (the default) the runtime
-# skips the apt/uv build execs and only verifies the image's provenance marker,
-# so a restricted engine never needs ghcr.io/debian/pypi at run time. Set
-# "false" only when ARCHESTRA_DAGGER_RUNTIME_IMAGE points at a non-baked image
-# that must build its toolchain at warm time.
-# ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT=true
+# Whether the base image is pre-baked: when "true" the runtime skips the apt/uv
+# build execs and only verifies the image's provenance marker, so a restricted
+# engine never needs ghcr.io/debian/pypi at run time. Defaults to "true" with
+# the baked default image and "false" when ARCHESTRA_DAGGER_RUNTIME_IMAGE is
+# overridden (a stock image still builds its toolchain at warm time). Set "true"
+# explicitly when overriding the image with a baked sandbox-base mirror.
+# ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT=
 
 # agent lifecycle hooks
 # "true" enables user-defined hook scripts that run at chat lifecycle events

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -326,9 +326,10 @@ ARCHESTRA_CODE_RUNTIME_ENABLED=false
 # kube-pod://dagger-runtime-engine-0?namespace=dagger&container=dagger-engine
 # tcp://dagger-runtime.dagger.svc.cluster.local:1234
 # ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST=
-# Sandbox base image. Defaults to the baked `sandbox-base:<version>` published
-# with each release (already contains the apt toolbelt + uv venv + deps).
-# Override to pull from a private registry / air-gapped mirror.
+# Sandbox base image. When prebuilt (the default), defaults to the baked
+# `sandbox-base:<version>` published with each release (already contains the apt
+# toolbelt + uv venv + deps); otherwise the runtime uses its stock buildable
+# base. Override to pull from a private registry / air-gapped mirror.
 # ARCHESTRA_DAGGER_RUNTIME_IMAGE=
 # Whether the base image is pre-baked: when "true" the runtime skips the apt/uv
 # build execs and only verifies the image's provenance marker, so a restricted

--- a/platform/backend/src/config.test.ts
+++ b/platform/backend/src/config.test.ts
@@ -33,6 +33,7 @@ import config, {
   parseSampleRate,
   parseTrustProxy,
   parseVirtualKeyDefaultExpiration,
+  resolveDaggerSandboxImage,
 } from "./config";
 
 // Mock the logger
@@ -895,6 +896,39 @@ describe("parseBasePrebuilt", () => {
     expect(
       parseBasePrebuilt({ envValue: "yes", usingDefaultImage: true }),
     ).toBe(false);
+  });
+});
+
+describe("resolveDaggerSandboxImage", () => {
+  test("should return the override regardless of prebuilt", () => {
+    expect(
+      resolveDaggerSandboxImage({
+        override: "registry.example.com/custom:1",
+        prebuilt: true,
+        version: "1.2.3",
+      }),
+    ).toBe("registry.example.com/custom:1");
+    expect(
+      resolveDaggerSandboxImage({
+        override: "registry.example.com/custom:1",
+        prebuilt: false,
+        version: "1.2.3",
+      }),
+    ).toBe("registry.example.com/custom:1");
+  });
+
+  test("should return the version-tagged baked image when prebuilt and no override", () => {
+    expect(
+      resolveDaggerSandboxImage({ prebuilt: true, version: "1.2.3" }),
+    ).toBe(
+      "europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/sandbox-base:1.2.3",
+    );
+  });
+
+  test("should return undefined when not prebuilt and no override (stock build path)", () => {
+    expect(
+      resolveDaggerSandboxImage({ prebuilt: false, version: "1.2.3" }),
+    ).toBeUndefined();
   });
 });
 

--- a/platform/backend/src/config.test.ts
+++ b/platform/backend/src/config.test.ts
@@ -18,6 +18,7 @@ import config, {
   getTrustedOrigins,
   parseActiveChatRunPollIntervalMs,
   parseAuditLogRetentionDays,
+  parseBasePrebuilt,
   parseBlobStorageProvider,
   parseBodyLimit,
   parseCodeRuntimeDaggerRunnerHost,
@@ -848,6 +849,32 @@ describe("parseDatabasePoolMax", () => {
     expect(logger.warn).toHaveBeenCalledWith(
       'Invalid ARCHESTRA_DATABASE_POOL_MAX value "501", using default 50',
     );
+  });
+});
+
+describe("parseBasePrebuilt", () => {
+  test("should default to true when unset", () => {
+    expect(parseBasePrebuilt(undefined)).toBe(true);
+  });
+
+  test("should default to true for empty or whitespace-only value", () => {
+    expect(parseBasePrebuilt("")).toBe(true);
+    expect(parseBasePrebuilt("   ")).toBe(true);
+  });
+
+  test("should be true only for an exact 'true'", () => {
+    expect(parseBasePrebuilt("true")).toBe(true);
+    expect(parseBasePrebuilt("  true  ")).toBe(true);
+  });
+
+  test("should be false for 'false'", () => {
+    expect(parseBasePrebuilt("false")).toBe(false);
+  });
+
+  test("should be false for any other explicit value", () => {
+    expect(parseBasePrebuilt("1")).toBe(false);
+    expect(parseBasePrebuilt("True")).toBe(false);
+    expect(parseBasePrebuilt("yes")).toBe(false);
   });
 });
 

--- a/platform/backend/src/config.test.ts
+++ b/platform/backend/src/config.test.ts
@@ -853,28 +853,48 @@ describe("parseDatabasePoolMax", () => {
 });
 
 describe("parseBasePrebuilt", () => {
-  test("should default to true when unset", () => {
-    expect(parseBasePrebuilt(undefined)).toBe(true);
+  test("should default to true when unset and using the default image", () => {
+    expect(parseBasePrebuilt({ usingDefaultImage: true })).toBe(true);
   });
 
-  test("should default to true for empty or whitespace-only value", () => {
-    expect(parseBasePrebuilt("")).toBe(true);
-    expect(parseBasePrebuilt("   ")).toBe(true);
+  test("should default to false when unset and the image is overridden", () => {
+    expect(parseBasePrebuilt({ usingDefaultImage: false })).toBe(false);
   });
 
-  test("should be true only for an exact 'true'", () => {
-    expect(parseBasePrebuilt("true")).toBe(true);
-    expect(parseBasePrebuilt("  true  ")).toBe(true);
+  test("should track usingDefaultImage for empty or whitespace-only value", () => {
+    expect(parseBasePrebuilt({ envValue: "", usingDefaultImage: true })).toBe(
+      true,
+    );
+    expect(
+      parseBasePrebuilt({ envValue: "   ", usingDefaultImage: false }),
+    ).toBe(false);
   });
 
-  test("should be false for 'false'", () => {
-    expect(parseBasePrebuilt("false")).toBe(false);
+  test("should honor an explicit 'true' over usingDefaultImage", () => {
+    expect(
+      parseBasePrebuilt({ envValue: "true", usingDefaultImage: false }),
+    ).toBe(true);
+    expect(
+      parseBasePrebuilt({ envValue: "  true  ", usingDefaultImage: false }),
+    ).toBe(true);
   });
 
-  test("should be false for any other explicit value", () => {
-    expect(parseBasePrebuilt("1")).toBe(false);
-    expect(parseBasePrebuilt("True")).toBe(false);
-    expect(parseBasePrebuilt("yes")).toBe(false);
+  test("should honor an explicit 'false' over usingDefaultImage", () => {
+    expect(
+      parseBasePrebuilt({ envValue: "false", usingDefaultImage: true }),
+    ).toBe(false);
+  });
+
+  test("should treat any other explicit value as false", () => {
+    expect(parseBasePrebuilt({ envValue: "1", usingDefaultImage: true })).toBe(
+      false,
+    );
+    expect(
+      parseBasePrebuilt({ envValue: "True", usingDefaultImage: true }),
+    ).toBe(false);
+    expect(
+      parseBasePrebuilt({ envValue: "yes", usingDefaultImage: true }),
+    ).toBe(false);
   });
 });
 

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -379,17 +379,24 @@ export const parseContentMaxLength = (
 
 /**
  * Whether the Dagger sandbox base is pre-baked (skip the apt/uv warm-base build,
- * verify only the provenance marker). Defaults true to match the baked default
- * image; an explicit value wins so an operator pointing at a non-baked custom
- * image can turn it off. Only an exact "true"/"false" is honored; an unset or
- * empty value falls back to the default.
+ * verify only the provenance marker). An explicit "true"/"false" always wins.
+ * When unset it tracks `usingDefaultImage`: the baked default image is prebuilt,
+ * but overriding ARCHESTRA_DAGGER_RUNTIME_IMAGE with a stock/non-baked image
+ * keeps the build-at-warm-time behavior unless prebuilt is opted into explicitly
+ * — so a custom image that never set this flag isn't silently broken.
  *
  * @public — exported for testability
  */
-export const parseBasePrebuilt = (envValue?: string | undefined): boolean => {
+export const parseBasePrebuilt = ({
+  envValue,
+  usingDefaultImage,
+}: {
+  envValue?: string | undefined;
+  usingDefaultImage: boolean;
+}): boolean => {
   const value = envValue?.trim();
   if (!value) {
-    return true;
+    return usingDefaultImage;
   }
   return value === "true";
 };
@@ -712,8 +719,9 @@ const mcpServerBaseImage =
 // which ships the apt toolbelt + uv venv + deps so a network-restricted engine
 // never reaches github/debian/pypi at warm time. Operators override the image
 // (e.g. an air-gapped mirror) via ARCHESTRA_DAGGER_RUNTIME_IMAGE.
+const daggerRuntimeImageOverride = process.env.ARCHESTRA_DAGGER_RUNTIME_IMAGE;
 const daggerRuntimeImage =
-  process.env.ARCHESTRA_DAGGER_RUNTIME_IMAGE ||
+  daggerRuntimeImageOverride ||
   `europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/sandbox-base:${appVersion}`;
 
 const knowledgeFileBlobStorageProvider = parseBlobStorageProvider(
@@ -1191,9 +1199,10 @@ const config = {
     enabled: daggerRuntimeEnabled,
     runnerHost: daggerRuntimeRunnerHost,
     baseImage: daggerRuntimeImage,
-    basePrebuilt: parseBasePrebuilt(
-      process.env.ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT,
-    ),
+    basePrebuilt: parseBasePrebuilt({
+      envValue: process.env.ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT,
+      usingDefaultImage: !daggerRuntimeImageOverride,
+    }),
     cliBin:
       process.env.ARCHESTRA_DAGGER_RUNTIME_CLI_BIN ||
       process.env.ARCHESTRA_CODE_RUNTIME_DAGGER_CLI_BIN ||

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -401,6 +401,33 @@ export const parseBasePrebuilt = ({
   return value === "true";
 };
 
+/**
+ * The Dagger sandbox base image, or `undefined` to let the native runtime fall
+ * back to its stock buildable base. An operator override always wins. Otherwise
+ * the baked `sandbox-base` (which only works in prebuilt mode — it runs as a
+ * non-root user with the toolchain already installed) is used when prebuilt, and
+ * nothing is forced when not, so a `prebuilt=false` deployment without an
+ * override keeps the build-at-warm-time path on a stock image.
+ *
+ * @public — exported for testability
+ */
+export const resolveDaggerSandboxImage = ({
+  override,
+  prebuilt,
+  version,
+}: {
+  override?: string | undefined;
+  prebuilt: boolean;
+  version: string;
+}): string | undefined => {
+  if (override) {
+    return override;
+  }
+  return prebuilt
+    ? `europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/sandbox-base:${version}`
+    : undefined;
+};
+
 /** @public — exported for testability */
 export const parseDatabasePoolMax = (envValue?: string | undefined): number => {
   const value = envValue?.trim();
@@ -714,15 +741,16 @@ const mcpServerBaseImage =
   process.env.ARCHESTRA_ORCHESTRATOR_MCP_SERVER_BASE_IMAGE ||
   `europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-base:${appVersion}`;
 
-// The Dagger code-runtime sandbox base. Defaults to the baked `sandbox-base`
-// image published with each release (tagged with the running platform version),
-// which ships the apt toolbelt + uv venv + deps so a network-restricted engine
-// never reaches github/debian/pypi at warm time. Operators override the image
-// (e.g. an air-gapped mirror) via ARCHESTRA_DAGGER_RUNTIME_IMAGE.
 const daggerRuntimeImageOverride = process.env.ARCHESTRA_DAGGER_RUNTIME_IMAGE;
-const daggerRuntimeImage =
-  daggerRuntimeImageOverride ||
-  `europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/sandbox-base:${appVersion}`;
+const daggerRuntimeBasePrebuilt = parseBasePrebuilt({
+  envValue: process.env.ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT,
+  usingDefaultImage: !daggerRuntimeImageOverride,
+});
+const daggerRuntimeImage = resolveDaggerSandboxImage({
+  override: daggerRuntimeImageOverride,
+  prebuilt: daggerRuntimeBasePrebuilt,
+  version: appVersion,
+});
 
 const knowledgeFileBlobStorageProvider = parseBlobStorageProvider(
   process.env.ARCHESTRA_KNOWLEDGE_BASE_FILE_UPLOAD_BLOB_STORAGE_PROVIDER,
@@ -1199,10 +1227,7 @@ const config = {
     enabled: daggerRuntimeEnabled,
     runnerHost: daggerRuntimeRunnerHost,
     baseImage: daggerRuntimeImage,
-    basePrebuilt: parseBasePrebuilt({
-      envValue: process.env.ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT,
-      usingDefaultImage: !daggerRuntimeImageOverride,
-    }),
+    basePrebuilt: daggerRuntimeBasePrebuilt,
     cliBin:
       process.env.ARCHESTRA_DAGGER_RUNTIME_CLI_BIN ||
       process.env.ARCHESTRA_CODE_RUNTIME_DAGGER_CLI_BIN ||

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -377,6 +377,23 @@ export const parseContentMaxLength = (
   return parsed;
 };
 
+/**
+ * Whether the Dagger sandbox base is pre-baked (skip the apt/uv warm-base build,
+ * verify only the provenance marker). Defaults true to match the baked default
+ * image; an explicit value wins so an operator pointing at a non-baked custom
+ * image can turn it off. Only an exact "true"/"false" is honored; an unset or
+ * empty value falls back to the default.
+ *
+ * @public — exported for testability
+ */
+export const parseBasePrebuilt = (envValue?: string | undefined): boolean => {
+  const value = envValue?.trim();
+  if (!value) {
+    return true;
+  }
+  return value === "true";
+};
+
 /** @public — exported for testability */
 export const parseDatabasePoolMax = (envValue?: string | undefined): number => {
   const value = envValue?.trim();
@@ -689,6 +706,15 @@ export const getAnalyticsConfig = () => ({
 const mcpServerBaseImage =
   process.env.ARCHESTRA_ORCHESTRATOR_MCP_SERVER_BASE_IMAGE ||
   `europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-base:${appVersion}`;
+
+// The Dagger code-runtime sandbox base. Defaults to the baked `sandbox-base`
+// image published with each release (tagged with the running platform version),
+// which ships the apt toolbelt + uv venv + deps so a network-restricted engine
+// never reaches github/debian/pypi at warm time. Operators override the image
+// (e.g. an air-gapped mirror) via ARCHESTRA_DAGGER_RUNTIME_IMAGE.
+const daggerRuntimeImage =
+  process.env.ARCHESTRA_DAGGER_RUNTIME_IMAGE ||
+  `europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/sandbox-base:${appVersion}`;
 
 const knowledgeFileBlobStorageProvider = parseBlobStorageProvider(
   process.env.ARCHESTRA_KNOWLEDGE_BASE_FILE_UPLOAD_BLOB_STORAGE_PROVIDER,
@@ -1164,6 +1190,10 @@ const config = {
   daggerRuntime: {
     enabled: daggerRuntimeEnabled,
     runnerHost: daggerRuntimeRunnerHost,
+    baseImage: daggerRuntimeImage,
+    basePrebuilt: parseBasePrebuilt(
+      process.env.ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT,
+    ),
     cliBin:
       process.env.ARCHESTRA_DAGGER_RUNTIME_CLI_BIN ||
       process.env.ARCHESTRA_CODE_RUNTIME_DAGGER_CLI_BIN ||

--- a/platform/backend/src/sandbox-runtime/sandbox-runtime-service.ts
+++ b/platform/backend/src/sandbox-runtime/sandbox-runtime-service.ts
@@ -289,13 +289,21 @@ class SandboxRuntimeService {
   }
 
   private applyDaggerEnv(): void {
-    const { runnerHost, cliBin } = config.daggerRuntime;
+    const { runnerHost, cliBin, baseImage, basePrebuilt } =
+      config.daggerRuntime;
     if (runnerHost) {
       process.env._EXPERIMENTAL_DAGGER_RUNNER_HOST = runnerHost;
     }
     if (cliBin) {
       process.env._EXPERIMENTAL_DAGGER_CLI_BIN = cliBin;
     }
+    // the native addon reads these from the process env at warm-base build time;
+    // baseImage already resolves the operator override, so writing it back is the
+    // bridge from config to the Rust session.
+    process.env.ARCHESTRA_DAGGER_RUNTIME_IMAGE = baseImage;
+    process.env.ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT = basePrebuilt
+      ? "true"
+      : "false";
   }
 
   private limits(overrides?: LimitOverrides) {

--- a/platform/backend/src/sandbox-runtime/sandbox-runtime-service.ts
+++ b/platform/backend/src/sandbox-runtime/sandbox-runtime-service.ts
@@ -297,10 +297,12 @@ class SandboxRuntimeService {
     if (cliBin) {
       process.env._EXPERIMENTAL_DAGGER_CLI_BIN = cliBin;
     }
-    // the native addon reads these from the process env at warm-base build time;
-    // baseImage already resolves the operator override, so writing it back is the
-    // bridge from config to the Rust session.
-    process.env.ARCHESTRA_DAGGER_RUNTIME_IMAGE = baseImage;
+    // the native addon reads these from the process env at warm-base build time.
+    // baseImage is undefined when no image is forced (non-prebuilt, no override),
+    // so leave the var unset and let the runtime use its stock buildable base.
+    if (baseImage) {
+      process.env.ARCHESTRA_DAGGER_RUNTIME_IMAGE = baseImage;
+    }
     process.env.ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT = basePrebuilt
       ? "true"
       : "false";


### PR DESCRIPTION
## Summary

The Dagger code-runtime warm base runs apt/uv setup execs that pull from `ghcr.io`, Debian mirrors, and PyPI at engine startup. On egress-filtered clusters (EKS with strict `ApplicationNetworkPolicy`, GKE FQDN policies) those calls are blocked, so the engine fails to warm and the sandbox reports "engine unreachable."

The baked `sandbox-base` image — published alongside every platform release — already contains the toolbelt + uv venv + deps. With `ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT=true` the warm base only verifies the image's provenance marker, no network needed.

This makes the prebuilt baked image the **default** for code-runtime deployments, owned by the backend exactly like the MCP server base image (`config.ts`, tagged with the running `appVersion` — no hardcoded pin, no version drift). The two values the native Dagger session reads are bridged into the process env in `applyDaggerEnv()`, next to the existing `_EXPERIMENTAL_DAGGER_*` plumbing.

`prebuilt` is the master switch:
- No overrides → baked `sandbox-base:<version>`, prebuilt on (the egress-safe default).
- `ARCHESTRA_DAGGER_RUNTIME_IMAGE` overridden (e.g. an air-gapped mirror) → prebuilt defaults off so a stock image still builds its toolchain at warm time; set `ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT=true` when the override is itself a baked mirror.
- `ARCHESTRA_CODE_RUNTIME_BASE_PREBUILT=false` with no override → falls back to the runtime's stock buildable base (preserves the pre-baked-image behavior).

Supersedes #5637, which configured this in the Helm chart; this moves it to the backend to match the MCP base image pattern and avoid pinning a duplicate version in `values.yaml`.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>