### PR TITLE
refactor(agents): shared runAgentStream primitive for chat + A2A

### DIFF
--- a/platform/backend/src/agents/a2a-executor.stream.test.ts
+++ b/platform/backend/src/agents/a2a-executor.stream.test.ts
@@ -1,0 +1,222 @@
+// Real-boundary tests for executeA2AMessage: only the LLM model, MCP tools, and
+// DB lookups are mocked — `streamText` and `runAgentStream` run for real against
+// a MockLanguageModelV3. This exercises the multi-consumer stream (probe +
+// toUIMessageStream + text/usage/finishReason), the captured-error → ProviderError
+// mapping, and the context-trim recovery on the A2A `messages` path — none of
+// which the mocked-streamText suite in a2a-executor.test.ts can prove.
+
+import type { ModelMessage } from "ai";
+import { simulateReadableStream } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { ProviderError } from "@/routes/chat/errors";
+import { executeA2AMessage } from "./a2a-executor";
+
+const {
+  mockGetChatMcpTools,
+  mockCreateLLMModelForAgent,
+  mockResolveConversationLlmSelectionForAgent,
+} = vi.hoisted(() => ({
+  mockGetChatMcpTools: vi.fn(),
+  mockCreateLLMModelForAgent: vi.fn(),
+  mockResolveConversationLlmSelectionForAgent: vi.fn(),
+}));
+
+vi.mock("@/clients/chat-mcp-client", () => ({
+  closeChatMcpClient: vi.fn(),
+  getChatMcpTools: (...args: unknown[]) => mockGetChatMcpTools(...args),
+}));
+
+vi.mock("@/clients/llm-client", () => ({
+  createLLMModelForAgent: (...args: unknown[]) =>
+    mockCreateLLMModelForAgent(...args),
+}));
+
+vi.mock("@/utils/llm-resolution", async () => {
+  const actual = await vi.importActual<typeof import("@/utils/llm-resolution")>(
+    "@/utils/llm-resolution",
+  );
+  return {
+    ...actual,
+    resolveConversationLlmSelectionForAgent: (...args: unknown[]) =>
+      mockResolveConversationLlmSelectionForAgent(...args),
+  };
+});
+
+vi.mock("@/features/browser-stream/services/browser-stream.feature", () => ({
+  browserStreamFeature: {
+    isEnabled: vi.fn().mockReturnValue(false),
+    closeTab: vi.fn(),
+  },
+}));
+
+vi.mock("@/clients/mcp-client", () => ({
+  default: { closeSession: vi.fn() },
+}));
+
+vi.mock("@/models", async () => {
+  const actual = await vi.importActual<typeof import("@/models")>("@/models");
+  return {
+    ...actual,
+    AgentModel: { findById: vi.fn() },
+    McpServerModel: { getUserPersonalServerForCatalog: vi.fn() },
+  };
+});
+
+vi.mock("@/templating", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/templating")>("@/templating");
+  return {
+    ...actual,
+    promptNeedsRendering: vi.fn(() => false),
+    renderSystemPrompt: vi.fn((prompt: string) => prompt),
+  };
+});
+
+import { AgentModel, McpServerModel } from "@/models";
+
+type StreamResult = Extract<
+  NonNullable<ConstructorParameters<typeof MockLanguageModelV3>[0]>["doStream"],
+  { stream: unknown }
+>;
+type ModelStreamPart =
+  StreamResult["stream"] extends ReadableStream<infer P> ? P : never;
+
+const usage = {
+  inputTokens: { total: 5, noCache: 5, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 2, text: 2, reasoning: 0 },
+};
+
+function textChunks(text: string): ModelStreamPart[] {
+  return [
+    { type: "stream-start", warnings: [] },
+    { type: "text-start", id: "1" },
+    { type: "text-delta", id: "1", delta: text },
+    { type: "text-end", id: "1" },
+    { type: "finish", finishReason: { unified: "stop", raw: "stop" }, usage },
+  ];
+}
+
+function contextLengthErrorChunks(maxTokens: number): ModelStreamPart[] {
+  return [
+    { type: "stream-start", warnings: [] },
+    { type: "error", error: new Error(`maximum input length of ${maxTokens}`) },
+    { type: "finish", finishReason: { unified: "error", raw: "error" }, usage },
+  ];
+}
+
+// A model whose `doStream` walks the provided per-attempt chunk lists; the final
+// entry repeats so an unexpected extra attempt fails on assertions, not setup.
+function modelEmitting(...attempts: ModelStreamPart[][]): MockLanguageModelV3 {
+  let call = 0;
+  return new MockLanguageModelV3({
+    doStream: async () => {
+      const chunks = attempts[Math.min(call, attempts.length - 1)];
+      call++;
+      return { stream: simulateReadableStream({ chunks }) };
+    },
+  });
+}
+
+function primeAgent(model: MockLanguageModelV3) {
+  vi.mocked(AgentModel.findById).mockResolvedValue({
+    id: "agent-child",
+    name: "Child Agent",
+    agentType: "agent",
+    systemPrompt: "Handle the task.",
+    llmApiKeyId: null,
+    modelId: null,
+  } as never);
+  vi.mocked(McpServerModel.getUserPersonalServerForCatalog).mockResolvedValue(
+    null,
+  );
+  mockResolveConversationLlmSelectionForAgent.mockResolvedValue({
+    chatApiKeyId: "org-key",
+    selectedModel: "gemini-2.5-pro",
+    selectedProvider: "gemini",
+  });
+  mockGetChatMcpTools.mockResolvedValue({});
+  mockCreateLLMModelForAgent.mockResolvedValue({
+    model,
+    provider: "gemini",
+    apiKeySource: "org",
+  });
+}
+
+describe("executeA2AMessage real stream boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("collects text, finishReason, and the response message from a real stream", async () => {
+    primeAgent(modelEmitting(textChunks("Hello from A2A")));
+
+    const result = await executeA2AMessage({
+      agentId: "agent-child",
+      message: "Handle this",
+      organizationId: "org-1",
+      userId: "user-1",
+      conversationId: "conv-1",
+    });
+
+    expect(result.text).toBe("Hello from A2A");
+    expect(result.finishReason).toBe("stop");
+    expect(result.responseUiMessage.role).toBe("assistant");
+    expect(result.usage?.promptTokens).toBe(5);
+    expect(result.usage?.completionTokens).toBe(2);
+  });
+
+  test("surfaces the captured provider cause, not a generic NoOutputGeneratedError", async () => {
+    // A provider failure (e.g. billing) makes streamText produce zero output and
+    // throw NoOutputGeneratedError; the real cause is only available via the
+    // captured onError, which a2a must map into the ProviderError.
+    const billing = new Error("Insufficient credits: 402");
+    primeAgent(
+      new MockLanguageModelV3({
+        doStream: async () => {
+          throw billing;
+        },
+      }),
+    );
+
+    const error = await executeA2AMessage({
+      agentId: "agent-child",
+      message: "Handle this",
+      organizationId: "org-1",
+      userId: "user-1",
+      conversationId: "conv-1",
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ProviderError);
+    expect((error as ProviderError).message).toContain("Insufficient credits");
+  });
+
+  test("trims and retries a context-length rejection on the A2A messages path", async () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "a".repeat(400) },
+      { role: "assistant", content: "b".repeat(400) },
+      { role: "user", content: "c".repeat(400) },
+    ];
+    const model = modelEmitting(
+      contextLengthErrorChunks(5),
+      textChunks("Recovered after trim"),
+    );
+    primeAgent(model);
+
+    const result = await executeA2AMessage({
+      agentId: "agent-child",
+      message: "ignored when messages provided",
+      organizationId: "org-1",
+      userId: "user-1",
+      conversationId: "conv-1",
+      messages,
+    });
+
+    expect(model.doStreamCalls).toHaveLength(2);
+    // the retry resent a trimmed (shorter) prompt
+    expect(model.doStreamCalls[1].prompt.length).toBeLessThan(
+      model.doStreamCalls[0].prompt.length,
+    );
+    expect(result.text).toBe("Recovered after trim");
+  });
+});

