### PR TITLE
feat(llm-proxy): forward http(s) image URLs to Anthropic via url source

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2972,25 +2972,47 @@
                                 ]
                               },
                               "source": {
-                                "type": "object",
-                                "properties": {
-                                  "type": {
-                                    "type": "string",
-                                    "enum": [
-                                      "base64"
+                                "anyOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "base64"
+                                        ]
+                                      },
+                                      "media_type": {
+                                        "type": "string"
+                                      },
+                                      "data": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "media_type",
+                                      "data"
                                     ]
                                   },
-                                  "media_type": {
-                                    "type": "string"
-                                  },
-                                  "data": {
-                                    "type": "string"
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "url"
+                                        ]
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "url"
+                                    ]
                                   }
-                                },
-                                "required": [
-                                  "type",
-                                  "media_type",
-                                  "data"
                                 ]
                               },
                               "cache_control": {
@@ -3136,25 +3158,47 @@
                                                       ]
                                                     },
                                                     "source": {
-                                                      "type": "object",
-                                                      "properties": {
-                                                        "type": {
-                                                          "type": "string",
-                                                          "enum": [
-                                                            "base64"
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "type": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "base64"
+                                                              ]
+                                                            },
+                                                            "media_type": {
+                                                              "type": "string"
+                                                            },
+                                                            "data": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "type",
+                                                            "media_type",
+                                                            "data"
                                                           ]
                                                         },
-                                                        "media_type": {
-                                                          "type": "string"
-                                                        },
-                                                        "data": {
-                                                          "type": "string"
+                                                        {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "type": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "url"
+                                                              ]
+                                                            },
+                                                            "url": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "type",
+                                                            "url"
+                                                          ]
                                                         }
-                                                      },
-                                                      "required": [
-                                                        "type",
-                                                        "media_type",
-                                                        "data"
                                                       ]
                                                     },
                                                     "cache_control": {
@@ -3336,25 +3380,47 @@
                                               ]
                                             },
                                             "source": {
-                                              "type": "object",
-                                              "properties": {
-                                                "type": {
-                                                  "type": "string",
-                                                  "enum": [
-                                                    "base64"
+                                              "anyOf": [
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "base64"
+                                                      ]
+                                                    },
+                                                    "media_type": {
+                                                      "type": "string"
+                                                    },
+                                                    "data": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "media_type",
+                                                    "data"
                                                   ]
                                                 },
-                                                "media_type": {
-                                                  "type": "string"
-                                                },
-                                                "data": {
-                                                  "type": "string"
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "url"
+                                                      ]
+                                                    },
+                                                    "url": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "url"
+                                                  ]
                                                 }
-                                              },
-                                              "required": [
-                                                "type",
-                                                "media_type",
-                                                "data"
                                               ]
                                             },
                                             "cache_control": {
@@ -3500,25 +3566,47 @@
                                                                     ]
                                                                   },
                                                                   "source": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                      "type": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                          "base64"
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                          "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                              "base64"
+                                                                            ]
+                                                                          },
+                                                                          "media_type": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "data": {
+                                                                            "type": "string"
+                                                                          }
+                                                                        },
+                                                                        "required": [
+                                                                          "type",
+                                                                          "media_type",
+                                                                          "data"
                                                                         ]
                                                                       },
-                                                                      "media_type": {
-                                                                        "type": "string"
-                                                                      },
-                                                                      "data": {
-                                                                        "type": "string"
+                                                                      {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                          "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                              "url"
+                                                                            ]
+                                                                          },
+                                                                          "url": {
+                                                                            "type": "string"
+                                                                          }
+                                                                        },
+                                                                        "required": [
+                                                                          "type",
+                                                                          "url"
+                                                                        ]
                                                                       }
-                                                                    },
-                                                                    "required": [
-                                                                      "type",
-                                                                      "media_type",
-                                                                      "data"
                                                                     ]
                                                                   },
                                                                   "cache_control": {
@@ -20145,27 +20233,50 @@
                                 ]
                               },
                               "source": {
-                                "type": "object",
-                                "properties": {
-                                  "type": {
-                                    "type": "string",
-                                    "enum": [
-                                      "base64"
-                                    ]
+                                "anyOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "base64"
+                                        ]
+                                      },
+                                      "media_type": {
+                                        "type": "string"
+                                      },
+                                      "data": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "media_type",
+                                      "data"
+                                    ],
+                                    "additionalProperties": false
                                   },
