### PR TITLE
fix(mcp): let non-admin members re-authenticate their MCP connections

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -175150,7 +175150,7 @@
         "tags": [
           "MCP Server"
         ],
-        "description": "Update MCP server secret after re-authentication (clears OAuth refresh errors)\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`mcpServerInstallation:update`: Modify installed MCP server configuration",
+        "description": "Update MCP server secret after re-authentication (clears OAuth refresh errors)\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`mcpServerInstallation:create`: Install MCP servers from the registry",
         "requestBody": {
           "required": true,
           "content": {
@@ -175644,7 +175644,7 @@
         "x-required-permissions": {
           "kind": "static",
           "permissions": [
-            "mcpServerInstallation:update"
+            "mcpServerInstallation:create"
           ]
         }
       }

--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -217,6 +217,24 @@ export function InternalMCPCatalog({
   const [detailsServerName, setDetailsServerName] = useState<string | null>(
     null,
   );
+
+  // The connection being re-authenticated keeps its existing scope, so the
+  // install dialogs need its scope/team to lock the selector (otherwise the
+  // selector treats re-auth as a fresh install and disables the already-used
+  // scope, leaving the owner unable to re-authenticate their own connection).
+  const reauthServer = useMemo(
+    () =>
+      reauthServerId
+        ? installedServers?.find((server) => server.id === reauthServerId)
+        : undefined,
+    [reauthServerId, installedServers],
+  );
+  const reauthExistingScope: McpServerInstallScope | undefined = reauthServerId
+    ? (reauthServer?.scope ?? (reauthServer?.teamId ? "team" : "personal"))
+    : undefined;
+  const reauthExistingTeamId: string | null | undefined = reauthServerId
+    ? (reauthServer?.teamId ?? null)
+    : undefined;
   const { data: detailsServerData } = useMcpRegistryServer(detailsServerName);
 
   const { data: _userIsMcpServerAdmin } = useHasPermissions({
@@ -1725,8 +1743,12 @@ export function InternalMCPCatalog({
         }
         isReauth={!!reauthServerId}
         isReinstall={!!reinstallServerId && !reauthServerId}
-        existingTeamId={reinstallServerTeamId}
-        existingScope={reinstallServerScope}
+        existingTeamId={
+          reauthServerId ? reauthExistingTeamId : reinstallServerTeamId
+        }
+        existingScope={
+          reauthServerId ? reauthExistingScope : reinstallServerScope
+        }
         preselectedTeamId={preselectedTeamId}
         personalOnly={installPersonalOnly}
         orgOnly={installOrgOnly}
@@ -1753,6 +1775,7 @@ export function InternalMCPCatalog({
         preselectedTeamId={preselectedTeamId}
         personalOnly={installPersonalOnly}
         orgOnly={installOrgOnly}
+        isReauth={!!reauthServerId}
       />
 
       <ReinstallConfirmationDialog
@@ -1807,8 +1830,12 @@ export function InternalMCPCatalog({
             reauthMutation.isPending
           }
           isReinstall={!!reinstallServerId}
-          existingTeamId={reinstallServerTeamId}
-          existingScope={reinstallServerScope}
+          existingTeamId={
+            reauthServerId ? reauthExistingTeamId : reinstallServerTeamId
+          }
+          existingScope={
+            reauthServerId ? reauthExistingScope : reinstallServerScope
+          }
           isReauth={!!reauthServerId}
           preselectedTeamId={preselectedTeamId}
           personalOnly={installPersonalOnly}

--- a/platform/frontend/src/app/mcp/registry/_parts/local-server-install-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/local-server-install-dialog.tsx
@@ -571,10 +571,11 @@ export function LocalServerInstallDialog({
 
       <SelectMcpServerCredentialTypeAndTeams
         onTeamChange={setSelectedTeamId}
-        catalogId={isReinstall ? undefined : catalogItem?.id}
+        catalogId={isReinstall || isReauth ? undefined : catalogItem?.id}
         onScopeChange={setScope}
         onCanInstallChange={setCanInstall}
         isReinstall={isReinstall}
+        isReauth={isReauth}
         existingTeamId={existingTeamId}
         existingScope={existingScope}
         personalOnly={

--- a/platform/frontend/src/app/mcp/registry/_parts/remote-server-install-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/remote-server-install-dialog.tsx
@@ -397,6 +397,7 @@ export function RemoteServerInstallDialog({
         onScopeChange={setScope}
         onCanInstallChange={setCanInstall}
         isReinstall={isReinstall}
+        isReauth={isReauth}
         existingScope={existingScope}
         existingTeamId={existingTeamId}
         preselectedTeamId={preselectedTeamId}

--- a/platform/frontend/src/app/mcp/registry/_parts/select-mcp-server-credential-type-and-teams.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/select-mcp-server-credential-type-and-teams.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SelectMcpServerCredentialTypeAndTeams } from "./select-mcp-server-credential-type-and-teams";
+
+const CATALOG_ID = "cat-1";
+const CURRENT_USER_ID = "user-1";
+
+// A personal connection the current user already installed for this catalog.
+const installedServers = [
+  {
+    id: "srv-1",
+    catalogId: CATALOG_ID,
+    scope: "personal",
+    ownerId: CURRENT_USER_ID,
+    teamId: null,
+  },
+];
+
+vi.mock("@/lib/mcp/mcp-server.query", () => ({
+  useMcpServers: () => ({ data: installedServers }),
+}));
+
+vi.mock("@/lib/auth/auth.query", () => ({
+  useSession: () => ({ data: { user: { id: CURRENT_USER_ID } } }),
+  // Member role: no mcpServerInstallation:update and no :admin.
+  useHasPermissions: () => ({ data: false }),
+}));
+
+vi.mock("@/lib/teams/team.query", () => ({
+  useAssignableTeams: () => ({ data: [], isLoading: false }),
+}));
+
+describe("SelectMcpServerCredentialTypeAndTeams", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("blocks a fresh install when every scope is already taken", async () => {
+    const onCanInstallChange = vi.fn();
+
+    render(
+      <SelectMcpServerCredentialTypeAndTeams
+        onTeamChange={vi.fn()}
+        catalogId={CATALOG_ID}
+        onCanInstallChange={onCanInstallChange}
+      />,
+    );
+
+    // Personal already installed, no team/org permission → nothing installable.
+    await waitFor(() =>
+      expect(onCanInstallChange).toHaveBeenLastCalledWith(false),
+    );
+    expect(screen.getByText("Already installed")).toBeInTheDocument();
+  });
+
+  it("lets the owner re-authenticate their existing personal connection", async () => {
+    const onCanInstallChange = vi.fn();
+
+    render(
+      <SelectMcpServerCredentialTypeAndTeams
+        onTeamChange={vi.fn()}
+        catalogId={CATALOG_ID}
+        onCanInstallChange={onCanInstallChange}
+        isReauth
+        existingScope="personal"
+      />,
+    );
+
+    // Re-auth locks to the existing (personal) scope instead of disabling it,
+    // so the connection stays editable and the dead-end notice is gone.
+    await waitFor(() =>
+      expect(onCanInstallChange).toHaveBeenLastCalledWith(true),
+    );
+    expect(screen.queryByText("Already installed")).not.toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/_parts/select-mcp-server-credential-type-and-teams.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/select-mcp-server-credential-type-and-teams.tsx
@@ -37,9 +37,17 @@ interface SelectMcpServerCredentialTypeAndTeamsProps {
   onScopeChange?: (scope: McpServerInstallScope) => void;
   /** When true, this is a reinstall - scope is locked to existing value */
   isReinstall?: boolean;
-  /** The team ID of the existing server being reinstalled (null/undefined = personal/org) */
+  /**
+   * When true, this is a re-authentication. Like reinstall, the connection's
+   * scope cannot change — it is locked to the existing value. Without this the
+   * selector treats re-auth as a fresh install and disables the already-used
+   * scope ("already installed"), leaving the owner unable to re-authenticate
+   * their own connection.
+   */
+  isReauth?: boolean;
+  /** The team ID of the existing server being reinstalled/re-authenticated (null/undefined = personal/org) */
   existingTeamId?: string | null;
-  /** The scope of the existing server being reinstalled */
+  /** The scope of the existing server being reinstalled/re-authenticated */
   existingScope?: McpServerInstallScope;
   /** When true, only personal installation is allowed */
   personalOnly?: boolean;
@@ -58,6 +66,7 @@ export function SelectMcpServerCredentialTypeAndTeams({
   catalogId,
   onScopeChange,
   isReinstall = false,
+  isReauth = false,
   existingTeamId,
   existingScope,
   personalOnly = false,
@@ -66,6 +75,10 @@ export function SelectMcpServerCredentialTypeAndTeams({
   onCanInstallChange,
   preselectedTeamId,
 }: SelectMcpServerCredentialTypeAndTeamsProps) {
+  // Reinstall and re-auth both keep the connection's existing scope — neither
+  // picks a new one, so the scope is locked to the existing value rather than
+  // disabled because the scope is "already installed".
+  const lockToExistingScope = isReinstall || isReauth;
   const { data: installedServers } = useMcpServers();
   const { data: session } = useSession();
   const currentUserId = session?.user?.id;
@@ -122,13 +135,13 @@ export function SelectMcpServerCredentialTypeAndTeams({
 
   const availableTeams = useMemo(() => {
     if (!teams) return [];
-    if (isReinstall) return teams;
+    if (lockToExistingScope) return teams;
     if (!catalogId) return teams;
     return teams.filter((t) => !teamsWithInstallation.includes(t.id));
-  }, [teams, catalogId, teamsWithInstallation, isReinstall]);
+  }, [teams, catalogId, teamsWithInstallation, lockToExistingScope]);
 
   const initialScope: McpServerInstallScope = useMemo(() => {
-    if (isReinstall) {
+    if (lockToExistingScope) {
       return existingScope ?? (existingTeamId ? "team" : "personal");
     }
     if (orgOnly) return "org";
@@ -138,7 +151,7 @@ export function SelectMcpServerCredentialTypeAndTeams({
     if (hasPersonalInstallation && availableTeams.length > 0) return "team";
     return "personal";
   }, [
-    isReinstall,
+    lockToExistingScope,
     existingScope,
     existingTeamId,
     orgOnly,
@@ -151,31 +164,31 @@ export function SelectMcpServerCredentialTypeAndTeams({
 
   const [scope, setScope] = useState<McpServerInstallScope>(initialScope);
   const [selectedTeamId, setSelectedTeamId] = useState<string | null>(() => {
-    if (isReinstall) return existingTeamId ?? null;
+    if (lockToExistingScope) return existingTeamId ?? null;
     if (preselectedTeamId) return preselectedTeamId;
     return null;
   });
 
-  // WHY: During reinstall, lock scope to existing value (can't change ownership).
-  // Personal is disabled if: reinstalling a non-personal server, or (for new install)
-  // already has personal or BYOS enabled.
+  // WHY: During reinstall/re-auth, lock scope to existing value (can't change
+  // ownership). Personal is disabled if: reinstalling/re-authing a non-personal
+  // server, or (for new install) already has personal or BYOS enabled.
   const isPersonalDisabled =
     teamOnly || orgOnly
       ? true
       : personalOnly
         ? false
-        : isReinstall
+        : lockToExistingScope
           ? initialScope !== "personal"
           : hasPersonalInstallation;
 
   // WHY: Team options are disabled if:
   // 1. personalOnly or orgOnly mode (only that scope is allowed)
-  // 2. Reinstalling a non-team server (can't switch to team)
+  // 2. Reinstalling/re-authing a non-team server (can't switch to team)
   // 3. User lacks mcpServer:update permission (members can never create team installations)
   const isTeamDisabled =
     personalOnly || orgOnly
       ? true
-      : isReinstall
+      : lockToExistingScope
         ? initialScope !== "team"
         : !hasMcpServerUpdate || availableTeams.length === 0;
 
@@ -185,7 +198,7 @@ export function SelectMcpServerCredentialTypeAndTeams({
       ? true
       : orgOnly
         ? false
-        : isReinstall
+        : lockToExistingScope
           ? initialScope !== "org"
           : !isMcpServerAdmin || hasOrgInstallation;
 
@@ -266,7 +279,7 @@ export function SelectMcpServerCredentialTypeAndTeams({
   ]);
 
   useEffect(() => {
-    if (isReinstall) {
+    if (lockToExistingScope) {
       onScopeChange?.(initialScope);
       onTeamChange(initialScope === "team" ? (existingTeamId ?? null) : null);
       return;
@@ -299,7 +312,7 @@ export function SelectMcpServerCredentialTypeAndTeams({
     onScopeChange?.(scope);
     onTeamChange(scope === "team" ? selectedTeamId : null);
   }, [
-    isReinstall,
+    lockToExistingScope,
     initialScope,
     existingTeamId,
     visibilityOptions,

--- a/platform/frontend/src/components/chat/editable-user-message.tsx
+++ b/platform/frontend/src/components/chat/editable-user-message.tsx
@@ -12,7 +12,6 @@ import {
 import { MessageActions } from "@/components/chat/message-actions";
 import { UserMessageText } from "@/components/chat/user-message-text";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import {
   getAttachmentFallbackLabel,
   isCsvAttachment,

--- a/platform/frontend/src/components/oauth-confirmation-dialog.test.tsx
+++ b/platform/frontend/src/components/oauth-confirmation-dialog.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEffect } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { OAuthConfirmationDialog } from "./oauth-confirmation-dialog";
+
+// Simulate a catalog item that is already installed everywhere the caller can
+// install it — the real selector reports canInstall=false and renders the
+// "Already installed" notice in that situation.
+vi.mock(
+  "@/app/mcp/registry/_parts/select-mcp-server-credential-type-and-teams",
+  () => ({
+    SelectMcpServerCredentialTypeAndTeams: ({
+      onCanInstallChange,
+    }: {
+      onCanInstallChange: (value: boolean) => void;
+    }) => {
+      useEffect(() => {
+        onCanInstallChange(false);
+      }, [onCanInstallChange]);
+      return (
+        <div data-testid="credential-type-selector">Already installed</div>
+      );
+    },
+  }),
+);
+
+vi.mock("@/lib/config/config.query", () => ({
+  useFeature: () => false,
+}));
+
+describe("OAuthConfirmationDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("blocks installing a server that is already installed everywhere", () => {
+    render(
+      <OAuthConfirmationDialog
+        open
+        onOpenChange={vi.fn()}
+        serverName="PLAY"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+        catalogId="catalog-1"
+      />,
+    );
+
+    // Install mode renders the scope selector, which reports "already installed"
+    // and removes the "Continue to Authorization" action.
+    expect(screen.getByTestId("credential-type-selector")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /continue to authorization/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("lets the user re-authorize an already-installed connection", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+
+    render(
+      <OAuthConfirmationDialog
+        open
+        onOpenChange={vi.fn()}
+        serverName="PLAY"
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+        catalogId="catalog-1"
+        isReauth
+      />,
+    );
+
+    // Re-auth keeps the existing scope, so the selector (and its dead-end
+    // "Already installed" state) is skipped and the user can proceed.
+    expect(
+      screen.queryByTestId("credential-type-selector"),
+    ).not.toBeInTheDocument();
+
+    const continueButton = screen.getByRole("button", {
+      name: /continue to authorization/i,
+    });
+    expect(continueButton).toBeInTheDocument();
+
+    await user.click(continueButton);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/platform/frontend/src/components/oauth-confirmation-dialog.tsx
+++ b/platform/frontend/src/components/oauth-confirmation-dialog.tsx
@@ -33,6 +33,14 @@ interface OAuthConfirmationDialogProps {
   personalOnly?: boolean;
   /** When true, only organization-wide installation is allowed */
   orgOnly?: boolean;
+  /**
+   * When true, the dialog re-authorizes an existing connection rather than
+   * installing a new one. Re-auth keeps the connection's existing scope, so the
+   * scope/credential-type selector is skipped — rendering it would surface an
+   * "Already installed" dead-end (no scope is installable) and hide the
+   * "Continue to Authorization" button.
+   */
+  isReauth?: boolean;
 }
 
 export function OAuthConfirmationDialog({
@@ -45,6 +53,7 @@ export function OAuthConfirmationDialog({
   preselectedTeamId,
   personalOnly = false,
   orgOnly = false,
+  isReauth = false,
 }: OAuthConfirmationDialogProps) {
   const [scope, setScope] = useState<McpServerInstallScope>(
     orgOnly ? "org" : preselectedTeamId ? "team" : "personal",
@@ -119,15 +128,22 @@ export function OAuthConfirmationDialog({
         </Alert>
       ) : null}
 
-      <SelectMcpServerCredentialTypeAndTeams
-        onTeamChange={setSelectedTeamId}
-        onScopeChange={setScope}
-        catalogId={catalogId}
-        onCanInstallChange={setCanInstall}
-        preselectedTeamId={preselectedTeamId}
-        personalOnly={personalOnly}
-        orgOnly={orgOnly}
-      />
+      {isReauth ? (
+        <p className="text-muted-foreground text-sm">
+          You'll re-authorize your existing {serverName} connection. Its access
+          settings stay the same.
+        </p>
+      ) : (
+        <SelectMcpServerCredentialTypeAndTeams
+          onTeamChange={setSelectedTeamId}
+          onScopeChange={setScope}
+          catalogId={catalogId}
+          onCanInstallChange={setCanInstall}
+          preselectedTeamId={preselectedTeamId}
+          personalOnly={personalOnly}
+          orgOnly={orgOnly}
+        />
+      )}
     </StandardFormDialog>
   );
 }

--- a/platform/shared/access-control.test.ts
+++ b/platform/shared/access-control.test.ts
@@ -7,7 +7,11 @@ import {
   predefinedPermissionsMap,
   requiredEndpointPermissionsMap,
 } from "./access-control";
-import { internalResources, type Resource } from "./permission.types";
+import {
+  type Action,
+  internalResources,
+  type Resource,
+} from "./permission.types";
 import { ADMIN_ROLE_NAME } from "./roles";
 import { RouteId } from "./routes";
 
@@ -92,6 +96,44 @@ describe("access-control", () => {
       const required =
         requiredEndpointPermissionsMap[RouteId.GetSkillSandboxArtifact];
       expect(required?.sandbox).toContain("execute");
+    });
+  });
+
+  describe("MCP server re-authentication route", () => {
+    // Returns true when `rolePermissions` covers every resource:action pair the
+    // route's RBAC middleware gate demands. Mirrors what hasPermission() does
+    // for the requiredEndpointPermissionsMap entry before the handler runs.
+    const roleSatisfiesRoute = (
+      rolePermissions: Partial<Record<Resource, Action[]>>,
+      routeId: RouteId,
+    ): boolean => {
+      const required = requiredEndpointPermissionsMap[routeId] ?? {};
+      return Object.entries(required).every(([resource, actions]) =>
+        (actions as Action[]).every((action) =>
+          rolePermissions[resource as Resource]?.includes(action),
+        ),
+      );
+    };
+
+    // Re-authentication re-supplies credentials for a connection the caller can
+    // already install — it must not demand a stricter permission than install.
+    // The handler's own gate (mcp-server.ts) only requires mcpServerInstallation
+    // :create and then does scope-aware authorization; if the middleware gate
+    // asks for :update instead, members who installed a connection hit a bare
+    // 403 the moment their OAuth token expires and they try to re-authenticate.
+    test("requires the same install permission as InstallMcpServer", () => {
+      expect(
+        requiredEndpointPermissionsMap[RouteId.ReauthenticateMcpServer],
+      ).toEqual(requiredEndpointPermissionsMap[RouteId.InstallMcpServer]);
+    });
+
+    test("is satisfiable by the member role (members can install)", () => {
+      // Members can install (and therefore own) connections...
+      expect(memberPermissions.mcpServerInstallation).toContain("create");
+      // ...so the middleware gate must let them reach the re-auth handler.
+      expect(
+        roleSatisfiesRoute(memberPermissions, RouteId.ReauthenticateMcpServer),
+      ).toBe(true);
     });
   });
 });

--- a/platform/shared/access-control.ts
+++ b/platform/shared/access-control.ts
@@ -647,7 +647,13 @@ export const requiredEndpointPermissionsMap: Partial<
     mcpServerInstallation: ["delete"],
   },
   [RouteId.ReauthenticateMcpServer]: {
-    mcpServerInstallation: ["update"],
+    // Re-authentication re-supplies credentials for a connection the caller can
+    // already install, so it is gated like installation (:create), not :update.
+    // The handler does scope-aware authorization (owner-only for personal,
+    // team-admin for team, etc.) for the finer-grained check. Requiring :update
+    // here locked out members — who have :create but not :update — with a bare
+    // 403 the moment their OAuth token expired and they tried to re-authenticate.
+    mcpServerInstallation: ["create"],
   },
   [RouteId.ReinstallMcpServer]: {
     mcpServerInstallation: ["update"],

--- a/platform/shared/hey-api/clients/api/sdk.gen.ts
+++ b/platform/shared/hey-api/clients/api/sdk.gen.ts
@@ -3887,7 +3887,7 @@ export const getMcpServer = <ThrowOnError extends boolean = false>(options: Opti
  *
  * Authorization:
  *
- * `mcpServerInstallation:update`: Modify installed MCP server configuration
+ * `mcpServerInstallation:create`: Install MCP servers from the registry
  */
 export const reauthenticateMcpServer = <ThrowOnError extends boolean = false>(options: Options<ReauthenticateMcpServerData, ThrowOnError>) => (options.client ?? client).patch<ReauthenticateMcpServerResponses, ReauthenticateMcpServerErrors, ThrowOnError>({
     url: '/api/mcp_server/{id}/reauthenticate',


### PR DESCRIPTION
## Problem

Re-authenticating an MCP connection after its OAuth token / credentials expire was **impossible for non-admin members**. Depending on the entry point (built-in chat, the **Credentials → Re-authenticate** button, the deep-link re-auth URL, or the Slack flow), users hit either a bare **"Forbidden"** toast or an **"Already installed"** dead-end with no way to submit new credentials.

## Root causes (two independent bugs, both fixed)

### 1. RBAC gate stricter than the handler intends → bare 403
`PATCH /api/mcp_server/:id/reauthenticate` required `mcpServerInstallation:update` in the middleware permission map (`shared/access-control.ts`), but the route handler itself only requires `:create` and then performs **scope-aware authorization** (owner-only for personal, team-admin for team, admin for org). Members have `:create` but **not** `:update`, so the middleware rejected them with a bare `403 Forbidden` *before the handler ran*.

Every OAuth re-auth finishes by calling this PATCH (in `oauth-callback`), so the chat, credentials, and deep-link flows all failed at the final step. Fix: gate it like installation (`:create`), matching the handler's own check.

### 2. Scope selector treated re-auth as a fresh install → "Already installed"
The install dialogs reuse the credential-type / scope selector, which disables any scope that is "already installed". During re-auth the connection already exists, so the selector disabled the owner's own scope (*"You have already installed this server personally"*) or rendered an **"Already installed"** notice with no submit button.

Re-auth keeps the connection's existing scope, so the selector is now **locked to that scope** (same as reinstall) instead of disabled. This covers the pure-OAuth confirmation dialog, the remote/local credential dialogs, and the deep-link re-auth URL.

## Tests

- `shared/access-control.test.ts` — the re-auth route must be satisfiable by the member role and require the same permission as install. (Fails on old `:update` gate.)
- `frontend/.../oauth-confirmation-dialog.test.tsx` & `select-mcp-server-credential-type-and-teams.test.tsx` — re-auth keeps the connection editable instead of the "Already installed" dead-end. (Reauth case fails without the fix.)

Existing route tests couldn't catch bug #1 because they bypass the auth middleware and mock `hasPermission`; the gate lives in the permission-map data, so the regression test asserts that invariant directly.

## Manual verification (live server, real non-admin member)

| Permission gate | Member calls `reauthenticate` |
| --- | --- |
| `:update` (before) | `403 Forbidden` ← reproduces the reported symptom |
| `:create` (after)  | passes the gate → `404` for a nonexistent id |