### PR TITLE
fix(sidebar): play chats loaded animation only once

### DIFF
--- a/platform/frontend/src/app/_parts/chat-sidebar-section.test.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.test.tsx
@@ -191,6 +191,11 @@ function makeConv(
 }
 
 describe("ChatSidebarSection", () => {
+  const fadeIn = {
+    pending: () => true,
+    done: () => {},
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockConversations = [];
@@ -198,7 +203,7 @@ describe("ChatSidebarSection", () => {
 
   it("does not render when no conversations exist", () => {
     mockConversations = [];
-    const { container } = render(<ChatSidebarSection />);
+    const { container } = render(<ChatSidebarSection fadeIn={fadeIn} />);
     expect(container.innerHTML).toBe("");
   });
 
@@ -211,7 +216,7 @@ describe("ChatSidebarSection", () => {
       makeConv("c5", "Chat Five", { updatedAt: "2026-01-01T00:00:00Z" }),
     ];
 
-    render(<ChatSidebarSection />);
+    render(<ChatSidebarSection fadeIn={fadeIn} />);
 
     // Should show first 3 recent (conversations come pre-sorted from API)
     expect(screen.getByText("Chat One")).toBeInTheDocument();
@@ -243,7 +248,7 @@ describe("ChatSidebarSection", () => {
       makeConv("c4", "Unpinned One", { updatedAt: "2026-01-02T00:00:00Z" }),
     ];
 
-    render(<ChatSidebarSection />);
+    render(<ChatSidebarSection fadeIn={fadeIn} />);
 
     // Section labels
     expect(screen.getByText("Pinned")).toBeInTheDocument();
@@ -272,7 +277,7 @@ describe("ChatSidebarSection", () => {
       makeConv("c4", "Recent Three", { updatedAt: "2026-01-02T00:00:00Z" }),
     ];
 
-    render(<ChatSidebarSection />);
+    render(<ChatSidebarSection fadeIn={fadeIn} />);
 
     // Pinned shows in its own section; all 3 recents fit the slot budget.
     expect(screen.getByText("Pinned Chat")).toBeInTheDocument();
@@ -296,7 +301,7 @@ describe("ChatSidebarSection", () => {
       }),
     ];
 
-    render(<ChatSidebarSection />);
+    render(<ChatSidebarSection fadeIn={fadeIn} />);
 
     expect(screen.getByText("Pinned")).toBeInTheDocument();
     expect(screen.getByText("Pinned A")).toBeInTheDocument();
@@ -312,7 +317,7 @@ describe("ChatSidebarSection", () => {
       makeConv("c1", "Only Chat", { updatedAt: "2026-01-01T00:00:00Z" }),
     ];
 
-    render(<ChatSidebarSection />);
+    render(<ChatSidebarSection fadeIn={fadeIn} />);
 
     expect(screen.getByText("Only Chat")).toBeInTheDocument();
     expect(screen.queryByText("More")).not.toBeInTheDocument();

--- a/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
@@ -10,7 +10,7 @@ import {
   UsersRound,
 } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import { ChatListSkeleton } from "@/app/_parts/chat-list-skeleton";
 import { AgentIcon } from "@/components/agent-icon";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
@@ -56,10 +56,28 @@ import {
   getConversationShareTooltip,
 } from "@/lib/chat/chat-utils";
 import { useGlobalChat } from "@/lib/chat/global-chat.context";
+import type { Once } from "@/lib/hooks/use-once";
 import { cn } from "@/lib/utils";
 
 const DEFAULT_SIDEBAR_CHAT_SLOTS = 3;
 const MAX_TITLE_LENGTH = 100;
+
+function ChatListFadeIn({
+  fadeIn,
+  children,
+}: {
+  fadeIn: Once;
+  children: ReactNode;
+}) {
+  // Capture once so regular re-renders don't drop the class mid-animation.
+  const [className] = useState(() =>
+    fadeIn.pending() ? "animate-in fade-in-0 duration-300" : "",
+  );
+
+  useEffect(() => fadeIn.done(), [fadeIn.done]);
+
+  return <div className={className}>{children}</div>;
+}
 
 function AISparkleIcon({ isAnimating = false }: { isAnimating?: boolean }) {
   return (
@@ -73,12 +91,15 @@ function AISparkleIcon({ isAnimating = false }: { isAnimating?: boolean }) {
 export function ChatSidebarSection({
   slots = DEFAULT_SIDEBAR_CHAT_SLOTS,
   flat = false,
+  fadeIn,
 }: {
   /** How many chats to show before the "More" affordance. */
   slots?: number;
   /** Render without the sub-menu indentation (used by the Chats tab). */
   flat?: boolean;
-} = {}) {
+  /** One-shot latch so the list fades in only the first time it's shown this session. */
+  fadeIn: Once;
+}) {
   const router = useRouter();
   const pathname = usePathname();
   const isAuthenticated = useIsAuthenticated();
@@ -410,7 +431,7 @@ export function ChatSidebarSection({
       {isLoading ? (
         <ChatListSkeleton subClass={subClass} />
       ) : (
-        <div className="animate-in fade-in-0 duration-300">
+        <ChatListFadeIn fadeIn={fadeIn}>
           {pinnedChats.length > 0 && (
             <SidebarGroup className="pt-0">
               <SidebarGroupLabel>Pinned</SidebarGroupLabel>
@@ -453,7 +474,7 @@ export function ChatSidebarSection({
               </SidebarGroupContent>
             </SidebarGroup>
           )}
-        </div>
+        </ChatListFadeIn>
       )}
 
       <DeleteConfirmDialog

--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -58,6 +58,7 @@ import { useFeature } from "@/lib/config/config.query";
 
 import { useGithubStars } from "@/lib/github/github.query";
 import { useAppIconLogo } from "@/lib/hooks/use-app-name";
+import { useOnce } from "@/lib/hooks/use-once";
 import { cn } from "@/lib/utils";
 
 interface NavSubItem {
@@ -616,6 +617,7 @@ export function AppSidebar() {
   // Projects and My Files are gated behind the ARCHESTRA_PROJECTS_ENABLED env var.
   const projectsEnabled = useFeature("projectsEnabled") === true;
   const [sidebarMode, pickSidebarMode] = useSidebarMode(pathname);
+  const chatListFadeIn = useOnce();
   // Apps are gated behind the ARCHESTRA_APPS_ENABLED env var.
   const appsEnabled = useFeature("appsEnabled") === true;
 
@@ -694,7 +696,7 @@ export function AppSidebar() {
                     pinned. The fade hints there is more content below. */}
               <SidebarGroup className="min-h-0 flex-1 overflow-hidden p-0 after:pointer-events-none after:absolute after:right-2.5 after:bottom-0 after:left-0 after:z-10 after:h-8 after:bg-gradient-to-t after:from-sidebar after:to-transparent">
                 <SidebarGroupContent className="min-h-0 flex-1 overflow-y-auto pb-8 [scrollbar-gutter:stable] scrollbar-sidebar">
-                  <ChatSidebarSection slots={15} flat />
+                  <ChatSidebarSection slots={15} flat fadeIn={chatListFadeIn} />
                   <NavSecondary
                     items={[]}
                     pathname={pathname}

--- a/platform/frontend/src/lib/hooks/use-once.ts
+++ b/platform/frontend/src/lib/hooks/use-once.ts
@@ -1,0 +1,21 @@
+import { useMemo, useRef } from "react";
+
+export type Once = {
+  /** Pure read — `true` until `done()` is called. Safe to call during render. */
+  pending: () => boolean;
+  /** Latches the flag. Call from an effect, never during render. */
+  done: () => void;
+};
+
+export function useOnce(): Once {
+  const doneRef = useRef(false);
+  return useMemo(
+    () => ({
+      pending: () => !doneRef.current,
+      done: () => {
+        doneRef.current = true;
+      },
+    }),
+    [],
+  );
+}


### PR DESCRIPTION
## Summary 

Tiny follow up for https://github.com/archestra-ai/archestra/pull/5738

The sidebar chat list re-ran its fade-in animation on every mount — switching Chats/Studio tabs replayed it. Added a `useOnce` hook (passed from the stable AppSidebar) so the list fades in only the first time it's shown per session

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>