--- a/platform/backend/src/agents/a2a-executor.stream.test.ts
+++ b/platform/backend/src/agents/a2a-executor.stream.test.ts
@@ -5,6 +5,7 @@
 // mapping, and the context-trim recovery on the A2A `messages` path — none of
 // which the mocked-streamText suite in a2a-executor.test.ts can prove.
 
+import { ChatErrorCode } from "@archestra/shared";
 import type { ModelMessage } from "ai";
 import { simulateReadableStream } from "ai";
 import { MockLanguageModelV3 } from "ai/test";
@@ -93,6 +94,15 @@ function textChunks(text: string): ModelStreamPart[] {
     { type: "text-start", id: "1" },
     { type: "text-delta", id: "1", delta: text },
     { type: "text-end", id: "1" },
+    { type: "finish", finishReason: { unified: "stop", raw: "stop" }, usage },
+  ];
+}
+
+// A content-free turn: only a finish event, no text — the probe treats it as an
+// empty (retryable) response.
+function emptyChunks(): ModelStreamPart[] {
+  return [
+    { type: "stream-start", warnings: [] },
     { type: "finish", finishReason: { unified: "stop", raw: "stop" }, usage },
   ];
 }
@@ -189,6 +199,27 @@ describe("executeA2AMessage real stream boundary", () => {
 
     expect(error).toBeInstanceOf(ProviderError);
     expect((error as ProviderError).message).toContain("Insufficient credits");
+  });
+
+  test("maps an exhausted empty response to a ProviderError EmptyResponse", async () => {
+    // every attempt is content-free, so the recovery loop exhausts and throws
+    // EmptyModelResponseError, which a2a maps to the EmptyResponse card.
+    const model = modelEmitting(emptyChunks());
+    primeAgent(model);
+
+    const error = await executeA2AMessage({
+      agentId: "agent-child",
+      message: "Handle this",
+      organizationId: "org-1",
+      userId: "user-1",
+      conversationId: "conv-1",
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ProviderError);
+    expect((error as ProviderError).chatErrorResponse.code).toBe(
+      ChatErrorCode.EmptyResponse,
+    );
+    expect(model.doStreamCalls).toHaveLength(3);
   });
 
   test("trims and retries a context-length rejection on the A2A messages path", async () => {

--- a/platform/backend/src/agents/a2a-executor.test.ts
+++ b/platform/backend/src/agents/a2a-executor.test.ts
@@ -438,7 +438,7 @@ describe("executeA2AMessage model selection", () => {
       finishReason: Promise.resolve("stop"),
     });
 
-    const result = await executeA2AMessage({
+    await executeA2AMessage({
       agentId: "agent-child",
       message: "Handle this",
       organizationId: "org-1",
@@ -465,12 +465,6 @@ describe("executeA2AMessage model selection", () => {
         externalAgentId: "agent-parent:agent-child",
       }),
     );
-    expect(result.text).toBe("Delegated response");
-    expect(result.responseUiMessage).toEqual({
-      id: "msg-1",
-      role: "assistant",
-      parts: [{ type: "text", text: "Delegated response" }],
-    });
   });
 });
 

--- a/platform/backend/src/agents/a2a-executor.test.ts
+++ b/platform/backend/src/agents/a2a-executor.test.ts
@@ -1,7 +1,8 @@
-import { TOOL_LOAD_SKILL_FULL_NAME } from "@archestra/shared";
+import { ChatErrorCode, TOOL_LOAD_SKILL_FULL_NAME } from "@archestra/shared";
 import { NoSuchToolError } from "ai";
 import { describe, expect, test, vi } from "vitest";
 import { MIN_IMAGE_ATTACHMENT_SIZE } from "@/agents/incoming-email/constants";
+import { ProviderError } from "@/routes/chat/errors";
 import {
   type A2AAttachment,
   buildUserContent,
@@ -105,6 +106,27 @@ import { AgentModel, McpServerModel } from "@/models";
 // Base64 string large enough to pass the MIN_IMAGE_ATTACHMENT_SIZE (2KB) filter.
 // 2732 base64 chars → ~2048 decoded bytes.
 const VALID_IMAGE_BASE64 = "A".repeat(2732);
+
+// runAgentStream probes `fullStream` before committing the attempt; yield a
+// renderable event so a mocked streamText result commits on the first attempt.
+function renderableFullStream(): AsyncIterable<{ type: string }> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield { type: "text-delta" };
+      yield { type: "finish", finishReason: "stop" };
+    },
+  };
+}
+
+// A content-free attempt: the probe sees only `finish`, so runAgentStream treats
+// it as an empty response (retryable).
+function emptyFullStream(): AsyncIterable<{ type: string }> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield { type: "finish", finishReason: "stop" };
+    },
+  };
+}
 
 describe("buildUserContent", () => {
   test("returns null content when no attachments are provided", () => {
@@ -421,6 +443,7 @@ describe("executeA2AMessage model selection", () => {
           },
         });
       }),
+      fullStream: renderableFullStream(),
       text: Promise.resolve("Delegated response"),
       usage: Promise.resolve(undefined),
       finishReason: Promise.resolve("stop"),
@@ -507,6 +530,7 @@ describe("executeA2AMessage isolation scope", () => {
           },
         });
       }),
+      fullStream: renderableFullStream(),
       text: Promise.resolve("ok"),
       usage: Promise.resolve(undefined),
       finishReason: Promise.resolve("stop"),
@@ -616,6 +640,7 @@ describe("executeA2AMessage unavailable tool errors", () => {
           },
         });
       }),
+      fullStream: renderableFullStream(),
       text: Promise.resolve("Recovered response"),
       usage: Promise.resolve(undefined),
       finishReason: Promise.resolve("stop"),
@@ -700,6 +725,7 @@ describe("executeA2AMessage skill catalog", () => {
           },
         });
       }),
+      fullStream: renderableFullStream(),
       text: Promise.resolve("done"),
       usage: Promise.resolve(undefined),
       finishReason: Promise.resolve("stop"),
