### PR TITLE
fix(llm-proxy): forward multimodal content through model-router translators (Gemini, Anthropic, Cohere)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5428,20 +5428,32 @@
                                   "type": {
                                     "type": "string",
                                     "enum": [
-                                      "tool_result"
+                                      "image_url"
                                     ]
                                   },
-                                  "tool_call_id": {
-                                    "type": "string"
-                                  },
-                                  "content": {
-                                    "type": "string"
+                                  "image_url": {
+                                    "type": "object",
+                                    "properties": {
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "detail": {
+                                        "type": "string",
+                                        "enum": [
+                                          "auto",
+                                          "low",
+                                          "high"
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ]
                                   }
                                 },
                                 "required": [
                                   "type",
-                                  "tool_call_id",
-                                  "content"
+                                  "image_url"
                                 ]
                               }
                             ]
@@ -22697,20 +22709,33 @@
                                   "type": {
                                     "type": "string",
                                     "enum": [
-                                      "tool_result"
+                                      "image_url"
                                     ]
                                   },
-                                  "tool_call_id": {
-                                    "type": "string"
-                                  },
-                                  "content": {
-                                    "type": "string"
+                                  "image_url": {
+                                    "type": "object",
+                                    "properties": {
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "detail": {
+                                        "type": "string",
+                                        "enum": [
+                                          "auto",
+                                          "low",
+                                          "high"
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "additionalProperties": false
                                   }
                                 },
                                 "required": [
                                   "type",
-                                  "tool_call_id",
-                                  "content"
+                                  "image_url"
                                 ],
                                 "additionalProperties": false
                               }

--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -46,7 +46,7 @@ The prefix before `:` is the provider. The value after `:` is the provider's nat
 
 The `/models` response includes model-router-compatible text models for the providers mapped on the virtual key. Providers that use native request formats, including Anthropic, Bedrock, Gemini, and Cohere, are translated between OpenAI request/response formats and provider-native formats before forwarding.
 
-Model Router translation forwards inline non-text content where the provider's native format supports it: Gemini (base64 data URL images, audio, and files, plus http(s) image URLs), Anthropic (base64 data URL images and PDF files), Cohere (images via base64 data URI or web URL in user messages), and Bedrock (base64 data URL images). Gemini and Anthropic also forward images returned inside tool results. Other non-text parts, such as audio to Anthropic or any non-text content to Cohere tool results, are dropped because the provider format does not model them.
+Model Router translation forwards inline non-text content where the provider's native format supports it: Gemini (base64 data URL images, audio, and files), Anthropic (base64 data URL images and PDF files), Cohere (images via base64 data URI or web URL in user messages), and Bedrock (base64 data URL images). Anthropic also forwards images returned inside tool results. Content the provider format cannot represent is dropped — for example http(s) image URLs to Gemini (its `fileData` accepts only Files API or `gs://` URIs), audio to Anthropic, and non-text content in Gemini and Cohere tool results.
 
 ## OpenAI
 

--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -46,7 +46,7 @@ The prefix before `:` is the provider. The value after `:` is the provider's nat
 
 The `/models` response includes model-router-compatible text models for the providers mapped on the virtual key. Providers that use native request formats, including Anthropic, Bedrock, Gemini, and Cohere, are translated between OpenAI request/response formats and provider-native formats before forwarding.
 
-Model Router translation is text-first. Anthropic, Gemini, and Cohere routes currently drop non-text content parts such as OpenAI `image_url` message parts; Bedrock supports base64 data URL images.
+Model Router translation forwards inline non-text content where the provider's native format supports it: Gemini (base64 data URL images, audio, and files, plus http(s) image URLs), Anthropic (base64 data URL images and PDF files), Cohere (images via base64 data URI or web URL in user messages), and Bedrock (base64 data URL images). Gemini and Anthropic also forward images returned inside tool results. Other non-text parts, such as audio to Anthropic or any non-text content to Cohere tool results, are dropped because the provider format does not model them.
 
 ## OpenAI
 

--- a/platform/backend/src/routes/proxy/adapters/anthropic-openai-translator.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic-openai-translator.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "@/test";
+import type { OpenAi } from "@/types";
+import { openaiToAnthropic } from "./anthropic-openai-translator";
+
+type OpenAiRequest = OpenAi.Types.ChatCompletionsRequest;
+
+function req(overrides: Partial<OpenAiRequest> = {}): OpenAiRequest {
+  return {
+    model: "claude-sonnet-4-6",
+    messages: [{ role: "user", content: "hello" }],
+    ...overrides,
+  } as OpenAiRequest;
+}
+
+describe("openaiToAnthropic — multimodal user content", () => {
+  test("forwards a base64 image as an image block instead of dropping it", () => {
+    const request = req({
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "describe this" },
+            {
+              type: "image_url",
+              image_url: { url: "data:image/jpeg;base64,AAAABBBB" },
+            },
+          ],
+        },
+      ],
+      // biome-ignore lint/suspicious/noExplicitAny: minimal multimodal message
+    } as any);
+
+    const { anthropicBody } = openaiToAnthropic(request);
+
+    expect(anthropicBody.messages[0].content).toEqual([
+      { type: "text", text: "describe this" },
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/jpeg", data: "AAAABBBB" },
+      },
+    ]);
+  });
+
+  test("forwards a base64 PDF file as a document block", () => {
+    const request = req({
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              file: {
+                filename: "report.pdf",
+                file_data: "data:application/pdf;base64,JVBERi0=",
+              },
+            },
+          ],
+        },
+      ],
+      // biome-ignore lint/suspicious/noExplicitAny: minimal multimodal message
+    } as any);
+
+    const { anthropicBody } = openaiToAnthropic(request);
+
+    expect(anthropicBody.messages[0].content).toEqual([
+      {
+        type: "document",
+        source: {
+          type: "base64",
+          media_type: "application/pdf",
+          data: "JVBERi0=",
+        },
+      },
+    ]);
+  });
+
+  test("still passes a plain string user message through unchanged", () => {
+    const { anthropicBody } = openaiToAnthropic(req());
+    expect(anthropicBody.messages[0].content).toBe("hello");
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/anthropic-openai-translator.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic-openai-translator.test.ts
@@ -78,4 +78,63 @@ describe("openaiToAnthropic — multimodal user content", () => {
     const { anthropicBody } = openaiToAnthropic(req());
     expect(anthropicBody.messages[0].content).toBe("hello");
   });
+
+  test("forwards images inside a tool result as image blocks", () => {
+    const request = req({
+      messages: [
+        { role: "user", content: "go" },
+        {
+          role: "tool",
+          tool_call_id: "call_1",
+          content: [
+            { type: "text", text: "here is the chart" },
+            {
+              type: "image_url",
+              image_url: { url: "data:image/png;base64,Q0hBUlQ=" },
+            },
+          ],
+        },
+      ],
+      // biome-ignore lint/suspicious/noExplicitAny: minimal tool-result message
+    } as any);
+
+    const { anthropicBody } = openaiToAnthropic(request);
+    // messages[0] is the user turn; messages[1] carries the tool_result.
+    expect(anthropicBody.messages[1].content).toEqual([
+      {
+        type: "tool_result",
+        tool_use_id: "call_1",
+        content: [
+          { type: "text", text: "here is the chart" },
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: "Q0hBUlQ=",
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("falls back to text for a tool result with no convertible media", () => {
+    const request = req({
+      messages: [
+        { role: "user", content: "go" },
+        { role: "tool", tool_call_id: "call_1", content: "plain result" },
+      ],
+      // biome-ignore lint/suspicious/noExplicitAny: minimal tool-result message
+    } as any);
+
+    const { anthropicBody } = openaiToAnthropic(request);
+    expect(anthropicBody.messages[1].content).toEqual([
+      {
+        type: "tool_result",
+        tool_use_id: "call_1",
+        content: "plain result",
+      },
+    ]);
+  });
 });

--- a/platform/backend/src/routes/proxy/adapters/anthropic-openai-translator.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic-openai-translator.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
 import type { Anthropic, OpenAi } from "@/types";
 import {
+  type NormalizedContentPart,
+  normalizeOpenAiContentParts,
   parseDataUrl,
   parseJsonObject,
   stringifyTextContent,
@@ -84,13 +86,20 @@ export function openaiToAnthropic(req: OpenAiRequest): {
     }
 
     if (message.role === "tool") {
+      // Anthropic tool_result content accepts text and image blocks, so forward
+      // images returned by a tool instead of flattening them to text. Text-only
+      // results stay a plain string to match prior behavior.
+      const normalized = normalizeOpenAiContentParts(message.content);
+      const hasMedia = normalized.some((part) => part.kind !== "text");
       messages.push({
         role: "user",
         content: [
           {
             type: "tool_result",
             tool_use_id: message.tool_call_id ?? "",
-            content: stringifyTextContent(message.content),
+            content: hasMedia
+              ? userContentToAnthropicBlocks(message.content)
+              : stringifyTextContent(message.content),
           },
         ],
       });
@@ -213,72 +222,73 @@ export function mapStopReason(
 }
 
 type AnthropicUserContent = AnthropicRequest["messages"][number]["content"];
+type AnthropicToolResultContent = NonNullable<
+  Extract<
+    Extract<AnthropicUserContent, readonly unknown[]>[number],
+    { type: "tool_result" }
+  >["content"]
+>;
 
 // Converts an OpenAI user-message `content` into Anthropic content, preserving
 // images (base64 data URLs → image blocks) and PDF files (→ document blocks)
 // instead of dropping every non-text part. A plain string passes through
-// unchanged; http(s) image URLs are dropped since Anthropic's base64 image
-// source is the only multimodal source modeled here.
+// unchanged; nothing convertible falls back to an empty string since Anthropic
+// requires non-empty content.
 function userContentToAnthropicContent(content: unknown): AnthropicUserContent {
   if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-
-  const blocks: Array<Record<string, unknown>> = [];
-  for (const part of content as Array<Record<string, LooseContentValue>>) {
-    if (!part || typeof part !== "object") continue;
-
-    if (part.type === "text") {
-      if (typeof part.text === "string" && part.text) {
-        blocks.push({ type: "text", text: part.text });
-      }
-      continue;
-    }
-
-    if (part.type === "image_url") {
-      const url = String(getNested(part.image_url, "url") ?? "");
-      const inline = parseDataUrl(url);
-      if (inline) {
-        blocks.push({
-          type: "image",
-          source: {
-            type: "base64",
-            media_type: inline.mimeType,
-            data: inline.data,
-          },
-        });
-      }
-      continue;
-    }
-
-    if (part.type === "file") {
-      const fileData = String(getNested(part.file, "file_data") ?? "");
-      const inline = parseDataUrl(fileData);
-      if (inline && inline.mimeType === "application/pdf") {
-        blocks.push({
-          type: "document",
-          source: {
-            type: "base64",
-            media_type: "application/pdf",
-            data: inline.data,
-          },
-        });
-      }
-    }
-  }
-
-  // Anthropic requires non-empty content; fall back to an empty string when
-  // nothing convertible remained.
+  const blocks = userContentToAnthropicBlocks(content);
   if (blocks.length === 0) return "";
-  return blocks as AnthropicUserContent;
+  return blocks as unknown as AnthropicUserContent;
 }
 
-type LooseContentValue = string | Record<string, unknown> | undefined;
-
-function getNested(value: LooseContentValue, key: string): unknown {
-  if (value && typeof value === "object") {
-    return (value as Record<string, unknown>)[key];
+// Maps OpenAI content parts to Anthropic content blocks (text, base64 image,
+// base64 PDF document). Shared by user messages and tool_result blocks. http(s)
+// image URLs and audio are dropped since Anthropic's typed schema models only
+// base64 image/PDF sources here.
+function userContentToAnthropicBlocks(
+  content: unknown,
+): AnthropicToolResultContent {
+  const blocks: Array<Record<string, unknown>> = [];
+  for (const part of normalizeOpenAiContentParts(content)) {
+    const block = normalizedPartToAnthropicBlock(part);
+    if (block) blocks.push(block);
   }
-  return undefined;
+  return blocks as unknown as AnthropicToolResultContent;
+}
+
+function normalizedPartToAnthropicBlock(
+  part: NormalizedContentPart,
+): Record<string, unknown> | null {
+  switch (part.kind) {
+    case "text":
+      return { type: "text", text: part.text };
+    case "image": {
+      const inline = parseDataUrl(part.url);
+      if (!inline) return null;
+      return {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: inline.mimeType,
+          data: inline.data,
+        },
+      };
+    }
+    case "file": {
+      const inline = parseDataUrl(part.fileData);
+      if (!inline || inline.mimeType !== "application/pdf") return null;
+      return {
+        type: "document",
+        source: {
+          type: "base64",
+          media_type: "application/pdf",
+          data: inline.data,
+        },
+      };
+    }
+    case "audio":
+      return null;
+  }
 }
 
 function toAnthropicToolChoice(

--- a/platform/backend/src/routes/proxy/adapters/anthropic-openai-translator.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic-openai-translator.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { Anthropic, OpenAi } from "@/types";
 import {
+  parseDataUrl,
   parseJsonObject,
   stringifyTextContent,
 } from "./openai-translator-utils";
@@ -52,7 +53,7 @@ export function openaiToAnthropic(req: OpenAiRequest): {
     if (message.role === "user") {
       messages.push({
         role: "user",
-        content: stringifyTextContent(message.content),
+        content: userContentToAnthropicContent(message.content),
       });
       continue;
     }
@@ -209,6 +210,75 @@ export function mapStopReason(
   if (reason === "tool_use") return "tool_calls";
   if (reason === "stop_sequence" || reason === "end_turn") return "stop";
   return "stop";
+}
+
+type AnthropicUserContent = AnthropicRequest["messages"][number]["content"];
+
+// Converts an OpenAI user-message `content` into Anthropic content, preserving
+// images (base64 data URLs → image blocks) and PDF files (→ document blocks)
+// instead of dropping every non-text part. A plain string passes through
+// unchanged; http(s) image URLs are dropped since Anthropic's base64 image
+// source is the only multimodal source modeled here.
+function userContentToAnthropicContent(content: unknown): AnthropicUserContent {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+
+  const blocks: Array<Record<string, unknown>> = [];
+  for (const part of content as Array<Record<string, LooseContentValue>>) {
+    if (!part || typeof part !== "object") continue;
+
+    if (part.type === "text") {
+      if (typeof part.text === "string" && part.text) {
+        blocks.push({ type: "text", text: part.text });
+      }
+      continue;
+    }
+
+    if (part.type === "image_url") {
+      const url = String(getNested(part.image_url, "url") ?? "");
+      const inline = parseDataUrl(url);
+      if (inline) {
+        blocks.push({
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: inline.mimeType,
+            data: inline.data,
+          },
+        });
+      }
+      continue;
+    }
+
+    if (part.type === "file") {
+      const fileData = String(getNested(part.file, "file_data") ?? "");
+      const inline = parseDataUrl(fileData);
+      if (inline && inline.mimeType === "application/pdf") {
+        blocks.push({
+          type: "document",
+          source: {
+            type: "base64",
+            media_type: "application/pdf",
+            data: inline.data,
+          },
+        });
+      }
+    }
+  }
+
+  // Anthropic requires non-empty content; fall back to an empty string when
+  // nothing convertible remained.
+  if (blocks.length === 0) return "";
+  return blocks as AnthropicUserContent;
+}
+
+type LooseContentValue = string | Record<string, unknown> | undefined;
+
+function getNested(value: LooseContentValue, key: string): unknown {
+  if (value && typeof value === "object") {
+    return (value as Record<string, unknown>)[key];
+  }
+  return undefined;
 }
 
 function toAnthropicToolChoice(

--- a/platform/backend/src/routes/proxy/adapters/cohere-openai-translator.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/cohere-openai-translator.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "@/test";
+import type { OpenAi } from "@/types";
+import { openaiToCohere } from "./cohere-openai-translator";
+
+type OpenAiRequest = OpenAi.Types.ChatCompletionsRequest;
+
+function req(overrides: Partial<OpenAiRequest> = {}): OpenAiRequest {
+  return {
+    model: "command-a-vision-07-2025",
+    messages: [{ role: "user", content: "hello" }],
+    ...overrides,
+  } as OpenAiRequest;
+}
+
+describe("openaiToCohere — multimodal user content", () => {
+  test("forwards an image as an image_url block instead of dropping it", () => {
+    const request = req({
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "describe this" },
+            {
+              type: "image_url",
+              image_url: { url: "data:image/png;base64,AAAABBBB" },
+            },
+          ],
+        },
+      ],
+      // biome-ignore lint/suspicious/noExplicitAny: minimal multimodal message
+    } as any);
+
+    const { cohereBody } = openaiToCohere(request);
+
+    expect(cohereBody.messages[0].content).toEqual([
+      { type: "text", text: "describe this" },
+      {
+        type: "image_url",
+        image_url: { url: "data:image/png;base64,AAAABBBB" },
+      },
+    ]);
+  });
+
+  test("forwards a web image URL unchanged", () => {
+    const request = req({
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image_url",
+              image_url: { url: "https://example.com/cat.png" },
+            },
+          ],
+        },
+      ],
+      // biome-ignore lint/suspicious/noExplicitAny: minimal multimodal message
+    } as any);
+
+    const { cohereBody } = openaiToCohere(request);
+
+    expect(cohereBody.messages[0].content).toEqual([
+      { type: "image_url", image_url: { url: "https://example.com/cat.png" } },
+    ]);
+  });
+
+  test("still passes a plain string user message through unchanged", () => {
+    const { cohereBody } = openaiToCohere(req());
+    expect(cohereBody.messages[0].content).toBe("hello");
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/cohere-openai-translator.ts
+++ b/platform/backend/src/routes/proxy/adapters/cohere-openai-translator.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from "node:crypto";
 import type { Cohere, OpenAi } from "@/types";
-import { stringifyTextContent } from "./openai-translator-utils";
+import {
+  normalizeOpenAiContentParts,
+  stringifyTextContent,
+} from "./openai-translator-utils";
 
 type OpenAiRequest = OpenAi.Types.ChatCompletionsRequest;
 type OpenAiResponse = OpenAi.Types.ChatCompletionsResponse;
@@ -50,7 +53,7 @@ export function openaiToCohere(req: OpenAiRequest): {
     if (message.role === "user") {
       messages.push({
         role: "user",
-        content: stringifyTextContent(message.content),
+        content: userContentToCohereContent(message.content),
       });
       continue;
     }
@@ -189,4 +192,28 @@ export function mapCohereFinishReason(
   if (reason === "TOOL_CALL") return "tool_calls";
   if (reason === "ERROR") return "content_filter";
   return "stop";
+}
+
+type CohereUserContent = Cohere.Types.UserMessage["content"];
+
+// Converts an OpenAI user-message `content` into Cohere content, forwarding
+// images as `image_url` blocks instead of dropping them. Cohere accepts both
+// base64 data URIs and web URLs, so the url passes through unchanged. Audio and
+// file parts are dropped since Cohere models no such user content block.
+function userContentToCohereContent(content: unknown): CohereUserContent {
+  if (typeof content === "string") return content;
+
+  const blocks: Array<Record<string, unknown>> = [];
+  for (const part of normalizeOpenAiContentParts(content)) {
+    if (part.kind === "text") {
+      blocks.push({ type: "text", text: part.text });
+    } else if (part.kind === "image") {
+      blocks.push({ type: "image_url", image_url: { url: part.url } });
+    }
+  }
+
+  // Cohere requires non-empty content; fall back to text-only when nothing
+  // convertible remained.
+  if (blocks.length === 0) return stringifyTextContent(content);
+  return blocks as unknown as CohereUserContent;
 }

--- a/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.test.ts
@@ -82,3 +82,81 @@ describe("openaiToGemini — tool schema sanitization", () => {
     expect(params.properties.color.enum).toEqual(["red", "green"]);
   });
 });
+
+describe("openaiToGemini — multimodal user content", () => {
+  test("forwards a base64 image as inlineData instead of dropping it", () => {
+    const request = req({
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "describe this" },
+            {
+              type: "image_url",
+              image_url: { url: "data:image/png;base64,AAAABBBB" },
+            },
+          ],
+        },
+      ],
+      // biome-ignore lint/suspicious/noExplicitAny: minimal multimodal message
+    } as any);
+
+    const { geminiBody } = openaiToGemini(request);
+
+    expect(geminiBody.contents[0].parts).toEqual([
+      { text: "describe this" },
+      { inlineData: { mimeType: "image/png", data: "AAAABBBB" } },
+    ]);
+  });
+
+  test("forwards an http image URL as a fileData reference", () => {
+    const request = req({
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image_url",
+              image_url: { url: "https://example.com/cat.png" },
+            },
+          ],
+        },
+      ],
+      // biome-ignore lint/suspicious/noExplicitAny: minimal multimodal message
+    } as any);
+
+    const { geminiBody } = openaiToGemini(request);
+
+    expect(geminiBody.contents[0].parts).toEqual([
+      { fileData: { fileUri: "https://example.com/cat.png" } },
+    ]);
+  });
+
+  test("forwards base64 input_audio as inlineData", () => {
+    const request = req({
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "input_audio",
+              input_audio: { data: "QUJD", format: "wav" },
+            },
+          ],
+        },
+      ],
+      // biome-ignore lint/suspicious/noExplicitAny: minimal multimodal message
+    } as any);
+
+    const { geminiBody } = openaiToGemini(request);
+
+    expect(geminiBody.contents[0].parts).toEqual([
+      { inlineData: { mimeType: "audio/wav", data: "QUJD" } },
+    ]);
+  });
+
+  test("still emits a plain text part for a string user message", () => {
+    const { geminiBody } = openaiToGemini(req());
+    expect(geminiBody.contents[0].parts).toEqual([{ text: "hello" }]);
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.test.ts
@@ -109,12 +109,13 @@ describe("openaiToGemini — multimodal user content", () => {
     ]);
   });
 
