### PR TITLE
fix(archestra-bench): analyzer small-N guards + reliable submission

### DIFF
--- a/archestra-bench/analyzer/src/analyze.rs
+++ b/archestra-bench/analyzer/src/analyze.rs
@@ -123,6 +123,12 @@ pub const REDUCE_SYSTEM_PROMPT: &str = "You analyze AI-agent trajectories from t
      show an issue (for breadth) and prefer fixes that generalize across models over patching one \
      model's quirk; never discount a struggle merely because the model is weak. Only set one aside \
      when it is pure raw model capability that no loop, tool, or system-prompt change could address.\n\n\
+     Calibrate each recommendation to the evidence behind it. The run metrics show how many rollouts \
+     and tasks this report rests on; when that set is small or a pattern appears only once or twice, \
+     present the finding as a prioritized hypothesis to review, not an implementation directive. \
+     Weigh the ongoing maintenance cost of any NEW surface you propose — a helper utility, an extra \
+     tool, a new abstraction — against how often the friction actually occurred; on thin evidence \
+     prefer tuning an existing tool, error message, or prompt over adding new machinery.\n\n\
      You have read-only file tools (read_file, glob, grep, git) over the whole repository: both the \
      benchmark fixtures under `archestra-bench/` and the Archestra product under `platform/`. For \
      every issue surfaced in the analyses, cross-check it against the real definition — read the \

--- a/archestra-bench/analyzer/src/analyze.rs
+++ b/archestra-bench/analyzer/src/analyze.rs
@@ -15,6 +15,12 @@ use crate::runmeta::RolloutId;
 const MAP_MAX_TOKENS: u64 = 4096;
 /// Hard cap on each per-rollout analysis so a runaway summary cannot blow the reducer's context.
 const MAP_ANALYSIS_CAP_CHARS: usize = 6000;
+/// Compact the reduce agent's context before it overruns the reduce model's window. nitpicker
+/// defaults `compact_threshold` to None (compaction off); without this the agent's conversation
+/// grows unbounded as it reads analyses + raw trajectories + repo source until the provider rejects
+/// the request. Sized below the smallest reduce-model window we run (kimi-for-coding = 262144) with
+/// headroom for one turn's tool results plus the 8192 output cap.
+const REDUCE_COMPACT_THRESHOLD: u64 = 180_000;
 
 /// Map a lane's provider onto nitpicker's `LLMProvider`. `base_url` is unsupported for OpenRouter, so
 /// passing it there is a hard error rather than a silently ignored flag.
