### PR TITLE
feat(llm): authorization_code grant for manually registered LLM OAuth clients

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -163409,6 +163409,13 @@
                       "organizationId": {
                         "type": "string"
                       },
+                      "grantType": {
+                        "type": "string",
+                        "enum": [
+                          "client_credentials",
+                          "authorization_code"
+                        ]
+                      },
                       "allowedLlmProxyIds": {
                         "type": "array",
                         "items": {
@@ -163460,6 +163467,12 @@
                           "additionalProperties": false
                         }
                       },
+                      "redirectUris": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
                       "disabled": {
                         "type": "boolean"
                       },
@@ -163477,8 +163490,10 @@
                       "clientId",
                       "name",
                       "organizationId",
+                      "grantType",
                       "allowedLlmProxyIds",
                       "providerApiKeys",
+                      "redirectUris",
                       "disabled",
                       "createdAt",
                       "updatedAt"
@@ -163743,8 +163758,15 @@
                     "minLength": 1,
                     "maxLength": 256
                   },
+                  "grantType": {
+                    "default": "client_credentials",
+                    "type": "string",
+                    "enum": [
+                      "client_credentials",
+                      "authorization_code"
+                    ]
+                  },
                   "allowedLlmProxyIds": {
-                    "minItems": 1,
                     "type": "array",
                     "items": {
                       "type": "string",
@@ -163753,7 +163775,6 @@
                     }
                   },
                   "providerApiKeys": {
-                    "minItems": 1,
                     "type": "array",
                     "items": {
                       "type": "object",
@@ -163792,12 +163813,17 @@
                         "providerApiKeyId"
                       ]
                     }
+                  },
+                  "redirectUris": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uri"
+                    }
                   }
                 },
                 "required": [
-                  "name",
-                  "allowedLlmProxyIds",
-                  "providerApiKeys"
+                  "name"
                 ]
               }
             }
@@ -163822,6 +163848,13 @@
                     },
                     "organizationId": {
                       "type": "string"
+                    },
+                    "grantType": {
+                      "type": "string",
+                      "enum": [
+                        "client_credentials",
+                        "authorization_code"
+                      ]
                     },
                     "allowedLlmProxyIds": {
                       "type": "array",
@@ -163874,6 +163907,12 @@
                         "additionalProperties": false
                       }
                     },
+                    "redirectUris": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "disabled": {
                       "type": "boolean"
                     },
@@ -163894,8 +163933,10 @@
                     "clientId",
                     "name",
                     "organizationId",
+                    "grantType",
                     "allowedLlmProxyIds",
                     "providerApiKeys",
+                    "redirectUris",
                     "disabled",
                     "createdAt",
                     "updatedAt",
@@ -164162,8 +164203,15 @@
                     "minLength": 1,
                     "maxLength": 256
                   },
+                  "grantType": {
+                    "default": "client_credentials",
+                    "type": "string",
+                    "enum": [
+                      "client_credentials",
+                      "authorization_code"
+                    ]
+                  },
                   "allowedLlmProxyIds": {
-                    "minItems": 1,
                     "type": "array",
                     "items": {
                       "type": "string",
@@ -164172,7 +164220,6 @@
                     }
                   },
                   "providerApiKeys": {
-                    "minItems": 1,
                     "type": "array",
                     "items": {
                       "type": "object",
@@ -164211,12 +164258,17 @@
                         "providerApiKeyId"
                       ]
                     }
+                  },
+                  "redirectUris": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uri"
+                    }
                   }
                 },
                 "required": [
-                  "name",
-                  "allowedLlmProxyIds",
-                  "providerApiKeys"
+                  "name"
                 ]
               }
             }
@@ -164251,6 +164303,13 @@
                     },
                     "organizationId": {
                       "type": "string"
+                    },
+                    "grantType": {
+                      "type": "string",
+                      "enum": [
+                        "client_credentials",
+                        "authorization_code"
+                      ]
                     },
                     "allowedLlmProxyIds": {
                       "type": "array",
@@ -164303,6 +164362,12 @@
                         "additionalProperties": false
                       }
                     },
+                    "redirectUris": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "disabled": {
                       "type": "boolean"
                     },
@@ -164320,8 +164385,10 @@
                     "clientId",
                     "name",
                     "organizationId",
+                    "grantType",
                     "allowedLlmProxyIds",
                     "providerApiKeys",
+                    "redirectUris",
                     "disabled",
                     "createdAt",
                     "updatedAt"
@@ -164877,6 +164944,13 @@
                     "organizationId": {
                       "type": "string"
                     },
+                    "grantType": {
+                      "type": "string",
+                      "enum": [
+                        "client_credentials",
+                        "authorization_code"
+                      ]
+                    },
                     "allowedLlmProxyIds": {
                       "type": "array",
                       "items": {
@@ -164928,6 +165002,12 @@
                         "additionalProperties": false
                       }
                     },
+                    "redirectUris": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "disabled": {
                       "type": "boolean"
                     },
@@ -164948,8 +165028,10 @@
                     "clientId",
                     "name",
                     "organizationId",
+                    "grantType",
                     "allowedLlmProxyIds",
                     "providerApiKeys",
+                    "redirectUris",
                     "disabled",
                     "createdAt",
                     "updatedAt",

--- a/docs/pages/platform-llm-proxy-authentication.md
+++ b/docs/pages/platform-llm-proxy-authentication.md
@@ -3,7 +3,7 @@ title: Authentication
 category: LLM Proxy
 order: 3
 description: Authentication methods for the LLM Proxy
-lastUpdated: 2026-05-04
+lastUpdated: 2026-06-18
 ---
 
 <!--
@@ -16,8 +16,8 @@ The LLM Proxy supports direct provider API keys, virtual API keys, OAuth access 
 | --- | --- | --- | --- |
 | Direct provider key | Simple provider-specific proxy calls | No | Sends the raw provider key with each request. |
 | Virtual API key | Provider-specific LLM clients, generic Model Router clients, and individual developers | Yes | Works as a provider key replacement on provider-specific proxy routes, or as the `apiKey` for Model Router clients. |
-| LLM OAuth client access token | Backend services, production apps, and external bots | Yes | Uses OAuth client credentials to issue short-lived bearer tokens. |
-| User OAuth access token | Custom apps acting for an individual user | Yes | Uses the authorization code flow with consent and the `llm:proxy` scope. |
+| LLM OAuth client access token | Backend services, production apps, and external bots | Yes | OAuth `client_credentials` grant; the client brings its own provider keys. |
+| User OAuth access token | Apps acting for an individual user | Yes | Authorization code flow with the `llm:proxy` scope; the app can self-register or be pre-registered (confidential) on the OAuth Clients page. Resolves the user's own provider keys. |
 | JWKS | Enterprise IdP JWT callers | Provider routes | Resolves a user from an external IdP JWT. |
 
 ## Direct Provider API Key
@@ -86,19 +86,21 @@ curl -X POST "https://archestra.example.com/v1/model-router/{proxyId}/responses"
 
 ## LLM OAuth Clients
 
