### PR TITLE
feat(archestra-bench): configurable platform feature flags via env [platform]

### DIFF
--- a/archestra-bench/core/src/lib.rs
+++ b/archestra-bench/core/src/lib.rs
@@ -99,6 +99,8 @@ pub struct RunMeta {
     pub lane: String,
     pub provider: String,
     pub model: String,
+    #[serde(default)]
+    pub tool_exposure_mode: Option<String>,
     pub outcome: String,
     #[serde(default)]
     pub finish_reason: Option<String>,
@@ -255,6 +257,14 @@ mod tests {
         assert!(m.is_pass());
         assert_eq!(m.turn_count, 0);
         assert_eq!(m.rollout_id().to_string(), "e/t__l");
+        // Older run.json predates the flag -> absent field must default to None, not fail to parse.
+        assert_eq!(m.tool_exposure_mode, None);
+
+        let with_flag: RunMeta = serde_json::from_str(
+            r#"{"env_id":"e","task_id":"t","lane":"l","provider":"p","model":"m","outcome":"passed","tool_exposure_mode":"full"}"#,
+        )
+        .unwrap();
+        assert_eq!(with_flag.tool_exposure_mode.as_deref(), Some("full"));
     }
 
     #[test]

--- a/archestra-bench/envs/basic.toml
+++ b/archestra-bench/envs/basic.toml
@@ -7,6 +7,13 @@ tasks = ["pi-gif-zip", "crypto-price", "median-salary", "nitpicker-version", "gi
 # once and let concurrent lanes share it. Sandbox workspaces are per-conversation, so lanes don't clash.
 share_backend = true
 
+# Platform feature flags applied when creating this env's agents. Optional; defaults shown.
+# `tool_exposure_mode`: "search_and_run_only" (model discovers tools via search_tools/run_tool) or
+# "full" (model gets the whole assigned tool list up front). To A/B a flag, flip it and run twice --
+# task ids are globally unique across envs, so the same tasks can't sit in two envs in one run.
+# [platform]
+# tool_exposure_mode = "search_and_run_only"
+
 # All skills from the two public skill libraries, pinned. A broad, realistic skill surface; the agent
 # picks whatever helps (e.g. the document skills for the xlsx task). `cap` unset = import all.
 [[skills]]

--- a/archestra-bench/runner/src/client.rs
+++ b/archestra-bench/runner/src/client.rs
@@ -12,6 +12,8 @@ use serde_json::Value as JsonValue;
 use tokio::sync::Mutex;
 use tokio::time::{Duration, sleep, timeout};
 
+use crate::config::types::ToolExposureMode;
+
 const DEFAULT_CHAT_TIMEOUT_S: f64 = 1800.0;
 
 /// Sampling temperature pinned on every benchmark chat request. Greedy decoding (`0.0`) is the main
@@ -89,7 +91,7 @@ pub struct AgentCreate {
     #[serde(rename = "systemPrompt", skip_serializing_if = "Option::is_none")]
     pub system_prompt: Option<String>,
     #[serde(rename = "toolExposureMode")]
-    pub tool_exposure_mode: String,
+    pub tool_exposure_mode: ToolExposureMode,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1254,6 +1256,36 @@ mod tests {
         assert_eq!(v["serverType"], "remote");
         assert_eq!(v["serverUrl"], "http://127.0.0.1:1/mcp");
         assert!(v.get("server_url").is_none(), "snake_case key leaked");
+    }
+
+    #[test]
+    fn test_agent_create_serializes_tool_exposure_mode_wire_value() {
+        let agent = AgentCreate {
+            name: "a".into(),
+            scope: "org".into(),
+            agent_type: "agent".into(),
+            system_prompt: None,
+            tool_exposure_mode: ToolExposureMode::SearchAndRunOnly,
+        };
+        let v = serde_json::to_value(&agent).unwrap();
+        assert_eq!(v["toolExposureMode"], "search_and_run_only");
+        assert!(
+            v.get("tool_exposure_mode").is_none(),
+            "snake_case key leaked"
+        );
+        assert!(
+            v.get("systemPrompt").is_none(),
+            "empty prompt must be omitted"
+        );
+
+        let full = AgentCreate {
+            tool_exposure_mode: ToolExposureMode::Full,
+            ..agent
+        };
+        assert_eq!(
+            serde_json::to_value(&full).unwrap()["toolExposureMode"],
+            "full"
+        );
     }
 
     #[test]

--- a/archestra-bench/runner/src/config/envs.rs
+++ b/archestra-bench/runner/src/config/envs.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 use std::path::Path;
+use std::str::FromStr;
 
 use super::tasks::TaskConfigError;
 use super::toml_util::{self, TomlTable};
-use super::types::{EnvConfig, Mcp, SkillRef};
+use super::types::{EnvConfig, Mcp, PlatformConfig, SkillRef, ToolExposureMode};
 
 // Empty by default: lanes mimic a regular Archestra user who sets no custom system prompt, so the
 // agent runs on Archestra's stock chat instructions. Submission guidance is appended to the user
@@ -134,6 +135,8 @@ fn load_env(path: &Path, root: &Path) -> Result<EnvConfig, EnvConfigError> {
     )?;
     let share_backend = toml_util::opt_bool(&data, "share_backend", &ctx, false)?;
 
+    let platform = load_platform(&data, &ctx)?;
+
     Ok(EnvConfig {
         id: env_id,
         name,
@@ -144,7 +147,22 @@ fn load_env(path: &Path, root: &Path) -> Result<EnvConfig, EnvConfigError> {
         tasks,
         tools,
         share_backend,
+        platform,
     })
+}
+
+fn load_platform(data: &TomlTable, ctx: &str) -> Result<PlatformConfig, EnvConfigError> {
+    let platform = toml_util::table_with_default(data, "platform", ctx)?;
+    let platform_ctx = format!("{ctx} [platform]");
+    let mode = toml_util::req_str_with_default(
+        &platform,
+        "tool_exposure_mode",
+        &platform_ctx,
+        ToolExposureMode::default().as_str(),
+    )?;
+    let tool_exposure_mode = ToolExposureMode::from_str(&mode)
+        .map_err(|e| EnvConfigError(format!("{platform_ctx}: {e}")))?;
+    Ok(PlatformConfig { tool_exposure_mode })
 }
 
 fn load_skills(data: &TomlTable, ctx: &str) -> Result<Vec<SkillRef>, EnvConfigError> {
@@ -280,6 +298,51 @@ share_backend = {}
         assert!(envs["basic"].share_backend);
         assert!(!envs["api"].share_backend);
         assert_eq!(envs["api"].tools, vec!["create_skill"]);
+    }
+
+    // Write an env that declares task `t1` plus a verbatim `[platform]` fragment, then load it.
+    fn load_env_with_platform(platform_fragment: &str) -> Result<EnvConfig, EnvConfigError> {
+        let tmp = tempfile::tempdir().unwrap();
+        make_task_dir(tmp.path(), "t1");
+        let path = tmp.path().join("e.toml");
+        let content = format!("id = \"e\"\nname = \"e\"\ntasks = [\"t1\"]\n{platform_fragment}");
+        std::fs::write(&path, content).unwrap();
+        load_env(&path, tmp.path())
+    }
+
+    #[test]
+    fn test_platform_defaults_to_search_and_run_only() {
+        let env = load_env_with_platform("").unwrap();
+        assert_eq!(
+            env.platform.tool_exposure_mode,
+            ToolExposureMode::SearchAndRunOnly
+        );
+    }
+
+    #[test]
+    fn test_platform_full_is_parsed() {
+        let env = load_env_with_platform("[platform]\ntool_exposure_mode = \"full\"\n").unwrap();
+        assert_eq!(env.platform.tool_exposure_mode, ToolExposureMode::Full);
+    }
+
+    #[test]
+    fn test_platform_unknown_mode_errors() {
+        let err =
+            load_env_with_platform("[platform]\ntool_exposure_mode = \"nope\"\n").unwrap_err();
+        assert!(err.0.contains("tool_exposure_mode"), "{}", err.0);
+        assert!(err.0.contains("nope"), "{}", err.0);
+    }
+
+    #[test]
+    fn test_platform_non_string_mode_errors() {
+        let err = load_env_with_platform("[platform]\ntool_exposure_mode = 7\n").unwrap_err();
+        assert!(err.0.contains("must be a string"), "{}", err.0);
+    }
+
+    #[test]
+    fn test_platform_non_table_errors() {
+        let err = load_env_with_platform("platform = \"x\"\n").unwrap_err();
+        assert!(err.0.contains("[platform] must be a table"), "{}", err.0);
     }
 
     #[test]

--- a/archestra-bench/runner/src/config/types.rs
+++ b/archestra-bench/runner/src/config/types.rs
@@ -1,4 +1,55 @@
 use std::path::PathBuf;
+use std::str::FromStr;
+
+use serde::Serialize;
+
+/// How the platform exposes an agent's assigned tools to the model. Mirrors the backend's closed
+/// `ToolExposureModeSchema` (platform/backend/src/types/agent.ts:44) -- keep the variants in sync; an
+/// unknown value in an env's `[platform]` block is a loud config error, never a passed-through string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolExposureMode {
+    /// The model gets the entire assigned tool list up front; no meta-tools.
+    Full,
+    /// The model sees only the `search_tools`/`run_tool` meta-tools and discovers its tools at runtime.
+    #[default]
+    SearchAndRunOnly,
+}
+
+impl ToolExposureMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ToolExposureMode::Full => "full",
+            ToolExposureMode::SearchAndRunOnly => "search_and_run_only",
+        }
+    }
+}
+
+impl std::fmt::Display for ToolExposureMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for ToolExposureMode {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "full" => Ok(ToolExposureMode::Full),
+            "search_and_run_only" => Ok(ToolExposureMode::SearchAndRunOnly),
+            other => Err(format!(
+                "unknown tool_exposure_mode {other:?}; expected one of [full, search_and_run_only]"
+            )),
+        }
+    }
+}
+
+/// Platform feature flags applied when creating an env's agents. One typed field per backend flag the
+/// benchmark can toggle; defaults preserve current behavior. Add a flag here + in `AgentCreate`.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct PlatformConfig {
+    pub tool_exposure_mode: ToolExposureMode,
+}
 
 #[derive(Debug, Clone)]
 pub struct SkillRef {
@@ -25,6 +76,7 @@ pub struct EnvConfig {
     pub tasks: Vec<Task>,
     pub tools: Vec<String>,
     pub share_backend: bool,
+    pub platform: PlatformConfig,
 }
 
 #[derive(Debug, Clone)]
@@ -66,5 +118,39 @@ impl Task {
 
     pub fn expected_dir(&self) -> PathBuf {
         self.dir.join("expected")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_exposure_mode_serializes_to_backend_wire_strings() {
+        assert_eq!(
+            serde_json::to_value(ToolExposureMode::Full).unwrap(),
+            serde_json::json!("full")
+        );
+        assert_eq!(
+            serde_json::to_value(ToolExposureMode::SearchAndRunOnly).unwrap(),
+            serde_json::json!("search_and_run_only")
+        );
+    }
+
+    #[test]
+    fn tool_exposure_mode_default_preserves_current_behavior() {
+        assert_eq!(
+            ToolExposureMode::default(),
+            ToolExposureMode::SearchAndRunOnly
+        );
+    }
+
+    #[test]
+    fn tool_exposure_mode_from_str_roundtrips_and_rejects_unknown() {
+        for mode in [ToolExposureMode::Full, ToolExposureMode::SearchAndRunOnly] {
+            assert_eq!(ToolExposureMode::from_str(mode.as_str()).unwrap(), mode);
+        }
+        let err = ToolExposureMode::from_str("nope").unwrap_err();
+        assert!(err.contains("nope"), "{err}");
     }
 }

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -770,6 +770,7 @@ fn infra_results_for_lane(
             "lane": lane.name,
             "provider": lane.provider,
             "model": lane.model,
+            "tool_exposure_mode": env.platform.tool_exposure_mode,
             "outcome": Outcome::AgentError.value(),
             "agent_error": format!("infra: {error}"),
             "finished_at": stamp,
@@ -2540,6 +2541,33 @@ mod tests {
             config["environments"][0]["tool_exposure_mode"],
             "search_and_run_only"
         );
+    }
+
+    #[test]
+    fn infra_failure_run_json_records_tool_exposure_mode() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = RunCtx {
+            root_run_dir: tmp.path().to_path_buf(),
+            run_id: "rid".to_string(),
+            api_keys: std::collections::HashMap::new(),
+            envs_dir: tmp.path().to_path_buf(),
+            update_mcp_lock: false,
+        };
+        let mut env = dummy_env("e", vec![dummy_task("t1")]);
+        env.platform.tool_exposure_mode = crate::config::types::ToolExposureMode::Full;
+        let lane = dummy_lane("l1");
+        let progress = ProgressBar::hidden();
+        // Setup failed before any agent existed -- the env's configured flag must still land in
+        // run.json, since that is where the analyzer reads it (RunMeta).
+        infra_results_for_lane(&env, &env.tasks, &lane, &ctx, &progress, "boom");
+        let run_json = tmp
+            .path()
+            .join(run_subdir("e", "t1", &lane))
+            .join("run.json");
+        let meta: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(run_json).unwrap()).unwrap();
+        assert_eq!(meta["tool_exposure_mode"], "full");
+        assert_eq!(meta["outcome"], Outcome::AgentError.value());
     }
 
     #[tokio::test]

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -17,7 +17,7 @@ use crate::client::{
     AgentCreate, ChatRecordKind, ChatRunResult, ChatStreamRecord, EvalClient, FilePart,
     apply_chat_event,
 };
