### PR TITLE
docs(apps): list all nine auto-assigned app tools

### DIFF
--- a/docs/pages/platform-apps.md
+++ b/docs/pages/platform-apps.md
@@ -20,7 +20,7 @@ Ships behind `ARCHESTRA_APPS_ENABLED` (off by default). See [Deployment](./platf
 
 Create an app from a starter template (the HTML seed) and a name. Editing the HTML forks a new immutable version; the head version is served when the app runs. Run an app standalone at `/apps/:id/run` (no chat chrome), or from chat: a successful `create_app`, `update_app`, or `render_app` call renders the app inline in the conversation. Both surfaces drive the same app-bound runtime, so behavior is identical.
 
-While the feature is enabled, newly created agents get the app management tools (`create_app`, `update_app`, `render_app`, `list_apps`, `delete_app`) assigned by default, so "build me an app" works in chat without per-agent setup. The tools can be unassigned per agent like any other; agents created before the feature was enabled need them assigned manually.
+While the feature is enabled, newly created agents get the full app tool set assigned by default — the authoring loop (`create_app`, `read_app`, `edit_app`, `update_app`, `preview_app_tool`, `get_app_diagnostics`) plus `render_app`, `list_apps`, and `delete_app` — so "build me an app" works in chat without per-agent setup. The tools can be unassigned per agent like any other; agents created before the feature was enabled need them assigned manually.
 
 ## The Apps SDK
 


### PR DESCRIPTION
The MCP Apps doc stated that newly created agents are auto-assigned five app tools (`create_app`, `update_app`, `render_app`, `list_apps`, `delete_app`). The actual auto-assign set is nine — it also includes `read_app`, `edit_app`, `preview_app_tool`, and `get_app_diagnostics`. A reader provisioning or auditing an agent's tools would have undercounted what an app-building agent can do.

The four missing tools are already described elsewhere on the page (the build→render→fix loop); only the "assigned by default" list was stale.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>