### PR TITLE
fix(bench): dedicated Postgres, per-lane projects, unmasked file conflicts

### DIFF
--- a/archestra-bench/README.md
+++ b/archestra-bench/README.md
@@ -20,7 +20,7 @@ tasks derived from real Archestra workflows, each one permanent regression prote
 start the harness-owned benchmark MCP (submit_result) in-process
   -> for each environment:
        boot a fresh backend on a new port over a fresh, migrated database
-         (reusing the dev stack's shared Postgres + Dagger engine)
+         (on a dedicated bench Postgres the runner provisions; reusing the dev stack's Dagger engine)
        -> seed: provider key + models, the env's web-pinned skills, its remote MCPs,
                 the benchmark MCP; create the env's agent and lock its tool surface
        -> for each task x model:
@@ -128,10 +128,11 @@ tool and skill catalog is the subject under test; `tools = ["create_skill"]`) wi
 ## Lifecycle: fresh backend over shared infra
 
 The harness does not run its own Tilt stack. It reuses the developer's already-running stack's
-shared Postgres and Dagger code-runtime engine, and stands up only what must be isolated per env: a
-fresh database (migrated from scratch) plus a second backend **process** on a new port. The backend
-reads `process.env` directly, so benchmark overrides (fresh DB URL, new API/metrics ports, shared
-Dagger host) take effect without a git worktree, a second Tilt, or any edit to `platform/.env`. The
+Dagger code-runtime engine, provisions a dedicated bench Postgres of its own (so DB traffic skips
+Tilt's port-forward), and stands up only what must be isolated per env: a fresh database (migrated
+from scratch) plus a second backend **process** on a new port. The backend reads `process.env`
+directly, so benchmark overrides (fresh DB URL, new API/metrics ports, shared Dagger host) take
+effect without a git worktree, a second Tilt, or any edit to `platform/.env`. The
 second backend runs the already-built `dist/server.mjs` the main stack keeps fresh, so it never
 starts a competing `tsdown --watch`. Teardown always runs: the backend process group is killed and
 the benchmark database is dropped.
@@ -210,8 +211,14 @@ not the raw per-token SSE chunks), `run.json`,
 ## Prerequisites
 
 - A running Archestra dev stack (`tilt up` with `ARCHESTRA_CODE_RUNTIME_ENABLED=true`) providing the