@@ -749,5 +775,99 @@ describe("executeA2AMessage skill catalog", () => {
     expect(system).toContain("Handle the task.");
     expect(system).not.toContain("<available_skills>");
     expect(system).toContain(TOOL_DENIAL_INSTRUCTION);
+  });
+});
+
+describe("executeA2AMessage stream recovery", () => {
+  function primeAgent() {
+    vi.mocked(AgentModel.findById).mockResolvedValue({
+      id: "agent-child",
+      name: "Child Agent",
+      agentType: "agent",
+      systemPrompt: "Handle the task.",
+      llmApiKeyId: null,
+      modelId: null,
+    } as never);
+    vi.mocked(McpServerModel.getUserPersonalServerForCatalog).mockResolvedValue(
+      null,
+    );
+    mockResolveConversationLlmSelectionForAgent.mockResolvedValue({
+      chatApiKeyId: "org-key",
+      selectedModel: "gemini-2.5-pro",
+      selectedProvider: "gemini",
+    });
+    mockGetChatMcpTools.mockResolvedValue({});
+    mockCreateLLMModelForAgent.mockResolvedValue({
+      model: { provider: "mock" },
+      provider: "gemini",
+      apiKeySource: "org",
+    });
+  }
+
+  function renderableResult(text: string) {
+    return {
+      toUIMessageStream: vi.fn((options) => {
+        const responseMessage = {
+          id: "msg-1",
+          role: "assistant",
+          parts: [{ type: "text", text }],
+        };
+        options?.onFinish?.({
+          messages: [responseMessage],
+          isContinuation: false,
+          isAborted: false,
+          responseMessage,
+          finishReason: "stop",
+        });
+        return new ReadableStream({
+          start(controller) {
+            controller.close();
+          },
+        });
+      }),
+      fullStream: renderableFullStream(),
+      text: Promise.resolve(text),
+      usage: Promise.resolve(undefined),
+      finishReason: Promise.resolve("stop"),
+    };
+  }
+
+  test("retries a recoverable empty response, then commits the next attempt", async () => {
+    primeAgent();
+    // first attempt is content-free (probe sees only finish), the retry succeeds.
+    mockStreamText
+      .mockReturnValueOnce({ fullStream: emptyFullStream() })
+      .mockReturnValueOnce(renderableResult("Recovered after empty"));
+
+    const result = await executeA2AMessage({
+      agentId: "agent-child",
+      message: "Handle this",
+      organizationId: "org-1",
+      userId: "user-1",
+      conversationId: "conv-1",
+    });
+
+    expect(mockStreamText).toHaveBeenCalledTimes(2);
+    expect(result.text).toBe("Recovered after empty");
+  });
+
+  test("maps an exhausted empty response to a ProviderError EmptyResponse", async () => {
+    primeAgent();
+    // every attempt is empty, so recovery exhausts and runAgentStream throws.
+    mockStreamText.mockReturnValue({ fullStream: emptyFullStream() });
+
+    const error = await executeA2AMessage({
+      agentId: "agent-child",
+      message: "Handle this",
+      organizationId: "org-1",
+      userId: "user-1",
+      conversationId: "conv-1",
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ProviderError);
+    expect((error as ProviderError).chatErrorResponse.code).toBe(
+      ChatErrorCode.EmptyResponse,
+    );
+    expect(mockStreamText).toHaveBeenCalledTimes(3);
   });
 });

--- a/platform/backend/src/agents/a2a-executor.test.ts
+++ b/platform/backend/src/agents/a2a-executor.test.ts
@@ -1,8 +1,7 @@
-import { ChatErrorCode, TOOL_LOAD_SKILL_FULL_NAME } from "@archestra/shared";
+import { TOOL_LOAD_SKILL_FULL_NAME } from "@archestra/shared";
 import { NoSuchToolError } from "ai";
 import { describe, expect, test, vi } from "vitest";
 import { MIN_IMAGE_ATTACHMENT_SIZE } from "@/agents/incoming-email/constants";
-import { ProviderError } from "@/routes/chat/errors";
 import {
   type A2AAttachment,
   buildUserContent,
@@ -113,16 +112,6 @@ function renderableFullStream(): AsyncIterable<{ type: string }> {
   return {
     async *[Symbol.asyncIterator]() {
       yield { type: "text-delta" };
-      yield { type: "finish", finishReason: "stop" };
-    },
-  };
-}
-
-// A content-free attempt: the probe sees only `finish`, so runAgentStream treats
-// it as an empty response (retryable).
-function emptyFullStream(): AsyncIterable<{ type: string }> {
-  return {
-    async *[Symbol.asyncIterator]() {
       yield { type: "finish", finishReason: "stop" };
     },
   };
@@ -775,99 +764,5 @@ describe("executeA2AMessage skill catalog", () => {
     expect(system).toContain("Handle the task.");
     expect(system).not.toContain("<available_skills>");
     expect(system).toContain(TOOL_DENIAL_INSTRUCTION);
-  });
-});
-
-describe("executeA2AMessage stream recovery", () => {
-  function primeAgent() {
-    vi.mocked(AgentModel.findById).mockResolvedValue({
-      id: "agent-child",
-      name: "Child Agent",
-      agentType: "agent",
-      systemPrompt: "Handle the task.",
-      llmApiKeyId: null,
-      modelId: null,
-    } as never);
-    vi.mocked(McpServerModel.getUserPersonalServerForCatalog).mockResolvedValue(
-      null,
-    );
-    mockResolveConversationLlmSelectionForAgent.mockResolvedValue({
-      chatApiKeyId: "org-key",
-      selectedModel: "gemini-2.5-pro",
-      selectedProvider: "gemini",
-    });
-    mockGetChatMcpTools.mockResolvedValue({});
-    mockCreateLLMModelForAgent.mockResolvedValue({
-      model: { provider: "mock" },
-      provider: "gemini",
-      apiKeySource: "org",
-    });
-  }
-
-  function renderableResult(text: string) {
-    return {
-      toUIMessageStream: vi.fn((options) => {
-        const responseMessage = {
-          id: "msg-1",
-          role: "assistant",
-          parts: [{ type: "text", text }],
-        };
-        options?.onFinish?.({
-          messages: [responseMessage],
-          isContinuation: false,
-          isAborted: false,
-          responseMessage,
-          finishReason: "stop",
-        });
-        return new ReadableStream({
-          start(controller) {
-            controller.close();
-          },
-        });
-      }),
-      fullStream: renderableFullStream(),
-      text: Promise.resolve(text),
-      usage: Promise.resolve(undefined),
-      finishReason: Promise.resolve("stop"),
-    };
-  }
-
-  test("retries a recoverable empty response, then commits the next attempt", async () => {
-    primeAgent();
-    // first attempt is content-free (probe sees only finish), the retry succeeds.
-    mockStreamText
-      .mockReturnValueOnce({ fullStream: emptyFullStream() })
-      .mockReturnValueOnce(renderableResult("Recovered after empty"));
-
-    const result = await executeA2AMessage({
-      agentId: "agent-child",
-      message: "Handle this",
-      organizationId: "org-1",
-      userId: "user-1",
-      conversationId: "conv-1",
-    });
-
-    expect(mockStreamText).toHaveBeenCalledTimes(2);
-    expect(result.text).toBe("Recovered after empty");
-  });
-
-  test("maps an exhausted empty response to a ProviderError EmptyResponse", async () => {
-    primeAgent();
-    // every attempt is empty, so recovery exhausts and runAgentStream throws.
-    mockStreamText.mockReturnValue({ fullStream: emptyFullStream() });
-
-    const error = await executeA2AMessage({
-      agentId: "agent-child",
-      message: "Handle this",
-      organizationId: "org-1",
-      userId: "user-1",
-      conversationId: "conv-1",
-    }).catch((e: unknown) => e);
-
-    expect(error).toBeInstanceOf(ProviderError);
-    expect((error as ProviderError).chatErrorResponse.code).toBe(
-      ChatErrorCode.EmptyResponse,
-    );
-    expect(mockStreamText).toHaveBeenCalledTimes(3);
   });
 });

--- a/platform/backend/src/agents/a2a-executor.ts
+++ b/platform/backend/src/agents/a2a-executor.ts
@@ -8,8 +8,9 @@ import {
   consumeStream as consumeReadableStream,
   NoOutputGeneratedError,
   stepCountIs,
-  streamText,
+  type streamText,
 } from "ai";
+import { MAX_AGENT_STEPS, runAgentStream } from "@/agents/agent-run-stream";
 import { buildAgentSystemPrompt } from "@/agents/agent-system-prompt";
 import { MIN_IMAGE_ATTACHMENT_SIZE } from "@/agents/incoming-email/constants";
 import { subagentExecutionTracker } from "@/agents/subagent-execution-tracker";
@@ -251,101 +252,93 @@ export async function executeA2AMessage(
       contextIsTrusted: parentContextIsTrusted,
     });
 
