### PR TITLE
perf(mcp-gateway): drop redundant heavy server lookups in tool execution

### DIFF
--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -599,6 +599,41 @@ describe("McpClient", () => {
 
         getSecretSpy.mockRestore();
       });
+
+      test("resolves and executes a tool without the heavy server-detail lookup", async () => {
+        const tool = await ToolModel.createToolIfNotExists({
+          name: "github-mcp-server__lightweight_resolution",
+          description: "Lightweight resolution tool",
+          parameters: {},
+          catalogId,
+        });
+
+        await AgentToolModel.create(agentId, tool.id, {
+          mcpServerId,
+          credentialResolutionMode: "static",
+        });
+
+        mockCallTool.mockResolvedValue({
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+        });
+
+        // findById() performs a 4-table join plus a per-server mcp_server_user
+        // lookup; the tool-execution hot path must not pay that cost since it
+        // only needs base columns (name/secretId). Resolving with the heavier
+        // query is what produced the N+1 under repeated tool calls.
+        const findByIdSpy = vi.spyOn(McpServerModel, "findById");
+
+        const result = await mcpClient.executeToolCallForOwner(
+          { id: "call_lightweight", name: tool.name, arguments: {} },
+          agentOwner(agentId),
+        );
+
+        expect(result.isError).toBe(false);
+        expect(findByIdSpy).not.toHaveBeenCalled();
+
+        findByIdSpy.mockRestore();
+      });
     });
 
     // The catalog item defines how agents connect when credentials resolve at
@@ -826,7 +861,10 @@ describe("McpClient", () => {
           content: [{ type: "text", text: "via org service account" }],
           isError: false,
         });
-        const findByIdSpy = vi.spyOn(McpServerModel, "findById");
+        // The resolved target server is the one whose secrets get loaded, so
+        // observe resolution through the lightweight server lookup the secrets
+        // path performs for the chosen target.
+        const findByIdsBasicSpy = vi.spyOn(McpServerModel, "findByIdsBasic");
 
         const result = await mcpClient.executeToolCallForOwner(
           { id: "call_all_mode", name: tool.name, arguments: {} },
@@ -836,8 +874,10 @@ describe("McpClient", () => {
 
         expect(result.isError).toBe(false);
         // Resolved via the catalog's org pin, not the static assignment's server.
-        expect(findByIdSpy).toHaveBeenCalledWith(orgServer.id);
-        expect(findByIdSpy).not.toHaveBeenCalledWith(pinnedAwayServer.id);
+        expect(findByIdsBasicSpy).toHaveBeenCalledWith([orgServer.id]);
+        expect(findByIdsBasicSpy).not.toHaveBeenCalledWith([
+          pinnedAwayServer.id,
+        ]);
       });
     });
 

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -395,7 +395,6 @@ class McpClient {
       return targetMcpServerIdResult.error;
     }
     const { targetMcpServerId, mcpServerName } = targetMcpServerIdResult;
-    const _targetMcpServer = await McpServerModel.findById(targetMcpServerId);
     const effectiveEnterpriseManagedConfig =
       catalogItem.enterpriseManagedConfig ?? null;
     if (
@@ -841,8 +840,9 @@ class McpClient {
           const catalogDisplayName = tool.catalogName || tool.catalogId;
           // Credentials exist but failed → "expired/invalid" message with manage link
           if (targetMcpServerId) {
-            const targetServer =
-              await McpServerModel.findById(targetMcpServerId);
+            const [targetServer] = await McpServerModel.findByIdsBasic([
+              targetMcpServerId,
+            ]);
             if (
               targetServer?.ownerId &&
               !targetServer.teamId &&
@@ -1335,7 +1335,13 @@ class McpClient {
       }
     | { error: CommonToolResult }
   > {
-    const mcpServer = await McpServerModel.findById(targetMcpServerId);
+    // Resolving secrets only needs the base server row (id + secretId).
+    // findById() additionally performs a 4-table join and a per-server
+    // mcp_server_user lookup, which turns into an N+1 when several tool calls
+    // in the same turn target the same server. Use the lightweight lookup.
+    const [mcpServer] = await McpServerModel.findByIdsBasic([
+      targetMcpServerId,
+    ]);
     if (!mcpServer) {
       return {
         error: await this.createErrorResult(
@@ -1367,9 +1373,10 @@ class McpClient {
     return result;
   }
 
-  private async fetchSecretsForLoadedMcpServer(
-    mcpServer: NonNullable<Awaited<ReturnType<typeof McpServerModel.findById>>>,
-  ): Promise<{
+  private async fetchSecretsForLoadedMcpServer(mcpServer: {
+    id: string;
+    secretId: string | null;
+  }): Promise<{
     secrets: Record<string, unknown>;
     secretId?: string;
     serverState: CachedServerState;
@@ -1434,7 +1441,10 @@ class McpClient {
           ),
         };
       }
-      const mcpServer = await McpServerModel.findById(tool.mcpServerId);
+      // Only the display name is needed here, so avoid the heavier findById().
+      const [mcpServer] = await McpServerModel.findByIdsBasic([
+        tool.mcpServerId,
+      ]);
       logger.info(
         {
           toolName: toolCall.name,
@@ -1454,9 +1464,9 @@ class McpClient {
     if (tool.credentialResolutionMode === "enterprise_managed") {
       const explicitTargetMcpServerId = tool.mcpServerId;
       if (explicitTargetMcpServerId) {
-        const mcpServer = await McpServerModel.findById(
+        const [mcpServer] = await McpServerModel.findByIdsBasic([
           explicitTargetMcpServerId,
-        );
+        ]);
         return {
           targetMcpServerId: explicitTargetMcpServerId,
           mcpServerName: mcpServer?.name || fallbackName,
@@ -3418,9 +3428,9 @@ class McpClient {
     );
   }
 
-  private toCachedServerState(
-    mcpServer: NonNullable<Awaited<ReturnType<typeof McpServerModel.findById>>>,
-  ): CachedServerState {
+  private toCachedServerState(mcpServer: {
+    secretId: string | null;
+  }): CachedServerState {
     return {
       secretId: mcpServer.secretId ?? null,
       credentialFingerprint: null,


### PR DESCRIPTION
## Summary

The MCP tool-execution path resolved the target MCP server with `McpServerModel.findById()`, which performs a 4-table join (`user`/`team`/`secret`) **plus** a separate per-server `mcp_server_user` membership lookup. That heavy lookup was issued several times for a single tool call:

- once on an assignment whose result was never read (dead query),
- again while determining the target server (only the display name is needed),
- again while loading secrets (only `id` + `secretId` are needed),
- and on the auth-error branch (only `ownerId`/`teamId` are needed).

When a single turn issues multiple tool calls against the same server, these repeat into an N+1 against that server and add avoidable pressure on the database connection pool — which in turn makes unrelated hot-path auth/session queries intermittently slow.

## Changes

- Resolve the target server via the existing lightweight `findByIdsBasic()` (a single base-row `SELECT`, no joins, no membership lookup) on every path that only needs base columns.
- Remove the dead lookup whose result was never used.
- Narrow the two private helper signatures (`fetchSecretsForLoadedMcpServer`, `toCachedServerState`) to the minimal shape they actually consume.

No behavioral change: the joined detail fields (owner email, team name, secret storage flags, member list) were not consumed on any of these paths.