### PR TITLE
fix(chat): stop header title render loop during typing animation

### DIFF
--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -1889,31 +1889,36 @@ export function ChatPageContent({
                 {/* Left side - conversation title */}
                 {conversationId && conversation && (
                   <div className="flex items-center flex-shrink min-w-0">
-                    <TruncatedTooltip
-                      content={getConversationDisplayTitle(
-                        conversation.title,
-                        conversation.messages,
-                      )}
-                    >
+                    {/* Skip TruncatedTooltip while the title animates: its
+                        resize measurement re-renders on every TypingText tick,
+                        which loops past React's nested-update cap. */}
+                    {headerAnimatingTitles.has(conversation.id) ? (
                       <h1 className="text-base font-normal text-muted-foreground truncate max-w-[360px] cursor-default">
-                        {headerAnimatingTitles.has(conversation.id) ? (
-                          <TypingText
-                            text={getConversationDisplayTitle(
-                              conversation.title,
-                              conversation.messages,
-                            )}
-                            typingSpeed={35}
-                            showCursor
-                            cursorClassName="bg-muted-foreground"
-                          />
-                        ) : (
-                          getConversationDisplayTitle(
+                        <TypingText
+                          text={getConversationDisplayTitle(
                             conversation.title,
                             conversation.messages,
-                          )
-                        )}
+                          )}
+                          typingSpeed={35}
+                          showCursor
+                          cursorClassName="bg-muted-foreground"
+                        />
                       </h1>
-                    </TruncatedTooltip>
+                    ) : (
+                      <TruncatedTooltip
+                        content={getConversationDisplayTitle(
+                          conversation.title,
+                          conversation.messages,
+                        )}
+                      >
+                        <h1 className="text-base font-normal text-muted-foreground truncate max-w-[360px] cursor-default">
+                          {getConversationDisplayTitle(
+                            conversation.title,
+                            conversation.messages,
+                          )}
+                        </h1>
+                      </TruncatedTooltip>
+                    )}
                   </div>
                 )}
                 {/* Right side - desktop: panel toggle */}


### PR DESCRIPTION
## Problem

Runtime `Maximum update depth exceeded` from the chat header `<h1>`. Intermittent — a cold reload does not reproduce it.

## Root cause

The header nested the live, per-character-resizing `TypingText` *inside* the Radix `TruncatedTooltip` trigger. That branch only renders during the ~3s `headerAnimatingTitles` window after a title is auto-generated. While the trigger content grows every 35ms, the tooltip's resize measurement re-renders on every tick, looping past React's nested-update cap. Stable (non-animating) titles never loop.

## Fix

Make the two cases mutually exclusive: render the animating title as a bare truncating `<h1>` (no tooltip), and keep `TruncatedTooltip` only for the static title. A comment marks why the tooltip is excluded during animation so it isn't re-added.

## Notes

- Sidebar already renders `TypingText` outside a tooltip, so no change there.
- Reviewed by Codex (approve with nits); the comment nit is applied. Memoizing the title helper is pre-existing and left out of scope.

## Test

No unit test added: the loop relies on Radix's resize-observer measurement, which doesn't fire under jsdom, so it can't be reproduced deterministically there. Verify by triggering a title (re)generation so the 3s animation runs and confirming no loop.

https://claude.ai/code/session_019bvU47esxRFHiwAY79G6Dv

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>