-                                  "media_type": {
-                                    "type": "string"
-                                  },
-                                  "data": {
-                                    "type": "string"
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "url"
+                                        ]
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "url"
+                                    ],
+                                    "additionalProperties": false
                                   }
-                                },
-                                "required": [
-                                  "type",
-                                  "media_type",
-                                  "data"
-                                ],
-                                "additionalProperties": false
+                                ]
                               },
                               "cache_control": {
                                 "nullable": true
@@ -20315,27 +20426,50 @@
                                                       ]
                                                     },
                                                     "source": {
-                                                      "type": "object",
-                                                      "properties": {
-                                                        "type": {
-                                                          "type": "string",
-                                                          "enum": [
-                                                            "base64"
-                                                          ]
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "type": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "base64"
+                                                              ]
+                                                            },
+                                                            "media_type": {
+                                                              "type": "string"
+                                                            },
+                                                            "data": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "type",
+                                                            "media_type",
+                                                            "data"
+                                                          ],
+                                                          "additionalProperties": false
                                                         },
-                                                        "media_type": {
-                                                          "type": "string"
-                                                        },
-                                                        "data": {
-                                                          "type": "string"
+                                                        {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "type": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "url"
+                                                              ]
+                                                            },
+                                                            "url": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "type",
+                                                            "url"
+                                                          ],
+                                                          "additionalProperties": false
                                                         }
-                                                      },
-                                                      "required": [
-                                                        "type",
-                                                        "media_type",
-                                                        "data"
-                                                      ],
-                                                      "additionalProperties": false
+                                                      ]
                                                     },
                                                     "cache_control": {
                                                       "nullable": true
@@ -20524,27 +20658,50 @@
                                               ]
                                             },
                                             "source": {
-                                              "type": "object",
-                                              "properties": {
-                                                "type": {
-                                                  "type": "string",
-                                                  "enum": [
-                                                    "base64"
-                                                  ]
+                                              "anyOf": [
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "base64"
+                                                      ]
+                                                    },
+                                                    "media_type": {
+                                                      "type": "string"
+                                                    },
+                                                    "data": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "media_type",
+                                                    "data"
+                                                  ],
+                                                  "additionalProperties": false
                                                 },
-                                                "media_type": {
-                                                  "type": "string"
-                                                },
-                                                "data": {
-                                                  "type": "string"
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "url"
+                                                      ]
+                                                    },
+                                                    "url": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "url"
+                                                  ],
+                                                  "additionalProperties": false
                                                 }
-                                              },
-                                              "required": [
-                                                "type",
-                                                "media_type",
-                                                "data"
-                                              ],
-                                              "additionalProperties": false
+                                              ]
                                             },
                                             "cache_control": {
                                               "nullable": true
@@ -20694,27 +20851,50 @@
                                                                     ]
                                                                   },
                                                                   "source": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                      "type": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                          "base64"
-                                                                        ]
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                          "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                              "base64"
+                                                                            ]
+                                                                          },
+                                                                          "media_type": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "data": {
+                                                                            "type": "string"
+                                                                          }
+                                                                        },
+                                                                        "required": [
+                                                                          "type",
+                                                                          "media_type",
+                                                                          "data"
+                                                                        ],
+                                                                        "additionalProperties": false
                                                                       },
-                                                                      "media_type": {
-                                                                        "type": "string"
-                                                                      },
-                                                                      "data": {
-                                                                        "type": "string"
+                                                                      {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                          "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                              "url"
+                                                                            ]
+                                                                          },
+                                                                          "url": {
+                                                                            "type": "string"
+                                                                          }
+                                                                        },
+                                                                        "required": [
+                                                                          "type",
+                                                                          "url"
+                                                                        ],
+                                                                        "additionalProperties": false
                                                                       }
