### PR TITLE
feat(llm): add env var to manually configure LLM proxy upstream timeout

### DIFF
--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -202,7 +202,12 @@ jobs:
           # reachable. The Dagger client only does TLS against a trusted local
           # engine session, so attacker-controlled CRL parsing is not reachable.
           # Revisit once dagger-sdk moves to reqwest 0.12 / rustls 0.23.
-          allow-ghsas: GHSA-82j2-j2ch-gfr8
+          # GHSA-vmh5-mc38-953g (undici HIGH, TLS bypass via SOCKS5 ProxyAgent, >=7.23.0 <7.28.0)
+          # GHSA-5v7r-6r5c-r473 (undici MODERATE, cache whitespace bypass, >=7.0.0 <7.28.0)
+          # Fix is undici 7.28.0 (published 2026-06-15, clears minimumReleaseAge on 2026-06-22).
+          # Neither applies: we use plain Agent (no ProxyAgent/SOCKS5), outbound LLM traffic only.
+          # TODO: remove both entries and bump undici to 7.28.0 after 2026-06-22.
+          allow-ghsas: GHSA-82j2-j2ch-gfr8, GHSA-vmh5-mc38-953g, GHSA-5v7r-6r5c-r473
 
   dependency-review-merge-group:
     name: Dependency Review

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -202,12 +202,7 @@ jobs:
           # reachable. The Dagger client only does TLS against a trusted local
           # engine session, so attacker-controlled CRL parsing is not reachable.
           # Revisit once dagger-sdk moves to reqwest 0.12 / rustls 0.23.
-          # GHSA-vmh5-mc38-953g (undici HIGH, TLS bypass via SOCKS5 ProxyAgent, >=7.23.0 <7.28.0)
-          # GHSA-5v7r-6r5c-r473 (undici MODERATE, cache whitespace bypass, >=7.0.0 <7.28.0)
-          # Fix is undici 7.28.0 (published 2026-06-15, clears minimumReleaseAge on 2026-06-22).
-          # Neither applies: we use plain Agent (no ProxyAgent/SOCKS5), outbound LLM traffic only.
-          # TODO: remove both entries and bump undici to 7.28.0 after 2026-06-22.
-          allow-ghsas: GHSA-82j2-j2ch-gfr8, GHSA-vmh5-mc38-953g, GHSA-5v7r-6r5c-r473
+          allow-ghsas: GHSA-82j2-j2ch-gfr8
 
   dependency-review-merge-group:
     name: Dependency Review

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -1038,6 +1038,11 @@ These environment variables set the default base URL for each LLM provider. Per-
   - Set to `0` to create virtual keys that never expire by default
   - Users can override this per-key when creating virtual keys via the UI
 
+- **`ARCHESTRA_LLM_PROXY_UPSTREAM_TIMEOUT_MS`** - Headers/body timeout (milliseconds) for LLM-call fetches, applied as a custom undici dispatcher on both the chat→proxy and proxy→upstream hops.
+  - Default: unset, i.e. undici's defaults (5 minutes for both headers and body timeout)
+  - Opt-in: set a larger value (e.g. `600000` for 10 minutes) when an upstream's time-to-first-token can exceed 5 minutes — typically a slow CPU-only Ollama or vLLM model — which otherwise fails with `Headers Timeout Error`
+  - Keep it finite so genuinely-dead upstreams still surface as errors
+
 - **`ARCHESTRA_BEDROCK_IAM_AUTH_ENABLED`** - Enable AWS IAM authentication for Bedrock.
   - Default: `false`
   - Set to `true` to use the AWS credential chain (IRSA, instance profiles, env vars) instead of API keys

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -12,6 +12,10 @@ ARCHESTRA_GEMINI_BASE_URL=https://generativelanguage.googleapis.com
 ARCHESTRA_COHERE_BASE_URL=https://api.cohere.ai
 # Ollama Base URL (uncomment if using Ollama)
 # ARCHESTRA_OLLAMA_BASE_URL=http://localhost:11434/v1
+# Upstream timeout (ms) for LLM-call fetches (chat→proxy and proxy→upstream).
+# Opt-in: unset = undici defaults (5 min headers/body timeout). Raise it for slow
+# upstreams such as CPU Ollama whose first token can take longer than 5 min.
+# ARCHESTRA_LLM_PROXY_UPSTREAM_TIMEOUT_MS=600000
 # vLLM Base URL (uncomment if using vLLM)
 # ARCHESTRA_VLLM_BASE_URL=http://localhost:8000/v1
 # Zhipuai Base URL (optional - defaults to https://api.z.ai/api/paas/v4)