-  test("forwards an http image URL as a fileData reference", () => {
+  test("drops an http image URL Gemini cannot inline, keeping the text", () => {
     const request = req({
       messages: [
         {
           role: "user",
           content: [
+            { type: "text", text: "look at this" },
             {
               type: "image_url",
               image_url: { url: "https://example.com/cat.png" },
@@ -127,9 +128,9 @@ describe("openaiToGemini — multimodal user content", () => {
 
     const { geminiBody } = openaiToGemini(request);
 
-    expect(geminiBody.contents[0].parts).toEqual([
-      { fileData: { fileUri: "https://example.com/cat.png" } },
-    ]);
+    // Gemini's fileData accepts only Files API / gs:// URIs, so a plain web URL
+    // is dropped rather than forwarded as an invalid fileData reference.
+    expect(geminiBody.contents[0].parts).toEqual([{ text: "look at this" }]);
   });
 
   test("forwards base64 input_audio as inlineData", () => {
@@ -160,20 +161,14 @@ describe("openaiToGemini — multimodal user content", () => {
     expect(geminiBody.contents[0].parts).toEqual([{ text: "hello" }]);
   });
 
-  test("keeps tool-result text and appends images as sibling media parts", () => {
+  test("forwards tool-result text into the functionResponse payload", () => {
     const request = req({
       messages: [
         { role: "user", content: "go" },
         {
           role: "tool",
           tool_call_id: "call_1",
-          content: [
-            { type: "text", text: "here is the chart" },
-            {
-              type: "image_url",
-              image_url: { url: "data:image/png;base64,Q0hBUlQ=" },
-            },
-          ],
+          content: [{ type: "text", text: "the result" }],
         },
       ],
       // biome-ignore lint/suspicious/noExplicitAny: minimal tool-result message
@@ -186,10 +181,9 @@ describe("openaiToGemini — multimodal user content", () => {
         functionResponse: {
           id: "call_1",
           name: "tool_result",
-          response: { content: "here is the chart" },
+          response: { content: "the result" },
         },
       },
-      { inlineData: { mimeType: "image/png", data: "Q0hBUlQ=" } },
     ]);
   });
 });

--- a/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.test.ts
@@ -159,4 +159,37 @@ describe("openaiToGemini — multimodal user content", () => {
     const { geminiBody } = openaiToGemini(req());
     expect(geminiBody.contents[0].parts).toEqual([{ text: "hello" }]);
   });
+
+  test("keeps tool-result text and appends images as sibling media parts", () => {
+    const request = req({
+      messages: [
+        { role: "user", content: "go" },
+        {
+          role: "tool",
+          tool_call_id: "call_1",
+          content: [
+            { type: "text", text: "here is the chart" },
+            {
+              type: "image_url",
+              image_url: { url: "data:image/png;base64,Q0hBUlQ=" },
+            },
+          ],
+        },
+      ],
+      // biome-ignore lint/suspicious/noExplicitAny: minimal tool-result message
+    } as any);
+
+    const { geminiBody } = openaiToGemini(request);
+    // contents[0] is the user message; contents[1] is the tool result.
+    expect(geminiBody.contents[1].parts).toEqual([
+      {
+        functionResponse: {
+          id: "call_1",
+          name: "tool_result",
+          response: { content: "here is the chart" },
+        },
+      },
+      { inlineData: { mimeType: "image/png", data: "Q0hBUlQ=" } },
+    ]);
+  });
 });

--- a/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.ts
@@ -88,18 +88,10 @@ export function openaiToGemini(req: OpenAiRequest): {
     }
 
     if (message.role === "tool") {
-      // Gemini function responses carry only a JSON payload, so keep the text
-      // in the response object and append any images/files as sibling media
-      // parts in the same turn rather than dropping them.
-      const normalized = normalizeOpenAiContentParts(message.content);
-      const text = normalized
-        .filter((part) => part.kind === "text")
-        .map((part) => part.text)
-        .join("\n");
-      const mediaParts = normalized
-        .filter((part) => part.kind !== "text")
-        .map(normalizedPartToGeminiPart)
-        .filter((part): part is Gemini.Types.MessagePart => part !== null);
+      // Gemini carries tool results as a JSON functionResponse payload. Media in
+      // a tool result must be nested inside `functionResponse.parts` with
+      // displayName/$ref references (Gemini 3 only), which our schema does not
+      // model, so tool-result content is forwarded as text.
       contents.push({
         role: "user",
         parts: [
@@ -109,10 +101,9 @@ export function openaiToGemini(req: OpenAiRequest): {
               // OpenAI tool result messages only include tool_call_id, not the
               // original function name. Use a stable synthetic name for Gemini.
               name: "tool_result",
-              response: { content: text },
+              response: { content: stringifyTextContent(message.content) },
             },
           },
-          ...mediaParts,
         ],
       });
     }
@@ -287,9 +278,11 @@ function userContentToGeminiParts(
   return parts;
 }
 
-// Maps one normalized content part to a Gemini part. Inline base64 data URLs
-// become `inlineData`; http(s) image URLs become `fileData` references, which
-// Gemini fetches itself. Returns null for parts Gemini can't represent.
+// Maps one normalized content part to a Gemini part. Only inline base64 data
+// URLs are forwarded (as `inlineData`). Returns null for parts Gemini can't
+// represent — notably http(s) image URLs: Gemini's `fileData.fileUri` accepts
+// only Files API / gs:// URIs, not arbitrary web URLs, and we don't fetch and
+// re-encode external content server-side, so such images are dropped.
 function normalizedPartToGeminiPart(
   part: NormalizedContentPart,
 ): Gemini.Types.MessagePart | null {
@@ -300,9 +293,6 @@ function normalizedPartToGeminiPart(
       const inline = parseDataUrl(part.url);
       if (inline) {
         return { inlineData: { mimeType: inline.mimeType, data: inline.data } };
-      }
-      if (/^https?:\/\//i.test(part.url)) {
-        return { fileData: { fileUri: part.url } };
       }
       return null;
     }

--- a/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { Gemini, OpenAi } from "@/types";
 import { sanitizeGeminiToolSchema } from "./gemini-schema";
 import {
+  parseDataUrl,
   parseJsonObject,
   stringifyTextContent,
 } from "./openai-translator-utils";
@@ -52,9 +53,12 @@ export function openaiToGemini(req: OpenAiRequest): {
     }
 
     if (message.role === "user") {
+      const parts = userContentToGeminiParts(message.content);
       contents.push({
+        // Gemini rejects a content entry with no parts; keep an empty text
+        // part for messages that carried no convertible content.
         role: "user",
-        parts: [{ text: stringifyTextContent(message.content) }],
+        parts: parts.length > 0 ? parts : [{ text: "" }],
       });
       continue;
     }
@@ -253,4 +257,71 @@ function toGeminiToolChoice(
   if (toolChoice === "required") return "ANY";
   if (toolChoice === "none") return "NONE";
   return "AUTO";
+}
+
+// Converts an OpenAI user-message `content` (string or array of content parts)
+// into Gemini parts, preserving images/files/audio instead of dropping every
+// non-text part. Inline base64 data URLs become `inlineData`; http(s) image
+// URLs become `fileData` references, which Gemini fetches itself.
+function userContentToGeminiParts(
+  content: unknown,
+): Gemini.Types.MessagePart[] {
+  if (typeof content === "string") {
+    return content ? [{ text: content }] : [];
+  }
+  if (!Array.isArray(content)) return [];
+
+  const parts: Gemini.Types.MessagePart[] = [];
+  for (const part of content as Array<Record<string, LooseContentValue>>) {
+    if (!part || typeof part !== "object") continue;
+
+    if (part.type === "text") {
+      if (typeof part.text === "string" && part.text) {
+        parts.push({ text: part.text });
+      }
+      continue;
+    }
+
+    if (part.type === "image_url") {
+      const url = String(getNested(part.image_url, "url") ?? "");
+      const inline = parseDataUrl(url);
+      if (inline) {
+        parts.push({
+          inlineData: { mimeType: inline.mimeType, data: inline.data },
+        });
+      } else if (/^https?:\/\//i.test(url)) {
+        parts.push({ fileData: { fileUri: url } });
+      }
+      continue;
+    }
+
+    if (part.type === "input_audio") {
+      const data = String(getNested(part.input_audio, "data") ?? "");
+      const format = String(getNested(part.input_audio, "format") ?? "");
+      if (data && format) {
+        parts.push({ inlineData: { mimeType: `audio/${format}`, data } });
+      }
+      continue;
+    }
+
+    if (part.type === "file") {
+      const fileData = String(getNested(part.file, "file_data") ?? "");
+      const inline = parseDataUrl(fileData);
+      if (inline) {
+        parts.push({
+          inlineData: { mimeType: inline.mimeType, data: inline.data },
+        });
+      }
+    }
+  }
+  return parts;
+}
+
+type LooseContentValue = string | Record<string, unknown> | undefined;
+
+function getNested(value: LooseContentValue, key: string): unknown {
+  if (value && typeof value === "object") {
+    return (value as Record<string, unknown>)[key];
+  }
+  return undefined;
 }

--- a/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.ts
@@ -2,6 +2,8 @@ import { randomUUID } from "node:crypto";
 import type { Gemini, OpenAi } from "@/types";
 import { sanitizeGeminiToolSchema } from "./gemini-schema";
 import {
+  type NormalizedContentPart,
+  normalizeOpenAiContentParts,
   parseDataUrl,
   parseJsonObject,
   stringifyTextContent,
@@ -86,6 +88,18 @@ export function openaiToGemini(req: OpenAiRequest): {
     }
 
     if (message.role === "tool") {
+      // Gemini function responses carry only a JSON payload, so keep the text
+      // in the response object and append any images/files as sibling media
+      // parts in the same turn rather than dropping them.
+      const normalized = normalizeOpenAiContentParts(message.content);
+      const text = normalized
+        .filter((part) => part.kind === "text")
+        .map((part) => part.text)
+        .join("\n");
+      const mediaParts = normalized
+        .filter((part) => part.kind !== "text")
+        .map(normalizedPartToGeminiPart)
+        .filter((part): part is Gemini.Types.MessagePart => part !== null);
       contents.push({
         role: "user",
         parts: [
@@ -95,9 +109,10 @@ export function openaiToGemini(req: OpenAiRequest): {
               // OpenAI tool result messages only include tool_call_id, not the
               // original function name. Use a stable synthetic name for Gemini.
               name: "tool_result",
-              response: { content: stringifyTextContent(message.content) },
+              response: { content: text },
             },
           },
+          ...mediaParts,
         ],
       });
     }
@@ -259,69 +274,48 @@ function toGeminiToolChoice(
   return "AUTO";
 }
 
-// Converts an OpenAI user-message `content` (string or array of content parts)
-// into Gemini parts, preserving images/files/audio instead of dropping every
-// non-text part. Inline base64 data URLs become `inlineData`; http(s) image
-// URLs become `fileData` references, which Gemini fetches itself.
+// Converts an OpenAI user-message `content` into Gemini parts, preserving
+// images/files/audio instead of dropping every non-text part.
 function userContentToGeminiParts(
   content: unknown,
 ): Gemini.Types.MessagePart[] {
-  if (typeof content === "string") {
-    return content ? [{ text: content }] : [];
-  }
-  if (!Array.isArray(content)) return [];
-
   const parts: Gemini.Types.MessagePart[] = [];
-  for (const part of content as Array<Record<string, LooseContentValue>>) {
-    if (!part || typeof part !== "object") continue;
-
-    if (part.type === "text") {
-      if (typeof part.text === "string" && part.text) {
-        parts.push({ text: part.text });
-      }
-      continue;
-    }
-
-    if (part.type === "image_url") {
-      const url = String(getNested(part.image_url, "url") ?? "");
-      const inline = parseDataUrl(url);
-      if (inline) {
-        parts.push({
-          inlineData: { mimeType: inline.mimeType, data: inline.data },
-        });
-      } else if (/^https?:\/\//i.test(url)) {
-        parts.push({ fileData: { fileUri: url } });
-      }
-      continue;
-    }
-
-    if (part.type === "input_audio") {
-      const data = String(getNested(part.input_audio, "data") ?? "");
-      const format = String(getNested(part.input_audio, "format") ?? "");
-      if (data && format) {
-        parts.push({ inlineData: { mimeType: `audio/${format}`, data } });
-      }
-      continue;
-    }
-
-    if (part.type === "file") {
-      const fileData = String(getNested(part.file, "file_data") ?? "");
-      const inline = parseDataUrl(fileData);
-      if (inline) {
-        parts.push({
-          inlineData: { mimeType: inline.mimeType, data: inline.data },
-        });
-      }
-    }
+  for (const part of normalizeOpenAiContentParts(content)) {
+    const geminiPart = normalizedPartToGeminiPart(part);
+    if (geminiPart) parts.push(geminiPart);
   }
   return parts;
 }
 
-type LooseContentValue = string | Record<string, unknown> | undefined;
-
-function getNested(value: LooseContentValue, key: string): unknown {
-  if (value && typeof value === "object") {
-    return (value as Record<string, unknown>)[key];
+// Maps one normalized content part to a Gemini part. Inline base64 data URLs
+// become `inlineData`; http(s) image URLs become `fileData` references, which
+// Gemini fetches itself. Returns null for parts Gemini can't represent.
+function normalizedPartToGeminiPart(
+  part: NormalizedContentPart,
+): Gemini.Types.MessagePart | null {
+  switch (part.kind) {
+    case "text":
+      return { text: part.text };
+    case "image": {
+      const inline = parseDataUrl(part.url);
+      if (inline) {
+        return { inlineData: { mimeType: inline.mimeType, data: inline.data } };
+      }
+      if (/^https?:\/\//i.test(part.url)) {
+        return { fileData: { fileUri: part.url } };
+      }
+      return null;
+    }
+    case "audio":
+      return {
+        inlineData: { mimeType: `audio/${part.format}`, data: part.data },
+      };
+    case "file": {
+      const inline = parseDataUrl(part.fileData);
+      if (inline) {
+        return { inlineData: { mimeType: inline.mimeType, data: inline.data } };
+      }
+      return null;
+    }
   }
-  return undefined;
 }

--- a/platform/backend/src/routes/proxy/adapters/openai-translator-utils.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-translator-utils.ts
@@ -23,6 +23,19 @@ export function stringifyTextContent(
     .join(separator);
 }
 
+// Parses a base64 data URL (`data:<mime>;base64,<payload>`) into its MIME type
+// and raw base64 payload. Returns null for plain http(s) URLs or malformed
+// input so callers can fall back to a URL reference or drop the part. Used by
+// the non-OpenAI-wire translators to forward inline images/files instead of
+// dropping every non-text content part.
+export function parseDataUrl(
+  url: string,
+): { mimeType: string; data: string } | null {
+  const match = /^data:([^;,]+);base64,(.+)$/i.exec(url);
+  if (!match) return null;
+  return { mimeType: match[1].toLowerCase(), data: match[2] };
+}
+
 export function parseJsonObject(raw: unknown): Record<string, unknown> {
   if (typeof raw !== "string") return {};
 

--- a/platform/backend/src/routes/proxy/adapters/openai-translator-utils.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-translator-utils.ts
@@ -36,6 +36,61 @@ export function parseDataUrl(
   return { mimeType: match[1].toLowerCase(), data: match[2] };
 }
 
+// Provider-agnostic view of an OpenAI message content part. The non-OpenAI-wire
+// translators normalize `content` into these once, then map each part into
+// their provider-native shape — so the OpenAI parsing rules live in one place.
+export type NormalizedContentPart =
+  | { kind: "text"; text: string }
+  | { kind: "image"; url: string }
+  | { kind: "audio"; data: string; format: string }
+  | { kind: "file"; fileData: string; filename?: string };
+
+// Normalizes an OpenAI message `content` (string or array of content parts)
+// into a flat list of typed parts, preserving images/files/audio instead of
+// dropping every non-text part. A plain string becomes a single text part;
+// empty text and unrecognized parts are skipped.
+export function normalizeOpenAiContentParts(
+  content: unknown,
+): NormalizedContentPart[] {
+  if (typeof content === "string") {
+    return content ? [{ kind: "text", text: content }] : [];
+  }
+  if (!Array.isArray(content)) return [];
+
+  const parts: NormalizedContentPart[] = [];
+  for (const raw of content) {
+    if (!raw || typeof raw !== "object") continue;
+    const part = raw as Record<string, unknown>;
+
+    if (part.type === "text") {
+      const text = readStringField(part, "text");
+      if (text) parts.push({ kind: "text", text });
+    } else if (part.type === "image_url") {
+      const url = readStringField(part.image_url, "url");
+      if (url) parts.push({ kind: "image", url });
+    } else if (part.type === "input_audio") {
+      const data = readStringField(part.input_audio, "data");
+      const format = readStringField(part.input_audio, "format");
+      if (data && format) parts.push({ kind: "audio", data, format });
+    } else if (part.type === "file") {
+      const fileData = readStringField(part.file, "file_data");
+      const filename = readStringField(part.file, "filename");
+      if (fileData) {
+        parts.push({ kind: "file", fileData, filename: filename || undefined });
+      }
+    }
+  }
+  return parts;
+}
+
+function readStringField(value: unknown, key: string): string {
+  if (value && typeof value === "object") {
+    const field = (value as Record<string, unknown>)[key];
+    if (typeof field === "string") return field;
+  }
+  return "";
+}
+
 export function parseJsonObject(raw: unknown): Record<string, unknown> {
   if (typeof raw !== "string") return {};
 

--- a/platform/backend/src/types/llm-providers/cohere/messages.ts
+++ b/platform/backend/src/types/llm-providers/cohere/messages.ts
@@ -21,9 +21,24 @@ export const CohereMessageContentBlockSchema = z.union([
   }),
 ]);
 
+// Cohere v2 user messages accept image content blocks; `url` may be a base64
+// data URI or a web URL. https://docs.cohere.com/reference/chat
+export const CohereImageUrlContentSchema = z.object({
+  type: z.literal("image_url"),
+  image_url: z.object({
+    url: z.string(),
+    detail: z.enum(["auto", "low", "high"]).optional(),
+  }),
+});
+
+const CohereUserContentBlockSchema = z.union([
+  CohereTextContentSchema,
+  CohereImageUrlContentSchema,
+]);
+
 export const CohereUserMessageSchema = z.object({
   role: z.literal("user"),
-  content: z.union([z.string(), z.array(CohereMessageContentBlockSchema)]),
+  content: z.union([z.string(), z.array(CohereUserContentBlockSchema)]),
 });
 
 export const CohereAssistantMessageSchema = z.object({

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -1862,9 +1862,11 @@ export type CohereChatRequestInput = {
             type: 'text';
             text: string;
         } | {
-            type: 'tool_result';
-            tool_call_id: string;
-            content: string;
+            type: 'image_url';
+            image_url: {
+                url: string;
+                detail?: 'auto' | 'low' | 'high';
+            };
         }>;
     } | {
         role: 'assistant';
@@ -7158,9 +7160,11 @@ export type CohereChatRequest = {
             type: 'text';
             text: string;
         } | {
-            type: 'tool_result';
-            tool_call_id: string;
-            content: string;
+            type: 'image_url';
+            image_url: {
+                url: string;
+                detail?: 'auto' | 'low' | 'high';
+            };
         }>;
     } | {
         role: 'assistant';


### PR DESCRIPTION
## Problem

A community user routing Google ADK agents through the model router (ADK → LiteLLM → `/v1/model-router/{id}` → Gemini) reported that **images/files are silently dropped** — the model only ever receives text.

Root cause is on our side. The Gemini, Anthropic, and Cohere model-router translators ran every user-message `content` through `stringifyTextContent()`, which keeps only `type: "text"` parts and returns `""` for everything else. So `image_url`, `file`, and `input_audio` parts were stripped before the request left Archestra — even though all three providers support multimodal input. (Bedrock already handled images; the others never did.)

## Fix

Add a shared `parseDataUrl()` helper and a single `normalizeOpenAiContentParts()` normalizer in `openai-translator-utils.ts`, so each translator maps from one provider-agnostic representation instead of duplicating OpenAI content parsing. Then forward non-text parts per provider, in the exact shape each provider's native API documents.

**User messages**
- **Gemini**: base64 data URL images / audio / files → `inlineData`. http(s) image URLs are **dropped** — Gemini's `fileData.fileUri` accepts only Files API / `gs://` URIs, and we don't fetch + re-encode external content server-side.
- **Anthropic**: base64 data URL images → `image` blocks (base64 source); base64 PDF files → `document` blocks. http image URLs and audio are dropped (the typed schema models only base64 image / PDF sources).
- **Cohere**: images → `image_url` content blocks (base64 data URI **or** web URL, per Cohere v2). Adds the image content block to the Cohere message schema (`types/llm-providers/cohere/messages.ts`).

**Tool results**
- **Anthropic**: forwards images as `image` blocks inside `tool_result` content (text-only results stay a plain string).
- **Gemini / Cohere**: tool-result content stays text-only — Gemini requires media nested inside `functionResponse.parts` with `displayName`/`$ref` (Gemini 3 only, not modeled by our schema), and Cohere models no image content in tool messages.

Plain string user messages are unchanged; system/assistant messages remain text.

## Validation

Translated shapes were checked against each provider's API docs (an earlier draft got the Gemini `fileData`-URL and Gemini tool-result-media shapes wrong; both corrected). The outgoing body is sent as-is (no Zod re-parse), so there is no field-stripping at runtime.

**Live smoke test (end-to-end against real provider APIs)** — built a multimodal OpenAI request with a solid-red test PNG, ran it through the real translator, POSTed the translated native body to the live endpoint, and asked the vision model to name the color:

| Provider | Model | Result |
| --- | --- | --- |
| Gemini | `gemini-2.5-flash` | ✅ 200, answered "red" |
| Anthropic | `claude-sonnet-4-6` | ✅ 200, answered "red" |
| Cohere | `command-a-vision-07-2025` | ✅ 200, answered "red" |

All three accepted the translated multimodal body and the model correctly saw the image — confirming the reported bug is fixed on the wire, not just in unit-test expectations. (PDF/document and Anthropic tool-result image shapes were validated against docs + schema, not separately live-tested.)

## Docs

Updated `docs/pages/platform-supported-llm-providers.md` to describe the new per-provider behavior and what is intentionally dropped.

## Tests

- `gemini-openai-translator.test.ts`: base64 image → `inlineData`, base64 audio → `inlineData`, http image URL dropped (text kept), tool-result text into `functionResponse`, string passthrough.
- `anthropic-openai-translator.test.ts` (new): base64 image → `image` block, base64 PDF → `document` block, tool-result images, text-only tool-result fallback, string passthrough.
- `cohere-openai-translator.test.ts` (new): data-URI image → `image_url` block, web-URL image passthrough, string passthrough.

All 15 translator tests pass; the rest of the proxy-adapter suite passes. `biome check`, `pnpm type-check`, and `knip` (dev + production) are clean for the changed files.