### PR TITLE
feat(mcp-apps): shareable app connector as a native OAuth remote MCP server

### DIFF
--- a/platform/backend/src/auth/fastify-plugin/middleware.test.ts
+++ b/platform/backend/src/auth/fastify-plugin/middleware.test.ts
@@ -2,6 +2,7 @@ import { SupportedProviders } from "@archestra/shared";
 import * as Sentry from "@sentry/node";
 import type { FastifyReply, FastifyRequest } from "fastify";
 import { vi } from "vitest";
+import config from "@/config";
 import { afterEach, describe, expect, test } from "@/test";
 import { Authnz } from "./middleware";
 
@@ -683,6 +684,75 @@ describe("Authnz", () => {
       expect(() => {
         authnz.setSentryUserContext(mockUser, mockRequest);
       }).not.toThrow();
+    });
+  });
+
+  describe("MCP App connector auth", () => {
+    const CONNECTOR_URL = "/api/mcp/app/11111111-1111-1111-1111-111111111111";
+    const makeReply = () =>
+      ({
+        status: vi.fn().mockReturnThis(),
+        send: vi.fn(),
+        header: vi.fn().mockReturnThis(),
+      }) as unknown as FastifyReply;
+
+    test("stands down for a Bearer connector request (validated in-route)", async () => {
+      const mockRequest = {
+        url: CONNECTOR_URL,
+        method: "POST",
+        headers: { authorization: "Bearer connector-token" },
+      } as FastifyRequest;
+      const mockReply = makeReply();
+
+      await authnz.handle(mockRequest, mockReply);
+
+      // Skipped here so the route validates the token; no auth failure, no challenge.
+      expect(mockReply.status).not.toHaveBeenCalled();
+      expect(mockReply.send).not.toHaveBeenCalled();
+      expect(mockReply.header).not.toHaveBeenCalled();
+    });
+
+    test("challenges a credential-less connector request (RFC 9728) when apps are enabled", async () => {
+      const original = config.apps.enabled;
+      (config.apps as { enabled: boolean }).enabled = true;
+      try {
+        const mockRequest = {
+          url: CONNECTOR_URL,
+          method: "POST",
+          headers: { host: "localhost:9000" },
+        } as FastifyRequest;
+        const mockReply = makeReply();
+
+        await expect(authnz.handle(mockRequest, mockReply)).rejects.toThrow(
+          "Unauthenticated",
+        );
+        expect(mockReply.header).toHaveBeenCalledWith(
+          "WWW-Authenticate",
+          expect.stringContaining("resource_metadata"),
+        );
+      } finally {
+        (config.apps as { enabled: boolean }).enabled = original;
+      }
+    });
+
+    test("does not challenge a connector request when apps are disabled (dark)", async () => {
+      const original = config.apps.enabled;
+      (config.apps as { enabled: boolean }).enabled = false;
+      try {
+        const mockRequest = {
+          url: CONNECTOR_URL,
+          method: "POST",
+          headers: { host: "localhost:9000" },
+        } as FastifyRequest;
+        const mockReply = makeReply();
+
+        await expect(authnz.handle(mockRequest, mockReply)).rejects.toThrow(
+          "Unauthenticated",
+        );
+        expect(mockReply.header).not.toHaveBeenCalled();
+      } finally {
+        (config.apps as { enabled: boolean }).enabled = original;
+      }
     });
   });
 });

--- a/platform/backend/src/auth/fastify-plugin/middleware.ts
+++ b/platform/backend/src/auth/fastify-plugin/middleware.ts
@@ -7,6 +7,7 @@ import config from "@/config";
 import logger from "@/logging";
 import { ServiceAccountModel, UserModel } from "@/models";
 import { MODEL_ROUTER_PREFIX } from "@/routes/proxy/common";