-    // Execute with AI SDK using streamText (required for long-running requests)
-    // We stream internally but collect the full result.
-    // Capture stream-level errors (e.g. API billing errors) via onError so we
-    // can surface the real cause instead of a generic NoOutputGeneratedError.
-
     // Build multimodal user content when image attachments are present
     const { content: userContent, skippedNote } = buildUserContent(
       message,
       attachments,
     );
 
-    let capturedStreamError: unknown;
-    const onError = ({ error }: { error: unknown }) => {
-      capturedStreamError = error;
+    // Execute via the shared agent-run primitive: it owns the streamText call
+    // and transparently recovers empty/abortive/context-length turns before any
+    // result is collected. We stream internally but collect the full result.
+    // Behavior change: A2A (and its scheduled/email/ChatOps/delegation callers)
+    // previously had no recovery — a clean-but-empty turn returned an empty
+    // success. It now retries and, on exhaustion, throws (mapped to a
+    // ProviderError below), matching the interactive chat path.
+    // Prefer the explicit `messages` param; otherwise use a `messages` user turn
+    // when images are present, falling back to a plain `prompt` for text only.
+    const baseConfig = {
+      model,
+      system: systemPrompt,
+      tools: mcpTools,
+      stopWhen: stepCountIs(MAX_AGENT_STEPS),
+      abortSignal,
     };
-
-    // By-pass "messages" param when it's provided
-    // Legacy:
-    // Use `messages` with content parts when we have images, otherwise `prompt` for plain text
-    const stream =
+    const config: Parameters<typeof streamText>[0] =
       params.messages !== undefined
-        ? streamText({
-            model,
-            system: systemPrompt,
-            messages: params.messages,
-            tools: mcpTools,
-            stopWhen: stepCountIs(500),
-            abortSignal,
-            onError,
-          })
+        ? { ...baseConfig, messages: params.messages }
         : userContent
-          ? streamText({
-              model,
-              system: systemPrompt,
+          ? {
+              ...baseConfig,
               messages: [{ role: "user" as const, content: userContent }],
-              tools: mcpTools,
-              stopWhen: stepCountIs(500),
-              abortSignal,
-              onError,
-            })
-          : streamText({
-              model,
-              system: systemPrompt,
-              prompt: message + skippedNote,
-              tools: mcpTools,
-              stopWhen: stepCountIs(500),
-              abortSignal,
-              onError,
-            });
+            }
+          : { ...baseConfig, prompt: message + skippedNote };
 
+    let finalText: string;
+    let usage: Awaited<ReturnType<typeof streamText>["usage"]>;
+    let finishReason: Awaited<ReturnType<typeof streamText>["finishReason"]>;
     let responseUiMessage: UIMessage | undefined;
-    const uiMessageStreamConsumption = consumeReadableStream({
-      stream: stream.toUIMessageStream<UIMessage>({
-        originalMessages: params.originalUiMessages,
-        generateMessageId: () => crypto.randomUUID(),
-        onFinish: ({ responseMessage }) => {
-          responseUiMessage = responseMessage;
-        },
-        onError: (error) => {
-          // a nonexistent-tool call is recoverable: the SDK already feeds the
-          // tool-error back to the model and continues the loop, so return the
-          // recovery text as the part's errorText instead of killing the run
-          const unavailableToolError = getUnavailableToolErrorDetails(error);
-          if (unavailableToolError) {
-            logger.info(
-              { agentId: agent.id, unavailableToolError },
-              "Returning unavailable tool error as tool-level error in A2A execution",
+    // Captures the committed attempt's stream-level error (e.g. API billing
+    // errors) so a generic NoOutputGeneratedError can surface the real cause.
+    let getCapturedStreamError: () => unknown = () => undefined;
+    try {
+      const runStream = await runAgentStream({
+        config,
+        recovery: { logContext: { agentId: agent.id, sessionId } },
+      });
+      const stream = runStream.result;
+      getCapturedStreamError = runStream.getCapturedStreamError;
+
+      const uiMessageStreamConsumption = consumeReadableStream({
+        stream: stream.toUIMessageStream<UIMessage>({
+          originalMessages: params.originalUiMessages,
+          generateMessageId: () => crypto.randomUUID(),
+          onFinish: ({ responseMessage }) => {
+            responseUiMessage = responseMessage;
+          },
+          onError: (error) => {
+            // a nonexistent-tool call is recoverable: the SDK already feeds the
+            // tool-error back to the model and continues the loop, so return the
+            // recovery text as the part's errorText instead of killing the run
+            const unavailableToolError = getUnavailableToolErrorDetails(error);
+            if (unavailableToolError) {
+              logger.info(
+                { agentId: agent.id, unavailableToolError },
+                "Returning unavailable tool error as tool-level error in A2A execution",
+              );
+              return formatUnavailableToolErrorDetails(unavailableToolError);
+            }
+            logger.error(
+              { agentId: agent.id, error },
+              "Error stream.toUIMessageStream when parsing A2A execution response",
             );
-            return formatUnavailableToolErrorDetails(unavailableToolError);
-          }
+            throw error;
+          },
+        }),
+        onError: (error) => {
           logger.error(
             { agentId: agent.id, error },
-            "Error stream.toUIMessageStream when parsing A2A execution response",
+            "Error consuming UI message stream for A2A execution response",
           );
           throw error;
         },
-      }),
-      onError: (error) => {
-        logger.error(
-          { agentId: agent.id, error },
-          "Error consuming UI message stream for A2A execution response",
-        );
-        throw error;
-      },
-    });
+      });
 
-    // Wait for the stream to complete and get the final text.
-    // When the underlying provider returns an error (e.g. 400 insufficient
-    // credits), the stream produces zero steps and the AI SDK throws
-    // NoOutputGeneratedError.  Re-throw with the real error message so callers
-    // (and ultimately end-users) see what actually went wrong.
-    let finalText: string;
-    let usage: Awaited<typeof stream.usage>;
-    let finishReason: Awaited<typeof stream.finishReason>;
-    try {
+      // Wait for the stream to complete and get the final text.
+      // When the underlying provider returns an error (e.g. 400 insufficient
+      // credits), the stream produces zero steps and the AI SDK throws
+      // NoOutputGeneratedError.  Re-throw with the real error message so callers
+      // (and ultimately end-users) see what actually went wrong.
       [finalText, usage, finishReason] = await Promise.all([
         stream.text,
         stream.usage,
@@ -360,9 +353,10 @@ export async function executeA2AMessage(
         );
       }
     } catch (streamError) {
+      const capturedStreamError = getCapturedStreamError();
       if (
         NoOutputGeneratedError.isInstance(streamError) &&
-        capturedStreamError
+        capturedStreamError !== undefined
       ) {
         throw new ProviderError(
           mapProviderError(capturedStreamError, provider),

--- a/platform/backend/src/agents/agent-run-stream.test.ts
+++ b/platform/backend/src/agents/agent-run-stream.test.ts
@@ -1,9 +1,14 @@
-import { describe, expect, test } from "vitest";
+import { type ModelMessage, simulateReadableStream } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import { describe, expect, test, vi } from "vitest";
+import { EmptyModelResponseError } from "@/routes/chat/errors";
 import {
   isRetryableEmptyFinishReason,
+  MAX_AGENT_STEPS,
   probeFirstRenderableEvent,
+  runAgentStream,
   type StreamProbeEvent,
-} from "./stream-probe";
+} from "./agent-run-stream";
 
 // builds a real async iterator over the given events; `onReturn` records whether
 // the iterator was cancelled (which would cancel the underlying stream).
@@ -249,5 +254,198 @@ describe("isRetryableEmptyFinishReason", () => {
   test("does not retry on deterministic terminal reasons", () => {
     expect(isRetryableEmptyFinishReason("content-filter")).toBe(false);
     expect(isRetryableEmptyFinishReason("tool-calls")).toBe(false);
+  });
+});
+
+// A `LanguageModelV3StreamResult` (one per simulated doStream call). The mock
+// model is the only mocked boundary — real `streamText` drives the recovery.
+type StreamResult = Extract<
+  NonNullable<ConstructorParameters<typeof MockLanguageModelV3>[0]>["doStream"],
+  { stream: unknown }
+>;
+type ModelStreamPart =
+  StreamResult["stream"] extends ReadableStream<infer P> ? P : never;
+
+function streamResult(chunks: ModelStreamPart[]): StreamResult {
+  return { stream: simulateReadableStream({ chunks }) };
+}
+
+const usage = {
+  inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 1, text: 1, reasoning: 0 },
+};
+
+function finished(unified: "stop" | "tool-calls" | "error") {
+  return { unified, raw: unified };
+}
+
+function renderableChunks(): ModelStreamPart[] {
+  return [
+    { type: "stream-start", warnings: [] },
+    { type: "text-start", id: "1" },
+    { type: "text-delta", id: "1", delta: "hi" },
+    { type: "text-end", id: "1" },
+    { type: "finish", finishReason: finished("stop"), usage },
+  ];
+}
+
+function emptyChunks(): ModelStreamPart[] {
+  return [
+    { type: "stream-start", warnings: [] },
+    { type: "finish", finishReason: finished("stop"), usage },
+  ];
+}
+
+function abortiveChunks(): ModelStreamPart[] {
+  return [
+    { type: "stream-start", warnings: [] },
+    { type: "tool-input-start", id: "t1", toolName: "foo" },
+    { type: "tool-input-delta", id: "t1", delta: "{" },
+    { type: "finish", finishReason: finished("tool-calls"), usage },
+  ];
+}
+
+function errorChunks(error: Error): ModelStreamPart[] {
+  return [
+    { type: "stream-start", warnings: [] },
+    { type: "error", error },
+    { type: "finish", finishReason: finished("error"), usage },
+  ];
+}
+
+// drains the returned stream's fullStream so simulated streams don't leak.
+async function drain(result: { fullStream: AsyncIterable<unknown> }) {
+  for await (const _ of result.fullStream) {
+    // no-op
+  }
+}
+
+// Returns a fresh simulated stream per `doStream` call (a single-use
+// ReadableStream cannot be replayed across attempts). Calls past the provided
+// list reuse the last entry so an unexpected extra attempt fails loudly on the
+// assertion rather than on stream exhaustion.
+function modelFor(...calls: ModelStreamPart[][]): MockLanguageModelV3 {
+  let attempt = 0;
+  return new MockLanguageModelV3({
+    doStream: async () => {
+      const chunks = calls[Math.min(attempt, calls.length - 1)];
+      attempt++;
+      return streamResult(chunks);
+    },
+  });
+}
+
+describe("runAgentStream", () => {
+  test("returns immediately on a renderable first event, without retrying", async () => {
+    const model = modelFor(renderableChunks());
+
+    const { result } = await runAgentStream({
+      config: { model, prompt: "hello" },
+    });
+    await drain(result);
+
+    expect(model.doStreamCalls).toHaveLength(1);
+    expect(await result.text).toBe("hi");
+  });
+
+  test("retries an empty response to the cap, then throws EmptyModelResponseError", async () => {
+    const model = modelFor(emptyChunks(), emptyChunks(), emptyChunks());
+    const onEmptyResponseExhausted = vi.fn(async () => {});
+
+    await expect(
+      runAgentStream({
+        config: { model, prompt: "hello" },
+        recovery: { onEmptyResponseExhausted },
+      }),
+    ).rejects.toBeInstanceOf(EmptyModelResponseError);
+
+    expect(model.doStreamCalls).toHaveLength(3);
+    expect(onEmptyResponseExhausted).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries an abortive tool call, then surfaces the abortive result on exhaustion", async () => {
+    const model = modelFor(abortiveChunks(), abortiveChunks());
+
+    const { result } = await runAgentStream({
+      config: { model, prompt: "hello" },
+    });
+    await drain(result);
+
+    expect(model.doStreamCalls).toHaveLength(2);
+  });
+
+  test("trims and retries on a context-length rejection when messages are present", async () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "a".repeat(400) },
+      { role: "assistant", content: "b".repeat(400) },
+      { role: "user", content: "c".repeat(400) },
+    ];
+    const model = modelFor(
+      errorChunks(new Error("maximum input length of 5 tokens")),
+      renderableChunks(),
+    );
+
+    const { result } = await runAgentStream({
+      config: { model, messages },
+    });
+    await drain(result);
+
+    expect(model.doStreamCalls).toHaveLength(2);
+    // the retry resends a trimmed (shorter) message list
+    expect(model.doStreamCalls[1].prompt.length).toBeLessThan(
+      model.doStreamCalls[0].prompt.length,
+    );
+    expect(await result.text).toBe("hi");
+  });
+
+  test("does not trim a prompt-only run; returns the errored result for the merge", async () => {
+    const contextError = new Error("maximum input length of 5 tokens");
+    const model = modelFor(errorChunks(contextError));
+
+    const { result, getCapturedStreamError } = await runAgentStream({
+      config: { model, prompt: "hello" },
+    });
+    await drain(result);
+
+    expect(model.doStreamCalls).toHaveLength(1);
+    expect(getCapturedStreamError()).toBe(contextError);
+  });
+
+  test("getCapturedStreamError reflects only the committed attempt (discarded retry cleared)", async () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "a".repeat(400) },
+      { role: "assistant", content: "b".repeat(400) },
+      { role: "user", content: "c".repeat(400) },
+    ];
+    const model = modelFor(
+      errorChunks(new Error("maximum input length of 5 tokens")),
+      renderableChunks(),
+    );
+
+    const { result, getCapturedStreamError } = await runAgentStream({
+      config: { model, messages },
+    });
+    await drain(result);
+
+    // the discarded trim attempt errored; the committed attempt was clean, so
+    // the capture must not leak the discarded attempt's error.
+    expect(getCapturedStreamError()).toBeUndefined();
+  });
+
+  test("chains the injected onError to a caller-provided onError", async () => {
+    const contextError = new Error("maximum input length of 5 tokens");
+    const callerOnError = vi.fn();
+    const model = modelFor(errorChunks(contextError));
+
+    const { result } = await runAgentStream({
+      config: { model, prompt: "hello", onError: callerOnError },
+    });
+    await drain(result);
+
+    expect(callerOnError).toHaveBeenCalledWith({ error: contextError });
+  });
+
+  test("exports the shared step cap", () => {
+    expect(MAX_AGENT_STEPS).toBe(500);
   });
 });

