### PR TITLE
feat(sidebar): relocate settings nav from horizontal tabs into the left sidebar

### DIFF
--- a/platform/frontend/src/app/_parts/app-shell.tsx
+++ b/platform/frontend/src/app/_parts/app-shell.tsx
@@ -39,6 +39,7 @@ export function AppShell({ children }: AppShellProps) {
   const pathname = usePathname();
   const isBrowserPreview = pathname.startsWith("/chat/browser-preview/");
   const isAuthPage = pathname.startsWith("/auth/");
+  const isSettingsPage = pathname.startsWith("/settings");
   // Chat and project detail pages are viewport-locked, two-pane layouts
   // (content + right Files sidebar) that scroll each pane independently. They
   // need their children slot bounded to the viewport (min-h-0) so their
@@ -100,7 +101,7 @@ export function AppShell({ children }: AppShellProps) {
     <NavigationStatusProvider>
       <SidebarProvider defaultOpen={!shouldCollapse}>
         <AppSidebar />
-        <NavAwareSidebarCircleToggle />
+        {!isSettingsPage && <NavAwareSidebarCircleToggle />}
         <MaintenanceModeOverlay />
         <main className="h-screen w-full flex flex-col bg-background min-w-0 relative overflow-y-auto">
           {notification && (

--- a/platform/frontend/src/app/_parts/settings-sidebar.tsx
+++ b/platform/frontend/src/app/_parts/settings-sidebar.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { ArrowLeft } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { SidebarPrefetchLink } from "@/app/_parts/sidebar-prefetch-link";
+import type { SettingsNavGroup } from "@/app/settings/settings-tabs";
+import {
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
+} from "@/components/ui/sidebar";
+
+// The settings variant's inner content (back-button header + grouped settings
+// nav). It is rendered inside the single shared <Sidebar> in AppSidebar — so it
+// returns a fragment, NOT its own <Sidebar>. Keeping one <Sidebar> means one
+// mobile <Sheet>, which never remounts when switching between settings and
+// chats/studio, so the drawer slide-in only plays on a genuine open.
+export function SettingsSidebarContent({
+  returnPath,
+  groups,
+  pathname,
+  isAuthenticated,
+}: {
+  returnPath: string;
+  groups: SettingsNavGroup[];
+  pathname: string;
+  isAuthenticated: boolean;
+}) {
+  const router = useRouter();
+
+  return (
+    <>
+      <SidebarHeader className="pt-4 group-data-[collapsible=icon]:pt-2 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:gap-1">
+        <button
+          type="button"
+          onClick={() => router.push(returnPath)}
+          className="flex h-8 items-center gap-1.5 rounded-md px-2 text-left text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0"
+        >
+          <ArrowLeft className="size-4 shrink-0" />
+          <span className="text-sm font-semibold group-data-[collapsible=icon]:hidden">
+            Settings
+          </span>
+        </button>
+      </SidebarHeader>
+      <SidebarContent>
+        {isAuthenticated && <NavSettings groups={groups} pathname={pathname} />}
+      </SidebarContent>
+    </>
+  );
+}
+
+// Grouped settings destinations (Personal / Organization), using the same
+// SidebarGroup primitives as the rest of the sidebar.
+function NavSettings({
+  groups,
+  pathname,
+}: {
+  groups: SettingsNavGroup[];
+  pathname: string;
+}) {
+  const { isMobile, setOpenMobile } = useSidebar();
+
+  return (
+    <>
+      {groups.map((group) => (
+        <SidebarGroup key={group.label}>
+          <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {group.items.map((item) => (
+                <SidebarMenuItem key={item.href}>
+                  <SidebarMenuButton
+                    asChild
+                    tooltip={item.label}
+                    isActive={pathname.startsWith(item.href)}
+                  >
+                    <SidebarPrefetchLink
+                      href={item.href}
+                      onClick={() => {
+                        if (isMobile) setOpenMobile(false);
+                      }}
+                    >
+                      <span>{item.label}</span>
+                    </SidebarPrefetchLink>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      ))}
+    </>
+  );
+}

--- a/platform/frontend/src/app/_parts/sidebar-prefetch-link.tsx
+++ b/platform/frontend/src/app/_parts/sidebar-prefetch-link.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import type { ComponentProps } from "react";
+
+/**
+ * Sidebar links opt out of Next.js viewport prefetch to avoid fetching every
+ * visible sidebar route's RSC payload when the app shell mounts. Hover/focus
+ * prefetch keeps intentional navigation fast without competing with initial
+ * page API requests.
+ */
+export function SidebarPrefetchLink({
+  href,
+  onFocus,
+  onMouseEnter,
+  ...props
+}: ComponentProps<typeof Link>) {
+  const router = useRouter();
+
+  return (
+    <Link
+      href={href}
+      prefetch={false}
+      onFocus={(event) => {
+        const prefetchHref = getPrefetchHref(href);
+        if (prefetchHref) router.prefetch(prefetchHref);
+        onFocus?.(event);
+      }}
+      onMouseEnter={(event) => {
+        const prefetchHref = getPrefetchHref(href);
+        if (prefetchHref) router.prefetch(prefetchHref);
+        onMouseEnter?.(event);
+      }}
+      {...props}
+    />
+  );
+}
+
+/**
+ * Converts a Next.js Link href into the string URL required by router.prefetch.
+ * Sidebar links currently pass strings, but this keeps manual prefetch safe if
+ * a future item uses a UrlObject with query or hash fields.
+ */
+function getPrefetchHref(href: ComponentProps<typeof Link>["href"]) {
+  if (typeof href === "string") return href;
+  if (!href.pathname) return null;
+
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(href.query ?? {})) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item != null) searchParams.append(key, String(item));
+      }
+      continue;
+    }
+    if (value != null) searchParams.set(key, String(value));
+  }
+
+  const query = searchParams.toString();
+  return `${href.pathname}${query ? `?${query}` : ""}${href.hash ?? ""}`;
+}

--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -47,7 +47,6 @@ import {
   SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,

--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -29,11 +29,16 @@ import {
   Sparkles,
   Star,
 } from "lucide-react";
-import Link from "next/link";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import React from "react";
 import { ChatSidebarSection } from "@/app/_parts/chat-sidebar-section";
+import { SettingsSidebarContent } from "@/app/_parts/settings-sidebar";
+import { SidebarPrefetchLink } from "@/app/_parts/sidebar-prefetch-link";
 import { SidebarUserMenu } from "@/app/_parts/sidebar-user-menu";
+import {
+  useSettingsNavGroups,
+  useSettingsReturnPath,
+} from "@/app/settings/settings-tabs";
 import { AppLogo } from "@/components/app-logo";
 import { SidebarWarningsAccordion } from "@/components/sidebar-warnings-accordion";
 import {
@@ -42,6 +47,7 @@ import {
   SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
@@ -589,9 +595,47 @@ const NavSecondary = ({
   );
 };
 
+// Shared sidebar footer (warnings + user menu). Identical across the default
+// and settings sidebar variants.
+const SidebarUserFooter = ({
+  isAuthenticated,
+}: {
+  isAuthenticated: boolean;
+}) => (
+  <SidebarFooter>
+    <SidebarWarningsAccordion />
+    {isAuthenticated && (
+      <SidebarGroup className="mt-auto p-0">
+        <SidebarGroupContent>
+          <div
+            data-testid={E2eTestId.SidebarUserProfile}
+            className={cn(
+              "overflow-hidden",
+              // Collapsed: hide text/chevron, show only avatar circle
+              "group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center",
+              "group-data-[collapsible=icon]:[&_button]:size-7 group-data-[collapsible=icon]:[&_button]:min-w-0 group-data-[collapsible=icon]:[&_button]:rounded-full group-data-[collapsible=icon]:[&_button]:p-0",
+              "group-data-[collapsible=icon]:[&_[data-slot=avatar]]:size-7",
+              "group-data-[collapsible=icon]:[&_[data-slot=avatar-fallback]]:text-[9px]",
+              "group-data-[collapsible=icon]:[&_button>div]:gap-0",
+              "group-data-[collapsible=icon]:[&_button>div>div:not([data-slot=avatar])]:hidden",
+              "group-data-[collapsible=icon]:[&_button>svg]:hidden",
+            )}
+          >
+            <SidebarUserMenu />
+          </div>
+        </SidebarGroupContent>
+      </SidebarGroup>
+    )}
+  </SidebarFooter>
+);
+
 export function AppSidebar() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const { open, setOpen, isMobile } = useSidebar();
+  const isSettingsRoute = pathname.startsWith("/settings");
+  const settingsReturnPath = useSettingsReturnPath();
+  const settingsNavGroups = useSettingsNavGroups();
   const isAuthenticated = useIsAuthenticated();
   const showCommunityLinks = !config.enterpriseFeatures.fullWhiteLabeling;
   // GitHub stars are cosmetic and external, so defer them until after the
@@ -660,43 +704,83 @@ export function AppSidebar() {
       }));
   }, [showConnect, skillsEnabled, appsEnabled, projectsEnabled]);
 
+  React.useLayoutEffect(() => {
+    if (isSettingsRoute && !isMobile && !open) {
+      setOpen(true);
+    }
+  }, [isSettingsRoute, isMobile, open, setOpen]);
+
   return (
     <Sidebar collapsible="icon">
-      <SidebarHeader className="pt-4 group-data-[collapsible=icon]:pt-2 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:gap-1">
-        <div className="group-data-[collapsible=icon]:hidden">
-          <SidebarPrefetchLink href="/chat" className="block min-w-0">
-            <AppLogo />
-          </SidebarPrefetchLink>
-        </div>
-        <SidebarPrefetchLink
-          href="/chat"
-          className="hidden group-data-[collapsible=icon]:flex"
-        >
-          <img src={appIconLogo} alt="Logo" className="size-7" />
-        </SidebarPrefetchLink>
-        {isAuthenticated && permissionMap && (
-          <SidebarModeToggle mode={sidebarMode} onPick={pickSidebarMode} />
-        )}
-      </SidebarHeader>
-      <SidebarContent>
-        {isAuthenticated &&
-          permissionMap &&
-          (sidebarMode === "chats" ? (
-            <>
-              <NavPrimary
-                items={filteredChatsNavItems}
-                groups={[]}
-                pathname={pathname}
-                searchParams={searchParams}
-                permissionMap={permissionMap}
-              />
-              {/* The chat list (Pinned + Recents, labeled inside
+      {isSettingsRoute ? (
+        <SettingsSidebarContent
+          returnPath={settingsReturnPath}
+          groups={settingsNavGroups}
+          pathname={pathname}
+          isAuthenticated={Boolean(isAuthenticated && permissionMap)}
+        />
+      ) : (
+        <>
+          <SidebarHeader className="pt-4 group-data-[collapsible=icon]:pt-2 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:gap-1">
+            <div className="group-data-[collapsible=icon]:hidden">
+              <SidebarPrefetchLink href="/chat" className="block min-w-0">
+                <AppLogo />
+              </SidebarPrefetchLink>
+            </div>
+            <SidebarPrefetchLink
+              href="/chat"
+              className="hidden group-data-[collapsible=icon]:flex"
+            >
+              <img src={appIconLogo} alt="Logo" className="size-7" />
+            </SidebarPrefetchLink>
+            {isAuthenticated && permissionMap && (
+              <SidebarModeToggle mode={sidebarMode} onPick={pickSidebarMode} />
+            )}
+          </SidebarHeader>
+          <SidebarContent>
+            {isAuthenticated &&
+              permissionMap &&
+              (sidebarMode === "chats" ? (
+                <>
+                  <NavPrimary
+                    items={filteredChatsNavItems}
+                    groups={[]}
+                    pathname={pathname}
+                    searchParams={searchParams}
+                    permissionMap={permissionMap}
+                  />
+                  {/* The chat list (Pinned + Recents, labeled inside
                     ChatSidebarSection) and the community links below it scroll
                     together within this region, while the nav above stays
                     pinned. The fade hints there is more content below. */}
-              <SidebarGroup className="min-h-0 flex-1 overflow-hidden p-0 after:pointer-events-none after:absolute after:right-2.5 after:bottom-0 after:left-0 after:z-10 after:h-8 after:bg-gradient-to-t after:from-sidebar after:to-transparent">
-                <SidebarGroupContent className="min-h-0 flex-1 overflow-y-auto pb-8 [scrollbar-gutter:stable] scrollbar-sidebar">
-                  <ChatSidebarSection slots={15} flat fadeIn={chatListFadeIn} />
+                  <SidebarGroup className="min-h-0 flex-1 overflow-hidden p-0 after:pointer-events-none after:absolute after:right-2.5 after:bottom-0 after:left-0 after:z-10 after:h-8 after:bg-gradient-to-t after:from-sidebar after:to-transparent">
+                    <SidebarGroupContent className="min-h-0 flex-1 overflow-y-auto pb-8 [scrollbar-gutter:stable] scrollbar-sidebar">
+                      <ChatSidebarSection
+                        slots={15}
+                        flat
+                        fadeIn={chatListFadeIn}
+                      />
+                      <NavSecondary
+                        items={[]}
+                        pathname={pathname}
+                        searchParams={searchParams}
+                        permissionMap={permissionMap}
+                        showCommunityLinks={showCommunityLinks}
+                        starCount={formattedStarCount}
+                        className="mt-2.5"
+                      />
+                    </SidebarGroupContent>
+                  </SidebarGroup>
+                </>
+              ) : (
+                <>
+                  <NavPrimary
+                    items={[]}
+                    groups={filteredNavGroups}
+                    pathname={pathname}
+                    searchParams={searchParams}
+                    permissionMap={permissionMap}
+                  />
                   <NavSecondary
                     items={[]}
                     pathname={pathname}
@@ -704,124 +788,32 @@ export function AppSidebar() {
                     permissionMap={permissionMap}
                     showCommunityLinks={showCommunityLinks}
                     starCount={formattedStarCount}
-                    className="mt-2.5"
+                    className="mt-auto"
                   />
-                </SidebarGroupContent>
-              </SidebarGroup>
-            </>
-          ) : (
-            <>
-              <NavPrimary
-                items={[]}
-                groups={filteredNavGroups}
-                pathname={pathname}
-                searchParams={searchParams}
-                permissionMap={permissionMap}
-              />
+                </>
+              ))}
+            {!isAuthenticated && showCommunityLinks && (
               <NavSecondary
                 items={[]}
                 pathname={pathname}
                 searchParams={searchParams}
-                permissionMap={permissionMap}
+                permissionMap={{}}
                 showCommunityLinks={showCommunityLinks}
                 starCount={formattedStarCount}
-                className="mt-auto"
               />
-            </>
-          ))}
-        {!isAuthenticated && showCommunityLinks && (
-          <NavSecondary
-            items={[]}
-            pathname={pathname}
-            searchParams={searchParams}
-            permissionMap={{}}
-            showCommunityLinks={showCommunityLinks}
-            starCount={formattedStarCount}
-          />
-        )}
-      </SidebarContent>
-      <SidebarFooter>
-        <SidebarWarningsAccordion />
-        {isAuthenticated && (
-          <SidebarGroup className="mt-auto p-0">
-            <SidebarGroupContent>
-              <div
-                data-testid={E2eTestId.SidebarUserProfile}
-                className={cn(
-                  "overflow-hidden",
-                  // Collapsed: hide text/chevron, show only avatar circle
-                  "group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center",
-                  "group-data-[collapsible=icon]:[&_button]:size-7 group-data-[collapsible=icon]:[&_button]:min-w-0 group-data-[collapsible=icon]:[&_button]:rounded-full group-data-[collapsible=icon]:[&_button]:p-0",
-                  "group-data-[collapsible=icon]:[&_[data-slot=avatar]]:size-7",
-                  "group-data-[collapsible=icon]:[&_[data-slot=avatar-fallback]]:text-[9px]",
-                  "group-data-[collapsible=icon]:[&_button>div]:gap-0",
-                  "group-data-[collapsible=icon]:[&_button>div>div:not([data-slot=avatar])]:hidden",
-                  "group-data-[collapsible=icon]:[&_button>svg]:hidden",
-                )}
-              >
-                <SidebarUserMenu />
-              </div>
-            </SidebarGroupContent>
-          </SidebarGroup>
-        )}
-      </SidebarFooter>
+            )}
+          </SidebarContent>
+        </>
+      )}
+      {/* Shared across both variants; kept outside the ternary so it never
+          remounts (and never flashes) when switching settings ⇄ chats/studio. */}
+      <SidebarUserFooter
+        isAuthenticated={
+          isSettingsRoute
+            ? Boolean(isAuthenticated && permissionMap)
+            : isAuthenticated
+        }
+      />
     </Sidebar>
   );
