### PR TITLE
fix(archestra-bench): keep task context across stages + capture prompts

### DIFF
--- a/archestra-bench/analyzer/src/trajectory.rs
+++ b/archestra-bench/analyzer/src/trajectory.rs
@@ -105,6 +105,19 @@ pub fn format_to_markdown(events: &[Event]) -> String {
     let mut out = String::from("# Agent trajectory\n\n");
     for event in events {
         match event {
+            Event::Prompts {
+                system_prompt,
+                user_message,
+            } => {
+                if !system_prompt.trim().is_empty() {
+                    out.push_str("### System prompt\n");
+                    out.push_str(&cap_chars(system_prompt, MAX_FIELD_CHARS));
+                    out.push_str("\n\n");
+                }
+                out.push_str("### Task\n");
+                out.push_str(&cap_chars(user_message, MAX_FIELD_CHARS));
+                out.push_str("\n\n");
+            }
             Event::AssistantText { text } => {
                 out.push_str("### Agent\n");
                 out.push_str(&cap_chars(text, MAX_FIELD_CHARS));
@@ -170,12 +183,15 @@ mod tests {
             r#"{"sequence":11,"timestamp":"t","kind":"infra_error","error":"boot failed"}"#,
             r#"{"sequence":12,"timestamp":"t","kind":"parse_error","raw":"...","reason":"bad chunk"}"#,
             r#"{"sequence":13,"timestamp":"t","kind":"chat_stream","event":{"type":"x"}}"#,
+            r#"{"sequence":14,"timestamp":"t","kind":"prompts","system_prompt":"be helpful","user_message":"find the answer"}"#,
         ]);
         let events = load_trajectory(&path).unwrap();
-        assert_eq!(events.len(), 13);
+        assert_eq!(events.len(), 14);
 
         let md = format_to_markdown(&events);
         assert!(md.contains("### Agent\nthinking"));
+        assert!(md.contains("### System prompt\nbe helpful"));
+        assert!(md.contains("### Task\nfind the answer"));
         assert!(md.contains("### Tool call: `run`"));
         assert!(md.contains("### Tool result"));
         assert!(md.contains("boom"));

--- a/archestra-bench/core/src/lib.rs
+++ b/archestra-bench/core/src/lib.rs
@@ -168,6 +168,14 @@ impl RunMeta {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum Event {
     ConversationCreated,
+    /// The agent's configured system prompt plus the initial task message, captured once at
+    /// conversation start. This is the harness-side configured input, not the full prompt the
+    /// platform materializes server-side (skill catalog, tool instructions, hook context).
+    Prompts {
+        #[serde(default)]
+        system_prompt: String,
+        user_message: String,
+    },
     AssistantText {
         text: String,
     },
@@ -257,5 +265,23 @@ mod tests {
         assert!(matches!(tool, Event::ToolCall { .. }));
         let unknown: Event = serde_json::from_str(r#"{"kind":"brand_new_kind"}"#).unwrap();
         assert!(matches!(unknown, Event::Unknown));
+    }
+
+    #[test]
+    fn event_parses_prompts_with_default_system_prompt() {
+        let with_system: Event = serde_json::from_str(
+            r#"{"kind":"prompts","system_prompt":"be helpful","user_message":"do the task"}"#,
+        )
+        .unwrap();
+        assert!(
+            matches!(with_system, Event::Prompts { system_prompt, user_message }
+                if system_prompt == "be helpful" && user_message == "do the task")
+        );
+        let no_system: Event =
+            serde_json::from_str(r#"{"kind":"prompts","user_message":"do the task"}"#).unwrap();
+        assert!(
+            matches!(no_system, Event::Prompts { system_prompt, user_message }
+                if system_prompt.is_empty() && user_message == "do the task")
+        );
     }
 }

--- a/archestra-bench/runner/src/client.rs
+++ b/archestra-bench/runner/src/client.rs
@@ -653,9 +653,27 @@ impl EvalClient {
         )
     }
 
+    /// Fetch a conversation's persisted messages in UI-message shape (`{id, role, parts, ...}`).
+    /// The platform chat route is request-body-authoritative — it never backfills history from the
+    /// DB — so callers must resend these on follow-up turns to preserve context across stages.
+    pub async fn get_conversation_messages(
+        &self,
+        conversation_id: &str,
+    ) -> Result<Vec<JsonValue>, ClientError> {
+        let body = self
+            .get_json(&format!("/api/chat/conversations/{conversation_id}"))
+            .await?;
+        Ok(body
+            .get("messages")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default())
+    }
+
     pub async fn stream_chat_records(
         &self,
         conversation_id: &str,
+        prior_messages: &[JsonValue],
         text: &str,
         files: &[FilePart],
     ) -> Result<impl Stream<Item = ChatStreamRecord> + use<'_>, ClientError> {
@@ -666,13 +684,17 @@ impl EvalClient {
         for file in files {
             parts.push(file.to_data_url_part());
         }
+        // Resend the persisted history verbatim (keeping each message's backend id, so
+        // persistNewMessages dedupes them) and append only the new user turn with a fresh id.
+        let mut messages = prior_messages.to_vec();
+        messages.push(serde_json::json!({
+            "id": uuid::Uuid::new_v4().to_string(),
+            "role": "user",
+            "parts": parts,
+        }));
         let body = serde_json::json!({
             "id": conversation_id,
-            "messages": [{
-                "id": uuid::Uuid::new_v4().to_string(),
-                "role": "user",
-                "parts": parts,
-            }],
+            "messages": messages,
             "trigger": "submit-message",
         });
         let url = self.url("/api/chat", None);

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -1058,6 +1058,7 @@ async fn run_lane(
             &submit_tool,
             &root_run_dir,
             &env.id,
+            &env.agent_system_prompt,
             &lane,
             &agent_id,
             &task,
@@ -1077,6 +1078,7 @@ async fn run_one(
     submit_tool: &str,
     root_run_dir: &Path,
     env_id: &str,
+    agent_system_prompt: &str,
     lane: &Lane,
     agent_id: &str,
     task: &Task,
@@ -1137,6 +1139,7 @@ async fn run_one(
         bench_mcp,
         submit_tool,
         env_id,
+        agent_system_prompt,
         lane,
         agent_id,
         task,
@@ -1160,6 +1163,7 @@ async fn grade_rollout(
     bench_mcp: BenchmarkMcp,
     _submit_tool: &str,
     env_id: &str,
+    agent_system_prompt: &str,
     lane: &Lane,
     agent_id: &str,
     task: &Task,
@@ -1199,6 +1203,25 @@ async fn grade_rollout(
         ("cell".to_string(), rollout_token(rollout_key, &lane.model)),
         ("agent_id".to_string(), agent_id.to_string()),
     ]);
+
+    // Capture once: the agent's configured system prompt plus the expanded stage-0 task text
+    // (pre-SUBMIT_INSTRUCTION, i.e. the human-authored prompt). drive_stage appends
+    // SUBMIT_INSTRUCTION when it actually sends each stage.
+    let initial_user_message = task
+        .stages
+        .first()
+        .map(|stage| expand_runtime(&stage.text, &runtime))
+        .unwrap_or_default();
+    artifacts
+        .append(
+            "prompts",
+            serde_json::json!({
+                "system_prompt": agent_system_prompt,
+                "user_message": initial_user_message,
+            }),
+        )
+        .await;
+
     let mut run = ChatRunResult::default();
     let mut stage_error: Option<String> = None;
     let final_stage = task.stages.len().saturating_sub(1);
@@ -1214,6 +1237,7 @@ async fn grade_rollout(
             &mut run,
             artifacts,
             &runtime,
+            index > 0,
         )
         .await?;
         if stage_error.is_some() {
@@ -1248,6 +1272,7 @@ async fn grade_rollout(
             &mut run,
             artifacts,
             &runtime,
+            true,
         )
         .await?;
     }
@@ -1425,6 +1450,7 @@ async fn drive_stage(
     run: &mut ChatRunResult,
     artifacts: &RunArtifacts,
     runtime: &HashMap<String, String>,
+    expect_prior_history: bool,
 ) -> Result<Option<String>, RunError> {
     let files: Vec<FilePart> = stage
         .files
@@ -1447,8 +1473,25 @@ async fn drive_stage(
     let mut coalescer = StreamCoalescer::new(artifacts);
     run.stage_tokens = None;
 
+    // Resend prior turns so the agent keeps task context across stages and submit-nudges; the
+    // platform builds LLM context from the request body only. The first turn has no history yet;
+    // a later turn that fetches an empty history means the prior turn failed to persist, so fail
+    // the rollout loudly rather than silently run the agent on contextless history.
+    let prior_messages = if expect_prior_history {
+        let messages = client.get_conversation_messages(conversation_id).await?;
+        if messages.is_empty() {
+            return Ok(Some(
+                "conversation history empty on a follow-up turn; the prior turn likely failed to \
+                 persist — refusing to continue on contextless history"
+                    .to_string(),
+            ));
+        }
+        messages
+    } else {
+        Vec::new()
+    };
     let mut stream = client
-        .stream_chat_records(conversation_id, &text, &files)
+        .stream_chat_records(conversation_id, &prior_messages, &text, &files)
         .await?;
     loop {
         let record = match timeout(STREAM_IDLE_TIMEOUT, stream.next()).await {


### PR DESCRIPTION
Two surgical fixes surfaced while analyzing bench run `20260617_212330`.

## Stage-context loss (the bug)
The platform chat route builds LLM context from the request body only — it never backfills history from the DB. The bench runner posted just the current stage's message, so on stage 2+ and on submit-nudges the model received an empty history and replied "I don't see any task… start of a new conversation" (caused `no_submission`/garbage outcomes for several lanes).

Fix, runner-side: before each follow-up turn, fetch the persisted conversation (`GET /api/chat/conversations/:id`) and resend it verbatim. Messages keep their backend ids, so `persistNewMessages` dedupes them (no double-insert). If a follow-up turn fetches an empty history (prior turn failed to persist), the rollout fails loudly rather than scoring on contextless history.

## Prompt capture
Trajectories recorded no prompt, so "did the agent understand the task?" required grepping the backend log. New `prompts` trajectory event records the configured system prompt + initial task text (rendered by the analyzer). Captures the harness-side configured input, not the full server-materialized prompt.

## Validation
`cargo build/test/clippy` clean (runner + analyzer + core tests, including new `prompts` round-trip + render tests).

A `search_tools` weak-match-hint change was scoped out — a correct relevance signal needs IDF-aware discriminative-term coverage, which is a separate, non-surgical change.

https://claude.ai/code/session_01YUNGYjELxEeTHdqVa3pQjJ

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>