### PR TITLE
refactor(chat): unify chat/agent system-prompt construction

### DIFF
--- a/platform/backend/src/agents/a2a-executor.test.ts
+++ b/platform/backend/src/agents/a2a-executor.test.ts
@@ -7,6 +7,7 @@ import {
   buildUserContent,
   executeA2AMessage,
 } from "./a2a-executor";
+import { TOOL_DENIAL_INSTRUCTION } from "./agent-system-prompt";
 
 const {
   mockStreamText,
@@ -731,7 +732,7 @@ describe("executeA2AMessage skill catalog", () => {
     expect(system).toContain("<available_skills>");
   });
 
-  test("leaves the system prompt unchanged when no skill tools are available", async () => {
+  test("omits the skill catalog but keeps the shared tool instructions when no skill tools are available", async () => {
     primeMocks({});
     mockBuildSkillCatalogPrompt.mockResolvedValue("<available_skills>...");
 
@@ -745,6 +746,8 @@ describe("executeA2AMessage skill catalog", () => {
 
     expect(mockBuildSkillCatalogPrompt).not.toHaveBeenCalled();
     const system = mockStreamText.mock.calls[0]?.[0].system;
-    expect(system).toBe("Handle the task.");
+    expect(system).toContain("Handle the task.");
+    expect(system).not.toContain("<available_skills>");
+    expect(system).toContain(TOOL_DENIAL_INSTRUCTION);
   });
 });

--- a/platform/backend/src/agents/a2a-executor.ts
+++ b/platform/backend/src/agents/a2a-executor.ts
@@ -1,9 +1,7 @@
 import crypto from "node:crypto";
 import {
-  buildUserSystemPromptContext,
   type InteractionSource,
   PLAYWRIGHT_MCP_CATALOG_ID,
-  TOOL_LOAD_SKILL_SHORT_NAME,
 } from "@archestra/shared";
 import type { ModelMessage, UIMessage, UserContent } from "ai";
 import {
@@ -12,27 +10,21 @@ import {
   stepCountIs,
   streamText,
 } from "ai";
+import { buildAgentSystemPrompt } from "@/agents/agent-system-prompt";
 import { MIN_IMAGE_ATTACHMENT_SIZE } from "@/agents/incoming-email/constants";
 import { subagentExecutionTracker } from "@/agents/subagent-execution-tracker";
-import { archestraMcpBranding } from "@/archestra-mcp-server";
 import { closeChatMcpClient, getChatMcpTools } from "@/clients/chat-mcp-client";
 import { createLLMModelForAgent } from "@/clients/llm-client";
 import mcpClient from "@/clients/mcp-client";
 import logger from "@/logging";
-import { AgentModel, McpServerModel, TeamModel, UserModel } from "@/models";
+import { AgentModel, McpServerModel } from "@/models";
 import {
   formatUnavailableToolErrorDetails,
   getUnavailableToolErrorDetails,
   mapProviderError,
   ProviderError,
 } from "@/routes/chat/errors";
-import { buildSkillCatalogPrompt } from "@/skills/skill-catalog-prompt";
 import { executionSandboxRegistry } from "@/skills-sandbox/execution-sandbox-registry";
-import {
-  promptNeedsRendering,
-  renderSystemPrompt,
-  type UserSystemPromptContext,
-} from "@/templating";
 import { resolveConversationLlmSelectionForAgent } from "@/utils/llm-resolution";
 
 /**
@@ -194,29 +186,6 @@ export async function executeA2AMessage(
       userId,
     });
 
-  // Build system prompt from agent's systemPrompt field
-  let systemPrompt: string | undefined;
-
-  // Build template context only when prompts use Handlebars syntax
-  let promptContext: UserSystemPromptContext | null = null;
-  if (promptNeedsRendering(agent.systemPrompt)) {
-    const [userDetails, userTeams] = await Promise.all([
-      UserModel.getById(userId),
-      TeamModel.getUserTeamsForOrganization({ userId, organizationId }),
-    ]);
-    promptContext = buildUserSystemPromptContext({
-      userName: userDetails?.name ?? "",
-      userEmail: userDetails?.email ?? "",
-      userTeams: userTeams.map((t) => t.name),
-    });
-  }
-
-  const renderedPrompt = renderSystemPrompt(agent.systemPrompt, promptContext);
-
-  if (renderedPrompt) {
-    systemPrompt = renderedPrompt;
-  }
-
   // Track subagent execution so the browser preview can skip screenshots
   // while subagents are active (prevents flickering from tab switching).
   // Only track delegated calls — direct A2A calls have no browser preview.
@@ -243,22 +212,13 @@ export async function executeA2AMessage(
       scheduleTriggerRunId,
     });
 
-    // eagerly list the agent's skills in the prompt — autonomous runs have no
-    // human to type a slash command — but only when the agent can load them.
-    if (
-      archestraMcpBranding.getToolName(TOOL_LOAD_SKILL_SHORT_NAME) in mcpTools
-    ) {
-      const skillCatalogPrompt = await buildSkillCatalogPrompt({
-        organizationId,
-        userId,
-        agentId: agent.id,
-      });
-      if (skillCatalogPrompt) {
-        systemPrompt =
-          [systemPrompt, skillCatalogPrompt].filter(Boolean).join("\n\n") ||
-          undefined;
-      }
-    }
+    const systemPrompt = await buildAgentSystemPrompt({
+      agent,
+      mcpTools,
+      organizationId,
+      userId,
+      agentId: agent.id,
+    });
 
     logger.info(
       {
@@ -267,7 +227,7 @@ export async function executeA2AMessage(
         orgId: organizationId,
         toolCount: Object.keys(mcpTools).length,
         model: selectedModel,
-        hasSystemPrompt: !!systemPrompt,
+        hasSystemPrompt: !!agent.systemPrompt,
         isolationKey,
         isDirectExecutionOutsideConversation,
       },

--- a/platform/backend/src/agents/agent-system-prompt.test.ts
+++ b/platform/backend/src/agents/agent-system-prompt.test.ts
@@ -1,0 +1,228 @@
+import { ADMIN_ROLE_NAME, TOOL_LOAD_SKILL_SHORT_NAME } from "@archestra/shared";
+import type { Tool } from "ai";
+import { archestraMcpBranding } from "@/archestra-mcp-server";
+import { SkillModel } from "@/models";
+import { describe, expect, test } from "@/test";
+import {
+  buildAgentSystemPrompt,
+  TOOL_DENIAL_INSTRUCTION,
+  TOOL_UI_RESULT_INSTRUCTION,
+} from "./agent-system-prompt";
+
+const loadSkillToolName = archestraMcpBranding.getToolName(
+  TOOL_LOAD_SKILL_SHORT_NAME,
+);
+const someTool: Record<string, Tool> = { some_tool: {} as Tool };
+const withLoadSkill: Record<string, Tool> = { [loadSkillToolName]: {} as Tool };
+
+async function seedSkill(organizationId: string) {
+  return await SkillModel.createWithFiles({
+    skill: {
+      organizationId,
+      name: "pdf-processing",
+      description: "Extract text from PDF files.",
+      content: "# PDF Processing\nUse pdftotext.",
+      metadata: {},
+      sourceType: "manual",
+      scope: "org",
+    },
+    files: [],
+  });
+}
+
+describe("buildAgentSystemPrompt", () => {
+  test("passes the base prompt through and always appends the denial instruction", async ({
+    makeAgent,
+    makeUser,
+    makeMember,
+  }) => {
+    const agent = await makeAgent({
+      systemPrompt: "You are helpful.",
+      toolExposureMode: "full",
+    });
+    const user = await makeUser();
+    await makeMember(user.id, agent.organizationId);
+
+    const prompt = await buildAgentSystemPrompt({
+      agent,
+      mcpTools: {},
+      organizationId: agent.organizationId,
+      userId: user.id,
+      agentId: agent.id,
+    });
+
+    expect(prompt).toBe(`You are helpful.\n\n${TOOL_DENIAL_INSTRUCTION}`);
+  });
+
+  test("renders Handlebars user context from a fetched user and their teams", async ({
+    makeAgent,
+    makeUser,
+    makeMember,
+    makeTeam,
+    makeTeamMember,
+  }) => {
+    const agent = await makeAgent({
+      systemPrompt: "Hi {{user.name}} <{{user.email}}>. Teams: {{user.teams}}.",
+      toolExposureMode: "full",
+    });
+    const user = await makeUser({ email: "alice@test.com" });
+    await makeMember(user.id, agent.organizationId);
+    const team = await makeTeam(agent.organizationId, user.id, {
+      name: "Platform",
+    });
+    await makeTeamMember(team.id, user.id);
+
+    const prompt = await buildAgentSystemPrompt({
+      agent,
+      mcpTools: {},
+      organizationId: agent.organizationId,
+      userId: user.id,
+      agentId: agent.id,
+    });
+
+    expect(prompt).toContain("<alice@test.com>.");
+    expect(prompt).toContain("Teams: Platform.");
+  });
+
+  test("includes the skill catalog only when the load-skill tool is present", async ({
+    makeAgent,
+    makeUser,
+    makeMember,
+  }) => {
+    const agent = await makeAgent({
+      systemPrompt: "Base.",
+      toolExposureMode: "full",
+    });
+    const user = await makeUser();
+    await makeMember(user.id, agent.organizationId, { role: ADMIN_ROLE_NAME });
+    await seedSkill(agent.organizationId);
+
+    const withCatalog = await buildAgentSystemPrompt({
+      agent,
+      mcpTools: withLoadSkill,
+      organizationId: agent.organizationId,
+      userId: user.id,
+      agentId: agent.id,
+    });
+    expect(withCatalog).toContain("<available_skills>");
+    expect(withCatalog).toContain("pdf-processing");
+
+    const withoutCatalog = await buildAgentSystemPrompt({
+      agent,
+      mcpTools: someTool,
+      organizationId: agent.organizationId,
+      userId: user.id,
+      agentId: agent.id,
+    });
+    expect(withoutCatalog).not.toContain("<available_skills>");
+  });
+
+  test("adds the tool-result instruction only when tools are present", async ({
+    makeAgent,
+    makeUser,
+    makeMember,
+  }) => {
+    const agent = await makeAgent({
+      systemPrompt: "Base.",
+      toolExposureMode: "full",
+    });
+    const user = await makeUser();
+    await makeMember(user.id, agent.organizationId);
+    const common = {
+      agent,
+      organizationId: agent.organizationId,
+      userId: user.id,
+      agentId: agent.id,
+    };
+
+    expect(
+      await buildAgentSystemPrompt({ ...common, mcpTools: someTool }),
+    ).toContain(TOOL_UI_RESULT_INSTRUCTION);
+    expect(
+      await buildAgentSystemPrompt({ ...common, mcpTools: {} }),
+    ).not.toContain(TOOL_UI_RESULT_INSTRUCTION);
+  });
+
+  test("adds the tool-loading instruction only in search_and_run_only mode", async ({
+    makeAgent,
+    makeUser,
+    makeMember,
+  }) => {
+    const user = await makeUser();
+    const searchAgent = await makeAgent({
+      systemPrompt: "Base.",
+      toolExposureMode: "search_and_run_only",
+    });
+    await makeMember(user.id, searchAgent.organizationId);
+
+    const searchPrompt = await buildAgentSystemPrompt({
+      agent: searchAgent,
+      mcpTools: {},
+      organizationId: searchAgent.organizationId,
+      userId: user.id,
+      agentId: searchAgent.id,
+    });
+    expect(searchPrompt).toContain("must be discovered");
+
+    const fullAgent = await makeAgent({
+      systemPrompt: "Base.",
+      toolExposureMode: "full",
+      organizationId: searchAgent.organizationId,
+    });
+    const fullPrompt = await buildAgentSystemPrompt({
+      agent: fullAgent,
+      mcpTools: {},
+      organizationId: fullAgent.organizationId,
+      userId: user.id,
+      agentId: fullAgent.id,
+    });
+    expect(fullPrompt).not.toContain("must be discovered");
+  });
+
+  test("appends the hook session context last", async ({
+    makeAgent,
+    makeUser,
+    makeMember,
+  }) => {
+    const agent = await makeAgent({
+      systemPrompt: "Base.",
+      toolExposureMode: "full",
+    });
+    const user = await makeUser();
+    await makeMember(user.id, agent.organizationId);
+
+    const prompt = await buildAgentSystemPrompt({
+      agent,
+      mcpTools: {},
+      organizationId: agent.organizationId,
+      userId: user.id,
+      agentId: agent.id,
+      hookSessionContext: "SESSION-CONTEXT-MARKER",
+    });
+
+    expect(prompt?.endsWith("SESSION-CONTEXT-MARKER")).toBe(true);
+  });
+
+  test("returns the denial instruction alone for an agent with no base prompt or tools", async ({
+    makeAgent,
+    makeUser,
+    makeMember,
+  }) => {
+    const agent = await makeAgent({
+      systemPrompt: null,
+      toolExposureMode: "full",
+    });
+    const user = await makeUser();
+    await makeMember(user.id, agent.organizationId);
+
+    const prompt = await buildAgentSystemPrompt({
+      agent,
+      mcpTools: {},
+      organizationId: agent.organizationId,
+      userId: user.id,
+      agentId: agent.id,
+    });
+
+    expect(prompt).toBe(TOOL_DENIAL_INSTRUCTION);
+  });
+});

--- a/platform/backend/src/agents/agent-system-prompt.ts
+++ b/platform/backend/src/agents/agent-system-prompt.ts
@@ -1,0 +1,134 @@
+import {
+  buildUserSystemPromptContext,
+  TOOL_LOAD_SKILL_SHORT_NAME,
+  TOOL_RUN_TOOL_SHORT_NAME,
+  TOOL_SEARCH_TOOLS_SHORT_NAME,
+} from "@archestra/shared";
+import type { Tool } from "ai";
+import { archestraMcpBranding } from "@/archestra-mcp-server";
+import { TeamModel, UserModel } from "@/models";
+import { buildSkillCatalogPrompt } from "@/skills/skill-catalog-prompt";
+import {
+  promptNeedsRendering,
+  renderSystemPrompt,
+  type UserSystemPromptContext,
+} from "@/templating";
+import type { ToolExposureMode } from "@/types";
+
+/** @public — canonical instruction text, asserted by the assembler tests. */
+export const TOOL_DENIAL_INSTRUCTION =
+  "When a tool execution is not approved by the user, do not retry it. Explain what happened and ask the user what they'd like to do instead.";
+
+/** @public — canonical instruction text, asserted by the assembler tests. */
+export const TOOL_UI_RESULT_INSTRUCTION =
+  "When a tool result includes a UI resource, it means an interactive UI was rendered for the user. Respond with at most one brief sentence. Never describe, list, or explain what the UI shows.";
+
+/**
+ * Compose an agent's system prompt: render its base prompt (with Handlebars
+ * user context when needed), eagerly list its loadable skills, and append the
+ * tool-behavior instructions implied by its tool set and exposure mode. Shared
+ * by the interactive chat path and the autonomous A2A path so both produce the
+ * same prompt from the same inputs.
+ */
+export async function buildAgentSystemPrompt(params: {
+  agent: {
+    systemPrompt: string | null;
+    toolExposureMode: ToolExposureMode;
+  };
+  mcpTools: Record<string, Tool>;
+  organizationId: string;
+  userId: string;
+  agentId: string;
+  /**
+   * Pre-resolved invoking user. The chat path has it in hand; the A2A path
+   * omits it and it is fetched on demand only when the prompt uses templating.
+   */
+  user?: { name: string; email: string };
+  /** Context injected by SessionStart hooks (chat only), appended last. */
+  hookSessionContext?: string;
+}): Promise<string | undefined> {
+  const {
+    agent,
+    mcpTools,
+    organizationId,
+    userId,
+    agentId,
+    user,
+    hookSessionContext,
+  } = params;
+
+  const renderedPrompt = await renderAgentPrompt({
+    systemPrompt: agent.systemPrompt,
+    organizationId,
+    userId,
+    user,
+  });
+
+  const toolLoadingInstructions =
+    agent.toolExposureMode === "search_and_run_only"
+      ? buildLoadToolsWhenNeededSystemPrompt()
+      : null;
+
+  const toolResultInstructions =
+    Object.keys(mcpTools).length > 0 ? TOOL_UI_RESULT_INSTRUCTION : null;
+
+  // eagerly list the agent's skills in the prompt (like Claude Code /
+  // opencode), but only when the agent can actually load them.
+  const skillCatalogPrompt =
+    archestraMcpBranding.getToolName(TOOL_LOAD_SKILL_SHORT_NAME) in mcpTools
+      ? await buildSkillCatalogPrompt({ organizationId, userId, agentId })
+      : null;
+
+  return (
+    [
+      toolLoadingInstructions,
+      renderedPrompt,
+      skillCatalogPrompt,
+      TOOL_DENIAL_INSTRUCTION,
+      toolResultInstructions,
+      hookSessionContext,
+    ]
+      .filter(Boolean)
+      .join("\n\n") || undefined
+  );
+}
+
+// ===== Internal helpers =====
+
+async function renderAgentPrompt(params: {
+  systemPrompt: string | null;
+  organizationId: string;
+  userId: string;
+  user?: { name: string; email: string };
+}): Promise<string | null> {
+  const { systemPrompt, organizationId, userId, user } = params;
+
+  // Build template context only when prompts use Handlebars syntax.
+  let promptContext: UserSystemPromptContext | null = null;
+  if (promptNeedsRendering(systemPrompt)) {
+    const [resolvedUser, userTeams] = await Promise.all([
+      user ?? UserModel.getById(userId),
+      TeamModel.getUserTeamsForOrganization({ userId, organizationId }),
+    ]);
+    promptContext = buildUserSystemPromptContext({
+      userName: resolvedUser?.name ?? "",
+      userEmail: resolvedUser?.email ?? "",
+      userTeams: userTeams.map((t) => t.name),
+    });
+  }
+
+  return renderSystemPrompt(systemPrompt, promptContext);
+}
+
+function buildLoadToolsWhenNeededSystemPrompt(): string {
+  const searchToolsName = archestraMcpBranding.getToolName(
+    TOOL_SEARCH_TOOLS_SHORT_NAME,
+  );
+  const runToolName = archestraMcpBranding.getToolName(
+    TOOL_RUN_TOOL_SHORT_NAME,
+  );
+
+  return `Some available tools are not listed upfront and must be discovered. If the visible tools do not fit the task, call \`${searchToolsName}\` to find relevant tools, then call \`${runToolName}\` with a tool name it returned. Only pass \`${runToolName}\` a tool name that \`${searchToolsName}\` returned or that appeared verbatim earlier in this conversation; if you do not have an exact name, call \`${searchToolsName}\` first.
+
+\`${runToolName}\` takes exactly two arguments: \`tool_name\` (the exact name) and \`tool_args\` (an object holding the target tool's own parameters). Put every target parameter inside \`tool_args\` — not alongside \`tool_name\`. For example, to call a tool \`acme__send_message\` that takes \`channel\` and \`text\`, call \`${runToolName}\` with \`{"tool_name": "acme__send_message", "tool_args": {"channel": "#general", "text": "hi"}}\`. The \`${searchToolsName}\` parameter signatures are summaries; if a \`${runToolName}\` call is rejected as invalid, the error describes the expected input (for third-party tools, the target tool's full input schema) — use it to correct the call.`;
+}

--- a/platform/backend/src/routes/chat/build-chat-context.ts
+++ b/platform/backend/src/routes/chat/build-chat-context.ts
@@ -1,24 +1,12 @@
-import {
-  buildUserSystemPromptContext,
-  TOOL_LOAD_SKILL_SHORT_NAME,
-  TOOL_RUN_TOOL_SHORT_NAME,
-  TOOL_SEARCH_TOOLS_SHORT_NAME,
-} from "@archestra/shared";
 import type { Tool } from "ai";
-import { archestraMcpBranding } from "@/archestra-mcp-server";
+import { buildAgentSystemPrompt } from "@/agents/agent-system-prompt";
 import {
   getChatMcpTools,
   getChatMcpToolUiResourceUris,
 } from "@/clients/chat-mcp-client";
 import type { ChatMcpElicitationBridge } from "@/clients/chat-mcp-elicitation";
 import type { CollectedHookRun } from "@/hooks/hook-run-parts";
-import { ConversationEnabledToolModel, TeamModel } from "@/models";
-import { buildSkillCatalogPrompt } from "@/skills/skill-catalog-prompt";
-import {
-  promptNeedsRendering,
-  renderSystemPrompt,
-  type UserSystemPromptContext,
-} from "@/templating";
+import { ConversationEnabledToolModel } from "@/models";
 import type { ToolExposureMode } from "@/types";
 
 /**
@@ -88,60 +76,15 @@ export async function buildChatContext(params: {
     getChatMcpToolUiResourceUris(agentId),
   ]);
 
-  // Build template context only when prompts use Handlebars syntax
-  let promptContext: UserSystemPromptContext | null = null;
-  if (promptNeedsRendering(agent.systemPrompt)) {
-    const userTeams = await TeamModel.getUserTeamsForOrganization({
-      userId: user.id,
-      organizationId,
-    });
-    promptContext = buildUserSystemPromptContext({
-      userName: user.name,
-      userEmail: user.email,
-      userTeams: userTeams.map((t) => t.name),
-    });
-  }
-
-  const renderedPrompt = renderSystemPrompt(agent.systemPrompt, promptContext);
-
-  let toolResultInstructions: string = "";
-  // Add MCP UI instruction when tools are available
-  if (Object.keys(mcpTools).length > 0) {
-    toolResultInstructions =
-      "When a tool result includes a UI resource, it means an interactive UI was rendered for the user. Respond with at most one brief sentence. Never describe, list, or explain what the UI shows.";
-  }
-
-  const toolDenialInstruction =
-    "When a tool execution is not approved by the user, do not retry it. Explain what happened and ask the user what they'd like to do instead.";
-
-  const toolLoadingInstructions =
-    agent.toolExposureMode === "search_and_run_only"
-      ? buildLoadToolsWhenNeededSystemPrompt()
-      : "";
-
-  // eagerly list the agent's skills in the prompt (like Claude Code /
-  // opencode), but only when the agent can actually load them.
-  const skillCatalogPrompt =
-    archestraMcpBranding.getToolName(TOOL_LOAD_SKILL_SHORT_NAME) in mcpTools
-      ? await buildSkillCatalogPrompt({
-          organizationId,
-          userId: user.id,
-          agentId,
-        })
-      : null;
-
-  const systemPrompt =
-    [
-      toolLoadingInstructions,
-      renderedPrompt,
-      skillCatalogPrompt,
-      toolDenialInstruction,
-      toolResultInstructions,
-      // Context returned by SessionStart hooks.
-      hookSessionContext,
-    ]
-      .filter(Boolean)
-      .join("\n\n") || undefined;
+  const systemPrompt = await buildAgentSystemPrompt({
+    agent,
+    mcpTools,
+    organizationId,
+    userId: user.id,
+    agentId,
+    user: { name: user.name, email: user.email },
+    hookSessionContext,
+  });
 
   return {
     mcpTools,
@@ -152,19 +95,4 @@ export async function buildChatContext(params: {
       enabledToolCount: enabledToolIds.length,
     },
   };
-}
-
-// ===== Internal helpers =====
-
-function buildLoadToolsWhenNeededSystemPrompt(): string {
-  const searchToolsName = archestraMcpBranding.getToolName(
-    TOOL_SEARCH_TOOLS_SHORT_NAME,
-  );
-  const runToolName = archestraMcpBranding.getToolName(
-    TOOL_RUN_TOOL_SHORT_NAME,
-  );
-
-  return `Some available tools are not listed upfront and must be discovered. If the visible tools do not fit the task, call \`${searchToolsName}\` to find relevant tools, then call \`${runToolName}\` with a tool name it returned. Only pass \`${runToolName}\` a tool name that \`${searchToolsName}\` returned or that appeared verbatim earlier in this conversation; if you do not have an exact name, call \`${searchToolsName}\` first.
-
-\`${runToolName}\` takes exactly two arguments: \`tool_name\` (the exact name) and \`tool_args\` (an object holding the target tool's own parameters). Put every target parameter inside \`tool_args\` — not alongside \`tool_name\`. For example, to call a tool \`acme__send_message\` that takes \`channel\` and \`text\`, call \`${runToolName}\` with \`{"tool_name": "acme__send_message", "tool_args": {"channel": "#general", "text": "hi"}}\`. The \`${searchToolsName}\` parameter signatures are summaries; if a \`${runToolName}\` call is rejected as invalid, the error describes the expected input (for third-party tools, the target tool's full input schema) — use it to correct the call.`;
 }


### PR DESCRIPTION
## What

Collapse the two drifted system-prompt assembly sites into one assembler.

Previously the interactive chat path (`build-chat-context.ts`) and the A2A execution path (`a2a-executor.ts`) each built the agent system prompt independently and had drifted: A2A omitted the tool-loading, tool-denial, and tool-result instructions. This adds `backend/src/agents/agent-system-prompt.ts` as the single source of truth for fragment order and the instruction strings; both paths delegate to it.

## Behavior

- **Chat path: unchanged** — identical fragment order and conditions.
- **A2A / subagent / email / scheduled: converged** — these agents now receive the tool-loading (`search_and_run_only`), tool-denial, and tool-result instructions they previously lacked.

## Diff shape

The two call sites shrink (`build-chat-context.ts` −70, `a2a-executor.ts` −41); the new module is the consolidated home, not a new layer.

## Tests

- New `agent-system-prompt.test.ts` — behavior tests against real templating + DB (fragment inclusion conditions, Handlebars user/team rendering via on-demand user fetch, skill catalog gating, denial-only minimal case).
- Updated one A2A test to pin the converged prompt.
- `pnpm type-check`, `pnpm lint`, `pnpm knip`, and the `src/routes/chat` + `src/agents` suites pass.

https://claude.ai/code/session_016EeFCnZCmy9yAFYVEuA4hn