-}
-
-/**
- * Sidebar links opt out of Next.js viewport prefetch to avoid fetching every
- * visible sidebar route's RSC payload when the app shell mounts. Hover/focus
- * prefetch keeps intentional navigation fast without competing with initial
- * page API requests.
- */
-function SidebarPrefetchLink({
-  href,
-  onFocus,
-  onMouseEnter,
-  ...props
-}: React.ComponentProps<typeof Link>) {
-  const router = useRouter();
-
-  return (
-    <Link
-      href={href}
-      prefetch={false}
-      onFocus={(event) => {
-        const prefetchHref = getPrefetchHref(href);
-        if (prefetchHref) router.prefetch(prefetchHref);
-        onFocus?.(event);
-      }}
-      onMouseEnter={(event) => {
-        const prefetchHref = getPrefetchHref(href);
-        if (prefetchHref) router.prefetch(prefetchHref);
-        onMouseEnter?.(event);
-      }}
-      {...props}
-    />
-  );
-}
-
-/**
- * Converts a Next.js Link href into the string URL required by router.prefetch.
- * Sidebar links currently pass strings, but this keeps manual prefetch safe if
- * a future item uses a UrlObject with query or hash fields.
- */
-function getPrefetchHref(href: React.ComponentProps<typeof Link>["href"]) {
-  if (typeof href === "string") return href;
-  if (!href.pathname) return null;
-
-  const searchParams = new URLSearchParams();
-  for (const [key, value] of Object.entries(href.query ?? {})) {
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        if (item != null) searchParams.append(key, String(item));
-      }
-      continue;
-    }
-    if (value != null) searchParams.set(key, String(value));
-  }
-
-  const query = searchParams.toString();
-  return `${href.pathname}${query ? `?${query}` : ""}${href.hash ?? ""}`;
 }

