### PR TITLE
test(backend): de-mock DB-backed tests, drop trivial tests and comments

### DIFF
--- a/platform/backend/src/agents/a2a-executor.test.ts
+++ b/platform/backend/src/agents/a2a-executor.test.ts
@@ -1,7 +1,8 @@
 import { TOOL_LOAD_SKILL_FULL_NAME } from "@archestra/shared";
 import { NoSuchToolError } from "ai";
-import { describe, expect, test, vi } from "vitest";
+import { describe, vi } from "vitest";
 import { MIN_IMAGE_ATTACHMENT_SIZE } from "@/agents/incoming-email/constants";
+import { expect, test } from "@/test";
 import {
   type A2AAttachment,
   buildUserContent,
@@ -70,37 +71,6 @@ vi.mock("@/skills/skill-catalog-prompt", () => ({
   buildSkillCatalogPrompt: (...args: unknown[]) =>
     mockBuildSkillCatalogPrompt(...args),
 }));
-
-vi.mock("@/models", async () => {
-  const actual = await vi.importActual<typeof import("@/models")>("@/models");
-  return {
-    ...actual,
-    AgentModel: {
-      findById: vi.fn(),
-    },
-    McpServerModel: {
-      getUserPersonalServerForCatalog: vi.fn(),
-    },
-    TeamModel: {
-      getUserTeams: vi.fn(),
-    },
-    UserModel: {
-      getById: vi.fn(),
-    },
-  };
-});
-
-vi.mock("@/templating", async () => {
-  const actual =
-    await vi.importActual<typeof import("@/templating")>("@/templating");
-  return {
-    ...actual,
-    promptNeedsRendering: vi.fn(() => false),
-    renderSystemPrompt: vi.fn((prompt: string) => prompt),
-  };
-});
-
-import { AgentModel, McpServerModel } from "@/models";
 
 // Base64 string large enough to pass the MIN_IMAGE_ATTACHMENT_SIZE (2KB) filter.
 // 2732 base64 chars → ~2048 decoded bytes.
@@ -387,18 +357,21 @@ describe("buildUserContent", () => {
 });
 
 describe("executeA2AMessage model selection", () => {
-  test("uses the shared conversation selection so delegated agents inherit the organization default model", async () => {
-    vi.mocked(AgentModel.findById).mockResolvedValue({
-      id: "agent-child",
-      name: "Child Agent",
+  test("uses the shared conversation selection so delegated agents inherit the organization default model", async ({
+    makeUser,
+    makeOrganization,
+    makeMember,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id);
+    const agent = await makeAgent({
+      organizationId: org.id,
       agentType: "agent",
       systemPrompt: "Handle the task.",
-      llmApiKeyId: null,
-      modelId: null,
-    } as never);
-    vi.mocked(McpServerModel.getUserPersonalServerForCatalog).mockResolvedValue(
-      null,
-    );
+    });
+
     mockResolveConversationLlmSelectionForAgent.mockResolvedValue({
       chatApiKeyId: "org-key",
       selectedModel: "gemini-2.5-pro",
@@ -439,10 +412,10 @@ describe("executeA2AMessage model selection", () => {
     });
 
     await executeA2AMessage({
-      agentId: "agent-child",
+      agentId: agent.id,
       message: "Handle this",
-      organizationId: "org-1",
-      userId: "user-1",
+      organizationId: org.id,
+      userId: user.id,
       conversationId: "conv-1",
       parentDelegationChain: "agent-parent",
     });
@@ -452,17 +425,17 @@ describe("executeA2AMessage model selection", () => {
         llmApiKeyId: null,
         modelId: null,
       },
-      organizationId: "org-1",
-      userId: "user-1",
+      organizationId: org.id,
+      userId: user.id,
     });
     expect(mockCreateLLMModelForAgent).toHaveBeenCalledWith(
       expect.objectContaining({
-        organizationId: "org-1",
-        userId: "user-1",
-        agentId: "agent-child",
+        organizationId: org.id,
+        userId: user.id,
+        agentId: agent.id,
         model: "gemini-2.5-pro",
         provider: "gemini",
-        externalAgentId: "agent-parent:agent-child",
+        externalAgentId: `agent-parent:${agent.id}`,
       }),
     );
   });
@@ -471,17 +444,6 @@ describe("executeA2AMessage model selection", () => {
 describe("executeA2AMessage isolation scope", () => {
   function primeExecutionMocks() {
     mockGetChatMcpTools.mockClear();
-    vi.mocked(AgentModel.findById).mockResolvedValue({
-      id: "agent-child",
-      name: "Child Agent",
-      agentType: "agent",
-      systemPrompt: "Handle the task.",
-      llmApiKeyId: null,
-      modelId: null,
-    } as never);
-    vi.mocked(McpServerModel.getUserPersonalServerForCatalog).mockResolvedValue(
-      null,
-    );
     mockResolveConversationLlmSelectionForAgent.mockResolvedValue({
       chatApiKeyId: "org-key",
       selectedModel: "gemini-2.5-pro",
@@ -527,12 +489,21 @@ describe("executeA2AMessage isolation scope", () => {
     };
   }
 
-  test("headless executions never fabricate a conversation id for tools", async () => {
+  test("headless executions never fabricate a conversation id for tools", async ({
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const agent = await makeAgent({
+      organizationId: org.id,
+      agentType: "agent",
+      systemPrompt: "Handle the task.",
+    });
     primeExecutionMocks();
     await executeA2AMessage({
-      agentId: "agent-child",
+      agentId: agent.id,
       message: "Handle this",
-      organizationId: "org-1",
+      organizationId: org.id,
       userId: "user-1",
     });
 
@@ -543,12 +514,21 @@ describe("executeA2AMessage isolation scope", () => {
     expect(wiring.isolationKey).toEqual(expect.any(String));
   });
 
-  test("chat-delegated executions scope isolation by the real conversation id", async () => {
+  test("chat-delegated executions scope isolation by the real conversation id", async ({
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const agent = await makeAgent({
+      organizationId: org.id,
+      agentType: "agent",
+      systemPrompt: "Handle the task.",
+    });
     primeExecutionMocks();
     await executeA2AMessage({
-      agentId: "agent-child",
+      agentId: agent.id,
       message: "Handle this",
-      organizationId: "org-1",
+      organizationId: org.id,
       userId: "user-1",
       conversationId: "conv-1",
     });
@@ -558,12 +538,21 @@ describe("executeA2AMessage isolation scope", () => {
     expect(wiring.isolationKey).toBe("conv-1");
   });
 
-  test("headless delegation inherits the parent's isolation key", async () => {
+  test("headless delegation inherits the parent's isolation key", async ({
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const agent = await makeAgent({
+      organizationId: org.id,
+      agentType: "agent",
+      systemPrompt: "Handle the task.",
+    });
     primeExecutionMocks();
     await executeA2AMessage({
-      agentId: "agent-child",
+      agentId: agent.id,
       message: "Handle this",
-      organizationId: "org-1",
+      organizationId: org.id,
       userId: "user-1",
       isolationKey: "parent-execution-key",
     });
@@ -575,18 +564,17 @@ describe("executeA2AMessage isolation scope", () => {
 });
 
 describe("executeA2AMessage unavailable tool errors", () => {
-  test("recovers unavailable-tool stream errors instead of failing the run", async () => {
-    vi.mocked(AgentModel.findById).mockResolvedValue({
-      id: "agent-child",
-      name: "Child Agent",
+  test("recovers unavailable-tool stream errors instead of failing the run", async ({
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const agent = await makeAgent({
+      organizationId: org.id,
       agentType: "agent",
       systemPrompt: "Handle the task.",
-      llmApiKeyId: null,
-      modelId: null,
-    } as never);
-    vi.mocked(McpServerModel.getUserPersonalServerForCatalog).mockResolvedValue(
-      null,
-    );
+    });
+
     mockResolveConversationLlmSelectionForAgent.mockResolvedValue({
       chatApiKeyId: "org-key",
       selectedModel: "claude-sonnet-4-6",
@@ -630,9 +618,9 @@ describe("executeA2AMessage unavailable tool errors", () => {
     });
 
     await executeA2AMessage({
-      agentId: "agent-child",
+      agentId: agent.id,
       message: "Handle this",
-      organizationId: "org-1",
+      organizationId: org.id,
       userId: "user-1",
       conversationId: "conv-1",
     });
@@ -666,17 +654,6 @@ describe("executeA2AMessage skill catalog", () => {
   function primeMocks(tools: Record<string, unknown>) {
     mockStreamText.mockClear();
     mockBuildSkillCatalogPrompt.mockClear();
-    vi.mocked(AgentModel.findById).mockResolvedValue({
-      id: "agent-skill",
-      name: "Skill Agent",
-      agentType: "agent",
-      systemPrompt: "Handle the task.",
-      llmApiKeyId: null,
-      modelId: null,
-    } as never);
-    vi.mocked(McpServerModel.getUserPersonalServerForCatalog).mockResolvedValue(
-      null,
-    );
     mockResolveConversationLlmSelectionForAgent.mockResolvedValue({
       chatApiKeyId: "org-key",
       selectedModel: "gemini-2.5-pro",
@@ -715,7 +692,16 @@ describe("executeA2AMessage skill catalog", () => {
     });
   }
 
-  test("appends the skill catalog to the system prompt when the agent can load skills", async () => {
+  test("appends the skill catalog to the system prompt when the agent can load skills", async ({
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const agent = await makeAgent({
+      organizationId: org.id,
+      agentType: "agent",
+      systemPrompt: "Handle the task.",
+    });
     primeMocks({
       [TOOL_LOAD_SKILL_FULL_NAME]: { description: "Load" },
     });
@@ -724,31 +710,40 @@ describe("executeA2AMessage skill catalog", () => {
     );
 
     await executeA2AMessage({
-      agentId: "agent-skill",
+      agentId: agent.id,
       message: "do it",
-      organizationId: "org-1",
+      organizationId: org.id,
       userId: "user-1",
       conversationId: "conv-1",
     });
 
     expect(mockBuildSkillCatalogPrompt).toHaveBeenCalledWith({
-      organizationId: "org-1",
+      organizationId: org.id,
       userId: "user-1",
-      agentId: "agent-skill",
+      agentId: agent.id,
     });
     const system = mockStreamText.mock.calls[0]?.[0].system;
     expect(system).toContain("Handle the task.");
     expect(system).toContain("<available_skills>");
   });
 
-  test("omits the skill catalog but keeps the shared tool instructions when no skill tools are available", async () => {
+  test("omits the skill catalog but keeps the shared tool instructions when no skill tools are available", async ({
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const agent = await makeAgent({
+      organizationId: org.id,
+      agentType: "agent",
+      systemPrompt: "Handle the task.",
+    });
     primeMocks({});
     mockBuildSkillCatalogPrompt.mockResolvedValue("<available_skills>...");
 
     await executeA2AMessage({
-      agentId: "agent-skill",
+      agentId: agent.id,
       message: "do it",
-      organizationId: "org-1",
+      organizationId: org.id,
       userId: "user-1",
       conversationId: "conv-1",
     });

--- a/platform/backend/src/agents/chatops/chatops-manager.test.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.test.ts
@@ -40,10 +40,6 @@ describe("matchesAgentName", () => {
     expect(matchesAgentName("Agent  Peter", "Agent Peter")).toBe(true);
   });
 
-  test("matches with spaces in both", () => {
-    expect(matchesAgentName("Agent Peter", "Agent Peter")).toBe(true);
-  });
-
   test("returns false for partial match", () => {
     expect(matchesAgentName("Agent", "Agent Peter")).toBe(false);
   });
@@ -926,38 +922,6 @@ describe("ChatOpsManager.getAccessibleChatopsAgents personal agent filtering", (
     const manager = new ChatOpsManager();
     const agents = await manager.getAccessibleChatopsAgents({
       senderEmail: "channeluser@example.com",
-      isDm: false,
-    });
-
-    expect(agents.some((a) => a.id === orgAgent.id)).toBe(true);
-    expect(agents.some((a) => a.id === personalAgent.id)).toBe(false);
-  });
-
-  test("excludes personal agents when isDm is not specified", async ({
-    makeUser,
-    makeOrganization,
-    makeInternalAgent,
-    makeMember,
-  }) => {
-    const user = await makeUser({ email: "defaultuser@example.com" });
-    const org = await makeOrganization();
-    await makeMember(user.id, org.id, { role: "admin" });
-
-    const orgAgent = await makeInternalAgent({
-      organizationId: org.id,
-      name: "Org Agent",
-      scope: "org",
-    });
-    const personalAgent = await makeInternalAgent({
-      organizationId: org.id,
-      name: "Personal Agent",
-      scope: "personal",
-      authorId: user.id,
-    });
-
-    const manager = new ChatOpsManager();
-    const agents = await manager.getAccessibleChatopsAgents({
-      senderEmail: "defaultuser@example.com",
       isDm: false,
     });
 
@@ -2300,11 +2264,11 @@ describe("buildChatOpsSessionId", () => {
     expect(result.length).toBeLessThanOrEqual(58);
   });
 
-  test("produces same hash for same channel ID (deterministic)", () => {
+  test("hashes the same long channel ID to a stable session ID", () => {
     const longChannelId =
       "a:15T7kNVP8YbByYGI_Fpc-Ci4cqqlrOfJiumEhUcnvNEZtyranEbXyAUqrNC9jGpSyulMgLurq6nD51ASEEq7sXfK3zetvCvC_XYj37IVz-tFUihy9HjP6YdqWnMw0URwu";
-    const a = buildChatOpsSessionId("ms-teams", longChannelId);
-    const b = buildChatOpsSessionId("ms-teams", longChannelId);
-    expect(a).toBe(b);
+    expect(buildChatOpsSessionId("ms-teams", longChannelId)).toBe(
+      buildChatOpsSessionId("ms-teams", longChannelId),
+    );
   });
 });

--- a/platform/backend/src/archestra-mcp-server/index.test.ts
+++ b/platform/backend/src/archestra-mcp-server/index.test.ts
@@ -4,6 +4,7 @@ import {
   MCP_SERVER_TOOL_NAME_SEPARATOR,
   TOOL_SEARCH_TOOLS_SHORT_NAME,
 } from "@archestra/shared";
+import { z } from "zod";
 import { beforeEach, describe, expect, test } from "@/test";
 import type { Agent } from "@/types";
 import { __test, type ArchestraContext, executeArchestraTool } from ".";
@@ -111,23 +112,7 @@ describe("executeArchestraTool", () => {
 
     test("catches output schema errors in one spot", () => {
       const result = __test.validateToolResult(
-        {
-          safeParse: (value: unknown) =>
-            value && typeof value === "object" && "requiredField" in value
-              ? ({ success: true, data: value } as const)
-              : ({
-                  success: false,
-                  error: {
-                    issues: [
-                      {
-                        code: "custom",
-                        path: ["requiredField"],
-                        message: "Missing required field",
-                      },
-                    ],
-                  },
-                } as const),
-        } as any,
+        z.object({ requiredField: z.string() }),
         {
           content: [{ type: "text", text: "bad output" }],
           structuredContent: {},

--- a/platform/backend/src/archestra-mcp-server/rbac.test.ts
+++ b/platform/backend/src/archestra-mcp-server/rbac.test.ts
@@ -39,16 +39,6 @@ describe("TOOL_PERMISSIONS map", () => {
     }
   });
 
-  test("every entry has valid resource and action or is null", () => {
-    for (const [name, perm] of Object.entries(TOOL_PERMISSIONS)) {
-      if (perm === null) continue;
-      expect(perm, `${name} should have resource`).toHaveProperty("resource");
-      expect(perm, `${name} should have action`).toHaveProperty("action");
-      expect(typeof perm.resource).toBe("string");
-      expect(typeof perm.action).toBe("string");
-    }
-  });
-
   test("read_app reads and edit_app updates", () => {
     expect(TOOL_PERMISSIONS.read_app).toEqual({
       resource: "app",

--- a/platform/backend/src/archestra-mcp-server/sandbox.test.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.test.ts
@@ -41,7 +41,6 @@ import {
   executeArchestraTool,
   getArchestraMcpTools,
 } from ".";
-import { TOOL_PERMISSIONS } from "./rbac";
 
 function textOf(result: { content: unknown[] }): string {
   return (result.content[0] as any).text as string;
@@ -71,13 +70,6 @@ describe("sandbox tools (runtime disabled)", () => {
     expect(names).not.toContain(TOOL_RUN_COMMAND_FULL_NAME);
     expect(names).not.toContain(TOOL_DOWNLOAD_FILE_FULL_NAME);
     expect(names).not.toContain(TOOL_UPLOAD_FILE_FULL_NAME);
-  });
-
-  test("all sandbox tools require sandbox:execute", () => {
-    const perm = { resource: "sandbox", action: "execute" };
-    expect(TOOL_PERMISSIONS.run_command).toEqual(perm);
-    expect(TOOL_PERMISSIONS.download_file).toEqual(perm);
-    expect(TOOL_PERMISSIONS.upload_file).toEqual(perm);
   });
 
   test("run_command returns a clean error when the runtime is disabled", async ({

--- a/platform/backend/src/clients/chat-mcp-client.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.test.ts
@@ -11,7 +11,6 @@ import { jsonSchema, type Tool } from "ai";
 import { beforeEach, vi } from "vitest";
 import { archestraMcpBranding } from "@/archestra-mcp-server";
 import { TeamTokenModel } from "@/models";
-import ToolModel from "@/models/tool";
 import { resolveSessionExternalIdpToken } from "@/services/identity-providers/session-token";
 import { describe, expect, test } from "@/test";
 import { agentOwner } from "@/types";
@@ -1250,37 +1249,34 @@ describe("getChatMcpToolUiResourceUris", () => {
 
   test("returns only tools that have a UI resource URI in meta", async ({
     makeAgent,
+    makeAgentTool,
+    makeInternalMcpCatalog,
+    makeTool,
   }) => {
     const agent = await makeAgent();
+    const catalog = await makeInternalMcpCatalog();
 
-    const mockTools = [
-      {
-        id: "tool-1",
-        name: "server__get-stats",
-        description: "Get stats",
-        parameters: {},
-        meta: { _meta: { ui: { resourceUri: "resource://server/stats-ui" } } },
-      },
-      {
-        id: "tool-2",
-        name: "server__get-info",
-        description: "Get info",
-        parameters: {},
-        meta: null, // no UI
-      },
-      {
-        id: "tool-3",
-        name: "server__show-chart",
-        description: "Show chart",
-        parameters: {},
-        meta: { _meta: { ui: { resourceUri: "resource://server/chart-ui" } } },
-      },
-    ];
-
-    const spy = vi
-      .spyOn(ToolModel, "getMcpToolsByAgent")
-      // biome-ignore lint/suspicious/noExplicitAny: test mock data
-      .mockResolvedValueOnce(mockTools as any);
+    const statsTool = await makeTool({
+      name: "server__get-stats",
+      description: "Get stats",
+      catalogId: catalog.id,
+      meta: { _meta: { ui: { resourceUri: "resource://server/stats-ui" } } },
+    });
+    const infoTool = await makeTool({
+      name: "server__get-info",
+      description: "Get info",
+      catalogId: catalog.id,
+      meta: null,
+    });
+    const chartTool = await makeTool({
+      name: "server__show-chart",
+      description: "Show chart",
+      catalogId: catalog.id,
+      meta: { _meta: { ui: { resourceUri: "resource://server/chart-ui" } } },
+    });
+    await makeAgentTool(agent.id, statsTool.id);
+    await makeAgentTool(agent.id, infoTool.id);
+    await makeAgentTool(agent.id, chartTool.id);
 
     const result = await chatClient.getChatMcpToolUiResourceUris(agent.id);
 
@@ -1289,35 +1285,28 @@ describe("getChatMcpToolUiResourceUris", () => {
       "server__show-chart": "resource://server/chart-ui",
     });
     expect(result).not.toHaveProperty("server__get-info");
-
-    spy.mockRestore();
   });
 
   test("returns empty record when no tools have a UI resource URI", async ({
     makeAgent,
+    makeAgentTool,
+    makeInternalMcpCatalog,
+    makeTool,
   }) => {
     const agent = await makeAgent();
+    const catalog = await makeInternalMcpCatalog();
 
-    const mockTools = [
-      {
-        id: "tool-1",
-        name: "server__query",
-        description: "Query",
-        parameters: {},
-        meta: { annotations: { audience: ["assistant"] } }, // no _meta.ui
-      },
-    ];
-
-    const spy = vi
-      .spyOn(ToolModel, "getMcpToolsByAgent")
-      // biome-ignore lint/suspicious/noExplicitAny: test mock data
-      .mockResolvedValueOnce(mockTools as any);
+    const queryTool = await makeTool({
+      name: "server__query",
+      description: "Query",
+      catalogId: catalog.id,
+      meta: { annotations: { audience: ["assistant"] } }, // no _meta.ui
+    });
+    await makeAgentTool(agent.id, queryTool.id);
 
     const result = await chatClient.getChatMcpToolUiResourceUris(agent.id);
 
     expect(result).toEqual({});
-
-    spy.mockRestore();
   });
 });
 
@@ -1785,16 +1774,18 @@ describe("buildArchestraToolOutput", () => {
 
   test("attaches the target tool's UI resource when dispatched via run_tool", async ({
     makeAgent,
+    makeAgentTool,
+    makeInternalMcpCatalog,
+    makeTool,
   }) => {
     const agent = await makeAgent();
-    const mockToolDef = {
+    const catalog = await makeInternalMcpCatalog();
+    const targetTool = await makeTool({
       name: "excalidraw__create_view",
+      catalogId: catalog.id,
       meta: { _meta: { ui: { resourceUri: "ui://excalidraw/mcp-app.html" } } },
-    };
-    const spy = vi
-      .spyOn(ToolModel, "findByNameForAgent")
-      // biome-ignore lint/suspicious/noExplicitAny: test mock data
-      .mockResolvedValueOnce(mockToolDef as any);
+    });
+    await makeAgentTool(agent.id, targetTool.id);
 
     const result = await buildArchestraToolOutput({
       response: archestraResponse,
@@ -1806,7 +1797,6 @@ describe("buildArchestraToolOutput", () => {
       agentId: agent.id,
     });
 
-    expect(spy).toHaveBeenCalledWith("excalidraw__create_view", agent.id);
     expect(typeof result).toBe("object");
     expect(result).toMatchObject({
       content: "Diagram displayed!",
@@ -1816,18 +1806,53 @@ describe("buildArchestraToolOutput", () => {
       },
       structuredContent: { checkpoint: "abc" },
     });
+  });
 
-    spy.mockRestore();
+  test("does not attach the UI resource when the target tool is not assigned to the agent", async ({
+    makeAgent,
+    makeAgentTool,
+    makeInternalMcpCatalog,
+    makeTool,
+  }) => {
+    const owner = await makeAgent();
+    const catalog = await makeInternalMcpCatalog();
+    const targetTool = await makeTool({
+      name: "excalidraw__create_view",
+      catalogId: catalog.id,
+      meta: { _meta: { ui: { resourceUri: "ui://excalidraw/mcp-app.html" } } },
+    });
+    await makeAgentTool(owner.id, targetTool.id);
+
+    // A different agent without the tool assigned must not resolve it: the
+    // target lookup is scoped to the caller's agent, so no UI resource attaches.
+    const otherAgent = await makeAgent();
+    const result = await buildArchestraToolOutput({
+      response: archestraResponse,
+      toolName: "archestra__run_tool",
+      toolArguments: {
+        tool_name: "excalidraw__create_view",
+        tool_args: { elements: "[]" },
+      },
+      agentId: otherAgent.id,
+    });
+
+    expect(result).toBe("Diagram displayed!");
   });
 
   test("returns plain text when the dispatched target has no UI resource", async ({
     makeAgent,
+    makeAgentTool,
+    makeInternalMcpCatalog,
+    makeTool,
   }) => {
     const agent = await makeAgent();
-    const spy = vi
-      .spyOn(ToolModel, "findByNameForAgent")
-      // biome-ignore lint/suspicious/noExplicitAny: test mock data
-      .mockResolvedValueOnce({ name: "context7__search", meta: null } as any);
+    const catalog = await makeInternalMcpCatalog();
+    const targetTool = await makeTool({
+      name: "context7__search",
+      catalogId: catalog.id,
+      meta: null,
+    });
+    await makeAgentTool(agent.id, targetTool.id);
 
     const result = await buildArchestraToolOutput({
       response: archestraResponse,
@@ -1837,8 +1862,6 @@ describe("buildArchestraToolOutput", () => {
     });
 
     expect(result).toBe("Diagram displayed!");
-
-    spy.mockRestore();
   });
 });
 

--- a/platform/backend/src/clients/chat-tool-builder.ts
+++ b/platform/backend/src/clients/chat-tool-builder.ts
@@ -139,7 +139,6 @@ export function buildMcpGatewayTool(params: {
           }
 
           let toolResult: string | { content: string; [key: string]: unknown };
-          // Check if this is an Archestra tool - handle directly without DB lookup
           if (archestraMcpBranding.isToolName(mcpTool.name)) {
             logger.debug(
               {
@@ -272,7 +271,6 @@ export function buildAgentDelegationTool(params: {
     chatOpsThreadId: ctx.chatOpsThreadId,
     sessionId: ctx.sessionId,
     scheduleTriggerRunId: ctx.scheduleTriggerRunId,
-    // Pass delegation chain for tracking delegated agent calls
     delegationChain: ctx.delegationChain,
     abortSignal: ctx.abortSignal,
     tokenAuth: buildTokenAuthContext({
@@ -731,7 +729,6 @@ async function executeMcpTool(ctx: ToolExecutionContext): Promise<{
     }
   }
 
-  // Execute via mcpClient
   const toolCall = {
     id: randomUUID(),
     name: toolName,
@@ -810,7 +807,6 @@ async function executeMcpTool(ctx: ToolExecutionContext): Promise<{
     };
   }
 
-  // Sync browser state if needed
   logger.debug(
     { isolationKey, toolName, isEnabled: browserStreamFeature.isEnabled() },
     "[executeMcpTool] Checking browser sync conditions",
@@ -1324,7 +1320,6 @@ function normalizeJsonSchema(schema: unknown): JSONSchema7 {
     additionalProperties: false,
   };
 
-  // If schema is missing or invalid, return a minimal valid schema
   if (!isRecord(schema)) {
     return fallbackSchema;
   }
@@ -1360,7 +1355,6 @@ function addAdditionalPropertiesFalse(
       result.additionalProperties = false;
     }
 
-    // Recurse into properties
     if (isRecord(result.properties)) {
       const newProps: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(result.properties)) {
@@ -1372,7 +1366,6 @@ function addAdditionalPropertiesFalse(
     }
   }
 
-  // Recurse into array items
   if (result.type === "array" && isRecord(result.items)) {
     result.items = addAdditionalPropertiesFalse(result.items);
   }

--- a/platform/backend/src/routes/chat/routes.test.ts
+++ b/platform/backend/src/routes/chat/routes.test.ts
@@ -1129,33 +1129,6 @@ describe("buildChatStopConditions", () => {
 });
 
 describe("generateConversationTitle", () => {
-  it("returns generated title on success", async () => {
-    mockGenerateText.mockResolvedValueOnce({
-      text: "  Debug React Error  ",
-    });
-
-    const result = await generateConversationTitle({
-      provider: "anthropic",
-      apiKey: "test-key",
-      modelName: "claude-test",
-      baseUrl: null,
-      agentId: "title-agent-id",
-      userId: "user-id",
-      conversationId: "conversation-id",
-      systemPrompt: "Generate a title.",
-      firstUserMessage: "Help me debug this React error",
-      firstAssistantMessage: "I can help with that.",
-    });
-
-    expect(result).toBe("Debug React Error");
-    expect(mockGenerateText).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model: "mocked-model",
-        prompt: expect.stringContaining("Help me debug this React error"),
-      }),
-    );
-  });
-
   it("returns null when LLM call fails", async () => {
     mockGenerateText.mockRejectedValueOnce(new Error("API Error"));
 
@@ -1249,34 +1222,5 @@ describe("generateConversationTitle", () => {
     const callArg = mockGenerateText.mock.calls[0][0];
     expect(callArg.maxOutputTokens).toBeLessThanOrEqual(64);
     expect(callArg.maxOutputTokens).toBeGreaterThan(0);
-  });
-});
-
-describe("title generation integration", () => {
-  it("extractFirstMessages and buildTitlePrompt work together", () => {
-    const messages = [
-      {
-        role: "user",
-        parts: [{ type: "text", text: "Help me debug this error" }],
-      },
-      {
-        role: "assistant",
-        parts: [
-          {
-            type: "text",
-            text: "I can help you debug that. What error are you seeing?",
-          },
-        ],
-      },
-    ];
-
-    const { firstUserMessage, firstAssistantMessage } =
-      extractFirstMessages(messages);
-    const prompt = buildTitlePrompt(firstUserMessage, firstAssistantMessage);
-
-    expect(prompt).toContain("User: Help me debug this error");
-    expect(prompt).toContain(
-      "Assistant: I can help you debug that. What error are you seeing?",
-    );
   });
 });

--- a/platform/backend/src/routes/chatops-slash-command.test.ts
+++ b/platform/backend/src/routes/chatops-slash-command.test.ts
@@ -1,30 +1,30 @@
 import fastifyFormbody from "@fastify/formbody";
 import { vi } from "vitest";
-import { SLACK_SLASH_COMMANDS } from "@/agents/chatops/constants";
+import { ChatOpsChannelBindingModel } from "@/models";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import chatopsRoutes from "./chatops";
 
 // =============================================================================
-// Mocks — only mock what the route handler directly calls
+// Mocks — only the network seams (Slack provider I/O) and the rate-limit gate.
+// The real SlackProvider.handleSlashCommand runs against the real PGlite DB,
+// real models, and the real ensureProvisionedUser provisioning path.
 // =============================================================================
 
 const {
   getUserEmailMock,
+  getUserNameMock,
   sendReplyMock,
   sendAgentSelectionCardMock,
+  sendDirectMessageMock,
   validateWebhookRequestMock,
-  findByChannelMock,
-  findByEmailMock,
-  findByIdMock,
 } = vi.hoisted(() => ({
   getUserEmailMock: vi.fn(),
+  getUserNameMock: vi.fn(),
   sendReplyMock: vi.fn(),
   sendAgentSelectionCardMock: vi.fn(),
+  sendDirectMessageMock: vi.fn(),
   validateWebhookRequestMock: vi.fn(),
-  findByChannelMock: vi.fn(),
-  findByEmailMock: vi.fn(),
-  findByIdMock: vi.fn(),
 }));
 
 vi.mock("@/agents/chatops/chatops-manager", async () => {
@@ -44,8 +44,8 @@ vi.mock("@/agents/chatops/chatops-manager", async () => {
     sendReply: sendReplyMock,
     sendAgentSelectionCard: sendAgentSelectionCardMock,
     sendEphemeralMessage: vi.fn().mockResolvedValue(undefined),
-    sendDirectMessage: vi.fn().mockResolvedValue(undefined),
-    getUserName: vi.fn().mockResolvedValue("Test User"),
+    sendDirectMessage: sendDirectMessageMock,
+    getUserName: getUserNameMock,
     eventHandler: null,
   };
   // Bind handleSlashCommand so `this` refers to mockProvider
@@ -69,58 +69,11 @@ vi.mock("@/agents/utils", () => ({
   isRateLimited: vi.fn(() => false),
 }));
 
-const autoProvisionUserMock = vi.fn().mockResolvedValue({
-  userId: "auto-provisioned-user-id",
-  invitationId: "auto-invitation-id",
-});
-
-vi.mock("@/agents/chatops/auto-provision", () => ({
-  autoProvisionUser: (...args: unknown[]) => autoProvisionUserMock(...args),
-  ensureProvisionedUser: async (params: {
-    email: string;
-    resolveDisplayName: () => Promise<string>;
-    provider: string;
-  }) => {
-    const existing = await findByEmailMock(params.email.toLowerCase());
-    if (existing) {
-      return { user: existing, invitationId: null };
-    }
-    const { invitationId } = await autoProvisionUserMock({
-      email: params.email,
-      name: await params.resolveDisplayName(),
-      provider: params.provider,
-    });
-    const user = await findByEmailMock(params.email.toLowerCase());
-    return user ? { user, invitationId } : null;
-  },
-  isSsoConfigured: vi.fn().mockResolvedValue(false),
-  buildWelcomeMessage: vi.fn().mockReturnValue({
-    text: "Hey there 👋 We created an Archestra account for you.",
-    actionUrl:
-      "http://localhost:3000/auth/sign-up-with-invitation?invitationId=test",
-    actionLabel: "Finish Signup",
-  }),
-}));
-
-vi.mock("@/models", () => ({
-  AgentModel: { findById: findByIdMock },
-  ChatOpsChannelBindingModel: {
-    findByChannel: findByChannelMock,
-    upsertByChannel: vi.fn(),
-    findByOrganization: vi.fn(() => []),
-    deleteByIdAndOrganization: vi.fn(),
-    findByIdAndOrganization: vi.fn(),
-    update: vi.fn(),
-    updateNames: vi.fn(),
-    deleteDuplicateBindings: vi.fn(),
-  },
-  OrganizationModel: { getFirst: vi.fn(() => ({ id: "org-1" })) },
-  UserModel: { findByEmail: findByEmailMock },
-}));
-
 // =============================================================================
 // Helpers
 // =============================================================================
+
+const REGISTERED_EMAIL = "user@test.com";
 
 function makeSlashCommandBody(
   command: string,
@@ -166,25 +119,25 @@ async function injectSlashCommand(
 
 describe("POST /api/webhooks/chatops/slack/slash-command", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     validateWebhookRequestMock.mockResolvedValue(true);
-    getUserEmailMock.mockResolvedValue("user@test.com");
-    findByEmailMock.mockResolvedValue({ id: "user-1", email: "user@test.com" });
-    findByChannelMock.mockResolvedValue(null);
-    findByIdMock.mockResolvedValue({ id: "agent-1", name: "Test Agent" });
+    getUserEmailMock.mockResolvedValue(REGISTERED_EMAIL);
+    getUserNameMock.mockResolvedValue("Test User");
+    sendDirectMessageMock.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  test("SLACK_SLASH_COMMANDS has expected command names", () => {
-    expect(SLACK_SLASH_COMMANDS.SELECT_AGENT).toBe("/archestra-select-agent");
-    expect(SLACK_SLASH_COMMANDS.STATUS).toBe("/archestra-status");
-    expect(SLACK_SLASH_COMMANDS.HELP).toBe("/archestra-help");
-  });
+  test("/archestra-help returns ephemeral help message", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser({ email: REGISTERED_EMAIL });
+    await makeMember(user.id, org.id);
 
-  test("/archestra-help returns ephemeral help message", async () => {
     const app = await createApp();
 
     const response = await injectSlashCommand(app, "/archestra-help");
@@ -199,7 +152,15 @@ describe("POST /api/webhooks/chatops/slack/slash-command", () => {
     await app.close();
   });
 
-  test("slugified app-name slash commands are accepted", async () => {
+  test("slugified app-name slash commands are accepted", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser({ email: REGISTERED_EMAIL });
+    await makeMember(user.id, org.id);
+
     const app = await createApp();
 
     const response = await injectSlashCommand(app, "/archestra-staging-help");
@@ -214,7 +175,15 @@ describe("POST /api/webhooks/chatops/slack/slash-command", () => {
     await app.close();
   });
 
-  test("/archestra-status returns ephemeral status when no binding", async () => {
+  test("/archestra-status returns ephemeral status when no binding", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser({ email: REGISTERED_EMAIL });
+    await makeMember(user.id, org.id);
+
     const app = await createApp();
 
     const response = await injectSlashCommand(app, "/archestra-status");
@@ -227,18 +196,25 @@ describe("POST /api/webhooks/chatops/slack/slash-command", () => {
     await app.close();
   });
 
-  test("/archestra-status returns agent name when binding exists", async () => {
-    findByChannelMock.mockResolvedValueOnce({
-      id: "binding-1",
-      organizationId: "org-1",
+  test("/archestra-status returns agent name when binding exists", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser({ email: REGISTERED_EMAIL });
+    await makeMember(user.id, org.id);
+    const agent = await makeAgent({
+      organizationId: org.id,
+      name: "Test Agent",
+    });
+    await ChatOpsChannelBindingModel.create({
+      organizationId: org.id,
       provider: "slack",
       channelId: "C12345",
       workspaceId: "T12345",
-      agentId: "agent-1",
-      channelName: null,
-      workspaceName: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
+      agentId: agent.id,
     });
 
     const app = await createApp();
@@ -267,7 +243,15 @@ describe("POST /api/webhooks/chatops/slack/slash-command", () => {
     await app.close();
   });
 
-  test("unknown command returns ephemeral error", async () => {
+  test("unknown command returns ephemeral error", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser({ email: REGISTERED_EMAIL });
+    await makeMember(user.id, org.id);
+
     const app = await createApp();
 
     const response = await injectSlashCommand(app, "/archestra-unknown");
@@ -280,11 +264,13 @@ describe("POST /api/webhooks/chatops/slack/slash-command", () => {
     await app.close();
   });
 
-  test("unregistered user is auto-provisioned and can use commands", async () => {
-    // First call returns undefined (user not found), second returns auto-provisioned user
-    findByEmailMock
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce({ id: "auto-user-id", email: "test@example.com" });
+  test("unregistered user is auto-provisioned and can use commands", async ({
+    makeOrganization,
+  }) => {
+    // Org exists but the sender has no user/member row yet — the real
+    // ensureProvisionedUser must create them so the command succeeds.
+    const org = await makeOrganization();
+    getUserEmailMock.mockResolvedValue("newcomer@example.com");
 
     const app = await createApp();
 
@@ -295,12 +281,21 @@ describe("POST /api/webhooks/chatops/slack/slash-command", () => {
     expect(json.response_type).toBe("ephemeral");
     // Should get the help text, not a rejection
     expect(json.text).toContain("Available commands");
-    expect(autoProvisionUserMock).toHaveBeenCalled();
+
+    // The provisioning path created a real user + member in the org.
+    const { UserModel, MemberModel } = await import("@/models");
+    const provisioned = await UserModel.findByEmail("newcomer@example.com");
+    if (!provisioned) throw new Error("expected a provisioned user");
+    const membership = await MemberModel.getByUserId(provisioned.id, org.id);
+    expect(membership).toBeDefined();
 
     await app.close();
   });
 
-  test("unresolvable email gets ephemeral rejection", async () => {
+  test("unresolvable email gets ephemeral rejection", async ({
+    makeOrganization,
+  }) => {
+    await makeOrganization();
     getUserEmailMock.mockResolvedValueOnce(null);
 
     const app = await createApp();

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
@@ -112,12 +112,8 @@ describe("toSpanUserInfo", () => {
     });
   });
 
-  test("returns null for null input", () => {
-    expect(toSpanUserInfo(null)).toBeNull();
-  });
-
-  test("returns null for undefined input", () => {
-    expect(toSpanUserInfo(undefined)).toBeNull();
+  test.each([null, undefined])("returns null for %s input", (input) => {
+    expect(toSpanUserInfo(input)).toBeNull();
   });
 });
 
@@ -379,17 +375,11 @@ describe("buildInteractionRecord", () => {
     expect(record.toonCostSavings).toBe("0.0001200000");
   });
 
-  test("includes source when provided", () => {
-    const record = buildInteractionRecord({
-      ...baseParams,
-      source: "chatops:slack",
-    });
-    expect(record.source).toBe("chatops:slack");
-  });
-
-  test("source is undefined when not provided", () => {
-    const record = buildInteractionRecord(baseParams);
-    expect(record.source).toBeUndefined();
+  test("passes source through when provided, undefined otherwise", () => {
+    expect(
+      buildInteractionRecord({ ...baseParams, source: "chatops:slack" }).source,
+    ).toBe("chatops:slack");
+    expect(buildInteractionRecord(baseParams).source).toBeUndefined();
   });
 });
 

--- a/platform/backend/src/server.test.ts
+++ b/platform/backend/src/server.test.ts
@@ -26,7 +26,6 @@ vi.mock("@sentry/node", async (importOriginal) => {
 
 import config from "@/config";
 // Import after mock setup
-import { isDatabaseHealthy } from "@/database";
 import healthRoutes from "@/routes/health";
 import { createFastifyInstance } from "./server";
 
@@ -38,150 +37,29 @@ const _processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
 
 describe("createFastifyInstance", () => {
   describe("error handling", () => {
-    test("handles ApiError with 400 status code", async () => {
+    test.each([
+      [400, "Validation failed", "api_validation_error"],
+      [401, "Unauthenticated", "api_authentication_error"],
+      [403, "Forbidden", "api_authorization_error"],
+      [404, "Not found", "api_not_found_error"],
+      [500, "Internal server error", "api_internal_server_error"],
+      [409, "Resource conflict", "api_conflict_error"],
+      [418, "I'm a teapot", "unknown_api_error"],
+    ])("maps ApiError %i to its error type", async (statusCode, message, type) => {
       const app = createFastifyInstance();
 
-      app.get("/test-400", async () => {
-        throw new ApiError(400, "Validation failed");
+      app.get(`/test-${statusCode}`, async () => {
+        throw new ApiError(statusCode, message);
       });
 
       const response = await app.inject({
         method: "GET",
-        url: "/test-400",
+        url: `/test-${statusCode}`,
       });
 
-      expect(response.statusCode).toBe(400);
+      expect(response.statusCode).toBe(statusCode);
       expect(response.json()).toEqual({
-        error: {
-          message: "Validation failed",
-          type: "api_validation_error",
-        },
-      });
-    });
-
-    test("handles ApiError with 401 status code", async () => {
-      const app = createFastifyInstance();
-
-      app.get("/test-401", async () => {
-        throw new ApiError(401, "Unauthenticated");
-      });
-
-      const response = await app.inject({
-        method: "GET",
-        url: "/test-401",
-      });
-
-      expect(response.statusCode).toBe(401);
-      expect(response.json()).toEqual({
-        error: {
-          message: "Unauthenticated",
-          type: "api_authentication_error",
-        },
-      });
-    });
-
-    test("handles ApiError with 403 status code", async () => {
-      const app = createFastifyInstance();
-
-      app.get("/test-403", async () => {
-        throw new ApiError(403, "Forbidden");
-      });
-
-      const response = await app.inject({
-        method: "GET",
-        url: "/test-403",
-      });
-
-      expect(response.statusCode).toBe(403);
-      expect(response.json()).toEqual({
-        error: {
-          message: "Forbidden",
-          type: "api_authorization_error",
-        },
-      });
-    });
-
-    test("handles ApiError with 404 status code", async () => {
-      const app = createFastifyInstance();
-
-      app.get("/test-404", async () => {
-        throw new ApiError(404, "Not found");
-      });
-
-      const response = await app.inject({
-        method: "GET",
-        url: "/test-404",
-      });
-
-      expect(response.statusCode).toBe(404);
-      expect(response.json()).toEqual({
-        error: {
-          message: "Not found",
-          type: "api_not_found_error",
-        },
-      });
-    });
-
-    test("handles ApiError with 500 status code", async () => {
-      const app = createFastifyInstance();
-
-      app.get("/test-500", async () => {
-        throw new ApiError(500, "Internal server error");
-      });
-
-      const response = await app.inject({
-        method: "GET",
-        url: "/test-500",
-      });
-
-      expect(response.statusCode).toBe(500);
-      expect(response.json()).toEqual({
-        error: {
-          message: "Internal server error",
-          type: "api_internal_server_error",
-        },
-      });
-    });
-
-    test("handles ApiError with 409 status code", async () => {
-      const app = createFastifyInstance();
-
-      app.get("/test-409", async () => {
-        throw new ApiError(409, "Resource conflict");
-      });
-
-      const response = await app.inject({
-        method: "GET",
-        url: "/test-409",
-      });
-
-      expect(response.statusCode).toBe(409);
-      expect(response.json()).toEqual({
-        error: {
-          message: "Resource conflict",
-          type: "api_conflict_error",
-        },
-      });
-    });
-
-    test("handles ApiError with unknown status code", async () => {
-      const app = createFastifyInstance();
-
-      app.get("/test-unknown", async () => {
-        throw new ApiError(418, "I'm a teapot");
-      });
-
-      const response = await app.inject({
-        method: "GET",
-        url: "/test-unknown",
-      });
-
-      expect(response.statusCode).toBe(418);
-      expect(response.json()).toEqual({
-        error: {
-          message: "I'm a teapot",
-          type: "unknown_api_error",
-        },
+        error: { message, type },
       });
     });
 
@@ -727,14 +605,6 @@ describe("createFastifyInstance", () => {
         query: "value",
       });
     });
-  });
-});
-
-describe("isDatabaseHealthy", () => {
-  test("returns true when database is reachable", async () => {
-    // Using PGlite in tests, the database should be healthy
-    const result = await isDatabaseHealthy();
-    expect(result).toBe(true);
   });
 });
 

--- a/platform/shared/archestra-mcp-server.test.ts
+++ b/platform/shared/archestra-mcp-server.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, expectTypeOf, test } from "vitest";
 import { AGENT_TOOL_PREFIX, isAgentTool } from "./agents";
 import {
-  ARCHESTRA_TOOL_SHORT_NAMES,
   getArchestraMcpServerName,
   getArchestraToolFullName,
   getArchestraToolPrefix,
@@ -12,20 +11,9 @@ import {
 } from "./archestra-mcp-server";
 
 describe("archestra MCP tool names", () => {
-  test("contains the shared special tool short names", () => {
-    expect(ARCHESTRA_TOOL_SHORT_NAMES).toContain("create_agent");
-    expect(ARCHESTRA_TOOL_SHORT_NAMES).toContain("swap_agent");
-    expect(ARCHESTRA_TOOL_SHORT_NAMES).toContain("artifact_write");
-  });
-
-  test("builds a fully-qualified Archestra tool name", () => {
-    expect(getArchestraToolFullName("create_agent")).toBe(
-      TOOL_CREATE_AGENT_FULL_NAME,
-    );
-  });
-
-  test("preserves literal full-name typing", () => {
+  test("builds a fully-qualified Archestra tool name with literal typing", () => {
     const fullName = getArchestraToolFullName("create_agent");
+    expect(fullName).toBe(TOOL_CREATE_AGENT_FULL_NAME);
     expectTypeOf(fullName).toEqualTypeOf<typeof TOOL_CREATE_AGENT_FULL_NAME>();
   });
 


### PR DESCRIPTION
Removes over-mocked tests and trivial tests/comments across recently-touched backend code. Test-only except 7 comment deletions in `chat-tool-builder.ts`. Net **−319 lines**.

## De-mock (real PGlite instead of stubbed `@/models`)
- `a2a-executor.test.ts` — drop `vi.mock("@/models")`; seed real agents/orgs; keep LLM/MCP-network boundary mocks.
- `chatops-slash-command.test.ts` — drop `vi.mock("@/models")` + `vi.mock("auto-provision")`; auto-provisioning now asserts a real user + member row.
- `chat-mcp-client.test.ts` — `vi.spyOn(ToolModel)` stubs → `makeTool` fixtures; adds a real-data test pinning the run_tool target lookup to the caller's agent.
- `index.test.ts` — hand-rolled `safeParse` fake → real Zod schema.

## Trivial / duplicate deletes (surviving coverage cited inline)
sandbox constant-echo, rbac type-restate, shared constant-membership, chatops-manager duplicate + degenerate normalizer case, chat/routes title duplicate + helper-composition test, server mock-echo health probe.

## Consolidations (no coverage lost)
server ApiError table → `test.each`; llm-proxy null/undefined and source tests merged.

## Comments
7 next-line-restating comments removed from `chat-tool-builder.ts`.

## Validation
`pnpm vitest run` green for all touched files · biome clean · type-check clean (backend + shared) · knip clean.

https://claude.ai/code/session_014dwwY2JyJKz7yz33qoGPpK