+import { getPublicRequestOrigin } from "@/routes/request-origin";
 import {
   ARCHESTRA_CATALOG_PROXY_PREFIX,
   CONNECTION_SETUP_SCRIPT_PREFIX,
@@ -20,10 +21,14 @@ import {
   WELL_KNOWN_ACME_PREFIX,
   WELL_KNOWN_OAUTH_PREFIX,
 } from "@/routes/route-paths";
+import {
+  appIdFromConnectorPath,
+  connectorWwwAuthenticate,
+} from "@/services/apps/app-connector-resource";
 import { ApiError } from "@/types";
 
 export class Authnz {
-  public handle = async (request: FastifyRequest, _reply: FastifyReply) => {
+  public handle = async (request: FastifyRequest, reply: FastifyReply) => {
     const requestId = request.id;
 
     // custom logic to skip auth check
@@ -37,6 +42,10 @@ export class Authnz {
         { requestId, url: request.url },
         "[Authnz] Authentication failed",
       );
+      // A credential-less request to an MCP App connector gets the RFC 9728
+      // challenge here (it has no Bearer header, so it was not skipped above and
+      // never reaches the route); an invalid Bearer token is challenged in-route.
+      this.maybeSetConnectorChallenge(request, reply);
       throw new ApiError(401, "Unauthenticated");
     }
 
@@ -129,10 +138,11 @@ export class Authnz {
       url === METRICS_PATH ||
       url === "/test" ||
       url.startsWith(config.mcpGateway.endpoint) ||
-      // MCP app runtime: external MCP clients authenticate with a Bearer token
-      // validated in-route (like the MCP gateway). Cookie/session requests from
-      // Archestra's own frontend carry no Bearer header and fall through to the
-      // normal session auth below, so that path is unchanged.
+      // MCP App connector: a Bearer request (a personal token or the native
+      // OAuth flow's audience-bound token) is validated in-route, so it stands
+      // down here. A session request carries no Bearer and falls through to the
+      // normal session auth below (unchanged); a credential-less request also
+      // falls through and is answered with the RFC 9728 challenge in handle().
       (url.startsWith("/api/mcp/app/") &&
         typeof headers.authorization === "string" &&
         /^Bearer\s+/i.test(headers.authorization)) ||
@@ -173,6 +183,25 @@ export class Authnz {
       return true;
     }
     return false;
+  };
+
+  private maybeSetConnectorChallenge = (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ): void => {
+    // Dark when the feature is off: no OAuth challenge that would advertise the
+    // connector mechanism exists (FR-1).
+    if (!config.apps.enabled) {
+      return;
+    }
+    const appId = appIdFromConnectorPath(request.url);
+    if (!appId) {
+      return;
+    }
+    reply.header(
+      "WWW-Authenticate",
+      connectorWwwAuthenticate(getPublicRequestOrigin(request), appId),
+    );
   };
 
   private isAuthenticated = async (request: FastifyRequest) => {

--- a/platform/backend/src/auth/fastify-plugin/middleware.ts
+++ b/platform/backend/src/auth/fastify-plugin/middleware.ts
@@ -143,7 +143,7 @@ export class Authnz {
       // down here. A session request carries no Bearer and falls through to the
       // normal session auth below (unchanged); a credential-less request also
       // falls through and is answered with the RFC 9728 challenge in handle().
-      (url.startsWith("/api/mcp/app/") &&
+      (appIdFromConnectorPath(url) !== null &&
         typeof headers.authorization === "string" &&
         /^Bearer\s+/i.test(headers.authorization)) ||
       // Public skill marketplace git endpoint: token in URL, no session

--- a/platform/backend/src/auth/fastify-plugin/middleware.ts
+++ b/platform/backend/src/auth/fastify-plugin/middleware.ts
@@ -190,7 +190,7 @@ export class Authnz {
     reply: FastifyReply,
   ): void => {
     // Dark when the feature is off: no OAuth challenge that would advertise the
-    // connector mechanism exists (FR-1).
+    // connector mechanism exists.
     if (!config.apps.enabled) {
       return;
     }

--- a/platform/backend/src/models/index.ts
+++ b/platform/backend/src/models/index.ts
@@ -62,6 +62,7 @@ export { default as MessageModel } from "./message";
 export { default as ModelModel } from "./model";
 export { default as OAuthAccessTokenModel } from "./oauth-access-token";
 export { default as OAuthClientModel } from "./oauth-client";
+export { default as OAuthRefreshTokenModel } from "./oauth-refresh-token";
 export { default as OptimizationRuleModel } from "./optimization-rule";
 export { default as OrganizationModel } from "./organization";
 export { default as OrganizationRoleModel } from "./organization-role";

--- a/platform/backend/src/models/oauth-access-token.test.ts
+++ b/platform/backend/src/models/oauth-access-token.test.ts
@@ -256,4 +256,64 @@ describe("OAuthAccessTokenModel", () => {
       expect(updated).toBeNull();
     });
   });
+
+  describe("bindReferenceIdByTokenHashWhenUnbound", () => {
+    test("binds the audience when the token is still unbound", async ({
+      makeUser,
+      makeOAuthClient,
+      makeOAuthAccessToken,
+    }) => {
+      const user = await makeUser();
+      const client = await makeOAuthClient({ userId: user.id });
+      await makeOAuthAccessToken(client.clientId, user.id, {
+        token: "unbound-token-hash",
+        referenceId: null,
+      });
+
+      const bound =
+        await OAuthAccessTokenModel.bindReferenceIdByTokenHashWhenUnbound({
+          tokenHash: "unbound-token-hash",
+          referenceId: "mcp-app-resource:https://host/api/mcp/app/app-1",
+        });
+
+      expect(bound?.referenceId).toBe(
+        "mcp-app-resource:https://host/api/mcp/app/app-1",
+      );
+    });
+
+    test("never overwrites a token that is already bound", async ({
+      makeUser,
+      makeOAuthClient,
+      makeOAuthAccessToken,
+    }) => {
+      const user = await makeUser();
+      const client = await makeOAuthClient({ userId: user.id });
+      await makeOAuthAccessToken(client.clientId, user.id, {
+        token: "already-bound-token-hash",
+        referenceId: "mcp-resource:some-gateway",
+      });
+
+      const bound =
+        await OAuthAccessTokenModel.bindReferenceIdByTokenHashWhenUnbound({
+          tokenHash: "already-bound-token-hash",
+          referenceId: "mcp-app-resource:https://host/api/mcp/app/app-1",
+        });
+
+      expect(bound).toBeNull();
+      const found = await OAuthAccessTokenModel.getByTokenHash(
+        "already-bound-token-hash",
+      );
+      expect(found?.referenceId).toBe("mcp-resource:some-gateway");
+    });
+
+    test("returns null when the token hash does not match", async () => {
+      const bound =
+        await OAuthAccessTokenModel.bindReferenceIdByTokenHashWhenUnbound({
+          tokenHash: "missing-token-hash",
+          referenceId: "mcp-app-resource:https://host/api/mcp/app/app-1",
+        });
+
+      expect(bound).toBeNull();
+    });
+  });
 });

--- a/platform/backend/src/models/oauth-access-token.ts
+++ b/platform/backend/src/models/oauth-access-token.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import db, { schema } from "@/database";
 
 class OAuthAccessTokenModel {
@@ -107,6 +107,32 @@ class OAuthAccessTokenModel {
       .update(schema.oauthAccessTokensTable)
       .set({ expiresAt: params.expiresAt })
       .where(eq(schema.oauthAccessTokensTable.token, params.tokenHash))
+      .returning();
+
+    return accessToken ?? null;
+  }
+
+  /**
+   * Bind a freshly minted token to a resource audience, only while it is still
+   * unbound. better-auth issues opaque tokens with a null `referenceId`; the
+   * shareable-App connector mint stamps the audience here. The `IS NULL` guard
+   * makes this a one-shot write so it can never clobber a binding another issuer
+   * (e.g. the enterprise-managed `mcp-resource:` path) already set. Returns the
+   * updated row, or null when the token was absent or already bound.
+   */
+  static async bindReferenceIdByTokenHashWhenUnbound(params: {
+    tokenHash: string;
+    referenceId: string;
+  }) {
+    const [accessToken] = await db
+      .update(schema.oauthAccessTokensTable)
+      .set({ referenceId: params.referenceId })
+      .where(
+        and(
+          eq(schema.oauthAccessTokensTable.token, params.tokenHash),
+          isNull(schema.oauthAccessTokensTable.referenceId),
+        ),
+      )
       .returning();
 
     return accessToken ?? null;

--- a/platform/backend/src/models/oauth-refresh-token.test.ts
+++ b/platform/backend/src/models/oauth-refresh-token.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "@/test";
+import OAuthRefreshTokenModel from "./oauth-refresh-token";
+
+const APP_REF = "mcp-app-resource:https://host/api/mcp/app/app-1";
+const OTHER_REF = "mcp-app-resource:https://host/api/mcp/app/app-2";
+
+describe("OAuthRefreshTokenModel", () => {
+  describe("getById", () => {
+    test("returns the row's id and (initially null) referenceId", async ({
+      makeUser,
+      makeOAuthClient,
+      makeOAuthRefreshToken,
+    }) => {
+      const user = await makeUser();
+      const client = await makeOAuthClient({ userId: user.id });
+      const refreshToken = await makeOAuthRefreshToken(
+        client.clientId,
+        user.id,
+      );
+
+      const found = await OAuthRefreshTokenModel.getById(refreshToken.id);
+
+      expect(found?.id).toBe(refreshToken.id);
+      expect(found?.referenceId).toBeNull();
+    });
+
+    test("returns null when the id does not match", async () => {
+      const found = await OAuthRefreshTokenModel.getById(crypto.randomUUID());
+
+      expect(found).toBeNull();
+    });
+
+    test("reflects a binding written by bindReferenceIdByIdWhenUnbound", async ({
+      makeUser,
+      makeOAuthClient,
+      makeOAuthRefreshToken,
+    }) => {
+      const user = await makeUser();
+      const client = await makeOAuthClient({ userId: user.id });
+      const refreshToken = await makeOAuthRefreshToken(
+        client.clientId,
+        user.id,
+      );
+
+      await OAuthRefreshTokenModel.bindReferenceIdByIdWhenUnbound({
+        id: refreshToken.id,
+        referenceId: APP_REF,
+      });
+
+      const found = await OAuthRefreshTokenModel.getById(refreshToken.id);
+      expect(found?.referenceId).toBe(APP_REF);
+    });
+  });
+
+  describe("bindReferenceIdByIdWhenUnbound", () => {
+    test("binds the audience when the token is still unbound", async ({
+      makeUser,
+      makeOAuthClient,
+      makeOAuthRefreshToken,
+    }) => {
+      const user = await makeUser();
+      const client = await makeOAuthClient({ userId: user.id });
+      const refreshToken = await makeOAuthRefreshToken(
+        client.clientId,
+        user.id,
+      );
+
+      const bound = await OAuthRefreshTokenModel.bindReferenceIdByIdWhenUnbound(
+        {
+          id: refreshToken.id,
+          referenceId: APP_REF,
+        },
+      );
+
+      expect(bound?.referenceId).toBe(APP_REF);
+    });
+
+    test("never overwrites a token that is already bound", async ({
+      makeUser,
+      makeOAuthClient,
+      makeOAuthRefreshToken,
+    }) => {
+      const user = await makeUser();
+      const client = await makeOAuthClient({ userId: user.id });
+      const refreshToken = await makeOAuthRefreshToken(
+        client.clientId,
+        user.id,
+      );
+      await OAuthRefreshTokenModel.bindReferenceIdByIdWhenUnbound({
+        id: refreshToken.id,
+        referenceId: APP_REF,
+      });
+
+      const rebind =
+        await OAuthRefreshTokenModel.bindReferenceIdByIdWhenUnbound({
+          id: refreshToken.id,
+          referenceId: OTHER_REF,
+        });
+
+      expect(rebind).toBeNull();
+      const found = await OAuthRefreshTokenModel.getById(refreshToken.id);
+      expect(found?.referenceId).toBe(APP_REF);
+    });
+
+    test("returns null when the id does not match", async () => {
+      const bound = await OAuthRefreshTokenModel.bindReferenceIdByIdWhenUnbound(
+        {
+          id: crypto.randomUUID(),
+          referenceId: APP_REF,
+        },
+      );
+
+      expect(bound).toBeNull();
+    });
+  });
+});

--- a/platform/backend/src/models/oauth-refresh-token.ts
+++ b/platform/backend/src/models/oauth-refresh-token.ts
@@ -1,0 +1,46 @@
+import { and, eq, isNull } from "drizzle-orm";
+import db, { schema } from "@/database";
+
+class OAuthRefreshTokenModel {
+  /**
+   * Read a refresh token's resource binding. The shareable-App connector mint
+   * reads this on a `refresh_token` grant so a refreshed access token inherits
+   * the audience even when the client omits the `resource` parameter.
+   */
+  static async getById(id: string) {
+    const [row] = await db
+      .select({
+        id: schema.oauthRefreshTokensTable.id,
+        referenceId: schema.oauthRefreshTokensTable.referenceId,
+      })
+      .from(schema.oauthRefreshTokensTable)
+      .where(eq(schema.oauthRefreshTokensTable.id, id))
+      .limit(1);
+    return row ?? null;
+  }
+
+  /**
+   * Bind a refresh token to a resource audience while it is still unbound, so a
+   * later refresh that omits `resource` can carry the binding forward. The
+   * `IS NULL` guard keeps this a one-shot write that never overwrites a binding
+   * another issuer set.
+   */
+  static async bindReferenceIdByIdWhenUnbound(params: {
+    id: string;
+    referenceId: string;
+  }) {
+    const [row] = await db
+      .update(schema.oauthRefreshTokensTable)
+      .set({ referenceId: params.referenceId })
+      .where(
+        and(
+          eq(schema.oauthRefreshTokensTable.id, params.id),
+          isNull(schema.oauthRefreshTokensTable.referenceId),
+        ),
+      )
+      .returning();
+    return row ?? null;
+  }
+}
+
+export default OAuthRefreshTokenModel;

--- a/platform/backend/src/routes/auth.test.ts
+++ b/platform/backend/src/routes/auth.test.ts
@@ -1045,6 +1045,32 @@ describe("bindAppConnectorTokenAudience", () => {
     expect(row?.referenceId).toBeNull();
   });
 
+  test("a connector-targeted resource on an untrusted origin fails closed (not an unbound token)", async ({
+    makeUser,
+    makeOAuthClient,
+    makeOAuthAccessToken,
+  }) => {
+    const user = await makeUser();
+    const client = await makeOAuthClient({ userId: user.id });
+    const rawToken = `tok-${crypto.randomUUID()}`;
+    await makeOAuthAccessToken(client.clientId, user.id, {
+      token: sha256(rawToken),
+      referenceId: null,
+    });
+    const { bindAppConnectorTokenAudience } = await import("./auth");
+    const result = await bindAppConnectorTokenAudience({
+      // Connector-shaped, but the origin is not one this server serves — must
+      // not fall through to an unbound mcp token.
+      resource: `https://evil.example.com/api/mcp/app/${APP_A}`,
+      responseBody: JSON.stringify({ access_token: rawToken }),
+      grantType: "authorization_code",
+      tokenEndpointOrigin: ORIGIN,
+    });
+    expect(result.status).toBe("error");
+    const row = await OAuthAccessTokenModel.getByTokenHash(sha256(rawToken));
+    expect(row?.referenceId).toBeNull();
+  });
+
   test("refresh honors the inherited binding for the same resource and when omitted", async ({
     makeUser,
     makeOAuthClient,

--- a/platform/backend/src/routes/auth.test.ts
+++ b/platform/backend/src/routes/auth.test.ts
@@ -13,6 +13,10 @@ import OAuthAccessTokenModel from "@/models/oauth-access-token";
 import OrganizationModel from "@/models/organization";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
+import {
+  appConnectorAudienceRef,
+  buildConnectorResourceUri,
+} from "@/services/apps/app-connector-resource";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 
 vi.mock("@/auth", () => ({
@@ -980,3 +984,111 @@ async function createAuthTestApp(): Promise<FastifyInstanceWithZod> {
   await app.register(authRoutes);
   return app;
 }
+
+describe("bindAppConnectorTokenAudience", () => {
+  const ORIGIN = "http://localhost:9000";
+  const APP_A = "11111111-1111-4111-8111-111111111111";
+  const APP_B = "22222222-2222-4222-8222-222222222222";
+  const connA = `${ORIGIN}/api/mcp/app/${APP_A}`;
+  const connB = `${ORIGIN}/api/mcp/app/${APP_B}`;
+  const refA = appConnectorAudienceRef(
+    buildConnectorResourceUri(ORIGIN, APP_A) as string,
+  );
+  const sha256 = (v: string) =>
+    createHash("sha256").update(v).digest("base64url");
+
+  test("authorization_code grant stamps the consented connector audience", async ({
+    makeUser,
+    makeOAuthClient,
+    makeOAuthAccessToken,
+  }) => {
+    const user = await makeUser();
+    const client = await makeOAuthClient({ userId: user.id });
+    const rawToken = `tok-${crypto.randomUUID()}`;
+    await makeOAuthAccessToken(client.clientId, user.id, {
+      token: sha256(rawToken),
+      referenceId: null,
+    });
+    const { bindAppConnectorTokenAudience } = await import("./auth");
+    const result = await bindAppConnectorTokenAudience({
+      resource: connA,
+      responseBody: JSON.stringify({ access_token: rawToken }),
+      grantType: "authorization_code",
+      tokenEndpointOrigin: ORIGIN,
+    });
+    expect(result.status).toBe("ok");
+    const row = await OAuthAccessTokenModel.getByTokenHash(sha256(rawToken));
+    expect(row?.referenceId).toBe(refA);
+  });
+
+  test("a grant with no connector resource leaves the token unbound", async ({
+    makeUser,
+    makeOAuthClient,
+    makeOAuthAccessToken,
+  }) => {
+    const user = await makeUser();
+    const client = await makeOAuthClient({ userId: user.id });
+    const rawToken = `tok-${crypto.randomUUID()}`;
+    await makeOAuthAccessToken(client.clientId, user.id, {
+      token: sha256(rawToken),
+      referenceId: null,
+    });
+    const { bindAppConnectorTokenAudience } = await import("./auth");
+    const result = await bindAppConnectorTokenAudience({
+      resource: undefined,
+      responseBody: JSON.stringify({ access_token: rawToken }),
+      grantType: "authorization_code",
+      tokenEndpointOrigin: ORIGIN,
+    });
+    expect(result.status).toBe("skip");
+    const row = await OAuthAccessTokenModel.getByTokenHash(sha256(rawToken));
+    expect(row?.referenceId).toBeNull();
+  });
+
+  test("refresh honors the inherited binding for the same resource and when omitted", async ({
+    makeUser,
+    makeOAuthClient,
+    makeOAuthAccessToken,
+  }) => {
+    const user = await makeUser();
+    const { bindAppConnectorTokenAudience } = await import("./auth");
+    for (const resource of [connA, undefined]) {
+      const client = await makeOAuthClient({ userId: user.id });
+      const rawToken = `tok-${crypto.randomUUID()}`;
+      // better-auth carries the audience onto the refreshed token.
+      await makeOAuthAccessToken(client.clientId, user.id, {
+        token: sha256(rawToken),
+        referenceId: refA,
+      });
+      const result = await bindAppConnectorTokenAudience({
+        resource,
+        responseBody: JSON.stringify({ access_token: rawToken }),
+        grantType: "refresh_token",
+        tokenEndpointOrigin: ORIGIN,
+      });
+      expect(result.status).toBe("ok");
+    }
+  });
+
+  test("refresh rejects an attempt to re-target a different connector", async ({
+    makeUser,
+    makeOAuthClient,
+    makeOAuthAccessToken,
+  }) => {
+    const user = await makeUser();
+    const client = await makeOAuthClient({ userId: user.id });
+    const rawToken = `tok-${crypto.randomUUID()}`;
+    await makeOAuthAccessToken(client.clientId, user.id, {
+      token: sha256(rawToken),
+      referenceId: refA,
+    });
+    const { bindAppConnectorTokenAudience } = await import("./auth");
+    const result = await bindAppConnectorTokenAudience({
+      resource: connB,
+      responseBody: JSON.stringify({ access_token: rawToken }),
+      grantType: "refresh_token",
+      tokenEndpointOrigin: ORIGIN,
+    });
+    expect(result.status).toBe("error");
+  });
+});

--- a/platform/backend/src/routes/auth.ts
+++ b/platform/backend/src/routes/auth.ts
@@ -26,10 +26,16 @@ import {
   MemberModel,
   OAuthAccessTokenModel,
   OAuthClientModel,
+  OAuthRefreshTokenModel,
   OrganizationModel,
   UserModel,
   UserTokenModel,
 } from "@/models";
+import {
+  appConnectorAudienceRef,
+  isAppConnectorAudienceRef,
+  resolveAppConnectorResource,
+} from "@/services/apps/app-connector-resource";
 import {
   buildOAuthIssuer,
   exchangeIdentityAssertionForAccessToken,
@@ -494,6 +500,25 @@ const authRoutes: FastifyPluginAsyncZod = async (fastify) => {
           },
           "[auth:oauth2/token] Token request failed",
         );
+      }
+
+      // Bind a shareable-App connector token to its canonical resource URI
+      // (RFC 8707) so it is accepted only at its own connector. Fail closed if
+      // an app-connector resource was requested but the binding can't be written
+      // — better to error than hand back a token that silently 401s.
+      if (response.ok) {
+        const connectorBinding = await bindAppConnectorTokenAudience({
+          resource,
+          responseBody,
+          grantType: body?.grant_type,
+          tokenEndpointOrigin,
+        });
+        if (connectorBinding.status === "error") {
+          return reply.status(400).send({
+            error: "invalid_target",
+            error_description: connectorBinding.message,
+          });
+        }
       }
 
       reply.status(response.status);
@@ -1199,4 +1224,125 @@ function getProfileIdFromReferenceId(
 
 function hashOAuthAccessTokenForLookup(oauthAccessToken: string): string {
   return OAuthAccessTokenModel.hashTokenForLookup(oauthAccessToken);
+}
+
+/**
+ * Bind a freshly minted access token to a shareable-App connector resource
+ * (RFC 8707), so the connector accepts it only at its own canonical URI. The
+ * `resource` parameter is stripped before better-auth (which rejects a dynamic
+ * audience), so the binding is stamped here, after mint. On an authorization_code
+ * grant the audience is the consented `resource`; on a refresh_token grant it is
+ * the audience carried on the refresh token from the original grant — a refresh
+ * cannot re-target a different connector. Returns `error` when an app-connector
+ * resource was requested but the token could not be bound to it, so the caller
+ * fails the request rather than return a token that silently 401s.
+ *
+ * @public — exercised by auth.test.ts
+ */
+export async function bindAppConnectorTokenAudience(params: {
+  resource: unknown;
+  responseBody: string | null;
+  grantType: unknown;
+  tokenEndpointOrigin: string;
+}): Promise<{ status: "ok" | "skip" } | { status: "error"; message: string }> {
+  if (!params.responseBody) {
+    return { status: "skip" };
+  }
+  const tokenBody = parseOAuthTokenResponseBody(params.responseBody);
+  const accessToken =
+    typeof tokenBody?.access_token === "string" ? tokenBody.access_token : null;
+  if (!accessToken) {
+    return { status: "skip" };
+  }
+
+  const allowedOrigins = new Set([
+    new URL(buildOAuthIssuer()).origin,
+    params.tokenEndpointOrigin,
+  ]);
+  const requestedCanonical = resolveAppConnectorResource(
+    params.resource,
+    allowedOrigins,
+  );
+  const requestedRef = requestedCanonical
+    ? appConnectorAudienceRef(requestedCanonical)
+    : null;
+  const tokenHash = hashOAuthAccessTokenForLookup(accessToken);
+
+  if (params.grantType === "refresh_token") {
+    // better-auth carries the original grant's audience onto the refreshed
+    // token, so a refresh cannot acquire a connector the original grant did not
+    // authorize. Honor that inherited binding and reject an attempt to
+    // re-target a different connector (RFC 8707 invalid_target).
+    const refreshed = await OAuthAccessTokenModel.getByTokenHash(tokenHash);
+    let inheritedRef = isAppConnectorAudienceRef(refreshed?.referenceId)
+      ? (refreshed?.referenceId ?? null)
+      : null;
+    if (!inheritedRef && refreshed?.refreshId) {
+      const refresh = await OAuthRefreshTokenModel.getById(refreshed.refreshId);
+      inheritedRef = isAppConnectorAudienceRef(refresh?.referenceId)
+        ? (refresh?.referenceId ?? null)
+        : null;
+    }
+    if (requestedRef && requestedRef !== inheritedRef) {
+      return {
+        status: "error",
+        message: "The refresh token is not bound to the requested resource.",
+      };
+    }
+    if (!inheritedRef) {
+      return { status: "skip" };
+    }
+    // Stamp the access token only if better-auth did not already inherit it.
+    if (refreshed?.referenceId !== inheritedRef) {
+      await OAuthAccessTokenModel.bindReferenceIdByTokenHashWhenUnbound({
+        tokenHash,
+        referenceId: inheritedRef,
+      });
+    }
+    return { status: "ok" };
+  }
+
+  // Initial (authorization_code) grant: stamp the consented connector audience.
+  if (!requestedRef) {
+    return { status: "skip" };
+  }
+  const bound =
+    await OAuthAccessTokenModel.bindReferenceIdByTokenHashWhenUnbound({
+      tokenHash,
+      referenceId: requestedRef,
+    });
+  if (!bound) {
+    // A prior stamp of the same audience is success (idempotent); any other
+    // unbindable state fails closed.
+    const existing = await OAuthAccessTokenModel.getByTokenHash(tokenHash);
+    if (existing?.referenceId === requestedRef) {
+      return { status: "ok" };
+    }
+    logger.error(
+      { requestedRef },
+      "[auth:oauth2/token] could not bind app connector token to its resource",
+    );
+    return {
+      status: "error",
+      message: "Unable to bind the access token to the requested resource.",
+    };
+  }
+  // Carry the binding onto the refresh token so better-auth inherits it on later
+  // refreshes. Best-effort: if it can't be written, a future refresh that omits
+  // `resource` yields an unbound token the connector rejects (fail-closed).
+  if (bound.refreshId) {
+    const carried = await OAuthRefreshTokenModel.bindReferenceIdByIdWhenUnbound(
+      {
+        id: bound.refreshId,
+        referenceId: requestedRef,
+      },
+    );
+    if (!carried) {
+      logger.warn(
+        { refreshId: bound.refreshId, requestedRef },
+        "[auth:oauth2/token] could not carry the connector audience onto the refresh token",
+      );
+    }
+  }
+  return { status: "ok" };
 }

--- a/platform/backend/src/routes/auth.ts
+++ b/platform/backend/src/routes/auth.ts
@@ -34,6 +34,7 @@ import {
 import {
   appConnectorAudienceRef,
   isAppConnectorAudienceRef,
+  isConnectorTargetedResource,
   resolveAppConnectorResource,
 } from "@/services/apps/app-connector-resource";
 import {
@@ -1266,6 +1267,21 @@ export async function bindAppConnectorTokenAudience(params: {
   const requestedRef = requestedCanonical
     ? appConnectorAudienceRef(requestedCanonical)
     : null;
+
+  // A `resource` that targets a connector path but did not resolve to a trusted
+  // canonical URI (an untrusted origin like https://evil.example.com/api/mcp/app/<id>,
+  // or a malformed/sub-path connector URL) must fail closed with RFC 8707
+  // invalid_target. Falling through to "skip" would mint an unbound `mcp` token,
+  // which still authenticates the MCP gateway via the user-access path. Absent or
+  // non-connector resources are unaffected (they bind elsewhere or not at all).
+  if (!requestedRef && isConnectorTargetedResource(params.resource)) {
+    return {
+      status: "error",
+      message:
+        "The requested resource is not a valid connector on this server.",
+    };
+  }
+
   const tokenHash = hashOAuthAccessTokenForLookup(accessToken);
 
   if (params.grantType === "refresh_token") {

--- a/platform/backend/src/routes/mcp-app-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-app-gateway.utils.ts
@@ -292,11 +292,11 @@ export async function validateAppGatewayToken(
 /**
  * Resolve a shareable-App connector OAuth access token to its viewer. The native
  * connector flow mints an audience-bound token (see the token endpoint), and the
- * connector accepts it only when bound to its own canonical URI (LIM-1) and
- * resolving a single viewer (LIM-3). Unlike the personal-token path, an OAuth
- * token is not organization-scoped, so the viewer is confirmed a member of the
- * app's organization here — `userHasAppAccess` trusts the caller's org for an
- * org-scoped app, so the membership check is what holds the org boundary (CON-7).
+ * connector accepts it only when bound to its own canonical URI and resolving a
+ * single viewer. Unlike the personal-token path, an OAuth token is not
+ * organization-scoped, so the viewer is confirmed a member of the app's
+ * organization here — `userHasAppAccess` trusts the caller's org for an
+ * org-scoped app, so the membership check is what holds the org boundary.
  */
 export async function validateAppConnectorOAuthToken(params: {
   token: string;
@@ -314,14 +314,14 @@ export async function validateAppConnectorOAuthToken(params: {
     return { ok: false, reason: "invalid" };
   }
   // The token's audience must equal this connector's own canonical URI: an
-  // unbound token, a gateway token, or another app's token is rejected (LIM-1).
+  // unbound token, a gateway token, or another app's token is rejected.
   if (
     accessToken.referenceId !==
     appConnectorAudienceRef(params.connectorResourceUri)
   ) {
     return { ok: false, reason: "invalid" };
   }
-  // A token with no acting user (client credentials) carries no viewer (LIM-3).
+  // A token with no acting user (client credentials) carries no viewer.
   if (!accessToken.userId) {
     return { ok: false, reason: "no_viewer" };
   }
@@ -427,8 +427,7 @@ async function buildAppToolList(appId: string): Promise<McpListTool[]> {
       // The runtime LLM completion stays in tools/list (so an app's own
       // tools/call is still relayed by a foreign host) but is marked app-only,
       // so the host's model can't invoke it to spend the viewer's metered LLM
-      // budget directly (FR-7). Other built-ins (the data store) stay
-      // model-visible per FR-5.
+      // budget directly. Other built-ins (the data store) stay model-visible.
       if (
         archestraMcpBranding.getToolShortName(tool.name) ===
         TOOL_APP_LLM_COMPLETE_SHORT_NAME

--- a/platform/backend/src/routes/mcp-app-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-app-gateway.utils.ts
@@ -1,6 +1,8 @@
 import {
   getArchestraAppResourceUri,
   MCP_APPS_SERVER_EXTENSION_CAPABILITIES,
+  OAUTH_TOKEN_ID_PREFIX,
+  TOOL_APP_LLM_COMPLETE_SHORT_NAME,
 } from "@archestra/shared";
 import { RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -24,10 +26,13 @@ import {
   AppToolModel,
   AppVersionModel,
   McpToolCallModel,
+  MemberModel,
+  OAuthAccessTokenModel,
   TeamTokenModel,
   UserModel,
   UserTokenModel,
 } from "@/models";
+import { appConnectorAudienceRef } from "@/services/apps/app-connector-resource";
 import {
   type AppSdkTool,
   injectAppSdk,
@@ -285,6 +290,61 @@ export async function validateAppGatewayToken(
 }
 
 /**
+ * Resolve a shareable-App connector OAuth access token to its viewer. The native
+ * connector flow mints an audience-bound token (see the token endpoint), and the
+ * connector accepts it only when bound to its own canonical URI (LIM-1) and
+ * resolving a single viewer (LIM-3). Unlike the personal-token path, an OAuth
+ * token is not organization-scoped, so the viewer is confirmed a member of the
+ * app's organization here — `userHasAppAccess` trusts the caller's org for an
+ * org-scoped app, so the membership check is what holds the org boundary (CON-7).
+ */
+export async function validateAppConnectorOAuthToken(params: {
+  token: string;
+  appId: string;
+  connectorResourceUri: string;
+}): Promise<AppGatewayTokenAuth> {
+  const accessToken = await OAuthAccessTokenModel.getByTokenHash(
+    OAuthAccessTokenModel.hashTokenForLookup(params.token),
+  );
+  if (
+    !accessToken ||
+    accessToken.refreshTokenRevoked ||
+    accessToken.expiresAt < new Date()
+  ) {
+    return { ok: false, reason: "invalid" };
+  }
+  // The token's audience must equal this connector's own canonical URI: an
+  // unbound token, a gateway token, or another app's token is rejected (LIM-1).
+  if (
+    accessToken.referenceId !==
+    appConnectorAudienceRef(params.connectorResourceUri)
+  ) {
+    return { ok: false, reason: "invalid" };
+  }
+  // A token with no acting user (client credentials) carries no viewer (LIM-3).
+  if (!accessToken.userId) {
+    return { ok: false, reason: "no_viewer" };
+  }
+  const app = await AppModel.findById(params.appId);
+  if (!app) {
+    return { ok: false, reason: "invalid" };
+  }
+  const membership = await MemberModel.getByUserId(
+    accessToken.userId,
+    app.organizationId,
+  );
+  if (!membership) {
+    return { ok: false, reason: "invalid" };
+  }
+  return {
+    ok: true,
+    userId: accessToken.userId,
+    organizationId: app.organizationId,
+    tokenId: `${OAUTH_TOKEN_ID_PREFIX}${accessToken.id}`,
+  };
+}
+
+/**
  * The app endpoint's tool list (assigned upstream tools + the App Data Store
  * built-ins), RBAC-filtered for the viewing user. Shared by the MCP
  * tools/list handler and the SDK bootstrap.
@@ -356,10 +416,34 @@ async function buildAppToolList(appId: string): Promise<McpListTool[]> {
     };
   });
 
-  const builtInTools = getArchestraMcpTools().filter((tool) => {
-    const shortName = archestraMcpBranding.getToolShortName(tool.name);
-    return shortName !== null && APP_RUNTIME_BUILTIN_SHORT_NAMES.has(shortName);
-  });
+  const builtInTools = getArchestraMcpTools()
+    .filter((tool) => {
+      const shortName = archestraMcpBranding.getToolShortName(tool.name);
+      return (
+        shortName !== null && APP_RUNTIME_BUILTIN_SHORT_NAMES.has(shortName)
+      );
+    })
+    .map((tool): McpListTool => {
+      // The runtime LLM completion stays in tools/list (so an app's own
+      // tools/call is still relayed by a foreign host) but is marked app-only,
+      // so the host's model can't invoke it to spend the viewer's metered LLM
+      // budget directly (FR-7). Other built-ins (the data store) stay
+      // model-visible per FR-5.
+      if (
+        archestraMcpBranding.getToolShortName(tool.name) ===
+        TOOL_APP_LLM_COMPLETE_SHORT_NAME
+      ) {
+        return withAppOnlyVisibility(tool);
+      }
+      return tool;
+    });
 
   return [...upstreamTools, ...builtInTools];
+}
+
+/** Mark a tool callable by the app's own code but invisible to the host model. */
+function withAppOnlyVisibility(tool: McpListTool): McpListTool {
+  const meta = (tool._meta ?? {}) as Record<string, unknown>;
+  const ui = (meta.ui ?? {}) as Record<string, unknown>;
+  return { ...tool, _meta: { ...meta, ui: { ...ui, visibility: ["app"] } } };
 }

--- a/platform/backend/src/routes/mcp-app-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-app-gateway.utils.ts
@@ -1,6 +1,7 @@
 import {
   getArchestraAppResourceUri,
   MCP_APPS_SERVER_EXTENSION_CAPABILITIES,
+  MCP_GATEWAY_OAUTH_SCOPE,
   OAUTH_TOKEN_ID_PREFIX,
   TOOL_APP_LLM_COMPLETE_SHORT_NAME,
 } from "@archestra/shared";
@@ -311,6 +312,13 @@ export async function validateAppConnectorOAuthToken(params: {
     accessToken.refreshTokenRevoked ||
     accessToken.expiresAt < new Date()
   ) {
+    return { ok: false, reason: "invalid" };
+  }
+  // Audience binding alone is not authorization: a client can bind any token to
+  // the connector by passing the resource, so a token consented to a lesser
+  // scope (e.g. `openid profile`) must not reach the connector without the mcp
+  // scope the user actually consented to. Parallels the gateway scope check.
+  if (!accessToken.scopes?.includes(MCP_GATEWAY_OAUTH_SCOPE)) {
     return { ok: false, reason: "invalid" };
   }
   // The token's audience must equal this connector's own canonical URI: an

--- a/platform/backend/src/routes/mcp-app-proxy.test.ts
+++ b/platform/backend/src/routes/mcp-app-proxy.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { prepareAppEnvelope } from "@archestra/app-runtime-rs";
 import {
   getArchestraAppResourceUri,
@@ -17,6 +18,10 @@ import { vi } from "vitest";
 import config from "@/config";
 import db, { schema } from "@/database";
 import { AppDataModel, TeamTokenModel, UserTokenModel } from "@/models";
+import {
+  appConnectorAudienceRef,
+  buildConnectorResourceUri,
+} from "@/services/apps/app-connector-resource";
 import { APP_PLATFORM_CSP } from "@/services/apps/app-ui-policy";
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "@/test";
 import { ApiError } from "@/types";
@@ -104,6 +109,20 @@ const JSON_RPC_HEADERS = {
   "content-type": "application/json",
   accept: "application/json, text/event-stream",
 };
+
+// The OAuth path validates the token's audience against the connector URI the
+// route derives from the request origin, so pin the host and bind tokens to the
+// matching canonical URI.
+const bearerLocal = (token: string) => ({
+  ...bearer(token),
+  host: "localhost",
+});
+const sha256 = (value: string) =>
+  createHash("sha256").update(value).digest("base64url");
+const connectorRef = (appId: string) =>
+  appConnectorAudienceRef(
+    buildConnectorResourceUri("http://localhost", appId) as string,
+  );
 
 describe("mcpAppProxyRoutes POST /api/mcp/app/:appId", () => {
   let app: FastifyInstance;
@@ -632,6 +651,8 @@ describe("mcpAppProxyRoutes POST /api/mcp/app/:appId", () => {
     });
 
     expect(response.statusCode).toBe(401);
+    // No valid token → RFC 9728 challenge so the client can discover the AS.
+    expect(response.headers["www-authenticate"]).toContain("resource_metadata");
   });
 
   test("a user token cannot reach an app its viewer may not see", async ({
@@ -683,5 +704,198 @@ describe("mcpAppProxyRoutes POST /api/mcp/app/:appId", () => {
 
     (config.apps as { enabled: boolean }).enabled = true;
     expect(response.statusCode).toBe(404);
+  });
+
+  test("accepts an audience-bound OAuth token and hides llm_complete from the model", async ({
+    makeApp,
+    makeUser,
+    makeMember,
+    makeOAuthClient,
+    makeOAuthAccessToken,
+  }) => {
+    const created = await makeApp();
+    const user = await makeUser();
+    await makeMember(user.id, created.organizationId, { role: "admin" });
+    const client = await makeOAuthClient({ userId: user.id });
+    const rawToken = `connector-${crypto.randomUUID()}`;
+    await makeOAuthAccessToken(client.clientId, user.id, {
+      token: sha256(rawToken),
+      referenceId: connectorRef(created.id),
+      scopes: ["mcp"],
+    });
+    app = await buildBearerApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp/app/${created.id}`,
+      headers: bearerLocal(rawToken),
+      payload: { jsonrpc: "2.0", method: "tools/list", id: 1 },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const tools = response.json().result.tools as Array<{
+      name: string;
+      _meta?: { ui?: { visibility?: string[] } };
+    }>;
+    expect(tools.map((t) => t.name)).toContain("open");
+    // The runtime LLM completion stays listed but app-only, so a foreign host's
+    // model can't invoke it; the data store stays model-visible.
+    const llm = tools.find((t) => t.name === "archestra__llm_complete");
+    expect(llm?._meta?.ui?.visibility).toEqual(["app"]);
+    const dataGet = tools.find((t) => t.name === "archestra__app_data_get");
+    expect(dataGet).toBeDefined();
+    expect(dataGet?._meta?.ui?.visibility).not.toEqual(["app"]);
+  });
+
+  test("rejects an OAuth token bound to another app's connector (wrong audience)", async ({
+    makeApp,
+    makeUser,
+    makeMember,
+    makeOAuthClient,
+    makeOAuthAccessToken,
+  }) => {
+    const created = await makeApp();
+    const otherApp = await makeApp();
+    const user = await makeUser();
+    await makeMember(user.id, created.organizationId, { role: "member" });
+    const client = await makeOAuthClient({ userId: user.id });
+    const rawToken = `connector-${crypto.randomUUID()}`;
+    await makeOAuthAccessToken(client.clientId, user.id, {
+      token: sha256(rawToken),
+      referenceId: connectorRef(otherApp.id),
+      scopes: ["mcp"],
+    });
+    app = await buildBearerApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp/app/${created.id}`,
+      headers: bearerLocal(rawToken),
+      payload: { jsonrpc: "2.0", method: "tools/list", id: 1 },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.headers["www-authenticate"]).toContain("resource_metadata");
+  });
+
+  test("rejects an unbound OAuth token (no audience)", async ({
+    makeApp,
+    makeUser,
+    makeMember,
+    makeOAuthClient,
+    makeOAuthAccessToken,
+  }) => {
+    const created = await makeApp();
+    const user = await makeUser();
+    await makeMember(user.id, created.organizationId, { role: "member" });
+    const client = await makeOAuthClient({ userId: user.id });
+    const rawToken = `connector-${crypto.randomUUID()}`;
+    await makeOAuthAccessToken(client.clientId, user.id, {
+      token: sha256(rawToken),
+      referenceId: null,
+      scopes: ["mcp"],
+    });
+    app = await buildBearerApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp/app/${created.id}`,
+      headers: bearerLocal(rawToken),
+      payload: { jsonrpc: "2.0", method: "tools/list", id: 1 },
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  test("rejects an expired audience-bound OAuth token", async ({
+    makeApp,
+    makeUser,
+    makeMember,
+    makeOAuthClient,
+    makeOAuthAccessToken,
+  }) => {
+    const created = await makeApp();
+    const user = await makeUser();
+    await makeMember(user.id, created.organizationId, { role: "member" });
+    const client = await makeOAuthClient({ userId: user.id });
+    const rawToken = `connector-${crypto.randomUUID()}`;
+    await makeOAuthAccessToken(client.clientId, user.id, {
+      token: sha256(rawToken),
+      referenceId: connectorRef(created.id),
+      scopes: ["mcp"],
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    app = await buildBearerApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp/app/${created.id}`,
+      headers: bearerLocal(rawToken),
+      payload: { jsonrpc: "2.0", method: "tools/list", id: 1 },
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  test("rejects an audience-bound OAuth token whose refresh token was revoked", async ({
+    makeApp,
+    makeUser,
+    makeMember,
+    makeOAuthClient,
+    makeOAuthRefreshToken,
+    makeOAuthAccessToken,
+  }) => {
+    const created = await makeApp();
+    const user = await makeUser();
+    await makeMember(user.id, created.organizationId, { role: "member" });
+    const client = await makeOAuthClient({ userId: user.id });
+    const refresh = await makeOAuthRefreshToken(client.clientId, user.id, {
+      revoked: new Date(),
+    });
+    const rawToken = `connector-${crypto.randomUUID()}`;
+    await makeOAuthAccessToken(client.clientId, user.id, {
+      token: sha256(rawToken),
+      referenceId: connectorRef(created.id),
+      scopes: ["mcp"],
+      refreshId: refresh.id,
+    });
+    app = await buildBearerApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp/app/${created.id}`,
+      headers: bearerLocal(rawToken),
+      payload: { jsonrpc: "2.0", method: "tools/list", id: 1 },
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  test("rejects an audience-bound OAuth token whose viewer is not a member of the app's org", async ({
+    makeApp,
+    makeUser,
+    makeOAuthClient,
+    makeOAuthAccessToken,
+  }) => {
+    const created = await makeApp();
+    // A valid, correctly-bound token, but the viewer never joined the app's org.
+    const outsider = await makeUser();
+    const client = await makeOAuthClient({ userId: outsider.id });
+    const rawToken = `connector-${crypto.randomUUID()}`;
+    await makeOAuthAccessToken(client.clientId, outsider.id, {
+      token: sha256(rawToken),
+      referenceId: connectorRef(created.id),
+      scopes: ["mcp"],
+    });
+    app = await buildBearerApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp/app/${created.id}`,
+      headers: bearerLocal(rawToken),
+      payload: { jsonrpc: "2.0", method: "tools/list", id: 1 },
+    });
+
+    expect(response.statusCode).toBe(401);
   });
 });

--- a/platform/backend/src/routes/mcp-app-proxy.test.ts
+++ b/platform/backend/src/routes/mcp-app-proxy.test.ts
@@ -807,6 +807,38 @@ describe("mcpAppProxyRoutes POST /api/mcp/app/:appId", () => {
     expect(response.statusCode).toBe(401);
   });
 
+  test("rejects an audience-bound OAuth token lacking the mcp scope", async ({
+    makeApp,
+    makeUser,
+    makeMember,
+    makeOAuthClient,
+    makeOAuthAccessToken,
+  }) => {
+    const created = await makeApp();
+    const user = await makeUser();
+    await makeMember(user.id, created.organizationId, { role: "admin" });
+    const client = await makeOAuthClient({ userId: user.id });
+    const rawToken = `connector-${crypto.randomUUID()}`;
+    // Correctly audience-bound to this connector, but consented only to a lesser
+    // scope — audience binding is not consent, so the connector must reject it.
+    await makeOAuthAccessToken(client.clientId, user.id, {
+      token: sha256(rawToken),
+      referenceId: connectorRef(created.id),
+      scopes: ["openid", "profile"],
+    });
+    app = await buildBearerApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp/app/${created.id}`,
+      headers: bearerLocal(rawToken),
+      payload: { jsonrpc: "2.0", method: "tools/list", id: 1 },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.headers["www-authenticate"]).toContain("resource_metadata");
+  });
+
   test("rejects an expired audience-bound OAuth token", async ({
     makeApp,
     makeUser,

--- a/platform/backend/src/routes/mcp-app-proxy.ts
+++ b/platform/backend/src/routes/mcp-app-proxy.ts
@@ -83,7 +83,7 @@ const mcpAppProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
         if (!auth.ok) {
           if (auth.kind === "challenge") {
             // No valid token → re-issue the RFC 9728 challenge so the client can
-            // (re)discover the authorization server (FR-2).
+            // (re)discover the authorization server.
             setConnectorChallenge(request, reply, appId);
             return reply.status(401).send({
               error: { message: "Unauthorized", type: "unauthorized" },
@@ -112,8 +112,8 @@ const mcpAppProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
       }
 
       // Verify the viewer may view this app. The OAuth path bypasses the cache so
-      // a revoked token or lost view access is denied on the next request (FR-10);
-      // the session and personal-token paths keep the short-lived cache (keyed by
+      // a revoked token or lost view access is denied on the next request; the
+      // session and personal-token paths keep the short-lived cache (keyed by
       // app+user+org so entries can't leak across orgs).
       const appCacheKey = `${appId}:${userId}:${organizationId}`;
       let app = bypassAccessCache ? undefined : appAccessCache.get(appCacheKey);
@@ -228,10 +228,10 @@ const NO_VIEWER_MESSAGE =
 
 /**
  * Resolve a connector Bearer token to its viewer, or signal that the request
- * must be challenged (no valid token, FR-2) or refused (a token resolving no
- * viewer, LIM-3). The token is tried as a personal token first, then as a native
- * audience-bound OAuth token. The OAuth path bypasses the app-access cache so a
- * revoked token or lost view access is denied on the next request (FR-10).
+ * must be challenged (no valid token) or refused (a token resolving no viewer).
+ * The token is tried as a personal token first, then as a native audience-bound
+ * OAuth token. The OAuth path bypasses the app-access cache so a revoked token or
+ * lost view access is denied on the next request.
  */
 async function resolveBearerAuth(
   request: FastifyRequest,
@@ -298,7 +298,7 @@ function userTokenAuthContext(auth: {
 /**
  * Attach the RFC 9728 `WWW-Authenticate` challenge pointing at this connector's
  * protected-resource metadata, so a client discovers the authorization server
- * and the scope to request (FR-2).
+ * and the scope to request.
  */
 function setConnectorChallenge(
   request: FastifyRequest,

--- a/platform/backend/src/routes/mcp-app-proxy.ts
+++ b/platform/backend/src/routes/mcp-app-proxy.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { RouteId } from "@archestra/shared";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { FastifyReply, FastifyRequest } from "fastify";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import QuickLRU from "quick-lru";
 import { z } from "zod";
@@ -8,11 +9,16 @@ import { userHasPermission } from "@/auth/utils";
 import type { TokenAuthContext } from "@/clients/mcp-client";
 import config from "@/config";
 import { AppModel } from "@/models";
+import {
+  buildConnectorResourceUri,
+  connectorWwwAuthenticate,
+} from "@/services/apps/app-connector-resource";
 import { gateAppToolCall } from "@/services/apps/app-tool-runtime-gate";
 import { ApiError, type App, UuidIdSchema } from "@/types";
 import {
   APP_LAUNCH_TOOL_NAME,
   createAppServer,
+  validateAppConnectorOAuthToken,
   validateAppGatewayToken,
 } from "./mcp-app-gateway.utils";
 import {
@@ -20,6 +26,7 @@ import {
   ensureRequestSocketDestroySoon,
   extractBearerToken,
 } from "./mcp-gateway.utils";
+import { getPublicRequestOrigin } from "./request-origin";
 
 /**
  * App-bound MCP proxy: `POST /api/mcp/app/:appId`. Carries an app's runtime
@@ -58,38 +65,37 @@ const mcpAppProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
       const { appId } = request.params as { appId: string };
       const body = request.body as Record<string, unknown>;
 
-      // External MCP clients present a Bearer token (validated here); Archestra's
-      // own frontend uses the browser session (request.user, populated upstream).
+      // An external client presents a Bearer token — a personal token or the
+      // native OAuth flow's audience-bound token — validated here; Archestra's
+      // own frontend uses the browser session (request.user, populated by the
+      // auth middleware, which stands down only for the Bearer path). A Bearer
+      // connection builds a fresh server per request (AppServerCache is keyed by
+      // (app, user), so reuse across tokens would leak context); the session
+      // path keeps the cache.
       const bearer = extractBearerToken(request);
       let userId: string;
       let organizationId: string;
       let tokenAuth: TokenAuthContext;
-      // A Bearer connection builds a fresh server per request: AppServerCache is
-      // keyed only by (app, user), so reusing across tokens would leak one
-      // token's credentials/context into another's calls. The session path keeps
-      // the cache (one auth context per browser user).
       let useServerCache: boolean;
+      let bypassAccessCache: boolean;
       if (bearer) {
-        const appAuth = await validateAppGatewayToken(bearer);
-        if (!appAuth.ok) {
-          throw appAuth.reason === "no_viewer"
-            ? new ApiError(
-                403,
-                "App endpoints require a user-scoped token; organization/team tokens have no viewer.",
-              )
-            : new ApiError(401, "Unauthorized");
+        const auth = await resolveBearerAuth(request, appId, bearer);
+        if (!auth.ok) {
+          if (auth.kind === "challenge") {
+            // No valid token → re-issue the RFC 9728 challenge so the client can
+            // (re)discover the authorization server (FR-2).
+            setConnectorChallenge(request, reply, appId);
+            return reply.status(401).send({
+              error: { message: "Unauthorized", type: "unauthorized" },
+            });
+          }
+          throw new ApiError(403, auth.message);
         }
-        userId = appAuth.userId;
-        organizationId = appAuth.organizationId;
-        tokenAuth = {
-          tokenId: appAuth.tokenId,
-          teamId: null,
-          isOrganizationToken: false,
-          isUserToken: true,
-          userId,
-          organizationId,
-        };
+        userId = auth.userId;
+        organizationId = auth.organizationId;
+        tokenAuth = auth.tokenAuth;
         useServerCache = false;
+        bypassAccessCache = auth.bypassAccessCache;
       } else {
         userId = request.user.id;
         organizationId = request.organizationId;
@@ -102,12 +108,15 @@ const mcpAppProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
           organizationId,
         };
         useServerCache = true;
+        bypassAccessCache = false;
       }
 
-      // Verify the viewer may view this app (short-lived cache keyed by
+      // Verify the viewer may view this app. The OAuth path bypasses the cache so
+      // a revoked token or lost view access is denied on the next request (FR-10);
+      // the session and personal-token paths keep the short-lived cache (keyed by
       // app+user+org so entries can't leak across orgs).
       const appCacheKey = `${appId}:${userId}:${organizationId}`;
-      let app = appAccessCache.get(appCacheKey);
+      let app = bypassAccessCache ? undefined : appAccessCache.get(appCacheKey);
       if (!app) {
         const isAppAdmin = await userHasPermission(
           userId,
@@ -122,7 +131,7 @@ const mcpAppProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
             userId,
             isAppAdmin,
           })) ?? undefined;
-        if (app) {
+        if (app && !bypassAccessCache) {
           appAccessCache.set(appCacheKey, app);
         }
       }
@@ -202,6 +211,105 @@ const mcpAppProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
 // =============================================================================
 // Internal helpers
 // =============================================================================
+
+type BearerAuth =
+  | {
+      ok: true;
+      userId: string;
+      organizationId: string;
+      tokenAuth: TokenAuthContext;
+      bypassAccessCache: boolean;
+    }
+  | { ok: false; kind: "challenge" }
+  | { ok: false; kind: "forbidden"; message: string };
+
+const NO_VIEWER_MESSAGE =
+  "App endpoints require a user-scoped token; organization/team tokens have no viewer.";
+
+/**
+ * Resolve a connector Bearer token to its viewer, or signal that the request
+ * must be challenged (no valid token, FR-2) or refused (a token resolving no
+ * viewer, LIM-3). The token is tried as a personal token first, then as a native
+ * audience-bound OAuth token. The OAuth path bypasses the app-access cache so a
+ * revoked token or lost view access is denied on the next request (FR-10).
+ */
+async function resolveBearerAuth(
+  request: FastifyRequest,
+  appId: string,
+  bearer: string,
+): Promise<BearerAuth> {
+  const personal = await validateAppGatewayToken(bearer);
+  if (personal.ok) {
+    return {
+      ok: true,
+      userId: personal.userId,
+      organizationId: personal.organizationId,
+      tokenAuth: userTokenAuthContext(personal),
+      bypassAccessCache: false,
+    };
+  }
+  if (personal.reason === "no_viewer") {
+    return { ok: false, kind: "forbidden", message: NO_VIEWER_MESSAGE };
+  }
+
+  // Not a personal/team token — try the native OAuth token, which must be
+  // audience-bound to this connector's own canonical URI.
+  const connectorResourceUri = buildConnectorResourceUri(
+    getPublicRequestOrigin(request),
+    appId,
+  );
+  if (connectorResourceUri) {
+    const oauth = await validateAppConnectorOAuthToken({
+      token: bearer,
+      appId,
+      connectorResourceUri,
+    });
+    if (oauth.ok) {
+      return {
+        ok: true,
+        userId: oauth.userId,
+        organizationId: oauth.organizationId,
+        tokenAuth: userTokenAuthContext(oauth),
+        bypassAccessCache: true,
+      };
+    }
+    if (oauth.reason === "no_viewer") {
+      return { ok: false, kind: "forbidden", message: NO_VIEWER_MESSAGE };
+    }
+  }
+  return { ok: false, kind: "challenge" };
+}
+
+function userTokenAuthContext(auth: {
+  tokenId: string;
+  userId: string;
+  organizationId: string;
+}): TokenAuthContext {
+  return {
+    tokenId: auth.tokenId,
+    teamId: null,
+    isOrganizationToken: false,
+    isUserToken: true,
+    userId: auth.userId,
+    organizationId: auth.organizationId,
+  };
+}
+
+/**
+ * Attach the RFC 9728 `WWW-Authenticate` challenge pointing at this connector's
+ * protected-resource metadata, so a client discovers the authorization server
+ * and the scope to request (FR-2).
+ */
+function setConnectorChallenge(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  appId: string,
+): void {
+  reply.header(
+    "WWW-Authenticate",
+    connectorWwwAuthenticate(getPublicRequestOrigin(request), appId),
+  );
+}
 
 /** Minimal reply surface the JSON-RPC gate needs — set the HTTP status to 200. */
 interface StatusReply {

--- a/platform/backend/src/routes/mcp-gateway.utils.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.test.ts
@@ -27,6 +27,10 @@ import {
   ToolModel,
   UserTokenModel,
 } from "@/models";
+import {
+  appConnectorAudienceRef,
+  buildConnectorResourceUri,
+} from "@/services/apps/app-connector-resource";
 import { MCP_RESOURCE_REFERENCE_PREFIX } from "@/services/identity-providers/enterprise-managed/authorization";
 import type { JwksValidationResult } from "@/services/jwks-validator";
 import { describe, expect, test } from "@/test";
@@ -672,6 +676,43 @@ describe("validateMCPGatewayToken", () => {
       await makeOAuthAccessToken(client.clientId, user.id, {
         token: tokenHash,
         referenceId: `${MCP_RESOURCE_REFERENCE_PREFIX}${otherAgent.id}`,
+      });
+
+      const result = await validateOAuthToken(targetAgent.id, rawToken);
+
+      expect(result).toBeNull();
+    });
+
+    test("validateOAuthToken returns null for a token bound to an app connector", async ({
+      makeUser,
+      makeOrganization,
+      makeMember,
+      makeOAuthClient,
+      makeOAuthAccessToken,
+      makeAgent,
+    }) => {
+      const user = await makeUser();
+      const org = await makeOrganization();
+      await makeMember(user.id, org.id, { role: "admin" });
+
+      const client = await makeOAuthClient({ userId: user.id });
+      const targetAgent = await makeAgent({ organizationId: org.id });
+
+      const rawToken = `app-connector-token-${crypto.randomUUID()}`;
+      const tokenHash = createHash("sha256")
+        .update(rawToken)
+        .digest("base64url");
+
+      // A token bound to an App connector must never authenticate the gateway,
+      // even for an admin who would otherwise pass the user-access check.
+      await makeOAuthAccessToken(client.clientId, user.id, {
+        token: tokenHash,
+        referenceId: appConnectorAudienceRef(
+          buildConnectorResourceUri(
+            "https://host",
+            "11111111-1111-1111-1111-111111111111",
+          ) as string,
+        ),
       });
 
       const result = await validateOAuthToken(targetAgent.id, rawToken);

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -65,6 +65,7 @@ import {
   ATTR_MCP_IS_ERROR_RESULT,
   startActiveMcpSpan,
 } from "@/observability/tracing";
+import { isAppConnectorAudienceRef } from "@/services/apps/app-connector-resource";
 import { MCP_RESOURCE_REFERENCE_PREFIX } from "@/services/identity-providers/enterprise-managed/authorization";
 import {
   discoverOidcJwksUrl,
@@ -931,6 +932,17 @@ async function validateOAuthTokenByHash(params: {
           tokenReferenceId: accessToken.referenceId,
         },
         "validateOAuthToken: token is bound to a different MCP resource",
+      );
+      return null;
+    }
+
+    // A token audience-bound to a shareable-App connector is valid only at that
+    // connector, never at the MCP gateway — reject it before the user-access
+    // branch would otherwise accept it on team membership alone.
+    if (isAppConnectorAudienceRef(accessToken.referenceId)) {
+      logger.warn(
+        { profileId: params.profileId },
+        "validateOAuthToken: rejecting an app-connector-bound token at the MCP gateway",
       );
       return null;
     }

--- a/platform/backend/src/routes/oauth-server.test.ts
+++ b/platform/backend/src/routes/oauth-server.test.ts
@@ -81,30 +81,36 @@ describe("OAuth Server - Well-Known Endpoints", () => {
     test("returns app-connector metadata when the apps feature is enabled", async () => {
       const original = config.apps.enabled;
       (config.apps as { enabled: boolean }).enabled = true;
-      const response = await app.inject({
-        method: "GET",
-        url: "/.well-known/oauth-protected-resource/api/mcp/app/11111111-1111-1111-1111-111111111111",
-        headers: { host: "localhost:9000" },
-      });
-      (config.apps as { enabled: boolean }).enabled = original;
+      try {
+        const response = await app.inject({
+          method: "GET",
+          url: "/.well-known/oauth-protected-resource/api/mcp/app/11111111-1111-1111-1111-111111111111",
+          headers: { host: "localhost:9000" },
+        });
 
-      expect(response.statusCode).toBe(200);
-      expect(response.json().resource).toBe(
-        "http://localhost:9000/api/mcp/app/11111111-1111-1111-1111-111111111111",
-      );
+        expect(response.statusCode).toBe(200);
+        expect(response.json().resource).toBe(
+          "http://localhost:9000/api/mcp/app/11111111-1111-1111-1111-111111111111",
+        );
+      } finally {
+        (config.apps as { enabled: boolean }).enabled = original;
+      }
     });
 
     test("app-connector discovery is dark (404) when the apps feature is disabled", async () => {
       const original = config.apps.enabled;
       (config.apps as { enabled: boolean }).enabled = false;
-      const response = await app.inject({
-        method: "GET",
-        url: "/.well-known/oauth-protected-resource/api/mcp/app/11111111-1111-1111-1111-111111111111",
-        headers: { host: "localhost:9000" },
-      });
-      (config.apps as { enabled: boolean }).enabled = original;
+      try {
+        const response = await app.inject({
+          method: "GET",
+          url: "/.well-known/oauth-protected-resource/api/mcp/app/11111111-1111-1111-1111-111111111111",
+          headers: { host: "localhost:9000" },
+        });
 
-      expect(response.statusCode).toBe(404);
+        expect(response.statusCode).toBe(404);
+      } finally {
+        (config.apps as { enabled: boolean }).enabled = original;
+      }
     });
   });
 

--- a/platform/backend/src/routes/oauth-server.test.ts
+++ b/platform/backend/src/routes/oauth-server.test.ts
@@ -5,7 +5,7 @@ import {
   validatorCompiler,
   type ZodTypeProvider,
 } from "fastify-type-provider-zod";
-import { parseTrustProxy } from "@/config";
+import config, { parseTrustProxy } from "@/config";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import oauthServerRoutes from "./oauth-server";
 
@@ -76,6 +76,35 @@ describe("OAuth Server - Well-Known Endpoints", () => {
 
       expect(body.resource).toBe("http://localhost:9000/v1/mcp/test-id");
       expect(body.authorization_servers).toEqual(["http://localhost:9000"]);
+    });
+
+    test("returns app-connector metadata when the apps feature is enabled", async () => {
+      const original = config.apps.enabled;
+      (config.apps as { enabled: boolean }).enabled = true;
+      const response = await app.inject({
+        method: "GET",
+        url: "/.well-known/oauth-protected-resource/api/mcp/app/11111111-1111-1111-1111-111111111111",
+        headers: { host: "localhost:9000" },
+      });
+      (config.apps as { enabled: boolean }).enabled = original;
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().resource).toBe(
+        "http://localhost:9000/api/mcp/app/11111111-1111-1111-1111-111111111111",
+      );
+    });
+
+    test("app-connector discovery is dark (404) when the apps feature is disabled", async () => {
+      const original = config.apps.enabled;
+      (config.apps as { enabled: boolean }).enabled = false;
+      const response = await app.inject({
+        method: "GET",
+        url: "/.well-known/oauth-protected-resource/api/mcp/app/11111111-1111-1111-1111-111111111111",
+        headers: { host: "localhost:9000" },
+      });
+      (config.apps as { enabled: boolean }).enabled = original;
+
+      expect(response.statusCode).toBe(404);
     });
   });
 

--- a/platform/backend/src/routes/oauth-server.ts
+++ b/platform/backend/src/routes/oauth-server.ts
@@ -9,6 +9,8 @@ import { z } from "zod";
 import config from "@/config";
 import db, { schema as dbSchema } from "@/database";
 import { AgentModel } from "@/models";
+import { APP_CONNECTOR_PATH_PREFIX } from "@/services/apps/app-connector-resource";
+import { ApiError } from "@/types";
 import { getPublicRequestOrigin } from "./request-origin";
 
 /**
@@ -51,6 +53,15 @@ const oauthServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
         "/.well-known/oauth-protected-resource",
         "",
       );
+
+      // An MCP App connector's discovery is dark when the feature is off, so it
+      // does not reveal that an app exists (FR-1).
+      if (
+        resourcePath.startsWith(APP_CONNECTOR_PATH_PREFIX) &&
+        !config.apps.enabled
+      ) {
+        throw new ApiError(404, "Not found");
+      }
 
       // Check if the profile has an external IdP configured
       const authorizationServers = [baseUrl];
@@ -157,6 +168,12 @@ export default oauthServerRoutes;
 async function extractProfileIdFromResourcePath(
   resourcePath: string,
 ): Promise<string | null> {
+  // A shareable-App connector resolves only against Archestra's own
+  // authorization server, never a profile's external IdP — so its app id is not
+  // an agent id to look up.
+  if (resourcePath.startsWith(APP_CONNECTOR_PATH_PREFIX)) {
+    return null;
+  }
   const segments = resourcePath.split("/").filter(Boolean);
   const lastSegment = segments.at(-1);
   if (!lastSegment) return null;

--- a/platform/backend/src/routes/oauth-server.ts
+++ b/platform/backend/src/routes/oauth-server.ts
@@ -55,7 +55,7 @@ const oauthServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
       );
 
       // An MCP App connector's discovery is dark when the feature is off, so it
-      // does not reveal that an app exists (FR-1).
+      // does not reveal that an app exists.
       if (
         resourcePath.startsWith(APP_CONNECTOR_PATH_PREFIX) &&
         !config.apps.enabled

--- a/platform/backend/src/routes/proxy/llm-proxy-auth.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-auth.ts
@@ -26,6 +26,7 @@ import {
 } from "@/models";
 import { validateExternalIdpToken } from "@/routes/mcp-gateway.utils";
 import { getSecretValueForLlmProviderApiKey } from "@/secrets-manager";
+import { isAppConnectorAudienceRef } from "@/services/apps/app-connector-resource";
 import { type Agent, ApiError } from "@/types";
 import { resolveProviderApiKey } from "@/utils/llm-api-key-resolution";
 import { isLoopbackAddress } from "@/utils/network";
@@ -204,6 +205,9 @@ export async function validateLlmOAuthAccessToken(params: {
   }
   if (accessToken.refreshTokenRevoked) {
     throw new ApiError(401, "Invalid LLM OAuth access token.");
+  }
+  if (isAppConnectorAudienceRef(accessToken.referenceId)) {
+    throw new ApiError(403, "Access token is bound to an app connector.");
   }
   if (!hasLlmProxyScope(accessToken.scopes)) {
     throw new ApiError(403, "Access token is missing LLM proxy scope.");

--- a/platform/backend/src/routes/proxy/routes/model-router.ts
+++ b/platform/backend/src/routes/proxy/routes/model-router.ts
@@ -22,6 +22,7 @@ import {
   VirtualApiKeyModel,
 } from "@/models";
 import { getSecretValueForLlmProviderApiKey } from "@/secrets-manager";
+import { isAppConnectorAudienceRef } from "@/services/apps/app-connector-resource";
 import type { Agent, LLMProvider } from "@/types";
 import {
   ApiError,
@@ -855,6 +856,9 @@ async function getModelRouterOAuthClientAuth(
     accessToken.refreshTokenRevoked
   ) {
     throw new ApiError(401, "Invalid LLM OAuth client access token.");
+  }
+  if (isAppConnectorAudienceRef(accessToken.referenceId)) {
+    throw new ApiError(403, "Access token is bound to an app connector.");
   }
   if (!accessToken.scopes?.some((scope) => scope === LLM_PROXY_OAUTH_SCOPE)) {
     throw new ApiError(403, "Access token is missing Model Router scope.");

--- a/platform/backend/src/routes/request-origin.ts
+++ b/platform/backend/src/routes/request-origin.ts
@@ -10,7 +10,7 @@ import logger from "@/logging";
  *
  * The code which gets the origin is taken form the fastify.
  *
- * MUST BE USED ONLY FOR MCP GATEWAY OAUTH.
+ * MUST BE USED ONLY FOR MCP OAUTH (the MCP gateway and the shareable-App connector).
  */
 export function getPublicRequestOrigin(request: FastifyRequest): string {
   const result = computePublicRequestOrigin(request);

--- a/platform/backend/src/routes/request-origin.ts
+++ b/platform/backend/src/routes/request-origin.ts
@@ -4,11 +4,11 @@ import config, { getMCPGatewayOauthAllowedPublicHosts } from "@/config";
 import logger from "@/logging";
 
 /**
- * Return the public origin for a request. This is used to build the OAuth protected resource metadata URL.
- * It's needed to nmake sure mcp gateway oauth works out of the box, without the need to set ARCHESTRA_TRUST_PROXY. (it's too broad)
- * Idea is to scope publc oriing only to Oauth and additionally validate hosts to prevent X-Forwarded-Host header spoofing.
- *
- * The code which gets the origin is taken form the fastify.
+ * Return the public origin for a request — used to build the OAuth
+ * protected-resource metadata URL. Scoping origin derivation to OAuth lets MCP
+ * gateway OAuth work out of the box without the (too-broad) ARCHESTRA_TRUST_PROXY,
+ * while still validating the forwarded host to prevent X-Forwarded-Host spoofing.
+ * The origin-derivation logic is adapted from Fastify.
  *
  * MUST BE USED ONLY FOR MCP OAUTH (the MCP gateway and the shareable-App connector).
  */

--- a/platform/backend/src/services/apps/app-connector-resource.test.ts
+++ b/platform/backend/src/services/apps/app-connector-resource.test.ts
@@ -6,6 +6,7 @@ import {
   canonicalizeConnectorResourceUri,
   connectorWwwAuthenticate,
   isAppConnectorAudienceRef,
+  isConnectorTargetedResource,
   resolveAppConnectorResource,
 } from "./app-connector-resource";
 
@@ -64,6 +65,60 @@ describe("resolveAppConnectorResource", () => {
       ),
     ).toBeNull();
     expect(resolveAppConnectorResource(undefined, allowed)).toBeNull();
+  });
+
+  test("matches an allowed origin that differs only by host case or default port", () => {
+    // allowedOrigins are request-derived and may carry a mixed-case host or an
+    // explicit :443; the canonical origin is lowercased/port-stripped. Both must
+    // be normalized before compare, or a valid resource is wrongly rejected.
+    const messyAllowed = new Set([
+      "https://App.Example.com:443",
+      "HTTP://Localhost:80",
+    ]);
+    expect(
+      resolveAppConnectorResource(
+        `https://app.example.com/api/mcp/app/${APP_ID}`,
+        messyAllowed,
+      ),
+    ).toBe(`https://app.example.com/api/mcp/app/${APP_ID}`);
+    expect(
+      resolveAppConnectorResource(
+        `http://localhost/api/mcp/app/${APP_ID}`,
+        messyAllowed,
+      ),
+    ).toBe(`http://localhost/api/mcp/app/${APP_ID}`);
+  });
+});
+
+describe("isConnectorTargetedResource", () => {
+  test("true for any /api/mcp/app/ path, even an untrusted origin or sub-path", () => {
+    expect(
+      isConnectorTargetedResource(
+        `https://app.example.com/api/mcp/app/${APP_ID}`,
+      ),
+    ).toBe(true);
+    // The cases resolveAppConnectorResource rejects but which must still fail
+    // closed rather than mint an unbound token.
+    expect(
+      isConnectorTargetedResource(
+        `https://evil.example.com/api/mcp/app/${APP_ID}`,
+      ),
+    ).toBe(true);
+    expect(
+      isConnectorTargetedResource(
+        `https://app.example.com/api/mcp/app/${APP_ID}/extra`,
+      ),
+    ).toBe(true);
+  });
+
+  test("false for an absent or non-connector resource", () => {
+    expect(isConnectorTargetedResource(undefined)).toBe(false);
+    expect(isConnectorTargetedResource("")).toBe(false);
+    expect(isConnectorTargetedResource("not a url")).toBe(false);
+    expect(
+      isConnectorTargetedResource("https://app.example.com/api/mcp/gateway/x"),
+    ).toBe(false);
+    expect(isConnectorTargetedResource("https://app.example.com/")).toBe(false);
   });
 });
 

--- a/platform/backend/src/services/apps/app-connector-resource.test.ts
+++ b/platform/backend/src/services/apps/app-connector-resource.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "vitest";
+import {
+  appConnectorAudienceRef,
+  appIdFromConnectorPath,
+  buildConnectorResourceUri,
+  canonicalizeConnectorResourceUri,
+  connectorWwwAuthenticate,
+  isAppConnectorAudienceRef,
+  resolveAppConnectorResource,
+} from "./app-connector-resource";
+
+const APP_ID = "11111111-1111-1111-1111-111111111111";
+
+describe("canonicalizeConnectorResourceUri", () => {
+  test("lowercases the host and strips trailing slash, query, and fragment", () => {
+    expect(
+      canonicalizeConnectorResourceUri(
+        `https://Example.COM/api/mcp/app/${APP_ID}/?x=1#frag`,
+      ),
+    ).toBe(`https://example.com/api/mcp/app/${APP_ID}`);
+  });
+
+  test("drops the default port but keeps a non-default port", () => {
+    expect(
+      canonicalizeConnectorResourceUri(
+        `http://localhost:80/api/mcp/app/${APP_ID}`,
+      ),
+    ).toBe(`http://localhost/api/mcp/app/${APP_ID}`);
+    expect(
+      canonicalizeConnectorResourceUri(
+        `http://localhost:9000/api/mcp/app/${APP_ID}`,
+      ),
+    ).toBe(`http://localhost:9000/api/mcp/app/${APP_ID}`);
+  });
+
+  test("rejects a non-connector path, a sub-path, a bad scheme, and garbage", () => {
+    expect(
+      canonicalizeConnectorResourceUri(`https://h/v1/mcp/${APP_ID}`),
+    ).toBeNull();
+    expect(
+      canonicalizeConnectorResourceUri(`https://h/api/mcp/app/${APP_ID}/extra`),
+    ).toBeNull();
+    expect(
+      canonicalizeConnectorResourceUri(`ftp://h/api/mcp/app/${APP_ID}`),
+    ).toBeNull();
+    expect(canonicalizeConnectorResourceUri("not a url")).toBeNull();
+  });
+});
+
+describe("resolveAppConnectorResource", () => {
+  const allowed = new Set(["https://app.example.com"]);
+
+  test("accepts a connector URI on an allowed origin only", () => {
+    expect(
+      resolveAppConnectorResource(
+        `https://app.example.com/api/mcp/app/${APP_ID}`,
+        allowed,
+      ),
+    ).toBe(`https://app.example.com/api/mcp/app/${APP_ID}`);
+    expect(
+      resolveAppConnectorResource(
+        `https://evil.example.com/api/mcp/app/${APP_ID}`,
+        allowed,
+      ),
+    ).toBeNull();
+    expect(resolveAppConnectorResource(undefined, allowed)).toBeNull();
+  });
+});
+
+describe("appConnectorAudienceRef / isAppConnectorAudienceRef", () => {
+  test("a built ref is recognized; other prefixes and null are not", () => {
+    const ref = appConnectorAudienceRef(`https://h/api/mcp/app/${APP_ID}`);
+    expect(ref).toBe(`mcp-app-resource:https://h/api/mcp/app/${APP_ID}`);
+    expect(isAppConnectorAudienceRef(ref)).toBe(true);
+    expect(isAppConnectorAudienceRef("mcp-resource:abc")).toBe(false);
+    expect(isAppConnectorAudienceRef("mcp-oauth-client:abc")).toBe(false);
+    expect(isAppConnectorAudienceRef(null)).toBe(false);
+  });
+});
+
+describe("buildConnectorResourceUri", () => {
+  test("builds and canonicalizes from an origin and appId", () => {
+    expect(buildConnectorResourceUri("https://Host", APP_ID)).toBe(
+      `https://host/api/mcp/app/${APP_ID}`,
+    );
+  });
+});
+
+describe("connectorWwwAuthenticate", () => {
+  test("points at the protected-resource metadata and requests the mcp scope", () => {
+    expect(connectorWwwAuthenticate("https://host", APP_ID)).toBe(
+      `Bearer resource_metadata="https://host/.well-known/oauth-protected-resource/api/mcp/app/${APP_ID}", scope="mcp"`,
+    );
+  });
+});
+
+describe("appIdFromConnectorPath", () => {
+  test("extracts the appId from a connector path, with or without a query", () => {
+    expect(appIdFromConnectorPath(`/api/mcp/app/${APP_ID}`)).toBe(APP_ID);
+    expect(appIdFromConnectorPath(`/api/mcp/app/${APP_ID}?x=1`)).toBe(APP_ID);
+  });
+
+  test("returns null for a non-connector path or an empty id", () => {
+    expect(appIdFromConnectorPath("/api/apps")).toBeNull();
+    expect(appIdFromConnectorPath("/api/mcp/app/")).toBeNull();
+  });
+});

--- a/platform/backend/src/services/apps/app-connector-resource.ts
+++ b/platform/backend/src/services/apps/app-connector-resource.ts
@@ -17,7 +17,7 @@ export const APP_CONNECTOR_PATH_PREFIX = "/api/mcp/app/";
 const CONNECTOR_PATH_RE = /^\/api\/mcp\/app\/([^/]+)$/;
 
 /**
- * Canonicalize a connector resource URI per RFC 8707 / LIM-2: lowercased host,
+ * Canonicalize a connector resource URI per RFC 8707: lowercased host,
  * no trailing slash, no query, no fragment. Returns null when the input is not
  * a well-formed `http(s)` connector URL — so a token can never be bound to an
  * arbitrary URL. The scheme is preserved (https in production, http in local
@@ -92,8 +92,8 @@ export function isAppConnectorAudienceRef(
 /**
  * The RFC 9728 `WWW-Authenticate: Bearer` challenge for a connector, pointing a
  * client at the connector's protected-resource metadata and the scope to
- * request (FR-2). Emitted by both the auth middleware (a credential-less
- * discovery request) and the route (an invalid token).
+ * request. Emitted by both the auth middleware (a credential-less discovery
+ * request) and the route (an invalid token).
  */
 export function connectorWwwAuthenticate(
   origin: string,

--- a/platform/backend/src/services/apps/app-connector-resource.ts
+++ b/platform/backend/src/services/apps/app-connector-resource.ts
@@ -57,7 +57,45 @@ export function resolveAppConnectorResource(
   if (!canonical) {
     return null;
   }
-  return allowedOrigins.has(new URL(canonical).origin) ? canonical : null;
+  // Compare both sides as normalized `URL.origin` (lowercased host, default
+  // :80/:443 stripped). `allowedOrigins` is built from request-derived strings
+  // (a Host/X-Forwarded-Host that may carry a mixed-case host or an explicit
+  // default port), while the canonical origin is already normalized — a raw
+  // string compare would reject a valid resource and leave the token unbound.
+  const target = new URL(canonical).origin;
+  for (const origin of allowedOrigins) {
+    let normalized: string;
+    try {
+      normalized = new URL(origin).origin;
+    } catch {
+      continue;
+    }
+    if (normalized === target) {
+      return canonical;
+    }
+  }
+  return null;
+}
+
+/**
+ * Whether a client-supplied `resource` targets a connector path at all — any
+ * `/api/mcp/app/...` URL — including one that fails {@link
+ * resolveAppConnectorResource} (an untrusted origin, or a sub-path). The token
+ * endpoint uses this to fail closed (RFC 8707 `invalid_target`) on a
+ * connector-intended `resource` it cannot bind, rather than fall through to an
+ * unbound token that would still authenticate the MCP gateway.
+ */
+export function isConnectorTargetedResource(raw: unknown): boolean {
+  if (typeof raw !== "string") {
+    return false;
+  }
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+  return url.pathname.startsWith(APP_CONNECTOR_PATH_PREFIX);
 }
 
 /** The connector's own canonical resource URI, derived from the request origin. */

--- a/platform/backend/src/services/apps/app-connector-resource.ts
+++ b/platform/backend/src/services/apps/app-connector-resource.ts
@@ -1,0 +1,114 @@
+import {
+  MCP_APP_RESOURCE_REFERENCE_PREFIX,
+  MCP_GATEWAY_OAUTH_SCOPE,
+} from "@archestra/shared";
+
+/**
+ * The shareable MCP App connector's OAuth resource identity. A connector URL
+ * (`/api/mcp/app/:appId`) is an RFC 8707 resource: an access token is minted
+ * audience-bound to its canonical URI and accepted only at that connector.
+ * These pure helpers are shared by the mint side (the token endpoint) and the
+ * validate side (the connector), so both derive the identical canonical string.
+ */
+
+/** Route segment a connector URL lives under, e.g. `/api/mcp/app/<appId>`. */
+export const APP_CONNECTOR_PATH_PREFIX = "/api/mcp/app/";
+
+const CONNECTOR_PATH_RE = /^\/api\/mcp\/app\/([^/]+)$/;
+
+/**
+ * Canonicalize a connector resource URI per RFC 8707 / LIM-2: lowercased host,
+ * no trailing slash, no query, no fragment. Returns null when the input is not
+ * a well-formed `http(s)` connector URL — so a token can never be bound to an
+ * arbitrary URL. The scheme is preserved (https in production, http in local
+ * dev) since both sides derive it from the same request origin.
+ *
+ * @public — exercised directly by app-connector-resource.test.ts
+ */
+export function canonicalizeConnectorResourceUri(raw: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    return null;
+  }
+  const path = url.pathname.replace(/\/+$/, "");
+  if (!CONNECTOR_PATH_RE.test(path)) {
+    return null;
+  }
+  return `${url.protocol}//${url.host.toLowerCase()}${path}`;
+}
+
+/**
+ * Canonicalize a client-supplied `resource` only when its origin is trusted, so
+ * the token endpoint never stamps a binding to an origin it does not serve.
+ */
+export function resolveAppConnectorResource(
+  raw: unknown,
+  allowedOrigins: Set<string>,
+): string | null {
+  if (typeof raw !== "string") {
+    return null;
+  }
+  const canonical = canonicalizeConnectorResourceUri(raw);
+  if (!canonical) {
+    return null;
+  }
+  return allowedOrigins.has(new URL(canonical).origin) ? canonical : null;
+}
+
+/** The connector's own canonical resource URI, derived from the request origin. */
+export function buildConnectorResourceUri(
+  origin: string,
+  appId: string,
+): string | null {
+  return canonicalizeConnectorResourceUri(
+    `${origin}${APP_CONNECTOR_PATH_PREFIX}${appId}`,
+  );
+}
+
+/** The `referenceId` value that binds a token to a connector's canonical URI. */
+export function appConnectorAudienceRef(canonicalUri: string): string {
+  return `${MCP_APP_RESOURCE_REFERENCE_PREFIX}${canonicalUri}`;
+}
+
+/**
+ * Whether a token's `referenceId` binds it to a shareable App connector. Other
+ * OAuth resource validators (the MCP gateway, the LLM proxy) call this to reject
+ * a connector-bound token presented at a resource it was not issued for.
+ */
+export function isAppConnectorAudienceRef(
+  referenceId: string | null | undefined,
+): boolean {
+  return (
+    typeof referenceId === "string" &&
+    referenceId.startsWith(MCP_APP_RESOURCE_REFERENCE_PREFIX)
+  );
+}
+
+/**
+ * The RFC 9728 `WWW-Authenticate: Bearer` challenge for a connector, pointing a
+ * client at the connector's protected-resource metadata and the scope to
+ * request (FR-2). Emitted by both the auth middleware (a credential-less
+ * discovery request) and the route (an invalid token).
+ */
+export function connectorWwwAuthenticate(
+  origin: string,
+  appId: string,
+): string {
+  const resourceMetadataUrl = `${origin}/.well-known/oauth-protected-resource${APP_CONNECTOR_PATH_PREFIX}${appId}`;
+  return `Bearer resource_metadata="${resourceMetadataUrl}", scope="${MCP_GATEWAY_OAUTH_SCOPE}"`;
+}
+
+/** The app id in a connector request path, e.g. `/api/mcp/app/<appId>`. */
+export function appIdFromConnectorPath(pathname: string): string | null {
+  if (!pathname.startsWith(APP_CONNECTOR_PATH_PREFIX)) {
+    return null;
+  }
+  const rest = pathname.slice(APP_CONNECTOR_PATH_PREFIX.length);
+  const appId = rest.split(/[/?#]/, 1)[0];
+  return appId || null;
+}

--- a/platform/frontend/src/app/apps/[appId]/page.client.tsx
+++ b/platform/frontend/src/app/apps/[appId]/page.client.tsx
@@ -10,6 +10,7 @@ import { useApp } from "@/lib/app.query";
 import { useSession } from "@/lib/auth/auth.query";
 import { AppRuntimeFrame } from "../_parts/app-runtime-frame";
 import { AppSettingsForm } from "../_parts/app-settings-form";
+import { AppShareTab } from "../_parts/app-share-tab";
 import { AppToolsTab } from "../_parts/app-tools-tab";
 import { AppVersionsTab } from "../_parts/app-versions-tab";
 
@@ -57,6 +58,7 @@ export default function AppDetailPage({ appId }: { appId: string }) {
         <TabsList>
           <TabsTrigger value="preview">Preview</TabsTrigger>
           <TabsTrigger value="tools">Tools</TabsTrigger>
+          <TabsTrigger value="share">Share</TabsTrigger>
           <TabsTrigger value="versions">Versions</TabsTrigger>
           <TabsTrigger value="settings">Settings</TabsTrigger>
         </TabsList>
@@ -69,6 +71,10 @@ export default function AppDetailPage({ appId }: { appId: string }) {
 
         <TabsContent value="tools">
           <AppToolsTab appId={appId} />
+        </TabsContent>
+
+        <TabsContent value="share">
+          <AppShareTab appId={appId} />
         </TabsContent>
 
         <TabsContent value="versions">

--- a/platform/frontend/src/app/apps/_parts/app-share-tab.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-share-tab.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { DocsPage, getDocsUrl } from "@archestra/shared";
+import { CopyableCode } from "@/components/copyable-code";
+import { ExternalDocsLink } from "@/components/external-docs-link";
+import { Skeleton } from "@/components/ui/skeleton";
+import { usePublicBaseUrl } from "@/lib/config/config.query";
+import { useAppName } from "@/lib/hooks/use-app-name";
+
+export function AppShareTab({ appId }: { appId: string }) {
+  const baseUrl = usePublicBaseUrl();
+  const appName = useAppName();
+
+  return (
+    <div className="max-w-2xl space-y-4 py-2">
+      <div className="space-y-1">
+        <h3 className="text-sm font-medium">Connector URL</h3>
+        <p className="text-sm text-muted-foreground">
+          Add this app to an external MCP client (e.g. Claude Desktop &rarr;
+          Settings &rarr; Connectors &rarr; Add custom connector) by pasting
+          this URL. Whoever connects authenticates as themselves and runs the
+          app with their own access, so sharing the URL grants nothing on its
+          own.
+        </p>
+      </div>
+
+      {baseUrl ? (
+        <CopyableCode
+          value={`${baseUrl}/api/mcp/app/${appId}`}
+          toastMessage="Connector URL copied"
+          variant="primary"
+        />
+      ) : (
+        <Skeleton className="h-10 w-full" />
+      )}
+
+      <ExternalDocsLink href={getDocsUrl(DocsPage.PlatformApps)}>
+        Learn about {appName} apps
+      </ExternalDocsLink>
+    </div>
+  );
+}

--- a/platform/shared/oauth.ts
+++ b/platform/shared/oauth.ts
@@ -77,6 +77,18 @@ export const MCP_OAUTH_CLIENT_ID_PREFIX = "mcp_oauth_";
 export const MCP_OAUTH_CLIENT_REFERENCE_PREFIX = "mcp-oauth-client:";
 
 /**
+ * referenceId prefix that binds an access token to a single shareable MCP App
+ * connector, suffixed with the connector's canonical resource URI
+ * (`https://host/api/mcp/app/<appId>`, RFC 8707). The connector accepts a token
+ * only when this binding matches its own canonical URI; every other OAuth
+ * resource validator rejects this prefix. Distinct from `mcp-resource:`
+ * (per-profile, enterprise-managed) and `mcp-oauth-client:` (service account).
+ * The `mcp` scope is coarse, so this binding is the sole per-connector
+ * isolation — it is load-bearing.
+ */
+export const MCP_APP_RESOURCE_REFERENCE_PREFIX = "mcp-app-resource:";
+
+/**
  * Path for deep-linking to MCP catalog install dialogs.
  * Used by backend error messages and frontend routing.
  * Append `?install={catalogId}` to auto-open the install dialog.


### PR DESCRIPTION
## Summary

An Archestra-owned MCP App can now be shared as an OAuth-protected **remote MCP server** that a standards-conformant client connects to at `POST /api/mcp/app/:appId`. The recipient pastes the connector URL, authenticates as **their own viewer**, and the app's UI renders **inside that foreign host** with its tools and data store working. Because owned apps already execute as the viewing user (per-viewer RBAC, resolved credentials, partitioned data, audited as the app), sharing a connector URL confers no access the recipient does not already hold — it only saves them building the app.

The whole feature stays gated by `ARCHESTRA_APPS_ENABLED`; when off, the connector and its OAuth discovery documents are unreachable and leak no existence.

### How a foreign client connects

- A credential-less request is answered with the RFC 9728 `WWW-Authenticate: Bearer resource_metadata="…"` challenge pointing at the connector's own protected-resource metadata, so the client discovers the authorization server (CIMD/DCR/PKCE already advertised).
- The native flow mints an access token **audience-bound to the connector's canonical URI**, validated by direct canonical-URI compare and gated on the `mcp` scope. A token issued for app A is rejected at app B (cross-connector anti-replay); a token resolving no single viewer (org/team) is refused `403`; a token consented to a lesser scope is refused even when audience-bound. Refresh keeps the binding (carry-forward), and the gateway / LLM-proxy reject an app-connector audience so the token can't be replayed off the connector.
- `archestra__llm_complete` stays **app-callable** but is withheld from the host model's `tools/list`, so the host's own model cannot spend the viewer's metered LLM budget — the metering and per-user/per-org limits hold on the external path.
- The OAuth path **bypasses the app-access cache**, so a revoked token or revoked view access is denied on the very next request.
- The connector URL is surfaced on the app detail page to anyone who can view the app — it is not a secret and confers no access on its own (a recipient still authenticates as their own viewer and needs their own view access), so it is gated no more narrowly than the app's existing view scope; no secret is minted.
