### PR TITLE
feat(sidebar): separate pinned and recents, polish and fixes

### DIFF
--- a/platform/frontend/src/app/_parts/chat-list-skeleton.tsx
+++ b/platform/frontend/src/app/_parts/chat-list-skeleton.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubItem,
+} from "@/components/ui/sidebar";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const SKELETON_REVEAL_DELAY_MS = 500;
+const SKELETON_ROW_WIDTHS = ["w-3/4", "w-full", "w-5/6"];
+
+export function ChatListSkeleton({ subClass }: { subClass: string }) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setVisible(true), SKELETON_REVEAL_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <SidebarGroup className="pt-0">
+      <SidebarGroupLabel>Recents</SidebarGroupLabel>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuSub className={subClass}>
+              {SKELETON_ROW_WIDTHS.map((width) => (
+                <SidebarMenuSubItem key={width}>
+                  <div className="flex w-full items-center justify-between gap-1">
+                    <div className="flex h-8 w-full flex-1 items-center gap-2 rounded-md p-2">
+                      <Skeleton
+                        className={`h-4 ${width} bg-sidebar-foreground/5`}
+                      />
+                    </div>
+                  </div>
+                </SidebarMenuSubItem>
+              ))}
+            </SidebarMenuSub>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}

--- a/platform/frontend/src/app/_parts/chat-sidebar-section.test.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.test.tsx
@@ -69,6 +69,21 @@ vi.mock("@/lib/chat/chat.query", () => ({
 // Minimal sidebar UI mock - render children directly
 vi.mock("@/components/ui/sidebar", () => ({
   useSidebar: () => ({ isMobile: false, setOpenMobile: vi.fn() }),
+  SidebarGroup: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SidebarGroupLabel: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SidebarGroupContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SidebarMenu: ({ children }: { children: React.ReactNode }) => (
+    <ul>{children}</ul>
+  ),
+  SidebarMenuItem: ({ children }: { children: React.ReactNode }) => (
+    <li>{children}</li>
+  ),
   SidebarMenuButton: ({
     children,
     onClick,
@@ -211,7 +226,7 @@ describe("ChatSidebarSection", () => {
     expect(screen.getByText("More")).toBeInTheDocument();
   });
 
-  it("shows only pinned chats when 3 are pinned (no recent unpinned)", () => {
+  it("shows pinned and recents in separate sections", () => {
     mockConversations = [
       makeConv("c1", "Pinned One", {
         pinnedAt: "2026-01-05T00:00:00Z",
@@ -230,19 +245,23 @@ describe("ChatSidebarSection", () => {
 
     render(<ChatSidebarSection />);
 
-    // All 3 pinned should show
+    // Section labels
+    expect(screen.getByText("Pinned")).toBeInTheDocument();
+    expect(screen.getByText("Recents")).toBeInTheDocument();
+
+    // Pinned chats are not capped by the recents budget — all 3 show...
     expect(screen.getByText("Pinned One")).toBeInTheDocument();
     expect(screen.getByText("Pinned Two")).toBeInTheDocument();
     expect(screen.getByText("Pinned Three")).toBeInTheDocument();
 
-    // Unpinned should NOT show (all 3 slots taken by pinned)
-    expect(screen.queryByText("Unpinned One")).not.toBeInTheDocument();
+    // ...and the unpinned chat still shows under Recents.
+    expect(screen.getByText("Unpinned One")).toBeInTheDocument();
 
-    // Should show "More" to open search
-    expect(screen.getByText("More")).toBeInTheDocument();
+    // Only 1 unpinned recent, so no "More".
+    expect(screen.queryByText("More")).not.toBeInTheDocument();
   });
 
-  it("fills remaining slots with recent chats when fewer than 3 are pinned", () => {
+  it("shows all recents when within the slot budget", () => {
     mockConversations = [
       makeConv("c1", "Pinned Chat", {
         pinnedAt: "2026-01-05T00:00:00Z",
@@ -255,19 +274,17 @@ describe("ChatSidebarSection", () => {
 
     render(<ChatSidebarSection />);
 
-    // 1 pinned + 2 recent = 3 total
+    // Pinned shows in its own section; all 3 recents fit the slot budget.
     expect(screen.getByText("Pinned Chat")).toBeInTheDocument();
     expect(screen.getByText("Recent One")).toBeInTheDocument();
     expect(screen.getByText("Recent Two")).toBeInTheDocument();
+    expect(screen.getByText("Recent Three")).toBeInTheDocument();
 
-    // 3rd recent should NOT show (only 2 remaining slots)
-    expect(screen.queryByText("Recent Three")).not.toBeInTheDocument();
-
-    // Should show "More" to open search
-    expect(screen.getByText("More")).toBeInTheDocument();
+    // 3 unpinned == slots, so no "More".
+    expect(screen.queryByText("More")).not.toBeInTheDocument();
   });
 
-  it("shows 2 pinned + 1 recent when 2 are pinned", () => {
+  it("does not render a Recents section or 'More' when all chats are pinned", () => {
     mockConversations = [
       makeConv("c1", "Pinned A", {
         pinnedAt: "2026-01-05T00:00:00Z",
@@ -277,19 +294,17 @@ describe("ChatSidebarSection", () => {
         pinnedAt: "2026-01-04T00:00:00Z",
         updatedAt: "2026-01-04T00:00:00Z",
       }),
-      makeConv("c3", "Recent A", { updatedAt: "2026-01-03T00:00:00Z" }),
-      makeConv("c4", "Recent B", { updatedAt: "2026-01-02T00:00:00Z" }),
     ];
 
     render(<ChatSidebarSection />);
 
-    // 2 pinned + 1 recent = 3 total
+    expect(screen.getByText("Pinned")).toBeInTheDocument();
     expect(screen.getByText("Pinned A")).toBeInTheDocument();
     expect(screen.getByText("Pinned B")).toBeInTheDocument();
-    expect(screen.getByText("Recent A")).toBeInTheDocument();
 
-    // 2nd recent should not show
-    expect(screen.queryByText("Recent B")).not.toBeInTheDocument();
+    // No unpinned chats → no Recents section and no dangling "More".
+    expect(screen.queryByText("Recents")).not.toBeInTheDocument();
+    expect(screen.queryByText("More")).not.toBeInTheDocument();
   });
 
   it("does not show 'More' when total conversations fit in slots", () => {

--- a/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
@@ -34,6 +34,7 @@ import {
   SidebarMenuSubItem,
   useSidebar,
 } from "@/components/ui/sidebar";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   Tooltip,
   TooltipContent,
@@ -407,16 +408,26 @@ export function ChatSidebarSection({
   return (
     <>
       {isLoading ? (
-        <SidebarMenuSub className={subClass}>
-          <SidebarMenuSubItem>
-            <div className="flex items-center gap-2 px-2 py-1.5">
-              <div className="h-3 w-3 animate-spin rounded-full border border-muted-foreground border-t-transparent" />
-              <span className="text-xs text-muted-foreground">
-                Loading chats...
-              </span>
-            </div>
-          </SidebarMenuSubItem>
-        </SidebarMenuSub>
+        <SidebarGroup className="pt-0">
+          <SidebarGroupLabel>Recents</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuSub className={subClass}>
+                  {Array.from({ length: 5 }).map((_, i) => (
+                    <SidebarMenuSubItem key={i}>
+                      <div className="flex w-full items-center justify-between gap-1">
+                        <div className="flex h-8 w-full flex-1 items-center gap-2 rounded-md p-2">
+                          <Skeleton className="h-4 w-full bg-sidebar-foreground/10" />
+                        </div>
+                      </div>
+                    </SidebarMenuSubItem>
+                  ))}
+                </SidebarMenuSub>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
       ) : (
         <>
           {pinnedChats.length > 0 && (

--- a/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
@@ -23,7 +23,12 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
   SidebarMenuButton,
+  SidebarMenuItem,
   SidebarMenuSub,
   SidebarMenuSubButton,
   SidebarMenuSubItem,
@@ -109,10 +114,8 @@ export function ChatSidebarSection({
     ? (pathname.split("/").at(-1) ?? null)
     : null;
 
-  const pinnedChats = conversations.filter((c) => c.pinnedAt).slice(0, slots);
-  const recentUnpinnedChats = conversations
-    .filter((c) => !c.pinnedAt)
-    .slice(0, Math.max(0, slots - pinnedChats.length));
+  const pinnedChats = conversations.filter((c) => c.pinnedAt);
+  const recentUnpinnedChats = conversations.filter((c) => !c.pinnedAt);
 
   useEffect(() => {
     if (editingId && inputRef.current) {
@@ -198,10 +201,7 @@ export function ChatSidebarSection({
     );
   };
 
-  const renderConversationItem = (
-    conv: (typeof conversations)[number],
-    showPinIcon = false,
-  ) => {
+  const renderConversationItem = (conv: (typeof conversations)[number]) => {
     const isCurrentConversation = currentConversationId === conv.id;
     const displayTitle = getConversationDisplayTitle(conv.title, conv.messages);
     const hasRecentlyGeneratedTitle = animatingTitleIds.has(conv.id);
@@ -267,9 +267,6 @@ export function ChatSidebarSection({
               className="cursor-pointer flex-1 justify-between"
             >
               <span className="flex items-center gap-2 min-w-0 flex-1">
-                {showPinIcon && (
-                  <Pin className="h-3 w-3 shrink-0 text-muted-foreground" />
-                )}
                 {conv.share && (
                   <TooltipProvider>
                     <Tooltip>
@@ -404,12 +401,13 @@ export function ChatSidebarSection({
     return null;
   }
 
+  const subClass = flat ? "mx-0 border-l-0 px-0" : "mx-0 ml-3.5 px-0 pl-2.5";
+  const showMore = recentUnpinnedChats.length > slots;
+
   return (
     <>
-      <SidebarMenuSub
-        className={flat ? "mx-0 border-l-0 px-0" : "mx-0 ml-3.5 px-0 pl-2.5"}
-      >
-        {isLoading ? (
+      {isLoading ? (
+        <SidebarMenuSub className={subClass}>
           <SidebarMenuSubItem>
             <div className="flex items-center gap-2 px-2 py-1.5">
               <div className="h-3 w-3 animate-spin rounded-full border border-muted-foreground border-t-transparent" />
@@ -418,25 +416,53 @@ export function ChatSidebarSection({
               </span>
             </div>
           </SidebarMenuSubItem>
-        ) : (
-          <>
-            {pinnedChats.map((conv) => renderConversationItem(conv, true))}
-            {recentUnpinnedChats.map((conv) => renderConversationItem(conv))}
-            {conversations.length >
-              pinnedChats.length + recentUnpinnedChats.length && (
-              <SidebarMenuSubItem>
-                <SidebarMenuSubButton
-                  className="cursor-pointer text-sidebar-foreground/70"
-                  onClick={openConversationSearch}
-                >
-                  <MoreHorizontal />
-                  <span>More</span>
-                </SidebarMenuSubButton>
-              </SidebarMenuSubItem>
-            )}
-          </>
-        )}
-      </SidebarMenuSub>
+        </SidebarMenuSub>
+      ) : (
+        <>
+          {pinnedChats.length > 0 && (
+            <SidebarGroup className="pt-0">
+              <SidebarGroupLabel>Pinned</SidebarGroupLabel>
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  <SidebarMenuItem>
+                    <SidebarMenuSub className={subClass}>
+                      {pinnedChats.map((conv) => renderConversationItem(conv))}
+                    </SidebarMenuSub>
+                  </SidebarMenuItem>
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+          )}
+
+          {recentUnpinnedChats.length > 0 && (
+            <SidebarGroup className="pt-0">
+              <SidebarGroupLabel>Recents</SidebarGroupLabel>
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  <SidebarMenuItem>
+                    <SidebarMenuSub className={subClass}>
+                      {recentUnpinnedChats
+                        .slice(0, slots)
+                        .map((conv) => renderConversationItem(conv))}
+                      {showMore && (
+                        <SidebarMenuSubItem>
+                          <SidebarMenuSubButton
+                            className="cursor-pointer text-sidebar-foreground/70"
+                            onClick={openConversationSearch}
+                          >
+                            <MoreHorizontal />
+                            <span>More</span>
+                          </SidebarMenuSubButton>
+                        </SidebarMenuSubItem>
+                      )}
+                    </SidebarMenuSub>
+                  </SidebarMenuItem>
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+          )}
+        </>
+      )}
 
       <DeleteConfirmDialog
         open={deleteConfirmId !== null}

--- a/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
+import { ChatListSkeleton } from "@/app/_parts/chat-list-skeleton";
 import { AgentIcon } from "@/components/agent-icon";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { TruncatedText } from "@/components/truncated-text";
@@ -34,7 +35,6 @@ import {
   SidebarMenuSubItem,
   useSidebar,
 } from "@/components/ui/sidebar";
-import { Skeleton } from "@/components/ui/skeleton";
 import {
   Tooltip,
   TooltipContent,
@@ -408,28 +408,9 @@ export function ChatSidebarSection({
   return (
     <>
       {isLoading ? (
-        <SidebarGroup className="pt-0">
-          <SidebarGroupLabel>Recents</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <SidebarMenuItem>
-                <SidebarMenuSub className={subClass}>
-                  {Array.from({ length: 5 }).map((_, i) => (
-                    <SidebarMenuSubItem key={i}>
-                      <div className="flex w-full items-center justify-between gap-1">
-                        <div className="flex h-8 w-full flex-1 items-center gap-2 rounded-md p-2">
-                          <Skeleton className="h-4 w-full bg-sidebar-foreground/10" />
-                        </div>
-                      </div>
-                    </SidebarMenuSubItem>
-                  ))}
-                </SidebarMenuSub>
-              </SidebarMenuItem>
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
+        <ChatListSkeleton subClass={subClass} />
       ) : (
-        <>
+        <div className="animate-in fade-in-0 duration-300">
           {pinnedChats.length > 0 && (
             <SidebarGroup className="pt-0">
               <SidebarGroupLabel>Pinned</SidebarGroupLabel>
@@ -472,7 +453,7 @@ export function ChatSidebarSection({
               </SidebarGroupContent>
             </SidebarGroup>
           )}
-        </>
+        </div>
       )}
 
       <DeleteConfirmDialog

--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -192,7 +192,7 @@ function SidebarModeToggle({
   );
 
   return (
-    <div className="mx-2 mt-1 flex rounded-lg border bg-muted p-0.5 group-data-[collapsible=icon]:hidden">
+    <div className="flex rounded-lg border bg-muted p-0.5 group-data-[collapsible=icon]:hidden">
       {segment("chats", "Chats", MessageCircle)}
       {segment("studio", "Studio", PencilRuler)}
     </div>
@@ -672,61 +672,61 @@ export function AppSidebar() {
         >
           <img src={appIconLogo} alt="Logo" className="size-7" />
         </SidebarPrefetchLink>
+        {isAuthenticated && permissionMap && (
+          <SidebarModeToggle mode={sidebarMode} onPick={pickSidebarMode} />
+        )}
       </SidebarHeader>
       <SidebarContent>
-        {isAuthenticated && permissionMap && (
-          <>
-            <SidebarModeToggle mode={sidebarMode} onPick={pickSidebarMode} />
-            {sidebarMode === "chats" ? (
-              <>
-                <NavPrimary
-                  items={filteredChatsNavItems}
-                  groups={[]}
-                  pathname={pathname}
-                  searchParams={searchParams}
-                  permissionMap={permissionMap}
-                />
-                {/* The chat list (Pinned + Recents, labeled inside
+        {isAuthenticated &&
+          permissionMap &&
+          (sidebarMode === "chats" ? (
+            <>
+              <NavPrimary
+                items={filteredChatsNavItems}
+                groups={[]}
+                pathname={pathname}
+                searchParams={searchParams}
+                permissionMap={permissionMap}
+              />
+              {/* The chat list (Pinned + Recents, labeled inside
                     ChatSidebarSection) and the community links below it scroll
                     together within this region, while the nav above stays
                     pinned. The fade hints there is more content below. */}
-                <SidebarGroup className="min-h-0 flex-1 overflow-hidden p-0 after:pointer-events-none after:absolute after:right-2.5 after:bottom-0 after:left-0 after:z-10 after:h-8 after:bg-gradient-to-t after:from-sidebar after:to-transparent">
-                  <SidebarGroupContent className="min-h-0 flex-1 overflow-y-auto pb-8 [scrollbar-gutter:stable] scrollbar-sidebar">
-                    <ChatSidebarSection slots={15} flat />
-                    <NavSecondary
-                      items={[]}
-                      pathname={pathname}
-                      searchParams={searchParams}
-                      permissionMap={permissionMap}
-                      showCommunityLinks={showCommunityLinks}
-                      starCount={formattedStarCount}
-                      className="mt-2.5"
-                    />
-                  </SidebarGroupContent>
-                </SidebarGroup>
-              </>
-            ) : (
-              <>
-                <NavPrimary
-                  items={[]}
-                  groups={filteredNavGroups}
-                  pathname={pathname}
-                  searchParams={searchParams}
-                  permissionMap={permissionMap}
-                />
-                <NavSecondary
-                  items={[]}
-                  pathname={pathname}
-                  searchParams={searchParams}
-                  permissionMap={permissionMap}
-                  showCommunityLinks={showCommunityLinks}
-                  starCount={formattedStarCount}
-                  className="mt-auto"
-                />
-              </>
-            )}
-          </>
-        )}
+              <SidebarGroup className="min-h-0 flex-1 overflow-hidden p-0 after:pointer-events-none after:absolute after:right-2.5 after:bottom-0 after:left-0 after:z-10 after:h-8 after:bg-gradient-to-t after:from-sidebar after:to-transparent">
+                <SidebarGroupContent className="min-h-0 flex-1 overflow-y-auto pb-8 [scrollbar-gutter:stable] scrollbar-sidebar">
+                  <ChatSidebarSection slots={15} flat />
+                  <NavSecondary
+                    items={[]}
+                    pathname={pathname}
+                    searchParams={searchParams}
+                    permissionMap={permissionMap}
+                    showCommunityLinks={showCommunityLinks}
+                    starCount={formattedStarCount}
+                    className="mt-2.5"
+                  />
+                </SidebarGroupContent>
+              </SidebarGroup>
+            </>
+          ) : (
+            <>
+              <NavPrimary
+                items={[]}
+                groups={filteredNavGroups}
+                pathname={pathname}
+                searchParams={searchParams}
+                permissionMap={permissionMap}
+              />
+              <NavSecondary
+                items={[]}
+                pathname={pathname}
+                searchParams={searchParams}
+                permissionMap={permissionMap}
+                showCommunityLinks={showCommunityLinks}
+                starCount={formattedStarCount}
+                className="mt-auto"
+              />
+            </>
+          ))}
         {!isAuthenticated && showCommunityLinks && (
           <NavSecondary
             items={[]}

--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -700,6 +700,7 @@ export function AppSidebar() {
                       permissionMap={permissionMap}
                       showCommunityLinks={showCommunityLinks}
                       starCount={formattedStarCount}
+                      className="mt-2.5"
                     />
                   </SidebarGroupContent>
                 </SidebarGroup>

--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -691,7 +691,7 @@ export function AppSidebar() {
                     together within this region, while the nav above stays
                     pinned. The fade hints there is more content below. */}
                 <SidebarGroup className="min-h-0 flex-1 overflow-hidden p-0 after:pointer-events-none after:absolute after:right-0 after:bottom-0 after:left-0 after:z-10 after:h-8 after:bg-gradient-to-t after:from-sidebar after:to-transparent">
-                  <SidebarGroupContent className="min-h-0 flex-1 overflow-y-auto pb-8 [scrollbar-gutter:stable]">
+                  <SidebarGroupContent className="min-h-0 flex-1 overflow-y-auto pb-8 [scrollbar-gutter:stable] scrollbar-sidebar">
                     <ChatSidebarSection slots={15} flat />
                     <NavSecondary
                       items={[]}

--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -42,6 +42,7 @@ import {
   SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
@@ -505,6 +506,9 @@ const NavSecondary = ({
 
   return (
     <SidebarGroup className={className}>
+      {(permittedItems.length > 0 || showCommunityLinks) && (
+        <SidebarGroupLabel>Help</SidebarGroupLabel>
+      )}
       <SidebarGroupContent>
         <SidebarMenu>
           {permittedItems.map((item) => (
@@ -687,34 +691,43 @@ export function AppSidebar() {
                   permissionMap={permissionMap}
                 />
                 {/* The chat list (Pinned + Recents, labeled inside
-                    ChatSidebarSection) scrolls within its own region so the
-                    community links below (NavSecondary, mt-auto) stay pinned to
-                    the bottom on the chats tab instead of being pushed
-                    off-screen. The fade hints there are more chats below. */}
+                    ChatSidebarSection) and the community links below it scroll
+                    together within this region, while the nav above stays
+                    pinned. The fade hints there is more content below. */}
                 <SidebarGroup className="min-h-0 flex-1 overflow-hidden p-0 after:pointer-events-none after:absolute after:right-0 after:bottom-0 after:left-0 after:z-10 after:h-8 after:bg-gradient-to-t after:from-sidebar after:to-transparent">
-                  <SidebarGroupContent className="min-h-0 flex-1 overflow-y-auto">
+                  <SidebarGroupContent className="min-h-0 flex-1 overflow-y-auto pb-8">
                     <ChatSidebarSection slots={15} flat />
+                    <NavSecondary
+                      items={[]}
+                      pathname={pathname}
+                      searchParams={searchParams}
+                      permissionMap={permissionMap}
+                      showCommunityLinks={showCommunityLinks}
+                      starCount={formattedStarCount}
+                    />
                   </SidebarGroupContent>
                 </SidebarGroup>
               </>
             ) : (
-              <NavPrimary
-                items={[]}
-                groups={filteredNavGroups}
-                pathname={pathname}
-                searchParams={searchParams}
-                permissionMap={permissionMap}
-              />
+              <>
+                <NavPrimary
+                  items={[]}
+                  groups={filteredNavGroups}
+                  pathname={pathname}
+                  searchParams={searchParams}
+                  permissionMap={permissionMap}
+                />
+                <NavSecondary
+                  items={[]}
+                  pathname={pathname}
+                  searchParams={searchParams}
+                  permissionMap={permissionMap}
+                  showCommunityLinks={showCommunityLinks}
+                  starCount={formattedStarCount}
+                  className="mt-auto"
+                />
+              </>
             )}
-            <NavSecondary
-              items={[]}
-              pathname={pathname}
-              searchParams={searchParams}
-              permissionMap={permissionMap}
-              showCommunityLinks={showCommunityLinks}
-              starCount={formattedStarCount}
-              className="mt-auto"
-            />
           </>
         )}
         {!isAuthenticated && showCommunityLinks && (

--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -42,7 +42,6 @@ import {
   SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
@@ -687,17 +686,14 @@ export function AppSidebar() {
                   searchParams={searchParams}
                   permissionMap={permissionMap}
                 />
-                {/* Recents scrolls within its own region so the community
-                    links below (NavSecondary, mt-auto) stay pinned to the
-                    bottom on the chats tab instead of being pushed off-screen. */}
-                <SidebarGroup className="min-h-0 flex-1 overflow-hidden pt-0">
-                  <SidebarGroupLabel>Recents</SidebarGroupLabel>
+                {/* The chat list (Pinned + Recents, labeled inside
+                    ChatSidebarSection) scrolls within its own region so the
+                    community links below (NavSecondary, mt-auto) stay pinned to
+                    the bottom on the chats tab instead of being pushed
+                    off-screen. The fade hints there are more chats below. */}
+                <SidebarGroup className="min-h-0 flex-1 overflow-hidden p-0 after:pointer-events-none after:absolute after:right-0 after:bottom-0 after:left-0 after:z-10 after:h-8 after:bg-gradient-to-t after:from-sidebar after:to-transparent">
                   <SidebarGroupContent className="min-h-0 flex-1 overflow-y-auto">
-                    <SidebarMenu>
-                      <SidebarMenuItem>
-                        <ChatSidebarSection slots={15} flat />
-                      </SidebarMenuItem>
-                    </SidebarMenu>
+                    <ChatSidebarSection slots={15} flat />
                   </SidebarGroupContent>
                 </SidebarGroup>
               </>

--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -690,7 +690,7 @@ export function AppSidebar() {
                     ChatSidebarSection) and the community links below it scroll
                     together within this region, while the nav above stays
                     pinned. The fade hints there is more content below. */}
-                <SidebarGroup className="min-h-0 flex-1 overflow-hidden p-0 after:pointer-events-none after:absolute after:right-0 after:bottom-0 after:left-0 after:z-10 after:h-8 after:bg-gradient-to-t after:from-sidebar after:to-transparent">
+                <SidebarGroup className="min-h-0 flex-1 overflow-hidden p-0 after:pointer-events-none after:absolute after:right-2.5 after:bottom-0 after:left-0 after:z-10 after:h-8 after:bg-gradient-to-t after:from-sidebar after:to-transparent">
                   <SidebarGroupContent className="min-h-0 flex-1 overflow-y-auto pb-8 [scrollbar-gutter:stable] scrollbar-sidebar">
                     <ChatSidebarSection slots={15} flat />
                     <NavSecondary

--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -42,7 +42,6 @@ import {
   SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
@@ -506,9 +505,6 @@ const NavSecondary = ({
 
   return (
     <SidebarGroup className={className}>
-      {(permittedItems.length > 0 || showCommunityLinks) && (
-        <SidebarGroupLabel>Help</SidebarGroupLabel>
-      )}
       <SidebarGroupContent>
         <SidebarMenu>
           {permittedItems.map((item) => (

--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -695,7 +695,7 @@ export function AppSidebar() {
                     together within this region, while the nav above stays
                     pinned. The fade hints there is more content below. */}
                 <SidebarGroup className="min-h-0 flex-1 overflow-hidden p-0 after:pointer-events-none after:absolute after:right-0 after:bottom-0 after:left-0 after:z-10 after:h-8 after:bg-gradient-to-t after:from-sidebar after:to-transparent">
-                  <SidebarGroupContent className="min-h-0 flex-1 overflow-y-auto pb-8">
+                  <SidebarGroupContent className="min-h-0 flex-1 overflow-y-auto pb-8 [scrollbar-gutter:stable]">
                     <ChatSidebarSection slots={15} flat />
                     <NavSecondary
                       items={[]}

--- a/platform/frontend/src/app/globals.css
+++ b/platform/frontend/src/app/globals.css
@@ -220,21 +220,26 @@ div:has(> [data-testid="emoji-picker-list-header"]) {
   color: var(--muted-foreground) !important;
 }
 
-/* Thin scrollbar for sidebar */
-[data-sidebar="sidebar"] {
+/* Thin scrollbar for sidebar scroll regions */
+@utility scrollbar-sidebar {
   scrollbar-width: thin;
-  scrollbar-color: hsl(var(--sidebar-accent)) transparent;
-}
-[data-sidebar="sidebar"] ::-webkit-scrollbar {
-  width: 2px;
-}
-[data-sidebar="sidebar"] ::-webkit-scrollbar-track {
-  background: transparent;
-}
-[data-sidebar="sidebar"] ::-webkit-scrollbar-thumb {
-  background-color: hsl(var(--sidebar-accent));
-  border-radius: 9999px;
-}
-[data-sidebar="sidebar"] ::-webkit-scrollbar-thumb:hover {
-  background-color: hsl(var(--sidebar-accent-foreground) / 0.3);
+  scrollbar-color: var(--color-sidebar-accent) transparent;
+
+  &::-webkit-scrollbar {
+    width: 2px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--color-sidebar-accent);
+    border-radius: 9999px;
+  }
+  &::-webkit-scrollbar-thumb:hover {
+    background-color: color-mix(
+      in oklab,
+      var(--color-sidebar-accent-foreground) 30%,
+      transparent
+    );
+  }
 }

--- a/platform/frontend/src/app/globals.css
+++ b/platform/frontend/src/app/globals.css
@@ -107,6 +107,8 @@
   --shadow-lg: 0 1px 3px 0px hsl(0 0% 0% / 0.10), 0 4px 6px -1px hsl(0 0% 0% / 0.10);
   --shadow-xl: 0 1px 3px 0px hsl(0 0% 0% / 0.10), 0 8px 10px -1px hsl(0 0% 0% / 0.10);
   --tracking-normal: 0em;
+  --scrollbar-thumb: color-mix(in oklab, var(--muted-foreground) 20%, transparent);
+  --scrollbar-thumb-hover: color-mix(in oklab, var(--muted-foreground) 45%, transparent);
 }
 
 @layer base {
@@ -223,7 +225,7 @@ div:has(> [data-testid="emoji-picker-list-header"]) {
 /* Thin scrollbar for sidebar scroll regions */
 @utility scrollbar-sidebar {
   scrollbar-width: thin;
-  scrollbar-color: var(--color-sidebar-accent) transparent;
+  scrollbar-color: var(--scrollbar-thumb) transparent;
 
   &::-webkit-scrollbar {
     width: 2px;
@@ -232,14 +234,10 @@ div:has(> [data-testid="emoji-picker-list-header"]) {
     background: transparent;
   }
   &::-webkit-scrollbar-thumb {
-    background-color: var(--color-sidebar-accent);
+    background-color: var(--scrollbar-thumb);
     border-radius: 9999px;
   }
   &::-webkit-scrollbar-thumb:hover {
-    background-color: color-mix(
-      in oklab,
-      var(--color-sidebar-accent-foreground) 30%,
-      transparent
-    );
+    background-color: var(--scrollbar-thumb-hover);
   }
 }

--- a/platform/frontend/src/app/globals.css
+++ b/platform/frontend/src/app/globals.css
@@ -226,6 +226,7 @@ div:has(> [data-testid="emoji-picker-list-header"]) {
 @utility scrollbar-sidebar {
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb) transparent;
+  padding-inline-end: 2px;
 
   &::-webkit-scrollbar {
     width: 2px;

--- a/platform/frontend/src/components/ui/sidebar.tsx
+++ b/platform/frontend/src/components/ui/sidebar.tsx
@@ -466,7 +466,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto group-data-[collapsible=icon]:overflow-hidden",
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto group-data-[collapsible=icon]:overflow-hidden scrollbar-sidebar",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary

Polish and bug fixes for the sidebar — chat list layout, loading states, and sticky behavior.

## Changes

### Chat list
- Separate **Pinned** and **Recent** chats into distinct sections
- Add a skeleton loading animation for the chat list, delayed slightly to avoid flicker on
fast loads (as per Apple's HIG)
- Add a bottom fade hint indicating more scrollable content below

### Visual fixes
- Keep the **Chats / Studio** toggle pinned to the top by moving it into the sidebar header
(it previously scrolled away on the Studio tab)
- Add a stable scroll gutter so content doesn't shift when the scrollbar appears
- Stop the scrollbar from fading
- Fix a sidebar color glitch

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>