### PR TITLE
fix(docker): drop corepack/pnpm from runtime image (undici CVE-2026-12151)

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -372,6 +372,13 @@ RUN set -eux; \
     rm -f picomatch-4.0.4.tgz; \
     grep -q '"version": "4.0.4"' "$target/package.json"
 
+# CVE-2026-12151: corepack's cached pnpm bundles undici 6.26.0 (<6.27.0) at
+# /root/.cache/node/corepack/.../dist/node_modules/undici — pnpm overrides cannot
+# reach it. pnpm is only needed at build time (the prod install above); runtime DB
+# migrations call drizzle-kit directly (see docker/supervisord/supervisord.conf),
+# so drop corepack/pnpm from the final image entirely.
+RUN rm -rf /root/.cache/node/corepack /usr/local/bin/pnpm /usr/local/bin/pnpx
+
 # Copy built backend
 COPY --from=builder /app/backend/dist ./backend/dist
 COPY --from=builder /app/backend/scripts ./backend/scripts

--- a/platform/docker/supervisord/supervisord.conf
+++ b/platform/docker/supervisord/supervisord.conf
@@ -30,7 +30,7 @@ pidfile=/var/run/supervisord.pid
 directory=/app/backend
 # Maintenance mode must be able to boot when the external database is down for
 # planned work, so the Docker entrypoint skips migrations while the message is set.
-command=/bin/sh -c "if [ -n \"$ARCHESTRA_MAINTENANCE_MODE_MESSAGE\" ]; then ./scripts/start-production.sh; else sleep 5 && pnpm db:migrate && ./scripts/start-production.sh; fi"
+command=/bin/sh -c "if [ -n \"$ARCHESTRA_MAINTENANCE_MODE_MESSAGE\" ]; then ./scripts/start-production.sh; else sleep 5 && ./node_modules/.bin/drizzle-kit migrate && ./scripts/start-production.sh; fi"
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
## Problem
Docker Scout flags HIGH **CVE-2026-12151** (undici <6.27.0, uncontrolled resource consumption) against the platform image. The flagged `undici@6.26.0` is bundled inside corepack's cached pnpm at `/root/.cache/node/corepack/.../pnpm/<ver>/dist/node_modules/undici` — **not** an app dependency (app undici is already pinned to `7.28.0` via a pnpm override). The override can't reach pnpm's own bundled copy, and the latest pnpm (11.8.0) still bundles 6.26.0, so a pnpm bump doesn't clear it.

## Fix
pnpm is only needed at build time. The sole runtime pnpm caller was supervisord's `pnpm db:migrate`.
- **`supervisord.conf`**: call `./node_modules/.bin/drizzle-kit migrate` directly. cwd is `/app/backend`, `drizzle-kit` is a prod dependency, and this is exactly what `pnpm db:migrate` resolved to.
- **`Dockerfile`**: after the prod install, `rm -rf` the corepack cache + pnpm shims from the final stage.

This removes the vulnerable file outright (no new dependency to vet) and shrinks the runtime surface, mirroring the existing npm-removal block.

## Verification
- Reproduced the `--prod` install: `backend/node_modules/.bin/drizzle-kit migrate` resolves and runs (`drizzle-kit@0.31.9`).
- The removed path matches exactly what Scout indexed in the scanned image.
- `drizzle.config.ts` imports only `node:path`/`dotenv`/`drizzle-kit` (no `backend/src`), so it runs standalone in the image.
- Merged-FS removal is consistent with the existing picomatch overwrite pattern Scout already honors here.
- Platform E2E exercises migrate-on-boot, so a broken migrate call fails CI.

https://claude.ai/code/session_01TPkfDjtNHwgx4xdfapAMu2

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>