--- a/platform/backend/package.json
+++ b/platform/backend/package.json
@@ -148,6 +148,7 @@
     "quick-lru": "^7.3.0",
     "safe-regex2": "5.1.0",
     "tiktoken": "^1.0.22",
+    "undici": "7.24.5",
     "ws": "^8.20.1",
     "zod": "catalog:"
   },

--- a/platform/backend/package.json
+++ b/platform/backend/package.json
@@ -148,7 +148,7 @@
     "quick-lru": "^7.3.0",
     "safe-regex2": "5.1.0",
     "tiktoken": "^1.0.22",
-    "undici": "7.24.5",
+    "undici": "7.28.0",
     "ws": "^8.20.1",
     "zod": "catalog:"
   },

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -35,6 +35,7 @@ import {
   isBedrockIamAuthEnabled,
 } from "@/clients/bedrock-credentials";
 import { isVertexAiEnabled } from "@/clients/gemini-client";
+import { getLlmUpstreamDispatcher } from "@/clients/llm-upstream-dispatcher";
 import { openRouterAttributionHeaders } from "@/clients/openrouter-attribution";
 import config from "@/config";
 import logger from "@/logging";
@@ -628,7 +629,19 @@ function createTracedFetch(): typeof globalThis.fetch {
     for (const [key, value] of Object.entries(carrier)) {
       headers.set(key, value);
     }
-    return globalThis.fetch(input, { ...init, headers });
+    // Opt-in upstream timeout dispatcher; undefined leaves undici defaults
+    // untouched. See @/clients/llm-upstream-dispatcher.
+    const dispatcher = getLlmUpstreamDispatcher();
+
+    if (!dispatcher) {
+      return globalThis.fetch(input, { ...init, headers });
+    }
+
+    return globalThis.fetch(input, {
+      ...init,
+      headers,
+      dispatcher,
+    } as RequestInit);
   };
 }
 