-use crate::config::types::{EnvConfig, Stage, Task};
+use crate::config::types::{EnvConfig, Stage, Task, ToolExposureMode};
 use crate::config::{Lane, load_envs, load_lanes};
 use crate::lifecycle::Instance;
 use crate::mcp_lock;
@@ -36,9 +36,6 @@ use crate::verify::{VerifyOutcome, run_verifier};
 // lane only ever discovers its own server); isolated lanes own their backend and use the bare name.
 const BENCH_MCP_NAME: &str = "final_answer";
 const SUBMIT_TOOL_SUFFIX: &str = "__submit_result";
-// Agents run in search_and_run_only mode: the model gets the search_tools/run_tool meta tools and
-// discovers its assigned tools dynamically rather than seeing the full list up front.
-const AGENT_TOOL_EXPOSURE_MODE: &str = "search_and_run_only";
 // Appended to every user message. Kept short and tool-agnostic: it nudges submission without naming
 // the search/run meta-tools (Archestra's stock prompt already explains discovery), so a model that
 // solves the task still closes the loop by finding and calling its submit tool instead of replying in
@@ -851,6 +848,7 @@ async fn setup_lane_agent(
         client,
         &format!("{}-{}", env.agent_name, lane.slug()),
         &env.agent_system_prompt,
+        env.platform.tool_exposure_mode,
     )
     .await?;
     let submit_tool =
