### PR TITLE
feat(mcp): additive gateway access grant on authorization_code OAuth clients

### DIFF
--- a/docs/pages/mcp-authentication.md
+++ b/docs/pages/mcp-authentication.md
@@ -92,7 +92,13 @@ The application runs the standard browser flow:
 - `GET /api/auth/oauth2/authorize` with `response_type=code`, `scope=mcp` (add `offline_access` for a refresh token), the registered `redirect_uri`, and a PKCE challenge.
 - `POST /api/auth/oauth2/token` with `grant_type=authorization_code`, `client_id`, `client_secret`, and the PKCE verifier.
 
-The result is a normal user OAuth access token, sent to the gateway as `Authorization: Bearer <token>`. Only the registered application can complete the flow, and the signed-in user must already have access to the gateway.
+The result is a normal user OAuth access token, sent to the gateway as `Authorization: Bearer <token>`. Only the registered application can complete the flow. By default the signed-in user reaches only the gateways their own permissions already allow.
+
+#### Gateway access grant
+
+Optionally, assign one or more gateways to the client as an **access grant**. Any user who authenticates through the client may then reach those gateways **in addition to** their own role-based access — even gateways they otherwise couldn't reach. The grant is additive (it never removes access) and admin-controlled (only admins register clients and set the list).
+
+This lets you gate a gateway behind a specific trusted app: restrict the gateway so it isn't reachable on its own (assign it to a team with no members — an org-wide gateway is open to all members), then grant it through the client. The gateway is then reachable only by users who come through that app. Leave the grant empty for pure identity passthrough, where access stays governed entirely by each user's permissions.
 
 To restrict OAuth flows to pre-registered clients only, set `ARCHESTRA_AUTH_DCR_ENABLED=false`. This disables Dynamic Client Registration and CIMD auto-registration (above), so the gateway accepts OAuth flows only from clients you registered explicitly — both `client_credentials` and `authorization_code`.
 