-LLM OAuth clients are registered clients that call LLM proxy endpoints with OAuth client credentials. Use them for backend services, production apps, automation jobs, and external bots. The OAuth client receives a `client_id` and one-time `client_secret`, exchanges them for a fixed 1-hour access token, and uses that token as the proxy bearer token.
+LLM OAuth clients are clients you register to call LLM proxy endpoints. They support two grants: **client credentials** (an application acting as itself, covered here) and **authorization code** (a pre-registered app acting on behalf of a signed-in user — see [On Behalf of Users](#on-behalf-of-users-authorization-code)).
+
+With the `client_credentials` grant, use them for backend services, production apps, automation jobs, and external bots. The OAuth client receives a `client_id` and one-time `client_secret`, exchanges them for a fixed 1-hour access token, and uses that token as the proxy bearer token.
 
 Virtual keys are still the recommended path for generic LLM clients that cannot fetch OAuth tokens. LLM OAuth clients are better when you control the service code and can request a token before calling an LLM proxy. See [Model Router Client Credentials](/docs/platform-model-router-client-credentials-example) for a complete service-app example.
 
 ### Managing OAuth Clients
 
 1. Go to **LLM Proxies > Credentials > OAuth Clients**
-2. Create an OAuth client
-3. Select the LLM proxies it can access
-4. Map the provider API keys it can use
+2. Create an OAuth client and choose its grant type
+3. For an application (client credentials): select the LLM proxies it can access and map the provider API keys it can use
+4. For acting on behalf of users (authorization code): add the application's redirect URIs
 5. Copy the generated `client_id` and `client_secret` (the secret is shown only once)
 
-You can edit an OAuth client later to update its name, allowed LLM proxies, or provider key mappings. Rotate the client secret when the existing secret needs to be replaced.
+You can edit a client_credentials client later to update its name, allowed LLM proxies, or provider key mappings; edit an authorization_code client to update its redirect URIs. The grant type is fixed at creation. Rotate the client secret when the existing secret needs to be replaced.
 
 ### Getting an Access Token
 
@@ -135,11 +137,18 @@ For Model Router routes, the OAuth client must have a provider key mapping for t
 
 LLM logs and traces record the authenticated OAuth client separately from `X-Archestra-Agent-Id`. Use `X-Archestra-Agent-Id` as a caller-provided label, not as proof of client identity.
 
-### User OAuth Apps
+### On Behalf of Users (Authorization Code)
 
-Custom applications can also use the OAuth authorization code flow when they act on behalf of an individual user. The application redirects the user to the authorization endpoint with the `llm:proxy` scope, the user approves the consent screen, and the application exchanges the code for a user access token.
+An application can act on behalf of an individual **user** instead of as itself. It runs the OAuth authorization code flow with the `llm:proxy` scope, the user approves the consent screen, and the application exchanges the code for a user-bound access token used as the proxy bearer token.
 
-User OAuth tokens do not use the LLM OAuth Clients page. Provider-specific routes and Model Router resolve provider keys from the authorized user's accessible Model Provider keys: personal keys, org-wide keys, and team keys for teams the user belongs to.
+Register such an application one of two ways:
+
+- **Pre-registered (recommended for known apps)**: create an OAuth client on the **OAuth Clients** page with the "On behalf of users" grant type and add its redirect URIs. It is confidential — it gets a `client_id` and one-time `client_secret`, and PKCE is required — so only that application can complete the flow. To allow only pre-registered clients, set `ARCHESTRA_AUTH_DCR_ENABLED=false`.
+- **Self-registered**: a client registers dynamically (DCR) or via a client-ID metadata document (CIMD) and runs the same flow. These do not use the OAuth Clients page.
+
+The application redirects the user to `GET /api/auth/oauth2/authorize` (`response_type=code`, `scope=llm:proxy`, add `offline_access` for a refresh token, the registered `redirect_uri`, and a PKCE challenge), then exchanges the code at `POST /api/auth/oauth2/token` (`grant_type=authorization_code`, `client_id`, `client_secret`, PKCE verifier).
+
+Either way the token is user-bound and carries no provider keys of its own: provider-specific routes and Model Router resolve provider keys from the authorized user's accessible Model Provider keys (personal keys, org-wide keys, and team keys for teams the user belongs to), and the user's cost limits and policies apply.
 
 The user OAuth token lifetime is controlled by **Settings > Organization > Auth > OAuth token lifetime**. The same setting applies to newly issued user OAuth tokens for MCP and custom application authorization-code flows. It does not change the fixed 1-hour lifetime for LLM OAuth client credentials tokens.
 

--- a/platform/backend/src/models/llm-oauth-client.ts
+++ b/platform/backend/src/models/llm-oauth-client.ts
@@ -1,10 +1,15 @@
 import { randomBytes } from "node:crypto";
-import { LLM_PROXY_OAUTH_SCOPE } from "@archestra/shared";
+import {
+  LLM_PROXY_OAUTH_SCOPE,
+  OFFLINE_ACCESS_OAUTH_SCOPE,
+} from "@archestra/shared";
 import { hashPassword, verifyPassword } from "better-auth/crypto";
 import { and, eq, ilike, inArray, sql } from "drizzle-orm";
+import { hashOauthClientSecret } from "@/auth/oauth-client-secret";
 import db, { schema } from "@/database";
 import {
   LLM_OAUTH_CLIENT_METADATA_TYPE,
+  type LlmOauthClientGrantType,
   LlmOauthClientMetadataSchema,
   type LlmOauthClientProviderKey,
 } from "@/types/llm-oauth-client";
@@ -42,16 +47,31 @@ class LlmOauthClientModel {
   static async create(params: {
     organizationId: string;
     name: string;
-    allowedLlmProxyIds: string[];
-    providerApiKeys: LlmOauthClientProviderKey[];
+    grantType?: LlmOauthClientGrantType;
+    allowedLlmProxyIds?: string[];
+    providerApiKeys?: LlmOauthClientProviderKey[];
+    redirectUris?: string[];
   }) {
+    const grantType = params.grantType ?? "client_credentials";
+    const isAuthorizationCode = grantType === "authorization_code";
     const clientSecret = createClientSecret();
-    const clientSecretHash = await hashClientSecret(clientSecret);
+    // authorization_code secrets are verified by better-auth (deterministic
+    // hash); client_credentials secrets are verified by this model (bcrypt).
+    const clientSecretHash = isAuthorizationCode
+      ? hashOauthClientSecret(clientSecret)
+      : await hashClientSecret(clientSecret);
+    // For authorization_code the acting user's own identity governs proxy access
+    // and provider-key resolution, so neither field applies to those clients.
     const metadata = {
       type: LLM_OAUTH_CLIENT_METADATA_TYPE,
       organizationId: params.organizationId,
-      allowedLlmProxyIds: params.allowedLlmProxyIds,
-      providerApiKeys: params.providerApiKeys,
+      grantType,
+      allowedLlmProxyIds: isAuthorizationCode
+        ? []
+        : (params.allowedLlmProxyIds ?? []),
+      providerApiKeys: isAuthorizationCode
+        ? []
+        : (params.providerApiKeys ?? []),
     };
 
     const [client] = await db
@@ -61,12 +81,20 @@ class LlmOauthClientModel {
         clientId: `llm_oauth_${randomBytes(18).toString("base64url")}`,
         clientSecret: clientSecretHash,
         name: params.name,
-        redirectUris: [],
+        // authorization_code is a confidential client (client_secret_post) that
+        // additionally requires PKCE; its tokens flow through better-auth's
+        // standard authorize→token exchange and are user-bound.
+        redirectUris: isAuthorizationCode ? (params.redirectUris ?? []) : [],
         tokenEndpointAuthMethod: "client_secret_post",
-        grantTypes: ["client_credentials"],
-        responseTypes: [],
+        grantTypes: isAuthorizationCode
+          ? ["authorization_code", "refresh_token"]
+          : ["client_credentials"],
+        responseTypes: isAuthorizationCode ? ["code"] : [],
+        requirePKCE: isAuthorizationCode,
         public: false,
-        scopes: [LLM_PROXY_OAUTH_SCOPE],
+        scopes: isAuthorizationCode
+          ? [LLM_PROXY_OAUTH_SCOPE, OFFLINE_ACCESS_OAUTH_SCOPE]
+          : [LLM_PROXY_OAUTH_SCOPE],
         type: "service",
         metadata,
         createdAt: new Date(),
@@ -149,11 +177,18 @@ class LlmOauthClientModel {
   }
 
   static async rotateSecret(params: { id: string; organizationId: string }) {
+    // Hash the new secret with the scheme this client's grant type uses.
+    const existing = await LlmOauthClientModel.findById(params);
+    if (!existing) return null;
     const clientSecret = createClientSecret();
+    const clientSecretHash =
+      existing.grantType === "authorization_code"
+        ? hashOauthClientSecret(clientSecret)
+        : await hashClientSecret(clientSecret);
     const [client] = await db
       .update(schema.oauthClientsTable)
       .set({
-        clientSecret: await hashClientSecret(clientSecret),
+        clientSecret: clientSecretHash,
         updatedAt: new Date(),
       })
       .where(
@@ -176,14 +211,33 @@ class LlmOauthClientModel {
     id: string;
     organizationId: string;
     name: string;
-    allowedLlmProxyIds: string[];
-    providerApiKeys: LlmOauthClientProviderKey[];
+    allowedLlmProxyIds?: string[];
+    providerApiKeys?: LlmOauthClientProviderKey[];
+    redirectUris?: string[];
   }) {
+    // The grant type is fixed at creation; reload the client to preserve it and
+    // to apply only the fields that grant type actually uses.
+    const existing = await LlmOauthClientModel.findById({
+      id: params.id,
+      organizationId: params.organizationId,
+    });
+    if (!existing) return null;
+    const isAuthorizationCode = existing.grantType === "authorization_code";
+
     const metadata = {
       type: LLM_OAUTH_CLIENT_METADATA_TYPE,
       organizationId: params.organizationId,
-      allowedLlmProxyIds: params.allowedLlmProxyIds,
-      providerApiKeys: params.providerApiKeys,
+      grantType: existing.grantType,
+      allowedLlmProxyIds: isAuthorizationCode
+        ? []
+        : (params.allowedLlmProxyIds ?? existing.allowedLlmProxyIds),
+      providerApiKeys: isAuthorizationCode
+        ? []
+        : (params.providerApiKeys ??
+          existing.providerApiKeys.map((key) => ({
+            provider: key.provider,
+            providerApiKeyId: key.providerApiKeyId,
+          }))),
     };
 
     const [client] = await db
@@ -191,6 +245,9 @@ class LlmOauthClientModel {
       .set({
         name: params.name,
         metadata,
+        ...(isAuthorizationCode
+          ? { redirectUris: params.redirectUris ?? existing.redirectUris }
+          : {}),
         updatedAt: new Date(),
       })
       .where(
@@ -232,6 +289,7 @@ class LlmOauthClientModel {
       name: client.name,
       clientId: client.clientId,
       organizationId: client.organizationId,
+      grantType: client.grantType,
       allowedLlmProxyIds: [...client.allowedLlmProxyIds].sort(),
       // Sort by providerApiKeyId so audit diffs ignore source ordering and
       // only flag genuine add/remove changes.
@@ -242,6 +300,7 @@ class LlmOauthClientModel {
           providerApiKeyId: p.providerApiKeyId,
           providerApiKeyName: p.providerApiKeyName,
         })),
+      redirectUris: [...client.redirectUris].sort(),
       disabled: client.disabled,
       createdAt: client.createdAt.toISOString(),
       updatedAt: client.updatedAt.toISOString(),
@@ -303,6 +362,7 @@ async function hydrateOauthClients(
         clientId: client.clientId,
         name: client.name ?? client.clientId,
         organizationId: metadata.organizationId,
+        grantType: metadata.grantType,
         allowedLlmProxyIds: metadata.allowedLlmProxyIds,
         providerApiKeys: metadata.providerApiKeys.map((mapping) => ({
           ...mapping,
@@ -310,6 +370,7 @@ async function hydrateOauthClients(
             apiKeyNames.get(mapping.providerApiKeyId) ??
             mapping.providerApiKeyId,
         })),
+        redirectUris: client.redirectUris ?? [],
         disabled: client.disabled ?? false,
         createdAt: client.createdAt,
         updatedAt: client.updatedAt,

--- a/platform/backend/src/routes/llm-oauth-clients.proxy-auth.test.ts
+++ b/platform/backend/src/routes/llm-oauth-clients.proxy-auth.test.ts
@@ -1,0 +1,110 @@
+import { randomBytes } from "node:crypto";
+import { LLM_PROXY_OAUTH_SCOPE } from "@archestra/shared";
+import { LlmOauthClientModel, OAuthAccessTokenModel } from "@/models";
+import { describe, expect, test } from "@/test";
+import { validateLlmOAuthAccessToken } from "./proxy/llm-proxy-auth";
+
+/**
+ * End-to-end authorization tests for LLM OAuth client (authorization_code)
+ * tokens at the LLM proxy boundary. An authorization_code client mints
+ * USER-BOUND tokens via better-auth's standard authorize→token exchange. These
+ * carry an acting user but no provider keys of their own, so the proxy must
+ * resolve the user's identity on the user-token path and pick the user's own
+ * provider key — that is what makes a pre-registered client act on behalf of
+ * the signed-in user (the LLM analog of per-user resolution).
+ */
+describe("LLM OAuth authorization_code proxy authorization", () => {
+  async function mintUserToken(params: { clientId: string; userId: string }) {
+    const accessToken = randomBytes(32).toString("base64url");
+    await OAuthAccessTokenModel.create({
+      tokenHash: OAuthAccessTokenModel.hashTokenForLookup(accessToken),
+      clientId: params.clientId,
+      userId: params.userId,
+      expiresAt: new Date(Date.now() + 3_600_000),
+      scopes: [LLM_PROXY_OAUTH_SCOPE],
+      // No referenceId → user-identity path (not the client_credentials branch).
+      referenceId: null,
+    });
+    return accessToken;
+  }
+
+  test("resolves the acting user and their own provider key", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: "member" });
+    const proxy = await makeAgent({
+      organizationId: org.id,
+      agentType: "llm_proxy",
+    });
+    // The user's own (org-scoped) provider key — NOT a key stored on the client.
+    const secret = await makeSecret({ secret: { apiKey: "sk-user-openai" } });
+    await makeLlmProviderApiKey(org.id, secret.id, { provider: "openai" });
+
+    const { oauthClient } = await LlmOauthClientModel.create({
+      organizationId: org.id,
+      name: "Agentic Chat Server",
+      grantType: "authorization_code",
+      redirectUris: ["https://chat.example.com/oauth/callback"],
+    });
+    // The authorization_code client carries no provider keys of its own.
+    expect(oauthClient.providerApiKeys).toEqual([]);
+
+    const token = await mintUserToken({
+      clientId: oauthClient.clientId,
+      userId: user.id,
+    });
+
+    const result = await validateLlmOAuthAccessToken({
+      tokenValue: token,
+      expectedProvider: "openai",
+      agent: proxy,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.authMethod).toBe("oauth_user");
+    expect(result?.userId).toBe(user.id);
+    // Resolved from the USER's own key, not the client.
+    expect(result?.apiKey).toBe("sk-user-openai");
+    expect(result?.authenticatedApp?.clientId).toBe(oauthClient.clientId);
+  });
+
+  test("rejects a token whose user cannot access the proxy", async ({
+    makeOrganization,
+    makeUser,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    // A user with no membership in the proxy's organization.
+    const outsider = await makeUser();
+    const proxy = await makeAgent({
+      organizationId: org.id,
+      agentType: "llm_proxy",
+    });
+    const { oauthClient } = await LlmOauthClientModel.create({
+      organizationId: org.id,
+      name: "Agentic Chat Server",
+      grantType: "authorization_code",
+      redirectUris: ["https://chat.example.com/oauth/callback"],
+    });
+
+    const token = await mintUserToken({
+      clientId: oauthClient.clientId,
+      userId: outsider.id,
+    });
+
+    await expect(
+      validateLlmOAuthAccessToken({
+        tokenValue: token,
+        expectedProvider: "openai",
+        agent: proxy,
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/platform/backend/src/routes/llm-oauth-clients.test.ts
+++ b/platform/backend/src/routes/llm-oauth-clients.test.ts
@@ -1,3 +1,6 @@
+import { eq } from "drizzle-orm";
+import { hashOauthClientSecret } from "@/auth/oauth-client-secret";
+import db, { schema } from "@/database";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
@@ -231,5 +234,122 @@ describe("llmOauthClientsRoutes", () => {
     expect(response.json().error.message).toContain(
       'Only one provider API key can be mapped for provider "openai"',
     );
+  });
+
+  test("creates an authorization_code client registered as a confidential, PKCE client", async () => {
+    const createResponse = await app.inject({
+      method: "POST",
+      url: "/api/llm-oauth-clients",
+      payload: {
+        name: "Agentic Chat Server",
+        grantType: "authorization_code",
+        redirectUris: ["https://chat.example.com/oauth/callback"],
+      },
+    });
+
+    expect(createResponse.statusCode).toBe(200);
+    const created = createResponse.json();
+    expect(created.clientId).toMatch(/^llm_oauth_/);
+    expect(created.clientSecret).toMatch(/^llm_secret_/);
+    expect(created.grantType).toBe("authorization_code");
+    expect(created.redirectUris).toEqual([
+      "https://chat.example.com/oauth/callback",
+    ]);
+    // authorization_code access + provider keys are governed by the acting user.
+    expect(created.allowedLlmProxyIds).toEqual([]);
+    expect(created.providerApiKeys).toEqual([]);
+
+    // The underlying oauth_client row must be wired for better-auth's
+    // authorize→token exchange (confidential, PKCE, llm:proxy + offline_access).
+    const [row] = await db
+      .select()
+      .from(schema.oauthClientsTable)
+      .where(eq(schema.oauthClientsTable.id, created.id));
+    expect(row.grantTypes).toEqual(["authorization_code", "refresh_token"]);
+    expect(row.responseTypes).toEqual(["code"]);
+    expect(row.requirePKCE).toBe(true);
+    expect(row.public).toBe(false);
+    expect(row.tokenEndpointAuthMethod).toBe("client_secret_post");
+    expect(row.scopes).toEqual(
+      expect.arrayContaining(["llm:proxy", "offline_access"]),
+    );
+    // better-auth verifies the secret at the token endpoint by hashing the
+    // presented value and comparing it to what is stored, so the stored secret
+    // must be exactly this deterministic hash (not a bcrypt hash, which it could
+    // never match). This is the contract that makes the real token exchange work.
+    expect(row.clientSecret).toBe(hashOauthClientSecret(created.clientSecret));
+  });
+
+  test("requires at least one redirect URI for authorization_code clients", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/llm-oauth-clients",
+      payload: { name: "No Redirects", grantType: "authorization_code" },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  test("rejects an invalid redirect URI", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/llm-oauth-clients",
+      payload: {
+        name: "Bad Redirect",
+        grantType: "authorization_code",
+        redirectUris: ["not-a-url"],
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  test("does not require proxies or provider keys for authorization_code clients", async () => {
+    // No LLM proxy or provider key exists, yet an authorization_code client must
+    // still be creatable — its access and keys come from the acting user.
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/llm-oauth-clients",
+      payload: {
+        name: "Gatewayless",
+        grantType: "authorization_code",
+        redirectUris: ["https://app.example.com/callback"],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  test("updates redirect URIs for an authorization_code client", async () => {
+    const created = (
+      await app.inject({
+        method: "POST",
+        url: "/api/llm-oauth-clients",
+        payload: {
+          name: "Chat Server",
+          grantType: "authorization_code",
+          redirectUris: ["https://chat.example.com/oauth/callback"],
+        },
+      })
+    ).json();
+
+    const updateResponse = await app.inject({
+      method: "PUT",
+      url: `/api/llm-oauth-clients/${created.id}`,
+      payload: {
+        name: "Chat Server",
+        grantType: "authorization_code",
+        redirectUris: [
+          "https://chat.example.com/oauth/callback",
+          "https://chat.example.com/oauth/callback2",
+        ],
+      },
+    });
+
+    expect(updateResponse.statusCode).toBe(200);
+    expect(updateResponse.json().redirectUris).toEqual([
+      "https://chat.example.com/oauth/callback",
+      "https://chat.example.com/oauth/callback2",
+    ]);
   });
 });

--- a/platform/backend/src/routes/llm-oauth-clients.ts
+++ b/platform/backend/src/routes/llm-oauth-clients.ts
@@ -13,6 +13,7 @@ import {
 import {
   ApiError,
   constructResponseSchema,
+  LlmOauthClientGrantTypeSchema,
   LlmOauthClientSchema,
   LlmOauthClientWithSecretSchema,
 } from "@/types";
@@ -22,13 +23,55 @@ const LlmOauthClientProviderKeyBodySchema = z.object({
   providerApiKeyId: z.string().uuid(),
 });
 
-const CreateLlmOauthClientBodySchema = z.object({
-  name: z.string().min(1).max(256),
-  allowedLlmProxyIds: z.array(z.string().uuid()).min(1),
-  providerApiKeys: z.array(LlmOauthClientProviderKeyBodySchema).min(1),
-});
+/**
+ * Both grant types share one body shape. `grantType` defaults to
+ * `client_credentials` so existing callers keep working unchanged.
+ * - client_credentials: requires `allowedLlmProxyIds` and `providerApiKeys`;
+ *   `redirectUris` is ignored.
+ * - authorization_code: requires `redirectUris`; the proxy list and provider
+ *   keys are ignored (the acting user's identity governs proxy access and
+ *   per-user key resolution).
+ */
+const LlmOauthClientBodySchema = z
+  .object({
+    name: z.string().min(1).max(256),
+    grantType: LlmOauthClientGrantTypeSchema.default("client_credentials"),
+    allowedLlmProxyIds: z.array(z.string().uuid()).optional(),
+    providerApiKeys: z.array(LlmOauthClientProviderKeyBodySchema).optional(),
+    redirectUris: z.array(z.string().url()).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.grantType === "authorization_code") {
+      if (!value.redirectUris || value.redirectUris.length === 0) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["redirectUris"],
+          message:
+            "At least one redirect URI is required for authorization_code clients",
+        });
+      }
+      return;
+    }
+    if (!value.allowedLlmProxyIds || value.allowedLlmProxyIds.length === 0) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["allowedLlmProxyIds"],
+        message:
+          "At least one LLM proxy is required for client_credentials clients",
+      });
+    }
+    if (!value.providerApiKeys || value.providerApiKeys.length === 0) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["providerApiKeys"],
+        message:
+          "At least one provider API key is required for client_credentials clients",
+      });
+    }
+  });
 
-const UpdateLlmOauthClientBodySchema = CreateLlmOauthClientBodySchema;
+const CreateLlmOauthClientBodySchema = LlmOauthClientBodySchema;
+const UpdateLlmOauthClientBodySchema = LlmOauthClientBodySchema;
 
 const llmOauthClientsRoutes: FastifyPluginAsyncZod = async (fastify) => {
   fastify.get(
@@ -68,12 +111,20 @@ const llmOauthClientsRoutes: FastifyPluginAsyncZod = async (fastify) => {
       },
     },
     async ({ body, organizationId }, reply) => {
-      await validateLlmOauthClientConfig({ ...body, organizationId });
+      if (body.grantType === "client_credentials") {
+        await validateLlmOauthClientConfig({
+          organizationId,
+          allowedLlmProxyIds: body.allowedLlmProxyIds ?? [],
+          providerApiKeys: body.providerApiKeys ?? [],
+        });
+      }
       const { oauthClient, clientSecret } = await LlmOauthClientModel.create({
         organizationId,
         name: body.name,
+        grantType: body.grantType,
         allowedLlmProxyIds: body.allowedLlmProxyIds,
         providerApiKeys: body.providerApiKeys,
+        redirectUris: body.redirectUris,
       });
       return reply.send({ ...oauthClient, clientSecret });
     },
@@ -92,13 +143,20 @@ const llmOauthClientsRoutes: FastifyPluginAsyncZod = async (fastify) => {
       },
     },
     async ({ params, body, organizationId }, reply) => {
-      await validateLlmOauthClientConfig({ ...body, organizationId });
+      if (body.grantType === "client_credentials") {
+        await validateLlmOauthClientConfig({
+          organizationId,
+          allowedLlmProxyIds: body.allowedLlmProxyIds ?? [],
+          providerApiKeys: body.providerApiKeys ?? [],
+        });
+      }
       const oauthClient = await LlmOauthClientModel.update({
         id: params.id,
         organizationId,
         name: body.name,
         allowedLlmProxyIds: body.allowedLlmProxyIds,
         providerApiKeys: body.providerApiKeys,
+        redirectUris: body.redirectUris,
       });
       if (!oauthClient) {
         throw new ApiError(404, "LLM OAuth client not found");

--- a/platform/backend/src/types/llm-oauth-client.ts
+++ b/platform/backend/src/types/llm-oauth-client.ts
@@ -6,6 +6,24 @@ import { z } from "zod";
 
 export const LLM_OAUTH_CLIENT_METADATA_TYPE = "llm_oauth_client";
 
+/**
+ * Which OAuth grant an LLM OAuth client uses:
+ * - `client_credentials`: a shared application credential with no acting user.
+ *   It brings its own provider keys (`providerApiKeys`) and is scoped to an
+ *   explicit list of LLM proxies (`allowedLlmProxyIds`).
+ * - `authorization_code`: a pre-registered client that mints user-bound tokens,
+ *   so the proxy resolves the acting user's own provider keys, cost limits, and
+ *   policies. The client carries no provider keys and no proxy list — the user's
+ *   identity governs both — so it is identified by its `redirectUris` instead.
+ */
+export const LlmOauthClientGrantTypeSchema = z.enum([
+  "client_credentials",
+  "authorization_code",
+]);
+export type LlmOauthClientGrantType = z.infer<
+  typeof LlmOauthClientGrantTypeSchema
+>;
+
 export const LlmOauthClientProviderKeySchema = z.object({
   provider: SupportedProvidersSchema,
   providerApiKeyId: z.string().uuid(),
@@ -15,7 +33,10 @@ export const LlmOauthClientMetadataSchema = z.object({
   type: z.literal(LLM_OAUTH_CLIENT_METADATA_TYPE),
   organizationId: z.string(),
   allowedLlmProxyIds: z.array(z.string().uuid()).default([]),
-  providerApiKeys: z.array(LlmOauthClientProviderKeySchema),
+  providerApiKeys: z.array(LlmOauthClientProviderKeySchema).default([]),
+  // Rows created before authorization_code support have no grantType; treat
+  // them as the original client_credentials clients.
+  grantType: LlmOauthClientGrantTypeSchema.default("client_credentials"),
 });
 
 export const LlmOauthClientSchema = z.object({
@@ -23,12 +44,14 @@ export const LlmOauthClientSchema = z.object({
   clientId: z.string(),
   name: z.string(),
   organizationId: z.string(),
+  grantType: LlmOauthClientGrantTypeSchema,
   allowedLlmProxyIds: z.array(z.string()),
   providerApiKeys: z.array(
     LlmOauthClientProviderKeySchema.extend({
       providerApiKeyName: z.string(),
     }),
   ),
+  redirectUris: z.array(z.string()),
   disabled: z.boolean(),
   createdAt: z.date(),
   updatedAt: z.date(),

--- a/platform/frontend/src/app/llm/credentials/layout.tsx
+++ b/platform/frontend/src/app/llm/credentials/layout.tsx
@@ -24,7 +24,7 @@ const PAGE_CONFIG: Record<string, { title: string; description: string }> = {
   "/llm/credentials/oauth-clients": {
     title: "OAuth Clients",
     description:
-      "Register backend services and bots that authenticate to the Model Router with OAuth client credentials",
+      "Register applications that authenticate to LLM proxies with OAuth — as an application (client credentials) or on behalf of users (authorization code)",
   },
 };
 

--- a/platform/frontend/src/app/llm/credentials/oauth-clients/page.tsx
+++ b/platform/frontend/src/app/llm/credentials/oauth-clients/page.tsx
@@ -21,6 +21,7 @@ import {
 import { ProviderKeyAccessFields } from "@/components/proxy-auth-provider-key-fields";
 import { SearchInput } from "@/components/search-input";
 import { TableRowActions } from "@/components/table-row-actions";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
 import {
@@ -30,6 +31,8 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Textarea } from "@/components/ui/textarea";
 import { useProfiles } from "@/lib/agent.query";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
 import {
@@ -45,6 +48,43 @@ import { useSetCredentialsAction } from "../layout";
 
 type LlmOauthClient =
   archestraApiTypes.GetLlmOauthClientsResponses["200"][number];
+type GrantType = LlmOauthClient["grantType"];
+type CreatedCredentials = {
+  clientId: string;
+  clientSecret: string;
+  grantType: GrantType;
+};
+
+const GRANT_TYPE_OPTIONS: {
+  value: GrantType;
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: "client_credentials",
+    label: "Application (client credentials)",
+    description:
+      "A backend service or bot calls the proxy as itself, with no acting user, using provider keys you map to it.",
+  },
+  {
+    value: "authorization_code",
+    label: "On behalf of users (authorization code)",
+    description:
+      "A pre-registered app obtains user-scoped tokens, so the proxy resolves each user's own provider keys, cost limits, and policies.",
+  },
+];
+
+const GRANT_TYPE_LABEL: Record<GrantType, string> = {
+  client_credentials: "Application",
+  authorization_code: "User-delegated",
+};
+
+function parseRedirectUris(text: string): string[] {
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
 
 export default function OAuthClientsPage() {
   const { searchParams, updateQueryParams } = useDataTableQueryParams();
@@ -66,20 +106,16 @@ export default function OAuthClientsPage() {
   const deleteMutation = useDeleteLlmOauthClient();
 
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
-  const [createdCredentials, setCreatedCredentials] = useState<{
-    clientId: string;
-    clientSecret: string;
-  } | null>(null);
+  const [createdCredentials, setCreatedCredentials] =
+    useState<CreatedCredentials | null>(null);
   const [providerApiKeyFilterOpen, setProviderApiKeyFilterOpen] =
     useState(false);
   const [deletingOAuthClient, setDeletingOAuthClient] =
     useState<LlmOauthClient | null>(null);
   const [editingOAuthClient, setEditingOAuthClient] =
     useState<LlmOauthClient | null>(null);
-  const [rotatedCredentials, setRotatedCredentials] = useState<{
-    clientId: string;
-    clientSecret: string;
-  } | null>(null);
+  const [rotatedCredentials, setRotatedCredentials] =
+    useState<CreatedCredentials | null>(null);
   const [rotatingOAuthClient, setRotatingOAuthClient] =
     useState<LlmOauthClient | null>(null);
 
@@ -113,11 +149,22 @@ export default function OAuthClientsPage() {
         ),
       },
       {
+        id: "grantType",
+        header: "Type",
+        cell: ({ row }) => (
+          <Badge variant="secondary">
+            {GRANT_TYPE_LABEL[row.original.grantType]}
+          </Badge>
+        ),
+      },
+      {
         id: "proxies",
         header: "LLM Proxies",
         cell: ({ row }) => (
           <span className="text-sm text-muted-foreground">
-            {row.original.allowedLlmProxyIds.length}
+            {row.original.grantType === "authorization_code"
+              ? "—"
+              : row.original.allowedLlmProxyIds.length}
           </span>
         ),
       },
@@ -126,7 +173,9 @@ export default function OAuthClientsPage() {
         header: "Providers",
         cell: ({ row }) => (
           <span className="text-sm text-muted-foreground">
-            {formatProviderKeySummary(row.original.providerApiKeys)}
+            {row.original.grantType === "authorization_code"
+              ? "—"
+              : formatProviderKeySummary(row.original.providerApiKeys)}
           </span>
         ),
       },
@@ -233,6 +282,7 @@ export default function OAuthClientsPage() {
             setCreatedCredentials({
               clientId: result.clientId,
               clientSecret: result.clientSecret,
+              grantType: result.grantType,
             });
             setIsCreateDialogOpen(false);
           }
@@ -297,6 +347,7 @@ export default function OAuthClientsPage() {
             setRotatedCredentials({
               clientId: result.clientId,
               clientSecret: result.clientSecret,
+              grantType: result.grantType,
             });
           }
           setRotatingOAuthClient(null);
@@ -346,43 +397,52 @@ function CreateOAuthClientDialog({
   isSubmitting: boolean;
 }) {
   const [name, setName] = useState("");
+  const [grantType, setGrantType] = useState<GrantType>("client_credentials");
   const [selectedProxyIds, setSelectedProxyIds] = useState<string[]>([]);
   const [providerApiKeyIds, setProviderApiKeyIds] = useState<ProviderApiKeyMap>(
     {},
   );
+  const [redirectUrisText, setRedirectUrisText] = useState("");
 
   useEffect(() => {
     if (open) {
       setName("");
+      setGrantType("client_credentials");
       setSelectedProxyIds([]);
       setProviderApiKeyIds({});
+      setRedirectUrisText("");
     }
   }, [open]);
 
   const mappedProviderApiKeys = providerApiKeyMapToArray(providerApiKeyIds);
+  const redirectUris = parseRedirectUris(redirectUrisText);
+  const isAuthorizationCode = grantType === "authorization_code";
   const canSubmit =
     name.trim().length > 0 &&
-    selectedProxyIds.length > 0 &&
-    mappedProviderApiKeys.length > 0;
+    (isAuthorizationCode
+      ? redirectUris.length > 0
+      : selectedProxyIds.length > 0 && mappedProviderApiKeys.length > 0);
 
   return (
     <FormDialog
       open={open}
       onOpenChange={onOpenChange}
       title="Create OAuth Client"
-      description="Register a backend service or bot that can call LLM proxies with OAuth client credentials."
+      description="Register an application that authenticates to LLM proxies with OAuth."
     >
       <DialogForm
         onSubmit={async (event) => {
           event.preventDefault();
-          await onSubmit({
-            name: name.trim(),
-            allowedLlmProxyIds: selectedProxyIds,
-            providerApiKeys: mappedProviderApiKeys,
-          });
-          setName("");
-          setSelectedProxyIds([]);
-          setProviderApiKeyIds({});
+          await onSubmit(
+            isAuthorizationCode
+              ? { name: name.trim(), grantType, redirectUris }
+              : {
+                  name: name.trim(),
+                  grantType,
+                  allowedLlmProxyIds: selectedProxyIds,
+                  providerApiKeys: mappedProviderApiKeys,
+                },
+          );
         }}
       >
         <DialogBody className="space-y-4">
@@ -396,25 +456,36 @@ function CreateOAuthClientDialog({
             />
           </div>
 
-          <div className="space-y-2">
-            <Label>Allowed LLM proxies</Label>
-            <AgentSelector
-              mode="multiple"
-              flat
-              agents={llmProxies}
-              value={selectedProxyIds}
-              onValueChange={setSelectedProxyIds}
-              placeholder="Select LLM proxies"
-              searchPlaceholder="Search LLM proxies"
-              emptyMessage="No LLM proxies found"
-            />
-          </div>
+          <GrantTypeField value={grantType} onChange={setGrantType} />
 
-          <ProviderKeyAccessFields
-            providerApiKeyIds={providerApiKeyIds}
-            onProviderApiKeyIdsChange={setProviderApiKeyIds}
-            providerApiKeys={providerApiKeys}
-          />
+          {isAuthorizationCode ? (
+            <RedirectUrisField
+              value={redirectUrisText}
+              onChange={setRedirectUrisText}
+            />
+          ) : (
+            <>
+              <div className="space-y-2">
+                <Label>Allowed LLM proxies</Label>
+                <AgentSelector
+                  mode="multiple"
+                  flat
+                  agents={llmProxies}
+                  value={selectedProxyIds}
+                  onValueChange={setSelectedProxyIds}
+                  placeholder="Select LLM proxies"
+                  searchPlaceholder="Search LLM proxies"
+                  emptyMessage="No LLM proxies found"
+                />
+              </div>
+
+              <ProviderKeyAccessFields
+                providerApiKeyIds={providerApiKeyIds}
+                onProviderApiKeyIdsChange={setProviderApiKeyIds}
+                providerApiKeys={providerApiKeys}
+              />
+            </>
+          )}
         </DialogBody>
         <DialogStickyFooter>
           <Button
@@ -456,37 +527,57 @@ function EditOAuthClientDialog({
   const [providerApiKeyIds, setProviderApiKeyIds] = useState<ProviderApiKeyMap>(
     {},
   );
+  const [redirectUrisText, setRedirectUrisText] = useState("");
 
   useEffect(() => {
     if (!oauthClient) return;
     setName(oauthClient.name);
     setSelectedProxyIds(oauthClient.allowedLlmProxyIds);
     setProviderApiKeyIds(providerApiKeyArrayToMap(oauthClient.providerApiKeys));
+    setRedirectUrisText(oauthClient.redirectUris.join("\n"));
   }, [oauthClient]);
 
+  // The grant type is fixed at creation, so only its own configuration is editable.
+  const isAuthorizationCode = oauthClient?.grantType === "authorization_code";
   const mappedProviderApiKeys = providerApiKeyMapToArray(providerApiKeyIds);
+  const redirectUris = parseRedirectUris(redirectUrisText);
   const canSubmit =
     !!oauthClient &&
     name.trim().length > 0 &&
-    selectedProxyIds.length > 0 &&
-    mappedProviderApiKeys.length > 0;
+    (isAuthorizationCode
+      ? redirectUris.length > 0
+      : selectedProxyIds.length > 0 && mappedProviderApiKeys.length > 0);
 
   return (
     <FormDialog
       open={!!oauthClient}
       onOpenChange={onOpenChange}
       title="Edit OAuth Client"
-      description="Update the LLM proxies and provider keys this OAuth client can use."
+      description={
+        isAuthorizationCode
+          ? "Update the redirect URIs this OAuth client can use."
+          : "Update the LLM proxies and provider keys this OAuth client can use."
+      }
     >
       <DialogForm
         onSubmit={async (event) => {
           event.preventDefault();
           if (!oauthClient) return;
-          await onSubmit(oauthClient.id, {
-            name: name.trim(),
-            allowedLlmProxyIds: selectedProxyIds,
-            providerApiKeys: mappedProviderApiKeys,
-          });
+          await onSubmit(
+            oauthClient.id,
+            isAuthorizationCode
+              ? {
+                  name: name.trim(),
+                  grantType: oauthClient.grantType,
+                  redirectUris,
+                }
+              : {
+                  name: name.trim(),
+                  grantType: oauthClient.grantType,
+                  allowedLlmProxyIds: selectedProxyIds,
+                  providerApiKeys: mappedProviderApiKeys,
+                },
+          );
         }}
       >
         <DialogBody className="space-y-4">
@@ -500,25 +591,34 @@ function EditOAuthClientDialog({
             />
           </div>
 
-          <div className="space-y-2">
-            <Label>Allowed LLM proxies</Label>
-            <AgentSelector
-              mode="multiple"
-              flat
-              agents={llmProxies}
-              value={selectedProxyIds}
-              onValueChange={setSelectedProxyIds}
-              placeholder="Select LLM proxies"
-              searchPlaceholder="Search LLM proxies"
-              emptyMessage="No LLM proxies found"
+          {isAuthorizationCode ? (
+            <RedirectUrisField
+              value={redirectUrisText}
+              onChange={setRedirectUrisText}
             />
-          </div>
+          ) : (
+            <>
+              <div className="space-y-2">
+                <Label>Allowed LLM proxies</Label>
+                <AgentSelector
+                  mode="multiple"
+                  flat
+                  agents={llmProxies}
+                  value={selectedProxyIds}
+                  onValueChange={setSelectedProxyIds}
+                  placeholder="Select LLM proxies"
+                  searchPlaceholder="Search LLM proxies"
+                  emptyMessage="No LLM proxies found"
+                />
+              </div>
 
-          <ProviderKeyAccessFields
-            providerApiKeyIds={providerApiKeyIds}
-            onProviderApiKeyIdsChange={setProviderApiKeyIds}
-            providerApiKeys={providerApiKeys}
-          />
+              <ProviderKeyAccessFields
+                providerApiKeyIds={providerApiKeyIds}
+                onProviderApiKeyIdsChange={setProviderApiKeyIds}
+                providerApiKeys={providerApiKeys}
+              />
+            </>
+          )}
         </DialogBody>
         <DialogStickyFooter>
           <Button
@@ -537,6 +637,71 @@ function EditOAuthClientDialog({
   );
 }
 
+function GrantTypeField({
+  value,
+  onChange,
+}: {
+  value: GrantType;
+  onChange: (value: GrantType) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label>Grant type</Label>
+      <RadioGroup
+        value={value}
+        onValueChange={(next) => onChange(next as GrantType)}
+        className="gap-2"
+      >
+        {GRANT_TYPE_OPTIONS.map((option) => (
+          <Label
+            key={option.value}
+            htmlFor={`grant-type-${option.value}`}
+            className="flex cursor-pointer items-start gap-3 rounded-md border p-3 font-normal has-[:checked]:border-primary"
+          >
+            <RadioGroupItem
+              id={`grant-type-${option.value}`}
+              value={option.value}
+              className="mt-0.5"
+            />
+            <div className="space-y-1">
+              <div className="font-medium">{option.label}</div>
+              <p className="text-sm text-muted-foreground">
+                {option.description}
+              </p>
+            </div>
+          </Label>
+        ))}
+      </RadioGroup>
+    </div>
+  );
+}
+
+function RedirectUrisField({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor="oauth-client-redirect-uris">Redirect URIs</Label>
+      <Textarea
+        id="oauth-client-redirect-uris"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={"https://your-app.example.com/oauth/callback"}
+        rows={3}
+      />
+      <p className="text-sm text-muted-foreground">
+        The registering application's own callback URL(s) — where users are sent
+        after they authorize, not an address on this server. Must match the
+        <code className="mx-1">redirect_uri</code>the app sends. One per line.
+      </p>
+    </div>
+  );
+}
+
 function CredentialsDialog({
   open,
   onOpenChange,
@@ -546,12 +711,13 @@ function CredentialsDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
   title: string;
-  credentials: { clientId: string; clientSecret: string } | null;
+  credentials: CreatedCredentials | null;
 }) {
-  const tokenEndpoint =
+  const endpoint = (path: string) =>
     typeof window === "undefined"
-      ? "/api/auth/oauth2/token"
-      : new URL("/api/auth/oauth2/token", window.location.origin).toString();
+      ? path
+      : new URL(path, window.location.origin).toString();
+  const isAuthorizationCode = credentials?.grantType === "authorization_code";
 
   return (
     <FormDialog
@@ -571,12 +737,25 @@ function CredentialsDialog({
               <Label>Client Secret</Label>
               <CopyableCode value={credentials.clientSecret} />
             </div>
+            {isAuthorizationCode && (
+              <div className="rounded-md border bg-muted/40 p-3 text-sm">
+                <div className="mb-2 flex items-center gap-2 font-medium">
+                  <KeyRound className="h-4 w-4" />
+                  Authorization endpoint
+                </div>
+                <CopyableCode value={endpoint("/api/auth/oauth2/authorize")} />
+                <p className="mt-2 text-muted-foreground">
+                  Use the authorization code flow with PKCE and the{" "}
+                  <code>llm:proxy</code> scope.
+                </p>
+              </div>
+            )}
             <div className="rounded-md border bg-muted/40 p-3 text-sm">
               <div className="mb-2 flex items-center gap-2 font-medium">
                 <KeyRound className="h-4 w-4" />
                 Token endpoint
               </div>
-              <CopyableCode value={tokenEndpoint} />
+              <CopyableCode value={endpoint("/api/auth/oauth2/token")} />
             </div>
           </>
         )}

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -42788,12 +42788,14 @@ export type GetLlmOauthClientsResponses = {
         clientId: string;
         name: string;
         organizationId: string;
+        grantType: 'client_credentials' | 'authorization_code';
         allowedLlmProxyIds: Array<string>;
         providerApiKeys: Array<{
             provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
             providerApiKeyId: string;
             providerApiKeyName: string;
         }>;
+        redirectUris: Array<string>;
         disabled: boolean;
         createdAt: string;
         updatedAt: string;
@@ -42805,11 +42807,13 @@ export type GetLlmOauthClientsResponse = GetLlmOauthClientsResponses[keyof GetLl
 export type CreateLlmOauthClientData = {
     body: {
         name: string;
-        allowedLlmProxyIds: Array<string>;
-        providerApiKeys: Array<{
+        grantType?: 'client_credentials' | 'authorization_code';
+        allowedLlmProxyIds?: Array<string>;
+        providerApiKeys?: Array<{
             provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
             providerApiKeyId: string;
         }>;
+        redirectUris?: Array<string>;
     };
     path?: never;
     query?: never;
@@ -42890,12 +42894,14 @@ export type CreateLlmOauthClientResponses = {
         clientId: string;
         name: string;
         organizationId: string;
+        grantType: 'client_credentials' | 'authorization_code';
         allowedLlmProxyIds: Array<string>;
         providerApiKeys: Array<{
             provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
             providerApiKeyId: string;
             providerApiKeyName: string;
         }>;
+        redirectUris: Array<string>;
         disabled: boolean;
         createdAt: string;
         updatedAt: string;
@@ -42993,11 +42999,13 @@ export type DeleteLlmOauthClientResponse = DeleteLlmOauthClientResponses[keyof D
 export type UpdateLlmOauthClientData = {
     body: {
         name: string;
-        allowedLlmProxyIds: Array<string>;
-        providerApiKeys: Array<{
+        grantType?: 'client_credentials' | 'authorization_code';
+        allowedLlmProxyIds?: Array<string>;
+        providerApiKeys?: Array<{
             provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
             providerApiKeyId: string;
         }>;
+        redirectUris?: Array<string>;
     };
     path: {
         id: string;
@@ -43080,12 +43088,14 @@ export type UpdateLlmOauthClientResponses = {
         clientId: string;
         name: string;
         organizationId: string;
+        grantType: 'client_credentials' | 'authorization_code';
         allowedLlmProxyIds: Array<string>;
         providerApiKeys: Array<{
             provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
             providerApiKeyId: string;
             providerApiKeyName: string;
         }>;
+        redirectUris: Array<string>;
         disabled: boolean;
         createdAt: string;
         updatedAt: string;
@@ -43177,12 +43187,14 @@ export type RotateLlmOauthClientSecretResponses = {
         clientId: string;
         name: string;
         organizationId: string;
+        grantType: 'client_credentials' | 'authorization_code';
         allowedLlmProxyIds: Array<string>;
         providerApiKeys: Array<{
             provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
             providerApiKeyId: string;
             providerApiKeyName: string;
         }>;
+        redirectUris: Array<string>;
         disabled: boolean;
         createdAt: string;
         updatedAt: string;


### PR DESCRIPTION
## What

Ports the merged MCP-gateway feature (#5683) to the **LLM proxy's** LLM OAuth clients, which were `client_credentials`-only. A **pre-registered confidential** client can now mint **user-bound** tokens, so the proxy acts with the signed-in user's identity rather than as one shared application credential.

## Why

This is the symmetric counterpart to #5683. The same agentic-chat-backend scenario that wants per-user MCP gateway access also wants per-user LLM proxy access: with a `client_credentials` LLM client, calls are charged to a shared credential with fixed provider keys; with `authorization_code`, the proxy resolves **each user's own** provider keys, **cost limits**, and **policies**. The user authorization-code flow already existed for *self-registered* (DCR/CIMD) clients — the gap was a *pre-registered, confidential* client, exactly as on the MCP side.

## How it works

- `LlmOauthClient` gains a **`grantType`** (`client_credentials` | `authorization_code`). An `authorization_code` client registers **confidential + PKCE** (`grantTypes=[authorization_code, refresh_token]`, `responseTypes=[code]`, `requirePKCE`, `scopes=[llm:proxy, offline_access]`) with **redirect URIs**, and carries **no provider keys and no proxy list** — the acting user governs both.
- **No proxy-auth changes.** `validateLlmOAuthAccessToken` already dispatches on `userId` presence to the user-token path, which resolves the user's own key via `resolveProviderApiKey({ userId })`. A user-bound `authorization_code` token flows through unchanged.
- **Secret verification reuses #5683's merged plumbing.** `authorization_code` secrets are stored as the deterministic hash better-auth verifies (`hashOauthClientSecret`); `client_credentials` keep bcrypt (verified by this model). The global `oauthProvider.storeClientSecret` config and the `ARCHESTRA_AUTH_DCR_ENABLED` disable-DCR toggle from #5683 already cover `llm:proxy`.

### Scope of change
- **No DB migration** — `grantType` lives in `metadata`; `oauth_client` already has the needed columns. Existing `client_credentials` clients read back with `grantType` defaulted and behave identically.
- **No new routes / RBAC** — reuses `/api/llm-oauth-clients` with an extended body (`grantType` defaults to `client_credentials`).

## Frontend

- The **LLM Proxies > Credentials > OAuth Clients** create/edit dialog gains a grant-type selector: `authorization_code` shows **redirect URIs**, `client_credentials` keeps the proxies + provider-key fields. A "Type" column distinguishes them; the credentials dialog surfaces the authorization endpoint.

## Docs

- `platform-llm-proxy-authentication.md`: top method table updated; the LLM OAuth Clients intro + "Managing OAuth Clients" steps now cover both grants; the user-OAuth section documents the **pre-registered confidential** path alongside self-registration (DCR/CIMD) and the disable-DCR toggle.

## Tests

- **Route-level integration**: create / validate / update `authorization_code` clients; confirms the `oauth_client` row is confidential + PKCE with the right grant/response types and `llm:proxy + offline_access` scopes; **asserts the stored secret equals the deterministic hash better-auth expects** (regression guard); redirect-URI required + URL-validated; proxies/provider-keys not required.
- **Proxy-auth integration**: a user-bound `authorization_code` token resolves the acting user (`authMethod: oauth_user`, `userId`) and **the user's own provider key** (not the client's) via the real `validateLlmOAuthAccessToken` → `resolveProviderApiKey` path; rejected when the user can't access the proxy.
- Existing `client_credentials` model/route/proxy-auth tests still pass. Backend type-check, knip (dev+production), Biome clean; frontend type-check + knip clean.

## Verification note

The browser authorize→token exchange is the same better-auth machinery verified live end-to-end in #5683 (it's scope-agnostic — `llm:proxy` vs `mcp`). The LLM-specific surface — user-bound token → per-user provider-key resolution — is covered by the proxy-auth integration test against the real resolver (PGlite, not mocked). Happy to spin up a live instance for a full `llm:proxy` round-trip if you'd like belt-and-suspenders.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>