--- a/platform/frontend/src/app/settings/layout.tsx
+++ b/platform/frontend/src/app/settings/layout.tsx
@@ -3,7 +3,6 @@
 import { usePathname } from "next/navigation";
 import { createContext, useContext, useMemo, useState } from "react";
 import { PageLayout } from "@/components/page-layout";
-import { useSettingsTabs } from "./settings-tabs";
 
 const PAGE_CONFIG: Record<string, { title: string; description: string }> = {
   "/settings/account": {
@@ -93,7 +92,6 @@ export default function SettingsLayout({
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
-  const tabs = useSettingsTabs();
   const [actionButton, setActionButton] = useState<React.ReactNode>(null);
 
   const config = pathname.startsWith("/settings/service-accounts/")
@@ -110,7 +108,6 @@ export default function SettingsLayout({
       <PageLayout
         title={config.title}
         description={config.description}
-        tabs={tabs}
         actionButton={actionButton}
       >
         {children}

--- a/platform/frontend/src/app/settings/layout.tsx
+++ b/platform/frontend/src/app/settings/layout.tsx
@@ -20,7 +20,7 @@ const PAGE_CONFIG: Record<string, { title: string; description: string }> = {
       "Create and manage organization service accounts for programmatic access.",
   },
   "/settings/agents": {
-    title: "Agents",
+    title: "Agent Defaults",
     description:
       "Configure default agent behavior and agent-related platform settings.",
   },
@@ -40,17 +40,17 @@ const PAGE_CONFIG: Record<string, { title: string; description: string }> = {
       "Configure SSO, linked downstream IdPs, and identity provider integrations.",
   },
   "/settings/knowledge": {
-    title: "Knowledge",
+    title: "Knowledge Retrieval",
     description:
       "Configure embedding, reranking, and knowledge system defaults.",
   },
   "/settings/llm": {
-    title: "LLM",
+    title: "LLM Defaults",
     description:
       "Configure platform-wide LLM behavior, like tool-result compression and default cost limits.",
   },
   "/settings/organization": {
-    title: "Organization",
+    title: "Appearance & Auth",
     description:
       "Manage organization-wide appearance and authentication settings",
   },

--- a/platform/frontend/src/app/settings/settings-tabs.test.tsx
+++ b/platform/frontend/src/app/settings/settings-tabs.test.tsx
@@ -3,12 +3,22 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { authClient } from "@/lib/clients/auth/auth-client";
-import { useSettingsTabs } from "./settings-tabs";
+import {
+  type SettingsNavGroup,
+  useSettingsNavGroups,
+  useSettingsReturnPath,
+} from "./settings-tabs";
 
 vi.mock("@/lib/clients/auth/auth-client", () => ({
   authClient: {
     getSession: vi.fn(),
   },
+}));
+
+let mockPathname = "/chat";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
 }));
 
 let mockPermissions: Permissions = {};
@@ -58,6 +68,7 @@ beforeEach(() => {
   mockPermissions = {};
   mockSecretsType = "DB";
   mockEnterpriseFeatures = false;
+  mockPathname = "/chat";
 
   vi.mocked(authClient.getSession).mockResolvedValue({
     data: {
@@ -67,24 +78,49 @@ beforeEach(() => {
   } as Awaited<ReturnType<typeof authClient.getSession>>);
 });
 
-function getTabLabels(tabs: Array<{ label: string }>) {
-  return tabs.map((t) => t.label);
+function groupNames(groups: SettingsNavGroup[]) {
+  return groups.map((g) => g.label);
 }
 
-describe("useSettingsTabs", () => {
-  it("always shows Your Account tab", async () => {
-    const { result } = renderHook(() => useSettingsTabs(), {
+function allLabels(groups: SettingsNavGroup[]) {
+  return groups.flatMap((g) => g.items.map((i) => i.label));
+}
+
+function itemsOf(groups: SettingsNavGroup[], group: string) {
+  return (groups.find((g) => g.label === group)?.items ?? []).map(
+    (i) => i.label,
+  );
+}
+
+describe("useSettingsNavGroups", () => {
+  it("always shows Your Account in Personal and drops the empty Organization group", async () => {
+    const { result } = renderHook(() => useSettingsNavGroups(), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => {
-      const labels = getTabLabels(result.current);
-      expect(labels).toContain("Your Account");
-      expect(labels).not.toContain("API Keys");
+      expect(groupNames(result.current)).toEqual(["Personal"]);
+      expect(itemsOf(result.current, "Personal")).toContain("Your Account");
+      expect(allLabels(result.current)).not.toContain("API Keys");
     });
   });
 
-  it("shows admin tabs when user has all permissions", async () => {
+  it("shows API Keys under Personal when user has apiKey:read", async () => {
+    mockPermissions = { apiKey: ["read"] };
+
+    const { result } = renderHook(() => useSettingsNavGroups(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(itemsOf(result.current, "Personal")).toEqual([
+        "Your Account",
+        "API Keys",
+      ]);
+    });
+  });
+
+  it("groups org-wide items under Organization when user has admin permissions", async () => {
     mockPermissions = {
       member: ["read"],
       team: ["read"],
@@ -96,193 +132,168 @@ describe("useSettingsTabs", () => {
       agentSettings: ["read"],
     };
 
-    const { result } = renderHook(() => useSettingsTabs(), {
+    const { result } = renderHook(() => useSettingsNavGroups(), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => {
-      const labels = getTabLabels(result.current);
-      expect(labels).toContain("API Keys");
-      expect(labels).toContain("Service Accounts");
-      expect(labels).toContain("Agents");
-      expect(labels).toContain("LLM");
-      expect(labels).toContain("Users");
-      expect(labels).toContain("Teams");
-      expect(labels).toContain("Roles");
-      expect(labels).toContain("Organization");
+      expect(groupNames(result.current)).toEqual(["Personal", "Organization"]);
+      const org = itemsOf(result.current, "Organization");
+      expect(org).toContain("Overview");
+      expect(org).toContain("Users");
+      expect(org).toContain("Teams");
+      expect(org).toContain("Roles");
+      expect(org).toContain("Service Accounts");
+      expect(org).toContain("LLM");
+      expect(org).toContain("Agents");
     });
   });
 
-  it("shows LLM tab when user has llmSettings:read permission", async () => {
-    mockPermissions = {
-      llmSettings: ["read"],
-    };
+  it("shows LLM under Organization when user has llmSettings:read", async () => {
+    mockPermissions = { llmSettings: ["read"] };
 
-    const { result } = renderHook(() => useSettingsTabs(), {
+    const { result } = renderHook(() => useSettingsNavGroups(), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => {
-      const labels = getTabLabels(result.current);
-      expect(labels).toContain("LLM");
+      expect(itemsOf(result.current, "Organization")).toContain("LLM");
     });
   });
 
-  it("shows Service Accounts tab when user has serviceAccount:read permission", async () => {
-    mockPermissions = {
-      serviceAccount: ["read"],
-    };
-
-    const { result } = renderHook(() => useSettingsTabs(), {
-      wrapper: createWrapper(),
-    });
-
-    await waitFor(() => {
-      const labels = getTabLabels(result.current);
-      expect(labels).toContain("Service Accounts");
-    });
-  });
-
-  it("hides LLM tab when user lacks llmSettings:read permission", async () => {
+  it("hides LLM when user lacks llmSettings:read", async () => {
     mockPermissions = {};
 
-    const { result } = renderHook(() => useSettingsTabs(), {
+    const { result } = renderHook(() => useSettingsNavGroups(), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => {
-      const labels = getTabLabels(result.current);
-      expect(labels).not.toContain("LLM");
+      expect(allLabels(result.current)).not.toContain("LLM");
     });
   });
 
-  it("hides Users tab when user lacks member:read permission", async () => {
-    mockPermissions = {
-      team: ["read"],
-      ac: ["read"],
-    };
+  it("shows Service Accounts when user has serviceAccount:read", async () => {
+    mockPermissions = { serviceAccount: ["read"] };
 
-    const { result } = renderHook(() => useSettingsTabs(), {
+    const { result } = renderHook(() => useSettingsNavGroups(), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => {
-      const labels = getTabLabels(result.current);
+      expect(itemsOf(result.current, "Organization")).toContain(
+        "Service Accounts",
+      );
+    });
+  });
+
+  it("hides Users when user lacks member:read", async () => {
+    mockPermissions = { team: ["read"], ac: ["read"] };
+
+    const { result } = renderHook(() => useSettingsNavGroups(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      const labels = allLabels(result.current);
       expect(labels).not.toContain("Users");
       expect(labels).toContain("Teams");
       expect(labels).toContain("Roles");
     });
   });
 
-  it("hides Roles tab when user lacks ac:read permission", async () => {
-    mockPermissions = {
-      member: ["read"],
-      team: ["read"],
-    };
+  it("hides Roles when user lacks ac:read", async () => {
+    mockPermissions = { member: ["read"], team: ["read"] };
 
-    const { result } = renderHook(() => useSettingsTabs(), {
+    const { result } = renderHook(() => useSettingsNavGroups(), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => {
-      const labels = getTabLabels(result.current);
+      const labels = allLabels(result.current);
       expect(labels).toContain("Users");
       expect(labels).toContain("Teams");
       expect(labels).not.toContain("Roles");
     });
   });
 
-  it("shows Secrets tab only when using Vault storage and user has permission", async () => {
+  it("shows Secrets only with Vault storage and secret:read", async () => {
     mockSecretsType = "Vault";
-    mockPermissions = {
-      secret: ["read"],
-    };
+    mockPermissions = { secret: ["read"] };
 
-    const { result } = renderHook(() => useSettingsTabs(), {
+    const { result } = renderHook(() => useSettingsNavGroups(), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => {
-      const labels = getTabLabels(result.current);
-      expect(labels).toContain("Secrets");
+      expect(allLabels(result.current)).toContain("Secrets");
     });
   });
 
-  it("hides Secrets tab when using DB storage", async () => {
+  it("hides Secrets with DB storage", async () => {
     mockSecretsType = "DB";
-    mockPermissions = {
-      secret: ["read"],
-    };
+    mockPermissions = { secret: ["read"] };
 
-    const { result } = renderHook(() => useSettingsTabs(), {
+    const { result } = renderHook(() => useSettingsNavGroups(), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => {
-      const labels = getTabLabels(result.current);
-      expect(labels).not.toContain("Secrets");
+      expect(allLabels(result.current)).not.toContain("Secrets");
     });
   });
 
-  it("shows Identity Providers tab only when enterprise features enabled and user has permission", async () => {
+  it("shows Identity Providers only with enterprise features and permission", async () => {
     mockEnterpriseFeatures = true;
-    mockPermissions = {
-      identityProvider: ["read"],
-    };
+    mockPermissions = { identityProvider: ["read"] };
 
-    const { result } = renderHook(() => useSettingsTabs(), {
+    const { result } = renderHook(() => useSettingsNavGroups(), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => {
-      const labels = getTabLabels(result.current);
-      expect(labels).toContain("Identity Providers");
+      expect(allLabels(result.current)).toContain("Identity Providers");
     });
   });
 
-  it("hides Identity Providers tab when enterprise features disabled", async () => {
+  it("hides Identity Providers when enterprise features disabled", async () => {
     mockEnterpriseFeatures = false;
-    mockPermissions = {
-      identityProvider: ["read"],
-    };
+    mockPermissions = { identityProvider: ["read"] };
 
-    const { result } = renderHook(() => useSettingsTabs(), {
+    const { result } = renderHook(() => useSettingsNavGroups(), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => {
-      const labels = getTabLabels(result.current);
-      expect(labels).not.toContain("Identity Providers");
+      expect(allLabels(result.current)).not.toContain("Identity Providers");
     });
   });
 
-  it("shows GitHub tab when user has githubAppConfig:read permission", async () => {
+  it("shows GitHub when user has githubAppConfig:read", async () => {
     mockPermissions = { githubAppConfig: ["read"] };
 
-    const { result } = renderHook(() => useSettingsTabs(), {
+    const { result } = renderHook(() => useSettingsNavGroups(), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => {
-      const labels = getTabLabels(result.current);
-      expect(labels).toContain("GitHub");
+      expect(allLabels(result.current)).toContain("GitHub");
     });
   });
 
-  it("hides GitHub tab when user lacks githubAppConfig:read permission", async () => {
+  it("hides GitHub when user lacks githubAppConfig:read", async () => {
     mockPermissions = {};
 
-    const { result } = renderHook(() => useSettingsTabs(), {
+    const { result } = renderHook(() => useSettingsNavGroups(), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => {
-      const labels = getTabLabels(result.current);
-      expect(labels).not.toContain("GitHub");
+      expect(allLabels(result.current)).not.toContain("GitHub");
     });
   });
 
-  it("maintains correct tab order", async () => {
+  it("maintains Personal-then-Organization grouping and intra-group order", async () => {
     mockEnterpriseFeatures = true;
     mockSecretsType = "Vault";
     mockPermissions = {
@@ -295,30 +306,67 @@ describe("useSettingsTabs", () => {
       organizationSettings: ["read"],
       apiKey: ["read"],
       serviceAccount: ["read"],
+      environment: ["admin"],
       llmSettings: ["read"],
       agentSettings: ["read"],
+      knowledgeSettings: ["read"],
     };
 
-    const { result } = renderHook(() => useSettingsTabs(), {
+    const { result } = renderHook(() => useSettingsNavGroups(), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => {
-      const labels = getTabLabels(result.current);
-      expect(labels).toEqual([
+      expect(groupNames(result.current)).toEqual(["Personal", "Organization"]);
+      expect(itemsOf(result.current, "Personal")).toEqual([
         "Your Account",
         "API Keys",
-        "Service Accounts",
-        "Agents",
-        "LLM",
+      ]);
+      expect(itemsOf(result.current, "Organization")).toEqual([
+        "Overview",
         "Users",
         "Teams",
         "Roles",
+        "Service Accounts",
+        "Environments",
+        "Secrets",
         "GitHub",
         "Identity Providers",
-        "Secrets",
-        "Organization",
+        "LLM",
+        "Agents",
+        "Knowledge",
       ]);
     });
+  });
+});
+
+describe("useSettingsReturnPath", () => {
+  it("returns the page visited before entering settings", () => {
+    mockPathname = "/llm/logs";
+    const { result, rerender } = renderHook(() => useSettingsReturnPath());
+
+    mockPathname = "/settings/account";
+    rerender();
+
+    expect(result.current).toBe("/llm/logs");
+  });
+
+  it("falls back to New Chat when settings is the first route", () => {
+    mockPathname = "/settings/account";
+    const { result } = renderHook(() => useSettingsReturnPath());
+
+    expect(result.current).toBe("/chat");
+  });
+
+  it("keeps the original entry page while navigating between settings sections", () => {
+    mockPathname = "/llm/logs";
+    const { result, rerender } = renderHook(() => useSettingsReturnPath());
+
+    mockPathname = "/settings/account";
+    rerender();
+    mockPathname = "/settings/llm";
+    rerender();
+
+    expect(result.current).toBe("/llm/logs");
   });
 });

--- a/platform/frontend/src/app/settings/settings-tabs.test.tsx
+++ b/platform/frontend/src/app/settings/settings-tabs.test.tsx
@@ -139,13 +139,13 @@ describe("useSettingsNavGroups", () => {
     await waitFor(() => {
       expect(groupNames(result.current)).toEqual(["Personal", "Organization"]);
       const org = itemsOf(result.current, "Organization");
-      expect(org).toContain("Overview");
+      expect(org).toContain("Appearance & Auth");
       expect(org).toContain("Users");
       expect(org).toContain("Teams");
       expect(org).toContain("Roles");
       expect(org).toContain("Service Accounts");
-      expect(org).toContain("LLM");
-      expect(org).toContain("Agents");
+      expect(org).toContain("LLM Defaults");
+      expect(org).toContain("Agent Defaults");
     });
   });
 
@@ -157,7 +157,9 @@ describe("useSettingsNavGroups", () => {
     });
 
     await waitFor(() => {
-      expect(itemsOf(result.current, "Organization")).toContain("LLM");
+      expect(itemsOf(result.current, "Organization")).toContain(
+        "LLM Defaults",
+      );
     });
   });
 
@@ -169,7 +171,7 @@ describe("useSettingsNavGroups", () => {
     });
 
     await waitFor(() => {
-      expect(allLabels(result.current)).not.toContain("LLM");
+      expect(allLabels(result.current)).not.toContain("LLM Defaults");
     });
   });
 
@@ -323,7 +325,7 @@ describe("useSettingsNavGroups", () => {
         "API Keys",
       ]);
       expect(itemsOf(result.current, "Organization")).toEqual([
-        "Overview",
+        "Appearance & Auth",
         "Users",
         "Teams",
         "Roles",
@@ -332,9 +334,9 @@ describe("useSettingsNavGroups", () => {
         "Secrets",
         "GitHub",
         "Identity Providers",
-        "LLM",
-        "Agents",
-        "Knowledge",
+        "LLM Defaults",
+        "Agent Defaults",
+        "Knowledge Retrieval",
       ]);
     });
   });

--- a/platform/frontend/src/app/settings/settings-tabs.test.tsx
+++ b/platform/frontend/src/app/settings/settings-tabs.test.tsx
@@ -157,9 +157,7 @@ describe("useSettingsNavGroups", () => {
     });
 
     await waitFor(() => {
-      expect(itemsOf(result.current, "Organization")).toContain(
-        "LLM Defaults",
-      );
+      expect(itemsOf(result.current, "Organization")).toContain("LLM Defaults");
     });
   });
 

--- a/platform/frontend/src/app/settings/settings-tabs.ts
+++ b/platform/frontend/src/app/settings/settings-tabs.ts
@@ -1,31 +1,41 @@
 import { requiredPagePermissionsMap } from "@archestra/shared/access-control";
+import { usePathname } from "next/navigation";
+import React from "react";
 import { usePermissionMap } from "@/lib/auth/auth.query";
 import config from "@/lib/config/config";
 
 import { useSecretsType } from "@/lib/secrets.query";
 
-export function useSettingsTabs() {
+interface SettingsNavItem {
+  label: string;
+  href: string;
+}
+
+export interface SettingsNavGroup {
+  label: string;
+  items: SettingsNavItem[];
+}
+
+/**
+ * Settings navigation grouped by scope: a "Personal" group (your account + your
+ * programmatic tokens) and an "Organization" group (org-wide admin config,
+ * including the org-wide AI defaults). Items are permission-gated the same way
+ * the page routes are (via `requiredPagePermissionsMap`); empty groups drop out.
+ */
+export function useSettingsNavGroups(): SettingsNavGroup[] {
   const permissionMap = usePermissionMap(requiredPagePermissionsMap);
   const { data: secretsType } = useSecretsType();
-  return [
+
+  const personal: SettingsNavItem[] = [
     { label: "Your Account", href: "/settings/account" },
     ...(permissionMap?.["/settings/api-keys"]
       ? [{ label: "API Keys", href: "/settings/api-keys" }]
       : []),
-    ...(permissionMap?.["/settings/service-accounts"]
-      ? [{ label: "Service Accounts", href: "/settings/service-accounts" }]
-      : []),
-    ...(permissionMap?.["/settings/agents"]
-      ? [{ label: "Agents", href: "/settings/agents" }]
-      : []),
-    ...(permissionMap?.["/settings/llm"]
-      ? [{ label: "LLM", href: "/settings/llm" }]
-      : []),
-    ...(permissionMap?.["/settings/knowledge"]
-      ? [{ label: "Knowledge", href: "/settings/knowledge" }]
-      : []),
-    ...(permissionMap?.["/settings/environments"]
-      ? [{ label: "Environments", href: "/settings/environments" }]
+  ];
+
+  const organization: SettingsNavItem[] = [
+    ...(permissionMap?.["/settings/organization"]
+      ? [{ label: "Overview", href: "/settings/organization" }]
       : []),
     ...(permissionMap?.["/settings/users"]
       ? [{ label: "Users", href: "/settings/users" }]
@@ -36,6 +46,15 @@ export function useSettingsTabs() {
     ...(permissionMap?.["/settings/roles"]
       ? [{ label: "Roles", href: "/settings/roles" }]
       : []),
+    ...(permissionMap?.["/settings/service-accounts"]
+      ? [{ label: "Service Accounts", href: "/settings/service-accounts" }]
+      : []),
+    ...(permissionMap?.["/settings/environments"]
+      ? [{ label: "Environments", href: "/settings/environments" }]
+      : []),
+    ...(secretsType?.type === "Vault" && permissionMap?.["/settings/secrets"]
+      ? [{ label: "Secrets", href: "/settings/secrets" }]
+      : []),
     ...(permissionMap?.["/settings/github"]
       ? [{ label: "GitHub", href: "/settings/github" }]
       : []),
@@ -43,11 +62,46 @@ export function useSettingsTabs() {
     permissionMap?.["/settings/identity-providers"]
       ? [{ label: "Identity Providers", href: "/settings/identity-providers" }]
       : []),
-    ...(secretsType?.type === "Vault" && permissionMap?.["/settings/secrets"]
-      ? [{ label: "Secrets", href: "/settings/secrets" }]
+    ...(permissionMap?.["/settings/llm"]
+      ? [{ label: "LLM", href: "/settings/llm" }]
       : []),
-    ...(permissionMap?.["/settings/organization"]
-      ? [{ label: "Organization", href: "/settings/organization" }]
+    ...(permissionMap?.["/settings/agents"]
+      ? [{ label: "Agents", href: "/settings/agents" }]
+      : []),
+    ...(permissionMap?.["/settings/knowledge"]
+      ? [{ label: "Knowledge", href: "/settings/knowledge" }]
       : []),
   ];
+
+  const groups: SettingsNavGroup[] = [];
+  if (personal.length > 0) {
+    groups.push({ label: "Personal", items: personal });
+  }
+  if (organization.length > 0) {
+    groups.push({ label: "Organization", items: organization });
+  }
+  return groups;
+}
+
+// Where the settings "back" button returns to when there is no prior in-app
+// page (deep link / new tab / reload) — the first chats nav item, New Chat.
+const SETTINGS_FALLBACK_PATH = "/chat";
+
+/**
+ * Resolves where the settings "back" button should navigate. Tracks the last
+ * non-settings route the user visited (so back returns to the page they came
+ * from) and falls back to New Chat when there is none. Must be called from an
+ * always-mounted component so the ref survives client-side navigations.
+ */
+export function useSettingsReturnPath(): string {
+  const pathname = usePathname();
+  const lastNonSettingsPath = React.useRef<string | null>(null);
+
+  React.useEffect(() => {
+    if (!pathname.startsWith("/settings")) {
+      lastNonSettingsPath.current = pathname;
+    }
+  }, [pathname]);
+
+  return lastNonSettingsPath.current ?? SETTINGS_FALLBACK_PATH;
 }

--- a/platform/frontend/src/app/settings/settings-tabs.ts
+++ b/platform/frontend/src/app/settings/settings-tabs.ts
@@ -35,7 +35,7 @@ export function useSettingsNavGroups(): SettingsNavGroup[] {
 
   const organization: SettingsNavItem[] = [
     ...(permissionMap?.["/settings/organization"]
-      ? [{ label: "Overview", href: "/settings/organization" }]
+      ? [{ label: "Appearance & Auth", href: "/settings/organization" }]
       : []),
     ...(permissionMap?.["/settings/users"]
       ? [{ label: "Users", href: "/settings/users" }]
@@ -63,13 +63,13 @@ export function useSettingsNavGroups(): SettingsNavGroup[] {
       ? [{ label: "Identity Providers", href: "/settings/identity-providers" }]
       : []),
     ...(permissionMap?.["/settings/llm"]
-      ? [{ label: "LLM", href: "/settings/llm" }]
+      ? [{ label: "LLM Defaults", href: "/settings/llm" }]
       : []),
     ...(permissionMap?.["/settings/agents"]
-      ? [{ label: "Agents", href: "/settings/agents" }]
+      ? [{ label: "Agent Defaults", href: "/settings/agents" }]
       : []),
     ...(permissionMap?.["/settings/knowledge"]
-      ? [{ label: "Knowledge", href: "/settings/knowledge" }]
+      ? [{ label: "Knowledge Retrieval", href: "/settings/knowledge" }]
       : []),
   ];
 

--- a/platform/frontend/src/components/settings/role-permissions-card.tsx
+++ b/platform/frontend/src/components/settings/role-permissions-card.tsx
@@ -68,15 +68,15 @@ const actionLabels: Record<Action, string> = {
 export function RolePermissionsCard() {
   const { data: session } = useSession();
   const { data: activeOrg } = useActiveOrganization();
-  const { data: role, isLoading: isRoleLoading } = useActiveMemberRole(
-    activeOrg?.id,
-  );
+  const { data: role } = useActiveMemberRole(activeOrg?.id);
   const { data: permissions, isLoading: isPermissionsLoading } =
     useAllPermissions();
 
-  const isLoading = isRoleLoading || isPermissionsLoading;
-
-  if (isLoading) {
+  // Gate the card on the permissions query only. The role query becomes enabled
+  // a tick later (once the active org resolves) and has no cached data, so
+  // folding it into the loading gate makes the whole card flash to a skeleton
+  // after the cached permissions have already rendered. Load the role inline.
+  if (isPermissionsLoading && !permissions) {
     return (
       <Card>
         <CardContent className="space-y-4">
@@ -104,9 +104,7 @@ export function RolePermissionsCard() {
           <span className="flex h-8 items-center text-muted-foreground">
             Role:
           </span>
-          <span className="flex h-8 items-center capitalize">
-            {role || "—"}
-          </span>
+          <span className="flex h-8 items-center capitalize">{role}</span>
         </div>
         {permissions && (
           <>

--- a/platform/frontend/src/components/tokens/platform-token-card.tsx
+++ b/platform/frontend/src/components/tokens/platform-token-card.tsx
@@ -27,19 +27,27 @@ export function PlatformTokenCard({
   action,
 }: PlatformTokenCardProps) {
   const showAction = !isLoading && !error && tokenExists;
+  // The loaded state is header-only, with the action button in the header. While
+  // loading, show a button-shaped skeleton in that same slot so it swaps in place
+  // without moving or resizing the card. Only error/empty render a content block.
+  const showContent = error || (!isLoading && !tokenExists);
 
   return (
     <Card>
       <SettingsCardHeader
         title={title}
         description={description}
-        action={showAction ? action : undefined}
+        action={
+          isLoading ? (
+            <Skeleton className="h-9 w-36" />
+          ) : showAction ? (
+            action
+          ) : undefined
+        }
       />
-      {!showAction && (
+      {showContent && (
         <CardContent>
-          {isLoading ? (
-            <Skeleton className="h-10 w-full max-w-sm" />
-          ) : error ? (
+          {error ? (
             <Alert variant="destructive">
               <AlertDescription>
                 Failed to load token. Please try refreshing the page.

--- a/platform/frontend/src/components/ui/skeleton.tsx
+++ b/platform/frontend/src/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("bg-accent animate-pulse rounded-md", className)}
+      className={cn("bg-muted animate-pulse rounded-md", className)}
       {...props}
     />
   );


### PR DESCRIPTION
Moves settings navigation from horizontal tabs into the sidebar, grouped into **Personal** and **Organization** sections.

Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/e1d42f27-029d-4ea9-977b-8107f60752e1)  |  ![](https://github.com/user-attachments/assets/53639fc7-8e1a-41d8-a7f8-09c0d33646f3)

## Why

A few problems with the current horizontal tabs:

- **Too many tabs** -- settings outgrew the tab bar. UX guidelines usually advise avoiding more than four tabs — at five or more, the container becomes cramped. Tabs offer no grouping or labels and do not help to choose. 
- **No personal-vs-org separation** -- flat tabs didn't help to understand what was personal vs. org-wide, or what even belongs in Settings.
- Tabs look like **sub-navigation** of Your account page -- primary tabs must be placed at the top, moving them to the sidebar solves it.

## Renames

Some settings labels reused the exact names of top-level product pages, even though the pages only hold platform defaults. I found it misleading and suggest following settings pages to be renamed:

- Overview → Appearance & Auth (/settings/organization) — page only has branding + 2FA/auth. "Overview" implied a dashboard it isn't, and clashed with the "Organization" page title.
- LLM → LLM Defaults (/settings/llm) — collided with the LLM Proxies in the sidebar. Settings page is to set or default compression + default cost limit.
- Agents → Agent Defaults (/settings/agents) — same, collided with the top-level Agents item
- Knowledge → Knowledge Retrieval (/settings/knowledge) — collided with the Knowledge in the sidebar. This page only configures the embedding → reranking pipeline. Major RAG platform name it "retrieval" (e.g. Google "Retrieval and ranking")

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>