-                                                                    },
-                                                                    "required": [
-                                                                      "type",
-                                                                      "media_type",
-                                                                      "data"
-                                                                    ],
-                                                                    "additionalProperties": false
+                                                                    ]
                                                                   },
                                                                   "cache_control": {
                                                                     "nullable": true

--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -46,7 +46,7 @@ The prefix before `:` is the provider. The value after `:` is the provider's nat
 
 The `/models` response includes model-router-compatible text models for the providers mapped on the virtual key. Providers that use native request formats, including Anthropic, Bedrock, Gemini, and Cohere, are translated between OpenAI request/response formats and provider-native formats before forwarding.
 
-Model Router translation forwards inline non-text content where the provider's native format supports it: Gemini (base64 data URL images, audio, and files), Anthropic (base64 data URL images and PDF files), Cohere (images via base64 data URI or web URL in user messages), and Bedrock (base64 data URL images). Anthropic also forwards images returned inside tool results. Content the provider format cannot represent is dropped — for example http(s) image URLs to Gemini (its `fileData` accepts only Files API or `gs://` URIs), audio to Anthropic, and non-text content in Gemini and Cohere tool results.
+Model Router translation forwards inline non-text content where the provider's native format supports it: Gemini (base64 data URL images, audio, and files), Anthropic (base64 data URL images and PDF files, plus http(s) image URLs), Cohere (images via base64 data URI or web URL in user messages), and Bedrock (base64 data URL images). Anthropic also forwards images returned inside tool results. Content the provider format cannot represent is dropped — for example http(s) image URLs to Gemini (its `fileData` accepts only Files API or `gs://` URIs), audio to Anthropic, and non-text content in Gemini and Cohere tool results.
 
 ## OpenAI
 

--- a/platform/backend/src/routes/proxy/adapters/anthropic-openai-translator.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic-openai-translator.test.ts
@@ -41,6 +41,32 @@ describe("openaiToAnthropic — multimodal user content", () => {
     ]);
   });
 
