### PR TITLE
fix(bench): full trajectory rendering + transient-timeout retry; sandbox stderr on failure

### DIFF
--- a/archestra-bench/analyzer/src/lib.rs
+++ b/archestra-bench/analyzer/src/lib.rs
@@ -59,7 +59,8 @@ fn note(mp: &MultiProgress, msg: impl AsRef<str>) {
     }
 }
 
-/// One discovered benchmark rollout with its trajectory already rendered to the markdown fed to map.
+/// One discovered benchmark rollout with its trajectory rendered to markdown in full — the same
+/// untruncated text is both persisted as `trajectory.md` and fed to the map-phase LLM.
 #[derive(Debug)]
 struct Rollout {
     id: RolloutId,
@@ -200,8 +201,8 @@ pub struct PrepareManifest {
 pub fn prepare_run_dir(run_dir: &Path) -> Result<PrepareManifest> {
     let mut rollouts = discover_rollouts(run_dir)?;
 
-    // Persist the rendered trajectory next to its source jsonl (same side effect as `analyze`), so
-    // an external map phase reads the exact markdown the Rust map phase would.
+    // Persist the full rendered trajectory next to its source jsonl (same side effect as `analyze`),
+    // so external tooling reads the complete, untruncated trajectory.
     for rollout in &rollouts {
         let md_path = rollout.dir.join("trajectory.md");
         std::fs::write(&md_path, &rollout.markdown)
@@ -265,8 +266,8 @@ pub async fn analyze(cfg: AnalyzeConfig) -> Result<()> {
         format!("● {total} rollouts in {}", cfg.run_dir.display()),
     );
 
-    // Persist the rendered trajectory we feed the map phase next to its source jsonl, so the map
-    // input is inspectable after the fact. `trajectory.md` is never re-discovered (glob wants jsonl).
+    // Persist the full rendered trajectory next to its source jsonl, so the rollout is inspectable
+    // after the fact in full. `trajectory.md` is never re-discovered (glob wants jsonl).
     for rollout in &rollouts {
         let md_path = rollout.dir.join("trajectory.md");
         std::fs::write(&md_path, &rollout.markdown)
@@ -602,8 +603,8 @@ mod tests {
 
         let manifest = prepare_run_dir(run.path()).unwrap();
 
-        // trajectory.md is rendered next to each source jsonl, byte-identical to what
-        // format_to_markdown produces (so the map phase reads exactly the Rust-rendered trajectory).
+        // trajectory.md is rendered next to each source jsonl, byte-identical to the full
+        // trajectory rendering.
         let glm_dir = run.path().join("basic/pi__glm");
         let expected =
             format_to_markdown(&load_trajectory(&glm_dir.join("trajectory.jsonl")).unwrap());

--- a/archestra-bench/analyzer/src/trajectory.rs
+++ b/archestra-bench/analyzer/src/trajectory.rs
@@ -4,30 +4,16 @@
 //! Each line is one `kind`-tagged event. Parsing is clean-or-fail: a non-JSON line or a
 //! known-kind record missing a required field aborts the rollout with its `path:line`; only an
 //! unrecognised `kind` degrades to [`Event::Unknown`] (forward-compat with new event kinds).
+//!
+//! Rendering is verbatim: every field is emitted in full, both for the persisted `trajectory.md`
+//! artifact and for the map-phase LLM input. The trajectory is the analysis's primary evidence, so
+//! nothing in it is truncated — a long tool output or system prompt is signal, not noise to cap.
 
 use std::fmt;
 use std::path::{Path, PathBuf};
 
 use archestra_bench_core::Event;
 use serde_json::Value;
-
-/// Per-field render cap (Unicode scalar values), so a single huge tool blob or reasoning dump
-/// cannot dominate the map prompt.
-const MAX_FIELD_CHARS: usize = 8192;
-
-/// Char-safe truncation: keeps the prefix and appends a marker. Cuts on a char boundary, so it
-/// never panics on multibyte input.
-fn cap_chars(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
-        return s.to_string();
-    }
-    let cut = s.char_indices().nth(max).map(|(i, _)| i).unwrap_or(s.len());
-    format!(
-        "{}\n[truncated, {} chars total]",
-        &s[..cut],
-        s.chars().count()
-    )
-}
 
 /// A parse failure pinned to its source line, so the operator can find the offending record.
 #[derive(Debug)]
@@ -74,23 +60,6 @@ pub fn load_trajectory(path: &Path) -> Result<Vec<Event>, LoadError> {
     Ok(events)
 }
 
-/// Replace any string longer than `MAX_FIELD_CHARS` with a placeholder, recursing into
-/// nested objects/arrays so a single huge tool output cannot dominate the prompt.
-fn truncate_long_strings(value: &Value) -> Value {
-    match value {
-        Value::String(s) if s.chars().count() > MAX_FIELD_CHARS => {
-            Value::String(format!("[truncated {} chars]", s.chars().count()))
-        }
-        Value::Object(map) => Value::Object(
-            map.iter()
-                .map(|(k, v)| (k.clone(), truncate_long_strings(v)))
-                .collect(),
-        ),
-        Value::Array(items) => Value::Array(items.iter().map(truncate_long_strings).collect()),
-        other => other.clone(),
-    }
-}
-
 /// The product's built-in dispatcher that forwards a call to a discovered MCP tool. It is optional
 /// (a deployment can turn it off) but on by default, so most agents reach `submit_result` and other
 /// discovered tools *through* it. Rendered verbatim it reads as a distinct tool the agent "should
@@ -112,15 +81,15 @@ fn unwrap_dispatch<'a>(tool_name: &'a str, input: &'a Value) -> (String, &'a Val
 }
 
 fn render_value(value: &Value) -> String {
-    let truncated = truncate_long_strings(value);
-    match &truncated {
+    match value {
         Value::String(s) => s.clone(),
         other => serde_json::to_string_pretty(other).unwrap_or_else(|_| other.to_string()),
     }
 }
 
-/// Render the trajectory as readable markdown for an LLM: reasoning, tool calls, tool results,
-/// and terminal errors. Bookkeeping events (token usage, finish, conversation id) are elided.
+/// Render the trajectory as readable markdown: reasoning, tool calls, tool results, and terminal
+/// errors. Bookkeeping events (token usage, finish, conversation id) are elided. Every field is
+/// rendered in full — the trajectory is the analysis's evidence, so nothing is truncated.
 pub fn format_to_markdown(events: &[Event]) -> String {
     let mut out = String::from("# Agent trajectory\n\n");
     for event in events {
@@ -131,16 +100,16 @@ pub fn format_to_markdown(events: &[Event]) -> String {
             } => {
                 if !system_prompt.trim().is_empty() {
                     out.push_str("### System prompt\n");
-                    out.push_str(&cap_chars(system_prompt, MAX_FIELD_CHARS));
+                    out.push_str(system_prompt);
                     out.push_str("\n\n");
                 }
                 out.push_str("### Task\n");
-                out.push_str(&cap_chars(user_message, MAX_FIELD_CHARS));
+                out.push_str(user_message);
                 out.push_str("\n\n");
             }
             Event::AssistantText { text } => {
                 out.push_str("### Agent\n");
-                out.push_str(&cap_chars(text, MAX_FIELD_CHARS));
+                out.push_str(text);
                 out.push_str("\n\n");
             }
             Event::ToolCall { tool_name, input } => {
@@ -169,7 +138,7 @@ pub fn format_to_markdown(events: &[Event]) -> String {
             }
             Event::EffectivePrompt(data) => {
                 out.push_str("### Effective system prompt\n");
-                out.push_str(&cap_chars(&data.system_prompt, MAX_FIELD_CHARS));
+                out.push_str(&data.system_prompt);
                 out.push_str(&format!(
                     "\n\n_tools ({}): {}_\n_sampling: temperature={:?} max_tokens={:?} top_p={:?}_\n_used by {} call(s)_\n\n",
                     data.tools.len(),
@@ -297,25 +266,22 @@ mod tests {
     }
 
     #[test]
-    fn oversized_nested_strings_are_truncated() {
-        let big = "z".repeat(MAX_FIELD_CHARS + 10);
-        let line =
-            format!(r#"{{"kind":"tool_output","tool_call_id":"x","output":{{"log":"{big}"}}}}"#);
-        let (_dir, path) = write_fixture(&[&line]);
-        let events = load_trajectory(&path).unwrap();
-        let md = format_to_markdown(&events);
-        assert!(md.contains("[truncated"));
-        assert!(!md.contains(&big));
-    }
-
-    #[test]
-    fn oversized_assistant_text_is_capped() {
-        let big = "q".repeat(MAX_FIELD_CHARS + 50);
-        let line = format!(r#"{{"kind":"assistant_text","id":"a","text":"{big}"}}"#);
-        let (_dir, path) = write_fixture(&[&line]);
+    fn every_field_renders_in_full_without_truncation() {
+        // The trajectory is the analysis's evidence: a huge tool output, assistant text, and system
+        // prompt must all survive verbatim — no field is ever capped.
+        let big = "z".repeat(40_000);
+        let lines = [
+            format!(r#"{{"kind":"prompts","system_prompt":"{big}","user_message":"{big}"}}"#),
+            format!(r#"{{"kind":"assistant_text","id":"a","text":"{big}"}}"#),
+            format!(r#"{{"kind":"tool_output","tool_call_id":"x","output":{{"log":"{big}"}}}}"#),
+        ];
+        let refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+        let (_dir, path) = write_fixture(&refs);
         let md = format_to_markdown(&load_trajectory(&path).unwrap());
-        assert!(md.contains("[truncated"));
-        assert!(!md.contains(&big));
+        assert!(!md.contains("truncated"), "no field may be truncated");
+        // 3 verbatim copies in the body (system prompt, task, agent text) plus the JSON-escaped tool
+        // output — the raw run all appears at least 3 times.
+        assert!(md.matches(&big).count() >= 3);
     }
 
     #[test]
@@ -341,14 +307,5 @@ mod tests {
         assert!(md.contains("### Tool call: `archestra__run_command`"));
         assert!(md.contains("### Tool call: `archestra__run_tool`"));
         assert!(md.contains("\"oops\": true"));
-    }
-
-    #[test]
-    fn cap_chars_never_splits_multibyte() {
-        // 10 multibyte chars, cap at 4 → must cut on a char boundary without panicking.
-        let s = "héllo wörld".chars().take(10).collect::<String>();
-        let capped = cap_chars(&s, 4);
-        assert!(capped.starts_with("héll"));
-        assert!(capped.contains("[truncated"));
     }
 }

--- a/archestra-bench/runner/src/client.rs
+++ b/archestra-bench/runner/src/client.rs
@@ -690,9 +690,27 @@ impl EvalClient {
             ("sortBy".to_string(), "createdAt".to_string()),
             ("sortDirection".to_string(), "asc".to_string()),
         ];
-        let body = self
-            .request(Method::GET, "/api/interactions", Some(&params), None)
-            .await?;
+        // Post-run enrichment polls this endpoint repeatedly while many rollouts hammer the same
+        // backend, so a transient transport failure (timeout / dropped connection, surfaced as
+        // status 0) is expected under load. Retry those with linear backoff so one slow poll does
+        // not abort the whole interaction capture; genuine HTTP errors propagate immediately.
+        // Up to this many retries on top of the initial request (so 5 total attempts at worst).
+        const MAX_TRANSIENT_RETRIES: u32 = 4;
+        const RETRY_BACKOFF: Duration = Duration::from_millis(500);
+        let mut attempt = 0u32;
+        let body = loop {
+            match self
+                .request(Method::GET, "/api/interactions", Some(&params), None)
+                .await
+            {
+                Ok(body) => break body,
+                Err(e) if e.status == 0 && attempt < MAX_TRANSIENT_RETRIES => {
+                    attempt += 1;
+                    sleep(RETRY_BACKOFF * attempt).await;
+                }
+                Err(e) => return Err(e.into()),
+            }
+        };
         let data = body
             .get("data")
             .and_then(JsonValue::as_array)

--- a/platform/backend/src/archestra-mcp-server/sandbox.test.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.test.ts
@@ -306,6 +306,63 @@ describe("sandbox tools (runtime enabled)", () => {
       expect(clean).not.toContain("binary (NUL) bytes");
     });
 
+    test("surfaces an empty-stderr section on a non-zero exit, but not on success", async () => {
+      const ctx = await makeConversationCtx();
+      const spy = vi.spyOn(skillSandboxRuntimeService, "runCommand");
+
+      // a command failed without writing to stderr: the model must still see an
+      // explicit (empty) stderr section so it can tell "no stderr" from "stderr
+      // withheld" rather than the section silently vanishing.
+      spy.mockResolvedValue({
+        commandId: "cmd-1",
+        sandboxId: "x" as any,
+        command: "exit 1",
+        cwd: null,
+        stdout: "",
+        stderr: "",
+        exitCode: 1,
+        durationMs: 5,
+        timedOut: false,
+        truncated: false,
+        binaryStripped: false,
+        stagingNotices: [],
+      });
+      const failed = textOf(
+        await executeArchestraTool(
+          TOOL_RUN_COMMAND_FULL_NAME,
+          { command: "exit 1" },
+          ctx,
+        ),
+      );
+      // Assert the empty marker belongs to the stderr section specifically — stdout is
+      // also empty here, so a bare "(empty)" check could pass on the stdout section alone.
+      expect(failed).toContain("stderr:\n(empty)");
+
+      // success with empty stderr stays terse — no stderr section.
+      spy.mockResolvedValue({
+        commandId: "cmd-2",
+        sandboxId: "x" as any,
+        command: "true",
+        cwd: null,
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+        durationMs: 5,
+        timedOut: false,
+        truncated: false,
+        binaryStripped: false,
+        stagingNotices: [],
+      });
+      const ok = textOf(
+        await executeArchestraTool(
+          TOOL_RUN_COMMAND_FULL_NAME,
+          { command: "true" },
+          ctx,
+        ),
+      );
+      expect(ok).not.toContain("stderr:");
+    });
+
     test("omits the truncation warning when output is complete", async () => {
       const ctx = await makeConversationCtx();
       stubRunCommand("x");

--- a/platform/backend/src/archestra-mcp-server/sandbox.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.ts
@@ -2008,8 +2008,12 @@ function formatCommandSummary(result: {
     );
   }
   lines.push("", "stdout:", result.stdout || "(empty)");
-  if (result.stderr) {
-    lines.push("", "stderr:", result.stderr);
+  // On a non-zero exit always surface a stderr section (marked empty when truly
+  // blank) — symmetric to stdout, so a failing command never leaves the agent
+  // unable to tell "no stderr" from "stderr withheld". On success keep it terse:
+  // only show stderr when there is something to show.
+  if (result.stderr || result.exitCode !== 0) {
+    lines.push("", "stderr:", result.stderr || "(empty)");
   }
   return lines.join("\n");
 }


### PR DESCRIPTION
Three independent fixes.

## bench: render full trajectory, never truncate fields
The analyzer applied an 8192-char per-field cap to the single rendering used for **both** the persisted `trajectory.md` artifact and the map-phase LLM input. A real Archestra effective system prompt (~24.7k chars) was cut at 8192 — losing most of the model's standing context for both human inspection and the analysis itself. The trajectory is the analysis's primary evidence, so every field now renders verbatim for both consumers. Removed the cap machinery (`MAX_FIELD_CHARS`, `cap_field`, `truncate_long_strings`, `Rollout.map_markdown`).

Verified by re-rendering `lena-png-size__or-owl`: 47KB → 64KB, zero truncation markers, full system prompt through the closing `</available_skills>` tag.

## bench: retry transient timeouts when fetching interactions
Post-run effective-prompt capture polls `/api/interactions` while many rollouts hammer the same backend; a single timed-out poll (transport status 0) aborted the whole capture. Transient transport errors now retry with linear backoff; genuine HTTP errors still propagate immediately.

## sandbox: always show stderr section on non-zero exit
The agent-facing command summary appended stderr only when non-empty, so a failing command with empty stderr silently dropped the section — the model couldn't tell "no stderr" from "stderr withheld". On a non-zero exit the stderr section is always shown (`(empty)` when blank), symmetric to stdout; the success path stays terse.

https://claude.ai/code/session_01515LjwtcGgCTRtkdKnuU2i

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>