### PR TITLE
feat(bench): capture the effective prompt the model received

### DIFF
--- a/archestra-bench/analyzer/src/trajectory.rs
+++ b/archestra-bench/analyzer/src/trajectory.rs
@@ -167,6 +167,22 @@ pub fn format_to_markdown(events: &[Event]) -> String {
             Event::StageComplete { stage } => {
                 out.push_str(&format!("---\n_stage {stage} complete_\n\n"));
             }
+            Event::EffectivePrompt(data) => {
+                out.push_str("### Effective system prompt\n");
+                out.push_str(&cap_chars(&data.system_prompt, MAX_FIELD_CHARS));
+                out.push_str(&format!(
+                    "\n\n_tools ({}): {}_\n_sampling: temperature={:?} max_tokens={:?} top_p={:?}_\n_used by {} call(s)_\n\n",
+                    data.tools.len(),
+                    data.tools.join(", "),
+                    data.sampling.temperature,
+                    data.sampling.max_tokens,
+                    data.sampling.top_p,
+                    data.interaction_count,
+                ));
+            }
+            Event::EffectivePromptError { error } => {
+                out.push_str(&format!("### ⚠️ Effective-prompt capture error\n{error}\n\n"));
+            }
             Event::ConversationCreated | Event::TokenUsage | Event::Finish | Event::Unknown => {}
         }
     }
@@ -225,6 +241,20 @@ mod tests {
             md.contains("bad chunk"),
             "parse_error must render its reason"
         );
+    }
+
+    #[test]
+    fn effective_prompt_and_its_error_render() {
+        let (_dir, path) = write_fixture(&[
+            r#"{"sequence":1,"timestamp":"t","kind":"effective_prompt","system_prompt":"you are helpful","tools":["archestra__search_tools","archestra__run_tool"],"sampling":{"temperature":0.0,"max_tokens":8192,"top_p":null},"interaction_count":5}"#,
+            r#"{"sequence":2,"timestamp":"t","kind":"effective_prompt_error","error":"context varied across 2 interactions"}"#,
+        ]);
+        let md = format_to_markdown(&load_trajectory(&path).unwrap());
+        assert!(md.contains("### Effective system prompt\nyou are helpful"));
+        assert!(md.contains("archestra__search_tools, archestra__run_tool"));
+        assert!(md.contains("used by 5 call(s)"));
+        // The diagnostic must reach the rendered trajectory, not vanish.
+        assert!(md.contains("context varied across 2 interactions"));
     }
 
     #[test]

--- a/archestra-bench/core/src/lib.rs
+++ b/archestra-bench/core/src/lib.rs
@@ -6,7 +6,7 @@
 
 use std::fmt;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 mod lanes;
@@ -210,9 +210,40 @@ pub enum Event {
         #[serde(default)]
         reason: Option<String>,
     },
+    /// The effective context the model actually received on the wire, recovered post-run from the
+    /// platform's persisted provider request (system prompt + tool names + sampling). Unlike
+    /// [`Event::Prompts`] (the harness-side configured input), this is what was assembled and sent
+    /// server-side. Normally one per conversation; more than one signals a context that drifted.
+    EffectivePrompt(EffectivePromptData),
+    /// A detected anomaly while recovering the effective prompt (fetch failed, unhandled provider
+    /// shape, empty system prompt, no interactions despite turns, or a context that varied). Surfaced
+    /// loudly instead of writing a silent null.
+    EffectivePromptError {
+        error: String,
+    },
     /// Raw stream framing the harness could not classify, plus any future event kinds.
     #[serde(other)]
     Unknown,
+}
+
+/// Normalized decoding parameters, mapped from each provider's own field names
+/// (`max_output_tokens`/`maxOutputTokens` -> `max_tokens`, `topP` -> `top_p`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SamplingParams {
+    pub temperature: Option<f64>,
+    pub max_tokens: Option<i64>,
+    pub top_p: Option<f64>,
+}
+
+/// Payload of [`Event::EffectivePrompt`]. The harness builds and serializes this; the analyzer reads
+/// it back through the enum. `system_prompt` is required — an absent one is an error path, not a null.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EffectivePromptData {
+    pub system_prompt: String,
+    #[serde(default)]
+    pub tools: Vec<String>,
+    pub sampling: SamplingParams,
+    pub interaction_count: usize,
 }
 
 #[cfg(test)]