@@ -288,6 +294,7 @@ pub async fn reduce(
     // `work` stays alive (and thus on disk) until this fn returns, then drops and is removed.
     let mut builder = AgentBuilder::new("trajectory-analyst", model, REDUCE_SYSTEM_PROMPT, client)
         .max_turns(max_turns)
+        .compact_threshold(REDUCE_COMPACT_THRESHOLD)
         .subagent_system_prompt(REDUCE_SUBAGENT_SYSTEM_PROMPT);
     if let Some(progress) = progress {
         builder = builder.progress(progress);

--- a/archestra-bench/envs/archestra-api.toml
+++ b/archestra-bench/envs/archestra-api.toml
@@ -7,9 +7,6 @@ tasks = ["author-skill", "letter-count"]
 # here is what lets it survive the strip/assert guard that otherwise forbids mutating the library.
 tools = ["create_skill"]
 
-[agent]
-system_prompt = """You are an expert operator of Archestra's own management API, working inside a sandboxed environment. You can run shell commands, author and load skills, and introspect the tools and skills available to you. When a task is complete, hand in your answer by calling the submit_result tool."""
-
 # No web skills: the built-in skill catalog is part of the subject under test. Three public, no-auth
 # remote MCPs ARE seeded -- their tools get assigned to the agent, enlarging the tool surface so the
 # `letter-count` introspection is non-trivial (the verifier recomputes from the same live surface, so

--- a/archestra-bench/envs/basic.toml
+++ b/archestra-bench/envs/basic.toml
@@ -7,9 +7,6 @@ tasks = ["pi-gif-zip", "crypto-price", "median-salary", "nitpicker-version", "gi
 # once and let concurrent lanes share it. Sandbox workspaces are per-conversation, so lanes don't clash.
 share_backend = true
 
-[agent]
-system_prompt = """You are an expert software engineer working inside a sandboxed environment. You can run shell commands, install packages, read staged files, and use any installed skills. When a task is complete, hand in your answer by calling the submit_result tool."""
-
 # All skills from the two public skill libraries, pinned. A broad, realistic skill surface; the agent
 # picks whatever helps (e.g. the document skills for the xlsx task). `cap` unset = import all.
 [[skills]]

--- a/archestra-bench/runner/src/client.rs
+++ b/archestra-bench/runner/src/client.rs
@@ -471,6 +471,20 @@ impl EvalClient {
         Ok(())
     }
 
+    /// Turn off org-wide tool auto-assignment so `search_tools` returns only each agent's *assigned*
+    /// tools. Without this, a shared backend's discovery surfaces every lane's sibling `final_answer`
+    /// submit server, leaving the model to guess which one is its own.
+    pub async fn disable_tool_auto_assignment(&self) -> Result<(), ClientError> {
+        self.request(
+            Method::PATCH,
+            "/api/organization/security-settings",
+            None,
+            Some(&serde_json::json!({ "allowToolAutoAssignment": false })),
+        )
+        .await?;
+        Ok(())
+    }
+
     pub async fn list_catalog(&self) -> Result<Vec<HashMap<String, JsonValue>>, ClientError> {
         items(
             self.request(Method::GET, "/api/internal_mcp_catalog", None, None)

--- a/archestra-bench/runner/src/config/envs.rs
+++ b/archestra-bench/runner/src/config/envs.rs
@@ -5,8 +5,10 @@ use super::tasks::TaskConfigError;
 use super::toml_util::{self, TomlTable};
 use super::types::{EnvConfig, Mcp, SkillRef};
 
-const DEFAULT_SYSTEM_PROMPT: &str =
-    "You are an expert software engineer completing a benchmark task.";
+// Empty by default: lanes mimic a regular Archestra user who sets no custom system prompt, so the
+// agent runs on Archestra's stock chat instructions. Submission guidance is appended to the user
+// message instead (see SUBMIT_INSTRUCTION in run.rs).
+const DEFAULT_SYSTEM_PROMPT: &str = "";
 
 #[derive(Debug, thiserror::Error)]
 #[error("env config error: {0}")]

--- a/archestra-bench/runner/src/mcp_server.rs
+++ b/archestra-bench/runner/src/mcp_server.rs
@@ -214,6 +214,17 @@ impl BenchmarkMcp {
         Submission::None
     }
 
+    /// Whether the active task has already captured a submission (accepted or format-rejected),
+    /// without consuming the context the way `take_submission` does. Lets the runner distinguish a
+    /// genuine "stopped without submitting" from a task that already reached the submit tool.
+    pub async fn has_submission(&self, task_key: &str) -> bool {
+        let guard = self.ctx.lock().await;
+        matches!(
+            guard.as_ref(),
+            Some(ctx) if ctx.task_key == task_key && (ctx.accepted.is_some() || ctx.failed)
+        )
+    }
+
     pub async fn stop(&self) {
         self.cancel.cancel();
     }

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -38,6 +38,12 @@ const SUBMIT_TOOL_SUFFIX: &str = "__submit_result";
 // Agents run in search_and_run_only mode: the model gets the search_tools/run_tool meta tools and
 // discovers its assigned tools dynamically rather than seeing the full list up front.
 const AGENT_TOOL_EXPOSURE_MODE: &str = "search_and_run_only";
+// Appended to every user message. Kept short and tool-agnostic: it nudges submission without naming
+// the search/run meta-tools (Archestra's stock prompt already explains discovery), so a model that
+// solves the task still closes the loop by finding and calling its submit tool instead of replying in
+// prose.
+const SUBMIT_INSTRUCTION: &str =
+    "When you are done, find a tool to submit your final result -- replying in chat does not submit it.";
 const STATE_NAME: &str = "state.json";
 const MAX_WORKERS_CAP: usize = 4;
 // Last-resort net for a wedged backend: if the chat stream emits nothing for this long, give up on
@@ -814,7 +820,7 @@ async fn ensure_agent(
             name: name.to_string(),
             scope: "org".to_string(),
             agent_type: "agent".to_string(),
-            system_prompt: Some(system_prompt.to_string()),
+            system_prompt: (!system_prompt.trim().is_empty()).then(|| system_prompt.to_string()),
             tool_exposure_mode: AGENT_TOOL_EXPOSURE_MODE.to_string(),
         })
         .await?;
@@ -1393,7 +1399,10 @@ async fn drive_stage(
             data: std::fs::read(task.inputs_dir().join(&f.src)).unwrap_or_default(),
         })
         .collect();
-    let text = expand_runtime(&stage.text, runtime);
+    let text = format!(
+        "{}\n\n{SUBMIT_INSTRUCTION}",
+        expand_runtime(&stage.text, runtime)
+    );
     let mut stream_parse_error: Option<String> = None;
     let mut coalescer = StreamCoalescer::new(artifacts);
     run.stage_tokens = None;

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -17,7 +17,7 @@ use crate::client::{
     AgentCreate, ChatRecordKind, ChatRunResult, ChatStreamRecord, EvalClient, FilePart,
     apply_chat_event,
 };
-use crate::config::types::{EnvConfig, Task};
+use crate::config::types::{EnvConfig, Stage, Task};
 use crate::config::{Lane, load_envs, load_lanes};
 use crate::lifecycle::Instance;
 use crate::mcp_server::{BenchmarkMcp, Submission};
@@ -44,6 +44,10 @@ const AGENT_TOOL_EXPOSURE_MODE: &str = "search_and_run_only";
 // prose.
 const SUBMIT_INSTRUCTION: &str =
     "When you are done, find a tool to submit your final result -- replying in chat does not submit it.";
+// One-shot follow-up sent when a lane ends its turn without submitting. drive_stage still appends
+// SUBMIT_INSTRUCTION, so this only has to call out the omission.
+const SUBMIT_NUDGE: &str =
+    "You ended your turn without submitting a result. The task is not complete until you submit it.";
 const STATE_NAME: &str = "state.json";
 const MAX_WORKERS_CAP: usize = 4;
 // Last-resort net for a wedged backend: if the chat stream emits nothing for this long, give up on
@@ -1221,6 +1225,31 @@ async fn grade_rollout(
                 serde_json::json!({"stage": index, "finish_reason": run.finish_reason}),
             )
             .await;
+    }
+
+    // Safety net: a capable model often solves the task and reports the answer in chat, then ends its
+    // turn without ever calling the submit tool. If it stopped voluntarily with nothing submitted,
+    // prompt it once more. Bounded to a single extra turn, and only on a clean `stop`, so a model that
+    // genuinely refuses or already hit an error/limit still terminates.
+    if stage_error.is_none()
+        && run.finish_reason.as_deref() == Some("stop")
+        && !bench_mcp.has_submission(rollout_key).await
+    {
+        artifacts.append("submit_nudge", serde_json::json!({})).await;
+        let nudge = Stage {
+            text: SUBMIT_NUDGE.to_string(),
+            files: Vec::new(),
+        };
+        stage_error = drive_stage(
+            &client,
+            &conversation_id,
+            &nudge,
+            task,
+            &mut run,
+            artifacts,
+            &runtime,
+        )
+        .await?;
     }
 
     metadata["finish_reason"] =

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -28,11 +28,11 @@ use crate::seeding::{
 };
 use crate::verify::{VerifyOutcome, run_verifier};
 
-// Model-visible MCP server name (tools surface as `<name>-<lane>__submit_result`). Kept neutral so
+// Model-visible MCP server name (tools surface as `<name>[-<token>]__submit_result`). Kept neutral so
 // the agent is not cued that it is being evaluated, which can shift model behavior.
-// The model sees the bench tool as `<BENCH_MCP_NAME>[-<idx>]__submit_result`, so this name must never
-// encode the lane/model identity. Shared-backend envs append an opaque lane index (registry names must
-// be unique per backend); isolated lanes own their backend and use the bare name.
+// The name must never encode lane/model identity or position. Shared-backend envs append an opaque
+// random token (registry names must be unique per backend, and tool auto-assignment is disabled so a
+// lane only ever discovers its own server); isolated lanes own their backend and use the bare name.
 const BENCH_MCP_NAME: &str = "final_answer";
 const SUBMIT_TOOL_SUFFIX: &str = "__submit_result";
 // Agents run in search_and_run_only mode: the model gets the search_tools/run_tool meta tools and
@@ -508,6 +508,11 @@ async fn setup_shared_env(
         return Err(e.to_string());
     }
 
+    if let Err(e) = client.disable_tool_auto_assignment().await {
+        let _ = instance.shutdown().await;
+        return Err(e.to_string());
+    }
+
     for sref in &env.skills {
         if let Err(e) = seed_skill_ref(
             &client,
@@ -525,8 +530,9 @@ async fn setup_shared_env(
     }
 
     let mut setups: Vec<(Lane, String, String, BenchmarkMcp)> = Vec::new();
-    for (idx, lane) in env_plan.lanes.iter().enumerate() {
-        let mcp = match BenchmarkMcp::start(format!("{BENCH_MCP_NAME}-{idx}")).await {
+    for lane in &env_plan.lanes {
+        let token = &uuid::Uuid::new_v4().simple().to_string()[..8];
+        let mcp = match BenchmarkMcp::start(format!("{BENCH_MCP_NAME}-{token}")).await {
             Ok(m) => m,
             Err(e) => {
                 stop_mcps(&setups).await;
@@ -607,6 +613,11 @@ async fn run_isolated_lane(
     };
 
     if let Err(e) = client.enable_skill_defaults().await {
+        let _ = instance.shutdown().await;
+        return infra_results_for_lane(&env, &tasks, &lane, &ctx, &progress, &e.to_string());
+    }
+
+    if let Err(e) = client.disable_tool_auto_assignment().await {
         let _ = instance.shutdown().await;
         return infra_results_for_lane(&env, &tasks, &lane, &ctx, &progress, &e.to_string());
     }

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -10,6 +10,7 @@ use sha2::{Digest, Sha256};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
+use tokio::time::{Duration, timeout};
 use tracing::{error, info, warn};
 
 use crate::client::{
@@ -39,6 +40,10 @@ const SUBMIT_TOOL_SUFFIX: &str = "__submit_result";
 const AGENT_TOOL_EXPOSURE_MODE: &str = "search_and_run_only";
 const STATE_NAME: &str = "state.json";
 const MAX_WORKERS_CAP: usize = 4;
+// Last-resort net for a wedged backend: if the chat stream emits nothing for this long, give up on
+// the stage. Set above the backend's 10-min stale-run reaper so that backstop wins in the normal
+// case and this only fires when the backend stops emitting entirely.
+const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 
 const REQUIRED_TOOL_SHORT_NAMES: &[&str] = &[
     "artifact_write",
@@ -1396,7 +1401,20 @@ async fn drive_stage(
     let mut stream = client
         .stream_chat_records(conversation_id, &text, &files)
         .await?;
-    while let Some(record) = stream.next().await {
+    loop {
+        let record = match timeout(STREAM_IDLE_TIMEOUT, stream.next()).await {
+            Ok(Some(record)) => record,
+            Ok(None) => break,
+            Err(_) => {
+                if stream_parse_error.is_none() {
+                    stream_parse_error = Some(format!(
+                        "chat stream idle for {}s",
+                        STREAM_IDLE_TIMEOUT.as_secs()
+                    ));
+                }
+                break;
+            }
+        };
         coalescer.feed(&record).await;
         match record.kind {
             ChatRecordKind::Event if record.event.is_some() => {


### PR DESCRIPTION
## Summary
- Submission is now a user-message postfix instead of a persona system prompt: lanes run as a default Archestra user, and every user message ends with a short tool-agnostic nudge to find and call a submit tool (prose ≠ submission). Removes the dominant `no_submission` failure where models computed the right answer but wrote it in chat.
- Safety net: if a lane ends its turn with a clean `stop` and nothing submitted, it gets one follow-up turn prompting it to call the submit tool, then submission is taken as before. Bounded to a single extra turn; skips turn-exhaustion and error endings.
- Shared-backend submit tools are scoped to their own lane: org-wide tool auto-assignment is disabled so `search_tools` returns only a lane's assigned tools (hiding sibling lanes' submit servers), and each submit server gets an opaque token name instead of a sequential index.
- Analyzer reduce step guarded against small-N overreaction.
- Reduce-agent compaction enabled to bound context.
- Stream-idle timeout added to the chat stage.