### PR TITLE
docs(platform): relax test and commit rules in CLAUDE.md

### DIFF
--- a/platform/CLAUDE.md
+++ b/platform/CLAUDE.md
@@ -11,9 +11,9 @@
 1. **Use pnpm** for package management
 2. **Use Tilt for development** - `tilt up` to start the full environment
 4. **Documentation Updates** - For any feature or system changes, audit `../docs/pages` to determine if existing content needs modification/updates or if new documentation should be added. Follow the writing guidelines in `../docs/docs_writer_prompt.md`
-5. **Always Add Tests** - When working on any feature, ALWAYS add or modify appropriate test cases (unit tests, integration tests, or e2e tests under `platform/e2e-tests/tests`)
+5. **Add Tests for Behavior** - When a change alters observable behavior, add or update tests that pin that behavior (unit, integration, or e2e under `platform/e2e-tests/tests`). Favor behavior-focused tests over implementation-detail ones — skip tests that only assert wiring, prop plumbing, or incidental markup. Tests exercise real code; mock only true process boundaries (network, clock, subprocesses, externally-owned storage). Skipping tests is a judgment call to state explicitly, not a silent default
 6. **Enterprise Edition Imports** - NEVER directly import from `.ee.ts` files unless the importing file is itself an `.ee.ts` file. Use runtime conditional logic with `config.enterpriseFeatures.core` checks instead to avoid bundling enterprise code into free builds
-7. **No Auto Commits** - Never commit or push changes without explicit user approval. Always ask before running git commit or git push
+7. **Commit Freely, Push With Approval** - Committing locally as you land reviewable slices is fine. Never push, open, or update a PR without explicit user approval, and never amend commits
 8. **No Database Modifications Without Approval** - NEVER run INSERT, UPDATE, DELETE, or any data-modifying SQL queries without explicit user approval. SELECT queries for reading data are allowed. Always ask before modifying database data directly.
 9. **NEVER MENTION REAL CUSTOMER NAMES OR IDENTIFIERS ANYWHERE IN CODE, COMMENTS, TESTS, DOCS, COMMITS, OR PR TEXT!!!!!!!!!!**
 10. **Never copy anything from Sentry into code, comments, tests, docs, commits, or PR text — and do not mention Sentry itself.** Sentry is for diagnosing the problem; describe the bug in neutral terms and cite no IDs, environments, URLs, user info, or stack snippets from there.


### PR DESCRIPTION
Relax two rigid rules in `platform/CLAUDE.md` toward a judgment-first approach:

- **Add Tests for Behavior** (was *Always Add Tests*): tie tests to observable behavior changes, favor behavior-focused over implementation-detail tests, mock only true process boundaries, and treat skipping as an explicit judgment call.
- **Commit Freely, Push With Approval** (was *No Auto Commits*): allow local commits on reviewable slices; keep the approval gate on push/PR; never amend.

https://claude.ai/code/session_019THWeLzVFoTRj9dHuVikwW

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>