@@ -293,5 +324,35 @@ mod tests {
             matches!(no_system, Event::Prompts { system_prompt, user_message }
                 if system_prompt.is_empty() && user_message == "do the task")
         );
+    }
+
+    #[test]
+    fn effective_prompt_round_trips_through_the_enum() {
+        let data = EffectivePromptData {
+            system_prompt: "you are helpful".to_string(),
+            tools: vec!["archestra__search_tools".to_string()],
+            sampling: SamplingParams {
+                temperature: Some(0.0),
+                max_tokens: Some(8192),
+                top_p: None,
+            },
+            interaction_count: 3,
+        };
+        // The harness serializes the payload, then prefixes the kind tag (as RunArtifacts::append does).
+        let mut line = serde_json::to_value(&data).unwrap();
+        line.as_object_mut()
+            .unwrap()
+            .insert("kind".to_string(), "effective_prompt".into());
+        let parsed: Event = serde_json::from_value(line).unwrap();
+        assert!(matches!(parsed, Event::EffectivePrompt(d) if d == data));
+    }
+
+    #[test]
+    fn effective_prompt_error_parses() {
+        let parsed: Event = serde_json::from_str(
+            r#"{"kind":"effective_prompt_error","sequence":4,"error":"context varied"}"#,
+        )
+        .unwrap();
+        assert!(matches!(parsed, Event::EffectivePromptError { error } if error == "context varied"));
     }
 }

--- a/archestra-bench/runner/src/client.rs
+++ b/archestra-bench/runner/src/client.rs
@@ -614,6 +614,102 @@ impl EvalClient {
             .unwrap_or_default())
     }
 