@@ -862,8 +860,12 @@ async fn ensure_agent(
     client: &EvalClient,
     name: &str,
     system_prompt: &str,
+    tool_exposure_mode: ToolExposureMode,
 ) -> Result<String, RunError> {
     let existing = client.list_agents(Some(name), Some("org")).await?;
+    // Reuse by name is intra-run idempotency only: each run boots a fresh per-run database that
+    // teardown drops (see lifecycle::Instance::start), so no agent created with a different
+    // tool_exposure_mode can survive into a later run with a flipped flag.
     if let Some(agent) = existing
         .iter()
         .find(|a| a.get("name").and_then(|v| v.as_str()) == Some(name))
@@ -880,7 +882,7 @@ async fn ensure_agent(
             scope: "org".to_string(),
             agent_type: "agent".to_string(),
             system_prompt: (!system_prompt.trim().is_empty()).then(|| system_prompt.to_string()),
-            tool_exposure_mode: AGENT_TOOL_EXPOSURE_MODE.to_string(),
+            tool_exposure_mode,
         })
         .await?;
     Ok(created
@@ -1103,6 +1105,7 @@ async fn run_lane(
             &root_run_dir,
             &env.id,
             &env.agent_system_prompt,
+            env.platform.tool_exposure_mode,
             &lane,
             &agent_id,
             &task,
@@ -1123,6 +1126,7 @@ async fn run_one(
     root_run_dir: &Path,
     env_id: &str,
     agent_system_prompt: &str,
+    tool_exposure_mode: ToolExposureMode,
     lane: &Lane,
     agent_id: &str,
     task: &Task,
@@ -1158,6 +1162,7 @@ async fn run_one(
         "lane": lane.name,
         "provider": lane.provider,
         "model": lane.model,
+        "tool_exposure_mode": tool_exposure_mode,
         "model_id": resolved.model_id,
         "chat_api_key_id": resolved.api_key_id,
         "submit_tool": submit_tool,
@@ -2220,6 +2225,7 @@ async fn write_run_config(
                 "id": p.env.id,
                 "tasks": p.tasks.iter().map(|t| &t.id).collect::<Vec<_>>(),
                 "share_backend": p.share_backend(),
+                "tool_exposure_mode": p.env.platform.tool_exposure_mode,
             })
         })
         .collect();
@@ -2364,6 +2370,7 @@ mod tests {
             tasks,
             tools: vec![],
             share_backend: false,
+            platform: crate::config::types::PlatformConfig::default(),
         }
     }
 
