### PR TITLE
chore(deps): drop redundant lodash override

### DIFF
--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -55,7 +55,6 @@ overrides:
   d3-path: 3.1.0
   hono: 4.12.25
   kysely: 0.28.17
-  lodash: '>=4.18.0'
   lodash-es: 4.18.1
   fast-xml-parser: 5.7.2
   fast-xml-builder: '>=1.1.7'

--- a/platform/pnpm-workspace.yaml
+++ b/platform/pnpm-workspace.yaml
@@ -53,7 +53,6 @@ overrides:
   # CVE-2026-54290 (HIGH, permissive cross-domain policy) fixed in 4.12.25.
   hono: 4.12.25
   kysely: 0.28.17
-  lodash: '>=4.18.0'
   lodash-es: 4.18.1
   fast-xml-parser: 5.7.2
   fast-xml-builder: '>=1.1.7'


### PR DESCRIPTION
## Summary

Removes the `lodash: '>=4.18.0'` entry from `platform/pnpm-workspace.yaml` `overrides`. Consumers depend on lodash via `^4.17.x` ranges that `4.18.1` already satisfies, so the graph resolves to `4.18.1` without the override — the pin does nothing.

Removing it leaves resolution unchanged: the only `pnpm-lock.yaml` delta is the dropped override line, with no shift under `importers`/`packages`/`snapshots`. No new high/critical `pnpm audit` advisories.

Keeps the override list scoped to pins that are actually load-bearing.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>