### PR TITLE
fix(chat,bench): retry abortive tool calls, coerce sandbox target, repair harmony tool names

### DIFF
--- a/platform/backend/src/archestra-mcp-server/__snapshots__/skill-tool-text.test.ts.snap
+++ b/platform/backend/src/archestra-mcp-server/__snapshots__/skill-tool-text.test.ts.snap
@@ -74,38 +74,19 @@ exports[`skill and sandbox tool text > archestra__download_file 1`] = `
         "type": "string",
       },
       "target": {
-        "anyOf": [
-          {
-            "additionalProperties": false,
-            "description": "Run against a brand-new isolated sandbox; its id is returned.",
-            "properties": {
-              "fresh": {
-                "const": true,
-                "type": "boolean",
-              },
-            },
-            "required": [
-              "fresh",
-            ],
-            "type": "object",
+        "additionalProperties": false,
+        "description": "Which sandbox to use. Omit (or leave empty) for the conversation's default sandbox (created on first use). Pass \`{ "fresh": true }\` for a new isolated sandbox, or \`{ "id": "<uuid>" }\` to target a specific one.",
+        "properties": {
+          "fresh": {
+            "description": "Set true for a brand-new isolated sandbox; its id is returned.",
+            "type": "boolean",
           },
-          {
-            "additionalProperties": false,
-            "description": "Run against a specific existing sandbox.",
-            "properties": {
-              "id": {
-                "description": "An existing sandbox id returned by an earlier call.",
-                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
-                "type": "string",
-              },
-            },
-            "required": [
-              "id",
-            ],
-            "type": "object",
+          "id": {
+            "description": "An existing sandbox id (UUID) returned by an earlier call.",
+            "type": "string",
           },
-        ],
-        "description": "Which sandbox to use. Omit for the conversation's default sandbox (created on first use). Pass \`{ "fresh": true }\` for a new isolated sandbox, or \`{ "id": "<uuid>" }\` to target a specific one.",
+        },
+        "type": "object",
       },
     },
     "required": [
@@ -178,38 +159,19 @@ exports[`skill and sandbox tool text > archestra__run_command 1`] = `
         "type": "string",
       },
       "target": {
-        "anyOf": [
-          {
-            "additionalProperties": false,
-            "description": "Run against a brand-new isolated sandbox; its id is returned.",
-            "properties": {
-              "fresh": {
-                "const": true,
-                "type": "boolean",
-              },
-            },
-            "required": [
-              "fresh",
-            ],
-            "type": "object",
+        "additionalProperties": false,
+        "description": "Which sandbox to use. Omit (or leave empty) for the conversation's default sandbox (created on first use). Pass \`{ "fresh": true }\` for a new isolated sandbox, or \`{ "id": "<uuid>" }\` to target a specific one.",
+        "properties": {
+          "fresh": {
+            "description": "Set true for a brand-new isolated sandbox; its id is returned.",
+            "type": "boolean",
           },
-          {
-            "additionalProperties": false,
-            "description": "Run against a specific existing sandbox.",
-            "properties": {
-              "id": {
-                "description": "An existing sandbox id returned by an earlier call.",
-                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
-                "type": "string",
-              },
-            },
-            "required": [
-              "id",
-            ],
-            "type": "object",
+          "id": {
+            "description": "An existing sandbox id (UUID) returned by an earlier call.",
+            "type": "string",
           },
-        ],
-        "description": "Which sandbox to use. Omit for the conversation's default sandbox (created on first use). Pass \`{ "fresh": true }\` for a new isolated sandbox, or \`{ "id": "<uuid>" }\` to target a specific one.",
+        },
+        "type": "object",
       },
       "timeoutSeconds": {
         "description": "Optional wall-clock limit in seconds, capped at the deployment maximum.",
@@ -467,38 +429,19 @@ exports[`skill and sandbox tool text > archestra__upload_file 1`] = `
         ],
       },
       "target": {
-        "anyOf": [
-          {
-            "additionalProperties": false,
-            "description": "Run against a brand-new isolated sandbox; its id is returned.",
-            "properties": {
-              "fresh": {
-                "const": true,
-                "type": "boolean",
-              },
-            },
-            "required": [
-              "fresh",
-            ],
-            "type": "object",
+        "additionalProperties": false,
+        "description": "Which sandbox to use. Omit (or leave empty) for the conversation's default sandbox (created on first use). Pass \`{ "fresh": true }\` for a new isolated sandbox, or \`{ "id": "<uuid>" }\` to target a specific one.",
+        "properties": {
+          "fresh": {
+            "description": "Set true for a brand-new isolated sandbox; its id is returned.",
+            "type": "boolean",
           },
-          {
-            "additionalProperties": false,
-            "description": "Run against a specific existing sandbox.",
-            "properties": {
-              "id": {
-                "description": "An existing sandbox id returned by an earlier call.",
-                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
-                "type": "string",
-              },
-            },
-            "required": [
-              "id",
-            ],
-            "type": "object",
+          "id": {
+            "description": "An existing sandbox id (UUID) returned by an earlier call.",
+            "type": "string",
           },
-        ],
-        "description": "Which sandbox to use. Omit for the conversation's default sandbox (created on first use). Pass \`{ "fresh": true }\` for a new isolated sandbox, or \`{ "id": "<uuid>" }\` to target a specific one.",
+        },
+        "type": "object",
       },
     },
     "required": [

--- a/platform/backend/src/archestra-mcp-server/sandbox.test.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.test.ts
@@ -343,6 +343,62 @@ describe("sandbox tools (runtime enabled)", () => {
       );
     });
 
+    test("target {fresh:false} resolves to the conversation default sandbox", async () => {
+      const ctx = await makeConversationCtx();
+      const runSpy = stubRunCommand("x");
+
+      const result = await executeArchestraTool(
+        TOOL_RUN_COMMAND_FULL_NAME,
+        { command: "echo hi", target: { fresh: false } },
+        ctx,
+      );
+
+      expect(result.isError).toBeFalsy();
+      const sandboxes = await SkillSandboxModel.listForConversation({
+        conversationId: ctx.conversationId as string,
+        organizationId,
+      });
+      expect(sandboxes).toHaveLength(1);
+      expect(sandboxes[0].isDefault).toBe(true);
+      expect(runSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ sandboxId: sandboxes[0].id }),
+      );
+    });
+
+    test("target with an empty id resolves to the conversation default sandbox", async () => {
+      const ctx = await makeConversationCtx();
+      const runSpy = stubRunCommand("x");
+
+      const result = await executeArchestraTool(
+        TOOL_RUN_COMMAND_FULL_NAME,
+        { command: "echo hi", target: { id: "" } },
+        ctx,
+      );
+
+      expect(result.isError).toBeFalsy();
+      const sandboxes = await SkillSandboxModel.listForConversation({
+        conversationId: ctx.conversationId as string,
+        organizationId,
+      });
+      expect(sandboxes).toHaveLength(1);
+      expect(sandboxes[0].isDefault).toBe(true);
+      expect(runSpy).toHaveBeenCalled();
+    });
+
+    test("target with a non-empty but malformed id returns a clear error", async () => {
+      const ctx = await makeConversationCtx();
+      stubRunCommand("x");
+
+      const result = await executeArchestraTool(
+        TOOL_RUN_COMMAND_FULL_NAME,
+        { command: "echo hi", target: { id: "not-a-uuid" } },
+        ctx,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toContain("UUID");
+    });
+
     test("target {id} from a different conversation is rejected", async () => {
       const ctxA = await makeConversationCtx();
       stubRunCommand("x");

--- a/platform/backend/src/archestra-mcp-server/sandbox.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.ts
@@ -67,31 +67,35 @@ const UUID_REGEX =
 // typed target — no magic strings. omitted = the conversation's default
 // sandbox (lazily created); { fresh: true } = a new isolated sandbox (its id is
 // returned); { id } = an explicit existing sandbox in the same conversation.
+// Both fields are optional and weakly typed on purpose: models routinely guess
+// `{ fresh: false }` or `{ id: "" }` meaning "the default sandbox", so the
+// schema accepts those shapes and `normalizeTarget` maps any no-op guess back to
+// the default rather than rejecting it.
 const SandboxTargetSchema = z
-  .union([
-    z
-      .strictObject({ fresh: z.literal(true) })
+  .strictObject({
+    fresh: z
+      .boolean()
+      .optional()
       .describe(
-        "Run against a brand-new isolated sandbox; its id is returned.",
+        "Set true for a brand-new isolated sandbox; its id is returned.",
       ),
-    z
-      .strictObject({
-        id: z
-          .string()
-          .trim()
-          .regex(UUID_REGEX, "must be a sandbox id (UUID)")
-          .describe("An existing sandbox id returned by an earlier call."),
-      })
-      .describe("Run against a specific existing sandbox."),
-  ])
+    id: z
+      .string()
+      .optional()
+      .describe("An existing sandbox id (UUID) returned by an earlier call."),
+  })
   .optional()
   .describe(
-    "Which sandbox to use. Omit for the conversation's default sandbox " +
-      '(created on first use). Pass `{ "fresh": true }` for a new isolated ' +
+    "Which sandbox to use. Omit (or leave empty) for the conversation's default " +
+      'sandbox (created on first use). Pass `{ "fresh": true }` for a new isolated ' +
       'sandbox, or `{ "id": "<uuid>" }` to target a specific one.',
   );
 
 type SandboxTarget = z.infer<typeof SandboxTargetSchema>;
+
+// Canonical target intent after normalizing a (loosely typed) SandboxTarget:
+// a fresh sandbox, a specific id, or the default (undefined).
+type SandboxTargetIntent = { fresh: true } | { id: string } | undefined;
 
 const RunCommandSchema = z
   .strictObject({
@@ -825,6 +829,34 @@ function ensureUsable(
 }
 
 /**
+ * Map a loosely-typed {@link SandboxTarget} to a canonical intent. Models often
+ * express "the default sandbox" as `{ fresh: false }`, `{ id: "" }`, or `{}`, so
+ * those collapse to the default (undefined). `fresh: true` wins over an id; a
+ * non-empty id is validated as a UUID and otherwise reported clearly.
+ */
+function normalizeTarget(
+  target: SandboxTarget,
+): { intent: SandboxTargetIntent } | { error: string } {
+  if (!target) {
+    return { intent: undefined };
+  }
+  if (target.fresh === true) {
+    return { intent: { fresh: true } };
+  }
+  const id = target.id?.trim();
+  if (id) {
+    if (!UUID_REGEX.test(id)) {
+      return {
+        error: `target.id must be a sandbox id (UUID). Omit \`target\` to use the conversation's default sandbox, or pass \`target: { fresh: true }\` to create a new one.`,
+      };
+    }
+    return { intent: { id } };
+  }
+  // `{ fresh: false }`, `{ id: "" }`, or `{}` — the model meant the default.
+  return { intent: undefined };
+}
+
+/**
  * Resolve a {@link SandboxTarget} to a concrete sandbox id, creating the
  * conversation default (or a fresh sandbox) as needed. Explicit ids are scoped
  * to the calling user + organization.
@@ -838,8 +870,14 @@ async function resolveTarget(params: {
   const conversationId = context.conversationId ?? null;
   const isolationKey = context.isolationKey ?? null;
 
-  if (target && "id" in target) {
-    const sandbox = await SkillSandboxModel.findById(target.id);
+  const normalized = normalizeTarget(target);
+  if ("error" in normalized) {
+    return { error: normalized.error };
+  }
+  const intent = normalized.intent;
+
+  if (intent && "id" in intent) {
+    const sandbox = await SkillSandboxModel.findById(intent.id);
     // scope to the same org + user + conversation (or, for conversation-less
     // sandboxes, the same execution): an explicit id must not be a back door
     // to a sandbox from another conversation or another headless execution.
@@ -859,19 +897,19 @@ async function resolveTarget(params: {
           organizationId: userCtx.organizationId,
           userId: userCtx.userId,
           conversationId,
-          targetId: target.id,
+          targetId: intent.id,
           reason: "out_of_scope_sandbox_id",
         },
         "[Sandbox] rejected out-of-scope sandbox id",
       );
       return {
-        error: `No accessible sandbox with id ${target.id} exists. Omit \`target\` to use the conversation's default sandbox, or pass \`target: { fresh: true }\` to create a new one.`,
+        error: `No accessible sandbox with id ${intent.id} exists. Omit \`target\` to use the conversation's default sandbox, or pass \`target: { fresh: true }\` to create a new one.`,
       };
     }
     return { sandboxId: asSandboxId(sandbox.id) };
   }
 
-  if (target && "fresh" in target) {
+  if (intent && "fresh" in intent) {
     let sandbox: Awaited<ReturnType<typeof SkillSandboxModel.create>>;
     try {
       sandbox = await SkillSandboxModel.create({

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -805,7 +805,10 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   abortSignal: chatAbortController.signal,
                   // Repair tool names that carry a leaked harmony channel marker
                   // (e.g. `archestra__run_command<|channel|>commentary`) before
-                  // they surface as an unrecoverable NoSuchToolError.
+                  // they surface as an unrecoverable NoSuchToolError. Repair lands
+                  // at tool-call parse, so the earlier tool-input-start chunk keeps
+                  // the raw name — execution is correct, but an MCP App UI start
+                  // keyed off that earlier name may not render for such calls.
                   experimental_repairToolCall: async ({ toolCall, error }) => {
                     if (!NoSuchToolError.isInstance(error)) {
                       return null;

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -18,6 +18,7 @@ import {
   generateId,
   generateText,
   hasToolCall,
+  NoSuchToolError,
   stepCountIs,
   type UIMessage,
   type UIMessageChunk,
@@ -140,6 +141,7 @@ import {
   type ChatStreamTextConfig,
   streamTextWithRecovery,
 } from "./stream-probe";
+import { repairHarmonyToolName } from "./tool-call-repair";
 import { createToolUiStartTransform } from "./tool-ui-stream";
 
 const PromoteChatAttachmentResultSchema = z.object({
@@ -790,16 +792,51 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   );
                 }
 
+                // Flipped once streamTextWithRecovery returns the committed
+                // result. The probe drains discarded retry attempts before this,
+                // so their onStepFinish callbacks must not emit usage events.
+                let hasCommittedResult = false;
+
                 const streamTextConfig: ChatStreamTextConfig = {
                   model,
                   messages: modelMessages,
                   ...(supportsToolCalling && { tools: mcpTools }),
                   stopWhen: buildChatStopConditions(),
                   abortSignal: chatAbortController.signal,
+                  // Repair tool names that carry a leaked harmony channel marker
+                  // (e.g. `archestra__run_command<|channel|>commentary`) before
+                  // they surface as an unrecoverable NoSuchToolError.
+                  experimental_repairToolCall: async ({ toolCall, error }) => {
+                    if (!NoSuchToolError.isInstance(error)) {
+                      return null;
+                    }
+                    const repaired = repairHarmonyToolName(
+                      toolCall.toolName,
+                      Object.keys(mcpTools),
+                    );
+                    if (!repaired) {
+                      return null;
+                    }
+                    logger.info(
+                      {
+                        conversationId,
+                        requestedToolName: toolCall.toolName,
+                        repairedToolName: repaired,
+                      },
+                      "Repaired harmony-marked tool name",
+                    );
+                    return { ...toolCall, toolName: repaired };
+                  },
                   // Emit per-step usage so the context indicator tracks the
                   // prompt growing across tool round-trips, instead of jumping
-                  // only once when the whole turn finishes.
+                  // only once when the whole turn finishes. Suppressed for
+                  // discarded retry attempts (empty/abortive) that the probe
+                  // drains before a result is committed, so their usage never
+                  // reaches the client.
                   onStepFinish: ({ usage, finishReason }) => {
+                    if (!hasCommittedResult) {
+                      return;
+                    }
                     writer.write({
                       type: "data-token-usage",
                       data: {
@@ -901,6 +938,9 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                     }
                   },
                 });
+                // The committed result's steps finish after this point; allow
+                // their usage events through (discarded attempts already drained).
+                hasCommittedResult = true;
 
                 // Surface provider warnings (e.g. a sampling param dropped for a reasoning model)
                 // without blocking the stream, so a silently-ignored `temperature` is diagnosable.

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -803,7 +803,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   ...(supportsToolCalling && { tools: mcpTools }),
                   stopWhen: buildChatStopConditions(),
                   abortSignal: chatAbortController.signal,
-                  // Repair tool names that carry a leaked harmony channel marker
+                  // Repair tool names that carry a leaked harmony sentinel token
                   // (e.g. `archestra__run_command<|channel|>commentary`) before
                   // they surface as an unrecoverable NoSuchToolError. Repair lands
                   // at tool-call parse, so the earlier tool-input-start chunk keeps

--- a/platform/backend/src/routes/chat/stream-probe.test.ts
+++ b/platform/backend/src/routes/chat/stream-probe.test.ts
@@ -55,6 +55,49 @@ describe("probeFirstRenderableEvent", () => {
     });
   });
 
+  test("reports abortive when a tool call starts but the turn finishes without a tool-call", async () => {
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "start-step" },
+      { type: "tool-input-start" },
+      { type: "tool-input-delta" },
+      { type: "finish", finishReason: "tool-calls" },
+    ];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "abortive",
+      finishReason: "tool-calls",
+    });
+  });
+
+  test("reports abortive when a tool-input stream ends without any finish event", async () => {
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "tool-input-start" },
+      { type: "tool-input-delta" },
+    ];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "abortive",
+      finishReason: "unknown",
+    });
+  });
+
+  test("a completed tool call after tool-input streaming is renderable, not abortive", async () => {
+    const events: StreamProbeEvent[] = [
+      { type: "start" },
+      { type: "tool-input-start" },
+      { type: "tool-input-delta" },
+      { type: "tool-input-end" },
+      { type: "tool-call" },
+      { type: "finish", finishReason: "tool-calls" },
+    ];
+
+    expect(await probeFirstRenderableEvent(iteratorOf(events))).toEqual({
+      kind: "renderable",
+    });
+  });
+
   test("treats a resume turn opening with tool-output-denied as renderable", async () => {
     const events: StreamProbeEvent[] = [
       { type: "start" },

--- a/platform/backend/src/routes/chat/stream-probe.test.ts
+++ b/platform/backend/src/routes/chat/stream-probe.test.ts
@@ -61,6 +61,7 @@ describe("probeFirstRenderableEvent", () => {
       { type: "start-step" },
       { type: "tool-input-start" },
       { type: "tool-input-delta" },
+      { type: "finish-step", finishReason: "tool-calls" },
       { type: "finish", finishReason: "tool-calls" },
     ];
 

--- a/platform/backend/src/routes/chat/stream-probe.ts
+++ b/platform/backend/src/routes/chat/stream-probe.ts
@@ -22,13 +22,17 @@ export type ChatStreamTextConfig = Parameters<typeof streamText>[0] & {
  * Run streamText, probing each attempt's stream for its first renderable event
  * before the caller merges it to the client. This lets us, before anything
  * reaches the user:
- *   - trim + retry on a context-length rejection (vLLM/LiteLLM), and
+ *   - trim + retry on a context-length rejection (vLLM/LiteLLM),
  *   - silently retry a clean-but-empty response (a stupid-model / inference
- *     glitch), then surface a stream error if it persists.
+ *     glitch), then surface a stream error if it persists, and
+ *   - retry an abortive tool call (the model started streaming tool input but
+ *     the stream ended before a completed `tool-call`), then surface the
+ *     existing IncompleteToolCall error if it persists.
  * tee() buffers the stream, so consuming the probe prefix does not drop events
- * from the caller's toUIMessageStream merge. Returning on the first
- * *renderable* event (not first text) keeps Gemini's tool-call-before-text
- * turns streaming the tool indicator promptly.
+ * from the caller's toUIMessageStream merge. Commit happens on the first
+ * *committing* event — content or a completed `tool-call`, not the opening
+ * `tool-input-start` — so an abortive tool call is caught before anything
+ * reaches the client; the cost is a slightly later tool indicator.
  *
  * A probed error other than a trimmable context-length rejection returns the
  * errored result so the caller's merge surfaces it through the existing
@@ -54,8 +58,13 @@ export async function streamTextWithRecovery(params: {
   // avoid an unbounded loop; on the cap we fall through to the merge and let
   // the existing onError surface it.
   const MAX_CONTEXT_TRIM_ATTEMPTS = 1;
+  // a truncated tool call is usually a transient provider glitch; one retry
+  // recovers most. On the cap we return the abortive result so the abortive-turn
+  // tracker surfaces IncompleteToolCall, the same outcome as before this retry.
+  const MAX_ABORTIVE_TOOL_CALL_ATTEMPTS = 2;
   let emptyResponseAttempts = 0;
   let contextTrimAttempts = 0;
+  let abortiveToolCallAttempts = 0;
   // the config the loop retries from; trim replaces its messages so a later
   // empty-response retry reuses the trimmed payload instead of resending the
   // original (too-large) one.
@@ -103,6 +112,33 @@ export async function streamTextWithRecovery(params: {
       return result;
     }
 
+    if (probe.kind === "abortive") {
+      abortiveToolCallAttempts++;
+      if (abortiveToolCallAttempts < MAX_ABORTIVE_TOOL_CALL_ATTEMPTS) {
+        logger.warn(
+          {
+            conversationId,
+            finishReason: probe.finishReason,
+            rawFinishReason: probe.rawFinishReason,
+            attempt: abortiveToolCallAttempts,
+          },
+          "[AbortiveToolCall] tool call truncated mid-stream, retrying",
+        );
+        result = streamText(currentConfig);
+        continue;
+      }
+      // Exhausted: surface the abortive turn through the merge so the
+      // abortive-turn tracker emits IncompleteToolCall (unchanged end state).
+      logger.warn(
+        {
+          conversationId,
+          attempts: abortiveToolCallAttempts,
+        },
+        "[AbortiveToolCall] retries exhausted, surfacing incomplete tool call",
+      );
+      return result;
+    }
+
     // probe.kind === "empty": the provider finished with no content.
     emptyResponseAttempts++;
     const canRetryEmptyResponse =
@@ -143,19 +179,23 @@ export type StreamProbeEvent = {
 export type StreamProbeOutcome =
   | { kind: "renderable" }
   | { kind: "empty"; finishReason: string; rawFinishReason?: string }
+  // The model began streaming a tool call (tool-input-*) but the stream ended
+  // before the call completed (no tool-call). Recoverable like an empty turn.
+  | { kind: "abortive"; finishReason: string; rawFinishReason?: string }
   | { kind: "aborted" }
   | { kind: "error"; error: unknown };
 
 // fullStream event types that carry (or commit to) content the chat UI renders.
 // Seeing any of these means the turn is not empty and should stream normally.
+// `tool-input-*` is deliberately absent: a lone tool-input stream that never
+// reaches `tool-call` is an abortive (truncated) tool call we want to retry, so
+// the probe holds commit until the completed `tool-call` arrives. The cost is a
+// slightly later tool indicator (after args finish streaming) for healthy turns.
 const RENDERABLE_EVENT_TYPES: ReadonlySet<string> = new Set([
   "text-start",
   "text-delta",
   "reasoning-start",
   "reasoning-delta",
-  "tool-input-start",
-  "tool-input-delta",
-  "tool-input-end",
   "tool-call",
   "tool-result",
   // tool failure, denial, and approval-request parts are all UI-rendered turn
@@ -166,6 +206,15 @@ const RENDERABLE_EVENT_TYPES: ReadonlySet<string> = new Set([
   "tool-approval-request",
   "source",
   "file",
+]);
+
+// tool-input streaming events: pending, not committing. Seeing one means a tool
+// call started; if the stream ends before a committing `tool-call`, it was
+// abortive.
+const PENDING_TOOL_INPUT_EVENT_TYPES: ReadonlySet<string> = new Set([
+  "tool-input-start",
+  "tool-input-delta",
+  "tool-input-end",
 ]);
 
 // finishReasons where a content-free turn is plausibly a transient model/inference
@@ -192,6 +241,11 @@ export function isRetryableEmptyFinishReason(finishReason: string): boolean {
 export async function probeFirstRenderableEvent(
   iterator: AsyncIterator<StreamProbeEvent>,
 ): Promise<StreamProbeOutcome> {
+  // A tool call started streaming (tool-input-*) but has not yet reached a
+  // committing `tool-call`. If the stream ends in this state, the turn is
+  // abortive rather than merely empty.
+  let sawPendingToolInput = false;
+
   while (true) {
     let result: IteratorResult<StreamProbeEvent>;
     try {
@@ -201,8 +255,10 @@ export async function probeFirstRenderableEvent(
     }
 
     if (result.done) {
-      // stream ended without a terminal finish event — nothing renderable seen.
-      return { kind: "empty", finishReason: "unknown" };
+      // stream ended without a terminal finish event.
+      return sawPendingToolInput
+        ? { kind: "abortive", finishReason: "unknown" }
+        : { kind: "empty", finishReason: "unknown" };
     }
 
     const event = result.value;
@@ -211,22 +267,29 @@ export async function probeFirstRenderableEvent(
       return { kind: "renderable" };
     }
 
+    if (PENDING_TOOL_INPUT_EVENT_TYPES.has(event.type)) {
+      sawPendingToolInput = true;
+      continue;
+    }
+
     switch (event.type) {
       case "error":
         return { kind: "error", error: event.error };
       case "abort":
         return { kind: "aborted" };
-      case "finish":
-        return {
-          kind: "empty",
-          finishReason:
-            typeof event.finishReason === "string"
-              ? event.finishReason
-              : "unknown",
-          ...(typeof event.rawFinishReason === "string" && {
-            rawFinishReason: event.rawFinishReason,
-          }),
-        };
+      case "finish": {
+        const finishReason =
+          typeof event.finishReason === "string"
+            ? event.finishReason
+            : "unknown";
+        const rawFinishReason =
+          typeof event.rawFinishReason === "string"
+            ? { rawFinishReason: event.rawFinishReason }
+            : {};
+        return sawPendingToolInput
+          ? { kind: "abortive", finishReason, ...rawFinishReason }
+          : { kind: "empty", finishReason, ...rawFinishReason };
+      }
       // control parts (start, start-step, finish-step, text-end, ...) carry no
       // content on their own — keep pulling until content, finish, or error.
       default:

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -1294,6 +1294,50 @@ const RENDERABLE_STREAM_EVENTS = [
   { type: "text-delta", text: "hi" },
   { type: "finish", finishReason: "stop" },
 ];
+// model began streaming a tool call but the stream ended before a completed
+// tool-call — an abortive (truncated) turn.
+const ABORTIVE_TOOL_CALL_STREAM_EVENTS = [
+  { type: "start" },
+  { type: "start-step" },
+  { type: "tool-input-start" },
+  { type: "tool-input-delta" },
+  { type: "finish", finishReason: "tool-calls" },
+];
+
+// Like fakeStreamResult, but fires the config's onStepFinish as the step
+// finishes during probe consumption — mimicking how real streamText invokes the
+// callback, so the route's usage-suppression guard can be exercised. The probe
+// drains a discarded attempt before any result is committed, so onStepFinish
+// here runs while hasCommittedResult is still false.
+function fakeStreamResultFiringStepFinish(
+  config: { onStepFinish?: (args: unknown) => void },
+  events: Array<Record<string, unknown>>,
+) {
+  const result = fakeStreamResult(events);
+  const baseIterator = result.fullStream[Symbol.asyncIterator];
+  result.fullStream[Symbol.asyncIterator] = () => {
+    const it = baseIterator();
+    return {
+      next: async () => {
+        const r = await it.next();
+        if (!r.done && (r.value as { type?: string })?.type === "finish") {
+          config.onStepFinish?.({
+            usage: {
+              inputTokens: 5,
+              outputTokens: 1,
+              totalTokens: 6,
+              cachedInputTokens: 0,
+            },
+            finishReason: "tool-calls",
+          });
+        }
+        return r;
+      },
+      return: it.return,
+    };
+  };
+  return result;
+}
 
 // Composition tests: the ordering and wiring between the (individually
 // unit-tested) helpers — injection-before-normalization, compaction event
@@ -1555,6 +1599,67 @@ describe("POST /api/chat handler composition", () => {
 
     // initial attempt + exactly one trim retry, then fall through to the merge.
     expect(mockStreamText).toHaveBeenCalledTimes(2);
+  });
+
+  test("retries an abortive tool call, then streams the renderable one", async ({
+    expect,
+  }) => {
+    mockStreamText
+      .mockImplementationOnce(() =>
+        fakeStreamResult(ABORTIVE_TOOL_CALL_STREAM_EVENTS),
+      )
+      .mockImplementationOnce(() => fakeStreamResult(RENDERABLE_STREAM_EVENTS));
+
+    const response = await postMessage();
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    expect(mockStreamText).toHaveBeenCalledTimes(2);
+    expect(capturedOuterErrorPayload).toBeUndefined();
+  });
+
+  test("bounds abortive tool-call retries and commits the result (tracker surfaces the incomplete call)", async ({
+    expect,
+  }) => {
+    mockStreamText.mockImplementation(() =>
+      fakeStreamResult(ABORTIVE_TOOL_CALL_STREAM_EVENTS),
+    );
+
+    const response = await postMessage();
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    // initial attempt + exactly one retry, then commit (the abortive-turn
+    // tracker emits IncompleteToolCall inline rather than throwing).
+    expect(mockStreamText).toHaveBeenCalledTimes(2);
+    expect(writerEvents.filter((e) => e.kind === "merge")).not.toHaveLength(0);
+    expect(capturedOuterErrorPayload).toBeUndefined();
+  });
+
+  test("does not emit token-usage from a discarded abortive retry attempt", async ({
+    expect,
+  }) => {
+    mockStreamText
+      .mockImplementationOnce(
+        (config: { onStepFinish?: (a: unknown) => void }) =>
+          fakeStreamResultFiringStepFinish(
+            config,
+            ABORTIVE_TOOL_CALL_STREAM_EVENTS,
+          ),
+      )
+      .mockImplementationOnce(() => fakeStreamResult(RENDERABLE_STREAM_EVENTS));
+
+    const response = await postMessage();
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    expect(mockStreamText).toHaveBeenCalledTimes(2);
+    const usageWrites = writerEvents.filter(
+      (e) =>
+        e.kind === "write" &&
+        (e.value as { type?: string })?.type === "data-token-usage",
+    );
+    expect(usageWrites).toHaveLength(0);
   });
 
   test("injects slash-command skill activation into the model-bound messages but not the persisted ones", async ({

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -1301,6 +1301,7 @@ const ABORTIVE_TOOL_CALL_STREAM_EVENTS = [
   { type: "start-step" },
   { type: "tool-input-start" },
   { type: "tool-input-delta" },
+  { type: "finish-step", finishReason: "tool-calls" },
   { type: "finish", finishReason: "tool-calls" },
 ];
 
@@ -1621,8 +1622,14 @@ describe("POST /api/chat handler composition", () => {
   test("bounds abortive tool-call retries and commits the result (tracker surfaces the incomplete call)", async ({
     expect,
   }) => {
+    // the merged UI stream replays the unresolved tool call so the abortive-turn
+    // tracker (piped onto the merge) can append its error chunk.
     mockStreamText.mockImplementation(() =>
-      fakeStreamResult(ABORTIVE_TOOL_CALL_STREAM_EVENTS),
+      fakeStreamResult(ABORTIVE_TOOL_CALL_STREAM_EVENTS, {
+        uiChunks: [
+          { type: "tool-input-start", toolCallId: "t1", toolName: "x" },
+        ],
+      }),
     );
 
     const response = await postMessage();
@@ -1632,8 +1639,16 @@ describe("POST /api/chat handler composition", () => {
     // initial attempt + exactly one retry, then commit (the abortive-turn
     // tracker emits IncompleteToolCall inline rather than throwing).
     expect(mockStreamText).toHaveBeenCalledTimes(2);
-    expect(writerEvents.filter((e) => e.kind === "merge")).not.toHaveLength(0);
     expect(capturedOuterErrorPayload).toBeUndefined();
+
+    const merged = mergedStreams.at(-1);
+    expect(merged).toBeDefined();
+    const chunks = (await readAll(merged as ReadableStream<unknown>)) as Array<{
+      type?: string;
+      errorText?: string;
+    }>;
+    const errorChunk = chunks.find((c) => c.type === "error");
+    expect(errorChunk?.errorText).toContain("incomplete_tool_call");
   });
 
   test("does not emit token-usage from a discarded abortive retry attempt", async ({

--- a/platform/backend/src/routes/chat/tool-call-repair.test.ts
+++ b/platform/backend/src/routes/chat/tool-call-repair.test.ts
@@ -17,7 +17,13 @@ describe("repairHarmonyToolName", () => {
     ).toBe("archestra__run_command");
   });
 
-  test("strips any marker variant, not just commentary", () => {
+  test("strips any harmony token, not just channel", () => {
+    expect(
+      repairHarmonyToolName(
+        "archestra__run_command<|constrain|>json",
+        AVAILABLE,
+      ),
+    ).toBe("archestra__run_command");
     expect(
       repairHarmonyToolName(
         "archestra__search_tools<|channel|>analysis",
@@ -35,13 +41,13 @@ describe("repairHarmonyToolName", () => {
     ).toBe("context7__resolve-library-id");
   });
 
-  test("returns null for an already-valid name (no marker)", () => {
+  test("returns null for an already-valid name (no token)", () => {
     expect(
       repairHarmonyToolName("archestra__run_command", AVAILABLE),
     ).toBeNull();
   });
 
-  test("returns null when the cleaned name is not a registered tool", () => {
+  test("returns null when the cleaned prefix is not a registered tool", () => {
     expect(
       repairHarmonyToolName(
         "archestra__ghost_tool<|channel|>commentary",
@@ -50,20 +56,40 @@ describe("repairHarmonyToolName", () => {
     ).toBeNull();
   });
 
-  test("returns null when the marker is at the very start (nothing left)", () => {
+  test("returns null when the token is at the very start (nothing left)", () => {
     expect(
       repairHarmonyToolName("<|channel|>commentary", AVAILABLE),
     ).toBeNull();
   });
 
-  test("returns null for a genuinely-unknown name without a marker", () => {
+  test("returns null for a genuinely-unknown name without a token", () => {
     expect(repairHarmonyToolName("totally_made_up", AVAILABLE)).toBeNull();
   });
 
-  test("does not strip an arbitrary `<|` that is not the harmony channel marker", () => {
+  test("does not strip an unclosed `<|` that is not a harmony token", () => {
     // a partial/garbage marker must not silently re-map to a different tool.
     expect(
       repairHarmonyToolName("archestra__run_command<|garbage", AVAILABLE),
     ).toBeNull();
+  });
+
+  test("does not strip a closed sentinel outside the harmony vocabulary", () => {
+    // a closed `<|word|>` that is not a real harmony token must not trigger
+    // repair — only the registered-tool match would otherwise gate it.
+    expect(
+      repairHarmonyToolName(
+        "archestra__run_command<|garbage|>suffix",
+        AVAILABLE,
+      ),
+    ).toBeNull();
+  });
+
+  test("splits on the first harmony token when several are present", () => {
+    expect(
+      repairHarmonyToolName(
+        "archestra__run_command<|constrain|>json<|channel|>commentary",
+        AVAILABLE,
+      ),
+    ).toBe("archestra__run_command");
   });
 });

--- a/platform/backend/src/routes/chat/tool-call-repair.test.ts
+++ b/platform/backend/src/routes/chat/tool-call-repair.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "vitest";
+import { repairHarmonyToolName } from "./tool-call-repair";
+
+const AVAILABLE = [
+  "archestra__run_command",
+  "archestra__search_tools",
+  "context7__resolve-library-id",
+];
+
+describe("repairHarmonyToolName", () => {
+  test("strips a harmony channel marker and matches the registered tool", () => {
+    expect(
+      repairHarmonyToolName(
+        "archestra__run_command<|channel|>commentary",
+        AVAILABLE,
+      ),
+    ).toBe("archestra__run_command");
+  });
+
+  test("strips any marker variant, not just commentary", () => {
+    expect(
+      repairHarmonyToolName(
+        "archestra__search_tools<|channel|>analysis",
+        AVAILABLE,
+      ),
+    ).toBe("archestra__search_tools");
+  });
+
+  test("repairs non-archestra MCP tools too", () => {
+    expect(
+      repairHarmonyToolName(
+        "context7__resolve-library-id<|channel|>final",
+        AVAILABLE,
+      ),
+    ).toBe("context7__resolve-library-id");
+  });
+
+  test("returns null for an already-valid name (no marker)", () => {
+    expect(
+      repairHarmonyToolName("archestra__run_command", AVAILABLE),
+    ).toBeNull();
+  });
+
+  test("returns null when the cleaned name is not a registered tool", () => {
+    expect(
+      repairHarmonyToolName(
+        "archestra__ghost_tool<|channel|>commentary",
+        AVAILABLE,
+      ),
+    ).toBeNull();
+  });
+
+  test("returns null when the marker is at the very start (nothing left)", () => {
+    expect(
+      repairHarmonyToolName("<|channel|>commentary", AVAILABLE),
+    ).toBeNull();
+  });
+
+  test("returns null for a genuinely-unknown name without a marker", () => {
+    expect(repairHarmonyToolName("totally_made_up", AVAILABLE)).toBeNull();
+  });
+});

--- a/platform/backend/src/routes/chat/tool-call-repair.test.ts
+++ b/platform/backend/src/routes/chat/tool-call-repair.test.ts
@@ -59,4 +59,11 @@ describe("repairHarmonyToolName", () => {
   test("returns null for a genuinely-unknown name without a marker", () => {
     expect(repairHarmonyToolName("totally_made_up", AVAILABLE)).toBeNull();
   });
+
+  test("does not strip an arbitrary `<|` that is not the harmony channel marker", () => {
+    // a partial/garbage marker must not silently re-map to a different tool.
+    expect(
+      repairHarmonyToolName("archestra__run_command<|garbage", AVAILABLE),
+    ).toBeNull();
+  });
 });

--- a/platform/backend/src/routes/chat/tool-call-repair.ts
+++ b/platform/backend/src/routes/chat/tool-call-repair.ts
@@ -5,9 +5,11 @@
 // NoSuchToolError. This strips the marker so the call can be re-mapped to the
 // tool the model meant.
 
-// Harmony channel markers always open with this sequence, which never appears in
-// a valid tool name. Everything from the first occurrence onward is dropped.
-const HARMONY_MARKER = "<|";
+// The exact harmony channel marker the model leaks into the function-name field
+// (e.g. `...<|channel|>commentary`). Matching the full marker rather than a bare
+// `<|` avoids re-mapping an arbitrary unknown name that merely happens to contain
+// `<|`, which could otherwise execute a different tool than the model named.
+const HARMONY_CHANNEL_MARKER = "<|channel|>";
 
 /**
  * Strip a leaked harmony channel marker from a tool name. Returns the cleaned
@@ -18,12 +20,12 @@ export function repairHarmonyToolName(
   toolName: string,
   availableNames: Iterable<string>,
 ): string | null {
-  const markerIndex = toolName.indexOf(HARMONY_MARKER);
+  const markerIndex = toolName.indexOf(HARMONY_CHANNEL_MARKER);
   if (markerIndex === -1) {
     return null;
   }
   const cleaned = toolName.slice(0, markerIndex).trim();
-  if (cleaned === "" || cleaned === toolName) {
+  if (cleaned === "") {
     return null;
   }
   for (const name of availableNames) {

--- a/platform/backend/src/routes/chat/tool-call-repair.ts
+++ b/platform/backend/src/routes/chat/tool-call-repair.ts
@@ -1,30 +1,35 @@
 // Some models (notably OpenAI harmony-format models served via OpenRouter) leak
-// a reasoning-channel marker into the tool-name field, e.g.
-// `archestra__run_command<|channel|>commentary`. The marker is never part of a
-// real tool name, so the call fails to match any registered tool and surfaces a
-// NoSuchToolError. This strips the marker so the call can be re-mapped to the
-// tool the model meant.
+// a reasoning-channel token into the tool-name field, e.g.
+// `archestra__run_command<|channel|>commentary` or `...<|constrain|>json`. The
+// token is never part of a real tool name, so the call fails to match any
+// registered tool and surfaces a NoSuchToolError. This strips the leaked token
+// so the call can be re-mapped to the tool the model meant.
 
-// The exact harmony channel marker the model leaks into the function-name field
-// (e.g. `...<|channel|>commentary`). Matching the full marker rather than a bare
-// `<|` avoids re-mapping an arbitrary unknown name that merely happens to contain
-// `<|`, which could otherwise execute a different tool than the model named.
-const HARMONY_CHANNEL_MARKER = "<|channel|>";
+// A harmony sentinel token at the leak boundary. The set is the closed harmony
+// special-token vocabulary — matching the exact names (not a generic `<|word|>`)
+// keeps repair from firing on an arbitrary closed sentinel a non-harmony model
+// might emit. The registered-tool exact-match below is the real safety gate; this
+// only narrows what counts as a leak worth repairing. Extend if harmony grows.
+const HARMONY_SENTINEL =
+  /<\|(?:start|end|message|channel|constrain|return|call)\|>/;
 
 /**
- * Strip a leaked harmony channel marker from a tool name. Returns the cleaned
- * name only when it differs from the original AND matches a registered tool;
- * otherwise null (no repair — let the existing not-found path handle it).
+ * Strip a leaked harmony sentinel token from a tool name. Returns the cleaned
+ * name only when a real harmony token is present AND the prefix matches a
+ * registered tool; otherwise null (no repair — let the existing not-found path
+ * handle it).
  */
 export function repairHarmonyToolName(
   toolName: string,
   availableNames: Iterable<string>,
 ): string | null {
-  const markerIndex = toolName.indexOf(HARMONY_CHANNEL_MARKER);
-  if (markerIndex === -1) {
+  const match = HARMONY_SENTINEL.exec(toolName);
+  if (match === null) {
     return null;
   }
-  const cleaned = toolName.slice(0, markerIndex).trim();
+  // Only a suffix leak is expected (`NAME<|…`): a sentinel at index 0 leaves
+  // nothing to map, and the prefix before the first token is the intended name.
+  const cleaned = toolName.slice(0, match.index).trim();
   if (cleaned === "") {
     return null;
   }

--- a/platform/backend/src/routes/chat/tool-call-repair.ts
+++ b/platform/backend/src/routes/chat/tool-call-repair.ts
@@ -1,0 +1,35 @@
+// Some models (notably OpenAI harmony-format models served via OpenRouter) leak
+// a reasoning-channel marker into the tool-name field, e.g.
+// `archestra__run_command<|channel|>commentary`. The marker is never part of a
+// real tool name, so the call fails to match any registered tool and surfaces a
+// NoSuchToolError. This strips the marker so the call can be re-mapped to the
+// tool the model meant.
+
+// Harmony channel markers always open with this sequence, which never appears in
+// a valid tool name. Everything from the first occurrence onward is dropped.
+const HARMONY_MARKER = "<|";
+
+/**
+ * Strip a leaked harmony channel marker from a tool name. Returns the cleaned
+ * name only when it differs from the original AND matches a registered tool;
+ * otherwise null (no repair — let the existing not-found path handle it).
+ */
+export function repairHarmonyToolName(
+  toolName: string,
+  availableNames: Iterable<string>,
+): string | null {
+  const markerIndex = toolName.indexOf(HARMONY_MARKER);
+  if (markerIndex === -1) {
+    return null;
+  }
+  const cleaned = toolName.slice(0, markerIndex).trim();
+  if (cleaned === "" || cleaned === toolName) {
+    return null;
+  }
+  for (const name of availableNames) {
+    if (name === cleaned) {
+      return cleaned;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
Three product-side fixes surfaced by archestra-bench run `20260618_125639`.

## Abortive tool calls (`incomplete_tool_call`)
The platform marks a truncated tool call retryable but nothing retried it, so a single abortive turn killed a whole bench task. The stream probe now holds commit on a lone `tool-input-*` stream and retries (×2) when it ends before a completed `tool-call`, before anything reaches the client. On exhaustion the existing `IncompleteToolCall` error still surfaces. Discarded retry attempts no longer emit `data-token-usage` events.

Trade-off: the tool indicator commits on the completed `tool-call` rather than `tool-input-start`, so it appears after args finish streaming.

## `run_command` `target`
Models routinely guess `{fresh:false}` / `{id:""}` / `{}` meaning "the default sandbox"; these hit a plain-union fallback and were rejected with an opaque `target: Invalid input`. The schema now accepts these shapes and `normalizeTarget` coerces them to the default sandbox. A non-empty malformed `id` still returns a clear error, and id scoping is unchanged.

## Harmony tool-name marker
Some models leak a harmony reasoning-channel token into the tool name (e.g. `archestra__run_command<|channel|>commentary`), which failed to match any tool. `experimental_repairToolCall` strips the leaked token and re-maps to the real tool before it surfaces as a `NoSuchToolError`; covers archestra and external MCP tools.

The token is matched against the closed harmony special-token vocabulary (`<|channel|>`, `<|constrain|>`, `<|call|>`, …), not a generic `<|word|>`, so repair never fires on an arbitrary closed sentinel a non-harmony model might emit. The registered-tool exact-match remains the safety gate: a cleaned name only repairs when it matches a real tool, otherwise the existing not-found path handles it.

## Tests
- `tool-call-repair.test.ts` — token stripping across the vocabulary, first-sentinel-wins, no-op, unclosed/closed-non-harmony, and non-match cases
- `stream-probe.test.ts` — abortive detection (finish and stream-end), completed tool call stays renderable
- `stream-route.test.ts` — abortive retry-then-renderable, bounded retries + commit, no usage leak from a discarded attempt
- `sandbox.test.ts` — `{fresh:false}` / empty id coerce to default, malformed id errors

https://claude.ai/code/session_01UZtzbUjQtwPpGgMrpdcWEi

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