@@ -2528,6 +2535,11 @@ mod tests {
             .collect();
         // two envs, but each lane listed exactly once and in declaration order.
         assert_eq!(names, ["l1", "l2"]);
+        // each env records its active tool exposure mode (default here) for reproducibility.
+        assert_eq!(
+            config["environments"][0]["tool_exposure_mode"],
+            "search_and_run_only"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Replaces the hardcoded `AGENT_TOOL_EXPOSURE_MODE` const in the runner with a typed, per-env `[platform]` config block, so the platform `toolExposureMode` flag can be flipped from config and future platform flags drop in with a one-line change.

```toml
# envs/<id>.toml
[platform]
tool_exposure_mode = "full"   # default: "search_and_run_only" (current behavior)
```

## How

- `ToolExposureMode` closed enum + `PlatformConfig` on `EnvConfig` (`runner/src/config/types.rs`), mirroring the existing `Provider` idiom — unknown values are a loud config error, never passed through. Wire strings match `platform/backend/src/types/agent.ts:44`.
- Parsed in `load_env` via the existing `toml_util` helpers; threaded into `AgentCreate` (replacing the const).
- Recorded for reproducibility in each rollout's `run.json` (incl. infra-failure rollouts), the shared `RunMeta` (`core`), and the run `config.json`.
- Defaults preserve current `search_and_run_only` behavior byte-for-byte.

## Compare workflow

Per-env scope: to A/B a flag, flip it and run twice (task ids are globally unique across envs, so the same tasks can't sit in two envs in one run).

## Adding the next flag

Struct field on `PlatformConfig` + one parser line + one `AgentCreate` field (+ optional `RunMeta` field if it should be analyzer-visible).

## Validation

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, full `cargo test` (10 new tests: wire values, default preservation, parse errors incl. non-string/non-table, `RunMeta` back-compat, infra-failure recording).

https://claude.ai/code/session_01RGRVGk4FsSXCJponfM2zFd

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>