### PR TITLE
docs(environments): clarify egress policies apply to self-hosted MCPs only; add Environments subsections to Agents & MCP pages

### DIFF
--- a/docs/pages/platform-agents.md
+++ b/docs/pages/platform-agents.md
@@ -3,7 +3,7 @@ title: Overview
 category: Agents
 order: 1
 description: Agent overview, invocation paths, knowledge sources, and prompt templating
-lastUpdated: 2026-06-03
+lastUpdated: 2026-06-18
 ---
 
 <!--
@@ -58,6 +58,12 @@ Agents can be assigned one or more Knowledge Bases or knowledge connectors. This
 When at least one knowledge source is assigned, Archestra automatically adds the built-in [`query_knowledge_sources`](/docs/platform-archestra-mcp-server#query_knowledge_sources) tool to that agent. The model can call it during a run to search across the assigned sources and pull relevant context into its answer.
 
 See [Knowledge Bases](/docs/platform-knowledge-bases) for how retrieval works and how sources are assigned. See [Archestra MCP Server](/docs/platform-archestra-mcp-server) for the built-in tool behavior and RBAC requirements.
+
+## Environments
+
+An agent can be assigned to an [environment](/docs/platform-private-registry#environments). The agent's code sandbox then runs under that environment's egress network policy — the same machinery that governs self-hosted MCP server pods — so its outbound network access is restricted to what the policy allows. With no environment assigned, the agent uses the default runtime.
+
+See [Network Egress Policies](/docs/platform-private-registry#network-egress-policies) for how policies are configured and which destinations are reachable.
 
 ## Delegation
 

--- a/docs/pages/platform-mcp.md
+++ b/docs/pages/platform-mcp.md
@@ -3,7 +3,7 @@ title: Overview
 category: MCP
 order: -1
 description: How MCP servers, gateways, authentication, and orchestration fit together
-lastUpdated: 2026-05-05
+lastUpdated: 2026-06-18
 ---
 
 <!--
@@ -48,6 +48,12 @@ Self-hosted MCP servers run inside your Kubernetes cluster through the MCP Orche
 Both types can be assigned to Agents and MCP Gateways. The client does not need to know which runtime backs each tool.
 
 Some MCP servers expose resources through `resources/list` instead of callable tools through `tools/list`. When a remote server has resources but no tools, Archestra creates read-resource tools during installation so agents can access those resources through the normal tool assignment flow.
+
+## Environments
+
+A self-hosted MCP server is deployed into an [environment](/docs/platform-private-registry#environments) — a deployment target that controls the Kubernetes namespace it runs in and the egress network policy applied to its pod. Use environments to isolate a sandbox server from production resources or to limit what a server can reach on the network.
+
+Egress policies govern self-hosted servers only. Remote MCP servers run outside Archestra and are reached over HTTP, so an environment's network policy does not apply to them. See [Network Egress Policies](/docs/platform-private-registry#network-egress-policies) for the full model.
 
 ## Authentication Model
 

--- a/docs/pages/platform-private-registry.md
+++ b/docs/pages/platform-private-registry.md
@@ -3,7 +3,7 @@ title: Private MCP Registry
 category: MCP
 order: 2
 description: Managing your organization's MCP servers in a private registry
-lastUpdated: 2026-06-01
+lastUpdated: 2026-06-18
 ---
 
 <!--
@@ -87,6 +87,8 @@ An environment can be marked **restricted**. Only members with the `environment:
 Network egress policies are configured directly on environments. They can disable internet egress, allow all egress, or restrict egress to selected IP/CIDR ranges. Domain presets and custom domains require a supported FQDN policy provider; Kubernetes `NetworkPolicy` alone only enforces IP/CIDR rules.
 
 When an MCP server runs in an environment, Archestra uses the environment's network policy, then the organization default network policy, then the built-in unrestricted policy.
+
+Egress policies apply only to **self-hosted servers**, which run as pods inside your cluster. **Remote servers** run outside Archestra and are reached over HTTP from the Archestra backend, so an environment's egress policy does not govern their network access — a remote server keeps working regardless of the environment it is assigned to. A self-hosted server that needs broad outbound access — for example a browser-automation server that visits arbitrary sites — will fail or time out under a restrictive policy unless its destinations are allowlisted, while a remote server reached over HTTP is unaffected.
 
 | Cluster provider        | IP/CIDR rules                                                         | Domain rules                                                                               |
 | ----------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |


### PR DESCRIPTION
## Why

Someone testing the Environments feature asked whether network egress policies apply to remote MCP servers. They saw the built-in Playwright MCP (self-hosted) time out while a remote MCP worked fine. The docs did not make the self-hosted-vs-remote distinction explicit, and the Environments concept was only documented on the Private MCP Registry page with no entry point from the Agents or MCP overview pages.

## What changed

- **`platform-private-registry.md`** (canonical Environments section): added a paragraph to **Network Egress Policies** stating that egress policies govern **self-hosted** servers (cluster pods) only. **Remote** servers are reached over HTTP from the backend and are unaffected by an environment's policy. Calls out that a self-hosted server needing broad outbound access (e.g. browser automation) will fail/time out under a restrictive policy unless its destinations are allowlisted — which is exactly the Playwright-vs-remote-MCP behavior.
- **`platform-agents.md`**: new lightweight **Environments** subsection — an agent can be assigned to an environment and its code sandbox runs under that environment's egress policy (same machinery as self-hosted MCP pods). Links to the canonical section.
- **`platform-mcp.md`**: new lightweight **Environments** subsection — self-hosted servers deploy into environments (namespace + egress policy); remote servers are not governed by them. Links to the canonical section.