### PR TITLE
fix(sandbox-rs): use blocking OTLP client so telemetry export survives

### DIFF
--- a/platform/archestra-rs/Cargo.lock
+++ b/platform/archestra-rs/Cargo.lock
@@ -1730,7 +1730,9 @@ checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",

--- a/platform/archestra-rs/sandbox-core/Cargo.toml
+++ b/platform/archestra-rs/sandbox-core/Cargo.toml
@@ -32,7 +32,10 @@ opentelemetry-otlp = { version = "0.32", default-features = false, features = [
     "trace",
     "logs",
     "http-proto",
-    "reqwest-client",
+    # blocking client: the OTLP batch processor exports from its own non-Tokio
+    # thread, where the async reqwest client panics ("no reactor running") and
+    # kills the export pipeline. the blocking client runs the request inline.
+    "reqwest-blocking-client",
     "reqwest-rustls-webpki-roots",
 ], optional = true }
 opentelemetry-appender-tracing = { version = "0.32", optional = true }


### PR DESCRIPTION
## Problem

The sandbox OTLP exporter was built with `opentelemetry-otlp`'s async `reqwest-client`. opentelemetry_sdk 0.32 runs the batch processors on dedicated **non-Tokio** OS threads, so the async reqwest client panics on first export:

```
thread 'OpenTelemetry.Logs.BatchProcessor' panicked:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
```

Both the log and trace batch threads die (~11s after backend boot). After that, **no sandbox traces or logs are exported at all**, and the backend log floods with `AfterShutdown` warnings (~5,449 in one benchmark run).

## Fix

Switch the OTLP exporter to the blocking reqwest client (`reqwest-blocking-client`). `opentelemetry-otlp` selects the HTTP client by feature priority (async `reqwest-client` > hyper > blocking); dropping the async feature makes `.with_http()` select the blocking client, which runs the request synchronously on the batch thread with no reactor required. TLS (`reqwest-rustls-webpki-roots`) is unchanged.

One-line feature swap; no `telemetry.rs` change.

## Validation

- `cargo build/clippy --all-targets -D warnings/test -p sandbox_core --features telemetry` all pass.
- Root cause and client selection confirmed against `opentelemetry-otlp 0.32` source; blocking client runs on the SDK's own `std::thread` (no nested-runtime risk).
- Remaining manual check (needs the full backend + Dagger + collector): re-run a sandbox command and confirm `grep -c "no reactor running"` → 0 and `grep -c AfterShutdown` → ~0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>