### PR TITLE
refactor(frontend): share one EnvironmentSelector across MCP and agent forms

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type archestraApiTypes, DocsPage, E2eTestId } from "@archestra/shared";
+import { type archestraApiTypes, DocsPage } from "@archestra/shared";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   AlertTriangle,
@@ -31,6 +31,7 @@ import {
   type EnterpriseManagedConfigInput,
   EnterpriseManagedCredentialFields,
 } from "@/components/enterprise-managed-credential-fields";
+import { EnvironmentSelector } from "@/components/environment-selector";
 import { EnvironmentVariablesFormField } from "@/components/environment-variables-form-field";
 import { ExternalDocsLink } from "@/components/external-docs-link";
 import { HeaderDialog, type HeaderDraft } from "@/components/header-dialog";
@@ -108,11 +109,6 @@ const ExternalSecretSelector = lazy(
     // biome-ignore lint/style/noRestrictedImports: lazy loading
     import("@/components/external-secret-selector.ee"),
 );
-
-// Sentinel value for the default environment option (null assignment). The shadcn
-// Select cannot use an empty-string item value, so a sentinel maps to `null`
-// (no environment assigned).
-const ENVIRONMENT_DEFAULT_VALUE = "__default__";
 
 interface McpCatalogFormProps {
   mode: "create" | "edit";
@@ -547,22 +543,7 @@ export function McpCatalogForm({
   });
   const { data: environmentList } = useEnvironments();
   const environments = environmentList?.environments;
-  // Deploying to a restricted environment needs environment:deploy-to-restricted;
-  // environment:admin (full environment management) implies it.
-  const { data: hasEnvAdmin } = useHasPermissions({ environment: ["admin"] });
-  const { data: hasDeployToRestricted } = useHasPermissions({
-    environment: ["deploy-to-restricted"],
-  });
-  const canDeployRestricted =
-    (hasEnvAdmin ?? false) || (hasDeployToRestricted ?? false);
   const defaultEnvironment = useDefaultEnvironment();
-  // Environments the user can deploy to. Restricted environments the user can't
-  // deploy to are hidden entirely. The default is always available.
-  const accessibleEnvironments = (environments ?? []).filter(
-    (e) => !e.restricted || canDeployRestricted,
-  );
-  const hasCustomEnvironmentOptions = accessibleEnvironments.length > 0;
-  const canManageEnvironments = hasEnvAdmin ?? false;
   // Validate static config values (env vars + headers) against the rule of the
   // environment this item is bound to (or the org default when unbound), so a
   // forbidden value is flagged inline and can't be saved. Passed to both
@@ -1020,81 +1001,12 @@ export function McpCatalogForm({
               <FormField
                 control={form.control}
                 name="environmentId"
-                render={({ field }) => {
-                  const environmentOptions = [
-                    {
-                      value: ENVIRONMENT_DEFAULT_VALUE,
-                      label: defaultEnvironment.name,
-                      description: defaultEnvironment.description ?? "",
-                    },
-                    ...accessibleEnvironments.map((environment) => ({
-                      value: environment.id,
-                      label: environment.name,
-                      description: environment.description ?? "",
-                    })),
-                  ];
-                  const selectedValue =
-                    field.value ?? ENVIRONMENT_DEFAULT_VALUE;
-                  const selectedDescription = environmentOptions.find(
-                    (option) => option.value === selectedValue,
-                  )?.description;
-
-                  return (
-                    <FormItem className="space-y-2">
-                      <Label>Environment</Label>
-                      <FormControl>
-                        <Select
-                          value={selectedValue}
-                          disabled={!hasCustomEnvironmentOptions}
-                          onValueChange={(value) =>
-                            field.onChange(
-                              value === ENVIRONMENT_DEFAULT_VALUE
-                                ? null
-                                : value,
-                            )
-                          }
-                        >
-                          <SelectTrigger
-                            className="w-full"
-                            data-testid={E2eTestId.SelectEnvironment}
-                          >
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent position="popper">
-                            {environmentOptions.map((option) => (
-                              <SelectItem
-                                key={option.value}
-                                value={option.value}
-                                description={option.description || undefined}
-                              >
-                                {option.label}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </FormControl>
-                      {selectedDescription ? (
-                        <p className="text-xs text-muted-foreground">
-                          {selectedDescription}
-                        </p>
-                      ) : null}
-                      {!hasCustomEnvironmentOptions ? (
-                        <FormDescription>
-                          Only the default environment is available.{" "}
-                          {canManageEnvironments ? (
-                            <Link
-                              href="/settings/environments"
-                              className="underline underline-offset-2"
-                            >
-                              Manage environments
-                            </Link>
-                          ) : null}
-                        </FormDescription>
-                      ) : null}
-                      <FormMessage />
-                    </FormItem>
-                  );
-                }}
+                render={({ field }) => (
+                  <EnvironmentSelector
+                    value={field.value ?? null}
+                    onChange={field.onChange}
+                  />
+                )}
               />
               {hasEnvRuleViolations && (
                 <div

--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -52,6 +52,7 @@ import {
   type McpEnvConflict,
 } from "@/components/agent-tools-editor";
 import { ModelSelector } from "@/components/chat/model-selector";
+import { EnvironmentSelector } from "@/components/environment-selector";
 import { ExternalDocsLink } from "@/components/external-docs-link";
 import { LlmProviderApiKeyDropdown } from "@/components/llm-provider-api-key-dropdown";
 import {
@@ -602,20 +603,9 @@ export function AgentDialog({
   const { data: environmentsData } = useEnvironments(
     open && agentType === "agent" && !!agentEnvironmentsEnabled,
   );
+  // Used to resolve the selected environment's name for the tools editor; the
+  // EnvironmentSelector owns its own list + permission filtering.
   const environments = environmentsData?.environments ?? [];
-  // Assigning a restricted environment needs environment:deploy-to-restricted
-  // (environment:admin implies it); the backend enforces it, so hide the
-  // restricted environments the caller can't deploy to rather than letting them
-  // pick one and fail on save — same gate the MCP-catalog form uses.
-  const { data: hasEnvAdmin } = useHasPermissions({ environment: ["admin"] });
-  const { data: hasDeployToRestricted } = useHasPermissions({
-    environment: ["deploy-to-restricted"],
-  });
-  const canDeployRestricted =
-    (hasEnvAdmin ?? false) || (hasDeployToRestricted ?? false);
-  const accessibleEnvironments = environments.filter(
-    (env) => !env.restricted || canDeployRestricted,
-  );
   // Scope the agent's MCP list to its environment only when the feature is on
   // for an internal agent (same gate as the environment selector).
   const environmentScopingEnabled =
@@ -1330,32 +1320,16 @@ export function AgentDialog({
 
               {/* Sandbox Environment (Agent only): binds the agent's code
                   sandbox to a per-environment Dagger engine + egress policy.
-                  Feature-flagged off by default. */}
-              {isInternalAgent &&
-                agentEnvironmentsEnabled &&
-                accessibleEnvironments.length > 0 && (
-                  <div className="rounded-lg border bg-card p-4 space-y-2">
-                    <Label>Environment</Label>
-                    <Select
-                      value={environmentId ?? "none"}
-                      onValueChange={(value) =>
-                        setEnvironmentId(value === "none" ? null : value)
-                      }
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Default" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="none">Default</SelectItem>
-                        {accessibleEnvironments.map((env) => (
-                          <SelectItem key={env.id} value={env.id}>
-                            {env.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                )}
+                  Feature-flagged off by default; hidden when only the default
+                  environment is available. */}
+              {isInternalAgent && agentEnvironmentsEnabled && (
+                <EnvironmentSelector
+                  value={environmentId ?? null}
+                  onChange={setEnvironmentId}
+                  hideWhenOnlyDefault
+                  className="rounded-lg border bg-card p-4"
+                />
+              )}
 
               {/* Suggested Prompts (Agent only, not built-in, collapsible) */}
               {isInternalAgent && !isBuiltIn && (

--- a/platform/frontend/src/components/environment-selector.tsx
+++ b/platform/frontend/src/components/environment-selector.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { E2eTestId } from "@archestra/shared";
+import Link from "next/link";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useEnvironments } from "@/lib/environment.query";
+import { useDefaultEnvironment } from "@/lib/organization.query";
+import { cn } from "@/lib/utils";
+
+// shadcn Select can't use an empty string value, so the org default (a null
+// environmentId) is represented by this sentinel internally.
+const DEFAULT_ENVIRONMENT_VALUE = "__default__";
+
+interface EnvironmentSelectorProps {
+  /** Selected environment id; null selects the org default. */
+  value: string | null;
+  onChange: (environmentId: string | null) => void;
+  /**
+   * When set and no custom environments are accessible, render nothing instead
+   * of a disabled default-only select (the agent dialog hides the field in that
+   * case; the MCP form shows the disabled state).
+   */
+  hideWhenOnlyDefault?: boolean;
+  /** Applied to the field's root element, e.g. a card wrapper for the agent dialog. */
+  className?: string;
+}
+
+export function EnvironmentSelector({
+  value,
+  onChange,
+  hideWhenOnlyDefault,
+  className,
+}: EnvironmentSelectorProps) {
+  const { data: environmentList } = useEnvironments();
+  const environments = environmentList?.environments ?? [];
+  const defaultEnvironment = useDefaultEnvironment();
+  // Deploying to a restricted environment needs environment:deploy-to-restricted;
+  // environment:admin (full environment management) implies it.
+  const { data: hasEnvAdmin } = useHasPermissions({ environment: ["admin"] });
+  const { data: hasDeployToRestricted } = useHasPermissions({
+    environment: ["deploy-to-restricted"],
+  });
+  const canDeployRestricted =
+    (hasEnvAdmin ?? false) || (hasDeployToRestricted ?? false);
+  // Restricted environments the user can't deploy to are hidden entirely; the
+  // default is always available.
+  const accessibleEnvironments = environments.filter(
+    (environment) => !environment.restricted || canDeployRestricted,
+  );
+  const hasCustomEnvironmentOptions = accessibleEnvironments.length > 0;
+  const canManageEnvironments = hasEnvAdmin ?? false;
+
+  if (hideWhenOnlyDefault && !hasCustomEnvironmentOptions) return null;
+
+  const options = [
+    {
+      value: DEFAULT_ENVIRONMENT_VALUE,
+      label: defaultEnvironment.name,
+      description: defaultEnvironment.description ?? "",
+    },
+    ...accessibleEnvironments.map((environment) => ({
+      value: environment.id,
+      label: environment.name,
+      description: environment.description ?? "",
+    })),
+  ];
+  const selectedValue = value ?? DEFAULT_ENVIRONMENT_VALUE;
+  const selectedDescription = options.find(
+    (option) => option.value === selectedValue,
+  )?.description;
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      <Label>Environment</Label>
+      <Select
+        value={selectedValue}
+        disabled={!hasCustomEnvironmentOptions}
+        onValueChange={(next) =>
+          onChange(next === DEFAULT_ENVIRONMENT_VALUE ? null : next)
+        }
+      >
+        <SelectTrigger
+          className="w-full"
+          data-testid={E2eTestId.SelectEnvironment}
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent position="popper">
+          {options.map((option) => (
+            <SelectItem
+              key={option.value}
+              value={option.value}
+              description={option.description || undefined}
+            >
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {selectedDescription ? (
+        <p className="text-xs text-muted-foreground">{selectedDescription}</p>
+      ) : null}
+      {!hasCustomEnvironmentOptions ? (
+        <p className="text-xs text-muted-foreground">
+          Only the default environment is available.{" "}
+          {canManageEnvironments ? (
+            <Link
+              href="/settings/environments"
+              className="underline underline-offset-2"
+            >
+              Manage environments
+            </Link>
+          ) : null}
+        </p>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

The MCP catalog form and the agent dialog each rendered their own Environment picker, and the two had drifted: the MCP form's selector showed each environment's description (in the dropdown items and below the select) plus a "only the default is available / manage environments" helper, while the agent dialog's was a bare name-only dropdown. Picking an environment in the agent dialog gave the user no description to go on.

This extracts the MCP form's richer selector into a single shared `EnvironmentSelector` component and uses it in both places, so the agent dialog now shows environment descriptions too and the two forms can't drift again. The component self-fetches the environment list, the caller's deploy permissions (to hide restricted environments they can't deploy to), and the org default, so each form just passes the selected value and an onChange. The agent dialog passes `hideWhenOnlyDefault` to preserve its behavior of hiding the field entirely when no custom environment exists, and supplies its own card styling via `className`. Both forms continue to map the "Default" option to a null environmentId.

No behavior change to the MCP form; the agent dialog gains the description display.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>