### PR TITLE
fix: scope pending signup cleanup

### DIFF
--- a/platform/backend/src/models/invitation.ts
+++ b/platform/backend/src/models/invitation.ts
@@ -1,6 +1,9 @@
-import { MEMBER_ROLE_NAME } from "@archestra/shared";
-import { and, eq } from "drizzle-orm";
-import db, { schema } from "@/database";
+import {
+  AUTO_PROVISIONED_INVITATION_STATUS,
+  MEMBER_ROLE_NAME,
+} from "@archestra/shared";
+import { and, eq, inArray, like } from "drizzle-orm";
+import db, { schema, type Transaction } from "@/database";
 import logger from "@/logging";
 import type {
   BetterAuthSession,
@@ -68,6 +71,84 @@ class InvitationModel {
       "InvitationModel.findPendingByEmail: completed",
     );
     return pending;
+  }
+
+  static async findAutoProvisionedByEmailsInOrg(params: {
+    emails: string[];
+    organizationId: string;
+    tx?: Transaction;
+  }) {
+    const uniqueEmails = [...new Set(params.emails)];
+    if (uniqueEmails.length === 0) return [];
+
+    logger.debug(
+      {
+        organizationId: params.organizationId,
+        emailCount: uniqueEmails.length,
+      },
+      "InvitationModel.findAutoProvisionedByEmailsInOrg: fetching invitations",
+    );
+
+    const dbOrTx = params.tx ?? db;
+    const invitations = await dbOrTx
+      .select({
+        id: schema.invitationsTable.id,
+        email: schema.invitationsTable.email,
+        status: schema.invitationsTable.status,
+      })
+      .from(schema.invitationsTable)
+      .where(
+        and(
+          eq(schema.invitationsTable.organizationId, params.organizationId),
+          inArray(schema.invitationsTable.email, uniqueEmails),
+          like(
+            schema.invitationsTable.status,
+            `${AUTO_PROVISIONED_INVITATION_STATUS}%`,
+          ),
+        ),
+      );
+
+    logger.debug(
+      { organizationId: params.organizationId, count: invitations.length },
+      "InvitationModel.findAutoProvisionedByEmailsInOrg: completed",
+    );
+    return invitations;
+  }
+
+  static async deleteAutoProvisionedForEmailInOrg(params: {
+    email: string;
+    organizationId: string;
+    tx?: Transaction;
+  }): Promise<number> {
+    logger.debug(
+      { email: params.email, organizationId: params.organizationId },
+      "InvitationModel.deleteAutoProvisionedForEmailInOrg: deleting invitations",
+    );
+
+    const dbOrTx = params.tx ?? db;
+    const deleted = await dbOrTx
+      .delete(schema.invitationsTable)
+      .where(
+        and(
+          eq(schema.invitationsTable.email, params.email),
+          eq(schema.invitationsTable.organizationId, params.organizationId),
+          like(
+            schema.invitationsTable.status,
+            `${AUTO_PROVISIONED_INVITATION_STATUS}%`,
+          ),
+        ),
+      )
+      .returning({ id: schema.invitationsTable.id });
+
+    logger.debug(
+      {
+        email: params.email,
+        organizationId: params.organizationId,
+        count: deleted.length,
+      },
+      "InvitationModel.deleteAutoProvisionedForEmailInOrg: completed",
+    );
+    return deleted.length;
   }
 
   /**

--- a/platform/backend/src/models/member.ts
+++ b/platform/backend/src/models/member.ts
@@ -1,5 +1,5 @@
 import type { AnyRoleName } from "@archestra/shared";
-import { and, count, eq, ilike, inArray, or } from "drizzle-orm";
+import { and, count, eq, ilike, inArray, isNull, or } from "drizzle-orm";
 import db, { schema, type Transaction } from "@/database";
 import { createPaginatedResult } from "@/database/utils/pagination";
 import logger from "@/logging";
@@ -59,8 +59,13 @@ class MemberModel {
    * the original membership is always older than any later duplicate created
    * (e.g. by an auto-accepted invitation), so it wins.
    */