--- a/platform/backend/src/clients/llm-upstream-dispatcher.test.ts
+++ b/platform/backend/src/clients/llm-upstream-dispatcher.test.ts
@@ -1,0 +1,70 @@
+import { createServer, type Server } from "node:http";
+import { Agent } from "undici";
+import config from "@/config";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import { getLlmUpstreamDispatcher } from "./llm-upstream-dispatcher";
+
+describe("getLlmUpstreamDispatcher", () => {
+  test("returns an Agent when a timeout is configured, undefined otherwise", () => {
+    const result = getLlmUpstreamDispatcher();
+    if (config.llm.proxy.upstreamTimeoutMs === undefined) {
+      expect(result).toBeUndefined();
+    } else {
+      expect(result).toBeInstanceOf(Agent);
+    }
+  });
+});
+
+// Guards the core mechanism the fix relies on: a custom undici Agent with a
+// raised headersTimeout, passed via the `dispatcher` option, actually governs
+// global fetch's time-to-first-byte (and guards against the undici regression
+// class where a configured headersTimeout fails to apply).
+describe("undici Agent headersTimeout enforcement", () => {
+  let server: Server;
+  let url = "";
+  let headerDelayMs = 0;
+
+  beforeEach(async () => {
+    server = createServer((_req, res) => {
+      setTimeout(() => {
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end("ok");
+      }, headerDelayMs);
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", () => resolve()),
+    );
+    const addr = server.address();
+    if (addr && typeof addr === "object") {
+      url = `http://127.0.0.1:${addr.port}/`;
+    }
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  test("aborts with UND_ERR_HEADERS_TIMEOUT when headers arrive after the timeout", async () => {
+    headerDelayMs = 1000;
+    const dispatcher = new Agent({ headersTimeout: 150, bodyTimeout: 150 });
+    try {
+      await expect(
+        globalThis.fetch(url, { dispatcher } as RequestInit),
+      ).rejects.toMatchObject({ cause: { code: "UND_ERR_HEADERS_TIMEOUT" } });
+    } finally {
+      await dispatcher.close();
+    }
+  });
+
+  test("completes when the timeout is generous enough", async () => {
+    headerDelayMs = 100;
+    const dispatcher = new Agent({ headersTimeout: 5000, bodyTimeout: 5000 });
+    try {
+      const res = await globalThis.fetch(url, { dispatcher } as RequestInit);
+      expect(res.status).toBe(200);
+      await res.text();
+    } finally {
+      await dispatcher.close();
+    }
+  });
+});

--- a/platform/backend/src/clients/llm-upstream-dispatcher.test.ts
+++ b/platform/backend/src/clients/llm-upstream-dispatcher.test.ts
@@ -7,7 +7,7 @@ import { getLlmUpstreamDispatcher } from "./llm-upstream-dispatcher";
 describe("getLlmUpstreamDispatcher", () => {
   test("returns an Agent when a timeout is configured, undefined otherwise", () => {
     const result = getLlmUpstreamDispatcher();
-    if (config.llm.proxy.upstreamTimeoutMs === undefined) {
+    if (config.llmProxy.upstreamTimeoutMs === undefined) {
       expect(result).toBeUndefined();
     } else {
       expect(result).toBeInstanceOf(Agent);

--- a/platform/backend/src/clients/llm-upstream-dispatcher.ts
+++ b/platform/backend/src/clients/llm-upstream-dispatcher.ts
@@ -17,7 +17,7 @@ import config from "@/config";
 let dispatcher: Agent | undefined;
 
 export function getLlmUpstreamDispatcher(): Agent | undefined {
-  const upstreamTimeoutMs = config.llm.proxy.upstreamTimeoutMs;
+  const upstreamTimeoutMs = config.llmProxy.upstreamTimeoutMs;
   if (!upstreamTimeoutMs) {
     return;
   }

--- a/platform/backend/src/clients/llm-upstream-dispatcher.ts
+++ b/platform/backend/src/clients/llm-upstream-dispatcher.ts
@@ -1,0 +1,31 @@
+import { Agent } from "undici";
+import config from "@/config";
+
+/**
+ * Shared undici dispatcher for outbound LLM-call fetches.
+ *
+ * Node's `globalThis.fetch` is backed by undici, whose default `headersTimeout`
+ * and `bodyTimeout` are both 5 min — which aborts slow-but-healthy upstreams
+ * with `UND_ERR_HEADERS_TIMEOUT`. This Agent raises both timeouts to a
+ * configurable value and is injected per-request via the `dispatcher` option on
+ * the LLM-call fetches (chat → proxy and proxy → upstream), keeping the change
+ * scoped to LLM traffic rather than every fetch in the process.
+ *
+ * Opt-in: when `ARCHESTRA_LLM_PROXY_UPSTREAM_TIMEOUT_MS` is unset, this returns
+ * `undefined` and callers leave undici's defaults untouched (no dispatcher).
+ */
+let dispatcher: Agent | undefined;
+
+export function getLlmUpstreamDispatcher(): Agent | undefined {
+  const upstreamTimeoutMs = config.llm.proxy.upstreamTimeoutMs;
+  if (!upstreamTimeoutMs) {
+    return;
+  }
+
+  dispatcher ??= new Agent({
+    headersTimeout: upstreamTimeoutMs,
+    bodyTimeout: upstreamTimeoutMs,
+  });
+
+  return dispatcher;
+}

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -963,6 +963,14 @@ const config = {
       baseUrl:
         process.env.ARCHESTRA_OLLAMA_BASE_URL ?? "http://localhost:11434/v1",
     },
+    proxy: {
+      upstreamTimeoutMs: process.env.ARCHESTRA_LLM_PROXY_UPSTREAM_TIMEOUT_MS
+        ? parsePositiveInt(
+            process.env.ARCHESTRA_LLM_PROXY_UPSTREAM_TIMEOUT_MS,
+            300000,
+          )
+        : undefined,
+    },
     zhipuai: {
       baseUrl:
         process.env.ARCHESTRA_ZHIPUAI_BASE_URL ||

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -963,14 +963,6 @@ const config = {
       baseUrl:
         process.env.ARCHESTRA_OLLAMA_BASE_URL ?? "http://localhost:11434/v1",
     },
-    proxy: {
-      upstreamTimeoutMs: process.env.ARCHESTRA_LLM_PROXY_UPSTREAM_TIMEOUT_MS
-        ? parsePositiveInt(
-            process.env.ARCHESTRA_LLM_PROXY_UPSTREAM_TIMEOUT_MS,
-            300000,
-          )
-        : undefined,
-    },
     zhipuai: {
       baseUrl:
         process.env.ARCHESTRA_ZHIPUAI_BASE_URL ||
@@ -1350,6 +1342,12 @@ const config = {
     virtualKeyDefaultExpirationSeconds: parseVirtualKeyDefaultExpiration(
       process.env.ARCHESTRA_LLM_PROXY_VIRTUAL_KEYS_DEFAULT_EXPIRATION_SECONDS,
     ),
+    upstreamTimeoutMs: process.env.ARCHESTRA_LLM_PROXY_UPSTREAM_TIMEOUT_MS
+      ? parsePositiveInt(
+          process.env.ARCHESTRA_LLM_PROXY_UPSTREAM_TIMEOUT_MS,
+          300000,
+        )
+      : undefined,
   },
   kb: {
     hybridSearchEnabled:

--- a/platform/backend/src/observability/metrics/llm.ts
+++ b/platform/backend/src/observability/metrics/llm.ts
@@ -11,6 +11,7 @@
 import type { InteractionSource, SupportedProvider } from "@archestra/shared";
 import type { GoogleGenAI } from "@google/genai";
 import client from "prom-client";
+import { getLlmUpstreamDispatcher } from "@/clients/llm-upstream-dispatcher";
 import logger from "@/logging";
 import { getUsageTokens as getAnthropicUsage } from "@/routes/proxy/adapters/anthropic";
 import { getUsageTokens as getCohereUsage } from "@/routes/proxy/adapters/cohere";
@@ -613,6 +614,12 @@ export function getObservableFetch(
     url: string | URL | Request,
     init?: RequestInit,
   ): Promise<Response> {
+    // Opt-in upstream timeout dispatcher; undefined leaves undici defaults (and
+    // `init`) untouched. See @/clients/llm-upstream-dispatcher.
+    const dispatcher = getLlmUpstreamDispatcher();
+    const dispatchedInit = dispatcher
+      ? ({ ...init, dispatcher } as RequestInit)
+      : init;
     logger.info(
       {
         url: typeof url === "string" ? url : url.toString(),
@@ -622,7 +629,7 @@ export function getObservableFetch(
     );
     if (!llmRequestDuration) {
       logger.warn("LLM metrics not initialized, skipping duration tracking");
-      return fetch(url, init);
+      return fetch(url, dispatchedInit);
     }
 
     // Extract model from request body if available
@@ -641,7 +648,7 @@ export function getObservableFetch(
     let model = requestModel;
 
     try {
-      response = await fetch(url, init);
+      response = await fetch(url, dispatchedInit);
       const duration = (Date.now() - startTime) / 1000;
       const status = response.status.toString();
 

--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -458,8 +458,8 @@ importers:
         specifier: ^1.0.22
         version: 1.0.22
       undici:
-        specifier: 7.24.5
-        version: 7.24.5
+        specifier: 7.28.0
+        version: 7.28.0
       ws:
         specifier: '>=8.21.0'
         version: 8.21.0

--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -457,6 +457,9 @@ importers:
       tiktoken:
         specifier: ^1.0.22
         version: 1.0.22
+      undici:
+        specifier: 7.24.5
+        version: 7.24.5
       ws:
         specifier: '>=8.21.0'
         version: 8.21.0


### PR DESCRIPTION
## Problem
Chatting with slow models fails with `Headers Timeout Error` after roughly 5 minutes, even if it will eventually respond. 

Node's `globalThis.fetch` is backed by `undici`, whose default `headersTimeout` and `bodyTimeout` are both exactly 300 000 ms (5 min). LLM calls go through two hops, each subject to that cap independently:

```
browser --> chat endpoint -- [Hop 1, 5 min cap] --> LLM proxy -- [Hop 2, 5 min cap] --> SLOW LLM MODEL
```

When a model's TTFT exceeds 5 min, undici aborts the fetch before it responds. 

## Fix
Introduce an opt-in `ARCHESTRA_LLM_PROXY_UPSTREAM_TIMEOUT_MS` env var that, when set, creates
a custom undici Agent with raised `headersTimeout` and `bodyTimeout`. The dispatcher is injected
per-request on both hops. The change is scoped to LLM traffic only (not setGlobalDispatcher), and is fully opt-in:

- `llm-client.ts` — inject dispatcher for Hop 1
- `metrics/llm.ts` — inject dispatcher for Hop 2

## Test plan
### Setup
Run Ollama locally and start the delay proxy (written for this fix; sits in front of Ollama and holds all requests for a configurable duration, making it possible to reproduce the undici `headersTimeout` deterministically without a genuinely slow model): https://gist.github.com/vadik49b/57ba3284a3d85eac274476b3044f9138

```
SHIM_DELAY_MS=330000 deno run --allow-net --allow-env ollama-slow-shim.ts
# then set ARCHESTRA_OLLAMA_BASE_URL=http://localhost:11500/v1
```

### Plan
- [ ] Regression baseline — env var unset, proxy delay 330 s → chat request fails with
Headers Timeout Error after ~5 min, confirming the bug
- [ ] Fix works — set `ARCHESTRA_LLM_PROXY_UPSTREAM_TIMEOUT_MS=600000`, proxy delay 330 s →
request survives the hold and completes normally
- [ ] Cap works both ways — set `ARCHESTRA_LLM_PROXY_UPSTREAM_TIMEOUT_MS=2000`, proxy delay 10 s →
request fails in ~2 s, no long hang

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>