### PR TITLE
fix(helm): migration job calls drizzle-kit directly, not pnpm

### DIFF
--- a/platform/helm/archestra/templates/migration-job.yaml
+++ b/platform/helm/archestra/templates/migration-job.yaml
@@ -2,7 +2,7 @@
 {{/*
 Database migration Job.
 
-Runs `pnpm db:migrate` as a Helm pre-upgrade hook so the target version's
+Runs `drizzle-kit migrate` as a Helm pre-upgrade hook so the target version's
 schema is applied before web and worker Deployments roll. Fresh installs are
 covered by the web pod running migrations on startup plus the worker
 wait-for-migrations init container.
@@ -45,9 +45,9 @@ spec:
           imagePullPolicy: {{ .Values.archestra.imagePullPolicy | default "IfNotPresent" }}
           workingDir: /app/backend
           {{- if .Values.archestra.initContainers.vaultSecrets.enabled }}
-          {{- include "archestra-platform.vaultSecretsCommand" "pnpm db:migrate" | nindent 10 }}
+          {{- include "archestra-platform.vaultSecretsCommand" "./node_modules/.bin/drizzle-kit migrate" | nindent 10 }}
           {{- else }}
-          command: ["pnpm", "db:migrate"]
+          command: ["./node_modules/.bin/drizzle-kit", "migrate"]
           {{- end }}
           env:
             {{- range $key, $value := .Values.archestra.migrationJob.env }}

--- a/platform/helm/archestra/tests/archestra_migration_job_test.yaml
+++ b/platform/helm/archestra/tests/archestra_migration_job_test.yaml
@@ -31,8 +31,8 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].command
           value:
-            - pnpm
-            - db:migrate
+            - ./node_modules/.bin/drizzle-kit
+            - migrate
 
   - it: does not create the migration job when disabled
     set:


### PR DESCRIPTION
## Problem
Every staging deploy on `main` has failed since #5710 with:
```
Error: UPGRADE FAILED: pre-upgrade hooks failed:
  * job archestra-platform-migrate failed: BackoffLimitExceeded
```

#5710 removed pnpm/corepack from the runtime image and rewired the supervisord migrate-on-boot path to call `./node_modules/.bin/drizzle-kit migrate` directly — but missed the **Helm pre-upgrade migration job** (`migration-job.yaml`), which still ran `pnpm db:migrate`. With pnpm gone, the job retries to `BackoffLimitExceeded` and aborts the Helm upgrade. E2E exercises only the supervisord path, not the Helm hook, so it slipped through.

## Fix
Point the migration job at drizzle-kit directly, mirroring the supervisord change. `db:migrate` is literally `drizzle-kit migrate`, workingDir is already `/app/backend`, and drizzle-kit is a prod dependency.

https://claude.ai/code/session_01AQREYcFexaidf1AKp2KKqh

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>