--- a/platform/backend/src/models/mcp-oauth-client.ts
+++ b/platform/backend/src/models/mcp-oauth-client.ts
@@ -55,16 +55,18 @@ class McpOauthClientModel {
     const clientSecretHash = isAuthorizationCode
       ? hashOauthClientSecret(clientSecret)
       : await hashClientSecret(clientSecret);
-    // allowedGatewayIds only governs client_credentials tokens (the gateway
-    // validator keys on it). authorization_code access is governed by the acting
-    // user's own permissions, so it is always stored empty for those clients.
+    // allowedGatewayIds governs both grant types, but differently:
+    // - client_credentials: the SOLE authority — the token may only reach
+    //   gateways on this list (there is no acting user).
+    // - authorization_code: an ADDITIVE, admin-controlled grant — a user who
+    //   authenticates through this client may reach these gateways IN ADDITION
+    //   to whatever their own RBAC already allows. Empty = pure identity
+    //   passthrough (the original behavior).
     const metadata = {
       type: MCP_OAUTH_CLIENT_METADATA_TYPE,
       organizationId: params.organizationId,
       grantType,
-      allowedGatewayIds: isAuthorizationCode
-        ? []
-        : (params.allowedGatewayIds ?? []),
+      allowedGatewayIds: params.allowedGatewayIds ?? [],
     };
 
     const [client] = await db
@@ -209,13 +211,13 @@ class McpOauthClientModel {
     if (!existing) return null;
     const isAuthorizationCode = existing.grantType === "authorization_code";
 
+    // allowedGatewayIds applies to both grant types (see create()); update it
+    // for either, falling back to the existing value when omitted.
     const metadata = {
       type: MCP_OAUTH_CLIENT_METADATA_TYPE,
       organizationId: params.organizationId,
       grantType: existing.grantType,
-      allowedGatewayIds: isAuthorizationCode
-        ? []
-        : (params.allowedGatewayIds ?? existing.allowedGatewayIds),
+      allowedGatewayIds: params.allowedGatewayIds ?? existing.allowedGatewayIds,
     };
 
     const [client] = await db

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -987,18 +987,31 @@ async function validateOAuthTokenByHash(params: {
       };
     }
 
-    // Non-admin: user can access profile if it's teamless (org-wide) or shares a team
-    if (
-      !(await AgentTeamModel.userHasAgentAccess(
-        userId,
-        params.profileId,
-        false,
-        agent,
-      ))
-    ) {
+    // Non-admin access has two additive sources:
+    //   1. the user's own RBAC (profile is teamless/org-wide or shares a team), or
+    //   2. an admin-controlled grant on the authorization_code MCP OAuth client
+    //      that minted this token — its allowedGatewayIds may grant access to
+    //      gateways the user could not otherwise reach (e.g. a gateway reachable
+    //      only through a specific pre-registered app).
+    const hasRbacAccess = await AgentTeamModel.userHasAgentAccess(
+      userId,
+      params.profileId,
+      false,
+      agent,
+    );
+    const hasClientGrant =
+      hasRbacAccess || !accessToken.clientId
+        ? false
+        : await mcpOauthClientGrantsGatewayAccess({
+            clientId: accessToken.clientId,
+            profileId: params.profileId,
+            organizationId,
+          });
+
+    if (!hasRbacAccess && !hasClientGrant) {
       logger.warn(
         { profileId: params.profileId, userId },
-        "validateOAuthToken: profile not accessible via OAuth token (no shared teams)",
+        "validateOAuthToken: profile not accessible via OAuth token (no RBAC access and no client grant)",
       );
       return null;
     }
@@ -1094,6 +1107,29 @@ async function validateMcpOauthClientToken(params: {
     isOrganizationToken: false,
     organizationId,
   };
+}
+
+/**
+ * Whether the authorization_code MCP OAuth client that minted a user-bound token
+ * grants access to a gateway beyond the user's own RBAC. This is an additive,
+ * admin-controlled access grant: only client_credentials clients use
+ * allowedGatewayIds as a sole authority, whereas an authorization_code client's
+ * list confers extra access to anyone who authenticates through it. Disabled or
+ * deleted clients (findByClientId returns null) grant nothing.
+ */
+async function mcpOauthClientGrantsGatewayAccess(params: {
+  clientId: string;
+  profileId: string;
+  organizationId: string;
+}): Promise<boolean> {
+  const oauthClient = await McpOauthClientModel.findByClientId(params.clientId);
+  if (!oauthClient || oauthClient.grantType !== "authorization_code") {
+    return false;
+  }
+  if (oauthClient.organizationId !== params.organizationId) {
+    return false;
+  }
+  return oauthClient.allowedGatewayIds.includes(params.profileId);
 }
 
 /**

--- a/platform/backend/src/routes/mcp-oauth-clients.gateway-auth.test.ts
+++ b/platform/backend/src/routes/mcp-oauth-clients.gateway-auth.test.ts
@@ -292,7 +292,7 @@ describe("MCP OAuth client gateway authorization", () => {
     const user = await makeUser();
     await makeMember(user.id, org.id, { role: "member" });
     // A team-scoped gateway tied to a team the user is not a member of must stay
-    // inaccessible — a pre-registered client does not widen the user's own access.
+    // inaccessible when the client carries NO gateway grant.
     const owningTeam = await makeTeam(org.id, user.id, { name: "Owners" });
     const gateway = await makeAgent({
       organizationId: org.id,
@@ -318,5 +318,108 @@ describe("MCP OAuth client gateway authorization", () => {
     });
 
     expect(await validateMCPGatewayToken(gateway.id, accessToken)).toBeNull();
+  });
+
+  /**
+   * Additive client grant: an authorization_code client's allowedGatewayIds
+   * grants its users access to a gateway they could NOT reach through their own
+   * RBAC. This is the "gateway reachable only through a specific trusted app"
+   * use case — admin-controlled and additive (it never removes access).
+   */
+  test("grants gateway access via the client's allowedGatewayIds even when the user has no RBAC access", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+    makeTeam,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: "member" });
+    // A restricted (team-scoped) gateway the user is NOT a member of — no RBAC
+    // access on their own.
+    const owningTeam = await makeTeam(org.id, user.id, { name: "Owners" });
+    const gateway = await makeAgent({
+      organizationId: org.id,
+      agentType: "mcp_gateway",
+      scope: "team",
+      teams: [owningTeam.id],
+    });
+    // The client is scoped to that gateway, so authenticating through it grants
+    // access.
+    const { oauthClient } = await McpOauthClientModel.create({
+      organizationId: org.id,
+      name: "Chat Interface",
+      grantType: "authorization_code",
+      redirectUris: ["https://chat.example.com/oauth/callback"],
+      allowedGatewayIds: [gateway.id],
+    });
+
+    const accessToken = `${randomBytes(32).toString("base64url")}`;
+    await OAuthAccessTokenModel.create({
+      tokenHash: OAuthAccessTokenModel.hashTokenForLookup(accessToken),
+      clientId: oauthClient.clientId,
+      userId: user.id,
+      expiresAt: new Date(Date.now() + 3_600_000),
+      scopes: [MCP_GATEWAY_OAUTH_SCOPE],
+      referenceId: null,
+    });
+
+    const result = await validateMCPGatewayToken(gateway.id, accessToken);
+
+    expect(result).not.toBeNull();
+    expect(result?.isUserToken).toBe(true);
+    expect(result?.userId).toBe(user.id);
+    expect(result?.organizationId).toBe(org.id);
+  });
+
+  test("does not grant access for a gateway outside the client's allowedGatewayIds", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+    makeTeam,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: "member" });
+    const owningTeam = await makeTeam(org.id, user.id, { name: "Owners" });
+    const grantedGateway = await makeAgent({
+      organizationId: org.id,
+      agentType: "mcp_gateway",
+      scope: "team",
+      teams: [owningTeam.id],
+    });
+    const otherGateway = await makeAgent({
+      organizationId: org.id,
+      agentType: "mcp_gateway",
+      scope: "team",
+      teams: [owningTeam.id],
+    });
+    const { oauthClient } = await McpOauthClientModel.create({
+      organizationId: org.id,
+      name: "Chat Interface",
+      grantType: "authorization_code",
+      redirectUris: ["https://chat.example.com/oauth/callback"],
+      allowedGatewayIds: [grantedGateway.id],
+    });
+
+    const accessToken = `${randomBytes(32).toString("base64url")}`;
+    await OAuthAccessTokenModel.create({
+      tokenHash: OAuthAccessTokenModel.hashTokenForLookup(accessToken),
+      clientId: oauthClient.clientId,
+      userId: user.id,
+      expiresAt: new Date(Date.now() + 3_600_000),
+      scopes: [MCP_GATEWAY_OAUTH_SCOPE],
+      referenceId: null,
+    });
+
+    // Granted gateway is reachable; a different gateway is not.
+    expect(
+      await validateMCPGatewayToken(grantedGateway.id, accessToken),
+    ).not.toBeNull();
+    expect(
+      await validateMCPGatewayToken(otherGateway.id, accessToken),
+    ).toBeNull();
   });
 });

