### PR TITLE
fix(llm): abort upstream call on client disconnect

### DIFF
--- a/platform/backend/src/clients/bedrock-client.ts
+++ b/platform/backend/src/clients/bedrock-client.ts
@@ -72,6 +72,7 @@ export class BedrockClient {
   async converse(
     modelId: string,
     request: Record<string, unknown>,
+    signal?: AbortSignal,
   ): Promise<ConverseResponse> {
     const url = this.buildUrl(modelId, "converse");
     const body = JSON.stringify(request);
@@ -86,6 +87,7 @@ export class BedrockClient {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body,
+      signal,
     });
 
     if (!response.ok) {
@@ -114,6 +116,7 @@ export class BedrockClient {
   async converseStream(
     modelId: string,
     request: Record<string, unknown>,
+    signal?: AbortSignal,
   ): Promise<AsyncIterable<BedrockStreamEventWithRaw>> {
     const url = this.buildUrl(modelId, "converse-stream");
     const body = JSON.stringify(request);
@@ -128,6 +131,7 @@ export class BedrockClient {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body,
+      signal,
     });
 
     if (!response.ok) {

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -1222,17 +1222,22 @@ export const anthropicAdapterFactory: LLMProvider<
   async execute(
     client: unknown,
     request: AnthropicRequest,
+    signal?: AbortSignal,
   ): Promise<AnthropicResponse> {
     const anthropicClient = client as AnthropicProvider;
-    return anthropicClient.messages.create({
-      ...request,
-      stream: false,
-    } as AnthropicProvider.Messages.MessageCreateParamsNonStreaming);
+    return anthropicClient.messages.create(
+      {
+        ...request,
+        stream: false,
+      } as AnthropicProvider.Messages.MessageCreateParamsNonStreaming,
+      { signal },
+    );
   },
 
   async executeStream(
     client: unknown,
     request: AnthropicRequest,
+    signal?: AbortSignal,
   ): Promise<AsyncIterable<AnthropicStreamChunk>> {
     const anthropicClient = client as AnthropicProvider;
     // use the raw create() stream rather than the messages.stream() helper: the
@@ -1240,10 +1245,13 @@ export const anthropicAdapterFactory: LLMProvider<
     // throws (unguarded) when a non-conformant upstream emits deltas that
     // concatenate into more than one JSON value. we do our own guarded tool-call
     // accumulation in processChunk, so the raw event stream is all we need.
-    return anthropicClient.messages.create({
-      ...request,
-      stream: true,
-    } as AnthropicProvider.Messages.MessageCreateParamsStreaming);
+    return anthropicClient.messages.create(
+      {
+        ...request,
+        stream: true,
+      } as AnthropicProvider.Messages.MessageCreateParamsStreaming,
+      { signal },
+    );
   },
 
   extractInternalCode(error: unknown): ArchestraInternalErrorCode | undefined {

--- a/platform/backend/src/routes/proxy/adapters/azure-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure-responses.ts
@@ -145,24 +145,30 @@ export const azureResponsesAdapterFactory: LLMProvider<
   async execute(
     client: unknown,
     request: AzureResponsesRequest,
+    signal?: AbortSignal,
   ): Promise<AzureResponsesResponse> {
     const azureClient = client as OpenAIProvider;
 
     return (await azureClient.responses.create(
       request as ResponseCreateParamsNonStreaming,
+      { signal },
     )) as unknown as AzureResponsesResponse;
   },
 
   async executeStream(
     client: unknown,
     request: AzureResponsesRequest,
+    signal?: AbortSignal,
   ): Promise<AsyncIterable<AzureResponsesStreamChunk>> {
     const azureClient = client as OpenAIProvider;
 
-    return (await azureClient.responses.create({
-      ...request,
-      stream: true,
-    } as ResponseCreateParamsStreaming)) as AsyncIterable<AzureResponsesStreamChunk>;
+    return (await azureClient.responses.create(
+      {
+        ...request,
+        stream: true,
+      } as ResponseCreateParamsStreaming,
+      { signal },
+    )) as AsyncIterable<AzureResponsesStreamChunk>;
   },
 
   extractInternalCode(error: unknown): ArchestraInternalErrorCode | undefined {

--- a/platform/backend/src/routes/proxy/adapters/azure.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure.ts
@@ -297,6 +297,7 @@ export const azureAdapterFactory: LLMProvider<
   async execute(
     client: unknown,
     request: AzureRequest,
+    signal?: AbortSignal,
   ): Promise<AzureResponse> {
     const azureClient = getAzureClientForRequest(client, request.model);
     const azureRequest = {
@@ -304,14 +305,15 @@ export const azureAdapterFactory: LLMProvider<
       stream: false,
     } as unknown as ChatCompletionCreateParamsNonStreaming;
 
-    return (await azureClient.chat.completions.create(
-      azureRequest,
-    )) as unknown as AzureResponse;
+    return (await azureClient.chat.completions.create(azureRequest, {
+      signal,
+    })) as unknown as AzureResponse;
   },
 
   async executeStream(
     client: unknown,
     request: AzureRequest,
+    signal?: AbortSignal,
   ): Promise<AsyncIterable<AzureStreamChunk>> {
     const azureClient = getAzureClientForRequest(client, request.model);
     const azureRequest = {
@@ -320,7 +322,9 @@ export const azureAdapterFactory: LLMProvider<
       stream_options: { include_usage: true },
     } as unknown as ChatCompletionCreateParamsStreaming;
 
-    const stream = await azureClient.chat.completions.create(azureRequest);
+    const stream = await azureClient.chat.completions.create(azureRequest, {
+      signal,
+    });
 
     return {
       [Symbol.asyncIterator]: async function* () {

--- a/platform/backend/src/routes/proxy/adapters/bedrock.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.ts
@@ -1706,6 +1706,7 @@ export const bedrockAdapterFactory: LLMProvider<
   async execute(
     client: unknown,
     request: BedrockRequest,
+    signal?: AbortSignal,
   ): Promise<BedrockResponse> {
     const bedrockClient = client as BedrockClient;
     const { commandInput, toolNameMapping } =
@@ -1715,6 +1716,7 @@ export const bedrockAdapterFactory: LLMProvider<
     const response = await bedrockClient.converse(
       request.modelId,
       commandInput,
+      signal,
     );
 
     // Convert response to our internal format with decoded tool names
@@ -1777,12 +1779,13 @@ export const bedrockAdapterFactory: LLMProvider<
   async executeStream(
     client: unknown,
     request: BedrockRequest,
+    signal?: AbortSignal,
   ): Promise<AsyncIterable<BedrockStreamEventWithRaw>> {
     const bedrockClient = client as BedrockClient;
     const { commandInput } = buildBedrockCommandContext(request);
 
     // Use fetch-based client.converseStream() - returns events with __rawBytes already set
-    return bedrockClient.converseStream(request.modelId, commandInput);
+    return bedrockClient.converseStream(request.modelId, commandInput, signal);
   },
 
   extractInternalCode(error: unknown): ArchestraInternalErrorCode | undefined {

--- a/platform/backend/src/routes/proxy/adapters/cerebras.ts
+++ b/platform/backend/src/routes/proxy/adapters/cerebras.ts
@@ -1119,20 +1119,22 @@ export const cerebrasAdapterFactory: LLMProvider<
   async execute(
     client: unknown,
     request: CerebrasRequest,
+    signal?: AbortSignal,
   ): Promise<CerebrasResponse> {
     const cerebrasClient = client as OpenAIProvider;
     const cerebrasRequest = {
       ...request,
       stream: false,
     } as unknown as ChatCompletionCreateParamsNonStreaming;
-    return cerebrasClient.chat.completions.create(
-      cerebrasRequest,
-    ) as Promise<CerebrasResponse>;
+    return cerebrasClient.chat.completions.create(cerebrasRequest, {
+      signal,
+    }) as Promise<CerebrasResponse>;
   },
 
   async executeStream(
     client: unknown,
     request: CerebrasRequest,
+    signal?: AbortSignal,
   ): Promise<AsyncIterable<CerebrasStreamChunk>> {
     const cerebrasClient = client as OpenAIProvider;
     const cerebrasRequest = {
@@ -1140,8 +1142,10 @@ export const cerebrasAdapterFactory: LLMProvider<
       stream: true,
       stream_options: { include_usage: true },
     } as unknown as ChatCompletionCreateParamsStreaming;
-    const stream =
-      await cerebrasClient.chat.completions.create(cerebrasRequest);
+    const stream = await cerebrasClient.chat.completions.create(
+      cerebrasRequest,
+      { signal },
+    );
 
     return {
       [Symbol.asyncIterator]: async function* () {

--- a/platform/backend/src/routes/proxy/adapters/cohere.ts
+++ b/platform/backend/src/routes/proxy/adapters/cohere.ts
@@ -815,8 +815,14 @@ export async function convertToolResultsToToon(
 
 interface CohereClient {
   chat: {
-    create: (request: CohereRequest) => Promise<CohereResponse>;
-    stream: (request: CohereRequest) => AsyncIterable<CohereStreamChunk>;
+    create: (
+      request: CohereRequest,
+      signal?: AbortSignal,
+    ) => Promise<CohereResponse>;
+    stream: (
+      request: CohereRequest,
+      signal?: AbortSignal,
+    ) => AsyncIterable<CohereStreamChunk>;
   };
 }
 
@@ -837,7 +843,10 @@ function createCohereClient(
 
   return {
     chat: {
-      create: async (request: CohereRequest): Promise<CohereResponse> => {
+      create: async (
+        request: CohereRequest,
+        signal?: AbortSignal,
+      ): Promise<CohereResponse> => {
         const response = await observableFetch(`${baseUrl}/v2/chat`, {
           method: "POST",
           headers: {
@@ -846,6 +855,7 @@ function createCohereClient(
             ...options.defaultHeaders,
           },
           body: JSON.stringify({ ...request, stream: false }),
+          signal,
         });
 
         if (!response.ok) {
@@ -859,6 +869,7 @@ function createCohereClient(
       },
       stream: async function* (
         request: CohereRequest,
+        signal?: AbortSignal,
       ): AsyncIterable<CohereStreamChunk> {
         const response = await observableFetch(`${baseUrl}/v2/chat`, {
           method: "POST",
@@ -868,6 +879,7 @@ function createCohereClient(
             ...options.defaultHeaders,
           },
           body: JSON.stringify({ ...request, stream: true }),
+          signal,
         });
 
         if (!response.ok) {
@@ -981,8 +993,12 @@ export const cohereAdapterFactory: LLMProvider<
     return new CohereStreamAdapter();
   },
 
-  async execute(client: CohereClient, request: CohereRequest) {
-    const response = await client.chat.create(request);
+  async execute(
+    client: CohereClient,
+    request: CohereRequest,
+    signal?: AbortSignal,
+  ) {
+    const response = await client.chat.create(request, signal);
     logger.debug({ response }, "Cohere raw response");
     if (!response) {
       throw new Error("'Cohere's API has returned an undefined response.");
@@ -990,8 +1006,12 @@ export const cohereAdapterFactory: LLMProvider<
     return response;
   },
 
-  async executeStream(client: CohereClient, request: CohereRequest) {
-    return client.chat.stream(request);
+  async executeStream(
+    client: CohereClient,
+    request: CohereRequest,
+    signal?: AbortSignal,
+  ) {
+    return client.chat.stream(request, signal);
   },
 
   extractErrorMessage,

--- a/platform/backend/src/routes/proxy/adapters/execute-signal.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/execute-signal.test.ts
@@ -1,0 +1,154 @@
+import { vi } from "vitest";
+import { describe, expect, test } from "@/test";
+import { anthropicAdapterFactory } from "./anthropic";
+import { cohereAdapterFactory } from "./cohere";
+import { geminiAdapterFactory } from "./gemini";
+import { openaiAdapterFactory } from "./openai";
+import { openAiResponsesAdapterFactory } from "./openai-responses";
+
+/**
+ * Each LLM adapter's `execute`/`executeStream` must forward the `AbortSignal`
+ * threaded by the proxy handler (commit `fix(llm): abort upstream call on
+ * client disconnect`) down to the underlying SDK / fetch call — otherwise an
+ * inbound disconnect can't cancel the upstream request. The 20+ providers
+ * collapse into a handful of call-shapes; we cover one representative of each.
+ */
+
+// An async iterable that yields nothing — stand-in for an SDK stream so the
+// wrapping `for await` in executeStream completes immediately.
+function emptyStream(): AsyncIterable<unknown> {
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        next: async () => ({ done: true, value: undefined }),
+      };
+    },
+  };
+}
+
+describe("adapter execute/executeStream forward the AbortSignal", () => {
+  test("OpenAI SDK chat shape (openai) forwards signal via request options", async () => {
+    const signal = new AbortController().signal;
+    const create = vi
+      .fn()
+      .mockResolvedValueOnce({ id: "resp" }) // execute
+      .mockResolvedValueOnce(emptyStream()); // executeStream
+    const client = { chat: { completions: { create } } };
+
+    await openaiAdapterFactory.execute(
+      client,
+      { model: "gpt-4o", messages: [] } as never,
+      signal,
+    );
+    expect(create.mock.calls[0][1]).toEqual({ signal });
+
+    await openaiAdapterFactory.executeStream(
+      client,
+      { model: "gpt-4o", messages: [] } as never,
+      signal,
+    );
+    expect(create.mock.calls[1][1]).toEqual({ signal });
+  });
+
+  test("Responses API shape (openai-responses) forwards signal via request options", async () => {
+    const signal = new AbortController().signal;
+    const create = vi
+      .fn()
+      .mockResolvedValueOnce({ id: "resp" })
+      .mockResolvedValueOnce(emptyStream());
+    const client = { responses: { create } };
+
+    await openAiResponsesAdapterFactory.execute(
+      client,
+      { model: "gpt-4o", input: [] } as never,
+      signal,
+    );
+    expect(create.mock.calls[0][1]).toEqual({ signal });
+
+    await openAiResponsesAdapterFactory.executeStream(
+      client,
+      { model: "gpt-4o", input: [] } as never,
+      signal,
+    );
+    expect(create.mock.calls[1][1]).toEqual({ signal });
+  });
+
+  test("Anthropic SDK shape forwards signal via request options", async () => {
+    const signal = new AbortController().signal;
+    const create = vi
+      .fn()
+      .mockResolvedValueOnce({ content: [] })
+      .mockResolvedValueOnce(emptyStream());
+    const client = { messages: { create } };
+
+    await anthropicAdapterFactory.execute(
+      client,
+      { model: "claude-3-5-sonnet-20241022", messages: [], max_tokens: 16 },
+      signal,
+    );
+    expect(create.mock.calls[0][1]).toEqual({ signal });
+
+    await anthropicAdapterFactory.executeStream(
+      client,
+      { model: "claude-3-5-sonnet-20241022", messages: [], max_tokens: 16 },
+      signal,
+    );
+    expect(create.mock.calls[1][1]).toEqual({ signal });
+  });
+
+  test("Gemini SDK shape forwards signal via config.abortSignal", async () => {
+    const signal = new AbortController().signal;
+    const sdkResponse = {
+      candidates: [
+        { content: { role: "model", parts: [{ text: "hi" }] }, index: 0 },
+      ],
+      usageMetadata: {
+        promptTokenCount: 1,
+        candidatesTokenCount: 1,
+        totalTokenCount: 2,
+      },
+      modelVersion: "gemini-2.5-pro",
+      responseId: "r",
+    };
+    const generateContent = vi.fn().mockResolvedValue(sdkResponse);
+    const generateContentStream = vi.fn().mockResolvedValue(emptyStream());
+    const client = { models: { generateContent, generateContentStream } };
+    const request = {
+      contents: [],
+      _model: "gemini-2.5-pro",
+      _isStreaming: false,
+    } as never;
+
+    await geminiAdapterFactory.execute(client, request, signal);
+    expect(generateContent.mock.calls[0][0].config.abortSignal).toBe(signal);
+
+    await geminiAdapterFactory.executeStream(client, request, signal);
+    expect(generateContentStream.mock.calls[0][0].config.abortSignal).toBe(
+      signal,
+    );
+  });
+
+  test("raw-fetch shape (cohere) forwards signal to fetch", async () => {
+    const signal = new AbortController().signal;
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ id: "c" })));
+
+    // No `agent` option => the client uses the global fetch directly (no
+    // observability wrapper), so the spy sees the call.
+    const client = cohereAdapterFactory.createClient("test-key", {
+      source: "api",
+    });
+
+    try {
+      await cohereAdapterFactory.execute(
+        client,
+        { model: "command-r", messages: [] } as never,
+        signal,
+      );
+      expect(fetchSpy.mock.calls[0][1]?.signal).toBe(signal);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/gemini.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini.ts
@@ -1390,6 +1390,7 @@ export const geminiAdapterFactory: LLMProvider<
   async execute(
     client: unknown,
     request: GeminiRequestWithModel,
+    signal?: AbortSignal,
   ): Promise<GeminiResponse> {
     const genAI = client as GoogleGenAI;
     const model = request._model ?? "gemini-2.5-pro";
@@ -1406,11 +1407,12 @@ export const geminiAdapterFactory: LLMProvider<
       { ...request, contents: request.contents || [] },
       model,
       tools,
-    );
+    ) as GenerateContentParameters;
 
-    const response = await genAI.models.generateContent(
-      sdkParams as GenerateContentParameters,
-    );
+    const response = await genAI.models.generateContent({
+      ...sdkParams,
+      config: { ...sdkParams.config, abortSignal: signal },
+    });
 
     // Convert SDK response to REST format
     return sdkResponseToRestResponse(response, model);
@@ -1419,6 +1421,7 @@ export const geminiAdapterFactory: LLMProvider<
   async executeStream(
     client: unknown,
     request: GeminiRequestWithModel,
+    signal?: AbortSignal,
   ): Promise<AsyncIterable<GeminiStreamChunk>> {
     const genAI = client as GoogleGenAI;
     const model = request._model ?? "gemini-2.5-pro";
@@ -1435,11 +1438,12 @@ export const geminiAdapterFactory: LLMProvider<
       { ...request, contents: request.contents || [] },
       model,
       tools,
-    );
+    ) as GenerateContentParameters;
 
-    const streamingResponse = await genAI.models.generateContentStream(
-      sdkParams as GenerateContentParameters,
-    );
+    const streamingResponse = await genAI.models.generateContentStream({
+      ...sdkParams,
+      config: { ...sdkParams.config, abortSignal: signal },
+    });
 
     // Return async iterable that yields stream chunks
     return {

--- a/platform/backend/src/routes/proxy/adapters/groq.ts
+++ b/platform/backend/src/routes/proxy/adapters/groq.ts
@@ -236,21 +236,26 @@ export const groqAdapterFactory: LLMProvider<
     });
   },
 
-  async execute(client: unknown, request: GroqRequest): Promise<GroqResponse> {
+  async execute(
+    client: unknown,
+    request: GroqRequest,
+    signal?: AbortSignal,
+  ): Promise<GroqResponse> {
     const groqClient = client as OpenAIProvider;
     const groqRequest = {
       ...request,
       stream: false,
     } as unknown as ChatCompletionCreateParamsNonStreaming;
 
-    return (await groqClient.chat.completions.create(
-      groqRequest,
-    )) as unknown as GroqResponse;
+    return (await groqClient.chat.completions.create(groqRequest, {
+      signal,
+    })) as unknown as GroqResponse;
   },
 
   async executeStream(
     client: unknown,
     request: GroqRequest,
+    signal?: AbortSignal,
   ): Promise<AsyncIterable<GroqStreamChunk>> {
     const groqClient = client as OpenAIProvider;
     const groqRequest = {
@@ -259,7 +264,9 @@ export const groqAdapterFactory: LLMProvider<
       stream_options: { include_usage: true },
     } as unknown as ChatCompletionCreateParamsStreaming;
 
-    const stream = await groqClient.chat.completions.create(groqRequest);
+    const stream = await groqClient.chat.completions.create(groqRequest, {
+      signal,
+    });
 
     return {
       [Symbol.asyncIterator]: async function* () {

--- a/platform/backend/src/routes/proxy/adapters/minimax.ts
+++ b/platform/backend/src/routes/proxy/adapters/minimax.ts
@@ -59,7 +59,10 @@ class MinimaxClient {
     this.customFetch = customFetch;
   }
 
-  async chatCompletions(request: MinimaxRequest): Promise<MinimaxResponse> {
+  async chatCompletions(
+    request: MinimaxRequest,
+    signal?: AbortSignal,
+  ): Promise<MinimaxResponse> {
     const fetchFn = this.customFetch || fetch;
     const response = await fetchFn(`${this.baseURL}/chat/completions`, {
       method: "POST",
@@ -71,6 +74,7 @@ class MinimaxClient {
         ...request,
         stream: false,
       }),
+      signal,
     });
 
     if (!response.ok) {
@@ -96,6 +100,7 @@ class MinimaxClient {
 
   async chatCompletionsStream(
     request: MinimaxRequest,
+    signal?: AbortSignal,
   ): Promise<AsyncIterable<MinimaxStreamChunk>> {
     const fetchFn = this.customFetch || fetch;
     const response = await fetchFn(`${this.baseURL}/chat/completions`, {
@@ -108,6 +113,7 @@ class MinimaxClient {
         ...request,
         stream: true,
       }),
+      signal,
     });
 
     if (!response.ok) {
@@ -1082,23 +1088,31 @@ export const minimaxAdapterFactory: LLMProvider<
   async execute(
     client: unknown,
     request: MinimaxRequest,
+    signal?: AbortSignal,
   ): Promise<MinimaxResponse> {
     const minimaxClient = client as MinimaxClient;
-    return minimaxClient.chatCompletions({
-      ...request,
-      stream: false,
-    });
+    return minimaxClient.chatCompletions(
+      {
+        ...request,
+        stream: false,
+      },
+      signal,
+    );
   },
 
   async executeStream(
     client: unknown,
     request: MinimaxRequest,
+    signal?: AbortSignal,
   ): Promise<AsyncIterable<MinimaxStreamChunk>> {
     const minimaxClient = client as MinimaxClient;
-    return minimaxClient.chatCompletionsStream({
-      ...request,
-      stream: true,
-    });
+    return minimaxClient.chatCompletionsStream(
+      {
+        ...request,
+        stream: true,
+      },
+      signal,
+    );
   },
 
   extractInternalCode(error: unknown): ArchestraInternalErrorCode | undefined {

--- a/platform/backend/src/routes/proxy/adapters/mistral.ts
+++ b/platform/backend/src/routes/proxy/adapters/mistral.ts
@@ -248,6 +248,7 @@ export const mistralAdapterFactory: LLMProvider<
   async execute(
     client: unknown,
     request: MistralRequest,
+    signal?: AbortSignal,
   ): Promise<MistralResponse> {
     const mistralClient = client as OpenAIProvider;
     const mistralRequest = {
@@ -255,14 +256,15 @@ export const mistralAdapterFactory: LLMProvider<
       stream: false,
     } as unknown as ChatCompletionCreateParamsNonStreaming;
     // Cast through unknown because MistralResponse uses .passthrough() which adds index signature
-    return mistralClient.chat.completions.create(
-      mistralRequest,
-    ) as unknown as Promise<MistralResponse>;
+    return mistralClient.chat.completions.create(mistralRequest, {
+      signal,
+    }) as unknown as Promise<MistralResponse>;
   },
 
   async executeStream(
     client: unknown,
     request: MistralRequest,
+    signal?: AbortSignal,
   ): Promise<AsyncIterable<MistralStreamChunk>> {
     const mistralClient = client as OpenAIProvider;
     const mistralRequest = {
@@ -270,7 +272,9 @@ export const mistralAdapterFactory: LLMProvider<
       stream: true,
       stream_options: { include_usage: true },
     } as unknown as ChatCompletionCreateParamsStreaming;
-    const stream = await mistralClient.chat.completions.create(mistralRequest);
+    const stream = await mistralClient.chat.completions.create(mistralRequest, {
+      signal,
+    });
 
     return {
       [Symbol.asyncIterator]: async function* () {

--- a/platform/backend/src/routes/proxy/adapters/ollama.ts
+++ b/platform/backend/src/routes/proxy/adapters/ollama.ts
@@ -1173,20 +1173,22 @@ export const ollamaAdapterFactory: LLMProvider<
   async execute(
     client: unknown,
     request: OllamaRequest,
+    signal?: AbortSignal,
   ): Promise<OllamaResponse> {
     const ollamaClient = client as OpenAIProvider;
     const ollamaRequest = {
       ...request,
       stream: false,
     } as unknown as ChatCompletionCreateParamsNonStreaming;
-    return ollamaClient.chat.completions.create(
-      ollamaRequest,
-    ) as Promise<OllamaResponse>;
+    return ollamaClient.chat.completions.create(ollamaRequest, {
+      signal,
+    }) as Promise<OllamaResponse>;
   },
 
   async executeStream(
     client: unknown,
     request: OllamaRequest,
+    signal?: AbortSignal,
   ): Promise<AsyncIterable<OllamaStreamChunk>> {
     const ollamaClient = client as OpenAIProvider;
     const ollamaRequest = {
@@ -1195,7 +1197,9 @@ export const ollamaAdapterFactory: LLMProvider<
       stream_options: { include_usage: true },
     } as unknown as ChatCompletionCreateParamsStreaming;
 
-    const stream = await ollamaClient.chat.completions.create(ollamaRequest);
+    const stream = await ollamaClient.chat.completions.create(ollamaRequest, {
+      signal,
+    });
 
     return {
       [Symbol.asyncIterator]: async function* () {

--- a/platform/backend/src/routes/proxy/adapters/openai-compatible-adapter.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-compatible-adapter.ts
@@ -83,20 +83,25 @@ export function createOpenAiCompatibleAdapterFactory(
 
     createClient,
 
-    async execute(client: unknown, request: Request): Promise<Response> {
+    async execute(
+      client: unknown,
+      request: Request,
+      signal?: AbortSignal,
+    ): Promise<Response> {
       const openaiClient = client as OpenAIProvider;
       const params = {
         ...request,
         stream: false,
       } as unknown as ChatCompletionCreateParamsNonStreaming;
-      return openaiClient.chat.completions.create(
-        params,
-      ) as unknown as Promise<Response>;
+      return openaiClient.chat.completions.create(params, {
+        signal,
+      }) as unknown as Promise<Response>;
     },
 
     async executeStream(
       client: unknown,
       request: Request,
+      signal?: AbortSignal,
     ): Promise<AsyncIterable<StreamChunk>> {
       const openaiClient = client as OpenAIProvider;
       const params = {
@@ -104,7 +109,9 @@ export function createOpenAiCompatibleAdapterFactory(
         stream: true,
         stream_options: { include_usage: true },
       } as unknown as ChatCompletionCreateParamsStreaming;
-      const stream = await openaiClient.chat.completions.create(params);
+      const stream = await openaiClient.chat.completions.create(params, {
+        signal,
+      });
 
       return {
         [Symbol.asyncIterator]: async function* () {

--- a/platform/backend/src/routes/proxy/adapters/openai-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-responses.ts
@@ -111,24 +111,30 @@ export const openAiResponsesAdapterFactory: LLMProvider<
   async execute(
     client: unknown,
     request: OpenAiResponsesRequest,
+    signal?: AbortSignal,
   ): Promise<OpenAiResponsesResponse> {
     const openaiClient = client as OpenAIProvider;
 
     return (await openaiClient.responses.create(
       request as ResponseCreateParamsNonStreaming,
+      { signal },
     )) as unknown as OpenAiResponsesResponse;
   },
 
   async executeStream(
     client: unknown,
     request: OpenAiResponsesRequest,
+    signal?: AbortSignal,
   ): Promise<AsyncIterable<OpenAiResponsesStreamChunk>> {
     const openaiClient = client as OpenAIProvider;
 
-    return (await openaiClient.responses.create({
-      ...request,
-      stream: true,
-    } as ResponseCreateParamsStreaming)) as AsyncIterable<OpenAiResponsesStreamChunk>;
+    return (await openaiClient.responses.create(
+      {
+        ...request,
+        stream: true,
+      } as ResponseCreateParamsStreaming,
+      { signal },
+    )) as AsyncIterable<OpenAiResponsesStreamChunk>;
   },
 
   extractInternalCode(error: unknown): ArchestraInternalErrorCode | undefined {

--- a/platform/backend/src/routes/proxy/adapters/openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai.ts
@@ -1493,20 +1493,22 @@ export const openaiAdapterFactory: LLMProvider<
   async execute(
     client: unknown,
     request: OpenAiRequest,
+    signal?: AbortSignal,
   ): Promise<OpenAiResponse> {
     const openaiClient = client as OpenAIProvider;
     const openaiRequest = {
       ...request,
       stream: false,
     } as unknown as ChatCompletionCreateParamsNonStreaming;
-    return openaiClient.chat.completions.create(
-      openaiRequest,
-    ) as Promise<OpenAiResponse>;
+    return openaiClient.chat.completions.create(openaiRequest, {
+      signal,
+    }) as Promise<OpenAiResponse>;
   },
 
   async executeStream(
     client: unknown,
     request: OpenAiRequest,
+    signal?: AbortSignal,
   ): Promise<AsyncIterable<OpenAiStreamChunk>> {
     const openaiClient = client as OpenAIProvider;
     const openaiRequest = {
@@ -1514,7 +1516,9 @@ export const openaiAdapterFactory: LLMProvider<
       stream: true,
       stream_options: { include_usage: true },
     } as unknown as ChatCompletionCreateParamsStreaming;
-    const stream = await openaiClient.chat.completions.create(openaiRequest);
+    const stream = await openaiClient.chat.completions.create(openaiRequest, {
+      signal,
+    });
 
     return {
       [Symbol.asyncIterator]: async function* () {

--- a/platform/backend/src/routes/proxy/adapters/openrouter.ts
+++ b/platform/backend/src/routes/proxy/adapters/openrouter.ts
@@ -262,6 +262,7 @@ export const openrouterAdapterFactory: LLMProvider<
   async execute(
     client: unknown,
     request: OpenrouterRequest,
+    signal?: AbortSignal,
   ): Promise<OpenrouterResponse> {
     const openrouterClient = client as OpenAIProvider;
     const openrouterRequest = {
@@ -269,14 +270,15 @@ export const openrouterAdapterFactory: LLMProvider<
       stream: false,
     } as unknown as ChatCompletionCreateParamsNonStreaming;
 
-    return (await openrouterClient.chat.completions.create(
-      openrouterRequest,
-    )) as unknown as OpenrouterResponse;
+    return (await openrouterClient.chat.completions.create(openrouterRequest, {
+      signal,
+    })) as unknown as OpenrouterResponse;
   },
 
   async executeStream(
     client: unknown,
     request: OpenrouterRequest,
+    signal?: AbortSignal,
   ): Promise<AsyncIterable<OpenrouterStreamChunk>> {
     const openrouterClient = client as OpenAIProvider;
     const openrouterRequest = {
@@ -285,8 +287,10 @@ export const openrouterAdapterFactory: LLMProvider<
       stream_options: { include_usage: true },
     } as unknown as ChatCompletionCreateParamsStreaming;
 
-    const stream =
-      await openrouterClient.chat.completions.create(openrouterRequest);
+    const stream = await openrouterClient.chat.completions.create(
+      openrouterRequest,
+      { signal },
+    );
 
     return {
       [Symbol.asyncIterator]: async function* () {

--- a/platform/backend/src/routes/proxy/adapters/perplexity.ts
+++ b/platform/backend/src/routes/proxy/adapters/perplexity.ts
@@ -496,20 +496,24 @@ export const perplexityAdapterFactory: LLMProvider<
   async execute(
     client: unknown,
     request: PerplexityRequest,
+    signal?: AbortSignal,
   ): Promise<PerplexityResponse> {
     const perplexityClient = client as OpenAIProvider;
     const perplexityRequest = {
       ...request,
       stream: false,
     } as unknown as ChatCompletionCreateParamsNonStreaming;
-    const response =
-      await perplexityClient.chat.completions.create(perplexityRequest);
+    const response = await perplexityClient.chat.completions.create(
+      perplexityRequest,
+      { signal },
+    );
     return response as unknown as PerplexityResponse;
   },
 
   async executeStream(
     client: unknown,
     request: PerplexityRequest,
+    signal?: AbortSignal,
   ): Promise<AsyncIterable<PerplexityStreamChunk>> {
     const perplexityClient = client as OpenAIProvider;
     const perplexityRequest = {
@@ -517,8 +521,10 @@ export const perplexityAdapterFactory: LLMProvider<
       stream: true,
       stream_options: { include_usage: true },
     } as unknown as ChatCompletionCreateParamsStreaming;
-    const stream =
-      await perplexityClient.chat.completions.create(perplexityRequest);
+    const stream = await perplexityClient.chat.completions.create(
+      perplexityRequest,
+      { signal },
+    );
 
     return {
       [Symbol.asyncIterator]: async function* () {

--- a/platform/backend/src/routes/proxy/adapters/vllm.ts
+++ b/platform/backend/src/routes/proxy/adapters/vllm.ts
@@ -1170,20 +1170,25 @@ export const vllmAdapterFactory: LLMProvider<
     });
   },
 
-  async execute(client: unknown, request: VllmRequest): Promise<VllmResponse> {
+  async execute(
+    client: unknown,
+    request: VllmRequest,
+    signal?: AbortSignal,
+  ): Promise<VllmResponse> {
     const vllmClient = client as OpenAIProvider;
     const vllmRequest = {
       ...request,
       stream: false,
     } as unknown as ChatCompletionCreateParamsNonStreaming;
-    return vllmClient.chat.completions.create(
-      vllmRequest,
-    ) as Promise<VllmResponse>;
+    return vllmClient.chat.completions.create(vllmRequest, {
+      signal,
+    }) as Promise<VllmResponse>;
   },
 
   async executeStream(
     client: unknown,
     request: VllmRequest,
+    signal?: AbortSignal,
   ): Promise<AsyncIterable<VllmStreamChunk>> {
     const vllmClient = client as OpenAIProvider;
     const vllmRequest = {
@@ -1191,7 +1196,9 @@ export const vllmAdapterFactory: LLMProvider<
       stream: true,
       stream_options: { include_usage: true },
     } as unknown as ChatCompletionCreateParamsStreaming;
-    const stream = await vllmClient.chat.completions.create(vllmRequest);
+    const stream = await vllmClient.chat.completions.create(vllmRequest, {
+      signal,
+    });
 
     return {
       [Symbol.asyncIterator]: async function* () {

--- a/platform/backend/src/routes/proxy/adapters/xai.ts
+++ b/platform/backend/src/routes/proxy/adapters/xai.ts
@@ -234,21 +234,26 @@ export const xaiAdapterFactory: LLMProvider<
     });
   },
 
-  async execute(client: unknown, request: XaiRequest): Promise<XaiResponse> {
+  async execute(
+    client: unknown,
+    request: XaiRequest,
+    signal?: AbortSignal,
+  ): Promise<XaiResponse> {
     const xaiClient = client as OpenAIProvider;
     const xaiRequest = {
       ...request,
       stream: false,
     } as unknown as ChatCompletionCreateParamsNonStreaming;
 
-    return (await xaiClient.chat.completions.create(
-      xaiRequest,
-    )) as unknown as XaiResponse;
+    return (await xaiClient.chat.completions.create(xaiRequest, {
+      signal,
+    })) as unknown as XaiResponse;
   },
 
   async executeStream(
     client: unknown,
     request: XaiRequest,
+    signal?: AbortSignal,
   ): Promise<AsyncIterable<XaiStreamChunk>> {
     const xaiClient = client as OpenAIProvider;
     const xaiRequest = {
@@ -257,7 +262,9 @@ export const xaiAdapterFactory: LLMProvider<
       stream_options: { include_usage: true },
     } as unknown as ChatCompletionCreateParamsStreaming;
 
-    const stream = await xaiClient.chat.completions.create(xaiRequest);
+    const stream = await xaiClient.chat.completions.create(xaiRequest, {
+      signal,
+    });
 
     return {
       [Symbol.asyncIterator]: async function* () {

--- a/platform/backend/src/routes/proxy/adapters/zhipuai.ts
+++ b/platform/backend/src/routes/proxy/adapters/zhipuai.ts
@@ -57,7 +57,10 @@ class ZhipuaiClient {
     this.customFetch = customFetch;
   }
 
-  async chatCompletions(request: ZhipuaiRequest): Promise<ZhipuaiResponse> {
+  async chatCompletions(
+    request: ZhipuaiRequest,
+    signal?: AbortSignal,
+  ): Promise<ZhipuaiResponse> {
     const fetchFn = this.customFetch || fetch;
     const response = await fetchFn(`${this.baseURL}/chat/completions`, {
       method: "POST",
@@ -69,6 +72,7 @@ class ZhipuaiClient {
         ...request,
         stream: false,
       }),
+      signal,
     });
 
     if (!response.ok) {
@@ -101,6 +105,7 @@ class ZhipuaiClient {
 
   async chatCompletionsStream(
     request: ZhipuaiRequest,
+    signal?: AbortSignal,
   ): Promise<AsyncIterable<ZhipuaiStreamChunk>> {
     const fetchFn = this.customFetch || fetch;
     const response = await fetchFn(`${this.baseURL}/chat/completions`, {
@@ -113,6 +118,7 @@ class ZhipuaiClient {
         ...request,
         stream: true,
       }),
+      signal,
     });
 
     if (!response.ok) {
@@ -1013,17 +1019,19 @@ export const zhipuaiAdapterFactory: LLMProvider<
   async execute(
     client: unknown,
     request: ZhipuaiRequest,
+    signal?: AbortSignal,
   ): Promise<ZhipuaiResponse> {
     const zhipuaiClient = client as ZhipuaiClient;
-    return zhipuaiClient.chatCompletions(request);
+    return zhipuaiClient.chatCompletions(request, signal);
   },
 
   async executeStream(
     client: unknown,
     request: ZhipuaiRequest,
+    signal?: AbortSignal,
   ): Promise<AsyncIterable<ZhipuaiStreamChunk>> {
     const zhipuaiClient = client as ZhipuaiClient;
-    return zhipuaiClient.chatCompletionsStream(request);
+    return zhipuaiClient.chatCompletionsStream(request, signal);
   },
 
   extractInternalCode(error: unknown): ArchestraInternalErrorCode | undefined {

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -78,6 +78,7 @@ import {
   virtualKeyRateLimiter,
 } from "./llm-proxy-auth";
 import {
+  abortUpstreamOnClientDisconnect,
   buildInteractionRecord,
   calculateInteractionCosts,
   handleError,
@@ -1006,6 +1007,12 @@ async function handleStreaming<
     `[${providerName}Proxy] Starting streaming request`,
   );
 
+  const [upstreamAbortSignal, unsubscribeFromClientDisconnect] =
+    abortUpstreamOnClientDisconnect(
+      reply,
+      () => streamCompleted || reply.raw.writableFinished,
+    );
+
   try {
     // Execute streaming request with tracing — the span covers the full streaming
     // operation (request → all chunks consumed) so we can set response attributes
@@ -1030,7 +1037,11 @@ async function handleStreaming<
       parentContext,
       user: toSpanUserInfo(resolvedUser),
       callback: async (llmSpan) => {
-        const stream = await provider.executeStream(client, request);
+        const stream = await provider.executeStream(
+          client,
+          request,
+          upstreamAbortSignal,
+        );
 
         // Process chunks
         // Per-tool buffer/stream decisions: only "Allow always" tools stream immediately.
@@ -1290,6 +1301,8 @@ async function handleStreaming<
       provider.extractInternalCode.bind(provider),
     );
   } finally {
+    unsubscribeFromClientDisconnect();
+
     // Always record interaction (whether stream completed or was aborted)
     if (!streamCompleted) {
       logger.info(
@@ -1446,106 +1459,120 @@ async function handleNonStreaming<
     `[${providerName}Proxy] Starting non-streaming request`,
   );
 
+  const [upstreamAbortSignal, unsubscribeFromClientDisconnect] =
+    abortUpstreamOnClientDisconnect(reply, () => reply.raw.writableEnded);
+
   // Execute request with tracing
-  const { responseAdapter } = await utils.tracing.startActiveLlmSpan({
-    operationName: provider.spanName,
-    provider: providerName,
-    model: actualModel,
-    stream: false,
-    agent,
-    teams,
-    userTeams,
-    sessionId,
-    executionId,
-    externalAgentId,
-    authMethod,
-    authenticatedApp,
-    source,
-    serverAddress: provider.getBaseUrl(),
-    promptMessages: provider
-      .createRequestAdapter(originalRequest)
-      .getProviderMessages(),
-    parentContext,
-    user: toSpanUserInfo(resolvedUser),
-    callback: async (llmSpan) => {
-      const result = await provider.execute(client, request);
-      const adapter = provider.createResponseAdapter(result);
+  const { responseAdapter } = await utils.tracing
+    .startActiveLlmSpan({
+      operationName: provider.spanName,
+      provider: providerName,
+      model: actualModel,
+      stream: false,
+      agent,
+      teams,
+      userTeams,
+      sessionId,
+      executionId,
+      externalAgentId,
+      authMethod,
+      authenticatedApp,
+      source,
+      serverAddress: provider.getBaseUrl(),
+      promptMessages: provider
+        .createRequestAdapter(originalRequest)
+        .getProviderMessages(),
+      parentContext,
+      user: toSpanUserInfo(resolvedUser),
+      callback: async (llmSpan) => {
+        const result = await provider.execute(
+          client,
+          request,
+          upstreamAbortSignal,
+        );
+        const adapter = provider.createResponseAdapter(result);
 
-      // Set response attributes on span per OTEL GenAI semconv
-      const usage = adapter.getUsage();
-      llmSpan.setAttribute(ATTR_GENAI_RESPONSE_MODEL, adapter.getModel());
-      llmSpan.setAttribute(ATTR_GENAI_RESPONSE_ID, adapter.getId());
-      // Per the GenAI semconv, gen_ai.usage.input_tokens includes cached tokens.
-      // Internally usage.inputTokens is uncached-only (cost, metrics, and DB
-      // depend on that), so add cache read/write back for the span attributes.
-      // The uncached value is still derivable as input_tokens -
-      // cache_read.input_tokens - cache_creation.input_tokens.
-      const totalInputTokens =
-        usage.inputTokens +
-        (usage.cacheReadTokens ?? 0) +
-        (usage.cacheWriteTokens ?? 0);
-      llmSpan.setAttribute(ATTR_GENAI_USAGE_INPUT_TOKENS, totalInputTokens);
-      llmSpan.setAttribute(ATTR_GENAI_USAGE_OUTPUT_TOKENS, usage.outputTokens);
-      llmSpan.setAttribute(
-        ATTR_GENAI_USAGE_TOTAL_TOKENS,
-        totalInputTokens + usage.outputTokens,
-      );
-      if (usage.cacheReadTokens) {
+        // Set response attributes on span per OTEL GenAI semconv
+        const usage = adapter.getUsage();
+        llmSpan.setAttribute(ATTR_GENAI_RESPONSE_MODEL, adapter.getModel());
+        llmSpan.setAttribute(ATTR_GENAI_RESPONSE_ID, adapter.getId());
+        // Per the GenAI semconv, gen_ai.usage.input_tokens includes cached tokens.
+        // Internally usage.inputTokens is uncached-only (cost, metrics, and DB
+        // depend on that), so add cache read/write back for the span attributes.
+        // The uncached value is still derivable as input_tokens -
+        // cache_read.input_tokens - cache_creation.input_tokens.
+        const totalInputTokens =
+          usage.inputTokens +
+          (usage.cacheReadTokens ?? 0) +
+          (usage.cacheWriteTokens ?? 0);
+        llmSpan.setAttribute(ATTR_GENAI_USAGE_INPUT_TOKENS, totalInputTokens);
         llmSpan.setAttribute(
-          ATTR_GENAI_USAGE_CACHE_READ_INPUT_TOKENS,
-          usage.cacheReadTokens,
+          ATTR_GENAI_USAGE_OUTPUT_TOKENS,
+          usage.outputTokens,
         );
-      }
-      if (usage.cacheWriteTokens) {
         llmSpan.setAttribute(
-          ATTR_GENAI_USAGE_CACHE_CREATION_INPUT_TOKENS,
-          usage.cacheWriteTokens,
+          ATTR_GENAI_USAGE_TOTAL_TOKENS,
+          totalInputTokens + usage.outputTokens,
         );
-      }
-      if (usage.cacheWrite1hTokens) {
-        llmSpan.setAttribute(
-          ATTR_ARCHESTRA_USAGE_CACHE_CREATION_1H_INPUT_TOKENS,
-          usage.cacheWrite1hTokens,
-        );
-      }
-      if (usage.reasoningTokens) {
-        llmSpan.setAttribute(
-          ATTR_GENAI_USAGE_REASONING_OUTPUT_TOKENS,
-          usage.reasoningTokens,
-        );
-      }
-      const cost = await utils.costOptimization.calculateCost(
-        actualModel,
-        usage.inputTokens,
-        usage.outputTokens,
-        providerName,
-        {
-          readTokens: usage.cacheReadTokens,
-          writeTokens: usage.cacheWriteTokens,
-          write1hTokens: usage.cacheWrite1hTokens,
-        },
-      );
-      if (cost !== undefined) {
-        llmSpan.setAttribute(ATTR_ARCHESTRA_COST, cost);
-      }
-      llmSpan.setAttribute(
-        ATTR_GENAI_RESPONSE_FINISH_REASONS,
-        adapter.getFinishReasons(),
-      );
-
-      // Capture completion content
-      if (captureContent) {
-        const text = adapter.getText?.();
-        if (text) {
-          llmSpan.addEvent(EVENT_GENAI_CONTENT_COMPLETION, {
-            [ATTR_GENAI_COMPLETION]: text.slice(0, contentMaxLength),
-          });
+        if (usage.cacheReadTokens) {
+          llmSpan.setAttribute(
+            ATTR_GENAI_USAGE_CACHE_READ_INPUT_TOKENS,
+            usage.cacheReadTokens,
+          );
         }
-      }
+        if (usage.cacheWriteTokens) {
+          llmSpan.setAttribute(
+            ATTR_GENAI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+            usage.cacheWriteTokens,
+          );
+        }
+        if (usage.cacheWrite1hTokens) {
+          llmSpan.setAttribute(
+            ATTR_ARCHESTRA_USAGE_CACHE_CREATION_1H_INPUT_TOKENS,
+            usage.cacheWrite1hTokens,
+          );
+        }
+        if (usage.reasoningTokens) {
+          llmSpan.setAttribute(
+            ATTR_GENAI_USAGE_REASONING_OUTPUT_TOKENS,
+            usage.reasoningTokens,
+          );
+        }
+        const cost = await utils.costOptimization.calculateCost(
+          actualModel,
+          usage.inputTokens,
+          usage.outputTokens,
+          providerName,
+          {
+            readTokens: usage.cacheReadTokens,
+            writeTokens: usage.cacheWriteTokens,
+            write1hTokens: usage.cacheWrite1hTokens,
+          },
+        );
+        if (cost !== undefined) {
+          llmSpan.setAttribute(ATTR_ARCHESTRA_COST, cost);
+        }
+        llmSpan.setAttribute(
+          ATTR_GENAI_RESPONSE_FINISH_REASONS,
+          adapter.getFinishReasons(),
+        );
 
-      return { response: result, responseAdapter: adapter };
-    },
-  });
+        // Capture completion content
+        if (captureContent) {
+          const text = adapter.getText?.();
+          if (text) {
+            llmSpan.addEvent(EVENT_GENAI_CONTENT_COMPLETION, {
+              [ATTR_GENAI_COMPLETION]: text.slice(0, contentMaxLength),
+            });
+          }
+        }
+
+        return { response: result, responseAdapter: adapter };
+      },
+    })
+    .finally(() => {
+      unsubscribeFromClientDisconnect();
+    });
 
   const toolCalls = responseAdapter.getToolCalls();
   logger.debug(

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
@@ -89,7 +89,10 @@ vi.mock("@/observability", async (importOriginal) => {
 });
 
 // Import after mocks
+import { EventEmitter } from "node:events";
+import type { FastifyReply } from "fastify";
 import {
+  abortUpstreamOnClientDisconnect,
   buildInteractionRecord,
   calculateInteractionCosts,
   normalizeToolCallsForPolicy,
@@ -510,5 +513,53 @@ describe("withSessionContext", () => {
     expect(withSpy).not.toHaveBeenCalled();
 
     withSpy.mockRestore();
+  });
+});
+
+// --------------------------------------------------------------------------
+// abortUpstreamOnClientDisconnect
+// --------------------------------------------------------------------------
+
+describe("abortUpstreamOnClientDisconnect", () => {
+  // A fake reply whose `.raw` is an EventEmitter so we can drive the "close"
+  // event and toggle the completion flags the guard reads.
+  function makeReply(): FastifyReply {
+    const raw = new EventEmitter();
+    return { raw } as unknown as FastifyReply;
+  }
+
+  test("aborts when the client closes before the response is done", () => {
+    const reply = makeReply();
+    const [signal] = abortUpstreamOnClientDisconnect(reply, () => false);
+
+    expect(signal.aborted).toBe(false);
+    reply.raw.emit("close");
+    expect(signal.aborted).toBe(true);
+  });
+
+  test("does NOT abort when close fires after the response completed", () => {
+    const reply = makeReply();
+    // Node emits "close" on every response, including successful ones — the
+    // guard must prevent a spurious abort in that case.
+    const [signal] = abortUpstreamOnClientDisconnect(reply, () => true);
+
+    reply.raw.emit("close");
+    expect(signal.aborted).toBe(false);
+  });
+
+  test("unsubscribe removes the close listener (no leak)", () => {
+    const reply = makeReply();
+    const [signal, unsubscribe] = abortUpstreamOnClientDisconnect(
+      reply,
+      () => false,
+    );
+
+    expect(reply.raw.listenerCount("close")).toBe(1);
+    unsubscribe();
+    expect(reply.raw.listenerCount("close")).toBe(0);
+
+    // A close after unsubscribe must not abort.
+    reply.raw.emit("close");
+    expect(signal.aborted).toBe(false);
   });
 });

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
@@ -248,6 +248,30 @@ export function withSessionContext<T>(
   return otelContext.with(ctx, fn);
 }
 
+/**
+ * Watches the inbound client connection and returns `[signal, unsubscribe]`:
+ * - `signal` fires when the client disconnects before the response is done. Pass it to the upstream call so a disconnect cancels it.
+ * - `unsubscribe` detaches the listener from inbound client connection.
+ *
+ * `isResponseDone` (e.g. `writableEnded`) tells the watcher to ignore the `"close"` event that Node also emits on a successful response.
+ */
+export function abortUpstreamOnClientDisconnect(
+  reply: FastifyReply,
+  isResponseDone: () => boolean,
+): [signal: AbortSignal, unsubscribe: () => void] {
+  const controller = new AbortController();
+
+  const onClose = () => {
+    if (!isResponseDone()) {
+      controller.abort();
+    }
+  };
+
+  reply.raw.on("close", onClose);
+
+  return [controller.signal, () => reply.raw.off("close", onClose)];
+}
+
 export function handleError(
   error: unknown,
   reply: FastifyReply,

--- a/platform/backend/src/types/llm-provider.ts
+++ b/platform/backend/src/types/llm-provider.ts
@@ -399,12 +399,17 @@ export interface LLMProvider<TRequest, TResponse, TMessages, TChunk, THeaders> {
   // ---------------------------------------------------------------------------
 
   /** Execute non-streaming request */
-  execute(client: unknown, request: TRequest): Promise<TResponse>;
+  execute(
+    client: unknown,
+    request: TRequest,
+    signal?: AbortSignal,
+  ): Promise<TResponse>;
 
   /** Execute streaming request */
   executeStream(
     client: unknown,
     request: TRequest,
+    signal?: AbortSignal,
   ): Promise<AsyncIterable<TChunk>>;
 
   /**


### PR DESCRIPTION
⚠️ Work in progress

Clicking **Stop** didn't stop the model: the proxy kept the upstream generation running until it tried to write to the already-closed socket, wasting CPU/tokens. This PR propagates cancellation. The proxy detects its inbound connection closing and forwards an `AbortSignal` to the provider SDK call.

## Changes

> ❓ Right now a cancelled upstream is logged as an error. It works fine, but it adds noise to error logs/metrics. Is keeping it as an error ok for now, or it's better to treat client disconnects as a "499 client closed request" (nginx convention) instead?

- `execute`/`executeStream` gain an optional `signal?: AbortSignal`.
- Proxy handler aborts on inbound `reply.raw` close and forwards the signal.
- Updated every adapter to support AbortSignal
- Pass abort signals to each SDK

Each SDK takes an abort differently (OpenAI/Anthropic `{ signal }`, Gemini `config.abortSignal`, Cohere/Bedrock/MiniMax/Zhipu custom fetch clients), and Gemini/Bedrock don't use the shared observable fetch. Each edit is a one-line. 

 ## Test plan
 
I tested Ollama (OpenAI-SDK path) and Anthropic locally, but the rest will have to do on staging.

Verified locally via logs:
- **Stop mid-stream:** `APIUserAbortError: Request was aborted.` thrown from `executeStream`/`makeRequest` → `Stream was aborted before completion`. Upstream dropped ~100 ms after Stop, no token-usage logged.
- **Hop-1 failure (no browser):** with `ARCHESTRA_LLM_PROXY_UPSTREAM_TIMEOUT_MS=1000` + a 5 s upstream delay, hop 1 times out (`UND_ERR_HEADERS_TIMEOUT`) and each failure cancels hop 2 (`APIUserAbortError`).
- **Tab close / navigate-away:** not cancelled — `Chat connection closed (navigate
  away), stream continues in background`. Reopening the chat reattaches.
  
Will have to do the same for other providers on staging

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>