### PR TITLE
perf(database): clear health check timeout after successful database probe

### DIFF
--- a/platform/backend/src/database/index.ts
+++ b/platform/backend/src/database/index.ts
@@ -120,17 +120,22 @@ export async function isDatabaseHealthy(): Promise<boolean> {
     return false;
   }
 
+  let timeoutHandle: NodeJS.Timeout | undefined;
   try {
     await Promise.race([
       pool.query("SELECT 1"),
-      new Promise((_, reject) =>
-        setTimeout(() => reject(new Error("Health check timeout")), 3000),
-      ),
+      new Promise((_, reject) => {
+        timeoutHandle = setTimeout(() => reject(new Error("Health check timeout")), 3000);
+      }),
     ]);
     return true;
   } catch (error) {
     logger.warn({ error }, "Database health check failed");
     return false;
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
   }
 }
 

--- a/platform/backend/src/database/index.ts
+++ b/platform/backend/src/database/index.ts
@@ -125,7 +125,10 @@ export async function isDatabaseHealthy(): Promise<boolean> {
     await Promise.race([
       pool.query("SELECT 1"),
       new Promise((_, reject) => {
-        timeoutHandle = setTimeout(() => reject(new Error("Health check timeout")), 3000);
+        timeoutHandle = setTimeout(
+          () => reject(new Error("Health check timeout")),
+          3000,
+        );
       }),
     ]);
     return true;


### PR DESCRIPTION
## Summary

- Store the timeout handle used by the database health check.
- Clear the timeout in a `finally` block after `Promise.race()` completes.
- Preserve existing behavior while avoiding unnecessary pending timers.

Closes #5694.