-  shared Postgres (host-reachable on `localhost:5432`) and the Dagger engine (`tcp://127.0.0.1:1234`),
-  with the backend built (`dist/server.mjs`).
+  Dagger engine (`tcp://127.0.0.1:1234`), with the backend built (`dist/server.mjs`).
+- Docker, so the runner can provision the dedicated bench Postgres (`dev/docker-compose.bench-pg.yml`,
+  host-reachable on `localhost:5544`). This bypasses the dev stack's slow kubectl port-forward, but on
+  macOS the host→Colima-VM path still crosses Colima's network proxy, which can drop a burst of idle
+  pooled connections under concurrent load (`withDbRetry` absorbs almost all; the occasional leak is a
+  retry-able flake). For the cleanest connection path, set `ARCHESTRA_BENCH_DATABASE_URL` to a **native
+  host Postgres** (e.g. Postgres.app or `brew install postgresql@18 pgvector`), skipping docker and the
+  VM entirely; the same override also points the bench at any Postgres you manage.
 - A real provider key in the environment for each lane you run (e.g. `OPENROUTER_API_KEY`,
   `KIMI_API_KEY`, `ZAI_API_KEY`; see each lane's `api_key_env` in `lanes.toml`).
 - A Rust toolchain to build `archestra-bench`, and local `uv` for the ephemeral verifier environments.

--- a/archestra-bench/dev/docker-compose.bench-pg.yml
+++ b/archestra-bench/dev/docker-compose.bench-pg.yml
@@ -1,0 +1,32 @@
+# Dedicated Postgres for archestra-bench runs.
+#
+# The dev stack's Postgres is only reachable through Tilt's kubectl port-forward,
+# which throttles new-connection establishment under concurrent lanes (p50 grows
+# to seconds) and trips the backend pool's connect timeout, surfacing as
+# agent_error. A directly-published port establishes in single-digit
+# milliseconds, so the benchmark uses its own Postgres instead.
+#
+# Brought up idempotently by the runner (`docker compose up -d --wait`) and left
+# running between runs. Each run still creates and drops its own throwaway
+# database on this server, so nothing accumulates. To point the benchmark at a
+# Postgres you manage yourself, set ARCHESTRA_BENCH_DATABASE_URL and this file is
+# ignored.
+#
+# pgvector image (matching the dev stack's Postgres 18 major): the platform
+# migrations require the `vector` extension, which stock postgres lacks.
+# Host port 5544 avoids the 5433 already published by docker-compose-n8n.yml.
+services:
+  bench-postgres:
+    image: pgvector/pgvector:pg18
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - "5544:5432"
+    command: ["postgres", "-c", "max_connections=200"]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
+      interval: 1s
+      timeout: 3s
+      retries: 60

--- a/archestra-bench/runner/src/client.rs
+++ b/archestra-bench/runner/src/client.rs
@@ -397,6 +397,22 @@ impl EvalClient {
         require_str_field(&body, "id", "POST /api/teams")
     }
 
+    /// Create a project. Files produced in its conversations are owned by the project rather than the
+    /// author, so lanes sharing one backend stay isolated even when they save identically named files.
+    pub async fn create_project(&self, name: &str) -> Result<String, ClientError> {
+        let body = require_dict(
+            self.request(
+                Method::POST,
+                "/api/projects",
+                None,
+                Some(&serde_json::json!({"name": name})),
+            )
+            .await?,
+            "POST /api/projects",
+        )?;
+        require_str_field(&body, "id", "POST /api/projects")
+    }
+
     pub async fn list_skills(
         &self,
         search: Option<&str>,
@@ -564,12 +580,19 @@ impl EvalClient {
         title: Option<&str>,
         model_id: Option<&str>,
         chat_api_key_id: Option<&str>,
+        project_id: Option<&str>,
     ) -> Result<HashMap<String, JsonValue>, ClientError> {
         let mut body = serde_json::Map::new();
         body.insert(
             "agentId".to_string(),
             JsonValue::String(agent_id.to_string()),
         );
+        if let Some(project_id) = project_id {
+            body.insert(
+                "projectId".to_string(),
+                JsonValue::String(project_id.to_string()),
+            );
+        }
         if let Some(title) = title {
             body.insert("title".to_string(), JsonValue::String(title.to_string()));
         }
@@ -716,14 +739,18 @@ impl EvalClient {
             .and_then(JsonValue::as_array)
             .cloned()
             .ok_or_else(|| {
-                ContractError(format!("GET /api/interactions: missing `data` array: {body}"))
+                ContractError(format!(
+                    "GET /api/interactions: missing `data` array: {body}"
+                ))
             })?;
         let total = body
             .get("pagination")
             .and_then(|p| p.get("total"))
             .and_then(JsonValue::as_u64)
             .ok_or_else(|| {
-                ContractError(format!("GET /api/interactions: missing `pagination.total`: {body}"))
+                ContractError(format!(
+                    "GET /api/interactions: missing `pagination.total`: {body}"
+                ))
             })? as usize;
         Ok((data, total))
     }

--- a/archestra-bench/runner/src/lifecycle.rs
+++ b/archestra-bench/runner/src/lifecycle.rs
@@ -124,6 +124,14 @@ const DAGGER_RUNNER_HOST: &str = "tcp://127.0.0.1:1234";
 const DEV_AUTH_SECRET: &str = "better-auth-secret-12345678901234567890";
 const DEFAULT_ADMIN_EMAIL: &str = "admin@example.com";
 const DEFAULT_ADMIN_PASSWORD: &str = "password";
+/// The dedicated bench Postgres the runner provisions when no external one is configured.
+/// Credentials and port must match `archestra-bench/dev/docker-compose.bench-pg.yml`.
+const DEFAULT_BENCH_DATABASE_URL: &str = "postgres://postgres:postgres@localhost:5544/postgres";
+const BENCH_PG_COMPOSE_PROJECT: &str = "archestra-bench";
+
+/// Provision the dedicated bench Postgres at most once per process. Isolated lanes call
+/// [`Instance::start`] concurrently, so this serializes the `docker compose up` across them.
+static BENCH_PG_READY: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
 
 #[derive(Debug, thiserror::Error)]
 pub enum LifecycleError {
@@ -154,8 +162,10 @@ pub struct Instance {
     env: HashMap<String, String>,
     maint_db_url: String,
     db_url: String,
+    db_managed: bool,
     api_port: u16,
     metrics_port: u16,
+    bench_compose: PathBuf,
     teardown_id: Option<u64>,
 }
 
@@ -163,6 +173,10 @@ impl Instance {
     pub fn new(repo_root: PathBuf, run_id: impl Into<String>, log_path: PathBuf) -> Self {
         let run_id = run_id.into();
         let platform = repo_root.join("platform");
+        let bench_compose = repo_root
+            .join("archestra-bench")
+            .join("dev")
+            .join("docker-compose.bench-pg.yml");
         Self {
             run_id,
             log_path,
@@ -176,8 +190,10 @@ impl Instance {
             env: HashMap::new(),
             maint_db_url: String::new(),
             db_url: String::new(),
+            db_managed: true,
             api_port: 0,
             metrics_port: 0,
+            bench_compose,
             teardown_id: None,
         }
     }
@@ -191,13 +207,21 @@ impl Instance {
             )));
         }
         self.env = parse_env_file(&env_path)?;
-        self.maint_db_url = self
-            .env
-            .get("ARCHESTRA_DATABASE_URL")
-            .ok_or_else(|| {
-                LifecycleError::Config("ARCHESTRA_DATABASE_URL not set in .env".to_string())
-            })?
-            .clone();
+        let (bench_db_url, managed) = resolve_bench_db_url(&self.env);
+        self.db_managed = managed;
+        info!(
+            "bench Postgres: {} ({})",
+            redacted_db_location(&bench_db_url),
+            if managed {
+                "runner-managed container"
+            } else {
+                "external (ARCHESTRA_BENCH_DATABASE_URL)"
+            }
+        );
+        if managed {
+            ensure_bench_postgres(&self.bench_compose).await?;
+        }
+        self.maint_db_url = bench_db_url;
         self.db_name = benchmark_db_name(&self.run_id);
         self.db_url = with_dbname(&self.maint_db_url, &self.db_name);
         self.api_port = free_port().await?;
@@ -246,8 +270,9 @@ impl Instance {
             tokio_postgres::connect(&libpq_url(&self.maint_db_url), tokio_postgres::NoTls)
                 .await
                 .map_err(|e| {
-                    LifecycleError::Postgres(shared_postgres_unavailable_message(
+                    LifecycleError::Postgres(bench_postgres_unavailable_message(
                         &self.maint_db_url,
+                        self.db_managed,
                         e,
                     ))
                 })?;
@@ -466,11 +491,70 @@ pub fn with_dbname(db_url: &str, dbname: &str) -> String {
     parsed.to_string()
 }
 
-pub fn shared_postgres_unavailable_message(db_url: &str, _error: impl std::fmt::Display) -> String {
-    format!(
-        "cannot connect to shared Archestra Postgres at {}; start the dev stack from platform/ with ARCHESTRA_CODE_RUNTIME_ENABLED=true and `tilt up`, or restore the configured Postgres port-forward",
-        redacted_db_location(db_url)
-    )
+/// Resolve the Postgres the benchmark uses, and whether the runner owns its lifecycle.
+/// An explicit `ARCHESTRA_BENCH_DATABASE_URL` (process env or `.env`) points at a Postgres the
+/// operator manages — the runner leaves it alone. Otherwise it defaults to, and provisions, the
+/// dedicated container in `docker-compose.bench-pg.yml`, bypassing the dev stack's slow port-forward.
+fn resolve_bench_db_url(env: &HashMap<String, String>) -> (String, bool) {
+    let explicit = std::env::var("ARCHESTRA_BENCH_DATABASE_URL")
+        .ok()
+        .or_else(|| env.get("ARCHESTRA_BENCH_DATABASE_URL").cloned())
+        .filter(|s| !s.trim().is_empty());
+    match explicit {
+        Some(url) => (url, false),
+        None => (DEFAULT_BENCH_DATABASE_URL.to_string(), true),
+    }
+}
+
+/// Bring the dedicated bench Postgres up and block until it is healthy. Idempotent: `docker compose
+/// up -d --wait` reconciles an already-running container and returns fast, and [`BENCH_PG_READY`]
+/// collapses concurrent callers into a single invocation.
+async fn ensure_bench_postgres(compose_file: &Path) -> Result<(), LifecycleError> {
+    BENCH_PG_READY
+        .get_or_try_init(|| async {
+            info!(
+                "ensuring dedicated bench Postgres ({})",
+                compose_file.display()
+            );
+            let compose = compose_file.to_string_lossy();
+            let output = Command::new("docker")
+                .args(["compose", "-p", BENCH_PG_COMPOSE_PROJECT, "-f"])
+                .arg(compose.as_ref())
+                .args(["up", "-d", "--wait"])
+                .output()
+                .await
+                .map_err(|e| {
+                    LifecycleError::Config(format!(
+                        "failed to run `docker compose` for the bench Postgres (is Docker installed and running?): {e}"
+                    ))
+                })?;
+            if !output.status.success() {
+                return Err(LifecycleError::Postgres(format!(
+                    "could not start the dedicated bench Postgres: {}",
+                    String::from_utf8_lossy(&output.stderr).trim()
+                )));
+            }
+            Ok(())
+        })
+        .await
+        .copied()
+}
+
+pub fn bench_postgres_unavailable_message(
+    db_url: &str,
+    managed: bool,
+    _error: impl std::fmt::Display,
+) -> String {
+    let location = redacted_db_location(db_url);
+    if managed {
+        format!(
+            "cannot connect to the runner-managed bench Postgres at {location}; ensure Docker is running so `docker compose` can provision it, or set ARCHESTRA_BENCH_DATABASE_URL to a Postgres you manage"
+        )
+    } else {
+        format!(
+            "cannot connect to the bench Postgres at {location} from ARCHESTRA_BENCH_DATABASE_URL; ensure it is reachable, or unset it to let the runner provision a dedicated container"
+        )
+    }
 }
 
 pub fn redacted_db_location(db_url: &str) -> String {
@@ -524,6 +608,9 @@ pub fn build_backend_env(
         dagger_cli_bin.to_string(),
     );
     env.insert("ARCHESTRA_ANALYTICS".to_string(), "disabled".to_string());
+    // Per-lane projects isolate file ownership so lanes sharing one backend don't collide on common
+    // artifact names; the feature must be on for `POST /api/projects` and project-scoped conversations.
+    env.insert("ARCHESTRA_PROJECTS_ENABLED".to_string(), "true".to_string());
     env
 }
 

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -34,6 +34,10 @@ use crate::verify::{VerifyOutcome, run_verifier};
 // random token (registry names must be unique per backend, and tool auto-assignment is disabled so a
 // lane only ever discovers its own server); isolated lanes own their backend and use the bare name.
 const BENCH_MCP_NAME: &str = "final_answer";
+// Per-lane project name. Each lane gets its own project (distinct id) so file ownership is isolated;
+// the name is neutral and identical across lanes -- like BENCH_MCP_NAME it must not encode lane/model
+// identity or cue the agent it is being evaluated, since it can surface in a file-conflict message.
+const PROJECT_NAME: &str = "Workspace";
 const SUBMIT_TOOL_SUFFIX: &str = "__submit_result";
 // Appended to every user message. Kept short and tool-agnostic: it nudges submission without naming
 // the search/run meta-tools (Archestra's stock prompt already explains discovery), so a model that
@@ -310,6 +314,7 @@ struct SharedLaneSetup {
     submit_tool: String,
     mcp: BenchmarkMcp,
     resolved: ResolvedModel,
+    project_id: String,
 }
 
 /// One unit of work for a lane: that lane's tasks against a single env. A lane drains its stops serially.
@@ -414,6 +419,7 @@ async fn execute_plan(plan: Vec<EnvPlan>, ctx: RunCtx, max_workers: usize) -> Ve
                                 setup.mcp,
                                 setup.submit_tool,
                                 setup.agent_id,
+                                Some(setup.project_id),
                                 ctx.root_run_dir.clone(),
                                 setup.resolved,
                                 progress.clone(),
@@ -468,8 +474,8 @@ fn note(mp: &MultiProgress, msg: impl AsRef<str>) {
 
 /// Cancel the in-process server task of every prepared benchmark MCP — called on a setup-error path so a
 /// partially-prepared env doesn't leak listener tasks for the rest of the run.
-async fn stop_mcps(setups: &[(Lane, String, String, BenchmarkMcp)]) {
-    for (_, _, _, mcp) in setups {
+async fn stop_mcps(setups: &[(Lane, String, String, BenchmarkMcp, String)]) {
+    for (_, _, _, mcp, _) in setups {
         mcp.stop().await;
     }
 }
@@ -534,7 +540,7 @@ async fn setup_shared_env(
         }
     }
 
-    let mut setups: Vec<(Lane, String, String, BenchmarkMcp)> = Vec::new();
+    let mut setups: Vec<(Lane, String, String, BenchmarkMcp, String)> = Vec::new();
     for lane in &env_plan.lanes {
         let token = &uuid::Uuid::new_v4().simple().to_string()[..8];
         let mcp = match BenchmarkMcp::start(format!("{BENCH_MCP_NAME}-{token}")).await {
@@ -546,7 +552,26 @@ async fn setup_shared_env(
             }
         };
         match setup_lane_agent(&client, env, lane, &mcp, &team_id).await {
-            Ok((agent_id, submit_tool)) => setups.push((lane.clone(), agent_id, submit_tool, mcp)),
+            Ok((agent_id, submit_tool)) => {
+                // One project per lane so lanes no longer collide on the shared user's
+                // `(user_id, filename)` personal-file index when they save identically named
+                // artifacts. The opaque token keeps the name (and its derived slug) unique per the
+                // projects `(user_id, name)` / `(org, slug)` indexes -- all lanes share one user.
+                // Residual: a lane's tasks share this project, so two tasks emitting the *same*
+                // filename would collide on `(project_id, filename)`; today each task uses a distinct
+                // artifact name, so this does not bite. Revisit (per-rollout project) if that changes.
+                let project_name = format!("{PROJECT_NAME} {token}");
+                let project_id = match client.create_project(&project_name).await {
+                    Ok(id) => id,
+                    Err(e) => {
+                        mcp.stop().await;
+                        stop_mcps(&setups).await;
+                        let _ = instance.shutdown().await;
+                        return Err(e.to_string());
+                    }
+                };
+                setups.push((lane.clone(), agent_id, submit_tool, mcp, project_id));
+            }
             Err(e) => {
                 mcp.stop().await;
                 stop_mcps(&setups).await;
@@ -557,7 +582,7 @@ async fn setup_shared_env(
     }
 
     if !env.mcps.is_empty() {
-        let agent_ids: Vec<String> = setups.iter().map(|(_, id, _, _)| id.clone()).collect();
+        let agent_ids: Vec<String> = setups.iter().map(|(_, id, _, _, _)| id.clone()).collect();
         let registered = match seed_mcp_fixtures(&client, &env.mcps, "org", Some(&agent_ids)).await
         {
             Ok(registered) => registered,
@@ -586,7 +611,7 @@ async fn setup_shared_env(
 
     let lane_setups = setups
         .into_iter()
-        .map(|(lane, agent_id, submit_tool, mcp)| {
+        .map(|(lane, agent_id, submit_tool, mcp, project_id)| {
             let resolved = resolved[&lane.name].clone();
             (
                 lane.name.clone(),
@@ -596,6 +621,7 @@ async fn setup_shared_env(
                     submit_tool,
                     mcp,
                     resolved,
+                    project_id,
                 },
             )
         })
@@ -674,7 +700,8 @@ async fn run_isolated_lane(
         }
     };
 
-    let (agent_id, submit_tool) = match setup_lane_agent(&client, &env, &lane, &mcp, &team_id).await {
+    let (agent_id, submit_tool) = match setup_lane_agent(&client, &env, &lane, &mcp, &team_id).await
+    {
         Ok(s) => s,
         Err(e) => {
             mcp.stop().await;
@@ -727,6 +754,7 @@ async fn run_isolated_lane(
         mcp,
         submit_tool,
         agent_id,
+        None,
         ctx.root_run_dir.clone(),
         resolved,
         progress,
@@ -1100,6 +1128,7 @@ async fn run_lane(
     mcp: BenchmarkMcp,
     submit_tool: String,
     agent_id: String,
+    project_id: Option<String>,
     root_run_dir: PathBuf,
     resolved: ResolvedModel,
     progress: ProgressBar,
@@ -1118,6 +1147,7 @@ async fn run_lane(
             env.platform.tool_exposure_mode,
             &lane,
             &agent_id,
+            project_id.as_deref(),
             &task,
             &resolved,
         )
@@ -1139,6 +1169,7 @@ async fn run_one(
     tool_exposure_mode: ToolExposureMode,
     lane: &Lane,
     agent_id: &str,
+    project_id: Option<&str>,
     task: &Task,
     resolved: &ResolvedModel,
 ) -> RunResult {
@@ -1201,6 +1232,7 @@ async fn run_one(
         agent_system_prompt,
         lane,
         agent_id,
+        project_id,
         task,
         resolved,
         &artifacts,
@@ -1258,7 +1290,9 @@ async fn capture_effective_prompts(
     }
     for error in &outcome.errors {
         warn!("effective-prompt anomaly: {error}");
-        artifacts.append_error("effective_prompt_error", error).await;
+        artifacts
+            .append_error("effective_prompt_error", error)
+            .await;
     }
 }
 
@@ -1270,6 +1304,7 @@ async fn grade_rollout(
     agent_system_prompt: &str,
     lane: &Lane,
     agent_id: &str,
+    project_id: Option<&str>,
     task: &Task,
     resolved: &ResolvedModel,
     artifacts: &RunArtifacts,
@@ -1287,6 +1322,7 @@ async fn grade_rollout(
             Some(rollout_key),
             Some(&resolved.model_id),
             Some(&resolved.api_key_id),
+            project_id,
         )
         .await?;
     let conversation_id = conversation

--- a/platform/backend/src/archestra-mcp-server/sandbox.test.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.test.ts
@@ -16,12 +16,14 @@ import {
   ConversationFileTouchModel,
   ConversationModel,
   FileModel,
+  FileNameExistsError,
   ProjectModel,
   SkillModel,
   SkillSandboxModel,
   SkillSandboxReplayEventModel,
   SkillVersionModel,
 } from "@/models";
+import { sandboxRuntimeService } from "@/sandbox-runtime/sandbox-runtime-service";
 import { executionSandboxRegistry } from "@/skills-sandbox/execution-sandbox-registry";
 import { fileStore } from "@/skills-sandbox/file-store";
 import { skillSandboxRuntimeService } from "@/skills-sandbox/skill-sandbox-runtime-service";
@@ -36,7 +38,7 @@ import {
   test,
   vi,
 } from "@/test";
-import type { Agent } from "@/types";
+import { type Agent, asSandboxId } from "@/types";
 import {
   type ArchestraContext,
   executeArchestraTool,
@@ -792,6 +794,55 @@ describe("sandbox tools (runtime enabled)", () => {
       expect(result.isError).toBe(false);
       const contents = result.content as Array<{ type: string }>;
       expect(contents.map((c) => c.type)).toEqual(["text"]);
+    });
+
+    test("surfaces a name collision as a clean, non-retryable error", async () => {
+      const ctx = await makeConversationCtx();
+      vi.spyOn(skillSandboxRuntimeService, "exportArtifact").mockRejectedValue(
+        new FileNameExistsError("report.pdf"),
+      );
+
+      const result = await executeArchestraTool(
+        TOOL_DOWNLOAD_FILE_FULL_NAME,
+        { path: "out/report.pdf", mimeType: "application/pdf" },
+        ctx,
+      );
+
+      expect(result.isError).toBe(true);
+      const text = textOf(result);
+      expect(text).toContain("already exists");
+      expect(text).not.toContain("Try the operation again");
+    });
+
+    // Guards the propagation path the handler test above cannot reach: the real
+    // exportArtifact must let a typed name collision escape rather than flatten it
+    // into a generic, retryable storage error. Only the Dagger boundary is stubbed.
+    test("exportArtifact rethrows a name collision instead of masking it", async () => {
+      const sandbox = await SkillSandboxModel.create({
+        organizationId,
+        userId,
+        conversationId: null,
+        defaultCwd: "/home/sandbox",
+      });
+      // Stub only the Dagger runtime boundary: its availability gate and the
+      // artifact read. fileStore + the files table stay real so the collision
+      // (and its rethrow) is genuine.
+      vi.spyOn(sandboxRuntimeService, "isEnabled", "get").mockReturnValue(true);
+      vi.spyOn(sandboxRuntimeService, "readArtifact").mockResolvedValue({
+        dataBase64: Buffer.from("pi=3.14159").toString("base64"),
+        sizeBytes: 10,
+      });
+
+      const params = {
+        sandboxId: asSandboxId(sandbox.id),
+        caller: { userId, organizationId },
+        path: "out/result.txt",
+        projectId: null,
+      };
+      await skillSandboxRuntimeService.exportArtifact(params);
+      await expect(
+        skillSandboxRuntimeService.exportArtifact(params),
+      ).rejects.toBeInstanceOf(FileNameExistsError);
     });
   });
 

--- a/platform/backend/src/archestra-mcp-server/sandbox.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.ts
@@ -1662,6 +1662,11 @@ function handleRuntimeError(
   sandboxId: SandboxId,
   tool: string,
 ) {
+  if (error instanceof FileNameExistsError) {
+    return errorResult(
+      `${error.message}. Choose a different name, or delete the existing file first.`,
+    );
+  }
   if (error instanceof SkillSandboxError) {
     return errorResult(error.message);
   }

--- a/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
+++ b/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
@@ -3,6 +3,7 @@ import config from "@/config";
 import logger from "@/logging";
 import {
   ConversationAttachmentModel,
+  FileNameExistsError,
   SkillInvalidFilePathError,
   SkillSandboxFileModel,
   SkillSandboxModel,
@@ -253,6 +254,10 @@ class SkillSandboxRuntimeService {
           data,
         });
       } catch (dbError) {
+        // A name collision is a real, actionable conflict — surface it typed so
+        // the caller renders a non-retryable "already exists" message instead of
+        // masking it as a generic, retryable storage error.
+        if (dbError instanceof FileNameExistsError) throw dbError;
         logger.error(
           { err: dbError, sandboxId: params.sandboxId },
           "[SkillSandbox] failed to persist artifact",


### PR DESCRIPTION
Targets the archestra-bench `agent_error` epidemic and two defects feeding it. Large net improvement; see the honest validation caveat below.

## Root cause (revised after validation)
The bench backend (a host node process) reached Postgres through Tilt's `kubectl port-forward`, whose new-connection establishment throttled badly under concurrent lanes → the backend pool's `connectionTimeoutMillis` tripped → `agent_error`. The original run was **55/59 agent_errors, all connection-related**.

Switching to a dedicated Postgres on a published docker port removes the *kubectl* port-forward, but the host→Colima-VM path still traverses Colima's network proxy. So this is a big mitigation, **not** a full elimination — the residual fragility is the Mac/VM network layer (both paths cross it).

## Changes
- **Dedicated bench Postgres** (`dev/docker-compose.bench-pg.yml`, `pgvector/pgvector:pg18`, host port 5544), provisioned idempotently by the runner (`docker compose up -d --wait`, `OnceCell`-guarded). Override with `ARCHESTRA_BENCH_DATABASE_URL` — point it at a **native host Postgres** to skip the VM network layer entirely. Shared `.env`, Tiltfile, and 9187 metrics forward untouched.
- **Per-lane project isolation**: `ARCHESTRA_PROJECTS_ENABLED=true` + `EvalClient::create_project` + `projectId` on conversation create. Each shared-backend lane gets its own project (neutral name + opaque token for the `(user_id,name)`/`(org,slug)` indexes), so lanes stop colliding on the personal-file `(user_id, filename)` unique index.
- **Unmask `FileNameExistsError`** on the artifact path: `exportArtifact` rethrows the typed conflict before the generic `SkillSandboxError` wrap; `handleRuntimeError` returns a clean, non-retryable "already exists" message (mirrors `save_result`).

## Validation (4-lane run: minimax-3, minimax-27, glm, glm-flash; 52 rollouts)
- **36/52 passed**; 10 failed + 5 no_submission = model capability.
- **Connection-driven failure: 55/59 → 1/52.** One ~5s burst (20:55:07) dropped all idle pooled connections to 5544 at once (a Colima VM network hiccup); `withDbRetry` absorbed 52 blips, 1 leaked through as a 401 in the auth middleware (minimax-3/invoice-approval). So the epidemic is gone but the connection path is not pristine.
- **Collision fix proven**: identical artifacts coexist across distinct non-null `project_id`s (`monte_carlo_pi.gif` ×3 / 3 projects, `pi.zip` ×2 / 2); no collisions.
- Migrations run clean against the pgvector image. `cargo clippy --all-targets -- -D warnings` clean; runner tests pass. `pnpm --filter @backend test` green incl. a real-`exportArtifact` rethrow regression test (verified it fails without the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)