-  static async getByUserId(userId: string, organizationId: string) {
-    const [member] = await db
+  static async getByUserId(
+    userId: string,
+    organizationId: string,
+    tx?: Transaction,
+  ) {
+    const dbOrTx = tx ?? db;
+    const [member] = await dbOrTx
       .select()
       .from(schema.membersTable)
       .where(
@@ -72,6 +77,36 @@ class MemberModel {
       .orderBy(schema.membersTable.createdAt, schema.membersTable.id)
       .limit(1);
     return member;
+  }
+
+  static async listMembersWithoutAccounts(
+    organizationId: string,
+    tx?: Transaction,
+  ) {
+    const dbOrTx = tx ?? db;
+    return await dbOrTx
+      .select({
+        id: schema.usersTable.id,
+        email: schema.usersTable.email,
+        name: schema.usersTable.name,
+        image: schema.usersTable.image,
+        role: schema.membersTable.role,
+      })
+      .from(schema.membersTable)
+      .innerJoin(
+        schema.usersTable,
+        eq(schema.membersTable.userId, schema.usersTable.id),
+      )
+      .leftJoin(
+        schema.accountsTable,
+        eq(schema.accountsTable.userId, schema.usersTable.id),
+      )
+      .where(
+        and(
+          eq(schema.membersTable.organizationId, organizationId),
+          isNull(schema.accountsTable.id),
+        ),
+      );
   }
 
   /**

--- a/platform/backend/src/models/user-token.ts
+++ b/platform/backend/src/models/user-token.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto";
 import { ARCHESTRA_TOKEN_PREFIX } from "@archestra/shared";
 import { and, eq } from "drizzle-orm";
-import db, { schema } from "@/database";
+import db, { schema, type Transaction } from "@/database";
 import logger from "@/logging";
 import { secretManager } from "@/secrets-manager";
 import type { SelectUserToken } from "@/types";
@@ -108,8 +108,12 @@ class UserTokenModel {
   /**
    * Find a token by ID
    */
-  static async findById(id: string): Promise<SelectUserToken | null> {
-    const [token] = await db
+  static async findById(
+    id: string,
+    tx?: Transaction,
+  ): Promise<SelectUserToken | null> {
+    const dbOrTx = tx ?? db;
+    const [token] = await dbOrTx
       .select()
       .from(schema.userTokensTable)
       .where(eq(schema.userTokensTable.id, id))
@@ -124,8 +128,10 @@ class UserTokenModel {
   static async findByUserAndOrg(
     userId: string,
     organizationId: string,
+    tx?: Transaction,
   ): Promise<SelectUserToken | null> {
-    const [token] = await db
+    const dbOrTx = tx ?? db;
+    const [token] = await dbOrTx
       .select()
       .from(schema.userTokensTable)
       .where(
@@ -164,7 +170,7 @@ class UserTokenModel {
       .where(eq(schema.userTokensTable.id, id));
 
     // Also delete the secret explicitly
-    await secretManager().deleteSecret(token.secretId);
+    await UserTokenModel.deleteSecret(token.secretId);
 
     logger.info({ tokenId: id }, "UserTokenModel.delete: token deleted");
 
@@ -182,6 +188,29 @@ class UserTokenModel {
     if (!token) return false;
 
     return UserTokenModel.delete(token.id);
+  }
+
+  static async deleteRecordByUserAndOrg(
+    userId: string,
+    organizationId: string,
+    tx: Transaction,
+  ): Promise<SelectUserToken | null> {
+    const token = await UserTokenModel.findByUserAndOrg(
+      userId,
+      organizationId,
+      tx,
+    );
+    if (!token) return null;
+
+    await tx
+      .delete(schema.userTokensTable)
+      .where(eq(schema.userTokensTable.id, token.id));
+
+    return token;
+  }
+
+  static async deleteSecret(secretId: string): Promise<void> {
+    await secretManager().deleteSecret(secretId);
   }
 
   /**

--- a/platform/backend/src/models/user.ts
+++ b/platform/backend/src/models/user.ts
@@ -75,9 +75,10 @@ class UserModel {
   /**
    * Get a user by ID with their organization membership
    */
-  static async getById(id: string) {
+  static async getById(id: string, tx?: Transaction) {
     logger.trace("UserModel.getById: fetching user");
-    const [user] = await db
+    const dbOrTx = tx ?? db;
+    const [user] = await dbOrTx
       .select({
         ...getTableColumns(schema.usersTable),
         organizationId: schema.membersTable.organizationId,

--- a/platform/backend/src/routes/organization-pending-signup.test.ts
+++ b/platform/backend/src/routes/organization-pending-signup.test.ts
@@ -1,0 +1,211 @@
+import { AUTO_PROVISIONED_INVITATION_STATUS } from "@archestra/shared";
+import InvitationModel from "@/models/invitation";
+import MemberModel from "@/models/member";
+import UserModel from "@/models/user";
+import UserTokenModel from "@/models/user-token";
+import { secretManager } from "@/secrets-manager";
+import type { FastifyInstanceWithZod } from "@/server";
+import { createFastifyInstance } from "@/server";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import type { User } from "@/types";
+
+describe("organization pending signup routes", () => {
+  let app: FastifyInstanceWithZod;
+  let user: User;
+  let organizationId: string;
+
+  beforeEach(
+    async ({ makeAccount, makeAdmin, makeMember, makeOrganization }) => {
+      user = await makeAdmin();
+      await makeAccount(user.id);
+      const organization = await makeOrganization();
+      organizationId = organization.id;
+      await makeMember(user.id, organizationId, { role: "admin" });
+
+      app = createFastifyInstance();
+      app.addHook("onRequest", async (request) => {
+        (request as typeof request & { user: unknown }).user = user;
+        (
+          request as typeof request & { organizationId: string }
+        ).organizationId = organizationId;
+      });
+
+      const { default: organizationRoutes } = await import("./organization");
+      await app.register(organizationRoutes);
+    },
+  );
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  test("signup status uses auto-provisioned invitation metadata from the current organization", async ({
+    makeInvitation,
+    makeMember,
+    makeOrganization,
+    makeUser,
+  }) => {
+    const otherOrganization = await makeOrganization();
+    const pendingUser = await makeUser({
+      email: "pending-status@example.com",
+      emailVerified: false,
+    });
+    await makeMember(pendingUser.id, organizationId, { role: "member" });
+
+    const currentOrgInvitation = await makeInvitation(organizationId, user.id, {
+      email: pendingUser.email,
+      status: `${AUTO_PROVISIONED_INVITATION_STATUS}:slack`,
+    });
+    await makeInvitation(otherOrganization.id, user.id, {
+      email: pendingUser.email,
+      status: `${AUTO_PROVISIONED_INVITATION_STATUS}:ms-teams`,
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/organization/members/signup-status",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().pendingSignupMembers).toEqual([
+      expect.objectContaining({
+        userId: pendingUser.id,
+        provider: "slack",
+        invitationId: currentOrgInvitation.id,
+      }),
+    ]);
+  });
+
+  test("deleting a pending signup member only cleans up the current organization", async ({
+    makeInvitation,
+    makeMember,
+    makeOrganization,
+    makeUser,
+  }) => {
+    const otherOrganization = await makeOrganization();
+    const pendingUser = await makeUser({
+      email: "pending-delete@example.com",
+      emailVerified: false,
+    });
+    await makeMember(pendingUser.id, organizationId, { role: "member" });
+    await makeMember(pendingUser.id, otherOrganization.id, { role: "member" });
+
+    const currentOrgInvitation = await makeInvitation(organizationId, user.id, {
+      email: pendingUser.email,
+      status: `${AUTO_PROVISIONED_INVITATION_STATUS}:slack`,
+    });
+    const otherOrgInvitation = await makeInvitation(
+      otherOrganization.id,
+      user.id,
+      {
+        email: pendingUser.email,
+        status: `${AUTO_PROVISIONED_INVITATION_STATUS}:ms-teams`,
+      },
+    );
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: `/api/organization/members/${pendingUser.id}/pending-signup`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(
+      await InvitationModel.getById(currentOrgInvitation.id),
+    ).toBeUndefined();
+    expect(await InvitationModel.getById(otherOrgInvitation.id)).toBeDefined();
+    expect(
+      await MemberModel.getByUserId(pendingUser.id, organizationId),
+    ).toBeUndefined();
+    expect(
+      await MemberModel.getByUserId(pendingUser.id, otherOrganization.id),
+    ).toBeDefined();
+    expect(await UserModel.getById(pendingUser.id)).toBeDefined();
+  });
+
+  test("deleting a pending signup member without other memberships deletes the user and token secret", async ({
+    makeInvitation,
+    makeMember,
+    makeUser,
+  }) => {
+    const pendingUser = await makeUser({
+      email: "pending-delete-only-org@example.com",
+      emailVerified: false,
+    });
+    await makeMember(pendingUser.id, organizationId, { role: "member" });
+
+    const invitation = await makeInvitation(organizationId, user.id, {
+      email: pendingUser.email,
+      status: `${AUTO_PROVISIONED_INVITATION_STATUS}:slack`,
+    });
+    const { token } = await UserTokenModel.create(
+      pendingUser.id,
+      organizationId,
+    );
+    expect(await secretManager().getSecret(token.secretId)).not.toBeNull();
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: `/api/organization/members/${pendingUser.id}/pending-signup`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(await InvitationModel.getById(invitation.id)).toBeUndefined();
+    expect(
+      await MemberModel.getByUserId(pendingUser.id, organizationId),
+    ).toBeUndefined();
+    expect(await UserModel.findByEmail(pendingUser.email)).toBeUndefined();
+    expect(
+      await UserTokenModel.findByUserAndOrg(pendingUser.id, organizationId),
+    ).toBeNull();
+    expect(await secretManager().getSecret(token.secretId)).toBeNull();
+  });
+
+  test("rejects deleting a member who has completed signup", async ({
+    makeAccount,
+    makeInvitation,
+    makeMember,
+    makeUser,
+  }) => {
+    const signedUpUser = await makeUser({
+      email: "signed-up@example.com",
+    });
+    await makeAccount(signedUpUser.id);
+    await makeMember(signedUpUser.id, organizationId, { role: "member" });
+    const invitation = await makeInvitation(organizationId, user.id, {
+      email: signedUpUser.email,
+      status: `${AUTO_PROVISIONED_INVITATION_STATUS}:slack`,
+    });
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: `/api/organization/members/${signedUpUser.id}/pending-signup`,
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error.message).toBe(
+      "Cannot delete a member who has already completed signup",
+    );
+    expect(await InvitationModel.getById(invitation.id)).toBeDefined();
+    expect(
+      await MemberModel.getByUserId(signedUpUser.id, organizationId),
+    ).toBeDefined();
+    expect(await UserModel.findByEmail(signedUpUser.email)).toBeDefined();
+  });
+
+  test("returns 404 when the user is not a member of the current organization", async ({
+    makeUser,
+  }) => {
+    const outsideUser = await makeUser({
+      email: "outside-current-org@example.com",
+    });
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: `/api/organization/members/${outsideUser.id}/pending-signup`,
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json().error.message).toBe("Member not found");
+    expect(await UserModel.findByEmail(outsideUser.email)).toBeDefined();
+  });
+});

--- a/platform/backend/src/routes/organization.ts
+++ b/platform/backend/src/routes/organization.ts
@@ -1,16 +1,13 @@
 import {
-  AUTO_PROVISIONED_INVITATION_STATUS,
   addNomicTaskPrefix,
   isModelSelectionComplete,
   providerRequiresPerUserCredential,
   RouteId,
   type SupportedProvider,
 } from "@archestra/shared";
-import { and, eq, inArray, like } from "drizzle-orm";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
 import config from "@/config";
-import db, { schema } from "@/database";
 import { syncBuiltInSkillsForOrganization } from "@/database/seed";
 import mcpServerRuntimeManager from "@/k8s/mcp-server-runtime/manager";
 import { callEmbedding } from "@/knowledge-base/embedding-clients";
@@ -20,7 +17,6 @@ import {
   AgentModel,
   InteractionModel,
   InternalMcpCatalogModel,
-  InvitationModel,
   KbDocumentModel,
   KnowledgeBaseConnectorModel,
   LlmProviderApiKeyModel,
@@ -29,10 +25,12 @@ import {
   ModelModel,
   OrganizationModel,
   ToolModel,
-  UserModel,
-  UserTokenModel,
 } from "@/models";
 import { reconcileCatalogDeployments } from "@/services/environments/deployment-reconciliation";
+import {
+  deletePendingSignupMember,
+  listPendingSignupMembers,
+} from "@/services/organization-pending-signup";
 import {
   ApiError,
   AppearanceSettingsSchema,
@@ -750,93 +748,8 @@ const organizationRoutes: FastifyPluginAsyncZod = async (fastify) => {
       },
     },
     async ({ organizationId }, reply) => {
-      // Get all member user IDs for this organization
-      const members = await db
-        .select({ userId: schema.membersTable.userId })
-        .from(schema.membersTable)
-        .where(eq(schema.membersTable.organizationId, organizationId));
-
-      if (members.length === 0) {
-        return reply.send({ pendingSignupMembers: [] });
-      }
-
-      const memberUserIds = members.map((m) => m.userId);
-
-      // Find which of these users have an account record
-      const usersWithAccounts = await db
-        .select({ userId: schema.accountsTable.userId })
-        .from(schema.accountsTable)
-        .where(inArray(schema.accountsTable.userId, memberUserIds));
-
-      const hasAccountSet = new Set(usersWithAccounts.map((a) => a.userId));
-      const pendingUserIds = memberUserIds.filter(
-        (id) => !hasAccountSet.has(id),
-      );
-
-      if (pendingUserIds.length === 0) {
-        return reply.send({ pendingSignupMembers: [] });
-      }
-
-      // Look up auto-provisioned invitations to get provider and invitation ID
-      const invitations = await db
-        .select({
-          id: schema.invitationsTable.id,
-          email: schema.invitationsTable.email,
-          status: schema.invitationsTable.status,
-        })
-        .from(schema.invitationsTable)
-        .where(
-          like(
-            schema.invitationsTable.status,
-            `${AUTO_PROVISIONED_INVITATION_STATUS}%`,
-          ),
-        );
-
-      // Build email → { provider, invitationId } map
-      const emailToInvitation = new Map<
-        string,
-        { provider: string | null; invitationId: string }
-      >();
-      for (const inv of invitations) {
-        const parts = inv.status.split(":");
-        emailToInvitation.set(inv.email, {
-          provider: parts.length === 2 ? parts[1] : null,
-          invitationId: inv.id,
-        });
-      }
-
-      // Get emails for pending users
-      const pendingUsers = await db
-        .select({
-          id: schema.usersTable.id,
-          email: schema.usersTable.email,
-          name: schema.usersTable.name,
-          image: schema.usersTable.image,
-          role: schema.membersTable.role,
-        })
-        .from(schema.membersTable)
-        .innerJoin(
-          schema.usersTable,
-          eq(schema.membersTable.userId, schema.usersTable.id),
-        )
-        .where(
-          and(
-            eq(schema.membersTable.organizationId, organizationId),
-            inArray(schema.usersTable.id, pendingUserIds),
-          ),
-        );
-
-      const pendingSignupMembers = pendingUsers.map((u) => {
-        const inv = emailToInvitation.get(u.email);
-        return {
-          userId: u.id,
-          name: u.name,
-          email: u.email,
-          image: u.image,
-          role: u.role,
-          provider: inv?.provider ?? null,
-          invitationId: inv?.invitationId ?? null,
-        };
+      const pendingSignupMembers = await listPendingSignupMembers({
+        organizationId,
       });
 
       return reply.send({ pendingSignupMembers });
@@ -845,7 +758,7 @@ const organizationRoutes: FastifyPluginAsyncZod = async (fastify) => {
 
   /**
    * Delete an auto-provisioned member who hasn't completed signup.
-   * Removes the member, invitation, user token, and user record.
+   * Removes the member, invitation, personal token, and user record if unused.
    */
   fastify.delete(
     "/api/organization/members/:userId/pending-signup",
@@ -861,53 +774,7 @@ const organizationRoutes: FastifyPluginAsyncZod = async (fastify) => {
     },
     async ({ organizationId, params }, reply) => {
       const { userId } = params;
-
-      // Verify user has no account (is actually pending signup)
-      const [account] = await db
-        .select({ userId: schema.accountsTable.userId })
-        .from(schema.accountsTable)
-        .where(eq(schema.accountsTable.userId, userId))
-        .limit(1);
-
-      if (account) {
-        throw new ApiError(
-          400,
-          "Cannot delete a member who has already completed signup",
-        );
-      }
-
-      // Get user email to find their invitation
-      const user = await UserModel.getById(userId);
-      if (!user) {
-        throw new ApiError(404, "User not found");
-      }
-
-      // Delete invitation(s) with auto-provisioned status for this email
-      const invitations = await db
-        .select({ id: schema.invitationsTable.id })
-        .from(schema.invitationsTable)
-        .where(
-          and(
-            eq(schema.invitationsTable.email, user.email),
-            like(
-              schema.invitationsTable.status,
-              `${AUTO_PROVISIONED_INVITATION_STATUS}%`,
-            ),
-          ),
-        );
-
-      for (const inv of invitations) {
-        await InvitationModel.delete(inv.id);
-      }
-
-      // Delete personal tokens
-      await UserTokenModel.deleteByUserAndOrg(userId, organizationId);
-
-      // Delete member record
-      await MemberModel.deleteByMemberOrUserId(userId, organizationId);
-
-      // Delete user record (no other memberships since auto-provisioned)
-      await UserModel.delete(userId);
+      await deletePendingSignupMember({ userId, organizationId });
 
       return reply.send({ success: true });
     },

--- a/platform/backend/src/services/organization-pending-signup.ts
+++ b/platform/backend/src/services/organization-pending-signup.ts
@@ -1,0 +1,117 @@
+import { withDbTransaction } from "@/database";
+import {
+  AccountModel,
+  InvitationModel,
+  MemberModel,
+  UserModel,
+  UserTokenModel,
+} from "@/models";
+import { ApiError } from "@/types";
+
+type PendingSignupMember = {
+  userId: string;
+  name: string | null;
+  email: string;
+  image: string | null;
+  role: string;
+  provider: string | null;
+  invitationId: string | null;
+};
+
+export async function listPendingSignupMembers(params: {
+  organizationId: string;
+}): Promise<PendingSignupMember[]> {
+  const pendingUsers = await MemberModel.listMembersWithoutAccounts(
+    params.organizationId,
+  );
+
+  const invitations = await InvitationModel.findAutoProvisionedByEmailsInOrg({
+    emails: pendingUsers.map((user) => user.email),
+    organizationId: params.organizationId,
+  });
+
+  const emailToInvitation = new Map<
+    string,
+    { provider: string | null; invitationId: string }
+  >();
+  for (const invitation of invitations) {
+    const parts = invitation.status.split(":");
+    emailToInvitation.set(invitation.email, {
+      provider: parts.length === 2 ? parts[1] : null,
+      invitationId: invitation.id,
+    });
+  }
+
+  return pendingUsers.map((user) => {
+    const invitation = emailToInvitation.get(user.email);
+    return {
+      userId: user.id,
+      name: user.name,
+      email: user.email,
+      image: user.image,
+      role: user.role,
+      provider: invitation?.provider ?? null,
+      invitationId: invitation?.invitationId ?? null,
+    };
+  });
+}
+
+export async function deletePendingSignupMember(params: {
+  userId: string;
+  organizationId: string;
+}): Promise<void> {
+  let deletedUserTokenSecretId: string | null = null;
+
+  await withDbTransaction(async (tx) => {
+    const accounts = await AccountModel.getAllByUserId(params.userId, tx);
+
+    if (accounts.length > 0) {
+      throw new ApiError(
+        400,
+        "Cannot delete a member who has already completed signup",
+      );
+    }
+
+    const member = await MemberModel.getByUserId(
+      params.userId,
+      params.organizationId,
+      tx,
+    );
+    if (!member) {
+      throw new ApiError(404, "Member not found");
+    }
+
+    const user = await UserModel.getById(params.userId, tx);
+    if (!user) {
+      throw new ApiError(404, "User not found");
+    }
+
+    await InvitationModel.deleteAutoProvisionedForEmailInOrg({
+      email: user.email,
+      organizationId: params.organizationId,
+      tx,
+    });
+
+    const deletedUserToken = await UserTokenModel.deleteRecordByUserAndOrg(
+      params.userId,
+      params.organizationId,
+      tx,
+    );
+    deletedUserTokenSecretId = deletedUserToken?.secretId ?? null;
+
+    await MemberModel.deleteByMemberOrUserId(
+      params.userId,
+      params.organizationId,
+      tx,
+    );
+
+    const hasMembership = await MemberModel.hasAnyMembership(params.userId, tx);
+    if (!hasMembership) {
+      await UserModel.delete(params.userId, tx);
+    }
+  });
+
+  if (deletedUserTokenSecretId) {
+    await UserTokenModel.deleteSecret(deletedUserTokenSecretId);
+  }
+}


### PR DESCRIPTION
## Summary

Fixes pending signup cleanup so organization member cleanup does not affect records in other organizations.

- Scope pending signup invitation metadata lookup to the current organization
- Delete only current-org auto-provisioned invitations for a pending member
- Delete the global user record only when no memberships remain
- Move cross-model cleanup into a service and run DB cleanup in a transaction
- Add regression tests for cross-org invitations, multi-org membership preservation, completed-signup rejection, missing-member handling, and token secret cleanup