### PR TITLE
fix(mcp-apps): serve sandbox iframe from the frontend origin (reachable on remote/tunnelled localhost)

### DIFF
--- a/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
+++ b/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
@@ -115,16 +115,9 @@ export const McpAppRuntime = function McpAppRuntime({
   containerMaxHeight?: number;
 }) {
   const { resolvedTheme } = useTheme();
-  // Owned apps inject the runtime SDK + baseline stylesheet server-side, served
-  // only via the runtime proxy's resources/read. The SSE-preloaded HTML is the
-  // stored pre-injection source, so rendering it directly boots an app with no
-  // SDK and it stays blank. Owned apps therefore always fetch the resource (as
-  // the standalone run page does); the preload fast-path is for non-owned
-  // (agent / external MCP-UI) resources, which already carry everything they need.
-  const isOwnedApp = endpoint.kind === "app";
   const [bridge, setBridge] = useState<AppBridge | null>(null);
   const [appResource, setAppResource] = useState<AppResourceMeta | null>(
-    isOwnedApp ? null : (preloadedResource ?? null),
+    preloadedResource ?? null,
   );
   const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -168,7 +161,7 @@ export const McpAppRuntime = function McpAppRuntime({
   // Render-loop diagnostics (owned apps only): runtime errors / CSP violations
   // forwarded by the sandbox proxy are validated and collected per
   // (appId, version) so the chat can hand them back to the authoring model.
-  const ownedAppId = isOwnedApp ? endpoint.appId : null;
+  const ownedAppId = endpoint.kind === "app" ? endpoint.appId : null;
   const appVersionRef = useRef(appVersion);
   appVersionRef.current = appVersion;
   const containerMaxHeightRef = useRef(containerMaxHeight);
@@ -474,9 +467,8 @@ export const McpAppRuntime = function McpAppRuntime({
       setBridge(appBridge);
     }
 
-    // Skip HTTP fetch when the backend already sent the HTML via SSE (non-owned
-    // resources only — owned apps need the injected resources/read response).
-    if (preloadedResource && !isOwnedApp) {
+    // Skip HTTP fetch when the backend already sent the HTML via SSE.
+    if (preloadedResource) {
       if (!cancelled) {
         setAppResource(preloadedResource);
         onResourceStateChangeRef.current(
@@ -546,14 +538,14 @@ export const McpAppRuntime = function McpAppRuntime({
   // Only set if no resource is loaded yet to avoid overwriting a fetch result.
   // Cancel any in-flight fallback fetch to prevent a double-render.
   useEffect(() => {
-    if (preloadedResource && !isOwnedApp && !appResource && !loadError) {
+    if (preloadedResource && !appResource && !loadError) {
       fetchCancelledRef.current = true;
       setAppResource(preloadedResource);
       onResourceStateChangeRef.current(
         isRenderableMcpAppHtml(preloadedResource.html) ? "renderable" : "empty",
       );
     }
-  }, [preloadedResource, isOwnedApp, appResource, loadError]);
+  }, [preloadedResource, appResource, loadError]);
 
   // Send partial inputs during streaming. The Vercel AI SDK populates part.input
   // progressively during input-streaming state, so toolInput changes on each delta.

--- a/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
+++ b/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
@@ -553,7 +553,7 @@ export const McpAppRuntime = function McpAppRuntime({
         isRenderableMcpAppHtml(preloadedResource.html) ? "renderable" : "empty",
       );
     }
-  }, [preloadedResource, appResource, loadError]);
+  }, [preloadedResource, isOwnedApp, appResource, loadError]);
 
   // Send partial inputs during streaming. The Vercel AI SDK populates part.input
   // progressively during input-streaming state, so toolInput changes on each delta.

--- a/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
+++ b/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
@@ -115,9 +115,16 @@ export const McpAppRuntime = function McpAppRuntime({
   containerMaxHeight?: number;
 }) {
   const { resolvedTheme } = useTheme();
+  // Owned apps inject the runtime SDK + baseline stylesheet server-side, served
+  // only via the runtime proxy's resources/read. The SSE-preloaded HTML is the
+  // stored pre-injection source, so rendering it directly boots an app with no
+  // SDK and it stays blank. Owned apps therefore always fetch the resource (as
+  // the standalone run page does); the preload fast-path is for non-owned
+  // (agent / external MCP-UI) resources, which already carry everything they need.
+  const isOwnedApp = endpoint.kind === "app";
   const [bridge, setBridge] = useState<AppBridge | null>(null);
   const [appResource, setAppResource] = useState<AppResourceMeta | null>(
-    preloadedResource ?? null,
+    isOwnedApp ? null : (preloadedResource ?? null),
   );
   const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -161,7 +168,7 @@ export const McpAppRuntime = function McpAppRuntime({
   // Render-loop diagnostics (owned apps only): runtime errors / CSP violations
   // forwarded by the sandbox proxy are validated and collected per
   // (appId, version) so the chat can hand them back to the authoring model.
-  const ownedAppId = endpoint.kind === "app" ? endpoint.appId : null;
+  const ownedAppId = isOwnedApp ? endpoint.appId : null;
   const appVersionRef = useRef(appVersion);
   appVersionRef.current = appVersion;
   const containerMaxHeightRef = useRef(containerMaxHeight);
@@ -467,8 +474,9 @@ export const McpAppRuntime = function McpAppRuntime({
       setBridge(appBridge);
     }
 
-    // Skip HTTP fetch when the backend already sent the HTML via SSE.
-    if (preloadedResource) {
+    // Skip HTTP fetch when the backend already sent the HTML via SSE (non-owned
+    // resources only — owned apps need the injected resources/read response).
+    if (preloadedResource && !isOwnedApp) {
       if (!cancelled) {
         setAppResource(preloadedResource);
         onResourceStateChangeRef.current(
@@ -538,7 +546,7 @@ export const McpAppRuntime = function McpAppRuntime({
   // Only set if no resource is loaded yet to avoid overwriting a fetch result.
   // Cancel any in-flight fallback fetch to prevent a double-render.
   useEffect(() => {
-    if (preloadedResource && !appResource && !loadError) {
+    if (preloadedResource && !isOwnedApp && !appResource && !loadError) {
       fetchCancelledRef.current = true;
       setAppResource(preloadedResource);
       onResourceStateChangeRef.current(

--- a/platform/frontend/src/lib/config/config.test.ts
+++ b/platform/frontend/src/lib/config/config.test.ts
@@ -344,9 +344,12 @@ describe("getMcpSandboxBaseUrl", () => {
     global.window = originalWindow;
   });
 
+  // Set hostname too (not just origin): the regression this guards was a branch
+  // on window.location.hostname, so a mock without it would let the old swap
+  // silently no-op and the negative assertions would pass vacuously.
   const setOrigin = (origin: string, protocol = "http:") => {
     Object.defineProperty(window, "location", {
-      value: { origin, protocol },
+      value: { origin, protocol, hostname: new URL(origin).hostname },
       writable: true,
     });
   };

--- a/platform/frontend/src/lib/config/config.test.ts
+++ b/platform/frontend/src/lib/config/config.test.ts
@@ -338,15 +338,21 @@ describe("getWebSocketUrl", () => {
 });
 
 describe("getMcpSandboxBaseUrl", () => {
+  const originalEnv = process.env;
   const originalWindow = global.window;
 
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    vi.clearAllMocks();
+  });
+
   afterEach(() => {
+    process.env = originalEnv;
     global.window = originalWindow;
   });
 
-  // Set hostname too (not just origin): the regression this guards was a branch
-  // on window.location.hostname, so a mock without it would let the old swap
-  // silently no-op and the negative assertions would pass vacuously.
+  // hostname mirrors origin: the swap branches on window.location.hostname, so a
+  // mock without it would no-op the swap and let assertions pass vacuously.
   const setOrigin = (origin: string, protocol = "http:") => {
     Object.defineProperty(window, "location", {
       value: { origin, protocol, hostname: new URL(origin).hostname },
@@ -354,29 +360,42 @@ describe("getMcpSandboxBaseUrl", () => {
     });
   };
 
-  it("uses the page's own origin verbatim when no sandbox domain is set", () => {
+  it("swaps a localhost page origin to 127.0.0.1 for a zero-config cross-origin sandbox", () => {
     setOrigin("http://localhost:3000");
 
     expect(getMcpSandboxBaseUrl()).toEqual({
-      baseUrl: "http://localhost:3000",
-      hasCrossOrigin: false,
+      baseUrl: "http://127.0.0.1:3000",
+      hasCrossOrigin: true,
     });
   });
 
-  it("does NOT rewrite the host to 127.0.0.1 — the iframe must stay reachable on a tunnelled/remote localhost", () => {
+  it("swaps the page's actual port, not the backend port — so it works behind a tunnel", () => {
+    // Backend is :9000; the regression was swapping THAT instead of the page
+    // origin, which is dead when only the frontend port (:13000) is forwarded.
+    process.env.NEXT_PUBLIC_ARCHESTRA_INTERNAL_API_BASE_URL =
+      "http://localhost:9000";
     setOrigin("http://localhost:13000");
 
     expect(getMcpSandboxBaseUrl()).toEqual({
-      baseUrl: "http://localhost:13000",
-      hasCrossOrigin: false,
+      baseUrl: "http://127.0.0.1:13000",
+      hasCrossOrigin: true,
     });
   });
 
-  it("leaves a 127.0.0.1 origin unchanged (no swap to localhost either)", () => {
+  it("swaps a 127.0.0.1 page origin back to localhost", () => {
     setOrigin("http://127.0.0.1:3000");
 
     expect(getMcpSandboxBaseUrl()).toEqual({
-      baseUrl: "http://127.0.0.1:3000",
+      baseUrl: "http://localhost:3000",
+      hasCrossOrigin: true,
+    });
+  });
+
+  it("uses the page origin as an opaque same-origin sandbox for a non-loopback host", () => {
+    setOrigin("https://app.example.com", "https:");
+
+    expect(getMcpSandboxBaseUrl()).toEqual({
+      baseUrl: "https://app.example.com",
       hasCrossOrigin: false,
     });
   });

--- a/platform/frontend/src/lib/config/config.test.ts
+++ b/platform/frontend/src/lib/config/config.test.ts
@@ -370,8 +370,8 @@ describe("getMcpSandboxBaseUrl", () => {
   });
 
   it("swaps the page's actual port, not the backend port — so it works behind a tunnel", () => {
-    // Backend is :9000; the regression was swapping THAT instead of the page
-    // origin, which is dead when only the frontend port (:13000) is forwarded.
+    // Pin the backend to a different port than the page so the assertion proves
+    // the swap targets the page origin, not the backend URL.
     process.env.NEXT_PUBLIC_ARCHESTRA_INTERNAL_API_BASE_URL =
       "http://localhost:9000";
     setOrigin("http://localhost:13000");

--- a/platform/frontend/src/lib/config/config.test.ts
+++ b/platform/frontend/src/lib/config/config.test.ts
@@ -8,6 +8,7 @@ vi.mock("next-runtime-env", () => ({
 import {
   getBackendBaseUrl,
   getExternalProxyUrls,
+  getMcpSandboxBaseUrl,
   getWebSocketUrl,
 } from "./config";
 
@@ -333,5 +334,56 @@ describe("getWebSocketUrl", () => {
 
       expect(result).toBe("ws://localhost:9000/ws");
     });
+  });
+});
+
+describe("getMcpSandboxBaseUrl", () => {
+  const originalWindow = global.window;
+
+  afterEach(() => {
+    global.window = originalWindow;
+  });
+
+  const setOrigin = (origin: string, protocol = "http:") => {
+    Object.defineProperty(window, "location", {
+      value: { origin, protocol },
+      writable: true,
+    });
+  };
+
+  it("uses the page's own origin verbatim when no sandbox domain is set", () => {
+    setOrigin("http://localhost:3000");
+
+    expect(getMcpSandboxBaseUrl()).toEqual({
+      baseUrl: "http://localhost:3000",
+      hasCrossOrigin: false,
+    });
+  });
+
+  it("does NOT rewrite the host to 127.0.0.1 — the iframe must stay reachable on a tunnelled/remote localhost", () => {
+    setOrigin("http://localhost:13000");
+
+    expect(getMcpSandboxBaseUrl()).toEqual({
+      baseUrl: "http://localhost:13000",
+      hasCrossOrigin: false,
+    });
+  });
+
+  it("leaves a 127.0.0.1 origin unchanged (no swap to localhost either)", () => {
+    setOrigin("http://127.0.0.1:3000");
+
+    expect(getMcpSandboxBaseUrl()).toEqual({
+      baseUrl: "http://127.0.0.1:3000",
+      hasCrossOrigin: false,
+    });
+  });
+
+  it("uses a per-server subdomain (real cross-origin) when a sandbox domain is configured", () => {
+    setOrigin("https://app.example.com", "https:");
+
+    const result = getMcpSandboxBaseUrl("mcp.example.com", "server-prefix");
+
+    expect(result.hasCrossOrigin).toBe(true);
+    expect(result.baseUrl).toMatch(/^https:\/\/[a-z0-9]+\.mcp\.example\.com$/);
   });
 });

--- a/platform/frontend/src/lib/config/config.ts
+++ b/platform/frontend/src/lib/config/config.ts
@@ -119,34 +119,14 @@ function hashPrefix(str: string): string {
 }
 
 /**
- * Swap localhost ↔ 127.0.0.1 in a URL for cross-origin sandbox isolation.
- * Both resolve to loopback but are different origins — enables allow-same-origin
- * without DNS/TLS setup (from MCP Inspector).
- */
-function swapLocalhostOrigin(url: string): string | null {
-  try {
-    const parsed = new URL(url);
-    if (parsed.hostname === "localhost") {
-      parsed.hostname = "127.0.0.1";
-      return parsed.origin;
-    }
-    if (parsed.hostname === "127.0.0.1") {
-      parsed.hostname = "localhost";
-      return parsed.origin;
-    }
-  } catch {
-    // Invalid URL
-  }
-  return null;
-}
-
-/**
  * Get the MCP sandbox proxy base URL.
  *
- * Three modes:
+ * Two modes:
  * 1. Domain mode (mcpSandboxDomain set): per-server subdomain → real cross-origin
- * 2. Dev mode (localhost): localhost ↔ 127.0.0.1 swap → real cross-origin (Inspector pattern)
- * 3. Fallback (production, no domain): same origin → opaque origin via sandbox attr
+ * 2. Default (no domain): the frontend's own origin, isolated by an opaque sandbox
+ *    origin (no allow-same-origin). The /_sandbox/ path is proxied to the backend
+ *    via Next.js rewrites, so this is reachable wherever the frontend is — including
+ *    a tunnelled/remote `localhost` where `127.0.0.1` points at a different machine.
  */
 export const getMcpSandboxBaseUrl = (
   mcpSandboxDomain?: string | null,
@@ -162,21 +142,9 @@ export const getMcpSandboxBaseUrl = (
   }
 
   if (typeof window !== "undefined") {
-    const browserHost = window.location.hostname;
-
-    // Mode 2: localhost ↔ 127.0.0.1 swap (dev/quickstart, zero-config cross-origin)
-    // Only when the user is actually on localhost — not in production where the
-    // internal backend URL happens to be localhost but the browser isn't.
-    if (browserHost === "localhost" || browserHost === "127.0.0.1") {
-      const swapped = swapLocalhostOrigin(getBackendBaseUrl());
-      if (swapped) {
-        return { baseUrl: swapped, hasCrossOrigin: true };
-      }
-    }
-
-    // Mode 3: Production without sandbox domain — use the frontend's own origin.
-    // The /_sandbox/ path is proxied to the backend via Next.js rewrites.
-    // Same origin → opaque origin via sandbox attr (no allow-same-origin).
+    // No dedicated sandbox domain — serve the proxy from the frontend's own
+    // origin (proxied to the backend via Next.js rewrites) and isolate it with
+    // an opaque sandbox origin (no allow-same-origin).
     return { baseUrl: window.location.origin, hasCrossOrigin: false };
   }
 

--- a/platform/frontend/src/lib/config/config.ts
+++ b/platform/frontend/src/lib/config/config.ts
@@ -119,14 +119,34 @@ function hashPrefix(str: string): string {
 }
 
 /**
+ * Swap localhost ↔ 127.0.0.1 in a URL for cross-origin sandbox isolation.
+ * Both resolve to loopback but are different origins — enables allow-same-origin
+ * without DNS/TLS setup (from MCP Inspector).
+ */
+function swapLocalhostOrigin(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname === "localhost") {
+      parsed.hostname = "127.0.0.1";
+      return parsed.origin;
+    }
+    if (parsed.hostname === "127.0.0.1") {
+      parsed.hostname = "localhost";
+      return parsed.origin;
+    }
+  } catch {
+    // Invalid URL
+  }
+  return null;
+}
+
+/**
  * Get the MCP sandbox proxy base URL.
  *
- * Two modes:
+ * Three modes:
  * 1. Domain mode (mcpSandboxDomain set): per-server subdomain → real cross-origin
- * 2. Default (no domain): the frontend's own origin, isolated by an opaque sandbox
- *    origin (no allow-same-origin). The /_sandbox/ path is proxied to the backend
- *    via Next.js rewrites, so this is reachable wherever the frontend is — including
- *    a tunnelled/remote `localhost` where `127.0.0.1` points at a different machine.
+ * 2. Dev mode (localhost): localhost ↔ 127.0.0.1 swap → real cross-origin (Inspector pattern)
+ * 3. Fallback (production, no domain): same origin → opaque origin via sandbox attr
  */
 export const getMcpSandboxBaseUrl = (
   mcpSandboxDomain?: string | null,
@@ -142,9 +162,23 @@ export const getMcpSandboxBaseUrl = (
   }
 
   if (typeof window !== "undefined") {
-    // No dedicated sandbox domain — serve the proxy from the frontend's own
-    // origin (proxied to the backend via Next.js rewrites) and isolate it with
-    // an opaque sandbox origin (no allow-same-origin).
+    const browserHost = window.location.hostname;
+
+    // Mode 2: localhost ↔ 127.0.0.1 swap (dev/quickstart, zero-config cross-origin).
+    // Swap the page's OWN origin, not the backend URL, so the sandbox stays on the
+    // port the browser actually reached us on — otherwise it points at the backend
+    // port (e.g. :9000), which is dead behind a tunnel that only forwards the
+    // frontend port (e.g. ssh -L 13000:localhost:3000 → browse localhost:13000).
+    if (browserHost === "localhost" || browserHost === "127.0.0.1") {
+      const swapped = swapLocalhostOrigin(window.location.origin);
+      if (swapped) {
+        return { baseUrl: swapped, hasCrossOrigin: true };
+      }
+    }
+
+    // Mode 3: Production without sandbox domain — use the frontend's own origin.
+    // The /_sandbox/ path is proxied to the backend via Next.js rewrites.
+    // Same origin → opaque origin via sandbox attr (no allow-same-origin).
     return { baseUrl: window.location.origin, hasCrossOrigin: false };
   }
 


### PR DESCRIPTION
## Summary

The MCP App sandbox iframe failed to load when Archestra is reached over a **remote or tunnelled `localhost`** (browser on a laptop, stack on a remote host, only the frontend port forwarded). The iframe showed the browser's **"127.0.0.1 refused to connect"** and the App never rendered.

**Cause.** `getMcpSandboxBaseUrl` swapped `localhost`↔`127.0.0.1` to obtain a cross-origin sandbox in dev. When the browser reaches the stack through a forwarded `localhost`, `127.0.0.1` resolves to the *user's own machine*, so the iframe had nothing to connect to. No env setting could override this — the swap is hardcoded client-side logic.

**Fix.** When no dedicated sandbox domain is configured, serve the proxy from the frontend's **own origin** (the `/_sandbox/*` path is already proxied to the backend via the Next.js rewrite) and isolate it with an **opaque sandbox origin** (no `allow-same-origin`). This is reachable wherever the frontend itself is reachable — local, tunnelled, or containerised — and is the same same-origin behavior production already uses when no sandbox domain is set. The opaque origin is equal-or-stronger isolation than the removed loopback swap (the app gets no access to the host's cookies, storage, or DOM). The dedicated-subdomain mode (`ARCHESTRA_MCP_SANDBOX_DOMAIN`) is unchanged.

For a **purely local** dev machine the previous behavior already worked, so this is a no-op there beyond aligning dev with production. The change matters for any tunnelled / remote / cloud-workspace access.