### PR TITLE
fix(mcp-apps): harden shareable-app connector token binding and lifetime

### DIFF
--- a/platform/backend/src/routes/auth.test.ts
+++ b/platform/backend/src/routes/auth.test.ts
@@ -4,9 +4,11 @@ import {
   LLM_PROXY_OAUTH_SCOPE,
   MCP_GATEWAY_OAUTH_SCOPE,
 } from "@archestra/shared";
+import { eq } from "drizzle-orm";
 import { vi } from "vitest";
 import { betterAuth } from "@/auth";
 import config from "@/config";
+import db, { schema } from "@/database";
 import LlmOauthClientModel from "@/models/llm-oauth-client";
 import McpOauthClientModel from "@/models/mcp-oauth-client";
 import OAuthAccessTokenModel from "@/models/oauth-access-token";
@@ -1148,7 +1150,139 @@ describe("bindAppConnectorTokenAudience", () => {
     }
   });
 
-  test("refresh rejects an attempt to re-target a different connector", async ({
+  // A refresh cannot re-target: better-auth ignores the requested `resource` and
+  // inherits the original audience, and it has already rotated (revoked the old
+  // refresh token) by the time we run — so erroring on a mismatch would strand a
+  // working session for no gain. Honor the inherited binding instead.
+  test("refresh honors the inherited binding and never strands on a mismatched resource", async ({
+    makeUser,
+    makeOAuthClient,
+    makeOAuthAccessToken,
+  }) => {
+    const user = await makeUser();
+    const { bindAppConnectorTokenAudience } = await import("./auth");
+    const mismatches: unknown[] = [
+      connB, // a different connector
+      [connB, connA], // a repeated connector array (refresh ignores `resource`)
+      `https://evil.example.com/api/mcp/app/${APP_A}`, // an untrusted origin
+    ];
+    for (const resource of mismatches) {
+      const client = await makeOAuthClient({ userId: user.id });
+      const rawToken = `tok-${crypto.randomUUID()}`;
+      await makeOAuthAccessToken(client.clientId, user.id, {
+        token: sha256(rawToken),
+        referenceId: refA,
+      });
+      const result = await bindAppConnectorTokenAudience({
+        resource,
+        responseBody: JSON.stringify({ access_token: rawToken }),
+        grantType: "refresh_token",
+        tokenEndpointOrigin: ORIGIN,
+      });
+      expect(result.status).toBe("ok");
+      // The rotated token stays bound to the ORIGINAL connector; the requested
+      // resource is ignored (connector B would still reject this token).
+      const row = await OAuthAccessTokenModel.getByTokenHash(sha256(rawToken));
+      expect(row?.referenceId).toBe(refA);
+    }
+  });
+
+  test("refresh of an originally-unbound token does not acquire a connector", async ({
+    makeUser,
+    makeOAuthClient,
+    makeOAuthAccessToken,
+  }) => {
+    const user = await makeUser();
+    const client = await makeOAuthClient({ userId: user.id });
+    const rawToken = `tok-${crypto.randomUUID()}`;
+    // The original grant never bound a connector, so a refresh that names one
+    // cannot acquire it — the token stays unbound (and the connector rejects it).
+    await makeOAuthAccessToken(client.clientId, user.id, {
+      token: sha256(rawToken),
+      referenceId: null,
+    });
+    const { bindAppConnectorTokenAudience } = await import("./auth");
+    const result = await bindAppConnectorTokenAudience({
+      resource: connA,
+      responseBody: JSON.stringify({ access_token: rawToken }),
+      grantType: "refresh_token",
+      tokenEndpointOrigin: ORIGIN,
+    });
+    expect(result.status).toBe("skip");
+    const row = await OAuthAccessTokenModel.getByTokenHash(sha256(rawToken));
+    expect(row?.referenceId).toBeNull();
+  });
+
+  test("refresh stamps the inherited binding when the access token came back unbound", async ({
+    makeUser,
+    makeOAuthClient,
+    makeOAuthAccessToken,
+    makeOAuthRefreshToken,
+  }) => {
+    const user = await makeUser();
+    const client = await makeOAuthClient({ userId: user.id });
+    // The refresh token carries the original grant's connector audience, but the
+    // refreshed access token came back unbound — the binding must be recovered
+    // from the refresh token and stamped onto the access token.
+    const refresh = await makeOAuthRefreshToken(client.clientId, user.id);
+    await db
+      .update(schema.oauthRefreshTokensTable)
+      .set({ referenceId: refA })
+      .where(eq(schema.oauthRefreshTokensTable.id, refresh.id));
+    const rawToken = `tok-${crypto.randomUUID()}`;
+    await makeOAuthAccessToken(client.clientId, user.id, {
+      token: sha256(rawToken),
+      referenceId: null,
+      refreshId: refresh.id,
+    });
+    const { bindAppConnectorTokenAudience } = await import("./auth");
+    const result = await bindAppConnectorTokenAudience({
+      resource: undefined,
+      responseBody: JSON.stringify({ access_token: rawToken }),
+      grantType: "refresh_token",
+      tokenEndpointOrigin: ORIGIN,
+    });
+    expect(result.status).toBe("ok");
+    const row = await OAuthAccessTokenModel.getByTokenHash(sha256(rawToken));
+    expect(row?.referenceId).toBe(refA);
+  });
+
+  // RFC 8707 permits repeated `resource` params (a JS array). A connector token
+  // binds to exactly one audience, so a connector named among repeated resources
+  // can't be honored on the initial grant — fail closed rather than mint an
+  // unbound token. Only the authorization_code path applies these checks.
+  test("authorization_code fails closed for a resource array naming a connector", async ({
+    makeUser,
+    makeOAuthClient,
+    makeOAuthAccessToken,
+  }) => {
+    const user = await makeUser();
+    const { bindAppConnectorTokenAudience } = await import("./auth");
+    const arrays: unknown[] = [
+      [connA, connB], // two distinct connectors
+      [connA, connA], // the same connector twice
+      [connA, `${ORIGIN}/v1/mcp/some-agent`], // connector mixed with a gateway resource
+    ];
+    for (const resource of arrays) {
+      const client = await makeOAuthClient({ userId: user.id });
+      const rawToken = `tok-${crypto.randomUUID()}`;
+      await makeOAuthAccessToken(client.clientId, user.id, {
+        token: sha256(rawToken),
+        referenceId: null,
+      });
+      const result = await bindAppConnectorTokenAudience({
+        resource,
+        responseBody: JSON.stringify({ access_token: rawToken }),
+        grantType: "authorization_code",
+        tokenEndpointOrigin: ORIGIN,
+      });
+      expect(result.status).toBe("error");
+      const row = await OAuthAccessTokenModel.getByTokenHash(sha256(rawToken));
+      expect(row?.referenceId).toBeNull();
+    }
+  });
+
+  test("authorization_code with only non-connector resources leaves the token unbound", async ({
     makeUser,
     makeOAuthClient,
     makeOAuthAccessToken,
@@ -1158,15 +1292,144 @@ describe("bindAppConnectorTokenAudience", () => {
     const rawToken = `tok-${crypto.randomUUID()}`;
     await makeOAuthAccessToken(client.clientId, user.id, {
       token: sha256(rawToken),
-      referenceId: refA,
+      referenceId: null,
     });
     const { bindAppConnectorTokenAudience } = await import("./auth");
     const result = await bindAppConnectorTokenAudience({
-      resource: connB,
+      // No connector among them — not our concern, so it binds elsewhere or not
+      // at all (here: not at all).
+      resource: [`${ORIGIN}/v1/mcp/agent-a`, `${ORIGIN}/v1/mcp/agent-b`],
       responseBody: JSON.stringify({ access_token: rawToken }),
-      grantType: "refresh_token",
+      grantType: "authorization_code",
       tokenEndpointOrigin: ORIGIN,
     });
-    expect(result.status).toBe("error");
+    expect(result.status).toBe("skip");
+    const row = await OAuthAccessTokenModel.getByTokenHash(sha256(rawToken));
+    expect(row?.referenceId).toBeNull();
+  });
+});
+
+describe("getOAuthAccessTokenLifetimeSeconds — shareable-App connector tokens", () => {
+  const ORIGIN = "http://localhost:9000";
+  const APP_ORG_LIFETIME = 1111;
+  const FIRST_MEMBERSHIP_LIFETIME = 600;
+
+  const setOrgLifetime = (organizationId: string, seconds: number) =>
+    db
+      .update(schema.organizationsTable)
+      .set({ oauthAccessTokenLifetimeSeconds: seconds })
+      .where(eq(schema.organizationsTable.id, organizationId));
+
+  test("a connector token uses the app's org lifetime, not the viewer's first membership", async ({
+    makeUser,
+    makeOrganization,
+    makeMember,
+    makeApp,
+  }) => {
+    const user = await makeUser();
+    // The viewer's only (→ first) membership is a different org with its own
+    // lifetime — the bug returned this for connector tokens.
+    const firstOrg = await makeOrganization();
+    await setOrgLifetime(firstOrg.id, FIRST_MEMBERSHIP_LIFETIME);
+    await makeMember(user.id, firstOrg.id);
+    // The app lives in an org the viewer is not a member of.
+    const appOrg = await makeOrganization();
+    await setOrgLifetime(appOrg.id, APP_ORG_LIFETIME);
+    const app = await makeApp({ organizationId: appOrg.id });
+    const connectorUri = buildConnectorResourceUri(ORIGIN, app.id) as string;
+
+    const { getOAuthAccessTokenLifetimeSeconds } = await import("./auth");
+
+    // authorization_code: the connector is named by the requested `resource`.
+    await expect(
+      getOAuthAccessTokenLifetimeSeconds({
+        resource: connectorUri,
+        referenceId: null,
+        tokenEndpointOrigin: ORIGIN,
+        userId: user.id,
+      }),
+    ).resolves.toBe(APP_ORG_LIFETIME);
+
+    // refresh: better-auth inherits the audience ref onto the token, so `resource`
+    // is absent but the binding identifies the connector.
+    await expect(
+      getOAuthAccessTokenLifetimeSeconds({
+        resource: undefined,
+        referenceId: appConnectorAudienceRef(connectorUri),
+        tokenEndpointOrigin: ORIGIN,
+        userId: user.id,
+      }),
+    ).resolves.toBe(APP_ORG_LIFETIME);
+
+    // A non-connector request still falls back to the viewer's first membership,
+    // proving the connector branch is what redirects to the app's org above.
+    await expect(
+      getOAuthAccessTokenLifetimeSeconds({
+        resource: undefined,
+        referenceId: null,
+        tokenEndpointOrigin: ORIGIN,
+        userId: user.id,
+      }),
+    ).resolves.toBe(FIRST_MEMBERSHIP_LIFETIME);
+  });
+
+  test("a connector resource on an untrusted origin does not resolve an app org", async ({
+    makeUser,
+    makeOrganization,
+    makeMember,
+    makeApp,
+  }) => {
+    const user = await makeUser();
+    const firstOrg = await makeOrganization();
+    await setOrgLifetime(firstOrg.id, FIRST_MEMBERSHIP_LIFETIME);
+    await makeMember(user.id, firstOrg.id);
+    const appOrg = await makeOrganization();
+    await setOrgLifetime(appOrg.id, APP_ORG_LIFETIME);
+    const app = await makeApp({ organizationId: appOrg.id });
+
+    const { getOAuthAccessTokenLifetimeSeconds } = await import("./auth");
+    // Same app id, but an origin this server does not serve — must not bind to the
+    // app's org; falls back to the viewer's first membership.
+    await expect(
+      getOAuthAccessTokenLifetimeSeconds({
+        resource: `https://evil.example.com/api/mcp/app/${app.id}`,
+        referenceId: null,
+        tokenEndpointOrigin: ORIGIN,
+        userId: user.id,
+      }),
+    ).resolves.toBe(FIRST_MEMBERSHIP_LIFETIME);
+  });
+
+  test("on refresh the lifetime follows the inherited binding, not a re-sent resource", async ({
+    makeUser,
+    makeOrganization,
+    makeMember,
+    makeApp,
+  }) => {
+    const user = await makeUser();
+    const firstOrg = await makeOrganization();
+    await setOrgLifetime(firstOrg.id, FIRST_MEMBERSHIP_LIFETIME);
+    await makeMember(user.id, firstOrg.id);
+    // The token is bound (inherited) to appA's connector; the client re-sends a
+    // different connector (appB) on refresh. better-auth ignores the re-sent
+    // resource, so the lifetime must come from appA's org, not appB's.
+    const orgA = await makeOrganization();
+    await setOrgLifetime(orgA.id, APP_ORG_LIFETIME);
+    const appA = await makeApp({ organizationId: orgA.id });
+    const orgB = await makeOrganization();
+    await setOrgLifetime(orgB.id, APP_ORG_LIFETIME + 222);
+    const appB = await makeApp({ organizationId: orgB.id });
+
+    const { getOAuthAccessTokenLifetimeSeconds } = await import("./auth");
+    await expect(
+      getOAuthAccessTokenLifetimeSeconds({
+        resource: buildConnectorResourceUri(ORIGIN, appB.id) as string,
+        referenceId: appConnectorAudienceRef(
+          buildConnectorResourceUri(ORIGIN, appA.id) as string,
+        ),
+        tokenEndpointOrigin: ORIGIN,
+        userId: user.id,
+      }),
+    ).resolves.toBe(APP_ORG_LIFETIME);
   });
 });

--- a/platform/backend/src/routes/auth.ts
+++ b/platform/backend/src/routes/auth.ts
@@ -21,6 +21,7 @@ import logger from "@/logging";
 import {
   AccountModel,
   AgentModel,
+  AppModel,
   LlmOauthClientModel,
   McpOauthClientModel,
   MemberModel,
@@ -33,6 +34,8 @@ import {
 } from "@/models";
 import {
   appConnectorAudienceRef,
+  appIdFromConnectorPath,
+  connectorResourceUriFromAudienceRef,
   isAppConnectorAudienceRef,
   isConnectorTargetedResource,
   resolveAppConnectorResource,
@@ -474,8 +477,32 @@ const authRoutes: FastifyPluginAsyncZod = async (fastify) => {
       });
 
       const response = await betterAuth.handler(req);
+      const rawResponseBody = response.body ? await response.text() : null;
+
+      // Bind a shareable-App connector token to its canonical resource URI
+      // (RFC 8707) so it is accepted only at its own connector — before deriving
+      // the lifetime below, which follows the bound app's org policy and so needs
+      // the binding settled first. Fail closed if an app-connector resource was
+      // requested but the binding can't be written, rather than hand back a token
+      // that silently 401s.
+      if (response.ok) {
+        const connectorBinding = await bindAppConnectorTokenAudience({
+          resource,
+          responseBody: rawResponseBody,
+          grantType: body?.grant_type,
+          tokenEndpointOrigin,
+        });
+        if (connectorBinding.status === "error") {
+          return reply.status(400).send({
+            error: "invalid_target",
+            error_description: connectorBinding.message,
+          });
+        }
+      }
+
       const responseBody = await applyOrganizationOAuthTokenLifetimeToResponse({
-        response,
+        responseText: rawResponseBody,
+        ok: response.ok,
         resource,
         tokenEndpointOrigin,
       });
@@ -509,25 +536,6 @@ const authRoutes: FastifyPluginAsyncZod = async (fastify) => {
           },
           "[auth:oauth2/token] Token request failed",
         );
-      }
-
-      // Bind a shareable-App connector token to its canonical resource URI
-      // (RFC 8707) so it is accepted only at its own connector. Fail closed if
-      // an app-connector resource was requested but the binding can't be written
-      // — better to error than hand back a token that silently 401s.
-      if (response.ok) {
-        const connectorBinding = await bindAppConnectorTokenAudience({
-          resource,
-          responseBody,
-          grantType: body?.grant_type,
-          tokenEndpointOrigin,
-        });
-        if (connectorBinding.status === "error") {
-          return reply.status(400).send({
-            error: "invalid_target",
-            error_description: connectorBinding.message,
-          });
-        }
       }
 
       reply.status(response.status);
@@ -1099,16 +1107,16 @@ function buildBetterAuthForwardedHeaders(
 }
 
 async function applyOrganizationOAuthTokenLifetimeToResponse(params: {
-  response: Response;
+  responseText: string | null;
+  ok: boolean;
   resource: unknown;
   tokenEndpointOrigin: string;
 }): Promise<string | null> {
-  if (!params.response.body) {
+  const { responseText } = params;
+  if (responseText === null) {
     return null;
   }
-
-  const responseText = await params.response.text();
-  if (!params.response.ok) {
+  if (!params.ok) {
     return responseText;
   }
 
@@ -1156,12 +1164,33 @@ async function applyOrganizationOAuthTokenLifetimeToResponse(params: {
   });
 }
 
-async function getOAuthAccessTokenLifetimeSeconds(params: {
+/**
+ * @public — exercised by auth.test.ts (knip --production ignores tests)
+ */
+export async function getOAuthAccessTokenLifetimeSeconds(params: {
   resource: unknown;
   referenceId: string | null | undefined;
   tokenEndpointOrigin: string;
   userId: string;
 }): Promise<number | null> {
+  // A shareable-App connector token is scoped to the app's organization, not the
+  // viewer's first membership — resolve the app's org (via the token's bound
+  // audience ref, or the requested `resource`) so the token can't outlive the
+  // owning org's policy. The token endpoint binds the audience before applying
+  // the lifetime, so on both grants the ref identifies the connector here.
+  const connectorAppId = resolveConnectorAppId({
+    resource: params.resource,
+    referenceId: params.referenceId,
+    tokenEndpointOrigin: params.tokenEndpointOrigin,
+  });
+  if (connectorAppId) {
+    const app = await AppModel.findById(connectorAppId);
+    if (app) {
+      const organization = await OrganizationModel.getById(app.organizationId);
+      return organization?.oauthAccessTokenLifetimeSeconds ?? null;
+    }
+  }
+
   const profileId =
     (await getProfileIdFromResource({
       resource: params.resource,
@@ -1245,6 +1274,36 @@ function getProfileIdFromReferenceId(
   return referenceId.slice(MCP_RESOURCE_REFERENCE_PREFIX.length) || null;
 }
 
+/**
+ * The app id a connector token is bound to, from its audience ref or — as a
+ * fallback — the requested `resource`, else null. The ref is preferred and
+ * authoritative: it is the token's actual audience, and better-auth ignores a
+ * re-sent `resource` on refresh, so the resource must not drive resolution away
+ * from the binding. The ref was written by our own mint and is already trusted;
+ * the client-supplied resource only resolves on a trusted origin.
+ */
+function resolveConnectorAppId(params: {
+  resource: unknown;
+  referenceId: string | null | undefined;
+  tokenEndpointOrigin: string;
+}): string | null {
+  const allowedOrigins = new Set([
+    new URL(buildOAuthIssuer()).origin,
+    params.tokenEndpointOrigin,
+  ]);
+  const canonicalUri =
+    connectorResourceUriFromAudienceRef(params.referenceId) ??
+    resolveAppConnectorResource(params.resource, allowedOrigins);
+  if (!canonicalUri) {
+    return null;
+  }
+  try {
+    return appIdFromConnectorPath(new URL(canonicalUri).pathname);
+  } catch {
+    return null;
+  }
+}
+
 function hashOAuthAccessTokenForLookup(oauthAccessToken: string): string {
   return OAuthAccessTokenModel.hashTokenForLookup(oauthAccessToken);
 }
@@ -1254,11 +1313,12 @@ function hashOAuthAccessTokenForLookup(oauthAccessToken: string): string {
  * (RFC 8707), so the connector accepts it only at its own canonical URI. The
  * `resource` parameter is stripped before better-auth (which rejects a dynamic
  * audience), so the binding is stamped here, after mint. On an authorization_code
- * grant the audience is the consented `resource`; on a refresh_token grant it is
- * the audience carried on the refresh token from the original grant — a refresh
- * cannot re-target a different connector. Returns `error` when an app-connector
- * resource was requested but the token could not be bound to it, so the caller
- * fails the request rather than return a token that silently 401s.
+ * grant the audience is the consented `resource`, and a connector-targeted
+ * `resource` that cannot be bound returns `error` (RFC 8707 invalid_target) so
+ * the caller fails the request rather than hand back a token that silently 401s.
+ * On a refresh_token grant the audience is whatever better-auth inherited from
+ * the original grant; the requested `resource` is advisory there and never errors
+ * (see {@link bindRefreshedConnectorToken}).
  *
  * @public — exercised by auth.test.ts
  */
@@ -1278,6 +1338,37 @@ export async function bindAppConnectorTokenAudience(params: {
     return { status: "skip" };
   }
 
+  const tokenHash = hashOAuthAccessTokenForLookup(accessToken);
+
+  // On a refresh better-auth ignores the requested `resource` and inherits the
+  // original grant's audience, so the resource-shape checks below must not run
+  // here — erroring on a refresh would strand the token better-auth has already
+  // rotated. The inherited binding is authoritative.
+  if (params.grantType === "refresh_token") {
+    return bindRefreshedConnectorToken({
+      tokenHash,
+      resource: params.resource,
+      tokenEndpointOrigin: params.tokenEndpointOrigin,
+    });
+  }
+
+  // Initial (authorization_code) grant: the requested `resource` determines a
+  // new binding. RFC 8707 permits repeated `resource` parameters, which arrive
+  // as an array; a connector token binds to exactly one audience, so a connector
+  // named among repeated resources cannot be honored and fails closed rather than
+  // fall through to an unbound `mcp` token (which still authenticates the MCP
+  // gateway via the user-access path). A lone connector resource always arrives
+  // as a string.
+  if (Array.isArray(params.resource)) {
+    if (params.resource.some(isConnectorTargetedResource)) {
+      return {
+        status: "error",
+        message: "A connector resource must be requested as the sole audience.",
+      };
+    }
+    return { status: "skip" };
+  }
+
   const allowedOrigins = new Set([
     new URL(buildOAuthIssuer()).origin,
     params.tokenEndpointOrigin,
@@ -1290,12 +1381,11 @@ export async function bindAppConnectorTokenAudience(params: {
     ? appConnectorAudienceRef(requestedCanonical)
     : null;
 
-  // A `resource` that targets a connector path but did not resolve to a trusted
-  // canonical URI (an untrusted origin like https://evil.example.com/api/mcp/app/<id>,
-  // or a malformed/sub-path connector URL) must fail closed with RFC 8707
-  // invalid_target. Falling through to "skip" would mint an unbound `mcp` token,
-  // which still authenticates the MCP gateway via the user-access path. Absent or
-  // non-connector resources are unaffected (they bind elsewhere or not at all).
+  // A connector-targeted `resource` that did not resolve to a trusted canonical
+  // URI (an untrusted origin like https://evil.example.com/api/mcp/app/<id>, or a
+  // malformed/sub-path connector URL) fails closed with RFC 8707 invalid_target.
+  // Absent or non-connector resources are unaffected (they bind elsewhere or not
+  // at all).
   if (!requestedRef && isConnectorTargetedResource(params.resource)) {
     return {
       status: "error",
@@ -1303,44 +1393,6 @@ export async function bindAppConnectorTokenAudience(params: {
         "The requested resource is not a valid connector on this server.",
     };
   }
-
-  const tokenHash = hashOAuthAccessTokenForLookup(accessToken);
-
-  if (params.grantType === "refresh_token") {
-    // better-auth carries the original grant's audience onto the refreshed
-    // token, so a refresh cannot acquire a connector the original grant did not
-    // authorize. Honor that inherited binding and reject an attempt to
-    // re-target a different connector (RFC 8707 invalid_target).
-    const refreshed = await OAuthAccessTokenModel.getByTokenHash(tokenHash);
-    let inheritedRef = isAppConnectorAudienceRef(refreshed?.referenceId)
-      ? (refreshed?.referenceId ?? null)
-      : null;
-    if (!inheritedRef && refreshed?.refreshId) {
-      const refresh = await OAuthRefreshTokenModel.getById(refreshed.refreshId);
-      inheritedRef = isAppConnectorAudienceRef(refresh?.referenceId)
-        ? (refresh?.referenceId ?? null)
-        : null;
-    }
-    if (requestedRef && requestedRef !== inheritedRef) {
-      return {
-        status: "error",
-        message: "The refresh token is not bound to the requested resource.",
-      };
-    }
-    if (!inheritedRef) {
-      return { status: "skip" };
-    }
-    // Stamp the access token only if better-auth did not already inherit it.
-    if (refreshed?.referenceId !== inheritedRef) {
-      await OAuthAccessTokenModel.bindReferenceIdByTokenHashWhenUnbound({
-        tokenHash,
-        referenceId: inheritedRef,
-      });
-    }
-    return { status: "ok" };
-  }
-
-  // Initial (authorization_code) grant: stamp the consented connector audience.
   if (!requestedRef) {
     return { status: "skip" };
   }
@@ -1380,6 +1432,84 @@ export async function bindAppConnectorTokenAudience(params: {
         { refreshId: bound.refreshId, requestedRef },
         "[auth:oauth2/token] could not carry the connector audience onto the refresh token",
       );
+    }
+  }
+  return { status: "ok" };
+}
+
+/**
+ * Bind a refreshed token to the connector audience better-auth inherited from
+ * the original grant (carried via the refresh token's `referenceId`). The
+ * requested `resource` is advisory on refresh: better-auth ignores it and cannot
+ * re-target the audience, so a mismatch is logged, never errored — erroring would
+ * strand the session better-auth has already rotated (the old refresh token is
+ * revoked the moment the new one is minted). Returns `skip` for a non-connector
+ * token.
+ */
+async function bindRefreshedConnectorToken(params: {
+  tokenHash: string;
+  resource: unknown;
+  tokenEndpointOrigin: string;
+}): Promise<{ status: "ok" | "skip" }> {
+  const refreshed = await OAuthAccessTokenModel.getByTokenHash(
+    params.tokenHash,
+  );
+  let inheritedRef = isAppConnectorAudienceRef(refreshed?.referenceId)
+    ? (refreshed?.referenceId ?? null)
+    : null;
+  if (!inheritedRef && refreshed?.refreshId) {
+    const refresh = await OAuthRefreshTokenModel.getById(refreshed.refreshId);
+    inheritedRef = isAppConnectorAudienceRef(refresh?.referenceId)
+      ? (refresh?.referenceId ?? null)
+      : null;
+  }
+  if (!inheritedRef) {
+    return { status: "skip" };
+  }
+
+  // Surface a client that asked to re-target a different connector on refresh: it
+  // gets the inherited binding regardless, but the discrepancy is worth a log.
+  const allowedOrigins = new Set([
+    new URL(buildOAuthIssuer()).origin,
+    params.tokenEndpointOrigin,
+  ]);
+  const requestedCanonical = resolveAppConnectorResource(
+    params.resource,
+    allowedOrigins,
+  );
+  const requestedRef = requestedCanonical
+    ? appConnectorAudienceRef(requestedCanonical)
+    : null;
+  if (requestedRef && requestedRef !== inheritedRef) {
+    logger.warn(
+      { requestedRef, inheritedRef },
+      "[auth:oauth2/token] refresh requested a different connector audience; honoring the inherited binding",
+    );
+  }
+
+  // Stamp the access token only if better-auth did not already inherit it. The
+  // stamp is a one-shot IS NULL write: a no-op when the row already carries the
+  // audience (idempotent success). Unlike the authorization_code path this never
+  // fails the request — better-auth has already rotated the refresh token, so
+  // erroring would strand the session. But if the row ended up unbound or bound
+  // to a different audience (stale/partial write, corruption), the refreshed
+  // token would 401 at its connector, so surface that rather than assume success.
+  if (refreshed?.referenceId !== inheritedRef) {
+    const bound =
+      await OAuthAccessTokenModel.bindReferenceIdByTokenHashWhenUnbound({
+        tokenHash: params.tokenHash,
+        referenceId: inheritedRef,
+      });
+    if (!bound) {
+      const existing = await OAuthAccessTokenModel.getByTokenHash(
+        params.tokenHash,
+      );
+      if (existing?.referenceId !== inheritedRef) {
+        logger.error(
+          { inheritedRef, existingRef: existing?.referenceId ?? null },
+          "[auth:oauth2/token] refreshed token could not inherit its connector audience",
+        );
+      }
     }
   }
   return { status: "ok" };

--- a/platform/backend/src/services/apps/app-connector-resource.test.ts
+++ b/platform/backend/src/services/apps/app-connector-resource.test.ts
@@ -4,6 +4,7 @@ import {
   appIdFromConnectorPath,
   buildConnectorResourceUri,
   canonicalizeConnectorResourceUri,
+  connectorResourceUriFromAudienceRef,
   connectorWwwAuthenticate,
   isAppConnectorAudienceRef,
   isConnectorTargetedResource,
@@ -158,5 +159,25 @@ describe("appIdFromConnectorPath", () => {
   test("returns null for a non-connector path or an empty id", () => {
     expect(appIdFromConnectorPath("/api/apps")).toBeNull();
     expect(appIdFromConnectorPath("/api/mcp/app/")).toBeNull();
+  });
+});
+
+describe("connectorResourceUriFromAudienceRef", () => {
+  test("round-trips a connector audience ref back to its canonical URI", () => {
+    const uri = `https://host/api/mcp/app/${APP_ID}`;
+    expect(
+      connectorResourceUriFromAudienceRef(appConnectorAudienceRef(uri)),
+    ).toBe(uri);
+  });
+
+  test("returns null for a non-connector ref or absent value", () => {
+    expect(connectorResourceUriFromAudienceRef("mcp-resource:abc")).toBeNull();
+    expect(
+      connectorResourceUriFromAudienceRef("mcp-oauth-client:abc"),
+    ).toBeNull();
+    expect(connectorResourceUriFromAudienceRef("not-a-ref")).toBeNull();
+    expect(connectorResourceUriFromAudienceRef("mcp-app-resource:")).toBeNull();
+    expect(connectorResourceUriFromAudienceRef(null)).toBeNull();
+    expect(connectorResourceUriFromAudienceRef(undefined)).toBeNull();
   });
 });

--- a/platform/backend/src/services/apps/app-connector-resource.ts
+++ b/platform/backend/src/services/apps/app-connector-resource.ts
@@ -128,6 +128,25 @@ export function isAppConnectorAudienceRef(
 }
 
 /**
+ * The connector's canonical resource URI recovered from a token's audience ref,
+ * or null when the ref does not bind to a connector. Inverse of {@link
+ * appConnectorAudienceRef}: lets the token endpoint resolve the owning app from
+ * a refreshed token, whose binding better-auth inherits without re-sending the
+ * `resource`.
+ */
+export function connectorResourceUriFromAudienceRef(
+  referenceId: string | null | undefined,
+): string | null {
+  if (
+    typeof referenceId !== "string" ||
+    !referenceId.startsWith(MCP_APP_RESOURCE_REFERENCE_PREFIX)
+  ) {
+    return null;
+  }
+  return referenceId.slice(MCP_APP_RESOURCE_REFERENCE_PREFIX.length) || null;
+}
+
+/**
  * The RFC 9728 `WWW-Authenticate: Bearer` challenge for a connector, pointing a
  * client at the connector's protected-resource metadata and the scope to
  * request. Emitted by both the auth middleware (a credential-less discovery


### PR DESCRIPTION
Three RFC 8707 / OAuth correctness fixes in the shareable-App connector token mint (`POST /api/auth/oauth2/token`), following review of the connector feature (#5689).

A client that sends a repeated `resource` parameter (which arrives as an array) could obtain a token that was never bound to the connector it named — an unbound `mcp` token still usable at the general MCP gateway. A connector named among repeated resources now fails closed with `invalid_target`, matching the single-`resource` behavior.

A refresh that named a different connector than the token's inherited audience used to return `invalid_target` only after better-auth had already rotated (revoked) the refresh token, permanently stranding the user's session and forcing reauthorization. Since better-auth ignores `resource` on refresh and cannot re-target the audience, the inherited binding is now honored — the rotated session survives — and a mismatch is logged instead of erroring.

A connector token for an app whose organization was not the viewer's first membership took the wrong organization's OAuth token lifetime, so it could outlive the owning org's policy. The token's audience is now bound before its lifetime is derived, so the lifetime always follows the bound app's organization.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>