--- a/platform/backend/src/routes/mcp-oauth-clients.test.ts
+++ b/platform/backend/src/routes/mcp-oauth-clients.test.ts
@@ -295,4 +295,55 @@ describe("mcpOauthClientsRoutes", () => {
       "https://chat.example.com/oauth/callback2",
     ]);
   });
+
+  test("creates an authorization_code client with an additive gateway grant", async ({
+    makeAgent,
+  }) => {
+    const gateway = await makeAgent({
+      organizationId,
+      name: "Chat Gateway",
+      agentType: "mcp_gateway",
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/mcp-oauth-clients",
+      payload: {
+        name: "Chat Interface",
+        grantType: "authorization_code",
+        redirectUris: ["https://chat.example.com/oauth/callback"],
+        allowedGatewayIds: [gateway.id],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().grantType).toBe("authorization_code");
+    expect(response.json().allowedGatewayIds).toEqual([gateway.id]);
+  });
+
+  test("validates the gateway grant on an authorization_code client", async ({
+    makeAgent,
+  }) => {
+    // A non-gateway agent in the grant list is rejected, just like for
+    // client_credentials clients.
+    const llmProxy = await makeAgent({
+      organizationId,
+      name: "Not A Gateway",
+      agentType: "llm_proxy",
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/mcp-oauth-clients",
+      payload: {
+        name: "Chat Interface",
+        grantType: "authorization_code",
+        redirectUris: ["https://chat.example.com/oauth/callback"],
+        allowedGatewayIds: [llmProxy.id],
+      },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json().error.message).toContain("MCP gateway not found");
+  });
 });

--- a/platform/backend/src/routes/mcp-oauth-clients.ts
+++ b/platform/backend/src/routes/mcp-oauth-clients.ts
@@ -13,9 +13,12 @@ import {
 /**
  * Both grant types share one body shape. `grantType` defaults to
  * `client_credentials` so existing callers keep working unchanged.
- * - client_credentials: requires `allowedGatewayIds`; `redirectUris` is ignored.
- * - authorization_code: requires `redirectUris`; `allowedGatewayIds` is ignored
- *   (gateway access is governed by the acting user's permissions).
+ * - client_credentials: requires `allowedGatewayIds` (the sole authority for the
+ *   token); `redirectUris` is ignored.
+ * - authorization_code: requires `redirectUris`. `allowedGatewayIds` is optional
+ *   here and acts as an additive, admin-controlled grant — users who
+ *   authenticate through the client may reach those gateways on top of their own
+ *   RBAC. Empty means pure identity passthrough.
  */
 const McpOauthClientBodySchema = z
   .object({
@@ -86,10 +89,10 @@ const mcpOauthClientsRoutes: FastifyPluginAsyncZod = async (fastify) => {
       },
     },
     async ({ body, organizationId }, reply) => {
-      if (body.grantType === "client_credentials") {
+      if (body.allowedGatewayIds && body.allowedGatewayIds.length > 0) {
         await validateMcpOauthClientConfig({
           organizationId,
-          allowedGatewayIds: body.allowedGatewayIds ?? [],
+          allowedGatewayIds: body.allowedGatewayIds,
         });
       }
       const { oauthClient, clientSecret } = await McpOauthClientModel.create({
@@ -116,10 +119,10 @@ const mcpOauthClientsRoutes: FastifyPluginAsyncZod = async (fastify) => {
       },
     },
     async ({ params, body, organizationId }, reply) => {
-      if (body.grantType === "client_credentials") {
+      if (body.allowedGatewayIds && body.allowedGatewayIds.length > 0) {
         await validateMcpOauthClientConfig({
           organizationId,
-          allowedGatewayIds: body.allowedGatewayIds ?? [],
+          allowedGatewayIds: body.allowedGatewayIds,
         });
       }
       const oauthClient = await McpOauthClientModel.update({

--- a/platform/frontend/src/app/mcp/credentials/oauth-clients/page.tsx
+++ b/platform/frontend/src/app/mcp/credentials/oauth-clients/page.tsx
@@ -372,7 +372,12 @@ function CreateOAuthClientDialog({
           event.preventDefault();
           await onSubmit(
             isAuthorizationCode
-              ? { name: name.trim(), grantType, redirectUris }
+              ? {
+                  name: name.trim(),
+                  grantType,
+                  redirectUris,
+                  allowedGatewayIds: selectedGatewayIds,
+                }
               : {
                   name: name.trim(),
                   grantType,
@@ -395,10 +400,17 @@ function CreateOAuthClientDialog({
           <GrantTypeField value={grantType} onChange={setGrantType} />
 
           {isAuthorizationCode ? (
-            <RedirectUrisField
-              value={redirectUrisText}
-              onChange={setRedirectUrisText}
-            />
+            <>
+              <RedirectUrisField
+                value={redirectUrisText}
+                onChange={setRedirectUrisText}
+              />
+              <GatewayGrantField
+                gateways={gateways}
+                value={selectedGatewayIds}
+                onValueChange={setSelectedGatewayIds}
+              />
+            </>
           ) : (
             <div className="space-y-2">
               <Label>Allowed gateways</Label>
@@ -476,7 +488,7 @@ function EditOAuthClientDialog({
       title="Edit OAuth Client"
       description={
         isAuthorizationCode
-          ? "Update the redirect URIs this OAuth client can use."
+          ? "Update the redirect URIs and gateway grant for this OAuth client."
           : "Update the gateways this OAuth client can access."
       }
     >
@@ -491,6 +503,7 @@ function EditOAuthClientDialog({
                   name: name.trim(),
                   grantType: oauthClient.grantType,
                   redirectUris,
+                  allowedGatewayIds: selectedGatewayIds,
                 }
               : {
                   name: name.trim(),
@@ -512,10 +525,17 @@ function EditOAuthClientDialog({
           </div>
 
           {isAuthorizationCode ? (
-            <RedirectUrisField
-              value={redirectUrisText}
-              onChange={setRedirectUrisText}
-            />
+            <>
+              <RedirectUrisField
+                value={redirectUrisText}
+                onChange={setRedirectUrisText}
+              />
+              <GatewayGrantField
+                gateways={gateways}
+                value={selectedGatewayIds}
+                onValueChange={setSelectedGatewayIds}
+              />
+            </>
           ) : (
             <div className="space-y-2">
               <Label>Allowed gateways</Label>
@@ -609,6 +629,39 @@ function RedirectUrisField({
         The registering application's own callback URL(s) — where users are sent
         after they authorize, not an address on this server. Must match the
         <code className="mx-1">redirect_uri</code>the app sends. One per line.
+      </p>
+    </div>
+  );
+}
+
+function GatewayGrantField({
+  gateways,
+  value,
+  onValueChange,
+}: {
+  gateways: AgentSelectorAgent[];
+  value: string[];
+  onValueChange: (value: string[]) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label>Gateway access grant (optional)</Label>
+      <AgentSelector
+        mode="multiple"
+        flat
+        agents={gateways}
+        value={value}
+        onValueChange={onValueChange}
+        placeholder="Select gateways to grant"
+        searchPlaceholder="Search gateways"
+        emptyMessage="No gateways found"
+      />
+      <p className="text-sm text-muted-foreground">
+        Grants any user who authenticates through this client access to the
+        selected gateways — <strong>in addition to</strong> their own role-based
+        access, even gateways they otherwise couldn't reach. Leave empty for
+        pure identity passthrough (access stays governed by each user's
+        permissions).
       </p>
     </div>
   );


### PR DESCRIPTION
## What

Lets an admin attach an `allowedGatewayIds` **grant** to an `authorization_code` MCP OAuth client. Any user who authenticates through the client may then reach those gateways **in addition to** their own RBAC — even gateways they otherwise couldn't reach.

Addresses the follow-up feedback on #5683 (issue #5679): *"a gateway reachable only through a specific trusted app."*

## Why

#5683 made the `authorization_code` client a pure **identity passthrough** — gateway access was decided solely by the acting user's RBAC; `allowedGatewayIds` was forced empty. The reporter clarified they want the client to be able to **grant** gateway access: restrict a gateway so it isn't reachable on its own, then expose it *only* through a trusted pre-registered app (e.g. the full GitHub gateway reachable only via the official chat backend, not a user's Cursor).

RBAC can't express "only via this app" — a team member reaches the gateway from any client. This adds that dimension.

## How it works

Access on the user-bound path becomes **`user-RBAC ∪ client-grant`**:

- Model/routes: stop forcing `allowedGatewayIds: []` for `authorization_code` clients; validate the gateways (must be `mcp_gateway`, same org) for either grant type when provided.
- Gateway validator (`mcp-gateway.utils.ts`): after the RBAC check fails, also grant access if the token's **minting** `authorization_code` client lists this gateway (same org; disabled/deleted clients grant nothing). User identity for Resolve-at-call-time is unchanged.
- Frontend: the `authorization_code` create/edit dialog gains an optional **gateway grant** picker with a clear *"grants access beyond a user's role-based access"* warning.
- Docs: documents the additive grant and the precondition (restrict the gateway — an org-wide gateway is already open to all members).

## Safety / design

- **Admin-controlled** — only admins register clients and set the list, so it's a deliberate access policy, not end-user escalation.
- **Additive** — it never removes access; empty list = the original passthrough behavior.

## Tests

- Gateway-auth: a user with **no RBAC access** to a team-scoped gateway gains access via the client's grant; and is still rejected for a gateway **outside** the grant.
- Route: create/validate an `authorization_code` client with a gateway grant (non-gateway agents rejected).
- Existing `client_credentials` + passthrough tests still pass. Type-check, knip (dev+production), Biome clean; frontend type-check clean. No schema/codegen changes.

## Follow-up

The symmetric grant for the **LLM proxy** (`allowedLlmProxyIds` on `authorization_code` LLM clients) will be a stacked PR on #5685, since that branch isn't merged yet.

> Note: this is a deliberate "client can broaden RBAC" capability. It's surfaced with a UI warning + docs; if we'd prefer it never be implicit, we can gate it behind an explicit per-client toggle — easy to add.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>