+  test("forwards an http image URL as a url source block", () => {
+    const request = req({
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image_url",
+              image_url: { url: "https://example.com/cat.png" },
+            },
+          ],
+        },
+      ],
+      // biome-ignore lint/suspicious/noExplicitAny: minimal multimodal message
+    } as any);
+
+    const { anthropicBody } = openaiToAnthropic(request);
+
+    expect(anthropicBody.messages[0].content).toEqual([
+      {
+        type: "image",
+        source: { type: "url", url: "https://example.com/cat.png" },
+      },
+    ]);
+  });
+
   test("forwards a base64 PDF file as a document block", () => {
     const request = req({
       messages: [

--- a/platform/backend/src/routes/proxy/adapters/anthropic-openai-translator.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic-openai-translator.ts
@@ -241,10 +241,10 @@ function userContentToAnthropicContent(content: unknown): AnthropicUserContent {
   return blocks as unknown as AnthropicUserContent;
 }
 
-// Maps OpenAI content parts to Anthropic content blocks (text, base64 image,
-// base64 PDF document). Shared by user messages and tool_result blocks. http(s)
-// image URLs and audio are dropped since Anthropic's typed schema models only
-// base64 image/PDF sources here.
+// Maps OpenAI content parts to Anthropic content blocks (text, image, base64
+// PDF document). Shared by user messages and tool_result blocks. Images use a
+// base64 source for data URLs and a url source for http(s) URLs (Anthropic
+// fetches them). Audio is dropped since Anthropic models no audio source here.
 function userContentToAnthropicBlocks(
   content: unknown,
 ): AnthropicToolResultContent {
@@ -264,15 +264,20 @@ function normalizedPartToAnthropicBlock(
       return { type: "text", text: part.text };
     case "image": {
       const inline = parseDataUrl(part.url);
-      if (!inline) return null;
-      return {
-        type: "image",
-        source: {
-          type: "base64",
-          media_type: inline.mimeType,
-          data: inline.data,
-        },
-      };
+      if (inline) {
+        return {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: inline.mimeType,
+            data: inline.data,
+          },
+        };
+      }
+      if (/^https?:\/\//i.test(part.url)) {
+        return { type: "image", source: { type: "url", url: part.url } };
+      }
+      return null;
     }
     case "file": {
       const inline = parseDataUrl(part.fileData);

--- a/platform/backend/src/types/llm-providers/anthropic/messages.ts
+++ b/platform/backend/src/types/llm-providers/anthropic/messages.ts
@@ -38,11 +38,19 @@ const TextBlockParamSchema = z.object({
 
 const ImageBlockParamSchema = z.object({
   type: z.enum(["image"]),
-  source: z.object({
-    type: z.enum(["base64"]),
-    media_type: z.string(),
-    data: z.string(),
-  }),
+  // Anthropic accepts either an inline base64 source or a URL source it fetches
+  // itself. https://platform.claude.com/docs/en/build-with-claude/vision
+  source: z.union([
+    z.object({
+      type: z.enum(["base64"]),
+      media_type: z.string(),
+      data: z.string(),
+    }),
+    z.object({
+      type: z.enum(["url"]),
+      url: z.string(),
+    }),
+  ]),
   cache_control: z.any().nullable().optional(),
 });
 

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -1261,6 +1261,9 @@ export type AnthropicMessagesRequestInput = {
                 type: 'base64';
                 media_type: string;
                 data: string;
+            } | {
+                type: 'url';
+                url: string;
             };
             cache_control?: unknown;
         } | {
@@ -1289,6 +1292,9 @@ export type AnthropicMessagesRequestInput = {
                         type: 'base64';
                         media_type: string;
                         data: string;
+                    } | {
+                        type: 'url';
+                        url: string;
                     };
                     cache_control?: unknown;
                 }>;
@@ -1327,6 +1333,9 @@ export type AnthropicMessagesRequestInput = {
                     type: 'base64';
                     media_type: string;
                     data: string;
+                } | {
+                    type: 'url';
+                    url: string;
                 };
                 cache_control?: unknown;
             } | {
@@ -1355,6 +1364,9 @@ export type AnthropicMessagesRequestInput = {
                             type: 'base64';
                             media_type: string;
                             data: string;
+                        } | {
+                            type: 'url';
+                            url: string;
                         };
                         cache_control?: unknown;
                     }>;
@@ -6559,6 +6571,9 @@ export type AnthropicMessagesRequest = {
                 type: 'base64';
                 media_type: string;
                 data: string;
+            } | {
+                type: 'url';
+                url: string;
             };
             cache_control?: unknown;
         } | {
@@ -6587,6 +6602,9 @@ export type AnthropicMessagesRequest = {
                         type: 'base64';
                         media_type: string;
                         data: string;
+                    } | {
+                        type: 'url';
+                        url: string;
                     };
                     cache_control?: unknown;
                 }>;
@@ -6625,6 +6643,9 @@ export type AnthropicMessagesRequest = {
                     type: 'base64';
                     media_type: string;
                     data: string;
+                } | {
+                    type: 'url';
+                    url: string;
                 };
                 cache_control?: unknown;
             } | {
@@ -6653,6 +6674,9 @@ export type AnthropicMessagesRequest = {
                             type: 'base64';
                             media_type: string;
                             data: string;
+                        } | {
+                            type: 'url';
+                            url: string;
                         };
                         cache_control?: unknown;
                     }>;


### PR DESCRIPTION
## What & why

Follow-up to #5709 (multimodal forwarding). A community user asked whether the model router could accept **image URLs**, not just base64. It already works for Cohere; this adds it for **Anthropic**.

Previously the Anthropic translator only forwarded base64 data URL images and **dropped** http(s) `image_url` URLs, because our typed image schema modeled only a base64 source. Anthropic's Messages API natively accepts a **url image source** (`source: { type: "url", url }`) that Anthropic fetches itself — so we now forward http(s) image URLs that way instead of dropping them.

## Changes

- **Schema** (`types/llm-providers/anthropic/messages.ts`): `ImageBlockParamSchema.source` is now a union of the existing base64 source and a `{ type: "url", url }` source.
- **Translator** (`anthropic-openai-translator.ts`): `image` parts map base64 data URLs → base64 source (unchanged) and http(s) URLs → url source. Shared by user messages and `tool_result` blocks.
- **Generated** (`docs/openapi.json`, `platform/shared/hey-api/clients/api/types.gen.ts`): regenerated via `pnpm codegen` for the new image source variant.
- **Docs** (`platform-supported-llm-providers.md`): Anthropic line now notes http(s) image URL support. *(This file carries a "human-built / no-AI" marker; flagging the one-clause factual edit for review — same line updated and approved in #5709.)*
- **Test**: new case asserting an http image URL → `{ type: "image", source: { type: "url", url } }`.

## Scope notes

- **Cohere** already forwards image URLs (Cohere fetches them) — no change.
- **Gemini** still drops http(s) image URLs: its `fileData.fileUri` accepts only Files API / `gs://` URIs, so supporting URLs there would require Archestra to fetch + re-encode server-side (SSRF surface) — intentionally out of scope.
- **Files/PDFs by URL**: not addressable here — OpenAI's `file` content part has no URL field, so URL support only applies to images via `image_url`.