+    /// All persisted LLM-proxy interactions for a chat session (the chat route sets the interaction
+    /// `sessionId` to the conversation id), in chronological order. Used post-run to recover the
+    /// effective prompt the model received. Pages the capped API and waits out the write race: the
+    /// proxy persists each row in a `finally` after the chat stream ends, so a naive single fetch
+    /// can miss the last call.
+    pub async fn fetch_session_interactions(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<JsonValue>, ClientError> {
+        const PAGE: usize = 100;
+        const MAX_REFETCH: usize = 5;
+        // The total can keep growing while we page (the proxy is still flushing rows), so settle on a
+        // stable count, page it fully, then re-verify the count did not move under us; retry if it did.
+        for _ in 0..MAX_REFETCH {
+            let total = self.stable_interaction_total(session_id).await?;
+            let mut all: Vec<JsonValue> = Vec::with_capacity(total);
+            while all.len() < total {
+                let (page, _) = self.interactions_page(session_id, PAGE, all.len()).await?;
+                if page.is_empty() {
+                    return Err(ContractError(format!(
+                        "GET /api/interactions: pagination gap for session {session_id}: got {} of {total} rows",
+                        all.len()
+                    ))
+                    .into());
+                }
+                all.extend(page);
+            }
+            let (_, total_after) = self.interactions_page(session_id, 1, 0).await?;
+            if total_after == all.len() {
+                return Ok(all);
+            }
+        }
+        Err(ContractError(format!(
+            "GET /api/interactions: interaction count for session {session_id} never stabilized"
+        ))
+        .into())
+    }
+
+    /// Poll the interaction count with the cheapest possible query until it holds steady across several
+    /// consecutive samples, so a row the proxy is still flushing (it persists each in a `finally` after
+    /// the stream ends) is not missed by a single lucky-quiet read.
+    async fn stable_interaction_total(&self, session_id: &str) -> Result<usize, ClientError> {
+        const NEEDED_STABLE: usize = 3;
+        const MAX_ATTEMPTS: usize = 20;
+        const INTERVAL: Duration = Duration::from_millis(300);
+        let (_, mut prev) = self.interactions_page(session_id, 1, 0).await?;
+        let mut stable = 1;
+        for _ in 0..MAX_ATTEMPTS {
+            sleep(INTERVAL).await;
+            let (_, current) = self.interactions_page(session_id, 1, 0).await?;
+            if current == prev {
+                stable += 1;
+                if stable >= NEEDED_STABLE {
+                    return Ok(current);
+                }
+            } else {
+                stable = 1;
+                prev = current;
+            }
+        }
+        Ok(prev)
+    }
+
+    async fn interactions_page(
+        &self,
+        session_id: &str,
+        limit: usize,
+        offset: usize,
+    ) -> Result<(Vec<JsonValue>, usize), ClientError> {
+        let params = [
+            ("sessionId".to_string(), session_id.to_string()),
+            ("limit".to_string(), limit.to_string()),
+            ("offset".to_string(), offset.to_string()),
+            ("sortBy".to_string(), "createdAt".to_string()),
+            ("sortDirection".to_string(), "asc".to_string()),
+        ];
+        let body = self
+            .request(Method::GET, "/api/interactions", Some(&params), None)
+            .await?;
+        let data = body
+            .get("data")
+            .and_then(JsonValue::as_array)
+            .cloned()
+            .ok_or_else(|| {
+                ContractError(format!("GET /api/interactions: missing `data` array: {body}"))
+            })?;
+        let total = body
+            .get("pagination")
+            .and_then(|p| p.get("total"))
+            .and_then(JsonValue::as_u64)
+            .ok_or_else(|| {
+                ContractError(format!("GET /api/interactions: missing `pagination.total`: {body}"))
+            })? as usize;
+        Ok((data, total))
+    }
+
     pub async fn stream_chat_records(
         &self,
         conversation_id: &str,

--- a/archestra-bench/runner/src/interactions.rs
+++ b/archestra-bench/runner/src/interactions.rs
@@ -1,0 +1,454 @@
+//! Recover the *effective* prompt the model received from the platform's persisted provider
+//! requests (the `interactions` rows the LLM proxy writes). Pure, provider-shape-aware, and loud:
+//! anything it cannot extract becomes an explicit error string, never a silent null.
+//!
+//! The effective context (system prompt + tool names + sampling) is expected to be constant within a
+//! bench conversation, so the normal result is exactly one [`EffectivePromptData`]; any variation, an
+//! unhandled provider shape, or a missing system prompt is reported in `errors`.
+
+use archestra_bench_core::{EffectivePromptData, SamplingParams};
+use serde_json::Value;
+
+/// Distinct effective contexts (normally one) plus any anomalies detected while extracting them.
+pub struct ExtractionOutcome {
+    pub prompts: Vec<EffectivePromptData>,
+    pub errors: Vec<String>,
+}
+
+pub fn extract_effective_prompts(interactions: &[Value]) -> ExtractionOutcome {
+    let mut prompts: Vec<EffectivePromptData> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+
+    for interaction in interactions {
+        let type_tag = interaction
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+
+        // Skip non-chat calls outright — they carry no model-facing system prompt.
+        if type_tag.ends_with(":embeddings") {
+            continue;
+        }
+
+        let body = request_body(interaction);
+        let extracted = match type_tag.as_str() {
+            t if t.ends_with(":chatCompletions") => extract_openai_chat(body),
+            "anthropic:messages" => extract_anthropic(body),
+            t if t.ends_with(":responses") => extract_openai_responses(body),
+            "gemini:generateContent" => extract_gemini(body),
+            "" => {
+                errors.push("interaction missing a `type` discriminator".to_string());
+                continue;
+            }
+            other => {
+                errors.push(format!("unhandled interaction type: {other}"));
+                continue;
+            }
+        };
+
+        match extracted {
+            Some((system, tools, sampling)) => merge(&mut prompts, system, tools, sampling),
+            None => errors.push(format!(
+                "interaction type {type_tag}: could not extract a system prompt"
+            )),
+        }
+    }
+
+    if prompts.len() > 1 {
+        errors.push(format!(
+            "effective context varied across the conversation: {} distinct contexts (expected 1)",
+            prompts.len()
+        ));
+    }
+
+    // We were handed interactions yet produced neither a prompt nor an error (e.g. every row was an
+    // embedding) — surface it rather than returning an empty, signal-free outcome.
+    if prompts.is_empty() && errors.is_empty() && !interactions.is_empty() {
+        errors.push(
+            "interactions present but no model-facing prompt could be extracted from any of them"
+                .to_string(),
+        );
+    }
+
+    ExtractionOutcome { prompts, errors }
+}
+
+// ===== Internal helpers =====
+
+/// The mutated payload actually sent upstream (`processedRequest`) when present, else the original
+/// (`request`). Returns `Value::Null` if neither exists, which extractors degrade to `None`.
+fn request_body(interaction: &Value) -> &Value {
+    match interaction.get("processedRequest") {
+        Some(v) if !v.is_null() => v,
+        _ => interaction.get("request").unwrap_or(&Value::Null),
+    }
+}
+
+/// Accumulate an extracted context into the distinct-context list, comparing by everything except the
+/// running count so repeated identical calls collapse into one entry.
+fn merge(
+    prompts: &mut Vec<EffectivePromptData>,
+    system_prompt: String,
+    tools: Vec<String>,
+    sampling: SamplingParams,
+) {
+    if let Some(existing) = prompts
+        .iter_mut()
+        .find(|p| p.system_prompt == system_prompt && p.tools == tools && p.sampling == sampling)
+    {
+        existing.interaction_count += 1;
+        return;
+    }
+    prompts.push(EffectivePromptData {
+        system_prompt,
+        tools,
+        sampling,
+        interaction_count: 1,
+    });
+}
+
+/// A `system`/`developer` role — both carry the effective system instruction in current OpenAI usage.
+fn is_system_role(role: Option<&Value>) -> bool {
+    matches!(role.and_then(Value::as_str), Some("system" | "developer"))
+}
+
+/// Stitch the system instruction from a Responses request's `input[]` items (system/developer roles).
+fn responses_input_system(req: &Value) -> Option<String> {
+    let parts: Vec<String> = req
+        .get("input")
+        .and_then(Value::as_array)?
+        .iter()
+        .filter(|it| is_system_role(it.get("role")))
+        .filter_map(|it| it.get("content").and_then(join_text))
+        .collect();
+    (!parts.is_empty()).then(|| parts.join("\n"))
+}
+
+/// A string, or an array of `{text: "..."}` parts joined with newlines. `None` if empty/absent — both
+/// Anthropic `system` blocks, OpenAI message content arrays, and Gemini `parts` use this shape.
+fn join_text(value: &Value) -> Option<String> {
+    match value {
+        Value::String(s) => (!s.is_empty()).then(|| s.clone()),
+        Value::Array(items) => {
+            let parts: Vec<String> = items
+                .iter()
+                .filter_map(|it| it.get("text").and_then(Value::as_str))
+                .map(str::to_string)
+                .collect();
+            (!parts.is_empty()).then(|| parts.join("\n"))
+        }
+        _ => None,
+    }
+}
+
+fn extract_openai_chat(req: &Value) -> Option<(String, Vec<String>, SamplingParams)> {
+    let system = req
+        .get("messages")
+        .and_then(Value::as_array)?
+        .iter()
+        .find(|m| is_system_role(m.get("role")))
+        .and_then(|m| m.get("content"))
+        .and_then(join_text)?;
+    let tools = names(req.get("tools"), |t| {
+        t.get("function").and_then(|f| f.get("name"))
+    });
+    let sampling = SamplingParams {
+        temperature: f64_at(req, "temperature"),
+        max_tokens: i64_at(req, "max_tokens").or_else(|| i64_at(req, "max_completion_tokens")),
+        top_p: f64_at(req, "top_p"),
+    };
+    Some((system, tools, sampling))
+}
+
+fn extract_anthropic(req: &Value) -> Option<(String, Vec<String>, SamplingParams)> {
+    let system = req.get("system").and_then(join_text)?;
+    let tools = names(req.get("tools"), |t| t.get("name"));
+    let sampling = SamplingParams {
+        temperature: f64_at(req, "temperature"),
+        max_tokens: i64_at(req, "max_tokens"),
+        top_p: f64_at(req, "top_p"),
+    };
+    Some((system, tools, sampling))
+}
+
+fn extract_openai_responses(req: &Value) -> Option<(String, Vec<String>, SamplingParams)> {
+    // The Responses API carries the system instruction either as top-level `instructions` or as
+    // system/developer items inside `input[]`.
+    let system = req
+        .get("instructions")
+        .and_then(join_text)
+        .or_else(|| responses_input_system(req))?;
+    let tools = names(req.get("tools"), |t| t.get("name"));
+    let sampling = SamplingParams {
+        temperature: f64_at(req, "temperature"),
+        max_tokens: i64_at(req, "max_output_tokens"),
+        top_p: f64_at(req, "top_p"),
+    };
+    Some((system, tools, sampling))
+}
+
+fn extract_gemini(req: &Value) -> Option<(String, Vec<String>, SamplingParams)> {
+    let system = req
+        .get("systemInstruction")
+        .and_then(|si| si.get("parts"))
+        .and_then(join_text)?;
+    // tools may be a single object or an array of them; each holds functionDeclarations[].name.
+    let tool_groups: Vec<Value> = match req.get("tools") {
+        Some(Value::Array(arr)) => arr.clone(),
+        Some(obj @ Value::Object(_)) => vec![obj.clone()],
+        _ => Vec::new(),
+    };
+    let tools = tool_groups
+        .iter()
+        .filter_map(|g| g.get("functionDeclarations").and_then(Value::as_array))
+        .flatten()
+        .filter_map(|d| d.get("name").and_then(Value::as_str))
+        .map(str::to_string)
+        .collect();
+    let cfg = req.get("generationConfig").unwrap_or(&Value::Null);
+    let sampling = SamplingParams {
+        temperature: f64_at(cfg, "temperature"),
+        max_tokens: i64_at(cfg, "maxOutputTokens"),
+        top_p: f64_at(cfg, "topP"),
+    };
+    Some((system, tools, sampling))
+}
+
+/// Collect tool names from a `tools` array, locating each name via `pick` (provider-specific path).
+fn names(tools: Option<&Value>, pick: impl Fn(&Value) -> Option<&Value>) -> Vec<String> {
+    tools
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|t| pick(t).and_then(Value::as_str))
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn f64_at(v: &Value, key: &str) -> Option<f64> {
+    v.get(key).and_then(Value::as_f64)
+}
+
+fn i64_at(v: &Value, key: &str) -> Option<i64> {
+    v.get(key).and_then(Value::as_i64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sampling(t: Option<f64>, m: Option<i64>, p: Option<f64>) -> SamplingParams {
+        SamplingParams {
+            temperature: t,
+            max_tokens: m,
+            top_p: p,
+        }
+    }
+
+    #[test]
+    fn openai_chat_shape() {
+        let it = json!({
+            "type": "openrouter:chatCompletions",
+            "request": {
+                "messages": [
+                    {"role": "system", "content": "be helpful"},
+                    {"role": "user", "content": "hi"}
+                ],
+                "tools": [{"type": "function", "function": {"name": "search_tools"}}],
+                "temperature": 0.0, "max_tokens": 8192
+            }
+        });
+        let out = extract_effective_prompts(&[it]);
+        assert!(out.errors.is_empty());
+        assert_eq!(out.prompts.len(), 1);
+        let p = &out.prompts[0];
+        assert_eq!(p.system_prompt, "be helpful");
+        assert_eq!(p.tools, vec!["search_tools"]);
+        assert_eq!(p.sampling, sampling(Some(0.0), Some(8192), None));
+        assert_eq!(p.interaction_count, 1);
+    }
+
+    #[test]
+    fn anthropic_shape_with_text_block_system() {
+        let it = json!({
+            "type": "anthropic:messages",
+            "request": {
+                "system": [{"type": "text", "text": "denial rule"}],
+                "tools": [{"name": "run_tool"}],
+                "temperature": 1.0, "max_tokens": 4096, "top_p": 0.9
+            }
+        });
+        let out = extract_effective_prompts(&[it]);
+        assert!(out.errors.is_empty());
+        assert_eq!(out.prompts[0].system_prompt, "denial rule");
+        assert_eq!(out.prompts[0].tools, vec!["run_tool"]);
+        assert_eq!(out.prompts[0].sampling, sampling(Some(1.0), Some(4096), Some(0.9)));
+    }
+
+    #[test]
+    fn gemini_shape() {
+        let it = json!({
+            "type": "gemini:generateContent",
+            "request": {
+                "systemInstruction": {"parts": [{"text": "sys a"}, {"text": "sys b"}]},
+                "tools": [{"functionDeclarations": [{"name": "f1"}, {"name": "f2"}]}],
+                "generationConfig": {"temperature": 0.5, "maxOutputTokens": 2048, "topP": 0.8}
+            }
+        });
+        let out = extract_effective_prompts(&[it]);
+        assert!(out.errors.is_empty());
+        assert_eq!(out.prompts[0].system_prompt, "sys a\nsys b");
+        assert_eq!(out.prompts[0].tools, vec!["f1", "f2"]);
+        assert_eq!(out.prompts[0].sampling, sampling(Some(0.5), Some(2048), Some(0.8)));
+    }
+
+    #[test]
+    fn openai_responses_shape() {
+        let it = json!({
+            "type": "openai:responses",
+            "request": {
+                "instructions": "responses sys",
+                "tools": [{"type": "function", "name": "t1"}],
+                "temperature": 0.2, "max_output_tokens": 1000
+            }
+        });
+        let out = extract_effective_prompts(&[it]);
+        assert!(out.errors.is_empty());
+        assert_eq!(out.prompts[0].system_prompt, "responses sys");
+        assert_eq!(out.prompts[0].tools, vec!["t1"]);
+        assert_eq!(out.prompts[0].sampling, sampling(Some(0.2), Some(1000), None));
+    }
+
+    #[test]
+    fn processed_request_is_preferred_over_request() {
+        let it = json!({
+            "type": "anthropic:messages",
+            "request": {"system": "original", "max_tokens": 1},
+            "processedRequest": {"system": "mutated", "max_tokens": 2}
+        });
+        let out = extract_effective_prompts(&[it]);
+        assert_eq!(out.prompts[0].system_prompt, "mutated");
+        assert_eq!(out.prompts[0].sampling.max_tokens, Some(2));
+    }
+
+    #[test]
+    fn null_processed_request_falls_back_to_request() {
+        let it = json!({
+            "type": "anthropic:messages",
+            "request": {"system": "original", "max_tokens": 1},
+            "processedRequest": null
+        });
+        let out = extract_effective_prompts(&[it]);
+        assert_eq!(out.prompts[0].system_prompt, "original");
+    }
+
+    #[test]
+    fn identical_contexts_collapse_into_one_with_count() {
+        let it = json!({
+            "type": "anthropic:messages",
+            "request": {"system": "s", "tools": [{"name": "a"}], "max_tokens": 10}
+        });
+        let out = extract_effective_prompts(&[it.clone(), it.clone(), it]);
+        assert!(out.errors.is_empty());
+        assert_eq!(out.prompts.len(), 1);
+        assert_eq!(out.prompts[0].interaction_count, 3);
+    }
+
+    #[test]
+    fn varying_context_is_flagged_as_an_anomaly() {
+        let a = json!({"type": "anthropic:messages", "request": {"system": "A"}});
+        let b = json!({"type": "anthropic:messages", "request": {"system": "B"}});
+        let out = extract_effective_prompts(&[a, b]);
+        assert_eq!(out.prompts.len(), 2);
+        assert_eq!(out.errors.len(), 1);
+        assert!(out.errors[0].contains("varied"));
+    }
+
+    #[test]
+    fn unhandled_type_is_an_explicit_error() {
+        let it = json!({"type": "bedrock:converse", "request": {}});
+        let out = extract_effective_prompts(&[it]);
+        assert!(out.prompts.is_empty());
+        assert_eq!(out.errors.len(), 1);
+        assert!(out.errors[0].contains("bedrock:converse"));
+    }
+
+    #[test]
+    fn empty_system_for_handled_type_is_an_error_not_a_null() {
+        let it = json!({"type": "anthropic:messages", "request": {"max_tokens": 10}});
+        let out = extract_effective_prompts(&[it]);
+        assert!(out.prompts.is_empty());
+        assert_eq!(out.errors.len(), 1);
+        assert!(out.errors[0].contains("could not extract a system prompt"));
+    }
+
+    #[test]
+    fn embeddings_among_real_calls_are_skipped() {
+        let chat = json!({
+            "type": "openai:chatCompletions",
+            "request": {"messages": [{"role": "system", "content": "s"}]}
+        });
+        let emb = json!({"type": "openai:embeddings", "request": {"input": "x"}});
+        let out = extract_effective_prompts(&[emb, chat]);
+        assert!(out.errors.is_empty());
+        assert_eq!(out.prompts.len(), 1);
+        assert_eq!(out.prompts[0].system_prompt, "s");
+    }
+
+    #[test]
+    fn only_embeddings_is_flagged_not_silent() {
+        let emb = json!({"type": "openai:embeddings", "request": {"input": "x"}});
+        let out = extract_effective_prompts(&[emb.clone(), emb]);
+        assert!(out.prompts.is_empty());
+        assert_eq!(out.errors.len(), 1);
+        assert!(out.errors[0].contains("no model-facing prompt"));
+    }
+
+    #[test]
+    fn developer_role_is_treated_as_system() {
+        let it = json!({
+            "type": "openai:chatCompletions",
+            "request": {"messages": [{"role": "developer", "content": "dev rules"}]}
+        });
+        let out = extract_effective_prompts(&[it]);
+        assert!(out.errors.is_empty());
+        assert_eq!(out.prompts[0].system_prompt, "dev rules");
+    }
+
+    #[test]
+    fn responses_reads_system_from_input_items() {
+        let it = json!({
+            "type": "openai:responses",
+            "request": {
+                "input": [
+                    {"role": "developer", "content": [{"type": "input_text", "text": "from input"}]},
+                    {"role": "user", "content": "hi"}
+                ],
+                "tools": [{"type": "function", "name": "t1"}]
+            }
+        });
+        let out = extract_effective_prompts(&[it]);
+        assert!(out.errors.is_empty());
+        assert_eq!(out.prompts[0].system_prompt, "from input");
+        assert_eq!(out.prompts[0].tools, vec!["t1"]);
+    }
+
+    #[test]
+    fn gemini_tools_as_single_object() {
+        let it = json!({
+            "type": "gemini:generateContent",
+            "request": {
+                "systemInstruction": {"parts": [{"text": "sys"}]},
+                "tools": {"functionDeclarations": [{"name": "f1"}]},
+                "generationConfig": {"temperature": 0.5}
+            }
+        });
+        let out = extract_effective_prompts(&[it]);
+        assert!(out.errors.is_empty());
+        assert_eq!(out.prompts[0].tools, vec!["f1"]);
+    }
+}

--- a/archestra-bench/runner/src/lib.rs
+++ b/archestra-bench/runner/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod chat_stream;
 pub mod client;
 pub mod config;
+pub mod interactions;
 pub mod lifecycle;
 pub mod mcp_lock;
 pub mod mcp_server;

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -17,6 +17,7 @@ use crate::chat_stream::{ChatRecordKind, ChatRunResult, ChatStreamRecord, apply_
 use crate::client::{AgentCreate, EvalClient, FilePart};
 use crate::config::types::{EnvConfig, Stage, Task, ToolExposureMode};
 use crate::config::{Lane, load_envs, load_lanes};
+use crate::interactions::extract_effective_prompts;
 use crate::lifecycle::Instance;
 use crate::mcp_lock;
 use crate::mcp_server::{BenchmarkMcp, Submission};
@@ -1216,6 +1217,51 @@ async fn run_one(
     }
 }
 
+/// Recover the effective prompt(s) the model received from the platform's persisted provider requests
+/// and record them in the trajectory. Observability enrichment: every failure is surfaced as a
+/// loud `effective_prompt_error` event plus a warn log, but never propagated — a capture problem must
+/// not fail an otherwise-complete rollout.
+async fn capture_effective_prompts(
+    client: &EvalClient,
+    conversation_id: &str,
+    turn_count: usize,
+    artifacts: &RunArtifacts,
+) {
+    let interactions = match client.fetch_session_interactions(conversation_id).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            let msg = format!("failed to fetch interactions: {e}");
+            warn!("{msg}");
+            artifacts.append_error("effective_prompt_error", &msg).await;
+            return;
+        }
+    };
+
+    if turn_count > 0 && interactions.is_empty() {
+        let msg = "no interactions found despite the conversation taking turns".to_string();
+        warn!("{msg}");
+        artifacts.append_error("effective_prompt_error", &msg).await;
+        return;
+    }
+
+    let outcome = extract_effective_prompts(&interactions);
+    for prompt in &outcome.prompts {
+        match serde_json::to_value(prompt) {
+            Ok(value) => artifacts.append("effective_prompt", value).await,
+            Err(e) => {
+                warn!("failed to serialize effective prompt: {e}");
+                artifacts
+                    .append_error("effective_prompt_error", &e.to_string())
+                    .await;
+            }
+        }
+    }
+    for error in &outcome.errors {
+        warn!("effective-prompt anomaly: {error}");
+        artifacts.append_error("effective_prompt_error", error).await;
+    }
+}
+
 async fn grade_rollout(
     client: EvalClient,
     bench_mcp: BenchmarkMcp,
@@ -1246,7 +1292,8 @@ async fn grade_rollout(
     let conversation_id = conversation
         .get("id")
         .and_then(|v| v.as_str())
-        .unwrap_or("")
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| RunError::Config("create_conversation returned no `id`".to_string()))?
         .to_string();
     metadata["conversation_id"] = serde_json::Value::String(conversation_id.clone());
     artifacts
@@ -1336,6 +1383,8 @@ async fn grade_rollout(
         )
         .await?;
     }
+
+    capture_effective_prompts(&client, &conversation_id, run.turn_count, artifacts).await;
 
     metadata["finish_reason"] =
         serde_json::to_value(&run.finish_reason).unwrap_or(serde_json::Value::Null);


### PR DESCRIPTION
The bench only logged the lane-configured system prompt (empty by default), not what the model actually received. This recovers the **effective prompt** from the platform's persisted LLM-proxy `interactions` after each task — **no backend changes**.

## What's captured
New `effective_prompt` trajectory event (one per distinct context):
- assembled system prompt (the real one — e.g. `search_and_run_only` tool-discovery instructions, not the empty configured prompt)
- exposed tool names
- normalized sampling (`temperature` / `max_tokens` / `top_p`)
- `interaction_count` — LLM calls that ran under that context

## No silent degradation
A typed `effective_prompt_error` event (+ warn log) fires on any anomaly: fetch failure, unhandled provider shape, empty system prompt, turns-but-zero-interactions, >1 distinct context, or interactions that yielded nothing. `system_prompt` is a required field — absence is an error path, not a null.

## Provider coverage
`*:chatCompletions` (OpenRouter / minimax / openai / +10), `anthropic:messages`, `*:responses` (incl. `input[]` system/developer), `gemini:generateContent`. `*:embeddings` skipped; anything else → loud error. Prefers `processedRequest` (the mutated payload sent upstream) over `request`.

## Fetch
Paginated (API caps `limit` at 100) with a write-race stabilization poll — the proxy persists each interaction row in a `finally` after the chat stream ends, so a single fetch can miss the last call. Errors on a pagination gap rather than returning a short result.

## Validation
- Live glm run: one `effective_prompt` (`interaction_count: 6`, 15 tools, `temperature 0.0`), zero errors.
- Workspace tests pass; `cargo clippy --all-targets -- -D warnings` clean.

The existing `prompts` event stays — it documents the configured input; `effective_prompt` documents the wire reality.

https://claude.ai/code/session_01MSNRzMgCjwWELtNY2whcCi

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>