### PR TITLE
fix: restrict Bedrock prompt cache TTL

### DIFF
--- a/platform/backend/src/routes/chat/normalization/apply-prompt-cache.test.ts
+++ b/platform/backend/src/routes/chat/normalization/apply-prompt-cache.test.ts
@@ -298,7 +298,7 @@ describe("applyPromptCacheBreakpoints", () => {
 
     const [sonnet46] = applyPromptCacheBreakpoints({
       provider: "bedrock",
-      model: "global.anthropic.claude-sonnet-4-6-20250514-v1:0",
+      model: "global.anthropic.claude-sonnet-4-6-v1:0",
       messages: [userMessage("a")],
     });
     expect(bedrockCachePoint(sonnet46)).toEqual({ type: "default" });

--- a/platform/backend/src/routes/chat/normalization/apply-prompt-cache.test.ts
+++ b/platform/backend/src/routes/chat/normalization/apply-prompt-cache.test.ts
@@ -279,13 +279,41 @@ describe("applyPromptCacheBreakpoints", () => {
     });
   });
 
-  it("uses a 1h TTL for a Bedrock Sonnet 4.5+ inference profile", () => {
+  it("uses a 1h TTL for Bedrock Claude 4.5 inference profiles", () => {
     const [result] = applyPromptCacheBreakpoints({
+      provider: "bedrock",
+      model: "us.anthropic.claude-opus-4-5-20251101-v1:0",
+      messages: [userMessage("a")],
+    });
+    expect(bedrockCachePoint(result)).toEqual({ type: "default", ttl: "1h" });
+  });
+
+  it("keeps the 5m default for Bedrock Claude 4.6 inference profiles", () => {
+    const [opus46] = applyPromptCacheBreakpoints({
       provider: "bedrock",
       model: "us.anthropic.claude-opus-4-6-v1:0",
       messages: [userMessage("a")],
     });
-    expect(bedrockCachePoint(result)).toEqual({ type: "default", ttl: "1h" });
+    expect(bedrockCachePoint(opus46)).toEqual({ type: "default" });
+
+    const [sonnet46] = applyPromptCacheBreakpoints({
+      provider: "bedrock",
+      model: "global.anthropic.claude-sonnet-4-6-20250514-v1:0",
+      messages: [userMessage("a")],
+    });
+    expect(bedrockCachePoint(sonnet46)).toEqual({ type: "default" });
+  });
+
+  it("uses a 1h TTL for Anthropic Claude 4.6 models", () => {
+    const [result] = applyPromptCacheBreakpoints({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      messages: [userMessage("a")],
+    });
+    expect(anthropicCacheControl(result)).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
   });
 
   it("keeps the 5m default for older models and when model is absent", () => {

--- a/platform/backend/src/routes/chat/normalization/apply-prompt-cache.ts
+++ b/platform/backend/src/routes/chat/normalization/apply-prompt-cache.ts
@@ -1,5 +1,12 @@
 import type { ModelMessage } from "ai";
 
+// Anthropic-direct and Bedrock expose 1-hour cache TTL support on different
+// model sets. Keep the match provider-specific so unsupported/newer Bedrock
+// models fall back to the 5-minute default instead of sending an invalid ttl.
+const CLAUDE_45_AND_NEWER_ONE_HOUR_CACHE_MODEL =
+  /claude-(?:sonnet|haiku|opus)-4-[5-9](?!\d)/;
+const CLAUDE_45_ONE_HOUR_CACHE_MODEL = /claude-(?:sonnet|haiku|opus)-4-5(?!\d)/;
+
 // Per-provider cache-breakpoint marker, written into a message's
 // `providerOptions`. Anthropic and Amazon Bedrock both require explicit
 // breakpoints and both cap at 4 per request; only the providerOptions key and
@@ -7,24 +14,34 @@ import type { ModelMessage } from "ai";
 //   - Anthropic: `{ anthropic: { cacheControl: { type: "ephemeral" } } }`
 //   - Bedrock:   `{ bedrock:   { cachePoint:   { type: "default"   } } }`
 const CACHE_BREAKPOINTS = {
-  anthropic: { key: "anthropic", field: "cacheControl", type: "ephemeral" },
-  bedrock: { key: "bedrock", field: "cachePoint", type: "default" },
+  anthropic: {
+    key: "anthropic",
+    field: "cacheControl",
+    type: "ephemeral",
+    oneHourCacheModel: CLAUDE_45_AND_NEWER_ONE_HOUR_CACHE_MODEL,
+  },
+  bedrock: {
+    key: "bedrock",
+    field: "cachePoint",
+    type: "default",
+    oneHourCacheModel: CLAUDE_45_ONE_HOUR_CACHE_MODEL,
+  },
 } as const;
 
 type CacheBreakpointConfig =
   (typeof CACHE_BREAKPOINTS)[keyof typeof CACHE_BREAKPOINTS];
 
-// Claude Sonnet/Haiku/Opus 4.5 and newer support a 1-hour cache TTL; older
-// models (and other providers) only support the 5-minute default. Matches bare
-// ids ("claude-sonnet-4-5") and Bedrock inference-profile ids
-// ("us.anthropic.claude-opus-4-6-..."). Claude Sonnet/Opus 4
-// ("claude-sonnet-4-20250514") and Claude 3.x are intentionally excluded.
+// Matches bare ids ("claude-sonnet-4-5") and provider-specific ids
+// ("us.anthropic.claude-opus-4-5-..."). Claude Sonnet/Opus 4
+// ("claude-sonnet-4-20250514") and Claude 3.x are intentionally excluded by
+// both provider-specific regexes.
 // `(?!\d)` stops the minor-version digit from matching the leading digit of a
 // dated id like "claude-sonnet-4-20250514" (Sonnet 4, not 4.5).
-const ONE_HOUR_CACHE_MODEL = /claude-(?:sonnet|haiku|opus)-4-[5-9](?!\d)/;
-
-function supportsOneHourCache(model: string): boolean {
-  return ONE_HOUR_CACHE_MODEL.test(model);
+function supportsOneHourCache(
+  config: CacheBreakpointConfig,
+  model: string,
+): boolean {
+  return config.oneHourCacheModel.test(model);
 }
 
 // Anthropic and Bedrock both reject a request with more than 4 cache
@@ -88,7 +105,7 @@ export function applyPromptCacheBreakpoints(params: {
   // one — so mixing 1h here with those 5m markers can fail the request. Staying
   // uniformly 5m when any marker pre-exists keeps ordering valid.
   const useOneHour =
-    !!model && supportsOneHourCache(model) && existingBreakpoints === 0;
+    !!model && supportsOneHourCache(config, model) && existingBreakpoints === 0;
   const markerValue = useOneHour
     ? { type: config.type, ttl: "1h" }
     : { type: config.type };

--- a/platform/backend/src/routes/chat/normalization/apply-prompt-cache.ts
+++ b/platform/backend/src/routes/chat/normalization/apply-prompt-cache.ts
@@ -3,8 +3,15 @@ import type { ModelMessage } from "ai";
 // Anthropic-direct and Bedrock expose 1-hour cache TTL support on different
 // model sets. Keep the match provider-specific so unsupported/newer Bedrock
 // models fall back to the 5-minute default instead of sending an invalid ttl.
+//
+// Anthropic-direct: 1h TTL is broadly available across the 4.5+ generation.
 const CLAUDE_45_AND_NEWER_ONE_HOUR_CACHE_MODEL =
   /claude-(?:sonnet|haiku|opus)-4-[5-9](?!\d)/;
+// Bedrock: per AWS docs only the 4.5 generation supports the 1h TTL; 4.6
+// supports 5m only and *rejects* the whole request when sent ttl:"1h". Pinned
+// to 4.5 so newer/unknown ids degrade safely to 5m. Widen this when AWS
+// documents 1h support for a newer Bedrock model (e.g. 4.7+).
+// https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
 const CLAUDE_45_ONE_HOUR_CACHE_MODEL = /claude-(?:sonnet|haiku|opus)-4-5(?!\d)/;
 
 // Per-provider cache-breakpoint marker, written into a message's


### PR DESCRIPTION
## Summary
- Restrict Bedrock 1h prompt cache TTL to Claude 4.5 models.
- Keep Anthropic 4.5+ 1h TTL behavior unchanged.

Fixes #5696