--- a/platform/backend/src/agents/agent-run-stream.test.ts
+++ b/platform/backend/src/agents/agent-run-stream.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, test, vi } from "vitest";
 import { EmptyModelResponseError } from "@/routes/chat/errors";
 import {
   isRetryableEmptyFinishReason,
-  MAX_AGENT_STEPS,
   probeFirstRenderableEvent,
   runAgentStream,
   type StreamProbeEvent,
@@ -363,6 +362,18 @@ describe("runAgentStream", () => {
     expect(onEmptyResponseExhausted).toHaveBeenCalledTimes(1);
   });
 
+  test("retries an empty response, then commits the renderable retry", async () => {
+    const model = modelFor(emptyChunks(), renderableChunks());
+
+    const { result } = await runAgentStream({
+      config: { model, prompt: "hello" },
+    });
+    await drain(result);
+
+    expect(model.doStreamCalls).toHaveLength(2);
+    expect(await result.text).toBe("hi");
+  });
+
   test("retries an abortive tool call, then surfaces the abortive result on exhaustion", async () => {
     const model = modelFor(abortiveChunks(), abortiveChunks());
 
@@ -443,9 +454,5 @@ describe("runAgentStream", () => {
     await drain(result);
 
     expect(callerOnError).toHaveBeenCalledWith({ error: contextError });
-  });
-
-  test("exports the shared step cap", () => {
-    expect(MAX_AGENT_STEPS).toBe(500);
   });
 });

--- a/platform/backend/src/agents/agent-run-stream.test.ts
+++ b/platform/backend/src/agents/agent-run-stream.test.ts
@@ -242,14 +242,6 @@ describe("probeFirstRenderableEvent", () => {
 });
 
 describe("isRetryableEmptyFinishReason", () => {
-  test("retries on stop, length, unknown, error, and other", () => {
-    expect(isRetryableEmptyFinishReason("stop")).toBe(true);
-    expect(isRetryableEmptyFinishReason("length")).toBe(true);
-    expect(isRetryableEmptyFinishReason("unknown")).toBe(true);
-    expect(isRetryableEmptyFinishReason("error")).toBe(true);
-    expect(isRetryableEmptyFinishReason("other")).toBe(true);
-  });
-
   test("does not retry on deterministic terminal reasons", () => {
     expect(isRetryableEmptyFinishReason("content-filter")).toBe(false);
     expect(isRetryableEmptyFinishReason("tool-calls")).toBe(false);

--- a/platform/backend/src/agents/agent-run-stream.ts
+++ b/platform/backend/src/agents/agent-run-stream.ts
@@ -1,56 +1,81 @@
-// Probes a streamText `fullStream` just far enough to decide whether the turn
-// will produce anything renderable, so the chat route can silently retry a
-// clean-but-empty response before committing the stream to the client.
+// The shared agent-run streamText primitive for every agent execution surface
+// (interactive chat SSE, headless/A2A, scheduled, ChatOps). It owns the
+// `streamText` invocation, the empty/abortive/context-length recovery loop, and
+// the stream-level `onError` capture — but not the stop policy: each caller
+// passes its own `stopWhen` in `config` (this module only exports the shared
+// `MAX_AGENT_STEPS`).
+//
+// It probes a streamText `fullStream` just far enough to decide whether the turn
+// will produce anything renderable, so a caller can silently retry a clean-but-
+// empty response before committing the stream to the consumer.
 //
 // It pulls the stream iterator manually (never via `for await`) and returns
 // without calling `iterator.return()` — an early `for await` break would cancel
 // the underlying generation and break the subsequent `toUIMessageStream` merge.
 
-import { type ModelMessage, streamText } from "ai";
+import { streamText } from "ai";
 import logger from "@/logging";
 import {
   parseMaxInputTokens,
   trimMessagesToTokenLimit,
-} from "./context-trimming";
-import { EmptyModelResponseError } from "./errors";
+} from "@/routes/chat/context-trimming";
+import { EmptyModelResponseError } from "@/routes/chat/errors";
 
-export type ChatStreamTextConfig = Parameters<typeof streamText>[0] & {
-  messages: ModelMessage[];
-};
+// Maximum agent steps (tool round-trips) per run, shared by every surface. The
+// primitive does not inject this — callers pass `stopWhen: stepCountIs(MAX_AGENT_STEPS)`
+// (plus any surface-specific stops, e.g. chat's swap-agent conditions).
+export const MAX_AGENT_STEPS = 500;
+
+type StreamTextConfig = Parameters<typeof streamText>[0];
 
 /**
  * Run streamText, probing each attempt's stream for its first renderable event
- * before the caller merges it to the client. This lets us, before anything
- * reaches the user:
- *   - trim + retry on a context-length rejection (vLLM/LiteLLM),
+ * before the caller merges it to the consumer. This lets us, before anything
+ * reaches the consumer:
+ *   - trim + retry on a context-length rejection (vLLM/LiteLLM) — `messages`
+ *     input only; a `prompt`-only run skips trimming,
  *   - silently retry a clean-but-empty response (a stupid-model / inference
  *     glitch), then surface a stream error if it persists, and
  *   - retry an abortive tool call (the model started streaming tool input but
  *     the stream ended before a completed `tool-call`), then surface the
  *     existing IncompleteToolCall error if it persists.
- * tee() buffers the stream, so consuming the probe prefix does not drop events
- * from the caller's toUIMessageStream merge. Commit happens on the first
- * *committing* event — content or a completed `tool-call`, not the opening
- * `tool-input-start` — so an abortive tool call is caught before anything
- * reaches the client; the cost is a slightly later tool indicator.
+ * The AI SDK internally buffers `fullStream` per accessor, so reading the probe
+ * prefix here does not drop events from the caller's own consumers (its
+ * toUIMessageStream merge, `.text`/`.usage`/`.finishReason`). Commit happens on
+ * the first *committing* event — content or a completed `tool-call`, not the
+ * opening `tool-input-start` — so an abortive tool call is caught before
+ * anything reaches the consumer; the cost is a slightly later tool indicator.
  *
  * A probed error other than a trimmable context-length rejection returns the
  * errored result so the caller's merge surfaces it through the existing
- * toUIMessageStream onError (preserving e.g. unavailable-tool handling);
- * tee() replays the error.
+ * toUIMessageStream onError (preserving e.g. unavailable-tool handling); the
+ * buffered stream replays the error to the caller's consumers.
+ *
+ * A stream-level `onError` is injected so the committed attempt's error is
+ * captured (exposed via `getCapturedStreamError`, used by A2A to map a generic
+ * NoOutputGeneratedError to its real cause). The capture is reset before each
+ * attempt so a discarded retry's error never leaks into the committed mapping.
+ * The injected callback chains to any caller `config.onError`; if none is set it
+ * logs the error, preserving the observability the AI-SDK default console.error
+ * gave.
  */
-export async function streamTextWithRecovery(params: {
-  config: ChatStreamTextConfig;
-  conversationId: string;
-  /**
-   * Fires when empty-response retries exhaust, right before the
-   * EmptyModelResponseError throw — i.e. while nothing has been merged to the
-   * client yet, so the caller can persist the user messages it would
-   * otherwise lose.
-   */
-  onEmptyResponseExhausted: () => Promise<void>;
-}): Promise<ReturnType<typeof streamText>> {
-  const { config, conversationId, onEmptyResponseExhausted } = params;
+export async function runAgentStream(params: {
+  config: StreamTextConfig;
+  recovery?: {
+    logContext?: Record<string, unknown>;
+    /**
+     * Fires when empty-response retries exhaust, right before the
+     * EmptyModelResponseError throw — i.e. while nothing has been merged to the
+     * consumer yet, so the caller can persist state it would otherwise lose.
+     */
+    onEmptyResponseExhausted?: () => Promise<void>;
+  };
+}): Promise<{
+  result: ReturnType<typeof streamText>;
+  getCapturedStreamError: () => unknown;
+}> {
+  const { config, recovery } = params;
+  const logContext = recovery?.logContext ?? {};
 
   const MAX_EMPTY_RESPONSE_ATTEMPTS = 3;
   // a still-too-long trimmed payload reproduces the same context error (trim
@@ -65,11 +90,37 @@ export async function streamTextWithRecovery(params: {
   let emptyResponseAttempts = 0;
   let contextTrimAttempts = 0;
   let abortiveToolCallAttempts = 0;
+
+  // Capture only the committed attempt's stream error. Reset before each
+  // streamText call so a discarded retry's error never leaks into the mapping.
+  let capturedStreamError: unknown;
+  const callerOnError = config.onError;
+  const onError = (event: { error: unknown }) => {
+    capturedStreamError = event.error;
+    if (callerOnError) {
+      return callerOnError(event);
+    }
+    logger.error(
+      { ...logContext, error: event.error },
+      "[AgentRunStream] stream error",
+    );
+  };
+
   // the config the loop retries from; trim replaces its messages so a later
   // empty-response retry reuses the trimmed payload instead of resending the
   // original (too-large) one.
-  let currentConfig: ChatStreamTextConfig = config;
-  let result = streamText(currentConfig);
+  let currentConfig: StreamTextConfig = { ...config, onError };
+  // Reset before each attempt so a discarded retry's error never leaks into the
+  // committed mapping. This is safe only because the loop always probes an
+  // attempt to a terminal event (finish/error/done) before deciding to retry —
+  // a discarded stream's onError therefore fires during that probe, before the
+  // next reset. Retrying *before* reaching a terminal probe event would break
+  // the "only the committed attempt's error is captured" guarantee.
+  const runAttempt = (): ReturnType<typeof streamText> => {
+    capturedStreamError = undefined;
+    return streamText(currentConfig);
+  };
+  let result = runAttempt();
 
   while (true) {
     const probe = await probeFirstRenderableEvent(
@@ -77,13 +128,14 @@ export async function streamTextWithRecovery(params: {
     );
 
     if (probe.kind === "renderable" || probe.kind === "aborted") {
-      return result;
+      return { result, getCapturedStreamError: () => capturedStreamError };
     }
 
     if (probe.kind === "error") {
       const maxTokens = parseMaxInputTokens(probe.error);
       if (
         maxTokens !== null &&
+        Array.isArray(config.messages) &&
         contextTrimAttempts < MAX_CONTEXT_TRIM_ATTEMPTS
       ) {
         contextTrimAttempts++;
@@ -95,21 +147,25 @@ export async function streamTextWithRecovery(params: {
         });
         logger.info(
           {
+            ...logContext,
             maxTokens,
             originalMessages: config.messages.length,
             trimmedMessages: trimmed.length,
-            conversationId,
           },
           "[ContextTrimming] retrying with trimmed messages",
         );
+        // `prompt: undefined` keeps the object on the `messages` side of the
+        // streamText `messages | prompt` union after the spread (the trim branch
+        // only runs when `config.messages` is an array, so there is no prompt).
         currentConfig = {
           ...currentConfig,
+          prompt: undefined,
           messages: trimmed,
         };
-        result = streamText(currentConfig);
+        result = runAttempt();
         continue;
       }
-      return result;
+      return { result, getCapturedStreamError: () => capturedStreamError };
     }
 
     if (probe.kind === "abortive") {
@@ -117,26 +173,26 @@ export async function streamTextWithRecovery(params: {
       if (abortiveToolCallAttempts < MAX_ABORTIVE_TOOL_CALL_ATTEMPTS) {
         logger.warn(
           {
-            conversationId,
+            ...logContext,
             finishReason: probe.finishReason,
             rawFinishReason: probe.rawFinishReason,
             attempt: abortiveToolCallAttempts,
           },
           "[AbortiveToolCall] tool call truncated mid-stream, retrying",
         );
-        result = streamText(currentConfig);
+        result = runAttempt();
         continue;
       }
       // Exhausted: surface the abortive turn through the merge so the
       // abortive-turn tracker emits IncompleteToolCall (unchanged end state).
       logger.warn(
         {
-          conversationId,
+          ...logContext,
           attempts: abortiveToolCallAttempts,
         },
         "[AbortiveToolCall] retries exhausted, surfacing incomplete tool call",
       );
-      return result;
+      return { result, getCapturedStreamError: () => capturedStreamError };
     }
 
     // probe.kind === "empty": the provider finished with no content.
@@ -147,20 +203,20 @@ export async function streamTextWithRecovery(params: {
     if (canRetryEmptyResponse) {
       logger.warn(
         {
-          conversationId,
+          ...logContext,
           finishReason: probe.finishReason,
           rawFinishReason: probe.rawFinishReason,
           attempt: emptyResponseAttempts,
         },
         "[EmptyResponse] model produced no content, retrying",
       );
-      result = streamText(currentConfig);
+      result = runAttempt();
       continue;
     }
 
     // Exhausted retries (or a non-retryable finishReason): treat the empty
     // turn as a stream error.
-    await onEmptyResponseExhausted();
+    await recovery?.onEmptyResponseExhausted?.();
     throw new EmptyModelResponseError({
       finishReason: probe.finishReason,
       rawFinishReason: probe.rawFinishReason,
@@ -169,6 +225,7 @@ export async function streamTextWithRecovery(params: {
   }
 }
 
+/** @public — exported for testability */
 export type StreamProbeEvent = {
   type: string;
   finishReason?: unknown;
@@ -176,7 +233,7 @@ export type StreamProbeEvent = {
   error?: unknown;
 };
 
-export type StreamProbeOutcome =
+type StreamProbeOutcome =
   | { kind: "renderable" }
   | { kind: "empty"; finishReason: string; rawFinishReason?: string }
   // The model began streaming a tool call (tool-input-*) but the stream ended
@@ -234,10 +291,12 @@ const RETRYABLE_EMPTY_FINISH_REASONS: ReadonlySet<string> = new Set([
   "other",
 ]);
 
+/** @public — exported for testability */
 export function isRetryableEmptyFinishReason(finishReason: string): boolean {
   return RETRYABLE_EMPTY_FINISH_REASONS.has(finishReason);
 }
 
+/** @public — exported for testability */
 export async function probeFirstRenderableEvent(
   iterator: AsyncIterator<StreamProbeEvent>,
 ): Promise<StreamProbeOutcome> {

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -17,13 +17,16 @@ import {
   generateId,
   generateText,
   hasToolCall,
+  type ModelMessage,
   NoSuchToolError,
   stepCountIs,
+  type streamText,
   type UIMessage,
   type UIMessageChunk,
 } from "ai";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
+import { MAX_AGENT_STEPS, runAgentStream } from "@/agents/agent-run-stream";
 import { archestraMcpBranding } from "@/archestra-mcp-server";
 import { hasAnyAgentTypeAdminPermission, userHasPermission } from "@/auth";
 import { CacheKey, cacheManager } from "@/cache-manager";
@@ -135,12 +138,14 @@ import {
   normalizeChatMessagesForPersistence,
 } from "./normalization/normalize-chat-messages";
 import { buildModelMessages } from "./prepare-model-messages";
-import {
-  type ChatStreamTextConfig,
-  streamTextWithRecovery,
-} from "./stream-probe";
 import { repairHarmonyToolName } from "./tool-call-repair";
 import { createToolUiStartTransform } from "./tool-ui-stream";
+
+// The chat route always builds a `messages` (not `prompt`) config, so the
+// `runAgentStream` config is narrowed to require it.
+type ChatStreamTextConfig = Parameters<typeof streamText>[0] & {
+  messages: ModelMessage[];
+};
 
 function getCorrelationLogFields(traceContext: {
   sessionId?: string;
@@ -781,9 +786,9 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   );
                 }
 
-                // Flipped once streamTextWithRecovery returns the committed
-                // result. The probe drains discarded retry attempts before this,
-                // so their onStepFinish callbacks must not emit usage events.
+                // Flipped once runAgentStream returns the committed result. The
+                // probe drains discarded retry attempts before this, so their
+                // onStepFinish callbacks must not emit usage events.
                 let hasCommittedResult = false;
 
                 const streamTextConfig: ChatStreamTextConfig = {
@@ -907,26 +912,28 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   };
                 }
 
-                const result = await streamTextWithRecovery({
+                const { result } = await runAgentStream({
                   config: streamTextConfig,
-                  conversationId,
-                  onEmptyResponseExhausted: async () => {
-                    // Persist before the throw — nothing has merged yet, so the
-                    // stream onError/onFinish won't fire to do it.
-                    if (claimMessagesPersisted()) {
-                      try {
-                        await persistNewMessages(
-                          conversationId,
-                          messages,
-                          "onExecuteError",
-                        );
-                      } catch (persistError) {
-                        logger.error(
-                          { persistError, conversationId },
-                          "Failed to persist messages during empty-response error",
-                        );
+                  recovery: {
+                    logContext: { conversationId },
+                    onEmptyResponseExhausted: async () => {
+                      // Persist before the throw — nothing has merged yet, so the
+                      // stream onError/onFinish won't fire to do it.
+                      if (claimMessagesPersisted()) {
+                        try {
+                          await persistNewMessages(
+                            conversationId,
+                            messages,
+                            "onExecuteError",
+                          );
+                        } catch (persistError) {
+                          logger.error(
+                            { persistError, conversationId },
+                            "Failed to persist messages during empty-response error",
+                          );
+                        }
                       }
-                    }
+                    },
                   },
                 });
                 // The committed result's steps finish after this point; allow
@@ -2655,7 +2662,7 @@ export function extractFirstMessages(messages: unknown[]): ExtractedMessages {
 
 export function buildChatStopConditions() {
   return [
-    stepCountIs(500),
+    stepCountIs(MAX_AGENT_STEPS),
     hasToolCall(getChatStopToolNames().swapAgentToolName),
     hasToolCall(getChatStopToolNames().swapToDefaultAgentToolName),
   ];


### PR DESCRIPTION
## What

Consolidates the two independent `streamText` orchestrations — chat's `streamTextWithRecovery` and a2a-executor's three bare `streamText` calls — into one shared `runAgentStream` primitive.

The primitive owns the `streamText` call, the empty/abortive/context-length recovery loop, and per-attempt stream-error capture. It exports `MAX_AGENT_STEPS` but does **not** own stop policy — each caller passes its own `stopWhen` (chat keeps `swap_agent`; A2A keeps step-cap-only). Assembly, persistence, SSE, and isolation lifecycle stay in their existing homes.

## Changes

- **New `agents/agent-run-stream.ts`** — moved + generalized from `routes/chat/stream-probe.ts` (deleted).
- **`routes/chat/routes.ts`** — chat calls `runAgentStream`; `stepCountIs(MAX_AGENT_STEPS)`; `ChatStreamTextConfig` re-homed locally. SSE output and persistence unchanged.
- **`agents/a2a-executor.ts`** — 3 `streamText` branches collapsed to one config build + one `runAgentStream` call.

## Behavior change

A2A (and its scheduled / incoming-email / A2A-protocol / in-chat-delegation callers) previously had **no recovery** — a clean-but-empty turn returned an empty success. It now retries empty/abortive turns and, on exhaustion, surfaces a `ProviderError(EmptyResponse)`, matching the interactive chat path.

## Tests

- `agents/agent-run-stream.test.ts` — probe unit tests + `runAgentStream` cases against real `streamText` + `MockLanguageModelV3`.
- `agents/a2a-executor.stream.test.ts` (new) — real-boundary suite (mocks only the model/tools/DB): multi-consumer collection, captured provider-error → `ProviderError` mapping, and context-trim recovery on the `messages` path.
- `agents/a2a-executor.test.ts` — `fullStream` added to existing mocks + empty-recovery / exhaustion cases.

## Known debt (out of scope)

`agent-run-stream.ts` imports `routes/chat/{context-trimming,errors}` — pre-existing entanglement (a2a-executor already imported `routes/chat/errors`); relocating those to a neutral home is deferred.

## Validation

`type-check` · `lint` · `knip` (dev+production) · backend tests all pass.

https://claude.ai/code/session_01WbLVwGWCYySPkxQDt92LXm

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>