### PR TITLE
feat(frontend): rename Triggers to Messaging Channels in sidebar

### DIFF
--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -638,6 +638,9 @@ export function AppSidebar() {
         items: group.items
           .filter((item) => {
             if (item.title === "Connect" && !showConnect) return false;
+            // Skills are gated behind the ARCHESTRA_AGENTS_SKILLS_ENABLED env
+            // var. It's a top-level item now, so gate it here (not in subItems).
+            if (item.url === "/agents/skills" && !skillsEnabled) return false;
             return true;
           })
           .map((item) =>
@@ -645,7 +648,6 @@ export function AppSidebar() {
               ? {
                   ...item,
                   subItems: item.subItems.filter((sub) => {
-                    if (sub.url === "/agents/skills") return skillsEnabled;
                     // With projects on, schedules are managed per-project on the
                     // project detail page, so the standalone entry is hidden.
                     if (sub.url === "/scheduled-tasks") return !projectsEnabled;

--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -17,6 +17,7 @@ import {
   FolderKanban,
   FolderOpen,
   Github,
+  Inbox,
   type LucideIcon,
   MessageCircle,
   MessagesSquare,
@@ -25,6 +26,7 @@ import {
   PencilRuler,
   Route,
   Slack,
+  Sparkles,
   Star,
 } from "lucide-react";
 import Link from "next/link";
@@ -213,24 +215,26 @@ const contentNavGroups: NavGroup[] = [
           !pathname.startsWith("/agents/skills"),
         subItems: [
           {
-            title: "Skills",
-            url: "/agents/skills",
-            customIsActive: (pathname: string) =>
-              pathname.startsWith("/agents/skills"),
-          },
-          {
-            title: "Scheduled",
+            title: "Scheduled Tasks",
             url: "/scheduled-tasks",
             customIsActive: (pathname: string) =>
               pathname.startsWith("/scheduled-tasks"),
           },
-          {
-            title: "Triggers",
-            url: "/agents/triggers",
-            customIsActive: (pathname: string) =>
-              pathname.startsWith("/agents/triggers"),
-          },
         ],
+      },
+      {
+        title: "Skills",
+        url: "/agents/skills",
+        icon: Sparkles,
+        customIsActive: (pathname: string) =>
+          pathname.startsWith("/agents/skills"),
+      },
+      {
+        title: "Messaging Channels",
+        url: "/agents/triggers",
+        icon: Inbox,
+        customIsActive: (pathname: string) =>
+          pathname.startsWith("/agents/triggers"),
       },
     ],
   },

--- a/platform/frontend/src/app/agents/triggers/layout.tsx
+++ b/platform/frontend/src/app/agents/triggers/layout.tsx
@@ -105,8 +105,8 @@ export default function AgentTriggersLayout({
 
   return (
     <PageLayout
-      title="Triggers"
-      description="Manage how agents are invoked through schedules and messaging channels"
+      title="Messaging Channels"
+      description="Manage how agents are invoked through Slack, Microsoft Teams, email, and A2A"
       tabs={tabs}
     >
       {children}


### PR DESCRIPTION
## Summary

Tidy up the agent sidebar navigation and clarify the "Triggers" concept.

- Rename the **Triggers** sidebar item and its page header to **Messaging Channels** (its tabs are Slack, MS Teams, email, and A2A); tighten the page description to match.
- Promote **Skills** and **Messaging Channels** from sub-items of *Agents* to top-level sidebar rows (top-level items require an icon — `Sparkles` for Skills, `Inbox` for Messaging Channels).
- Rename the **Scheduled** sidebar item to **Scheduled Tasks**, matching its existing page header.

## Sidebar structure

Before:
```
Agents
  ├─ Skills
  ├─ Scheduled
  └─ Triggers
```

After:
```
Agents
  └─ Scheduled Tasks
Skills
Messaging Channels
```

## Notes

- Labels-only: routes are unchanged (`/agents/triggers`, `/agents/skills`, `/scheduled-tasks`), so no redirects are needed.
- No tests added — this is a pure navigation copy/structure change with no behavior change (an explicit judgment call per `platform/CLAUDE.md`).
- Icons (`Sparkles` / `Inbox`) are easy to swap if a different choice is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>